### PR TITLE
cast scalar value in invoke to float

### DIFF
--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -793,9 +793,9 @@ class AdaGrad(Optimizer):
             srt = op.sqrt(adjusted_add)
             div = _internal._scatter_elemwise_div(grad, srt)
             retained_weight = sparse.retain(weight, grad.indices)
-            to_add = sparse.elemwise_add(div, _internal._mul_scalar(retained_weight, wd))
+            to_add = sparse.elemwise_add(div, _internal._mul_scalar(retained_weight, float(wd)))
             assert len(to_add.indices) == grad_indices_count
-            weight[:] = sparse.elemwise_add(weight, _internal._mul_scalar(to_add, -lr))
+            weight[:] = sparse.elemwise_add(weight, _internal._mul_scalar(to_add, float(-lr)))
             state[:] = history
             assert state.stype == save_history_stype
             assert len(history_indices) == grad_indices_count

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -2759,7 +2759,7 @@ def full(shape, val, dtype=None, **kwargs):
     """
     if dtype is None:
         dtype = _numpy.float32
-    return _internal._full(shape=shape, dtype=dtype, value=val, **kwargs)
+    return _internal._full(shape=shape, dtype=dtype, value=float(val), **kwargs)
 
 # pylint: disable=redefined-outer-name
 def arange(start, stop=None, step=1.0, repeat=1, name=None, dtype=None):


### PR DESCRIPTION
Doing float() cast in other places since we know now there's a precision problem with scalar numpy object types
