### PR TITLE
Add Autograd doc to gluon page

### DIFF
--- a/docs/api/python/autograd.md
+++ b/docs/api/python/autograd.md
@@ -1,0 +1,32 @@
+# Autograd Package
+
+
+```eval_rst
+.. currentmodule:: mxnet.autograd
+```
+
+```eval_rst
+.. warning:: This package is currently experimental and may change in the near future.
+```
+
+<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+
+## Autograd
+
+```eval_rst
+.. currentmodule:: mxnet.autograd
+```
+
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    record
+    pause
+    mark_variables
+    backward
+    set_training
+    set_recording
+```
+

--- a/docs/api/python/gluon.md
+++ b/docs/api/python/gluon.md
@@ -151,6 +151,27 @@ in Python and then deploy with symbolic graph in C++ and Scala.
 ```
 
 
+
+## Autograd
+
+```eval_rst
+.. currentmodule:: mxnet.autograd
+```
+
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    record
+    pause
+    mark_variables
+    backward
+    set_training
+    set_recording
+```
+
+
 ## Loss functions
 
 ```eval_rst

--- a/docs/api/python/gluon.md
+++ b/docs/api/python/gluon.md
@@ -151,27 +151,6 @@ in Python and then deploy with symbolic graph in C++ and Scala.
 ```
 
 
-
-## Autograd
-
-```eval_rst
-.. currentmodule:: mxnet.autograd
-```
-
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    record
-    pause
-    mark_variables
-    backward
-    set_training
-    set_recording
-```
-
-
 ## Loss functions
 
 ```eval_rst

--- a/docs/api/python/index.md
+++ b/docs/api/python/index.md
@@ -28,6 +28,7 @@ imported by running:
    ndarray
    symbol
    module
+   autograd
    gluon
    rnn
    kvstore


### PR DESCRIPTION
I can't build the docs locally so this is currently untested. Fixes #7306. In reply to https://github.com/apache/incubator-mxnet/pull/7303#issuecomment-319790394