### PR TITLE
Default shape and context attributes for operators

### DIFF
--- a/python/mxnet/ndarray/op.py
+++ b/python/mxnet/ndarray/op.py
@@ -180,25 +180,28 @@ def %s(%s):
         keys.append('%s')
         vals.append(np.dtype(%s).name)""" % (dtype_name, dtype_name, dtype_name))
 
+        # This is for random operator only.
         # If the op has argument 'shape' but its value
         # is not provided, set it to (1,).
         if shape_name is not None:
             code.append("""
-    keys.append('%s')
-    if %s is _Null:
+    if %s is _Null and out is None:
+        keys.append('%s')
         vals.append('(1,)')
-    else:
-        vals.append(str(%s))""" % (shape_name, shape_name, shape_name))
+    elif %s is not _Null:
+        keys.append('%s')
+        vals.append(str(%s))""" % (shape_name, shape_name, shape_name, shape_name, shape_name))
 
         # If the op has argument 'ctx' but its value
         # is not provided, set it to context.current_context().
         if ctx_name is not None:
             code.append("""
-    keys.append('%s')
-    if %s is _Null:
+    if %s is _Null and out is None:
+        keys.append('%s')
         vals.append(str(current_context()))
-    else:
-        vals.append(str(%s))""" % (ctx_name, ctx_name, ctx_name))
+    elif %s is not _Null:
+        keys.append('%s')
+        vals.append(str(%s))""" % (ctx_name, ctx_name, ctx_name, ctx_name, ctx_name))
 
     code.append("""
     return _imperative_invoke(%d, ndargs, keys, vals, out)"""%(

--- a/python/mxnet/ndarray/op.py
+++ b/python/mxnet/ndarray/op.py
@@ -24,7 +24,7 @@ import ctypes
 import numpy as np  # pylint: disable=unused-import
 
 from ..ndarray_doc import _build_doc
-from ..context import current_context
+from ..context import current_context  # pylint: disable=unused-import
 
 # Use different version of SymbolBase
 # When possible, use cython to speedup part of computation.
@@ -188,7 +188,7 @@ def %s(%s):
     if %s is _Null:
         vals.append('(1,)')
     else:
-        vals.append(py_str(%s))""" % (shape_name, shape_name, shape_name))
+        vals.append(str(%s))""" % (shape_name, shape_name, shape_name))
 
         # If the op has argument 'ctx' but its value
         # is not provided, set it to context.current_context().
@@ -196,9 +196,9 @@ def %s(%s):
             code.append("""
     keys.append('%s')
     if %s is _Null:
-        vals.append('%s')
+        vals.append(str(current_context()))
     else:
-        vals.append(py_str(%s))""" % (ctx_name, ctx_name, py_str(current_context()), ctx_name))
+        vals.append(str(%s))""" % (ctx_name, ctx_name, ctx_name))
 
     code.append("""
     return _imperative_invoke(%d, ndargs, keys, vals, out)"""%(

--- a/python/mxnet/ndarray/op.py
+++ b/python/mxnet/ndarray/op.py
@@ -24,6 +24,7 @@ import ctypes
 import numpy as np  # pylint: disable=unused-import
 
 from ..ndarray_doc import _build_doc
+from ..context import current_context
 
 # Use different version of SymbolBase
 # When possible, use cython to speedup part of computation.
@@ -46,6 +47,13 @@ except ImportError:
 
 from ..base import mx_uint, check_call, _LIB, py_str, _init_op_module, _Null
 # pylint: enable=unused-import
+
+
+def _is_random_op(name):
+    """Check whether the name is a random operator name.
+    A random operator name should start with prefix random_
+    or is one of strings in random.__all__."""
+    return name.startswith('random_') or name.startswith('_random_')
 
 
 # pylint: disable=too-many-locals, invalid-name
@@ -83,16 +91,29 @@ def _make_ndarray_function(handle, name):
                          ret_type)
 
     dtype_name = None
+    shape_name = None
+    ctx_name = None
     arr_name = None
     ndsignature = []
     signature = []
     ndarg_names = []
     kwarg_names = []
+    is_random_op = _is_random_op(func_name)
     for i in range(narg):
         name, atype = arg_names[i], arg_types[i]
         if name == 'dtype':
             dtype_name = name
-            signature.append('%s=_Null'%name)
+            signature.append('%s=_Null' % name)
+        elif name == 'shape' and is_random_op:
+            # for random operators, we need to support default
+            # shape = (1,) in imperative invoke. In random op
+            # symbols, default shape is still an empty one
+            # since it may need to be inferred from other symbols
+            shape_name = name
+            signature.append('%s=_Null' % name)
+        elif name == 'ctx':
+            ctx_name = name
+            signature.append('%s=_Null' % name)
         elif atype.startswith('NDArray') or atype.startswith('Symbol'):
             assert not arr_name, \
                 "Op can only have one argument with variable " \
@@ -127,6 +148,7 @@ def %s(*%s, **kwargs):"""%(func_name, arr_name))
     if '%s' in kwargs:
         kwargs['%s'] = np.dtype(kwargs['%s']).name"""%(
             dtype_name, dtype_name, dtype_name))
