### PR TITLE
Implement Khatri-Rao operator

### DIFF
--- a/src/operator/c_lapack_api.h
+++ b/src/operator/c_lapack_api.h
@@ -149,22 +149,6 @@ inline void flip(int m, int n, DType *b, int ldb, DType *a, int lda) {
       b[j * ldb + i] = a[i * lda + j];
 }
 
-template <>
-inline void flip<cpu, float>(int m, int n,
-  float *b, int ldb, float *a, int lda) {
-  for (int i = 0; i < m; ++i)
-    for (int j = 0; j < n; ++j)
-      b[j * ldb + i] = a[i * lda + j];
-}
-
-template <>
-inline void flip<cpu, double>(int m, int n,
-  double *b, int ldb, double *a, int lda) {
-  for (int i = 0; i < m; ++i)
-    for (int j = 0; j < n; ++j)
-      b[j * ldb + i] = a[i * lda + j];
-}
-
 
 #if (MSHADOW_USE_MKL && MXNET_USE_LAPACK)
 

--- a/src/operator/c_lapack_api.h
+++ b/src/operator/c_lapack_api.h
@@ -143,7 +143,11 @@ inline char loup(char uplo, bool invert) { return invert ? (uplo == 'U' ? 'L' : 
  * \param lda leading dimension of a
  */
 template <typename xpu, typename DType>
-inline void flip(int m, int n, DType *b, int ldb, DType *a, int lda);
+inline void flip(int m, int n, DType *b, int ldb, DType *a, int lda) {
+  for (int i = 0; i < m; ++i)
+    for (int j = 0; j < n; ++j)
+      b[j * ldb + i] = a[i * lda + j];
+}
 
 template <>
 inline void flip<cpu, float>(int m, int n,

--- a/src/operator/contrib/krprod.cc
+++ b/src/operator/contrib/krprod.cc
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+n * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+/*!
+ *  \file krprod.cc
+ *  \brief Operator registration for Khatri-Rao product
+ *  \author Chris Swierczewski
+ */
+
+#include <mshadow/tensor.h>
+#include <mxnet/op_attr_types.h>
+#include <mxnet/operator_util.h>
+#include <vector>
+#include <algorithm>
+#include "../mshadow_op.h"
+#include "../mxnet_op.h"
+#include "../operator_common.h"
+#include "../elemwise_op_common.h"
+#include "krprod.h"
+#include "../../ndarray/ndarray_function.h"
+
+namespace mxnet {
+namespace op {
+
+DMLC_REGISTER_PARAMETER(KhatriRaoParam);
+
+NNVM_REGISTER_OP(khatri_rao)
+.describe(R"code(Computes the Khatri-Rao product of the input matrices.
+
+Given a collection of :math:`n` input matrices,
+
+.. math::
+   A_1 \in \mathbb{R}^{M_1 \times M}, \ldots, A_n \in \mathbb{R}^{M_n \times N},
+
+the (column-wise) Khatri-Rao product is defined as the matrix,
+
+.. math::
+   X = A_1 \otimes \cdots \otimes A_n \in \mathbb{R}^{(M_1 \cdots M_n) \times N},
+
+where the :math:`k`th column is equal to the column-wise outer product
+:math:`{A_1}_k \otimes \cdots \otimes {A_n}_k` where :math:`{A_i}_k` is the kth
+column of the ith matrix.
+
+When the flag `row_wise` is set to `True` the row-wise Khatri-Rao product is
+performed. This operation is more memory efficient.
+
+Example::
+
+  >>> A = mx.nd.array([[1, -1],
+  >>>                  [2, -3]])
+  >>> B = mx.nd.array([[1, 4],
+  >>>                  [2, 5],
+  >>>                  [3, 6]])
+  >>> C = mx.nd.khatri_rao(A, B)
+  >>> print(C.asnumpy())
+  [[  1.  -4.]
+   [  2.  -5.]
+   [  3.  -6.]
+   [  2. -12.]
+   [  4. -15.]
+   [  6. -18.]]
+
+)code" ADD_FILELINE)
+.set_attr_parser(ParamParser<KhatriRaoParam>)
+.set_num_inputs([](const nnvm::NodeAttrs& attrs) {
+    uint32_t ret = dmlc::get<KhatriRaoParam>(attrs.parsed).num_args;
+    return ret;
+  })
+.set_num_outputs(1)
+.set_attr<nnvm::FInferShape>("FInferShape", KhatriRaoShape)
+.set_attr<nnvm::FInferType>("FInferType",
+  [](const nnvm::NodeAttrs& attrs,
+     std::vector<int> *in_attrs,
+     std::vector<int> *out_attrs) {
+    return ElemwiseAttr<int, type_is_none, type_assign, true, type_string>(
+      attrs, in_attrs, out_attrs, -1);
+  })
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    uint32_t num_args = dmlc::get<KhatriRaoParam>(attrs.parsed).num_args;
+    std::vector<std::string> ret;
+    for (uint32_t i = 0; i < num_args; ++i)
+      ret.push_back(std::string("arg") + std::to_string(i));
+    return ret;
+  })
+.set_attr<FCompute>("FCompute<cpu>", KhatriRaoCompute<cpu>)
+.set_attr<std::string>("key_var_num_args", "num_args")
+.add_argument("args", "NDArray-or-Symbol[]", "Positional input matrices")
+.add_arguments(KhatriRaoParam::__FIELDS__());
+
+
+} // namespace op
+} // namespace mxnet

--- a/src/operator/contrib/krprod.h
+++ b/src/operator/contrib/krprod.h
@@ -21,7 +21,7 @@
  *  Copyright (c) 2017 by Contributors
  *  \file krprod.h
  *  \brief Core function for Khatri-Rao product
- *  \author Jencir Lee
+ *  \author Jencir Lee, Chris Swierczewski
  */
 #ifndef MXNET_OPERATOR_CONTRIB_KRPROD_H_
 #define MXNET_OPERATOR_CONTRIB_KRPROD_H_
@@ -245,6 +245,90 @@ inline void inv_khatri_rao
   FreeSpace(&hadamard_prod);
   if (info != 0)
     LOG(FATAL) << "The linear solver in inv_prod() returns " << info;
+}
+
+
+struct KhatriRaoParam : public dmlc::Parameter<KhatriRaoParam> {
+  int num_args;
+  bool row_wise = false;
+  DMLC_DECLARE_PARAMETER(KhatriRaoParam) {
+    DMLC_DECLARE_FIELD(num_args)
+      .set_lower_bound(1)
+      .describe("Number of input matrices.");
+    DMLC_DECLARE_FIELD(row_wise)
+      .set_default(false)
+      .describe("If `True`, performs the (more efficient) row-wise "
+                "Khatri-Rao product.");
+  }
+};
+
+
+inline bool KhatriRaoShape(const nnvm::NodeAttrs& attrs,
+                           std::vector<TShape> *in_attrs,
+                           std::vector<TShape> *out_attrs) {
+  CHECK_EQ(out_attrs->size(), 1);
+  CHECK_GE(in_attrs->size(), 1);
+
+  // swap the role of rows and columns if row_wise is `true`
+  const KhatriRaoParam& param = nnvm::get<KhatriRaoParam>(attrs.parsed);
+  size_t column_index = param.row_wise ? 0 : 1;
+  size_t row_index = 1^column_index;
+
+  // all input and output matrices must have the same number of rows/columns
+  // (when inputs_transposed is set to true/false)
+  int num_columns = static_cast<int>((*in_attrs)[0][column_index]);
+  int num_rows = 1;
+  for (const TShape& attr_shape : (*in_attrs)) {
+    CHECK_EQ(num_columns, static_cast<int>(attr_shape[column_index]));
+    num_rows *= attr_shape[row_index];
+  }
+
+  if (param.row_wise)
+    std::swap(num_rows, num_columns);
+  SHAPE_ASSIGN_CHECK(*out_attrs, 0, Shape2(num_rows, num_columns));
+  return true;
+}
+
+
+template<typename xpu, typename DType>
+inline void KhatriRaoCompute_(const nnvm::NodeAttrs &attrs,
+                              const OpContext &ctx,
+                              const std::vector<TBlob> &in_data,
+                              const std::vector<OpReqType> &req,
+                              const std::vector<TBlob> &out_data) {
+  using namespace mxnet_op;
+  if (req[0] == kNullOp) return;
+
+  Stream<xpu> *stream = ctx.get_stream<xpu>();
+  Tensor<xpu, 2, DType> out = out_data[0].get<xpu, 2, DType>(stream);
+  std::vector<Tensor<xpu, 2, DType> > ts_arr(in_data.size());
+  std::transform(in_data.begin(), in_data.end(), ts_arr.begin(),
+                 [&stream](TBlob blob) -> Tensor<xpu, 2, DType> {
+                   return blob.get<xpu, 2, DType>(stream);
+                 });
+
+  // the only difference between row_wise_kronecker and khatri_rao is that the
+  // latter performs a memory-level transpose of the input data before and after
+  // calling the former. skip this transposition if row_wise is set to `true`
+  const KhatriRaoParam& param = nnvm::get<KhatriRaoParam>(attrs.parsed);
+  if (param.row_wise)
+    row_wise_kronecker(out, ts_arr);
+  else
+    khatri_rao(out, ts_arr);
+}
+
+
+template<typename xpu>
+inline void KhatriRaoCompute(const nnvm::NodeAttrs &attrs,
+                             const OpContext &ctx,
+                             const std::vector<TBlob> &inputs,
+                             const std::vector<OpReqType> &req,
+                             const std::vector<TBlob> &outputs) {
+  using namespace mxnet_op;
+  CHECK_EQ(outputs.size(), 1U);
+  MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
+      KhatriRaoCompute_<xpu, DType>(attrs, ctx, inputs, req, outputs);
+  });
 }
 
 }  // namespace op

