### PR TITLE
Fix RCNN multi-gpu bucketing warning which may cause OOM error.

### DIFF
--- a/example/rcnn/rcnn/core/loader.py
+++ b/example/rcnn/rcnn/core/loader.py
@@ -148,11 +148,16 @@ class ROIIter(mx.io.DataIter):
                 vert = np.logical_not(horz)
                 horz_inds = np.where(horz)[0]
                 vert_inds = np.where(vert)[0]
+                # Avoid putting different aspect ratio image into the same bucket,
+                # which may cause bucketing warning.
+                pad_horz = self.batch_size - len(horz_inds) % self.batch_size
+                pad_vert = self.batch_size - len(vert_inds) % self.batch_size
+                horz_inds = np.hstack([horz_inds, horz_inds[:pad_horz]])
+                vert_inds = np.hstack([vert_inds, vert_inds[:pad_vert]])
                 inds = np.hstack((np.random.permutation(horz_inds), np.random.permutation(vert_inds)))
-                extra = inds.shape[0] % self.batch_size
-                inds_ = np.reshape(inds[:-extra], (-1, self.batch_size))
-                row_perm = np.random.permutation(np.arange(inds_.shape[0]))
-                inds[:-extra] = np.reshape(inds_[row_perm, :], (-1,))
+                inds = np.reshape(inds[:], (-1, self.batch_size))
+                row_perm = np.random.permutation(np.arange(inds.shape[0]))
+                inds = np.reshape(inds[row_perm, :], (-1,))
                 self.index = inds
             else:
                 np.random.shuffle(self.index)


### PR DESCRIPTION
There is two bug indeed.

1. When *extra* is zero, shuffle will not be executed. [loader.py#L153](https://github.com/dmlc/mxnet/blob/master/example/rcnn/rcnn/core/loader.py#L153-L154)

2. Different aspect ratio images may in the same bucket when
     *len（horz_inds）%self.batch_size != 0 and len（vert_inds)%self.batch_size != 0*
[loader.py#L145-L156](https://github.com/dmlc/mxnet/blob/master/example/rcnn/rcnn/core/loader.py#L145-L156)
In order to avoid this happening, I just pad some images that has the same aspect ratio.

Warning message as below:
```
WARNING:root:bucketing: data "data" has a shape (2L, 3L, 896L, 901L), which is larger than already allocated shape (2L, 3L, 600L, 1000L). Need to re-allocate. Consider putting default_bucket_key to be the bucket taking the largest input for better memory sharing.
```