### PR TITLE
Issue #7750: MXNet 0.11.0 Release Feedback: README File Part2

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Ask Questions
 
 License
 -------
-© Contributors, 2015-2017. Licensed under an [Apache-2.0](https://github.com/dmlc/mxnet/blob/master/LICENSE) license.
+Licensed under an [Apache-2.0](https://github.com/dmlc/mxnet/blob/master/LICENSE) license.
 
 Reference Paper
 ---------------


### PR DESCRIPTION
@nswamy @gautamkmr 
Fix Point 5 of [this issue](https://github.com/apache/incubator-mxnet/issues/7750) which mentions - 
"The README.md refers to the copyright being owned by Contributors. Needs updating to a license statement (with NOTICE handling the copyright side of things)."

However, some other Apache projects do not have this license section in the README.md file at all. 