### PR TITLE
add default hash to ndarray

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -286,6 +286,10 @@ fixed-size items.
         """x.__eq__(y) <=> x==y <=> mx.nd.equal(x, y) """
         return equal(self, other)
 
+    def __hash__(self):
+        """Default hash function."""
+        return id(self)//16
+
     def __ne__(self, other):
         """x.__ne__(y) <=> x!=y <=> mx.nd.not_equal(x, y) """
         return not_equal(self, other)


### PR DESCRIPTION
## Description ##
Define `__hash__` for NDArray for consistent py2 py3 behavior. The included hash function is the default in python2.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add `__hash__` to `NDArray`