### PR TITLE
Add ability to query MXNet version to C API

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -228,8 +228,12 @@ MXNET_DLL int MXDumpProfile();
 /*! \brief Set the number of OMP threads to use */
 MXNET_DLL int MXSetNumOMPThreads(int thread_num);
 
-/*! \brief Get the MXNet version number as an integer */
-MXNET_DLL int MXGetVersion();
+/*!
+ * \brief get the MXNet library version as an integer
+ * \param pointer to the integer holding the version number
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXGetVersion(int *version);
 
 //-------------------------------------
 // Part 1: NDArray creation and deletion

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -233,7 +233,7 @@ MXNET_DLL int MXSetNumOMPThreads(int thread_num);
  * \param pointer to the integer holding the version number
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXGetVersion(int *version);
+MXNET_DLL int MXGetVersion(int *out);
 
 //-------------------------------------
 // Part 1: NDArray creation and deletion

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -228,6 +228,9 @@ MXNET_DLL int MXDumpProfile();
 /*! \brief Set the number of OMP threads to use */
 MXNET_DLL int MXSetNumOMPThreads(int thread_num);
 
+/*! \brief Get the MXNet version number as an integer */
+MXNET_DLL int MXGetVersion();
+
 //-------------------------------------
 // Part 1: NDArray creation and deletion
 //-------------------------------------

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -136,9 +136,9 @@ int MXSetNumOMPThreads(int thread_num) {
   API_END();
 }
 
-int MXGetVersion(int *version) {
+int MXGetVersion(int *out) {
   API_BEGIN();
-  *version = static_cast<int>(MXNET_VERSION);
+  *out = static_cast<int>(MXNET_VERSION);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -136,7 +136,11 @@ int MXSetNumOMPThreads(int thread_num) {
   API_END();
 }
 
-int MXGetVersion() { return static_cast<int>(MXNET_VERSION); }
+int MXGetVersion(int *version) {
+  API_BEGIN();
+  *version = static_cast<int>(MXNET_VERSION);
+  API_END();
+}
 
 int MXNDArrayCreateNone(NDArrayHandle *out) {
   API_BEGIN();

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -136,6 +136,8 @@ int MXSetNumOMPThreads(int thread_num) {
   API_END();
 }
 
+int MXGetVersion() { return static_cast<int>(MXNET_VERSION); }
+
 int MXNDArrayCreateNone(NDArrayHandle *out) {
   API_BEGIN();
   *out = new NDArray();


### PR DESCRIPTION
It is useful for language bindings to have access to the version number directly.