### PR TITLE
remove usage of install command from code gen

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -22,30 +22,14 @@ import os
 import sys
 # need to use distutils.core for correct placement of cython dll
 kwargs = {}
-required_packages = ['numpy', 'requests', 'graphviz']
 if "--inplace" in sys.argv:
     from distutils.core import setup
     from distutils.extension import Extension
-    from distutils.command.install import install
 else:
     from setuptools import setup
     from setuptools.extension import Extension
-    kwargs = {'install_requires': required_packages,
-              'setup_requires': required_packages,
-              'tests_require': required_packages,
-              'zip_safe': False}
-    from setuptools.command.install import install
+    kwargs = {'install_requires': ['numpy', 'requests', 'graphviz'], 'zip_safe': False}
 from setuptools import find_packages
-
-class PostInstallCommand(install):
-    """Post-installation for installation mode."""
-    def run(self):
-        install.run(self)
-        from mxnet.base import _generate_op_module_signature
-        from mxnet.ndarray.register import _generate_ndarray_function_code
-        from mxnet.symbol.register import _generate_symbol_function_code
-        _generate_op_module_signature('mxnet', 'symbol', _generate_symbol_function_code)
-        _generate_op_module_signature('mxnet', 'ndarray', _generate_ndarray_function_code)
 
 with_cython = False
 if '--with-cython' in sys.argv:
@@ -62,6 +46,17 @@ exec(compile(open(libinfo_py, "rb").read(), libinfo_py, 'exec'), libinfo, libinf
 LIB_PATH = libinfo['find_lib_path']()
 __version__ = libinfo['__version__']
 
+sys.path.insert(0, CURRENT_DIR)
+
+# Try to generate auto-complete code
+try:
+    from mxnet.base import _generate_op_module_signature
+    from mxnet.ndarray.register import _generate_ndarray_function_code
+    from mxnet.symbol.register import _generate_symbol_function_code
+    _generate_op_module_signature('mxnet', 'symbol', _generate_symbol_function_code)
+    _generate_op_module_signature('mxnet', 'ndarray', _generate_ndarray_function_code)
+except: # pylint: disable=bare-except
+    pass
 
 def config_cython():
     """Try to configure cython and return cython configuration"""
@@ -103,6 +98,7 @@ def config_cython():
         print("WARNING: Cython is not installed, will compile without cython module")
         return []
 
+
 setup(name='mxnet',
       version=__version__,
       description=open(os.path.join(CURRENT_DIR, 'README.md')).read(),
@@ -110,5 +106,4 @@ setup(name='mxnet',
       data_files=[('mxnet', [LIB_PATH[0]])],
       url='https://github.com/dmlc/mxnet',
       ext_modules=config_cython(),
-      cmdclass={'install': PostInstallCommand},
       **kwargs)


### PR DESCRIPTION
## Description ##
This change removes the usage of install command to avoid the side-effect of inconsistent behavior than before.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Revert setup.py and add the code gen logic.

## Comments ##
- This change makes the additional assumption that `libmxnet.so` can be loaded onto the current system. Before the change, the assumption is only on its existence. 
