### PR TITLE
[BugFix][CoreML Converter] Dense layers w/o bias.

### DIFF
--- a/tools/coreml/converter/_layers.py
+++ b/tools/coreml/converter/_layers.py
@@ -262,10 +262,15 @@ def convert_dense(net, node, module, builder):
         A neural network builder object.
     """
     input_name, output_name = _get_input_output_name(net, node)
-    has_bias = True
     name = node['name']
 
     inputs = node['inputs']
+    param = node['attr']
+    if 'no_bias' in param.keys():
+        has_bias = not literal_eval(param['no_bias'])
+    else:
+        has_bias = True
+
     args, _ = module.get_params()
     W = args[_get_node_name(net, inputs[1][0])].asnumpy()
     if has_bias:

--- a/tools/coreml/converter/_layers.py
+++ b/tools/coreml/converter/_layers.py
@@ -265,7 +265,7 @@ def convert_dense(net, node, module, builder):
     name = node['name']
 
     inputs = node['inputs']
-    param = node['attr']
+    param = node['attrs']
     if 'no_bias' in param.keys():
         has_bias = not literal_eval(param['no_bias'])
     else:

--- a/tools/coreml/test/test_mxnet_converter.py
+++ b/tools/coreml/test/test_mxnet_converter.py
@@ -149,6 +149,13 @@ class SingleLayerTest(unittest.TestCase):
         net = mx.sym.FullyConnected(data=net, name='fc1', num_hidden=5)
         self._test_mxnet_model(net, input_shape=input_shape, mode='random')
 
+    def test_tiny_inner_product_no_bias(self):
+        np.random.seed(1988)
+        input_shape = (1, 10)
+        net = mx.sym.Variable('data')
+        net = mx.sym.FullyConnected(data=net, name='fc1', num_hidden=5, no_bias=True)
+        self._test_mxnet_model(net, input_shape=input_shape, mode='random')
+
     def test_tiny_softmax_random_input(self):
         np.random.seed(1988)
         input_shape = (1, 10)


### PR DESCRIPTION
## Description ##
The code was initially assuming bias to be true for dense layer. This change fixes that by relying on no_bias parameter.

## Checklist ##
### Essentials ###
- [Y] Passed code style checking (`make lint`)
- [Y] Changes are complete (i.e. I finished coding on this PR)
- [Y] All changes have test coverage
- [N/A] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [Y] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
This is related to issue: https://github.com/apache/incubator-mxnet/issues/8628
Note that lint score is low currently for this tool. Will open another pr which should improve the score.