### PR TITLE
[ImageIO] Fix image io for opencv3.3

### DIFF
--- a/plugin/opencv/cv_api.cc
+++ b/plugin/opencv/cv_api.cc
@@ -100,7 +100,11 @@ MXNET_DLL int MXCVImdecode(const unsigned char *img, const mx_uint len,
       ndout.CheckAndAlloc();
       cv::Mat buf(1, len, CV_8U, img_cpy);
       cv::Mat dst(dims[0], dims[1], flag == 0 ? CV_8U : CV_8UC3, ndout.data().dptr_);
+#if (CV_MAJOR_VERSION > 2 && CV_MINOR_VERSION >= 3)
+      cv::imdecode(buf, flag | cv::IMREAD_IGNORE_ORIENTATION, &dst);
+#else
       cv::imdecode(buf, flag, &dst);
+#endif
       CHECK(!dst.empty());
       delete[] img_cpy;
     }, ndout.ctx(), {}, {ndout.var()});

--- a/plugin/opencv/cv_api.cc
+++ b/plugin/opencv/cv_api.cc
@@ -100,7 +100,7 @@ MXNET_DLL int MXCVImdecode(const unsigned char *img, const mx_uint len,
       ndout.CheckAndAlloc();
       cv::Mat buf(1, len, CV_8U, img_cpy);
       cv::Mat dst(dims[0], dims[1], flag == 0 ? CV_8U : CV_8UC3, ndout.data().dptr_);
-#if (CV_MAJOR_VERSION > 2 && CV_MINOR_VERSION >= 3)
+#if (CV_MAJOR_VERSION > 3 || (CV_MAJOR_VERSION == 3 && CV_MINOR_VERSION >= 3))
       cv::imdecode(buf, flag | cv::IMREAD_IGNORE_ORIENTATION, &dst);
 #else
       cv::imdecode(buf, flag, &dst);

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -156,7 +156,10 @@ void ImdecodeImpl(int flag, bool to_rgb, void* data, size_t size,
   } else {
     dst = cv::Mat(out->shape()[0], out->shape()[1], flag == 0 ? CV_8U : CV_8UC3,
                 out->data().dptr_);
-#if (CV_MAJOR_VERSION > 2 || (CV_MAJOR_VERSION == 2 && CV_MINOR_VERSION >=4))
+#if (CV_MAJOR_VERSION > 2 && CV_MINOR_VERSION >= 3)
+    cv::imdecode(buf, flag | cv::IMREAD_IGNORE_ORIENTATION, &dst);
+    CHECK(!dst.empty()) << "Decoding failed. Invalid image file.";
+#elif (CV_MAJOR_VERSION > 2 || (CV_MAJOR_VERSION == 2 && CV_MINOR_VERSION >=4))
     cv::imdecode(buf, flag, &dst);
     CHECK(!dst.empty()) << "Decoding failed. Invalid image file.";
 #else

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -156,7 +156,7 @@ void ImdecodeImpl(int flag, bool to_rgb, void* data, size_t size,
   } else {
     dst = cv::Mat(out->shape()[0], out->shape()[1], flag == 0 ? CV_8U : CV_8UC3,
                 out->data().dptr_);
-#if (CV_MAJOR_VERSION > 2 && CV_MINOR_VERSION >= 3)
+#if (CV_MAJOR_VERSION > 3 || (CV_MAJOR_VERSION == 3 && CV_MINOR_VERSION >= 3))
     cv::imdecode(buf, flag | cv::IMREAD_IGNORE_ORIENTATION, &dst);
     CHECK(!dst.empty()) << "Decoding failed. Invalid image file.";
 #elif (CV_MAJOR_VERSION > 2 || (CV_MAJOR_VERSION == 2 && CV_MINOR_VERSION >=4))

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -159,7 +159,7 @@ void ImdecodeImpl(int flag, bool to_rgb, void* data, size_t size,
 #if (CV_MAJOR_VERSION > 3 || (CV_MAJOR_VERSION == 3 && CV_MINOR_VERSION >= 3))
     cv::imdecode(buf, flag | cv::IMREAD_IGNORE_ORIENTATION, &dst);
     CHECK(!dst.empty()) << "Decoding failed. Invalid image file.";
-#elif (CV_MAJOR_VERSION > 2 || (CV_MAJOR_VERSION == 2 && CV_MINOR_VERSION >=4))
+#elif(CV_MAJOR_VERSION > 2 || (CV_MAJOR_VERSION == 2 && CV_MINOR_VERSION >= 4))
     cv::imdecode(buf, flag, &dst);
     CHECK(!dst.empty()) << "Decoding failed. Invalid image file.";
 #else


### PR DESCRIPTION
## Description ##
Starting from OpenCV3.3 the `imdecode` function will automatically rotate the image based on the EXIF' orientation flag.
```c++
Mat imdecode( InputArray _buf, int flags )
{
    CV_TRACE_FUNCTION();

    Mat buf = _buf.getMat(), img;
    imdecode_( buf, flags, LOAD_MAT, &img );

    /// optionally rotate the data if EXIF' orientation flag says so
    if( !img.empty() && (flags & IMREAD_IGNORE_ORIENTATION) == 0 && flags != IMREAD_UNCHANGED )
    {
        ApplyExifOrientation(buf, img);
    }

    return img;
}
```

This can be disabled by setting the `cv::IMREAD_IGNORE_ORIENTATION` flag.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] add `IMREAD_IGNORE_ORIENTATION` flag when opencv 3.3 is used.

## Comments ##
