### PR TITLE
Add dtype to #7661 

### DIFF
--- a/python/mxnet/gluon/data/vision.py
+++ b/python/mxnet/gluon/data/vision.py
@@ -105,7 +105,7 @@ class MNIST(_DownloadedDataset):
             data = np.fromstring(fin.read(), dtype=np.uint8)
             data = data.reshape(len(label), 28, 28, 1)
 
-        self._data = nd.array(data)
+        self._data = nd.array(data, dtype=data.dtype)
         self._label = label
 
 


### PR DESCRIPTION
another thing i noticed is that now we can write:

```
def transform(data, label):
    return data.astype('float32')/255, label.astype('float32')
mnist_train = gluon.data.vision.FashionMNIST(train=True, transform=transform)
data, labe = mnist_train[0:10]
```

before PR #7661 it is not doable, because `data` in `transform` will be a list
