### PR TITLE
Disable long running tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ echo ${libs} | sed -e 's/,/ /g' | xargs md5sum
 def python2_ut(docker_type) {
   timeout(time: max_time, unit: 'MINUTES') {
     sh "${docker_run} ${docker_type} find . -name '*.pyc' -type f -delete"
-    sh "${docker_run} ${docker_type} PYTHONPATH=./python/ nosetests-2.7 --with-timer --verbose tests/python/unittest"
+    sh "${docker_run} ${docker_type} PYTHONPATH=./python/ nosetests-2.7 --with-timer --verbose -a '!nightly,!crashing' tests/python/unittest"
     sh "${docker_run} ${docker_type} PYTHONPATH=./python/ nosetests-2.7 --with-timer --verbose tests/python/train"
   }
 }
@@ -95,7 +95,7 @@ def python2_ut(docker_type) {
 def python3_ut(docker_type) {
   timeout(time: max_time, unit: 'MINUTES') {
     sh "${docker_run} ${docker_type} find . -name '*.pyc' -type f -delete"
-    sh "${docker_run} ${docker_type} PYTHONPATH=./python/ nosetests-3.4 --with-timer --verbose tests/python/unittest"
+    sh "${docker_run} ${docker_type} PYTHONPATH=./python/ nosetests-3.4 --with-timer --verbose -a '!nightly,!crashing' tests/python/unittest"
   }
 }
 
@@ -105,7 +105,7 @@ def python3_ut(docker_type) {
 def python2_gpu_ut(docker_type) {
   timeout(time: max_time, unit: 'MINUTES') {
     sh "${docker_run} ${docker_type} find . -name '*.pyc' -type f -delete"
-    sh "${docker_run} ${docker_type} PYTHONPATH=./python/ nosetests-2.7 --with-timer --verbose tests/python/gpu"
+    sh "${docker_run} ${docker_type} PYTHONPATH=./python/ nosetests-2.7 --with-timer --verbose -a '!nightly,!crashing' tests/python/gpu"
   }
 }
 
@@ -113,7 +113,7 @@ def python2_gpu_ut(docker_type) {
 def python3_gpu_ut(docker_type) {
   timeout(time: max_time, unit: 'MINUTES') {
     sh "${docker_run} ${docker_type} find . -name '*.pyc' -type f -delete"
-    sh "${docker_run} ${docker_type} PYTHONPATH=./python/ nosetests-3.4 --with-timer --verbose tests/python/gpu"
+    sh "${docker_run} ${docker_type} PYTHONPATH=./python/ nosetests-3.4 --with-timer --verbose -a '!nightly,!crashing' tests/python/gpu"
   }
 }
 

--- a/tests/python/gpu/test_forward.py
+++ b/tests/python/gpu/test_forward.py
@@ -19,11 +19,14 @@ import os
 import numpy as np
 import mxnet as mx
 from mxnet.test_utils import *
+from nose.plugins.attrib import attr
+
 
 def _get_model():
     if not os.path.exists('model/Inception-7-symbol.json'):
         download('http://data.mxnet.io/models/imagenet/inception-v3.tar.gz', dirname='model')
         os.system("cd model; tar -xf inception-v3.tar.gz --strip-components 1")
+
 
 def _dump_images(shape):
     import skimage.io
@@ -40,10 +43,13 @@ def _dump_images(shape):
     imgs = np.asarray(img_list, dtype=np.float32).transpose((0, 3, 1, 2)) - 128
     np.save('data/test_images_%d_%d.npy'%shape, imgs)
 
+
 def _get_data(shape):
     download("http://data.mxnet.io/data/test_images_%d_%d.npy" % (shape), dirname='data')
     download("http://data.mxnet.io/data/inception-v3-dump.npz", dirname="data")
 
+
+@attr('nightly')
 def test_consistency(dump=False):
     shape = (299, 299)
     _get_model()
@@ -63,6 +69,7 @@ def test_consistency(dump=False):
                            tol=1e-3, grad_req='null', raise_on_err=False, ground_truth=gt)
     if dump:
         np.savez('data/inception-v3-dump.npz', **{n: a.asnumpy() for n, a in gt.items()})
+
 
 if __name__ == '__main__':
     test_consistency(False)

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -82,6 +82,7 @@ def check_countsketch(in_dim,out_dim,n):
                 a[j,i] = out_grad.asnumpy()[j, h[0,i]] * s[0,i]
     assert_almost_equal(a,arr_grad[0].asnumpy(),rtol=1e-3, atol=1e-12)
 
+
 def test_countsketch():
     np.random.seed(0)
     nrepeat = 2
@@ -95,6 +96,7 @@ def test_countsketch():
         out_dim = np.random.randint(minoutdim, maxoutdim)
         n = np.random.randint(1,maxn)
         check_countsketch(in_dim, out_dim, n)
+
 
 def check_ifft(shape):
     shape_old = shape
@@ -177,6 +179,7 @@ def test_ifft():
             shape = tuple(np.random.randint(1, maxdim, size=order))
             check_ifft(shape)
 
+
 def check_fft(shape):
     sym = mx.sym.contrib.fft(name='fft', compute_size = 128)
     if len(shape) == 2:
@@ -255,6 +258,7 @@ def check_fft(shape):
         a = np.fft.ifft(out_grad_complex, n=None, axis=-1, norm=None)
         assert_almost_equal(a.real, exe.grad_arrays[0].asnumpy()/shape[3],rtol=1e-3, atol=1e-6)
 
+
 def test_fft():
     np.random.seed(0)
     nrepeat = 2
@@ -263,6 +267,7 @@ def test_fft():
         for order in [2,4]:
             shape = tuple(np.random.randint(1, maxdim, size=order))
             check_fft(shape)
+
 
 def test_batchnorm_with_type():
   ctx_list_v1_2D = [
@@ -372,12 +377,14 @@ def test_batchnorm_versions():
 
     check_consistency(sym_list, ctx_list)
 
+
   def test_1d_batchnorm(fix_gamma, use_global_stats):
     data = (2, 3, 20)
     test_batchnorm_versions_helper(batchnorm_op_list=['batchnorm_cpu',
                                                       'batchnorm_gpu', 'batchnorm_cudnn'],
                                    data=data,
                                    fix_gamma=fix_gamma, use_global_stats=use_global_stats)
+
 
   def test_2d_batchnorm(fix_gamma, use_global_stats):
     data = (2, 3, 10, 10)
@@ -386,6 +393,7 @@ def test_batchnorm_versions():
                                                       'batchnorm_gpu', 'batchnorm_cudnn'],
                                    data=data,
                                    fix_gamma=fix_gamma, use_global_stats=use_global_stats)
+
 
   def test_3d_batchnorm(fix_gamma, use_global_stats):
     data = (2, 3, 3, 5, 5)
@@ -444,11 +452,13 @@ def test_convolution_with_type():
     # test ability to turn off training on bias
     check_consistency(sym, ctx_list, grad_req={'conv_data': 'write', 'conv_weight': 'write', 'conv_bias': 'null'}, tol=tol)
 
+
 # Apply N symbols against each of M contexts, checking that all NxM combinations match.
 def check_consistency_NxM(sym_list, ctx_list):
     # e.g. if sym_list=[sym1, sym2] and ctx_list=[ctx1, ctx2, ctx3], then resulting lists are:
     # sym_list=[sym1, sym1, sym1, sym2, sym2, sym2] and ctx_list=[ctx1, ctx2, ctx3, ctx1, ctx2, ctx3]
     check_consistency(np.repeat(sym_list, len(ctx_list)), ctx_list * len(sym_list))
+
 
 def test_convolution_options():
     # 1D convolution
@@ -515,6 +525,7 @@ def test_convolution_options():
     sym_no_cudnn = mx.sym.Convolution(num_filter=3, kernel=(1,1,1), pad=(0,0,0), cudnn_off=True, name='conv')
     check_consistency_NxM([sym, sym_no_cudnn], ctx_list)
 
+
 def test_convolution_versions():
     # 2D convolution NCHW
     ctx_list = [{'ctx': mx.cpu(0), 'conv_data': (2, 2, 7, 7), 'type_dict': {'conv_data': np.float32}},
@@ -540,6 +551,7 @@ def test_convolution_versions():
     syms = [conv_cudnn, conv_cpu, conv_gpu]
     check_consistency(syms, ctx_list)
 
+
 def test_pooling_with_type():
     ctx_list = [{'ctx': mx.gpu(0), 'pool_data': (2, 2, 10, 10), 'type_dict': {'pool_data': np.float64}},
                 {'ctx': mx.gpu(0), 'pool_data': (2, 2, 10, 10), 'type_dict': {'pool_data': np.float32}},
@@ -554,6 +566,7 @@ def test_pooling_with_type():
 
     sym = mx.sym.Pooling(kernel=(300,300), pool_type='max', global_pool=True, name='pool')
     check_consistency(sym, ctx_list)
+
 
 def test_deconvolution_with_type():
     sym = mx.sym.Deconvolution(num_filter=2, kernel=(3,3), name='deconv')
@@ -570,6 +583,7 @@ def test_deconvolution_with_type():
                np.dtype(np.int32): 0}
     check_consistency(sym, ctx_list, tol=tol)
     check_consistency(sym, ctx_list, tol=tol, grad_req="add")
+
 
 def test_deconvolution_options():
 
@@ -611,6 +625,7 @@ def test_deconvolution_options():
     sym_no_cudnn = mx.sym.Deconvolution(num_filter=2, kernel=(3,3), dilate=(2,2), cudnn_off=True, name='deconv')
     check_consistency_NxM([sym, sym_no_cudnn], ctx_list)
 
+
 #    # 3D convolution (not yet enabled)
 #    ctx_list = [{'ctx': mx.cpu(0), 'conv_data': (2, 2, 5, 7, 7), 'type_dict': {'conv_data': np.float64}},
 #                {'ctx': mx.cpu(0), 'conv_data': (2, 2, 5, 7, 7), 'type_dict': {'conv_data': np.float64}},
@@ -643,6 +658,7 @@ def test_bilinear_sampler_with_type():
     check_consistency(sym, ctx_list)
     check_consistency(sym, ctx_list, grad_req="add")
 
+
 def test_grid_generator_with_type():
     data = mx.sym.Variable('data')
     sym = mx.sym.GridGenerator(data=data, transform_type='affine', target_shape=(20, 20))
@@ -655,6 +671,7 @@ def test_grid_generator_with_type():
                 {'ctx': mx.cpu(0), 'data': (3, 2, 20, 20), 'type_dict': {'data': np.float32}}]
     check_consistency(sym, ctx_list)
     check_consistency(sym, ctx_list, grad_req="add")
+
 
 @unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/7645")
 def test_spatial_transformer_with_type():
@@ -670,6 +687,7 @@ def test_spatial_transformer_with_type():
                 {'ctx': mx.cpu(0), 'data': (1, 5, 10, 10), 'type_dict': {'data': np.float32}}]
     check_consistency(sym, ctx_list)
     check_consistency(sym, ctx_list, grad_req="add")
