### PR TITLE
Expand linalg gemm use

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,7 +155,7 @@ try {
           ws('workspace/amalgamation') {
             init_git()
             make('cpu', '-C amalgamation/ clean')
-            make('cpu', '-C amalgamation/ USE_BLAS=openblas')
+            make('cpu', '-C amalgamation/ USE_BLAS=openblas MIN=1')
           }
         }
       },

--- a/src/operator/convolution-inl.h
+++ b/src/operator/convolution-inl.h
@@ -40,6 +40,7 @@
 #include <utility>
 #include "./operator_common.h"
 #include "./nn/im2col.h"
+#include "./linalg.h"
 
 
 namespace mxnet {
@@ -160,7 +161,9 @@ class ConvolutionOp : public Operator {
              col_buffer.dptr<DType>());
       Tensor<xpu, 3, DType> output_3d = output_4d[n];
       for (index_t g = 0; g < group_; ++g) {
-        ASSIGN_DISPATCH(output_3d[g], req[conv::kOut], dot(weight_3d[g], col_buffer_3d[g]));
+        // Legacy approach shown here for comparison:
+        //   Assign(output_3d[g], req[conv::kOut], dot(weight_3d[g], col_buffer_3d[g]));
+        linalg_gemm(weight_3d[g], col_buffer_3d[g], output_3d[g], false, false, s, req[conv::kOut]);
       }
     }
     if (bias_term_) {
@@ -219,7 +222,9 @@ class ConvolutionOp : public Operator {
       Tensor<xpu, 3, DType> out_grad_3d = out_grad_4d[n];
       // gradient w.r.t. input data
       for (index_t g = 0; g < group_; ++g) {
-        col_buffer_3d[g] = dot(weight_3d[g].T(), out_grad_3d[g]);
+        // Legacy approach shown here for comparison:
+        //   col_buffer_3d[g] = dot(weight_3d[g].T(), out_grad_3d[g]);
+        linalg_gemm(weight_3d[g], out_grad_3d[g], col_buffer_3d[g], true, false, s);
       }
       col2im(s, col_buffer.dptr<DType>(), in_grad[conv::kData].shape_, col_buffer.shape_,
              param_.kernel, param_.pad, param_.stride, param_.dilate,
@@ -230,12 +235,10 @@ class ConvolutionOp : public Operator {
              col_buffer.shape_, param_.kernel, param_.pad, param_.stride, param_.dilate,
              col_buffer.dptr<DType>());
       for (index_t g = 0; g < group_; ++g) {
-        if (0 == n) {
-          ASSIGN_DISPATCH(dweight_3d[g], req[conv::kWeight],
-                          dot(out_grad_3d[g], col_buffer_3d[g].T()));
-        } else {
-          dweight_3d[g] += dot(out_grad_3d[g], col_buffer_3d[g].T());
-        }
+        auto request = (n == 0) ? req[conv::kWeight] : kAddTo;
+        // Legacy approach shown here for comparison:
+        //   Assign(dweight_3d[g], request, dot(out_grad_3d[g], col_buffer_3d[g].T()));
+        linalg_gemm(out_grad_3d[g], col_buffer_3d[g], dweight_3d[g], false, true, s, request);
       }
     }
 

--- a/src/operator/convolution_v1-inl.h
+++ b/src/operator/convolution_v1-inl.h
@@ -37,6 +37,7 @@
 #include <string>
 #include <utility>
 #include "./operator_common.h"
+#include "./linalg.h"
 
 namespace mxnet {
 namespace op {
@@ -180,7 +181,9 @@ class ConvolutionV1Op : public Operator {
       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
         mshadow::Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid,
                                        gstride * (gid + 1));
-        temp_dst[gid] = dot(wmat[gid], tmpc);
+        // Legacy approach shown here for comparison:
+        //   temp_dst[gid] = dot(wmat[gid], tmpc);
+        linalg_gemm(wmat[gid], tmpc, temp_dst[gid], false, false, s);
       }
       out.Slice(i, i + step) = swapaxis<1, 0>(reshape(temp_dst,
                                               mshadow::Shape4(param_.num_filter,
@@ -267,15 +270,21 @@ class ConvolutionV1Op : public Operator {
         Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid, gstride * (gid + 1));
         if (i == 0) {
           Tensor<xpu, 2, DType> tmp_gwmat = gwmat[gid];
-          Assign(tmp_gwmat, req[conv_v1::kWeight], dot(temp_dst[gid], tmpc.T()));
+          // Legacy approach shown here for comparison:
+          //   Assign(tmp_gwmat, req[conv_v1::kWeight], dot(temp_dst[gid], tmpc.T()));
+          linalg_gemm(temp_dst[gid], tmpc, tmp_gwmat, false, true, s, req[conv_v1::kWeight]);
         } else {
-          gwmat[gid] += dot(temp_dst[gid], tmpc.T());
+          // Legacy approach shown here for comparison:
+          //   gwmat[gid] += dot(temp_dst[gid], tmpc.T());
+          linalg_gemm(temp_dst[gid], tmpc, gwmat[gid], false, true, s, kAddTo);
         }
       }
 
       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
         Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid, gstride * (gid + 1));
-        tmpc = dot(wmat[gid].T(), temp_dst[gid]);
+        // Legacy approach shown here for comparison:
+        //   tmpc = dot(wmat[gid].T(), temp_dst[gid]);
+        linalg_gemm(wmat[gid], temp_dst[gid], tmpc, true, false, s);
       }
       if (param_.pad[0] == 0 && param_.pad[1] == 0) {
         Assign(gdata.Slice(i, i + step), req[conv_v1::kData],

--- a/src/operator/deconvolution-inl.h
+++ b/src/operator/deconvolution-inl.h
@@ -34,6 +34,7 @@
 #include <string>
 #include <utility>
 #include "./operator_common.h"
+#include "./linalg.h"
 
 
 namespace mxnet {
@@ -227,7 +228,9 @@ class DeconvolutionOp : public Operator {
       for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
         mshadow::Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid,
                                               gstride * (gid + 1));
-        tmpc = dot(wmat[gid].T(), temp_dst[gid]);
+        // Legacy approach shown here for comparison:
+        //   tmpc = dot(wmat[gid].T(), temp_dst[gid]);
+        linalg_gemm(wmat[gid], temp_dst[gid], tmpc, true, false, s);
       }
       if (o_pad[0] == 0 && o_pad[1] == 0) {
         out.Slice(i, i + step) = pack_col2patch(temp_col,
@@ -335,16 +338,23 @@ class DeconvolutionOp : public Operator {
         Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid, gstride * (gid + 1));
         if (i == 0) {
           Tensor<xpu, 2, DType> tmp_gwmat = gwmat[gid];
-          Assign(tmp_gwmat, req[deconv::kWeight], dot(temp_dst[gid], tmpc.T()));
+          // Legacy approach shown here for comparison:
+          //   Assign(tmp_gwmat, req[deconv::kWeight], dot(temp_dst[gid], tmpc.T()));
+          linalg_gemm(temp_dst[gid], tmpc, tmp_gwmat, false, true, s, req[deconv::kWeight]);
         } else {
-          gwmat[gid] += dot(temp_dst[gid], tmpc.T());
+          // Legacy approach shown here for comparison:
+          //   gwmat[gid] += dot(temp_dst[gid], tmpc.T());
+          linalg_gemm(temp_dst[gid], tmpc, gwmat[gid], false, true, s, kAddTo);
         }
       }
-      if (req[deconv::kData] == kWriteTo || req[deconv::kData] == kWriteInplace
-                                         || req[deconv::kData] == kAddTo) {
+      if (req[deconv::kData] == kWriteTo ||
+          req[deconv::kData] == kWriteInplace ||
+          req[deconv::kData] == kAddTo) {
         for (uint32_t gid = 0; gid < param_.num_group; ++gid) {
           Tensor<xpu, 2, DType> tmpc = temp_col.Slice(gstride * gid, gstride * (gid + 1));
-          temp_dst[gid] = dot(wmat[gid], tmpc);
+          // Legacy approach shown here for comparison:
+          //   temp_dst[gid] = dot(wmat[gid], tmpc);
+          linalg_gemm(wmat[gid], tmpc, temp_dst[gid], false, false, s);
         }
         Assign(gdata.Slice(i, i + step),
                req[deconv::kData],

--- a/src/operator/linalg_impl.h
+++ b/src/operator/linalg_impl.h
@@ -56,6 +56,8 @@ inline void check_gemm(const Tensor<xpu, 2, DType>& A, const Tensor<xpu, 2, DTyp
     << "Non compatible matrix dimensions between inputs A and B for gemm";
 }
 
+#if (MSHADOW_USE_CBLAS != 0)
+
 #define LINALG_CPU_GEMM(fname, DType) \
 template<> inline \
 void linalg_gemm<cpu, DType>(const Tensor<cpu, 2, DType>& A, const Tensor<cpu, 2, DType>& B, \
@@ -69,6 +71,17 @@ void linalg_gemm<cpu, DType>(const Tensor<cpu, 2, DType>& A, const Tensor<cpu, 2
 LINALG_CPU_GEMM(sgemm, float)
 LINALG_CPU_GEMM(dgemm, double)
 
+// Specialization of linalg_gemm<cpu, DType> for DType=mshadow::half::half_t.
+template<> inline
+void linalg_gemm<cpu, mshadow::half::half_t>(const Tensor<cpu, 2, mshadow::half::half_t>& A,
+                                             const Tensor<cpu, 2, mshadow::half::half_t>& B,
+                                             const Tensor<cpu, 2, mshadow::half::half_t>& C,
+                                             mshadow::half::half_t alpha,
+                                             mshadow::half::half_t beta,
+                                             bool tA, bool tB, Stream<cpu> *s) {
+  LOG(FATAL) << "FP16 gemm on cpu not implemented!";
+}
+
 #define LINALG_CPU_BATCH_GEMM(DType) \
 template<> inline \
 void linalg_batch_gemm<cpu, DType>(const Tensor<cpu, 3, DType>& A, const Tensor<cpu, 3, DType>& B, \
@@ -81,6 +94,8 @@ void linalg_batch_gemm<cpu, DType>(const Tensor<cpu, 3, DType>& A, const Tensor<
 }
 LINALG_CPU_BATCH_GEMM(float)
 LINALG_CPU_BATCH_GEMM(double)
+
+#endif  // (MSHADOW_USE_CBLAS != 0)
 
 #ifdef __CUDACC__
 
@@ -198,7 +213,7 @@ void linalg_batch_gemm<gpu, DType>(const Tensor<gpu, 3, DType>& A, const Tensor<
 LINALG_GPU_BATCH_GEMM(SgemmBatched, float)
 LINALG_GPU_BATCH_GEMM(DgemmBatched, double)
 
-#endif
+#endif  // __CUDACC__
 
 //////////////////////////////// TRSM ////////////////////////////////////////////
 
@@ -217,6 +232,8 @@ inline void check_trsm(const Tensor<xpu, 2, DType>& A, const Tensor<xpu, 2, DTyp
   CHECK(rightside || (B.size(0) == A.size(1)))
     << "Non compatible matrix dimensions between inputs A and B for trsm";
 }
+
+#if (MSHADOW_USE_CBLAS != 0)
 
 #define LINALG_CPU_TRSM(fname, DType) \
 template<> inline \
@@ -242,6 +259,8 @@ void linalg_batch_trsm<cpu, DType>(const Tensor<cpu, 3, DType>& A, const Tensor<
 }
 LINALG_CPU_BATCH_TRSM(float)
 LINALG_CPU_BATCH_TRSM(double)
+
+#endif  // (MSHADOW_USE_CBLAS != 0)
 
 #ifdef __CUDACC__
 
@@ -297,7 +316,7 @@ void linalg_batch_trsm<gpu, DType>(const Tensor<gpu, 3, DType>& A, const Tensor<
 LINALG_GPU_BATCH_TRSM(StrsmBatched, float)
 LINALG_GPU_BATCH_TRSM(DtrsmBatched, double)
 
-#endif
+#endif // __CUDACC__
 
 /*!
  * \brief Performs gemm, setting alpha and beta as appropriate for `req`.
@@ -332,6 +351,31 @@ inline void linalg_gemm(const Tensor<xpu, 2, DType>& A,
   }
 }
 
+// A cpu specialization for linalg_gemm<xpu, DType> that uses mshadow::dot(), if no cblas.
+#if (MSHADOW_USE_CBLAS == 0)
+template<typename DType>
+inline void linalg_gemm<cpu, DType>(const Tensor<cpu, 2, DType>& A,
+                        const Tensor<cpu, 2, DType>& B,
+                        const Tensor<cpu, 2, DType>& C,
+                        bool tA, bool tB, Stream<cpu> *s,
+                        mxnet::OpReqType req) {
+  using namespace mxnet;
+  switch (req) {
+    case kNullOp:
+      break;
+    case kWriteTo:
+    case kWriteInplace:
+      C = dot(tA ? A.T() : A, tB ? B.T() : B);
+      break;
+    case kAddTo:
+      C += dot(tA ? A.T() : A, tB ? B.T() : B);
+      break;
+    default:
+      LOG(FATAL) << "not reached";
+  }
+}
+#endif
+
 //////////////////////////////// TRMM ////////////////////////////////////////////
 
 // CPU/GPU-versions of BLAS3 function "trmm". Please refer to the BLAS3-documentation
@@ -349,6 +393,8 @@ inline void check_trmm(const Tensor<xpu, 2, DType>& A, const Tensor<xpu, 2, DTyp
   CHECK(rightside || (B.size(0) == A.size(1)))
     << "Non compatible matrix dimensions between inputs A and B for trmm";
 }
+
+#if (MSHADOW_USE_CBLAS != 0)
 
 #define LINALG_CPU_TRMM(fname, DType) \
 template<> inline \
@@ -374,6 +420,8 @@ void linalg_batch_trmm<xpu, DType>(const Tensor<xpu, 3, DType>& A, const Tensor<
 }
 LINALG_XPU_BATCH_TRMM(cpu, float)
 LINALG_XPU_BATCH_TRMM(cpu, double)
+
+#endif  // (MSHADOW_USE_CBLAS != 0)
 
 #ifdef __CUDACC__
 
@@ -401,7 +449,7 @@ LINALG_GPU_TRMM(Dtrmm, double)
 LINALG_XPU_BATCH_TRMM(gpu, float)
 LINALG_XPU_BATCH_TRMM(gpu, double)
 
-#endif
+#endif // __CUDACC__
 
 //////////////////////////////// POTRF ////////////////////////////////////////////
 
@@ -437,7 +485,7 @@ void linalg_batch_potrf<cpu, DType>(const Tensor<cpu, 3, DType>& A, bool lower, 
 LINALG_CPU_BATCH_POTRF(float)
 LINALG_CPU_BATCH_POTRF(double)
 
-#if MXNET_USE_CUSOLVER == 1
+#if defined(__CUDACC__) && MXNET_USE_CUSOLVER == 1
 
 #define LINALG_GPU_BUFFSIZE_POTRF(fname, DType) \
 inline int linalg_potrf_buffsize(const Tensor<gpu, 2, DType>& A, bool lower, Stream<gpu> *s) { \

--- a/src/operator/linalg_impl.h
+++ b/src/operator/linalg_impl.h
@@ -316,7 +316,7 @@ void linalg_batch_trsm<gpu, DType>(const Tensor<gpu, 3, DType>& A, const Tensor<
 LINALG_GPU_BATCH_TRSM(StrsmBatched, float)
 LINALG_GPU_BATCH_TRSM(DtrsmBatched, double)
 
-#endif // __CUDACC__
+#endif  // __CUDACC__
 
 /*!
  * \brief Performs gemm, setting alpha and beta as appropriate for `req`.
@@ -449,7 +449,7 @@ LINALG_GPU_TRMM(Dtrmm, double)
 LINALG_XPU_BATCH_TRMM(gpu, float)
 LINALG_XPU_BATCH_TRMM(gpu, double)
 
-#endif // __CUDACC__
+#endif  // __CUDACC__
 
 //////////////////////////////// POTRF ////////////////////////////////////////////
 

--- a/src/operator/spatial_transformer-inl.h
+++ b/src/operator/spatial_transformer-inl.h
@@ -35,6 +35,7 @@
 #include <string>
 #include <utility>
 #include "./operator_common.h"
+#include "./linalg.h"
 
 
 namespace mxnet {
@@ -100,7 +101,9 @@ class SpatialTransformerOp : public Operator {
     Copy(grid_dst, workspace, grid_dst.stream_);
     for (index_t batch = 0; batch < data.size(0); batch++) {
         if (param_.transform_type == st::kAffine) {
-          grid_src[batch] = dot(loc[batch], grid_dst);
+          // Legacy approach shown here for comparison:
+          //    grid_src[batch] = dot(loc[batch], grid_dst);
+          linalg_gemm(loc[batch], grid_dst, grid_src[batch], false, false, s);
         }
     }
     if (param_.sampler_type == st::kBilinear) {
@@ -133,7 +136,9 @@ class SpatialTransformerOp : public Operator {
     }
     for (index_t batch = 0; batch < data.size(0); batch++) {
         if (param_.transform_type == st::kAffine) {
-          gloc[batch] = dot(grid_src[batch], grid_dst.T());
+          // Legacy approach shown here for comparison:
+          //   gloc[batch] = dot(grid_src[batch], grid_dst.T());
+          linalg_gemm(grid_src[batch], grid_dst, gloc[batch], false, true, s);
         }
     }
   }


### PR DESCRIPTION
This substitutes linalg_gemm() for the direct use of mshadow::dot().  However, for the case where a cpu gemm is needed, but where MSHADOW_USE_CBLAS = 0, the linalg_gemm implementation still reverts to calling mshadow::dot().  Adds MIN=1 back to Jenkinsfile.  Relates to recent work of @asmushetzel and @piiswrong.