### PR TITLE
add getitem to container layers

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -162,6 +162,9 @@ class Block(object):
     def _alias(self):
         return self.__class__.__name__.lower()
 
+    def __len__(self):
+        return len(self._children)
+
     @property
     def prefix(self):
         """Prefix of this `Block`."""

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -162,9 +162,6 @@ class Block(object):
     def _alias(self):
         return self.__class__.__name__.lower()
 
-    def __len__(self):
-        return len(self._children)
-
     @property
     def prefix(self):
         """Prefix of this `Block`."""

--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -41,6 +41,9 @@ class Sequential(Block):
     def __getitem__(self, i):
         return self._children[i]
 
+    def __len__(self):
+        return len(self._children)
+
 
 class HybridSequential(HybridBlock):
     """Stacks `HybridBlock`s sequentially.
@@ -76,6 +79,9 @@ class HybridSequential(HybridBlock):
 
     def __getitem__(self, i):
         return self._children[i]
+
+    def __len__(self):
+        return len(self._children)
 
 
 class Dense(HybridBlock):

--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -38,6 +38,9 @@ class Sequential(Block):
         return s.format(name=self.__class__.__name__,
                         modstr=modstr)
 
+    def __getitem__(self, i):
+        return self._children[i]
+
 
 class HybridSequential(HybridBlock):
     """Stacks `HybridBlock`s sequentially.
@@ -70,6 +73,9 @@ class HybridSequential(HybridBlock):
                             if isinstance(block, Block)])
         return s.format(name=self.__class__.__name__,
                         modstr=modstr)
+
+    def __getitem__(self, i):
+        return self._children[i]
 
 
 class Dense(HybridBlock):

--- a/python/mxnet/gluon/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/rnn/rnn_cell.py
@@ -548,6 +548,9 @@ class SequentialRNNCell(RecurrentCell):
     def __getitem__(self, i):
         return self._children[i]
 
+    def __len__(self):
+        return len(self._children)
+
     def hybrid_forward(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/python/mxnet/gluon/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/rnn/rnn_cell.py
@@ -545,6 +545,9 @@ class SequentialRNNCell(RecurrentCell):
 
         return inputs, next_states
 
+    def __getitem__(self, i):
+        return self._children[i]
+
     def hybrid_forward(self, *args, **kwargs):
         raise NotImplementedError
 


### PR DESCRIPTION
This is to add `__getitem__` to the container layers so that it's easier to locate the child layers along with their weights. For example:
```
In [1]: from mxnet.gluon.model_zoo import vision as models

In [2]: net = models.alexnet(True)

In [3]: net.classifier
Out[3]:
HybridSequential(
  (0): Dense(4096, Activation(relu))
  (1): Dropout(p = 0.5)
  (2): Dense(4096, Activation(relu))
  (3): Dropout(p = 0.5)
  (4): Dense(1000, linear)
)

In [4]: net.classifier[2]
Out[4]: Dense(4096, Activation(relu))

In [5]: net.classifier[4]
Out[5]: Dense(1000, linear)
```