+
 
 # Checking max pooling consistency over the data sets of different float types is problematic
 # as one max value in a float32 data set may not be the max value in a float16 data set.
@@ -745,6 +763,7 @@ def test_pooling_versions():
                                                name='pool'))
         check_consistency(sym_list, ctx_list)
 
+
     def test_1d_pooling(pool_type):
         data = (2, 3, 20)
         kernel = (4,)
@@ -775,6 +794,7 @@ def test_pooling_versions():
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
                                      global_pool=True)
+
 
     def test_2d_pooling(pool_type):
         data = (2, 3, 20, 20)
@@ -1139,6 +1159,7 @@ def test_bidirectional():
     check_rnn_consistency(fused, stack)
     check_rnn_consistency(stack, fused)
 
+
 def test_unfuse():
     for mode in ['rnn_tanh', 'rnn_relu', 'lstm', 'gru']:
         fused = mx.rnn.FusedRNNCell(
@@ -1151,6 +1172,7 @@ def test_unfuse():
 
         check_rnn_consistency(fused, stack)
         check_rnn_consistency(stack, fused)
+
 
 def test_psroipooling_with_type():
     np.random.seed(1234)
@@ -1208,6 +1230,7 @@ def test_deformable_psroipooling_with_type():
     check_consistency(sym, ctx_list, grad_req={'deformable_psroipool_data': 'write',
                                                'deformable_psroipool_rois': 'null',
                                                'deformable_psroipool_trans': 'write'}, arg_params=arg_params)
+
 
 def test_deformable_convolution_with_type():
     np.random.seed(1234)
@@ -1313,6 +1336,9 @@ def test_deformable_convolution_options():
     sym = mx.sym.contrib.DeformableConvolution(num_filter=4, kernel=(3,3), num_deformable_group=2,
                                                name='deformable_conv')
 
+
+# Test crashing, see: https://github.com/apache/incubator-mxnet/issues/8564
+@attr('crashing')
 def test_residual_fused():
     cell = mx.rnn.ResidualCell(
             mx.rnn.FusedRNNCell(50, num_layers=3, mode='lstm',
@@ -1331,6 +1357,7 @@ def test_residual_fused():
                            rnn_parameters=mx.nd.zeros((61200,), ctx=mx.gpu(0)))
     expected_outputs = np.ones((10, 2, 50))+5
     assert np.array_equal(outputs[0].asnumpy(), expected_outputs)
+
 
 def check_rnn_layer(layer):
     layer.collect_params().initialize(ctx=[mx.cpu(0), mx.gpu(0)])
@@ -1361,6 +1388,7 @@ def test_rnn_layer():
 def test_sequence_reverse():
     check_sequence_reverse(mx.gpu(0))
 
+
 @unittest.skip("Test fails intermittently. Temporarily disabled until fixed. Tracked at https://github.com/apache/incubator-mxnet/issues/8211")
 def test_autograd_save_memory():
     x = mx.nd.zeros((128, 512, 512), ctx=mx.gpu(0))
@@ -1371,6 +1399,7 @@ def test_autograd_save_memory():
             x = x + 1
             x.wait_to_read()
     x.backward()
+
 
 def test_gluon_ctc_consistency():
     loss = mx.gluon.loss.CTCLoss()

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -20,6 +20,8 @@ import tarfile
 import mxnet as mx
 import numpy as np
 from mxnet import gluon
+from nose.plugins.attrib import attr
+
 
 def test_array_dataset():
     X = np.random.uniform(size=(10, 20))
@@ -57,6 +59,7 @@ def test_recordimage_dataset():
         assert x.shape[0] == 1 and x.shape[3] == 3
         assert y.asscalar() == i
 
+
 def test_sampler():
     seq_sampler = gluon.data.SequentialSampler(10)
     assert list(seq_sampler) == list(range(10))
@@ -69,6 +72,8 @@ def test_sampler():
     rand_batch_keep = gluon.data.BatchSampler(rand_sampler, 3, 'keep')
     assert sorted(sum(list(rand_batch_keep), [])) == list(range(10))
 
+
+@attr('nightly')
 def test_datasets():
     assert len(gluon.data.vision.MNIST(root='data/mnist')) == 60000
     assert len(gluon.data.vision.MNIST(root='data/mnist', train=False)) == 10000
@@ -79,6 +84,7 @@ def test_datasets():
     assert len(gluon.data.vision.CIFAR100(root='data/cifar100')) == 50000
     assert len(gluon.data.vision.CIFAR100(root='data/cifar100', fine_label=True)) == 50000
     assert len(gluon.data.vision.CIFAR100(root='data/cifar100', train=False)) == 10000
+
 
 def test_image_folder_dataset():
     prepare_record()

--- a/tests/python/unittest/test_gluon_model_zoo.py
+++ b/tests/python/unittest/test_gluon_model_zoo.py
@@ -20,6 +20,7 @@ import mxnet as mx
 from mxnet.gluon import nn
 from mxnet.gluon.model_zoo.custom_layers import HybridConcurrent, Identity
 from mxnet.gluon.model_zoo.vision import get_model
+from nose.plugins.attrib import attr
 import sys
 
 def eprint(*args, **kwargs):
@@ -50,6 +51,7 @@ def test_identity():
                                       x.asnumpy())
 
 
+@attr('nightly')
 def test_models():
     all_models = ['resnet18_v1', 'resnet34_v1', 'resnet50_v1', 'resnet101_v1', 'resnet152_v1',
                   'resnet18_v2', 'resnet34_v2', 'resnet50_v2', 'resnet101_v2', 'resnet152_v2',

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -29,8 +29,10 @@ except ImportError:
 import sys
 from common import get_data
 import unittest
+from nose.plugins.attrib import attr
 
 
+@attr('nightly')
 def test_MNISTIter():
     # prepare data
     get_data.GetMNIST_ubyte()
@@ -60,6 +62,8 @@ def test_MNISTIter():
     label_1 = train_dataiter.getlabel().asnumpy().flatten()
     assert(sum(label_0 - label_1) == 0)
 
+
+@attr('nightly')
 def test_Cifar10Rec():
     get_data.GetCifar10()
     dataiter = mx.io.ImageRecordIter(

--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -23,6 +23,7 @@ from functools import reduce
 from mxnet.module.executor_group import DataParallelExecutorGroup
 from common import assertRaises
 from collections import namedtuple
+from nose.plugins.attrib import attr
 
 import numpy.random as rnd
 
@@ -460,6 +461,7 @@ def test_executor_group():
                            shared_arg_names=shared_arg_names, extra_args=extra_args)
 
 
+@attr('nightly')
 def test_factorization_machine_module(verbose=False):
     """ Test factorization machine model with sparse operators """
     def check_factorization_machine_module(optimizer=None, num_epochs=None):

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -24,6 +24,8 @@ from nose.tools import raises
 from mxnet.test_utils import *
 from numpy.testing import assert_allclose
 import unittest
+from nose.plugins.attrib import attr
+
 
 def check_with_uniform(uf, arg_shapes, dim=None, npuf=None, rmin=-10, type_list=[np.float32]):
     """check function consistency with uniform random numbers"""
@@ -502,6 +504,8 @@ def test_arange():
                         dtype="int32").asnumpy()
     assert_almost_equal(pred, gt)
 
+
+@attr('nightly')
 def test_order(ctx=default_context()):
     def gt_topk(dat, axis, ret_typ, k, is_ascend):
         if ret_typ == "indices":

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -23,6 +23,7 @@ import random
 import itertools
 from numpy.testing import assert_allclose, assert_array_equal
 from mxnet.test_utils import *
+from nose.plugins.attrib import attr
 import unittest
 
 
@@ -1266,6 +1267,7 @@ def test_binary_op():
     test_bneq(a, b)
 
 
+@attr('nightly')
 def test_broadcast_binary_op():
     a = mx.sym.Variable('a')
     b = mx.sym.Variable('b')
@@ -2210,6 +2212,7 @@ def check_l2_normalization(in_shape, mode, ctx=default_context(), norm_eps=1e-10
     check_numeric_gradient(out, [in_data], numeric_eps=1e-3, rtol=1e-2, atol=1e-3)
 
 
+@attr('nightly')
 def test_l2_normalization():
     for mode in ['channel', 'spatial', 'instance']:
         for nbatch in [1, 4]:
@@ -2571,6 +2574,7 @@ def test_init():
     test_arange()
 
 
+@attr('nightly')
 def test_order():
     ctx = default_context()
 
@@ -3365,6 +3369,7 @@ def test_log_softmax():
             check_numeric_gradient(sym, [data], rtol=0.05, atol=1e-3)
 
 
+@attr('nightly')
 def test_pick():
     def test_pick_helper(index_type=np.int32):
         for _ in range(100):
@@ -3614,6 +3619,7 @@ def test_custom_op():
         y.backward()
 
 
+@attr('nightly')
 def test_psroipooling():
     for num_rois in [1, 2]:
         for num_classes, num_group in itertools.product([2, 3], [2, 3]):
@@ -3639,6 +3645,7 @@ def test_psroipooling():
                                                grad_nodes=grad_nodes, ctx=mx.gpu(0))
 
 
+@attr('nightly')
 def test_deformable_convolution():
     for num_batch in [1, 2]:
         for num_channel_data, num_deformable_group in itertools.product([4, 8], [1, 2]):
@@ -3676,6 +3683,7 @@ def test_deformable_convolution():
                                                    grad_nodes=grad_nodes, ctx=mx.gpu(0))
 
 
