### PR TITLE
Fix MNIST tutorial. Rebind before inference.

### DIFF
--- a/docs/tutorials/python/mnist.md
+++ b/docs/tutorials/python/mnist.md
@@ -114,6 +114,7 @@ After the above training completes, we can evaluate the trained model by running
 
 ```python
 test_iter = mx.io.NDArrayIter(mnist['test_data'], None, batch_size)
+mlp_model.bind(data_shapes=test_iter.provide_data, force_rebind=True, for_training=False)
 prob = mlp_model.predict(test_iter)
 assert prob.shape == (10000, 10)
 ```
@@ -122,6 +123,9 @@ Since the dataset also has labels for all test images, we can compute the accura
 
 ```python
 test_iter = mx.io.NDArrayIter(mnist['test_data'], mnist['test_label'], batch_size)
+mlp_model.bind(data_shapes=test_iter.provide_data, label_shapes=test_iter.provide_label,
+              force_rebind=True, for_training=False)
+
 # predict accuracy of mlp
 acc = mx.metric.Accuracy()
 mlp_model.score(test_iter, acc)
@@ -182,8 +186,12 @@ Finally, we'll use the trained LeNet model to generate predictions for the test 
 
 ```python
 test_iter = mx.io.NDArrayIter(mnist['test_data'], None, batch_size)
+lenet_model.bind(data_shapes=test_iter.provide_data, force_rebind=True, for_training=False)
 prob = lenet_model.predict(test_iter)
+
 test_iter = mx.io.NDArrayIter(mnist['test_data'], mnist['test_label'], batch_size)
+lenet_model.bind(data_shapes=test_iter.provide_data, label_shapes=test_iter.provide_label,
+              force_rebind=True, for_training=False)
 # predict accuracy for lenet
 acc = mx.metric.Accuracy()
 lenet_model.score(test_iter, acc)


### PR DESCRIPTION
Changes in master broke the MNIST tutorial and the tutorial now throws the following error:
```
RuntimeError                              Traceback (most recent call last)
<ipython-input-7-27c22fa63f26> in <module>()
      1 test_iter = mx.io.NDArrayIter(mnist['test_data'], None, batch_size)
      2 #mlp_model.bind(data_shapes=test_iter.provide_data, force_rebind=True, for_training=False)
----> 3 prob = mlp_model.predict(test_iter)
      4 assert prob.shape == (10000, 10)

~/anaconda3/envs/mxnew/lib/python3.6/site-packages/mxnet-0.10.1-py3.6.egg/mxnet/module/base_module.py in predict(self, eval_data, num_batch, merge_batches, reset, always_output_list)
    349             if num_batch is not None and nbatch == num_batch:
    350                 break
--> 351             self.forward(eval_batch, is_train=False)
    352             pad = eval_batch.pad
    353             outputs = [out[0:out.shape[0]-pad].copy() for out in self.get_outputs()]

~/anaconda3/envs/mxnew/lib/python3.6/site-packages/mxnet-0.10.1-py3.6.egg/mxnet/module/module.py in forward(self, data_batch, is_train)
    558         # If start to inference, force rebind module.
    559         if self._label_shapes and not data_batch.label:
--> 560             raise RuntimeError("If you are trying to do inference, rebind module "
    561                                "with 'force_rebind=True' and 'for_training=False'")
    562 

RuntimeError: If you are trying to do inference, rebind module with 'force_rebind=True' and 'for_training=False'
```

This commit modifies the tutorial to rebind module before inference.

@madjam @piiswrong 