### PR TITLE
slice operator supporting arbitrary values of step

### DIFF
--- a/src/common/static_array.h
+++ b/src/common/static_array.h
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file static_array.h
+ */
+#ifndef MXNET_COMMON_STATIC_ARRAY_H_
+#define MXNET_COMMON_STATIC_ARRAY_H_
+
+#include <mshadow/base.h>
+
+namespace mxnet {
+namespace common {
+
+/*! \brief
+ * Static array. This code is borrowed from struct Shape<ndim>,
+ * except that users can specify the type of the elements of
+ * the statically allocated array.
+ * The object instance of the struct is copyable between CPU and GPU.
+ * \tparam T element type of the array, must be copyable between CPU and GPU
+ * \tparam num number of elements in the array
+ */
+template<typename T, int num>
+struct StaticArray {
+  static const int kNum = num;
+
+  T array_[kNum];
+
+  /*! \brief default constructor, do nothing */
+  MSHADOW_XINLINE StaticArray(void) {}
+
+  /*! \brief constructor, fill in the array with the input value */
+  MSHADOW_XINLINE StaticArray(const T& val) {
+    #pragma unroll
+    for (int i = 0; i < num; ++i) {
+      this->array_[i] = val;
+    }
+  }
+
+  /*! \brief constuctor */
+  MSHADOW_XINLINE StaticArray(const StaticArray<T, num>& sa) {
+    #pragma unroll
+    for (int i = 0; i < num; ++i) {
+      this->array_[i] = sa[i];
+    }
+  }
+
+  MSHADOW_XINLINE T& operator[](const index_t idx) {
+    return array_[idx];
+  }
+
+  MSHADOW_XINLINE const T& operator[](const index_t idx) const {
+    return array_[idx];
+  }
+};  // StaticArray
+
+}  // namespace common
+}  // namespace mxnet
+#endif  // MXNET_COMMON_STATIC_ARRAY_H_

--- a/src/operator/mxnet_op.h
+++ b/src/operator/mxnet_op.h
@@ -108,6 +108,28 @@ inline int get_num_threads<cpu>(const int N) {
   }
 
 
