### PR TITLE
Update the threshold for diff

### DIFF
--- a/scala-package/core/src/test/scala/ml/dmlc/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/ml/dmlc/mxnet/NDArraySuite.scala
@@ -170,7 +170,7 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
       val result = (start until stop by step).flatMap(x => Array.fill[Float](repeat)(x))
       val range = NDArray.arange(start = start, stop = Some(stop), step = step,
         repeat = repeat, ctx = Context.cpu(), dType = DType.Float32)
-      assert(CheckUtils.reldiff(result.toArray, range.toArray) <= 1e-5f)
+      assert(CheckUtils.reldiff(result.toArray, range.toArray) <= 1e-4f)
     }
   }
 


### PR DESCRIPTION
@piiswrong @oza @nswamy @sandeep-krishnamurthy 

Sometimes the test fails due to flaky value in assert difference
eg: 
- arange *** FAILED ***
  1.14497025E-5 was not less than or equal to 1.0E-5 (NDArraySuite.scala:173)