### PR TITLE
v0.12 regression: Fix registration of children for Block

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -191,6 +191,8 @@ class Block(object):
                 for i, c in enumerate(self._children):
                     if c is existing:
                         self._children[i] = value
+            if isinstance(value, Block):
+                self.register_child(value)
         else:
             if isinstance(value, Block):
                 self.register_child(value)

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -333,6 +333,8 @@ class HybridBlock(Block):
     def __setattr__(self, name, value):
         """Registers parameters."""
         super(HybridBlock, self).__setattr__(name, value)
+        if isinstance(value, HybridBlock):
+            self._clear_cached_op()
         if isinstance(value, Parameter):
             assert name not in self._reg_params or \
                 not isinstance(self._reg_params[name], Parameter), \

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -191,7 +191,7 @@ class Block(object):
                 for i, c in enumerate(self._children):
                     if c is existing:
                         self._children[i] = value
-            if isinstance(value, Block):
+            elif isinstance(value, Block):
                 self.register_child(value)
         else:
             if isinstance(value, Block):

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -193,9 +193,8 @@ class Block(object):
                         self._children[i] = value
             elif isinstance(value, Block):
                 self.register_child(value)
-        else:
-            if isinstance(value, Block):
-                self.register_child(value)
+        elif isinstance(value, Block):
+            self.register_child(value)
 
         super(Block, self).__setattr__(name, value)
 

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -516,6 +516,20 @@ def test_hybrid_stale_cache():
     net.add(mx.gluon.nn.Flatten())
     assert net(mx.nd.ones((2,3,5))).shape == (2, 30)
 
+    net = mx.gluon.nn.HybridSequential()
+    with net.name_scope():
+        net.fc1 = mx.gluon.nn.Dense(10, weight_initializer='zeros',
+                                    bias_initializer='ones', flatten=False)
+        net.fc2 = mx.gluon.nn.Dense(10, weight_initializer='zeros',
+                                    bias_initializer='ones', flatten=False)
+    net.hybridize()
+    net.initialize()
+    net(mx.nd.ones((2,3,5)))
+
+    net.fc2 = mx.gluon.nn.Dense(10, weight_initializer='zeros',
+                                bias_initializer='ones', flatten=True)
+    net.initialize()
+    assert net(mx.nd.ones((2,3,5))).shape == (2, 10)
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
If the attribute is already declared (e.g. as None), the registration would fail.
Consider the following example:

```
class BaseClass(gluon.HybridBlock):
    some_block = None

class Implementation(BaseClass):
    def __init__(self):
        some_block = SomeBlock()

```

The regression was introduced by https://github.com/apache/incubator-mxnet/issues/7667