### PR TITLE
Passing user specified environment variables when using launch.py

### DIFF
--- a/tools/launch.py
+++ b/tools/launch.py
@@ -64,6 +64,9 @@ def main():
     parser.add_argument('--launcher', type=str, default='ssh',
                         choices = ['local', 'ssh', 'mpi', 'sge', 'yarn'],
                         help = 'the launcher to use')
+    parser.add_argument('--pass-env', type=str, default='',
+                        help = 'given a comma separated list of environment \
+                        variables, passes their values while launching job')
     parser.add_argument('command', nargs='+',
                         help = 'command for launching the program')
     args, unknown = parser.parse_known_args()

--- a/tools/launch.py
+++ b/tools/launch.py
@@ -35,7 +35,8 @@ def dmlc_opts(opts):
             '--num-servers', str(opts.num_servers),
             '--cluster', opts.launcher,
             '--host-file', opts.hostfile,
-            '--sync-dst-dir', opts.sync_dst_dir]
+            '--sync-dst-dir', opts.sync_dst_dir,
+            '--pass-env', opts.pass_env]
     args += opts.command;
     try:
         from dmlc_tracker import opts


### PR DESCRIPTION
## Description ##
Passes additional user specific environment variables when using launch.py. This is very helpful in passing variables like PYTHONPATH, MXNET_ENGINE_TYPE. I think this makes launching jobs for distributed training easier. 

If you have suggestions for a different name, please let me know.
The current usage is ```--pass-env A,B,C```.

Requires this PR in dmlc-core to be merged https://github.com/dmlc/dmlc-core/pull/324

Provides a way to solve this issue apache/incubator-mxnet#7857

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add additional arg in launch.py
- [x] Make dmlc_tracker submit function to accept this variable

## Comments ##
- I've only tested this with local and ssh. Not tested this with yarn, mpi, sge since I don't have those environments set up. But I think this should work even in those environments. Or should I remove them and only support local and ssh?
