### PR TITLE
Minor enhancement for the auto-encoder example

### DIFF
--- a/example/autoencoder/autoencoder.py
+++ b/example/autoencoder/autoencoder.py
@@ -148,12 +148,12 @@ class AutoEncoderModel(model.MXModel):
                 x = mx.symbol.Dropout(data=x, p=dropout)
         return x
 
-    def layerwise_pretrain(self, X, batch_size, n_iter, optimizer, l_rate, decay, lr_scheduler=None):
+    def layerwise_pretrain(self, X, batch_size, n_iter, optimizer, l_rate, decay, lr_scheduler=None, print_every=1000):
         def l2_norm(label, pred):
             return np.mean(np.square(label-pred))/2.0
         solver = Solver(optimizer, momentum=0.9, wd=decay, learning_rate=l_rate, lr_scheduler=lr_scheduler)
         solver.set_metric(mx.metric.CustomMetric(l2_norm))
-        solver.set_monitor(Monitor(1000))
+        solver.set_monitor(Monitor(print_every))
         data_iter = mx.io.NDArrayIter({'data': X}, batch_size=batch_size, shuffle=True,
                                       last_batch_handle='roll_over')
         for i in range(self.N):
@@ -168,12 +168,12 @@ class AutoEncoderModel(model.MXModel):
             solver.solve(self.xpu, self.stacks[i], self.args, self.args_grad, self.auxs, data_iter_i,
                          0, n_iter, {}, False)
 
-    def finetune(self, X, batch_size, n_iter, optimizer, l_rate, decay, lr_scheduler=None):
+    def finetune(self, X, batch_size, n_iter, optimizer, l_rate, decay, lr_scheduler=None, print_every=1000):
         def l2_norm(label, pred):
            return np.mean(np.square(label-pred))/2.0
         solver = Solver(optimizer, momentum=0.9, wd=decay, learning_rate=l_rate, lr_scheduler=lr_scheduler)
         solver.set_metric(mx.metric.CustomMetric(l2_norm))
-        solver.set_monitor(Monitor(1000))
+        solver.set_monitor(Monitor(print_every))
         data_iter = mx.io.NDArrayIter({'data': X}, batch_size=batch_size, shuffle=True,
                                       last_batch_handle='roll_over')
         logging.info('Fine tuning...')

--- a/example/autoencoder/mnist_sae.py
+++ b/example/autoencoder/mnist_sae.py
@@ -66,20 +66,20 @@ if __name__ == '__main__':
         try:
             import matplotlib
             from matplotlib import pyplot as plt
-            import model
-            matplotlib.interactive(True)
+            from model import extract_feature
             # sample a random image
             original_image = X[np.random.choice(X.shape[0]), :].reshape(1, 784)
             data_iter = mx.io.NDArrayIter({'data': original_image}, batch_size=1, shuffle=False,
                                           last_batch_handle='pad')
-            # remove list?
-            reconstructed_image = list(model.extract_feature(ae_model.decoder, ae_model.args,
-                                       ae_model.auxs, data_iter,
-                                       original_image.shape[0], ae_model.xpu).values())[0]
-            print(type(reconstructed_image))
-            plt.imshow(original_image)
+            # reconstruct the image
+            reconstructed_image = extract_feature(ae_model.decoder, ae_model.args,
+                                                  ae_model.auxs, data_iter, 1,
+                                                  ae_model.xpu).values()[0]
+            print("original image")
+            plt.imshow(original_image.reshape((28,28)))
             plt.show()
-            plt.imshow(reconstructed_image)
+            print("reconstructed image")
+            plt.imshow(reconstructed_image.reshape((28, 28)))
             plt.show()
         except ImportError:
             logging.info("matplotlib is required for visualization")

--- a/example/autoencoder/mnist_sae.py
+++ b/example/autoencoder/mnist_sae.py
@@ -28,9 +28,9 @@ parser.add_argument('--print-every', type=int, default=1000,
                     help='the interval of printing during training.')
 parser.add_argument('--batch-size', type=int, default=256,
                     help='the batch size used for training.')
