### PR TITLE
make MXDataIter work without indices

### DIFF
--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -814,10 +814,13 @@ class MXDataIter(DataIter):
         check_call(_LIB.MXDataIterGetIndex(self.handle,
                                            ctypes.byref(index_data),
                                            ctypes.byref(index_size)))
-        address = ctypes.addressof(index_data.contents)
-        dbuffer = (ctypes.c_uint64* index_size.value).from_address(address)
-        np_index = np.frombuffer(dbuffer, dtype=np.uint64)
-        return np_index.copy()
+        if index_size.value:
+            address = ctypes.addressof(index_data.contents)
+            dbuffer = (ctypes.c_uint64* index_size.value).from_address(address)
+            np_index = np.frombuffer(dbuffer, dtype=np.uint64)
+            return np_index.copy()
+        else:
+            return None
 
     def getpad(self):
         pad = ctypes.c_int(0)


### PR DESCRIPTION
indices are optional, custom cpp iterators providing data batches
without indices should work while using MXDataIter.

##Testing

python tests/python/unittest/test_io.py 
[10:58:26] src/io/iter_mnist.cc:91: MNISTIter: load 60000 images, shuffle=1, shape=(100,784)