### PR TITLE
Revert "Support sparse for custom python operators (#8620)"

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -147,9 +147,7 @@ enum CustomOpPropCallbacks {
   kCustomOpPropInferShape,
   kCustomOpPropDeclareBackwardDependency,
   kCustomOpPropCreateOperator,
-  kCustomOpPropInferType,
-  kCustomOpPropInferStorageType,
-  kCustomOpPropBackwardInferStorageType
+  kCustomOpPropInferType
 };
 
 
@@ -161,10 +159,6 @@ typedef int (*CustomOpListFunc)(char*** /*args*/, void* /*state*/);
 typedef int (*CustomOpInferShapeFunc)(int /*num_input*/, int* /*ndims*/,
                                       unsigned** /*shapes*/, void* /*state*/);
 typedef int (*CustomOpInferTypeFunc)(int /*num_input*/, int* /*types*/, void* /*state*/);
-typedef int (*CustomOpInferStorageTypeFunc)(int /*num_input*/, int* /*stypes*/, void* /*state*/);
-typedef int (*CustomOpBackwardInferStorageTypeFunc)(int /*num_input*/,
-                                                    int * /*stypes*/,
-                                                    void * /*state*/);
 typedef int (*CustomOpBwdDepFunc)(const int* /*out_grad*/, const int* /*in_data*/,
                                   const int* /*out_data*/, int* /*num_deps*/,
                                   int** /*rdeps*/, void* /*state*/);

--- a/src/operator/custom/custom.cc
+++ b/src/operator/custom/custom.cc
@@ -351,100 +351,20 @@ void Backward(const OpStatePtr& state,
   Imperative::Get()->set_is_recording(prev_recording);
 }
 
-inline bool BackwardInferStorageType(const nnvm::NodeAttrs& attrs,
-                                     const int dev_mask,
-                                     DispatchMode* dispatch_mode,
-                                     std::vector<int>* iattr,
-                                     std::vector<int>* oattr) {
-  const CustomParam& params = nnvm::get<CustomParam>(attrs.parsed);
-
-  if (params.info->num_callbacks <= kCustomOpPropBackwardInferStorageType) {
-    for (size_t i = 0; i < iattr->size(); i++) {
-      STORAGE_TYPE_ASSIGN_CHECK(*iattr, i, kDefaultStorage);
-    }
-    for (size_t i = 0; i < oattr->size(); i++) {
-      STORAGE_TYPE_ASSIGN_CHECK(*oattr, i, kDefaultStorage);
-    }
-    DISPATCH_MODE_ASSIGN_CHECK(dispatch_mode, 0, DispatchMode::kFComputeEx);
-    return true;
-  }
-
-  std::vector<int> stypes;
-  stypes.reserve(params.num_outs * 2 + params.num_args * 2 + params.num_auxs);
-  for (size_t i = 0; i < iattr->size(); ++i) {
-    stypes.push_back((*iattr)[i]);
-  }
-  for (size_t i = 0; i < oattr->size(); ++i) {
-    stypes.push_back((*oattr)[i]);
-  }
-
-  CHECK(reinterpret_cast<CustomOpBackwardInferStorageTypeFunc>(
-      params.info->callbacks[kCustomOpPropBackwardInferStorageType])(
-      stypes.size(), stypes.data(),
-      params.info->contexts[kCustomOpPropBackwardInferStorageType]));
-  for (size_t i = 0; i < 2 * params.num_outs + params.num_args; ++i) {
-    STORAGE_TYPE_ASSIGN_CHECK(*iattr, i, stypes[i]);
-  }
-  for (size_t i = 0; i < params.num_args; ++i) {
-    STORAGE_TYPE_ASSIGN_CHECK(
-        *oattr, i, stypes[i + 2 * params.num_outs + params.num_args]);
-  }
-  for (size_t i = 0; i < params.num_auxs; ++i) {
-    STORAGE_TYPE_ASSIGN_CHECK(
-        *iattr, i + 2 * params.num_outs + params.num_args,
-        stypes[i + 2 * params.num_outs + 2 * params.num_args]);
-  }
-
-  DISPATCH_MODE_ASSIGN_CHECK(dispatch_mode, 0, DispatchMode::kFComputeEx);
-  return true;
-}
-
 // infer storage function for custom op, which assigns kDefaultStorage for
 // all undefined stypes, and dispatch on DispatchMode::kFComputeEx.
