### PR TITLE
Fixing loss function code in tutorial

### DIFF
--- a/docs/tutorials/gluon/gluon.md
+++ b/docs/tutorials/gluon/gluon.md
@@ -102,7 +102,8 @@ To compute loss and backprop for one iteration, we do:
 label = mx.nd.arange(10)  # dummy label
 with autograd.record():
     output = net(data)
-    loss = gluon.loss.SoftmaxCrossEntropyLoss()(output, label)
+    L = gluon.loss.SoftmaxCrossEntropyLoss()
+    loss = L(output, label)
     loss.backward()
 print('loss:', loss)
 print('grad:', net.fc1.weight.grad())
@@ -129,7 +130,8 @@ trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.01})
 
 with autograd.record():
     output = net(data)
-    loss = gluon.loss.SoftmaxCrossEntropyLoss()(output, label)
+    L = gluon.loss.SoftmaxCrossEntropyLoss()
+    loss = L(output, label)
     loss.backward()
 
 # do the update. Trainer needs to know the batch size of data to normalize

--- a/docs/tutorials/gluon/gluon.md
+++ b/docs/tutorials/gluon/gluon.md
@@ -102,7 +102,7 @@ To compute loss and backprop for one iteration, we do:
 label = mx.nd.arange(10)  # dummy label
 with autograd.record():
     output = net(data)
-    loss = gluon.loss.softmax_cross_entropy_loss(output, label)
+    loss = gluon.loss.SoftmaxCrossEntropyLoss()(output, label)
     loss.backward()
 print('loss:', loss)
 print('grad:', net.fc1.weight.grad())
@@ -127,9 +127,9 @@ this is a commonly used functionality, gluon provide a `Trainer` class for it:
 ```python
 trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.01})
 
-with record():
+with autograd.record():
     output = net(data)
-    loss = gluon.loss.softmax_cross_entropy_loss(output, label)
+    loss = gluon.loss.SoftmaxCrossEntropyLoss()(output, label)
     loss.backward()
 
 # do the update. Trainer needs to know the batch size of data to normalize


### PR DESCRIPTION
The function softmax_cross_entropy_loss is no longer available in gluon.loss. Making the necessary update to the tutorial code.

Also, record() in one part of the tutorial is not preceded by autograd resulting in an undefined error, adding the reference to autograd.
