### PR TITLE
Fix link error on DEBUG=1. Need mshadow::gpu::kDevMask def in TU

### DIFF
--- a/src/common/rtc.cc
+++ b/src/common/rtc.cc
@@ -25,6 +25,8 @@
 
 #if MXNET_USE_CUDA
 
+const int mshadow::gpu::kDevMask;
+
 namespace mxnet {
 namespace rtc {
 


### PR DESCRIPTION
Quick fix for mshadow::gpu::kDevMask used in a translation unit (not a header), which causes undefined symbol in debug mode.

