### PR TITLE
dtype default to source_array.dtype for sparse ndarrays

### DIFF
--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -806,7 +806,7 @@ def csr_matrix(arg1, shape=None, ctx=None, dtype=None):
     shape : tuple of int, optional
         The shape of the csr matrix.
     ctx: Context, optional
-        Device context.
+        Device context (default is the current default context).
     dtype: str or numpy.dtype, optional
         The data type of the output array.
 
@@ -956,7 +956,7 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
     shape : tuple of int, optional
         The shape of the row sparse ndarray.
     ctx : Context, optional
-        Device context.
+        Device context (default is the current default context).
     dtype : str or numpy.dtype, optional
         The data type of the output array.
 

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -728,14 +728,14 @@ def _prepare_src_array(source_array, dtype):
     return source_array
 
 def _prepare_default_ctx(src_array, context):
-    """Prepare the default context if `context` is None. If `src_array` is an NDArray,
+    """Prepare the value of context if `context` is None. If `src_array` is an NDArray,
     return src_array.context. The current default context is returned otherwise."""
     if context is None:
         context = src_array.context if isinstance(src_array, NDArray) else Context.default_ctx
     return context
 
 def _prepare_default_dtype(src_array, dtype):
-    """Prepare the default dtype if `dtype` is None. If `src_array` is an NDArray, numpy.ndarray
+    """Prepare the value of dtype if `dtype` is None. If `src_array` is an NDArray, numpy.ndarray
     or scipy.sparse.csr.csr_matrix, return src_array.dtype. float32 is returned otherwise."""
     if dtype is None:
         if isinstance(src_array, (NDArray, np.ndarray)):
@@ -861,6 +861,8 @@ def csr_matrix(arg1, shape=None, ctx=None, dtype=None):
             raise ValueError("Unexpected input type: RowSparseNDArray")
         else:
             # construct a csr matrix from a dense one
+            # prepare default ctx and dtype since mx.nd.array doesn't use default values
+            # based on source_array
             ctx = _prepare_default_ctx(arg1, ctx)
             dtype = _prepare_default_dtype(arg1, dtype)
             dns = _array(arg1, ctx=ctx, dtype=dtype)
@@ -1020,6 +1022,8 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
             raise ValueError("Unexpected input type: CSRNDArray")
         else:
             # construct a csr matrix from a dense one
+            # prepare default ctx and dtype since mx.nd.array doesn't use default values
+            # based on source_array
             ctx = _prepare_default_ctx(arg1, ctx)
             dtype = _prepare_default_dtype(arg1, dtype)
             dns = _array(arg1, ctx=ctx, dtype=dtype)
@@ -1179,6 +1183,7 @@ def array(source_array, ctx=None, dtype=None):
     if isinstance(source_array, NDArray):
         assert(source_array.stype != 'default'), \
                "Please use `tostype` to create RowSparseNDArray or CSRNDArray from an NDArray"
+        # prepare dtype and ctx based on source_array, if not provided
         dtype = _prepare_default_dtype(source_array, dtype)
         ctx = _prepare_default_ctx(source_array, ctx)
         arr = empty(source_array.stype, source_array.shape, ctx=ctx, dtype=dtype)

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -727,13 +727,6 @@ def _prepare_src_array(source_array, dtype):
             raise TypeError('values must be array like object')
     return source_array
 
-def _prepare_default_ctx(src_array, context):
-    """Prepare the value of context if `context` is None. If `src_array` is an NDArray,
-    return src_array.context. The current default context is returned otherwise."""
-    if context is None:
-        context = src_array.context if isinstance(src_array, NDArray) else Context.default_ctx
-    return context
-
 def _prepare_default_dtype(src_array, dtype):
     """Prepare the value of dtype if `dtype` is None. If `src_array` is an NDArray, numpy.ndarray
     or scipy.sparse.csr.csr_matrix, return src_array.dtype. float32 is returned otherwise."""
@@ -760,9 +753,8 @@ def csr_matrix(arg1, shape=None, ctx=None, dtype=None):
         to construct a CSRNDArray with a dense 2D array ``D``
             -  **D** (*array_like*) - An object exposing the array interface, an object whose \
             `__array__` method returns an array, or any (nested) sequence.
-            - **ctx** (*Context, optional*) - Device context. \
-            The default context is ``D.context`` if ``D`` is an NDArray. The current default \
-            context otherwise.
+            - **ctx** (*Context, optional*) - Device context \
+            (default is the current default context).
             - **dtype** (*str or numpy.dtype, optional*) - The data type of the output array. \
             The default dtype is ``D.dtype`` if ``D`` is an NDArray or numpy.ndarray, \
             float32 otherwise.
