### PR TITLE
[RCNN] remove self-implemented speedometer

### DIFF
--- a/example/rcnn/rcnn/core/callback.py
+++ b/example/rcnn/rcnn/core/callback.py
@@ -15,42 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import time
-import logging
 import mxnet as mx
-
-
-class Speedometer(object):
-    def __init__(self, batch_size, frequent=50):
-        self.batch_size = batch_size
-        self.frequent = frequent
-        self.init = False
-        self.tic = 0
-        self.last_count = 0
-
-    def __call__(self, param):
-        """Callback to Show speed."""
-        count = param.nbatch
-        if self.last_count > count:
-            self.init = False
-        self.last_count = count
-
-        if self.init:
-            if count % self.frequent == 0:
-                speed = self.frequent * self.batch_size / (time.time() - self.tic)
-                if param.eval_metric is not None:
-                    name, value = param.eval_metric.get()
-                    s = "Epoch[%d] Batch [%d]\tSpeed: %.2f samples/sec\tTrain-" % (param.epoch, count, speed)
-                    for n, v in zip(name, value):
-                        s += "%s=%f,\t" % (n, v)
-                    logging.info(s)
-                else:
-                    logging.info("Iter[%d] Batch [%d]\tSpeed: %.2f samples/sec",
-                                 param.epoch, count, speed)
-                self.tic = time.time()
-        else:
-            self.init = True
-            self.tic = time.time()
 
 
 def do_checkpoint(prefix, means, stds):

--- a/example/rcnn/rcnn/tools/train_rcnn.py
+++ b/example/rcnn/rcnn/tools/train_rcnn.py
@@ -118,7 +118,7 @@ def train_rcnn(network, dataset, image_set, root_path, dataset_path,
     for child_metric in [eval_metric, cls_metric, bbox_metric]:
         eval_metrics.add(child_metric)
     # callback
-    batch_end_callback = callback.Speedometer(train_data.batch_size, frequent=frequent)
+    batch_end_callback = mx.callback.Speedometer(train_data.batch_size, frequent=frequent, auto_reset=false)
     epoch_end_callback = callback.do_checkpoint(prefix, means, stds)
     # decide learning rate
     base_lr = lr

--- a/example/rcnn/rcnn/tools/train_rpn.py
+++ b/example/rcnn/rcnn/tools/train_rpn.py
@@ -119,7 +119,7 @@ def train_rpn(network, dataset, image_set, root_path, dataset_path,
     for child_metric in [eval_metric, cls_metric, bbox_metric]:
         eval_metrics.add(child_metric)
     # callback
-    batch_end_callback = callback.Speedometer(train_data.batch_size, frequent=frequent)
+    batch_end_callback = mx.callback.Speedometer(train_data.batch_size, frequent=frequent, auto_reset=false)
     epoch_end_callback = mx.callback.do_checkpoint(prefix)
     # decide learning rate
     base_lr = lr

--- a/example/rcnn/train_end2end.py
+++ b/example/rcnn/train_end2end.py
@@ -126,7 +126,7 @@ def train_net(args, ctx, pretrained, epoch, prefix, begin_epoch, end_epoch,
     for child_metric in [rpn_eval_metric, rpn_cls_metric, rpn_bbox_metric, eval_metric, cls_metric, bbox_metric]:
         eval_metrics.add(child_metric)
     # callback
-    batch_end_callback = callback.Speedometer(train_data.batch_size, frequent=args.frequent)
+    batch_end_callback = mx.callback.Speedometer(train_data.batch_size, frequent=args.frequent, auto_reset=false)
     means = np.tile(np.array(config.TRAIN.BBOX_MEANS), config.NUM_CLASSES)
     stds = np.tile(np.array(config.TRAIN.BBOX_STDS), config.NUM_CLASSES)
     epoch_end_callback = callback.do_checkpoint(prefix, means, stds)


### PR DESCRIPTION
Because mx.callback.Speedometer has parameter `auto_rest` now, its behavior is the same with the self-implemented Speedometer when `auto_rest=false`.