### PR TITLE
Remove inline keyword from methods we want to generate code for.

### DIFF
--- a/cpp-package/include/mxnet-cpp/executor.hpp
+++ b/cpp-package/include/mxnet-cpp/executor.hpp
@@ -16,7 +16,7 @@
 
 namespace mxnet {
 namespace cpp {
-inline Executor::Executor(const Symbol &symbol, Context context,
+Executor::Executor(const Symbol &symbol, Context context,
                           const std::vector<NDArray> &arg_arrays,
                           const std::vector<NDArray> &grad_arrays,
                           const std::vector<OpReqType> &grad_reqs,
@@ -73,7 +73,7 @@ inline Executor::Executor(const Symbol &symbol, Context context,
   }
 }
 
-inline std::string Executor::DebugStr() {
+std::string Executor::DebugStr() {
   const char *output;
   MXExecutorPrint(handle_, &output);
   return std::string(output);

--- a/cpp-package/include/mxnet-cpp/io.hpp
+++ b/cpp-package/include/mxnet-cpp/io.hpp
@@ -14,49 +14,49 @@
 namespace mxnet {
 namespace cpp {
 
-inline MXDataIterMap*& MXDataIter::mxdataiter_map() {
+MXDataIterMap*& MXDataIter::mxdataiter_map() {
     static MXDataIterMap* mxdataiter_map_ = new MXDataIterMap;
     return mxdataiter_map_;
 }
 
-inline MXDataIter::MXDataIter(const std::string &mxdataiter_type) {
+MXDataIter::MXDataIter(const std::string &mxdataiter_type) {
   creator_ = mxdataiter_map()->GetMXDataIterCreator(mxdataiter_type);
   blob_ptr_ = std::make_shared<MXDataIterBlob>(nullptr);
 }
 
-inline void MXDataIter::BeforeFirst() {
+void MXDataIter::BeforeFirst() {
   int r = MXDataIterBeforeFirst(blob_ptr_->handle_);
   CHECK_EQ(r, 0);
 }
 
-inline bool MXDataIter::Next() {
+bool MXDataIter::Next() {
   int out;
   int r = MXDataIterNext(blob_ptr_->handle_, &out);
   CHECK_EQ(r, 0);
   return out;
 }
 
-inline NDArray MXDataIter::GetData() {
+NDArray MXDataIter::GetData() {
   NDArrayHandle handle;
   int r = MXDataIterGetData(blob_ptr_->handle_, &handle);
   CHECK_EQ(r, 0);
   return NDArray(handle);
 }
 
-inline NDArray MXDataIter::GetLabel() {
+NDArray MXDataIter::GetLabel() {
   NDArrayHandle handle;
   int r = MXDataIterGetLabel(blob_ptr_->handle_, &handle);
   CHECK_EQ(r, 0);
   return NDArray(handle);
 }
 
-inline int MXDataIter::GetPadNum() {
+int MXDataIter::GetPadNum() {
   int out;
   int r = MXDataIterGetPadNum(blob_ptr_->handle_, &out);
   CHECK_EQ(r, 0);
   return out;
 }
-inline std::vector<int> MXDataIter::GetIndex() {
+std::vector<int> MXDataIter::GetIndex() {
   uint64_t *out_index, out_size;
   int r = MXDataIterGetIndex(blob_ptr_->handle_, &out_index, &out_size);
   CHECK_EQ(r, 0);
@@ -67,7 +67,7 @@ inline std::vector<int> MXDataIter::GetIndex() {
   return ret;
 }
 
-inline MXDataIter MXDataIter::CreateDataIter() {
+MXDataIter MXDataIter::CreateDataIter() {
   std::vector<const char *> param_keys;
   std::vector<const char *> param_values;
 

--- a/cpp-package/include/mxnet-cpp/kvstore.hpp
+++ b/cpp-package/include/mxnet-cpp/kvstore.hpp
@@ -20,7 +20,7 @@
 namespace mxnet {
 namespace cpp {
 
-inline void KVStore::Controller(int head, const char* body, void* controller_handle) {
+void KVStore::Controller(int head, const char* body, void* controller_handle) {
   if (head == 0) {
     std::map<std::string, std::string> params;
     std::istringstream sin(body);
@@ -38,38 +38,38 @@ inline void KVStore::Controller(int head, const char* body, void* controller_han
   }
 }
 
-inline KVStoreHandle& KVStore::get_handle() {
+KVStoreHandle& KVStore::get_handle() {
   static KVStoreHandle handle_ = nullptr;
   return handle_;
 }
 
-inline std::unique_ptr<Optimizer>& KVStore::get_optimizer() {
+std::unique_ptr<Optimizer>& KVStore::get_optimizer() {
   static std::unique_ptr<Optimizer> optimizer_;
   return optimizer_;
 }
 
-inline KVStore*& KVStore::get_kvstore() {
+KVStore*& KVStore::get_kvstore() {
   static KVStore* kvstore_ = new KVStore;
   return kvstore_;
 }
 
-inline KVStore::KVStore() {}
+KVStore::KVStore() {}
 
-inline void KVStore::SetType(const std::string& type) {
+void KVStore::SetType(const std::string& type) {
   CHECK_EQ(MXKVStoreCreate(type.c_str(), &(get_kvstore()->get_handle())), 0);
 }
 
-inline void KVStore::RunServer() {
+void KVStore::RunServer() {
   CHECK_NE(GetRole(), "worker");
   CHECK_EQ(MXKVStoreRunServer(get_kvstore()->get_handle(), &Controller, 0), 0);
 }
 
-inline void KVStore::Init(int key, const NDArray& val) {
+void KVStore::Init(int key, const NDArray& val) {
   NDArrayHandle val_handle = val.GetHandle();
   CHECK_EQ(MXKVStoreInit(get_kvstore()->get_handle(), 1, &key, &val_handle), 0);
 }
 
-inline void KVStore::Init(const std::vector<int>& keys, const std::vector<NDArray>& vals) {
+void KVStore::Init(const std::vector<int>& keys, const std::vector<NDArray>& vals) {
   CHECK_EQ(keys.size(), vals.size());
   std::vector<NDArrayHandle> val_handles(vals.size());
   std::transform(vals.cbegin(), vals.cend(), val_handles.begin(),
@@ -81,12 +81,12 @@ inline void KVStore::Init(const std::vector<int>& keys, const std::vector<NDArra
       val_handles.data()), 0);
 }
 
-inline void KVStore::Push(int key, const NDArray& val, int priority) {
+void KVStore::Push(int key, const NDArray& val, int priority) {
   NDArrayHandle val_handle = val.GetHandle();
   CHECK_EQ(MXKVStorePush(get_kvstore()->get_handle(), 1, &key, &val_handle, priority), 0);
 }
 
-inline void KVStore::Push(const std::vector<int>& keys,
+void KVStore::Push(const std::vector<int>& keys,
                           const std::vector<NDArray>& vals,
                           int priority) {
   CHECK_EQ(keys.size(), vals.size());
@@ -100,12 +100,12 @@ inline void KVStore::Push(const std::vector<int>& keys,
       val_handles.data(), priority), 0);
 }
 
-inline void KVStore::Pull(int key, NDArray* out, int priority) {
+void KVStore::Pull(int key, NDArray* out, int priority) {
   NDArrayHandle out_handle = out->GetHandle();
   CHECK_EQ(MXKVStorePull(get_kvstore()->get_handle(), 1, &key, &out_handle, priority), 0);
 }
 
-inline void KVStore::Pull(const std::vector<int>& keys, std::vector<NDArray>* outs, int priority) {
+void KVStore::Pull(const std::vector<int>& keys, std::vector<NDArray>* outs, int priority) {
   CHECK_EQ(keys.size(), outs->size());
 
   std::vector<NDArrayHandle> out_handles(keys.size());
@@ -118,13 +118,13 @@ inline void KVStore::Pull(const std::vector<int>& keys, std::vector<NDArray>* ou
       out_handles.data(), priority), 0);
 }
 
-inline void KVStore::Updater(int key, NDArrayHandle recv, NDArrayHandle local,
+void KVStore::Updater(int key, NDArrayHandle recv, NDArrayHandle local,
                              void* handle_) {
   Optimizer *opt = static_cast<Optimizer*>(handle_);
   opt->Update(key, NDArray(local), NDArray(recv));
 }
 
-inline void KVStore::SetOptimizer(std::unique_ptr<Optimizer> optimizer, bool local) {
+void KVStore::SetOptimizer(std::unique_ptr<Optimizer> optimizer, bool local) {
   if (local) {
     get_kvstore()->get_optimizer() = std::move(optimizer);
     CHECK_EQ(MXKVStoreSetUpdater(get_kvstore()->get_handle(),
@@ -135,29 +135,29 @@ inline void KVStore::SetOptimizer(std::unique_ptr<Optimizer> optimizer, bool loc
   }
 }
 
-inline std::string KVStore::GetType() {
+std::string KVStore::GetType() {
   const char *type;
   CHECK_EQ(MXKVStoreGetType(get_kvstore()->get_handle(), &type), 0);
   return type;
 }
 
-inline int KVStore::GetRank() {
+int KVStore::GetRank() {
   int rank;
   CHECK_EQ(MXKVStoreGetRank(get_kvstore()->get_handle(), &rank), 0);
   return rank;
 }
 
-inline int KVStore::GetNumWorkers() {
+int KVStore::GetNumWorkers() {
   int num_workers;
   CHECK_EQ(MXKVStoreGetGroupSize(get_kvstore()->get_handle(), &num_workers), 0);
   return num_workers;
 }
 
-inline void KVStore::Barrier() {
+void KVStore::Barrier() {
   CHECK_EQ(MXKVStoreBarrier(get_kvstore()->get_handle()), 0);
 }
 
-inline std::string KVStore::GetRole() {
+std::string KVStore::GetRole() {
   int ret;
   CHECK_EQ(MXKVStoreIsSchedulerNode(&ret), 0);
   if (ret) {

--- a/cpp-package/include/mxnet-cpp/monitor.hpp
+++ b/cpp-package/include/mxnet-cpp/monitor.hpp
@@ -17,29 +17,29 @@
 
 namespace mxnet {
 namespace cpp {
-inline NDArray _default_monitor_func(const NDArray &x) {
+NDArray _default_monitor_func(const NDArray &x) {
   return Operator("norm").PushInput(x).Invoke()[0] / std::sqrt(x.Size());
 }
 
-inline Monitor::Monitor(int interval, std::regex pattern, StatFunc stat_func)
+Monitor::Monitor(int interval, std::regex pattern, StatFunc stat_func)
   : interval(interval), pattern(pattern), stat_func(stat_func), step(0) {
 }
 
-inline void Monitor::install(Executor *exe) {
+void Monitor::install(Executor *exe) {
   MXExecutorSetMonitorCallback(exe->handle_,
       static_cast<ExecutorMonitorCallback>(&Monitor::executor_callback),
       this);
   exes.push_back(exe);
 }
 
-inline void Monitor::tic() {
+void Monitor::tic() {
   if (step % interval == 0) {
     activated = true;
     stats.clear();
   }
 }
 
-inline std::vector<Monitor::Stat> Monitor::toc() {
+std::vector<Monitor::Stat> Monitor::toc() {
   std::vector<Monitor::Stat> results;
   if (activated) {
     activated = false;
@@ -69,7 +69,7 @@ inline std::vector<Monitor::Stat> Monitor::toc() {
   return results;
 }
 
-inline void Monitor::toc_print() {
+void Monitor::toc_print() {
   auto results = toc();
   std::vector<float> data(1);
   for (auto& stat : results) {
@@ -93,7 +93,7 @@ inline void Monitor::toc_print() {
   }
 }
 
-inline void Monitor::executor_callback(const char *name, NDArrayHandle handle,
+void Monitor::executor_callback(const char *name, NDArrayHandle handle,
     void *monitor_ptr) {
   Monitor *monitor = static_cast<Monitor*>(monitor_ptr);
   if (monitor->activated && std::regex_match(name, monitor->pattern)) {

--- a/cpp-package/include/mxnet-cpp/ndarray.hpp
+++ b/cpp-package/include/mxnet-cpp/ndarray.hpp
@@ -19,15 +19,15 @@
 namespace mxnet {
 namespace cpp {
 
-inline NDArray::NDArray() {
+NDArray::NDArray() {
   NDArrayHandle handle;
   CHECK_EQ(MXNDArrayCreateNone(&handle), 0);
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
-inline NDArray::NDArray(const NDArrayHandle &handle) {
+NDArray::NDArray(const NDArrayHandle &handle) {
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
-inline NDArray::NDArray(const std::vector<mx_uint> &shape, const Context &context,
+NDArray::NDArray(const std::vector<mx_uint> &shape, const Context &context,
                         bool delay_alloc) {
   NDArrayHandle handle;
   CHECK_EQ(MXNDArrayCreate(shape.data(), shape.size(), context.GetDeviceType(),
@@ -35,20 +35,20 @@ inline NDArray::NDArray(const std::vector<mx_uint> &shape, const Context &contex
            0);
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
-inline NDArray::NDArray(const Shape &shape, const Context &context, bool delay_alloc) {
+NDArray::NDArray(const Shape &shape, const Context &context, bool delay_alloc) {
   NDArrayHandle handle;
   CHECK_EQ(MXNDArrayCreate(shape.data(), shape.ndim(), context.GetDeviceType(),
                            context.GetDeviceId(), delay_alloc, &handle),
            0);
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
-inline NDArray::NDArray(const mx_float *data, size_t size) {
+NDArray::NDArray(const mx_float *data, size_t size) {
   NDArrayHandle handle;
   CHECK_EQ(MXNDArrayCreateNone(&handle), 0);
   MXNDArraySyncCopyFromCPU(handle, data, size);
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
-inline NDArray::NDArray(const mx_float *data, const Shape &shape,
+NDArray::NDArray(const mx_float *data, const Shape &shape,
                         const Context &context) {
   NDArrayHandle handle;
   CHECK_EQ(MXNDArrayCreate(shape.data(), shape.ndim(), context.GetDeviceType(),
@@ -57,7 +57,7 @@ inline NDArray::NDArray(const mx_float *data, const Shape &shape,
   MXNDArraySyncCopyFromCPU(handle, data, shape.Size());
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
-inline NDArray::NDArray(const std::vector<mx_float> &data, const Shape &shape,
+NDArray::NDArray(const std::vector<mx_float> &data, const Shape &shape,
                         const Context &context) {
   NDArrayHandle handle;
   CHECK_EQ(MXNDArrayCreate(shape.data(), shape.ndim(), context.GetDeviceType(),
@@ -66,143 +66,143 @@ inline NDArray::NDArray(const std::vector<mx_float> &data, const Shape &shape,
   MXNDArraySyncCopyFromCPU(handle, data.data(), shape.Size());
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
-inline NDArray::NDArray(const std::vector<mx_float> &data) {
+NDArray::NDArray(const std::vector<mx_float> &data) {
   NDArrayHandle handle;
   CHECK_EQ(MXNDArrayCreateNone(&handle), 0);
   MXNDArraySyncCopyFromCPU(handle, data.data(), data.size());
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
 
-inline NDArray NDArray::operator+(mx_float scalar) {
+NDArray NDArray::operator+(mx_float scalar) {
   NDArray ret;
   Operator("_plus_scalar")(*this, scalar).Invoke(ret);
   return ret;
 }
-inline NDArray NDArray::operator-(mx_float scalar) {
+NDArray NDArray::operator-(mx_float scalar) {
   NDArray ret;
   Operator("_minus_scalar")(*this, scalar).Invoke(ret);
   return ret;
 }
-inline NDArray NDArray::operator*(mx_float scalar) {
+NDArray NDArray::operator*(mx_float scalar) {
   NDArray ret;
   Operator("_mul_scalar")(*this, scalar).Invoke(ret);
   return ret;
 }
-inline NDArray NDArray::operator/(mx_float scalar) {
+NDArray NDArray::operator/(mx_float scalar) {
   NDArray ret;
   Operator("_div_scalar")(*this, scalar).Invoke(ret);
   return ret;
 }
-inline NDArray NDArray::operator%(mx_float scalar) {
+NDArray NDArray::operator%(mx_float scalar) {
   NDArray ret;
   Operator("_mod_scalar")(*this, scalar).Invoke(ret);
   return ret;
 }
-inline NDArray NDArray::operator+(const NDArray &rhs) {
+NDArray NDArray::operator+(const NDArray &rhs) {
   NDArray ret;
   Operator("_plus")(*this, rhs).Invoke(ret);
   return ret;
 }
-inline NDArray NDArray::operator-(const NDArray &rhs) {
+NDArray NDArray::operator-(const NDArray &rhs) {
   NDArray ret;
   Operator("_minus")(*this, rhs).Invoke(ret);
   return ret;
 }
-inline NDArray NDArray::operator*(const NDArray &rhs) {
+NDArray NDArray::operator*(const NDArray &rhs) {
   NDArray ret;
   Operator("_mul")(*this, rhs).Invoke(ret);
   return ret;
 }
-inline NDArray NDArray::operator/(const NDArray &rhs) {
+NDArray NDArray::operator/(const NDArray &rhs) {
   NDArray ret;
   Operator("_div")(*this, rhs).Invoke(ret);
   return ret;
 }
-inline NDArray NDArray::operator%(const NDArray &rhs) {
+NDArray NDArray::operator%(const NDArray &rhs) {
   NDArray ret;
   Operator("_mod")(*this, rhs).Invoke(ret);
   return ret;
 }
-inline NDArray &NDArray::operator=(mx_float scalar) {
+NDArray &NDArray::operator=(mx_float scalar) {
   Operator("_set_value")(scalar).Invoke(*this);
   return *this;
 }
-inline NDArray &NDArray::operator+=(mx_float scalar) {
+NDArray &NDArray::operator+=(mx_float scalar) {
   Operator("_plus_scalar")(*this, scalar).Invoke(*this);
   return *this;
 }
-inline NDArray &NDArray::operator-=(mx_float scalar) {
+NDArray &NDArray::operator-=(mx_float scalar) {
   Operator("_minus_scalar")(*this, scalar).Invoke(*this);
   return *this;
 }
-inline NDArray &NDArray::operator*=(mx_float scalar) {
+NDArray &NDArray::operator*=(mx_float scalar) {
   Operator("_mul_scalar")(*this, scalar).Invoke(*this);
   return *this;
 }
-inline NDArray &NDArray::operator/=(mx_float scalar) {
+NDArray &NDArray::operator/=(mx_float scalar) {
   Operator("_div_scalar")(*this, scalar).Invoke(*this);
   return *this;
 }
-inline NDArray &NDArray::operator%=(mx_float scalar) {
+NDArray &NDArray::operator%=(mx_float scalar) {
   Operator("_mod_scalar")(*this, scalar).Invoke(*this);
   return *this;
 }
-inline NDArray &NDArray::operator+=(const NDArray &rhs) {
+NDArray &NDArray::operator+=(const NDArray &rhs) {
   Operator("_plus")(*this, rhs).Invoke(*this);
   return *this;
 }
-inline NDArray &NDArray::operator-=(const NDArray &rhs) {
+NDArray &NDArray::operator-=(const NDArray &rhs) {
   Operator("_minus")(*this, rhs).Invoke(*this);
   return *this;
 }
-inline NDArray &NDArray::operator*=(const NDArray &rhs) {
+NDArray &NDArray::operator*=(const NDArray &rhs) {
   Operator("_mul")(*this, rhs).Invoke(*this);
   return *this;
 }
-inline NDArray &NDArray::operator/=(const NDArray &rhs) {
+NDArray &NDArray::operator/=(const NDArray &rhs) {
   Operator("_div")(*this, rhs).Invoke(*this);
   return *this;
 }
-inline NDArray &NDArray::operator%=(const NDArray &rhs) {
+NDArray &NDArray::operator%=(const NDArray &rhs) {
   Operator("_mod")(*this, rhs).Invoke(*this);
   return *this;
 }
 
-inline NDArray NDArray::ArgmaxChannel() {
+NDArray NDArray::ArgmaxChannel() {
   NDArray ret;
   Operator("argmax_channel")(*this).Invoke(ret);
   return ret;
 }
 
-inline void NDArray::SyncCopyFromCPU(const mx_float *data, size_t size) {
+void NDArray::SyncCopyFromCPU(const mx_float *data, size_t size) {
   MXNDArraySyncCopyFromCPU(blob_ptr_->handle_, data, size);
 }
-inline void NDArray::SyncCopyFromCPU(const std::vector<mx_float> &data) {
+void NDArray::SyncCopyFromCPU(const std::vector<mx_float> &data) {
   MXNDArraySyncCopyFromCPU(blob_ptr_->handle_, data.data(), data.size());
 }
-inline void NDArray::SyncCopyToCPU(mx_float *data, size_t size) {
+void NDArray::SyncCopyToCPU(mx_float *data, size_t size) {
   MXNDArraySyncCopyToCPU(blob_ptr_->handle_, data, size > 0 ? size : Size());
 }
-inline void NDArray::SyncCopyToCPU(std::vector<mx_float> *data, size_t size) {
+void NDArray::SyncCopyToCPU(std::vector<mx_float> *data, size_t size) {
   size = size > 0 ? size : Size();
   data->resize(size);
   MXNDArraySyncCopyToCPU(blob_ptr_->handle_, data->data(), size);
 }
-inline NDArray NDArray::Copy(const Context &ctx) const {
+NDArray NDArray::Copy(const Context &ctx) const {
   NDArray ret(GetShape(), ctx);
   Operator("_copyto")(*this).Invoke(ret);
   return ret;
 }
-inline NDArray NDArray::CopyTo(NDArray * other) const {
+NDArray NDArray::CopyTo(NDArray * other) const {
   Operator("_copyto")(*this).Invoke(*other);
   return *other;
 }
-inline NDArray NDArray::Slice(mx_uint begin, mx_uint end) const {
+NDArray NDArray::Slice(mx_uint begin, mx_uint end) const {
   NDArrayHandle handle;
   CHECK_EQ(MXNDArraySlice(GetHandle(), begin, end, &handle), 0);
   return NDArray(handle);
 }
-inline NDArray NDArray::Reshape(const Shape &new_shape) const {
+NDArray NDArray::Reshape(const Shape &new_shape) const {
   NDArrayHandle handle;
   std::vector<int> dims(new_shape.ndim());
   for (index_t i = 0; i < new_shape.ndim(); ++i) {
@@ -213,20 +213,20 @@ inline NDArray NDArray::Reshape(const Shape &new_shape) const {
       MXNDArrayReshape(GetHandle(), new_shape.ndim(), dims.data(), &handle), 0);
   return NDArray(handle);
 }
-inline void NDArray::WaitToRead() const {
+void NDArray::WaitToRead() const {
   CHECK_EQ(MXNDArrayWaitToRead(blob_ptr_->handle_), 0);
 }
-inline void NDArray::WaitToWrite() {
+void NDArray::WaitToWrite() {
   CHECK_EQ(MXNDArrayWaitToWrite(blob_ptr_->handle_), 0);
 }
-inline void NDArray::WaitAll() { CHECK_EQ(MXNDArrayWaitAll(), 0); }
-inline void NDArray::SampleGaussian(mx_float mu, mx_float sigma, NDArray *out) {
+void NDArray::WaitAll() { CHECK_EQ(MXNDArrayWaitAll(), 0); }
+void NDArray::SampleGaussian(mx_float mu, mx_float sigma, NDArray *out) {
   Operator("_sample_normal")(mu, sigma).Invoke(*out);
 }
-inline void NDArray::SampleUniform(mx_float begin, mx_float end, NDArray *out) {
+void NDArray::SampleUniform(mx_float begin, mx_float end, NDArray *out) {
   Operator("_sample_uniform")(begin, end).Invoke(*out);
 }
-inline void NDArray::Load(const std::string &file_name,
+void NDArray::Load(const std::string &file_name,
                           std::vector<NDArray> *array_list,
                           std::map<std::string, NDArray> *array_map) {
   mx_uint out_size, out_name_size;
@@ -247,7 +247,7 @@ inline void NDArray::Load(const std::string &file_name,
     }
   }
 }
-inline std::map<std::string, NDArray> NDArray::LoadToMap(
+std::map<std::string, NDArray> NDArray::LoadToMap(
     const std::string &file_name) {
   std::map<std::string, NDArray> array_map;
   mx_uint out_size, out_name_size;
@@ -264,7 +264,7 @@ inline std::map<std::string, NDArray> NDArray::LoadToMap(
   }
   return array_map;
 }
-inline std::vector<NDArray> NDArray::LoadToList(const std::string &file_name) {
+std::vector<NDArray> NDArray::LoadToList(const std::string &file_name) {
   std::vector<NDArray> array_list;
   mx_uint out_size, out_name_size;
   NDArrayHandle *out_arr;
@@ -277,7 +277,7 @@ inline std::vector<NDArray> NDArray::LoadToList(const std::string &file_name) {
   }
   return array_list;
 }
-inline void NDArray::Save(const std::string &file_name,
+void NDArray::Save(const std::string &file_name,
                           const std::map<std::string, NDArray> &array_map) {
   std::vector<NDArrayHandle> args;
   std::vector<const char *> keys;
@@ -289,7 +289,7 @@ inline void NDArray::Save(const std::string &file_name,
       MXNDArraySave(file_name.c_str(), args.size(), args.data(), keys.data()),
       0);
 }
-inline void NDArray::Save(const std::string &file_name,
+void NDArray::Save(const std::string &file_name,
                           const std::vector<NDArray> &array_list) {
   std::vector<NDArrayHandle> args;
   for (const auto &t : array_list) {
@@ -299,30 +299,30 @@ inline void NDArray::Save(const std::string &file_name,
            0);
 }
 
-inline size_t NDArray::Offset(size_t h, size_t w) const {
+size_t NDArray::Offset(size_t h, size_t w) const {
   return (h * GetShape()[1]) + w;
 }
 
-inline size_t NDArray::Offset(size_t c, size_t h, size_t w) const {
+size_t NDArray::Offset(size_t c, size_t h, size_t w) const {
   auto const shape = GetShape();
   return h * shape[0] * shape[2] + w * shape[0] + c;
 }
 
-inline mx_float NDArray::At(size_t h, size_t w) const {
+mx_float NDArray::At(size_t h, size_t w) const {
   return GetData()[Offset(h, w)];
 }
 
-inline mx_float NDArray::At(size_t c, size_t h, size_t w) const {
+mx_float NDArray::At(size_t c, size_t h, size_t w) const {
   return GetData()[Offset(c, h, w)];
 }
 
-inline size_t NDArray::Size() const {
+size_t NDArray::Size() const {
   size_t ret = 1;
   for (auto &i : GetShape()) ret *= i;
   return ret;
 }
 
-inline std::vector<mx_uint> NDArray::GetShape() const {
+std::vector<mx_uint> NDArray::GetShape() const {
   const mx_uint *out_pdata;
   mx_uint out_dim;
   MXNDArrayGetShape(blob_ptr_->handle_, &out_dim, &out_pdata);
@@ -333,13 +333,13 @@ inline std::vector<mx_uint> NDArray::GetShape() const {
   return ret;
 }
 
-inline int NDArray::GetDType() const {
+int NDArray::GetDType() const {
   int ret;
   MXNDArrayGetDType(blob_ptr_->handle_, &ret);
   return ret;
 }
 
-inline const mx_float *NDArray::GetData() const {
+const mx_float *NDArray::GetData() const {
   void *ret;
   CHECK_NE(GetContext().GetDeviceType(), DeviceType::kGPU);
   MXNDArrayGetData(blob_ptr_->handle_, &ret);
@@ -349,14 +349,14 @@ inline const mx_float *NDArray::GetData() const {
   return static_cast<mx_float*>(ret);
 }
 
-inline Context NDArray::GetContext() const {
+Context NDArray::GetContext() const {
   int out_dev_type;
   int out_dev_id;
   MXNDArrayGetContext(blob_ptr_->handle_, &out_dev_type, &out_dev_id);
   return Context((DeviceType)out_dev_type, out_dev_id);
 }
 
-inline std::ostream & operator<<(std::ostream &out, const NDArray &ndarray) {
+std::ostream & operator<<(std::ostream &out, const NDArray &ndarray) {
   // TODO(lx75249): Consider DType / beautify like numpy
   auto shape = ndarray.GetShape();
   NDArray cpu_array(ndarray.GetShape(), Context::cpu());

--- a/cpp-package/include/mxnet-cpp/operator.hpp
+++ b/cpp-package/include/mxnet-cpp/operator.hpp
@@ -24,22 +24,22 @@ namespace cpp {
  * like PushInput<NDArray, Args..., N>, which is not allowed in C++
  */
 template <>
-inline Operator& Operator::SetParam<NDArray>(int pos, const NDArray &value) {
+Operator& Operator::SetParam<NDArray>(int pos, const NDArray &value) {
   input_ndarrays_.push_back(value.GetHandle());
   return *this;
 }
 template <>
-inline Operator& Operator::SetParam<Symbol>(int pos, const Symbol &value) {
+Operator& Operator::SetParam<Symbol>(int pos, const Symbol &value) {
   input_symbols_.push_back(value.GetHandle());
   return *this;
 }
 
-inline OpMap*& Operator::op_map() {
+OpMap*& Operator::op_map() {
   static OpMap *op_map_ = new OpMap();
   return op_map_;
 }
 
-inline Operator::Operator(const std::string &operator_name) {
+Operator::Operator(const std::string &operator_name) {
   handle_ = op_map()->GetSymbolCreator(operator_name);
   const char *name;
   const char *description;
@@ -61,7 +61,7 @@ inline Operator::Operator(const std::string &operator_name) {
   }
 }
 
-inline Symbol Operator::CreateSymbol(const std::string &name) {
+Symbol Operator::CreateSymbol(const std::string &name) {
   if (input_keys_.size() > 0) {
     CHECK_EQ(input_keys_.size(), input_symbols_.size());
   }
@@ -89,7 +89,7 @@ inline Symbol Operator::CreateSymbol(const std::string &name) {
   return Symbol(symbol_handle);
 }
 
-inline void Operator::Invoke(std::vector<NDArray> &outputs) {
+void Operator::Invoke(std::vector<NDArray> &outputs) {
   if (input_keys_.size() > 0) {
     CHECK_EQ(input_keys_.size(), input_ndarrays_.size());
   }
@@ -129,24 +129,24 @@ inline void Operator::Invoke(std::vector<NDArray> &outputs) {
       });
 }
 
-inline std::vector<NDArray> Operator::Invoke() {
+std::vector<NDArray> Operator::Invoke() {
   std::vector<NDArray> outputs;
   Invoke(outputs);
   return outputs;
 }
 
-inline void Operator::Invoke(NDArray &output) {
+void Operator::Invoke(NDArray &output) {
   std::vector<NDArray> outputs{output};
   Invoke(outputs);
 }
 
-inline Operator &Operator::SetInput(const std::string &name, Symbol symbol) {
+Operator &Operator::SetInput(const std::string &name, Symbol symbol) {
   input_keys_.push_back(name.c_str());
   input_symbols_.push_back(symbol.GetHandle());
   return *this;
 }
 
-inline Operator &Operator::SetInput(const std::string &name, NDArray ndarray) {
+Operator &Operator::SetInput(const std::string &name, NDArray ndarray) {
   input_keys_.push_back(name.c_str());
   input_ndarrays_.push_back(ndarray.GetHandle());
   return *this;

--- a/cpp-package/include/mxnet-cpp/optimizer.hpp
+++ b/cpp-package/include/mxnet-cpp/optimizer.hpp
@@ -22,14 +22,14 @@
 namespace {
 
 // TODO(lx75249): Add imperative operators to op.h under ndarray namespace
-inline void _clip(mxnet::cpp::NDArray &data, float limit) {
+void _clip(mxnet::cpp::NDArray &data, float limit) {
   data = mxnet::cpp::Operator("clip")
     .SetParam("a_min", -limit)
     .SetParam("a_max", limit)
     .SetInput("data", data)
     .Invoke()[0];
 }
-inline mxnet::cpp::NDArray _sqrt(mxnet::cpp::NDArray data) {
+mxnet::cpp::NDArray _sqrt(mxnet::cpp::NDArray data) {
   return mxnet::cpp::Operator("sqrt")
     .SetInput("data", data)
     .Invoke()[0];
@@ -39,29 +39,29 @@ inline mxnet::cpp::NDArray _sqrt(mxnet::cpp::NDArray data) {
 
 namespace mxnet {
 namespace cpp {
-inline Optimizer::Optimizer(unsigned begin_num_update)
+Optimizer::Optimizer(unsigned begin_num_update)
   : begin_num_update_(begin_num_update),
     num_update_(begin_num_update_) {
   params_["lr"] = "0.01f";
   params_["wd"] = "0.f";
 }
 
-inline std::map<std::string, OptimizerCreator>& OptimizerRegistry::cmap() {
+std::map<std::string, OptimizerCreator>& OptimizerRegistry::cmap() {
   static std::map<std::string, OptimizerCreator> cmap_;
   return cmap_;
 }
 
-inline OpMap*& Optimizer::op_map() {
+OpMap*& Optimizer::op_map() {
   static OpMap *op_map_ = new OpMap();
   return op_map_;
 }
 
-inline Optimizer::~Optimizer() {}
+Optimizer::~Optimizer() {}
 
-inline void Optimizer::CreateState_(int index, NDArray weight) {
+void Optimizer::CreateState_(int index, NDArray weight) {
 }
 
-inline std::string Optimizer::Serialize() const {
+std::string Optimizer::Serialize() const {
   using ValueType = std::map<std::string, std::string>::value_type;
   auto params = params_;
   params.emplace("opt_type", GetType());
@@ -71,21 +71,21 @@ inline std::string Optimizer::Serialize() const {
     }).substr(1);
 }
 
-inline const std::vector<const char*> Optimizer::GetParamKeys_() const {
+const std::vector<const char*> Optimizer::GetParamKeys_() const {
   std::vector<const char*> keys;
   for (auto& iter : params_)
     keys.push_back(iter.first.c_str());
   return keys;
 }
 
-inline const std::vector<const char*> Optimizer::GetParamValues_() const {
+const std::vector<const char*> Optimizer::GetParamValues_() const {
   std::vector<const char*> values;
   for (auto& iter : params_)
     values.push_back(iter.second.c_str());
   return values;
 }
 
-inline unsigned Optimizer::UpdateCount_(int index) {
+unsigned Optimizer::UpdateCount_(int index) {
   if (count_.count(index) == 0) {
     count_.emplace(index, begin_num_update_);
   }
@@ -94,19 +94,19 @@ inline unsigned Optimizer::UpdateCount_(int index) {
   return new_count;
 }
 
-inline float Optimizer::GetLR_(int index) {
+float Optimizer::GetLR_(int index) {
   if (nullptr != lrScheduler_) {
     return lrScheduler_->GetLR(num_update_);
   }
   return std::stof(params_["lr"]);
 }
 
-inline float Optimizer::GetWD_(int index) {
+float Optimizer::GetWD_(int index) {
   float wd = std::stof(params_["wd"]);
   return wd;
 }
 
-inline Optimizer* OptimizerRegistry::Find(const std::string& name) {
+Optimizer* OptimizerRegistry::Find(const std::string& name) {
   MXNETCPP_REGISTER_OPTIMIZER(sgd, SGDOptimizer);
   MXNETCPP_REGISTER_OPTIMIZER(ccsgd, SGDOptimizer);  // For backward compatibility
   MXNETCPP_REGISTER_OPTIMIZER(rmsprop, RMSPropOptimizer);
@@ -119,29 +119,29 @@ inline Optimizer* OptimizerRegistry::Find(const std::string& name) {
   return it->second();
 }
 
-inline int OptimizerRegistry::__REGISTER__(const std::string& name, OptimizerCreator creator) {
+int OptimizerRegistry::__REGISTER__(const std::string& name, OptimizerCreator creator) {
   CHECK_EQ(cmap().count(name), 0) << name << " already registered";
   cmap().emplace(name, std::move(creator));
   return 0;
 }
 
-inline SGDOptimizer::SGDOptimizer(unsigned begin_num_update)
+SGDOptimizer::SGDOptimizer(unsigned begin_num_update)
   : Optimizer(begin_num_update) {
   update_handle_ = op_map()->GetSymbolCreator("sgd_update");
   mom_update_handle_ = op_map()->GetSymbolCreator("sgd_mom_update");
 }
 
-inline std::string SGDOptimizer::GetType() const {
+std::string SGDOptimizer::GetType() const {
   return "sgd";
 }
 
-inline SGDOptimizer::~SGDOptimizer() {
+SGDOptimizer::~SGDOptimizer() {
   for (auto &it : states_) {
     delete it.second;
   }
 }
 
-inline void SGDOptimizer::Update(int index, NDArray weight, NDArray grad) {
+void SGDOptimizer::Update(int index, NDArray weight, NDArray grad) {
   if (states_.count(index) == 0) {
     CreateState_(index, weight);
   }
@@ -173,7 +173,7 @@ inline void SGDOptimizer::Update(int index, NDArray weight, NDArray grad) {
   }
 }
 
-inline void SGDOptimizer::CreateState_(int index, NDArray weight) {
+void SGDOptimizer::CreateState_(int index, NDArray weight) {
   if (params_.count("momentum") == 0) {
     states_[index] = nullptr;
   } else {
@@ -182,7 +182,7 @@ inline void SGDOptimizer::CreateState_(int index, NDArray weight) {
   }
 }
 
-inline RMSPropOptimizer::RMSPropOptimizer(unsigned begin_num_update)
+RMSPropOptimizer::RMSPropOptimizer(unsigned begin_num_update)
   : Optimizer(begin_num_update) {
   update_handle_ = op_map()->GetSymbolCreator("rmsprop_update");
   alex_update_handle_ = op_map()->GetSymbolCreator("rmspropalex_update");
@@ -191,11 +191,11 @@ inline RMSPropOptimizer::RMSPropOptimizer(unsigned begin_num_update)
   SetParam("epsilon", 1e-8);
 }
 
-inline std::string RMSPropOptimizer::GetType() const {
+std::string RMSPropOptimizer::GetType() const {
   return "rmsprop";
 }
 
-inline RMSPropOptimizer::~RMSPropOptimizer() {
+RMSPropOptimizer::~RMSPropOptimizer() {
   for (auto &it : n_) {
     delete it.second;
   }
@@ -207,7 +207,7 @@ inline RMSPropOptimizer::~RMSPropOptimizer() {
   }
 }
 
-inline void RMSPropOptimizer::Update(int index, NDArray weight, NDArray grad) {
+void RMSPropOptimizer::Update(int index, NDArray weight, NDArray grad) {
   if (n_.count(index) == 0) {
     CreateState_(index, weight);
   }
@@ -235,7 +235,7 @@ inline void RMSPropOptimizer::Update(int index, NDArray weight, NDArray grad) {
       keys.size(), keys.data(), values.data());
 }
 
-inline void RMSPropOptimizer::CreateState_(int index, NDArray weight) {
+void RMSPropOptimizer::CreateState_(int index, NDArray weight) {
   n_[index] = new NDArray(weight.GetShape(), weight.GetContext());
   *n_[index] = 0;
   g_[index] = new NDArray(weight.GetShape(), weight.GetContext());
@@ -244,7 +244,7 @@ inline void RMSPropOptimizer::CreateState_(int index, NDArray weight) {
   *delta_[index] = 0;
 }
 
-inline AdamOptimizer::AdamOptimizer(unsigned begin_num_update)
+AdamOptimizer::AdamOptimizer(unsigned begin_num_update)
   : Optimizer(begin_num_update) {
   update_handle_ = op_map()->GetSymbolCreator("adam_update");
   SetParam("beta1", 0.9f);
@@ -252,11 +252,11 @@ inline AdamOptimizer::AdamOptimizer(unsigned begin_num_update)
   SetParam("epsilon", 1e-8);
 }
 
-inline std::string AdamOptimizer::GetType() const {
+std::string AdamOptimizer::GetType() const {
   return "adam";
 }
 
-inline AdamOptimizer::~AdamOptimizer() {
+AdamOptimizer::~AdamOptimizer() {
   for (auto &it : mean_) {
     delete it.second;
   }
@@ -265,7 +265,7 @@ inline AdamOptimizer::~AdamOptimizer() {
   }
 }
 
-inline void AdamOptimizer::Update(int index, NDArray weight, NDArray grad) {
+void AdamOptimizer::Update(int index, NDArray weight, NDArray grad) {
   if (mean_.count(index) == 0) {
     CreateState_(index, weight);
   }
@@ -302,23 +302,23 @@ inline void AdamOptimizer::Update(int index, NDArray weight, NDArray grad) {
     keys.size(), keys.data(), values.data());
 }
 
-inline void AdamOptimizer::CreateState_(int index, NDArray weight) {
+void AdamOptimizer::CreateState_(int index, NDArray weight) {
   mean_[index] = new NDArray(weight.GetShape(), weight.GetContext());
   *mean_[index] = 0;
   var_[index] = new NDArray(weight.GetShape(), weight.GetContext());
   *var_[index] = 0;
 }
 
-inline AdaGradOptimizer::AdaGradOptimizer(unsigned begin_num_update)
+AdaGradOptimizer::AdaGradOptimizer(unsigned begin_num_update)
   : Optimizer(begin_num_update) {
   SetParam("eps", 1e-7);
 }
 
-inline std::string AdaGradOptimizer::GetType() const {
+std::string AdaGradOptimizer::GetType() const {
   return "adagrad";
 }
 
-inline void AdaGradOptimizer::Update(int index, NDArray weight, NDArray grad) {
+void AdaGradOptimizer::Update(int index, NDArray weight, NDArray grad) {
   if (history_.count(index) == 0) {
     CreateState_(index, weight);
   }
@@ -338,28 +338,28 @@ inline void AdaGradOptimizer::Update(int index, NDArray weight, NDArray grad) {
   weight -= (grad / _sqrt(history + eps) + weight * wd) * lr;
 }
 
-inline AdaGradOptimizer::~AdaGradOptimizer() {
+AdaGradOptimizer::~AdaGradOptimizer() {
   for (auto& it : history_) {
     delete it.second;
   }
 }
 
-inline void AdaGradOptimizer::CreateState_(int index, NDArray weight) {
+void AdaGradOptimizer::CreateState_(int index, NDArray weight) {
   history_[index] = new NDArray(weight.GetShape(), weight.GetContext());
   *history_[index] = 0;
 }
 
-inline AdaDeltaOptimizer::AdaDeltaOptimizer(unsigned begin_num_update)
+AdaDeltaOptimizer::AdaDeltaOptimizer(unsigned begin_num_update)
   : Optimizer(begin_num_update) {
   SetParam("rho", 0.90f);
   SetParam("epsilon", 1e-5);
 }
 
-inline std::string AdaDeltaOptimizer::GetType() const {
+std::string AdaDeltaOptimizer::GetType() const {
   return "adadelta";
 }
 
-inline void AdaDeltaOptimizer::Update(int index, NDArray weight, NDArray grad) {
+void AdaDeltaOptimizer::Update(int index, NDArray weight, NDArray grad) {
   if (acc_g_.count(index) == 0) {
     CreateState_(index, weight);
   }
@@ -388,7 +388,7 @@ inline void AdaDeltaOptimizer::Update(int index, NDArray weight, NDArray grad) {
   weight -= delta;
 }
 
-inline AdaDeltaOptimizer::~AdaDeltaOptimizer() {
+AdaDeltaOptimizer::~AdaDeltaOptimizer() {
   for (auto& it : acc_g_) {
     delete it.second;
   }
@@ -397,7 +397,7 @@ inline AdaDeltaOptimizer::~AdaDeltaOptimizer() {
   }
 }
 
-inline void AdaDeltaOptimizer::CreateState_(int index, NDArray weight) {
+void AdaDeltaOptimizer::CreateState_(int index, NDArray weight) {
   acc_g_[index] = new NDArray(weight.GetShape(), weight.GetContext());
   *acc_g_[index] = 0;
   acc_delta_[index] = new NDArray(weight.GetShape(), weight.GetContext());

--- a/cpp-package/include/mxnet-cpp/symbol.hpp
+++ b/cpp-package/include/mxnet-cpp/symbol.hpp
@@ -20,46 +20,46 @@
 
 namespace mxnet {
 namespace cpp {
-inline OpMap*& Symbol::op_map() {
+OpMap*& Symbol::op_map() {
   static OpMap* op_map_ = new OpMap();
   return op_map_;
 }
-inline Symbol::Symbol(SymbolHandle handle) {
+Symbol::Symbol(SymbolHandle handle) {
   blob_ptr_ = std::make_shared<SymBlob>(handle);
 }
-inline Symbol::Symbol(const char *name) {
+Symbol::Symbol(const char *name) {
   SymbolHandle handle;
   CHECK_EQ(MXSymbolCreateVariable(name, &(handle)), 0);
   blob_ptr_ = std::make_shared<SymBlob>(handle);
 }
-inline Symbol::Symbol(const std::string &name) : Symbol(name.c_str()) {}
-inline Symbol Symbol::Variable(const std::string &name) { return Symbol(name); }
-inline Symbol Symbol::operator+(const Symbol &rhs) const { return _Plus(*this, rhs); }
-inline Symbol Symbol::operator-(const Symbol &rhs) const { return _Minus(*this, rhs); }
-inline Symbol Symbol::operator*(const Symbol &rhs) const { return _Mul(*this, rhs); }
-inline Symbol Symbol::operator/(const Symbol &rhs) const { return _Div(*this, rhs); }
-inline Symbol Symbol::operator%(const Symbol &rhs) const { return _Mod(*this, rhs); }
-inline Symbol Symbol::operator+(mx_float scalar) const {
+Symbol::Symbol(const std::string &name) : Symbol(name.c_str()) {}
+Symbol Symbol::Variable(const std::string &name) { return Symbol(name); }
+Symbol Symbol::operator+(const Symbol &rhs) const { return _Plus(*this, rhs); }
+Symbol Symbol::operator-(const Symbol &rhs) const { return _Minus(*this, rhs); }
+Symbol Symbol::operator*(const Symbol &rhs) const { return _Mul(*this, rhs); }
+Symbol Symbol::operator/(const Symbol &rhs) const { return _Div(*this, rhs); }
+Symbol Symbol::operator%(const Symbol &rhs) const { return _Mod(*this, rhs); }
+Symbol Symbol::operator+(mx_float scalar) const {
   return _PlusScalar(*this, scalar);
 }
-inline Symbol Symbol::operator-(mx_float scalar) const {
+Symbol Symbol::operator-(mx_float scalar) const {
   return _MinusScalar(*this, scalar);
 }
-inline Symbol Symbol::operator*(mx_float scalar) const {
+Symbol Symbol::operator*(mx_float scalar) const {
   return _MulScalar(*this, scalar);
 }
-inline Symbol Symbol::operator/(mx_float scalar) const {
+Symbol Symbol::operator/(mx_float scalar) const {
   return _DivScalar(*this, scalar);
 }
-inline Symbol Symbol::operator%(mx_float scalar) const {
+Symbol Symbol::operator%(mx_float scalar) const {
   return _ModScalar(*this, scalar);
 }
-inline Symbol Symbol::operator[](int index) {
+Symbol Symbol::operator[](int index) {
   SymbolHandle out;
   MXSymbolGetOutput(GetHandle(), index, &out);
   return Symbol(out);
 }
-inline Symbol Symbol::operator[](const std::string &index) {
+Symbol Symbol::operator[](const std::string &index) {
   auto outputs = ListOutputs();
   for (mx_uint i = 0; i < outputs.size(); ++i) {
     if (outputs[i] == index) {
@@ -69,7 +69,7 @@ inline Symbol Symbol::operator[](const std::string &index) {
   LOG(FATAL) << "Cannot find output that matches name " << index;
   return (*this)[0];
 }
-inline Symbol Symbol::Group(const std::vector<Symbol> &symbols) {
+Symbol Symbol::Group(const std::vector<Symbol> &symbols) {
   SymbolHandle out;
   std::vector<SymbolHandle> handle_list;
   for (const auto &t : symbols) {
@@ -78,31 +78,31 @@ inline Symbol Symbol::Group(const std::vector<Symbol> &symbols) {
   MXSymbolCreateGroup(handle_list.size(), handle_list.data(), &out);
   return Symbol(out);
 }
-inline Symbol Symbol::Load(const std::string &file_name) {
+Symbol Symbol::Load(const std::string &file_name) {
   op_map();
   SymbolHandle handle;
   CHECK_EQ(MXSymbolCreateFromFile(file_name.c_str(), &(handle)), 0);
   return Symbol(handle);
 }
-inline Symbol Symbol::LoadJSON(const std::string &json_str) {
+Symbol Symbol::LoadJSON(const std::string &json_str) {
   SymbolHandle handle;
   CHECK_EQ(MXSymbolCreateFromJSON(json_str.c_str(), &(handle)), 0);
   return Symbol(handle);
 }
-inline void Symbol::Save(const std::string &file_name) const {
+void Symbol::Save(const std::string &file_name) const {
   CHECK_EQ(MXSymbolSaveToFile(GetHandle(), file_name.c_str()), 0);
 }
-inline std::string Symbol::ToJSON() const {
+std::string Symbol::ToJSON() const {
   const char *out_json;
   CHECK_EQ(MXSymbolSaveToJSON(GetHandle(), &out_json), 0);
   return std::string(out_json);
 }
-inline Symbol Symbol::GetInternals() const {
+Symbol Symbol::GetInternals() const {
   SymbolHandle handle;
   CHECK_EQ(MXSymbolGetInternals(GetHandle(), &handle), 0);
   return Symbol(handle);
 }
-inline Symbol::Symbol(const std::string &operator_name, const std::string &name,
+Symbol::Symbol(const std::string &operator_name, const std::string &name,
                std::vector<const char *> input_keys,
                std::vector<SymbolHandle> input_values,
                std::vector<const char *> config_keys,
@@ -116,13 +116,13 @@ inline Symbol::Symbol(const std::string &operator_name, const std::string &name,
   blob_ptr_ = std::make_shared<SymBlob>(handle);
 }
 
-inline Symbol Symbol::Copy() const {
+Symbol Symbol::Copy() const {
   SymbolHandle handle;
   CHECK_EQ(MXSymbolCopy(GetHandle(), &handle), 0);
   return Symbol(handle);
 }
 
-inline std::vector<std::string> Symbol::ListArguments() const {
+std::vector<std::string> Symbol::ListArguments() const {
   std::vector<std::string> ret;
   mx_uint size;
   const char **sarr;
@@ -132,7 +132,7 @@ inline std::vector<std::string> Symbol::ListArguments() const {
   }
   return ret;
 }
-inline std::vector<std::string> Symbol::ListOutputs() const {
+std::vector<std::string> Symbol::ListOutputs() const {
   std::vector<std::string> ret;
   mx_uint size;
   const char **sarr;
@@ -142,7 +142,7 @@ inline std::vector<std::string> Symbol::ListOutputs() const {
   }
   return ret;
 }
-inline std::vector<std::string> Symbol::ListAuxiliaryStates() const {
+std::vector<std::string> Symbol::ListAuxiliaryStates() const {
   std::vector<std::string> ret;
   mx_uint size;
   const char **sarr;
@@ -153,7 +153,7 @@ inline std::vector<std::string> Symbol::ListAuxiliaryStates() const {
   return ret;
 }
 
-inline void Symbol::InferShape(
+void Symbol::InferShape(
     const std::map<std::string, std::vector<mx_uint> > &arg_shapes,
     std::vector<std::vector<mx_uint> > *in_shape,
     std::vector<std::vector<mx_uint> > *aux_shape,
@@ -213,7 +213,7 @@ inline void Symbol::InferShape(
   }
 }
 
-inline void Symbol::InferExecutorArrays(
+void Symbol::InferExecutorArrays(
     const Context &context, std::vector<NDArray> *arg_arrays,
     std::vector<NDArray> *grad_arrays, std::vector<OpReqType> *grad_reqs,
     std::vector<NDArray> *aux_arrays,
@@ -275,7 +275,7 @@ inline void Symbol::InferExecutorArrays(
     }
   }
 }
-inline void Symbol::InferArgsMap(
+void Symbol::InferArgsMap(
     const Context &context, std::map<std::string, NDArray> *args_map,
     const std::map<std::string, NDArray> &known_args) const {
 
@@ -305,7 +305,7 @@ inline void Symbol::InferArgsMap(
   }
 }
 
-inline Executor *Symbol::SimpleBind(
+Executor *Symbol::SimpleBind(
     const Context &context, const std::map<std::string, NDArray> &args_map,
     const std::map<std::string, NDArray> &arg_grad_store,
     const std::map<std::string, OpReqType> &grad_req_type,
@@ -323,7 +323,7 @@ inline Executor *Symbol::SimpleBind(
                       aux_arrays);
 }
 
-inline Executor *Symbol::Bind(const Context &context,
+Executor *Symbol::Bind(const Context &context,
                        const std::vector<NDArray> &arg_arrays,
                        const std::vector<NDArray> &grad_arrays,
                        const std::vector<OpReqType> &grad_reqs,
@@ -333,15 +333,15 @@ inline Executor *Symbol::Bind(const Context &context,
   return new Executor(*this, context, arg_arrays, grad_arrays, grad_reqs,
                       aux_arrays, group_to_ctx, shared_exec);
 }
-inline Symbol operator+(mx_float lhs, const Symbol &rhs) { return rhs + lhs; }
-inline Symbol operator-(mx_float lhs, const Symbol &rhs) {
+Symbol operator+(mx_float lhs, const Symbol &rhs) { return rhs + lhs; }
+Symbol operator-(mx_float lhs, const Symbol &rhs) {
   return mxnet::cpp::_RMinusScalar(lhs, rhs);
 }
-inline Symbol operator*(mx_float lhs, const Symbol &rhs) { return rhs * lhs; }
-inline Symbol operator/(mx_float lhs, const Symbol &rhs) {
+Symbol operator*(mx_float lhs, const Symbol &rhs) { return rhs * lhs; }
+Symbol operator/(mx_float lhs, const Symbol &rhs) {
   return mxnet::cpp::_RDivScalar(lhs, rhs);
 }
-inline Symbol operator%(mx_float lhs, const Symbol &rhs) {
+Symbol operator%(mx_float lhs, const Symbol &rhs) {
   return mxnet::cpp::_RModScalar(lhs, rhs);
 }
 }  // namespace cpp


### PR DESCRIPTION
When linking to a larger c++ project we want to generate code for all the methods in the .hpp files, the inline keyword prevents this and causes undefined symbols. The compiler normally uses it's own heuristics for inlining code, so this is unlikely to have any impact on the code generated.  