### PR TITLE
add license to new file, resolving jenkins build issues

### DIFF
--- a/example/bi-lstm-sort/gen_data.py
+++ b/example/bi-lstm-sort/gen_data.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import random
 
 vocab = [str(x) for x in range(100, 1000)]


### PR DESCRIPTION
This PR https://github.com/apache/incubator-mxnet/pull/6549 added a new file which didn't have a header. This caused all builds to fail sanity check. 

Example of a build is [here](https://builds.apache.org/blue/organizations/jenkins/incubator-mxnet/detail/master/233/pipeline)

Excerpt from that 
```
Traceback (most recent call last):
  File "tools/license_header.py", line 160, in <module>
    process_folder(os.path.join(os.path.dirname(__file__), '..'), args.action[0])
  File "tools/license_header.py", line 150, in process_folder
    'them automatically', excepts)
Exception: ('The following files do not contain a valid license, you can use `python tools/license_header.py add` to addthem automatically', ['example/bi-lstm-sort/gen_data.py'])
```

Used this tool to add a header