-parser.add_argument('--pretrain-iter', type=int, default=50000,
+parser.add_argument('--pretrain-num-iter', type=int, default=50000,
                     help='the number of iterations for pretraining.')
-parser.add_argument('--finetune-iter', type=int, default=100000,
+parser.add_argument('--finetune-num-iter', type=int, default=100000,
                     help='the number of iterations for fine-tuning.')
 parser.add_argument('--visualize', action='store_true',
                     help='whether to visualize the original image and the reconstructed one.')
@@ -44,8 +44,8 @@ opt = parser.parse_args()
 logging.info(opt)
 print_every = opt.print_every
 batch_size = opt.batch_size
-pretrain_iter = opt.pretrain_iter
-finetune_iter = opt.finetune_iter
+pretrain_num_iter = opt.pretrain_num_iter
+finetune_num_iter = opt.finetune_num_iter
 visualize = opt.visualize
 layers = [int(i) for i in opt.num_units.split(',')]
 
@@ -57,10 +57,10 @@ if __name__ == '__main__':
     train_X = X[:60000]
     val_X = X[60000:]
 
-    ae_model.layerwise_pretrain(train_X, batch_size, pretrain_iter, 'sgd', l_rate=0.1, decay=0.0,
-                                lr_scheduler=mx.misc.FactorScheduler(20000,0.1),
+    ae_model.layerwise_pretrain(train_X, batch_size, pretrain_num_iter, 'sgd', l_rate=0.1,
+                                decay=0.0, lr_scheduler=mx.misc.FactorScheduler(20000,0.1),
                                 print_every=print_every)
-    ae_model.finetune(train_X, batch_size, finetune_iter, 'sgd', l_rate=0.1, decay=0.0,
+    ae_model.finetune(train_X, batch_size, finetune_num_iter, 'sgd', l_rate=0.1, decay=0.0,
                       lr_scheduler=mx.misc.FactorScheduler(20000,0.1), print_every=print_every)
     ae_model.save('mnist_pt.arg')
     ae_model.load('mnist_pt.arg')

--- a/example/autoencoder/mnist_sae.py
+++ b/example/autoencoder/mnist_sae.py
@@ -15,29 +15,49 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# pylint: skip-file
 from __future__ import print_function
+import argparse
 import mxnet as mx
 import numpy as np
 import logging
 import data
 from autoencoder import AutoEncoderModel
 
+parser = argparse.ArgumentParser(description='Train an auto-encoder model for mnist dataset.')
+parser.add_argument('--print-every', type=int, default=1000,
+                    help='the interval of printing during training.')
+parser.add_argument('--batch-size', type=int, default=256,
+                    help='the batch size used for training.')
+parser.add_argument('--pretrain-iter', type=int, default=50000,
+                    help='the number of iterations for pretraining.')
+parser.add_argument('--finetune-iter', type=int, default=100000,
+                    help='the number of iterations for fine-tuning.')
+parser.add_argument('--visualize', action='store_true',
+                    help='whether to visualize the original image and the reconstructed one.')
+
+# set to INFO to see less information during training
+logging.basicConfig(level=logging.DEBUG)
+opt = parser.parse_args()
+logging.info(opt)
+print_every = opt.print_every
+batch_size = opt.batch_size
+pretrain_iter = opt.pretrain_iter
+finetune_iter = opt.finetune_iter
+visualize = opt.visualize
 
 if __name__ == '__main__':
-    # set to INFO to see less information during training
-    logging.basicConfig(level=logging.DEBUG)
-    ae_model = AutoEncoderModel(mx.gpu(0), [784,500,500,2000,10], pt_dropout=0.2,
+    ae_model = AutoEncoderModel(mx.cpu(0), [784,500,500,2000,10], pt_dropout=0.2,
         internal_act='relu', output_act='relu')
 
     X, _ = data.get_mnist()
     train_X = X[:60000]
     val_X = X[60000:]
 
-    ae_model.layerwise_pretrain(train_X, 256, 50000, 'sgd', l_rate=0.1, decay=0.0,
-                             lr_scheduler=mx.misc.FactorScheduler(20000,0.1))
-    ae_model.finetune(train_X, 256, 100000, 'sgd', l_rate=0.1, decay=0.0,
-                   lr_scheduler=mx.misc.FactorScheduler(20000,0.1))
+    ae_model.layerwise_pretrain(train_X, batch_size, pretrain_iter, 'sgd', l_rate=0.1, decay=0.0,
+                                lr_scheduler=mx.misc.FactorScheduler(20000,0.1),
+                                print_every=print_every)
+    ae_model.finetune(train_X, batch_size, finetune_iter, 'sgd', l_rate=0.1, decay=0.0,
+                      lr_scheduler=mx.misc.FactorScheduler(20000,0.1), print_every=print_every)
     ae_model.save('mnist_pt.arg')
     ae_model.load('mnist_pt.arg')
     print("Training error:", ae_model.eval(train_X))

--- a/example/autoencoder/mnist_sae.py
+++ b/example/autoencoder/mnist_sae.py
@@ -34,6 +34,9 @@ parser.add_argument('--finetune-iter', type=int, default=100000,
                     help='the number of iterations for fine-tuning.')
 parser.add_argument('--visualize', action='store_true',
                     help='whether to visualize the original image and the reconstructed one.')
+parser.add_argument('--num-units', type=str, default="784,500,500,2000,10",
+                    help='the number of hidden units for the layers of the encoder.' \
+                         'The decoder layers are created in the reverse order.')
 
 # set to INFO to see less information during training
 logging.basicConfig(level=logging.DEBUG)
@@ -44,9 +47,10 @@ batch_size = opt.batch_size
 pretrain_iter = opt.pretrain_iter
 finetune_iter = opt.finetune_iter
 visualize = opt.visualize
+layers = [int(i) for i in opt.num_units.split(',')]
 
 if __name__ == '__main__':
-    ae_model = AutoEncoderModel(mx.cpu(0), [784,500,500,2000,10], pt_dropout=0.2,
+    ae_model = AutoEncoderModel(mx.cpu(0), layers, pt_dropout=0.2,
         internal_act='relu', output_act='relu')
 
     X, _ = data.get_mnist()

--- a/example/autoencoder/mnist_sae.py
+++ b/example/autoencoder/mnist_sae.py
@@ -62,3 +62,24 @@ if __name__ == '__main__':
     ae_model.load('mnist_pt.arg')
     print("Training error:", ae_model.eval(train_X))
     print("Validation error:", ae_model.eval(val_X))
+    if visualize:
+        try:
+            import matplotlib
+            from matplotlib import pyplot as plt
+            import model
+            matplotlib.interactive(True)
+            # sample a random image
+            original_image = X[np.random.choice(X.shape[0]), :].reshape(1, 784)
+            data_iter = mx.io.NDArrayIter({'data': original_image}, batch_size=1, shuffle=False,
+                                          last_batch_handle='pad')
+            # remove list?
+            reconstructed_image = list(model.extract_feature(ae_model.decoder, ae_model.args,
+                                       ae_model.auxs, data_iter,
+                                       original_image.shape[0], ae_model.xpu).values())[0]
+            print(type(reconstructed_image))
+            plt.imshow(original_image)
+            plt.show()
+            plt.imshow(reconstructed_image)
+            plt.show()
+        except ImportError:
+            logging.info("matplotlib is required for visualization")

--- a/example/autoencoder/mnist_sae.py
+++ b/example/autoencoder/mnist_sae.py
@@ -68,7 +68,6 @@ if __name__ == '__main__':
     print("Validation error:", ae_model.eval(val_X))
     if visualize:
         try:
-            import matplotlib
             from matplotlib import pyplot as plt
             from model import extract_feature
             # sample a random image

--- a/example/autoencoder/solver.py
+++ b/example/autoencoder/solver.py
@@ -140,10 +140,3 @@ class Solver(object):
                 if self.iter_end_callback(i):
                     return
             exe.outputs[0].wait_to_read()
-
-
-
-
-
-
-


### PR DESCRIPTION
- add batch size, num units, num iterations as parser arguments
- add visualization option for inputs/outputs, which is commonly used when people try out auto-encoder for the first time

@szha @piiswrong 