### PR TITLE
 unit test for csv iter, doc update for libsvmiter

### DIFF
--- a/docs/api/python/io.md
+++ b/docs/api/python/io.md
@@ -56,6 +56,7 @@ A detailed tutorial is available at
 
     io.NDArrayIter
     io.CSVIter
+    io.LibSVMIter
     io.ImageRecordIter
     io.ImageRecordUInt8Iter
     io.MNISTIter

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -189,6 +189,7 @@ class DataIter(object):
     --------
     NDArrayIter : Data-iterator for MXNet NDArray or numpy-ndarray objects.
     CSVIter : Data-iterator for csv data.
+    LibSVMIter : Data-iterator for libsvm data.
     ImageIter : Data-iterator for images.
     """
     def __init__(self, batch_size=0):
@@ -721,7 +722,7 @@ class MXDataIter(DataIter):
     """A python wrapper a C++ data iterator.
 
     This iterator is the Python wrapper to all native C++ data iterators, such
-    as `CSVIter, `ImageRecordIter`, `MNISTIter`, etc. When initializing
+    as `CSVIter`, `ImageRecordIter`, `MNISTIter`, etc. When initializing
     `CSVIter` for example, you will get an `MXDataIter` instance to use in your
     Python code. Calls to `next`, `reset`, etc will be delegated to the
     underlying C++ data iterators.

--- a/src/io/inst_vector.h
+++ b/src/io/inst_vector.h
@@ -169,7 +169,7 @@ struct TBlobBatch {
   }
   /*! \brief destructor */
   ~TBlobBatch() {
-    delete inst_index;
+    delete[] inst_index;
   }
 };  // struct TBlobBatch
 

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -271,7 +271,7 @@ def test_CSVIter():
 
         data_train = mx.io.CSVIter(data_csv=data_path, data_shape=(8,8),
                                    label_csv=label_path, batch_size=100)
-        expected = mx.nd.ones((100, 8,8))
+        expected = mx.nd.ones((100, 8, 8))
         for batch in iter(data_train):
             assert_almost_equal(data_train.getdata().asnumpy(), expected.asnumpy())
 

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -257,6 +257,26 @@ def test_LibSVMIter():
     check_libSVMIter_synthetic()
     check_libSVMIter_news_data()
 
+def test_CSVIter():
+    def check_CSVIter_synthetic():
+        cwd = os.getcwd()
+        data_path = os.path.join(cwd, 'data.t')
+        label_path = os.path.join(cwd, 'label.t')
+        with open(data_path, 'w') as fout:
+            for i in range(1000):
+                fout.write(','.join(['1' for _ in range(8*8)]) + '\n')
+        with open(label_path, 'w') as fout:
+            for i in range(1000):
+                fout.write('0\n')
+
+        data_train = mx.io.CSVIter(data_csv=data_path, data_shape=(8,8),
+                                   label_csv=label_path, batch_size=100)
+        expected = mx.nd.ones((100, 8,8))
+        for batch in iter(data_train):
+            assert_almost_equal(data_train.getdata().asnumpy(), expected.asnumpy())
+
+    check_CSVIter_synthetic()
+
 if __name__ == "__main__":
     test_NDArrayIter()
     if h5py:
@@ -265,3 +285,4 @@ if __name__ == "__main__":
     test_Cifar10Rec()
     test_LibSVMIter()
     test_NDArrayIter_csr()
+    test_CSVIter()


### PR DESCRIPTION
- Add the missing unit test for csv iterator. 
- Found memory for `inst_index` was allocated with `new[]` but freed with `delete` which may cause undefined behavior in test_io.py. 
- updated doc for libsvm iter
@anirudh2290 @rahul003 

Doc Preview: http://ec2-54-187-32-207.us-west-2.compute.amazonaws.com/api/python/io.html#mxnet.io.LibSVMIter