### PR TITLE
re-enable tests

### DIFF
--- a/docker/install/python.sh
+++ b/docker/install/python.sh
@@ -24,5 +24,5 @@ apt-get update && apt-get install -y python-dev python3-dev
 # the version of the pip shipped with ubuntu may be too lower, install a recent version here
 cd /tmp && wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && python2 get-pip.py
 
-pip2 install nose pylint numpy nose-timer requests
-pip3 install nose pylint numpy nose-timer requests
+pip2 install nose flaky pylint numpy nose-timer requests
+pip3 install nose flaky pylint numpy nose-timer requests

--- a/docker_multiarch/Dockerfile.test.ubuntu-17.04
+++ b/docker_multiarch/Dockerfile.test.ubuntu-17.04
@@ -26,6 +26,8 @@ RUN valgrind build/tests/cpp/mxnet_test
 ############################
 # Python tests
 WORKDIR /work/mxnet/python
+RUN pip3 install flaky
+RUN pip install flaky
 RUN pip3 install -e .
 RUN pip install -e .
 

--- a/tests/ci_build/Dockerfile.crosstool
+++ b/tests/ci_build/Dockerfile.crosstool
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get -y upgrade
 # TOOLCHAIN DEPS
 RUN apt-get install -y python python-setuptools python-pip python-dev unzip gfortran
 RUN apt-get install -y git bison cvs flex gperf texinfo automake libtool help2man make libtool-bin libncurses5-dev g++ cmake wget gawk
-RUN pip install numpy nose
+RUN pip install numpy nose flaky
 
 # BUILD TOOLCHAIN
 RUN git clone https://github.com/arank/crosstool-NG

--- a/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
+++ b/tests/ci_build/Dockerfile.ubuntu1404_cuda75_cudnn5
@@ -11,16 +11,16 @@ RUN apt-get install -y libatlas-base-dev
 
 # PYTHON2
 RUN apt-get install -y python-setuptools python-pip python-dev unzip gfortran
-RUN pip install numpy nose scipy
+RUN pip install numpy nose flaky scipy
 
 # PYTHON3
 RUN apt-get install -y python3-setuptools python3-pip
-RUN pip3 install numpy nose scipy && ln -s -f /usr/local/bin/nosetests-3.4 /usr/local/bin/nosetests3
+RUN pip3 install numpy nose flaky scipy && ln -s -f /usr/local/bin/nosetests-3.4 /usr/local/bin/nosetests3
 
 # TESTDEPS
 RUN apt-get install -y libgtest-dev cmake wget
 RUN cd /usr/src/gtest && cmake CMakeLists.txt && make && cp *.a /usr/lib
-RUN pip install nose cpplint 'pylint==1.4.4' 'astroid==1.3.6'
+RUN pip install nose flaky cpplint 'pylint==1.4.4' 'astroid==1.3.6'
 
 # MAVEN
 RUN apt-get install -y software-properties-common

--- a/tests/ci_build/install/install_python2.sh
+++ b/tests/ci_build/install/install_python2.sh
@@ -32,5 +32,5 @@ if [ -f /usr/local/bin/pip ] && [ -f /usr/bin/pip ]; then
 fi
 
 ln -s -f /usr/local/bin/pip /usr/bin/pip
-for i in ipython[all] jupyter pandas scikit-image h5py pandas sklearn sympy; do echo "${i}..."; pip install -U $i >/dev/null; done
+for i in ipython[all] jupyter pandas scikit-image h5py pandas sklearn sympy flaky; do echo "${i}..."; pip install -U $i >/dev/null; done
 

--- a/tests/ci_build/install/install_testdeps.sh
+++ b/tests/ci_build/install/install_testdeps.sh
@@ -35,6 +35,6 @@ cp libgtest.a /usr/local/gtest/lib
 cp -r include/ /usr/local/gtest/
 export LD_LIBRARY_PATH=/usr/local/gtest/lib:$LD_LIBRARY_PATH
 
-pip3 install nose
+pip3 install nose flaky
 ln -s -f /opt/bin/nosetests /usr/local/bin/nosetests3
 ln -s -f /opt/bin/nosetests-3.4 /usr/local/bin/nosetests-3.4

--- a/tests/ci_build/install/ubuntu_install_python.sh
+++ b/tests/ci_build/install/ubuntu_install_python.sh
@@ -24,5 +24,5 @@ apt-get update && apt-get install -y python-dev python3-dev
 # the version of the pip shipped with ubuntu may be too lower, install a recent version here
 cd /tmp && wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py && python2 get-pip.py
 
