### PR TITLE
correct usage of bool arguments from command line

### DIFF
--- a/example/caffe/caffe_net.py
+++ b/example/caffe/caffe_net.py
@@ -19,7 +19,6 @@ import mxnet as mx
 from data import get_iterator
 import argparse
 import train_model
-from mxnet.test_utils import str2bool
 
 def get_mlp():
     """
@@ -78,8 +77,8 @@ def parse_args():
                         help='the cnn to use (mlp | lenet | <path to network json file>')
     parser.add_argument('--caffe-loss', type=int, default=0,
                         help='Use CaffeLoss symbol')
-    parser.add_argument('--caffe-data', type=str2bool, default=False,
-                        help='Use Caffe input-data layer (True | False)')
+    parser.add_argument('--caffe-data', action='store_true',
+                        help='Use Caffe input-data layer only if specified')
     parser.add_argument('--data-dir', type=str, default='mnist/',
                         help='the input data directory')
     parser.add_argument('--gpus', type=str,

--- a/example/caffe/caffe_net.py
+++ b/example/caffe/caffe_net.py
@@ -19,6 +19,7 @@ import mxnet as mx
 from data import get_iterator
 import argparse
 import train_model
+from mxnet.test_utils import str2bool
 
 def get_mlp():
     """
@@ -77,7 +78,7 @@ def parse_args():
                         help='the cnn to use (mlp | lenet | <path to network json file>')
     parser.add_argument('--caffe-loss', type=int, default=0,
                         help='Use CaffeLoss symbol')
