### PR TITLE
Doc src and fix

### DIFF
--- a/docs/api/python/gluon/model_zoo.md
+++ b/docs/api/python/gluon/model_zoo.md
@@ -13,6 +13,7 @@ This document lists the model APIs in Gluon:
     :nosignatures:
 
     mxnet.gluon.model_zoo
+    mxnet.gluon.model_zoo.vision
 ```
 
 The `Gluon Model Zoo` API, defined in the `gluon.model_zoo` package, provides pre-defined
@@ -185,6 +186,8 @@ In the rest of this document, we list routines provided by the `gluon.model_zoo`
 <script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
+
+.. automodule:: mxnet.gluon.model_zoo
 
 .. automodule:: mxnet.gluon.model_zoo.vision
     :members:

--- a/docs/api/python/ndarray/ndarray.md
+++ b/docs/api/python/ndarray/ndarray.md
@@ -559,13 +559,13 @@ The `ndarray` package provides several classes:
 .. autosummary::
     :nosignatures:
 
-    mxnet.nd.random.uniform
-    mxnet.nd.random.normal
-    mxnet.nd.random.gamma
-    mxnet.nd.random.exponential
-    mxnet.nd.random.poisson
-    mxnet.nd.random.negative_binomial
-    mxnet.nd.random.generalized_negative_binomial
+    mxnet.ndarray.random.uniform
+    mxnet.ndarray.random.normal
+    mxnet.ndarray.random.gamma
+    mxnet.ndarray.random.exponential
+    mxnet.ndarray.random.poisson
+    mxnet.ndarray.random.negative_binomial
+    mxnet.ndarray.random.generalized_negative_binomial
     mxnet.random.seed
 ```
 

--- a/docs/api/python/symbol/symbol.md
+++ b/docs/api/python/symbol/symbol.md
@@ -558,13 +558,13 @@ Composite multiple symbols into a new one by an operator.
 .. autosummary::
     :nosignatures:
 
-    mxnet.sym.random.uniform
-    mxnet.sym.random.normal
-    mxnet.sym.random.gamma
-    mxnet.sym.random.exponential
-    mxnet.sym.random.poisson
-    mxnet.sym.random.negative_binomial
-    mxnet.sym.random.generalized_negative_binomial
+    mxnet.symbol.random.uniform
+    mxnet.symbol.random.normal
+    mxnet.symbol.random.gamma
+    mxnet.symbol.random.exponential
+    mxnet.symbol.random.poisson
+    mxnet.symbol.random.negative_binomial
+    mxnet.symbol.random.generalized_negative_binomial
     mxnet.random.seed
 ```
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
     'sphinx.ext.mathjax',
+    'sphinx.ext.viewcode',
     'breathe',
     'mxdoc'
 ]

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -62,8 +62,12 @@ def generate_doxygen(app):
 
 def build_mxnet(app):
     """Build mxnet .so lib"""
-    _run_cmd("cd %s/.. && cp make/config.mk config.mk && make -j$(nproc) DEBUG=1" %
-            app.builder.srcdir)
+    if not os.path.exists(os.path.join(app.builder.srcdir, '..', 'config.mk')):
+        _run_cmd("cd %s/.. && cp make/config.mk config.mk && make -j$(nproc) DEBUG=1" %
+                app.builder.srcdir)
+    else:
+        _run_cmd("cd %s/.. && make -j$(nproc) DEBUG=1" %
+                app.builder.srcdir)
 
 def build_r_docs(app):
     """build r pdf"""

--- a/python/mxnet/gluon/model_zoo/vision/__init__.py
+++ b/python/mxnet/gluon/model_zoo/vision/__init__.py
@@ -30,6 +30,7 @@ This module contains definitions for the following model architectures:
 -  `MobileNet`_
 
 You can construct a model with random weights by calling its constructor:
+
 .. code::
 
     from mxnet.gluon.model_zoo import vision
@@ -39,8 +40,8 @@ You can construct a model with random weights by calling its constructor:
     densenet = vision.densenet_161()
 
 We provide pre-trained models for all the models except ResNet V2.
-These can constructed by passing
-``pretrained=True``:
+These can constructed by passing ``pretrained=True``:
+
 .. code::
 
     from mxnet.gluon.model_zoo import vision


### PR DESCRIPTION
## Description ##
Add a link for viewing source code in api doc. Updated doc can be found at http://mxnet-doc.s3-accelerate.dualstack.amazonaws.com/api/python/index.html

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] add `sphinx.ext.viewcode`
- [x] fix links

## Comments ##
- Code that is generated at run-time isn't available for viewing (e.g. frontend functions for operators)