### PR TITLE
Providing explicit null pointer for the provided_arg_stypes.

### DIFF
--- a/perl-package/AI-MXNetCAPI/mxnet_typemaps.i
+++ b/perl-package/AI-MXNetCAPI/mxnet_typemaps.i
@@ -822,13 +822,10 @@
 
 %typemap(in,numinputs=0) (const mx_uint num_provided_arg_stypes, const char** provided_arg_stype_names,
                           const int* provided_arg_stypes)
-                         (mx_uint temp1, char* temp2, int temp3)
 {
-    $2 = &temp2;
-    $3 = &temp3;
     $1 = 0;
-    *$2 = NULL;
-    *$3 = 0;
+    $2 = NULL;
+    $3 = NULL;
 }
 
 %typemap(in,numinputs=0) (mx_uint* num_aux_states,


### PR DESCRIPTION
@eric-haibin-lin @piiswrong @cjolivier01 
Instead of introducing a special case to C++ code to work around the bug in perl api, it's better to fix the original bug.
This makes this pull https://github.com/apache/incubator-mxnet/pull/7783 unnecessary I believe.