### PR TITLE
add Gluon PReLU activation layer

### DIFF
--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -19,8 +19,8 @@
 # pylint: disable= arguments-differ
 """Basic neural network layers."""
 __all__ = ['Sequential', 'HybridSequential', 'Dense', 'Activation',
-           'Dropout', 'BatchNorm', 'LeakyReLU', 'Embedding', 'Flatten',
-           'Lambda', 'HybridLambda']
+           'Dropout', 'BatchNorm', 'LeakyReLU', 'PReLU', 'Embedding', 
+           'Flatten', 'Lambda', 'HybridLambda']
 import warnings
 import numpy as np
 
@@ -414,6 +414,48 @@ class LeakyReLU(HybridBlock):
         s = '{name}({alpha})'
         return s.format(name=self.__class__.__name__,
                         alpha=self._alpha)
+
+
+class PReLU(HybridBlock):
+    r"""Parametric leaky version of a Rectified Linear Unit.
+
+    It learns a gradient when the unit is not active
+
+    .. math::
+
+        f\left(x\right) = \left\{
+            \begin{array}{lr}
+               \alpha x & : x \lt 0 \\
+                      x & : x \geq 0 \\
+            \end{array}
+        \right.\\
+    
+    where alpha is a learned parameter.
+
+    Parameters
+    ----------
+    alpha_initializer : Initializer
+        Initializer for the `embeddings` matrix.
+
+    Inputs:
+        - **data**: input tensor with arbitrary shape.
+
+    Outputs:
+        - **out**: output tensor with the same shape as `data`.
+    """
+    def __init__(self, alpha_initializer='zeros', *args):
+        super(PReLU, self).__init__(*args)
+        with self.name_scope():
+            self.alpha = self.params.get('alpha', shape=(1,), init=alpha_initializer)
+
+    def hybrid_forward(self, F, x, alpha):
+        pos = F.relu(x)
+        neg = F.broadcast_mul(F.negative(alpha), F.relu(F.negative(x)))
+        return pos + neg
+
+    def __repr__(self):
+        s = '{name}'
+        return s.format(name=self.__class__.__name__)
 
 
 class Embedding(HybridBlock):

--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -418,6 +418,7 @@ class LeakyReLU(HybridBlock):
 
 class PReLU(HybridBlock):
     r"""Parametric leaky version of a Rectified Linear Unit.
+    <https://arxiv.org/abs/1502.01852>`_ paper.
 
     It learns a gradient when the unit is not active
 


### PR DESCRIPTION
## Description ##
Adds a PReLU layer for Gluon per #8898. 

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##

