### PR TITLE
Gradient compression example and raise exception if kvstore type unsupported

### DIFF
--- a/example/gluon/word_language_model/train.py
+++ b/example/gluon/word_language_model/train.py
@@ -54,6 +54,11 @@ parser.add_argument('--log-interval', type=int, default=200, metavar='N',
                     help='report interval')
 parser.add_argument('--save', type=str, default='model.params',
                     help='path to save the final model')
+parser.add_argument('--gctype', type=str, default='none',
+                    help='type of gradient compression to use, \
+                          takes `2bit` or `none` for now.')
+parser.add_argument('--gcthreshold', type=float, default=0.5,
+                    help='threshold for 2bit gradient compression')
 args = parser.parse_args()
 
 
@@ -90,10 +95,13 @@ ntokens = len(corpus.dictionary)
 model = model.RNNModel(args.model, ntokens, args.emsize, args.nhid,
                        args.nlayers, args.dropout, args.tied)
 model.collect_params().initialize(mx.init.Xavier(), ctx=context)
+
+compression_params = None if args.gctype == 'none' else {'type': args.gctype, 'threshold': args.gcthreshold}
 trainer = gluon.Trainer(model.collect_params(), 'sgd',
                         {'learning_rate': args.lr,
                          'momentum': 0,
-                         'wd': 0})
+                         'wd': 0},
+                        compression_params=compression_params)
 loss = gluon.loss.SoftmaxCrossEntropyLoss()
 
 ###############################################################################

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -408,6 +408,8 @@ class KVStore(object):
             Other keys in this dictionary are optional and specific to the type
             of gradient compression.
         """
+        if (self.type() == 'device') or ('dist' in self.type()):
+            raise Exception('Gradient compression is not supported for this type of kvstore')
         ckeys, cvals = _ctype_dict(compression_params)
         check_call(_LIB.MXKVStoreSetGradientCompression(self.handle,
                                                         mx_uint(len(compression_params)),

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -408,7 +408,7 @@ class KVStore(object):
             Other keys in this dictionary are optional and specific to the type
             of gradient compression.
         """
-        if (self.type() == 'device') or ('dist' in self.type()):
+        if (self.type == 'device') or ('dist' in self.type):
             ckeys, cvals = _ctype_dict(compression_params)
             check_call(_LIB.MXKVStoreSetGradientCompression(self.handle,
                                                             mx_uint(len(compression_params)),

--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -409,11 +409,12 @@ class KVStore(object):
             of gradient compression.
         """
         if (self.type() == 'device') or ('dist' in self.type()):
+            ckeys, cvals = _ctype_dict(compression_params)
+            check_call(_LIB.MXKVStoreSetGradientCompression(self.handle,
+                                                            mx_uint(len(compression_params)),
+                                                            ckeys, cvals))
+        else:
             raise Exception('Gradient compression is not supported for this type of kvstore')
-        ckeys, cvals = _ctype_dict(compression_params)
-        check_call(_LIB.MXKVStoreSetGradientCompression(self.handle,
-                                                        mx_uint(len(compression_params)),
-                                                        ckeys, cvals))
 
     def set_optimizer(self, optimizer):
         """ Registers an optimizer with the kvstore.


### PR DESCRIPTION
## Description ##
Added gluon example for gradient compression and raise exception if kvstore type unsupported 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Added gluon example for gradient compression
- [x] Raise exception if kvstore type unsupported 

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here