### PR TITLE
add storage type logging to graph executor

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -111,41 +111,6 @@ inline std::string stype_string(const int x) {
   return "unknown";
 }
 
-/*! \brief log the storage types and dispatch modes of the graph */
-inline void LogStorageType(nnvm::Graph &g,
-                           const std::pair<uint32_t, uint32_t> node_range = {0, 0}) {
-  bool log_verbose = dmlc::GetEnv("MXNET_INFER_STORAGE_TYPE_VERBOSE_LOGGING", false);
-  if (log_verbose) {
-    const auto &idx = g.indexed_graph();
-    const auto& vstorage_type = g.GetAttr<StorageTypeVector>("storage_type");
-    const auto& dispatch_modes = g.GetAttr<DispatchModeVector>("dispatch_mode");
-    uint32_t node_start = 0, node_end = idx.num_nodes();
-    if (node_range.second > node_range.first) {
-      node_end = node_range.second;
-      node_start = node_range.first;
-    }
-    for (uint32_t nid = node_start; nid < node_end; ++nid) {
-      const auto& inode = idx[nid];
-      if (inode.source->is_variable()) {
-        LOG(INFO) << "node " << nid << " var";
-      } else {
-        LOG(INFO) << "node " << nid << " " << inode.source->attrs.op->name
-                  << ": " << common::dispatch_mode_string(dispatch_modes[nid]);
-        for (const auto& e : inode.inputs) {
-          auto eid = idx.entry_id(e);
-          LOG(INFO) << "\t\tinput " << eid << ": "
-                    << common::stype_string(vstorage_type[eid]);
-        }
-        for (uint32_t index = 0; index < inode.source->num_outputs(); ++index) {
-          uint32_t eid = idx.entry_id(nid, index);
-          LOG(INFO) << "\t\toutput " << eid << ": "
-                    << common::stype_string(vstorage_type[eid]);
-        }
-      }
-    }
-  }
-}
-
 // heuristic to dermine number of threads per GPU
 inline int GetNumThreadPerGPU() {
   // This is resource efficient option.

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -26,6 +26,7 @@
 
 #include <dmlc/logging.h>
 #include <dmlc/omp.h>
+#include <nnvm/graph.h>
 #include <mxnet/engine.h>
 #include <mxnet/ndarray.h>
 #include <mxnet/op_attr_types.h>
@@ -108,6 +109,41 @@ inline std::string stype_string(const int x) {
       return "row_sparse";
   }
   return "unknown";
+}
+
+/*! \brief log the storage types and dispatch modes of the graph */
+inline void LogStorageType(nnvm::Graph &g,
+                           const std::pair<uint32_t, uint32_t> node_range = {0, 0}) {
+  bool log_verbose = dmlc::GetEnv("MXNET_INFER_STORAGE_TYPE_VERBOSE_LOGGING", false);
+  if (log_verbose) {
+    const auto &idx = g.indexed_graph();
+    const auto& vstorage_type = g.GetAttr<StorageTypeVector>("storage_type");
+    const auto& dispatch_modes = g.GetAttr<DispatchModeVector>("dispatch_mode");
+    uint32_t node_start = 0, node_end = idx.num_nodes();
+    if (node_range.second > node_range.first) {
+      node_end = node_range.second;
+      node_start = node_range.first;
+    }
+    for (uint32_t nid = node_start; nid < node_end; ++nid) {
+      const auto& inode = idx[nid];
+      if (inode.source->is_variable()) {
+        LOG(INFO) << "node " << nid << " var";
+      } else {
+        LOG(INFO) << "node " << nid << " " << inode.source->attrs.op->name
+                  << ": " << common::dispatch_mode_string(dispatch_modes[nid]);
+        for (const auto& e : inode.inputs) {
+          auto eid = idx.entry_id(e);
+          LOG(INFO) << "\t\tinput " << eid << ": "
+                    << common::stype_string(vstorage_type[eid]);
+        }
+        for (uint32_t index = 0; index < inode.source->num_outputs(); ++index) {
+          uint32_t eid = idx.entry_id(nid, index);
+          LOG(INFO) << "\t\toutput " << eid << ": "
+                    << common::stype_string(vstorage_type[eid]);
+        }
+      }
+    }
+  }
 }
 
 // heuristic to dermine number of threads per GPU

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -592,6 +592,7 @@ void GraphExecutor::Init(nnvm::Symbol symbol,
 
   g.attrs["storage_type"] = std::make_shared<dmlc::any>(std::move(arg_stypes));
   g = InferStorageType(std::move(g), std::move(StorageTypeVector()), "");
+  common::LogStorageType(g);
   if (g.GetAttr<size_t>("storage_type_num_unknown_nodes") != 0U) {
     HandleInferStorageTypeError(num_forward_inputs_, g.indexed_graph(),
                                 g.GetAttr<StorageTypeVector>("storage_type"));
@@ -971,6 +972,7 @@ void GraphExecutor::Init(nnvm::Symbol symbol,
   }
 
   g = InferStorageType(std::move(g), std::move(arg_stypes), "__storage_type__");
+  common::LogStorageType(g);
   if (g.GetAttr<size_t>("storage_type_num_unknown_nodes") != 0U) {
     HandleInferStorageTypeError(num_forward_inputs_, g.indexed_graph(),
                                 g.GetAttr<StorageTypeVector>("storage_type"));

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -592,7 +592,6 @@ void GraphExecutor::Init(nnvm::Symbol symbol,
 
   g.attrs["storage_type"] = std::make_shared<dmlc::any>(std::move(arg_stypes));
   g = InferStorageType(std::move(g), std::move(StorageTypeVector()), "");
-  common::LogStorageType(g);
   if (g.GetAttr<size_t>("storage_type_num_unknown_nodes") != 0U) {
     HandleInferStorageTypeError(num_forward_inputs_, g.indexed_graph(),
                                 g.GetAttr<StorageTypeVector>("storage_type"));
@@ -972,7 +971,6 @@ void GraphExecutor::Init(nnvm::Symbol symbol,
   }
 
   g = InferStorageType(std::move(g), std::move(arg_stypes), "__storage_type__");
-  common::LogStorageType(g);
   if (g.GetAttr<size_t>("storage_type_num_unknown_nodes") != 0U) {
     HandleInferStorageTypeError(num_forward_inputs_, g.indexed_graph(),
                                 g.GetAttr<StorageTypeVector>("storage_type"));

--- a/src/executor/infer_graph_attr_pass.cc
+++ b/src/executor/infer_graph_attr_pass.cc
@@ -431,12 +431,46 @@ nnvm::Graph InferStorageType(nnvm::Graph&& graph,
   }
 
   // for storage type, the backward attr is not necessarily the same as it's correspondence
-  return InferAttr<int, FInferStorageType>(
+  nnvm::Graph ret = InferAttr<int, FInferStorageType>(
       std::move(graph), -1,
       "FInferStorageType", "storage_type_inputs", "storage_type_attr_key",
       "storage_type", "storage_type_num_unknown_nodes",
       [](const int t) { return t == -1; },
       DefaultStorageType, false, "dispatch_mode", DispatchMode::kVariable);
+
+  // log the storage types and dispatch modes of the graph
+  bool log_verbose = dmlc::GetEnv("MXNET_INFER_STORAGE_TYPE_VERBOSE_LOGGING", false);
+  if (log_verbose) {
+    const auto &idx = ret.indexed_graph();
+    const auto& vstorage_type = ret.GetAttr<StorageTypeVector>("storage_type");
+    const auto& dispatch_modes = ret.GetAttr<DispatchModeVector>("dispatch_mode");
+    uint32_t node_start = 0, node_end = idx.num_nodes();
+    if (ret.attrs.count("node_range")) {
+      const auto& range = ret.GetAttr<std::pair<uint32_t, uint32_t> >("node_range");
+      node_start = range.first;
+      node_end = range.second;
+    }
+    for (uint32_t nid = node_start; nid < node_end; ++nid) {
+      const auto& inode = idx[nid];
+      if (inode.source->is_variable()) {
+        LOG(INFO) << "node " << nid << " var";
+      } else {
+        LOG(INFO) << "node " << nid << " " << inode.source->attrs.op->name
+                  << ": " << common::dispatch_mode_string(dispatch_modes[nid]);
+        for (const auto& e : inode.inputs) {
+          auto eid = idx.entry_id(e);
+          LOG(INFO) << "\t\tinput " << eid << ": "
+                    << common::stype_string(vstorage_type[eid]);
+        }
+        for (uint32_t index = 0; index < inode.source->num_outputs(); ++index) {
+          uint32_t eid = idx.entry_id(nid, index);
+          LOG(INFO) << "\t\toutput " << eid << ": "
+                    << common::stype_string(vstorage_type[eid]);
+        }
+      }
+    }
+  }
+  return ret;
 }
 
 }  // namespace exec

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -551,37 +551,8 @@ inline bool CheckAndInferStorageType(nnvm::Graph* p_g, exec::DevMaskVector&& dev
     g.attrs["storage_type"] = std::make_shared<dmlc::any>(std::move(storage_types));
     g = exec::InferStorageType(std::move(g));
   }
+  common::LogStorageType(g, node_range);
 
-  const auto &idx = g.indexed_graph();
-  const auto& vstorage_type = g.GetAttr<StorageTypeVector>("storage_type");
-  const auto& dispatch_modes = g.GetAttr<DispatchModeVector>("dispatch_mode");
-  uint32_t node_start = 0, node_end = idx.num_nodes();
-  if (node_range.second > node_range.first) {
-    node_end = node_range.second;
-    node_start = node_range.first;
-  }
-  bool log_verbose = dmlc::GetEnv("MXNET_INFER_STORAGE_TYPE_VERBOSE_LOGGING", false);
-  if (log_verbose) {
-    for (uint32_t nid = node_start; nid < node_end; ++nid) {
-      const auto& inode = idx[nid];
-      if (inode.source->is_variable()) {
-        LOG(INFO) << "node " << nid << " var";
-      } else {
-        LOG(INFO) << "node " << nid << " " << inode.source->attrs.op->name
-                  << ": " << common::dispatch_mode_string(dispatch_modes[nid]);
-        for (const auto& e : inode.inputs) {
-          auto eid = idx.entry_id(e);
-          LOG(INFO) << "\t\tinput " << eid << ": "
-                    << common::stype_string(vstorage_type[eid]);
-        }
-        for (uint32_t index = 0; index < inode.source->num_outputs(); ++index) {
-          uint32_t eid = idx.entry_id(nid, index);
-          LOG(INFO) << "\t\toutput " << eid << ": "
-                    << common::stype_string(vstorage_type[eid]);
-        }
-      }
-    }
-  }
   CHECK_EQ(g.GetAttr<size_t>("storage_type_num_unknown_nodes"), 0U);
   return false;
 }

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -551,7 +551,6 @@ inline bool CheckAndInferStorageType(nnvm::Graph* p_g, exec::DevMaskVector&& dev
     g.attrs["storage_type"] = std::make_shared<dmlc::any>(std::move(storage_types));
     g = exec::InferStorageType(std::move(g));
   }
-  common::LogStorageType(g, node_range);
 
   CHECK_EQ(g.GetAttr<size_t>("storage_type_num_unknown_nodes"), 0U);
   return false;


### PR DESCRIPTION
This is mentioned in the tutorial PR #7921 and should be merged before that. 
The log message will be printed if env_var `MXNET_INFER_STORAGE_TYPE_VERBOSE_LOGGING` = 1

```
>>> os.environ['MXNET_INFER_STORAGE_TYPE_VERBOSE_LOGGING'] = "1"
>>> print(os.environ['MXNET_INFER_STORAGE_TYPE_VERBOSE_LOGGING'])
1
>>> # Data in csr format
... data = mx.sym.var('data', stype='csr', shape=(32, 10000))
>>> # Weight in row_sparse format
... weight = mx.sym.var('weight', stype='row_sparse', shape=(10000, 2))
>>> bias = mx.symbol.Variable("bias", shape=(2,))
>>> dot = mx.symbol.sparse.dot(data, weight)
>>> pred = mx.symbol.broadcast_add(dot, bias)
>>> y = mx.symbol.Variable("label")
>>> output = mx.symbol.SoftmaxOutput(data=pred, label=y, name="output")
>>> executor = output.simple_bind(ctx=mx.cpu())
[00:42:45] src/executor/../common/utils.h:130: node 0 var
[00:42:45] src/executor/../common/utils.h:130: node 1 var
[00:42:45] src/executor/../common/utils.h:132: node 2 dot: fcompute_ex
[00:42:45] src/executor/../common/utils.h:136:          input 0: csr
[00:42:45] src/executor/../common/utils.h:136:          input 1: row_sparse
[00:42:45] src/executor/../common/utils.h:141:          output 2: default
[00:42:45] src/executor/../common/utils.h:130: node 3 var
[00:42:45] src/executor/../common/utils.h:132: node 4 broadcast_add: fcompute
[00:42:45] src/executor/../common/utils.h:136:          input 2: default
[00:42:45] src/executor/../common/utils.h:136:          input 3: default
[00:42:45] src/executor/../common/utils.h:141:          output 4: default
[00:42:45] src/executor/../common/utils.h:130: node 5 var
[00:42:45] src/executor/../common/utils.h:132: node 6 SoftmaxOutput: fcompute
[00:42:45] src/executor/../common/utils.h:136:          input 4: default
[00:42:45] src/executor/../common/utils.h:136:          input 5: default
[00:42:45] src/executor/../common/utils.h:141:          output 6: default
[00:42:45] src/executor/../common/utils.h:132: node 7 _backward_SoftmaxOutput: fcompute
[00:42:45] src/executor/../common/utils.h:136:          input 5: default
[00:42:45] src/executor/../common/utils.h:136:          input 6: default
[00:42:45] src/executor/../common/utils.h:141:          output 7: default
[00:42:45] src/executor/../common/utils.h:141:          output 8: default
[00:42:45] src/executor/../common/utils.h:132: node 8 _backward_broadcast_add: fcompute
[00:42:45] src/executor/../common/utils.h:136:          input 7: default
[00:42:45] src/executor/../common/utils.h:141:          output 9: default
[00:42:45] src/executor/../common/utils.h:141:          output 10: default
[00:42:45] src/executor/../common/utils.h:132: node 9 _backward_dot: fcompute_ex
[00:42:45] src/executor/../common/utils.h:136:          input 9: default
[00:42:45] src/executor/../common/utils.h:136:          input 0: csr
[00:42:45] src/executor/../common/utils.h:136:          input 1: row_sparse
[00:42:45] src/executor/../common/utils.h:141:          output 11: default
[00:42:45] src/executor/../common/utils.h:141:          output 12: row_sparse
```
