### PR TITLE
Avoid odr-using static member that will cause undefined references in…

### DIFF
--- a/src/common/rtc.cc
+++ b/src/common/rtc.cc
@@ -74,7 +74,8 @@ CudaModule::Chunk::~Chunk() {
 CUfunction CudaModule::Chunk::GetFunction(
     const std::string& mangled_name,
     const Context& ctx) {
-  CHECK_EQ(ctx.dev_mask(), gpu::kDevMask)
+  int kDevMask = gpu::kDevMask;
+  CHECK_EQ(ctx.dev_mask(), kDevMask)
       << "CUDA Runtime compilation only supports Nvidia GPU.";
   auto iter = mod_.find(ctx.dev_id);
   CUmodule module;


### PR DESCRIPTION
Directly passing `mshadow::gpu::kDevMask` to `CHECK_EQ` violates odr-use rule of inplace initialized static data member, which causes undefined reference of `gpu::kDevMask` during linking time in some compilers.