### PR TITLE
csr ndarray iter with shuffle

### DIFF
--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -35,6 +35,7 @@ from .base import mx_real_t
 from .base import check_call, build_param_doc as _build_param_doc
 from .ndarray import NDArray
 from .ndarray.sparse import CSRNDArray
+from .ndarray.sparse import array as sparse_array
 from .ndarray import _ndarray_cls
 from .ndarray import array
 from .ndarray import concatenate
@@ -592,8 +593,8 @@ class NDArrayIter(DataIter):
     >>> label = {'label1':np.zeros(shape=(10,1)), 'label2':np.zeros(shape=(20,1))}
     >>> dataiter = mx.io.NDArrayIter(data, label, 3, True, last_batch_handle='discard')
 
-    `NDArrayIter` also supports ``mx.nd.sparse.CSRNDArray`` with `shuffle` set to `False`
-    and `last_batch_handle` set to `discard`.
+    `NDArrayIter` also supports ``mx.nd.sparse.CSRNDArray``
+    with `last_batch_handle` set to `discard`.
 
     >>> csr_data = mx.nd.array(np.arange(40).reshape((10,4))).tostype('csr')
     >>> labels = np.ones([10, 1])
@@ -630,10 +631,9 @@ class NDArrayIter(DataIter):
         super(NDArrayIter, self).__init__(batch_size)
 
         if ((_has_instance(data, CSRNDArray) or _has_instance(label, CSRNDArray)) and
-                (shuffle or last_batch_handle != 'discard')):
+                (last_batch_handle != 'discard')):
             raise NotImplementedError("`NDArrayIter` only supports ``CSRNDArray``" \
-                                      " with `shuffle` set to `False`" \
-                                      " and `last_batch_handle` set to `discard`.")
+                                      " with `last_batch_handle` set to `discard`.")
         self.data = _init_data(data, allow_empty=False, default_name=data_name)
         self.label = _init_data(label, allow_empty=True, default_name=label_name)
 
@@ -641,11 +641,15 @@ class NDArrayIter(DataIter):
         # shuffle data
         if shuffle:
             np.random.shuffle(self.idx)
-            self.data = [(k, array(v.asnumpy()[self.idx], v.context))
+            self.data = [(k, sparse_array(v.asscipy()[self.idx], v.context)
+                          if isinstance(v, CSRNDArray)
+                          else array(v.asnumpy()[self.idx], v.context))
                          if not (isinstance(v, h5py.Dataset)
                                  if h5py else False) else (k, v)
                          for k, v in self.data]
-            self.label = [(k, array(v.asnumpy()[self.idx], v.context))
+            self.label = [(k, sparse_array(v.asscipy()[self.idx], v.context)
+                           if isinstance(v, CSRNDArray)
+                           else array(v.asnumpy()[self.idx], v.context))
                           if not (isinstance(v, h5py.Dataset)
                                   if h5py else False) else (k, v)
                           for k, v in self.label]

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -161,13 +161,23 @@ def test_NDArrayIter_csr():
     shape = (num_rows, num_cols)
     csr, _ = rand_sparse_ndarray(shape, 'csr')
     dns = csr.asnumpy()
-    #test CSRNDArray with shuffle=True will throw NotImplementedError 
+
+    # CSRNDArray with last_batch_handle not equal to 'discard' will throw NotImplementedError 
     try:
-        csr_iter = mx.io.NDArrayIter({'data': csr}, dns, batch_size, shuffle=True,
-                                     last_batch_handle='discard')
+        csr_iter = mx.io.NDArrayIter({'data': csr}, dns, batch_size,
+                                     last_batch_handle='pad')
         assert(False)
     except NotImplementedError:
         pass
+    
+    # CSRNDArray with shuffle
+    csr_iter = iter(mx.io.NDArrayIter({'csr_data': csr, 'dns_data': dns}, dns, batch_size,
+                    shuffle=True, last_batch_handle='discard'))
+    num_batch = 0
+    for batch in csr_iter:
+        num_batch += 1
+
+    assert(num_batch == num_rows / batch_size)
 
     # make iterators
     csr_iter = iter(mx.io.NDArrayIter(csr, csr, batch_size, last_batch_handle='discard'))

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -27,7 +27,7 @@ try:
 except ImportError:
     h5py = None
 import sys
-from common import get_data
+from common import get_data, assertRaises
 import unittest
 
 
@@ -163,12 +163,8 @@ def test_NDArrayIter_csr():
     dns = csr.asnumpy()
 
     # CSRNDArray with last_batch_handle not equal to 'discard' will throw NotImplementedError 
-    try:
-        csr_iter = mx.io.NDArrayIter({'data': csr}, dns, batch_size,
-                                     last_batch_handle='pad')
-        assert(False)
-    except NotImplementedError:
-        pass
+    assertRaises(NotImplementedError, mx.io.NDArrayIter, {'data': csr}, dns, batch_size,
+                 last_batch_handle='pad')
     
     # CSRNDArray with shuffle
     csr_iter = iter(mx.io.NDArrayIter({'csr_data': csr, 'dns_data': dns}, dns, batch_size,
@@ -177,7 +173,7 @@ def test_NDArrayIter_csr():
     for batch in csr_iter:
         num_batch += 1
 
-    assert(num_batch == num_rows / batch_size)
+    assert(num_batch == num_rows // batch_size)
 
     # make iterators
     csr_iter = iter(mx.io.NDArrayIter(csr, csr, batch_size, last_batch_handle='discard'))


### PR DESCRIPTION
## Description ##
support `NDArrayIter` for `CSRNDArray` with `shuffle=True`.

As a feature requested in https://github.com/apache/incubator-mxnet/issues/8168.

cc @eric-haibin-lin 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] unittest

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Intersting edge cases to note here
