### PR TITLE
[Doc] improvement for default param 'TShape()'

### DIFF
--- a/src/operator/contrib/deformable_convolution-inl.h
+++ b/src/operator/contrib/deformable_convolution-inl.h
@@ -68,15 +68,15 @@ struct DeformableConvolutionParam : public dmlc::Parameter<DeformableConvolution
   bool no_bias;
   dmlc::optional<int> layout;
   DMLC_DECLARE_PARAMETER(DeformableConvolutionParam) {
-    DMLC_DECLARE_FIELD(kernel).describe("convolution kernel size: (h, w) or (d, h, w)");
+    DMLC_DECLARE_FIELD(kernel).describe("Convolution kernel size: (h, w) or (d, h, w)");
     DMLC_DECLARE_FIELD(stride).set_default(TShape())
-      .describe("convolution stride: (h, w) or (d, h, w)");
+      .describe("Convolution stride: (h, w) or (d, h, w). Defaults to 1 for each dimension.");
     DMLC_DECLARE_FIELD(dilate).set_default(TShape())
-      .describe("convolution dilate: (h, w) or (d, h, w)");
+      .describe("Convolution dilate: (h, w) or (d, h, w). Defaults to 1 for each dimension.");
     DMLC_DECLARE_FIELD(pad).set_default(TShape())
-      .describe("pad for convolution: (h, w) or (d, h, w)");
+      .describe("Zero pad for convolution: (h, w) or (d, h, w). Defaults to no padding.");
     DMLC_DECLARE_FIELD(num_filter).set_range(1, 100000)
-      .describe("convolution filter(channel) number");
+      .describe("Convolution filter(channel) number");
     DMLC_DECLARE_FIELD(num_group).set_default(1)
       .describe("Number of group partitions.");
     DMLC_DECLARE_FIELD(num_deformable_group).set_default(1)

--- a/src/operator/nn/convolution-inl.h
+++ b/src/operator/nn/convolution-inl.h
@@ -67,15 +67,15 @@ struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
   bool cudnn_off;
   dmlc::optional<int> layout;
   DMLC_DECLARE_PARAMETER(ConvolutionParam) {
-    DMLC_DECLARE_FIELD(kernel).describe("convolution kernel size: (h, w) or (d, h, w)");
+    DMLC_DECLARE_FIELD(kernel).describe("Convolution kernel size: (h, w) or (d, h, w)");
     DMLC_DECLARE_FIELD(stride).set_default(TShape())
-    .describe("convolution stride: (h, w) or (d, h, w)");
+    .describe("Convolution stride: (h, w) or (d, h, w). Defaults to 1 for each dimension.");
     DMLC_DECLARE_FIELD(dilate).set_default(TShape())
-    .describe("convolution dilate: (h, w) or (d, h, w)");
+    .describe("Convolution dilate: (h, w) or (d, h, w). Defaults to 1 for each dimension.");
     DMLC_DECLARE_FIELD(pad).set_default(TShape())
-    .describe("pad for convolution: (h, w) or (d, h, w)");
+    .describe("Zero pad for convolution: (h, w) or (d, h, w). Defaults to no padding.");
     DMLC_DECLARE_FIELD(num_filter).set_range(1, 100000)
-    .describe("convolution filter(channel) number");
+    .describe("Convolution filter(channel) number");
     DMLC_DECLARE_FIELD(num_group).set_default(1)
     .describe("Number of group partitions.");
     DMLC_DECLARE_FIELD(workspace).set_default(1024).set_range(0, 8192)

--- a/src/operator/nn/deconvolution-inl.h
+++ b/src/operator/nn/deconvolution-inl.h
@@ -66,9 +66,11 @@ struct DeconvolutionParam : public dmlc::Parameter<DeconvolutionParam> {
     DMLC_DECLARE_FIELD(kernel).describe("Deconvolution kernel size: (h, w) or (d, h, w). "
                   "This is same as the kernel size used for the corresponding convolution");
     DMLC_DECLARE_FIELD(stride).set_default(TShape())
-        .describe("The stride used for the corresponding convolution: (h, w) or (d, h, w).");
+        .describe("The stride used for the corresponding convolution: (h, w) or (d, h, w). "
+                  "Defaults to 1 for each dimension.");
     DMLC_DECLARE_FIELD(dilate).set_default(TShape())
-        .describe("Dilation factor for each dimension of the input: (h, w) or (d, h, w).");
+        .describe("Dilation factor for each dimension of the input: (h, w) or (d, h, w). "
+                  "Defaults to 1 for each dimension.");
     DMLC_DECLARE_FIELD(pad).set_default(TShape())
         .describe("The amount of implicit zero padding added during convolution for each "
                   "dimension of the input: "
@@ -76,7 +78,7 @@ struct DeconvolutionParam : public dmlc::Parameter<DeconvolutionParam> {
                   "``(kernel-1)/2`` is usually a good choice. "
                   "If `target_shape` is set, "
                   "`pad` will be ignored and a padding that will generate the target shape "
-                  "will be used.");
+                  "will be used. Defaults to no padding.");
     DMLC_DECLARE_FIELD(adj).set_default(TShape())
         .describe("Adjustment for output shape: (h, w) or (d, h, w). "
                   "If `target_shape` is set, "

--- a/src/operator/nn/pooling-inl.h
+++ b/src/operator/nn/pooling-inl.h
@@ -58,7 +58,7 @@ struct PoolingParam : public dmlc::Parameter<PoolingParam> {
 
     DMLC_DECLARE_FIELD(kernel)
     .enforce_nonzero()
-    .describe("pooling kernel size: (y, x) or (d, y, x)");
+    .describe("Pooling kernel size: (y, x) or (d, y, x)");
 
     DMLC_DECLARE_FIELD(pool_type)
     .add_enum("max", pool_enum::kMaxPooling)
@@ -73,10 +73,10 @@ struct PoolingParam : public dmlc::Parameter<PoolingParam> {
 
     DMLC_DECLARE_FIELD(stride).set_default(TShape())
     .enforce_nonzero()
-    .describe("stride: for pooling (y, x) or (d, y, x)");
+    .describe("Stride: for pooling (y, x) or (d, y, x). Defaults to 1 for each dimension.");
 
     DMLC_DECLARE_FIELD(pad).set_default(TShape())
-    .describe("pad for pooling: (y, x) or (d, y, x)");
+    .describe("Pad for pooling: (y, x) or (d, y, x). Defaults to no padding.");
   }
 };
 


### PR DESCRIPTION
## Description ##
Some operators have parameters with default value `TShape()`, but not well documented.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Conv & Pooling