### PR TITLE
Fix arange

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -1869,11 +1869,11 @@ def arange(start, stop=None, step=1.0, repeat=1, ctx=None, dtype=mx_real_t):
 
     Parameters
     ----------
-    start : float, optional
+    start : number, optional
         Start of interval. The default start value is 0.
-    stop : float
+    stop : number
         End of interval.
-    step : float, optional
+    step : number, optional
         Spacing between values. The default step size is 1.
     repeat : int, optional
         Number of times to repeat each element. The default repeat count is 1.

--- a/src/operator/tensor/init_op.h
+++ b/src/operator/tensor/init_op.h
@@ -301,9 +301,6 @@ void RangeCompute(const nnvm::NodeAttrs& attrs,
   const RangeParam& param = nnvm::get<RangeParam>(attrs.parsed);
   MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
     Tensor<xpu, 1, DType> out = outputs[0].FlatTo1D<xpu, DType>(s);
-    DType start = static_cast<DType>(param.start);
-    DType stop = static_cast<DType>(param.stop.value());
-    DType step = static_cast<DType>(param.step);
     ASSIGN_DISPATCH(out, req[0], range<DType>(static_cast<DType>(param.start),
                                               static_cast<DType>(param.stop.value()),
                                               static_cast<DType>(param.step),

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -497,6 +497,10 @@ def test_arange():
         gt = np.broadcast_to(gt.reshape((gt.shape[0], 1)), shape=(gt.shape[0], repeat)).ravel()
         pred = mx.nd.arange(start=start, stop=stop, step=step, repeat=repeat).asnumpy()
         assert_almost_equal(pred, gt)
+    gt = np.arange(start=0, stop=10000**2, step=10001, dtype=np.int32)
+    pred = mx.nd.arange(start=0, stop=10000**2, step=10001,
+                        dtype="int32").asnumpy()
+    assert_almost_equal(pred, gt)
 
 def test_order(ctx=default_context()):
     def gt_topk(dat, axis, ret_typ, k, is_ascend):


### PR DESCRIPTION
## Description ##
Fix the bug reported in https://github.com/apache/incubator-mxnet/issues/8242. 

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] When the `start`, `stop` and `step` are floats, the current code will calculate the output size by casting them to double in order to have high precision.
- [x] Update MShadow to the latest version