--- a/tests/python/unittest/test_contrib_krprod.py
+++ b/tests/python/unittest/test_contrib_krprod.py
@@ -26,15 +26,12 @@ from numpy.testing import assert_allclose
 def assert_mx_allclose(A, B, **kwds):
     return assert_allclose(A.asnumpy(), B.asnumpy(), **kwds)
 
+
 def test_krprod_one_input():
     A = mx.nd.arange(1,9).reshape((2,4))
     out = mx.nd.khatri_rao(A)
     assert_mx_allclose(out, A, rtol=1e-12)
 
-def test_krprod_one_input_row_wise():
-    A = mx.nd.arange(1,9).reshape((2,4))
-    out = mx.nd.khatri_rao(A, row_wise=True)
-    assert_mx_allclose(out, A, rtol=1e-12)
 
 def test_krprod_two_inputs():
     A = mx.nd.arange(1,7).reshape((3,2))
@@ -50,19 +47,6 @@ def test_krprod_two_inputs():
                             [21,32],[5,12],[15,24],[25,36],[35,48]])
     assert_mx_allclose(out, expected, rtol=1e-12)
 
-def test_krprod_two_inputs_row_wise():
-    A = mx.nd.arange(1,7).reshape((2,3))
-    B = mx.nd.arange(1,3).reshape((2,1))
-    out = mx.nd.khatri_rao(A, B, row_wise=True)
-    expected = mx.nd.array([[1,2,3],[8,10,12]])
-    assert_mx_allclose(out, expected, rtol=1e-12)
-
-    A = mx.nd.arange(1,7).reshape((2,3))
-    B = mx.nd.arange(1,9).reshape((2,4))
-    out = mx.nd.khatri_rao(A, B, row_wise=True)
-    expected = mx.nd.array([[1,2,3,4,2,4,6,8,3,6,9,12],
-                            [20,24,28,32,25,30,35,40,30,36,42,48]])
-    assert_mx_allclose(out, expected, rtol=1e-12)
 
 def test_krprod_three_inputs():
     A = mx.nd.arange(1,7).reshape((3,2))
