### PR TITLE
Fix computation of num_inputs for Python API create_operator_entry

### DIFF
--- a/src/operator/custom/custom.cc
+++ b/src/operator/custom/custom.cc
@@ -225,9 +225,8 @@ OpStatePtr CreateState(const NodeAttrs& attrs, Context ctx,
                        const std::vector<int>& in_type) {
   const CustomParam& params = nnvm::get<CustomParam>(attrs.parsed);
 
-  size_t total = params.num_args + params.num_outs + params.num_auxs;
-  std::vector<uint32_t*> shapes(total);
-  std::vector<int> ndims(total);
+  std::vector<uint32_t*> shapes(params.num_args);
+  std::vector<int> ndims(params.num_args);
   size_t buff_size = 0;
   for (const auto& i : in_shape) buff_size += i.ndim();
   std::vector<uint32_t> buff(buff_size);
@@ -246,7 +245,7 @@ OpStatePtr CreateState(const NodeAttrs& attrs, Context ctx,
   MXCallbackList *op_info = new MXCallbackList;
   CHECK(reinterpret_cast<CustomOpCreateFunc>(
       params.info->callbacks[kCustomOpPropCreateOperator])(
-          os.str().c_str(), shapes.size(), shapes.data(), ndims.data(), in_type.data(),
+          os.str().c_str(), params.num_args, shapes.data(), ndims.data(), in_type.data(),
           op_info, params.info->contexts[kCustomOpPropCreateOperator]));
 
   CustomParam state = params;


### PR DESCRIPTION
This solves the following problem in MXNet v.0.11.x (not present in v.0.10.0):

If a user creates a CustomOperator in Python that requires no arguments, but has at least one output, the [create_operator_entry](https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/operator.py#L754) callback from C++ receives a wrong `num_input` argument and then fails with the following error:

```
  File "/Users/fhieber/miniconda3/lib/python3.6/site-packages/mxnet/operator.py", line 763, in create_operator_entry
    dtypes = [dtypes[i] for i in range(num_inputs)]
  File "/Users/fhieber/miniconda3/lib/python3.6/site-packages/mxnet/operator.py", line 763, in <listcomp>
    dtypes = [dtypes[i] for i in range(num_inputs)]
ValueError: NULL pointer access
```

This is due to the C++ backend which initializes the `shapes` vector with a total size of in_args + out_args + aux_args in [CreateState](https://github.com/apache/incubator-mxnet/blob/master/src/operator/custom/custom.cc#L228). `shapes` will always be of at least size 1 (e.g for operators with 0 arguments and 1 output). The code then proceeds to write only to the `shapes` vector based on the `in_shape` argument, and does not write to index 1.

Back in the `create_operator_entry` Python function a wrong num_input causes a null pointer access in line 763.

The following example code reproduces the problem with the current master:
```
import mxnet as mx
import numpy as np
print(mx.__version__)
class MyCustomOp(mx.operator.CustomOp):

    def __init__(self, size: int) -> None:
        super().__init__()
        self.data = mx.nd.ones((size,))

    def forward(self, is_train, req, in_data, out_data, aux):
        self.assign(out_data[0], req[0], self.data)

    def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
        pass

@mx.operator.register("my_custom_op")
class AutoRegressiveBiasProp(mx.operator.CustomOpProp):

    def __init__(self, size: str) -> None:
        super().__init__()
        self.size = int(size)

    def list_arguments(self):
        return []

    def list_auxiliary_states(self):
        return []

    def list_outputs(self):
        return ['output']

    def infer_shape(self, in_shape):
        return [], [(self.size,)], []

    def infer_type(self, in_type):
        return [], [np.float32], []

    def create_operator(self, ctx, shapes, dtypes):
        return MyCustomOp(size=self.size)


op = mx.sym.Custom(size=4, name='my_custom', op_type='my_custom_op')
print(op.tojson())
print(op.list_inputs())
print(op.infer_shape())
op.simple_bind(ctx=mx.cpu())
```

but runs fine with this PR.

We have a need for such operators in our Sockeye project and would like to update to MXNet v.0.11.0. Hence it would be great one of the core maintainers ( @piiswrong ) could take a look at this and confirm that this change does not break anything else, or if there is a better way of handling custom operators without input arguments. It would also be great to backport this to the v.0.11.0 release for us to update to the stable version.
