### PR TITLE
Moved NVIDIA's cub module to 3rdparty directory

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,7 +14,7 @@
 	path = dlpack
 	url = https://github.com/dmlc/dlpack
 [submodule "cub"]
-	path = cub
+	path = 3rdparty/cub
 	url = https://github.com/dmlc/cub
 [submodule "3rdparty/openmp"]
 	path = 3rdparty/openmp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,7 +187,7 @@ endforeach()
 
 include_directories("include")
 include_directories("mshadow")
-include_directories("cub")
+include_directories("3rdparty/cub")
 include_directories("nnvm/include")
 include_directories("dmlc-core/include")
 include_directories("dlpack/include")

--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ LIB_DEP += $(DMLC_CORE)/libdmlc.a $(NNVM_PATH)/lib/libnnvm.a
 ALL_DEP = $(OBJ) $(EXTRA_OBJ) $(PLUGIN_OBJ) $(LIB_DEP)
 
 ifeq ($(USE_CUDA), 1)
-	CFLAGS += -I$(ROOTDIR)/cub
+	CFLAGS += -I$(ROOTDIR)/3rdparty/cub
 	ALL_DEP += $(CUOBJ) $(EXTRA_CUOBJ) $(PLUGIN_CUOBJ)
 	LDFLAGS += -lcuda -lcufft -lnvrtc
 	SCALA_PKG_PROFILE := $(SCALA_PKG_PROFILE)-gpu


### PR DESCRIPTION
@piiswrong @tqchen 
## Description ##

Moved NVIDIA's cub module to 3rdparty directory

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
