### PR TITLE
Fix bug in Parameter.initialize method

### DIFF
--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -297,8 +297,7 @@ class Parameter(object):
             ctx = [context.current_context()]
         if isinstance(ctx, Context):
             ctx = [ctx]
-        if init is None:
-            init = default_init if self.init is None else self.init
+        init = default_init if self.init is None else self.init
         if not self.shape or np.prod(self.shape) <= 0:
             if self._allow_deferred_init:
                 self._deferred_init = (init, ctx, default_init)


### PR DESCRIPTION
Fix bug: custom initialize function does not work
Example: `class MyInit` in https://github.com/mli/gluon-tutorials-zh/blob/master/chapter03_gluon-basics/parameters.md