### PR TITLE
Add gluon losses

### DIFF
--- a/docs/_static/mxnet.css
+++ b/docs/_static/mxnet.css
@@ -1156,6 +1156,8 @@ dl.last.docutils dt{
 
 dl.docutils dt {
     color: #555;
+    background-color: #f0f0f0;
+    border-bottom: solid #ccc;
 }
 
 /*----------------Model zoo page style------------------*/

--- a/docs/api/python/gluon/loss.md
+++ b/docs/api/python/gluon/loss.md
@@ -16,8 +16,14 @@ This package includes several commonly used loss functions in neural networks.
 
     L2Loss
     L1Loss
+    SigmoidBinaryCrossEntropyLoss
     SoftmaxCrossEntropyLoss
     KLDivLoss
+    HuberLoss
+    HingeLoss
+    SquaredHingeLoss
+    LogisticLoss
+    TripletLoss
     CTCLoss
 ```
 

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -113,16 +113,15 @@ class L2Loss(Loss):
     batch_axis : int, default 0
         The axis that represents mini-batch.
 
-
-    Input shape:
-        `output` is the prediction tensor.
-        `label` is the truth tensor and should have the same shape as `output`.
-        `sample_weight` is a matrix for per-sample weighting. Must be broadcastable to
-        the same shape as loss. For example, if loss has shape (64, 10) and you want
+    Inputs:
+        - output: prediction tensor with arbitrary shape
+        - label: truth tensor with the same size as output.
+        - sample_weight: element-wise weighting tensor. Must be broadcastable to
+        the same shape as output. For example, if output has shape (64, 10) and you want
         to weigh each sample in the batch separately, `sample_weight` should have shape (64, 1).
 
-    Output shape:
-        The loss output has the shape (batch_size,).
+    Outputs:
+        - loss: loss tensor with shape (batch_size,).
     """
     def __init__(self, weight=1., batch_axis=0, **kwargs):
         super(L2Loss, self).__init__(weight, batch_axis, **kwargs)

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -22,7 +22,8 @@ from __future__ import absolute_import
 __all__ = ['Loss', 'L2Loss', 'L1Loss',
            'SigmoidBinaryCrossEntropyLoss', 'SigmoidBCELoss',
            'SoftmaxCrossEntropyLoss', 'SoftmaxCELoss',
-           'KLDivLoss', 'CTCLoss']
+           'KLDivLoss', 'CTCLoss', 'HuberLoss', 'HingeLoss',
+           'SquaredHingeLoss', 'LogisticLoss', 'TripletLoss']
 
 from .. import ndarray
 from ..base import numeric_types
@@ -58,11 +59,9 @@ def _apply_weighting(F, loss, weight=None, sample_weight=None):
 
     return loss
 
-def _reshape_label_as_output(F, output, label):
-    # for symbolic output.shape is not available so we reshape
-    # to empty shape and let it be inferred from output's shape
-    # via the '-' operator later.
-    return label.reshape(output.shape) if F is ndarray else label.reshape(())
+def _reshape_like(F, x, y):
+    """Reshapes x to the same shape as y."""
+    return x.reshape(y.shape) if F is ndarray else x.reshape(())
 
 class Loss(HybridBlock):
     """Base class for loss.
@@ -92,18 +91,18 @@ class Loss(HybridBlock):
             The first input tensor.
         *args : list of Symbol or list of NDArray
             Additional input tensors.
+
         """
         # pylint: disable= invalid-name
         raise NotImplementedError
 
 
 class L2Loss(Loss):
-    """Calculates the mean squared error between output and label.
+    r"""Calculates the mean squared error between `pred` and `label`.
 
-    .. math::
-        L = \\frac{1}{2}\\sum_i \\vert {output}_i - {label}_i \\vert^2.
+    .. math:: L = \frac{1}{2} \sum_i \vert {pred}_i - {label}_i \vert^2.
 
-    Output and label can have arbitrary shape as long as they have the same
+    `pred` and `label` can have arbitrary shape as long as they have the same
     number of elements.
 
     Parameters
@@ -113,33 +112,36 @@ class L2Loss(Loss):
     batch_axis : int, default 0
         The axis that represents mini-batch.
 
+
     Inputs:
-        - output: prediction tensor with arbitrary shape
-        - label: truth tensor with the same size as output.
-        - sample_weight: element-wise weighting tensor. Must be broadcastable to
-        the same shape as output. For example, if output has shape (64, 10) and you want
-        to weigh each sample in the batch separately, `sample_weight` should have shape (64, 1).
+        - **pred**: prediction tensor with arbitrary shape
+        - **label**: target tensor with the same size as pred.
+        - **sample_weight**: element-wise weighting tensor. Must be broadcastable
+          to the same shape as pred. For example, if pred has shape (64, 10)
+          and you want to weigh each sample in the batch separately,
+          sample_weight should have shape (64, 1).
 
     Outputs:
-        - loss: loss tensor with shape (batch_size,).
+        - **loss**: loss tensor with shape (batch_size,). Dimenions other than
+          batch_axis are averaged out.
     """
     def __init__(self, weight=1., batch_axis=0, **kwargs):
         super(L2Loss, self).__init__(weight, batch_axis, **kwargs)
 
-    def hybrid_forward(self, F, output, label, sample_weight=None):
-        label = _reshape_label_as_output(F, output, label)
-        loss = F.square(output - label)
+    def hybrid_forward(self, F, pred, label, sample_weight=None):
+        label = _reshape_like(F, label, pred)
+        loss = F.square(pred - label)
         loss = _apply_weighting(F, loss, self._weight/2, sample_weight)
         return F.mean(loss, axis=self._batch_axis, exclude=True)
 
 
 class L1Loss(Loss):
-    """Calculates the mean absolute error between output and label.
+    r"""Calculates the mean absolute error between `pred` and `label`.
 
-    .. math::
-        L = \\frac{1}{2}\\sum_i \\vert {output}_i - {label}_i \\vert.
+    .. math:: L = \frac{1}{2} \sum_i \vert {pred}_i - {label}_i \vert.
 
-    Output and label must have the same shape.
+    `pred` and `label` can have arbitrary shape as long as they have the same
+    number of elements.
 
     Parameters
     ----------
@@ -149,22 +151,24 @@ class L1Loss(Loss):
         The axis that represents mini-batch.
 
 
-    Input shape:
-        `output` is the prediction tensor.
-        `label` is the truth tensor and should have the same shape as `output`.
-        `sample_weight` is a matrix for per-sample weighting. Must be broadcastable to
-        the same shape as loss. For example, if loss has shape (64, 10) and you want
-        to weigh each sample in the batch separately, `sample_weight` should have shape (64, 1).
+    Inputs:
+        - **pred**: prediction tensor with arbitrary shape
+        - **label**: target tensor with the same size as pred.
+        - **sample_weight**: element-wise weighting tensor. Must be broadcastable
+          to the same shape as pred. For example, if pred has shape (64, 10)
+          and you want to weigh each sample in the batch separately,
+          sample_weight should have shape (64, 1).
 
-    Output shape:
-        The loss output has the shape (batch_size,).
+    Outputs:
+        - **loss**: loss tensor with shape (batch_size,). Dimenions other than
+          batch_axis are averaged out.
     """
     def __init__(self, weight=None, batch_axis=0, **kwargs):
         super(L1Loss, self).__init__(weight, batch_axis, **kwargs)
 
-    def hybrid_forward(self, F, output, label, sample_weight=None):
-        label = _reshape_label_as_output(F, output, label)
-        loss = F.abs(output - label)
+    def hybrid_forward(self, F, pred, label, sample_weight=None):
+        label = _reshape_like(F, label, pred)
+        loss = F.abs(pred - label)
         loss = _apply_weighting(F, loss, self._weight, sample_weight)
         return F.mean(loss, axis=self._batch_axis, exclude=True)
 
@@ -172,45 +176,63 @@ class L1Loss(Loss):
 class SigmoidBinaryCrossEntropyLoss(Loss):
     r"""The cross-entropy loss for binary classification. (alias: SigmoidBCELoss)
 
-    BCE loss is useful when training logistic regression.
+    BCE loss is useful when training logistic regression. If `from_sigmoid`
+    is False (default), this loss computes:
 
     .. math::
-        loss(o, t) = - 1/n \\sum_i (t[i] * \\log(o[i]) + (1 - t[i]) * \\log(1 - o[i]))
 
+        prob = \frac{1}{1 + \exp(-{pred})}
+
+        L = - \sum_i {label}_i * \log({prob}_i) +
+            (1 - {label}_i) * \log(1 - {prob}_i)
+
+    If `from_sigmoid` is True, this loss computes:
+
+    .. math::
+
+        L = - \sum_i {label}_i * \log({pred}_i) +
+            (1 - {label}_i) * \log(1 - {pred}_i)
+
+
+    `pred` and `label` can have arbitrary shape as long as they have the same
+    number of elements.
 
     Parameters
     ----------
     from_sigmoid : bool, default is `False`
         Whether the input is from the output of sigmoid. Set this to false will make
-        the loss calculate sigmoid and then BCE, which is more numerically stable through
-        log-sum-exp trick.
+        the loss calculate sigmoid and BCE together, which is more numerically
+        stable through log-sum-exp trick.
     weight : float or None
         Global scalar weight for loss.
     batch_axis : int, default 0
         The axis that represents mini-batch.
 
 
-    Input shape:
-        `output` is the prediction tensor.
-        `label` is the truth tensor and should have the same shape as `output`.
-        `sample_weight` is a matrix for per-sample weighting. Must be broadcastable to
-        the same shape as loss. For example, if loss has shape (64, 10) and you want
-        to weigh each sample in the batch separately, `sample_weight` should have shape (64, 1).
+    Inputs:
+        - **pred**: prediction tensor with arbitrary shape
+        - **label**: target tensor with values in range `[0, 1]`. Must have the
+          same size as `pred`.
+        - **sample_weight**: element-wise weighting tensor. Must be broadcastable
+          to the same shape as pred. For example, if pred has shape (64, 10)
+          and you want to weigh each sample in the batch separately,
+          sample_weight should have shape (64, 1).
 
-    Output shape:
-        The loss output has the shape (batch_size,).
+    Outputs:
+        - **loss**: loss tensor with shape (batch_size,). Dimenions other than
+          batch_axis are averaged out.
     """
     def __init__(self, from_sigmoid=False, weight=None, batch_axis=0, **kwargs):
         super(SigmoidBinaryCrossEntropyLoss, self).__init__(weight, batch_axis, **kwargs)
         self._from_sigmoid = from_sigmoid
 
-    def hybrid_forward(self, F, output, label, sample_weight=None):
-        label = _reshape_label_as_output(F, output, label)
+    def hybrid_forward(self, F, pred, label, sample_weight=None):
+        label = _reshape_like(F, label, pred)
         if not self._from_sigmoid:
-            max_val = F.maximum(-output, 0)
-            loss = output - output*label + max_val + F.log(F.exp(-max_val)+F.exp(-output-max_val))
+            max_val = F.maximum(-pred, 0)
+            loss = pred - pred*label + max_val + F.log(F.exp(-max_val)+F.exp(-pred-max_val))
         else:
-            loss = -(F.log(output+1e-12)*label + F.log(1.-output+1e-12)*(1.-label))
+            loss = -(F.log(pred+1e-12)*label + F.log(1.-pred+1e-12)*(1.-label))
         loss = _apply_weighting(F, loss, self._weight, sample_weight)
         return F.mean(loss, axis=self._batch_axis, exclude=True)
 
@@ -218,25 +240,31 @@ SigmoidBCELoss = SigmoidBinaryCrossEntropyLoss
 
 
 class SoftmaxCrossEntropyLoss(Loss):
-    """Computes the softmax cross entropy loss. (alias: SoftmaxCELoss)
+    r"""Computes the softmax cross entropy loss. (alias: SoftmaxCELoss)
 
-    If `sparse_label` is `True`, label should contain integer category indicators:
-
-    .. math::
-        p = {softmax}({output})
-
-        L = -\\sum_i {log}(p_{i,{label}_i})
-
-    Label's shape should be output's shape without the `axis` dimension. i.e. for
-    `output.shape` = (1,2,3,4) and axis = 2, `label.shape` should be (1,2,4).
-
-    If `sparse_label` is `False`, label should contain probability distribution
-    with the same shape as output:
+    If `sparse_label` is `True` (default), label should contain integer
+    category indicators:
 
     .. math::
-        p = {softmax}({output})
 
-        L = -\\sum_i \\sum_j {label}_j {log}(p_{ij})
+        \DeclareMathOperator{softmax}{softmax}
+
+        p = \softmax({pred})
+
+        L = -\sum_i \log p_{i,{label}_i}
+
+    `label`'s shape should be `pred`'s shape with the `axis` dimension removed.
+    i.e. for `pred` with shape (1,2,3,4) and `axis = 2`, `label`'s shape should
+    be (1,2,4).
+
+    If `sparse_label` is `False`, `label` should contain probability distribution
+    and `label`'s shape should be the same with `pred`:
+
+    .. math::
+
+        p = \softmax({pred})
+
+        L = -\sum_i \sum_j {label}_j \log p_{ij}
 
     Parameters
     ----------
@@ -253,21 +281,24 @@ class SoftmaxCrossEntropyLoss(Loss):
         The axis that represents mini-batch.
 
 
-    Input shape:
-        `output` is the prediction tensor. The batch axis and softmax axis should be consistent
-        with the value used in the constructor.
-        `label` is the truth tensor. When `sparse_label` is true, `label` should have one less
-        dimension (axis) than `output` tensor. Otherwise, the shape of `label` must be the same as
-        output. For example, when `sparse_label` is true, if `output` has shape
-        `(batch_size, x1, x2, c)` and axis is `-1`, `label` should have shape
-        `(batch_size, x1, x2)`. If `sparse_label` is false, `label` should have shape
-        `(batch_size, x1, x2, c)`.
-        `sample_weight` is a matrix for per-sample weighting. Must be broadcastable to
-        the same shape as loss. For example, if loss has shape (64, 10) and you want
-        to weigh each sample in the batch separately, `sample_weight` should have shape (64, 1).
+    Inputs:
+        - **pred**: the prediction tensor, where the `batch_axis` dimension
+          ranges over batch size and `axis` dimension ranges over the number
+          of classes.
+        - **label**: the truth tensor. When `sparse_label` is True, `label`'s
+          shape should be `pred`'s shape with the `axis` dimension removed.
+          i.e. for `pred` with shape (1,2,3,4) and `axis = 2`, `label`'s shape
+          should be (1,2,4) and values should be integers between 0 and 2. If
+          `sparse_label` is False, `label`'s shape must be the same as `pred`
+          and values should be floats in the range `[0, 1]`.
+        - **sample_weight**: element-wise weighting tensor. Must be broadcastable
+          to the same shape as label. For example, if label has shape (64, 10)
+          and you want to weigh each sample in the batch separately,
+          sample_weight should have shape (64, 1).
 
-    Output shape:
-        The loss output has the shape (batch_size,).
+    Outputs:
+        - **loss**: loss tensor with shape (batch_size,). Dimenions other than
+          batch_axis are averaged out.
     """
     def __init__(self, axis=-1, sparse_label=True, from_logits=False, weight=None,
                  batch_axis=0, **kwargs):
@@ -276,13 +307,14 @@ class SoftmaxCrossEntropyLoss(Loss):
         self._sparse_label = sparse_label
         self._from_logits = from_logits
 
-    def hybrid_forward(self, F, output, label, sample_weight=None):
+    def hybrid_forward(self, F, pred, label, sample_weight=None):
         if not self._from_logits:
-            output = F.log_softmax(output)
+            pred = F.log_softmax(pred, self._axis)
         if self._sparse_label:
-            loss = -F.pick(output, label, axis=self._axis, keepdims=True)
+            loss = -F.pick(pred, label, axis=self._axis, keepdims=True)
         else:
-            loss = -F.sum(output*label, axis=self._axis, keepdims=True)
+            label = _reshape_like(F, label, pred)
+            loss = -F.sum(pred*label, axis=self._axis, keepdims=True)
         loss = _apply_weighting(F, loss, self._weight, sample_weight)
         return F.mean(loss, axis=self._batch_axis, exclude=True)
 
@@ -290,111 +322,139 @@ SoftmaxCELoss = SoftmaxCrossEntropyLoss
 
 
 class KLDivLoss(Loss):
-    """The Kullback-Leibler divergence loss.
+    r"""The Kullback-Leibler divergence loss.
 
-    KL divergence is a useful distance measure for continuous distributions
-    and is often useful when performing direct regression over the space of
-    (discretely sampled) continuous output distributions.
+    KL divergence measures the distance between contiguous distributions. It
+    can be used to minimize information loss when approximating a distribution.
+    If `from_logits` is True (default), loss is defined as:
 
-    .. _Kullback-Leibler divergence:
-        https://en.wikipedia.org/wiki/Kullback-Leibler_divergence
     .. math::
-        L = 1/n \\sum_i (label_i * (log(label_i) - output_i))
 
-    Label's shape should be the same as output's.
+        L = \sum_i {label}_i * \big[\log({label}_i) - {pred}_i\big]
+
+    If `from_logits` is False, loss is defined as:
+
+    .. math::
+
+        \DeclareMathOperator{softmax}{softmax}
+
+        prob = \softmax({pred})
+
+        L = \sum_i {label}_i * \big[\log({label}_i) - log({pred}_i)\big]
+
+
+    `pred` and `label` can have arbitrary shape as long as they have the same
+    number of elements.
 
     Parameters
     ----------
     from_logits : bool, default is `True`
         Whether the input is log probability (usually from log_softmax) instead
         of unnormalized numbers.
+    axis : int, default -1
+        The dimension along with to compute softmax. Only used when `from_logits`
+        is False.
     weight : float or None
         Global scalar weight for loss.
     batch_axis : int, default 0
         The axis that represents mini-batch.
 
 
-    Input shape:
-        `output` is the prediction tensor.
-        `label` is the truth tensor and should have the same shape as `output`.
-        `sample_weight` is a matrix for per-sample weighting. Must be broadcastable to
-        the same shape as loss. For example, if loss has shape (64, 10) and you want
-        to weigh each sample in the batch separately, `sample_weight` should have shape (64, 1).
+    Inputs:
+        - **pred**: prediction tensor with arbitrary shape. If `from_logits` is
+          True, `pred` should be log probabilities. Otherwise, it should be
+          unnormalized predictions, i.e. from a dense layer.
+        - **label**: truth tensor with values in range `(0, 1)`. Must have
+          the same size as `pred`.
+        - **sample_weight**: element-wise weighting tensor. Must be broadcastable
+          to the same shape as pred. For example, if pred has shape (64, 10)
+          and you want to weigh each sample in the batch separately,
+          sample_weight should have shape (64, 1).
 
-    Output shape:
-        The loss output has the shape (batch_size,).
+    Outputs:
+        - **loss**: loss tensor with shape (batch_size,). Dimenions other than
+          batch_axis are averaged out.
+
+
+    References
+    ----------
+        `Kullback-Leibler divergence
+        <https://en.wikipedia.org/wiki/Kullback-Leibler_divergence>`_
     """
-    def __init__(self, from_logits=True, weight=None, batch_axis=0, **kwargs):
+    def __init__(self, from_logits=True, axis=-1, weight=None, batch_axis=0,
+                 **kwargs):
         super(KLDivLoss, self).__init__(weight, batch_axis, **kwargs)
         self._from_logits = from_logits
+        self._axis = axis
 
-    def hybrid_forward(self, F, output, label, sample_weight=None):
+    def hybrid_forward(self, F, pred, label, sample_weight=None):
         if not self._from_logits:
-            output = F.log_softmax(output)
-        loss = label * (F.log(label+1e-12) - output)
+            pred = F.log_softmax(pred, self._axis)
+        loss = label * (F.log(label+1e-12) - pred)
         loss = _apply_weighting(F, loss, self._weight, sample_weight)
         return F.mean(loss, axis=self._batch_axis, exclude=True)
+
 
 class CTCLoss(Loss):
     r"""Connectionist Temporal Classification Loss.
 
-    See `"Connectionist Temporal Classification: Labelling Unsegmented
-    Sequence Data with Recurrent Neural Networks"
-    <http://www.cs.toronto.edu/~graves/icml_2006.pdf>`_ paper for more information.
 
     Parameters
     ----------
     layout : str, default 'NTC'
-        Layout of the output sequence activation vector.
+        Layout of prediction tensor. 'N', 'T', 'C' stands for batch size,
+        sequence length, and alphabet_size respectively.
     label_layout : str, default 'NT'
-        Layout of the labels.
+        Layout of the labels. 'N', 'T' stands for batch size, and sequence
+        length respectively.
     weight : float or None
         Global scalar weight for loss.
 
 
-    Input shape:
-        `data` is an activation tensor (i.e. before softmax).
-        Its shape depends on `layout`. For `layout='TNC'`, this
-        input has shape `(sequence_length, batch_size, alphabet_size)`
-        Note that the last dimension with index `alphabet_size-1` is reserved for special
-        blank character.
+    Inputs:
+        - **pred**: unnormalized prediction tensor (before softmax).
+          Its shape depends on `layout`. If `layout` is 'TNC', pred
+          should have shape `(sequence_length, batch_size, alphabet_size)`.
+          Note that in the last dimension, index `alphabet_size-1` is reserved
+          for internal use as blank label. So `alphabet_size` is one plus the
+          actual alphabet size.
 
-        `label` is the label index matrix with zero-indexed labels.
-        Its shape depends on `label_layout`. For `label_layout='TN'`, this
-        input has shape `(label_sequence_length, batch_size)`. Padding mask of value ``-1``
-        is available for dealing with unaligned label lengths.
-        When `label_lengths` is specified, label lengths are directly used and padding mask
-        is not allowed in the label.
-        When `label_lengths` is not specified, the first occurrence of ``-1``
-        in each sample marks the end of the label sequence of that sample.
+        - **label**: zero-based label tensor. Its shape depends on `label_layout`.
+          If `label_layout` is 'TN', `label` should have shape
+          `(label_sequence_length, batch_size)`.
 
-        For example, suppose the vocabulary is `[a, b, c]`, and in one batch we have three
-        sequences 'ba', 'cbb', and 'abac'. We can index the labels as `{'a': 0, 'b': 1, 'c': 2}`.
-        The alphabet size should be 4, and we reserve the channel index 3 for blank label
-        in data tensor. The padding mask value for extra length is -1, so the resulting `label`
-        tensor should be padded to be::
+        - **pred_lengths**: optional (default None), used for specifying the
+          length of each entry when different `pred` entries in the same batch
+          have different lengths. `pred_lengths` should have shape `(batch_size,)`.
 
-          [[1, 0, -1, -1], [2, 1, 1, -1], [0, 1, 0, 2]]
+        - **label_lengths**: optional (default None), used for specifying the
+          length of each entry when different `label` entries in the same batch
+          have different lengths. `label_lengths` should have shape `(batch_size,)`.
 
-        `data_lengths` is optional and defaults to None.
-        When specified, it represents the actual lengths of data.
-        The shape should be (batch_size,).
-        If None, the data lengths are treated as being equal to the max sequence length.
-        This should be used as the third argument when calling this loss.
+    Outputs:
+        - **loss**: output loss has shape `(batch_size,)`.
 
-        `label_lengths` is optional and defaults to None.
-        When specified, it represents the actual lengths of labels.
-        The shape should be (batch_size,).
-        If None, the label lengths are derived from the first occurrence of
-        the value specified by `padding_mask`.
-        This should be used as the fourth argument when calling this loss.
 
-    Output shape:
-        The CTC loss output has the shape (batch_size,).
+    **Example**: suppose the vocabulary is `[a, b, c]`, and in one batch we
+    have three sequences 'ba', 'cbb', and 'abac'. We can index the labels as
+    `{'a': 0, 'b': 1, 'c': 2, blank: 3}`. Then `alphabet_size` should be 4,
+    where label 3 is reserved for internal use by `CTCLoss`. We then need to
+    pad each sequence with `-1` to make a rectangular `label` tensor::
+
+        [[1, 0, -1, -1],
+         [2, 1,  1, -1],
+         [0, 1,  0,  2]]
+
+
+    References
+    ----------
+        `Connectionist Temporal Classification: Labelling Unsegmented
+        Sequence Data with Recurrent Neural Networks
+        <http://www.cs.toronto.edu/~graves/icml_2006.pdf>`_
     """
     def __init__(self, layout='NTC', label_layout='NT', weight=None, **kwargs):
         assert layout in ['NTC', 'TNC'],\
-               "Only 'NTC' and 'TNC' layouts for output are supported. Got: %s"%layout
+               "Only 'NTC' and 'TNC' layouts for pred are supported. Got: %s"%layout
         assert label_layout in ['NT', 'TN'],\
                "Only 'NT' and 'TN' layouts for label are supported. Got: %s"%label_layout
         self._layout = layout
@@ -402,49 +462,62 @@ class CTCLoss(Loss):
         batch_axis = label_layout.find('N')
         super(CTCLoss, self).__init__(weight, batch_axis, **kwargs)
 
-    def hybrid_forward(self, F, data, label,
-                       data_lengths=None, label_lengths=None, sample_weight=None):
+    def hybrid_forward(self, F, pred, label,
+                       pred_lengths=None, label_lengths=None, sample_weight=None):
         if self._layout == 'NTC':
-            data = F.swapaxes(data, 0, 1)
+            pred = F.swapaxes(pred, 0, 1)
         if self._batch_axis == 1:
             label = F.swapaxes(label, 0, 1)
-        loss = F.contrib.CTCLoss(data, label,
-                                 use_data_lengths=data_lengths is not None,
+        loss = F.contrib.CTCLoss(pred, label, pred_lengths, label_lengths,
+                                 use_data_lengths=pred_lengths is not None,
                                  use_label_lengths=label_lengths is not None,
-                                 data_lengths=data_lengths, label_lengths=label_lengths,
                                  blank_label='last')
         return _apply_weighting(F, loss, self._weight, sample_weight)
 
 
 class HuberLoss(Loss):
-    """Calculates smoothed L1 loss that is equal to L1 loss if absolute error
+    r"""Calculates smoothed L1 loss that is equal to L1 loss if absolute error
     exceeds rho but is equal to L2 loss otherwise. Also called SmoothedL1 loss.
 
     .. math::
-        L = \\begin{cases} \\frac{1}{2 \\rho} ({output}_i - {label}_i)^2 &
-                           \\text{ if } |{output}_i - {label}_i| < \\rho \\\
-                           |{output}_i - {label}_i| - \\frac{\\rho}{2} &
-                           \\text{ otherwise }
-            \\end{cases}
+        L = \sum_i \begin{cases} \frac{1}{2 {rho}} ({pred}_i - {label}_i)^2 &
+                           \text{ if } |{pred}_i - {label}_i| < {rho} \\
+                           |{pred}_i - {label}_i| - \frac{{rho}}{2} &
+                           \text{ otherwise }
+            \end{cases}
 
-    Output and label must have the same number of elements.
+    `pred` and `label` can have arbitrary shape as long as they have the same
+    number of elements.
 
     Parameters
     ----------
-    rho : float
-        Threshold for trimmed mean estimator. By default set to 1
+    rho : float, default 1
+        Threshold for trimmed mean estimator.
     weight : float or None
         Global scalar weight for loss.
     batch_axis : int, default 0
         The axis that represents mini-batch.
+
+
+    Inputs:
+        - **pred**: prediction tensor with arbitrary shape
+        - **label**: target tensor with the same size as pred.
+        - **sample_weight**: element-wise weighting tensor. Must be broadcastable
+          to the same shape as pred. For example, if pred has shape (64, 10)
+          and you want to weigh each sample in the batch separately,
+          sample_weight should have shape (64, 1).
+
+    Outputs:
+        - **loss**: loss tensor with shape (batch_size,). Dimenions other than
+          batch_axis are averaged out.
     """
     def __init__(self, rho=1, weight=None, batch_axis=0, **kwargs):
         super(HuberLoss, self).__init__(weight, batch_axis, **kwargs)
         self._rho = rho
 
-    def hybrid_forward(self, F, output, label, sample_weight=None):
-        label = _reshape_label_as_output(F, output, label)
-        loss = F.abs(output - label)
+    def hybrid_forward(self, F, pred, label, sample_weight=None):
+        label = _reshape_like(F, label, pred)
+        loss = F.abs(pred - label)
         loss = F.where(loss > self._rho, loss - 0.5 * self._rho,
                        (0.5/self._rho) * F.square(loss))
         loss = _apply_weighting(F, loss, self._weight, sample_weight)
@@ -452,13 +525,13 @@ class HuberLoss(Loss):
 
 
 class HingeLoss(Loss):
-    """Calculates the hinge loss function often used in SVMs:
+    r"""Calculates the hinge loss function often used in SVMs:
 
     .. math::
-        L = max(0, \\margin - {output}_i {label}_i)
+        L = \sum_i max(0, {margin} - {pred}_i \cdot {label}_i)
 
-    where output is the classifier prediction and label is the target tensor
-    containing values -1 or 1. Output and label must have the same number of
+    where `pred` is the classifier prediction and `label` is the target tensor
+    containing values -1 or 1. `pred` and `label` must have the same number of
     elements.
 
     Parameters
@@ -469,26 +542,41 @@ class HingeLoss(Loss):
         Global scalar weight for loss.
     batch_axis : int, default 0
         The axis that represents mini-batch.
+
+
+    Inputs:
+        - **pred**: prediction tensor with arbitrary shape.
+        - **label**: truth tensor with values -1 or 1. Must have the same size
+          as pred.
+        - **sample_weight**: element-wise weighting tensor. Must be broadcastable
+          to the same shape as pred. For example, if pred has shape (64, 10)
+          and you want to weigh each sample in the batch separately,
+          sample_weight should have shape (64, 1).
+
+    Outputs:
+        - **loss**: loss tensor with shape (batch_size,). Dimenions other than
+          batch_axis are averaged out.
     """
     def __init__(self, margin=1, weight=None, batch_axis=0, **kwargs):
         super(HingeLoss, self).__init__(weight, batch_axis, **kwargs)
         self._margin = margin
 
-    def hybrid_forward(self, F, output, label, sample_weight=None):
-        label = _reshape_label_as_output(F, output, label)
-        loss = F.relu(margin - output * label)
+    def hybrid_forward(self, F, pred, label, sample_weight=None):
+        label = _reshape_like(F, label, pred)
+        loss = F.relu(margin - pred * label)
         loss = _apply_weighting(F, loss, self._weight, sample_weight)
         return F.mean(loss, axis=self._batch_axis, exclude=True)
 
 
 class SquaredHingeLoss(Loss):
-    """Calculates the soft-margin loss function used in SVMs:
+    r"""Calculates the soft-margin loss function used in SVMs:
 
     .. math::
-        L = max(0, 1 - {output}_i {label}_i)^2
+        L = \sum_i max(0, {margin} - {pred}_i \cdot {label}_i)^2
 
-    Output and label can have arbitrary shape as long as they have the same
-    number of elements.
+    where `pred` is the classifier prediction and `label` is the target tensor
+    containing values -1 or 1. `pred` and `label` can have arbitrary shape as
+    long as they have the same number of elements.
 
     Parameters
     ----------
@@ -498,26 +586,41 @@ class SquaredHingeLoss(Loss):
         Global scalar weight for loss.
     batch_axis : int, default 0
         The axis that represents mini-batch.
+
+
+    Inputs:
+        - **pred**: prediction tensor with arbitrary shape
+        - **label**: truth tensor with values -1 or 1. Must have the same size
+          as pred.
+        - **sample_weight**: element-wise weighting tensor. Must be broadcastable
+          to the same shape as pred. For example, if pred has shape (64, 10)
+          and you want to weigh each sample in the batch separately,
+          sample_weight should have shape (64, 1).
+
+    Outputs:
+        - **loss**: loss tensor with shape (batch_size,). Dimenions other than
+          batch_axis are averaged out.
     """
     def __init__(self, margin=1, weight=None, batch_axis=0, **kwargs):
         super(SquaredHingeLoss, self).__init__(weight, batch_axis, **kwargs)
         self._margin = margin
 
-    def hybrid_forward(self, F, output, label, sample_weight=None):
-        label = _reshape_label_as_output(F, output, label)
-        loss = F.square(F.relu(self._margin - output * label))
+    def hybrid_forward(self, F, pred, label, sample_weight=None):
+        label = _reshape_like(F, label, pred)
+        loss = F.square(F.relu(self._margin - pred * label))
         loss = _apply_weighting(F, loss, self._weight, sample_weight)
         return F.mean(loss, axis=self._batch_axis, exclude=True)
 
 
 class LogisticLoss(Loss):
-    """Calculates the logistic loss (for binary losses only):
+    r"""Calculates the logistic loss (for binary losses only):
 
     .. math::
-        L = \\log(1 + \\exp(- {output}_i {label}_i))
+        L = \sum_i \log(1 + \exp(- {pred}_i \cdot {label}_i))
 
-    Output and label can have arbitrary shape as long as they have the same
-    number of elements.
+    where `pred` is the classifier prediction and `label` is the target tensor
+    containing values -1 or 1. `pred` and `label` can have arbitrary shape as
+    long as they have the same number of elements.
 
     Parameters
     ----------
@@ -525,25 +628,42 @@ class LogisticLoss(Loss):
         Global scalar weight for loss.
     batch_axis : int, default 0
         The axis that represents mini-batch.
+
+
+    Inputs:
+        - **pred**: prediction tensor with arbitrary shape.
+        - **label**: truth tensor with values -1 or 1. Must have the same size
+          as pred.
+        - **sample_weight**: element-wise weighting tensor. Must be broadcastable
+          to the same shape as pred. For example, if pred has shape (64, 10)
+          and you want to weigh each sample in the batch separately,
+          sample_weight should have shape (64, 1).
+
+    Outputs:
+        - **loss**: loss tensor with shape (batch_size,). Dimenions other than
+          batch_axis are averaged out.
     """
     def __init__(self, weight=None, batch_axis=0, **kwargs):
         super(Logistic, self).__init__(weight, batch_axis, **kwargs)
 
-    def hybrid_forward(self, F, output, label, sample_weight=None):
-        label = _reshape_label_as_output(F, output, label)
-        loss = F.log(1.0 + F.exp(-output * label))
+    def hybrid_forward(self, F, pred, label, sample_weight=None):
+        label = _reshape_like(F, label, pred)
+        loss = F.log(1.0 + F.exp(-pred * label))
         loss = _apply_weighting(F, loss, self._weight, sample_weight)
         return F.mean(loss, axis=self._batch_axis, exclude=True)
 
 
 class TripletLoss(Loss):
-    """Calculates the mean squared error between output and label:
+    r"""Calculates triplet loss given three input tensors and a positive margin.
+    Triplet loss measures the relative similarity between prediction, a positive
+    example and a negative example:
 
     .. math::
-        L = \\frac{1}{2}\\sum_i \\vert {output}_i - {label}_i \\vert^2.
+        L = \sum_i \max(\Vert {pred}_i - {pos_i} \Vert_2^2 -
+                        \Vert {pred}_i - {neg_i} \Vert_2^2 + {margin}, 0)
 
-    Output and label can have arbitrary shape as long as they have the same
-    number of elements.
+    `pred`, `positive` and `negative` can have arbitrary shape as long as they
+    have the same number of elements.
 
     Parameters
     ----------
@@ -551,17 +671,28 @@ class TripletLoss(Loss):
         Margin of separation between correct and incorrect pair.
     weight : float or None
         Global scalar weight for loss.
-    axis : int, default 1
-        The axis over which to sum distances.
     batch_axis : int, default 0
         The axis that represents mini-batch.
+
+
+    Inputs:
+        - **pred**: prediction tensor with arbitrary shape
+        - **positive**: positive example tensor with arbitrary shape. Must have
+          the same size as pred.
+        - **negative**: negative example tensor with arbitrary shape Must have
+          the same size as pred.
+
+    Outputs:
+        - **loss**: loss tensor with shape (batch_size,).
     """
     def __init__(self, margin=1, weight=None, batch_axis=0, **kwargs):
         super(TripletLoss, self).__init__(weight, batch_axis, **kwargs)
         self._margin = margin
 
-    def hybrid_forward(self, F, output, positive, negative):
-        loss = F.sum(F.square(output-positive) - F.square(output-negative),
+    def hybrid_forward(self, F, pred, positive, negative):
+        positive = _reshape_like(F, positive, pred)
+        negative = _reshape_like(F, negative, pred)
+        loss = F.sum(F.square(pred-positive) - F.square(pred-negative),
                      axis=self._batch_axis, exclude=True)
         loss = F.relu(loss + self._margin)
         return _apply_weighting(F, loss, self._weight, None)

--- a/src/operator/tensor/elemwise_unary_op.cc
+++ b/src/operator/tensor/elemwise_unary_op.cc
@@ -168,26 +168,52 @@ The storage type of ``make_loss`` output depends upon the input storage type:
 
 // identity output as first input, but attributes (shape and type) are constrained to be like rhs
 // storage type attribute is not constrained to be like rhs if it is already defined
-NNVM_REGISTER_OP(reshape_like)
-.describe("Reshape lhs to the same shape as rhs.")
-.add_alias("_identity_with_attr_like_rhs")
+NNVM_REGISTER_OP(_identity_with_attr_like_rhs)
 .set_num_inputs(2)
 .set_attr<nnvm::FListInputNames>("FListInputNames",
-  [](const NodeAttrs& attrs) {
-    return std::vector<std::string>{"lhs", "rhs"};
-  })
+  [](const NodeAttrs& attrs) { return std::vector<std::string>{"lhs", "rhs"}; })
 .set_attr<nnvm::FInplaceOption>(
     "FInplaceOption", [](const NodeAttrs& attrs) {
       return std::vector<std::pair<int, int> >{{0, 0}};
     })
 .set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
-    [](const NodeAttrs& attrs){
-      return std::vector<bool>{true};
-    })
+    [](const NodeAttrs& attrs){ return std::vector<bool>{true}; })
 .set_attr<nnvm::FIgnoreInputs>("FIgnoreInputs",
     [](const NodeAttrs& attrs) { return std::vector<uint32_t>(1, 1); })
 .set_attr<FCompute>("FCompute<cpu>", UnaryOp::IdentityCompute<cpu>)
 .set_attr<FComputeEx>("FComputeEx<cpu>", UnaryOp::IdentityComputeFirstItemEx<cpu>)
