### PR TITLE
fix VGG error in benchmark_score

### DIFF
--- a/example/image-classification/benchmark_score.py
+++ b/example/image-classification/benchmark_score.py
@@ -33,6 +33,9 @@ def get_symbol(network, batch_size):
     if 'resnet' in network:
         num_layers = int(network.split('-')[1])
         network = 'resnet'
+    if 'vgg' in network:
+        num_layers = int(network.split('-')[1])
+        network = 'vgg'
     net = import_module('symbols.'+network)
     sym = net.get_symbol(num_classes = 1000,
                          image_shape = ','.join([str(i) for i in image_shape]),
@@ -65,7 +68,7 @@ def score(network, dev, batch_size, num_batches):
     return num_batches*batch_size/(time.time() - tic)
 
 if __name__ == '__main__':
-    networks = ['alexnet', 'vgg', 'inception-bn', 'inception-v3', 'resnet-50', 'resnet-152']
+    networks = ['alexnet', 'vgg-16', 'inception-bn', 'inception-v3', 'resnet-50', 'resnet-152']
     devs = [mx.gpu(0)] if len(get_gpus()) > 0 else []
     # Enable USE_MKL2017_EXPERIMENTAL for better CPU performance
     devs.append(mx.cpu())


### PR DESCRIPTION
Signed-off-by: Andrey Parfenov <a1994ndrey@gmail.com>

## Description ##
example/image-classification/benchmark_score.py fails for VGG net with ""Invalide num_layers {}. Possible choices are 11,13,16,19.".format(num_layers)" caused by #7556 this PR fix that

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change