### PR TITLE
MXCallbackList is a struct

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1921,7 +1921,7 @@ MXNET_DLL int MXCustomOpRegister(const char* op_type, CustomOpPropCreator creato
  */
 MXNET_DLL int MXCustomFunctionRecord(int num_inputs, NDArrayHandle *inputs,
                                      int num_outputs, NDArrayHandle *outputs,
-                                     MXCallbackList *callbacks);
+                                     struct MXCallbackList *callbacks);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
C compiler complains about MXCallbackList:
```
In file included from 7.c:1:0:
../mxnet-bk/include/mxnet/c_api.h:1917:38: error: unknown type name ‘MXCallbackList’
                                      MXCallbackList *callbacks);
                                      ^
```
This PR fix this tiny error.