@@ -770,9 +762,8 @@ def csr_matrix(arg1, shape=None, ctx=None, dtype=None):
     - csr_matrix(S)
         to construct a CSRNDArray with a sparse 2D array ``S``
             -  **S** (*CSRNDArray or scipy.sparse.csr.csr_matrix*) - A sparse matrix.
-            - **ctx** (*Context, optional*) - Device context. \
-            The default context is ``S.context`` if ``S`` is a CSRNDArray. The current default \
-            context otherwise.
+            - **ctx** (*Context, optional*) - Device context \
+            (default is the current default context).
             - **dtype** (*str or numpy.dtype, optional*) - The data type of the output array. \
             The default dtype is ``S.dtype``.
 
@@ -802,8 +793,7 @@ def csr_matrix(arg1, shape=None, ctx=None, dtype=None):
             - **shape** (*tuple of int, optional*) - The shape of the array. The default \
             shape is inferred from the indices and indptr arrays.
             - **ctx** (*Context, optional*) - Device context \
-            The default context is ``data.context`` if ``data`` is an NDArray. The current default \
-            context otherwise.
+            (default is the current default context).
             - **dtype** (*str or numpy.dtype, optional*) - The data type of the output array. \
             The default dtype is ``data.dtype`` if ``data`` is an NDArray or numpy.ndarray, \
             float32 otherwise.
@@ -863,7 +853,6 @@ def csr_matrix(arg1, shape=None, ctx=None, dtype=None):
             # construct a csr matrix from a dense one
             # prepare default ctx and dtype since mx.nd.array doesn't use default values
             # based on source_array
-            ctx = _prepare_default_ctx(arg1, ctx)
             dtype = _prepare_default_dtype(arg1, dtype)
             dns = _array(arg1, ctx=ctx, dtype=dtype)
             _check_shape(dns.shape, shape)
