### PR TITLE
New tutorial of implementing operators in MXNet backend

### DIFF
--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -46,7 +46,7 @@ and full working examples, visit the [tutorials section](../tutorials/index.md).
 
 * [How do I contribute a patch to MXNet?](http://mxnet.io/community/contribute.html)
 
-* [How to implement operators in MXNet backend?](http://mxnet.io/how_to/add_op_in_backend.html)
+* [How do I implement operators in MXNet backend?](http://mxnet.io/how_to/add_op_in_backend.html)
 
 * [How do I create new operators in MXNet?](http://mxnet.io/how_to/new_op.html)
 

--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -46,6 +46,8 @@ and full working examples, visit the [tutorials section](../tutorials/index.md).
 
 * [How do I contribute a patch to MXNet?](http://mxnet.io/community/contribute.html)
 
+* [How to implement operators in MXNet backend?](http://mxnet.io/how_to/add_op_in_backend.html)
+
 * [How do I create new operators in MXNet?](http://mxnet.io/how_to/new_op.html)
 
 * [How do I set MXNet's environmental variables?](http://mxnet.io/how_to/env_var.html)

--- a/docs/how_to/add_op_in_backend.md
+++ b/docs/how_to/add_op_in_backend.md
@@ -3,13 +3,15 @@
 ## Introduction
 Operators are essential elements for constructing neural networks. They define mathematical formulas
 of transforming input data (tensors) to outputs. MXNet has a rich set of operators from simple ones,
-such as element-wise sum, to complicated ones, such as convolution. You may have noticed
+such as element-wise sum, to complicated ones, such as convolution, that is
+capable of constructing most of the popular neural networks. You may have noticed
 that many operators implemented in MXNet have their equivalent forms in Numpy, such as
 [repeat](https://docs.scipy.org/doc/numpy/reference/generated/numpy.repeat.html),
 [tile](https://docs.scipy.org/doc/numpy/reference/generated/numpy.tile.html),
 etc., and wonder why we could not simply use those Numpy operators in MXNet. One of the
 major reasons is that we need to support both CPU and GPU computing for the operators in MXNet,
-while Numpy operators do not have GPU computing capability. In addition, we have performed plenty of
+while Numpy operators do not possess GPU computing capability.
+In addition, we have performed plenty of
 optimizations for various components in MXNet, such as tensor data structure (`NDArray`),
 execution engine, computational graph and so on, for maximizing memory and runtime efficiency.
 An operator implemented under the MXNet operator framework would greatly
@@ -72,8 +74,8 @@ struct QuadraticParam : public dmlc::Parameter<QuadraticParam> {
 };
 ```
 
-The function calls in the above parameter struct are self-explanatory. Note that
-for each parameter, we set the default value to `0.0` such that users can
+The function calls in the above parameter struct are self-explanatory by their names.
+Note that for each parameter, we set the default value to `0.0` such that users can
 skip passing 0-value parameters through the quadratic operator interface. You
 can choose not to define the default value for a parameter if it is required
 at runtime. Meanwhile, adding brief descriptions to the parameters enables
@@ -142,9 +144,9 @@ Here are a few things to note about the above function:
 1. `attrs` contains parameters `a`, `b`, and `c` from user input.
 It's not used here since we don't rely on that information for shape inference.
 2. `in_attrs` is a vector containing all input shapes. Since there is
-only one input argument for operator `quadratic`, we use macro `CHECK_EQ`
+only one input argument for operator `quadratic`, we used macro `CHECK_EQ`
 to assert when the vector's size is wrong.
-3. `out_attrs` is a vector containing all output shapes. We also use
+3. `out_attrs` is a vector containing all output shapes. We also used
 `CHECK_EQ` to verify the size of the vector since there is only one output.
 4. We called macro `SHAPE_ASSIGN_CHECK` twice for mutual inference. One for
 inferring the output shape from the input shape, the other one is for inferring
@@ -152,7 +154,7 @@ the input shape from the output shape.
 If there are any unequal non-zero values in the same
 dimension of two shapes, such as (2, 3) and (3, 3), the macro would throw an
 exception with an error message for shape inference.
-5. At the end of the function body, we check whether the output shape
+5. At the end of the function body, we checked whether the output shape
 is completely known by testing whether its size is greater than 0. If not,
 the function should return `false` to notify the caller about shape inference failure.
 6. MXNet provides a convenience function implementing the logic of mutual inference
@@ -198,7 +200,7 @@ Forward function defines the operator's behavior in the forward pass
 of neural networks. For our `quadratic` operator, it simply implements
 the logic of running a tensor through the quadratic function by performing
 a few element-wise operations. We first paste the whole forward function code here
-and then let's go through it line by line.
+and then go through it line by line.
 ```cpp
 template<typename xpu>                                                        // 1
 void QuadraticOpForward(const nnvm::NodeAttrs& attrs,                         // 2

--- a/docs/how_to/add_op_in_backend.md
+++ b/docs/how_to/add_op_in_backend.md
@@ -517,3 +517,9 @@ struct for user-input parameters, walked through shape and type inference work f
 implemented forward and backward functions, and registered the operator
 using nnvm. Congratulations! You now know how to add operators.
 We welcome your contributions to MXNet.
+
+**Note**: Source code in the tutorial can be found in
+[quadratic_op-inl.h](https://github.com/reminisce/mxnet/blob/add_op_example_for_tutorial/src/operator/tensor/quadratic_op-inl.h),
+[quadratic_op.cc](https://github.com/reminisce/mxnet/blob/add_op_example_for_tutorial/src/operator/tensor/quadratic_op.cc),
+and
+[quadratic_op.cu](https://github.com/reminisce/mxnet/blob/add_op_example_for_tutorial/src/operator/tensor/quadratic_op.cu).

--- a/docs/how_to/add_op_in_backend.md
+++ b/docs/how_to/add_op_in_backend.md
@@ -46,8 +46,8 @@ Now let's walk through the process step by step.
 ### Parameter Registration
 We first define `struct QuadraticParam` as a placeholder for user-input
 parameters `a`, `b`, and `c` in `quadratic_op-inl.h`.
-The struct must inherit from a base template
-struct `dmlc::Parameter`, where the template argument is the derived struct
+The struct inherits from a base template
+struct called `dmlc::Parameter`, where the template argument is the derived struct
 `QuadraticParam`. This technique, which is called [curiously recurring template
 pattern](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern),
 achieves static polymorphism. It is similar to using a virtual function,
@@ -68,4 +68,101 @@ struct QuadraticParam : public dmlc::Parameter<QuadraticParam> {
       .describe("Constant term in the quadratic function.");
   }
 };
+```
+
+The function calls in the above parameter struct are self-explanatory. Note that
+for each parameter, we set the default value to 0.0 such that users can
+skip passing 0-value parameters to the quadratic operator interface. You
+can choose not to define the default value for a parameter if it is required
+at runtime. Meanwhile, adding brief descriptions to the parameters enables
+the documentation build to display them on the
+[MXNet documentation web page](https://mxnet.incubator.apache.org/api/python/index.html).
+
+### Attribute Inference
+Attribute inference means the process of deducing the properties of `NDArray`s
+in neural networks from user input information. Two most common attributes
+of `NDArray` are shape and dtype. Let's look at the following example.
+Given an input `NDArray` called `data`, you invoke the quadratic operator
+like this `output = mx.nd.quadratic(data, a=1, b=2, c=3)`. Before calculating
+the `output` values, its shape and dtype are inferred from the input
+`data`'s shape and dtype following
+the rules you defined in order to allocate memory space for the output tensor.
+
+One important thing to note that inference functions should be capable of
+performing mutual inference, for example,
+inferring input shape from output shape, inferring one argument's shape
+from another argument, etc. This is useful in building computational graphs
+for neural networks. Let's consider the following example.
+```python
+>>> import mxnet as mx
+>>> a = mx.sym.Variable('a', shape=(2, 0))
+>>> b = mx.sym.Variable('b')
+>>> c = mx.sym.Variable('c', shape=(0, 3))
+>>> d = a * b + b * c
+>>> print d.infer_shape()
+([(2L, 3L), (2L, 3L), (2L, 3L)], [(2L, 3L)], [])
+```
+In this example, we only specified values for `a`'s first dimension
+and `c`'s second dimension. The `0` in shape `(2, 0)` means the size
+of the second dimension is unknown, same for shape `(0, 3)`.
+However, the symbol `d` still successfully inferred the shapes
+for all the variables and final output. This is a result of mutual
+inference. In MXNet, the whole process can be interpreted as this:
+1. `a` and `b` are combined using an element-wise multiplication operator,
+so the shapes of `a` and `b` are same and `b`'s first dimension size is `2`.
+2. `b' and `c` are combined using an element-wise multiplication operator too,
+so the shapes of `b` and `c` are same and `b`'s second dimension size is `3`.
+3. Now `b`'s shape is completely known, so `a` and `c` missing dimension sizes
+are known as well.
+4. `d` is a result from adding `a * b` and `b * c`, so d should also
+have the same shape as `b`.
+
+The above four steps illustrate how shape inference works in MXNet. It is the
+logic implemented in the shape inference functions of operators
+element-wise multiplication and addition.
+
+For our quadratic operator, shape inference has the similar logic.
+```cpp
+inline bool QuadraticOpShape(const nnvm::NodeAttrs& attrs,
+                             std::vector<TShape>* in_attrs,
+                             std::vector<TShape>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+
+  SHAPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
+  SHAPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
+  return out_attrs->at(0).Size() != 0U; 
+}
+```
+Here are a few things to note about the above function:
+
+1. `attrs` contains parameters `a`, `b`, and `c` from user input.
+It's not used here since we don't need that information for shape inference.
+2. `in_attrs` is a vector containing all input shapes. Since there is
+only one input argument for operator `quadratic`, we use macro `CHECK_EQ`
+to assert when the vector's size is wrong.
+3. `out_attrs` is a vector containing all output shapes. We also use
+`CHECK_EQ` to verify the size of the vector since there is only one output.
+4. We called macro `SHAPE_ASSIGN_CHECK` twice for mutual inference. One for
+inferring output shape from input shape, the other one is for inferring
+input shape from output shape. If there are any unequal non-zero values in the same
+dimension of two shapes, such as (2, 3) and (3, 3), the macro would throw
+exception to generate error message for shape inference.
+5. At the end of the function body, we check whether the output shape
+is completely known by comparing whether its size is greater than 0. If not,
+the function should return 'false' to notify the caller about shape inference failure.
+
+The same logic goes for data type inference. We will leave the analysis of
+the following code sample to users.
+```
+inline bool QuadraticOpType(const nnvm::NodeAttrs& attrs,
+                            std::vector<int>* in_attrs,
+                            std::vector<int>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+
+  TYPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
+  TYPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
+  return out_attrs->at(0) != -1; 
+}
 ```

--- a/docs/how_to/add_op_in_backend.md
+++ b/docs/how_to/add_op_in_backend.md
@@ -1,0 +1,71 @@
+# A Beginner's Guide to Implementing Operators in MXNet Backend
+
+## Introduction
+Operators are essential elements for constructing neural networks. They define mathematical formulas
+of transforming input data (tensors) to outputs. MXNet has a rich set of operators from simple ones,
+such as element-wise sum, to complicated ones, such as convolution. You may have noticed
+that many operators implemented in MXNet have their equivalent forms in Numpy, such as repeat,
+tile, etc., and wonder why we could not simply use those Numpy operators in MXNet. One of the
+major reasons is that we need to support both CPU and GPU computing for the operators in MXNet,
+while Numpy operators do not have GPU computing capability. In addition, we have performed plenty of
+optimizations on various components in MXNet, such as tensor data structure (`NDArray`), execution engine,
+computational graph and so on, for maximizing memory and runtime efficiency. An operator implemented
+under the MXNet operator framework is able to greatly leverage those optimizations for exhaustive
+performance enhancement.
+
+In this tutorial, we are going to practice writing an operator using C++ in the MXNet backend. After
+finishing the implementation, we will add unit tests using Python testing the operator
+we just implemented.
+
+## Implementation
+### An Operator Example
+Let's take the [quadratic function](https://en.wikipedia.org/wiki/Quadratic_function)
+as an example: `f(x) = ax^2+bx+c`. We want to implement an operator called `quadratic`
+taking `x`, which is a tensor, as an input and generating an output tensor `y`
+satisfying `y.shape=x.shape` and each element of `y` is calculated by feeding the
+corresponding element of `x` into the quadratic function `f`.
+Here variables `a`, `b`, and `c` are user-input parameters.
+In frontend, the operator works like this:
+```python
+x = [[1, 2], [3, 4]]
+y = quadratic(data=x, a=1, b=2, c=3)
+y = [[6, 11], [18, 27]]
+```
+To implement this, we first create three files: `quadratic_op-inl.h`,
+`quadratic_op.cc`, and `quadratic_op.cu`. Then we are going to
+1. Define the paramter struct
+for registering `a`, `b`, and `c` in `quadratic_op-inl.h`.
+2. Define type and shape inference functions in `quadratic_op-inl.h`.
+3. Define forward and backward functions in `quadratic_op-inl.h`.
+4. Register the operator through the [nnvm](https://github.com/dmlc/nnvm)
+interface `quadratic_op.cc` for CPU computing and
+`quadratic_op.cu` for GPU computing.
+
+Now let's walk through the process step by step.
+
+### Parameter Registration
+We first define `struct QuadraticParam` as a placeholder for user-input
+parameters `a`, `b`, and `c` in `quadratic_op-inl.h`.
+The struct must inherit from a base template
+struct `dmlc::Parameter`, where the template argument is the derived struct
+`QuadraticParam`. This technique, which is called [curiously recurring template
+pattern](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern),
+achieves static polymorphism. It is similar to using a virtual function,
+but without the cost associated with dynamic polymorphism.
+
+```cpp
+struct QuadraticParam : public dmlc::Parameter<QuadraticParam> {
+  float a, b, c;
+  DMLC_DECLARE_PARAMETER(QuadraticParam) {
+    DMLC_DECLARE_FIELD(a)
+      .set_default(0.0)
+      .describe("Coefficient of the quadratic term in the quadratic function.");
+    DMLC_DECLARE_FIELD(b)
+      .set_default(0.0)
+      .describe("Coefficient of the linear term in the quadratic function.");
+    DMLC_DECLARE_FIELD(c)
+      .set_default(0.0)
+      .describe("Constant term in the quadratic function.");
+  }
+};
+```

--- a/docs/how_to/add_op_in_backend.md
+++ b/docs/how_to/add_op_in_backend.md
@@ -521,5 +521,6 @@ We welcome your contributions to MXNet.
 **Note**: Source code in the tutorial can be found in
 [quadratic_op-inl.h](https://github.com/reminisce/mxnet/blob/add_op_example_for_tutorial/src/operator/tensor/quadratic_op-inl.h),
 [quadratic_op.cc](https://github.com/reminisce/mxnet/blob/add_op_example_for_tutorial/src/operator/tensor/quadratic_op.cc),
+[quadratic_op.cu](https://github.com/reminisce/mxnet/blob/add_op_example_for_tutorial/src/operator/tensor/quadratic_op.cu),
 and
-[quadratic_op.cu](https://github.com/reminisce/mxnet/blob/add_op_example_for_tutorial/src/operator/tensor/quadratic_op.cu).
+[test_operator.py](https://github.com/reminisce/mxnet/blob/add_op_example_for_tutorial/tests/python/unittest/test_operator.py#L4008).

--- a/docs/how_to/add_op_in_backend.md
+++ b/docs/how_to/add_op_in_backend.md
@@ -46,9 +46,9 @@ respectively. We normally put pure tensor related operators
 the directory `src/operator/tensor`, and neural network operators
 (e.g. `Convolution`, `Pooling`, etc.) under `src/operator/nn`.
 You may have noticed that many neural network operators including
-`Convolution` and `Pooling` are saved directly under `src/operator`.
+`Convolution` and `Pooling` are currently saved under `src/operator`.
 We plan to move them to `src/operator/nn` for better file organization
-and clearer hierarchy.
+and clearer hierarchy in the future.
 
 Next, we are going to
 1. Define the parameter struct
@@ -109,7 +109,8 @@ the rules you defined in order to allocate memory space for the output tensor.
 
 One important thing to note that inference functions should be capable of
 performing **mutual inference**, i.e.
-inferring one argument's attribute from another argument's attribute.
+inferring one argument's attribute from another argument's attribute if
+possible according to the definition of the operator.
 This is very useful for a computational graph to deduce unknown attributes
 for a neural network in symbolic programming. Users can view the computational
 graph as a symbol with every element initialized for running data
@@ -194,7 +195,7 @@ the function should return `false` to notify the caller about shape inference fa
 for general element-wise operators with the following interface. Users can
 instantiate this function with `n_in=1` and `n_out=1` to replace the above
 function `QuadraticOpShape` in operator registration (explained later).
-The function `QuadraticOpShape` posted here is for illustration purpose only.
+The function `QuadraticOpShape` posted here is for the purpose of illustration only.
 ```cpp
 template<int n_in, int n_out>
 inline bool ElemwiseShape(const nnvm::NodeAttrs& attrs,
@@ -325,7 +326,7 @@ compilers. It enables CPU and GPU computing to share the same piece of code.
 into the same line of code. It's named `KERNEL_ASSIGN` because we call
 the code blocks running parallel computation kernels.
 On CPUs, the kernels are normally wrapped by the OpenMP `parallel` directive;
-while on GPUs, they the kernels launched by CUDA library.
+while on GPUs, they are the kernel functions launched by CUDA library.
 
 ```cpp
 template<int req>
@@ -514,7 +515,7 @@ of the input tensor will not be overwritten by the output.
 - Line 21: Add user input parameters `a`, `b`, and `c` as the attributes of the operator.
 - Line 22: Register an operator named `_backward_quadratic` for backward pass
 of the operator `quadratic`. The underscore prefix in the operator name indicates
-that this is an operator not exposed to frontend and only used in backend. The convention
+that this is an operator not exposed to users. The convention
 of naming an internally used backward operator is prepending the prefix `_backward_`
 to the corresponding forward operator name.
 - Line 23: Set the parameter parser for the operator `_backward_quadratic`.
@@ -540,11 +541,12 @@ NNVM_REGISTER_OP(_backward_quadratic)
 ### Unit Test
 Now we have finished implementing the operator `quadratic` in MXNet backend.
 If you use python, when you type `import mxnet as mx`, two python
-functions for calling your backend implementation are
+functions for invoking your backend implementation are
 generated on the fly: one is for imperative programming
-registered under module `mxnet.ndarray` or `mx.nd` for short;
+registered as `mxnet.ndarray.quadratic` or `mx.nd.quadratic` for short;
 the other one is for symbolic
-programming registered under module `mxnet.symbol` or `mx.sym` for short.
+programming registered under module `mxnet.symbol.quadratic`
+or `mx.sym.quadratic` for short.
 
 In order to unit test it in frontend, we need to add the following code
 to the python file `test_operator.py`. Note that while testing the
@@ -594,7 +596,7 @@ of passing incorrect expected results into `check_symbolic_backward`.
 ## Summary
 In this tutorial, we practiced implementing the operator `quadratic` in MXNet backend
 and unit testing the implementation in frontend. More specifically, we added parameter
-struct for user-input parameters, walked through shape and type inference work flow,
+struct for user-input parameters, walked through shape and type inference workflow,
 implemented forward and backward functions, and registered the operator
 using nnvm. Congratulations! You now know how to add operators.
 We welcome your contributions to MXNet.

--- a/docs/how_to/add_op_in_backend.md
+++ b/docs/how_to/add_op_in_backend.md
@@ -141,7 +141,7 @@ inline bool QuadraticOpShape(const nnvm::NodeAttrs& attrs,
 
   SHAPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
   SHAPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
-  return out_attrs->at(0).Size() != 0U;
+  return out_attrs->at(0).ndim() != 0U && out_attrs->at(0).Size() != 0U;
 }
 ```
 Here are a few things to note about the above function:

--- a/docs/how_to/add_op_in_backend.md
+++ b/docs/how_to/add_op_in_backend.md
@@ -131,7 +131,7 @@ inline bool QuadraticOpShape(const nnvm::NodeAttrs& attrs,
 
   SHAPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
   SHAPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
-  return out_attrs->at(0).Size() != 0U; 
+  return out_attrs->at(0).Size() != 0U;
 }
 ```
 Here are a few things to note about the above function:
@@ -175,7 +175,7 @@ inline bool QuadraticOpType(const nnvm::NodeAttrs& attrs,
 
   TYPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
   TYPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
-  return out_attrs->at(0) != -1; 
+  return out_attrs->at(0) != -1;
 }
 ```
 Again, MXNet provides the following convenience function for mutual
@@ -195,27 +195,27 @@ the logic of running a tensor through the quadratic function performing
 a few element-wise operations. We paste the whole forward function code here
 and let's go through it line by line.
 ```cpp
-template<typename xpu>                                                        // 1                                  
-void QuadraticOpForward(const nnvm::NodeAttrs& attrs,                         // 2                              
-                        const OpContext& ctx,                                 // 3                                  
-                        const std::vector<TBlob>& inputs,                     // 4                                  
-                        const std::vector<OpReqType>& req,                    // 5                                  
-                        const std::vector<TBlob>& outputs) {                  // 6                                  
-  CHECK_EQ(inputs.size(), 1U);                                                // 7                                  
-  CHECK_EQ(outputs.size(), 1U);                                               // 8                                  
-  CHECK_EQ(req.size(), 1U);                                                   // 9                                  
-  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();                            // 10                                  
-  const TBlob& in_data = inputs[0];                                           // 11                                  
-  const TBlob& out_data = outputs[0];                                         // 12                                  
-  const QuadraticParam& param = nnvm::get<QuadraticParam>(attrs.parsed);      // 13                                  
-  using namespace mxnet_op;                                                   // 14                                  
-  MSHADOW_TYPE_SWITCH(out_data.type_flag_, DType, {                           // 15                                  
-    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {                               // 16                                  
-      Kernel<quadratic_forward<req_type>, xpu>::Launch(                       // 17                                  
-          s, out_data.Size(), out_data.dptr<DType>(), in_data.dptr<DType>(),  // 18                                  
-          param.a, param.b, param.c);                                         // 19                                  
-    });                                                                       // 20                                  
-  });                                                                         // 21                                  
+template<typename xpu>                                                        // 1   
+void QuadraticOpForward(const nnvm::NodeAttrs& attrs,                         // 2                             
+                        const OpContext& ctx,                                 // 3                                 
+                        const std::vector<TBlob>& inputs,                     // 4                                 
+                        const std::vector<OpReqType>& req,                    // 5                                 
+                        const std::vector<TBlob>& outputs) {                  // 6                                 
+  CHECK_EQ(inputs.size(), 1U);                                                // 7                                 
+  CHECK_EQ(outputs.size(), 1U);                                               // 8                                 
+  CHECK_EQ(req.size(), 1U);                                                   // 9                                 
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();                            // 10                                 
+  const TBlob& in_data = inputs[0];                                           // 11                                 
+  const TBlob& out_data = outputs[0];                                         // 12                                 
+  const QuadraticParam& param = nnvm::get<QuadraticParam>(attrs.parsed);      // 13                                 
+  using namespace mxnet_op;                                                   // 14                                 
+  MSHADOW_TYPE_SWITCH(out_data.type_flag_, DType, {                           // 15                                 
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {                               // 16                                 
+      Kernel<quadratic_forward<req_type>, xpu>::Launch(                       // 17                                 
+          s, out_data.Size(), out_data.dptr<DType>(), in_data.dptr<DType>(),  // 18                                 
+          param.a, param.b, param.c);                                         // 19                                 
+    });                                                                       // 20                                 
+  });                                                                         // 21                                 
 }
 ```
 - Line 1: `attrs` contains the user input parameters `a`, `b`, and `c`


### PR DESCRIPTION
A new tutorial for implementing operators in MXNet backend, tailored for users interested in knowing about and contributing to MXNet C++ code base.
 
See [this link](https://github.com/reminisce/mxnet/blob/900a6997ded8f7124fc6323aa66408cb70e8253f/docs/how_to/add_op_in_backend.md) for a friendly view.

@piiswrong @eric-haibin-lin @anirudh2290 @cjolivier01 @rahul003 @madjam @bhavinthaker 