### PR TITLE
Removing WaitToWrite in dist kvstore

### DIFF
--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -141,7 +141,7 @@ class KVStore(object):
 
         This function returns immediately after adding an operator to the engine.
         The actual operation is executed asynchronously after all previous `push`
-        and `pull` calls for the same input key(s) are finished.
+        the same input key(s) are finished.
         There is no synchronization between workers. One can use ``_barrier()``
         to sync all workers.
 

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -141,7 +141,7 @@ class KVStore(object):
 
         This function returns immediately after adding an operator to the engine.
         The actual operation is executed asynchronously after all previous `push`
-        the same input key(s) are finished.
+        for the same input key(s) are finished.
         There is no synchronization between workers. One can use ``_barrier()``
         to sync all workers.
 

--- a/src/kvstore/kvstore_dist.h
+++ b/src/kvstore/kvstore_dist.h
@@ -271,7 +271,6 @@ class KVStoreDist : public KVStoreLocal {
       auto& send_buf = comm_buf_[key];
       const auto storage_type = merged.storage_type();
       if (merged.ctx().dev_mask() == cpu::kDevMask) {
-        // make sure the previous push/pull is completed
         send_buf = merged;  // avoid memory copy
       } else {
         if (send_buf.is_none()) {

--- a/src/kvstore/kvstore_dist.h
+++ b/src/kvstore/kvstore_dist.h
@@ -272,7 +272,6 @@ class KVStoreDist : public KVStoreLocal {
       const auto storage_type = merged.storage_type();
       if (merged.ctx().dev_mask() == cpu::kDevMask) {
         // make sure the previous push/pull is completed
-        send_buf.WaitToWrite();
         send_buf = merged;  // avoid memory copy
       } else {
         if (send_buf.is_none()) {


### PR DESCRIPTION
As reported in #8097 `WaitToWrite` blocks push until all gradients are computed, which was introduced in #7082. After discussing it again with @mli we decided to remove it and updated the document accordingly.

@solin319 