### PR TITLE
Fix Jenkins R gpu compilation failure

### DIFF
--- a/tests/ci_build/install/ubuntu_install_r.sh
+++ b/tests/ci_build/install/ubuntu_install_r.sh
@@ -24,5 +24,5 @@ gpg --keyserver keyserver.ubuntu.com --recv-key E084DAB9
 gpg -a --export E084DAB9 | apt-key add -
 
 apt-get update
-apt-get install -y r-base r-base-dev libxml2-dev libssl-dev
+apt-get install -y r-base r-base-dev libxml2-dev libssl-dev libxt-dev
 


### PR DESCRIPTION
xlib-backend.c:34:74: fatal error: X11/Intrinsic.h: No such file or directory
#include <X11/Intrinsic.h> /*-> Xlib.h Xutil.h Xresource.h .. */
^
compilation terminated.
make[1]: *** [xlib-backend.o] Error 1
make[1]: Leaving directory `/tmp/RtmpgjTXsi/R.INSTALLbad63cf92901/Cairo/src'
ERROR: compilation failed for package 'Cairo'

Fixing by installing necessary dependencies: libxt-dev