@@ -78,20 +62,4 @@ def test_krprod_three_inputs():
 
     out_BC = mx.nd.khatri_rao(B, C)
     out = mx.nd.khatri_rao(A, out_BC)
-    assert_mx_allclose(out, expected, rtol=1e-12)
-
-def test_krprod_three_inputs_row_wise():
-    A = mx.nd.arange(1,7).reshape((2,3))
-    B = mx.nd.arange(1,3).reshape((2,1))
-    C = mx.nd.arange(1,5).reshape((2,2))
-    out = mx.nd.khatri_rao(A, B, C, row_wise=True)
-    expected = mx.nd.array([[1,2,2,4,3,6],[24,32,30,40,36,48]])
-    assert_mx_allclose(out, expected, rtol=1e-12)
-
-    out_AB = mx.nd.khatri_rao(A, B, row_wise=True)
-    out = mx.nd.khatri_rao(out_AB, C, row_wise=True)
-    assert_mx_allclose(out, expected, rtol=1e-12)
-
-    out_BC = mx.nd.khatri_rao(B, C, row_wise=True)
-    out = mx.nd.khatri_rao(A, out_BC, row_wise=True)
     assert_mx_allclose(out, expected, rtol=1e-12)

--- a/tests/python/unittest/test_contrib_krprod.py
+++ b/tests/python/unittest/test_contrib_krprod.py
@@ -1,0 +1,97 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: skip-file
+
+from __future__ import print_function
+import numpy as np
+import mxnet as mx
+
+from numpy.testing import assert_allclose
+
+def assert_mx_allclose(A, B, **kwds):
+    return assert_allclose(A.asnumpy(), B.asnumpy(), **kwds)
+
+def test_krprod_one_input():
+    A = mx.nd.arange(1,9).reshape((2,4))
+    out = mx.nd.khatri_rao(A)
+    assert_mx_allclose(out, A, rtol=1e-12)
+
+def test_krprod_one_input_row_wise():
+    A = mx.nd.arange(1,9).reshape((2,4))
+    out = mx.nd.khatri_rao(A, row_wise=True)
+    assert_mx_allclose(out, A, rtol=1e-12)
+
+def test_krprod_two_inputs():
+    A = mx.nd.arange(1,7).reshape((3,2))
+    B = mx.nd.arange(1,3).reshape((1,2))
+    out = mx.nd.khatri_rao(A, B)
+    expected = mx.nd.array([[1,4],[3,8],[5,12]])
+    assert_mx_allclose(out, expected, rtol=1e-12)
+
+    A = mx.nd.arange(1,7).reshape((3,2))
+    B = mx.nd.arange(1,9).reshape((4,2))
+    out = mx.nd.khatri_rao(A, B)
+    expected = mx.nd.array([[1,4],[3,8],[5,12],[7,16],[3,8],[9,16],[15,24],
+                            [21,32],[5,12],[15,24],[25,36],[35,48]])
+    assert_mx_allclose(out, expected, rtol=1e-12)
+
+def test_krprod_two_inputs_row_wise():
+    A = mx.nd.arange(1,7).reshape((2,3))
+    B = mx.nd.arange(1,3).reshape((2,1))
+    out = mx.nd.khatri_rao(A, B, row_wise=True)
+    expected = mx.nd.array([[1,2,3],[8,10,12]])
+    assert_mx_allclose(out, expected, rtol=1e-12)
+
+    A = mx.nd.arange(1,7).reshape((2,3))
+    B = mx.nd.arange(1,9).reshape((2,4))
+    out = mx.nd.khatri_rao(A, B, row_wise=True)
+    expected = mx.nd.array([[1,2,3,4,2,4,6,8,3,6,9,12],
+                            [20,24,28,32,25,30,35,40,30,36,42,48]])
+    assert_mx_allclose(out, expected, rtol=1e-12)
+
+def test_krprod_three_inputs():
+    A = mx.nd.arange(1,7).reshape((3,2))
+    B = mx.nd.arange(1,3).reshape((1,2))
+    C = mx.nd.arange(1,5).reshape((2,2))
+    out = mx.nd.khatri_rao(A, B, C)
+    expected = mx.nd.array([[1,8],[3,16],[3,16],[9,32],[5,24],[15,48]])
+    assert_mx_allclose(out, expected, rtol=1e-12)
+
+    out_AB = mx.nd.khatri_rao(A, B)
+    out = mx.nd.khatri_rao(out_AB, C)
+    assert_mx_allclose(out, expected, rtol=1e-12)
+
+    out_BC = mx.nd.khatri_rao(B, C)
+    out = mx.nd.khatri_rao(A, out_BC)
+    assert_mx_allclose(out, expected, rtol=1e-12)
+
+def test_krprod_three_inputs_row_wise():
+    A = mx.nd.arange(1,7).reshape((2,3))
+    B = mx.nd.arange(1,3).reshape((2,1))
+    C = mx.nd.arange(1,5).reshape((2,2))
+    out = mx.nd.khatri_rao(A, B, C, row_wise=True)
+    expected = mx.nd.array([[1,2,2,4,3,6],[24,32,30,40,36,48]])
+    assert_mx_allclose(out, expected, rtol=1e-12)
+
+    out_AB = mx.nd.khatri_rao(A, B, row_wise=True)
+    out = mx.nd.khatri_rao(out_AB, C, row_wise=True)
+    assert_mx_allclose(out, expected, rtol=1e-12)
+
+    out_BC = mx.nd.khatri_rao(B, C, row_wise=True)
+    out = mx.nd.khatri_rao(A, out_BC, row_wise=True)
+    assert_mx_allclose(out, expected, rtol=1e-12)


### PR DESCRIPTION
Create an operator for the Khatri-Rao function implemented in #6567. The operator accepts a variable number of input matrix arguments as well as a flag indicating whether the Khatri-Rao product should be computed row-wise or column-wise. This option is provided because the row-wise operation is more memory efficient.

### A Note to Reviewers

This is my first time putting MXNet code up for review so please tear this code apart. I need to learn.

Additionally, I've knowingly omitted the Backwards/Gradient calculation.