### PR TITLE
fix elemwise_sum test script

### DIFF
--- a/src/operator/tensor/elemwise_sum.cu
+++ b/src/operator/tensor/elemwise_sum.cu
@@ -39,10 +39,8 @@ void ElementWiseSumComputeExGPU(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(req[0], kWriteTo) << "ElementWiseSumComputeExGPU only supports req = kWriteTo";
   if (inputs[0].storage_type() == kRowSparseStorage) {
     mshadow::Stream<gpu>* s = op_ctx.get_stream<gpu>();
-    Resource rsc = ResourceManager::Get()->Request(op_ctx.run_ctx.get_ctx(),
-        ResourceRequest(ResourceRequest::kTempSpace));
     NDArray out_nd = outputs[0];
-    mxnet::ndarray::ElementwiseSum<gpu>(s, rsc, inputs, &out_nd);
+    mxnet::ndarray::ElementwiseSum<gpu>(s, op_ctx.requested[0], inputs, &out_nd);
   } else {
     FCompExFallback<gpu>(attrs, op_ctx, inputs, req, outputs,
                          ElementWiseSumComputeWithHalf2<gpu>,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1498,8 +1498,8 @@ def test_sparse_elementwise_sum():
         inputs = [mx.symbol.Variable('arg%d' % i) for i in range(n)]
         out = mx.symbol.sparse.add_n(*inputs, name='esum')
         arr = []
-        arr_grad = [mx.nd.empty(shape) for _ in range(n)]
-        densities = [0, 0.01, 0.1, 0.2, 0.3, 0.4, 0.5, 1.0]
+        arr_grad = [mx.nd.empty(shape, stype=stype) for _ in range(n)]
+        densities = [0, 0.01, 0.5, 1.0]
         for i in range(n):
             arr.append(rand_ndarray(shape, stype, densities[np.random.randint(0, len(densities))]))
 


### PR DESCRIPTION
@sxjscience  I was going to fix it in #7947, but since that PR is not ready I am making this separate PR to fix it. I have no idea why the CI didn't catch it. 
The root cause of the problem is that #7577 changed _identity_attr_like_rhs op implementation and didn't check storage type inside the operator. These problems will be fixed in #7947 soon.
@piiswrong 