### PR TITLE
fix using default mean pixels

### DIFF
--- a/example/ssd/evaluate/evaluate_net.py
+++ b/example/ssd/evaluate/evaluate_net.py
@@ -81,7 +81,7 @@ def evaluate_net(net, path_imgrec, num_classes, mean_pixels, data_shape,
     model_prefix += '_' + str(data_shape[1])
 
     # iterator
-    eval_iter = DetRecordIter(path_imgrec, batch_size, data_shape,
+    eval_iter = DetRecordIter(path_imgrec, batch_size, data_shape, mean_pixels=mean_pixels,
                               path_imglist=path_imglist, **cfg.valid)
     # model params
     load_net, args, auxs = mx.model.load_checkpoint(model_prefix, epoch)


### PR DESCRIPTION
## Description ##
Hotfix for default mean pixel values for example/ssd/evaluate.py

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

#8310 