### PR TITLE
Optimizing the build

### DIFF
--- a/cpp-package/example/CMakeLists.txt
+++ b/cpp-package/example/CMakeLists.txt
@@ -17,11 +17,13 @@ file(GLOB_RECURSE CPP_PACKAGE_HEADERS
   "${CPP_PACKAGE_INCLUDE_DIR}/*.hpp"
   )
 
-add_custom_target(
-  cpp_package_deploy_library ALL
-  DEPENDS mxnet
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:mxnet> $<TARGET_FILE_DIR:mlp>
-)
+if (MSVC)
+ add_custom_target(
+   cpp_package_deploy_library ALL
+   DEPENDS mxnet
+   COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:mxnet> $<TARGET_FILE_DIR:mlp>
+ )
+endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,13 @@ if(GTEST_FOUND)
 
   include_directories(cpp/include)
 
+  if (NOT PRIVATE_RUNTIME_DIR)
+   set(PRIVATE_RUNTIME_DIR CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+  endif()
+
   add_executable(${PROJECT_NAME}_unit_tests ${UNIT_TEST_SOURCE})
+  set_property(TARGET ${PROJECT_NAME}_unit_tests
+               PROPERTY RUNTIME_OUTPUT_DIRECTORY ${PRIVATE_RUNTIME_DIR})
 
   if(UNITTEST_STATIC_LINK)
     target_link_libraries(${PROJECT_NAME}_unit_tests


### PR DESCRIPTION
1. Move the MSVC specific code under condition
2. Created a private ephemeral location so that build size can be reduced by utilizing that location.