### PR TITLE
update RCNN example for BaseModule::init_params

### DIFF
--- a/example/rcnn/rcnn/core/module.py
+++ b/example/rcnn/rcnn/core/module.py
@@ -80,7 +80,7 @@ class MutableModule(BaseModule):
         return self._curr_module.get_params()
 
     def init_params(self, initializer=Uniform(0.01), arg_params=None, aux_params=None,
-                    allow_missing=False, force_init=False):
+                    allow_missing=False, force_init=False, allow_extra=False):
         if self.params_initialized and not force_init:
             return
         assert self.binded, 'call bind before initializing the parameters'

--- a/example/rcnn/rcnn/core/module.py
+++ b/example/rcnn/rcnn/core/module.py
@@ -86,7 +86,7 @@ class MutableModule(BaseModule):
         assert self.binded, 'call bind before initializing the parameters'
         self._curr_module.init_params(initializer=initializer, arg_params=arg_params,
                                       aux_params=aux_params, allow_missing=allow_missing,
-                                      force_init=force_init)
+                                      force_init=force_init, allow_extra=allow_extra)
         self.params_initialized = True
 
     def bind(self, data_shapes, label_shapes=None, for_training=True,


### PR DESCRIPTION
It seems that a new argument(allow_extra) is added into BaseModule::init_params, which makes the old RCNN example unable to run. So I append it into the example. 