### PR TITLE
Sequential aug

### DIFF
--- a/docs/api/python/image/image.md
+++ b/docs/api/python/image/image.md
@@ -69,12 +69,13 @@ A list of supporting augmenters
     :nosignatures:
 
     image.Augmenter
+    image.SequentialAug
+    image.RandomOrderAug
     image.ResizeAug
     image.ForceResizeAug
     image.RandomCropAug
     image.RandomSizedCropAug
     image.CenterCropAug
-    image.RandomOrderAug
     image.BrightnessJitterAug
     image.ContrastJitterAug
     image.SaturationJitterAug

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -866,12 +866,13 @@ class HorizontalFlipAug(Augmenter):
 
 class CastAug(Augmenter):
     """Cast to float32"""
-    def __init__(self):
-        super(CastAug, self).__init__(type='float32')
+    def __init__(self, typ='float32'):
+        super(CastAug, self).__init__(type=typ)
+        self.typ = typ
 
     def __call__(self, src):
         """Augmenter body"""
-        src = src.astype(np.float32)
+        src = src.astype(self.typ)
         return src
 
 

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -506,7 +506,13 @@ class Augmenter(object):
 
 
 class SequentialAug(Augmenter):
-    """Composing a sequential augmenter list."""
+    """Composing a sequential augmenter list.
+
+    Parameters
+    ----------
+    ts : list of augmenters
+        A series of augmenters to be applied in sequential order.
+    """
     def __init__(self, ts):
         super(SequentialAug, self).__init__()
         self.ts = ts

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -505,6 +505,23 @@ class Augmenter(object):
         raise NotImplementedError("Must override implementation.")
 
 
+class SequentialAug(Augmenter):
+    """Composing a sequential augmenter list."""
+    def __init__(self, ts):
+        super(SequentialAug, self).__init__()
+        self.ts = ts
+
+    def dumps(self):
+        """Override the default to avoid duplicate dump."""
+        return [self.__class__.__name__.lower(), [x.dumps() for x in self.ts]]
+
+    def __call__(self, src):
+        """Augmenter body"""
+        for aug in self.ts:
+            src = aug(src)
+        return src
+
+
 class ResizeAug(Augmenter):
     """Make resize shorter edge to size augmenter.
 


### PR DESCRIPTION
## Description ##
Add SequentialAug to mx.image to allow composed augmenters in sequence.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
A simple addition to allow users to apply augmenters one by one.
