### PR TITLE
cuda support for new linear algebra operators

### DIFF
--- a/src/operator/linalg.h
+++ b/src/operator/linalg.h
@@ -143,7 +143,6 @@ void linalg_batch_syrk(const Tensor<xpu, 3, DType>& A,
 // CPU/GPU-versions of LAPACK functions "gelqf", "orglq". Please refer to the
 // LAPACK documentation for further details.
 // Note:
-// - The current implementation works for CPU only
 // - Both functions have A as input and output parameter
 // - Both functions require extra workspace, passed as 1D tensor
 // - We call orglq after gelqf. Apart from A, they also communicate via the

--- a/src/operator/linalg_impl.h
+++ b/src/operator/linalg_impl.h
@@ -519,7 +519,7 @@ void linalg_trmm<gpu, DType>(const Tensor<gpu, 2, DType>& A, const Tensor<gpu, 2
                             (rightside ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT), \
                             (lower ? CUBLAS_FILL_MODE_UPPER : CUBLAS_FILL_MODE_LOWER), \
                             (transpose ? CUBLAS_OP_T : CUBLAS_OP_N), \
-                            CUBLAS_DIAG_NON_UNIT, B.size(0), B.size(1), &alpha, \
+                            CUBLAS_DIAG_NON_UNIT, B.size(1), B.size(0), &alpha, \
                             A.dptr_, A.stride_, B.dptr_, B.stride_, \
                             B.dptr_, B.stride_)); \
 }
@@ -725,8 +725,6 @@ LINALG_GPU_BATCH_POTRI(double)
 // for further information about the function and its parameters.
 // Note that this is B = syrk(A, B), so B is input and output parameter.
 
-#if MSHADOW_USE_CBLAS == 1
-
 template<typename xpu, typename DType> inline
 void check_syrk(const Tensor<xpu, 2, DType>& A, const Tensor<xpu, 2, DType>& B,
                 DType alpha, DType beta, bool tA) {
@@ -736,6 +734,8 @@ void check_syrk(const Tensor<xpu, 2, DType>& A, const Tensor<xpu, 2, DType>& B,
   CHECK_EQ((tA ? A.size(1) : A.size(0)), B.size(0))
     << "Non compatible matrix dimensions between inputs A and B for syrk";
 }
+
+#if MSHADOW_USE_CBLAS == 1
 
 #define LINALG_CPU_SYRK(fname, DType) \
 template<> inline \
@@ -748,17 +748,6 @@ void linalg_syrk<cpu, DType>(const Tensor<cpu, 2, DType>& A, \
                 A.dptr_, A.stride_, beta, B.dptr_, B.stride_); \
 }
 
-#define LINALG_CPU_BATCH_SYRK(DType) \
-template<> inline \
-void linalg_batch_syrk(const Tensor<cpu, 3, DType>& A, \
-                       const Tensor<cpu, 3, DType>& B, DType alpha, DType beta, \
-                       bool tA, Stream<cpu> *s) { \
-  linalg_check_batch_size(A.size(0), B.size(0), B.size(0)); \
-  for (index_t i = 0; i < A.size(0); ++i) { \
-    linalg_syrk(A[i], B[i], alpha, beta, tA); \
-  } \
-}
-
 #else
 
 #define LINALG_CPU_SYRK(fname, DType) \
@@ -769,20 +758,48 @@ void linalg_syrk<cpu, DType>(const Tensor<cpu, 2, DType>& A, \
   LOG(FATAL) << "linalg_syrk not implemented by mxnet for cpu, needs cblas!"; \
 }
 
-#define LINALG_CPU_BATCH_SYRK(DType) \
-template<> inline \
-void linalg_batch_syrk(const Tensor<cpu, 3, DType>& A, \
-                       const Tensor<cpu, 3, DType>& B, DType alpha, DType beta, \
-                       bool tA, Stream<cpu> *s) { \
-  LOG(FATAL) << "linalg_batch_syrk not implemented by mxnet for cpu, needs cblas!"; \
-}
-
 #endif  // MSHADOW_USE_CBLAS == 1
+
+#define LINALG_XPU_BATCH_SYRK(xpu, DType) \
+template<> inline \
+void linalg_batch_syrk(const Tensor<xpu, 3, DType>& A, \
+                       const Tensor<xpu, 3, DType>& B, DType alpha, DType beta, \
+                       bool tA, Stream<xpu> *s) { \
+  linalg_check_batch_size(A.size(0), B.size(0), B.size(0)); \
+  for (index_t i = 0; i < A.size(0); ++i) { \
+    linalg_syrk(A[i], B[i], alpha, beta, tA, s); \
+  } \
+}
 
 LINALG_CPU_SYRK(ssyrk, float)
 LINALG_CPU_SYRK(dsyrk, double)