+@attr('nightly')
 def test_deformable_psroipooling():
     for num_rois in [1, 2]:
         for num_classes, num_group in itertools.product([2, 3], [2, 3]):

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -18,6 +18,7 @@
 import os
 import mxnet as mx
 import numpy as np
+from nose.plugins.attrib import attr
 
 def same(a, b):
     return np.sum(a != b) == 0
@@ -187,6 +188,8 @@ def check_with_device(device, dtype):
                 for check_name, check_func, tol in symbdic['checks']:
                     assert np.abs(check_func(samples, params)) < tol, "symbolic test: %s check for `%s` did not pass" % (check_name, name)
 
+
+@attr('nightly')
 def test_random():
     check_with_device(mx.context.current_context(), 'float16')
     check_with_device(mx.context.current_context(), 'float32')

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -24,6 +24,7 @@ from numpy.testing import assert_allclose
 import numpy.random as rnd
 
 from mxnet.ndarray.sparse import RowSparseNDArray, CSRNDArray
+from nose.plugins.attrib import attr
 
 
 def sparse_nd_ones(shape, stype):
@@ -270,6 +271,7 @@ def test_sparse_nd_binary_rop():
         check(lambda x: 0.5 <= x, stype)
         check(lambda x: 0.5 == x, stype)
 
