### PR TITLE
Fix typo in gluon l1loss docstring

### DIFF
--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -138,7 +138,7 @@ class L2Loss(Loss):
 class L1Loss(Loss):
     r"""Calculates the mean absolute error between `pred` and `label`.
 
-    .. math:: L = \frac{1}{2} \sum_i \vert {pred}_i - {label}_i \vert.
+    .. math:: L = \sum_i \vert {pred}_i - {label}_i \vert.
 
     `pred` and `label` can have arbitrary shape as long as they have the same
     number of elements.


### PR DESCRIPTION
## Description ##
Fix docstring typo

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fix docstring typo

## Comments ##
- NA
