### PR TITLE
Fixes #8292. Bug on Slice accessing uninitialized memory in param.beg…

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -473,7 +473,7 @@ void Slice(const nnvm::NodeAttrs& attrs,
   TShape begin(N), end(N);
   for (index_t i = 0; i < N; ++i) {
     int s = 0;
-    if (i < param.begin.ndim()) {
+    if (i < param.begin.ndim() && param.begin[i]) {
       s = *param.begin[i];
       if (s < 0) {
         s += inputs[0].size(i);

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -473,9 +473,14 @@ void Slice(const nnvm::NodeAttrs& attrs,
   TShape begin(N), end(N);
   for (index_t i = 0; i < N; ++i) {
     int s = 0;
-    if (param.begin[i]) {
+    if (i < param.begin.ndim()) {
       s = *param.begin[i];
-      if (s < 0) s += inputs[0].size(i);
+      if (s < 0) {
+        s += inputs[0].size(i);
+        CHECK(s >= 0)
+            << "Invalid slicing begin " << param.begin << " and end "
+            << param.end << " for data of shape " << inputs[0].shape_;
+      }
     }
     begin[i] = s;
     end[i] = s + outputs[0].size(i);


### PR DESCRIPTION
…in. (Out of bounds array access).

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change