-inline bool InferStorageType(const nnvm::NodeAttrs& attrs, const int dev_mask,
+inline bool InferStorageType(const nnvm::NodeAttrs& attrs,
+                             const int dev_mask,
                              DispatchMode* dispatch_mode,
-                             std::vector<int>* iattr, std::vector<int>* oattr) {
-  const CustomParam& params = nnvm::get<CustomParam>(attrs.parsed);
-
-  if (params.info->num_callbacks <= kCustomOpPropInferStorageType) {
-    for (size_t i = 0; i < iattr->size(); i++) {
-      STORAGE_TYPE_ASSIGN_CHECK(*iattr, i, kDefaultStorage);
-    }
-    for (size_t i = 0; i < oattr->size(); i++) {
-      STORAGE_TYPE_ASSIGN_CHECK(*oattr, i, kDefaultStorage);
-    }
-    DISPATCH_MODE_ASSIGN_CHECK(dispatch_mode, 0, DispatchMode::kFComputeEx);
-    return true;
+                             std::vector<int> *iattr,
+                             std::vector<int> *oattr) {
+  for (int& v : *oattr) {
+    if (v == -1) v = kDefaultStorage;
   }
-
-  std::vector<int> stypes;
-  stypes.reserve(params.num_args + params.num_outs + params.num_auxs);
-  for (size_t i = 0; i < params.num_args; ++i) {
-    stypes.push_back((*iattr)[i]);
+  for (int& v : *iattr) {
+    if (v == -1) v = kDefaultStorage;
   }
-  for (const auto& i : *oattr) {
-    stypes.push_back(i);
-  }
-  for (size_t i = 0; i < params.num_auxs; ++i) {
-    stypes.push_back((*iattr)[params.num_args + i]);
-  }
-
-  CHECK(reinterpret_cast<CustomOpInferStorageTypeFunc>(
-      params.info->callbacks[kCustomOpPropInferStorageType])(
-      stypes.size(), stypes.data(),
-      params.info->contexts[kCustomOpPropInferStorageType]));
-  for (size_t i = 0; i < params.num_args; ++i) {
-    STORAGE_TYPE_ASSIGN_CHECK(*iattr, i, stypes[i]);
-  }
-  for (size_t i = 0; i < params.num_outs; ++i) {
-    STORAGE_TYPE_ASSIGN_CHECK(*oattr, i, stypes[params.num_args + i]);
-  }
-  for (size_t i = 0; i < params.num_auxs; ++i) {
-    STORAGE_TYPE_ASSIGN_CHECK(*iattr, params.num_args + i,
-                              stypes[params.num_args + params.num_outs + i]);
-  }
-
-  DISPATCH_MODE_ASSIGN_CHECK(dispatch_mode, 0, DispatchMode::kFComputeEx);
+  dispatch_mode_assign(dispatch_mode, DispatchMode::kFComputeEx);
   return true;
 }
 
@@ -510,7 +430,7 @@ NNVM_REGISTER_OP(_backward_Custom)
   })
 .set_attr<FStatefulComputeEx>("FStatefulComputeEx<cpu>", Backward)
 .set_attr<FStatefulComputeEx>("FStatefulComputeEx<gpu>", Backward)
-.set_attr<FInferStorageType>("FInferStorageType", BackwardInferStorageType);
+.set_attr<FInferStorageType>("FInferStorageType", InferStorageType);
 
 }  // namespace custom
 }  // namespace op


### PR DESCRIPTION
Reverting sparse support for custom op because the backward_infer_storage_type interface is poorly designed.

@anirudh2290 please resubmit with new design