### PR TITLE
Profiler: set cpu/gpu num during execution

### DIFF
--- a/src/engine/profiler.cc
+++ b/src/engine/profiler.cc
@@ -31,7 +31,9 @@
 #include <chrono>
 #include <iostream>
 #include <fstream>
+#include <thread>
 #include "./profiler.h"
+#include "../common/cuda_utils.h"
 
 #if defined(_MSC_VER) && _MSC_VER <= 1800
 #include <Windows.h>
@@ -45,12 +47,11 @@ Profiler::Profiler()
   : state_(kNotRunning), enable_output_(false), filename_("profile.json") {
   this->init_time_ = NowInUsec();
 
-  // TODO(ziheng) get device number during execution
-  int kMaxNumCpus = 64;
-  this->cpu_num_ = kMaxNumCpus;
+  this->cpu_num_ = std::thread::hardware_concurrency();
 #if MXNET_USE_CUDA
-  int kMaxNumGpus = 32;
-  this->gpu_num_ = kMaxNumGpus;
+  int gpu_num = 0;
+  CUDA_CALL(cudaGetDeviceCount(&gpu_num));
+  this->gpu_num_ = (unsigned int)gpu_num;
 #else
   this->gpu_num_ = 0;
 #endif

--- a/src/engine/profiler.cc
+++ b/src/engine/profiler.cc
@@ -52,9 +52,8 @@ Profiler::Profiler()
 
   this->cpu_num_ = std::thread::hardware_concurrency();
 #if MXNET_USE_CUDA
-  int gpu_num = 0;
-  CUDA_CALL(cudaGetDeviceCount(&gpu_num));
-  this->gpu_num_ = (unsigned int)gpu_num;
+  int kMaxNumGpus = 32;
+  this->gpu_num_ = kMaxNumGpus;
 #else
   this->gpu_num_ = 0;
 #endif

--- a/src/engine/profiler.cc
+++ b/src/engine/profiler.cc
@@ -33,7 +33,10 @@
 #include <fstream>
 #include <thread>
 #include "./profiler.h"
+
+#if MXNET_USE_CUDA
 #include "../common/cuda_utils.h"
+#endif
 
 #if defined(_MSC_VER) && _MSC_VER <= 1800
 #include <Windows.h>


### PR DESCRIPTION
Signed-off-by: YujiOshima <yuji.oshima0x3fd@gmail.com>

## Description ##
In Profiler, set CPU and GPU number dynamically. 
Enable to use profiler in a large number of CPU or GPU environment.

@ZihengJiang 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
