### PR TITLE
[WIP] Fix custom op when used with need_top_grad=False

### DIFF
--- a/python/mxnet/operator.py
+++ b/python/mxnet/operator.py
@@ -563,7 +563,7 @@ class CustomOpProp(object):
             list of aux stypes calculated from in_stype,
             in the same order as declared in list_auxiliary_states.
         """
-        return in_stype, [in_stype[0]]*len(self.list_outputs()), \
+        return in_stype, [in_stype[0]]*len(self.list_arguments()), \
             [in_stype[0]]*len(self.list_auxiliary_states())
 
     def list_outputs(self):

--- a/python/mxnet/operator.py
+++ b/python/mxnet/operator.py
@@ -31,7 +31,7 @@ from .base import _LIB, check_call, MXCallbackList, c_array, c_array_buf
 from .base import c_str, mx_uint, mx_float, ctypes2numpy_shared, NDArrayHandle, py_str
 from . import symbol, context
 from .ndarray import NDArray, _DTYPE_NP_TO_MX, _DTYPE_MX_TO_NP
-from .ndarray.ndarray import _STORAGE_TYPE_STR_TO_ID, _STORAGE_TYPE_ID_TO_STR, _STORAGE_TYPE_DEFAULT
+from .ndarray.ndarray import _STORAGE_TYPE_STR_TO_ID, _STORAGE_TYPE_ID_TO_STR
 from .ndarray import _ndarray_cls
 
 

--- a/src/operator/custom/custom.cc
+++ b/src/operator/custom/custom.cc
@@ -370,7 +370,8 @@ inline bool BackwardInferStorageType(const nnvm::NodeAttrs& attrs,
   }
 
   std::vector<int> stypes;
-  stypes.reserve(params.num_outs * 2 + params.num_args * 2 + params.num_auxs);
+  const size_t num_bwd_args = params.bwd_idx.size();
+  stypes.reserve(num_bwd_args + params.num_args + params.num_auxs);
   for (size_t i = 0; i < iattr->size(); ++i) {
     stypes.push_back((*iattr)[i]);
   }
@@ -382,17 +383,17 @@ inline bool BackwardInferStorageType(const nnvm::NodeAttrs& attrs,
       params.info->callbacks[kCustomOpPropBackwardInferStorageType])(
       stypes.size(), stypes.data(),
       params.info->contexts[kCustomOpPropBackwardInferStorageType]));
-  for (size_t i = 0; i < 2 * params.num_outs + params.num_args; ++i) {
+  for (size_t i = 0; i < num_bwd_args; ++i) {
     STORAGE_TYPE_ASSIGN_CHECK(*iattr, i, stypes[i]);
   }
   for (size_t i = 0; i < params.num_args; ++i) {
     STORAGE_TYPE_ASSIGN_CHECK(
-        *oattr, i, stypes[i + 2 * params.num_outs + params.num_args]);
+        *oattr, i, stypes[i + num_bwd_args]);
   }
   for (size_t i = 0; i < params.num_auxs; ++i) {
     STORAGE_TYPE_ASSIGN_CHECK(
-        *iattr, i + 2 * params.num_outs + params.num_args,
-        stypes[i + 2 * params.num_outs + 2 * params.num_args]);
+        *iattr, i + num_bwd_args,
+        stypes[i + num_bwd_args + params.num_args]);
   }
 
   DISPATCH_MODE_ASSIGN_CHECK(dispatch_mode, 0, DispatchMode::kFComputeEx);

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -3652,7 +3652,6 @@ def test_custom_op():
     assert (x.grad.stype == 'csr')
     assert (y.stype == 'csr')
     assert (aux.stype == 'csr')
-    
     # test for backward compatibility, i.e. the correctness of default implementation of 
     # infer storage in custom operator
     class Mult(mx.operator.CustomOp):
@@ -3688,6 +3687,8 @@ def test_custom_op():
         y = mx.nd.Custom(lhs, rhs, op_type='mult')
         y.backward()
     mx.nd.waitall()
+    assert_almost_equal(rhs.asnumpy(), lhs.grad.asnumpy())
+    assert_almost_equal(lhs.asnumpy(), rhs.grad.asnumpy())
 
 def test_psroipooling():
     for num_rois in [1, 2]:

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -3652,6 +3652,42 @@ def test_custom_op():
     assert (x.grad.stype == 'csr')
     assert (y.stype == 'csr')
     assert (aux.stype == 'csr')
+    
+    # test for backward compatibility, i.e. the correctness of default implementation of 
+    # infer storage in custom operator
+    class Mult(mx.operator.CustomOp):
+        def forward(self, is_train, req, in_data, out_data, aux):
+            self.assign(out_data[0], req[0], in_data[0]*in_data[1])
+
+        def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
+            self.assign(in_grad[0], req[0], in_data[1]*out_grad[0])
+            self.assign(in_grad[1], req[1], in_data[0]*out_grad[0])
+
+    @mx.operator.register("mult")
+    class MultProp(mx.operator.CustomOpProp):
+        def __init__(self):
+            super(MultProp, self).__init__(need_top_grad=True)
+
+        def list_arguments(self):
+            return ['lhs', 'rhs']
+
+        def list_outputs(self):
+            return ['output']
+
+        def infer_shape(self, in_shape):
+            return in_shape, [in_shape[0]], []
+
+        def create_operator(self, ctx, shapes, dtypes):
+            return Mult()
+
+    lhs = mx.nd.array(np.random.uniform(-1, 1, size=(4, 10)))
+    rhs = mx.nd.array(np.random.uniform(-1, 1, size=(4, 10)))
+    lhs.attach_grad()
+    rhs.attach_grad()
+    with mx.contrib.autograd.train_section():
+        y = mx.nd.Custom(lhs, rhs, op_type='mult')
+        y.backward()
+    mx.nd.waitall()
 
 def test_psroipooling():
     for num_rois in [1, 2]:


### PR DESCRIPTION
## Description ##


## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fix custom op when used with need_top_grad=False (and when applicable, API doc)

## Comments ##
- Before this PR, the custom op failed with need_top_grad=False as the backward infer storage logic expected the out_grad to always be present. Requires #8721 to be merged.