+.set_attr<nnvm::FInferShape>("FInferShape", ElemwiseShape<2, 1>)
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseType<2, 1>)
+.set_attr<FInferStorageType>("FInferStorageType", IdentityAttrLikeRhsStorageType)
+.set_attr<nnvm::FGradient>(
+    "FGradient",  [](const nnvm::NodePtr& n,
+                     const std::vector<nnvm::NodeEntry>& ograds) {
+      auto lhs = MakeNonlossGradNode(
+          "_backward_copy", n, ograds, {},
+          std::unordered_map<std::string, std::string>());
+      auto ng = MakeNode("zeros_like", n->attrs.name + "_rhs_backward",
+                         {n->inputs[1]}, nullptr, &n);
+      lhs.push_back(nnvm::NodeEntry{ng, 0, 0});
+      return lhs;
+    })
+.add_argument("lhs", "NDArray-or-Symbol", "First input.")
+.add_argument("rhs", "NDArray-or-Symbol", "Second input.");
+
+
+NNVM_REGISTER_OP(reshape_like)
+.describe("Reshape lhs to have the same shape as rhs.")
+.set_num_inputs(2)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) { return std::vector<std::string>{"lhs", "rhs"}; })
+.set_attr<nnvm::FInplaceOption>(
+    "FInplaceOption", [](const NodeAttrs& attrs) {
+      return std::vector<std::pair<int, int> >{{0, 0}};
+    })
+.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+    [](const NodeAttrs& attrs){ return std::vector<bool>{true}; })
+.set_attr<nnvm::FIgnoreInputs>("FIgnoreInputs",
+    [](const NodeAttrs& attrs) { return std::vector<uint32_t>(1, 1); })
+.set_attr<FCompute>("FCompute<cpu>", UnaryOp::IdentityCompute<cpu>)
 .set_attr<nnvm::FInferShape>("FInferShape",
     [](const nnvm::NodeAttrs& attrs,
        std::vector<TShape> *in_attrs,
@@ -202,20 +228,20 @@ NNVM_REGISTER_OP(reshape_like)
       return true;
     })
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<2, 1>)
-.set_attr<FInferStorageType>("FInferStorageType", IdentityAttrLikeRhsStorageType)
 .set_attr<nnvm::FGradient>(
     "FGradient",  [](const nnvm::NodePtr& n,
                      const std::vector<nnvm::NodeEntry>& ograds) {
       auto lhs = MakeNonlossGradNode(
           "_backward_copy", n, ograds, {},
           std::unordered_map<std::string, std::string>());
-      auto ng = MakeNode("zeros_like", n->attrs.name + "rhs_backward",
+      auto ng = MakeNode("zeros_like", n->attrs.name + "_rhs_backward",
                          {n->inputs[1]}, nullptr, &n);
       lhs.push_back(nnvm::NodeEntry{ng, 0, 0});
       return lhs;
     })
 .add_argument("lhs", "NDArray-or-Symbol", "First input.")
 .add_argument("rhs", "NDArray-or-Symbol", "Second input.");
+
 
 DMLC_REGISTER_PARAMETER(CastParam);
 NNVM_REGISTER_OP(Cast)

--- a/src/operator/tensor/elemwise_unary_op.cu
+++ b/src/operator/tensor/elemwise_unary_op.cu
@@ -54,9 +54,12 @@ NNVM_REGISTER_OP(make_loss)
 .set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
 
 // identity output as first input, but attributes are constrainted to be like rhs
-NNVM_REGISTER_OP(reshape_like)
+NNVM_REGISTER_OP(_identity_with_attr_like_rhs)
 .set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>)
 .set_attr<FComputeEx>("FComputeEx<gpu>", UnaryOp::IdentityComputeFirstItemEx<gpu>);
