### PR TITLE
Adding opencv-python so import cv2 in the tutorial will actually work

### DIFF
--- a/docs/tutorials/python/predict_image.md
+++ b/docs/tutorials/python/predict_image.md
@@ -12,7 +12,7 @@ To complete this tutorial, we need:
 - [Python Requests](http://docs.python-requests.org/en/master/), [Matplotlib](https://matplotlib.org/) and [Jupyter Notebook](http://jupyter.org/index.html).
 
 ```
-$ pip install requests matplotlib jupyter
+$ pip install requests matplotlib jupyter opencv-python
 ```
 
 ## Loading


### PR DESCRIPTION
Small fix to make the predict-image tutorial work.