### PR TITLE
Locate liblapack.a in /usr/lib64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,10 @@ ifeq ($(USE_LAPACK), 1)
 ifeq ($(USE_BLAS),$(filter $(USE_BLAS),blas openblas atlas))
 ifeq (,$(wildcard /lib/liblapack.a))
 ifeq (,$(wildcard /usr/lib/liblapack.a))
+ifeq (,$(wildcard /usr/lib64/liblapack.a))
 ifeq (,$(wildcard $(USE_LAPACK_PATH)/liblapack.a))
 	USE_LAPACK = 0
+endif
 endif
 endif
 endif


### PR DESCRIPTION
I use openblas to provide lapack functionality.  Generally liblapack is softlinked from /usr/lib64/openblas.a to /usr/lib64/liblapack.a on my platform (amazon linux).  This works well, except that the Makefile seems to check a whitelist of lapack locations, and then disables lapack support if it doesn't find the lib.  This is a quick PR to include /usr/lib64 in the whitelist.