### PR TITLE
rename output layer of resnet

### DIFF
--- a/python/mxnet/gluon/model_zoo/vision/resnet.py
+++ b/python/mxnet/gluon/model_zoo/vision/resnet.py
@@ -320,13 +320,12 @@ class ResNetV2(HybridBlock):
                 self.features.add(self._make_layer(block, num_layer, channels[i+1],
                                                    stride, i+1, in_channels=in_channels))
                 in_channels = channels[i+1]
+            self.features.add(nn.BatchNorm())
+            self.features.add(nn.Activation('relu'))
+            self.features.add(nn.GlobalAvgPool2D())
+            self.features.add(nn.Flatten())
 
-            self.classifier = nn.HybridSequential(prefix='')
-            self.classifier.add(nn.BatchNorm())
-            self.classifier.add(nn.Activation('relu'))
-            self.classifier.add(nn.GlobalAvgPool2D())
-            self.classifier.add(nn.Flatten())
-            self.classifier.add(nn.Dense(classes, in_units=in_channels))
+            self.output = nn.Dense(classes, in_units=in_channels)
 
     def _make_layer(self, block, layers, channels, stride, stage_index, in_channels=0):
         layer = nn.HybridSequential(prefix='stage%d_'%stage_index)
@@ -339,7 +338,7 @@ class ResNetV2(HybridBlock):
 
     def hybrid_forward(self, F, x):
         x = self.features(x)
-        x = self.classifier(x)
+        x = self.output(x)
         return x
 
 


### PR DESCRIPTION
## Description ##
This is a missed change from #8446

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- reorganize and rename output layer of resnetv2