+
+NNVM_REGISTER_OP(reshape_like)
+.set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
 
 NNVM_REGISTER_OP(Cast)
 .set_attr<FCompute>("FCompute<gpu>", CastCompute<gpu>);

--- a/src/operator/tensor/elemwise_unary_op.cu
+++ b/src/operator/tensor/elemwise_unary_op.cu
@@ -54,7 +54,7 @@ NNVM_REGISTER_OP(make_loss)
 .set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
 
 // identity output as first input, but attributes are constrainted to be like rhs
-NNVM_REGISTER_OP(_identity_with_attr_like_rhs)
+NNVM_REGISTER_OP(reshape_like)
 .set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>)
 .set_attr<FComputeEx>("FComputeEx<gpu>", UnaryOp::IdentityComputeFirstItemEx<gpu>);
 


### PR DESCRIPTION
Added back some of the losses reverted in #8010

Losses that are not added back include
```python
class MultiClassHingeLoss(Loss):
    """Calculates the MaxMargin loss, aka multiclass soft-margin
       loss. This requires access to a multiclass loss matrix delta
       which measures the cost for misclassifying label y as y'. This
       matrix can be specified at construction time. If it does not
       exist, we will susbstitute it with a 0-1 loss with automagic
       size inference.

    .. math::
       L = {max}_{y} [\\delta({label}, y) + {output}[y]] - {output}_{label}

    Label's shape should be output's shape without the `axis` dimension. i.e. for
    `output.shape` = (1,2,3,4) and axis = 2, `label.shape` should be (1,2,4).

    Parameters
    ----------
    delta : loss matrix, default None. In this case it is presumed to
        be a (0,1) loss, i.e. a constant loss of 1 for all
        misclassifications. Otherwise its dimensionality must match
        that of the number of classes.
    axis : int, default -1
        The axis to sum over when taking the maximum.
    weight : float or None
        Global scalar weight for loss.
    batch_axis : int, default 0
        The axis that represents mini-batch.
    """
    def __init__(self, delta=None, axis=-1, weight=None, batch_axis=0, **kwargs):
        super(MaxMargin, self).__init__(weight, batch_axis, **kwargs)
        self._axis = axis
        self._delta = delta
        super(MaxMargin, self).__init__(weight, batch_axis, **kwargs)

    def hybrid_forward(self, F, output, label, sample_weight=None):
        # Check if the cost matrix has been defined. If not, use a
        # dumb (0,1) loss. This is only executed once, the first time
        # you invoke the loss.
        if (self._delta is None):
            classes = output.shape[self._axis]
            self._delta = F.ones(shape=(classes, classes))
            for i in range(classes):
                self._delta[i, i] = 0
        loss = -F.pick(output, label, axis=self._axis, keepdims=True)
        loss += F.max(output + F.take(self._delta, label), axis=self._axis, keepdims=True)
        loss = _apply_weighting(F, loss, self._weight, sample_weight)
        return F.mean(loss, axis=self._batch_axis, exclude=True)
```
there are multiple versions of mult hinge loss. Also the implementation here won't work on GPU. Use of delta matrix is over complicated.

