### PR TITLE
distribute training in fp16

### DIFF
--- a/R-package/src/kvstore.cc
+++ b/R-package/src/kvstore.cc
@@ -161,9 +161,9 @@ void KVStore::Update(int index, const NDArray& grad, NDArray *weight) {
 }
 
 
-Rcpp::RObject KVStore::Create(const char *type) {
+Rcpp::RObject KVStore::Create(const char *type, const char *data_type) {
   KVStoreHandle handle;
-  MX_CALL(MXKVStoreCreate(type, &handle));
+  MX_CALL(MXKVStoreCreate(type, data_type, &handle));
   return Rcpp::internal::make_new_object(new KVStore(handle));
 }
 

--- a/R-package/src/kvstore.h
+++ b/R-package/src/kvstore.h
@@ -65,7 +65,7 @@ class KVStore {
    * \brief create a KVStore
    * \return the created KVStore
    */
-  static Rcpp::RObject Create(const char *type);
+  static Rcpp::RObject Create(const char *type, const char *data_type = "float32");
   /*! \brief initialize the R cpp Module */
   static void InitRcppModule();
   // destructor

--- a/cpp-package/include/mxnet-cpp/kvstore.h
+++ b/cpp-package/include/mxnet-cpp/kvstore.h
@@ -35,7 +35,7 @@ namespace cpp {
 
 class KVStore {
  public:
-  static void SetType(const std::string& type);
+  static void SetType(const std::string& type, const std::string& data_type = "float32");
   static void RunServer();
   static void Init(int key, const NDArray& val);
   static void Init(const std::vector<int>& keys, const std::vector<NDArray>& vals);

--- a/cpp-package/include/mxnet-cpp/kvstore.hpp
+++ b/cpp-package/include/mxnet-cpp/kvstore.hpp
@@ -73,8 +73,8 @@ inline KVStore*& KVStore::get_kvstore() {
 
 inline KVStore::KVStore() {}
 
-inline void KVStore::SetType(const std::string& type) {
-  CHECK_EQ(MXKVStoreCreate(type.c_str(), &(get_kvstore()->get_handle())), 0);
+inline void KVStore::SetType(const std::string& type, const std::string& data_type) {
+  CHECK_EQ(MXKVStoreCreate(type.c_str(), data_type.c_str(), &(get_kvstore()->get_handle())), 0);
 }
 
 inline void KVStore::RunServer() {

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1529,7 +1529,8 @@ MXNET_DLL int MXInitPSEnv(mx_uint num_vars,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStoreCreate(const char *type,
-                              KVStoreHandle *out);
+                              const char *data_type,
+			      KVStoreHandle *out);
 /*!
  * \brief Delete a KVStore handle.
  * \param handle handle to the kvstore

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1530,7 +1530,7 @@ MXNET_DLL int MXInitPSEnv(mx_uint num_vars,
  */
 MXNET_DLL int MXKVStoreCreate(const char *type,
                               const char *data_type,
-			      KVStoreHandle *out);
+                              KVStoreHandle *out);
 /*!
  * \brief Delete a KVStore handle.
  * \param handle handle to the kvstore

--- a/include/mxnet/kvstore.h
+++ b/include/mxnet/kvstore.h
@@ -57,7 +57,7 @@ class KVStore {
    *   - 'dist_*' : multi-machines
    * \return a new created KVStore.
    */
-  static KVStore *Create(const char *type = "local");
+  static KVStore *Create(const char *type = "local", const char *data_type = "float32");
 
   /**
    * \brief return the type

--- a/perl-package/AI-MXNet/lib/AI/MXNet/KVStore.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/KVStore.pm
@@ -452,9 +452,9 @@ method _send_command_to_servers(Int $head, Str $body)
         The created AI::MXNet::KVStore
 =cut
 
-method create(Str $name='local')
+method create(Str $name='local', Str $data_type='float32')
 {
-    my $handle = check_call(AI::MXNetCAPI::KVStoreCreate($name));
+    my $handle = check_call(AI::MXNetCAPI::KVStoreCreate($name, $data_type));
     return __PACKAGE__->new(handle => $handle);
 }
 

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -531,7 +531,7 @@ class KVStore(object):
         check_call(_LIB.MXKVStoreSendCommmandToServers(
             self.handle, mx_uint(head), c_str(body)))
 
-def create(name='local'):
+def create(name='local', data_type='flaot32'):
     """Creates a new KVStore.
 
     For single machine training, there are two commonly used types:
@@ -570,5 +570,6 @@ def create(name='local'):
         raise TypeError('name must be a string')
     handle = KVStoreHandle()
     check_call(_LIB.MXKVStoreCreate(c_str(name),
+                                    c_str(data_type),
                                     ctypes.byref(handle)))
     return KVStore(handle)

--- a/python/mxnet/kvstore_server.py
+++ b/python/mxnet/kvstore_server.py
@@ -77,8 +77,8 @@ def _init_kvstore_server_module(data_type='float32'):
     is_worker = ctypes.c_int()
     check_call(_LIB.MXKVStoreIsWorkerNode(ctypes.byref(is_worker)))
     if is_worker.value == 0:
-        kvstore = create('dist')
-        server = KVStoreServer(kvstore, data_type)
+        kvstore = create('dist', data_type)
+        server = KVStoreServer(kvstore)
         server.run()
         sys.exit()
 

--- a/python/mxnet/kvstore_server.py
+++ b/python/mxnet/kvstore_server.py
@@ -72,13 +72,13 @@ class KVStoreServer(object):
         _ctrl_proto = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_char_p, ctypes.c_void_p)
         check_call(_LIB.MXKVStoreRunServer(self.handle, _ctrl_proto(self._controller()), None))
 
-def _init_kvstore_server_module():
+def _init_kvstore_server_module(data_type='float32'):
     """Start server/scheduler."""
     is_worker = ctypes.c_int()
     check_call(_LIB.MXKVStoreIsWorkerNode(ctypes.byref(is_worker)))
     if is_worker.value == 0:
         kvstore = create('dist')
-        server = KVStoreServer(kvstore)
+        server = KVStoreServer(kvstore, data_type)
         server.run()
         sys.exit()
 

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStore.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStore.scala
@@ -46,9 +46,9 @@ object KVStore {
    *     - dist works for multi-machines (multiple processes)
    * @return The created KVStore
    */
-  def create(name: String = "local"): KVStore = {
+  def create(name: String = "local", data_type: String = "float32"): KVStore = {
     val handle = new KVStoreHandleRef
-    checkCall(_LIB.mxKVStoreCreate(name, handle))
+    checkCall(_LIB.mxKVStoreCreate(name, data_type, handle))
     new KVStore(handle.value)
   }
 }

--- a/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/ml_dmlc_mxnet_native_c_api.cc
@@ -646,13 +646,14 @@ JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxKVStoreIsWorkerNode
 }
 
 JNIEXPORT jint JNICALL Java_ml_dmlc_mxnet_LibInfo_mxKVStoreCreate
-  (JNIEnv *env, jobject obj, jstring name, jobject kvStoreHandle) {
+  (JNIEnv *env, jobject obj, jstring name, jstring data_type_name, jobject kvStoreHandle) {
   jclass refLongClass = env->FindClass("ml/dmlc/mxnet/Base$RefLong");
   jfieldID refLongFid = env->GetFieldID(refLongClass, "value", "J");
 
   KVStoreHandle out;
   const char *type = env->GetStringUTFChars(name, 0);
-  int ret = MXKVStoreCreate(type, &out);
+  const char *data_type = env->GetStringUTFChars(data_type_name, 0);
+  int ret = MXKVStoreCreate(type, data_type, &out);
   env->ReleaseStringUTFChars(name, type);
 
   env->SetLongField(kvStoreHandle, refLongFid, reinterpret_cast<jlong>(out));

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -727,9 +727,10 @@ int MXDataIterGetPadNum(DataIterHandle handle, int *pad) {
 }
 
 int MXKVStoreCreate(const char *type,
-                    KVStoreHandle *out) {
+                    const char *data_type,
+		    KVStoreHandle *out) {
   API_BEGIN();
-  *out = KVStore::Create(type);
+  *out = KVStore::Create(type, data_type);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -728,7 +728,7 @@ int MXDataIterGetPadNum(DataIterHandle handle, int *pad) {
 
 int MXKVStoreCreate(const char *type,
                     const char *data_type,
-		    KVStoreHandle *out) {
+                    KVStoreHandle *out) {
   API_BEGIN();
   *out = KVStore::Create(type, data_type);
   API_END();

--- a/src/kvstore/kvstore_dist.h
+++ b/src/kvstore/kvstore_dist.h
@@ -571,6 +571,7 @@ class KVStoreDist : public KVStoreLocal {
   size_t bigarray_bound_;
   /// \brief send & recver buffer
   std::unordered_map<int, NDArray> comm_buf_;
+  std::unordered_map<int, NDArray> tmp_buf_;
   bool log_verbose_;
 };
 

--- a/src/kvstore/kvstore_dist.h
+++ b/src/kvstore/kvstore_dist.h
@@ -179,9 +179,9 @@ class KVStoreDist : public KVStoreLocal {
         recv_buf = NDArray(grouped_vals[i][0]->shape(), pinned_ctx_,
                            true, mshadow::DataType<DType>::kFlag);
       }
-	  auto& tmp = tmp_buf_[key];
+      auto& tmp = tmp_buf_[key];
       if (tmp.is_none()) {
-	    tmp = NDArray(grouped_vals[i][0]->shape(), pinned_ctx_,true, grouped_vals[i][0]->dtype());
+        tmp = NDArray(grouped_vals[i][0]->shape(), pinned_ctx_, true, grouped_vals[i][0]->dtype());
       }
       auto pull_from_servers = [this, key, recv_buf](
           RunContext rctx, Engine::CallbackOnComplete cb) {
@@ -207,12 +207,10 @@ class KVStoreDist : public KVStoreLocal {
           FnProperty::kNormal,
           priority,
           PROFILER_MESSAGE("KVStoreDistDefaultPull"));
-	  if (grouped_vals[i][0]->dtype() != mshadow::DataType<DType>::kFlag) {
-        //NDArray tmp = NDArray(grouped_vals[i][0]->shape(), pinned_ctx_,true, grouped_vals[i][0]->dtype());
+      if (grouped_vals[i][0]->dtype() != mshadow::DataType<DType>::kFlag) {
         CopyFromTo(recv_buf, &tmp, 0);
         comm_->Broadcast(key, tmp, grouped_vals[i], priority);
-      }
-      else {
+      } else {
         comm_->Broadcast(key, recv_buf, grouped_vals[i], priority);
       }
     }
@@ -288,20 +286,22 @@ class KVStoreDist : public KVStoreLocal {
           if (storage_type == kDefaultStorage) {
             send_buf = NDArray(merged.shape(), pinned_ctx_, true, mshadow::DataType<DType>::kFlag);
           } else {
-            send_buf = NDArray(storage_type, merged.shape(), pinned_ctx_, true, mshadow::DataType<DType>::kFlag);
+            send_buf = NDArray(storage_type, merged.shape(), pinned_ctx_,
+	                       true, mshadow::DataType<DType>::kFlag);
           }
         }
-		if (merged.dtype() == mshadow::DataType<DType>::kFlag) {
-		  send_buf = merged;
-		} else {
+        if (merged.dtype() == mshadow::DataType<DType>::kFlag) {
+          send_buf = merged;
+        } else {
           CopyFromTo(merged, &send_buf);
-		}
+        }
       } else {
         if (send_buf.is_none()) {
           if (storage_type == kDefaultStorage) {
             send_buf = NDArray(merged.shape(), pinned_ctx_, true, mshadow::DataType<DType>::kFlag);
           } else {
-            send_buf = NDArray(storage_type, merged.shape(), pinned_ctx_, true, mshadow::DataType<DType>::kFlag);
+            send_buf = NDArray(storage_type, merged.shape(), pinned_ctx_,
+	                       true, mshadow::DataType<DType>::kFlag);
           }
         }
         if (merged.dtype() == mshadow::DataType<DType>::kFlag) {

--- a/src/kvstore/kvstore_dist.h
+++ b/src/kvstore/kvstore_dist.h
@@ -287,7 +287,7 @@ class KVStoreDist : public KVStoreLocal {
             send_buf = NDArray(merged.shape(), pinned_ctx_, true, mshadow::DataType<DType>::kFlag);
           } else {
             send_buf = NDArray(storage_type, merged.shape(), pinned_ctx_,
-	                       true, mshadow::DataType<DType>::kFlag);
+                               true, mshadow::DataType<DType>::kFlag);
           }
         }
         if (merged.dtype() == mshadow::DataType<DType>::kFlag) {
@@ -301,7 +301,7 @@ class KVStoreDist : public KVStoreLocal {
             send_buf = NDArray(merged.shape(), pinned_ctx_, true, mshadow::DataType<DType>::kFlag);
           } else {
             send_buf = NDArray(storage_type, merged.shape(), pinned_ctx_,
-	                       true, mshadow::DataType<DType>::kFlag);
+                               true, mshadow::DataType<DType>::kFlag);
           }
         }
         if (merged.dtype() == mshadow::DataType<DType>::kFlag) {

--- a/src/kvstore/kvstore_dist_server.h
+++ b/src/kvstore/kvstore_dist_server.h
@@ -406,7 +406,7 @@ class KVStoreDistServer {
         if (merged.array.is_none()) {
           if (recved.dtype() != mshadow::DataType<real_t>::kFlag) {
             merged.array = NDArray(dshape, Context::CPU(0),
-	                           false, mshadow::DataType<real_t>::kFlag);
+                                   false, mshadow::DataType<real_t>::kFlag);
           } else {
             merged.array = NDArray(dshape, Context());
           }
@@ -439,11 +439,11 @@ class KVStoreDistServer {
       response.keys = req_data.keys;
       response.lens = {len};
       // TODO(mli) try to remove this CopyFrom
-      if (stored.dtype() != mshadow::DataType<DType>::kFlag || 
-      	  stored.ctx().dev_mask() != cpu::kDevMask) {
+      if (stored.dtype() != mshadow::DataType<DType>::kFlag ||
+          stored.ctx().dev_mask() != cpu::kDevMask) {
         stored.WaitToRead();
         NDArray tmp = NDArray(stored.shape(), Context::CPU(0),
-	                      false, mshadow::DataType<DType>::kFlag);
+                              false, mshadow::DataType<DType>::kFlag);
         CopyFromTo(stored, &tmp, 0);
         tmp.WaitToRead();
         response.vals.CopyFrom(static_cast<const DType*>(tmp.data().dptr_), len);


### PR DESCRIPTION
Update kvstore, make it can support fp16.
 1. Use copyfromto() to convert fp32 to fp16 before pass the key-value to PSLite.
 2.  In kvstore server, conver fp16 to fp32 and compute in cpu. If we want to compute in fp16, we must pass them to GPU first. Because it's very slow for cpu to compute fp16.
 3. We test several networks in 2 distributed machines. In test, weights and gradients were all in fp16. The speed result is shown below. 'fp16-server-16gpu' means kvstore server compute in fp16 format on gpu. 'fp16-server-32cpu' means kvstore server compute in fp32 format on cpu.

samples/sec

KVStore | dist_sync_device | dist_sync_device | dist_sync_device | dist_sync | dist_sync
-- | -- | -- | -- | -- | --
  | fp32 | fp16-server-16gpu | fp16-server-32cpu | fp16-server-16gpu | fp16-server-32cpu
alexnet | 715.52 | 1300 | - | 326 | -
inception_v3 | 231.82 | 182.23 | - | 238.93 | 243.05
inception_v4 | 112.48 | 90.75 | - | 116.72 | 116.4
resnet_50 | 368.38 | 311.09 | - | 387.77 | 392.24
resnet_101 | 222 | 185.88 | - | 232.47 | 234.51
resnet_152 | 156.82 | 122.3 | - | 165.82 | 166.9
vgg11 | 218.16 | 382.96 | 164.32 | - | -
vgg16 | 197.78 | 292.07 | 181.58 | - | -
vgg19 | 152.53 | 260.44 | 143.16 | - | -

The train accuracy are almost same between training in fp16 and original fp32.


step | fp16 | fp32
-- | -- | --
4550 | 0.421875 | 0.424844
4600 | 0.432812 | 0.434844
4650 | 0.429219 | 0.427812
4700 | 0.426719 | 0.425469
4750 | 0.423594 | 0.43375
4800 | 0.434375 | 0.435781
4850 | 0.442031 | 0.44
4900 | 0.43 | 0.443906
4950 | 0.449688 | 0.449375
5000 | 0.446406 | 0.451562

