### PR TITLE
Fix pip-test, install libgfortran3 on docker

### DIFF
--- a/tests/ci_build/pip_tests/Dockerfile.pip_dependencies
+++ b/tests/ci_build/pip_tests/Dockerfile.pip_dependencies
@@ -8,6 +8,7 @@ RUN apt-get install -y python python2.7 python3.4 python3.5 python3.6
 
 # install other dependencies
 RUN apt-get install -y wget git unzip gcc
+RUN apt-get install libgfortran3
 
 # install virtualenv
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && pip install virtualenv && rm -rf get-pip.py


### PR DESCRIPTION
## Description ##
The nightly test on Internal Jenkins called pip-test fails because the docker does not have the libfortran.so.3. 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
In this PR I have modified [this dockerfile](https://github.com/apache/incubator-mxnet/blob/master/tests/ci_build/pip_tests/Dockerfile.pip_dependencies) to install libfortran3 which is required for pip testing. 
I manually reproduced this issue on a host machine and verified that this change fixes the issue. 

## Comments ##
I tried some other suggestions available online like 'export' but they do not fix the issue (the .so does not exist on the docker at all). 
While I have done some manual testing I will monitor it to make sure it works once merged. 