+
 def test_sparse_nd_binary_iop():
     N = 3
     def check_binary(fn, stype):
@@ -298,6 +300,7 @@ def test_sparse_nd_binary_iop():
         for fn in fns:
             check_binary(fn, stype)
 
+
 def test_sparse_nd_negate():
     def check_sparse_nd_negate(shape, stype):
         npy = np.random.uniform(-10, 10, rand_shape_2d())
@@ -314,6 +317,7 @@ def test_sparse_nd_negate():
     stypes = ['csr', 'row_sparse']
     for stype in stypes:
         check_sparse_nd_negate(shape, stype)
+
 
 def test_sparse_nd_broadcast():
     sample_num = 1000
@@ -349,6 +353,7 @@ def test_sparse_nd_transpose():
         nd = mx.nd.array(npy).tostype(stype)
         assert_almost_equal(npy.T, (nd.T).asnumpy())
 
+
 def test_sparse_nd_storage_fallback():
     def check_output_fallback(shape):
         ones = mx.nd.ones(shape)
@@ -370,6 +375,7 @@ def test_sparse_nd_storage_fallback():
     check_output_fallback(shape)
     check_input_fallback(shape)
     check_fallback_with_temp_resource(shape)
+
 
 def test_sparse_nd_random():
     """ test sparse random operator on cpu """