```python
class EpsilonInsensitiveLoss(Loss):
    """Calculates a loss that is insensitive to absolute error smaller than
    epsilon.

    .. math::
        L = \\mathrm{max}(0, |{output}_i - {label}_i| - \\epsilon)

    Output and label must have the same number of elements.

    Parameters
    ----------
    epsilon : float
        Threshold for trimmed epsilon-insensitivity parameter. By default set to 0.1
    weight : float or None
        Global scalar weight for loss.
    batch_axis : int, default 0
        The axis that represents mini-batch.
    """
    def __init__(self, epsilon, weight=None, batch_axis=0, **kwargs):
        super(EpsilonInsensitiveLoss, self).__init__(weight, batch_axis, **kwargs)
        self._epsilon = epsilon

    def hybrid_forward(self, F, output, label, sample_weight=None):
        label = _reshape_label_as_output(F, output, label)
        loss = F.relu(F.abs(output - label) - self._epsilon)
        loss = _apply_weighting(F, loss, self._weight, sample_weight)
        return F.mean(loss, axis=self._batch_axis, exclude=True)

```
Don't like the name. Is there a better one?

```python

class ExponentialLoss(Loss):
    """Calculates the exponential hinge loss (quite obscure):

    .. math::
        L = \\exp(- {output}_i {label}_i)

    Output and label must have the same shape.

    Parameters
    ----------
    weight : float or None
        Global scalar weight for loss.
    batch_axis : int, default 0
        The axis that represents mini-batch.
    """
    def __init__(self, weight=None, batch_axis=0, **kwargs):
        super(Exponential, self).__init__(weight, batch_axis, **kwargs)

    def hybrid_forward(self, F, output, label, sample_weight=None):
        label = _reshape_label_as_output(F, output, label)
        loss = F.exp(-output * label)
        loss = _apply_weighting(F, loss, self._weight, sample_weight)
        return F.mean(loss, axis=self._batch_axis, exclude=True)

```
Since its obscure, do we still need to add it?

