### PR TITLE
[Discussion] Support caching multiple graphs in HybridBlock

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -319,21 +319,15 @@ class HybridBlock(Block):
     Refer `Hybrid tutorial <http://mxnet.io/tutorials/gluon/hybrid.html>`_ to see
     the end-to-end usage.
     """
-    def __init__(self, prefix=None, params=None, key_setter=None):
+    def __init__(self, prefix=None, params=None):
         super(HybridBlock, self).__init__(prefix=prefix, params=params)
         self._reg_params = {}
-        self._cached_op = {}
+        self._cached_graph = ()
+        self._cached_op = None
         self._cached_params = None
-        self._cached_graph = {}
         self._out_format = None
         self._in_format = None
         self._active = False
-        self._key = None
-        self._key_setter = key_setter
-
-    @property
-    def key(self):
-        return self._key
 
     def __setattr__(self, name, value):
         """Registers parameters."""
@@ -346,8 +340,8 @@ class HybridBlock(Block):
                 "Block construction instead."
             self._reg_params[name] = value
 
-    def _get_graph(self, *args, key):
-        if key not in self._cached_graph:
+    def _get_graph(self, *args):
+        if not self._cached_graph:
             args, self._in_format = _flatten(args)
             if len(args) > 1:
                 inputs = [symbol.var('data%d'%i) for i in range(len(args))]
@@ -360,31 +354,31 @@ class HybridBlock(Block):
                 out = self.hybrid_forward(symbol, *grouped_inputs, **params)  # pylint: disable=no-value-for-parameter
             out, self._out_format = _flatten(out)
 
-            self._cached_graph[key] = inputs, symbol.Group(out)
+            self._cached_graph = inputs, symbol.Group(out)
 
-        return self._cached_graph[key]
+        return self._cached_graph
 
-    def _build_cache(self, *args, key):
-        inputs, out = self._get_graph(*args, key=key)
-        self._cached_op[key] = ndarray.CachedOp(out)
+    def _build_cache(self, *args):
+        inputs, out = self._get_graph(*args)
+        self._cached_op = ndarray.CachedOp(out)
 
         params = dict(self.collect_params().items())
         self._cached_params = [params.get(name, None) for name in out.list_inputs()]
-        assert len(params) + len(self._cached_graph[key][0]) == len(out.list_inputs()), \
+        assert len(params) + len(self._cached_graph[0]) == len(out.list_inputs()), \
             "Wrong number of inputs."
 
         name2pos = {var.name: i for i, var in enumerate(inputs)}
         self._in_idx = [(i, name2pos[name]) for i, name in enumerate(out.list_inputs())
                         if name not in params]
 
-    def _call_cached_op(self, *args, key):
-        if key not in self._cached_op:
-            self._build_cache(*args, key=key)
+    def _call_cached_op(self, *args):
+        if self._cached_op is None:
+            self._build_cache(*args)
 
         try:
             cargs = [i.data() if i else None for i in self._cached_params]
         except DeferredInitializationError:
-            self.infer_shape(*args, key=key)
+            self.infer_shape(*args)
             for i in self._cached_params:
                 if i is not None:
                     i._finish_deferred_init()
@@ -394,14 +388,14 @@ class HybridBlock(Block):
         assert fmt == self._in_format, "Invalid input format"
         for i, j in self._in_idx:
             cargs[i] = args[j]
-        out = self._cached_op[key](*cargs)
+        out = self._cached_op(*cargs)
         if isinstance(out, NDArray):
             out = [out]
         return _regroup(out, self._out_format)[0]
 
-    def _clear_all_cached_ops(self):
-        self._cached_graph = {}
-        self._cached_op = {}
+    def _clear_cached_op(self):
+        self._cached_graph = ()
+        self._cached_op = None
 
     def register_child(self, block):
         if not isinstance(block, HybridBlock):
@@ -411,7 +405,7 @@ class HybridBlock(Block):
                 "please try HybridSequential instead"%(
                     str(block), str(type(block))))
         super(HybridBlock, self).register_child(block)
-        self._clear_all_cached_ops()
+        self._clear_cached_op()
 
     def hybridize(self, active=True):
         self._active = active
@@ -429,7 +423,7 @@ class HybridBlock(Block):
         for i in self.collect_params().values():
             i.shape = sdict[i.name]
 
-    def export(self, path, key=None):
+    def export(self, path):
         """Export HybridBlock to json format that can be loaded by `mxnet.mod.Module`
         or the C++ interface.
 
