### PR TITLE
Remove finalizers from Scala API

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -147,3 +147,5 @@ List of Contributors
 * [Jean Kossaifi](https://github.com/JeanKossaifi/)
 * [Kenta Kubo](https://github.com/kkk669/)
 * [Manu Seth](https://github.com/mseth10/)
+* [Calum Leslie](https://github.com/calumleslie)
+* [Andre Tamm](https://github.com/andretamm)

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Executor.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Executor.scala
@@ -18,6 +18,7 @@
 package ml.dmlc.mxnet
 
 import ml.dmlc.mxnet.Base._
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -34,7 +35,6 @@ object Executor {
  * Symbolic Executor component of MXNet <br />
  * <b>
  * WARNING: it is your responsibility to clear this object through dispose().
- * NEVER rely on the GC strategy
  * </b>
  *
  * @author Yizhi Liu
@@ -44,9 +44,8 @@ object Executor {
  * @param symbol
  * @see Symbol.bind : to create executor
  */
-// scalastyle:off finalize
 class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
-                              private[mxnet] val symbol: Symbol) {
+                              private[mxnet] val symbol: Symbol) extends WarnIfNotDisposed {
   private[mxnet] var argArrays: Array[NDArray] = null
   private[mxnet] var gradArrays: Array[NDArray] = null
   private[mxnet] var auxArrays: Array[NDArray] = null
@@ -58,12 +57,10 @@ class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
   private[mxnet] var _ctx: Context = null
   private[mxnet] var _gradsReq: Iterable[_] = null
   private[mxnet] var _group2ctx: Map[String, Context] = null
+  private val logger: Logger = LoggerFactory.getLogger(classOf[Executor])
 
   private var disposed = false
-
-  override protected def finalize(): Unit = {
-    dispose()
-  }
+  protected def isDisposed = disposed
 
   def dispose(): Unit = {
     if (!disposed) {
@@ -306,4 +303,3 @@ class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
     str.value
   }
 }
-// scalastyle:on finalize

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStore.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStore.scala
@@ -20,7 +20,7 @@ package ml.dmlc.mxnet
 import java.io._
 
 import ml.dmlc.mxnet.Base._
-import org.slf4j.{LoggerFactory, Logger}
+import org.slf4j.{Logger, LoggerFactory}
 
 /**
  * Key value store interface of MXNet for parameter synchronization.
@@ -37,7 +37,6 @@ object KVStore {
    * Create a new KVStore. <br />
    * <b>
    * WARNING: it is your responsibility to clear this object through dispose().
-   * NEVER rely on the GC strategy
    * </b>
    *
    * @param name : {'local', 'dist'}
@@ -53,15 +52,11 @@ object KVStore {
   }
 }
 
-// scalastyle:off finalize
-class KVStore(private[mxnet] val handle: KVStoreHandle) {
+class KVStore(private[mxnet] val handle: KVStoreHandle) extends WarnIfNotDisposed {
   private val logger: Logger = LoggerFactory.getLogger(classOf[KVStore])
   private var updaterFunc: MXKVStoreUpdater = null
   private var disposed = false
-
-  override protected def finalize(): Unit = {
-    dispose()
-  }
+  protected def isDisposed = disposed
 
   /**
    * Release the native memory.
@@ -306,4 +301,3 @@ class KVStore(private[mxnet] val handle: KVStoreHandle) {
     }
   }
 }
-// scalastyle:off finalize

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
@@ -445,7 +445,7 @@ object NDArray {
       val end = retShape.toArray
       for (arr <- arrays) {
         if (axis == 0) {
-          ret.slice(idx, idx + arr.shape(0)).set(arr)
+          ret.slice(idx, idx + arr.shape(0)).set(arr).dispose()
         } else {
           begin(axis) = idx
           end(axis) = idx + arr.shape(axis)

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/NDArray.scala
@@ -17,7 +17,7 @@
 
 package ml.dmlc.mxnet
 
-import java.nio.{ByteOrder, ByteBuffer}
+import java.nio.{ByteBuffer, ByteOrder}
 
 import ml.dmlc.mxnet.Base._
 import ml.dmlc.mxnet.DType.DType
@@ -543,20 +543,15 @@ object NDArray {
  * NDArray is basic ndarray/Tensor like data structure in mxnet. <br />
  * <b>
  * WARNING: it is your responsibility to clear this object through dispose().
- * NEVER rely on the GC strategy
  * </b>
  */
-// scalastyle:off finalize
 class NDArray private[mxnet](private[mxnet] val handle: NDArrayHandle,
-                             val writable: Boolean = true) {
+                             val writable: Boolean = true) extends WarnIfNotDisposed {
   // record arrays who construct this array instance
   // we use weak reference to prevent gc blocking
   private[mxnet] val dependencies = mutable.HashMap.empty[Long, WeakReference[NDArray]]
   private var disposed = false
   def isDisposed: Boolean = disposed
-  override protected def finalize(): Unit = {
-    dispose()
-  }
 
   def serialize(): Array[Byte] = {
     val buf = ArrayBuffer.empty[Byte]
@@ -1020,7 +1015,6 @@ class NDArray private[mxnet](private[mxnet] val handle: NDArrayHandle,
     shape.hashCode + toArray.hashCode
   }
 }
-// scalastyle:on finalize
 
 private[mxnet] object NDArrayConversions {
   implicit def int2Scalar(x: Int): NDArrayConversions = new NDArrayConversions(x.toFloat)

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
@@ -27,17 +27,12 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
  * Symbolic configuration API of mxnet. <br />
  * <b>
  * WARNING: it is your responsibility to clear this object through dispose().
- * NEVER rely on the GC strategy
  * </b>
  */
-// scalastyle:off finalize
-class Symbol private(private[mxnet] val handle: SymbolHandle) {
+class Symbol private(private[mxnet] val handle: SymbolHandle) extends WarnIfNotDisposed {
   private val logger: Logger = LoggerFactory.getLogger(classOf[Symbol])
   private var disposed = false
-
-  override protected def finalize(): Unit = {
-    dispose()
-  }
+  protected def isDisposed = disposed
 
   /**
    * Release the native memory.
@@ -828,7 +823,6 @@ class Symbol private(private[mxnet] val handle: SymbolHandle) {
   }
 }
 
-// scalastyle:on finalize
 @AddSymbolFunctions(false)
 object Symbol {
   private type SymbolCreateNamedFunc = Map[String, Any] => Symbol

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/MXDataIter.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/MXDataIter.scala
@@ -18,7 +18,7 @@
 package ml.dmlc.mxnet.io
 
 import ml.dmlc.mxnet.Base._
-import ml.dmlc.mxnet.{DataPack, DataBatch, DataIter, NDArray, Shape}
+import ml.dmlc.mxnet.{DataBatch, DataIter, DataPack, NDArray, Shape, WarnIfNotDisposed}
 import ml.dmlc.mxnet.IO._
 import org.slf4j.LoggerFactory
 
@@ -29,10 +29,11 @@ import scala.collection.mutable.ListBuffer
  * DataIter built in MXNet.
  * @param handle the handle to the underlying C++ Data Iterator
  */
-// scalastyle:off finalize
 private[mxnet] class MXDataIter(private[mxnet] val handle: DataIterHandle,
                                 dataName: String = "data",
-                                labelName: String = "label") extends DataIter {
+                                labelName: String = "label")
+  extends DataIter with WarnIfNotDisposed {
+
   private val logger = LoggerFactory.getLogger(classOf[MXDataIter])
 
   // use currentBatch to implement hasNext
@@ -57,9 +58,7 @@ private[mxnet] class MXDataIter(private[mxnet] val handle: DataIterHandle,
     }
 
   private var disposed = false
-  override protected def finalize(): Unit = {
-    dispose()
-  }
+  protected def isDisposed = disposed
 
   /**
    * Release the native memory.
@@ -169,7 +168,6 @@ private[mxnet] class MXDataIter(private[mxnet] val handle: DataIterHandle,
   override def batchSize: Int = _batchSize
 }
 
-// scalastyle:on finalize
 private[mxnet] class MXDataPack(iterName: String, params: Map[String, String]) extends DataPack {
   /**
     * get data iterator

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
@@ -145,8 +145,12 @@ class NDArrayIter (data: IndexedSeq[NDArray], label: IndexedSeq[NDArray] = Index
   private def _padData(ndArray: NDArray): NDArray = {
     val padNum = cursor + dataBatchSize - numData
     val newArray = NDArray.zeros(ndArray.slice(0, dataBatchSize).shape)
-    newArray.slice(0, dataBatchSize - padNum).set(ndArray.slice(cursor, numData))
-    newArray.slice(dataBatchSize - padNum, dataBatchSize).set(ndArray.slice(0, padNum))
+    val batch = ndArray.slice(cursor, numData)
+    val padding = ndArray.slice(0, padNum)
+    newArray.slice(0, dataBatchSize - padNum).set(batch).dispose()
+    newArray.slice(dataBatchSize - padNum, dataBatchSize).set(padding).dispose()
+    batch.dispose()
+    padding.dispose()
     newArray
   }
 

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/module/BaseModule.scala
@@ -188,6 +188,9 @@ abstract class BaseModule {
       batchEndCallback.foreach(callback => {
         callback.invoke(epoch, nBatch, evalMetric)
       })
+
+      evalBatch.dispose()
+
       nBatch += 1
     }
 
@@ -221,6 +224,7 @@ abstract class BaseModule {
     while (evalData.hasNext && nBatch != numBatch) {
       val evalBatch = evalData.next()
       outputList.append(predict(evalBatch))
+      evalBatch.dispose()
       nBatch += 1
     }
 
@@ -231,9 +235,12 @@ abstract class BaseModule {
     require(binded && paramsInitialized)
     forward(batch, isTrain = Option(false))
     val pad = batch.pad
-    getOutputsMerged().map(out =>
-      out.slice(0, out.shape(0)-pad).copy()
-    )
+    getOutputsMerged().map(out => {
+      val withoutPadding = out.slice(0, out.shape(0)-pad)
+      val copied = withoutPadding.copy()
+      withoutPadding.dispose()
+      copied
+    })
   }
 
   /**
@@ -254,7 +261,9 @@ abstract class BaseModule {
       "Cannot merge batches, as num of outputs is not the same in mini-batches." +
       "Maybe bucketing is used?")
     )
-    outputBatches.map(out => NDArray.concatenate(out))
+    val concatenatedOutput = outputBatches.map(out => NDArray.concatenate(out))
+    outputBatches.foreach(_.foreach(_.dispose()))
+    concatenatedOutput
   }
 
   // Symbol information
@@ -414,6 +423,8 @@ abstract class BaseModule {
         fitParams.batchEndCallback.foreach(callback =>
           callback.invoke(epoch, nBatch, fitParams.evalMetric)
         )
+
+        dataBatch.dispose()
 
         nBatch += 1
       }

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/util/WarnIfNotDisposed.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/util/WarnIfNotDisposed.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.mxnet
+
+import org.slf4j.{Logger, LoggerFactory}
+import scala.util.Try
+import scala.collection._
+
+private object WarnIfNotDisposed {
+  private val traceProperty = "mxnet.traceLeakedObjects"
+
+  private val logger: Logger = LoggerFactory.getLogger(classOf[WarnIfNotDisposed])
+
+  // This set represents the list of classes we've logged a warning about if we're not running
+  // in tracing mode. This is used to ensure we only log once.
+  // Don't need to synchronize on this set as it's usually used from a single finalizer thread.
+  private val classesWarned = mutable.Set.empty[String]
+
+  lazy val tracingEnabled = {
+    val value = Try(System.getProperty(traceProperty).toBoolean).getOrElse(false)
+    if (value) {
+      logger.info("Leaked object tracing is enabled (property {} is set)", traceProperty)
+    }
+    value
+  }
+}
+
+// scalastyle:off finalize
+protected trait WarnIfNotDisposed {
+  import WarnIfNotDisposed.logger
+  import WarnIfNotDisposed.traceProperty
+  import WarnIfNotDisposed.classesWarned
+
+  protected def isDisposed: Boolean
+
+  protected val creationTrace: Option[Array[StackTraceElement]] = if (tracingEnabled) {
+    Some(Thread.currentThread().getStackTrace())
+  } else {
+    None
+  }
+
+  override protected def finalize(): Unit = {
+    if (!isDisposed) logDisposeWarning()
+
+    super.finalize()
+  }
+
+  // overridable for testing
+  protected def tracingEnabled = WarnIfNotDisposed.tracingEnabled
+
+  protected def logDisposeWarning(): Unit = {
+    // The ":Any" casts below are working around the Slf4j Java API having overloaded methods that
+    // Scala doesn't resolve automatically.
+    if (creationTrace.isDefined) {
+      logger.warn(
+        "LEAK: An instance of {} was not disposed. Creation point of this resource was:\n\t{}",
+        getClass(), creationTrace.get.mkString("\n\t"): Any)
+    } else {
+      // Tracing disabled but we still warn the first time we see a leak to ensure the code author
+      // knows. We could warn every time but this can be very noisy.
+      val className = getClass().getName()
+      if (!classesWarned.contains(className)) {
+        logger.warn(
+          "LEAK: [one-time warning] An instance of {} was not disposed. " + //
+          "Set property {} to true to enable tracing",
+          className, traceProperty: Any)
+
+        classesWarned += className
+      }
+    }
+  }
+}
+// scalastyle:on finalize

--- a/scala-package/core/src/test/scala/ml/dmlc/mxnet/util/WarnIfNotDiposedSuite.scala
+++ b/scala-package/core/src/test/scala/ml/dmlc/mxnet/util/WarnIfNotDiposedSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.mxnet
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+// scalastyle:off finalize
+class Leakable(enableTracing: Boolean = false, markDisposed: Boolean = false)
+    extends WarnIfNotDisposed {
+  def isDisposed: Boolean = markDisposed
+  override protected def tracingEnabled = enableTracing
+
+  var warningWasLogged: Boolean = false
+  def getCreationTrace: Option[Array[StackTraceElement]] = creationTrace
+
+  override def finalize(): Unit = super.finalize()
+  override protected def logDisposeWarning() = {
+    warningWasLogged = true
+  }
+}
+// scalastyle:on finalize
+
+class WarnIfNotDisposedSuite extends FunSuite with BeforeAndAfterAll {
+  test("trace collected if tracing enabled") {
+    val leakable = new Leakable(enableTracing = true)
+
+    val trace = leakable.getCreationTrace
+    assert(trace.isDefined)
+    assert(trace.get.exists(el => el.getClassName() == getClass().getName()))
+  }
+
+  test("trace not collected if tracing disabled") {
+    val leakable = new Leakable(enableTracing = false)
+    assert(!leakable.getCreationTrace.isDefined)
+  }
+
+  test("no warning logged if object disposed") {
+    val notLeaked = new Leakable(markDisposed = true)
+    notLeaked.finalize()
+    assert(!notLeaked.warningWasLogged)
+  }
+
+  test("warning logged if object not disposed") {
+    val leaked = new Leakable(markDisposed = false)
+    leaked.finalize()
+    assert(leaked.warningWasLogged)
+  }
+}


### PR DESCRIPTION
## Description ##
This implements "Fix 1" from [this discussion on discuss.mxnet.io](https://discuss.mxnet.io/t/fixing-thread-safety-issues-in-scala-library/236), as well as fixing various resource leaks throughout the Scala library (separate commit).

The short version is:

* MXNet is not safe to call from multiple threads. Finalizers call from a separate thread in Java, so they are unsafe to use to call MXNet. We have seen this cause memory corruption and failures.
* Removing the finalizers means one can inadvertently leak resources that should be disposed. For this reason optional tracing behaviour is added to the library, to help users track down leaks.
* The separate commit fixing leaks fixes as many leaks as were required for us to do large prediction tasks (hundreds of millions of predictions) using a `Module` without incurring either memory corruption (as we did before the finalizers were removed) or memory exhaustion (as we did after they were removed). We now see no detected leaks. However for training we still see a relatively small number.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make scalapkg`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage _(see below)_
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] WarnIfDisposed trait replaces finalizers, _no tests_, API docs updated to remove references to the "GC strategy".
- [x] Leaks fixes, _no tests_ (no visible functional change)

## Comments ##
- We didn't find a non-intrusive way to write a test suite for these changes. Let us know if we should try harder to find one.