```python

class QuantileLoss(Loss):
    """Calculates Koenker's quantile regression loss function yielding an estimate of the
       appropriately chosen quantile rather than the mean (or median):

    .. math::
        L = {max}(\\tau ({output}_i - {label}_i), (1-\\tau) ({label}_i - {output}_i)

    Output and label must have the same shape.

    Parameters
    ----------
    tau : float
        Quantile of the estimator. By default set to 0.5, i.e. by
        default identical with L1 loss, up to a scaling factor.
        This must be in the range (0,1).
    weight : float or None
        Global scalar weight for loss.
    batch_axis : int, default 0
        The axis that represents mini-batch.
    """
    def __init__(self, tau=0.5, weight=None, batch_axis=0, **kwargs):
        super(Quantile, self).__init__(weight, batch_axis, **kwargs)
        self._tau = tau

    def hybrid_forward(self, F, output, label, sample_weight=None):
        label = _reshape_label_as_output(F, output, label)
        loss = output - label
        loss = F.maximum(self._tau * loss, (self._tau - 1.0)* loss)
        loss = _apply_weighting(F, loss, self._weight, sample_weight)
        return F.mean(loss, axis=self._batch_axis, exclude=True)

```
What is this for?

```python
class LangfordLoss(Loss):
    """Calculates the Huberized soft-margin loss that is used in VW (Vowpal Wabbit).
       It is given by a squared loss for margin values of [-1, 0] and by a linear
       loss for values larger than that.

    .. math::
        L = \\begin{cases}
          0 &
          \\text{ if } {output}_i {label}_i > 1 \\\
          \\frac{1}{2} - {output}_i {label}_i &
          \\text{ if } {output}_i {label}_i < 0 \\\
          \\frac{1}{2} (1 - {output}_i {label}_i)^2 &
          \\text{ otherwise }
          \\end{cases}

    Output and label must have the same shape.

    Parameters
    ----------
    weight : float or None
        Global scalar weight for loss.
    batch_axis : int, default 0
        The axis that represents mini-batch.
    """
    def __init__(self, weight=None, batch_axis=0, **kwargs):
        super(Langford, self).__init__(weight, batch_axis, **kwargs)

    def hybrid_forward(self, F, output, label, sample_weight=None):
        label = _reshape_label_as_output(F, output, label)
        loss = F.relu(1 - output * label)
        loss = F.where(loss < 1.0, 0.5 * (loss**2), loss - 0.5)
        loss = _apply_weighting(F, loss, self._weight, sample_weight)
        return F.mean(loss, axis=self._batch_axis, exclude=True)

```
add back later.

