### PR TITLE
[EXPERIMENT] increasing build timeout to 24hrs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ mx_lib = 'lib/libmxnet.so, lib/libmxnet.a, dmlc-core/libdmlc.a, nnvm/lib/libnnvm
 // command to start a docker container
 docker_run = 'tests/ci_build/ci_build.sh'
 // timeout in minutes
-max_time = 120
+max_time = 1440
 // assign any caught errors here
 err = null
 


### PR DESCRIPTION
## Description ##
All builds are timing out in the build queue since the number of ubuntu slaves is less. 
Ideally this timeout is meant for the build time on the executor, but somehow it even times out while a task waits in the queue. 

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Changed Timeout to 1440 minutes = 24hrs

## Comments ##
This is temporary until we move to a new CI.
mbaijal to monitor if this change helps. 