@@ -450,6 +456,7 @@ def test_sparse_nd_save_load():
             assert same(x.asnumpy(), y.asnumpy())
     os.remove(fname)
 
+
 def test_sparse_nd_unsupported():
     nd = mx.nd.zeros((2,2), stype='row_sparse')
     fn_slice = lambda x: x._slice(None, None)
@@ -462,6 +469,7 @@ def test_sparse_nd_unsupported():
             assert(False)
         except:
             pass
+
 
 def test_create_csr():
     def check_create_csr_from_nd(shape, density, dtype):
@@ -482,6 +490,7 @@ def test_create_csr():
         csr_copy = mx.nd.array(csr_created)
         assert(same(csr_copy.asnumpy(), csr_created.asnumpy()))
 
+
     def check_create_csr_from_coo(shape, density, dtype):
         matrix = rand_ndarray(shape, 'csr', density)
         sp_csr = matrix.asscipy()
@@ -497,6 +506,7 @@ def test_create_csr():
         assert csr_created.dtype == dtype, (csr_created.dtype, dtype)
         assert csr_created.data.dtype == dtype, (csr_created.data.dtype, dtype)
         assert csr_created.context == Context.default_ctx, (csr_created.context, Context.default_ctx)
+
 
     def check_create_csr_from_scipy(shape, density, f):
         def assert_csr_almost_equal(nd, sp):
