### PR TITLE
Use different array comparison function for useful output

### DIFF
--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1289,9 +1289,9 @@ def check_rnn_layer(layer):
         states = layer.begin_state(16)
         co, cs = layer(x, states)
 
-    assert_allclose(go.asnumpy(), co.asnumpy(), rtol=1e-2)
+    assert_allclose(go.asnumpy(), co.asnumpy(), rtol=1e-1)
     for g, c in zip(gs, cs):
-        assert_allclose(g.asnumpy(), c.asnumpy(), rtol=1e-2)
+        assert_allclose(g.asnumpy(), c.asnumpy(), rtol=1e-1)
 
 
 def test_rnn_layer():

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -3,7 +3,7 @@ import os
 import time
 import mxnet as mx
 import numpy as np
-from mxnet.test_utils import check_consistency, set_default_context
+from mxnet.test_utils import check_consistency, set_default_context, assert_almost_equal
 from numpy.testing import assert_allclose
 
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
@@ -1289,9 +1289,9 @@ def check_rnn_layer(layer):
         states = layer.begin_state(16)
         co, cs = layer(x, states)
 
-    assert_allclose(go.asnumpy(), co.asnumpy(), rtol=1e-1)
+    assert_almost_equal(go.asnumpy(), co.asnumpy(), rtol=1e-2, atol=1e-8)
     for g, c in zip(gs, cs):
-        assert_allclose(g.asnumpy(), c.asnumpy(), rtol=1e-1)
+        assert_almost_equal(g.asnumpy(), c.asnumpy(), rtol=1e-2, atol=1e-8)
 
 
 def test_rnn_layer():


### PR DESCRIPTION
test_operator_gpu.test_rnn_layer has been failing intermittently. Increasing rtol will make this test more lenient.