### PR TITLE
remove meaningless type qualifier

### DIFF
--- a/src/operator/operator_tune.h
+++ b/src/operator/operator_tune.h
@@ -155,7 +155,7 @@ class OperatorTuneByType : public OperatorTuneBase {
    * \return tune::TuningMode value for the current tuning mode
    */
   static MSHADOW_CINLINE tune::TuningMode tuning_mode() {
-    return tuning_mode_;
+    return const_cast<tune::TuningMode &>(tuning_mode_);
   }
 
   /*!

--- a/src/operator/operator_tune.h
+++ b/src/operator/operator_tune.h
@@ -154,7 +154,7 @@ class OperatorTuneByType : public OperatorTuneBase {
    * \brief Get the current tuning mode
    * \return tune::TuningMode value for the current tuning mode
    */
-  static MSHADOW_CINLINE volatile tune::TuningMode tuning_mode() {
+  static MSHADOW_CINLINE tune::TuningMode tuning_mode() {
     return tuning_mode_;
   }
 


### PR DESCRIPTION
## Description ##
Otherwise there are so many warnings `warning: type qualifier on return type is meaningless`.

```
g++ --version
g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-11)
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
cc @eric-haibin-lin @cjolivier01 

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