@@ -539,6 +549,7 @@ def test_create_csr():
         check_create_csr_from_scipy(shape, density, mx.nd.sparse.array)
         check_create_csr_from_scipy(shape, density, mx.nd.array)
 
+
 def test_create_row_sparse():
     dim0 = 50
     dim1 = 50
@@ -554,6 +565,7 @@ def test_create_row_sparse():
         assert same(rsp_created.indices.asnumpy(), indices.asnumpy())
         rsp_copy = mx.nd.array(rsp_created)
         assert(same(rsp_copy.asnumpy(), rsp_created.asnumpy()))
+
 
 def test_create_sparse_nd_infer_shape():
     def check_create_csr_infer_shape(shape, density, dtype):
@@ -597,6 +609,7 @@ def test_create_sparse_nd_infer_shape():
         check_create_rsp_infer_shape(shape, density, dtype)
         check_create_rsp_infer_shape(shape_3d, density, dtype)
 
+
 def test_create_sparse_nd_from_dense():
     def check_create_from_dns(shape, f, dense_arr, dtype, default_dtype, ctx):
         arr = f(dense_arr, dtype=dtype, ctx=ctx)
@@ -618,6 +631,7 @@ def test_create_sparse_nd_from_dense():
             default_dtype = dense_arr.dtype if isinstance(dense_arr, (NDArray, np.ndarray)) \
                             else np.float32
             check_create_from_dns(shape, f, dense_arr, dtype, default_dtype, ctx)
