### PR TITLE
Changing each task timeout from 60minutes to 120minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ mx_lib = 'lib/libmxnet.so, lib/libmxnet.a, dmlc-core/libdmlc.a, nnvm/lib/libnnvm
 // command to start a docker container
 docker_run = 'tests/ci_build/ci_build.sh'
 // timeout in minutes
-max_time = 60
+max_time = 120
 // assign any caught errors here
 err = null
 


### PR DESCRIPTION
@madjam @gautamkmr 
Increased the max_time from 60 mins to 120 minutes for each task in the Jenkinsfile since some build jobs fail due to a timeout. 
Moving forward, The plan is to analyze the exact time it takes for each task in the Jenkins Job and modify these timeouts accordingly.