### PR TITLE
rename and restructure model zoo models

### DIFF
--- a/python/mxnet/gluon/model_zoo/vision/alexnet.py
+++ b/python/mxnet/gluon/model_zoo/vision/alexnet.py
@@ -52,18 +52,16 @@ class AlexNet(HybridBlock):
                                             activation='relu'))
                 self.features.add(nn.MaxPool2D(pool_size=3, strides=2))
                 self.features.add(nn.Flatten())
+                self.features.add(nn.Dense(4096, activation='relu'))
+                self.features.add(nn.Dropout(0.5))
+                self.features.add(nn.Dense(4096, activation='relu'))
+                self.features.add(nn.Dropout(0.5))
 
-            self.classifier = nn.HybridSequential(prefix='')
-            with self.classifier.name_scope():
-                self.classifier.add(nn.Dense(4096, activation='relu'))
-                self.classifier.add(nn.Dropout(0.5))
-                self.classifier.add(nn.Dense(4096, activation='relu'))
-                self.classifier.add(nn.Dropout(0.5))
-                self.classifier.add(nn.Dense(classes))
+            self.output = nn.Dense(classes)
 
     def hybrid_forward(self, F, x):
         x = self.features(x)
-        x = self.classifier(x)
+        x = self.output(x)
         return x
 
 # Constructor

--- a/python/mxnet/gluon/model_zoo/vision/densenet.py
+++ b/python/mxnet/gluon/model_zoo/vision/densenet.py
@@ -103,11 +103,11 @@ class DenseNet(HybridBlock):
             self.features.add(nn.AvgPool2D(pool_size=7))
             self.features.add(nn.Flatten())
 
-            self.classifier = nn.Dense(classes)
+            self.output = nn.Dense(classes)
 
     def hybrid_forward(self, F, x):
         x = self.features(x)
-        x = self.classifier(x)
+        x = self.output(x)
         return x
 
 

--- a/python/mxnet/gluon/model_zoo/vision/inception.py
+++ b/python/mxnet/gluon/model_zoo/vision/inception.py
@@ -182,18 +182,17 @@ class Inception3(HybridBlock):
             self.features.add(_make_C(160, 'C2_'))
             self.features.add(_make_C(160, 'C3_'))
             self.features.add(_make_C(192, 'C4_'))
+            self.features.add(_make_D('D_'))
+            self.features.add(_make_E('E1_'))
+            self.features.add(_make_E('E2_'))
+            self.features.add(nn.AvgPool2D(pool_size=8))
+            self.features.add(nn.Dropout(0.5))
 
-            self.classifier = nn.HybridSequential(prefix='')
-            self.classifier.add(_make_D('D_'))
-            self.classifier.add(_make_E('E1_'))
-            self.classifier.add(_make_E('E2_'))
-            self.classifier.add(nn.AvgPool2D(pool_size=8))
-            self.classifier.add(nn.Dropout(0.5))
-            self.classifier.add(nn.Dense(classes))
+            self.output = nn.Dense(classes)
 
     def hybrid_forward(self, F, x):
         x = self.features(x)
-        x = self.classifier(x)
+        x = self.output(x)
         return x
 
 # Constructor

--- a/python/mxnet/gluon/model_zoo/vision/mobilenet.py
+++ b/python/mxnet/gluon/model_zoo/vision/mobilenet.py
@@ -65,13 +65,11 @@ class MobileNet(HybridBlock):
                 self.features.add(nn.GlobalAvgPool2D())
                 self.features.add(nn.Flatten())
 
-            self.classifier = nn.HybridSequential(prefix='')
-            with self.classifier.name_scope():
-                self.classifier.add(nn.Dense(classes))
+            self.output = nn.Dense(classes)
 
     def hybrid_forward(self, F, x):
         x = self.features(x)
-        x = self.classifier(x)
+        x = self.output(x)
         return x
 
 # Constructor

--- a/python/mxnet/gluon/model_zoo/vision/resnet.py
+++ b/python/mxnet/gluon/model_zoo/vision/resnet.py
@@ -261,10 +261,9 @@ class ResNetV1(HybridBlock):
                 stride = 1 if i == 0 else 2
                 self.features.add(self._make_layer(block, num_layer, channels[i+1],
                                                    stride, i+1, in_channels=channels[i]))
