### PR TITLE
Quiet regression stacktrace pr

### DIFF
--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1064,4 +1064,3 @@ def discard_stderr():
     finally:
         os.dup2(old_stderr, stderr_fileno)
         bit_bucket.close()
-

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -7,9 +7,11 @@ import struct
 import traceback
 import numbers
 import subprocess
+import sys
 import os
 import errno
 import logging
+from contextlib import contextmanager
 import numpy as np
 import numpy.testing as npt
 import mxnet as mx
@@ -1043,3 +1045,23 @@ def same_array(array1, array2):
         return False
     array1[:] -= 1
     return same(array1.asnumpy(), array2.asnumpy())
+
+@contextmanager
+def discard_stderr():
+    """
+    Discards error output of a routine if invoked as:
+
+    with discard_stderr():
+        ...
+    """
+
+    try:
+        stderr_fileno = sys.stderr.fileno()
+        old_stderr = os.dup(stderr_fileno)
+        bit_bucket = open(os.devnull, 'w')
+        os.dup2(bit_bucket.fileno(), stderr_fileno)
+        yield
+    finally:
+        os.dup2(old_stderr, stderr_fileno)
+        bit_bucket.close()
+

--- a/tests/python/unittest/test_autograd.py
+++ b/tests/python/unittest/test_autograd.py
@@ -222,13 +222,16 @@ def test_retain_grad():
         y.backward(retain_graph=False)
     assert (dx.asnumpy() == 2).all()
 
-    try:
-        with record():
-            y = x + 1
-            y.backward()
-            y.backward()
-    except Exception:
-        return
+    # The following sequence should throw an exception. We discard the expected
+    # stderr stack trace output for this operation to keep the test logs clean.
+    with discard_stderr():
+        try:
+            with record():
+                y = x + 1
+                y.backward()
+                y.backward()
+        except Exception:
+            return
 
     raise AssertionError(
         "differentiating the same graph twice without retain_graph should fail")

--- a/tests/python/unittest/test_contrib_autograd.py
+++ b/tests/python/unittest/test_contrib_autograd.py
@@ -150,13 +150,16 @@ def test_retain_grad():
         y.backward(retain_graph=False)
     assert (dx.asnumpy() == 2).all()
 
-    try:
-        with train_section():
-            y = x + 1
-            y.backward()
-            y.backward()
-    except Exception:
-        return
+    # The following sequence should throw an exception. We discard the expected
+    # stderr stack trace output for this operation to keep the test logs clean.
+    with discard_stderr():
+        try:
+            with train_section():
+                y = x + 1
+                y.backward()
+                y.backward()
+        except Exception:
+            return
 
     raise AssertionError(
         "differentiating the same graph twice without retain_graph should fail")

--- a/tests/python/unittest/test_symbol.py
+++ b/tests/python/unittest/test_symbol.py
@@ -1,31 +1,11 @@
 import copy
-import sys
 import os
 import re
 import mxnet as mx
 import numpy as np
 from common import models
+from mxnet.test_utils import discard_stderr
 import pickle as pkl
-from contextlib import contextmanager
-
-@contextmanager
-def discard_stderr():
-    """
-    Discards error output of a routine if invoked as:
-
-    with discard_stderr():
-        ...
-    """
-
-    try:
-        stderr_fileno = sys.stderr.fileno()
-        old_stderr = os.dup(stderr_fileno)
-        bit_bucket = open(os.devnull, 'w')
-        os.dup2(bit_bucket.fileno(), stderr_fileno)
-        yield
-    finally:
-        os.dup2(old_stderr, stderr_fileno)
-        bit_bucket.close()
 
 def test_symbol_basic():
     mlist = []


### PR DESCRIPTION
Permits unit tests to test for exception generation without the stack trace output appearing in the logs.  Introduces 'discard_stderr()', used as in:
```
    with discard_stderr():
        try:
            <code expected to generate an exception>
        except:
            return

    raise AssertionError("failed to generate expected error")
```