### PR TITLE
correct file path for API reference auto index

### DIFF
--- a/docs/api/python/gluon.md
+++ b/docs/api/python/gluon.md
@@ -197,7 +197,6 @@ in Python and then deploy with symbolic graph in C++ and Scala.
     Dataset
     ArrayDataset
     RecordFileDataset
-    ImageRecordDataset
 ```
 
 ```eval_rst
@@ -230,6 +229,7 @@ in Python and then deploy with symbolic graph in C++ and Scala.
     MNIST
     FashionMNIST
     CIFAR10
+    ImageRecordDataset
 ```
 
 ## Model Zoo

--- a/docs/api/python/ndarray/contrib.md
+++ b/docs/api/python/ndarray/contrib.md
@@ -53,7 +53,7 @@ In the rest of this document, we list routines provided by the `ndarray.contrib`
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 

--- a/docs/api/python/ndarray/linalg.md
+++ b/docs/api/python/ndarray/linalg.md
@@ -41,7 +41,7 @@ In the rest of this document, we list routines provided by the `ndarray.linalg` 
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 

--- a/docs/api/python/ndarray/ndarray.md
+++ b/docs/api/python/ndarray/ndarray.md
@@ -573,7 +573,7 @@ The `ndarray` package provides several classes:
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 

--- a/docs/api/python/ndarray/random.md
+++ b/docs/api/python/ndarray/random.md
@@ -40,7 +40,7 @@ In the rest of this document, we list routines provided by the `ndarray.random` 
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 

--- a/docs/api/python/ndarray/sparse.md
+++ b/docs/api/python/ndarray/sparse.md
@@ -254,7 +254,7 @@ We summarize the interface for each class in the following sections.
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 

--- a/docs/api/python/symbol/contrib.md
+++ b/docs/api/python/symbol/contrib.md
@@ -53,7 +53,7 @@ In the rest of this document, we list routines provided by the `symbol.contrib` 
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 

--- a/docs/api/python/symbol/linalg.md
+++ b/docs/api/python/symbol/linalg.md
@@ -41,7 +41,7 @@ In the rest of this document, we list routines provided by the `symbol.linalg` p
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 

--- a/docs/api/python/symbol/random.md
+++ b/docs/api/python/symbol/random.md
@@ -40,7 +40,7 @@ In the rest of this document, we list routines provided by the `symbol.random` p
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 

--- a/docs/api/python/symbol/sparse.md
+++ b/docs/api/python/symbol/sparse.md
@@ -101,7 +101,7 @@ In the rest of this document, we list sparse related routines provided by the
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 

--- a/docs/api/python/symbol/symbol.md
+++ b/docs/api/python/symbol/symbol.md
@@ -576,7 +576,7 @@ Composite multiple symbols into a new one by an operator.
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 


### PR DESCRIPTION
Preview: http://ec2-54-187-32-207.us-west-2.compute.amazonaws.com/api/python/ndarray/ndarray.html

This PR fixes the missing drop down list for API reference caused by the wrong path of the .js file. 
Also moved `ImageRecordDataset ` from `data` to `data.vision ` section. 

@szha @piiswrong @kevinthesun 