### PR TITLE
skip failing test temporarily

### DIFF
--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -18,6 +18,7 @@
 import sys
 import os
 import time
+import unittest
 import mxnet as mx
 import numpy as np
 from mxnet.test_utils import check_consistency, set_default_context, assert_almost_equal
@@ -640,6 +641,7 @@ def test_grid_generator_with_type():
     check_consistency(sym, ctx_list)
     check_consistency(sym, ctx_list, grad_req="add")
 
+@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/7645")
 def test_spatial_transformer_with_type():
     np.random.seed(1234)
     data = mx.sym.Variable('data')


### PR DESCRIPTION
This gpu test is failing once in 3 times and causing many builds to fail. Disabling the test till it gets fixed. 

Issue regarding the test is [here](https://github.com/apache/incubator-mxnet/issues/7645)

@sandeep-krishnamurthy 