### PR TITLE
Fixed Makefile so a null CUDA_ARCH is treated like an unset one.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,8 @@ endif
 
 # Sets 'CUDA_ARCH', which determines the GPU architectures supported
 # by the compiled kernels.  Users can edit the KNOWN_CUDA_ARCHS list below
-# to remove archs they don't wish to support to speed compilation, or they
-# can pre-set the CUDA_ARCH args in config.mk for full control.
+# to remove archs they don't wish to support to speed compilation, or they can
+# pre-set the CUDA_ARCH args in config.mk to a non-null value for full control.
 #
 # For archs in this list, nvcc will create a fat-binary that will include
 # the binaries (SASS) for all architectures supported by the installed version
@@ -175,7 +175,7 @@ endif
 # If these kernels are then run on a newer-architecture GPU, the binary will
 # be JIT-compiled by the updated driver from the included PTX.
 ifeq ($(USE_CUDA), 1)
-ifeq ($(origin CUDA_ARCH), undefined)
+ifeq ($(CUDA_ARCH),)
 	KNOWN_CUDA_ARCHS := 30 35 50 52 60 61 70
 	# Run nvcc on a zero-length file to check architecture-level support.
 	# Create args to include SASS in the fat binary for supported levels.


### PR DESCRIPTION
Users can override the Makefile's setting of CUDA_ARCH with their own value, but then they may think they can revert back to the default setting by leaving a line such as "CUDA_ARCH=" in their custom config.mk.  A defined, but null, CUDA_ARCH variable caused the platform to compile for all NVIDIA GPU architectures, including unsupported ones like Fermi.  This PR changes the behavior so that a null CUDA_ARCH is treated the same as an undefined one- the platform is compiled to the list of supported GPU architectures in the Makefile.