```python
class DualKLLoss(Loss):
    """Estimates the Kullback Leibler Divergence between two
       distributions by convex duality. See Nguyen, Wainwright and
       Jordan (NGW), 2008 for a detailed derivation. In a nutshell it
       estimates:

    .. math::
       KL(p\\|q) = E_p[\\log p(x)] - E_p[\\log q(x)]

       Clearly this isn't easy to compute. Hence, NGW use the dual of
       the F-divergence log p(x)/q(x) and pose it as an optimization
       problem. This leads to the following loss function, which is
       different for both distributions (which we treat as a binary
       classification problem). The function that is being estimated
       allows us to get the Radon-Nikodym via dp/dq = exp(f).

    .. math::
        L = \\begin{cases}
            \\exp(f) & \\text{ if } y = -1 \\\
             -f-1 & \text{ if } y = 1
          \\end{cases}

    Output and label must have the same shape.

    Parameters
    ----------
    weight : float or None
        Global scalar weight for loss.
    batch_axis : int, default 0
        The axis that represents mini-batch.
    """
    def __init__(self, weight=None, batch_axis=0, **kwargs):
        super(DualKL, self).__init__(weight, batch_axis, **kwargs)

    def hybrid_forward(self, F, output, label, sample_weight=None):
        label = _reshape_label_as_output(F, output, label)
        loss = F.where(label, output + 1, F.exp(output))
        loss = _apply_weighting(F, loss, self._weight, sample_weight)
        return F.mean(loss, axis=self._batch_axis, exclude=True)

```
Add back later.

