### PR TITLE
Adding .png to the list of allowed extensions in the im2rec.py

### DIFF
--- a/tools/im2rec.py
+++ b/tools/im2rec.py
@@ -216,7 +216,7 @@ def parse_args():
                         help='If this is set im2rec will create image list(s) by traversing root folder\
         and output to <prefix>.lst.\
         Otherwise im2rec will read <prefix>.lst and create a database at <prefix>.rec')
-    cgroup.add_argument('--exts', nargs='+', default=['.jpeg', '.jpg'],
+    cgroup.add_argument('--exts', nargs='+', default=['.jpeg', '.jpg', '.png'],
                         help='list of acceptable image extensions.')
     cgroup.add_argument('--chunks', type=int, default=1, help='number of chunks.')
     cgroup.add_argument('--train-ratio', type=float, default=1.0,


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [x ] Passed code style checking (`make lint`)
- [x ] Changes are complete (i.e. I finished coding on this PR)
- [x ] All changes have test coverage
- [x ] For user-facing API changes, API doc string has been updated.
- [x ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Adding .png as allowed in default extensions in the im2rec.py argument parser. Tested by running im2rec on a set of png images and was able to generate rec files. 

## Comments ##
- N/A
