### PR TITLE
Update install-mxnet-osx-python.sh

### DIFF
--- a/setup-utils/install-mxnet-osx-python.sh
+++ b/setup-utils/install-mxnet-osx-python.sh
@@ -29,11 +29,9 @@
 export MXNET_GITPATH="https://github.com/dmlc/mxnet.git"
 if [ -z ${MXNET_TAG} ];
 then
-	#
-	# TODO: Change this to latest tag
-	#       to avoid updating this value for every release
-	#
-	export MXNET_TAG="0.12.0"
+    export MXNET_BRANCH_TAG=""
+else
+    export MXNET_BRANCH_TAG="--branch $MXNET_TAG"
 fi
 
 export TARIKH=`/bin/date +%Y-%m-%d-%H:%M:%S`
@@ -362,19 +360,16 @@ download_mxnet() {
 
 	echo " "
 	echo "MXNET GIT Path = ${MXNET_GITPATH}"
-	#echo "MXNET Tag = ${MXNET_TAG}"
-	#echo "You can set \$MXNET_TAG to the appropriate github repo tag"
-	#echo "If not set, the default value used is the latest release"
-	echo " "
+	echo "MXNET Tag = ${MXNET_TAG}"
+    	echo "You can set \$MXNET_TAG to the appropriate github repo tag"
+    	echo "If not set, the default value used is the latest version on master"
+    	echo " "
 	sleep ${SLEEP_TIME}
 
-	chkret git clone ${MXNET_GITPATH} ${MXNET_HOME} --recursive
+	chkret git clone ${MXNET_BRANCH_TAG} ${MXNET_GITPATH} ${MXNET_HOME} --recursive
 	sleep ${SLEEP_TIME}
 	cd ${MXNET_HOME}
 	echo " "
-	#echo "Checkout tag = ${MXNET_TAG}"
-	#chkret git checkout ${MXNET_TAG}
-	#echo " "
 	sleep ${SLEEP_TIME}
 	echo "END: Download MXNet"
 	echo $LINE


### PR DESCRIPTION
Fixed handling of MXNET_TAG. If not set latest from master will be cloned to local directory. If a tag is specified, that tag will be used to clone the repository.

Tested with 
MXNET_TAG="1.0.0.rc0" and MXNET_TAG not set in local environment

## Description ##
Fixed handling of MXNET_TAG. If not set latest from master will be cloned to local directory. If a tag is specified, that tag will be used to clone the repository.

## Checklist ##
### Essentials ###
- [y] Passed code style checking (`make lint`)
- [y] Changes are complete (i.e. I finished coding on this PR)
- [n] All changes have test coverage
- [n] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [n] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [n] Feature1, tests, (and when applicable, API doc)
- [n] Feature2, tests, (and when applicable, API doc)

## Comments ##
- change does not include check if tag in repo exists, can be further enhancement.
I will work with Aaron to update documentation.