```python
class RelativeNoveltyLoss(Loss):
    """Estimates a relative novelty detector. See the Song, Teo and
       Smola (STS), 2009 for details. The main point is to estimate
       the ratio dp/dq well via max(0, rho - log dp/dq). As with the
       KL divergence estimator, the Fenchel-Legendre dual is easier to
       deal with. This leads to the following loss function:

    .. math::
        L = \\begin{cases}
            \\exp(f - rho) & \\text{ if } y = -1 \\\
             -f-1 & \\text{ if } y = 1 \\text{ and } f > 0 \\
            \\exp(f) & \\text{ if } y = 1 \\text{ and } f <= 0
          \\end{cases}

    output and label must have the same shape.

    Parameters
    ----------
    rho : float
        Relative probability weight for the most prevalent part of the
        probability distribution. It needs to be (0, 1).
    weight : float or None
        Global scalar weight for loss.
    batch_axis : int, default 0
        The axis that represents mini-batch.
    """
    def __init__(self, rho=0.1, weight=None, batch_axis=0, **kwargs):
        super(RelativeNovelty, self).__init__(weight, batch_axis, **kwargs)
        self._rho = rho

    def hybrid_forward(self, F, output, label, sample_weight=None):
        label = _reshape_label_as_output(F, output, label)
        loss = - F.where(output > 0, output + 1,  F.exp(output))
        loss = F.where(label, loss, F.exp(output - self._rho))
        loss = _apply_weighting(F, loss, self._weight, sample_weight)
        return F.mean(loss, axis=self._batch_axis, exclude=True)

```
a better name?

