### PR TITLE
Set dev_id in streams, also update mshadow.

### DIFF
--- a/src/common/cuda_utils.h
+++ b/src/common/cuda_utils.h
@@ -274,26 +274,32 @@ inline int SMArch(int device_id) {
 
 /*!
  * \brief Determine whether a cuda-capable gpu's architecture supports float16 math.
+ *        Assume not if device_id is negative.
  * \param device_id The device index of the cuda-capable gpu of interest.
  * \return whether the gpu's architecture supports float16 math.
  */
 inline bool SupportsFloat16Compute(int device_id) {
-  // Kepler and most Maxwell GPUs do not support fp16 compute
-  int computeCapabilityMajor = ComputeCapabilityMajor(device_id);
-  int computeCapabilityMinor = ComputeCapabilityMinor(device_id);
-  return (computeCapabilityMajor > 5) ||
-      (computeCapabilityMajor == 5 && computeCapabilityMinor >= 3);
+  if (device_id < 0) {
+    return false;
+  }
+  else {
+    // Kepler and most Maxwell GPUs do not support fp16 compute
+    int computeCapabilityMajor = ComputeCapabilityMajor(device_id);
+    return (computeCapabilityMajor > 5) ||
+           (computeCapabilityMajor == 5 && ComputeCapabilityMinor(device_id) >= 3);
+  }
 }
 
 /*!
  * \brief Determine whether a cuda-capable gpu's architecture supports Tensor Core math.
+ *        Assume not if device_id is negative.
  * \param device_id The device index of the cuda-capable gpu of interest.
  * \return whether the gpu's architecture supports Tensor Core math.
  */
 inline bool SupportsTensorCore(int device_id) {
   // Volta (sm_70) supports TensorCore algos
-  int computeCapabilityMajor = ComputeCapabilityMajor(device_id);
-  return (computeCapabilityMajor >= 7);
+  return device_id >= 0 &&
+         ComputeCapabilityMajor(device_id) >=7;
 }
 
 // The policy if the user hasn't set the environment variable MXNET_CUDA_ALLOW_TENSOR_CORE

--- a/src/common/cuda_utils.h
+++ b/src/common/cuda_utils.h
@@ -281,8 +281,7 @@ inline int SMArch(int device_id) {
 inline bool SupportsFloat16Compute(int device_id) {
   if (device_id < 0) {
     return false;
-  }
-  else {
+  } else {
     // Kepler and most Maxwell GPUs do not support fp16 compute
     int computeCapabilityMajor = ComputeCapabilityMajor(device_id);
     return (computeCapabilityMajor > 5) ||

--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -154,7 +154,7 @@ class NaiveEngine final : public Engine {
         streams_.resize(dev_id + 1, nullptr);
       }
       if (streams_[dev_id] == nullptr) {
-        streams_[dev_id] = mshadow::NewStream<gpu>(true, MXNET_USE_CUDNN != 0);
+        streams_[dev_id] = mshadow::NewStream<gpu>(true, MXNET_USE_CUDNN != 0, dev_id);
       }
       exec_fun(RunContext{exec_ctx, streams_[dev_id]}, callback);
 #else

--- a/src/engine/stream_manager.h
+++ b/src/engine/stream_manager.h
@@ -77,7 +77,7 @@ RunContext StreamManager<kNumGpus, kStreams>::GetRunContext(
         auto&& counter = gpu_cnt_.at(ctx.dev_id);
         if (counter == -1) {
           for (auto&& i : gpu_streams_.at(ctx.dev_id)) {
-            i = mshadow::NewStream<gpu>(true, MXNET_USE_CUDNN != 0);
+            i = mshadow::NewStream<gpu>(true, MXNET_USE_CUDNN != 0, ctx.dev_id);
           }
           counter = 0;
         }
@@ -108,7 +108,7 @@ RunContext StreamManager<kNumGpus, kStreams>::GetIORunContext(
       {
         std::lock_guard<std::mutex> lock{m_};
         if (gpu_io_streams_.at(ctx.dev_id) == nullptr) {
-          gpu_io_streams_.at(ctx.dev_id) = mshadow::NewStream<gpu>(false, false);
+          gpu_io_streams_.at(ctx.dev_id) = mshadow::NewStream<gpu>(false, false, ctx.dev_id);
         }
       }
       ret = RunContext{ctx, gpu_io_streams_.at(ctx.dev_id)};

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -183,9 +183,9 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
       // allocate stream
       mshadow::SetDevice<gpu>(ctx.dev_id);
       if (is_copy_worker) {
-        stream = mshadow::NewStream<gpu>(false, false);
+        stream = mshadow::NewStream<gpu>(false, false, ctx.dev_id);
       } else {
-        stream = mshadow::NewStream<gpu>(true, MXNET_USE_CUDNN != 0);
+        stream = mshadow::NewStream<gpu>(true, MXNET_USE_CUDNN != 0, ctx.dev_id);
       }
     } while (false);
     // execute task

--- a/tests/cpp/include/test_op.h
+++ b/tests/cpp/include/test_op.h
@@ -75,7 +75,8 @@ class BasicOperatorData {
     : opContext_(*opContext) {
       CHECK_EQ(opContext_.run_ctx.stream == nullptr, true)
         << "Invalid runtime context stream state";
-      opContext_.run_ctx.stream = mshadow::NewStream<gpu>(true, true);
+      auto device_id = opContext->run_ctx.get_ctx().dev_id;
+      opContext_.run_ctx.stream = mshadow::NewStream<gpu>(true, true, device_id);
       CHECK_EQ(opContext_.run_ctx.stream != nullptr, true)
         << "Unable to allocate a GPU stream";
     }


### PR DESCRIPTION
This sets the stream's dev_id field properly, so that in the future we can have low-level routines like linalg_gemm(... stream *s) make GPU-arch-specific choices based on the stream.  This change exposes an issue with an old version of mshadow, so we bundle this with an mshadow update.