### PR TITLE
Removed redundant hash of out_shape in algoreg key.

### DIFF
--- a/src/operator/cudnn_algoreg-inl.h
+++ b/src/operator/cudnn_algoreg-inl.h
@@ -155,7 +155,6 @@ class CuDNNAlgoReg {
       ret = dmlc::HashCombine(ret, key.data_shape);
       ret = dmlc::HashCombine(ret, key.weight_shape);
       ret = dmlc::HashCombine(ret, key.out_shape);
-      for (const auto& i : key.out_shape) ret = dmlc::HashCombine(ret, i);
       ret = dmlc::HashCombine(ret, static_cast<int>(key.cudnn_data_type));
       ret = dmlc::HashCombine(ret, static_cast<int>(key.cudnn_forward_compute_type));
       ret = dmlc::HashCombine(ret, static_cast<int>(key.cudnn_backward_compute_type));


### PR DESCRIPTION
The additional incorporation of out_shape was not harmful functionally, but is not needed.