### PR TITLE
Fix check of kvstore type

### DIFF
--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -408,7 +408,7 @@ class KVStore(object):
             Other keys in this dictionary are optional and specific to the type
             of gradient compression.
         """
-        if (self.type == 'device') or ('dist' in self.type):
+        if ('device' in self.type) or ('dist' in self.type):
             ckeys, cvals = _ctype_dict(compression_params)
             check_call(_LIB.MXKVStoreSetGradientCompression(self.handle,
                                                             mx_uint(len(compression_params)),


### PR DESCRIPTION
## Description ##
kvstore type can be something like local as well as have device in it. For such kvstores as well gradient compression is supported

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
