### PR TITLE
Fix missing of CUDA device on non-GPU host

### DIFF
--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -2301,7 +2301,9 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxCustomOpRegister
                   ptrsArr, (jsize)0, (jsize)size, reinterpret_cast<jlong*>(ptrs));
 #if MXNET_USE_CUDA
                 mxnet::NDArray* tmp = reinterpret_cast<mxnet::NDArray*>(ptrs[0]);
-                CUDA_CALL(cudaSetDevice(tmp->ctx().dev_id));
+                if (tmp->ctx().dev_type != mxnet::Context::kCPU) {
+                  CUDA_CALL(cudaSetDevice(tmp->ctx().dev_id));
+                }
 #endif
                 bool is_train =  true;
                 if (isTrain == 0) is_train = false;

--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -2301,7 +2301,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxCustomOpRegister
                   ptrsArr, (jsize)0, (jsize)size, reinterpret_cast<jlong*>(ptrs));
 #if MXNET_USE_CUDA
                 mxnet::NDArray* tmp = reinterpret_cast<mxnet::NDArray*>(ptrs[0]);
-                if (tmp->ctx().dev_type != mxnet::Context::kCPU) {
+                if (tmp->ctx().dev_type == mxnet::Context::kGPU
+                  || tmp->ctx().dev_type == mxnet::Context::kCPUPinned) {
                   CUDA_CALL(cudaSetDevice(tmp->ctx().dev_id));
                 }
 #endif

--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -2301,8 +2301,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxCustomOpRegister
                   ptrsArr, (jsize)0, (jsize)size, reinterpret_cast<jlong*>(ptrs));
 #if MXNET_USE_CUDA
                 mxnet::NDArray* tmp = reinterpret_cast<mxnet::NDArray*>(ptrs[0]);
-                if (tmp->ctx().dev_type == mxnet::Context::kGPU
-                  || tmp->ctx().dev_type == mxnet::Context::kCPUPinned) {
+                if (tmp->ctx().dev_type == mxnet::Context::kGPU || tmp->ctx().dev_type == mxnet::Context::kCPUPinned) {
                   CUDA_CALL(cudaSetDevice(tmp->ctx().dev_id));
                 }
 #endif

--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -2301,7 +2301,8 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxCustomOpRegister
                   ptrsArr, (jsize)0, (jsize)size, reinterpret_cast<jlong*>(ptrs));
 #if MXNET_USE_CUDA
                 mxnet::NDArray* tmp = reinterpret_cast<mxnet::NDArray*>(ptrs[0]);
-                if (tmp->ctx().dev_type == mxnet::Context::kGPU || tmp->ctx().dev_type == mxnet::Context::kCPUPinned) {
+                if (tmp->ctx().dev_type == mxnet::Context::kGPU 
+                  || tmp->ctx().dev_type == mxnet::Context::kCPUPinned) {
                   CUDA_CALL(cudaSetDevice(tmp->ctx().dev_id));
                 }
 #endif

--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -2301,7 +2301,7 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxCustomOpRegister
                   ptrsArr, (jsize)0, (jsize)size, reinterpret_cast<jlong*>(ptrs));
 #if MXNET_USE_CUDA
                 mxnet::NDArray* tmp = reinterpret_cast<mxnet::NDArray*>(ptrs[0]);
-                if (tmp->ctx().dev_type == mxnet::Context::kGPU 
+                if (tmp->ctx().dev_type == mxnet::Context::kGPU
                   || tmp->ctx().dev_type == mxnet::Context::kCPUPinned) {
                   CUDA_CALL(cudaSetDevice(tmp->ctx().dev_id));
                 }


### PR DESCRIPTION
The issue that "no CUDA-capable device is detected" occurs when calling MxNet from Java/Scala on a host without GPU. 

The user scenario is to run MxNet model on CPU-only host with Context input as cpu(0). The default GPU unit shares the same index of zero with the default CPU unit. By default the MXNET_USE_CUDA is enabled and the logic will proceed to the line of "CUDA_CALL". The calling of cudaSetDevice exits with exception since there is GPU found for index of zero. The proposal here is to enable the "CUDA_CALL" only when the device type of Context is not CPU.

The whole project with code changes proposed here has been built successfully in local host. After that the running of MxNet model was successful in CPU-only host for evaluation.