### PR TITLE
Fix softmax_cross_entropy

### DIFF
--- a/src/operator/loss_binary_op-inl.h
+++ b/src/operator/loss_binary_op-inl.h
@@ -43,7 +43,7 @@ inline bool SoftmaxCrossEntropyShape(const nnvm::NodeAttrs& attrs,
       << "SoftmaxCrossEntropy only accept 1D label";
   CHECK_EQ((*in_attrs)[0][0], (*in_attrs)[1][0])
       << "SoftmaxCrossEntropy: data label shape mismatch";
-  SHAPE_ASSIGN_CHECK(*out_attrs, 0, TShape(1));
+  SHAPE_ASSIGN_CHECK(*out_attrs, 0, TShape(mshadow::Shape1((*in_attrs)[0][0])));
   return true;
 }
 
@@ -77,7 +77,7 @@ void SoftmaxCrossEntropyForward(const nnvm::NodeAttrs& attrs,
         F<mshadow_op::log>(
             F<mshadow_op::maximum>(mat_choose_row_element(temp1, mlabel),
                                    scalar<DType>(1e-8f))));
-    ASSIGN_DISPATCH(out, req[0], sumall_except_dim<0>(temp2));
+    ASSIGN_DISPATCH(out, req[0], tdst);
   });
 }
 
@@ -100,7 +100,7 @@ void SoftmaxCrossEntropyBackward(const nnvm::NodeAttrs& attrs,
         mdata.shape_, s);
     mshadow::Softmax(temp, mdata);
     mshadow::SoftmaxGrad(temp, temp, mlabel);
-    ASSIGN_DISPATCH(mdata_grad, req[0], broadcast_scalar(mscale, temp.shape_) * temp);
+    ASSIGN_DISPATCH(mdata_grad, req[0], broadcast<0>(mscale, temp.shape_) * temp);
   });
 }
 

--- a/src/operator/loss_binary_op.cc
+++ b/src/operator/loss_binary_op.cc
@@ -59,6 +59,10 @@ Example::
 )code" ADD_FILELINE)
 .set_num_inputs(2)
 .set_num_outputs(1)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"data", "label"};
+  })
 .set_attr<nnvm::FInferShape>("FInferShape", SoftmaxCrossEntropyShape)
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<2, 1>)
 .set_attr<FResourceRequest>("FResourceRequest",

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -333,12 +333,6 @@ def check_softmax_with_shape(shape, xpu, preserve_shape=False):
     assert_almost_equal(grad.asnumpy(), np_softmax(x.asnumpy()) - l.asnumpy(), rtol=1e-4)
 
 
-def test_softmax():
-    check_softmax_with_shape((3, 4), default_context(), preserve_shape=False)
-    check_softmax_with_shape((3, 4), default_context(), preserve_shape=True)
-    check_softmax_with_shape((3, 4, 2), default_context(), preserve_shape=True)
-
-
 def test_softmax_cross_entropy():
     batch_size = 16
     num_class = 20


### PR DESCRIPTION
## Description ##
Fix softmax_cross_entropy operator "Not enough argument to call operator softmax_cross_entropy" issue https://github.com/apache/incubator-mxnet/issues/6874

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fix "Not enough argument to call operator softmax_cross_entropy" issue for softmax_cross_entropy operator.
- [x] Change output to be shape (batch_size,), which is consistent with gluon softmax loss.