### PR TITLE
Use backtrace from dmlc-core (dmlc::stack_trace())

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ mxnet_option(USE_MXNET_LIB_NAMING "Use MXNet library naming conventions." ON)
 mxnet_option(USE_GPROF            "Compile with gprof (profiling) flag" OFF)
 mxnet_option(USE_VTUNE            "Enable use of Intel Amplifier XE (VTune)" OFF) # one could set VTUNE_ROOT for search path
 mxnet_option(INSTALL_EXAMPLES     "Install the example source files." OFF)
+mxnet_option(USE_SIGNAL_HANDLER   "Print stack traces on segfaults." OFF)
 
 
 
@@ -572,6 +573,10 @@ install(TARGETS ${MXNET_INSTALL_TARGETS}
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 if (INSTALL_EXAMPLES)
   install(DIRECTORY example  DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME})
+endif()
+
+if (USE_SIGNAL_HANDLER)
+	add_definitions(-DMXNET_USE_SIGNAL_HANDLER=1)
 endif()
 
 # AUTO_INSTALL_DIR -> Optional: specify post-build install direcory

--- a/make/config.mk
+++ b/make/config.mk
@@ -33,7 +33,7 @@ DEBUG = 0
 # whether compile with profiler
 USE_PROFILER =
 
-# whether to turn on signal handler (e.g. segfault logger)
+# whether to turn on segfault signal handler to log the stack trace
 USE_SIGNAL_HANDLER =
 
 # the additional link flags you want to add

--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -25,37 +25,23 @@
 #include <signal.h>
 #include <dmlc/logging.h>
 #include <mxnet/engine.h>
-
 #include "engine/profiler.h"
 
 namespace mxnet {
-
-void segfault_logger(int sig) {
-  const int MAX_STACK_SIZE = 10;
-  void *stack[MAX_STACK_SIZE];
-
+#if MXNET_USE_SIGNAL_HANDLER && DMLC_LOG_STACK_TRACE
+static void SegfaultLogger(int sig) {
   fprintf(stderr, "\nSegmentation fault: %d\n\n", sig);
-
-#if DMLC_LOG_STACK_TRACE
-  int nframes = backtrace(stack, MAX_STACK_SIZE);
-  fprintf(stderr, "Stack trace returned %d entries:\n", nframes);
-  char **msgs = backtrace_symbols(stack, nframes);
-  if (msgs != nullptr) {
-    for (int i = 0; i < nframes; ++i) {
-      fprintf(stderr, "[bt] (%d) %s\n", i, msgs[i]);
-    }
-  }
-#endif  // DMLC_LOG_STACK_TRACE
-
+  fprintf(stderr, "%s", dmlc::StackTrace().c_str());
   exit(-1);
 }
+#endif
 
 class LibraryInitializer {
  public:
   LibraryInitializer() {
     dmlc::InitLogging("mxnet");
-#if MXNET_USE_SIGNAL_HANDLER
-    signal(SIGSEGV, segfault_logger);
+#if MXNET_USE_SIGNAL_HANDLER && DMLC_LOG_STACK_TRACE
+    signal(SIGSEGV, SegfaultLogger);
 #endif
 #if MXNET_USE_PROFILER
     // ensure profiler's constructor are called before atexit.


### PR DESCRIPTION
remove code duplication
demangle C++ symbols