-pip2 install nose pylint numpy nose-timer requests h5py scipy
-pip3 install nose pylint numpy nose-timer requests h5py scipy
+pip2 install nose pylint numpy nose-timer requests h5py scipy flaky
+pip3 install nose pylint numpy nose-timer requests h5py scipy flaky

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -19,6 +19,7 @@
 import mxnet as mx
 from mxnet.test_utils import *
 import numpy as np
+from flaky import flaky
 import os, gzip
 import pickle as pickle
 import time
@@ -248,8 +249,10 @@ def test_LibSVMIter():
     check_libSVMIter_synthetic()
     check_libSVMIter_news_data()
 
-@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/7826")
+@flaky(max_runs=3)
 def test_CSVIter():
+    """test_io.test_CSVIter.
+    Flaky. Tracked at https://github.com/apache/incubator-mxnet/issues/7826"""
     def check_CSVIter_synthetic():
         cwd = os.getcwd()
         data_path = os.path.join(cwd, 'data.t')

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -18,8 +18,8 @@
 import mxnet as mx
 import numpy as np
 import os
+from flaky import flaky
 import pickle as pkl
-import unittest
 from nose.tools import raises
 from mxnet.test_utils import almost_equal
 from mxnet.test_utils import assert_almost_equal
@@ -680,8 +680,10 @@ def test_iter():
     for i in range(x.size):
         assert same(y[i].asnumpy(), x[i].asnumpy())
 
-@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/8049")
+@flaky(max_runs=3)
 def test_cached():
+    """test_ndarray.test_cached.
+    Flaky. Tracked at https://github.com/apache/incubator-mxnet/issues/8049"""
     sym = mx.sym.Convolution(kernel=(3, 3), num_filter=10) + 2
     op = mx.nd.CachedOp(sym)
     data = mx.nd.ones((3, 4, 10, 10))

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -18,12 +18,12 @@
 # pylint: skip-file
 from __future__ import print_function
 import numpy as np
+from flaky import flaky
 import mxnet as mx
 import random
 import itertools
 from numpy.testing import assert_allclose, assert_array_equal
 from mxnet.test_utils import *
-import unittest
 
 
 def np_softmax(x, axis=-1):
@@ -926,8 +926,10 @@ def test_nearest_upsampling():
                     check_nearest_upsampling_with_shape(shapes, scale, root_scale)
 
 
-@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/8044")
+@flaky(max_runs=3)
 def test_batchnorm_training():
+    """test_operator.test_batchnorm_training.
+    Flaky. Tracked at https://github.com/apache/incubator-mxnet/issues/8044"""
     def check_batchnorm_training(stype):
         for shape in [(2, 3), (2, 3, 2, 2)]:
             data_tmp = np.random.normal(-0.1, 0.1, size=shape)

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -16,9 +16,9 @@
 # under the License.
 
 import numpy as np
+from flaky import flaky
 import mxnet as mx
 import mxnet.lr_scheduler as lr_scheduler
-import unittest
 from nose.tools import raises
 import math
 from mxnet.test_utils import *
@@ -538,8 +538,10 @@ class PyRMSProp(mx.optimizer.Optimizer):
         if self.clip_weights:
              mx.ndarray.clip(weight, -self.clip_weights, self.clip_weights, out=weight)
 
-@unittest.skip("Test fails intermittently. Temporarily disabled until fixed. Tracked at https://github.com/apache/incubator-mxnet/issues/8230")
+@flaky(max_runs=3)
 def test_rms():
+    """test_optimizer.test_rms.
+    Flaky. Tracked at https://github.com/apache/incubator-mxnet/issues/8230"""
     mx.random.seed(0)
     opt1 = PyRMSProp
     opt2 = mx.optimizer.RMSProp

--- a/tests/travis/setup.sh
+++ b/tests/travis/setup.sh
@@ -33,8 +33,8 @@ if [ ${TRAVIS_OS_NAME} == "osx" ]; then
     brew install ImageMagick
     brew install swig
     if [ ${TASK} == "python_test" ]; then
-        python -m pip install --user nose numpy cython scipy
-        python3 -m pip install --user nose numpy cython scipy
+        python -m pip install --user nose flaky numpy cython scipy
+        python3 -m pip install --user nose flaky numpy cython scipy
     fi
 fi
 


### PR DESCRIPTION
## Description ##
Re-enable tests that were disabled in #7648, #8265, #7829, #8045. The tests are marked as flaky, and are allowed maximum of three runs.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] re-enable tests and mark as flaky with three runs.

## Comments ##
- The tests are still flaky and needs fixing eventually.
- Adding flaky tests for new features should be discouraged.