-    parser.add_argument('--caffe-data', type=bool, default=False,
+    parser.add_argument('--caffe-data', type=str2bool, default=False,
                         help='Use Caffe input-data layer (True | False)')
     parser.add_argument('--data-dir', type=str, default='mnist/',
                         help='the input data directory')

--- a/example/cnn_chinese_text_classification/text_cnn.py
+++ b/example/cnn_chinese_text_classification/text_cnn.py
@@ -38,8 +38,8 @@ logger = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser(description="CNN for text classification",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument('--pretrained-embedding', type=str2bool, default=False,
-                    help='use pre-trained word2vec')
+parser.add_argument('--pretrained-embedding', action='store_true',
+                    help='use pre-trained word2vec only if specified')
 parser.add_argument('--num-embed', type=int, default=300,
                     help='embedding layer size')
 parser.add_argument('--gpus', type=str, default='',

--- a/example/cnn_chinese_text_classification/text_cnn.py
+++ b/example/cnn_chinese_text_classification/text_cnn.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 parser = argparse.ArgumentParser(description="CNN for text classification",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument('--pretrained-embedding', type=bool, default=False,
+parser.add_argument('--pretrained-embedding', type=str2bool, default=False,
                     help='use pre-trained word2vec')
 parser.add_argument('--num-embed', type=int, default=300,
                     help='embedding layer size')

--- a/example/cnn_text_classification/text_cnn.py
+++ b/example/cnn_text_classification/text_cnn.py
@@ -26,12 +26,13 @@ import numpy as np
 import argparse
 import logging
 import data_helpers
+from mxnet.test_utils import str2bool
 
 logging.basicConfig(level=logging.DEBUG)
 
 parser = argparse.ArgumentParser(description="CNN for text classification",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument('--pretrained-embedding', type=bool, default=False,
+parser.add_argument('--pretrained-embedding', type=str2bool, default=False,
                     help='use pre-trained word2vec')
 parser.add_argument('--num-embed', type=int, default=300,
                     help='embedding layer size')

--- a/example/cnn_text_classification/text_cnn.py
+++ b/example/cnn_text_classification/text_cnn.py
@@ -26,14 +26,13 @@ import numpy as np
 import argparse
 import logging
 import data_helpers
-from mxnet.test_utils import str2bool
 
 logging.basicConfig(level=logging.DEBUG)
 
 parser = argparse.ArgumentParser(description="CNN for text classification",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-parser.add_argument('--pretrained-embedding', type=str2bool, default=False,
-                    help='use pre-trained word2vec')
+parser.add_argument('--pretrained-embedding', action='store_true',
+                    help='use pre-trained word2vec only if specified')
 parser.add_argument('--num-embed', type=int, default=300,
                     help='embedding layer size')
 parser.add_argument('--gpus', type=str, default='',

--- a/example/reinforcement-learning/dqn/dqn_demo.py
+++ b/example/reinforcement-learning/dqn/dqn_demo.py
@@ -24,6 +24,7 @@ from atari_game import AtariGame
 from utils import *
 import logging
 import argparse
+from mxnet.test_utils import str2bool
 
 root = logging.getLogger()
 root.setLevel(logging.DEBUG)
@@ -55,7 +56,7 @@ def main():
                         help='Eps of the AdaGrad optimizer')
     parser.add_argument('--clip-gradient', required=False, type=float, default=None,
                         help='Clip threshold of the AdaGrad optimizer')
-    parser.add_argument('--double-q', required=False, type=bool, default=False,
+    parser.add_argument('--double-q', required=False, type=str2bool, default=False,
                         help='Use Double DQN')
     parser.add_argument('--wd', required=False, type=float, default=0.0,
                         help='Weight of the L2 Regularizer')

--- a/example/reinforcement-learning/dqn/dqn_demo.py
+++ b/example/reinforcement-learning/dqn/dqn_demo.py
@@ -24,7 +24,6 @@ from atari_game import AtariGame
 from utils import *
 import logging
 import argparse
-from mxnet.test_utils import str2bool
 
 root = logging.getLogger()
 root.setLevel(logging.DEBUG)
@@ -56,8 +55,8 @@ def main():
                         help='Eps of the AdaGrad optimizer')
     parser.add_argument('--clip-gradient', required=False, type=float, default=None,
                         help='Clip threshold of the AdaGrad optimizer')
-    parser.add_argument('--double-q', required=False, type=str2bool, default=False,
-                        help='Use Double DQN')
+    parser.add_argument('--double-q', action='store_true',
+                        help='Use Double DQN only if specified')
     parser.add_argument('--wd', required=False, type=float, default=0.0,
                         help='Weight of the L2 Regularizer')
     parser.add_argument('-c', '--ctx', required=False, type=str, default='gpu',

--- a/example/rnn/bucketing/cudnn_lstm_bucketing.py
+++ b/example/rnn/bucketing/cudnn_lstm_bucketing.py
@@ -223,7 +223,6 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG, format=head)
 
     args = parser.parse_args()
-    print(args.bidirectional)
     if args.num_layers >= 4 and len(args.gpus.split(',')) >= 4 and not args.stack_rnn:
         print('WARNING: stack-rnn is recommended to train complex model on multiple GPUs')
 

--- a/example/rnn/bucketing/cudnn_lstm_bucketing.py
+++ b/example/rnn/bucketing/cudnn_lstm_bucketing.py
@@ -223,6 +223,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG, format=head)
 
     args = parser.parse_args()
+
     if args.num_layers >= 4 and len(args.gpus.split(',')) >= 4 and not args.stack_rnn:
         print('WARNING: stack-rnn is recommended to train complex model on multiple GPUs')
 

--- a/example/rnn/bucketing/cudnn_lstm_bucketing.py
+++ b/example/rnn/bucketing/cudnn_lstm_bucketing.py
@@ -18,6 +18,7 @@
 import numpy as np
 import mxnet as mx
 import argparse
+from mxnet.test_utils import str2bool
 
 parser = argparse.ArgumentParser(description="Train RNN on Penn Tree Bank",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -33,7 +34,7 @@ parser.add_argument('--num-hidden', type=int, default=200,
                     help='hidden layer size')
 parser.add_argument('--num-embed', type=int, default=200,
                     help='embedding layer size')
-parser.add_argument('--bidirectional', type=bool, default=False,
+parser.add_argument('--bidirectional', type=str2bool, default=False,
                     help='whether to use bidirectional layers')
 parser.add_argument('--gpus', type=str,
                     help='list of gpus to run, e.g. 0 or 0,2,5. empty means using cpu. ' \
@@ -222,7 +223,7 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG, format=head)
 
     args = parser.parse_args()
-
+    print(args.bidirectional)
     if args.num_layers >= 4 and len(args.gpus.split(',')) >= 4 and not args.stack_rnn:
         print('WARNING: stack-rnn is recommended to train complex model on multiple GPUs')
 

--- a/example/rnn/bucketing/cudnn_lstm_bucketing.py
+++ b/example/rnn/bucketing/cudnn_lstm_bucketing.py
@@ -18,7 +18,6 @@
 import numpy as np
 import mxnet as mx
 import argparse
-from mxnet.test_utils import str2bool
 
 parser = argparse.ArgumentParser(description="Train RNN on Penn Tree Bank",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -34,8 +33,8 @@ parser.add_argument('--num-hidden', type=int, default=200,
                     help='hidden layer size')
 parser.add_argument('--num-embed', type=int, default=200,
                     help='embedding layer size')
-parser.add_argument('--bidirectional', type=str2bool, default=False,
-                    help='whether to use bidirectional layers')
+parser.add_argument('--bidirectional', action='store_true',
+                    help='uses bidirectional layers if specified')
 parser.add_argument('--gpus', type=str,
                     help='list of gpus to run, e.g. 0 or 0,2,5. empty means using cpu. ' \
                          'Increase batch size when using multiple gpus for best performance.')

--- a/example/ssd/demo.py
+++ b/example/ssd/demo.py
@@ -22,7 +22,6 @@ import os
 import sys
 from detect.detector import Detector
 from symbol.symbol_factory import get_symbol
-from mxnet.test_utils import str2bool
 
 def get_detector(net, prefix, epoch, data_shape, mean_pixels, ctx, num_class,
                  nms_thresh=0.5, force_nms=True, nms_topk=400):
@@ -89,10 +88,10 @@ def parse_args():
                         help='object visualize score threshold, default 0.6')
     parser.add_argument('--nms', dest='nms_thresh', type=float, default=0.5,
                         help='non-maximum suppression threshold, default 0.5')
-    parser.add_argument('--force', dest='force_nms', type=str2bool, default=True,
-                        help='force non-maximum suppression on different class')
-    parser.add_argument('--timer', dest='show_timer', type=str2bool, default=True,
-                        help='show detection time')
+    parser.add_argument('--no-force', dest='force_nms', action='store_false',
+                        help='dont force non-maximum suppression on different class')
+    parser.add_argument('--no-timer', dest='show_timer', action='store_false',
+                        help='dont show detection time')
     parser.add_argument('--deploy', dest='deploy_net', action='store_true', default=False,
                         help='Load network from json file, rather than from symbol')
     parser.add_argument('--class-names', dest='class_names', type=str,

--- a/example/ssd/demo.py
+++ b/example/ssd/demo.py
@@ -22,6 +22,7 @@ import os
 import sys
 from detect.detector import Detector
 from symbol.symbol_factory import get_symbol
+from mxnet.test_utils import str2bool
 
 def get_detector(net, prefix, epoch, data_shape, mean_pixels, ctx, num_class,
                  nms_thresh=0.5, force_nms=True, nms_topk=400):
@@ -88,9 +89,9 @@ def parse_args():
                         help='object visualize score threshold, default 0.6')
     parser.add_argument('--nms', dest='nms_thresh', type=float, default=0.5,
                         help='non-maximum suppression threshold, default 0.5')
-    parser.add_argument('--force', dest='force_nms', type=bool, default=True,
+    parser.add_argument('--force', dest='force_nms', type=str2bool, default=True,
                         help='force non-maximum suppression on different class')
-    parser.add_argument('--timer', dest='show_timer', type=bool, default=True,
+    parser.add_argument('--timer', dest='show_timer', type=str2bool, default=True,
                         help='show detection time')
     parser.add_argument('--deploy', dest='deploy_net', action='store_true', default=False,
                         help='Load network from json file, rather than from symbol')
@@ -100,6 +101,7 @@ def parse_args():
                         person, pottedplant, sheep, sofa, train, tvmonitor',
                         help='string of comma separated names, or text filename')
     args = parser.parse_args()
+    print(args.show_timer)
     return args
 
 def parse_class_names(class_names):

--- a/example/ssd/demo.py
+++ b/example/ssd/demo.py
@@ -101,7 +101,6 @@ def parse_args():
                         person, pottedplant, sheep, sofa, train, tvmonitor',
                         help='string of comma separated names, or text filename')
     args = parser.parse_args()
-    print(args.show_timer)
     return args
 
 def parse_class_names(class_names):

--- a/example/ssd/deploy.py
+++ b/example/ssd/deploy.py
@@ -23,6 +23,7 @@ import os
 import importlib
 import sys
 from symbol.symbol_factory import get_symbol
+from mxnet.test_utils import str2bool
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Convert a trained model to deploy model')
@@ -38,7 +39,7 @@ def parse_args():
                         default=20, type=int)
     parser.add_argument('--nms', dest='nms_thresh', type=float, default=0.5,
                         help='non-maximum suppression threshold, default 0.5')
-    parser.add_argument('--force', dest='force_nms', type=bool, default=True,
+    parser.add_argument('--force', dest='force_nms', type=str2bool, default=True,
                         help='force non-maximum suppression on different class')
     parser.add_argument('--topk', dest='nms_topk', type=int, default=400,
                         help='apply nms only to top k detections based on scores.')

--- a/example/ssd/deploy.py
+++ b/example/ssd/deploy.py
@@ -23,7 +23,6 @@ import os
 import importlib
 import sys
 from symbol.symbol_factory import get_symbol
-from mxnet.test_utils import str2bool
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Convert a trained model to deploy model')
@@ -39,8 +38,8 @@ def parse_args():
                         default=20, type=int)
     parser.add_argument('--nms', dest='nms_thresh', type=float, default=0.5,
                         help='non-maximum suppression threshold, default 0.5')
-    parser.add_argument('--force', dest='force_nms', type=str2bool, default=True,
-                        help='force non-maximum suppression on different class')
+    parser.add_argument('--no-force', dest='force_nms', action='store_false',
+                        help='dont force non-maximum suppression on different class')
     parser.add_argument('--topk', dest='nms_topk', type=int, default=400,
                         help='apply nms only to top k detections based on scores.')
     args = parser.parse_args()

--- a/example/ssd/evaluate.py
+++ b/example/ssd/evaluate.py
@@ -20,6 +20,7 @@ import tools.find_mxnet
 import mxnet as mx
 import os
 import sys
+from mxnet.test_utils import str2bool
 from evaluate.evaluate_net import evaluate_net
 
 def parse_args():
@@ -59,11 +60,11 @@ def parse_args():
                         help='non-maximum suppression threshold')
     parser.add_argument('--overlap', dest='overlap_thresh', type=float, default=0.5,
                         help='evaluation overlap threshold')
-    parser.add_argument('--force', dest='force_nms', type=bool, default=False,
+    parser.add_argument('--force', dest='force_nms', type=str2bool, default=False,
                         help='force non-maximum suppression on different class')
-    parser.add_argument('--use-difficult', dest='use_difficult', type=bool, default=False,
+    parser.add_argument('--use-difficult', dest='use_difficult', type=str2bool, default=False,
                         help='use difficult ground-truths in evaluation')
-    parser.add_argument('--voc07', dest='use_voc07_metric', type=bool, default=True,
+    parser.add_argument('--voc07', dest='use_voc07_metric', type=str2bool, default=True,
                         help='use PASCAL VOC 07 metric')
     parser.add_argument('--deploy', dest='deploy_net', help='Load network from model',
                         action='store_true', default=False)

--- a/example/ssd/evaluate.py
+++ b/example/ssd/evaluate.py
@@ -20,7 +20,6 @@ import tools.find_mxnet
 import mxnet as mx
 import os
 import sys
-from mxnet.test_utils import str2bool
 from evaluate.evaluate_net import evaluate_net
 
 def parse_args():
@@ -60,12 +59,12 @@ def parse_args():
                         help='non-maximum suppression threshold')
     parser.add_argument('--overlap', dest='overlap_thresh', type=float, default=0.5,
                         help='evaluation overlap threshold')
-    parser.add_argument('--force', dest='force_nms', type=str2bool, default=False,
+    parser.add_argument('--force', dest='force_nms', action='store_true',
                         help='force non-maximum suppression on different class')
-    parser.add_argument('--use-difficult', dest='use_difficult', type=str2bool, default=False,
+    parser.add_argument('--use-difficult', dest='use_difficult', action='store_true',
                         help='use difficult ground-truths in evaluation')
-    parser.add_argument('--voc07', dest='use_voc07_metric', type=str2bool, default=True,
-                        help='use PASCAL VOC 07 metric')
+    parser.add_argument('--no-voc07', dest='use_voc07_metric', action='store_false',
+                        help='dont use PASCAL VOC 07 metric')
     parser.add_argument('--deploy', dest='deploy_net', help='Load network from model',
                         action='store_true', default=False)
     args = parser.parse_args()

--- a/example/ssd/tools/prepare_dataset.py
+++ b/example/ssd/tools/prepare_dataset.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import sys, os
 import argparse
 import subprocess
+from mxnet.test_utils import str2bool
 curr_path = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(curr_path, '..'))
 from dataset.pascal_voc import PascalVoc
@@ -103,7 +104,7 @@ def parse_args():
                         default=os.path.join(curr_path, '..', 'data', 'VOCdevkit'),
                         type=str)
     parser.add_argument('--shuffle', dest='shuffle', help='shuffle list',
-                        type=bool, default=True)
+                        type=str2bool, default=True)
     args = parser.parse_args()
     return args
 

--- a/example/ssd/tools/prepare_dataset.py
+++ b/example/ssd/tools/prepare_dataset.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 import sys, os
 import argparse
 import subprocess
-from mxnet.test_utils import str2bool
 curr_path = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(curr_path, '..'))
 from dataset.pascal_voc import PascalVoc
@@ -103,8 +102,8 @@ def parse_args():
     parser.add_argument('--root', dest='root_path', help='dataset root path',
                         default=os.path.join(curr_path, '..', 'data', 'VOCdevkit'),
                         type=str)
-    parser.add_argument('--shuffle', dest='shuffle', help='shuffle list',
-                        type=str2bool, default=True)
+    parser.add_argument('--no-shuffle', dest='shuffle', help='shuffle list',
+                        action='store_false')
     args = parser.parse_args()
     return args
 

--- a/example/ssd/train.py
+++ b/example/ssd/train.py
@@ -20,6 +20,7 @@ import tools.find_mxnet
 import mxnet as mx
 import os
 import sys
+from mxnet.test_utils import str2bool
 from train.train_net import train_net
 
 def parse_args():
@@ -95,11 +96,11 @@ def parse_args():
                         help='non-maximum suppression threshold')
     parser.add_argument('--overlap', dest='overlap_thresh', type=float, default=0.5,
                         help='evaluation overlap threshold')
-    parser.add_argument('--force', dest='force_nms', type=bool, default=False,
+    parser.add_argument('--force', dest='force_nms', type=str2bool, default=False,
                         help='force non-maximum suppression on different class')
-    parser.add_argument('--use-difficult', dest='use_difficult', type=bool, default=False,
+    parser.add_argument('--use-difficult', dest='use_difficult', type=str2bool, default=False,
                         help='use difficult ground-truths in evaluation')
-    parser.add_argument('--voc07', dest='use_voc07_metric', type=bool, default=True,
+    parser.add_argument('--voc07', dest='use_voc07_metric', type=str2bool, default=True,
                         help='use PASCAL VOC 07 11-point metric')
     args = parser.parse_args()
     return args

--- a/example/ssd/train.py
+++ b/example/ssd/train.py
@@ -20,7 +20,6 @@ import tools.find_mxnet
 import mxnet as mx
 import os
 import sys
-from mxnet.test_utils import str2bool
 from train.train_net import train_net
 
 def parse_args():
@@ -96,12 +95,12 @@ def parse_args():
                         help='non-maximum suppression threshold')
     parser.add_argument('--overlap', dest='overlap_thresh', type=float, default=0.5,
                         help='evaluation overlap threshold')
-    parser.add_argument('--force', dest='force_nms', type=str2bool, default=False,
+    parser.add_argument('--force', dest='force_nms', action='store_true',
                         help='force non-maximum suppression on different class')
-    parser.add_argument('--use-difficult', dest='use_difficult', type=str2bool, default=False,
+    parser.add_argument('--use-difficult', dest='use_difficult', action='store_true',
                         help='use difficult ground-truths in evaluation')
-    parser.add_argument('--voc07', dest='use_voc07_metric', type=str2bool, default=True,
-                        help='use PASCAL VOC 07 11-point metric')
+    parser.add_argument('--no-voc07', dest='use_voc07_metric', action='store_false',
+                        help='dont use PASCAL VOC 07 11-point metric')
     args = parser.parse_args()
     return args
 

--- a/tools/im2rec.py
+++ b/tools/im2rec.py
@@ -211,7 +211,7 @@ def parse_args():
     parser.add_argument('root', help='path to folder containing images.')
 
     cgroup = parser.add_argument_group('Options for creating image lists')
-    cgroup.add_argument('--list', type=bool, default=False,
+    cgroup.add_argument('--list', type=str2bool, default=False,
                         help='If this is set im2rec will create image list(s) by traversing root folder\
         and output to <prefix>.lst.\
         Otherwise im2rec will read <prefix>.lst and create a database at <prefix>.rec')
@@ -222,20 +222,20 @@ def parse_args():
                         help='Ratio of images to use for training.')
     cgroup.add_argument('--test-ratio', type=float, default=0,
                         help='Ratio of images to use for testing.')
-    cgroup.add_argument('--recursive', type=bool, default=False,
+    cgroup.add_argument('--recursive', type=str2bool, default=False,
                         help='If true recursively walk through subdirs and assign an unique label\
         to images in each folder. Otherwise only include images in the root folder\
         and give them label 0.')
-    cgroup.add_argument('--shuffle', type=bool, default=True, help='If this is set as True, \
+    cgroup.add_argument('--shuffle', type=str2bool, default=True, help='If this is set as True, \
         im2rec will randomize the image order in <prefix>.lst')
 
     rgroup = parser.add_argument_group('Options for creating database')
-    rgroup.add_argument('--pass-through', type=bool, default=False,
+    rgroup.add_argument('--pass-through', type=str2bool, default=False,
                         help='whether to skip transformation and save image as is')
     rgroup.add_argument('--resize', type=int, default=0,
                         help='resize the shorter edge of image to the newsize, original images will\
         be packed by default.')
-    rgroup.add_argument('--center-crop', type=bool, default=False,
+    rgroup.add_argument('--center-crop', type=str2bool, default=False,
                         help='specify whether to crop the center image to make it rectangular.')
     rgroup.add_argument('--quality', type=int, default=95,
                         help='JPEG quality for encoding, 1-100; or PNG compression for encoding, 1-9')
@@ -250,7 +250,7 @@ def parse_args():
         -1:Loads image as such including alpha channel.')
     rgroup.add_argument('--encoding', type=str, default='.jpg', choices=['.jpg', '.png'],
                         help='specify the encoding of the images.')
-    rgroup.add_argument('--pack-label', type=bool, default=False,
+    rgroup.add_argument('--pack-label', type=str2bool, default=False,
         help='Whether to also pack multi dimensional label in the record file')
     args = parser.parse_args()
     args.prefix = os.path.abspath(args.prefix)

--- a/tools/im2rec.py
+++ b/tools/im2rec.py
@@ -211,7 +211,7 @@ def parse_args():
     parser.add_argument('root', help='path to folder containing images.')
 
     cgroup = parser.add_argument_group('Options for creating image lists')
-    cgroup.add_argument('--list', type=str2bool, default=False,
+    cgroup.add_argument('--list', action='store_true',
                         help='If this is set im2rec will create image list(s) by traversing root folder\
         and output to <prefix>.lst.\
         Otherwise im2rec will read <prefix>.lst and create a database at <prefix>.rec')
@@ -222,20 +222,21 @@ def parse_args():
                         help='Ratio of images to use for training.')
     cgroup.add_argument('--test-ratio', type=float, default=0,
                         help='Ratio of images to use for testing.')
-    cgroup.add_argument('--recursive', type=str2bool, default=False,
+    cgroup.add_argument('--recursive', action='store_true',
                         help='If true recursively walk through subdirs and assign an unique label\
         to images in each folder. Otherwise only include images in the root folder\
         and give them label 0.')
-    cgroup.add_argument('--shuffle', type=str2bool, default=True, help='If this is set as True, \
-        im2rec will randomize the image order in <prefix>.lst')
+    cgroup.add_argument('--no-shuffle', dest='shuffle', action='store_false',
+                        help='If this is passed, \
+        im2rec will not randomize the image order in <prefix>.lst')
 
     rgroup = parser.add_argument_group('Options for creating database')
-    rgroup.add_argument('--pass-through', type=str2bool, default=False,
+    rgroup.add_argument('--pass-through', action='store_true',
                         help='whether to skip transformation and save image as is')
     rgroup.add_argument('--resize', type=int, default=0,
                         help='resize the shorter edge of image to the newsize, original images will\
         be packed by default.')
-    rgroup.add_argument('--center-crop', type=str2bool, default=False,
+    rgroup.add_argument('--center-crop', action='store_true',
                         help='specify whether to crop the center image to make it rectangular.')
     rgroup.add_argument('--quality', type=int, default=95,
                         help='JPEG quality for encoding, 1-100; or PNG compression for encoding, 1-9')
@@ -250,7 +251,7 @@ def parse_args():
         -1:Loads image as such including alpha channel.')
     rgroup.add_argument('--encoding', type=str, default='.jpg', choices=['.jpg', '.png'],
                         help='specify the encoding of the images.')
-    rgroup.add_argument('--pack-label', type=str2bool, default=False,
+    rgroup.add_argument('--pack-label', action='store_true',
         help='Whether to also pack multi dimensional label in the record file')
     args = parser.parse_args()
     args.prefix = os.path.abspath(args.prefix)


### PR DESCRIPTION
## Description ##
When trying to convert any non empty string to bool, python returns True. 
> bool('False') 
> True

This means if a bool argument (`--shuffle`) has a default value of True, then passing `--shuffle False` will not set it to False. 

Correcting this by converting the string argument given to bool with a custom function. 

This is a fix with minimal change on user's end. Alternative (and the proper way) would be `--shuffle` and `--no-shuffle`. But that would require significant changes to the examples.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- Refer description above
- Fixes issues people have raised like https://github.com/apache/incubator-mxnet/issues/8875