-LINALG_CPU_BATCH_SYRK(float)
-LINALG_CPU_BATCH_SYRK(double)
+LINALG_XPU_BATCH_SYRK(cpu, float)
+LINALG_XPU_BATCH_SYRK(cpu, double)
+
+#ifdef __CUDACC__
+
+// cublas col-major processing accounted for by switching transpose and fill mode
+#define LINALG_GPU_SYRK(fname, DType) \
+template<> inline \
+void linalg_syrk<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
+                             const Tensor<gpu, 2, DType>& B, DType alpha, \
+                             DType beta, bool tA, Stream<gpu> *s) { \
+  using namespace mxnet; \
+  using mshadow::gpu; \
+  CHECK_NOTNULL(s); \
+  check_syrk(A, B, alpha, beta, tA); \
+  CUBLAS_CALL(cublas##fname(Stream<gpu>::GetBlasHandle(s), \
+              CUBLAS_FILL_MODE_UPPER, (tA ? CUBLAS_OP_N : CUBLAS_OP_T), \
+              B.size(1), (tA ? A.size(0) : A.size(1)), &alpha, \
+              A.dptr_, A.stride_, &beta, B.dptr_, B.stride_)); \
+}
+
+LINALG_GPU_SYRK(Ssyrk, float)
+LINALG_GPU_SYRK(Dsyrk, double)
+LINALG_XPU_BATCH_SYRK(gpu, float)
+LINALG_XPU_BATCH_SYRK(gpu, double)
+
+#endif  // __CUDACC__
 
 //////////////////////////////// GELQF ////////////////////////////////////////////
 
@@ -851,5 +868,102 @@ int linalg_gelqf_workspace_query<cpu, DType>(const Tensor<cpu, 2, DType>& A, \
 }
 LINALG_CPU_GELQF_WORKSPACE_QUERY(s, float)
 LINALG_CPU_GELQF_WORKSPACE_QUERY(d, double)
+
+#ifdef __CUDACC__
+
+#define LINALG_GPU_GELQF(fname, DType) \
+template<> inline \
+void linalg_gelqf<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
+                              const Tensor<gpu, 1, DType>& work, \
+                              Stream<gpu> *s) { \
+  using namespace mxnet; \
+  using mshadow::gpu; \
+  CHECK_NOTNULL(s); \
+  check_gelqf(A, work); \
+  int m(A.size(0)); \
+  int lwork(work.size(0) - m); \
+  Storage::Handle info = Storage::Get()->Alloc(sizeof(int), Context::GPU()); \
+  CUSOLVER_CALL(cusolver##fname(Stream<gpu>::GetSolverHandle(s), \
+                A.size(1), m, A.dptr_ , A.stride_, work.dptr_, \
+                work.dptr_ + m, lwork, static_cast<int *>(info.dptr))); \
+  Storage::Get()->Free(info); \
+}
+// Col-major QR-decomposition results in row-major LQ decomposition.
+LINALG_GPU_GELQF(DnSgeqrf, float)
+LINALG_GPU_GELQF(DnDgeqrf, double)
+
+// ORGLQ only available with cuda8 or higher.
+#if CUDA_VERSION >= 8000
+
+#define LINALG_GPU_ORGLQ(fname, DType) \
+template<> inline \
+void linalg_orglq<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
+                              const Tensor<gpu, 1, DType>& work, \
+                              Stream<gpu> *s) { \
+  using namespace mxnet; \
+  using mshadow::gpu; \
+  CHECK_NOTNULL(s); \
+  check_gelqf(A, work); \
+  int m(A.size(0)); \
+  int lwork(work.size(0) - m); \
+  Storage::Handle info = Storage::Get()->Alloc(sizeof(int), Context::GPU()); \
+  CUSOLVER_CALL(cusolver##fname(Stream<gpu>::GetSolverHandle(s), \
+                A.size(1), m, m, A.dptr_ , A.stride_, work.dptr_, \
+                work.dptr_ + m, lwork, static_cast<int *>(info.dptr))); \
+  Storage::Get()->Free(info); \
+}
+
+#else
+
+#define LINALG_GPU_ORGLQ(fname, DType) \
+template<> inline \
+void linalg_orglq<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
+                              const Tensor<gpu, 1, DType>& work, \
+                              Stream<gpu> *s) { \
+  LOG(FATAL) << "orglq requires CUDA version >= 8.0!"; \
+}
+
+#endif  // CUDA_VERSION >= 8000
+
+LINALG_GPU_ORGLQ(DnSorgqr, float)
+LINALG_GPU_ORGLQ(DnDorgqr, double)
+
+// ORGLQ only available with cuda8 or higher.
+#if CUDA_VERSION >= 8000
+
+#define LINALG_GPU_GELQF_WORKSPACE_QUERY(prefix, DType) \
+template<> inline \
+int linalg_gelqf_workspace_query<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
+                                             Stream<gpu> *s) { \
+  using namespace mxnet; \
+  using mshadow::gpu; \
+  int m(A.size(0)); \
+  int work1(0); \
+  CUSOLVER_CALL(cusolverDn##prefix##geqrf_bufferSize(Stream<gpu>::GetSolverHandle(s), \
+                A.size(1), m, A.dptr_ , A.stride_, &work1)); \
+  int work2(0);  \
+  Storage::Handle tau = Storage::Get()->Alloc(sizeof(DType), Context::GPU()); \
+  CUSOLVER_CALL(cusolverDn##prefix##orgqr_bufferSize(Stream<gpu>::GetSolverHandle(s), \
+                A.size(1), m, m, A.dptr_ , A.stride_, static_cast<DType *>(tau.dptr), &work2)); \
+  Storage::Get()->Free(tau); \
+  return std::max(work1, work2) + m; \
+}
+
+#else
+
+#define LINALG_GPU_GELQF_WORKSPACE_QUERY(prefix, DType) \
+template<> inline \
+int linalg_gelqf_workspace_query<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
+                                             Stream<gpu> *s) { \
+  LOG(FATAL) << "orglq requires CUDA version >= 8.0!"; \
+  return 0; \
+}
+
+#endif  // CUDA_VERSION >= 8000
+
+LINALG_GPU_GELQF_WORKSPACE_QUERY(S, float)
+LINALG_GPU_GELQF_WORKSPACE_QUERY(D, double)
+
+#endif  // __CUDACC__
 
 #endif  // MXNET_OPERATOR_LINALG_IMPL_H_