@@ -442,13 +436,11 @@ class HybridBlock(Block):
             Path to save model. Two files `path-symbol.json` and `path-0000.params`
             will be created.
         """
-        if key is None:
-            key = self._key
-        if key not in self._cached_graph:
+        if not self._cached_graph:
             raise RuntimeError(
                 "Please first call block.hybridize() and then run forward with "
                 "this block at least once before calling export.")
-        sym = self._cached_graph[key][1]
+        sym = self._cached_graph[1]
         sym.save('%s-symbol.json'%path)
 
         arg_names = set(sym.list_arguments())
@@ -465,19 +457,14 @@ class HybridBlock(Block):
     def forward(self, x, *args):
         """Defines the forward computation. Arguments can be either
         :py:class:`NDArray` or :py:class:`Symbol`."""
-        if self._key_setter:
-            self._key = self._key_setter(x, *args)
-            for c in self._children:
-                c._key = self._key
-
         if isinstance(x, NDArray):
             with x.context as ctx:
                 if self._active:
-                    return self._call_cached_op(x, *args, key=self._key)
+                    return self._call_cached_op(x, *args)
                 try:
                     params = {i: j.data(ctx) for i, j in self._reg_params.items()}
                 except DeferredInitializationError:
-                    self.infer_shape(x, *args, key=self._key)
+                    self.infer_shape(x, *args)
                     for i in self.collect_params().values():
                         i._finish_deferred_init()
                     params = {i: j.data(ctx) for i, j in self._reg_params.items()}
@@ -502,6 +489,52 @@ class HybridBlock(Block):
         """
         # pylint: disable= invalid-name
         raise NotImplementedError
+
+
+class KeyHybridBlock(HybridBlock):
+    def __init__(self, prefix=None, params=None, key_setter=None):
+        self._key_cached_op = {}
+        self._key_cached_graph = {}
+        self._key = None
+        self._key_setter = key_setter
+
+        super().__init__(prefix=prefix, params=params)
+
+    @property
+    def _cached_op(self):
+        if self._key in self._key_cached_op:
+            return self._key_cached_op[self._key]
+        else:
+            return None
+
+    @_cached_op.setter
+    def _cached_op(self, op):
+        self._key_cached_op[self._key] = op
+
+    @property
+    def _cached_graph(self):
+        if self._key in self._key_cached_graph:
+            return self._key_cached_graph[self._key]
+        else:
+            return ()
+
+    @_cached_graph.setter
+    def _cached_graph(self, graph):
+        self._key_cached_graph[self._key] = graph
+
+    @property
+    def key(self):
+        return self._key
+
+    def forward(self, x, *args):
+        """Defines the forward computation. Arguments can be either
+        :py:class:`NDArray` or :py:class:`Symbol`."""
+        if self._key_setter:
+            self._key = self._key_setter(x, *args)
+            for c in self._children:
+                c._key = self._key
+
+        return super().forward(x, *args)
 
 
 class SymbolBlock(HybridBlock):
@@ -563,22 +596,21 @@ class SymbolBlock(HybridBlock):
             if i not in input_names:
                 self.params.get(i, grad_req='null', allow_deferred_init=True)
 
-        self._cached_graph[self._key] = syms, out
-        self._build_cache(key=self._key)
+        self._cached_graph = syms, out
+        self._build_cache()
 
     def forward(self, x, *args):
         if isinstance(x, NDArray):
             with x.context:
-                return self._call_cached_op(x, *args, key=self._key)
+                return self._call_cached_op(x, *args)
 
         assert isinstance(x, Symbol), \
             "HybridBlock requires the first argument to forward be either " \
             "Symbol or NDArray, but got %s"%type(x)
         args, in_fmt = _flatten([x] + list(args))
         assert in_fmt == self._in_format, "Invalid input format"
-        ret = copy.copy(self._cached_graph[self._key][1])
-        ret._compose(**{k.name: v for k, v in
-                        zip(self._cached_graph[self._key][0], args)})
+        ret = copy.copy(self._cached_graph[1])
+        ret._compose(**{k.name: v for k, v in zip(self._cached_graph[0], args)})
         return _regroup(list(ret), self._out_format)[0]
 
     def hybrid_forward(self, F, x, *args, **kwargs):


### PR DESCRIPTION
It would be nice to have a HybridBlock with support for parameter sharing similar to the old BucketingModule. This PR implements that by adding an optional `key` and `key_setter`.
The caches for _op and _graph are specific to each key, while the parameter cache is the same for all keys.

The user defined key setter method is called at the beginning of `forward` and can be used to set the key based on the passed data (e.g. based on batch size or sequence length).

In the user defined `hybrid_forward` method the user can access the key via `self.key`. This is helpful, as once the Block is hybridized it is not anymore possible to access the shape in hybrid_forward.

This works and could be merged. But the design might not be optimal. So lets discuss here if you have any ideas for a better design.


For example, depending on the layout the following key_setters could be used:


```
def input_len_key_setter(layout):
    # args[0] is data
    # args[1] are states
    t_dim = layout.find('T')
    n_dim = layout.find('N')
    LayoutKey = collections.namedtuple("LayoutKey", ["T", "N"])
    return lambda *args: LayoutKey(T=args[0].shape[t_dim], N = args[0].shape[n_dim])

```