### PR TITLE
Fix build status of a image classification test

### DIFF
--- a/tests/nightly/test_image_classification.sh
+++ b/tests/nightly/test_image_classification.sh
@@ -21,6 +21,8 @@
 # setup
 export LD_LIBRARY_PATH=`pwd`/`dirname $0`/lib:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
 export PYTHONPATH=`pwd`/`dirname $0`/python
+# bc is required by sh2ju.sh
+apt-get install bc
 cd `pwd`/`dirname $0`
 . sh2ju.sh
 
@@ -59,8 +61,8 @@ juLog -name=Build -error=Error build
 # check if the final evaluation accuracy exceed the threshold
 check_val() {
     expected=$1
-    pass="Final validation >= $expected, Pass"
-    fail="Final validation < $expected, Fail"
+    pass="Final validation >= $expected, PASS"
+    fail="Final validation < $expected, FAIL"
     python ../../tools/parse_log.py log --format none | tail -n1 | \
         awk "{ if (\$3~/^[.0-9]+$/ && \$3 > $expected) print \"$pass\"; else print \"$fail\"}"
     rm -f log
@@ -88,6 +90,6 @@ test_lenet() {
        check_val $desired_accuracy
     done
 }
-juLog -name=Python.Lenet.Mnist -error=Fail test_lenet
+juLog -name=Python.Lenet.Mnist -error=FAIL test_lenet
 
 exit $errors


### PR DESCRIPTION
On a nightly build of this test, the final build status is shown as false. Example failed build is [here](http://jenkins-master-elb-1979848568.us-east-1.elb.amazonaws.com/job/ImageClassificationTests/63/console). The final status is marked as FAILED, because juLog checks for the regex match of argument -error. 'Fail' matches the output because of an opencv driver warning. More information about the driver warning is [here](https://stackoverflow.com/questions/12689304/ctypes-error-libdc1394-error-failed-to-initialize-libdc1394) . Changing this regex helps us overcome issues when this driver issue isn't fixed in the environment. 
Also installs bc which is needed by sh2ju.sh

Example successful build with the changes in this PR is [here](http://jenkins-master-elb-1979848568.us-east-1.elb.amazonaws.com/job/ImageClassificationTests/67/console) 

(Adding the driver resolution command to this test isn't a good idea because it entirely disables the driver on the instance)