### PR TITLE
Bugfix: Python 3 compatiblity during optimizer serialization.

### DIFF
--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -451,7 +451,7 @@ class KVStore(object):
             # send the optimizer to server
             try:
                 # use ASCII protocol 0, might be slower, but not a big ideal
-                optim_str = pickle.dumps(optimizer, 0)
+                optim_str = py_str(pickle.dumps(optimizer, 0))
             except:
                 raise
             self._send_command_to_servers(0, optim_str)


### PR DESCRIPTION
## Description ##
In python 3 `pickle.dumps` returns a `bytes` object (instead of the `str` object in python 2). The `c_str` function however expects a string (on which it will call `.encode`. The fix is to detect if the return value of `pickle.dumps` is not a `str`. This is only true in python 3. If so we manually convert the `bytes` object to `str`.

This is the full stack trace before the change:
```
[ERROR:__main__] UNCAUGHT EXCEPTION
Traceback (most recent call last):
  File "/opt/conda/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/conda/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/opt/conda/lib/python3.6/site-packages/sockeye/train.py", line 450, in <module>
    main()
  File "/opt/conda/lib/python3.6/site-packages/sockeye/train.py", line 446, in main
    mxmonitor_stat_func=args.monitor_stat_func)
  File "/opt/conda/lib/python3.6/site-packages/sockeye/training.py", line 218, in fit
    self.module.init_optimizer(kvstore=kvstore, optimizer=optimizer, optimizer_params=optimizer_params)
  File "/opt/conda/lib/python3.6/site-packages/mxnet-0.12.0-py3.6.egg/mxnet/module/bucketing_module.py", line 385, in init_optimizer
    force_init=force_init)
  File "/opt/conda/lib/python3.6/site-packages/mxnet-0.12.0-py3.6.egg/mxnet/module/module.py", line 531, in init_optimizer
    kvstore.set_optimizer(self._optimizer)
  File "/opt/conda/lib/python3.6/site-packages/mxnet-0.12.0-py3.6.egg/mxnet/kvstore.py", line 394, in set_optimizer
    self._send_command_to_servers(0, optim_str)
  File "/opt/conda/lib/python3.6/site-packages/mxnet-0.12.0-py3.6.egg/mxnet/kvstore.py", line 532, in _send_command_to_servers
    self.handle, mx_uint(head), c_str(body)))
  File "/opt/conda/lib/python3.6/site-packages/mxnet-0.12.0-py3.6.egg/mxnet/base.py", line 189, in c_str
    return ctypes.c_char_p(string.encode('utf-8'))
AttributeError: 'bytes' object has no attribute 'encode'
```