### PR TITLE
Temporarily disable MIN=1 and add clean in Amalgamation to fix test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,7 +154,8 @@ try {
         node('mxnetlinux') {
           ws('workspace/amalgamation') {
             init_git()
-            make('cpu', '-C amalgamation/ USE_BLAS=openblas MIN=1')
+            make('cpu', '-C amalgamation/ clean')
+            make('cpu', '-C amalgamation/ USE_BLAS=openblas')
           }
         }
       },


### PR DESCRIPTION
There are currently two problems in Amalgamation:

1. linalg introduces dependency on cblas but the MIN=1 mode of amalgamation (the most restricted mode) doesn't include cblas. I turned of MIN=1 for now. Please reenable it after linalg situation is resolved
2. The amalgamatiom makefile doesn't handle dependencies correctly thus mxnet_predict-all.cc is not regenerated when mxnet source files changes. I added clean every time to fix it for now.

@asmushetzel @mli 