### PR TITLE
  support monodimensional sparse array

### DIFF
--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -1184,6 +1184,7 @@ def zeros(stype, shape, ctx=None, dtype=None, **kwargs):
         aux_types = _STORAGE_AUX_TYPES[stype]
     else:
         raise ValueError("unknown storage type" + stype)
+    shape = (1, shape) if isinstance(shape, tuple) is False else shape
     out = _ndarray_cls(_new_alloc_handle(stype, shape, ctx, True, dtype, aux_types))
     return _internal._zeros(shape=shape, ctx=ctx, dtype=dtype, out=out, **kwargs)
 


### PR DESCRIPTION
  The end user reported the issue below:

  The following code

  b1 = nd.sparse.zeros('csr',shape=10, ctx=ctx)

  returns

  /usr/local/lib/python3.6/site-packages/mxnet/ndarray/sparse.py in _new_alloc_handle(stype, shape, ctx, delay_alloc, dtype, aux_types, aux_shapes)
         87     check_call(_LIB.MXNDArrayCreateSparseEx(
         88         ctypes.c_int(int(_STORAGE_TYPE_STR_TO_ID[stype])),
  ---> 89         c_array(mx_uint, shape),
         90         mx_uint(len(shape)),
         91         ctypes.c_int(ctx.device_typeid),

  /usr/local/lib/python3.6/site-packages/mxnet/base.py in c_array(ctype, values)
        214     2.0
        215     """
  --> 216     return (ctype * len(values))(*values)
        217
        218 def ctypes2buffer(cptr, length):

  TypeError: object of type 'int' has no len()

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
