### PR TITLE
Make gluon.Block cooperative in multiple inheritance setting

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -170,7 +170,7 @@ class Block(object):
         self._children = []
 
         # Cooperative design for multiple inheritance
-        super().__init__(**kwargs)
+        super(Block, self).__init__(**kwargs)
 
     def __repr__(self):
         s = '{name}(\n{modstr}\n)'

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -162,12 +162,15 @@ class Block(object):
             dense0 = nn.Dense(20)
             dense1 = nn.Dense(20, params=dense0.collect_params())
     """
-    def __init__(self, prefix=None, params=None):
+    def __init__(self, prefix=None, params=None, **kwargs):
         self._empty_prefix = prefix == ''
         self._prefix, self._params = _BlockScope.create(prefix, params, self._alias())
         self._name = self._prefix[:-1] if self._prefix.endswith('_') else self._prefix
         self._scope = _BlockScope(self)
         self._children = []
+
+        # Cooperative design for multiple inheritance
+        super().__init__(**kwargs)
 
     def __repr__(self):
         s = '{name}(\n{modstr}\n)'
@@ -319,8 +322,9 @@ class HybridBlock(Block):
     Refer `Hybrid tutorial <http://mxnet.io/tutorials/gluon/hybrid.html>`_ to see
     the end-to-end usage.
     """
-    def __init__(self, prefix=None, params=None):
-        super(HybridBlock, self).__init__(prefix=prefix, params=params)
+    def __init__(self, prefix=None, params=None, **kwargs):
+        # Cooperative design for multiple inheritance
+        super(HybridBlock, self).__init__(prefix=prefix, params=params, **kwargs)
         self._reg_params = {}
         self._cached_graph = ()
         self._cached_op = None


### PR DESCRIPTION
Pass further init kwargs to super(), i.e. make Block cooperative in a multiple
inheritance setting.

https://rhettinger.wordpress.com/2011/05/26/super-considered-super/

This PR enables a setting where a class inherits both from Gluon and another class, such as [traitlets](https://github.com/ipython/traitlets): 

```
class Net(gluon.Block, traitlets.config.Configurable):
    def __init__(self, **kwargs):
        super().__init__(**kwargs)
        with self.name_scope():
            [...]
```
This was not possible before, as gluon.Block would not pass on relevant kwargs to the init function higher up in MRO (Method Resolution Order).