### PR TITLE
Update test_operator_gpu.py

### DIFF
--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1425,7 +1425,7 @@ def test_cuda_rtc():
 
 def test_global_norm_clip_multi_device():
     x1 = mx.nd.ones((3,3), ctx=mx.gpu(0))
-    x2 = mx.nd.ones((4,4), ctx=mx.gpu(1))
+    x2 = mx.nd.ones((4,4), ctx=mx.cpu(0))
     norm = gluon.utils.clip_global_norm([x1, x2], 1.0)
     assert norm == 5.0
     assert_almost_equal(x1.asnumpy(), np.ones((3,3))/5)


### PR DESCRIPTION
change clip norm test to assume 1 gpu only

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
