### PR TITLE
add $(USE_CUDA_PATH)/lib(64)? as linking lib search dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,8 @@ ifneq ($(ADD_LDFLAGS), NONE)
 endif
 
 ifneq ($(USE_CUDA_PATH), NONE)
-	NVCC=$(USE_CUDA_PATH)/bin/nvcc
+	NVCC = $(USE_CUDA_PATH)/bin/nvcc
+	LDFLAGS += -L$(USE_CUDA_PATH)/lib64 -L$(USE_CUDA_PATH)/lib
 endif
 
 # Sets 'CUDA_ARCH', which determines the GPU architectures supported


### PR DESCRIPTION
I got something like this on master while built with USE_CUDA and USE_CUDNN
```
/sbin/ld: cannot find -lcudnn 
/sbin/ld: cannot find -lcufft                                              
collect2: error: ld returned 1 exit status                                                                                            
make: *** [Makefile:323: lib/libmxnet.so] Error 1                                                                         
make: *** Waiting for unfinished jobs....                                                    
=====================================================[ ERROR: MXNet ]=====================================================
                                                                          
LoadError: failed process: Process(`make -j8 USE_BLAS=openblas 'MSHADOW_LDFLAGS=-lm /usr/bin/../lib/libblas.so'`, ProcessExited(2)) [2]
while loading /home/iblis/.julia/v0.6/MXNet/deps/build.jl, in expression starting on line 74

==========================================================================================================================
```