### PR TITLE
Fix shape inference bug

### DIFF
--- a/src/executor/infer_graph_attr_pass.cc
+++ b/src/executor/infer_graph_attr_pass.cc
@@ -160,7 +160,10 @@ nnvm::Graph InferAttr(nnvm::Graph &&ret,
           uint32_t eid = idx.entry_id(nid, igrad[i].index);
           if (fis_none(rshape[eid])) {
             rshape[eid] = rshape[idx.entry_id(fnode.inputs[i])];
-          } else {
+          } else if (!fis_none(rshape[idx.entry_id(fnode.inputs[i])])) {
+            // Need to skip empty forward shape, because it may not be
+            // available now and it is possible to infer the forward
+            // shape in one of the next a few passes
             CHECK_EQ(rshape[eid], rshape[idx.entry_id(fnode.inputs[i])])
                 << "Backward shape inconsistent with the forward shape";
           }


### PR DESCRIPTION
This PR fixes a shape inference bug in function `InferAttr`.
Consider the following network:
```
weight --> abs_op --> sum_op 
                             \ 
                             add_op
                             /
data   --> fc_op --> sum_op
```
Given a data shape, if the shape forward inference starts from weight, there would be several node entries with unknown shapes for  abs_op and sum_op in the first pass. The weight shape is only known after fc_op's shape inference is done. When the backward shape inference starts, it assumes that all forward node entries' shapes are known. However, this is not true in this case and therefore, leads to `CHECK_EQ` failure.

The problem is fixed by skipping `CHECK_EQ` for empty shapes in the backward shape inference.

@piiswrong @eric-haibin-lin 