### PR TITLE
[build] explicitly install JDK8

### DIFF
--- a/docker/install/scala.sh
+++ b/docker/install/scala.sh
@@ -19,7 +19,7 @@
 
 # install libraries for mxnet's scala package on ubuntu
 
-apt-get install -y maven default-jdk
+apt-get install -y maven openjdk-8-jdk 
 
 wget http://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.deb
 dpkg -i scala-2.11.8.deb

--- a/docker/install/scala.sh
+++ b/docker/install/scala.sh
@@ -20,11 +20,11 @@
 # install libraries for mxnet's scala package on ubuntu
 
 
-apt-get install software-properties-common
+apt-get install -y software-properties-common
 add-apt-repository ppa:webupd8team/java -y
 apt-get update
-apt-get install oracle-java8-installer
-apt-get install oracle-java8-set-default
+apt-get install -y oracle-java8-installer
+apt-get install -y oracle-java8-set-default
 
 apt-get install -y maven 
 

--- a/docker/install/scala.sh
+++ b/docker/install/scala.sh
@@ -19,7 +19,12 @@
 
 # install libraries for mxnet's scala package on ubuntu
 
-apt-get install -y maven openjdk-8-jdk 
+add-apt-repository ppa:webupd8team/java -y
+apt-get update
+apt-get install oracle-java8-installer
+apt-get install oracle-java8-set-default
+
+apt-get install -y maven 
 
 wget http://downloads.lightbend.com/scala/2.11.8/scala-2.11.8.deb
 dpkg -i scala-2.11.8.deb

--- a/docker/install/scala.sh
+++ b/docker/install/scala.sh
@@ -21,8 +21,9 @@
 
 
 apt-get install -y software-properties-common
-add-apt-repository ppa:webupd8team/java -y
+add-apt-repository -y ppa:webupd8team/java
 apt-get update
+echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 apt-get install -y oracle-java8-installer
 apt-get install -y oracle-java8-set-default
 

--- a/docker/install/scala.sh
+++ b/docker/install/scala.sh
@@ -19,6 +19,8 @@
 
 # install libraries for mxnet's scala package on ubuntu
 
+
+apt-get install software-properties-common
 add-apt-repository ppa:webupd8team/java -y
 apt-get update
 apt-get install oracle-java8-installer

--- a/docs/get_started/build_from_source.md
+++ b/docs/get_started/build_from_source.md
@@ -367,6 +367,7 @@ Both JDK and Maven are required to build the Scala package.
 <div class="ubuntu">
 
 ```bash
+apt-get install software-properties-common
 add-apt-repository ppa:webupd8team/java -y
 apt-get update
 apt-get install oracle-java8-installer

--- a/docs/get_started/build_from_source.md
+++ b/docs/get_started/build_from_source.md
@@ -367,11 +367,11 @@ Both JDK and Maven are required to build the Scala package.
 <div class="ubuntu">
 
 ```bash
-apt-get install software-properties-common
+apt-get install -y software-properties-common
 add-apt-repository ppa:webupd8team/java -y
 apt-get update
-apt-get install oracle-java8-installer
-apt-get install oracle-java8-set-default
+apt-get install -y oracle-java8-installer
+apt-get install -y oracle-java8-set-default
 apt-get install -y maven
 ```
 

--- a/docs/get_started/build_from_source.md
+++ b/docs/get_started/build_from_source.md
@@ -367,7 +367,7 @@ Both JDK and Maven are required to build the Scala package.
 <div class="ubuntu">
 
 ```bash
-sudo apt-get install -y maven default-jdk
+sudo apt-get install -y maven openjdk-8-jdk
 ```
 
 </div>

--- a/docs/get_started/build_from_source.md
+++ b/docs/get_started/build_from_source.md
@@ -368,8 +368,9 @@ Both JDK and Maven are required to build the Scala package.
 
 ```bash
 apt-get install -y software-properties-common
-add-apt-repository ppa:webupd8team/java -y
+add-apt-repository -y ppa:webupd8team/java
 apt-get update
+echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 apt-get install -y oracle-java8-installer
 apt-get install -y oracle-java8-set-default
 apt-get install -y maven

--- a/docs/get_started/build_from_source.md
+++ b/docs/get_started/build_from_source.md
@@ -367,7 +367,11 @@ Both JDK and Maven are required to build the Scala package.
 <div class="ubuntu">
 
 ```bash
-sudo apt-get install -y maven openjdk-8-jdk
+add-apt-repository ppa:webupd8team/java -y
+apt-get update
+apt-get install oracle-java8-installer
+apt-get install oracle-java8-set-default
+apt-get install -y maven
 ```
 
 </div>

--- a/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
+++ b/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
@@ -23,6 +23,10 @@ RUN cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
 RUN pip install nose cpplint 'pylint==1.4.4' 'astroid==1.3.6'
 
 # MAVEN
+RUN add-apt-repository ppa:webupd8team/java -y
+RUN apt-get update
+RUN apt-get install oracle-java8-installer
+RUN apt-get install oracle-java8-set-default
 RUN apt-get install -y maven openjdk-8-jdk
 
 # R

