### PR TITLE
[MXNET-331] NVLink communication pattern updated 

### DIFF
--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -22,6 +22,7 @@
  */
 #ifndef MXNET_KVSTORE_COMM_H_
 #define MXNET_KVSTORE_COMM_H_
+#define NVLINK_SUPPORT 4
 #include <dmlc/omp.h>
 #include <algorithm>
 #include <limits>
@@ -674,7 +675,7 @@ class CommDevice : public Comm {
       CopyFromTo(src, (dst[dev_id]), priority);
       for (size_t i = 0; i < dst.size(); ++i) {
         if (i != static_cast<size_t>(dev_id)) {
-          CopyFromTo(*dst[dev_id], (dst[i]), priority);
+          CopyFromTo(*dst[dev_id], dst[i], priority);
         }
       }
     } else {
@@ -909,6 +910,7 @@ class CommDevice : public Comm {
     std::vector<NDArray> compressed_recv_buf;
   };
   std::unordered_map<int, BufferEntry> merge_buf_;
+  /// \brief the small buffer for partially merged data
   std::unordered_map<int, BufferEntry> stage_buf_;
   bool inited_;
 };

--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -568,8 +568,9 @@ class CommDevice : public Comm {
       if (buf.merged.is_none() && stage.copy_buf.empty()) {
         stage.copy_buf.resize(src.size());
         for (size_t j = 0; j < src.size(); ++j)
-          stage.copy_buf[j] = NDArray(stage.merged.shape(), stage.merged.ctx(),
-                                      true, stage.merged.dtype());
+          stage.copy_buf[j] =
+              NDArray(stage.merged.storage_type(), stage.merged.shape(),
+                      stage.merged.ctx(), true, stage.merged.dtype());
       }
       reduce_s.resize(stage.copy_buf.size());
       for (size_t i = 0, j = 0; i < src.size(); ++i) {

--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -647,7 +647,7 @@ class CommDevice : public Comm {
         buf.copy_buf.resize(group1.size() + 1);
         buf.compressed_recv_buf.resize(group1.size() + 1);
         buf.compressed_send_buf.resize(group1.size() + 1);
-        buf.residual.resize(group1.size() + 1);
+        buf.residual.resize(group1.size());
         stage.copy_buf.resize(group2.size());
         stage.compressed_recv_buf.resize(group2.size());
         stage.compressed_send_buf.resize(group2.size());
@@ -687,9 +687,6 @@ class CommDevice : public Comm {
         }
         buf.copy_buf[group1.size()] = NDArray(
             buf.merged.shape(), buf.merged.ctx(), false, buf.merged.dtype());
-        buf.residual[group1.size()] = NDArray(
-            buf.merged.shape(), stage.merged.ctx(), false, buf.merged.dtype());
-        buf.residual[group1.size()] = 0;
         int64_t small_size = gc_->GetCompressedSize(buf.merged.shape().Size());
         buf.compressed_recv_buf[group1.size()] = NDArray(
             TShape{small_size}, buf.merged.ctx(), false, buf.merged.dtype());
@@ -746,7 +743,7 @@ class CommDevice : public Comm {
       return stage.merged;
     } else {
       gc_->Quantize(stage.merged, &buf.compressed_send_buf[group1.size()],
-                    &(buf.residual[group1.size()]), priority);
+                    &(buf.residual[buf.residual.size()-1]), priority);
       CopyFromTo(buf.compressed_send_buf[group1.size()],
                  &(buf.compressed_recv_buf[group1.size()]), priority);
       gc_->Dequantize(buf.compressed_recv_buf[group1.size()],


### PR DESCRIPTION
## Description ##
(Optimized kvstore communication pattern to make full use of NVLinks)

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Device reduce
- [x] Device broadcast

## Comments ##
- The changes make kvstore to use more NVLinks/PCIe and avoid using QPI when both are present, edge cases include 4 and 8 gpus are used.
