### PR TITLE
Dist kvstore bug fix 

### DIFF
--- a/include/mxnet/kvstore.h
+++ b/include/mxnet/kvstore.h
@@ -184,7 +184,7 @@ class KVStore {
    */
   virtual void PullRowSparse(const std::vector<int>& str_keys,
                              const std::vector<std::pair<NDArray*, NDArray>>& val_rowids,
-                             const int priority = 0) = 0;
+                             int priority = 0) = 0;
 
   /*!
    * \brief pull a list of key-value pairs from the store, where each key is a string.
@@ -196,7 +196,7 @@ class KVStore {
    */
   virtual void PullRowSparse(const std::vector<std::string>& str_keys,
                              const std::vector<std::pair<NDArray*, NDArray>>& val_rowids,
-                             const int priority = 0) = 0;
+                             int priority = 0) = 0;
 
   /**
    * \brief the prototype of user-defined updater

--- a/src/kvstore/kvstore_dist_server.h
+++ b/src/kvstore/kvstore_dist_server.h
@@ -339,6 +339,7 @@ class KVStoreDistServer {
       auto len = unit_len * num_rows;
       // concat values
       response.vals.resize(len);
+      #pragma omp parallel for
       for (size_t i = 1; i <= num_rows; i++) {
         int key = DecodeKey(req_data.keys[i]);
         int64_t row_id = key - master_key;

--- a/src/kvstore/kvstore_local.h
+++ b/src/kvstore/kvstore_local.h
@@ -67,7 +67,7 @@ class KVStoreLocal : public KVStore {
   void Init(const std::vector<int>& keys,
             const std::vector<NDArray>& values) override {
     SetKeyType(kIntKey);
-    Init_(keys, values);
+    InitImpl(keys, values);
   }
 
   void Init(const std::vector<std::string>& str_keys,
@@ -84,28 +84,28 @@ class KVStoreLocal : public KVStore {
       reverse_str_key_dict_[key] = str_key;
       keys[i] = key;
     }
-    Init_(keys, values);
+    InitImpl(keys, values);
   }
 
   void Push(const std::vector<int>& keys,
             const std::vector<NDArray>& values,
             int priority) override {
     SetKeyType(kIntKey);
-    Push_(keys, values, priority);
+    PushImpl(keys, values, priority);
   }
 
   void Pull(const std::vector<int>& keys,
             const std::vector<NDArray*>& values,
             int priority) override {
     SetKeyType(kIntKey);
-    Pull_(keys, values, priority);
+    PullImpl(keys, values, priority);
   }
 
   void PullRowSparse(const std::vector<int>& keys,
                      const std::vector<std::pair<NDArray*, NDArray>>& val_rowids,
                      int priority = 0) override {
     SetKeyType(kIntKey);
-    PullRowSparse_(keys, val_rowids, priority);
+    PullRowSparseImpl(keys, val_rowids, priority);
   }
 
   void Push(const std::vector<std::string>& str_keys,
@@ -114,7 +114,7 @@ class KVStoreLocal : public KVStore {
     SetKeyType(kStringKey);
     std::vector<int> keys(str_keys.size());
     LookupKeys(str_keys, &keys);
-    Push_(keys, values, priority);
+    PushImpl(keys, values, priority);
   }
 
   void Pull(const std::vector<std::string>& str_keys,
@@ -123,21 +123,21 @@ class KVStoreLocal : public KVStore {
     SetKeyType(kStringKey);
     std::vector<int> keys(str_keys.size());
     LookupKeys(str_keys, &keys);
-    Pull_(keys, values, priority);
+    PullImpl(keys, values, priority);
   }
 
   void PullRowSparse(const std::vector<std::string>& str_keys,
                      const std::vector<std::pair<NDArray*, NDArray>>& val_rowids,
-                     const int priority = 0) override {
+                     int priority = 0) override {
     SetKeyType(kStringKey);
     std::vector<int> keys(str_keys.size());
     LookupKeys(str_keys, &keys);
-    PullRowSparse_(keys, val_rowids, priority);
+    PullRowSparseImpl(keys, val_rowids, priority);
   }
 
  private:
-  void Init_(const std::vector<int>& keys,
-             const std::vector<NDArray>& values) {
+  virtual void InitImpl(const std::vector<int>& keys,
+                        const std::vector<NDArray>& values) {
     for (size_t i = 0; i < keys.size(); ++i) {
       CHECK(local_.find(keys[i]) == local_.end())
           << "duplicate init of key " << keys[i];
@@ -146,9 +146,9 @@ class KVStoreLocal : public KVStore {
     }
   }
 
-  void Push_(const std::vector<int>& keys,
-             const std::vector<NDArray>& values,
-             int priority) {
+  virtual void PushImpl(const std::vector<int>& keys,
+                        const std::vector<NDArray>& values,
+                        int priority) {
     std::vector<int> uniq_keys;
     std::vector<std::vector<NDArray> > grouped_vals;
     GroupKVPairsPush(keys, values, &uniq_keys, &grouped_vals);
@@ -185,9 +185,9 @@ class KVStoreLocal : public KVStore {
     }
   }
 
-  void Pull_(const std::vector<int>& keys,
-             const std::vector<NDArray*>& values,
-             int priority) {
+  virtual void PullImpl(const std::vector<int>& keys,
+                        const std::vector<NDArray*>& values,
+                        int priority) {
     std::vector<int> uniq_keys;
     std::vector<std::vector<NDArray*> > grouped_vals;
     GroupKVPairsPull(keys, values, &uniq_keys, &grouped_vals);
@@ -200,9 +200,9 @@ class KVStoreLocal : public KVStore {
     }
   }
 
-  void PullRowSparse_(const std::vector<int>& keys,
-                      const std::vector<std::pair<NDArray*, NDArray>>& val_rowids,
-                      int priority = 0) {
+  virtual void PullRowSparseImpl(const std::vector<int>& keys,
+                                 const std::vector<std::pair<NDArray*, NDArray>>& val_rowids,
+                                 int priority = 0) {
     std::vector<int> uniq_keys;
     std::vector<std::vector<std::pair<NDArray*, NDArray>>> grouped_val_rowids;
     GroupKVPairsPullRsp(keys, val_rowids, &uniq_keys, &grouped_val_rowids);


### PR DESCRIPTION
- rename Pull_/Push_/RowSparsePull_  to `PxxxImpl` and make them `virtual` so that `KvstoreDist::Push(str_key)` will eventually call `KvstoreDist::PushImpl` instead of KvstoreLocal::PushImpl. Previously it always calls functions in KvstoreLocal. 
- parallel memcpy for row_sparse_pull on dist_server. Improves row_sparse_pull performance by ~30%