### PR TITLE
comment typo: there are there

### DIFF
--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -525,7 +525,7 @@ NNVM_REGISTER_OP(tile)
 .describe(R"code(Repeats the whole array multiple times.
 
 If ``reps`` has length *d*, and input array has dimension of *n*. There are
-there cases:
+three cases:
 
 - **n=d**. Repeat *i*-th dimension of the input by ``reps[i]`` times::
 


### PR DESCRIPTION
Corrected comment 'there are there' to say 'there are three cases:', an alternative is to say .there are these cases:'.

## Description ##
typo in comment

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
