### PR TITLE
Correct Initialization Description in Finetune Tutorial.

### DIFF
--- a/docs/faq/finetune.md
+++ b/docs/faq/finetune.md
@@ -145,8 +145,8 @@ def get_fine_tune_model(symbol, arg_params, num_classes, layer_name='flatten0'):
     return (net, new_args)
 ```
 
-Now we create a module. We first call `init_params` to randomly initialize parameters, next use `set_params` to replace all parameters except for the last fully-connected layer with pretrained model.
-
+Now we create a module. Note we pass the existing parameters from the loaded model via the `arg_params` argument.
+The parameters of the last fully-connected layer will be randomly initialized by the `initializer`.
 
 ```python
 import logging


### PR DESCRIPTION
## Description ##
The current description of this step references calls to `init_params` and `set_params`, but the code does not reflect this.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Update Finetune Tutorial
