### PR TITLE
Fix _arange start and stop arguments default and required settings

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -1679,6 +1679,12 @@ def arange(start, stop=None, step=1.0, repeat=1, ctx=None, dtype=mx_real_t):
     """
     if ctx is None:
         ctx = Context.default_ctx
+
+    # in case of mx.nd.arange(x) stop is set to x and start is set to 0
+    if stop is None:
+        stop = start
+        start = 0
+
     return _internal._arange(start=start, stop=stop, step=step, repeat=repeat,
                              dtype=dtype, ctx=str(ctx))
 # pylint: enable= no-member, protected-access, too-many-arguments

--- a/src/operator/tensor/init_op.h
+++ b/src/operator/tensor/init_op.h
@@ -70,9 +70,9 @@ struct RangeParam : public dmlc::Parameter<RangeParam> {
   int dtype;
   DMLC_DECLARE_PARAMETER(RangeParam) {
     DMLC_DECLARE_FIELD(start)
+    .set_default(0)
     .describe("Start of interval. The interval includes this value. The default start value is 0.");
     DMLC_DECLARE_FIELD(stop)
-    .set_default(dmlc::optional<real_t>())
     .describe("End of interval. The interval does not include this value,"
               " except in some cases where step is not an integer and"
               " floating point round-off affects the length of out.");


### PR DESCRIPTION
The _arange description text differs from the configuration of defaults and required parameters.

The start parameter should be optional and be defaulting to 0. 
The stop parameter should be required and not be marked as optional.