### PR TITLE
doc update

### DIFF
--- a/docs/_static/searchtools_custom.js
+++ b/docs/_static/searchtools_custom.js
@@ -10,7 +10,7 @@
  */
 
 
-/* Non-minified version JS is _stemmer.js if file is provided */ 
+/* Non-minified version JS is _stemmer.js if file is provided */
 /**
  * Porter Stemmer
  */
@@ -406,7 +406,7 @@ var Search = {
         return (left > right) ? -1 : ((left < right) ? 1 : 0);
       }
     });
-    
+
     //Render result for preview
     if(isPreview) {
         var prevNum = 0;
@@ -436,7 +436,7 @@ var Search = {
                 highlightstring + item[2]).html(item[1]));
             } else {
                 // normal html builders
-                var baseURL = 'http://mxnet.io/';
+                var baseURL = 'https://' + window.location.hostname + '/';
                 listItem.append($('<a/>').attr('href',
                 baseURL + item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX +
                 highlightstring + item[2]).html(item[1]));
@@ -719,7 +719,7 @@ var Search = {
         scoreDict[filenames[file]][titles[file]] += score;
       }
     }
-    
+
     for(var file in scoreDict) {
       for(var title in scoreDict[file]) {
         results.push([file, title, '', null, scoreDict[file][title]]);
@@ -757,14 +757,14 @@ var Search = {
 
 $(document).ready(function() {
   var searchBoxWidth = $('#search-input-wrap').width();
-  var searchBoxWidthModifier = 150; 
+  var searchBoxWidthModifier = 150;
   var focusInputColor = "white";
   var focusIconColor = "dimgray";
   var focusPlaceColor = "searchBoxExp";
   var normalInputColor = "transparent";
   var normalIconColor = "white";
   var normalPlaceColor = "searchBoxNorm";
-    
+
   function focusOut() {
     $("#search-input-wrap").css('width', '');
     $(".searchBox").width(searchBoxWidth);
@@ -793,14 +793,14 @@ $(document).ready(function() {
       isPreview = false;
     }
   });
-    
+
   //Click to focus out
   $('body').click(function (e) {
     if(e.target.id == 'search-preview' || e.target.name == 'q' || $(e.target).parents("#search-preview").size()) return;
 
     focusOut();
   });
-    
+
   //Press esc to focus out
   $(document).keyup(function(e) {
      if (e.keyCode == 27) { // escape key maps to keycode `27`
@@ -808,7 +808,7 @@ $(document).ready(function() {
        focusOut();
      }
   });
-    
+
   //Add search result preview
   $('#search-input-wrap input').on('input', function () {
       if($(this).val().length == 0) {

--- a/docs/api/python/executor/executor.md
+++ b/docs/api/python/executor/executor.md
@@ -1,0 +1,40 @@
+# Executor and Executor Manager
+
+The executor and executor manager are internal classes for managing symbolic
+graph execution. This document is only intended for reference for advanced users.
+
+## Executor
+
+```eval_rst
+.. currentmodule:: mxnet.executor
+
+.. autosummary::
+    :nosignatures:
+
+    Executor
+```
+
+## Executor Manager
+
+```eval_rst
+.. currentmodule:: mxnet.executor_manager
+
+.. autosummary::
+    :nosignatures:
+
+    DataParallelExecutorGroup
+    DataParallelExecutorManager
+```
+
+## API Reference
+
+<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+
+```eval_rst
+.. automodule:: mxnet.executor
+    :members:
+.. automodule:: mxnet.executor_manager
+    :members:
+```
+
+<script>auto_index("api-reference");</script>

--- a/docs/api/python/gluon/contrib.md
+++ b/docs/api/python/gluon/contrib.md
@@ -1,0 +1,61 @@
+# Gluon Contrib API
+
+## Overview
+
+This document lists the contrib APIs in Gluon:
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    mxnet.gluon.contrib
+```
+
+The `Gluon Contrib` API, defined in the `gluon.contrib` package, provides
+many useful experimental APIs for new features.
+This is a place for the community to try out the new features,
+so that feature contributors can receive feedback.
+
+```eval_rst
+.. warning:: This package contains experimental APIs and may change in the near future.
+```
+
+In the rest of this document, we list routines provided by the `gluon.contrib` package.
+
+## Contrib
+
+```eval_rst
+.. currentmodule:: mxnet.gluon.contrib
+
+.. autosummary::
+    :nosignatures:
+
+    rnn.VariationalDropoutCell
+    rnn.Conv1DRNNCell
+    rnn.Conv2DRNNCell
+    rnn.Conv3DRNNCell
+    rnn.Conv1DLSTMCell
+    rnn.Conv2DLSTMCell
+    rnn.Conv3DLSTMCell
+    rnn.Conv1DGRUCell
+    rnn.Conv2DGRUCell
+    rnn.Conv3DGRUCell
+```
+
+## API Reference
+
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
+
+```eval_rst
+
+.. automodule:: mxnet.gluon.contrib
+    :members:
+    :imported-members:
+
+.. automodule:: mxnet.gluon.contrib.rnn
+    :members:
+    :imported-members:
+
+```
+
+<script>auto_index("api-reference");</script>

--- a/docs/api/python/gluon/data.md
+++ b/docs/api/python/gluon/data.md
@@ -1,0 +1,89 @@
+# Gluon Data API
+
+## Overview
+
+This document lists the data APIs in Gluon:
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    mxnet.gluon.data
+    mxnet.gluon.data.vision
+```
+
+The `Gluon Data` API, defined in the `gluon.data` package, provides useful dataset loading
+and processing tools, as well as common public datasets.
+
+```eval_rst
+.. warning:: This package contains experimental APIs and may change in the near future.
+```
+
+In the rest of this document, we list routines provided by the `gluon.data` package.
+
+## Data
+
+```eval_rst
+.. currentmodule:: mxnet.gluon.data
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    Dataset
+    ArrayDataset
+    RecordFileDataset
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    Sampler
+    SequentialSampler
+    RandomSampler
+    BatchSampler
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    DataLoader
+```
+
+### Vision
+
+```eval_rst
+.. currentmodule:: mxnet.gluon.data.vision
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    MNIST
+    FashionMNIST
+    CIFAR10
+    CIFAR100
+    ImageRecordDataset
+    ImageFolderDataset
+```
+
+## API Reference
+
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
+
+```eval_rst
+
+.. automodule:: mxnet.gluon.data
+    :members:
+    :imported-members:
+
+.. automodule:: mxnet.gluon.data.vision
+    :members:
+
+```
+
+<script>auto_index("api-reference");</script>

--- a/docs/api/python/gluon/gluon.md
+++ b/docs/api/python/gluon/gluon.md
@@ -18,6 +18,19 @@ keeping most of the flexibility of low level API. Gluon supports both imperative
 and symbolic programming, making it easy to train complex models imperatively
 in Python and then deploy with symbolic graph in C++ and Scala.
 
+```eval_rst
+.. toctree::
+   :maxdepth: 1
+
+   nn.md
+   rnn.md
+   loss.md
+   data.md
+   model_zoo.md
+   contrib.md
+```
+
+
 ## Parameter
 
 ```eval_rst
@@ -38,104 +51,8 @@ in Python and then deploy with symbolic graph in C++ and Scala.
     Block
     HybridBlock
     SymbolBlock
-```
-
-## Neural Network Layers
-
-```eval_rst
-.. currentmodule:: mxnet.gluon.nn
-```
-
-### Containers
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    Sequential
-    HybridSequential
-```
-
-
-### Basic Layers
-
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    Dense
-    Activation
-    Dropout
-    BatchNorm
-    LeakyReLU
-    Embedding
-```
-
-
-### Convolutional Layers
-
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    Conv1D
-    Conv2D
-    Conv3D
-    Conv1DTranspose
-    Conv2DTranspose
-    Conv3DTranspose
-```
-
-
-
-### Pooling Layers
-
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    MaxPool1D
-    MaxPool2D
-    MaxPool3D
-    AvgPool1D
-    AvgPool2D
-    AvgPool3D
-    GlobalMaxPool1D
-    GlobalMaxPool2D
-    GlobalMaxPool3D
-    GlobalAvgPool1D
-    GlobalAvgPool2D
-    GlobalAvgPool3D
-```
-
-
-
-## Recurrent Layers
-
-```eval_rst
-.. currentmodule:: mxnet.gluon.rnn
-```
-
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    RecurrentCell
-    RNN
-    LSTM
-    GRU
-    RNNCell
-    LSTMCell
-    GRUCell
-    SequentialRNNCell
-    BidirectionalCell
-    DropoutCell
-    ZoneoutCell
-    ResidualCell
+    nn.Sequential
+    nn.HybridSequential
 ```
 
 
@@ -148,25 +65,6 @@ in Python and then deploy with symbolic graph in C++ and Scala.
     :nosignatures:
 
     Trainer
-```
-
-
-## Loss functions
-
-```eval_rst
-.. currentmodule:: mxnet.gluon.loss
-```
-
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    L2Loss
-    L1Loss
-    SoftmaxCrossEntropyLoss
-    KLDivLoss
-    CTCLoss
 ```
 
 ## Utilities
@@ -185,384 +83,23 @@ in Python and then deploy with symbolic graph in C++ and Scala.
     clip_global_norm
 ```
 
-## Data
-
-```eval_rst
-.. currentmodule:: mxnet.gluon.data
-```
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    Dataset
-    ArrayDataset
-    RecordFileDataset
-```
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    Sampler
-    SequentialSampler
-    RandomSampler
-    BatchSampler
-```
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    DataLoader
-```
-
-### Vision
-
-```eval_rst
-.. currentmodule:: mxnet.gluon.data.vision
-```
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    MNIST
-    FashionMNIST
-    CIFAR10
-    ImageRecordDataset
-```
-
-## Model Zoo
-
-Model zoo provides pre-defined and pre-trained models to help bootstrap machine learning applications.
-
-### Vision
-
-```eval_rst
-.. currentmodule:: mxnet.gluon.model_zoo.vision
-.. automodule:: mxnet.gluon.model_zoo.vision
-```
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    get_model
-```
-
-#### ResNet
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    resnet18_v1
-    resnet34_v1
-    resnet50_v1
-    resnet101_v1
-    resnet152_v1
-    resnet18_v2
-    resnet34_v2
-    resnet50_v2
-    resnet101_v2
-    resnet152_v2
-```
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    ResNetV1
-    ResNetV2
-    BasicBlockV1
-    BasicBlockV2
-    BottleneckV1
-    BottleneckV2
-    get_resnet
-```
-
-#### VGG
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    vgg11
-    vgg13
-    vgg16
-    vgg19
-    vgg11_bn
-    vgg13_bn
-    vgg16_bn
-    vgg19_bn
-```
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    VGG
-    get_vgg
-```
-
-#### Alexnet
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    alexnet
-```
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    AlexNet
-```
-
-#### DenseNet
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    densenet121
-    densenet161
-    densenet169
-    densenet201
-```
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    DenseNet
-```
-
-#### SqueezeNet
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    squeezenet1_0
-    squeezenet1_1
-```
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    SqueezeNet
-```
-
-#### Inception
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    inception_v3
-```
-
-```eval_rst
-.. autosummary::
-    :nosignatures:
-
-    Inception3
-```
 
 ## API Reference
 
 <script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
-.. autoclass:: mxnet.gluon.Parameter
+.. automodule:: mxnet.gluon
     :members:
-.. autoclass:: mxnet.gluon.ParameterDict
-    :members:
-
-.. autoclass:: mxnet.gluon.Block
-    :members:
-
-    .. automethod:: __call__
-.. autoclass:: mxnet.gluon.HybridBlock
-    :members:
-.. autoclass:: mxnet.gluon.SymbolBlock
-    :members:
+    :imported-members:
+    :special-members:
 
 .. autoclass:: mxnet.gluon.nn.Sequential
     :members:
 .. autoclass:: mxnet.gluon.nn.HybridSequential
     :members:
-.. autoclass:: mxnet.gluon.nn.Dense
-    :members:
-.. autoclass:: mxnet.gluon.nn.Activation
-    :members:
-.. autoclass:: mxnet.gluon.nn.Dropout
-    :members:
-.. autoclass:: mxnet.gluon.nn.BatchNorm
-    :members:
-.. autoclass:: mxnet.gluon.nn.LeakyReLU
-    :members:
-.. autoclass:: mxnet.gluon.nn.Embedding
-    :members:
-.. autoclass:: mxnet.gluon.nn.Conv1D
-    :members:
-.. autoclass:: mxnet.gluon.nn.Conv2D
-    :members:
-.. autoclass:: mxnet.gluon.nn.Conv3D
-    :members:
-.. autoclass:: mxnet.gluon.nn.Conv1DTranspose
-    :members:
-.. autoclass:: mxnet.gluon.nn.Conv2DTranspose
-    :members:
-.. autoclass:: mxnet.gluon.nn.Conv3DTranspose
-    :members:
-.. autoclass:: mxnet.gluon.nn.MaxPool1D
-    :members:
-.. autoclass:: mxnet.gluon.nn.MaxPool2D
-    :members:
-.. autoclass:: mxnet.gluon.nn.MaxPool3D
-    :members:
-.. autoclass:: mxnet.gluon.nn.AvgPool1D
-    :members:
-.. autoclass:: mxnet.gluon.nn.AvgPool2D
-    :members:
-.. autoclass:: mxnet.gluon.nn.AvgPool3D
-    :members:
-.. autoclass:: mxnet.gluon.nn.GlobalMaxPool1D
-    :members:
-.. autoclass:: mxnet.gluon.nn.GlobalMaxPool2D
-    :members:
-.. autoclass:: mxnet.gluon.nn.GlobalMaxPool3D
-    :members:
-.. autoclass:: mxnet.gluon.nn.GlobalAvgPool1D
-    :members:
-.. autoclass:: mxnet.gluon.nn.GlobalAvgPool2D
-    :members:
-.. autoclass:: mxnet.gluon.nn.GlobalAvgPool3D
-    :members:
 
-.. autoclass:: mxnet.gluon.rnn.RecurrentCell
-    :members:
-
-    .. automethod:: __call__
-.. autoclass:: mxnet.gluon.rnn.RNN
-    :members:
-.. autoclass:: mxnet.gluon.rnn.LSTM
-    :members:
-.. autoclass:: mxnet.gluon.rnn.GRU
-    :members:
-.. autoclass:: mxnet.gluon.rnn.RNNCell
-    :members:
-.. autoclass:: mxnet.gluon.rnn.LSTMCell
-    :members:
-.. autoclass:: mxnet.gluon.rnn.GRUCell
-    :members:
-.. autoclass:: mxnet.gluon.rnn.SequentialRNNCell
-    :members:
-.. autoclass:: mxnet.gluon.rnn.BidirectionalCell
-    :members:
-.. autoclass:: mxnet.gluon.rnn.DropoutCell
-    :members:
-.. autoclass:: mxnet.gluon.rnn.ZoneoutCell
-    :members:
-.. autoclass:: mxnet.gluon.rnn.ResidualCell
-    :members:
-
-.. autoclass:: mxnet.gluon.Trainer
-    :members:
-
-.. autoclass:: mxnet.gluon.loss.L2Loss
-    :members:
-.. autoclass:: mxnet.gluon.loss.L1Loss
-    :members:
-.. autoclass:: mxnet.gluon.loss.SoftmaxCrossEntropyLoss
-    :members:
-.. autoclass:: mxnet.gluon.loss.KLDivLoss
-    :members:
-.. autoclass:: mxnet.gluon.loss.CTCLoss
-    :members:
-.. automethod:: mxnet.gluon.utils.split_data
-
-.. automethod:: mxnet.gluon.utils.split_and_load
-
-.. automethod:: mxnet.gluon.utils.clip_global_norm
-
-.. autoclass:: mxnet.gluon.data.Dataset
-    :members:
-.. autoclass:: mxnet.gluon.data.ArrayDataset
-    :members:
-.. autoclass:: mxnet.gluon.data.RecordFileDataset
-    :members:
-.. autoclass:: mxnet.gluon.data.ImageRecordDataset
-    :members:
-.. autoclass:: mxnet.gluon.data.Sampler
-    :members:
-.. autoclass:: mxnet.gluon.data.SequentialSampler
-    :members:
-.. autoclass:: mxnet.gluon.data.RandomSampler
-    :members:
-.. autoclass:: mxnet.gluon.data.BatchSampler
-    :members:
-.. autoclass:: mxnet.gluon.data.DataLoader
-    :members:
-.. automodule:: mxnet.gluon.data.vision
-    :members:
-
-.. automethod:: mxnet.gluon.model_zoo.vision.get_model
-.. automethod:: mxnet.gluon.model_zoo.vision.resnet18_v1
-.. automethod:: mxnet.gluon.model_zoo.vision.resnet34_v1
-.. automethod:: mxnet.gluon.model_zoo.vision.resnet50_v1
-.. automethod:: mxnet.gluon.model_zoo.vision.resnet101_v1
-.. automethod:: mxnet.gluon.model_zoo.vision.resnet152_v1
-.. automethod:: mxnet.gluon.model_zoo.vision.resnet18_v2
-.. automethod:: mxnet.gluon.model_zoo.vision.resnet34_v2
-.. automethod:: mxnet.gluon.model_zoo.vision.resnet50_v2
-.. automethod:: mxnet.gluon.model_zoo.vision.resnet101_v2
-.. automethod:: mxnet.gluon.model_zoo.vision.resnet152_v2
-.. automethod:: mxnet.gluon.model_zoo.vision.get_resnet
-.. autoclass:: mxnet.gluon.model_zoo.vision.ResNetV1
-    :members:
-.. autoclass:: mxnet.gluon.model_zoo.vision.BasicBlockV1
-    :members:
-.. autoclass:: mxnet.gluon.model_zoo.vision.BottleneckV1
-    :members:
-.. autoclass:: mxnet.gluon.model_zoo.vision.ResNetV2
-    :members:
-.. autoclass:: mxnet.gluon.model_zoo.vision.BasicBlockV2
-    :members:
-.. autoclass:: mxnet.gluon.model_zoo.vision.BottleneckV2
-    :members:
-.. automethod:: mxnet.gluon.model_zoo.vision.vgg11
-.. automethod:: mxnet.gluon.model_zoo.vision.vgg13
-.. automethod:: mxnet.gluon.model_zoo.vision.vgg16
-.. automethod:: mxnet.gluon.model_zoo.vision.vgg19
-.. automethod:: mxnet.gluon.model_zoo.vision.vgg11_bn
-.. automethod:: mxnet.gluon.model_zoo.vision.vgg13_bn
-.. automethod:: mxnet.gluon.model_zoo.vision.vgg16_bn
-.. automethod:: mxnet.gluon.model_zoo.vision.vgg19_bn
-.. automethod:: mxnet.gluon.model_zoo.vision.get_vgg
-.. autoclass:: mxnet.gluon.model_zoo.vision.VGG
-    :members:
-.. automethod:: mxnet.gluon.model_zoo.vision.alexnet
-.. autoclass:: mxnet.gluon.model_zoo.vision.AlexNet
-    :members:
-.. automethod:: mxnet.gluon.model_zoo.vision.densenet121
-.. automethod:: mxnet.gluon.model_zoo.vision.densenet161
-.. automethod:: mxnet.gluon.model_zoo.vision.densenet169
-.. automethod:: mxnet.gluon.model_zoo.vision.densenet201
-.. autoclass:: mxnet.gluon.model_zoo.vision.DenseNet
-    :members:
-.. automethod:: mxnet.gluon.model_zoo.vision.squeezenet1_0
-.. automethod:: mxnet.gluon.model_zoo.vision.squeezenet1_1
-.. autoclass:: mxnet.gluon.model_zoo.vision.SqueezeNet
-    :members:
-.. automethod:: mxnet.gluon.model_zoo.vision.inception_v3
-.. autoclass:: mxnet.gluon.model_zoo.vision.Inception3
+.. automodule:: mxnet.gluon.utils
     :members:
 ```
 

--- a/docs/api/python/gluon/loss.md
+++ b/docs/api/python/gluon/loss.md
@@ -1,0 +1,34 @@
+# Gluon Loss API
+
+## Overview
+
+This document lists the loss API in Gluon:
+
+```eval_rst
+.. currentmodule:: mxnet.gluon.loss
+```
+
+This package includes several commonly used loss functions in neural networks.
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    L2Loss
+    L1Loss
+    SoftmaxCrossEntropyLoss
+    KLDivLoss
+    CTCLoss
+```
+
+
+## API Reference
+
+<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+
+```eval_rst
+.. automodule:: mxnet.gluon.loss
+    :members:
+```
+
+<script>auto_index("api-reference");</script>

--- a/docs/api/python/gluon/model_zoo.md
+++ b/docs/api/python/gluon/model_zoo.md
@@ -1,0 +1,195 @@
+# Gluon Model Zoo
+
+```eval_rst
+    .. currentmodule:: mxnet.gluon.model_zoo
+```
+
+## Overview
+
+This document lists the model APIs in Gluon:
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    mxnet.gluon.model_zoo
+```
+
+The `Gluon Model Zoo` API, defined in the `gluon.model_zoo` package, provides pre-defined
+and pre-trained models to help bootstrap machine learning applications.
+
+```eval_rst
+.. warning:: This package contains experimental APIs and may change in the near future.
+```
+
+In the rest of this document, we list routines provided by the `gluon.model_zoo` package.
+
+### Vision
+
+```eval_rst
+.. currentmodule:: mxnet.gluon.model_zoo.vision
+.. automodule:: mxnet.gluon.model_zoo.vision
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    get_model
+```
+
+#### ResNet
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    resnet18_v1
+    resnet34_v1
+    resnet50_v1
+    resnet101_v1
+    resnet152_v1
+    resnet18_v2
+    resnet34_v2
+    resnet50_v2
+    resnet101_v2
+    resnet152_v2
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    ResNetV1
+    ResNetV2
+    BasicBlockV1
+    BasicBlockV2
+    BottleneckV1
+    BottleneckV2
+    get_resnet
+```
+
+#### VGG
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    vgg11
+    vgg13
+    vgg16
+    vgg19
+    vgg11_bn
+    vgg13_bn
+    vgg16_bn
+    vgg19_bn
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    VGG
+    get_vgg
+```
+
+#### Alexnet
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    alexnet
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    AlexNet
+```
+
+#### DenseNet
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    densenet121
+    densenet161
+    densenet169
+    densenet201
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    DenseNet
+```
+
+#### SqueezeNet
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    squeezenet1_0
+    squeezenet1_1
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    SqueezeNet
+```
+
+#### Inception
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    inception_v3
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    Inception3
+```
+
+#### MobileNet
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    mobilenet1_0
+    mobilenet0_75
+    mobilenet0_5
+    mobilenet0_25
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    MobileNet
+```
+
+## API Reference
+
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
+
+```eval_rst
+
+.. automodule:: mxnet.gluon.model_zoo.vision
+    :members:
+    :imported-members:
+
+```
+
+<script>auto_index("api-reference");</script>

--- a/docs/api/python/gluon/nn.md
+++ b/docs/api/python/gluon/nn.md
@@ -72,6 +72,7 @@ This document lists the neural network blocks in Gluon:
 .. automodule:: mxnet.gluon.nn
     :members:
     :imported-members:
+    :exclude-members: Block, HybridBlock, SymbolBlock, Sequential, HybridSequential
 ```
 
 <script>auto_index("api-reference");</script>

--- a/docs/api/python/gluon/nn.md
+++ b/docs/api/python/gluon/nn.md
@@ -1,0 +1,77 @@
+# Gluon Neural Network Layers
+
+## Overview
+
+This document lists the neural network blocks in Gluon:
+
+```eval_rst
+.. currentmodule:: mxnet.gluon.nn
+```
+
+
+## Basic Layers
+
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    Dense
+    Activation
+    Dropout
+    BatchNorm
+    LeakyReLU
+    Embedding
+```
+
+
+## Convolutional Layers
+
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    Conv1D
+    Conv2D
+    Conv3D
+    Conv1DTranspose
+    Conv2DTranspose
+    Conv3DTranspose
+```
+
+
+
+## Pooling Layers
+
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    MaxPool1D
+    MaxPool2D
+    MaxPool3D
+    AvgPool1D
+    AvgPool2D
+    AvgPool3D
+    GlobalMaxPool1D
+    GlobalMaxPool2D
+    GlobalMaxPool3D
+    GlobalAvgPool1D
+    GlobalAvgPool2D
+    GlobalAvgPool3D
+```
+
+
+## API Reference
+
+<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+
+```eval_rst
+.. automodule:: mxnet.gluon.nn
+    :members:
+    :imported-members:
+```
+
+<script>auto_index("api-reference");</script>

--- a/docs/api/python/gluon/rnn.md
+++ b/docs/api/python/gluon/rnn.md
@@ -1,0 +1,65 @@
+# Gluon Recurrent Neural Network API
+
+## Overview
+
+This document lists the recurrent neural network API in Gluon:
+
+```eval_rst
+.. currentmodule:: mxnet.gluon.rnn
+```
+
+### Recurrent Layers
+
+Recurrent layers can be used in `Sequential` with other regular neural network layers. For example,
+to construct a sequence labeling model where a prediction is made for each time-step:
+
+```python
+>>> model = mx.gluon.nn.Sequential()
+>>> model.add(mx.gluon.nn.Embedding(30, 10))
+>>> model.add(mx.gluon.rnn.LSTM(20))
+>>> model.add(mx.gluon.nn.Dense(5, flatten=False))
+>>> model.initialize()
+>>> model(mx.nd.ones((2,3,5)))
+```
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    RNN
+    LSTM
+    GRU
+```
+
+### Recurrent Cells
+
+Recurrent cells exposes the intermediate recurrent states and allows for explicit stepping and
+unrolling, and thus provides more flexibility.
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    RNNCell
+    LSTMCell
+    GRUCell
+    RecurrentCell
+    SequentialRNNCell
+    BidirectionalCell
+    DropoutCell
+    ZoneoutCell
+    ResidualCell
+```
+
+
+## API Reference
+
+<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+
+```eval_rst
+.. automodule:: mxnet.gluon.rnn
+    :members:
+    :imported-members:
+```
+
+<script>auto_index("api-reference");</script>

--- a/docs/api/python/index.md
+++ b/docs/api/python/index.md
@@ -43,6 +43,7 @@ imported by running:
    symbol/linalg.md
    symbol/sparse.md
    symbol/contrib.md
+   symbol/rnn.md
 ```
 
 ## Module API
@@ -52,6 +53,7 @@ imported by running:
    :maxdepth: 1
 
    module/module.md
+   executor/executor.md
 ```
 
 ## Autograd API
@@ -70,15 +72,12 @@ imported by running:
    :maxdepth: 1
 
    gluon/gluon.md
-```
-
-## RNN API
-
-```eval_rst
-.. toctree::
-   :maxdepth: 1
-
-   rnn/rnn.md
+   gluon/nn.md
+   gluon/rnn.md
+   gluon/loss.md
+   gluon/data.md
+   gluon/model_zoo.md
+   gluon/contrib.md
 ```
 
 ## KVStore API

--- a/docs/api/python/ndarray/ndarray.md
+++ b/docs/api/python/ndarray/ndarray.md
@@ -214,6 +214,61 @@ The `ndarray` package provides several classes:
     NDArray.__pow__
 ```
 
+### Trigonometric functions
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    NDArray.sin
+    NDArray.cos
+    NDArray.tan
+    NDArray.arcsin
+    NDArray.arccos
+    NDArray.arctan
+    NDArray.degrees
+    NDArray.radians
+```
+
+### Hyperbolic functions
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    NDArray.sinh
+    NDArray.cosh
+    NDArray.tanh
+    NDArray.arcsinh
+    NDArray.arccosh
+    NDArray.arctanh
+```
+
+### Exponents and logarithms
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    NDArray.exp
+    NDArray.expm1
+    NDArray.log
+    NDArray.log10
+    NDArray.log2
+    NDArray.log1p
+```
+
+### Powers
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    NDArray.sqrt
+    NDArray.rsqrt
+    NDArray.square
+```
+
 ### In-place arithmetic operations
 
 ```eval_rst
@@ -435,7 +490,6 @@ The `ndarray` package provides several classes:
     ceil
     trunc
 ```
-
 
 ### Exponents and logarithms
 

--- a/docs/api/python/symbol/rnn.md
+++ b/docs/api/python/symbol/rnn.md
@@ -1,11 +1,11 @@
-# RNN Cell API
+# RNN Cell Symbol API
 
 ```eval_rst
 .. currentmodule:: mxnet.rnn
 ```
 
 ```eval_rst
-.. warning:: This package is currently experimental and may change in the near future.
+.. warning:: This package was experimental and may be deprecated in the near future.
 ```
 
 ## Overview

--- a/docs/api/python/symbol/symbol.md
+++ b/docs/api/python/symbol/symbol.md
@@ -91,6 +91,61 @@ Composite multiple symbols into a new one by an operator.
     Symbol.__pow__
 ```
 
+#### Trigonometric functions
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    Symbol.sin
+    Symbol.cos
+    Symbol.tan
+    Symbol.arcsin
+    Symbol.arccos
+    Symbol.arctan
+    Symbol.degrees
+    Symbol.radians
+```
+
+#### Hyperbolic functions
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    Symbol.sinh
+    Symbol.cosh
+    Symbol.tanh
+    Symbol.arcsinh
+    Symbol.arccosh
+    Symbol.arctanh
+```
+
+#### Exponents and logarithms
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    Symbol.exp
+    Symbol.expm1
+    Symbol.log
+    Symbol.log10
+    Symbol.log2
+    Symbol.log1p
+```
+
+#### Powers
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    Symbol.sqrt
+    Symbol.rsqrt
+    Symbol.square
+```
+
 #### Comparison operators
 
 ```eval_rst
@@ -351,6 +406,8 @@ Composite multiple symbols into a new one by an operator.
     one_hot
     pick
     where
+    gather_nd
+    scatter_nd
 ```
 
 ## Mathematical functions

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -18,6 +18,7 @@
 # coding: utf-8
 # pylint: disable= arguments-differ
 """Base container class for all neural network models."""
+__all__ = ['Block', 'HybridBlock', 'SymbolBlock']
 
 import copy
 
@@ -30,7 +31,7 @@ from .utils import _indent
 
 
 class _BlockScope(object):
-    """Scope for collecting child `Block`s."""
+    """Scope for collecting child `Block` s."""
     _current = None
 
     def __init__(self, block):
@@ -120,8 +121,8 @@ class Block(object):
     """Base class for all neural network layers and models. Your models should
     subclass this class.
 
-    `Block` can be nested recursively in a tree structure. You can create and
-    assign child `Block` as regular attributes::
+    :py:class:`Block` can be nested recursively in a tree structure. You can create and
+    assign child :py:class:`Block` as regular attributes::
 
         from mxnet.gluon import Block, nn
         from mxnet import ndarray as F
@@ -144,18 +145,19 @@ class Block(object):
         model(F.zeros((10, 10), ctx=mx.cpu(0)))
 
 
-    Child `Block` assigned this way will be registered and `collect_params`
+    Child :py:class:`Block` assigned this way will be registered and :py:meth:`collect_params`
     will collect their Parameters recursively.
 
     Parameters
     ----------
     prefix : str
         Prefix acts like a name space. It will be prepended to the names of all
-        Parameters and child `Block`s in this `Block`'s `name_scope`. Prefix
-        should be unique within one model to prevent name collisions.
+        Parameters and child :py:class:`Block` s in this :py:class:`Block` 's
+        :py:meth:`name_scope` .
+        Prefix should be unique within one model to prevent name collisions.
     params : ParameterDict or None
-        `ParameterDict` for sharing weights with the new `Block`. For example,
-        if you want `dense1` to share `dense0`'s weights, you can do::
+        :py:class:`ParameterDict` for sharing weights with the new :py:class:`Block`. For example,
+        if you want ``dense1`` to share ``dense0``'s weights, you can do::
 
             dense0 = nn.Dense(20)
             dense1 = nn.Dense(20, params=dense0.collect_params())
@@ -200,17 +202,17 @@ class Block(object):
 
     @property
     def prefix(self):
-        """Prefix of this `Block`."""
+        """Prefix of this :py:class:`Block`."""
         return self._prefix
 
     @property
     def name(self):
-        """Name of this `Block`, without '_' in the end."""
+        """Name of this :py:class:`Block`, without '_' in the end."""
         return self._name
 
     def name_scope(self):
-        """Returns a name space object managing a child `Block` and parameter
-        names. Should be used within a `with` statement::
+        """Returns a name space object managing a child :py:class:`Block` and parameter
+        names. Should be used within a ``with`` statement::
 
             with self.name_scope():
                 self.dense = nn.Dense(20)
@@ -219,12 +221,12 @@ class Block(object):
 
     @property
     def params(self):
-        """Returns this `Block`'s parameter dictionary (does not include its
+        """Returns this :py:class:`Block`'s parameter dictionary (does not include its
         children's parameters)."""
         return self._params
 
     def collect_params(self):
-        """Returns a `ParameterDict` containing this `Block` and all of its
+        """Returns a :py:class:`ParameterDict` containing this :py:class:`Block` and all of its
         children's Parameters."""
         ret = ParameterDict(self._params.prefix)
         ret.update(self.params)
@@ -259,19 +261,19 @@ class Block(object):
 
 
     def register_child(self, block):
-        """Registers block as a child of self. `Block`s assigned to self as
+        """Registers block as a child of self. :py:class:`Block` s assigned to self as
         attributes will be registered automatically."""
         self._children.append(block)
 
     def initialize(self, init=initializer.Uniform(), ctx=None, verbose=False):
-        """Initializes `Parameter`s of this `Block` and its children.
+        """Initializes :py:class:`Parameter` s of this :py:class:`Block` and its children.
 
-        Equivalent to `block.collect_params().initialize(...)`
+        Equivalent to ``block.collect_params().initialize(...)``
         """
         self.collect_params().initialize(init, ctx, verbose)
 
     def hybridize(self, active=True):
-        """Activates or deactivates `HybridBlock`s recursively. Has no effect on
+        """Activates or deactivates :py:class:`HybridBlock` s recursively. Has no effect on
         non-hybrid children.
 
         Parameters
@@ -287,7 +289,7 @@ class Block(object):
         return self.forward(*args)
 
     def forward(self, *args):
-        """Overrides to implement forward computation using `NDArray`. Only
+        """Overrides to implement forward computation using :py:class:`NDArray`. Only
         accepts positional arguments.
 
         Parameters
@@ -302,16 +304,17 @@ class Block(object):
 class HybridBlock(Block):
     """`HybridBlock` supports forwarding with both Symbol and NDArray.
 
-    Forward computation in `HybridBlock` must be static to work with `Symbol`s,
-    i.e. you cannot call `.asnumpy()`, `.shape`, `.dtype`, etc on tensors.
+    Forward computation in :py:class:`HybridBlock` must be static to work with :py:class:`Symbol` s,
+    i.e. you cannot call :py:meth:`NDArray.asnumpy`, :py:attr:`NDArray.shape`,
+    :py:attr:`NDArray.dtype`, etc on tensors.
     Also, you cannot use branching or loop logic that bases on non-constant
     expressions like random numbers or intermediate results, since they change
     the graph structure for each iteration.
 
-    Before activating with `hybridize()`, `HybridBlock` works just like normal
-    `Block`. After activation, `HybridBlock` will create a symbolic graph
+    Before activating with :py:meth:`hybridize()`, :py:class:`HybridBlock` works just like normal
+    :py:class:`Block`. After activation, :py:class:`HybridBlock` will create a symbolic graph
     representing the forward computation and cache it. On subsequent forwards,
-    the cached graph will be used instead of `hybrid_forward`.
+    the cached graph will be used instead of :py:meth:`hybrid_forward`.
 
     Refer `Hybrid tutorial <http://mxnet.io/tutorials/gluon/hybrid.html>`_ to see
     the end-to-end usage.
@@ -414,7 +417,7 @@ class HybridBlock(Block):
 
     def forward(self, x, *args):
         """Defines the forward computation. Arguments can be either
-        `NDArray` or `Symbol`."""
+        :py:class:`NDArray` or :py:class:`Symbol`."""
         if isinstance(x, NDArray):
             with x.context as ctx:
                 if self._active:

--- a/python/mxnet/gluon/contrib/rnn/__init__.py
+++ b/python/mxnet/gluon/contrib/rnn/__init__.py
@@ -19,6 +19,10 @@
 # pylint: disable=wildcard-import
 """Contrib recurrent neural network module."""
 
+from . import conv_rnn_cell, rnn_cell
+
 from .conv_rnn_cell import *
 
 from .rnn_cell import *
+
+__all__ = conv_rnn_cell.__all__ + rnn_cell.__all__

--- a/python/mxnet/gluon/contrib/rnn/conv_rnn_cell.py
+++ b/python/mxnet/gluon/contrib/rnn/conv_rnn_cell.py
@@ -18,6 +18,10 @@
 # pylint: disable=arguments-differ, too-many-lines
 # coding: utf-8
 """Definition of various recurrent neural network cells."""
+__all__ = ['Conv1DRNNCell', 'Conv2DRNNCell', 'Conv3DRNNCell',
+           'Conv1DLSTMCell', 'Conv2DLSTMCell', 'Conv3DLSTMCell',
+           'Conv1DGRUCell', 'Conv2DGRUCell', 'Conv3DGRUCell']
+
 
 from math import floor
 
@@ -472,13 +476,14 @@ class Conv1DLSTMCell(_ConvLSTMCell):
     <https://arxiv.org/abs/1506.04214>`_ paper. Xingjian et al. NIPS2015
 
     .. math::
-
-        i_t = \sigma(W_i \ast x_t + R_i \ast h_{t-1} + b_i)
-        f_t = \sigma(W_f \ast x_t + R_f \ast h_{t-1} + b_f)
-        o_t = \sigma(W_o \ast x_t + R_o \ast h_{t-1} + b_o)
-        c^\prime_t = tanh(W_c \ast x_t + R_c \ast h_{t-1} + b_c)
-        c_t = f_t \circ c_{t-1} + i_t \circ c^\prime_t
-        h_t = o_t \circ tanh(c_t)
+        \begin{array}{ll}
+        i_t = \sigma(W_i \ast x_t + R_i \ast h_{t-1} + b_i) \\
+        f_t = \sigma(W_f \ast x_t + R_f \ast h_{t-1} + b_f) \\
+        o_t = \sigma(W_o \ast x_t + R_o \ast h_{t-1} + b_o) \\
+        c^\prime_t = tanh(W_c \ast x_t + R_c \ast h_{t-1} + b_c) \\
+        c_t = f_t \circ c_{t-1} + i_t \circ c^\prime_t \\
+        h_t = o_t \circ tanh(c_t) \\
+        \end{array}
 
     Parameters
     ----------
@@ -548,13 +553,14 @@ class Conv2DLSTMCell(_ConvLSTMCell):
     <https://arxiv.org/abs/1506.04214>`_ paper. Xingjian et al. NIPS2015
 
     .. math::
-
-        i_t = \sigma(W_i \ast x_t + R_i \ast h_{t-1} + b_i)
-        f_t = \sigma(W_f \ast x_t + R_f \ast h_{t-1} + b_f)
-        o_t = \sigma(W_o \ast x_t + R_o \ast h_{t-1} + b_o)
-        c^\prime_t = tanh(W_c \ast x_t + R_c \ast h_{t-1} + b_c)
-        c_t = f_t \circ c_{t-1} + i_t \circ c^\prime_t
-        h_t = o_t \circ tanh(c_t)
+        \begin{array}{ll}
+        i_t = \sigma(W_i \ast x_t + R_i \ast h_{t-1} + b_i) \\
+        f_t = \sigma(W_f \ast x_t + R_f \ast h_{t-1} + b_f) \\
+        o_t = \sigma(W_o \ast x_t + R_o \ast h_{t-1} + b_o) \\
+        c^\prime_t = tanh(W_c \ast x_t + R_c \ast h_{t-1} + b_c) \\
+        c_t = f_t \circ c_{t-1} + i_t \circ c^\prime_t \\
+        h_t = o_t \circ tanh(c_t) \\
+        \end{array}
 
     Parameters
     ----------
@@ -624,13 +630,14 @@ class Conv3DLSTMCell(_ConvLSTMCell):
     <https://arxiv.org/abs/1506.04214>`_ paper. Xingjian et al. NIPS2015
 
     .. math::
-
-        i_t = \sigma(W_i \ast x_t + R_i \ast h_{t-1} + b_i)
-        f_t = \sigma(W_f \ast x_t + R_f \ast h_{t-1} + b_f)
-        o_t = \sigma(W_o \ast x_t + R_o \ast h_{t-1} + b_o)
-        c^\prime_t = tanh(W_c \ast x_t + R_c \ast h_{t-1} + b_c)
-        c_t = f_t \circ c_{t-1} + i_t \circ c^\prime_t
-        h_t = o_t \circ tanh(c_t)
+        \begin{array}{ll}
+        i_t = \sigma(W_i \ast x_t + R_i \ast h_{t-1} + b_i) \\
+        f_t = \sigma(W_f \ast x_t + R_f \ast h_{t-1} + b_f) \\
+        o_t = \sigma(W_o \ast x_t + R_o \ast h_{t-1} + b_o) \\
+        c^\prime_t = tanh(W_c \ast x_t + R_c \ast h_{t-1} + b_c) \\
+        c_t = f_t \circ c_{t-1} + i_t \circ c^\prime_t \\
+        h_t = o_t \circ tanh(c_t) \\
+        \end{array}
 
     Parameters
     ----------
@@ -755,11 +762,12 @@ class Conv1DGRUCell(_ConvGRUCell):
     r"""1D Convolutional Gated Rectified Unit (GRU) network cell.
 
     .. math::
-
-        r_t = \sigma(W_r \ast x_t + R_r \ast h_{t-1} + b_r)
-        z_t = \sigma(W_z \ast x_t + R_z \ast h_{t-1} + b_z)
-        n_t = tanh(W_i \ast x_t + b_i + r_t \circ (R_n \ast h_{t-1} + b_n))
-        h^\prime_t = (1 - z_t) \circ n_t + z_t \circ h
+        \begin{array}{ll}
+        r_t = \sigma(W_r \ast x_t + R_r \ast h_{t-1} + b_r) \\
+        z_t = \sigma(W_z \ast x_t + R_z \ast h_{t-1} + b_z) \\
+        n_t = tanh(W_i \ast x_t + b_i + r_t \circ (R_n \ast h_{t-1} + b_n)) \\
+        h^\prime_t = (1 - z_t) \circ n_t + z_t \circ h \\
+        \end{array}
 
     Parameters
     ----------
@@ -826,11 +834,12 @@ class Conv2DGRUCell(_ConvGRUCell):
     r"""2D Convolutional Gated Rectified Unit (GRU) network cell.
 
     .. math::
-
-        r_t = \sigma(W_r \ast x_t + R_r \ast h_{t-1} + b_r)
-        z_t = \sigma(W_z \ast x_t + R_z \ast h_{t-1} + b_z)
-        n_t = tanh(W_i \ast x_t + b_i + r_t \circ (R_n \ast h_{t-1} + b_n))
-        h^\prime_t = (1 - z_t) \circ n_t + z_t \circ h
+        \begin{array}{ll}
+        r_t = \sigma(W_r \ast x_t + R_r \ast h_{t-1} + b_r) \\
+        z_t = \sigma(W_z \ast x_t + R_z \ast h_{t-1} + b_z) \\
+        n_t = tanh(W_i \ast x_t + b_i + r_t \circ (R_n \ast h_{t-1} + b_n)) \\
+        h^\prime_t = (1 - z_t) \circ n_t + z_t \circ h \\
+        \end{array}
 
     Parameters
     ----------
@@ -897,11 +906,12 @@ class Conv3DGRUCell(_ConvGRUCell):
     r"""3D Convolutional Gated Rectified Unit (GRU) network cell.
 
     .. math::
-
-        r_t = \sigma(W_r \ast x_t + R_r \ast h_{t-1} + b_r)
-        z_t = \sigma(W_z \ast x_t + R_z \ast h_{t-1} + b_z)
-        n_t = tanh(W_i \ast x_t + b_i + r_t \circ (R_n \ast h_{t-1} + b_n))
-        h^\prime_t = (1 - z_t) \circ n_t + z_t \circ h
+        \begin{array}{ll}
+        r_t = \sigma(W_r \ast x_t + R_r \ast h_{t-1} + b_r) \\
+        z_t = \sigma(W_z \ast x_t + R_z \ast h_{t-1} + b_z) \\
+        n_t = tanh(W_i \ast x_t + b_i + r_t \circ (R_n \ast h_{t-1} + b_n)) \\
+        h^\prime_t = (1 - z_t) \circ n_t + z_t \circ h \\
+        \end{array}
 
     Parameters
     ----------

--- a/python/mxnet/gluon/contrib/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/contrib/rnn/rnn_cell.py
@@ -17,6 +17,7 @@
 
 # coding: utf-8
 """Definition of various recurrent neural network cells."""
+__all__ = ['VariationalDropoutCell']
 
 from ...rnn import BidirectionalCell, SequentialRNNCell, ModifierCell
 from ...rnn.rnn_cell import _format_sequence, _get_begin_state

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -18,6 +18,7 @@
 # coding: utf-8
 # pylint: disable=
 """Dataset generator."""
+__all__ = ['DataLoader']
 
 import numpy as np
 

--- a/python/mxnet/gluon/data/dataset.py
+++ b/python/mxnet/gluon/data/dataset.py
@@ -18,6 +18,8 @@
 # coding: utf-8
 # pylint: disable=
 """Dataset container."""
+__all__ = ['Dataset', 'ArrayDataset', 'RecordFileDataset']
+
 import os
 
 from ... import recordio, ndarray

--- a/python/mxnet/gluon/data/sampler.py
+++ b/python/mxnet/gluon/data/sampler.py
@@ -18,6 +18,7 @@
 # coding: utf-8
 # pylint: disable=
 """Dataset sampler."""
+__all__ = ['Sampler', 'SequentialSampler', 'RandomSampler', 'BatchSampler']
 
 import random
 

--- a/python/mxnet/gluon/data/vision.py
+++ b/python/mxnet/gluon/data/vision.py
@@ -18,6 +18,8 @@
 # coding: utf-8
 # pylint: disable=
 """Dataset container."""
+__all__ = ['MNIST', 'FashionMNIST', 'CIFAR10', 'CIFAR100',
+           'ImageRecordDataset', 'ImageFolderDataset']
 
 import os
 import gzip
@@ -69,7 +71,7 @@ class _DownloadedDataset(dataset.Dataset):
 
 
 class MNIST(_DownloadedDataset):
-    """MNIST handwritten digits dataset from `http://yann.lecun.com/exdb/mnist`_.
+    """MNIST handwritten digits dataset from http://yann.lecun.com/exdb/mnist
 
     Each sample is an image (in 3D NDArray) with shape (28, 28, 1).
 
@@ -80,9 +82,11 @@ class MNIST(_DownloadedDataset):
     train : bool, default True
         Whether to load the training or testing set.
     transform : function, default None
-        A user defined callback that transforms each instance. For example::
+        A user defined callback that transforms each sample. For example:
+    ::
 
-            transform=lambda data, label: (data.astype(np.float32)/255, label)
+        transform=lambda data, label: (data.astype(np.float32)/255, label)
+
     """
     def __init__(self, root='~/.mxnet/datasets/mnist', train=True,
                  transform=None):
@@ -125,7 +129,7 @@ class MNIST(_DownloadedDataset):
 class FashionMNIST(MNIST):
     """A dataset of Zalando's article images consisting of fashion products,
     a drop-in replacement of the original MNIST dataset from
-    `https://github.com/zalandoresearch/fashion-mnist`_.
+    https://github.com/zalandoresearch/fashion-mnist
 
     Each sample is an image (in 3D NDArray) with shape (28, 28, 1).
 
@@ -136,9 +140,11 @@ class FashionMNIST(MNIST):
     train : bool, default True
         Whether to load the training or testing set.
     transform : function, default None
-        A user defined callback that transforms each instance. For example::
+        A user defined callback that transforms each sample. For example:
+    ::
 
-            transform=lambda data, label: (data.astype(np.float32)/255, label)
+        transform=lambda data, label: (data.astype(np.float32)/255, label)
+
     """
     def __init__(self, root='~/.mxnet/datasets/fashion-mnist', train=True,
                  transform=None):
@@ -154,7 +160,7 @@ class FashionMNIST(MNIST):
 
 
 class CIFAR10(_DownloadedDataset):
-    """CIFAR10 image classification dataset from `https://www.cs.toronto.edu/~kriz/cifar.html`_.
+    """CIFAR10 image classification dataset from https://www.cs.toronto.edu/~kriz/cifar.html
 
     Each sample is an image (in 3D NDArray) with shape (32, 32, 1).
 
@@ -165,9 +171,11 @@ class CIFAR10(_DownloadedDataset):
     train : bool, default True
         Whether to load the training or testing set.
     transform : function, default None
-        A user defined callback that transforms each instance. For example::
+        A user defined callback that transforms each sample. For example:
+    ::
 
-            transform=lambda data, label: (data.astype(np.float32)/255, label)
+        transform=lambda data, label: (data.astype(np.float32)/255, label)
+
     """
     def __init__(self, root='~/.mxnet/datasets/cifar10', train=True,
                  transform=None):
@@ -212,7 +220,7 @@ class CIFAR10(_DownloadedDataset):
 
 
 class CIFAR100(CIFAR10):
-    """CIFAR100 image classification dataset from `https://www.cs.toronto.edu/~kriz/cifar.html`_.
+    """CIFAR100 image classification dataset from https://www.cs.toronto.edu/~kriz/cifar.html
 
     Each sample is an image (in 3D NDArray) with shape (32, 32, 1).
 
@@ -225,9 +233,11 @@ class CIFAR100(CIFAR10):
     train : bool, default True
         Whether to load the training or testing set.
     transform : function, default None
-        A user defined callback that transforms each instance. For example::
+        A user defined callback that transforms each sample. For example:
+    ::
 
-            transform=lambda data, label: (data.astype(np.float32)/255, label)
+        transform=lambda data, label: (data.astype(np.float32)/255, label)
+
     """
     def __init__(self, root='~/.mxnet/datasets/cifar100', fine_label=False, train=True,
                  transform=None):
@@ -259,9 +269,11 @@ class ImageRecordDataset(dataset.RecordFileDataset):
 
         If 1, always convert images to colored (RGB).
     transform : function, default None
-        A user defined callback that transforms each instance. For example::
+        A user defined callback that transforms each sample. For example:
+    ::
 
-            transform=lambda data, label: (data.astype(np.float32)/255, label)
+        transform=lambda data, label: (data.astype(np.float32)/255, label)
+
     """
     def __init__(self, filename, flag=1, transform=None):
         super(ImageRecordDataset, self).__init__(filename)
@@ -294,9 +306,10 @@ class ImageFolderDataset(dataset.Dataset):
         If 0, always convert loaded images to greyscale (1 channel).
         If 1, always convert loaded images to colored (3 channels).
     transform : callable, default None
-        A function that takes data and label and transforms them::
+        A function that takes data and label and transforms them:
+    ::
 
-            transform = lambda data, label: (data.astype(np.float32)/255, label)
+        transform = lambda data, label: (data.astype(np.float32)/255, label)
 
     Attributes
     ----------

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -19,6 +19,10 @@
 # pylint: disable=arguments-differ
 """ losses for training neural networks """
 from __future__ import absolute_import
+__all__ = ['Loss', 'L2Loss', 'L1Loss',
+           'SigmoidBinaryCrossEntropyLoss', 'SigmoidBCELoss',
+           'SoftmaxCrossEntropyLoss', 'SoftmaxCELoss',
+           'KLDivLoss', 'CTCLoss']
 
 from .. import ndarray
 from ..base import numeric_types
@@ -94,7 +98,7 @@ class Loss(HybridBlock):
 
 
 class L2Loss(Loss):
-    """Calculates the mean squared error between output and label:
+    """Calculates the mean squared error between output and label.
 
     .. math::
         L = \\frac{1}{2}\\sum_i \\Vert {output}_i - {label}_i \\Vert^2.
@@ -106,13 +110,19 @@ class L2Loss(Loss):
     ----------
     weight : float or None
         Global scalar weight for loss.
-    sample_weight : Symbol or None
-        Per sample weighting. Must be broadcastable to
-        the same shape as loss. For example, if loss has
-        shape (64, 10) and you want to weight each sample
-        in the batch, `sample_weight` should have shape (64, 1).
     batch_axis : int, default 0
         The axis that represents mini-batch.
+
+
+    Input shape:
+        `output` is the prediction tensor.
+        `label` is the truth tensor and should have the same shape as `output`.
+        `sample_weight` is a matrix for per-sample weighting. Must be broadcastable to
+        the same shape as loss. For example, if loss has shape (64, 10) and you want
+        to weigh each sample in the batch separately, `sample_weight` should have shape (64, 1).
+
+    Output shape:
+        The loss output has the shape (batch_size,).
     """
     def __init__(self, weight=1., batch_axis=0, **kwargs):
         super(L2Loss, self).__init__(weight, batch_axis, **kwargs)
@@ -125,7 +135,7 @@ class L2Loss(Loss):
 
 
 class L1Loss(Loss):
-    """Calculates the mean absolute error between output and label:
+    """Calculates the mean absolute error between output and label.
 
     .. math::
         L = \\frac{1}{2}\\sum_i \\vert {output}_i - {label}_i \\vert.
@@ -136,13 +146,19 @@ class L1Loss(Loss):
     ----------
     weight : float or None
         Global scalar weight for loss.
-    sample_weight : Symbol or None
-        Per sample weighting. Must be broadcastable to
-        the same shape as loss. For example, if loss has
-        shape (64, 10) and you want to weight each sample
-        in the batch, `sample_weight` should have shape (64, 1).
     batch_axis : int, default 0
         The axis that represents mini-batch.
+
+
+    Input shape:
+        `output` is the prediction tensor.
+        `label` is the truth tensor and should have the same shape as `output`.
+        `sample_weight` is a matrix for per-sample weighting. Must be broadcastable to
+        the same shape as loss. For example, if loss has shape (64, 10) and you want
+        to weigh each sample in the batch separately, `sample_weight` should have shape (64, 1).
+
+    Output shape:
+        The loss output has the shape (batch_size,).
     """
     def __init__(self, weight=None, batch_axis=0, **kwargs):
         super(L1Loss, self).__init__(weight, batch_axis, **kwargs)
@@ -171,13 +187,19 @@ class SigmoidBinaryCrossEntropyLoss(Loss):
         log-sum-exp trick.
     weight : float or None
         Global scalar weight for loss.
-    sample_weight : Symbol or None
-        Per sample weighting. Must be broadcastable to
-        the same shape as loss. For example, if loss has
-        shape (64, 10) and you want to weight each sample
-        in the batch, `sample_weight` should have shape (64, 1).
     batch_axis : int, default 0
         The axis that represents mini-batch.
+
+
+    Input shape:
+        `output` is the prediction tensor.
+        `label` is the truth tensor and should have the same shape as `output`.
+        `sample_weight` is a matrix for per-sample weighting. Must be broadcastable to
+        the same shape as loss. For example, if loss has shape (64, 10) and you want
+        to weigh each sample in the batch separately, `sample_weight` should have shape (64, 1).
+
+    Output shape:
+        The loss output has the shape (batch_size,).
     """
     def __init__(self, from_sigmoid=False, weight=None, batch_axis=0, **kwargs):
         super(SigmoidBinaryCrossEntropyLoss, self).__init__(weight, batch_axis, **kwargs)
@@ -228,13 +250,25 @@ class SoftmaxCrossEntropyLoss(Loss):
         of unnormalized numbers.
     weight : float or None
         Global scalar weight for loss.
-    sample_weight : Symbol or None
-        Per sample weighting. Must be broadcastable to
-        the same shape as loss. For example, if loss has
-        shape (64, 10) and you want to weight each sample
-        in the batch, `sample_weight` should have shape (64, 1).
     batch_axis : int, default 0
         The axis that represents mini-batch.
+
+
+    Input shape:
+        `output` is the prediction tensor. The batch axis and softmax axis should be consistent
+        with the value used in the constructor.
+        `label` is the truth tensor. When `sparse_label` is true, `label` should have one less
+        dimension (axis) than `output` tensor. Otherwise, the shape of `label` must be the same as
+        output. For example, when `sparse_label` is true, if `output` has shape
+        `(batch_size, x1, x2, c)` and axis is `-1`, `label` should have shape
+        `(batch_size, x1, x2)`. If `sparse_label` is false, `label` should have shape
+        `(batch_size, x1, x2, c)`.
+        `sample_weight` is a matrix for per-sample weighting. Must be broadcastable to
+        the same shape as loss. For example, if loss has shape (64, 10) and you want
+        to weigh each sample in the batch separately, `sample_weight` should have shape (64, 1).
+
+    Output shape:
+        The loss output has the shape (batch_size,).
     """
     def __init__(self, axis=-1, sparse_label=True, from_logits=False, weight=None,
                  batch_axis=0, **kwargs):
@@ -277,13 +311,19 @@ class KLDivLoss(Loss):
         of unnormalized numbers.
     weight : float or None
         Global scalar weight for loss.
-    sample_weight : Symbol or None
-        Per sample weighting. Must be broadcastable to
-        the same shape as loss. For example, if loss has
-        shape (64, 10) and you want to weight each sample
-        in the batch, `sample_weight` should have shape (64, 1).
     batch_axis : int, default 0
         The axis that represents mini-batch.
+
+
+    Input shape:
+        `output` is the prediction tensor.
+        `label` is the truth tensor and should have the same shape as `output`.
+        `sample_weight` is a matrix for per-sample weighting. Must be broadcastable to
+        the same shape as loss. For example, if loss has shape (64, 10) and you want
+        to weigh each sample in the batch separately, `sample_weight` should have shape (64, 1).
+
+    Output shape:
+        The loss output has the shape (batch_size,).
     """
     def __init__(self, from_logits=True, weight=None, batch_axis=0, **kwargs):
         super(KLDivLoss, self).__init__(weight, batch_axis, **kwargs)
@@ -312,14 +352,9 @@ class CTCLoss(Loss):
         Layout of the labels.
     weight : float or None
         Global scalar weight for loss.
-    sample_weight : Symbol or None
-        Per sample weighting. Must be broadcastable to
-        the same shape as loss. For example, if loss has
-        shape (64, 10) and you want to weight each sample
-        in the batch, `sample_weight` should have shape (64, 1).
-        This should be used as the fifth argument when calling this loss.
 
-    Input shapes:
+
+    Input shape:
         `data` is an activation tensor (i.e. before softmax).
         Its shape depends on `layout`. For `layout='TNC'`, this
         input has shape `(sequence_length, batch_size, alphabet_size)`

--- a/python/mxnet/gluon/model_zoo/custom_layers.py
+++ b/python/mxnet/gluon/model_zoo/custom_layers.py
@@ -18,6 +18,7 @@
 # coding: utf-8
 # pylint: disable= arguments-differ
 """Custom neural network layers in model_zoo."""
+__all__ = ['HybridConcurrent', 'Identity']
 
 from ..block import Block, HybridBlock
 from ..utils import _indent

--- a/python/mxnet/gluon/model_zoo/vision/__init__.py
+++ b/python/mxnet/gluon/model_zoo/vision/__init__.py
@@ -27,24 +27,25 @@ This module contains definitions for the following model architectures:
 -  `ResNet V2`_
 -  `SqueezeNet`_
 -  `VGG`_
+-  `MobileNet`_
 
 You can construct a model with random weights by calling its constructor:
 .. code::
 
-    import mxnet.gluon.models as models
-    resnet18 = models.resnet18_v1()
-    alexnet = models.alexnet()
-    squeezenet = models.squeezenet1_0()
-    densenet = models.densenet_161()
+    from mxnet.gluon.model_zoo import vision
+    resnet18 = vision.resnet18_v1()
+    alexnet = vision.alexnet()
+    squeezenet = vision.squeezenet1_0()
+    densenet = vision.densenet_161()
 
 We provide pre-trained models for all the models except ResNet V2.
 These can constructed by passing
 ``pretrained=True``:
 .. code::
 
-    import mxnet.gluon.models as models
-    resnet18 = models.resnet18_v1(pretrained=True)
-    alexnet = models.alexnet(pretrained=True)
+    from mxnet.gluon.model_zoo import vision
+    resnet18 = vision.resnet18_v1(pretrained=True)
+    alexnet = vision.alexnet(pretrained=True)
 
 Pretrained models are converted from torchvision.
 All pre-trained models expect input images normalized in the same way,
@@ -67,6 +68,7 @@ The transformation should preferrably happen at preprocessing. You can use
 .. _ResNet V2: https://arxiv.org/abs/1512.03385
 .. _SqueezeNet: https://arxiv.org/abs/1602.07360
 .. _VGG: https://arxiv.org/abs/1409.1556
+.. _MobileNet: https://arxiv.org/abs/1704.04861
 """
 
 from .alexnet import *

--- a/python/mxnet/gluon/nn/__init__.py
+++ b/python/mxnet/gluon/nn/__init__.py
@@ -19,6 +19,8 @@
 # pylint: disable=wildcard-import
 """Neural network layers."""
 
+from ..block import *
+
 from .basic_layers import *
 
 from .conv_layers import *

--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -18,7 +18,8 @@
 # coding: utf-8
 # pylint: disable= arguments-differ
 """Basic neural network layers."""
-
+__all__ = ['Sequential', 'HybridSequential', 'Dense', 'Activation',
+           'Dropout', 'BatchNorm', 'LeakyReLU', 'Embedding', 'Flatten']
 import warnings
 
 from ..block import Block, HybridBlock
@@ -26,7 +27,7 @@ from ..utils import _indent
 
 
 class Sequential(Block):
-    """Stacks `Block`s sequentially.
+    """Stacks Blocks sequentially.
 
     Example::
 
@@ -80,7 +81,7 @@ class Sequential(Block):
 
 
 class HybridSequential(HybridBlock):
-    """Stacks `HybridBlock`s sequentially.
+    """Stacks HybridBlocks sequentially.
 
     Example::
 
@@ -162,6 +163,7 @@ class Dense(HybridBlock):
 
 
     If ``flatten`` is set to be True, then the shapes are:
+
     Input shape:
         An N-D input with shape
         `(batch_size, x1, x2, ..., xn) with x1 * x2 * ... * xn equal to in_units`.
@@ -169,7 +171,9 @@ class Dense(HybridBlock):
     Output shape:
         The output would have shape `(batch_size, units)`.
 
+
     If ``flatten`` is set to be false, then the shapes are:
+
     Input shape:
         An N-D input with shape
         `(x1, x2, ..., xn, in_units)`.
@@ -370,12 +374,18 @@ class BatchNorm(HybridBlock):
 
 
 class LeakyReLU(HybridBlock):
-    """Leaky version of a Rectified Linear Unit.
+    r"""Leaky version of a Rectified Linear Unit.
 
-    It allows a small gradient when the unit is not active::
+    It allows a small gradient when the unit is not active
 
-        `f(x) = alpha * x for x < 0`,
-        `f(x) = x for x >= 0`.
+    .. math::
+
+        f\left(x\right) = \left\{
+            \begin{array}{lr}
+               \alpha x & : x \lt 0 \\
+                      x & : x \geq 0 \\
+            \end{array}
+        \right.\\
 
     Parameters
     ----------
@@ -390,6 +400,7 @@ class LeakyReLU(HybridBlock):
         Same shape as input.
     """
     def __init__(self, alpha, **kwargs):
+        assert alpha >= 0, "Slope coefficient for LeakyReLU must be no less than 0."
         super(LeakyReLU, self).__init__(**kwargs)
         self._alpha = alpha
 

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -18,6 +18,13 @@
 # coding: utf-8
 # pylint: disable= arguments-differ, too-many-lines
 """Convolutional neural network layers."""
+__all__ = ['Conv1D', 'Conv2D', 'Conv3D',
+           'Conv1DTranspose', 'Conv2DTranspose', 'Conv3DTranspose',
+           'MaxPool1D', 'MaxPool2D', 'MaxPool3D',
+           'AvgPool1D', 'AvgPool2D', 'AvgPool3D',
+           'GlobalMaxPool1D', 'GlobalMaxPool2D', 'GlobalMaxPool3D',
+           'GlobalAvgPool1D', 'GlobalAvgPool2D', 'GlobalAvgPool3D']
+
 from ..block import HybridBlock
 from ... import symbol
 from ...base import numeric_types

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -18,6 +18,8 @@
 # coding: utf-8
 # pylint: disable=
 """Neural network parameter."""
+__all__ = ['DeferredInitializationError', 'Parameter', 'ParameterDict',
+           'tensor_types']
 
 from collections import OrderedDict
 import warnings
@@ -39,11 +41,11 @@ class DeferredInitializationError(MXNetError):
     pass
 
 class Parameter(object):
-    """A Container holding parameters (weights) of `Block`s.
+    """A Container holding parameters (weights) of Blocks.
 
-    `Parameter` holds a copy of the parameter on each `Context` after
-    it is initialized with `Parameter.initialize(...)`. If `grad_req` is
-    not `null`, it will also hold a gradient array on each `Context`::
+    :py:class:`Parameter` holds a copy of the parameter on each :py:class:`Context` after
+    it is initialized with ``Parameter.initialize(...)``. If :py:attr:`grad_req` is
+    not ``'null'``, it will also hold a gradient array on each :py:class:`Context`::
 
         ctx = mx.gpu(0)
         x = mx.nd.zeros((16, 100), ctx=ctx)
@@ -60,18 +62,18 @@ class Parameter(object):
     grad_req : {'write', 'add', 'null'}, default 'write'
         Specifies how to update gradient to grad arrays.
 
-        - 'write' means everytime gradient is written to grad `NDArray`.
-        - 'add' means everytime gradient is added to the grad `NDArray`. You need
-          to manually call `zero_grad()` to clear the gradient buffer before each
+        - ``'write'`` means everytime gradient is written to grad :py:class:`NDArray`.
+        - ``'add'`` means everytime gradient is added to the grad :py:class:`NDArray`. You need
+          to manually call ``zero_grad()`` to clear the gradient buffer before each
           iteration when using this option.
         - 'null' means gradient is not requested for this parameter. gradient arrays
           will not be allocated.
     shape : tuple of int, default None
         Shape of this parameter. By default shape is not specified. Parameter with
-        unknown shape can be used for `Symbol` API, but `init` will throw an error
-        when using `NDArray` API.
+        unknown shape can be used for :py:class:`Symbol` API, but ``init`` will throw an error
+        when using :py:class:`NDArray` API.
     dtype : numpy.dtype or str, default 'float32'
-        Data type of this parameter. For example, numpy.float32 or 'float32'.
+        Data type of this parameter. For example, ``numpy.float32`` or ``'float32'``.
     lr_mult : float, default 1.0
         Learning rate multiplier. Learning rate will be multiplied by lr_mult
         when updating this parameter with optimizer.
@@ -83,13 +85,13 @@ class Parameter(object):
     Attributes
     ----------
     grad_req : {'write', 'add', 'null'}
-        This can be set before or after initialization. Setting grad_req to null
-        with `x.grad_req = 'null'` saves memory and computation when you don't
+        This can be set before or after initialization. Setting ``grad_req`` to ``'null'``
+        with ``x.grad_req = 'null'`` saves memory and computation when you don't
         need gradient w.r.t x.
     lr_mult : float
         Local learning rate multiplier for this Parameter. The actual learning rate
-        is calculated with `learning_rate * lr_mult`. You can set it with
-        `param.lr_mult = 2.0`
+        is calculated with ``learning_rate * lr_mult``. You can set it with
+        ``param.lr_mult = 2.0``
     wd_mult : float
         Local weight decay multiplier for this Parameter.
     """
@@ -248,20 +250,23 @@ class Parameter(object):
 
     def initialize(self, init=None, ctx=None, default_init=initializer.Uniform(),
                    force_reinit=False):
-        """Initializes parameter and gradient arrays. Only used for `NDArray` API.
+        """Initializes parameter and gradient arrays. Only used for :py:class:`NDArray` API.
 
         Parameters
         ----------
         init : Initializer
-            The initializer to use. Overrides `Parameter.init` and default_init.
-        ctx : Context or list of Context, defaults to `context.current_context()`.
+            The initializer to use. Overrides :py:meth:`Parameter.init` and default_init.
+        ctx : Context or list of Context, defaults to :py:meth:`context.current_context()`.
             Initialize Parameter on given context. If ctx is a list of Context, a
             copy will be made for each context.
 
-            .. note:: Copies are independent arrays. User is responsible for keeping
-            their values consistent when updating. Normally `gluon.Trainer` does this for you.
+            .. note::
+                Copies are independent arrays. User is responsible for keeping
+                their values consistent when updating.
+                Normally :py:class:`gluon.Trainer` does this for you.
+
         default_init : Initializer
-            Default initializer is used when both `init` and `Parameter.init` are `None`.
+            Default initializer is used when both :py:func:`init` and :py:meth:`Parameter.init` are ``None``.
         force_reinit : bool, default False
             Whether to force re-initialization if parameter is already initialized.
 
@@ -312,7 +317,7 @@ class Parameter(object):
     def reset_ctx(self, ctx):
         """Re-assign Parameter to other contexts.
 
-        ctx : Context or list of Context, default `context.current_context()`.
+        ctx : Context or list of Context, default ``context.current_context()``.
             Assign Parameter to given context. If ctx is a list of Context, a
             copy will be made for each context.
         """
@@ -375,7 +380,7 @@ class Parameter(object):
 
     def list_grad(self):
         """Returns gradient buffers on all contexts, in the same order
-        as `values`."""
+        as :py:meth:`values`."""
         if self._data is not None and self._grad is None:
             raise RuntimeError(
                 "Cannot get gradient array for Parameter %s " \
@@ -412,12 +417,12 @@ class ParameterDict(object):
 
     Parameters
     ----------
-    prefix : str, default ''
+    prefix : str, default ``''``
         The prefix to be prepended to all Parameters' names created by this dict.
     shared : ParameterDict or None
-        If not `None`, when this dict's `get` method creates a new parameter, will
-        first try to retrieve it from `shared` dict. Usually used for sharing
-        parameters with another `Block`.
+        If not ``None``, when this dict's :py:meth:`get` method creates a new parameter, will
+        first try to retrieve it from "shared" dict. Usually used for sharing
+        parameters with another Block.
     """
     def __init__(self, prefix='', shared=None):
         self._prefix = prefix
@@ -448,8 +453,8 @@ class ParameterDict(object):
 
     @property
     def prefix(self):
-        """Prefix of this dict. It will be prepended to Parameters' name created
-        with `get`."""
+        """Prefix of this dict. It will be prepended to :py:class:`Parameter`s' name created
+        with :py:func:`get`."""
         return self._prefix
 
     def _get_impl(self, name):
@@ -461,9 +466,9 @@ class ParameterDict(object):
         return None
 
     def get(self, name, **kwargs):
-        """Retrieves a `Parameter` with name `self.prefix+name`. If not found,
-        `get` will first try to retrieve it from `shared` dict. If still not
-        found, `get` will create a new `Parameter` with key-word arguments and
+        """Retrieves a :py:class:`Parameter` with name ``self.prefix+name``. If not found,
+        :py:func:`get` will first try to retrieve it from "shared" dict. If still not
+        found, :py:func:`get` will create a new :py:class:`Parameter` with key-word arguments and
         insert it to self.
 
         Parameters
@@ -472,12 +477,12 @@ class ParameterDict(object):
             Name of the desired Parameter. It will be prepended with this dictionary's
             prefix.
         **kwargs : dict
-            The rest of key-word arguments for the created `Parameter`.
+            The rest of key-word arguments for the created :py:class:`Parameter`.
 
         Returns
         -------
         Parameter
-            The created or retrieved `Parameter`.
+            The created or retrieved :py:class:`Parameter`.
         """
         name = self.prefix + name
         param = self._get_impl(name)
@@ -497,7 +502,7 @@ class ParameterDict(object):
         return param
 
     def update(self, other):
-        """Copies all Parameters in `other` to self."""
+        """Copies all Parameters in ``other`` to self."""
         for k, v in other.items():
             if k in self._params:
                 assert self._params[k] is v, \
@@ -508,14 +513,14 @@ class ParameterDict(object):
 
     def initialize(self, init=initializer.Uniform(), ctx=None, verbose=False,
                    force_reinit=False):
-        """Initializes all Parameters managed by this dictionary to be used for `NDArray`
-        API. It has no effect when using `Symbol` API.
+        """Initializes all Parameters managed by this dictionary to be used for :py:class:`NDArray`
+        API. It has no effect when using :py:class:`Symbol` API.
 
         Parameters
         ----------
         init : Initializer
-            Global default Initializer to be used when `Parameter.init` is `None`.
-            Otherwise, `Parameter.init` takes precedence.
+            Global default Initializer to be used when :py:meth:`Parameter.init` is ``None``.
+            Otherwise, :py:meth:`Parameter.init` takes precedence.
         ctx : Context or list of Context
             Keeps a copy of Parameters on one or many context(s).
         force_reinit : bool, default False
@@ -534,7 +539,7 @@ class ParameterDict(object):
     def reset_ctx(self, ctx):
         """Re-assign all Parameters to other contexts.
 
-        ctx : Context or list of Context, default `context.current_context()`.
+        ctx : Context or list of Context, default :py:meth:`context.current_context()`.
             Assign Parameter to given context. If ctx is a list of Context, a
             copy will be made for each context.
         """
@@ -579,7 +584,7 @@ class ParameterDict(object):
                     "Prefix %s is to be striped before saving, but Parameter " \
                     "%s does not start with %s. If you are using Block.save_params, " \
                     "This may be due to your Block shares parameters from other " \
-                    "Blocks or you forgot to use `with name_scope()`` during init. " \
+                    "Blocks or you forgot to use ``with name_scope()`` during init. " \
                     "Consider switching to Block.collect_params.save and " \
                     "Block.collect_params.load instead."%(
                         strip_prefix, param.name, strip_prefix))

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -266,7 +266,8 @@ class Parameter(object):
                 Normally :py:class:`gluon.Trainer` does this for you.
 
         default_init : Initializer
-            Default initializer is used when both :py:func:`init` and :py:meth:`Parameter.init` are ``None``.
+            Default initializer is used when both :py:func:`init`
+            and :py:meth:`Parameter.init` are ``None``.
         force_reinit : bool, default False
             Whether to force re-initialization if parameter is already initialized.
 

--- a/python/mxnet/gluon/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/rnn/rnn_cell.py
@@ -20,6 +20,11 @@
 # pylint: disable=too-many-branches, too-many-arguments, no-self-use
 # pylint: disable=too-many-lines, arguments-differ
 """Definition of various recurrent neural network cells."""
+__all__ = ['RecurrentCell', 'HybridRecurrentCell',
+           'RNNCell', 'LSTMCell', 'GRUCell',
+           'SequentialRNNCell', 'DropoutCell',
+           'ModifierCell', 'ZoneoutCell', 'ResidualCell',
+           'BidirectionalCell']
 
 from ... import symbol, ndarray
 from ...base import string_types, numeric_types, _as_list
@@ -277,7 +282,17 @@ class HybridRecurrentCell(RecurrentCell, HybridBlock):
 
 
 class RNNCell(HybridRecurrentCell):
-    """Simple recurrent neural network cell.
+    r"""Elman RNN recurrent neural network cell.
+
+    Each call computes the following function:
+
+    .. math::
+
+        h_t = \tanh(w_{ih} * x_t + b_{ih}  +  w_{hh} * h_{(t-1)} + b_{hh})
+
+    where :math:`h_t` is the hidden state at time `t`, and :math:`x_t` is the hidden
+    state of the previous layer at time `t` or :math:`input_t` for the first layer.
+    If nonlinearity='relu', then `ReLU` is used instead of `tanh`.
 
     Parameters
     ----------
@@ -345,7 +360,25 @@ class RNNCell(HybridRecurrentCell):
 
 
 class LSTMCell(HybridRecurrentCell):
-    """Long-Short Term Memory (LSTM) network cell.
+    r"""Long-Short Term Memory (LSTM) network cell.
+
+    Each call computes the following function:
+
+    .. math::
+        \begin{array}{ll}
+        i_t = sigmoid(W_{ii} x_t + b_{ii} + W_{hi} h_{(t-1)} + b_{hi}) \\
+        f_t = sigmoid(W_{if} x_t + b_{if} + W_{hf} h_{(t-1)} + b_{hf}) \\
+        g_t = \tanh(W_{ig} x_t + b_{ig} + W_{hc} h_{(t-1)} + b_{hg}) \\
+        o_t = sigmoid(W_{io} x_t + b_{io} + W_{ho} h_{(t-1)} + b_{ho}) \\
+        c_t = f_t * c_{(t-1)} + i_t * g_t \\
+        h_t = o_t * \tanh(c_t)
+        \end{array}
+
+    where :math:`h_t` is the hidden state at time `t`, :math:`c_t` is the
+    cell state at time `t`, :math:`x_t` is the hidden state of the previous
+    layer at time `t` or :math:`input_t` for the first layer, and :math:`i_t`,
+    :math:`f_t`, :math:`g_t`, :math:`o_t` are the input, forget, cell, and
+    out gates, respectively.
 
     Parameters
     ----------
@@ -420,9 +453,23 @@ class LSTMCell(HybridRecurrentCell):
 
 
 class GRUCell(HybridRecurrentCell):
-    """Gated Rectified Unit (GRU) network cell.
+    r"""Gated Rectified Unit (GRU) network cell.
     Note: this is an implementation of the cuDNN version of GRUs
     (slight modification compared to Cho et al. 2014).
+
+    Each call computes the following function:
+
+    .. math::
+        \begin{array}{ll}
+        r_t = sigmoid(W_{ir} x_t + b_{ir} + W_{hr} h_{(t-1)} + b_{hr}) \\
+        i_t = sigmoid(W_{ii} x_t + b_{ii} + W_hi h_{(t-1)} + b_{hi}) \\
+        n_t = \tanh(W_{in} x_t + b_{in} + r_t * (W_{hn} h_{(t-1)}+ b_{hn})) \\
+        h_t = (1 - i_t) * n_t + i_t * h_{(t-1)} \\
+        \end{array}
+
+    where :math:`h_t` is the hidden state at time `t`, :math:`x_t` is the hidden
+    state of the previous layer at time `t` or :math:`input_t` for the first layer,
+    and :math:`r_t`, :math:`i_t`, :math:`n_t` are the reset, input, and new gates, respectively.
 
     Parameters
     ----------

--- a/python/mxnet/gluon/rnn/rnn_layer.py
+++ b/python/mxnet/gluon/rnn/rnn_layer.py
@@ -21,9 +21,10 @@
 # pylint: disable=too-many-lines, arguments-differ
 """Definition of various recurrent neural network layers."""
 from __future__ import print_function
+__all__ = ['RNN', 'LSTM', 'GRU']
 
 from ... import ndarray
-from ..nn import Block
+from .. import Block
 from . import rnn_cell
 
 

--- a/python/mxnet/gluon/trainer.py
+++ b/python/mxnet/gluon/trainer.py
@@ -18,6 +18,7 @@
 # coding: utf-8
 # pylint: disable=
 """Parameter optimizer."""
+__all__ = ['Trainer']
 
 from .. import optimizer as opt
 from ..model import _create_kvstore

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -18,6 +18,9 @@
 # coding: utf-8
 # pylint: disable=
 """Parallelization utility optimizer."""
+__all__ = ['split_data', 'split_and_load', 'clip_global_norm',
+           'check_sha1', 'download']
+
 import os
 import hashlib
 import warnings

--- a/python/mxnet/ndarray/__init__.py
+++ b/python/mxnet/ndarray/__init__.py
@@ -17,7 +17,7 @@
 
 """NDArray API of MXNet."""
 
-from . import _internal, contrib, linalg, sparse, random
+from . import _internal, contrib, linalg, sparse, random, utils
 # pylint: disable=wildcard-import, redefined-builtin
 from .op import *
 from .ndarray import *
@@ -26,4 +26,4 @@ from .utils import load, save, zeros, empty, array
 from .sparse import _ndarray_cls
 from .ndarray import _GRAD_REQ_MAP
 
-__all__ = op.__all__ + ndarray.__all__ + ['contrib', 'linalg', 'random', 'sparse']
+__all__ = op.__all__ + ndarray.__all__ + utils.__all__ + ['contrib', 'linalg', 'random', 'sparse']

--- a/python/mxnet/ndarray/utils.py
+++ b/python/mxnet/ndarray/utils.py
@@ -33,6 +33,8 @@ try:
 except ImportError:
     spsp = None
 
+__all__ = ['zeros', 'empty', 'array', 'load', 'save']
+
 
 def zeros(shape, ctx=None, dtype=None, stype=None, aux_types=None, **kwargs):
     """Return a new array of given shape and type, filled with zeros.

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -132,7 +132,7 @@ def test_symbol_block():
     out = smodel(mx.sym.var('in'))
     assert len(out) == len(outputs.list_outputs())
 
-    class Net(nn.HybridBlock):
+    class Net(gluon.HybridBlock):
         def __init__(self, model):
             super(Net, self).__init__()
             self.model = model

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -132,7 +132,7 @@ def test_symbol_block():
     out = smodel(mx.sym.var('in'))
     assert len(out) == len(outputs.list_outputs())
 
-    class Net(gluon.HybridBlock):
+    class Net(nn.HybridBlock):
         def __init__(self, model):
             super(Net, self).__init__()
             self.model = model


### PR DESCRIPTION
This is to add/update/reorganize doc for Gluon and for
- [x] #7875: mobilenet api doc
- [x] #7264: conv rnn doc and new contrib package
- [x] #7067: var dropout doc
- [x] #7992 new fluent methods
- [x] missed doc in #7910 
- [x] missed doc in #7403 
- [x] dataset doc
- [x] model zoo doc
- [x] model zoo doc fix (mx.gluon.model_zoo.vision instead of mx.gluon.models) #7023
- [x] move the legacy rnn under symbol, since it only supports symbol
- [x] loss doc fix for #7918 
- [x] executor doc page
- [x] fix [broken links](https://mxnet.incubator.apache.org/versions/master/api/python/ndarray/ndarray.html#array-creation-routines) in NDArray API
- [x] make references to entities clickable links for Gluon docs.

Updated doc can be found at http://mxnet-doc.s3-website-us-east-1.amazonaws.com/api/python/index.html