### PR TITLE
fix errors for reinterpret_cast usage

### DIFF
--- a/cpp-package/example/feature_extract/feature_extract.cpp
+++ b/cpp-package/example/feature_extract/feature_extract.cpp
@@ -117,7 +117,7 @@ NDArray Data2NDArray() {
   NDArray ret(Shape(2, 3, 224, 224), global_ctx, false);
   ifstream inf("./img.dat", ios::binary);
   vector<float> data(2 * 3 * 224 * 224);
-  inf.read(reinterpret_cast<char *>data.data(), 2 * 3 * 224 * 224 * sizeof(float));
+  inf.read(reinterpret_cast<char *>(data.data()), 2 * 3 * 224 * 224 * sizeof(float));
   inf.close();
   ret.SyncCopyFromCPU(data.data(), 2 * 3 * 224 * 224);
   NDArray::WaitAll();

--- a/cpp-package/example/feature_extract/prepare_data_with_opencv.cpp
+++ b/cpp-package/example/feature_extract/prepare_data_with_opencv.cpp
@@ -45,7 +45,7 @@ void Mat2Array() {
     }
   }
   ofstream outf("./img.dat", ios::binary);
-  outf.write(reinterpret_cast<char *>array.data(), array.size() * sizeof(float));
+  outf.write(reinterpret_cast<char *>(array.data()), array.size() * sizeof(float));
   outf.close();
 }
 


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)
fix error for reinterpret_cast
## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Feature1, tests, (and when applicable, API doc)
- [x] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
