### PR TITLE
Disable Caffe Converter integration tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -485,17 +485,6 @@ try {
           }
         }
       },
-      'Caffe': {
-        node('mxnetlinux') {
-          ws('workspace/it-caffe') {
-            init_git()
-            unpack_lib('gpu')
-            timeout(time: max_time, unit: 'MINUTES') {
-              sh "${docker_run} caffe_gpu PYTHONPATH=/caffe/python:./python python tools/caffe_converter/test_converter.py"
-            }
-          }
-        }
-      },
       'cpp-package': {
         node('mxnetlinux') {
           ws('workspace/it-cpp-package') {


### PR DESCRIPTION
## Description ##
Disable Caffe Converter integration tests. The test is failing because it is not able to download files from caffe server.

This test can be enabled again after https://github.com/apache/incubator-mxnet/issues/8283 is fixed.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

