### PR TITLE
Use GNUInstallDirs and improve CMake handling of shared/static mxnet library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,16 +408,9 @@ else()
     add_library(mxnet_static STATIC ${SOURCE})
     # Need an arbitrary source file to trigger CMake to build the library
     add_library(mxnet SHARED)
-    # This has prolems, as it adds libmxnet_static to INTERFACE_LINK_LIBRARIES
-    target_link_libraries(mxnet "-Wl,--whole-archive $<TARGET_FILE:mxnet_static> -Wl,--no-whole-archive")
-    target_link_libraries(mxnet mxnet_static) # Let cmake understand the dependency
-    add_custom_target(
-        StaticallyLinkStaticMXNetLibrary ALL
-        BYPRODUCTS ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/libmxnet.a
-        WORKING_DIRECTORY ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
-        COMMAND ln -sf libmxnet_static.a libmxnet.a
-        DEPENDS mxnet_static
-    )
+    set_target_properties(mxnet_static PROPERTIES OUTPUT_NAME mxnet)
+    target_link_libraries(mxnet PRIVATE "-Wl,--whole-archive $<TARGET_FILE:mxnet_static> -Wl,--no-whole-archive")
+    target_link_libraries(mxnet PRIVATE mxnet_static) # Let cmake understand the dependency
   else()
     add_library(mxnet SHARED ${SOURCE})
   endif()
@@ -427,15 +420,15 @@ if(USE_DIST_KVSTORE)
   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/ps-lite/CMakeLists.txt)
     add_subdirectory("ps-lite")
     list(APPEND pslite_LINKER_LIBS pslite protobuf)
-    target_link_libraries(mxnet debug ${pslite_LINKER_LIBS_DEBUG})
-    target_link_libraries(mxnet optimized ${pslite_LINKER_LIBS_RELEASE})
+    target_link_libraries(mxnet PUBLIC debug ${pslite_LINKER_LIBS_DEBUG})
+    target_link_libraries(mxnet PUBLIC optimized ${pslite_LINKER_LIBS_RELEASE})
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
       list(APPEND mxnet_LINKER_LIBS ${pslite_LINKER_LIBS_DEBUG})
     else()
       list(APPEND mxnet_LINKER_LIBS ${pslite_LINKER_LIBS_RELEASE})
     endif()
-    target_link_libraries(mxnet debug ${pslite_LINKER_LIBS_DEBUG})
-    target_link_libraries(mxnet optimized ${pslite_LINKER_LIBS_RELEASE})
+    target_link_libraries(mxnet PUBLIC debug ${pslite_LINKER_LIBS_DEBUG})
+    target_link_libraries(mxnet PUBLIC optimized ${pslite_LINKER_LIBS_RELEASE})
 
   else()
     set(pslite_LINKER_LIBS protobuf zmq-static)
@@ -445,19 +438,18 @@ if(USE_DIST_KVSTORE)
   list(APPEND mxnet_LINKER_LIBS ${pslite_LINKER_LIBS})
 endif()
 
-target_link_libraries(mxnet ${mxnet_LINKER_LIBS})
+target_link_libraries(mxnet PUBLIC ${mxnet_LINKER_LIBS})
 
 if(USE_PLUGINS_WARPCTC)
-  target_link_libraries(mxnet debug ${WARPCTC_LIB_DEBUG})
-  target_link_libraries(mxnet optimized ${WARPCTC_LIB_RELEASE})
+  target_link_libraries(mxnet PUBLIC debug ${WARPCTC_LIB_DEBUG})
+  target_link_libraries(mxnet PUBLIC optimized ${WARPCTC_LIB_RELEASE})
 endif()
 
-target_link_libraries(mxnet dmlc)
+target_link_libraries(mxnet PUBLIC dmlc)
 
 if(MSVC AND USE_MXNET_LIB_NAMING)
   set_target_properties(mxnet PROPERTIES OUTPUT_NAME "libmxnet")
 endif()
-
 
 if(USE_PROFILER)
 	add_definitions(-DMXNET_USE_PROFILER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/Modules;${CMAKE_MODULE_PATH}")
 
+
 include(cmake/Utils.cmake)
 mxnet_option(USE_OPENCV           "Build with OpenCV support" ON)
 mxnet_option(USE_OPENMP           "Build with Openmp support" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,13 @@ mxnet_option(USE_MKL_EXPERIMENTAL "Use experimental MKL (if MKL enabled and foun
 mxnet_option(USE_JEMALLOC         "Build with Jemalloc support"   OFF)
 mxnet_option(USE_PROFILER         "Build with Profiler support"   OFF)
 mxnet_option(USE_DIST_KVSTORE     "Build with DIST_KVSTORE support" OFF)
-mxnet_option(USE_PLUGINS_WARPCTC	"Use WARPCTC Plugins" OFF)
+mxnet_option(USE_PLUGINS_WARPCTC  "Use WARPCTC Plugins" OFF)
 mxnet_option(USE_PLUGIN_CAFFE     "Use Caffe Plugin" OFF)
 mxnet_option(USE_CPP_PACKAGE      "Build C++ Package" OFF)
 mxnet_option(USE_MXNET_LIB_NAMING "Use MXNet library naming conventions." ON)
 mxnet_option(USE_GPROF            "Compile with gprof (profiling) flag" OFF)
 mxnet_option(USE_VTUNE            "Enable use of Intel Amplifier XE (VTune)" OFF) # one could set VTUNE_ROOT for search path
+mxnet_option(INSTALL_EXAMPLES     "Install the example source files." OFF)
 
 SET(EXTRA_OPERATORS "" CACHE PATH "EXTRA OPERATORS PATH")
 
@@ -398,10 +399,12 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
 endif()
 
+set(MXNET_INSTALL_TARGETS mxnet)
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin" AND USE_MXNET_LIB_NAMING)
   add_library(mxnet MODULE ${SOURCE})
 else()
   if(UNIX)
+    list(APPEND MXNET_INSTALL_TARGETS mxnet_static)
     add_library(mxnet_static STATIC ${SOURCE})
     # Need an arbitrary source file to trigger CMake to build the library
     add_library(mxnet SHARED)
@@ -461,6 +464,18 @@ if(USE_PROFILER)
 endif()
 
 add_subdirectory(tests)
+
+include(GNUInstallDirs)
+install(TARGETS ${MXNET_INSTALL_TARGETS}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if (INSTALL_EXAMPLES)
+  install(DIRECTORY example  DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
+endif()
 
 # AUTO_INSTALL_DIR -> Optional: specify post-build install direcory
 if(AUTO_INSTALL_DIR)


### PR DESCRIPTION
This PR does the same as dmlc/dmlc-core#257 but for mxnet. It uses `GNUInstallDirs.cmake` for standard (but overridable) installation locations for different types of files. Additionally, it uses plain CMake `install()` instead of custom targets that copy files around.

In addition, it prevents leaking `mxnet_static` and the flags ` "-Wl,--whole-archive $<TARGET_FILE:mxnet_static> -Wl,--no-whole-archive"` into `INTERFACE_LINK_LIBRARIES` of `mxnet` by marking them as private.

It also sets the output name of `mxnet_static` to `mxnet` to let CMake handle the output name rather than symlinking to `mxnet_static.a`.