### PR TITLE
change unnecessarily longer array

### DIFF
--- a/src/io/iter_image_recordio_2.cc
+++ b/src/io/iter_image_recordio_2.cc
@@ -360,10 +360,10 @@ inline void ImageRecordIOParser2<DType>::ParseChunk(dmlc::InputSplit::Blob * chu
           (rand_uniform(*(prnds_[tid])) * normalize_param_.max_random_illumination * 2
           - normalize_param_.max_random_illumination) * normalize_param_.scale;
       }
+      DType* RGBA = new DType[n_channels];
       for (int i = 0; i < res.rows; ++i) {
         uchar* im_data = res.ptr<uchar>(i);
         for (int j = 0; j < res.cols; ++j) {
-          DType* RGBA = new DType[n_channels];
           for (int k = 0; k < n_channels; ++k) {
             RGBA[k] = im_data[swap_indices[k]];
           }
@@ -412,9 +412,9 @@ inline void ImageRecordIOParser2<DType>::ParseChunk(dmlc::InputSplit::Blob * chu
             }
           }
           im_data += n_channels;
-          delete [] RGBA;
         }
       }
+      delete [] RGBA;
 
       mshadow::Tensor<cpu, 1> label = out.label().Back();
       if (label_map_ != nullptr) {

--- a/src/io/iter_image_recordio_2.cc
+++ b/src/io/iter_image_recordio_2.cc
@@ -360,7 +360,7 @@ inline void ImageRecordIOParser2<DType>::ParseChunk(dmlc::InputSplit::Blob * chu
           (rand_uniform(*(prnds_[tid])) * normalize_param_.max_random_illumination * 2
           - normalize_param_.max_random_illumination) * normalize_param_.scale;
       }
-      DType RGBA[4] = {}
+      DType RGBA[4] = {};
       for (int i = 0; i < res.rows; ++i) {
         uchar* im_data = res.ptr<uchar>(i);
         for (int j = 0; j < res.cols; ++j) {

--- a/src/io/iter_image_recordio_2.cc
+++ b/src/io/iter_image_recordio_2.cc
@@ -360,7 +360,7 @@ inline void ImageRecordIOParser2<DType>::ParseChunk(dmlc::InputSplit::Blob * chu
           (rand_uniform(*(prnds_[tid])) * normalize_param_.max_random_illumination * 2
           - normalize_param_.max_random_illumination) * normalize_param_.scale;
       }
-      DType* RGBA = new DType[n_channels];
+      DType RGBA[4] = {}
       for (int i = 0; i < res.rows; ++i) {
         uchar* im_data = res.ptr<uchar>(i);
         for (int j = 0; j < res.cols; ++j) {
@@ -414,7 +414,6 @@ inline void ImageRecordIOParser2<DType>::ParseChunk(dmlc::InputSplit::Blob * chu
           im_data += n_channels;
         }
       }
-      delete [] RGBA;
 
       mshadow::Tensor<cpu, 1> label = out.label().Back();
       if (label_map_ != nullptr) {

--- a/src/io/iter_image_recordio_2.cc
+++ b/src/io/iter_image_recordio_2.cc
@@ -363,7 +363,7 @@ inline void ImageRecordIOParser2<DType>::ParseChunk(dmlc::InputSplit::Blob * chu
       for (int i = 0; i < res.rows; ++i) {
         uchar* im_data = res.ptr<uchar>(i);
         for (int j = 0; j < res.cols; ++j) {
-          DType RGBA[4];
+          DType* RGBA = new DType[n_channels];
           for (int k = 0; k < n_channels; ++k) {
             RGBA[k] = im_data[swap_indices[k]];
           }
@@ -412,6 +412,7 @@ inline void ImageRecordIOParser2<DType>::ParseChunk(dmlc::InputSplit::Blob * chu
             }
           }
           im_data += n_channels;
+          delete [] RGBA;
         }
       }
 


### PR DESCRIPTION
simplifies code by removing the possibility of unused variables. This confused g++ earlier as some variables were uninitialized and unused. Removes three compiler warnings. 