### PR TITLE
fixed dcgan to use integer division so it won't die horribly in Python3 making users want to die as well

### DIFF
--- a/example/gluon/dcgan.py
+++ b/example/gluon/dcgan.py
@@ -14,11 +14,11 @@ import os
 import time
 
 def fill_buf(buf, i, img, shape):
-    n = buf.shape[0]/shape[1]
-    m = buf.shape[1]/shape[0]
+    n = buf.shape[0]//shape[1]
+    m = buf.shape[1]//shape[0]
 
     sx = (i%m)*shape[0]
-    sy = (i/m)*shape[1]
+    sy = (i//m)*shape[1]
     buf[sy:sy+shape[1], sx:sx+shape[0], :] = img
     return None
 


### PR DESCRIPTION
Fixed dcgan example for Python3 compatibility. Closes #7285 