### PR TITLE
sparse embedding operator, gpu implementation

### DIFF
--- a/example/sparse/matrix_factorization.py
+++ b/example/sparse/matrix_factorization.py
@@ -28,7 +28,7 @@ parser = argparse.ArgumentParser(description="Run matrix factorization with spar
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('--num-epoch', type=int, default=3,
                     help='number of epochs to train')
-parser.add_argument('--batch-size', type=int, default=4096,
+parser.add_argument('--batch-size', type=int, default=128,
                     help='number of examples per batch')
 parser.add_argument('--print-every', type=int, default=100,
                     help='logging frequency')

--- a/example/sparse/matrix_factorization.py
+++ b/example/sparse/matrix_factorization.py
@@ -22,6 +22,8 @@ import mxnet as mx
 import numpy as np
 from get_data import get_movielens_iter, get_movielens_data
 from matrix_fact_model import matrix_fact_net
+
+
 logging.basicConfig(level=logging.DEBUG)
 
 parser = argparse.ArgumentParser(description="Run matrix factorization with sparse embedding",
@@ -77,7 +79,6 @@ if __name__ == '__main__':
 
     # construct the model
     net = matrix_fact_net(factor_size, factor_size, max_user, max_movies, sparse_embed=use_sparse)
-    a = time.time()
 
     # initialize the module
     mod = mx.module.Module(symbol=net, context=ctx, data_names=['user', 'item'],

--- a/example/sparse/matrix_factorization.py
+++ b/example/sparse/matrix_factorization.py
@@ -28,7 +28,7 @@ parser = argparse.ArgumentParser(description="Run matrix factorization with spar
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('--num-epoch', type=int, default=3,
                     help='number of epochs to train')
-parser.add_argument('--batch-size', type=int, default=128,
+parser.add_argument('--batch-size', type=int, default=4096,
                     help='number of examples per batch')
 parser.add_argument('--print-every', type=int, default=100,
                     help='logging frequency')
@@ -36,6 +36,8 @@ parser.add_argument('--factor-size', type=int, default=128,
                     help="the factor size of the embedding operation")
 parser.add_argument('--use-dense', action='store_true',
                     help="use the dense embedding operator")
+parser.add_argument('--use-gpu', action='store_true',
+                    help="use gpu")
 parser.add_argument('--dummy-iter', action='store_true',
                     help="use the dummy data iterator for speed test")
 
@@ -63,7 +65,7 @@ if __name__ == '__main__':
     print_every = args.print_every
 
     momentum = 0.9
-    ctx = mx.cpu(0)
+    ctx = mx.gpu(0) if args.use_gpu else mx.cpu(0)
     learning_rate = 0.1
 
     # prepare dataset and iterators

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -26,6 +26,113 @@
 #include "./indexing_op.h"
 namespace mxnet {
 namespace op {
+
+template<>
+void SparseEmbeddingOpForwardRspImpl<cpu>(mshadow::Stream<cpu>* s,
+                                     const TBlob& data,
+                                     const NDArray& weight,
+                                     const OpReqType req,
+                                     const TBlob& output) {
+  if (req == kNullOp) return;
+  using namespace rowsparse;
+  using namespace mxnet_op;
+  // zeros weight
+  if (req == kWriteTo && !weight.storage_initialized()) {
+    size_t out_size = output.shape_.Size();
+    MSHADOW_TYPE_SWITCH(output.type_flag_, DType, {
+      Kernel<set_zero, cpu>::Launch(s, out_size, output.dptr<DType>());
+    })
+    return;
+  }
+  // check out-of-bound indices
+  bool is_valid = true;
+  MSHADOW_TYPE_SWITCH(data.type_flag_, DType, {
+    DType min = 0;
+    DType max = static_cast<DType>(weight.shape()[0] - 1);
+    // check with single thread is faster since data is small
+    DType* data_ptr = data.dptr<DType>();
+    size_t data_size = data.shape_.Size();
+    for (size_t i = 0; i < data_size; i++) {
+      if (data_ptr[i] > max || data_ptr[i] < min) is_valid = false;
+    }
+  })
+  CHECK(is_valid) << "SparseEmbedding input contains data out of bound";
+  // the weight is actually dense
+  if (weight.aux_shape(kIdx)[0] == weight.shape()[0]) {
+    EmbeddingOpForwardDnsImpl<cpu>(s, data, weight.data(), req, output);
+  } else {
+    EmbeddingOpForwardRspImpl<cpu>(s, data, weight, req, output);
+  }
+}
+
+
+template<>
+inline void SparseEmbeddingOpBackwardRspImpl<cpu>(const OpContext& ctx,
+                                             const TBlob& ograd,
+                                             const TBlob& data,
+                                             const OpReqType req,
+                                             const NDArray& output) {
+  using namespace mshadow;
+  using namespace mxnet_op;
+  using namespace mshadow::expr;
+  using namespace rowsparse;
+  using nnvm::dim_t;
+  if (req == kNullOp) return;
+  CHECK_EQ(req, kWriteTo) << "SparseEmbedding layer doesn't support "
+                          << "weight gradient calculation with req != write";
+
+  // Request temporary storage for marking non-zero rows and prefix sum
+  Stream<cpu> *s = ctx.get_stream<cpu>();
+  dim_t num_rows = output.shape()[0];
+  dim_t row_length = output.shape()[1];
+  // TODO(haibin) request less storage to save space in the future
+  size_t workspace_size = 2 * (num_rows * sizeof(dim_t));
+  Tensor<cpu, 1, char> workspace =
+    ctx.requested[embedding::kTempSpace].get_space_typed<cpu, 1, char>(
+      Shape1(workspace_size), s);
+  dim_t* row_flg = reinterpret_cast<dim_t*>(workspace.dptr_);
+  dim_t* prefix_sum = row_flg + num_rows;
+  dim_t data_size = static_cast<dim_t>(data.shape_.Size());
+
+  MSHADOW_TYPE_SWITCH(data.type_flag_, IType, {
+    MSHADOW_TYPE_SWITCH(ograd.type_flag_, DType, {
+      MSHADOW_TYPE_SWITCH(output.aux_type(kIdx), RType, {
+        // mark row flags
+        Fill<false>(s, TBlob(row_flg, mshadow::Shape1(num_rows), cpu::kDevMask), kWriteTo, 0);
+        Kernel<MarkRowFlgKernel, cpu>::Launch(s, data_size, row_flg, data.dptr<IType>());
+        // calculate inclusive prefix sum
+        // TODO(haibin) ideally this is should be done in parallel
+        prefix_sum[0] = row_flg[0];
+        for (dim_t i = 1; i < num_rows; i++) {
+          prefix_sum[i] = prefix_sum[i - 1] + row_flg[i];
+        }
+        // total number of non-zero rows
+        dim_t nnr = prefix_sum[num_rows - 1];
+        if (nnr == 0) {
+          FillZerosRspImpl(s, output);
+          return;
+        }
+        output.CheckAndAlloc({Shape1(nnr)});
+        RType* grad_row_idx = output.aux_data(kIdx).dptr<RType>();
+        // fill row_idx array of output matrix, using the row_flg values
+        Kernel<FillRspRowIdxKernel, cpu>::Launch(s, num_rows,
+               grad_row_idx, prefix_sum, num_rows);
+        // prefill with zeros
+        DType* grad_data = output.data().dptr<DType>();
+        Kernel<set_zero, cpu>::Launch(s, nnr * row_length, grad_data);
+        // add the final gradients
+        const int num_threads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
+        dim_t segment_len = (nnr + num_threads - 1) / num_threads;
+        Kernel<AddTakeGradRspKernel, cpu>::Launch(s, num_threads, grad_data, prefix_sum,
+                                                  ograd.dptr<DType>(), row_length,
+                                                  data.dptr<IType>(), data_size, segment_len,
+                                                  num_rows);
+      });
+    });
+  });
+}
+
+
 DMLC_REGISTER_PARAMETER(EmbeddingParam);
 DMLC_REGISTER_PARAMETER(TakeParam);
 DMLC_REGISTER_PARAMETER(OneHotParam);

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -29,10 +29,10 @@ namespace op {
 
 template<>
 void SparseEmbeddingOpForwardRspImpl<cpu>(mshadow::Stream<cpu>* s,
-                                     const TBlob& data,
-                                     const NDArray& weight,
-                                     const OpReqType req,
-                                     const TBlob& output) {
+                                          const TBlob& data,
+                                          const NDArray& weight,
+                                          const OpReqType req,
+                                          const TBlob& output) {
   if (req == kNullOp) return;
   using namespace rowsparse;
   using namespace mxnet_op;
@@ -68,10 +68,10 @@ void SparseEmbeddingOpForwardRspImpl<cpu>(mshadow::Stream<cpu>* s,
 
 template<>
 inline void SparseEmbeddingOpBackwardRspImpl<cpu>(const OpContext& ctx,
-                                             const TBlob& ograd,
-                                             const TBlob& data,
-                                             const OpReqType req,
-                                             const NDArray& output) {
+                                                  const TBlob& ograd,
+                                                  const TBlob& data,
+                                                  const OpReqType req,
+                                                  const NDArray& output) {
   using namespace mshadow;
   using namespace mxnet_op;
   using namespace mshadow::expr;

--- a/src/operator/tensor/indexing_op.cu
+++ b/src/operator/tensor/indexing_op.cu
@@ -82,7 +82,6 @@ void SparseEmbeddingOpForwardRspImpl<gpu>(mshadow::Stream<gpu>* s,
   MSHADOW_TYPE_SWITCH(data.type_flag_, DType, {
     DType min = 0;
     DType max = static_cast<DType>(weight.shape()[0] - 1);
-    // check with single thread is faster since data is small
     DType* data_ptr = data.dptr<DType>();
     size_t data_size = data.shape_.Size();
     int32_t* is_valid_ptr = NULL;

--- a/src/operator/tensor/indexing_op.cu
+++ b/src/operator/tensor/indexing_op.cu
@@ -42,7 +42,6 @@ struct is_valid_check {
 
 
 struct AddTakeGradRspGPUKernel {
-
   template<typename DType, typename IType>
   __device__ __forceinline__ static void Map(int tid,
                                              DType* out,
@@ -53,9 +52,8 @@ struct AddTakeGradRspGPUKernel {
     using nnvm::dim_t;
     const dim_t data_i = tid / row_length;
     const dim_t grad_i = tid % row_length;
-    
     const dim_t irow = static_cast<dim_t>(data[data_i]);
-    const dim_t rsp_row = prefix_sum[irow]-1;
+    const dim_t rsp_row = prefix_sum[irow] - 1;
     const DType val = ograd[data_i * row_length + grad_i];
     atomicAdd(static_cast<DType *>(&(out[rsp_row*row_length+grad_i])), val);
   }

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -187,9 +187,8 @@ inline bool SparseEmbeddingOpForwardStorageType(const nnvm::NodeAttrs& attrs,
   const int& weight_stype = in_attrs->at(embedding::kWeight);
   int& out_stype = out_attrs->at(embedding::kOut);
   bool dispatched = false;
-  const bool invalid_ctx = dev_mask != mshadow::cpu::kDevMask;
   if (!dispatched && data_stype == kDefaultStorage &&
-      weight_stype == kRowSparseStorage && !invalid_ctx) {
+      weight_stype == kRowSparseStorage) {
     // dns, rsp -> dns
     dispatched = storage_type_assign(&out_stype, kDefaultStorage,
                                      dispatch_mode, DispatchMode::kFComputeEx);
@@ -215,9 +214,8 @@ inline bool SparseEmbeddingOpBackwardStorageType(const nnvm::NodeAttrs& attrs,
   int& data_grad_stype = out_attrs->at(0);
   int& weight_grad_stype = out_attrs->at(1);
   bool dispatched = false;
-  const bool invalid_ctx = dev_mask != mshadow::cpu::kDevMask;
   if (!dispatched && ograd_stype == kDefaultStorage &&
-      data_stype == kDefaultStorage && !invalid_ctx) {
+      data_stype == kDefaultStorage) {
     // dns, dns -> dns, rsp
     if (type_assign(&data_grad_stype, kDefaultStorage) &&
         type_assign(&weight_grad_stype, kRowSparseStorage) &&
@@ -336,8 +334,8 @@ struct TakeRspKernel {
   }
 };
 
-inline void EmbeddingOpForwardRspImpl(mshadow::Stream<mshadow::cpu>* s,
-                                      const cpu& cpu_dev,
+template<typename xpu>
+inline void EmbeddingOpForwardRspImpl(mshadow::Stream<xpu>* s,
                                       const TBlob& data,
                                       const NDArray& weight,
                                       const OpReqType req,
@@ -351,7 +349,7 @@ inline void EmbeddingOpForwardRspImpl(mshadow::Stream<mshadow::cpu>* s,
           size_t data_size = data.shape_.Size();
           // only using the second dim since weight.ndim() == 2
           const nnvm::dim_t row_length = weight.shape()[1];
-          Kernel<TakeRspKernel<req_t>, cpu>::Launch(s, data_size, data.dptr<IType>(),
+          Kernel<TakeRspKernel<req_t>, xpu>::Launch(s, data_size, data.dptr<IType>(),
                                                     output.dptr<DType>(),
                                                     weight.aux_data(kIdx).dptr<RType>(),
                                                     weight.data().dptr<DType>(),
@@ -369,39 +367,7 @@ void SparseEmbeddingOpForwardRspImpl(mshadow::Stream<xpu>* s,
                                      const TBlob& data,
                                      const NDArray& weight,
                                      const OpReqType req,
-                                     const TBlob& output) {
-  if (req == kNullOp) return;
-  CHECK((std::is_same<xpu, mshadow::cpu>::value)) << "SparseEmbedding is only implemented for CPU";
-  using namespace rowsparse;
-  using namespace mxnet_op;
-  // zeros weight
-  if (req == kWriteTo && !weight.storage_initialized()) {
-    size_t out_size = output.shape_.Size();
-    MSHADOW_TYPE_SWITCH(output.type_flag_, DType, {
-      Kernel<set_zero, xpu>::Launch(s, out_size, output.dptr<DType>());
-    })
-    return;
-  }
-  // check out-of-bound indices
-  bool is_valid = true;
-  MSHADOW_TYPE_SWITCH(data.type_flag_, DType, {
-    DType min = 0;
-    DType max = static_cast<DType>(weight.shape()[0] - 1);
-    // check with single thread is faster since data is small
-    DType* data_ptr = data.dptr<DType>();
-    size_t data_size = data.shape_.Size();
-    for (size_t i = 0; i < data_size; i++) {
-      if (data_ptr[i] > max || data_ptr[i] < min) is_valid = false;
-    }
-  })
-  CHECK(is_valid) << "SparseEmbedding input contains data out of bound";
-  // the weight is actually dense
-  if (weight.aux_shape(kIdx)[0] == weight.shape()[0]) {
-    EmbeddingOpForwardDnsImpl(s, data, weight.data(), req, output);
-  } else {
-    EmbeddingOpForwardRspImpl(s, xpu(), data, weight, req, output);
-  }
-}
+                                     const TBlob& output);
 
 template<typename xpu>
 void EmbeddingOpForward(const nnvm::NodeAttrs& attrs,
@@ -576,7 +542,7 @@ struct AddTakeGradRspKernel {
    * \param nnr             total number of non-zero rows of result gradient
    */
   template<typename DType, typename IType>
-  MSHADOW_CINLINE static void Map(int tid,
+  MSHADOW_XINLINE static void Map(int tid,
                                   DType* grad,
                                   const nnvm::dim_t* prefix_sum,
                                   const DType* ograd,
@@ -587,7 +553,8 @@ struct AddTakeGradRspKernel {
                                   const nnvm::dim_t nnr) {
     using nnvm::dim_t;
     dim_t segment_start = tid * segment_length;
-    dim_t segment_end = std::min(nnr, segment_start + segment_length);
+    dim_t segment_end = nnr < (segment_start + segment_length) ? nnr :
+                        (segment_start + segment_length);
     // scan all data
     for (dim_t data_i = 0; data_i < data_size; data_i++) {
       dim_t data = static_cast<dim_t>(data_val[data_i]);
@@ -603,71 +570,12 @@ struct AddTakeGradRspKernel {
   }
 };
 
+template<typename xpu>
 inline void SparseEmbeddingOpBackwardRspImpl(const OpContext& ctx,
-                                             const cpu& cpu_dev,
                                              const TBlob& ograd,
                                              const TBlob& data,
                                              const OpReqType req,
-                                             const NDArray& output) {
-  using namespace mshadow;
-  using namespace mxnet_op;
-  using namespace mshadow::expr;
-  using namespace rowsparse;
-  using nnvm::dim_t;
-  if (req == kNullOp) return;
-  CHECK_EQ(req, kWriteTo) << "SparseEmbedding layer doesn't support "
-                          << "weight gradient calculation with req != write";
-
-  // Request temporary storage for marking non-zero rows and prefix sum
-  Stream<cpu> *s = ctx.get_stream<cpu>();
-  dim_t num_rows = output.shape()[0];
-  dim_t row_length = output.shape()[1];
-  // TODO(haibin) request less storage to save space in the future
-  size_t workspace_size = 2 * (num_rows * sizeof(dim_t));
-  Tensor<cpu, 1, char> workspace =
-    ctx.requested[embedding::kTempSpace].get_space_typed<cpu, 1, char>(
-      Shape1(workspace_size), s);
-  dim_t* row_flg = reinterpret_cast<dim_t*>(workspace.dptr_);
-  dim_t* prefix_sum = row_flg + num_rows;
-  dim_t data_size = static_cast<dim_t>(data.shape_.Size());
-
-  MSHADOW_TYPE_SWITCH(data.type_flag_, IType, {
-    MSHADOW_TYPE_SWITCH(ograd.type_flag_, DType, {
-      MSHADOW_TYPE_SWITCH(output.aux_type(kIdx), RType, {
-        // mark row flags
-        Fill<false>(s, TBlob(row_flg, mshadow::Shape1(num_rows), cpu::kDevMask), kWriteTo, 0);
-        Kernel<MarkRowFlgKernel, cpu>::Launch(s, data_size, row_flg, data.dptr<IType>());
-        // calculate inclusive prefix sum
-        // TODO(haibin) ideally this is should be done in parallel
-        prefix_sum[0] = row_flg[0];
-        for (dim_t i = 1; i < num_rows; i++) {
-          prefix_sum[i] = prefix_sum[i - 1] + row_flg[i];
-        }
-        // total number of non-zero rows
-        dim_t nnr = prefix_sum[num_rows - 1];
-        if (nnr == 0) {
-          FillZerosRspImpl(s, output);
-          return;
-        }
-        output.CheckAndAlloc({Shape1(nnr)});
-        RType* grad_row_idx = output.aux_data(kIdx).dptr<RType>();
-        // fill row_idx array of output matrix, using the row_flg values
-        Kernel<FillRspRowIdxKernel, cpu>::Launch(s, num_rows,
-               grad_row_idx, prefix_sum, num_rows);
-        // prefill with zeros
-        DType* grad_data = output.data().dptr<DType>();
-        Kernel<set_zero, cpu>::Launch(s, nnr * row_length, grad_data);
-        // add the final gradients
-        const int num_threads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
-        dim_t segment_len = (nnr + num_threads - 1) / num_threads;
-        Kernel<AddTakeGradRspKernel, cpu>::Launch(s, num_threads, grad_data, prefix_sum,
-                                                  ograd.dptr<DType>(), row_length,
-                                                  data.dptr<IType>(), data_size, segment_len,
-                                                  num_rows);
-      });
-    });
-  });
-}
+                                             const NDArray& output);
 
 template<typename xpu>
 void SparseEmbeddingOpBackwardEx(const nnvm::NodeAttrs& attrs,
@@ -687,8 +595,8 @@ void SparseEmbeddingOpBackwardEx(const nnvm::NodeAttrs& attrs,
           << "SparseEmbedding layer doesn't support calculate data gradient";
   if (data.storage_type() == kDefaultStorage && ograd.storage_type() == kDefaultStorage &&
       weight_grad.storage_type() == kRowSparseStorage) {
-    SparseEmbeddingOpBackwardRspImpl(ctx, xpu(), ograd.data(), data.data(),
-                                     req[embedding::kWeight], weight_grad);
+    SparseEmbeddingOpBackwardRspImpl<xpu>(ctx, ograd.data(), data.data(),
+                                          req[embedding::kWeight], weight_grad);
   } else {
     LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
   }

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -553,7 +553,7 @@ struct AddTakeGradRspKernel {
                                   const nnvm::dim_t nnr) {
     using nnvm::dim_t;
     dim_t segment_start = tid * segment_length;
-    dim_t segment_end = std::min(nnr, segment_start + segment_length);;
+    dim_t segment_end = std::min(nnr, segment_start + segment_length);
     // scan all data
     for (dim_t data_i = 0; data_i < data_size; data_i++) {
       dim_t data = static_cast<dim_t>(data_val[data_i]);

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -542,7 +542,7 @@ struct AddTakeGradRspKernel {
    * \param nnr             total number of non-zero rows of result gradient
    */
   template<typename DType, typename IType>
-  MSHADOW_XINLINE static void Map(int tid,
+  MSHADOW_CINLINE static void Map(int tid,
                                   DType* grad,
                                   const nnvm::dim_t* prefix_sum,
                                   const DType* ograd,
@@ -553,8 +553,7 @@ struct AddTakeGradRspKernel {
                                   const nnvm::dim_t nnr) {
     using nnvm::dim_t;
     dim_t segment_start = tid * segment_length;
-    dim_t segment_end = nnr < (segment_start + segment_length) ? nnr :
-                        (segment_start + segment_length);
+    dim_t segment_end = std::min(nnr, segment_start + segment_length);;
     // scan all data
     for (dim_t data_i = 0; data_i < data_size; data_i++) {
       dim_t data = static_cast<dim_t>(data_val[data_i]);

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1450,6 +1450,5 @@ def test_cross_device_autograd():
     assert_almost_equal(dx, x.grad.asnumpy())
 
 if __name__ == '__main__':
-    #import nose
-    #nose.runmodule()
-    test_sparse_embedding()
+    import nose
+    nose.runmodule()

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1450,5 +1450,6 @@ def test_cross_device_autograd():
     assert_almost_equal(dx, x.grad.asnumpy())
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    #import nose
+    #nose.runmodule()
+    test_sparse_embedding()

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1449,6 +1449,5 @@ def test_cross_device_autograd():
     assert_almost_equal(dx, x.grad.asnumpy())
 
 if __name__ == '__main__':
-    #import nose
-    #nose.runmodule()
-    test_sparse_embedding()
+    import nose
+    nose.runmodule()

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1449,5 +1449,6 @@ def test_cross_device_autograd():
     assert_almost_equal(dx, x.grad.asnumpy())
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    #import nose
+    #nose.runmodule()
+    test_sparse_embedding()

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1557,33 +1557,32 @@ def test_sparse_embedding():
         executor.backward([grad])
         assert_almost_equal(grad_map["embed_weight"].asnumpy(), np.dot(data_onehot.T, grad.asnumpy()))
 
-    if default_context().device_type == 'cpu':
-        densities = [0, 0.5, 1]
-        in_dim = 50
-        out_dim = 3
-        batch = 8
-        # init executor
-        data = mx.sym.Variable("data")
-        weight = mx.sym.Variable("embed_weight", stype='row_sparse')
-        embed = mx.sym.contrib.SparseEmbedding(data=data, weight=weight, input_dim=in_dim,
-                                               output_dim=out_dim, name="embed")
-        grad_req = {'data': 'null', 'embed_weight': 'write'}
-        exe_test = embed.simple_bind(default_context(), grad_req=grad_req, data=(batch,))
-        arg_map = dict(zip(embed.list_arguments(), exe_test.arg_arrays))
-        grad_map = dict(zip(embed.list_arguments(), exe_test.grad_arrays))
-        # init data
-        np_data = np.random.randint(low=0, high=in_dim, size=batch)
-        np_onehot = np.zeros((batch, in_dim))
-        np_onehot[np.arange(batch), np_data] = 1.0
-        arg_map["data"][:] = np_data
-        # init grad
-        np_grad = np.random.uniform(-1, 1, exe_test.outputs[0].shape)
-        grad = mx.nd.sparse.zeros('row_sparse', np_grad.shape)
-        grad[:] = np_grad
-        # weight
-        weight = arg_map["embed_weight"]
-        for density in densities:
-            check_sparse_embedding(exe_test, weight, np_onehot, grad, density)
+    densities = [0, 0.5, 1]
+    in_dim = 50
+    out_dim = 3
+    batch = 8
+    # init executor
+    data = mx.sym.Variable("data")
+    weight = mx.sym.Variable("embed_weight", stype='row_sparse')
+    embed = mx.sym.contrib.SparseEmbedding(data=data, weight=weight, input_dim=in_dim,
+                                           output_dim=out_dim, name="embed")
+    grad_req = {'data': 'null', 'embed_weight': 'write'}
+    exe_test = embed.simple_bind(default_context(), grad_req=grad_req, data=(batch,))
+    arg_map = dict(zip(embed.list_arguments(), exe_test.arg_arrays))
+    grad_map = dict(zip(embed.list_arguments(), exe_test.grad_arrays))
+    # init data
+    np_data = np.random.randint(low=0, high=in_dim, size=batch)
+    np_onehot = np.zeros((batch, in_dim))
+    np_onehot[np.arange(batch), np_data] = 1.0
+    arg_map["data"][:] = np_data
+    # init grad
+    np_grad = np.random.uniform(-1, 1, exe_test.outputs[0].shape)
+    grad = mx.nd.sparse.zeros('row_sparse', np_grad.shape)
+    grad[:] = np_grad
+    # weight
+    weight = arg_map["embed_weight"]
+    for density in densities:
+        check_sparse_embedding(exe_test, weight, np_onehot, grad, density)
 
 def test_scatter_ops():
     def csr_get_seen_points(name, csr_array, verbose=False):
@@ -1730,5 +1729,6 @@ def test_scatter_ops():
                           rhs_is_scalar=True, verbose=False, density=0.5)
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    #import nose
+    #nose.runmodule()
+    test_sparse_embedding()

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1729,5 +1729,6 @@ def test_scatter_ops():
                           rhs_is_scalar=True, verbose=False, density=0.5)
 
 if __name__ == '__main__':
-    import nose
-    nose.runmodule()
+    #import nose
+    #nose.runmodule()
+    test_sparse_embedding()

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1551,8 +1551,8 @@ def test_sparse_embedding():
         # update weight based on density
         weight[:] = rand_ndarray(weight.shape, 'row_sparse', density=density)
         # check forward
-        exe_test.forward(is_train=True)
-        assert_almost_equal(exe_test.outputs[0].asnumpy(), np.dot(data_onehot, weight.asnumpy()))
+        executor.forward(is_train=True)
+        assert_almost_equal(executor.outputs[0].asnumpy(), np.dot(data_onehot, weight.asnumpy()))
         # check backward
         executor.backward([grad])
         assert_almost_equal(grad_map["embed_weight"].asnumpy(), np.dot(data_onehot.T, grad.asnumpy()))

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1447,6 +1447,7 @@ def test_sparse_square_sum():
                     check_numeric_gradient(test, [rsp], grad_stype_dict={'data': 'row_sparse'},
                                            atol=1e-2, rtol=0.1)
 
+                    
 def test_sparse_storage_fallback():
     """ test operators which don't implement FComputeEx or FStatefulComputeEx """
     def check_broadcast_add(shape, lhs_stype, rhs_stype):

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1729,6 +1729,5 @@ def test_scatter_ops():
                           rhs_is_scalar=True, verbose=False, density=0.5)
 
 if __name__ == '__main__':
-    #import nose
-    #nose.runmodule()
-    test_sparse_embedding()
+    import nose
+    nose.runmodule()


### PR DESCRIPTION
## Description ##
running on the machine of 20 cores CPU and 8G 1080 GPU
```
def matrix_fact_net(factor_size, num_hidden, max_user, max_item, sparse_embed=True):
    # input
    user = mx.symbol.Variable('user')
    item = mx.symbol.Variable('item')
    score = mx.symbol.Variable('score')
    
    user_weight = mx.symbol.Variable('user_weight', stype='row_sparse')
    user = mx.symbol.contrib.SparseEmbedding(data=user, weight=user_weight,
                                             input_dim=max_user, output_dim=factor_size)
    item_weight = mx.symbol.Variable('item_weight', stype='row_sparse')
    item = mx.symbol.contrib.SparseEmbedding(data=item, weight=item_weight,
                                             input_dim=max_item, output_dim=factor_size)
    pred = user * item
    pred = mx.symbol.sum(data=pred, axis = 1)
    pred = mx.symbol.Flatten(data=pred)
    pred = mx.symbol.LinearRegressionOutput(data=pred, label=score)
    return pred
```
cpu, 
```
OMP_NUM_THREADS=16 python matrix_factorization.py --dummy-iter --batch-size 1024
INFO:root:Namespace(batch_size=1024, dummy_iter=True, factor_size=128, num_epoch=3, print_every=100, use_dense=False, use_gpu=False)
Preparing data iterators for ./ml-10M100K/r1.train ...
Preparing data iterators for ./ml-10M100K/r1.test ...
INFO:root:Training started ...
INFO:root:Epoch[0] Batch [100]  Speed: 225858.10 samples/sec    mse=10.866299
INFO:root:Epoch[0] Batch [200]  Speed: 212823.90 samples/sec    mse=2.113950
INFO:root:Epoch[0] Batch [300]  Speed: 261171.14 samples/sec    mse=0.234129
INFO:root:Epoch[0] Batch [400]  Speed: 263461.95 samples/sec    mse=0.043237
INFO:root:Epoch[0] Batch [500]  Speed: 263771.97 samples/sec    mse=0.010304
INFO:root:Epoch[0] Batch [600]  Speed: 261896.55 samples/sec    mse=0.003168
INFO:root:Epoch[0] Batch [700]  Speed: 212742.52 samples/sec    mse=0.001392
INFO:root:Epoch[0] Batch [800]  Speed: 258110.08 samples/sec    mse=0.000901
INFO:root:Epoch[0] Batch [900]  Speed: 237916.56 samples/sec    mse=0.000749
INFO:root:Epoch[0] Batch [1000] Speed: 235817.48 samples/sec    mse=0.000695
```

gpu,
```
OMP_NUM_THREADS=16 python matrix_factorization.py --dummy-iter --use-gpu --batch-size 1024
INFO:root:Namespace(batch_size=1024, dummy_iter=True, factor_size=128, num_epoch=3, print_every=100, use_dense=False, use_gpu=True)
Preparing data iterators for ./ml-10M100K/r1.train ...
Preparing data iterators for ./ml-10M100K/r1.test ...
INFO:root:Training started ...
INFO:root:Epoch[0] Batch [100]  Speed: 1311592.58 samples/sec   mse=10.819942
INFO:root:Epoch[0] Batch [200]  Speed: 1560172.36 samples/sec   mse=2.004076
INFO:root:Epoch[0] Batch [300]  Speed: 1253302.47 samples/sec   mse=0.237283
INFO:root:Epoch[0] Batch [400]  Speed: 1293844.12 samples/sec   mse=0.045319
INFO:root:Epoch[0] Batch [500]  Speed: 1513159.58 samples/sec   mse=0.011305
INFO:root:Epoch[0] Batch [600]  Speed: 1588557.60 samples/sec   mse=0.003488
INFO:root:Epoch[0] Batch [700]  Speed: 1480390.21 samples/sec   mse=0.001495
INFO:root:Epoch[0] Batch [800]  Speed: 1522449.58 samples/sec   mse=0.000935
INFO:root:Epoch[0] Batch [900]  Speed: 623557.03 samples/sec    mse=0.000758
INFO:root:Epoch[0] Batch [1000] Speed: 1485130.36 samples/sec   mse=0.000695
```
As a feature requested in https://github.com/apache/incubator-mxnet/issues/8168

cc @eric-haibin-lin 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
