### PR TITLE
Add note about deprecation of v1 versions of ImageRecordIter

### DIFF
--- a/src/io/iter_image_recordio.cc
+++ b/src/io/iter_image_recordio.cc
@@ -337,7 +337,9 @@ class ImageRecordIter : public IIterator<DataInst> {
 MXNET_REGISTER_IO_ITER(ImageRecordIter_v1)
 .describe(R"code(Iterating on image RecordIO files
 
-.. note:: ``ImageRecordIter_v1`` is deprecated. Use ``ImageRecordIter`` instead.
+.. note::
+
+  ``ImageRecordIter_v1`` is deprecated. Use ``ImageRecordIter`` instead.
 
 Read images batches from RecordIO files with a rich of data augmentation
 options.
@@ -363,7 +365,9 @@ files.
 MXNET_REGISTER_IO_ITER(ImageRecordUInt8Iter_v1)
 .describe(R"code(Iterating on image RecordIO files
 
-.. note:: ``ImageRecordUInt8Iter_v1`` is deprecated. Use ``ImageRecordUInt8Iter`` instead.
+.. note::
+
+  ``ImageRecordUInt8Iter_v1`` is deprecated. Use ``ImageRecordUInt8Iter`` instead.
 
 This iterator is identical to ``ImageRecordIter_v1`` except for using ``uint8`` as
 the data type instead of ``float``.

--- a/src/io/iter_image_recordio.cc
+++ b/src/io/iter_image_recordio.cc
@@ -337,6 +337,8 @@ class ImageRecordIter : public IIterator<DataInst> {
 MXNET_REGISTER_IO_ITER(ImageRecordIter_v1)
 .describe(R"code(Iterating on image RecordIO files
 
+.. note:: ``ImageRecordIter_v1`` is deprecated. Use ``ImageRecordIter`` instead.
+
 Read images batches from RecordIO files with a rich of data augmentation
 options.
 
@@ -361,7 +363,9 @@ files.
 MXNET_REGISTER_IO_ITER(ImageRecordUInt8Iter_v1)
 .describe(R"code(Iterating on image RecordIO files
 
-This iterator is identical to ``ImageRecordIter`` except for using ``uint8`` as
+.. note:: ``ImageRecordUInt8Iter_v1`` is deprecated. Use ``ImageRecordUInt8Iter`` instead.
+
+This iterator is identical to ``ImageRecordIter_v1`` except for using ``uint8`` as
 the data type instead of ``float``.
 
 )code" ADD_FILELINE)


### PR DESCRIPTION
## Description ##
#8636

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

## Comments ##
