### PR TITLE
Change node labels to match new slave configurations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ def init_git_win() {
 
 stage("Sanity Check") {
   timeout(time: max_time, unit: 'MINUTES') {
-    node('linux') {
+    node('mxnetlinux') {
       ws('workspace/sanity') {
         init_git()
         make('lint', 'cpplint rcpplint jnilint')
@@ -103,7 +103,7 @@ echo ${libs} | sed -e 's/,/ /g' | xargs md5sum
 
 stage('Build') {
   parallel 'CPU: Openblas': {
-    node('linux') {
+    node('mxnetlinux') {
       ws('workspace/build-cpu') {
         init_git()
         def flag = """ \
@@ -119,7 +119,7 @@ USE_BLAS=openblas             \
     }
   },
   'GPU: CUDA7.5+cuDNN5': {
-    node('GPU' && 'linux') {
+    node('mxnetlinux') {
       ws('workspace/build-gpu') {
         init_git()
         def flag = """ \
@@ -139,7 +139,7 @@ USE_CPP_PACKAGE=1             \
     }
   },
   'Amalgamation': {
-    node('linux') {
+    node('mxnetlinux') {
       ws('workspace/amalgamation') {
         init_git()
         make('cpu', '-C amalgamation/ USE_BLAS=openblas MIN=1')
@@ -147,7 +147,7 @@ USE_CPP_PACKAGE=1             \
     }
   },
   'GPU: MKLML': {
-    node('GPU' && 'linux') {
+    node('mxnetlinux') {
       ws('workspace/build-mklml') {
         init_git()
         def flag = """ \
@@ -168,7 +168,7 @@ USE_CPP_PACKAGE=1             \
     }
   },
   'CPU windows':{
-    node('windows') {
+    node('mxnetwindows') {
       ws('workspace/build-cpu') {
         withEnv(['OpenBLAS_HOME=C:\\mxnet\\openblas', 'OpenCV_DIR=C:\\mxnet\\opencv_vc14', 'CUDA_PATH=C:\\CUDA\\v8.0']) {
           init_git_win()
@@ -198,7 +198,7 @@ del /Q *.7z
        }
      },
      'GPU windows':{
-       node('windows') {
+       node('mxnetwindows') {
          ws('workspace/build-gpu') {
            withEnv(['OpenBLAS_HOME=C:\\mxnet\\openblas', 'OpenCV_DIR=C:\\mxnet\\opencv_vc14', 'CUDA_PATH=C:\\CUDA\\v8.0']) {
              init_git_win()
@@ -249,7 +249,7 @@ def python_gpu_ut(docker_type) {
 
 stage('Unit Test') {
   parallel 'Python2/3: CPU': {
-    node('linux') {
+    node('mxnetlinux') {
       ws('workspace/ut-python-cpu') {
         init_git()
         unpack_lib('cpu')
@@ -258,7 +258,7 @@ stage('Unit Test') {
     }
   },
   'Python2/3: GPU': {
-    node('GPU' && 'linux') {
+    node('mxnetlinux') {
       ws('workspace/ut-python-gpu') {
         init_git()
         unpack_lib('gpu', mx_lib)
@@ -267,7 +267,7 @@ stage('Unit Test') {
     }
   },
   'Python2/3: MKLML': {
-    node('GPU' && 'linux') {
+    node('mxnetlinux') {
       ws('workspace/ut-python-mklml') {
         init_git()
         unpack_lib('mklml')
@@ -277,7 +277,7 @@ stage('Unit Test') {
     }
   },
   'Scala: CPU': {
-    node('linux') {
+    node('mxnetlinux') {
       ws('workspace/ut-scala-cpu') {
         init_git()
         unpack_lib('cpu')
@@ -289,7 +289,7 @@ stage('Unit Test') {
     }
   },
   'R: CPU': {
-    node('linux') {
+    node('mxnetlinux') {
       ws('workspace/ut-r-cpu') {
         init_git()
         unpack_lib('cpu')
@@ -304,7 +304,7 @@ stage('Unit Test') {
     }
   },
   'R: GPU': {
-    node('GPU' && 'linux') {
+    node('mxnetlinux') {
       ws('workspace/ut-r-gpu') {
         init_git()
         unpack_lib('gpu')
@@ -319,7 +319,7 @@ stage('Unit Test') {
     }
   },
   'Python2/3: CPU Win':{
-    node('windows') {
+    node('mxnetwindows') {
       ws('workspace/ut-python-cpu') {
         init_git_win()
         unstash 'vc14_cpu'
@@ -339,7 +339,7 @@ C:\\mxnet\\test_cpu.bat"""
      }
    },
    'Python2/3: GPU Win':{
-     node('windows') {
+     node('mxnetwindows') {
        ws('workspace/ut-python-gpu') {
          init_git_win()
          unstash 'vc14_gpu'
@@ -363,7 +363,7 @@ C:\\mxnet\\test_gpu.bat"""
 
 stage('Integration Test') {
   parallel 'Python': {
-    node('GPU' && 'linux') {
+    node('mxnetlinux') {
       ws('workspace/it-python-gpu') {
         init_git()
         unpack_lib('gpu')
@@ -374,7 +374,7 @@ stage('Integration Test') {
     }
   },
   'Caffe': {
-    node('GPU' && 'linux') {
+    node('mxnetlinux') {
       ws('workspace/it-caffe') {
         init_git()
         unpack_lib('gpu')
@@ -385,7 +385,7 @@ stage('Integration Test') {
     }
   },
   'cpp-package': {
-    node('GPU' && 'linux') {
+    node('mxnetlinux') {
       ws('workspace/it-cpp-package') {
         init_git()
         unpack_lib('gpu')
@@ -399,7 +399,7 @@ stage('Integration Test') {
 }
 
 stage('Deploy') {
-  node('linux') {
+  node('mxnetlinux') {
     ws('workspace/docs') {
       if (env.BRANCH_NAME == "master") {
         init_git()


### PR DESCRIPTION
For our new CI on Apache, we configured slaves with more specific names. Without changing the node labels in this file to match the configuration, builds will fail.