### PR TITLE
fix custom op for backward compatibility

### DIFF
--- a/python/mxnet/operator.py
+++ b/python/mxnet/operator.py
@@ -563,7 +563,7 @@ class CustomOpProp(object):
             list of aux stypes calculated from in_stype,
             in the same order as declared in list_auxiliary_states.
         """
-        return in_stype, [in_stype[0]]*len(self.list_outputs()), \
+        return in_stype, [in_stype[0]]*len(self.list_arguments()), \
             [in_stype[0]]*len(self.list_auxiliary_states())
 
     def list_outputs(self):

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -3652,7 +3652,6 @@ def test_custom_op():
     assert (x.grad.stype == 'csr')
     assert (y.stype == 'csr')
     assert (aux.stype == 'csr')
-    
     # test for backward compatibility, i.e. the correctness of default implementation of 
     # infer storage in custom operator
     class Mult(mx.operator.CustomOp):
@@ -3688,6 +3687,8 @@ def test_custom_op():
         y = mx.nd.Custom(lhs, rhs, op_type='mult')
         y.backward()
     mx.nd.waitall()
+    assert_almost_equal(rhs.asnumpy(), lhs.grad.asnumpy())
+    assert_almost_equal(lhs.asnumpy(), rhs.grad.asnumpy())
 
 def test_psroipooling():
     for num_rois in [1, 2]:

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -3652,6 +3652,42 @@ def test_custom_op():
     assert (x.grad.stype == 'csr')
     assert (y.stype == 'csr')
     assert (aux.stype == 'csr')
+    
+    # test for backward compatibility, i.e. the correctness of default implementation of 
+    # infer storage in custom operator
+    class Mult(mx.operator.CustomOp):
+        def forward(self, is_train, req, in_data, out_data, aux):
+            self.assign(out_data[0], req[0], in_data[0]*in_data[1])
+
+        def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
+            self.assign(in_grad[0], req[0], in_data[1]*out_grad[0])
+            self.assign(in_grad[1], req[1], in_data[0]*out_grad[0])
+
+    @mx.operator.register("mult")
+    class MultProp(mx.operator.CustomOpProp):
+        def __init__(self):
+            super(MultProp, self).__init__(need_top_grad=True)
+
+        def list_arguments(self):
+            return ['lhs', 'rhs']
+
+        def list_outputs(self):
+            return ['output']
+
+        def infer_shape(self, in_shape):
+            return in_shape, [in_shape[0]], []
+
+        def create_operator(self, ctx, shapes, dtypes):
+            return Mult()
+
+    lhs = mx.nd.array(np.random.uniform(-1, 1, size=(4, 10)))
+    rhs = mx.nd.array(np.random.uniform(-1, 1, size=(4, 10)))
+    lhs.attach_grad()
+    rhs.attach_grad()
+    with mx.contrib.autograd.train_section():
+        y = mx.nd.Custom(lhs, rhs, op_type='mult')
+        y.backward()
+    mx.nd.waitall()
 
 def test_psroipooling():
     for num_rois in [1, 2]:


### PR DESCRIPTION
## Description ##
The default implementation `infer_storage_type_backward` in custom op has some problem.

Before this PR, the LR in sparse example is broken due to the custom op, and the added test will throw err message,
```
Error in mult.infer_type: Traceback (most recent call last):
  File "/home/hanfeng/zyh/mxnet/python/mxnet/operator.py", line 737, in infer_storage_type_backward_entry
    "stypes, got %d."%(total_outputs, len(ostype))
AssertionError: InferStorageTypeBackward Error: expecting 2 entries in returned output stypes, got 1.

[10:27:12] /home/hanfeng/zyh/mxnet/dmlc-core/include/dmlc/./logging.h:308: [10:27:12] src/operator/custom/custom.cc:383: Check failed: reinterpret_cast<CustomOpBackwardInferStorageTypeFunc>( params.info->callbacks[kCustomOpPropBackwardInferStorageType])( stypes.size(), stypes.data(), params.info->contexts[kCustomOpPropBackwardInferStorageType])
```
cc @eric-haibin-lin @anirudh2290

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
