### PR TITLE
Fix pip-test,  libgfortran3 installation needs flag '-y'

### DIFF
--- a/tests/ci_build/pip_tests/Dockerfile.pip_dependencies
+++ b/tests/ci_build/pip_tests/Dockerfile.pip_dependencies
@@ -8,7 +8,7 @@ RUN apt-get install -y python python2.7 python3.4 python3.5 python3.6
 
 # install other dependencies
 RUN apt-get install -y wget git unzip gcc
-RUN apt-get install libgfortran3
+RUN apt-get install -y libgfortran3
 
 # install virtualenv
 RUN wget https://bootstrap.pypa.io/get-pip.py && python get-pip.py && pip install virtualenv && rm -rf get-pip.py


### PR DESCRIPTION
## Description ##
This is a fix to a previous PR by me where I added a step to pip-test to instal libgfortran3. 
Though this ran fine for a while, it now started failing because it needed a runtime 'yes'. This PR adds the flag -y

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Added flag -y to libgfortran3 installation

