### PR TITLE
Fix a mistake in example/ssd/demo.py

### DIFF
--- a/example/ssd/demo.py
+++ b/example/ssd/demo.py
@@ -143,7 +143,7 @@ if __name__ == '__main__':
     class_names = parse_class_names(args.class_names)
     data_shape = parse_data_shape(args.data_shape)
     if args.prefix.endswith('_'):
-        prefix = args.prefix + args.network + '_' + str(args.data_shape[0])
+        prefix = args.prefix + args.network + '_' + str(data_shape[0])
     else:
         prefix = args.prefix
     detector = get_detector(network, prefix, args.epoch,


### PR DESCRIPTION
If the default arguments are used, `prefix` will be `ssd_resnet50_5`. This seems a mistake. The parsed `data_shape` should be used, but `args.data_shape` is used instead. So, I fixed it.