### PR TITLE
Optional reshape of predictions in Perplexity metric

### DIFF
--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -646,9 +646,13 @@ class Perplexity(EvalMetric):
         loss = 0.
         num = 0
         for label, pred in zip(labels, preds):
-            assert label.size == pred.size/pred.shape[-1], \
+            k = pred.shape[self.axis]
+            n = int(pred.size/k)
+            assert label.size == n, \
                 "shape mismatch: %s vs. %s"%(label.shape, pred.shape)
             label = label.as_in_context(pred.context).reshape((label.size,))
+            if len(pred.shape) > 2:
+                pred = pred.reshape((n, k))
             pred = ndarray.pick(pred, label.astype(dtype='int32'), axis=self.axis)
             if self.ignore_label is not None:
                 ignore = (label == self.ignore_label).astype(pred.dtype)


### PR DESCRIPTION
Fixes a shape issue with the Perplexity metric after #7949  and #8003 were merged: after these PRs, the executor group slices graph outputs according to the size of the batch axis. This forces graph/symbol outputs to be batch-major if used to compute metrics.
In cases like Sockeye, we used to feed label as `(batch_size, length)` into the graph, but return `(batch_size*length, vocab_size)` as output after SoftmaxOutput. This is also the required format for the Perplexity metric.
With the PRs mentioned above, this now fails, as the executor_group slices the `(batch_size*length, vocab_size)` output to `(batch_size, vocab_size)`, which is obviously wrong.

We can fix this by using `preserve_shape=True` in our SoftmaxOutput call and return `(batch_size, length, vocab_size)` outputs.
However, this caused the Perplexity metric to fail.

This PR fixes this by doing an optional reshape of the predictions to 2d.