@@ -874,7 +863,7 @@ def _csr_matrix_from_definition(data, indices, indptr, shape=None, ctx=None,
     """Create a `CSRNDArray` based on data, indices and indptr"""
     storage_type = 'csr'
     # context
-    ctx = _prepare_default_ctx(data, ctx)
+    ctx = Context.default_ctx if ctx is None else ctx
     # types
     dtype = _prepare_default_dtype(data, dtype)
     indptr_type = _STORAGE_AUX_TYPES[storage_type][0] if indptr_type is None else indptr_type
@@ -919,9 +908,8 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
         to construct a RowSparseNDArray with a dense ndarray ``D``
             -  **D** (*array_like*) - An object exposing the array interface, an object whose \
             `__array__` method returns an array, or any (nested) sequence.
-            - **ctx** (*Context, optional*) - Device context. \
-            The default context is ``D.context`` if ``D`` is an NDArray. The current default \
-            context otherwise.
+            - **ctx** (*Context, optional*) - Device context \
+            (default is the current default context).
             - **dtype** (*str or numpy.dtype, optional*) - The data type of the output array. \
             The default dtype is ``D.dtype`` if ``D`` is an NDArray or numpy.ndarray, \
             float32 otherwise.
@@ -929,8 +917,8 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
     - row_sparse_array(S)
         to construct a RowSparseNDArray with a sparse ndarray ``S``
             -  **S** (*RowSparseNDArray*) - A sparse ndarray.
-            - **ctx** (*Context, optional*) - Device context. \
-            The default context is ``S.context``.
+            - **ctx** (*Context, optional*) - Device context \
+            (default is the current default context).
             - **dtype** (*str or numpy.dtype, optional*) - The data type of the output array. \
             The default dtype is ``S.dtype``.
 
@@ -956,9 +944,8 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
             stores the row index for each row slice with non-zero elements.
             - **shape** (*tuple of int, optional*) - The shape of the array. The default \
             shape is inferred from the indices and indptr arrays.
-            - **ctx** (*Context, optional*) - Device context. \
-            The default context is ``data.context`` if ``data`` is an NDArray. The current \
-            default context otherwise.
+            - **ctx** (*Context, optional*) - Device context \
+            (default is the current default context).
             - **dtype** (*str or numpy.dtype, optional*) - The data type of the output array. \
             The default dtype is float32.
 
@@ -1022,9 +1009,8 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
             raise ValueError("Unexpected input type: CSRNDArray")
         else:
             # construct a csr matrix from a dense one
-            # prepare default ctx and dtype since mx.nd.array doesn't use default values
+            # prepare default dtype since mx.nd.array doesn't use default values
             # based on source_array
-            ctx = _prepare_default_ctx(arg1, ctx)
             dtype = _prepare_default_dtype(arg1, dtype)
             dns = _array(arg1, ctx=ctx, dtype=dtype)
             _check_shape(dns.shape, shape)
@@ -1035,7 +1021,7 @@ def _row_sparse_ndarray_from_definition(data, indices, shape=None, ctx=None,
     """Create a `RowSparseNDArray` based on data and indices"""
     storage_type = 'row_sparse'
     # context
-    ctx = _prepare_default_ctx(data, ctx)
+    ctx = Context.default_ctx if ctx is None else ctx
     # types
     dtype = _prepare_default_dtype(data, dtype)
     indices_type = _STORAGE_AUX_TYPES[storage_type][0] if indices_type is None else indices_type
@@ -1185,7 +1171,6 @@ def array(source_array, ctx=None, dtype=None):
                "Please use `tostype` to create RowSparseNDArray or CSRNDArray from an NDArray"
         # prepare dtype and ctx based on source_array, if not provided
         dtype = _prepare_default_dtype(source_array, dtype)
-        ctx = _prepare_default_ctx(source_array, ctx)
         arr = empty(source_array.stype, source_array.shape, ctx=ctx, dtype=dtype)
         arr[:] = source_array
         return arr

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -35,6 +35,8 @@ from test_loss import *
 #from test_rnn import *
 from test_gluon_rnn import *
 from test_sparse_ndarray import test_create_csr, test_create_row_sparse, test_sparse_nd_slice
+from test_sparse_ndarray import test_create_sparse_nd_empty, test_create_sparse_nd_from_sparse
+from test_sparse_ndarray import test_create_sparse_nd_from_dense, test_create_sparse_nd_infer_shape
 from test_sparse_operator import *
 from test_ndarray import *
 

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -464,10 +464,10 @@ def test_sparse_nd_unsupported():
             pass
 
 def test_create_csr():
-    def check_create_csr_from_nd(shape, density, dtype, ctx):
+    def check_create_csr_from_nd(shape, density, dtype):
         matrix = rand_ndarray(shape, 'csr', density)
         # create data array with provided dtype and ctx
-        data = mx.nd.array(matrix.data.asnumpy(), dtype=dtype, ctx=ctx)
+        data = mx.nd.array(matrix.data.asnumpy(), dtype=dtype)
         indptr = matrix.indptr
         indices = matrix.indices
         csr_created = mx.nd.sparse.csr_matrix((data, indices, indptr), shape=shape)
@@ -478,10 +478,7 @@ def test_create_csr():
         # verify csr matrix dtype and ctx is consistent from the ones provided
         assert csr_created.dtype == dtype
         assert csr_created.data.dtype == dtype
-        assert csr_created.context == ctx
-        assert csr_created.data.context == ctx
-        assert csr_created.indices.context == ctx
-        assert csr_created.indptr.context == ctx
+        assert csr_created.context == Context.default_ctx
         csr_copy = mx.nd.array(csr_created)
         assert(same(csr_copy.asnumpy(), csr_created.asnumpy()))
 
@@ -514,11 +511,10 @@ def test_create_csr():
     dim1 = 20
     densities = [0, 0.5]
     densities = [0]
-    ctx = mx.cpu(1)
     dtype = np.float64
     for density in densities:
         shape = rand_shape_2d(dim0, dim1)
-        check_create_csr_from_nd(shape, density, dtype, ctx)
+        check_create_csr_from_nd(shape, density, dtype)
         check_create_csr_from_scipy(shape, density, mx.nd.sparse.array)
         check_create_csr_from_scipy(shape, density, mx.nd.array)
 
@@ -582,55 +578,56 @@ def test_create_sparse_nd_infer_shape():
         check_create_rsp_infer_shape(shape_3d, density, dtype)
 
 def test_create_sparse_nd_from_dense():
-    def check_create_from_dns(shape, f, dense_arr, dtype, default_dtype, ctx, default_ctx):
+    def check_create_from_dns(shape, f, dense_arr, dtype, default_dtype, ctx):
         arr = f(dense_arr, dtype=dtype, ctx=ctx)
         assert(same(arr.asnumpy(), np.ones(shape)))
         assert(arr.dtype == dtype)
         # verify the default dtype inferred from dense arr
         arr2 = f(dense_arr)
         assert(arr2.dtype == default_dtype)
-        assert(arr2.context == default_ctx)
+        assert(arr2.context == Context.default_ctx)
     shape = rand_shape_2d()
     dtype = np.int32
-    dense_arrs = [mx.nd.ones(shape, dtype='float64'), np.ones(shape, dtype='float64'), \
-                  np.ones(shape, dtype='float64').tolist()]
+    src_dtype = np.float64
+    ctx = mx.cpu(1)
+    dense_arrs = [mx.nd.ones(shape, dtype=src_dtype), np.ones(shape, dtype=src_dtype), \
+                  np.ones(shape, dtype=src_dtype).tolist()]
     for f in [mx.nd.sparse.csr_matrix, mx.nd.sparse.row_sparse_array]:
         for dense_arr in dense_arrs:
             default_dtype = dense_arr.dtype if isinstance(dense_arr, (NDArray, np.ndarray)) \
                             else np.float32
-            default_ctx = dense_arr.context if isinstance(dense_arr, NDArray) \
-                          else Context.default_ctx
-            check_create_from_dns(shape, f, dense_arr, dtype, default_dtype, \
-                                  mx.cpu(1), default_ctx)
+            check_create_from_dns(shape, f, dense_arr, dtype, default_dtype, ctx)
 
 def test_create_sparse_nd_from_sparse():
-    def check_create_from_sp(shape, f, sp_arr, dtype, default_dtype, ctx, default_ctx):
+    def check_create_from_sp(shape, f, sp_arr, dtype, src_dtype, ctx):
         arr = f(sp_arr, dtype=dtype, ctx=ctx)
         assert(same(arr.asnumpy(), np.ones(shape)))
         assert(arr.dtype == dtype)
         assert(arr.context == ctx)
         # verify the default dtype inferred from dense arr
         arr2 = f(sp_arr)
-        assert(arr2.dtype == default_dtype)
-        assert(arr2.context == default_ctx)
+        assert(arr2.dtype == src_dtype)
+        assert(arr2.context == Context.default_ctx)
+
     shape = rand_shape_2d()
+    src_dtype = np.float64
     dtype = np.int32
-    csr_arrs = [mx.nd.ones(shape, dtype='float64').tostype('csr')]
-    rsp_arrs = [mx.nd.ones(shape, dtype='float64').tostype('row_sparse')]
+    ctx = mx.cpu(1)
+    ones = mx.nd.ones(shape, dtype=src_dtype)
+    csr_arrs = [ones.tostype('csr')]
+    rsp_arrs = [ones.tostype('row_sparse')]
     try:
         import scipy.sparse as spsp
-        csr_sp = spsp.csr_matrix(np.ones(shape, dtype='float64'))
+        csr_sp = spsp.csr_matrix(np.ones(shape, dtype=src_dtype))
         csr_arrs.append(csr_sp)
     except ImportError:
         print("Could not import scipy.sparse. Skipping unit tests for scipy csr creation")
+    f_csr = mx.nd.sparse.csr_matrix
+    f_rsp = mx.nd.sparse.row_sparse_array
     for sp_arr in csr_arrs:
-        default_ctx = sp_arr.context if isinstance(sp_arr, NDArray) else Context.default_ctx
-        check_create_from_sp(shape, mx.nd.sparse.csr_matrix, sp_arr, dtype, sp_arr.dtype, \
-                             mx.cpu(1), default_ctx)
+        check_create_from_sp(shape, f_csr, sp_arr, dtype, src_dtype, ctx)
     for sp_arr in rsp_arrs:
-        default_ctx = sp_arr.context if isinstance(sp_arr, NDArray) else Context.default_ctx
-        check_create_from_sp(shape, mx.nd.sparse.row_sparse_array, sp_arr, dtype, \
-                             sp_arr.dtype, mx.cpu(1), default_ctx)
+        check_create_from_sp(shape, f_rsp, sp_arr, dtype, src_dtype, ctx)
 
 def test_create_sparse_nd_empty():
     def check_empty(shape, stype):

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -581,6 +581,7 @@ def test_create_sparse_nd_from_dense():
         arr = f(dense_arr, dtype=dtype, ctx=ctx)
         assert(same(arr.asnumpy(), np.ones(shape)))
         assert(arr.dtype == dtype)
+        assert(arr.context == ctx)
         # verify the default dtype inferred from dense arr
         arr2 = f(dense_arr)
         assert(arr2.dtype == default_dtype)

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -510,7 +510,6 @@ def test_create_csr():
     dim0 = 20
     dim1 = 20
     densities = [0, 0.5]
-    densities = [0]
     dtype = np.float64
     for density in densities:
         shape = rand_shape_2d(dim0, dim1)


### PR DESCRIPTION
## Description ##
csr_matrix(source) always creates a new CSRNDArray with dtype=float32 instead of using source.dtype, which is not consistent with scipy.sparse.csr_matrix 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Intersting edge cases to note here
