### PR TITLE
Revised validating process of a bounding box in ImageDetIter

### DIFF
--- a/python/mxnet/image/detection.py
+++ b/python/mxnet/image/detection.py
@@ -726,10 +726,20 @@ class ImageDetIter(ImageIter):
                 %(str(raw.shape), obj_width)
             raise RuntimeError(msg)
         out = np.reshape(raw[header_width:], (-1, obj_width))
-        # remove bad ground-truths
-        valid = np.where(np.logical_and(out[:, 3] > out[:, 1], out[:, 4] > out[:, 2]))[0]
+
+        # remove invalid ground-truths
+        if ((obj_width - 1) / 4) == 1:  # If only two points were given
+            valid = np.where(np.logical_and(out[:, 3] > out[:, 1], out[:, 4] > out[:, 2]))[0]  # x1 > x0 and y1 > y0
+        elif ((obj_width - 1) / 4) == 2:  # Else if four points were given
+            check_x = np.logical_and(out[:, 3] > out[:, 1], out[:, 5] > out[:, 7])  # x1 > x0 and x2 > x3
+            check_y = np.logical_and(out[:, 6] > out[:, 4], out[:, 8] > out[:, 2])  # y2 > y1 and y3 > y0
+            valid = np.where(np.logical_and(check_x, check_y))[0]
+        else:  # If incorrect number of label was given
+            raise RuntimeError('Object width is not valid.')
+
         if valid.size < 1:
             raise RuntimeError('Encounter sample with no valid label.')
+
         return out[valid, :]
 
     def reshape(self, data_shape=None, label_shape=None):


### PR DESCRIPTION
## Description ##
The previous ImageDetIter validated a bounding box with two points only (left-top and right-bottom points). Many other datasets provides a bounding box label with four points (left-top, left-bottom, right-top, right-bottom). 

The new validating process of the bounding box in the ImageDetIter looks at the number of points given and validate appropriately. 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change