### PR TITLE
Doc updates for install and doc generation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ Then use the following commands to clone and
 build the documents.
 
 ```bash
-git clone --recursive https://github.com/dmlc/mxnet
+git clone --recursive https://github.com/apache/incubator-mxnet.git
 cd mxnet && make docs
 ```
 
@@ -17,6 +17,6 @@ Note:
 
 - If C++ codes have been changed, we suggest to remove the previous results to
   trigger the rebuild for all pages, namely run `make clean_docs`.
-- If C++ codes are failed to build, run `make clean`
+- If C++ code fails to build, run `make clean`
 - If CSS or javascript are changed, we often need to do a *force refresh* in the
   browser to clear the cache.

--- a/docs/get_started/install.md
+++ b/docs/get_started/install.md
@@ -506,10 +506,6 @@ pip install graphviz
 
 The following installation instructions have been tested on OSX Sierra and El Capitan.
 
-**Prerequisites**
-
-If not already installed, [download and install Xcode](https://developer.apple.com/xcode/) (or [insall it from the App Store](https://itunes.apple.com/us/app/xcode/id497799835)) for macOS. [Xcode](https://en.wikipedia.org/wiki/Xcode) is an integrated development environment for macOS containing a suite of software development tools like C/C++ compilers, BLAS library and more.
-
 <div class="virtualenv">
 <br/>
 
@@ -643,6 +639,12 @@ mxnet/python        latest              00d026968b3c        3 weeks ago         
 </div>
 
 <div class="build-from-source">
+<br/>
+
+**Prerequisites**
+
+If not already installed, [download and install Xcode](https://developer.apple.com/xcode/) (or [insall it from the App Store](https://itunes.apple.com/us/app/xcode/id497799835)) for macOS. [Xcode](https://en.wikipedia.org/wiki/Xcode) is an integrated development environment for macOS containing a suite of software development tools like C/C++ compilers, BLAS library and more.
+
 <br/>
 
 Building *MXNet* from source is a 2 step process.


### PR DESCRIPTION
- Fixed a typo and out of date git url in the doc's readme
- Updated install prerequisites to include XCODE only in the "build from source" section on Mac.