### PR TITLE
fixes broken compilation by including tensor_blob

### DIFF
--- a/src/io/inst_vector.h
+++ b/src/io/inst_vector.h
@@ -30,6 +30,7 @@
 #include <mxnet/base.h>
 #include <dmlc/base.h>
 #include <mshadow/tensor.h>
+#include <mshadow/tensor_blob.h>
 #include <vector>
 #include <string>
 


### PR DESCRIPTION
This PR https://github.com/dmlc/mshadow/pull/270 in mshadow removed a header file which causes mxnet compilation to break. This header file needs to be included from this file to replace it. Discussed with the author of that PR @ZihengJiang . 
With this inclusion, mxnet compiles fine with the latest commits of mshadow. So you could go ahead and merge the latest commits of mshadow as well along with this.