+
 
 def test_create_sparse_nd_from_sparse():
     def check_create_from_sp(shape, f, sp_arr, dtype, src_dtype, ctx):
@@ -649,6 +663,7 @@ def test_create_sparse_nd_from_sparse():
         check_create_from_sp(shape, f_csr, sp_arr, dtype, src_dtype, ctx)
     for sp_arr in rsp_arrs:
         check_create_from_sp(shape, f_rsp, sp_arr, dtype, src_dtype, ctx)
+
 
 def test_create_sparse_nd_empty():
     def check_empty(shape, stype):
@@ -689,6 +704,7 @@ def test_create_sparse_nd_empty():
     check_rsp_empty(shape, dtype, ctx)
     check_rsp_empty(shape_3d, dtype, ctx)
 
+
 def test_synthetic_dataset_generator():
     def test_powerlaw_generator(csr_arr, final_row=1):
         """Test power law distribution
@@ -720,6 +736,7 @@ def test_synthetic_dataset_generator():
     test_powerlaw_generator(csr_arr_small, final_row=1)
     test_powerlaw_generator(csr_arr_big, final_row=4)
     test_powerlaw_generator(csr_arr_square, final_row=6)
+
 
 def test_sparse_nd_exception():
     """ test invalid sparse operator will throw a exception """

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -18,9 +18,12 @@
 from mxnet.test_utils import *
 import random
 import warnings
+from nose.plugins.attrib import attr
+
 
 def is_scalar(var):
     return False if hasattr(var, "__len__") else True
+
 
 def get_result_type(call, dflt_stype):
     """Try to infer result storage type for a sparse matrix and a given unary operation"""
@@ -127,10 +130,12 @@ def get_fw_bw_result_types_2(forward_numpy_call,  fwd_res_dflt,
     return (get_result_type(forward_numpy_call,  fwd_res_dflt),
             get_result_type_2(backward_numpy_call, bwd_res_dflt))
 
+
 def get_fw_bw_result_types_with_scalar(forward_numpy_call,  fwd_res_dflt,
                                        backward_numpy_call, bwd_res_dflt):
     return (get_result_type_with_scalar(forward_numpy_call,  fwd_res_dflt),
             get_result_type_with_scalar(backward_numpy_call, bwd_res_dflt))
+
 
 def gen_rsp_random_indices(shape, density=.5, force_indices=None):
     assert density >= 0 and density <= 1
@@ -151,6 +156,9 @@ def gen_rsp_random_indices(shape, density=.5, force_indices=None):
 def all_zero(var):
     return 0
 
+
+# This test takes over a minute to run, moving to nightly builds.
+@attr('nightly')
 def test_elemwise_binary_ops():
     def test_elemwise_binary_op(name, lhs_stype, rhs_stype, shape,
                                 forward_mxnet_call, forward_numpy_call, backward_numpy_call,
@@ -684,6 +692,8 @@ def check_sparse_mathematical_core(name, stype,
         assert_almost_equal(arr_grad, input_grad, equal_nan=True)
 
 
+# This test takes several minutes to run.
+@attr('nightly')
 def test_sparse_mathematical_core():
     def util_sign(a):
         if np.isclose(a, -0, rtol=1.e-3, atol=1.e-3, equal_nan=True):
@@ -1135,6 +1145,7 @@ def test_elemwise_add_ex():
                               lhs_grad_stype='row_sparse', rhs_grad_stype='row_sparse')
 
 
+@attr('nightly')
 def test_cast_storage_ex():
     def check_cast_storage(shape, density, from_stype, to_stype, check_numeric_grad=True):
         x = mx.symbol.Variable('x', stype=from_stype)
@@ -1432,6 +1443,9 @@ def test_sparse_square_sum():
                     check_numeric_gradient(test, [rsp], grad_stype_dict={'data': 'row_sparse'},
                                            atol=1e-2, rtol=0.1)
 
+
+# This test takes several minutes to run, marking as nightly.
+@attr('nightly')
 def test_sparse_storage_fallback():
     """ test operators which don't implement FComputeEx or FStatefulComputeEx """
     def check_broadcast_add(shape, lhs_stype, rhs_stype):


### PR DESCRIPTION
## Description ##
As discussed here in a few threads, segmenting tests will go a long way in stabilizing our CI.  This PR is a WIP that aims to remove some of the most problematic tests.  All tests ignored here either crashed on a P3 instance with the release version (r 0.12) of mxnet from the deep learning AMI, or they took longer to run than a minute.  With these tests removed all tests were running in less than 2 minutes on a P3.

Tests are removed with test annotations (aka decorators).  Initially I've only used ```@nightly``` to indicate a test that would best be run on a nightly basis and ```@crashing``` to indicate a crashing test.  I'd propose we open issues for all crashing tests, assign owners and leave the tests ignored for the time being in the test suite.  I'd also like to discuss what the correct set of test annotations should be.  Should we consider ```@cuda_test```, ```@high_mem``` or ```@http_required``` test annotations for example?  Once we've decorated tests with annotations we can selectively choose to run them by passing the -a arg to nose (as shown in the new Jenkinsfile).

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)  (not run)
- [x] Changes are complete (i.e. I finished coding on this PR) (WIP)
- [x] All changes have test coverage (removes tests)
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Remove problem tests (slow running or crashing).