--- a/src/operator/tensor/la_op.cc
+++ b/src/operator/tensor/la_op.cc
@@ -415,6 +415,8 @@ Examples::
 NNVM_REGISTER_OP(_backward_linalg_sumlogdiag)
 .set_num_inputs(2)
 .set_num_outputs(1)
+.set_attr<nnvm::FInplaceOption>("FInplaceOption", [](const NodeAttrs& attrs)
+  { return std::vector<std::pair<int, int>>{{1, 0}}; })
 .set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& attrs)
   { return std::vector<ResourceRequest>{ResourceRequest::kTempSpace}; })
 .set_attr<nnvm::TIsBackward>("TIsBackward", true)

--- a/src/operator/tensor/la_op.cu
+++ b/src/operator/tensor/la_op.cu
@@ -51,6 +51,12 @@ NNVM_REGISTER_OP(_linalg_trsm)
 NNVM_REGISTER_OP(_backward_linalg_trsm)
 .set_attr<FCompute>("FCompute<gpu>", LaOpBackward<gpu, 2, 2, 4, 2, trsm_backward>);
 
+NNVM_REGISTER_OP(_linalg_syrk)
+.set_attr<FCompute>("FCompute<gpu>", LaOpForward<gpu, 2, 2, 1, 1, syrk>);
+
+NNVM_REGISTER_OP(_backward_linalg_syrk)
+.set_attr<FCompute>("FCompute<gpu>", LaOpBackward<gpu, 2, 2, 2, 1, syrk_backward>);
+
 NNVM_REGISTER_OP(_linalg_sumlogdiag)
 .set_attr<FCompute>("FCompute<gpu>", LaOpForward<gpu, 2, 0, 1, 1, sumlogdiag>);
 
@@ -70,6 +76,12 @@ NNVM_REGISTER_OP(_linalg_potrf)
 
 NNVM_REGISTER_OP(_backward_linalg_potrf)
 .set_attr<FCompute>("FCompute<gpu>", LaOpBackward<gpu, 2, 2, 2, 1, potrf_backward>);
+
+NNVM_REGISTER_OP(_linalg_gelqf)
+.set_attr<FCompute>("FCompute<gpu>", LaOpForward<gpu, 2, 2, 1, 2, gelqf>);
+
+NNVM_REGISTER_OP(_backward_linalg_gelqf)
+.set_attr<FCompute>("FCompute<gpu>", LaOpBackward<gpu, 2, 2, 4, 1, gelqf_backward>);
 
 #endif
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -3957,9 +3957,6 @@ def _gelqf_second_output(a):
     return mx.sym.broadcast_add(l, bogus_scal)
 
 def test_laop_2():
-    # Operators implemented for CPU only currently
-    if default_context() != mx.cpu():
-        return
     np.random.seed(1896893923)
     dtype = np.float64
     rtol_fw = 1e-7
@@ -4008,6 +4005,11 @@ def test_laop_2():
             check_grad(test_syrk2, [a_batch])
 
     # Tests for linalg_gelqf
+    # Currently disabled on GPU as they need cuda8
+    # and MxNet builds use cuda 7.5
+    if default_context() != mx.cpu():
+        return
+ 
     test_gelqf2 = _gelqf_combined_symbol(data1)  # Outputs (dot(Q, Q.T), dot(L, Q))
     test_gelqf_q = _gelqf_first_output(data1)  # Output Q (L is not dangling)
     test_gelqf_l = _gelqf_second_output(data1)  # Output L (Q is not dangling)


### PR DESCRIPTION
Add cuda support for syrk/gelqf linear algebra operators which was missing so far. 
Also fixes an issue in linalg_sumlogdiag that can lead to NAN values generated during backward pass.