+#define MXNET_NDIM_SWITCH(NDim, ndim, ...)         \
+  if (NDim == 0) {                                 \
+  } else if (NDim == 1) {                          \
+    const int ndim = 1;                            \
+    {__VA_ARGS__}                                  \
+  } else if (NDim == 2) {                          \
+    const int ndim = 2;                            \
+    {__VA_ARGS__}                                  \
+  } else if (NDim == 3) {                          \
+    const int ndim = 3;                            \
+    {__VA_ARGS__}                                  \
+  } else if (NDim == 4) {                          \
+    const int ndim = 4;                            \
+    {__VA_ARGS__}                                  \
+  } else if (NDim == 5) {                          \
+    const int ndim = 5;                            \
+    {__VA_ARGS__}                                  \
+  } else {                                         \
+    LOG(FATAL) << "ndim=" << NDim << "too large "; \
+  }
+
+
 /*!
  * \brief assign the val to out according
  * to request in Kernel::Launch

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -404,7 +404,8 @@ Examples::
 
   data = [2, 3, 0]
   indices = [[1, 1, 0], [0, 1, 0]]
-  scatter_nd(data, indices) = [[0, 0], [2, 3]]
+  shape = (2, 2)
+  scatter_nd(data, indices, shape) = [[0, 0], [2, 3]]
 
 )code")
 .set_num_outputs(1)

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -740,7 +740,7 @@ inline bool TakeOpShape(const nnvm::NodeAttrs& attrs,
     using namespace mshadow;
     const TShape &arrshape = (*in_attrs)[take_::kArr];
     const TShape &idxshape = (*in_attrs)[take_::kIdx];
-    if (idxshape.ndim() == 0) return false;
+    if (idxshape.ndim() == 0U || idxshape.Size() == 0U) return false;
 
     out_attrs->clear();
 

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -249,24 +249,38 @@ will return a new array with shape ``(2,1,3,4)``.
 NNVM_REGISTER_OP(slice)
 .add_alias("_sparse_slice")
 .add_alias("crop")
-.describe(R"code(Slices a contiguous region of the array.
+.describe(R"code(Slices a region of the array.
 
 .. note:: ``crop`` is deprecated. Use ``slice`` instead.
 
-This function returns a sliced continuous region of the array between the indices given
-by `begin` and `end`.
+This function returns a sliced array between the indices given
+by `begin` and `end` with the corresponding `step`.
 
-For an input array of `n` dimensions, slice operation with ``begin=(b_0, b_1...b_n-1)`` indices
-and ``end=(e_1, e_2, ... e_n)`` indices will result in an array with the shape
-``(e_1-b_0, ..., e_n-b_n-1)``.
+For an input array of ``shape=(d_0, d_1, ..., d_n-1)``,
+slice operation with ``begin=(b_0, b_1...b_m-1)``,
+``end=(e_0, e_1, ..., e_m-1)``, and ``step=(s_0, s_1, ..., s_m-1)``,
+where m <= n, results in an array with the shape
+``(|e_0-b_0|/|s_0|, ..., |e_m-1-b_m-1|/|s_m-1|, d_m, ..., d_n-1)``.
 
 The resulting array's *k*-th dimension contains elements
-from the *k*-th dimension of the input array with the open range ``[b_k, e_k)``.
+from the *k*-th dimension of the input array starting
+from index ``b_k`` (inclusive) with step ``s_k``
+until reaching ``e_k`` (exclusive).
+
+If the *k*-th elements are `None` in the sequence of `begin`, `end`,
+and `step`, the following rule will be used to set default values.
+If `s_k` is `None`, set `s_k=1`. If `s_k > 0`, set `b_k=0`, `e_k=d_k`;
+else, set `b_k=d_k-1`, `e_k=-1`.
 
 The storage type of ``slice`` output depends on storage types of inputs
 
 - slice(csr) = csr
 - otherwise, ``slice`` generates output with default storage
+
+.. note:: When input data storage type is csr, it only supports
+step=(), or step=(None,), or step=(1,) to generate a csr output.
+For other step parameter values, it falls back to slicing
+a dense tensor.
 
 Example::
 
@@ -276,14 +290,16 @@ Example::
 
   slice(x, begin=(0,1), end=(2,4)) = [[ 2.,  3.,  4.],
                                      [ 6.,  7.,  8.]]
-
+  slice(x, begin=(None, 0), end=(None, 3), step=(-1, 2)) = [[9., 11.],
+                                                            [5.,  7.],
+                                                            [1.,  3.]]
 )code" ADD_FILELINE)
 .set_attr_parser(ParamParser<SliceParam>)
-.set_attr<nnvm::FInferShape>("FInferShape", SliceShape)
+.set_attr<nnvm::FInferShape>("FInferShape", SliceOpShape)
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)
 .set_attr<FInferStorageType>("FInferStorageType", SliceForwardInferStorageType)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_slice"})
-.set_attr<FCompute>("FCompute<cpu>", Slice<cpu>)
+.set_attr<FCompute>("FCompute<cpu>", SliceOpForward<cpu>)
 .set_attr<FComputeEx>("FComputeEx<cpu>", SliceEx<cpu>)
 .add_argument("data", "NDArray-or-Symbol", "Source input")
 .add_arguments(SliceParam::__FIELDS__());
@@ -291,7 +307,7 @@ Example::
 NNVM_REGISTER_OP(_backward_slice)
 .set_attr_parser(ParamParser<SliceParam>)
 .set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_attr<FCompute>("FCompute<cpu>", SliceBackward<cpu>);
+.set_attr<FCompute>("FCompute<cpu>", SliceOpBackward<cpu>);
 
 NNVM_REGISTER_OP(_slice_assign)
 .add_alias("_crop_assign")

--- a/src/operator/tensor/matrix_op.cu
+++ b/src/operator/tensor/matrix_op.cu
@@ -39,10 +39,10 @@ NNVM_REGISTER_OP(expand_dims)
 .set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
 
 NNVM_REGISTER_OP(slice)
-.set_attr<FCompute>("FCompute<gpu>", Slice<gpu>);
+.set_attr<FCompute>("FCompute<gpu>", SliceOpForward<gpu>);
 
 NNVM_REGISTER_OP(_backward_slice)
-.set_attr<FCompute>("FCompute<gpu>", SliceBackward<gpu>);
+.set_attr<FCompute>("FCompute<gpu>", SliceOpBackward<gpu>);
 
 NNVM_REGISTER_OP(_slice_assign)
 .set_attr<FCompute>("FCompute<gpu>", SliceAssign<gpu>);

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -131,6 +131,21 @@ def test_sparse_nd_slice():
     result_dense = mx.nd.slice(mx.nd.array(A2), begin=(start, start_col), end=(end, end_col))
     assert same(result_dense.asnumpy(), result.asnumpy())
 
+    def check_slice_nd_csr_fallback(shape):
+        stype = 'csr'
+        A, _ = rand_sparse_ndarray(shape, stype)
+        A2 = A.asnumpy()
+        start = rnd.randint(0, shape[0] - 1)
+        end = rnd.randint(start + 1, shape[0])
+
+        # non-trivial step should fallback to dense slice op
+        result = mx.nd.sparse.slice(A, begin=(start,), end=(end + 1,), step=(2,))
+        result_dense = mx.nd.slice(mx.nd.array(A2), begin=(start,), end=(end + 1,), step=(2,))
+        assert same(result_dense.asnumpy(), result.asnumpy())
+
+    shape = (rnd.randint(2, 10), rnd.randint(1, 10))
+    check_slice_nd_csr_fallback(shape)
+
 
 def test_sparse_nd_equal():
     for stype in ['row_sparse', 'csr']:


### PR DESCRIPTION
## Description ##
- Re-implemented slice operator using Kernel::Launch
- Added support for arbitrary values of `step` along with `begin` and `end`, i.e. `slice(data, begin, end, step)`, where `step` is an optional parameter.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated.
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- The kernel implementation is based upon the parallelization approach of slice operator in mshadow with additional support for arbitrary value of `step`.
- This operator will be used in https://github.com/apache/incubator-mxnet/pull/8246 to support slicing `NDArray` with `step!=1`. Currently, it uses `gather_nd` op to realize that functionality, which has heavy overhead of making index `NDArray` from slices.
- Mini-benchmark `slice_v1` (**mshadow version**) and `slice` (**Kernel::Launch version**).

**Hardware**
p2.xlarge (4 omp threads)

**Commit**
[ba9de66](https://github.com/reminisce/mxnet/commit/ba9de669a752f232dcb21b0c11f9a4f91533af23)

**GPU build**
mx.nd.slice_v1: 10000 repeats costs 0.561281 seconds
mx.nd.slice:      10000 repeats costs 0.562561 seconds

**CPU-only build**
mx.nd.slice_v1: 10000 repeats costs 1.049587 seconds
mx.nd.slice:      10000 repeats costs 1.130866 seconds

**Benchmark script**
```python
 import mxnet as mx
 import numpy as np
 import time
 from mxnet.test_utils import same
 
 #ctx = mx.gpu(0)
 ctx = mx.cpu(0)
 
 repeat = 10000
 shape = (16, 16, 16, 16)
 a = mx.nd.arange(np.prod(shape), ctx=ctx).reshape(shape=shape)
 begin = (None, 1, 2)
 end = (shape[0], shape[1], shape[2])
 
 # warm up
 for i in range(100):
     b = mx.nd.slice_v1(a, begin=begin, end=end)
     c = mx.nd.slice(a, begin=begin, end=end)
 
 mx.nd.waitall()
 start = time.time()
 for i in range(repeat):
     c = mx.nd.slice_v1(a, begin=begin, end=end)
 mx.nd.waitall()
 elapsed = time.time() - start
 print("mx.nd.slice_v1: %d repeats costs %f seconds" % (repeat, elapsed))
 
 start = time.time()
 for i in range(repeat):
     b = mx.nd.slice(a, begin=begin, end=end)
 mx.nd.waitall()
 elapsed = time.time() - start
 print("mx.nd.slice: %d repeats costs %f seconds" % (repeat, elapsed))
 
 assert same(c.asnumpy(), b.asnumpy())
```
@piiswrong @eric-haibin-lin @anirudh2290 @rahul003 @cjolivier01 
