### PR TITLE
Fix arange bug on ARM

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2555,6 +2555,7 @@ def test_init():
                        (0, 10),
                        (5, 100, 4),
                        (50, -50, -2),
+                       (-100, 100, 1),
                        (1.3, 456.6, 1.3)]
         for dtype in dtype_list:
             for config in config_list:


### PR DESCRIPTION
## Description ##
This PR provides consistent behaviour for the arange operator between ARM and x86 devices.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Fixes edge cases when running arange on ARM.  These cases were failing the test_arange test.  The problem was routed in the fact that converting from floats to unsigned in C++ happens differently on different platforms.  ARM for example initializes the resulting unsigned data structure to 0, whereas x86 initializes it to the two's complement representation of the negative value.  Numpy uses the two's complement form both on x86 and ARM.  To maintain compatibility with Numpy, and consistency across devices I've changed our implementation to first cast to signed, then unsigned types.  This forces 2's complement form on both architectures.

Tracked this one down together with @larroy.  