### PR TITLE
Fix build error C2872 on VS2015

### DIFF
--- a/src/operator/linalg_impl.h
+++ b/src/operator/linalg_impl.h
@@ -400,6 +400,7 @@ void linalg_gemm<cpu, DType>(const Tensor<cpu, 2, DType>& A, \
                              bool tA, bool tB, Stream<cpu> *s, \
                              mxnet::OpReqType req) { \
   using namespace mxnet; \
+  using mshadow::cpu; \
   switch (req) { \
     case kNullOp: \
       break; \


### PR DESCRIPTION
I find the latest version will raise a build error in VS 2015. The error Code is C2872, which reports that the `cpu` is ambiguous (either mxnet::cpu or mshadow::cpu). This PR should fix the build.