### PR TITLE
Fix for "name epochs is not defined"

### DIFF
--- a/example/gluon/image_classification.py
+++ b/example/gluon/image_classification.py
@@ -184,7 +184,7 @@ def main():
                 optimizer = 'sgd',
                 optimizer_params = {'learning_rate': opt.lr, 'wd': opt.wd, 'momentum': opt.momentum},
                 initializer = mx.init.Xavier(magnitude=2))
-        mod.save_params('image-classifier-%s-%d-final.params'%(opt.model, epochs))
+        mod.save_params('image-classifier-%s-%d-final.params'%(opt.model, opt.epochs))
     else:
         if opt.mode == 'hybrid':
             net.hybridize()


### PR DESCRIPTION
## Description ##
Fix for "name epochs is not defined" when testing image_classification.py with symbolic mode.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

## Comments ##
