### PR TITLE
Use omp_get_max_threads() when OMP_NUM_THREADS environment set

### DIFF
--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -309,7 +309,7 @@ class ThreadedEngine : public Engine {
     // Otherwise, return the number of processors, not counting hyperthreading.
     // Test for set OMP_NUM_THREADS by checking against some nonsensical value
     const int max_threads = dmlc::GetEnv("OMP_NUM_THREADS", INT_MIN) == INT_MIN ?
-                            omp_get_num_procs() : omp_get_num_threads();
+                            omp_get_num_procs() : omp_get_max_threads();
     return max_threads;
 #else
     return 1;


### PR DESCRIPTION
Using wrong API call here. Only relevant if OMP_NUM_THREADS environment variable is set.

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated.
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Intersting edge cases to note here
