### PR TITLE
Small improvement to IndexTensorToVector

### DIFF
--- a/src/operator/sequence_op_common.h
+++ b/src/operator/sequence_op_common.h
@@ -45,7 +45,7 @@ inline IndexTensorToVector(mshadow::Tensor<gpu, 1, DType> data,
                       cudaMemcpyDeviceToHost, data.stream_->stream_);
   CHECK_EQ(cuda_status, cudaSuccess) << "cuda memcpy label error";
   for (int i = 0; i < max_seq_len; ++i) {
-    (*index_vec)[i] = static_cast<RType>(temp_index[i]);
+    (*index_vec)[i] = std::round(temp_index[i]);
   }
   free(temp_index);
 #endif
@@ -57,7 +57,7 @@ inline IndexTensorToVector(mshadow::Tensor<cpu, 1, DType> data,
   int max_seq_len = data.shape_.Size();
   DType *index_array = static_cast<DType *>(data.dptr_);
   for (int i = 0; i < max_seq_len; ++i)
-    (*index_vec)[i] = static_cast<RType>(index_array[i]);
+    (*index_vec)[i] = std::round(index_array[i]);
 }
 
 }  // namespace op

--- a/src/operator/sequence_op_common.h
+++ b/src/operator/sequence_op_common.h
@@ -45,7 +45,7 @@ inline IndexTensorToVector(mshadow::Tensor<gpu, 1, DType> data,
                       cudaMemcpyDeviceToHost, data.stream_->stream_);
   CHECK_EQ(cuda_status, cudaSuccess) << "cuda memcpy label error";
   for (int i = 0; i < max_seq_len; ++i) {
-    (*index_vec)[i] = std::round(temp_index[i]);
+    (*index_vec)[i] = static_cast<RType>(std::lround(temp_index[i]));
   }
   free(temp_index);
 #endif
@@ -57,7 +57,7 @@ inline IndexTensorToVector(mshadow::Tensor<cpu, 1, DType> data,
   int max_seq_len = data.shape_.Size();
   DType *index_array = static_cast<DType *>(data.dptr_);
   for (int i = 0; i < max_seq_len; ++i)
-    (*index_vec)[i] = std::round(index_array[i]);
+    (*index_vec)[i] = static_cast<RType>(std::lround(index_array[i]));
 }
 
 }  // namespace op


### PR DESCRIPTION
This fixes a bug I encountered with the python grad tester `numeric_grad` whilst writing tests for `SequenceLast` op. In this, `eps` is added and subtracted from all input arrays. For sequence layers, which have the lengths of the sequences, this causes problems: `1 - 0.0005 = 0.9995`, and `static_cast<int>(0.9995)` is `0`, which causes seg faults. 

I simply changed `static_cast` to `std::round` in `IndexTensorToVector`, which is much more robust to small numerical differences, and which allows my tests to pass (will add in another PR with these new tests once this is merged). It might still be good to fix `numeric_grad` so that it has an option to ignore arrays for which no grad can be calculated.