### PR TITLE
scipy style sparse ndarray constructor and misc sparse fixes

### DIFF
--- a/docs/api/python/ndarray/sparse.md
+++ b/docs/api/python/ndarray/sparse.md
@@ -16,7 +16,7 @@ This document lists the routines of the *n*-dimensional sparse array package:
 ```
 
 The `CSRNDArray` and `RowSparseNDArray` API, defined in the `ndarray.sparse` package, provides
-imperative sparse tensor operations on CPU.
+imperative sparse tensor operations on **CPU**.
 
 An `CSRNDArray` inherits from `NDArray`, and represents a two-dimensional, fixed-size array in compressed sparse row format.
 
@@ -37,6 +37,10 @@ array([0, 1, 1, 3])
 'csr'
 ```
 
+A detailed tutorial is available at
+[CSRNDArray - NDArray in Compressed Sparse Row Storage Format](https:https://mxnet.incubator.apache.org/versions/master/tutorials/sparse/csr.html).
+<br>
+
 An `RowSparseNDArray` inherits from `NDArray`, and represents a multi-dimensional, fixed-size array in row sparse format.
 
 ```python
@@ -53,16 +57,27 @@ array([0, 2])
 'row_sparse'
 ```
 
+A detailed tutorial is available at
+[RowSparseNDArray - NDArray for Sparse Gradient Updates](https://mxnet.incubator.apache.org/versions/master/tutorials/sparse/row_sparse.html).
+<br><br>
+
+
 ```eval_rst
 
 .. note:: ``mxnet.ndarray.sparse`` is similar to ``mxnet.ndarray`` in some aspects. But the differences are not negligible. For instance:
 
    - Only a subset of operators in ``mxnet.ndarray`` have specialized implementations in ``mxnet.ndarray.sparse``.
-     Operators such as reduction and broadcasting do not have sparse implementations yet.
+     Operators such as Convolution and broadcasting do not have sparse implementations yet.
    - The storage types (``stype``) of sparse operators' outputs depend on the storage types of inputs.
      By default the operators not available in ``mxnet.ndarray.sparse`` infer "default" (dense) storage type for outputs.
-     Please refer to the API reference section for further details on specific operators.
-   - GPU support for ``mxnet.ndarray.sparse`` is experimental.
+     Please refer to the [API Reference](#api-reference) section for further details on specific operators.
+   - GPU support for ``mxnet.ndarray.sparse`` is experimental. Only a few sparse operators are supported on GPU such as ``sparse.dot``.
+
+.. note:: ``mxnet.ndarray.sparse.CSRNDArray`` is similar to ``scipy.sparse.csr_matrix`` in some aspects. But they differ in a few aspects:
+
+   - The column indices (``CSRNDArray.indices``) for a given row are expected to be **sorted in ascending order**.
+     Duplicate column entries for the same row are not allowed.
+   - ``CSRNDArray.data``, ``CSRNDArray.indices`` and ``CSRNDArray.indptr`` always create deep copies, while it's not the case in ``scipy.sparse.csr_matrix``.
 
 ```
 

--- a/docs/api/python/ndarray/sparse.md
+++ b/docs/api/python/ndarray/sparse.md
@@ -75,7 +75,7 @@ A detailed tutorial is available at
 
 .. note:: ``mxnet.ndarray.sparse.CSRNDArray`` is similar to ``scipy.sparse.csr_matrix`` in some aspects. But they differ in a few aspects:
 
-   - The column indices (``CSRNDArray.indices``) for a given row are expected to be **sorted in ascending order**.
+   - In MXNet the column indices (``CSRNDArray.indices``) for a given row are expected to be **sorted in ascending order**.
      Duplicate column entries for the same row are not allowed.
    - ``CSRNDArray.data``, ``CSRNDArray.indices`` and ``CSRNDArray.indptr`` always create deep copies, while it's not the case in ``scipy.sparse.csr_matrix``.
 

--- a/docs/tutorials/sparse/csr.md
+++ b/docs/tutorials/sparse/csr.md
@@ -78,7 +78,7 @@ shape = (3, 4)
 data_list = [7, 8, 9]
 indices_list = [0, 2, 1]
 indptr_list = [0, 2, 2, 3]
-a = mx.nd.sparse.csr_matrix(data_list, indptr_list, indices_list, shape)
+a = mx.nd.sparse.csr_matrix((data_list, indices_list, indptr_list), shape)
 # Inspect the matrix
 a.asnumpy()
 ```
@@ -90,7 +90,7 @@ import numpy as np
 data_np = np.array([7, 8, 9])
 indptr_np = np.array([0, 2, 2, 3])
 indices_np = np.array([0, 2, 1])
-b = mx.nd.sparse.csr_matrix(data_np, indptr_np, indices_np, shape)
+b = mx.nd.sparse.csr_matrix((data_np, indices_np, indptr_np), shape)
 b.asnumpy()
 ```
 
@@ -256,7 +256,7 @@ shape = (3, 4)
 data = [7, 8, 9]
 indptr = [0, 2, 2, 3]
 indices = [0, 2, 1]
-a = mx.nd.sparse.csr_matrix(data, indptr, indices, shape) # a csr matrix as lhs
+a = mx.nd.sparse.csr_matrix((data, indices, indptr), shape) # a csr matrix as lhs
 rhs = mx.nd.ones((4, 1))      # a dense vector as rhs
 out = mx.nd.sparse.dot(a, rhs)  # invoke sparse dot operator specialized for dot(csr, dense)
 {'out':out}

--- a/docs/tutorials/sparse/csr.md
+++ b/docs/tutorials/sparse/csr.md
@@ -78,7 +78,7 @@ shape = (3, 4)
 data_list = [7, 8, 9]
 indices_list = [0, 2, 1]
 indptr_list = [0, 2, 2, 3]
-a = mx.nd.sparse.csr_matrix((data_list, indices_list, indptr_list), shape)
+a = mx.nd.sparse.csr_matrix((data_list, indices_list, indptr_list), shape=shape)
 # Inspect the matrix
 a.asnumpy()
 ```
@@ -90,7 +90,7 @@ import numpy as np
 data_np = np.array([7, 8, 9])
 indptr_np = np.array([0, 2, 2, 3])
 indices_np = np.array([0, 2, 1])
-b = mx.nd.sparse.csr_matrix((data_np, indices_np, indptr_np), shape)
+b = mx.nd.sparse.csr_matrix((data_np, indices_np, indptr_np), shape=shape)
 b.asnumpy()
 ```
 
@@ -256,7 +256,7 @@ shape = (3, 4)
 data = [7, 8, 9]
 indptr = [0, 2, 2, 3]
 indices = [0, 2, 1]
-a = mx.nd.sparse.csr_matrix((data, indices, indptr), shape) # a csr matrix as lhs
+a = mx.nd.sparse.csr_matrix((data, indices, indptr), shape=shape) # a csr matrix as lhs
 rhs = mx.nd.ones((4, 1))      # a dense vector as rhs
 out = mx.nd.sparse.dot(a, rhs)  # invoke sparse dot operator specialized for dot(csr, dense)
 {'out':out}

--- a/docs/tutorials/sparse/row_sparse.md
+++ b/docs/tutorials/sparse/row_sparse.md
@@ -142,11 +142,11 @@ import numpy as np
 shape = (6, 2)
 data_list = [[1, 2], [3, 4]]
 indices_list = [1, 4]
-a = mx.nd.sparse.row_sparse_array((data_list, indices_list), shape)
+a = mx.nd.sparse.row_sparse_array((data_list, indices_list), shape=shape)
 # Create a RowSparseNDArray with numpy arrays
 data_np = np.array([[1, 2], [3, 4]])
 indices_np = np.array([1, 4])
-b = mx.nd.sparse.row_sparse_array((data_np, indices_np), shape)
+b = mx.nd.sparse.row_sparse_array((data_np, indices_np), shape=shape)
 {'a':a, 'b':b}
 ```
 
@@ -280,7 +280,7 @@ data = [7, 8, 9]
 indptr = [0, 2, 2, 3]
 indices = [0, 2, 1]
 # A csr matrix as lhs
-lhs = mx.nd.sparse.csr_matrix((data, indices, indptr), shape)
+lhs = mx.nd.sparse.csr_matrix((data, indices, indptr), shape=shape)
 # A dense matrix as rhs
 rhs = mx.nd.ones((3, 2))
 # row_sparse result is inferred from sparse operator dot(csr.T, dense) based on input stypes
@@ -346,7 +346,7 @@ weight = mx.nd.ones(shape).tostype('row_sparse')
 # Create gradient
 data = [[1, 2], [4, 5]]
 indices = [1, 2]
-grad = mx.nd.sparse.row_sparse_array((data, indices), shape)
+grad = mx.nd.sparse.row_sparse_array((data, indices), shape=shape)
 sgd = mx.optimizer.SGD(learning_rate=0.01, momentum=0.01)
 # Create momentum
 momentum = sgd.create_state(0, weight)

--- a/docs/tutorials/sparse/row_sparse.md
+++ b/docs/tutorials/sparse/row_sparse.md
@@ -280,7 +280,7 @@ data = [7, 8, 9]
 indptr = [0, 2, 2, 3]
 indices = [0, 2, 1]
 # A csr matrix as lhs
-lhs = mx.nd.sparse.csr_matrix(data, indptr, indices, shape)
+lhs = mx.nd.sparse.csr_matrix((data, indices, indptr), shape)
 # A dense matrix as rhs
 rhs = mx.nd.ones((3, 2))
 # row_sparse result is inferred from sparse operator dot(csr.T, dense) based on input stypes

--- a/docs/tutorials/sparse/row_sparse.md
+++ b/docs/tutorials/sparse/row_sparse.md
@@ -263,7 +263,7 @@ You can retain a subset of row slices from a RowSparseNDArray specified by their
 ```python
 data = [[1, 2], [3, 4], [5, 6]]
 indices = [0, 2, 3]
-rsp = mx.nd.sparse.row_sparse_array((data, indices), (5, 2))
+rsp = mx.nd.sparse.row_sparse_array((data, indices), shape=(5, 2))
 # Retain row 0 and row 1
 rsp_retained = mx.nd.sparse.retain(rsp, mx.nd.array([0, 1]))
 {'rsp.asnumpy()': rsp.asnumpy(), 'rsp_retained': rsp_retained, 'rsp_retained.asnumpy()': rsp_retained.asnumpy()}

--- a/docs/tutorials/sparse/row_sparse.md
+++ b/docs/tutorials/sparse/row_sparse.md
@@ -142,11 +142,11 @@ import numpy as np
 shape = (6, 2)
 data_list = [[1, 2], [3, 4]]
 indices_list = [1, 4]
-a = mx.nd.sparse.row_sparse_array(data_list, indices_list, shape)
+a = mx.nd.sparse.row_sparse_array((data_list, indices_list), shape)
 # Create a RowSparseNDArray with numpy arrays
 data_np = np.array([[1, 2], [3, 4]])
 indices_np = np.array([1, 4])
-b = mx.nd.sparse.row_sparse_array(data_np, indices_np, shape)
+b = mx.nd.sparse.row_sparse_array((data_np, indices_np), shape)
 {'a':a, 'b':b}
 ```
 
@@ -263,7 +263,7 @@ You can retain a subset of row slices from a RowSparseNDArray specified by their
 ```python
 data = [[1, 2], [3, 4], [5, 6]]
 indices = [0, 2, 3]
-rsp = mx.nd.sparse.row_sparse_array(data, indices, (5, 2))
+rsp = mx.nd.sparse.row_sparse_array((data, indices), (5, 2))
 # Retain row 0 and row 1
 rsp_retained = mx.nd.sparse.retain(rsp, mx.nd.array([0, 1]))
 {'rsp.asnumpy()': rsp.asnumpy(), 'rsp_retained': rsp_retained, 'rsp_retained.asnumpy()': rsp_retained.asnumpy()}
@@ -346,7 +346,7 @@ weight = mx.nd.ones(shape).tostype('row_sparse')
 # Create gradient
 data = [[1, 2], [4, 5]]
 indices = [1, 2]
-grad = mx.nd.sparse.row_sparse_array(data, indices, shape)
+grad = mx.nd.sparse.row_sparse_array((data, indices), shape)
 sgd = mx.optimizer.SGD(learning_rate=0.01, momentum=0.01)
 # Create momentum
 momentum = sgd.create_state(0, weight)

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -115,7 +115,8 @@ class NDArray {
           aux_shapes = {TShape(mshadow::Shape1(0))};
         } else if (stype == kCSRStorage) {
           // aux shapes for indptr and indices
-          aux_shapes = {TShape(mshadow::Shape1(0)), TShape(mshadow::Shape1(0))};
+          CHECK_EQ(shape.ndim(), 2) << "Unexpected shape dimension: " << shape;
+          aux_shapes = {TShape(mshadow::Shape1(shape[0] + 1)), TShape(mshadow::Shape1(0))};
         } else {
           LOG(FATAL) << "Unknown storage type " << stype;
         }

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -115,8 +115,7 @@ class NDArray {
           aux_shapes = {TShape(mshadow::Shape1(0))};
         } else if (stype == kCSRStorage) {
           // aux shapes for indptr and indices
-          CHECK_EQ(shape.ndim(), 2) << "Unexpected shape dimension: " << shape;
-          aux_shapes = {TShape(mshadow::Shape1(shape[0] + 1)), TShape(mshadow::Shape1(0))};
+          aux_shapes = {TShape(mshadow::Shape1(0)), TShape(mshadow::Shape1(0))};
         } else {
           LOG(FATAL) << "Unknown storage type " << stype;
         }

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -318,7 +318,7 @@ class CSRNDArray(BaseSparseNDArray):
         >>> indptr = np.array([0, 2, 3, 6])
         >>> indices = np.array([0, 2, 2, 0, 1, 2])
         >>> data = np.array([1, 2, 3, 4, 5, 6])
-        >>> a = mx.nd.sparse.csr_matrix(data, indptr, indices, (3, 3))
+        >>> a = mx.nd.sparse.csr_matrix((data, indices, indptr), (3, 3))
         >>> a.asnumpy()
         array([[1, 0, 2],
                [0, 0, 3],
@@ -761,7 +761,7 @@ def csr_matrix(data, indptr, indices, shape, ctx=None, dtype=None, indptr_type=N
     Example
     -------
     >>> import mxnet as mx
-    >>> a = mx.nd.sparse.csr_matrix([1, 2, 3], [0, 1, 2, 2, 3], [1, 0, 2], (4, 3))
+    >>> a = mx.nd.sparse.csr_matrix(([1, 2, 3], [1, 0, 2], [0, 1, 2, 2, 3]), (4, 3))
     >>> a.asnumpy()
     array([[ 0.,  1.,  0.],
            [ 2.,  0.,  0.],
@@ -1010,7 +1010,7 @@ def array(source_array, ctx=None, dtype=None, aux_types=None):
         # preprocess scipy csr to canonical form
         csr = source_array.sorted_indices()
         csr.sum_duplicates()
-        arr = csr_matrix(csr.data, csr.indptr, csr.indices, csr.shape, dtype=dtype,
+        arr = csr_matrix((csr.data, csr.indices, csr.indptr), csr.shape, dtype=dtype,
                          indptr_type=indptr_type, indices_type=indices_type)
         return arr
     elif isinstance(source_array, (np.ndarray, np.generic)):

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -871,11 +871,13 @@ def _csr_matrix_from_definition(data, indices, indptr, shape=None, ctx=None,
     if not isinstance(indices, NDArray):
         indices = _array(indices, ctx, indices_type)
     if shape is None:
+        if indices.shape[0] == 0:
+            raise ValueError('invalid shape')
         shape = (len(indptr) - 1, op.max(indices).asscalar() + 1)
     # verify shapes
     aux_shapes = [indptr.shape, indices.shape]
     if data.ndim != 1 or indptr.ndim != 1 or indices.ndim != 1 or \
-        indptr.shape[0] == 0 or indices.shape[0] == 0 or len(shape) != 2:
+        indptr.shape[0] == 0 or len(shape) != 2:
         raise ValueError('invalid shape')
     result = CSRNDArray(_new_alloc_handle(storage_type, shape, ctx, False, dtype,
                                           [indptr_type, indices_type], aux_shapes))
@@ -1080,7 +1082,7 @@ def zeros(stype, shape, ctx=None, dtype=None, **kwargs):
     if stype == 'row_sparse' or stype == 'csr':
         aux_types = _STORAGE_AUX_TYPES[stype]
     else:
-        raise Exception("unknown storage type")
+        raise ValueError("unknown storage type" + stype)
     out = _ndarray_cls(_new_alloc_handle(stype, shape, ctx, True, dtype, aux_types))
     return _internal._zeros(shape=shape, ctx=ctx, dtype=dtype, out=out, **kwargs)
 

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -823,7 +823,7 @@ def csr_matrix(arg1, shape=None, ctx=None, dtype=None):
             # empty matrix with shape
             if shape and shape != arg1:
                 raise ValueError("Shape mismatch detected. " + str(shape) + " v.s. " + str(arg1))
-            return empty('csr', shape, ctx=ctx, dtype=dtype)
+            return empty('csr', arg1, ctx=ctx, dtype=dtype)
         elif arg_len == 3:
             # data, indices, indptr
             return _csr_matrix_from_definition(arg1[0], arg1[1], arg1[2], shape=shape, ctx=ctx, dtype=dtype)
@@ -836,7 +836,7 @@ def csr_matrix(arg1, shape=None, ctx=None, dtype=None):
         raise ValueError("Unexpected input type: RowSparseNDArray")
     else:
         # construct a csr matrix from a dense one
-        return _array(source_array, ctx=ctx, dtype=dtype).tostype('csr')
+        return _array(arg1, ctx=ctx, dtype=dtype).tostype('csr')
 
 def _csr_matrix_from_definition(data, indices, indptr, shape=None, ctx=None,
                                 dtype=None, indices_type=None, indptr_type=None):
@@ -968,7 +968,7 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
             if shape and shape != arg1:
                 raise ValueError("Shape mismatch detected. " + str(shape) + \
                                  " v.s. " + str(arg1))
-            return empty('csr', shape, ctx=ctx, dtype=dtype)
+            return empty('row_sparse', arg1, ctx=ctx, dtype=dtype)
         else:
             # len(arg1) = 2, is either shape or (data, indices)
             if isinstance(arg1[0], integer_types) and isinstance(arg1[1], integer_types):
@@ -976,7 +976,7 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
                 if shape and shape != arg1:
                     raise ValueError("Shape mismatch detected. " + str(shape) + \
                                      " v.s. " + str(arg1))
-                return empty('csr', shape, ctx=ctx, dtype=dtype)
+                return empty('row_sparse', arg1, ctx=ctx, dtype=dtype)
             else:
                 # data, indices, indptr
                 return _row_sparse_ndarray_from_definition(arg1[0], arg1[1], shape=shape,
@@ -988,7 +988,7 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
         raise ValueError("Unexpected input type: CSRNDArray")
     else:
         # construct a csr matrix from a dense one
-        return _array(source_array, ctx=ctx, dtype=dtype).tostype('rowsparse')
+        return _array(arg1, ctx=ctx, dtype=dtype).tostype('row_sparse')
 
 def _row_sparse_ndarray_from_definition(data, indices, shape=None, ctx=None,
                                        dtype=None, indices_type=None):
@@ -1104,8 +1104,7 @@ def empty(stype, shape, ctx=None, dtype=None):
         dtype = mx_real_t
     assert(stype is not None)
     if stype == 'csr' or stype == 'row_sparse':
-        return _ndarray_cls(_new_alloc_handle(stype, shape, ctx, True, dtype,
-                                              _STORAGE_AUX_TYPES[stype]))
+        return zeros(stype, shape, ctx=ctx, dtype=dtype)
     else:
         raise Exception("unknown stype : " + str(stype))
 
@@ -1143,7 +1142,7 @@ def array(source_array, ctx=None, dtype=None):
         assert(source_array.stype != 'default'), \
                "Please use `tostype` to create RowSparseNDArray or CSRNDArray from an NDArray"
         dtype = source_array.dtype if dtype is None else dtype
-        arr = empty(source_array.stype, source_array.shape, ctx, dtype)
+        arr = empty(source_array.stype, source_array.shape, ctx=ctx, dtype=dtype)
         arr[:] = source_array
         return arr
     elif spsp and isinstance(source_array, spsp.csr.csr_matrix):

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -835,15 +835,17 @@ def csr_matrix(arg1, shape=None, ctx=None, dtype=None):
             raise ValueError("Unexpected length of input tuple: " + str(arg_len))
     else:
         # construct a csr matrix from a sparse / dense one
-        _check_shape(arg1.shape, shape)
         if isinstance(arg1, CSRNDArray) or (spsp and isinstance(arg1, spsp.csr.csr_matrix)):
             # construct a csr matrix from scipy or CSRNDArray
+            _check_shape(arg1.shape, shape)
             return array(arg1, ctx=ctx, dtype=dtype)
         elif isinstance(arg1, RowSparseNDArray):
             raise ValueError("Unexpected input type: RowSparseNDArray")
         else:
             # construct a csr matrix from a dense one
-            return _array(arg1, ctx=ctx, dtype=dtype).tostype('csr')
+            dns = _array(arg1, ctx=ctx, dtype=dtype)
+            _check_shape(dns.shape, shape)
+            return dns.tostype('csr')
 
 def _csr_matrix_from_definition(data, indices, indptr, shape=None, ctx=None,
                                 dtype=None, indices_type=None, indptr_type=None):
@@ -989,15 +991,17 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
                                                            ctx=ctx, dtype=dtype)
     else:
         # construct a row sparse ndarray from a dense / sparse array
-        _check_shape(arg1.shape, shape)
         if isinstance(arg1, RowSparseNDArray):
             # construct a row sparse ndarray from RowSparseNDArray
+            _check_shape(arg1.shape, shape)
             return array(arg1, ctx=ctx, dtype=dtype)
         elif isinstance(arg1, CSRNDArray):
             raise ValueError("Unexpected input type: CSRNDArray")
         else:
             # construct a csr matrix from a dense one
-            return _array(arg1, ctx=ctx, dtype=dtype).tostype('row_sparse')
+            dns = _array(arg1, ctx=ctx, dtype=dtype)
+            _check_shape(dns.shape, shape)
+            return dns.tostype('row_sparse')
 
 def _row_sparse_ndarray_from_definition(data, indices, shape=None, ctx=None,
                                         dtype=None, indices_type=None):

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -875,8 +875,8 @@ def _csr_matrix_from_definition(data, indices, indptr, shape=None, ctx=None,
     # verify shapes
     aux_shapes = [indptr.shape, indices.shape]
     if data.ndim != 1 or indptr.ndim != 1 or indices.ndim != 1 or \
-       indptr.shape[0] == 0 or indices.shape[0] == 0 or len(shape) != 2:
-       raise ValueError('invalid shape')
+        indptr.shape[0] == 0 or indices.shape[0] == 0 or len(shape) != 2:
+        raise ValueError('invalid shape')
     result = CSRNDArray(_new_alloc_handle(storage_type, shape, ctx, False, dtype,
                                           [indptr_type, indices_type], aux_shapes))
     check_call(_LIB.MXNDArraySyncCopyFromNDArray(result.handle, data.handle, ctypes.c_int(-1)))

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -804,7 +804,7 @@ def csr_matrix(data, indptr, indices, shape, ctx=None, dtype=None, indptr_type=N
     return result
 
 
-def row_sparse_array(data, indices, shape, ctx=None, dtype=None, indices_type=None):
+def row_sparse_array((data, indices), shape, ctx=None, dtype=None, indices_type=None):
     """Creates a multidimensional row sparse array with a set of tensor slices at given indices.
 
     Parameters
@@ -830,7 +830,7 @@ def row_sparse_array(data, indices, shape, ctx=None, dtype=None, indices_type=No
 
     Example
     -------
-    >>> a = mx.nd.sparse.row_sparse_array([[1, 2], [3, 4]], [1, 4], (6, 2))
+    >>> a = mx.nd.sparse.row_sparse_array(([[1, 2], [3, 4]]), [1, 4], (6, 2))
     >>> a.asnumpy()
     array([[ 0.,  0.],
            [ 1.,  2.],

--- a/python/mxnet/ndarray/utils.py
+++ b/python/mxnet/ndarray/utils.py
@@ -36,7 +36,7 @@ except ImportError:
 __all__ = ['zeros', 'empty', 'array', 'load', 'save']
 
 
-def zeros(shape, ctx=None, dtype=None, stype=None, aux_types=None, **kwargs):
+def zeros(shape, ctx=None, dtype=None, stype=None, **kwargs):
     """Return a new array of given shape and type, filled with zeros.
 
     Parameters
@@ -49,10 +49,6 @@ def zeros(shape, ctx=None, dtype=None, stype=None, aux_types=None, **kwargs):
         An optional value type (default is `float32`)
     stype: string, optional
         The storage type of the empty array, such as 'row_sparse', 'csr', etc.
-    aux_types: list of numpy.dtype, optional
-        An optional list of types of the aux data for RowSparseNDArray or CSRNDArray.
-        The default value for CSRNDArray is [`int64`, `int64`] for `indptr` and `indices`.
-        The default value for RowSparseNDArray is [`int64`] for `indices`.
 
     Returns
     -------
@@ -69,10 +65,10 @@ def zeros(shape, ctx=None, dtype=None, stype=None, aux_types=None, **kwargs):
     if stype is None or stype == 'default':
         return _zeros_ndarray(shape, ctx, dtype, **kwargs)
     else:
-        return _zeros_sparse_ndarray(stype, shape, ctx, dtype, aux_types, **kwargs)
+        return _zeros_sparse_ndarray(stype, shape, ctx, dtype, **kwargs)
 
 
-def empty(shape, ctx=None, dtype=None, stype=None, aux_types=None):
+def empty(shape, ctx=None, dtype=None, stype=None):
     """Returns a new array of given shape and type, without initializing entries.
 
     Parameters
@@ -85,10 +81,6 @@ def empty(shape, ctx=None, dtype=None, stype=None, aux_types=None):
         An optional value type (default is `float32`).
     stype : str, optional
         An optional storage type (default is `default`).
-    aux_types: list of numpy.dtype, optional
-        An optional list of types of the aux data for RowSparseNDArray or CSRNDArray.
-        The default value for CSRNDArray is [`int64`, `int64`] for `indptr` and `indices`.
-        The default value for RowSparseNDArray is [`int64`] for `indices`.
 
     Returns
     -------
@@ -109,10 +101,10 @@ def empty(shape, ctx=None, dtype=None, stype=None, aux_types=None):
     if stype is None or stype == 'default':
         return _empty_ndarray(shape, ctx, dtype)
     else:
-        return _empty_sparse_ndarray(stype, shape, ctx, dtype, aux_types)
+        return _empty_sparse_ndarray(stype, shape, ctx, dtype)
 
 
-def array(source_array, ctx=None, dtype=None, aux_types=None):
+def array(source_array, ctx=None, dtype=None):
     """Creates an array from any object exposing the array interface.
 
     Parameters
@@ -125,10 +117,6 @@ def array(source_array, ctx=None, dtype=None, aux_types=None):
     dtype : str or numpy.dtype, optional
         The data type of the output array. The default dtype is ``source_array.dtype``
         if `source_array` is an `NDArray`, `float32` otherwise.
-    aux_types: list of numpy.dtype, optional
-        An optional list of types of the aux data for RowSparseNDArray or CSRNDArray.
-        The default value for CSRNDArray is [`int64`, `int64`] for `indptr` and `indices`.
-        The default value for RowSparseNDArray is [`int64`] for `indices`.
 
     Returns
     -------
@@ -150,9 +138,9 @@ def array(source_array, ctx=None, dtype=None, aux_types=None):
     <RowSparseNDArray 3x2 @cpu(0)>
     """
     if spsp is not None and isinstance(source_array, spsp.csr.csr_matrix):
-        return _sparse_array(source_array, ctx=ctx, dtype=dtype, aux_types=aux_types)
+        return _sparse_array(source_array, ctx=ctx, dtype=dtype)
     elif isinstance(source_array, NDArray) and source_array.stype != 'default':
-        return _sparse_array(source_array, ctx=ctx, dtype=dtype, aux_types=aux_types)
+        return _sparse_array(source_array, ctx=ctx, dtype=dtype)
     else:
         return _array(source_array, ctx=ctx, dtype=dtype)
 

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -316,7 +316,7 @@ def rand_sparse_ndarray(shape, stype, density=None, dtype=None, distribution=Non
         if modifier_func is not None:
             val = assign_each(val, modifier_func)
 
-        arr = mx.nd.sparse.row_sparse_array(val, indices, shape, indices_type=np.int64, dtype=dtype)
+        arr = mx.nd.sparse.row_sparse_array((val, indices), shape, indices_type=np.int64, dtype=dtype)
         return arr, (val, indices)
     elif stype == 'csr':
         assert len(shape) == 2

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -143,12 +143,7 @@ def _get_uniform_dataset_csr(num_rows, num_cols, density=0.1, dtype=None,
                                     distribution="uniform")
     try:
         from scipy import sparse as spsp
-        while True:
-            csr = spsp.rand(num_rows, num_cols, density, dtype=dtype, format="csr")
-            # regenerate matrix if density != 0 but result is empty
-            if csr.nnz == 0 and density != 0:
-                continue
-            break
+        csr = spsp.rand(num_rows, num_cols, density, dtype=dtype, format="csr")
         if data_init is not None:
             csr.data.fill(data_init)
         if shuffle_csr_indices is True:
@@ -306,13 +301,8 @@ def rand_sparse_ndarray(shape, stype, density=None, dtype=None, distribution=Non
             indices = rsp_indices
             assert(len(indices) <= shape[0])
         else:
-            while True:
-                idx_sample = rnd.rand(shape[0])
-                indices = np.argwhere(idx_sample < density).flatten()
-                # redo sampling if density != 0 but sample result is empty
-                if indices.shape[0] == 0 and density != 0:
-                    continue
-                break
+            idx_sample = rnd.rand(shape[0])
+            indices = np.argwhere(idx_sample < density).flatten()
         if indices.shape[0] == 0:
             result = mx.nd.zeros(shape, stype='row_sparse', dtype=dtype)
             return result, (np.array([], dtype=dtype), np.array([]))

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -148,7 +148,7 @@ def _get_uniform_dataset_csr(num_rows, num_cols, density=0.1, dtype=None,
             csr.data.fill(data_init)
         if shuffle_csr_indices is True:
             shuffle_csr_column_indices(csr)
-        result = mx.nd.sparse.csr_matrix(csr.data, csr.indptr, csr.indices,
+        result = mx.nd.sparse.csr_matrix((csr.data, csr.indices, csr.indptr),
                                          (num_rows, num_cols), dtype=dtype)
     except ImportError:
         assert(data_init is None), \

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -145,6 +145,7 @@ def _get_uniform_dataset_csr(num_rows, num_cols, density=0.1, dtype=None,
         from scipy import sparse as spsp
         while True:
             csr = spsp.rand(num_rows, num_cols, density, dtype=dtype, format="csr")
+            # regenerate matrix if density != 0 but result is empty
             if csr.nnz == 0 and density != 0:
                 continue
             break

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -149,7 +149,7 @@ def _get_uniform_dataset_csr(num_rows, num_cols, density=0.1, dtype=None,
         if shuffle_csr_indices is True:
             shuffle_csr_column_indices(csr)
         result = mx.nd.sparse.csr_matrix((csr.data, csr.indices, csr.indptr),
-                                         (num_rows, num_cols), dtype=dtype)
+                                         shape=(num_rows, num_cols), dtype=dtype)
     except ImportError:
         assert(data_init is None), \
                "data_init option is not supported when scipy is absent"
@@ -316,7 +316,7 @@ def rand_sparse_ndarray(shape, stype, density=None, dtype=None, distribution=Non
         if modifier_func is not None:
             val = assign_each(val, modifier_func)
 
-        arr = mx.nd.sparse.row_sparse_array((val, indices), shape, indices_type=np.int64, dtype=dtype)
+        arr = mx.nd.sparse.row_sparse_array((val, indices), shape=shape, dtype=dtype)
         return arr, (val, indices)
     elif stype == 'csr':
         assert len(shape) == 2

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -465,8 +465,7 @@ def test_create_csr():
         data = matrix.data
         indptr = matrix.indptr
         indices = matrix.indices
-        csr_created = mx.nd.sparse.csr_matrix(data=data, indptr=indptr,
-                                              indices=indices, shape=shape)
+        csr_created = mx.nd.sparse.csr_matrix((data, indices, indptr), shape=shape)
         assert csr_created.stype == 'csr'
         assert same(csr_created.data.asnumpy(), data.asnumpy())
         assert same(csr_created.indptr.asnumpy(), indptr.asnumpy())

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -396,11 +396,11 @@ def test_sparse_nd_astype():
 
 def test_sparse_nd_pickle():
     np.random.seed(0)
-    repeat = 10
+    repeat = 1
     dim0 = 40
     dim1 = 40
     stypes = ['row_sparse', 'csr']
-    densities = [0, 0.01, 0.1, 0.2, 0.5]
+    densities = [0, 0.5]
     stype_dict = {'row_sparse': RowSparseNDArray, 'csr': CSRNDArray}
     for _ in range(repeat):
         shape = rand_shape_2d(dim0, dim1)
@@ -420,7 +420,7 @@ def test_sparse_nd_save_load():
     stypes = ['default', 'row_sparse', 'csr']
     stype_dict = {'default': NDArray, 'row_sparse': RowSparseNDArray, 'csr': CSRNDArray}
     num_data = 20
-    densities = [0, 0.01, 0.1, 0.2, 0.5]
+    densities = [0, 0.5]
     fname = 'tmp_list.bin'
     for _ in range(repeat):
         data_list1 = []
@@ -499,7 +499,7 @@ def test_create_csr():
 
     dim0 = 50
     dim1 = 50
-    densities = [0, 0.01, 0.1, 0.2, 0.5]
+    densities = [0, 0.5]
     for density in densities:
         shape = rand_shape_2d(dim0, dim1)
         check_create_csr_from_nd(shape, density)

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -568,8 +568,8 @@ def test_sparse_nd_exception():
     a = mx.nd.zeros((2,2))
     assert_exception(mx.nd.sparse.retain, mx.base.MXNetError,
                      a, invalid_arg="garbage_value")
-    assert_exception(mx.nd.sparse.zeros, NotImplementedError,
-                     'csr', (2,2), aux_types=[np.int32, np.int32])
+    #assert_exception(mx.nd.sparse.zeros, NotImplementedError,
+    #                 'csr', (2,2), aux_types=[np.int32, np.int32])
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -517,7 +517,7 @@ def test_create_row_sparse():
         matrix = rand_ndarray(shape, 'row_sparse', density)
         data = matrix.data
         indices = matrix.indices
-        rsp_created = mx.nd.sparse.row_sparse_array(data=data, indices=indices, shape=shape)
+        rsp_created = mx.nd.sparse.row_sparse_array((data, indices), shape=shape)
         assert rsp_created.stype == 'row_sparse'
         assert same(rsp_created.data.asnumpy(), data.asnumpy())
         assert same(rsp_created.indices.asnumpy(), indices.asnumpy())

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -566,31 +566,32 @@ def test_create_sparse_nd_infer_shape():
         check_create_rsp_infer_shape(shape_3d, density, dtype)
 
 def test_create_sparse_nd_from_dense():
-    def check_create_from_dns(shape, f, g, dtype):
-        nd = f(g(shape), dtype=dtype)
-        assert(same(nd.asnumpy(), np.ones(shape)))
-        assert(nd.dtype == dtype)
+    def check_create_from_dns(shape, f, dense_arr, dtype):
+        arr = f(dense_arr, dtype=dtype)
+        assert(same(arr.asnumpy(), np.ones(shape)))
+        assert(arr.dtype == dtype)
     shape = rand_shape_2d()
     dtype = np.int32
+    dense_arrs = [mx.nd.ones(shape), np.ones(shape), np.ones(shape).tolist()]
     for f in [mx.nd.sparse.csr_matrix, mx.nd.sparse.row_sparse_array]:
-        for g in [mx.nd.ones, np.ones]:
-            check_create_from_dns(shape, f, g, dtype)
+        for dense_arr in dense_arrs:
+            check_create_from_dns(shape, f, dense_arr, dtype)
 
 def test_create_sparse_nd_empty():
     def check_empty(shape, stype):
-        nd = mx.nd.empty(shape, stype=stype)
-        assert(nd.stype == stype)
-        assert same(nd.asnumpy(), np.zeros(shape))
+        arr = mx.nd.empty(shape, stype=stype)
+        assert(arr.stype == stype)
+        assert same(arr.asnumpy(), np.zeros(shape))
 
     def check_csr_empty(shape):
-        nd = mx.nd.sparse.csr_matrix(shape)
-        assert(nd.stype == 'csr')
-        assert same(nd.asnumpy(), np.zeros(shape))
+        arr = mx.nd.sparse.csr_matrix(shape)
+        assert(arr.stype == 'csr')
+        assert same(arr.asnumpy(), np.zeros(shape))
 
     def check_rsp_empty(shape):
-        nd = mx.nd.sparse.row_sparse_array(shape)
-        assert(nd.stype == 'row_sparse')
-        assert same(nd.asnumpy(), np.zeros(shape))
+        arr = mx.nd.sparse.row_sparse_array(shape)
+        assert(arr.stype == 'row_sparse')
+        assert same(arr.asnumpy(), np.zeros(shape))
 
     stypes = ['csr', 'row_sparse']
     shape = rand_shape_2d()
@@ -644,6 +645,8 @@ def test_sparse_nd_exception():
                      (2,2), shape=(3,2))
     assert_exception(mx.nd.sparse.row_sparse_array, ValueError,
                      (2,2), shape=(3,2))
+    assert_exception(mx.nd.sparse.zeros, ValueError,
+                     "invalid_stype", (2,2))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
- fix wrong usage of rowsparsepull in sparse LR example
- update csr_matrix / row_sparse_array interface like scipy
- misc doc updates

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated.
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Intersting edge cases to note here
