### PR TITLE
forbid setattr type changes and enable block replacement

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -175,7 +175,7 @@ class Block(object):
 
         if hasattr(self, name):
             existing = getattr(self, name)
-            if not name.startswith('_') and not isinstance(value, type(existing)):
+            if isinstance(existing, (Parameter, Block)) and not isinstance(value, type(existing)):
                 raise TypeError('Changing attribute type for {name} from {type1} to {type2}' \
                                 'is not allowed.'.format(name=name,
                                                          type1=type(existing),

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -182,7 +182,7 @@ class Block(object):
                                                          type2=type(value)))
             if isinstance(existing, Block):
                 for i, c in enumerate(self._children):
-                    if c == existing:
+                    if c is existing:
                         self._children[i] = value
         else:
             if isinstance(value, Block):

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -172,9 +172,23 @@ class Block(object):
 
     def __setattr__(self, name, value):
         """Registers parameters."""
+
+        if hasattr(self, name):
+            existing = getattr(self, name)
+            if not name.startswith('_') and not isinstance(value, type(existing)):
+                raise TypeError('Changing attribute type for {name} from {type1} to {type2}' \
+                                'is not allowed.'.format(name=name,
+                                                         type1=type(existing),
+                                                         type2=type(value)))
+            if isinstance(existing, Block):
+                for i, c in enumerate(self._children):
+                    if c == existing:
+                        self._children[i] = value
+        else:
+            if isinstance(value, Block):
+                self.register_child(value)
+
         super(Block, self).__setattr__(name, value)
-        if isinstance(value, Block):
-            self.register_child(value)
 
     def _alias(self):
         return self.__class__.__name__.lower()

--- a/python/mxnet/gluon/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/rnn/rnn_cell.py
@@ -671,7 +671,7 @@ class ZoneoutCell(ModifierCell):
         super(ZoneoutCell, self).__init__(base_cell)
         self.zoneout_outputs = zoneout_outputs
         self.zoneout_states = zoneout_states
-        self.prev_output = None
+        self._prev_output = None
 
     def __repr__(self):
         s = '{name}(p_out={zoneout_outputs}, p_state={zoneout_states}, {base_cell})'
@@ -683,14 +683,14 @@ class ZoneoutCell(ModifierCell):
 
     def reset(self):
         super(ZoneoutCell, self).reset()
-        self.prev_output = None
+        self._prev_output = None
 
     def hybrid_forward(self, F, inputs, states):
         cell, p_outputs, p_states = self.base_cell, self.zoneout_outputs, self.zoneout_states
         next_output, next_states = cell(inputs, states)
         mask = (lambda p, like: F.Dropout(F.ones_like(like), p=p))
 
-        prev_output = self.prev_output
+        prev_output = self._prev_output
         if prev_output is None:
             prev_output = F.zeros_like(next_output)
 
@@ -699,7 +699,7 @@ class ZoneoutCell(ModifierCell):
         states = ([F.where(mask(p_states, new_s), new_s, old_s) for new_s, old_s in
                    zip(next_states, states)] if p_states != 0. else next_states)
 
-        self.prev_output = output
+        self._prev_output = output
 
         return output, states
 

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import unittest
 import mxnet as mx
 from mxnet import gluon
 from mxnet.gluon import nn
@@ -367,6 +368,25 @@ def test_trainer():
     trainer.step(1)
 
     assert (x.data(mx.cpu(1)).asnumpy() == -3).all()
+
+class TestBlock(unittest.TestCase):
+    def test_block_attr(self):
+        b = gluon.Block()
+
+        # hidden variables can change types
+        b._a = None
+        b._a = 1
+
+        # regular variables can't change types
+        with self.assertRaises(TypeError) as context:
+            b.b = 1
+            b.b = (2,)
+
+        # set block attribute also sets _children
+        b.c = gluon.Block()
+        c2 = gluon.Block()
+        b.c = c2
+        assert b.c is c2 and b._children[0] is c2
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -15,11 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import unittest
 import mxnet as mx
 from mxnet import gluon
 from mxnet.gluon import nn
 import numpy as np
+from nose.tools import raises
 
 
 def test_parameter():
@@ -369,24 +369,37 @@ def test_trainer():
 
     assert (x.data(mx.cpu(1)).asnumpy() == -3).all()
 
-class TestBlock(unittest.TestCase):
-    def test_block_attr(self):
-        b = gluon.Block()
+def test_block_attr_hidden():
+    b = gluon.Block()
 
-        # hidden variables can change types
-        b._a = None
-        b._a = 1
+    # regular attributes can change types
+    b.a = None
+    b.a = 1
 
-        # regular variables can't change types
-        with self.assertRaises(TypeError) as context:
-            b.b = 1
-            b.b = (2,)
+@raises(TypeError)
+def test_block_attr_block():
+    b = gluon.Block()
 
-        # set block attribute also sets _children
-        b.c = gluon.Block()
-        c2 = gluon.Block()
-        b.c = c2
-        assert b.c is c2 and b._children[0] is c2
+    # regular variables can't change types
+    b.b = gluon.Block()
+    b.b = (2,)
+
+@raises(TypeError)
+def test_block_attr_param():
+    b = gluon.Block()
+
+    # regular variables can't change types
+    b.b = gluon.Parameter()
+    b.b = (2,)
+
+def test_block_attr_regular():
+    b = gluon.Block()
+
+    # set block attribute also sets _children
+    b.c = gluon.Block()
+    c2 = gluon.Block()
+    b.c = c2
+    assert b.c is c2 and b._children[0] is c2
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
this change includes:
1. prevent attributes whose names don't start with '_' from changing types
2. properly replace _children if both existing value and new value are blocks.