### PR TITLE
preserve dtype of src_array in nd.array

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -2212,6 +2212,15 @@ def full(shape, val, ctx=None, dtype=mx_real_t, out=None):
     out[:] = val
     return out
 
+def _prepare_dtype(src_array, dtype):
+    """Prepare dtype if `dtype` is None. If `src_array` is an NDArray or numpy.ndarray,
+    return src_array.dtype. float32 is returned otherwise."""
+    if dtype is None:
+        if isinstance(src_array, (NDArray, np.ndarray)):
+            dtype = src_array.dtype
+        else:
+            dtype = mx_real_t
+    return dtype
 
 def array(source_array, ctx=None, dtype=None):
     """Creates an array from any object exposing the array interface.
@@ -2232,15 +2241,12 @@ def array(source_array, ctx=None, dtype=None):
     NDArray
         An `NDArray` with the same contents as the `source_array`.
     """
-    if isinstance(source_array, NDArray):
-        dtype = source_array.dtype if dtype is None else dtype
-    else:
-        dtype = mx_real_t if dtype is None else dtype
-        if not isinstance(source_array, np.ndarray):
-            try:
-                source_array = np.array(source_array, dtype=dtype)
-            except:
-                raise TypeError('source_array must be array like object')
+    dtype = _prepare_dtype(source_array, dtype)
+    if not isinstance(source_array, (np.ndarray, NDArray)):
+        try:
+            source_array = np.array(source_array, dtype=dtype)
+        except:
+            raise TypeError('source_array must be array like object')
     arr = empty(source_array.shape, ctx, dtype)
     arr[:] = source_array
     return arr

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -935,6 +935,15 @@ def test_assign_float_value_to_ndarray():
     b[0] = a[0]
     assert same(a, b.asnumpy())
 
+def test_ndarray_dtype():
+    a = np.ones((1,), dtype=np.int64)
+    b = mx.nd.array(a)
+    assert(a.dtype == b.dtype)
+    a = mx.nd.array([1])
+    assert(a.dtype == np.float32)
+    a = mx.nd.ones((1,), dtype=np.int32)
+    b = mx.nd.array(a)
+    assert(b.dtype == np.int32)
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
preserve dtype of src_array in `nd.array`

cc @eric-haibin-lin 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [NA] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] unittest

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