+            self.features.add(nn.GlobalAvgPool2D())
 
-            self.classifier = nn.HybridSequential(prefix='')
-            self.classifier.add(nn.GlobalAvgPool2D())
-            self.classifier.add(nn.Dense(classes, in_units=channels[-1]))
+            self.output = nn.Dense(classes, in_units=channels[-1])
 
     def _make_layer(self, block, layers, channels, stride, stage_index, in_channels=0):
         layer = nn.HybridSequential(prefix='stage%d_'%stage_index)
@@ -277,7 +276,7 @@ class ResNetV1(HybridBlock):
 
     def hybrid_forward(self, F, x):
         x = self.features(x)
-        x = self.classifier(x)
+        x = self.output(x)
 
         return x
 

--- a/python/mxnet/gluon/model_zoo/vision/squeezenet.py
+++ b/python/mxnet/gluon/model_zoo/vision/squeezenet.py
@@ -93,17 +93,17 @@ class SqueezeNet(HybridBlock):
                 self.features.add(_make_fire(48, 192, 192))
                 self.features.add(_make_fire(64, 256, 256))
                 self.features.add(_make_fire(64, 256, 256))
+            self.features.add(nn.Dropout(0.5))
 
-            self.classifier = nn.HybridSequential(prefix='')
-            self.classifier.add(nn.Dropout(0.5))
-            self.classifier.add(nn.Conv2D(classes, kernel_size=1))
-            self.classifier.add(nn.Activation('relu'))
-            self.classifier.add(nn.AvgPool2D(13))
-            self.classifier.add(nn.Flatten())
+            self.output = nn.HybridSequential(prefix='')
+            self.output.add(nn.Conv2D(classes, kernel_size=1))
+            self.output.add(nn.Activation('relu'))
+            self.output.add(nn.AvgPool2D(13))
+            self.output.add(nn.Flatten())
 
     def hybrid_forward(self, F, x):
         x = self.features(x)
-        x = self.classifier(x)
+        x = self.output(x)
         return x
 
 # Constructor

--- a/python/mxnet/gluon/model_zoo/vision/vgg.py
+++ b/python/mxnet/gluon/model_zoo/vision/vgg.py
@@ -50,18 +50,17 @@ class VGG(HybridBlock):
         assert len(layers) == len(filters)
         with self.name_scope():
             self.features = self._make_features(layers, filters, batch_norm)
-            self.classifier = nn.HybridSequential(prefix='')
-            self.classifier.add(nn.Dense(4096, activation='relu',
-                                         weight_initializer='normal',
-                                         bias_initializer='zeros'))
-            self.classifier.add(nn.Dropout(rate=0.5))
-            self.classifier.add(nn.Dense(4096, activation='relu',
-                                         weight_initializer='normal',
-                                         bias_initializer='zeros'))
-            self.classifier.add(nn.Dropout(rate=0.5))
-            self.classifier.add(nn.Dense(classes,
-                                         weight_initializer='normal',
-                                         bias_initializer='zeros'))
+            self.features.add(nn.Dense(4096, activation='relu',
+                                       weight_initializer='normal',
+                                       bias_initializer='zeros'))
+            self.features.add(nn.Dropout(rate=0.5))
+            self.features.add(nn.Dense(4096, activation='relu',
+                                       weight_initializer='normal',
+                                       bias_initializer='zeros'))
+            self.features.add(nn.Dropout(rate=0.5))
+            self.output = nn.Dense(classes,
+                                   weight_initializer='normal',
+                                   bias_initializer='zeros')
 
     def _make_features(self, layers, filters, batch_norm):
         featurizer = nn.HybridSequential(prefix='')
@@ -80,7 +79,7 @@ class VGG(HybridBlock):
 
     def hybrid_forward(self, F, x):
         x = self.features(x)
-        x = self.classifier(x)
+        x = self.output(x)
         return x
 
 


### PR DESCRIPTION
## Description ##
Rename `.classifier` to `.output` and keep only the last dense or conv layer in `.output`.
@mli 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Rename `.classifier` to `.output`
- [x] Move extra layers that were in `.classifier` to `.features`.

## Comments ##
- This change is to make the division of `features` and `output` consistent across different networks. `classifier` is renamed to `output` because the network doesn't necessarily perform classification.
- I've tested locally that the pre-trained weights can still be loaded for all models after the change.
