### PR TITLE
Fixing the monitor callback of the bucketing module.

### DIFF
--- a/python/mxnet/module/bucketing_module.py
+++ b/python/mxnet/module/bucketing_module.py
@@ -85,6 +85,7 @@ class BucketingModule(BaseModule):
         self._curr_module = None
         self._curr_bucket_key = None
         self._params_dirty = False
+        self._monitor = None
 
     def _reset_bind(self):
         """Internal utility function to reset binding."""
@@ -356,6 +357,8 @@ class BucketingModule(BaseModule):
             module.bind(data_shapes, label_shapes, self._curr_module.for_training,
                         self._curr_module.inputs_need_grad,
                         force_rebind=False, shared_module=self._buckets[self._default_bucket_key])
+            if self._monitor is not None:
+                module.install_monitor(self._monitor)
             self._buckets[bucket_key] = module
 
         self._curr_module = self._buckets[bucket_key]
@@ -499,5 +502,6 @@ class BucketingModule(BaseModule):
     def install_monitor(self, mon):
         """Installs monitor on all executors """
         assert self.binded
+        self._monitor = mon
         for mod in self._buckets.values():
             mod.install_monitor(mon)


### PR DESCRIPTION
## Description ##
install_monitor was broken for the bucketing module, as it would only register the monitor with the buckets present at the time of the call (which most likely is only the module for the default bucket). With this PR we keep a reference to the monitor in order to be able to install it once we create the other modules/executors.