### PR TITLE
check num_provided_arg_types and nullptr in simple_bind api for perl

### DIFF
--- a/src/c_api/c_api_executor.cc
+++ b/src/c_api/c_api_executor.cc
@@ -259,8 +259,10 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
   std::vector<std::string> aux_state_names = sym->ListInputNames(nnvm::Symbol::kAuxiliaryStates);
 
   // attr_dict for setting up type_dict and arg/aux ctx
+  bool has_stype_provided = provided_arg_stypes != nullptr && num_provided_arg_stypes > 0;
+  bool has_dtype_provided = provided_arg_dtypes != nullptr && num_provided_arg_dtypes > 0;
   std::unordered_map<std::string, std::unordered_map<std::string, std::string>> attr_dict;
-  if (nullptr == provided_arg_dtypes || nullptr != g2c_keys || nullptr == provided_arg_stypes) {
+  if (!has_dtype_provided || nullptr != g2c_keys || !has_stype_provided) {
     std::vector<std::tuple<std::string, std::string, std::string>> attrs =
       sym->ListAttrsRecursive();
     attr_dict.reserve(attrs.size());
@@ -271,7 +273,7 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
 
   // setup arg_dtype_map
   std::unordered_map<std::string, int> arg_dtype_map;
-  if (nullptr == provided_arg_dtypes) {  // use attr_dict
+  if (!has_dtype_provided) {  // use attr_dict
     for (const auto& arg_name : in_arg_names) {
       const auto it = attr_dict.find(arg_name);
       if (it == attr_dict.end() || !it->second.count("__dtype__")) {
@@ -288,7 +290,7 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
 
   // setup arg_stype_map
   std::unordered_map<std::string, int> arg_stype_map;
-  if (nullptr == provided_arg_stypes) {  // use attr_dict
+  if (!has_stype_provided) {  // use attr_dict
     for (const auto& arg_name : in_arg_names) {
       const auto it = attr_dict.find(arg_name);
       if (it == attr_dict.end() || !it->second.count("__storage_type__")) {

--- a/src/c_api/c_api_executor.cc
+++ b/src/c_api/c_api_executor.cc
@@ -259,10 +259,10 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
   std::vector<std::string> aux_state_names = sym->ListInputNames(nnvm::Symbol::kAuxiliaryStates);
 
   // attr_dict for setting up type_dict and arg/aux ctx
-  bool has_stype_provided = provided_arg_stypes != nullptr && num_provided_arg_stypes > 0;
-  bool has_dtype_provided = provided_arg_dtypes != nullptr && num_provided_arg_dtypes > 0;
+  const bool has_stype_provided = provided_arg_stypes != nullptr && num_provided_arg_stypes > 0;
+  const bool has_dtype_provided = provided_arg_dtypes != nullptr && num_provided_arg_dtypes > 0;
   std::unordered_map<std::string, std::unordered_map<std::string, std::string>> attr_dict;
-  if (!has_dtype_provided || nullptr != g2c_keys || !has_stype_provided) {
+  if (!has_dtype_provided || !has_stype_provided || g2c_keys != nullptr) {
     std::vector<std::tuple<std::string, std::string, std::string>> attrs =
       sym->ListAttrsRecursive();
     attr_dict.reserve(attrs.size());


### PR DESCRIPTION
In the SimpleBind CAPI, it only checks if `provided_arg_stypes == nullptr ` to know whether any stype is passed in. In Perl, however, the default value for the pointer is not nullptr but some garbage value. See the code generated for Perl, where `arg19` and `arg20` are the value for the pointers: 
```
in perl-package/AI-MXNetCAPI/mxnet_wrap.cxx 
XS(_wrap_ExecutorSimpleBind) {
  {
    SymbolHandle arg1 = (SymbolHandle) 0 ;
    ... 
    mx_uint arg18 ;
    char **arg19 = (char **) 0 ;
    int *arg20 = (int *) 0 ;
    mx_uint arg21 ;
    char **arg22 = (char **) 0 ;
    int *arg23 = (int *) 0 ;
    ... 
    mx_uint temp118 ;
    char *temp218 ;
    int temp318 ;
    unsigned int val21 ;
    int ecode21 = 0 ;
    int temp123 ;
    char *temp223 ;
    ... 

    {
      arg19 = &temp218;  // <--------- not nullptr
      arg20 = &temp318;  // <--------- not nullptr 
      arg18 = 0;
      *arg19 = NULL;
      *arg20 = 0;
      .... 
```


@cjolivier01  #7577 failed Perl test because of this. I didn't check if there are more cases like this where CAPI assumes the default value of a pointer to be nullptr. @sergeykolychev 

@reminisce @piiswrong @bhavinthaker 