--- a/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
+++ b/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
@@ -26,8 +26,9 @@ RUN pip install nose cpplint 'pylint==1.4.4' 'astroid==1.3.6'
 RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:webupd8team/java -y
 RUN apt-get update
-RUN apt-get install oracle-java8-installer
-RUN apt-get install oracle-java8-set-default
+RUN echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
+RUN apt-get install -y oracle-java8-installer
+RUN apt-get install -y oracle-java8-set-default
 RUN apt-get install -y maven
 
 # R

--- a/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
+++ b/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
@@ -23,6 +23,7 @@ RUN cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
 RUN pip install nose cpplint 'pylint==1.4.4' 'astroid==1.3.6'
 
 # MAVEN
+RUN apt-get install software-properties-common
 RUN add-apt-repository ppa:webupd8team/java -y
 RUN apt-get update
 RUN apt-get install oracle-java8-installer

--- a/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
+++ b/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
@@ -23,7 +23,7 @@ RUN cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
 RUN pip install nose cpplint 'pylint==1.4.4' 'astroid==1.3.6'
 
 # MAVEN
-RUN apt-get install -y maven default-jdk
+RUN apt-get install -y maven openjdk-8-jdk
 
 # R
 RUN apt-get install -y software-properties-common r-base-core libcurl4-openssl-dev libssl-dev libxml2-dev

--- a/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
+++ b/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
@@ -23,12 +23,12 @@ RUN cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
 RUN pip install nose cpplint 'pylint==1.4.4' 'astroid==1.3.6'
 
 # MAVEN
-RUN apt-get install software-properties-common
+RUN apt-get install -y software-properties-common
 RUN add-apt-repository ppa:webupd8team/java -y
 RUN apt-get update
 RUN apt-get install oracle-java8-installer
 RUN apt-get install oracle-java8-set-default
-RUN apt-get install -y maven openjdk-8-jdk
+RUN apt-get install -y maven
 
 # R
 RUN apt-get install -y software-properties-common r-base-core libcurl4-openssl-dev libssl-dev libxml2-dev

--- a/tests/ci_build/install/ubuntu_install_scala.sh
+++ b/tests/ci_build/install/ubuntu_install_scala.sh
@@ -19,10 +19,9 @@
 
 # install libraries for mxnet's scala package on ubuntu
 
-apt-get install software-properties-common
+apt-get install -y software-properties-common
 add-apt-repository ppa:webupd8team/java -y
 apt-get update
-apt-get install oracle-java8-installer
-apt-get install oracle-java8-set-default
-
+apt-get install -y oracle-java8-installer
+apt-get install -y oracle-java8-set-default
 apt-get update && apt-get install -y maven

--- a/tests/ci_build/install/ubuntu_install_scala.sh
+++ b/tests/ci_build/install/ubuntu_install_scala.sh
@@ -19,6 +19,7 @@
 
 # install libraries for mxnet's scala package on ubuntu
 
+apt-get install software-properties-common
 add-apt-repository ppa:webupd8team/java -y
 apt-get update
 apt-get install oracle-java8-installer

--- a/tests/ci_build/install/ubuntu_install_scala.sh
+++ b/tests/ci_build/install/ubuntu_install_scala.sh
@@ -20,8 +20,9 @@
 # install libraries for mxnet's scala package on ubuntu
 
 apt-get install -y software-properties-common
-add-apt-repository ppa:webupd8team/java -y
+add-apt-repository -y ppa:webupd8team/java
 apt-get update
+echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 apt-get install -y oracle-java8-installer
 apt-get install -y oracle-java8-set-default
 apt-get update && apt-get install -y maven

--- a/tests/ci_build/install/ubuntu_install_scala.sh
+++ b/tests/ci_build/install/ubuntu_install_scala.sh
@@ -19,5 +19,9 @@
 
 # install libraries for mxnet's scala package on ubuntu
 
-apt-get update && apt-get install -y \
-    maven openjdk-8-jdk
+add-apt-repository ppa:webupd8team/java -y
+apt-get update
+apt-get install oracle-java8-installer
+apt-get install oracle-java8-set-default
+
+apt-get update && apt-get install -y maven

--- a/tests/ci_build/install/ubuntu_install_scala.sh
+++ b/tests/ci_build/install/ubuntu_install_scala.sh
@@ -20,4 +20,4 @@
 # install libraries for mxnet's scala package on ubuntu
 
 apt-get update && apt-get install -y \
-    maven default-jdk
+    maven openjdk-8-jdk


### PR DESCRIPTION
I had a PR failed on calling a Java 8 API: https://builds.apache.org/blue/rest/organizations/jenkins/pipelines/incubator-mxnet/branches/PR-7571/runs/2/nodes/234/steps/358/log/?start=0

I think the major reason is that in the OS where Jenkins runs, the default jdk points to JDK7 and it's time to move on to JDK8.....