### PR TITLE
Require Mouse v2.1.0 with explicit ‘v’

### DIFF
--- a/perl-package/AI-MXNet/Makefile.PL
+++ b/perl-package/AI-MXNet/Makefile.PL
@@ -22,7 +22,7 @@ my %WriteMakefileArgs = (
     "AI::MXNetCAPI" => "1.0101",
     "AI::NNVMCAPI" => "1.01",
     "Function::Parameters" => "1.0705",
-    "Mouse" => "2.1.0",
+    "Mouse" => "v2.1.0",
     "PDL" => "2.007",
     "GraphViz" => "2.14"
   },
@@ -38,7 +38,7 @@ my %FallbackPrereqs = (
   "AI::MXNetCAPI" => "1.0101",
   "AI::NNVMCAPI" => "1.01",
   "Function::Parameters" => "1.0705",
-  "Mouse" => "2.1.0",
+  "Mouse" => "v2.1.0",
   "PDL" => "2.007",
   "GraphViz" => "2.14"
 );


### PR DESCRIPTION
The ExtUtils::MakeMaker version that comes with perl 5.24.0 (7.10_01) does not like three-part versions without the initial v.  So it gives me the following message:
```
Warning: prerequisite Mouse 2.1.0 not found. We have v2.4.10.
```
And then installation does not proceed smoothly.

Adding the v solves this.