### PR TITLE
Properly check argument types in ndarray.save to avoid segfaults.

### DIFF
--- a/python/mxnet/ndarray.py
+++ b/python/mxnet/ndarray.py
@@ -2176,6 +2176,7 @@ def negative(arr):
     """
     return multiply(arr, -1.0)
 
+
 def load(fname):
     """Loads an array from file.
 
@@ -2223,7 +2224,7 @@ def save(fname, data):
     ----------
     fname : str
         The filename.
-    data : list of ``NDArray` or dict of str to ``NDArray``
+    data : ``NDArray``, list of ``NDArray` or dict of str to ``NDArray``
         The data to save.
 
     Examples
@@ -2237,6 +2238,8 @@ def save(fname, data):
     >>> mx.nd.load('my_dict')
     {'y': <NDArray 1x4 @cpu(0)>, 'x': <NDArray 2x3 @cpu(0)>}
     """
+    if isinstance(data, NDArray):
+        data = [data]
     handles = []
     if isinstance(data, dict):
         keys = []
@@ -2248,12 +2251,15 @@ def save(fname, data):
             keys.append(c_str(key))
             handles.append(val.handle)
         keys = c_array(ctypes.c_char_p, keys)
-    else:
+    elif isinstance(data, list):
         for val in data:
             if not isinstance(val, NDArray):
                 raise TypeError('save only accept dict str->NDArray or list of NDArray')
             handles.append(val.handle)
         keys = None
+    else:
+        raise ValueError("data needs to either be a NDArray, dict of str, NDArray pairs "
+                         "or a list of NDarrays.")
     check_call(_LIB.MXNDArraySave(c_str(fname),
                                   mx_uint(len(handles)),
                                   c_array(NDArrayHandle, handles),

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -209,11 +209,11 @@ def test_ndarray_pickle():
 
 def test_ndarray_saveload():
     np.random.seed(0)
-    maxdim = 5
     nrepeat = 10
     fname = 'tmp_list.bin'
     for repeat in range(nrepeat):
         data = []
+        # test save/load as list
         for i in range(10):
             data.append(random_ndarray(np.random.randint(1, 5)))
         mx.nd.save(fname, data)
@@ -221,6 +221,7 @@ def test_ndarray_saveload():
         assert len(data) == len(data2)
         for x, y in zip(data, data2):
             assert np.sum(x.asnumpy() != y.asnumpy()) == 0
+        # test save/load as dict
         dmap = {'ndarray xx %s' % i : x for i, x in enumerate(data)}
         mx.nd.save(fname, dmap)
         dmap2 = mx.nd.load(fname)
@@ -228,6 +229,14 @@ def test_ndarray_saveload():
         for k, x in dmap.items():
             y = dmap2[k]
             assert np.sum(x.asnumpy() != y.asnumpy()) == 0
+        # test save/load as ndarray
+        # we expect the single ndarray to be converted into a list containing the ndarray
+        single_ndarray = data[0]
+        mx.nd.save(fname, single_ndarray)
+        single_ndarray_loaded = mx.nd.load(fname)
+        assert len(single_ndarray_loaded) == 1
+        single_ndarray_loaded = single_ndarray_loaded[0]
+        assert np.sum(single_ndarray.asnumpy() != single_ndarray_loaded.asnumpy()) == 0
     os.remove(fname)
 
 def test_ndarray_legacy_load():


### PR DESCRIPTION
Prior to this change you could do the easy mistake of accidentally
passing in a ndarray as the second argument of mx.nd.save, instead of
a dict or list. This would lead to a segmentation fault. Here's the
example:
```
import mxnet as mx
d = mx.nd.zeros((12,12))
mx.nd.save("test", d)
```
The correct usage of mx.nd.save would have been
```
mx.nd.save("test", [d])
```
The reason why this crashes is very subtle. It involves the following
code from mx.nd.save:
```
for val in data:
   if not isinstance(val, NDArray):
       raise TypeError('save only accept dict str->NDArray or list of NDArray')
   handles.append(val.handle)
```
Basically if `data` is a ndarray we can still iterate over it. This
means we iterate over the individual rows. `val` will be a temporary
ndarray python object holding a reference to a new NDarray C++ object
in handle. The problem is that we keep a reference to `val.handle`
right before val and therefore also val.handle will be gargabe collected.