### PR TITLE
Sparse operator performance improvement

### DIFF
--- a/src/operator/tensor/elemwise_binary_op.h
+++ b/src/operator/tensor/elemwise_binary_op.h
@@ -86,14 +86,37 @@ class ElemwiseBinaryOp : public OpBase {
   };
 
   /*! \brief Fill contiguous dense output rows with value computed from 0 lhs and 0 rhs input */
-  template<typename xpu, typename DType, typename OP>
-  static inline size_t FillDense(mshadow::Stream<xpu> *s,
+//  template<typename DType, typename OP>
+//  static inline size_t FillDense(mshadow::Stream<gpu> *s,
+//                                 const size_t idx_l,
+//                                 const size_t idx_r,
+//                                 const OpReqType req,
+//                                 mshadow::Tensor<gpu, 2, DType> *out,
+//                                 const size_t iter_out) {
+//    using namespace mshadow::expr;
+//    const int index_out_min = std::min(idx_l, idx_r);
+//    if (static_cast<size_t>(index_out_min) > iter_out) {
+//      const size_t size = (*out)[iter_out].shape_.Size();
+//      const DType zero_input_val = OP::Map(DType(0), DType(0));
+//      #pragma omp parallel for
+//      for (int i = iter_out; i < index_out_min; ++i) {
+//        MXNET_ASSIGN_REQ_SWITCH(req, Req, {
+//          mxnet_op::Kernel<SetToScalar<Req>, gpu>::Launch(s, size, (*out)[i].dptr_,
+//                                                          zero_input_val);
+//        });
+//      }
+//    }
+//    return index_out_min;
+//  }
+
+  /*! \brief Fill contiguous dense output rows with value computed from 0 lhs and 0 rhs input */
+  template<typename DType, typename OP>
+  static inline size_t FillDense(mshadow::Stream<cpu> *s,
                                  const size_t idx_l,
                                  const size_t idx_r,
                                  const OpReqType req,
-                                 mshadow::Tensor<xpu, 2, DType> *out,
+                                 mshadow::Tensor<cpu, 2, DType> *out,
                                  const size_t iter_out) {
-    using namespace mshadow::expr;
     const int index_out_min = std::min(idx_l, idx_r);
     if (static_cast<size_t>(index_out_min) > iter_out) {
       const size_t size = (*out)[iter_out].shape_.Size();
@@ -101,8 +124,7 @@ class ElemwiseBinaryOp : public OpBase {
       #pragma omp parallel for
       for (int i = iter_out; i < index_out_min; ++i) {
         MXNET_ASSIGN_REQ_SWITCH(req, Req, {
-          mxnet_op::Kernel<SetToScalar<Req>, xpu>::Launch(s, size, (*out)[i].dptr_,
-                                                          zero_input_val);
+          SerialLaunchCPU<SetToScalar<Req>>(s, size, (*out)[i].dptr_, zero_input_val);
         });
       }
     }

--- a/src/operator/tensor/elemwise_binary_op.h
+++ b/src/operator/tensor/elemwise_binary_op.h
@@ -85,31 +85,10 @@ class ElemwiseBinaryOp : public OpBase {
     kTempSpace
   };
 
-  /*! \brief Fill contiguous dense output rows with value computed from 0 lhs and 0 rhs input */
-//  template<typename DType, typename OP>
-//  static inline size_t FillDense(mshadow::Stream<gpu> *s,
-//                                 const size_t idx_l,
-//                                 const size_t idx_r,
-//                                 const OpReqType req,
-//                                 mshadow::Tensor<gpu, 2, DType> *out,
-//                                 const size_t iter_out) {
-//    using namespace mshadow::expr;
-//    const int index_out_min = std::min(idx_l, idx_r);
-//    if (static_cast<size_t>(index_out_min) > iter_out) {
-//      const size_t size = (*out)[iter_out].shape_.Size();
-//      const DType zero_input_val = OP::Map(DType(0), DType(0));
-//      #pragma omp parallel for
-//      for (int i = iter_out; i < index_out_min; ++i) {
-//        MXNET_ASSIGN_REQ_SWITCH(req, Req, {
-//          mxnet_op::Kernel<SetToScalar<Req>, gpu>::Launch(s, size, (*out)[i].dptr_,
-//                                                          zero_input_val);
-//        });
-//      }
-//    }
-//    return index_out_min;
-//  }
-
-  /*! \brief Fill contiguous dense output rows with value computed from 0 lhs and 0 rhs input */
+  /*!
+   * \brief Fill contiguous dense output rows with value computed from 0 lhs and 0 rhs input
+   *        CPU-Only version
+   */
   template<typename DType, typename OP>
   static inline size_t FillDense(mshadow::Stream<cpu> *s,
                                  const size_t idx_l,

--- a/src/operator/tensor/elemwise_binary_scalar_op.h
+++ b/src/operator/tensor/elemwise_binary_scalar_op.h
@@ -141,8 +141,8 @@ class BinaryScalarOp : public UnaryOp {
     const size_t item_count = column_indexes.Size();
 
     // Pre-fill dense with 0-input/output value
-    FillDense<cpu, DType>(stream, output.shape().Size(), dense_fill_val,
-                          req, output.data().dptr<DType>());
+    FillDense<DType>(stream, output.shape().Size(), dense_fill_val,
+                     req, output.data().dptr<DType>());
 
     mshadow::Tensor<cpu, 2, DType> out = AsRowise2D<DType>(stream, output.data());
     if (item_count) {


### PR DESCRIPTION
## Description ##

Fix for reported long-running unit test:
  test_module.test_factorization_module.py

Don't use OMP for some simple sparse-specific operations, since the OMP overhead dramatically reduces performance, even under relatively dense conditions, such as the referenced unit test above.

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated.
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Intersting edge cases to note here