```python
class LogCoshLoss(Loss):
    """Calculates the smoothed L1 loss, aka log cosh loss in a
       numerically stable manner (i.e. without exponentiating large
       values of the cosh function.

    .. math::
        L = \\log 2 \\cosh ({output}_i - {label}_i)

    Output and label must have the same shape.

    Parameters
    ----------
    weight : float or None
        Global scalar weight for loss.
    batch_axis : int, default 0
        The axis that represents mini-batch.
    """
    def __init__(self, weight=None, batch_axis=0, **kwargs):
        super(LogCosh, self).__init__(weight, batch_axis, **kwargs)

    def hybrid_forward(self, F, output, label, sample_weight=None):
        label = _reshape_label_as_output(F, output, label)
        loss = F.abs(label - output)
        loss = loss + F.log(0.5 + 0.5 * F.exp(-2 * loss))
        loss = _apply_weighting(F, loss, self._weight, sample_weight)
        return F.mean(loss, axis=self._batch_axis, exclude=True)

```
better name?

```python
class PoissonLoss(Loss):
    """Calculates the Poisson loss function (up to the normalization
       by a factorial in the label, due to computational efficiency
       reasons).

       NOTE THAT THIS IS DIFFERENT FROM THE POISSON LOSS IN PYTORCH
       AND KERAS INSOFAR AS IT USES THE EPXONENTIAL VERSION. THAT ONE
       DOESN'T SUFFER FROM LOG 0 PROBLEMS.

    .. math::
        L = -\\log p({label}_i|{output}_i)
          = \\log {label}_i! + \\exp({output}_i) - {output}_i {label}_i

    Output and label must have the same shape.

    Parameters
    ----------
    weight : float or None
        Global scalar weight for loss.
    batch_axis : int, default 0
        The axis that represents mini-batch.
    """
    def __init__(self, weight=None, batch_axis=0, **kwargs):
        super(Poisson, self).__init__(weight, batch_axis, **kwargs)

    def hybrid_forward(self, F, output, label, sample_weight=None):
        label = _reshape_label_as_output(F, output, label)
        loss = F.exp(output) - output * label
        loss = _apply_weighting(F, loss, self._weight, sample_weight)
        return F.mean(loss, axis=self._batch_axis, exclude=True)
```
label is not necessarily a constant. It needs to be included in the loss