### PR TITLE
fix caffe model convert leakyrelu

### DIFF
--- a/tools/caffe_converter/convert_symbol.py
+++ b/tools/caffe_converter/convert_symbol.py
@@ -170,9 +170,10 @@ def _parse_proto(prototxt_fname):
         if layer.type == 'ReLU' or layer.type == 18:
             type_string = 'mx.symbol.Activation'
             param_string = "act_type='relu'"
-            if param.negative_slope > 0:
-                type_string = 'mx.symbol.LeakyReLU'
-                param_string = "act_type='leaky', slope=%f" % param.negative_slope
+            if hasattr(param, 'negative_slope'):
+                if param.negative_slope > 0:
+                    type_string = 'mx.symbol.LeakyReLU'
+                    param_string = "act_type='leaky', slope=%f" % param.negative_slope
             need_flatten[name] = need_flatten[mapping[layer.bottom[0]]]
         if layer.type == 'TanH' or layer.type == 23:
             type_string = 'mx.symbol.Activation'

--- a/tools/caffe_converter/convert_symbol.py
+++ b/tools/caffe_converter/convert_symbol.py
@@ -170,6 +170,9 @@ def _parse_proto(prototxt_fname):
         if layer.type == 'ReLU' or layer.type == 18:
             type_string = 'mx.symbol.Activation'
             param_string = "act_type='relu'"
+            if param.negative_slope > 0:
+                type_string = 'mx.symbol.LeakyReLU'
+                param_string = "act_type='leaky', slope=%f" % param.negative_slope
             need_flatten[name] = need_flatten[mapping[layer.bottom[0]]]
         if layer.type == 'TanH' or layer.type == 23:
             type_string = 'mx.symbol.Activation'

--- a/tools/caffe_converter/convert_symbol.py
+++ b/tools/caffe_converter/convert_symbol.py
@@ -170,6 +170,7 @@ def _parse_proto(prototxt_fname):
         if layer.type == 'ReLU' or layer.type == 18:
             type_string = 'mx.symbol.Activation'
             param_string = "act_type='relu'"
+            param = layer.relu_param
             if hasattr(param, 'negative_slope'):
                 if param.negative_slope > 0:
                     type_string = 'mx.symbol.LeakyReLU'


### PR DESCRIPTION
I tried to convert an trained caffe model to mxnet, but the predict result is wrong. Finally I found what cause the error.

I had some activation define in prototxt such as:

```
layer {
    bottom: "layer23-conv"
    top: "layer23-conv"
    name: "layer23-act"
    type: "ReLU"
    relu_param {
        negative_slope: 0.1
    }
}
```

in fact, according to caffe document:  

> Given an input value x, The ReLU layer computes the output as x if x > 0 and negative_slope * x if x <= 0.

so this is `LeakyRelu`, not `relu`. but the convert tools treat this as relu, so error happen.

I fixed this error, and the result is now the same with caffe.