### PR TITLE
[Scala] add BucketingModule

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
@@ -420,7 +420,7 @@ abstract class BaseModule {
 
       // one epoch of training is finished
       val (name, value) = fitParams.evalMetric.get
-      logger.info(s"Epoch[$epoch] Train-$name=$value")
+      logger.info(s"Epoch[$epoch] Train-${name.head}=${value.head}")
       val toc = System.currentTimeMillis
       logger.info(s"Epoch[$epoch] Time cost=${toc - tic}")
 
@@ -438,7 +438,7 @@ abstract class BaseModule {
           scoreEndCallback = fitParams.evalEndCallback,
           batchEndCallback = fitParams.evalBatchEndCallback, epoch = epoch)
         val (name, value) = res.get
-        logger.info(s"Epoch[$epoch] Validation-$name=$value")
+        logger.info(s"Epoch[$epoch] Validation-${name.head}=${value.head}")
       })
 
       // end of 1 epoch, reset the data-iter for another epoch

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
@@ -30,7 +30,7 @@ object BaseModule {
    * Check that all input names are in symbol's arguments.
    */
   @throws(classOf[IllegalArgumentException])
-  def _checkInputNames(symbol: Symbol, names: IndexedSeq[String],
+  private[module] def _checkInputNames(symbol: Symbol, names: IndexedSeq[String],
     typeName: String, throws: Boolean, logger: Logger): Unit = {
     val args = symbol.listArguments()
     for (name <- names) {

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
@@ -22,8 +22,31 @@ import java.io.IOException
 import ml.dmlc.mxnet.optimizer.SGD
 import ml.dmlc.mxnet._
 import org.slf4j.LoggerFactory
-
+import org.slf4j.Logger
 import scala.collection.mutable.ArrayBuffer
+
+object BaseModule {
+  /**
+   * Check that all input names are in symbol's arguments.
+   */
+  @throws(classOf[IllegalArgumentException])
+  def _checkInputNames(symbol: Symbol, names: IndexedSeq[String],
+    typeName: String, throws: Boolean, logger: Logger): Unit = {
+    val args = symbol.listArguments()
+    for (name <- names) {
+      if (!args.contains(name)) {
+        val candidates = args.filter ( arg =>
+          !arg.endsWith("_weight") && !arg.endsWith("_bias")
+          && !arg.endsWith("_gamma") && !arg.endsWith("_beta"))
+        val msg = s"You created Module with Module(..., ${typeName}_names=${names.mkString})" +
+          s" but input with name \'${name}\' is not found in symbol.listArguments(). " +
+          s"Did you mean one of:\n${candidates.mkString("\n\t")}"
+        if (throws) throw new IllegalArgumentException(msg)
+        else logger.warn(msg)
+      }
+    }
+  }
+}
 
 /**
  * The base class of a modules. A module represents a computation component. The design

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BucketingModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BucketingModule.scala
@@ -1,0 +1,404 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.mxnet.module
+
+import ml.dmlc.mxnet._
+import org.slf4j.LoggerFactory
+import org.slf4j.Logger
+import scala.collection.mutable.ArrayBuffer
+import ml.dmlc.mxnet.optimizer.SGD
+import scala.collection.immutable.ListMap
+import ml.dmlc.mxnet.module.BaseModule._
+
+/**
+ * This module helps to deal efficiently with varying-length inputs.
+ * @param symGen A function when called with a bucket key, returns a triple
+ *              ``(symbol, dataNames, labelNames)``.
+ * @param defaultBucketKey The key for the default bucket.
+ * @param contexts Default is cpu().
+ * @param workLoadList Default `None`, indicating uniform workload.
+ * @param fixedParamNames Default `None`, indicating no network parameters are fixed.
+ */
+class BucketingModule(symGen: AnyRef => (Symbol, IndexedSeq[String], IndexedSeq[String]),
+                     defaultBucketKey: AnyRef, contexts: Array[Context] = Context.cpu(),
+                     workLoadList: Option[IndexedSeq[Float]] = None,
+                     fixedParamNames: Option[Set[String]] = None) extends BaseModule {
+  private val logger = LoggerFactory.getLogger(classOf[BucketingModule])
+
+  {
+    val (sym, dNames, lNames) = symGen(defaultBucketKey)
+    val dataNameList = if (dNames == null) IndexedSeq.empty[String] else dNames
+    val labelNameList = if (lNames == null) IndexedSeq.empty[String] else lNames
+    val fixedParamNameList = fixedParamNames.getOrElse(IndexedSeq.empty[String]).toIndexedSeq
+
+    _checkInputNames(sym, dataNameList, "data", true, logger)
+    _checkInputNames(sym, labelNameList, "label", false, logger)
+    _checkInputNames(sym, fixedParamNameList, "fixed_param", true, logger)
+  }
+
+  private val workLoads = workLoadList.getOrElse(contexts.map(_ => 1f).toIndexedSeq)
+  require(workLoads.size == contexts.length)
+
+  private val _buckets = scala.collection.mutable.Map[AnyRef, Module]()
+  private var _currModule: Module = null
+  private var _currBucketKey = defaultBucketKey
+
+  private var paramsDirty = false
+
+  // Internal function to reset binded state.
+  private def resetBind(): Unit = {
+    this.binded = false
+    this._buckets.clear()
+    this._currModule = null
+    this._currBucketKey = defaultBucketKey
+  }
+
+  // Symbol information
+  // A list of names for data required by this module.
+  override def dataNames: IndexedSeq[String] = {
+    if (this.binded) this._currModule.dataNames
+    else this.symGen(this.defaultBucketKey)._2
+  }
+
+  // A list of names for the outputs of this module.
+  override def outputNames: IndexedSeq[String] = {
+    if (this.binded) this._currModule.outputNames
+    else this.symGen(this.defaultBucketKey)._1.listOutputs()
+  }
+
+  // Input/Output information
+  // A list of (name, shape) pairs specifying the data inputs to this module.
+  override def dataShapes: IndexedSeq[DataDesc] = {
+    require(this.binded)
+    this._currModule.dataShapes
+  }
+
+  /**
+   * A list of (name, shape) pairs specifying the label inputs to this module.
+   * If this module does not accept labels -- either it is a module without loss
+   * function, or it is not binded for training, then this should return an empty
+   * list `[]`.
+   */
+  override def labelShapes: IndexedSeq[DataDesc] = {
+    require(this.binded)
+    this._currModule.labelShapes
+  }
+
+  // A list of (name, shape) pairs specifying the outputs of this module.
+  override def outputShapes: IndexedSeq[(String, Shape)] = {
+    require(this.binded)
+    this._currModule.outputShapes
+  }
+
+  /**
+   * Get current parameters.
+   * `(arg_params, aux_params)`, each a dictionary of name to parameters (in
+   * `NDArray`) mapping.
+   */
+  override def getParams: (Map[String, NDArray], Map[String, NDArray]) = {
+    require(binded && paramsInitialized)
+    this._currModule.paramsDirty = this.paramsDirty
+    val params = this._currModule.getParams
+    this.paramsDirty = false
+    params
+  }
+
+  /**
+   * Assign parameter and aux state values.
+   * @param argParams Dictionary of name to value (`NDArray`) mapping.
+   * @param auxParams Dictionary of name to value (`NDArray`) mapping.
+   * @param allowMissing
+   *         If true, params could contain missing values, and the initializer will be
+   *         called to fill those missing params.
+   * @param forceInit
+   *         If true, will force re-initialize even if already initialized.
+   * @param allowExtra
+   *         Whether allow extra parameters that are not needed by symbol.
+   *         If this is True, no error will be thrown when argParams or auxParams
+   *         contain extra parameters that is not needed by the executor.
+   */
+  override def setParams(argParams: Map[String, NDArray],
+                auxParams: Map[String, NDArray],
+                allowMissing: Boolean = false,
+                forceInit: Boolean = true,
+                allowExtra: Boolean = false): Unit = {
+    if (!allowMissing) {
+      this.initParams(null, argParams, auxParams, allowMissing, forceInit, allowExtra)
+    } else if (this.paramsInitialized && !forceInit) {
+      logger.warn("Parameters already initialized and forceInit=false. " +
+        "setParams call ignored.")
+    } else {
+      this._currModule.setParams(
+        argParams, auxParams, allowMissing, forceInit, allowExtra)
+
+      // because we didn't update self._arg_params, they are dirty now.
+      this.paramsDirty = true
+      this.paramsInitialized = true
+    }
+  }
+
+  /**
+   * Initialize the parameters and auxiliary states.
+   * @param initializer Called to initialize parameters if needed.
+   * @param argParams If not None, should be a dictionary of existing arg_params.
+   *                  Initialization will be copied from that.
+   * @param auxParams If not None, should be a dictionary of existing aux_params.
+   *                  Initialization will be copied from that.
+   * @param allowMissing If true, params could contain missing values,
+   *                     and the initializer will be called to fill those missing params.
+   * @param forceInit If true, will force re-initialize even if already initialized.
+   * @param allowExtra Whether allow extra parameters that are not needed by symbol.
+   *         If this is True, no error will be thrown when argParams or auxParams
+   *         contain extra parameters that is not needed by the executor.
+   */
+  override def initParams(initializer: Initializer = new Uniform(0.01f),
+                          argParams: Map[String, NDArray] = null,
+                          auxParams: Map[String, NDArray] = null,
+                          allowMissing: Boolean = false,
+                          forceInit: Boolean = false,
+                          allowExtra: Boolean = false): Unit = {
+    if (paramsInitialized && !forceInit) {
+      return
+    }
+    require(binded, "call bind before initializing the parameters")
+    this._currModule.initParams(initializer, argParams, auxParams,
+      allowMissing, forceInit, allowExtra)
+    this.paramsDirty = false
+    this.paramsInitialized = true
+  }
+
+  /**
+   * Bind the symbols to construct executors. This is necessary before one
+   * can perform computation with the module.
+   * @param dataShapes Typically is `dataIter.provideData`.
+   * @param labelShapes Typically is `dataIter.provideLabel`.
+   * @param forTraining Default is `true`. Whether the executors should be bind for training.
+   * @param inputsNeedGrad Default is `false`.
+   *                       Whether the gradients to the input data need to be computed.
+   *                       Typically this is not needed.
+   *                       But this might be needed when implementing composition of modules.
+   * @param forceRebind Default is `false`.
+   *                    This function does nothing if the executors are already binded.
+   *                    But with this `true`, the executors will be forced to rebind.
+   * @param sharedModule Default is `None`. This is used in bucketing.
+   *                     When not `None`, the shared module essentially corresponds to
+   *                     a different bucket -- a module with different symbol
+   *                     but with the same sets of parameters
+   *                     (e.g. unrolled RNNs with different lengths).
+   */
+  override def bind(dataShapes: IndexedSeq[DataDesc],
+                    labelShapes: Option[IndexedSeq[DataDesc]] = None,
+                    forTraining: Boolean = true, inputsNeedGrad: Boolean = false,
+                    forceRebind: Boolean = false, sharedModule: Option[BaseModule] = None,
+                    gradReq: String = "write"): Unit = {
+    // in case we already initialized params, keep it
+    val (argParams, auxParams) =
+      if (this.paramsInitialized) this.getParams
+      else (null, null)
+
+    // force rebinding is typically used when one want to switch from
+    // training to prediction phase.
+    if (forceRebind) this.resetBind()
+
+    if (this.binded) {
+      logger.warn("Already bound, ignoring bind()")
+      return
+    }
+
+    require(sharedModule == None,
+      "shared_module for BucketingModule is not supported")
+
+    this.forTraining = forTraining
+    this.inputsNeedGrad = inputsNeedGrad
+    this.binded = true
+
+    val (sym, dNames, lNames) = this.symGen(this.defaultBucketKey)
+    val module = new Module(sym, dNames, lNames, this.contexts,
+      this.workLoadList, this.fixedParamNames)
+    module.bind(dataShapes, labelShapes, forTraining, inputsNeedGrad,
+      forceRebind = false, sharedModule = None, gradReq)
+    this._currModule = module
+    this._currBucketKey = this.defaultBucketKey
+    this._buckets(this.defaultBucketKey) = module
+
+    // copy back saved params, if already initialized
+    if (this.paramsInitialized) {
+      this.setParams(argParams, auxParams)
+    }
+  }
+
+  /**
+   * Switches to a different bucket. This will change ``this._currModule``.
+   * @param bucketKey The key of the target bucket.
+   * @param dataShapes Typically is `dataIter.provideData`.
+   * @param labelShapes Typically is `dataIter.provideLabel`.
+   */
+  def switchBucket(bucketKey: AnyRef, dataShapes: IndexedSeq[DataDesc],
+    labelShapes: Option[IndexedSeq[DataDesc]] = None): Unit = {
+    require(this.binded, "call bind before switching bucket")
+    if (!this._buckets.contains(bucketKey)) {
+      val (sym, dNames, lNames) = this.symGen(bucketKey)
+      val module = new Module(sym, dNames, lNames, this.contexts,
+        this.workLoadList, this.fixedParamNames)
+      module.bind(dataShapes, labelShapes, this._currModule.forTraining,
+        this._currModule.inputsNeedGrad, forceRebind = false,
+        sharedModule = Option(this._buckets(this.defaultBucketKey)))
+      this._buckets(bucketKey) = module
+    }
+
+    this._currModule = this._buckets(bucketKey)
+    this._currBucketKey = bucketKey
+  }
+
+  /**
+   * Install and initialize optimizers.
+   * @param kvstore
+   * @param optimizer
+   * @param resetOptimizer Default `True`, indicating whether we should set `rescaleGrad`
+   *                       & `idx2name` for optimizer according to executorGroup
+   * @param forceInit Default `False`, indicating whether we should force re-initializing
+   *                  the optimizer in the case an optimizer is already installed.
+   */
+  override def initOptimizer(kvstore: String = "local", optimizer: Optimizer = new SGD(),
+                    resetOptimizer: Boolean = true, forceInit: Boolean = false): Unit = {
+    require(binded && paramsInitialized)
+    if (optimizerInitialized && !forceInit) {
+      logger.warn("optimizer already initialized, ignoring ...")
+    } else {
+      this._currModule.initOptimizer(kvstore, optimizer, resetOptimizer, forceInit)
+      for (mod <- this._buckets.values) {
+        if (mod != this._currModule) mod.borrowOptimizer(this._currModule)
+      }
+      this.optimizerInitialized = true
+    }
+  }
+
+  /**
+   * Prepares a data batch for forward.
+   * @param dataBatch input data
+   */
+  def prepare(dataBatch: DataBatch): Unit = {
+    // perform bind if haven't done so
+    require(this.binded && this.paramsInitialized)
+    val bucketKey = dataBatch.bucketKey
+    val originalBucketKey = this._currBucketKey
+    this.switchBucket(bucketKey, dataBatch.provideData, Option(dataBatch.provideLabel))
+    // switch back
+    this.switchBucket(originalBucketKey, null, None)
+  }
+
+  /**
+   * Forward computation.
+   * @param dataBatch input data
+   * @param isTrain Default is `None`, which means `is_train` takes the value of `for_training`.
+   */
+  override def forward(dataBatch: DataBatch, isTrain: Option[Boolean] = None): Unit = {
+    require(binded && paramsInitialized)
+    this.switchBucket(dataBatch.bucketKey, dataBatch.provideData,
+      Option(dataBatch.provideLabel))
+    this._currModule.forward(dataBatch, isTrain)
+  }
+
+  /**
+   * Backward computation.
+   * @param outGrads Gradient on the outputs to be propagated back.
+   *                 This parameter is only needed when bind is called
+   *                 on outputs that are not a loss function.
+   */
+  override def backward(outGrads: Array[NDArray] = null): Unit = {
+    require(binded && paramsInitialized)
+    this._currModule.backward(outGrads)
+  }
+
+  // Update parameters according to the installed optimizer and the gradients computed
+  // in the previous forward-backward cycle.
+  override def update(): Unit = {
+    require(binded && paramsInitialized && optimizerInitialized)
+    this.paramsDirty = true
+    this._currModule.update()
+  }
+
+  /**
+   * Get outputs of the previous forward computation.
+   * @return In the case when data-parallelism is used,
+   *         the outputs will be collected from multiple devices.
+   *         The results will look like `[[out1_dev1, out1_dev2], [out2_dev1, out2_dev2]]`,
+   *         those `NDArray` might live on different devices.
+   */
+  override def getOutputs(): IndexedSeq[IndexedSeq[NDArray]] = {
+    require(binded && paramsInitialized)
+    this._currModule.getOutputs()
+  }
+
+  /**
+   * Get outputs of the previous forward computation.
+   * @return In the case when data-parallelism is used,
+   *         the outputs will be merged from multiple devices,
+   *         as they look like from a single executor.
+   *         The results will look like `[out1, out2]`
+   */
+  override def getOutputsMerged(): IndexedSeq[NDArray] = {
+    require(binded && paramsInitialized)
+    this._currModule.getOutputsMerged()
+  }
+
+  /**
+   * Get the gradients to the inputs, computed in the previous backward computation.
+   * @return In the case when data-parallelism is used,
+   *         the grads will be collected from multiple devices.
+   *         The results will look like `[[grad1_dev1, grad1_dev2], [grad2_dev1, grad2_dev2]]`,
+   *         those `NDArray` might live on different devices.
+   */
+  override def getInputGrads(): IndexedSeq[IndexedSeq[NDArray]] = {
+    require(binded && paramsInitialized && inputsNeedGrad)
+    this._currModule.getInputGrads()
+  }
+
+  /**
+   * Get the gradients to the inputs, computed in the previous backward computation.
+   * @return In the case when data-parallelism is used,
+   *         the grads will be merged from multiple devices,
+   *         as they look like from a single executor.
+   *         The results will look like `[grad1, grad2]`
+   */
+  override def getInputGradsMerged(): IndexedSeq[NDArray] = {
+    require(binded && paramsInitialized && inputsNeedGrad)
+    this._currModule.getInputGradsMerged()
+  }
+
+  /**
+   * Evaluate and accumulate evaluation metric on outputs of the last forward computation.
+   * @param evalMetric
+   * @param labels
+   */
+  override def updateMetric(evalMetric: EvalMetric, labels: IndexedSeq[NDArray]): Unit = {
+    require(binded && paramsInitialized)
+    this._currModule.updateMetric(evalMetric, labels)
+  }
+
+  override def getSymbol: Symbol = {
+    require(binded)
+    this._currModule.symbol
+  }
+
+  // Install monitor on all executors
+  override def installMonitor(monitor: Monitor): Unit = {
+    require(binded)
+    for (mod <- this._buckets.values) mod.installMonitor(monitor)
+  }
+}

--- a/scala-package/examples/scripts/rnn/run_lstm_bucketing.sh
+++ b/scala-package/examples/scripts/rnn/run_lstm_bucketing.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+MXNET_ROOT=$(cd "$(dirname $0)/../../../.."; pwd)
+OS=$(uname)
+if [ "$OS" = "Darwin" ]; then
+  CLASS_PATH=$MXNET_ROOT/scala-package/assembly/osx-x86_64-gpu/target/*:$MXNET_ROOT/scala-package/examples/target/*:$MXNET_ROOT/scala-package/examples/target/classes/lib/*
+else
+  CLASS_PATH=$MXNET_ROOT/scala-package/assembly/linux-x86_64-gpu/target/*:$MXNET_ROOT/scala-package/examples/target/*:$MXNET_ROOT/scala-package/examples/target/classes/lib/*
+fi
+
+DATA_TRAIN=$1
+DATA_VAL=$2
+NUM_EPOCH=5
+GPUS="0"
+SAVE_MODEL_PATH=./model/lstm
+
+java -Xmx4G -cp $CLASS_PATH \
+	ml.dmlc.mxnetexamples.rnn.LstmBucketing \
+	--data-train $DATA_TRAIN \
+	--data-val $DATA_VAL \
+	--num-epoch $NUM_EPOCH \
+	--gpus $GPUS \
+	--save-model-path $SAVE_MODEL_PATH

--- a/scala-package/examples/scripts/rnn/run_lstm_bucketing.sh
+++ b/scala-package/examples/scripts/rnn/run_lstm_bucketing.sh
@@ -33,9 +33,9 @@ GPUS="0"
 SAVE_MODEL_PATH=./model/lstm
 
 java -Xmx4G -cp $CLASS_PATH \
-	ml.dmlc.mxnetexamples.rnn.LstmBucketing \
-	--data-train $DATA_TRAIN \
-	--data-val $DATA_VAL \
-	--num-epoch $NUM_EPOCH \
-	--gpus $GPUS \
-	--save-model-path $SAVE_MODEL_PATH
+  ml.dmlc.mxnetexamples.rnn.LstmBucketing \
+  --data-train $DATA_TRAIN \
+  --data-val $DATA_VAL \
+  --num-epoch $NUM_EPOCH \
+  --gpus $GPUS \
+  --save-model-path $SAVE_MODEL_PATH

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/rnn/Lstm.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/rnn/Lstm.scala
@@ -77,8 +77,8 @@ object Lstm {
                                      i2hBias = Symbol.Variable(s"l${i}_i2h_bias"),
                                      h2hWeight = Symbol.Variable(s"l${i}_h2h_weight"),
                                      h2hBias = Symbol.Variable(s"l${i}_h2h_bias")))
-      lastStatesBuf.append(LSTMState(c = Symbol.Variable(s"l${i}_init_c"),
-                                     h = Symbol.Variable(s"l${i}_init_h")))
+      lastStatesBuf.append(LSTMState(c = Symbol.Variable(s"l${i}_init_c_beta"),
+                                     h = Symbol.Variable(s"l${i}_init_h_beta")))
     }
     val paramCells = paramCellsBuf.toArray
     val lastStates = lastStatesBuf.toArray
@@ -134,8 +134,8 @@ object Lstm {
                                            i2hBias = Symbol.Variable(s"l${i}_i2h_bias"),
                                            h2hWeight = Symbol.Variable(s"l${i}_h2h_weight"),
                                            h2hBias = Symbol.Variable(s"l${i}_h2h_bias"))
-      lastStates = lastStates :+ LSTMState(c = Symbol.Variable(s"l${i}_init_c"),
-                                           h = Symbol.Variable(s"l${i}_init_h"))
+      lastStates = lastStates :+ LSTMState(c = Symbol.Variable(s"l${i}_init_c_beta"),
+                                           h = Symbol.Variable(s"l${i}_init_h_beta"))
     }
     assert(lastStates.length == numLstmLayer)
 

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/rnn/LstmBucketing.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/rnn/LstmBucketing.scala
@@ -52,6 +52,7 @@ object LstmBucketing {
   private val logger: Logger = LoggerFactory.getLogger(classOf[LstmBucketing])
 
   def perplexity(label: NDArray, pred: NDArray): Float = {
+    pred.waitToRead()
     val labelArr = label.T.toArray.map(_.toInt)
     var loss = .0
     (0 until pred.shape(0)).foreach(i =>

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/rnn/LstmBucketing.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/rnn/LstmBucketing.scala
@@ -26,6 +26,8 @@ import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.JavaConverters._
+import ml.dmlc.mxnet.module.BucketingModule
+import ml.dmlc.mxnet.module.FitParams
 
 /**
  * Bucketing LSTM examples
@@ -74,25 +76,22 @@ object LstmBucketing {
       val numEmbed = 200
       val numLstmLayer = 2
 
-      val learningRate = 0.01f
-      val momentum = 0.0f
-
       logger.info("Building vocab ...")
       val vocab = BucketIo.defaultBuildVocab(inst.dataTrain)
 
-      class BucketSymGen extends SymbolGenerator {
-        override def generate(key: AnyRef): Symbol = {
-          val seqLen = key.asInstanceOf[Int]
-          Lstm.lstmUnroll(numLstmLayer, seqLen, vocab.size,
-            numHidden = numHidden, numEmbed = numEmbed, numLabel = vocab.size)
-        }
+      def BucketSymGen(key: AnyRef):
+        (Symbol, IndexedSeq[String], IndexedSeq[String]) = {
+        val seqLen = key.asInstanceOf[Int]
+        val sym = Lstm.lstmUnroll(numLstmLayer, seqLen, vocab.size,
+          numHidden = numHidden, numEmbed = numEmbed, numLabel = vocab.size)
+        (sym, IndexedSeq("data"), IndexedSeq("softmax_label"))
       }
 
       val initC = (0 until numLstmLayer).map(l =>
-        (s"l${l}_init_c", (batchSize, numHidden))
+        (s"l${l}_init_c_beta", (batchSize, numHidden))
       )
       val initH = (0 until numLstmLayer).map(l =>
-        (s"l${l}_init_h", (batchSize, numHidden))
+        (s"l${l}_init_h_beta", (batchSize, numHidden))
       )
       val initStates = initC ++ initH
 
@@ -101,18 +100,26 @@ object LstmBucketing {
       val dataVal = new BucketSentenceIter(inst.dataVal, vocab,
         buckets, batchSize, initStates)
 
+      val model = new BucketingModule(
+        symGen = BucketSymGen,
+        defaultBucketKey = dataTrain.defaultBucketKey,
+        contexts = contexts)
+
+      val fitParams = new FitParams()
+      fitParams.setEvalMetric(
+        new CustomMetric(perplexity, name = "perplexity"))
+      fitParams.setKVStore("device")
+      fitParams.setOptimizer(
+        new SGD(learningRate = 0.01f, momentum = 0f, wd = 0.00001f))
+      fitParams.setInitializer(new Xavier(factorType = "in", magnitude = 2.34f))
+      fitParams.setBatchEndCallback(new Speedometer(batchSize, 50))
+
       logger.info("Start training ...")
-      val model = FeedForward.newBuilder(new BucketSymGen())
-        .setContext(contexts)
-        .setNumEpoch(inst.numEpoch)
-        .setOptimizer(new SGD(learningRate = learningRate, momentum = momentum, wd = 0.00001f))
-        .setInitializer(new Xavier(factorType = "in", magnitude = 2.34f))
-        .setTrainData(dataTrain)
-        .setEvalData(dataVal)
-        .setEvalMetric(new CustomMetric(perplexity, name = "perplexity"))
-        .setBatchEndCallback(new Speedometer(batchSize, 50))
-        .build()
-      model.save(inst.saveModelPath)
+      model.fit(
+        trainData = dataTrain,
+        evalData = Some(dataVal),
+        numEpoch = inst.numEpoch, fitParams)
+      logger.info("Finished training...")
     } catch {
       case ex: Exception =>
         logger.error(ex.getMessage, ex)

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/rnn/RnnModel.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/rnn/RnnModel.scala
@@ -35,9 +35,9 @@ object RnnModel {
                                                dropout)
     private val batchSize = 1
     private val initC = (for (l <- 0 until numLstmLayer)
-                          yield (s"l${l}_init_c" -> Shape(batchSize, numHidden))).toMap
+                          yield (s"l${l}_init_c_beta" -> Shape(batchSize, numHidden))).toMap
     private val initH = (for (l <- 0 until numLstmLayer)
-                          yield (s"l${l}_init_h" -> Shape(batchSize, numHidden))).toMap
+                          yield (s"l${l}_init_h_beta" -> Shape(batchSize, numHidden))).toMap
     private val dataShape = Map("data" -> Shape(batchSize))
     private val inputShape = initC ++ initH ++ dataShape
     private val executor = sym.simpleBind(ctx = ctx, shapeDict = inputShape)
@@ -49,7 +49,7 @@ object RnnModel {
     }
 
     private var stateName = (Array[String]() /: (0 until numLstmLayer)) { (acc, i) =>
-      acc :+ s"l${i}_init_c"  :+ s"l${i}_init_h"
+      acc :+ s"l${i}_init_c_beta"  :+ s"l${i}_init_h_beta"
     }
 
     private val statesDict = stateName.zip(this.executor.outputs.drop(1)).toMap

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/rnn/TrainCharRnn.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/rnn/TrainCharRnn.scala
@@ -70,8 +70,10 @@ object TrainCharRnn {
       }
 
       // initalize states for LSTM
-      val initC = for (l <- 0 until numLstmLayer) yield (s"l${l}_init_c", (batchSize, numHidden))
-      val initH = for (l <- 0 until numLstmLayer) yield (s"l${l}_init_h", (batchSize, numHidden))
+      val initC = for (l <- 0 until numLstmLayer)
+        yield (s"l${l}_init_c_beta", (batchSize, numHidden))
+      val initH = for (l <- 0 until numLstmLayer)
+        yield (s"l${l}_init_h_beta", (batchSize, numHidden))
       val initStates = initC ++ initH
 
       val dataTrain = new BucketIo.BucketSentenceIter(incr.dataPath, vocab, buckets,


### PR DESCRIPTION
@javelinjs @CodingCat pls help to review, thanks.

The train log of the LstmBucketing example:
```bash
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/home/ldpe2g/Mxnet/MXNetScala/mxnet/scala-package/examples/target/classes/lib/slf4j-log4j12-1.7.7.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/home/ldpe2g/Mxnet/MXNetScala/mxnet/scala-package/assembly/linux-x86_64-gpu/target/mxnet-full_2.11-linux-x86_64-gpu-0.11.1-SNAPSHOT.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
2017-09-03 22:23:00,077 [main] [ml.dmlc.mxnet.examples.module.LstmBucketing] [INFO] - Building vocab ...
2017-09-03 22:23:01,047 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - Summary of dataset ==================
2017-09-03 22:23:01,049 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 10 : 19479 samples
2017-09-03 22:23:01,049 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 20 : 19336 samples
2017-09-03 22:23:01,049 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 30 : 12208 samples
2017-09-03 22:23:01,050 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 40 : 3962 samples
2017-09-03 22:23:01,050 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 50 : 845 samples
2017-09-03 22:23:01,050 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 60 : 160 samples
2017-09-03 22:23:01,087 [main] [MXNetJVM] [INFO] - Try loading mxnet-scala from native path.
2017-09-03 22:23:01,087 [main] [MXNetJVM] [INFO] - Try loading mxnet-scala-linux-x86_64-gpu from native path.
2017-09-03 22:23:01,087 [main] [MXNetJVM] [INFO] - Try loading mxnet-scala-linux-x86_64-cpu from native path.
2017-09-03 22:23:01,087 [main] [MXNetJVM] [WARN] - MXNet Scala native library not found in path. Copying native library from the archive. Consider installing the library somewhere in the path (for Windows: PATH, for Linux: LD_LIBRARY_PATH), or specifying by Java cmd option -Djava.library.path=[lib path].
2017-09-03 22:23:01,094 [main] [ml.dmlc.mxnet.util.NativeLibraryLoader] [INFO] - Loading libmxnet-scala.so from /lib/native/ copying to mxnet-scala
2017-09-03 22:23:01,861 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - Summary of dataset ==================
2017-09-03 22:23:01,862 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 10 : 1531 samples
2017-09-03 22:23:01,862 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 20 : 1518 samples
2017-09-03 22:23:01,862 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 30 : 980 samples
2017-09-03 22:23:01,862 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 40 : 322 samples
2017-09-03 22:23:01,862 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 50 : 65 samples
2017-09-03 22:23:01,862 [main] [ml.dmlc.mxnet.examples.module.BucketIo$BucketSentenceIter] [INFO] - bucket of len 60 : 10 samples
2017-09-03 22:23:01,952 [main] [ml.dmlc.mxnet.examples.module.LstmBucketing] [INFO] - Start training ...
2017-09-03 22:23:23,417 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [50]	Speed: 77.93 samples/sec	Train-perplexity=3411.144531
2017-09-03 22:23:41,439 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [100]	Speed: 88.78 samples/sec	Train-perplexity=1992.701172
2017-09-03 22:24:00,954 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [150]	Speed: 81.99 samples/sec	Train-perplexity=1451.561768
2017-09-03 22:24:19,145 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [200]	Speed: 87.96 samples/sec	Train-perplexity=1152.062866
2017-09-03 22:24:38,165 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [250]	Speed: 84.13 samples/sec	Train-perplexity=971.544922
2017-09-03 22:24:58,624 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [300]	Speed: 78.21 samples/sec	Train-perplexity=851.122986
2017-09-03 22:25:18,033 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [350]	Speed: 82.44 samples/sec	Train-perplexity=760.523315
2017-09-03 22:25:37,030 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [400]	Speed: 84.22 samples/sec	Train-perplexity=690.691223
2017-09-03 22:25:52,196 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [450]	Speed: 105.51 samples/sec	Train-perplexity=629.824768
2017-09-03 22:26:12,404 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [500]	Speed: 79.18 samples/sec	Train-perplexity=587.493652
2017-09-03 22:26:30,122 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [550]	Speed: 90.31 samples/sec	Train-perplexity=549.561340
2017-09-03 22:26:45,363 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [600]	Speed: 104.98 samples/sec	Train-perplexity=515.136047
2017-09-03 22:27:01,973 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [650]	Speed: 96.33 samples/sec	Train-perplexity=486.782349
2017-09-03 22:27:19,316 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [700]	Speed: 92.26 samples/sec	Train-perplexity=462.657806
2017-09-03 22:27:38,118 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [750]	Speed: 85.10 samples/sec	Train-perplexity=443.242981
2017-09-03 22:27:54,342 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [800]	Speed: 98.63 samples/sec	Train-perplexity=424.124054
2017-09-03 22:28:13,723 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [850]	Speed: 82.56 samples/sec	Train-perplexity=409.596039
2017-09-03 22:28:34,807 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [900]	Speed: 75.89 samples/sec	Train-perplexity=397.596893
2017-09-03 22:28:51,873 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [950]	Speed: 93.75 samples/sec	Train-perplexity=384.804413
2017-09-03 22:29:09,942 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1000]	Speed: 88.55 samples/sec	Train-perplexity=373.195343
2017-09-03 22:29:27,238 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1050]	Speed: 92.51 samples/sec	Train-perplexity=362.466766
2017-09-03 22:29:45,571 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1100]	Speed: 87.28 samples/sec	Train-perplexity=352.426636
2017-09-03 22:30:04,561 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1150]	Speed: 84.25 samples/sec	Train-perplexity=343.907318
2017-09-03 22:30:22,923 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1200]	Speed: 87.14 samples/sec	Train-perplexity=335.831635
2017-09-03 22:30:41,965 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1250]	Speed: 84.02 samples/sec	Train-perplexity=328.766724
2017-09-03 22:31:00,414 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1300]	Speed: 86.73 samples/sec	Train-perplexity=321.945465
2017-09-03 22:31:18,668 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1350]	Speed: 87.65 samples/sec	Train-perplexity=315.358246
2017-09-03 22:31:39,950 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1400]	Speed: 75.18 samples/sec	Train-perplexity=310.320557
2017-09-03 22:31:57,051 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1450]	Speed: 93.56 samples/sec	Train-perplexity=304.257355
2017-09-03 22:32:15,983 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1500]	Speed: 84.51 samples/sec	Train-perplexity=299.168793
2017-09-03 22:32:33,629 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1550]	Speed: 90.67 samples/sec	Train-perplexity=294.000275
2017-09-03 22:32:50,973 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1600]	Speed: 92.26 samples/sec	Train-perplexity=288.859192
2017-09-03 22:33:09,909 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1650]	Speed: 84.50 samples/sec	Train-perplexity=284.489929
2017-09-03 22:33:25,946 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [1700]	Speed: 99.77 samples/sec	Train-perplexity=279.440613
2017-09-03 22:33:42,917 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Train-perplexity=275.87402
2017-09-03 22:33:42,918 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Time cost=640295
2017-09-03 22:34:31,864 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[0] Validation-perplexity=135.74944
2017-09-03 22:34:52,242 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [50]	Speed: 79.21 samples/sec	Train-perplexity=149.827713
2017-09-03 22:35:10,406 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [100]	Speed: 88.09 samples/sec	Train-perplexity=141.559311
2017-09-03 22:35:30,007 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [150]	Speed: 81.63 samples/sec	Train-perplexity=140.457932
2017-09-03 22:35:47,977 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [200]	Speed: 89.04 samples/sec	Train-perplexity=136.181244
2017-09-03 22:36:07,003 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [250]	Speed: 84.10 samples/sec	Train-perplexity=136.614304
2017-09-03 22:36:27,666 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [300]	Speed: 77.43 samples/sec	Train-perplexity=138.839371
2017-09-03 22:36:47,304 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [350]	Speed: 81.48 samples/sec	Train-perplexity=138.929733
2017-09-03 22:37:06,063 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [400]	Speed: 85.29 samples/sec	Train-perplexity=138.329239
2017-09-03 22:37:21,321 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [450]	Speed: 104.86 samples/sec	Train-perplexity=133.660614
2017-09-03 22:37:41,310 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [500]	Speed: 80.04 samples/sec	Train-perplexity=134.786667
2017-09-03 22:37:59,160 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [550]	Speed: 89.64 samples/sec	Train-perplexity=133.518814
2017-09-03 22:38:14,416 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [600]	Speed: 104.89 samples/sec	Train-perplexity=130.510941
2017-09-03 22:38:31,438 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [650]	Speed: 94.00 samples/sec	Train-perplexity=128.771240
2017-09-03 22:38:48,702 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [700]	Speed: 92.68 samples/sec	Train-perplexity=127.466934
2017-09-03 22:39:07,420 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [750]	Speed: 85.48 samples/sec	Train-perplexity=127.654953
2017-09-03 22:39:23,879 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [800]	Speed: 97.21 samples/sec	Train-perplexity=126.170967
2017-09-03 22:39:43,467 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [850]	Speed: 81.68 samples/sec	Train-perplexity=126.689476
2017-09-03 22:40:04,779 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [900]	Speed: 75.08 samples/sec	Train-perplexity=127.866859
2017-09-03 22:40:22,307 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [950]	Speed: 91.28 samples/sec	Train-perplexity=127.413704
2017-09-03 22:40:40,799 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1000]	Speed: 86.52 samples/sec	Train-perplexity=126.988014
2017-09-03 22:40:58,185 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1050]	Speed: 92.03 samples/sec	Train-perplexity=126.445763
2017-09-03 22:41:16,609 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1100]	Speed: 86.84 samples/sec	Train-perplexity=125.787125
2017-09-03 22:41:35,430 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1150]	Speed: 85.02 samples/sec	Train-perplexity=125.664368
2017-09-03 22:41:53,563 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1200]	Speed: 88.24 samples/sec	Train-perplexity=125.385033
2017-09-03 22:42:12,418 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1250]	Speed: 84.86 samples/sec	Train-perplexity=125.397980
2017-09-03 22:42:31,169 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1300]	Speed: 85.33 samples/sec	Train-perplexity=125.195595
2017-09-03 22:42:49,496 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1350]	Speed: 87.30 samples/sec	Train-perplexity=124.862335
2017-09-03 22:43:10,928 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1400]	Speed: 74.65 samples/sec	Train-perplexity=125.385269
2017-09-03 22:43:27,795 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1450]	Speed: 94.87 samples/sec	Train-perplexity=124.727852
2017-09-03 22:43:46,464 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1500]	Speed: 85.70 samples/sec	Train-perplexity=124.616035
2017-09-03 22:44:04,330 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1550]	Speed: 89.56 samples/sec	Train-perplexity=124.209824
2017-09-03 22:44:21,333 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1600]	Speed: 94.10 samples/sec	Train-perplexity=123.627563
2017-09-03 22:44:40,098 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1650]	Speed: 85.27 samples/sec	Train-perplexity=123.456902
2017-09-03 22:44:55,869 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [1700]	Speed: 101.46 samples/sec	Train-perplexity=122.525131
2017-09-03 22:45:12,977 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Train-perplexity=122.39102
2017-09-03 22:45:12,977 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Time cost=641113
2017-09-03 22:46:02,314 [main] [ml.dmlc.mxnet.module.BaseModule] [INFO] - Epoch[1] Validation-perplexity=111.50342
2017-09-03 22:46:22,804 [main] [ml.dmlc.mxnet.Callback$Speedometer] [INFO] - Epoch[2] Batch [50]	Speed: 78.79 samples/sec	Train-perplexity=124.892357
```