+
         code.append("""
     _ = kwargs.pop('name', None)
     out = kwargs.pop('out', None)
@@ -137,7 +159,7 @@ def %s(*%s, **kwargs):"""%(func_name, arr_name))
 def %s(%s):
     ndargs = []
     keys = list(kwargs.keys())
-    vals = list(kwargs.values())"""%(func_name, ', '.join(signature)))
+    vals = list(kwargs.values())""" % (func_name, ', '.join(signature)))
         # NDArray args
         for name in ndarg_names: # pylint: disable=redefined-argument-from-local
             code.append("""
@@ -150,13 +172,33 @@ def %s(%s):
             code.append("""
     if %s is not _Null:
         keys.append('%s')
-        vals.append(%s)"""%(name, name, name))
+        vals.append(%s)""" % (name, name, name))
         # dtype
         if dtype_name is not None:
             code.append("""
     if %s is not _Null:
         keys.append('%s')
-        vals.append(np.dtype(%s).name)"""%(dtype_name, dtype_name, dtype_name))
+        vals.append(np.dtype(%s).name)""" % (dtype_name, dtype_name, dtype_name))
+
+        # If the op has argument 'shape' but its value
+        # is not provided, set it to (1,).
+        if shape_name is not None:
+            code.append("""
+    keys.append('%s')
+    if %s is _Null:
+        vals.append('(1,)')
+    else:
+        vals.append(py_str(%s))""" % (shape_name, shape_name, shape_name))
+
+        # If the op has argument 'ctx' but its value
+        # is not provided, set it to context.current_context().
+        if ctx_name is not None:
+            code.append("""
+    keys.append('%s')
+    if %s is _Null:
+        vals.append('%s')
+    else:
+        vals.append(py_str(%s))""" % (ctx_name, ctx_name, py_str(current_context()), ctx_name))
 
     code.append("""
     return _imperative_invoke(%d, ndargs, keys, vals, out)"""%(

--- a/python/mxnet/ndarray/op.py
+++ b/python/mxnet/ndarray/op.py
@@ -53,7 +53,7 @@ def _is_random_op(name):
     """Check whether the name is a random operator name.
     A random operator name should start with prefix random_
     or is one of strings in random.__all__."""
-    return name.startswith('random_') or name.startswith('_random_')
+    return name.startswith('random_') or name.startswith('_random_') or name.startswith('_sample_')
 
 
 # pylint: disable=too-many-locals, invalid-name

--- a/src/operator/random/sample_op.h
+++ b/src/operator/random/sample_op.h
@@ -52,7 +52,8 @@ struct SampleUniformParam : public dmlc::Parameter<SampleUniformParam> {
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
-              " Only used for imperative calls.");
+              " Only used for imperative calls."
+              " Note: In imperative mode, ctx defaults to the current context.");
     DMLC_DECLARE_FIELD(dtype)
     .add_enum("None", -1)
     .add_enum("float32", mshadow::kFloat32)
@@ -81,7 +82,8 @@ struct SampleNormalParam : public dmlc::Parameter<SampleNormalParam> {
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
-              " Only used for imperative calls.");
+              " Only used for imperative calls."
+              " Note: In imperative mode, ctx defaults to the current context.");
     DMLC_DECLARE_FIELD(dtype)
     .add_enum("None", -1)
     .add_enum("float32", mshadow::kFloat32)
@@ -110,7 +112,11 @@ struct SampleGammaParam : public dmlc::Parameter<SampleGammaParam> {
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
-              " Only used for imperative calls.");
+              " Only used for imperative calls."
+              " Note: In imperative mode, ctx defaults to the current context."
+              " If the current context is on GPU, users should override the"
+              " current context with a CPU context since this op has not been"
+              " implemented for GPU computing.");
     DMLC_DECLARE_FIELD(dtype)
     .add_enum("None", -1)
     .add_enum("float32", mshadow::kFloat32)
@@ -136,7 +142,11 @@ struct SampleExponentialParam : public dmlc::Parameter<SampleExponentialParam> {
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
-              " Only used for imperative calls.");
+              " Only used for imperative calls."
+              " Note: In imperative mode, ctx defaults to the current context."
+              " If the current context is on GPU, users should override the"
+              " current context with a CPU context since this op has not been"
+              " implemented for GPU computing.");
     DMLC_DECLARE_FIELD(dtype)
     .add_enum("None", -1)
     .add_enum("float32", mshadow::kFloat32)
@@ -162,7 +172,11 @@ struct SamplePoissonParam : public dmlc::Parameter<SamplePoissonParam> {
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
-              " Only used for imperative calls.");
+              " Only used for imperative calls."
+              " Note: In imperative mode, ctx defaults to the current context."
+              " If the current context is on GPU, users should override the"
+              " current context with a CPU context since this op has not been"
+              " implemented for GPU computing.");
     DMLC_DECLARE_FIELD(dtype)
     .add_enum("None", -1)
     .add_enum("float32", mshadow::kFloat32)
@@ -191,7 +205,11 @@ struct SampleNegBinomialParam : public dmlc::Parameter<SampleNegBinomialParam> {
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
-              " Only used for imperative calls.");
+              " Only used for imperative calls."
+              " Note: In imperative mode, ctx defaults to the current context."
+              " If the current context is on GPU, users should override the"
+              " current context with a CPU context since this op has not been"
+              " implemented for GPU computing.");
     DMLC_DECLARE_FIELD(dtype)
     .add_enum("None", -1)
     .add_enum("float32", mshadow::kFloat32)
@@ -220,7 +238,11 @@ struct SampleGenNegBinomialParam : public dmlc::Parameter<SampleGenNegBinomialPa
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
-              " Only used for imperative calls.");
+              " Only used for imperative calls."
+              " Note: In imperative mode, ctx defaults to the current context."
+              " If the current context is on GPU, users should override the"
+              " current context with a CPU context since this op has not been"
+              " implemented for GPU computing.");
     DMLC_DECLARE_FIELD(dtype)
     .add_enum("None", -1)
     .add_enum("float32", mshadow::kFloat32)

--- a/src/operator/random/sample_op.h
+++ b/src/operator/random/sample_op.h
@@ -48,7 +48,7 @@ struct SampleUniformParam : public dmlc::Parameter<SampleUniformParam> {
     .describe("Upper bound of the distribution.");
     DMLC_DECLARE_FIELD(shape)
     .set_default(TShape())
-    .describe("Shape of the output.");
+    .describe("Shape of the output. Note: In imperative mode, shape defaults to (1,).");
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
@@ -77,7 +77,7 @@ struct SampleNormalParam : public dmlc::Parameter<SampleNormalParam> {
     .describe("Standard deviation of the distribution.");
     DMLC_DECLARE_FIELD(shape)
     .set_default(TShape())
-    .describe("Shape of the output.");
+    .describe("Shape of the output. Note: In imperative mode, shape defaults to (1,).");
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
@@ -106,7 +106,7 @@ struct SampleGammaParam : public dmlc::Parameter<SampleGammaParam> {
     .describe("Beta parameter (scale) of the gamma distribution.");
     DMLC_DECLARE_FIELD(shape)
     .set_default(TShape())
-    .describe("Shape of the output.");
+    .describe("Shape of the output. Note: In imperative mode, shape defaults to (1,).");
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
@@ -132,7 +132,7 @@ struct SampleExponentialParam : public dmlc::Parameter<SampleExponentialParam> {
     .describe("Lambda parameter (rate) of the exponential distribution.");
     DMLC_DECLARE_FIELD(shape)
     .set_default(TShape())
-    .describe("Shape of the output.");
+    .describe("Shape of the output. Note: In imperative mode, shape defaults to (1,).");
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
@@ -158,7 +158,7 @@ struct SamplePoissonParam : public dmlc::Parameter<SamplePoissonParam> {
     .describe("Lambda parameter (rate) of the Poisson distribution.");
     DMLC_DECLARE_FIELD(shape)
     .set_default(TShape())
-    .describe("Shape of the output.");
+    .describe("Shape of the output. Note: In imperative mode, shape defaults to (1,).");
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
@@ -187,7 +187,7 @@ struct SampleNegBinomialParam : public dmlc::Parameter<SampleNegBinomialParam> {
     .describe("Failure probability in each experiment.");
     DMLC_DECLARE_FIELD(shape)
     .set_default(TShape())
-    .describe("Shape of the output.");
+    .describe("Shape of the output. Note: In imperative mode, shape defaults to (1,).");
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
@@ -216,7 +216,7 @@ struct SampleGenNegBinomialParam : public dmlc::Parameter<SampleGenNegBinomialPa
     .describe("Alpha (dispersion) parameter of the negative binomial distribution.");
     DMLC_DECLARE_FIELD(shape)
     .set_default(TShape())
-    .describe("Shape of the output.");
+    .describe("Shape of the output. Note: In imperative mode, shape defaults to (1,).");
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."

--- a/src/operator/tensor/init_op.h
+++ b/src/operator/tensor/init_op.h
@@ -115,9 +115,8 @@ inline bool InitShape(const nnvm::NodeAttrs& attrs,
   const ParamType& param = nnvm::get<ParamType>(attrs.parsed);
   CHECK_EQ(in_attrs->size(), 0U);
   CHECK_EQ(out_attrs->size(), 1U);
-  if ((*out_attrs)[0].ndim() != 0 && param.shape.ndim() == 0) return true;
   SHAPE_ASSIGN_CHECK(*out_attrs, 0, param.shape);
-  return true;
+  return (*out_attrs)[0].ndim() != 0U && (*out_attrs)[0].Size() != 0U;
 }
 
 template<typename ParamType>
@@ -128,7 +127,7 @@ inline bool InitType(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(in_attrs->size(), 0U);
   CHECK_EQ(out_attrs->size(), 1U);
   TYPE_ASSIGN_CHECK(*out_attrs, 0, param.dtype);
-  return true;
+  return (*out_attrs)[0] != -1;
 }
 
 template<typename xpu, int value>

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4088,6 +4088,38 @@ def test_dropout():
     assert (exe.grad_arrays[0].asnumpy() == exe.outputs[0].asnumpy()).all()
 
 
+def test_imperative_random_op_default_shape():
+    """For random operators, default shape is (1,), instead of ()."""
+    for name in dir(mx.nd):
+        if name.startswith('random_'):
+            random_op = getattr(mx.nd, name)
+            output = random_op()
+            assert output.shape == (1L,)
+
+    for name in dir(mx.nd.random):
+        if not name.startswith('_') and not name.endswith('_'):
+            random_op = getattr(mx.nd.random, name)
+            output = random_op()
+            assert output.shape == (1L,)
+
+
+def test_random_op_default_ctx():
+    """For the operators with ctx as one of the arguments,
+    default it to the current context if it's not provided at runtime.
+    Random operators are examples of this kind of operators."""
+    for name in dir(mx.nd):
+        if name.startswith('random_'):
+            random_op = getattr(mx.nd, name)
+            output = random_op()
+            assert output.context == mx.current_context()
+
+    for name in dir(mx.nd.random):
+        if not name.startswith('_') and not name.endswith('_'):
+            random_op = getattr(mx.nd.random, name)
+            output = random_op()
+            assert output.context == mx.current_context()
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4093,14 +4093,28 @@ def test_imperative_random_op_default_shape():
     for name in dir(mx.nd):
         if name.startswith('random_'):
             random_op = getattr(mx.nd, name)
-            output = random_op()
-            assert output.shape == (1L,)
+            # only uniform and normal have gpu implementation
+            # for other random ops, use `with Context(cpu(0))` to override
+            if name == 'random_uniform' or name == 'random_normal':
+                output = random_op()
+                assert output.shape == (1L,)
+            else:
+                with mx.Context(mx.cpu(0)):
+                    output = random_op()
+                    assert output.shape == (1L,)
 
     for name in dir(mx.nd.random):
         if not name.startswith('_') and not name.endswith('_'):
             random_op = getattr(mx.nd.random, name)
-            output = random_op()
-            assert output.shape == (1L,)
+            # only uniform and normal have gpu implementation
+            # for other random ops, use `with Context(cpu(0))` to override
+            if name == 'random_uniform' or name == 'random_normal':
+                output = random_op()
+                assert output.shape == (1L,)
+            else:
+                with mx.Context(mx.cpu(0)):
+                    output = random_op()
+                    assert output.shape == (1L,)
 
 
 def test_random_op_default_ctx():

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4097,11 +4097,11 @@ def test_imperative_random_op_default_shape():
             # for other random ops, use `with Context(cpu(0))` to override
             if name == 'random_uniform' or name == 'random_normal':
                 output = random_op()
-                assert output.shape == (1L,)
+                assert output.shape == (1,)
             else:
                 with mx.Context(mx.cpu(0)):
                     output = random_op()
-                    assert output.shape == (1L,)
+                    assert output.shape == (1,)
 
     for name in dir(mx.nd.random):
         if not name.startswith('_') and not name.endswith('_'):
@@ -4110,11 +4110,11 @@ def test_imperative_random_op_default_shape():
             # for other random ops, use `with Context(cpu(0))` to override
             if name == 'random_uniform' or name == 'random_normal':
                 output = random_op()
-                assert output.shape == (1L,)
+                assert output.shape == (1,)
             else:
                 with mx.Context(mx.cpu(0)):
                     output = random_op()
-                    assert output.shape == (1L,)
+                    assert output.shape == (1,)
 
 
 def test_random_op_default_ctx():


### PR DESCRIPTION
This PR resolves the issues reported by @szha as the following:

1. Imperative random operators such as `mx.nd.random.uniform()` results in segmentation fault when used without user input shapes. That's because the shape attribute defaults to an empty shape if it's not provided by users. But in Numpy, such statement `np.random.uniform()` can run through and prints a single value. In order to keep consistent with Numpy's behavior, we need to default `shape=(1,)` if it is not provided by users for random operators through either `shape` or `out` attribute imperatively. For symbolic random operators, default shape is still an empty one since it might need to be inferred from other symbolic variables.

2. For the imperative operators with `ctx` as one of its attributes, it should default to the `context.current_context` instead of `mx.cpu(0)` if users did not specify through either `ctx` or `out` attribute, so that the following use case can be supported:
```python
with mx.Context(mx.gpu(0)):
    output = mx.nd.random.uniform()
    assert output.context == mx.current_context()  # current ctx is gpu(0)
```

@piiswrong @szha @eric-haibin-lin 