### PR TITLE
Fix computation of num_inputs for Python API create_operator_entry fo…

### DIFF
--- a/src/operator/custom/custom.cc
+++ b/src/operator/custom/custom.cc
@@ -225,9 +225,8 @@ OpStatePtr CreateState(const NodeAttrs& attrs, Context ctx,
                        const std::vector<int>& in_type) {
   const CustomParam& params = nnvm::get<CustomParam>(attrs.parsed);
 
-  size_t total = params.num_args + params.num_outs + params.num_auxs;
-  std::vector<uint32_t*> shapes(total);
-  std::vector<int> ndims(total);
+  std::vector<uint32_t*> shapes(params.num_args);
+  std::vector<int> ndims(params.num_args);
   size_t buff_size = 0;
   for (const auto& i : in_shape) buff_size += i.ndim();
   std::vector<uint32_t> buff(buff_size);
@@ -246,7 +245,7 @@ OpStatePtr CreateState(const NodeAttrs& attrs, Context ctx,
   MXCallbackList *op_info = new MXCallbackList;
   CHECK(reinterpret_cast<CustomOpCreateFunc>(
       params.info->callbacks[kCustomOpPropCreateOperator])(
-          os.str().c_str(), shapes.size(), shapes.data(), ndims.data(), in_type.data(),
+          os.str().c_str(), params.num_args, shapes.data(), ndims.data(), in_type.data(),
           op_info, params.info->contexts[kCustomOpPropCreateOperator]));
 
   CustomParam state = params;


### PR DESCRIPTION
…r custom operators with 0 arguments.

This is the same change as in #7967 but against v0.11.0 branch.

Will this be built to Pypi package index automatically?