### PR TITLE
account for batch padding when updating metrics

### DIFF
--- a/python/mxnet/module/executor_group.py
+++ b/python/mxnet/module/executor_group.py
@@ -96,6 +96,19 @@ def _merge_multi_context(outputs, major_axis):
     return rets
 
 
+def _slice_axis(arr, axis, islice):
+    """Slices array along axis"""
+    if axis == 0:
+        # slicing NDArray along axis 0 can avoid copying
+        return arr[islice]
+    elif axis > 0:
+        # pylint: disable=no-member
+        return nd.slice_axis(arr, axis=axis, begin=islice.start,
+                             end=islice.stop).as_in_context(arr.context)
+        # pylint: enable=no-member
+    return arr
+
+
 class DataParallelExecutorGroup(object):
     """A group of executors that lives on a group of devices.
     This is a helper class used to implement data parallelization. Each mini-batch will
@@ -206,6 +219,7 @@ class DataParallelExecutorGroup(object):
 
         # initialize some instance variables
         self.batch_size = None
+        self.cur_batch_pad = None
         self.slices = None
         self.execs = []
         self._default_execs = None
@@ -400,6 +414,12 @@ class DataParallelExecutorGroup(object):
 
         """
         _load_data(data_batch, self.data_arrays, self.data_layouts)
+
+        if hasattr(data_batch, 'pad'):
+            self.cur_batch_pad = data_batch.pad
+        else:
+            self.cur_batch_pad = None
+
         if is_train is None:
             is_train = self.for_training
 
@@ -557,28 +577,23 @@ class DataParallelExecutorGroup(object):
             The metric used for evaluation.
         labels : list of NDArray
             Typically comes from `label` of a `DataBatch`.
-        begin : int
-            Starting index of used outputs.
-        end : int or None
-            Ending index of used outputs.
         """
+        pad = self.cur_batch_pad or 0
+        valid_stop = self.batch_size - pad
         for texec, islice in zip(self.execs, self.slices):
             labels_slice = []
-            for label, axis in zip(labels, self.label_layouts):
-                if axis == 0:
-                    # slicing NDArray along axis 0 can avoid copying
-                    labels_slice.append(label[islice])
-                elif axis > 0:
-                    # pylint: disable=no-member
-                    label_my_slice = nd.slice_axis(label, axis=axis, begin=islice.start,
-                                                   end=islice.stop).as_in_context(label.context)
-                    # pylint: enable=no-member
-                    labels_slice.append(label_my_slice)
-                else:
-                    labels_slice.append(label)
-
+            outputs_slice = []
+            if islice.start >= valid_stop:
+                break
+            if islice.stop > valid_stop:
+                islice = slice(islice.start, valid_stop)
+            oslice = slice(0, islice.stop - islice.start)
+            for label, laxis, output, oaxis in \
+                    zip(labels, self.label_layouts, texec.outputs, self.output_layouts):
+                labels_slice.append(_slice_axis(label, laxis, islice))
+                outputs_slice.append(_slice_axis(output, oaxis, oslice))
             labels_ = OrderedDict(zip(self.label_names, labels_slice))
-            preds = OrderedDict(zip(self.output_names, texec.outputs))
+            preds = OrderedDict(zip(self.output_names, outputs_slice))
             eval_metric.update_dict(labels_, preds)
 
     def _bind_ith_exec(self, i, data_shapes, label_shapes, shared_group):

--- a/python/mxnet/module/executor_group.py
+++ b/python/mxnet/module/executor_group.py
@@ -103,8 +103,7 @@ def _slice_axis(arr, axis, islice):
         return arr[islice]
     elif axis > 0:
         # pylint: disable=no-member
-        return nd.slice_axis(arr, axis=axis, begin=islice.start,
-                             end=islice.stop).as_in_context(arr.context)
+        return nd.slice(arr, axis=axis, begin=islice.start, end=islice.stop)
         # pylint: enable=no-member
     return arr
 
@@ -414,11 +413,7 @@ class DataParallelExecutorGroup(object):
 
         """
         _load_data(data_batch, self.data_arrays, self.data_layouts)
-
-        if hasattr(data_batch, 'pad'):
-            self.cur_batch_pad = data_batch.pad
-        else:
-            self.cur_batch_pad = None
+        self.cur_batch_pad = getattr(data_batch, 'pad', None)
 
         if is_train is None:
             is_train = self.for_training


### PR DESCRIPTION
Fixes executor_group.update_metric() to take account of batch padding. If a batch has padding, only the non padded data is used to update the metric. A unit test is included which demonstrates the fix.