### PR TITLE
Changed next() method to use the seq_size attribute

### DIFF
--- a/perl-package/AI-MXNet/examples/char_lstm.pl
+++ b/perl-package/AI-MXNet/examples/char_lstm.pl
@@ -133,7 +133,7 @@ method next()
         [$offset + 1 , $offset + $self->batch_size*$self->seq_size]
     )->reshape([$self->batch_size, $self->seq_size]);
     $self->seq_counter($self->seq_counter + 1);
-    if($self->seq_counter == $seq_size - 1)
+    if($self->seq_counter == $self->seq_size - 1)
     {
         $self->counter($self->counter + 1);
         $self->seq_counter(0);


### PR DESCRIPTION
Changed next() method to use the seq_size attribute and not the global variable $seq_size.