### PR TITLE
Adding code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # Owners of Apache MXNet
 
 # Global owners
-*			@piiswrong @mli
+*			@apache/mxnet-committers
 
 # Owners of language bindings
 R-package/*		@thirdwing


### PR DESCRIPTION
@nswamy @piiswrong @szha @cjolivier01 @pluskid 

In order to make the master branch protected all
the committers should be part of code owner.