### PR TITLE
Tweak a markdown list in note_engine.md

### DIFF
--- a/docs/architecture/note_engine.md
+++ b/docs/architecture/note_engine.md
@@ -274,7 +274,7 @@ most existing code can be scheduled by the dependency engine in two steps:
 
 
 1. Allocate the variable tags associated with resources like memory blob, PRNGS.
-	- Call `push` with the execution function as the original code to execute, and put the variable tags of
+2. Call `push` with the execution function as the original code to execute, and put the variable tags of
   corresponding resources correctly in `read_vars` and `mutate_vars`.
 
 ## Implementing the Generic Dependency Engine


### PR DESCRIPTION
This is a minor change to the markdown to make the "two step" list into a numbered list.


