### PR TITLE
The order of hue composed transformation

### DIFF
--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -727,11 +727,11 @@ class HueJitterAug(Augmenter):
         https://beesbuzz.biz/code/hsv_color_transforms.php
         """
         alpha = random.uniform(-self.hue, self.hue)
-        vsu = np.cos(alpha * np.pi)
-        vsw = np.sin(alpha * np.pi)
+        u = np.cos(alpha * np.pi)
+        w = np.sin(alpha * np.pi)
         bt = np.array([[1.0, 0.0, 0.0],
-                       [0.0, vsu, -vsw],
-                       [0.0, vsw, vsu]])
+                       [0.0, u, -w],
+                       [0.0, w, u]])
         t = np.dot(np.dot(self.ityiq, bt), self.tyiq).T
         src = nd.dot(src, nd.array(t))
         return src

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -732,7 +732,7 @@ class HueJitterAug(Augmenter):
         bt = np.array([[1.0, 0.0, 0.0],
                        [0.0, vsu, -vsw],
                        [0.0, vsw, vsu]])
-        t = np.dot(np.dot(self.tyiq, bt), self.ityiq).T
+        t = np.dot(np.dot(self.ityiq, bt), self.tyiq).T
         src = nd.dot(src, nd.array(t))
         return src
 


### PR DESCRIPTION
was incorrect. 
According to https://beesbuzz.biz/code/hsv_color_transforms.php
The final composed transform should be T_hsv  = T_rgb * T_H * T_S *  T_V * T_YIQ
translating to
        t = np.dot(np.dot(self.ityiq, bt), self.tyiq).T

With this correction, you can also change hue and saturation at the same time as  in https://beesbuzz.biz/code/hsv_color_transforms.php. 
For example:
        su = alpha_s * np.cos(alpha_h * np.pi)
        sw = alpha_s * np.sin(alpha_h * np.pi)
        bt = np.array([[alpha_v, 0.0, 0.0],
                       [0.0, su, -sw],
                       [0.0, sw, su]])
        t = np.dot(np.dot(self.ityiq, bt), self.tyiq).T
        src = nd.dot(src, nd.array(t))
        return src