### PR TITLE
Kill running PR builds when a new build is triggered for the same PR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,15 +138,10 @@ def python3_gpu_ut(docker_type) {
 }
 
 try {
-    stage("Purge") {
-        node('mxnetlinux') {
-            abortPreviousRunningBuilds()
-        }
-    }
-
     stage("Sanity Check") {
       timeout(time: max_time, unit: 'MINUTES') {
         node('mxnetlinux') {
+          abortPreviousRunningBuilds()
           ws('workspace/sanity') {
             init_git()
             sh "python tools/license_header.py check"


### PR DESCRIPTION
@nswamy @gautamkmr @sandeep-krishnamurthy 

This is Part 1 of a series of changes to the **current MXNet PR build Process**. 

**This change might lead to some issues on Apache Jenkins, specially with requiring some script approvals as indicated[ here](https://wiki.jenkins.io/display/JENKINS/Script+Security+Plugin)**

The code for this method has been picked as is from [this stackoverflow post](https://stackoverflow.com/questions/40760716/jenkins-abort-running-build-if-new-one-is-started) 

**Expected Behavior** - 
1. I have a added a new stage to our builds called 'Purge' (other name suggestions are welcome)
2. This stage runs on a 'mxnetlinux' slave at the moment. This means it joins the queue waiting for an idle slave before it can kill an existing PR build. If we want to avoid this, it can be changed to be scheduled to the master. 
3. The method called 'abortPreviousRunningBuilds' simply scans all build numbers for the current PR and checks their status. If it is not the current build but is still running, the status of the build is changed to Aborted. 

**Testing Done** - 
I have reproduced a multibranch pipeline job on our internal jenkins similar to apache. Tests have only been done on a feature branch and PRs. The master branch should work similarly. I have tested that -
1. When a new branch is created, the build goes through fine. 
2. If a new build is triggered on a branch (say using 'Build Now'), the purge stage works as expected. (This behavior might need to be changed specially for the master branch)
3. When a new PR is created, the build works fine
4. Any updates to the PR terminates the old build and a new one is created. 

![screen shot 2017-09-25 at 3 53 11 pm](https://user-images.githubusercontent.com/30911248/30834833-bb39756a-a209-11e7-98c1-a613d95b5fd6.png)
 
![screen shot 2017-09-25 at 3 52 16 pm](https://user-images.githubusercontent.com/30911248/30834847-d6b52a00-a209-11e7-8326-538e346a47e7.png)

