### PR TITLE
Do not use LG in case of DMLC_GLOG_DEFINED enabled

### DIFF
--- a/cpp-package/include/mxnet-cpp/lr_scheduler.h
+++ b/cpp-package/include/mxnet-cpp/lr_scheduler.h
@@ -74,10 +74,10 @@ class FactorScheduler : public LRScheduler {
       base_lr_ *= factor_;
       if (base_lr_ < stop_factor_lr_) {
         base_lr_ = stop_factor_lr_;
-        LG << "Update[" << num_update << "]: now learning rate arrived at " \
+        LOG(INFO) << "Update[" << num_update << "]: now learning rate arrived at " \
            << base_lr_ << ", will not change in the future";
       } else {
-        LG << "Update[" << num_update << "]: Change learning rate to " << base_lr_;
+        LOG(INFO) << "Update[" << num_update << "]: Change learning rate to " << base_lr_;
       }
     }
     return base_lr_;

--- a/cpp-package/include/mxnet-cpp/monitor.hpp
+++ b/cpp-package/include/mxnet-cpp/monitor.hpp
@@ -89,7 +89,7 @@ inline void Monitor::toc_print() {
       str = out.str();
     }
 
-    LG << "Batch: " << std::get<0>(stat) << ' ' << std::get<1>(stat) << ' ' << str;
+    LOG(INFO) << "Batch: " << std::get<0>(stat) << ' ' << std::get<1>(stat) << ' ' << str;
   }
 }
 


### PR DESCRIPTION
When DMLC_GLOG_DEFINED is enabled, glog will be used and LG will not be defined. Use LG will cause compilation failure.