### PR TITLE
Return to the upstream CUB

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/dmlc/dlpack
 [submodule "cub"]
 	path = cub
-	url = https://github.com/dmlc/cub
+	url = https://github.com/NVLabs/cub


### PR DESCRIPTION
Upstream CUB was cleaned to reduce the size of the history and uses 20 MB now.