### PR TITLE
New layer: split_like.

### DIFF
--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -295,6 +295,51 @@ NNVM_REGISTER_OP(reshape_like)
 .add_argument("rhs", "NDArray-or-Symbol", "Second input.");
 
 
+NNVM_REGISTER_OP(split_like)
+.describe("Split the first dim of lhs into two dims equal to first two dims of rhs.")
+.set_num_inputs(2)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) { return std::vector<std::string>{"lhs", "rhs"}; })
+.set_attr<nnvm::FInplaceOption>(
+    "FInplaceOption", [](const NodeAttrs& attrs) {
+      return std::vector<std::pair<int, int> >{{0, 0}};
+    })
+.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+    [](const NodeAttrs& attrs){ return std::vector<bool>{true}; })
+.set_attr<nnvm::FIgnoreInputs>("FIgnoreInputs",
+    [](const NodeAttrs& attrs) { return std::vector<uint32_t>(1, 1); })
+.set_attr<FCompute>("FCompute<cpu>", UnaryOp::IdentityCompute<cpu>)
+.set_attr<nnvm::FInferShape>("FInferShape",
+    [](const nnvm::NodeAttrs& attrs,
+       std::vector<TShape> *in_attrs,
+       std::vector<TShape> *out_attrs) {
+      TShape ishape = (*in_attrs)[0];
+      TShape rshape = (*in_attrs)[1];
+      TShape oshape(ishape.ndim() + 1);
+      oshape[0] = rshape[0];
+      oshape[1] = rshape[1];
+      for (size_t i = 1; i < ishape.ndim(); ++i) {
+        oshape[i + 1] = ishape[i];
+      }
+      SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);
+      return true;
+    })
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseType<2, 1>)
+.set_attr<nnvm::FGradient>(
+    "FGradient",  [](const nnvm::NodePtr& n,
+                     const std::vector<nnvm::NodeEntry>& ograds) {
+      if (CheckGradAllZero(ograds)) return MakeZeroGradNodes(n, ograds);
+      auto lhs = MakeGradNode("_backward_copy", n, ograds,
+                              std::unordered_map<std::string, std::string>());
+      auto ng = MakeNode("zeros_like", n->attrs.name + "_rhs_backward",
+                         {n->inputs[1]}, nullptr, &n);
+      lhs.push_back(nnvm::NodeEntry{ng, 0, 0});
+      return lhs;
+    })
+.add_argument("lhs", "NDArray-or-Symbol", "First input.")
+.add_argument("rhs", "NDArray-or-Symbol", "Second input.");
+
+
 DMLC_REGISTER_PARAMETER(CastParam);
 NNVM_REGISTER_OP(Cast)
 .add_alias("cast")

--- a/src/operator/tensor/elemwise_unary_op_basic.cu
+++ b/src/operator/tensor/elemwise_unary_op_basic.cu
@@ -63,6 +63,9 @@ NNVM_REGISTER_OP(_identity_with_attr_like_rhs)
 NNVM_REGISTER_OP(reshape_like)
 .set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
 
+NNVM_REGISTER_OP(split_like)
+.set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
+
 NNVM_REGISTER_OP(Cast)
 .set_attr<FCompute>("FCompute<gpu>", CastCompute<gpu>);
 


### PR DESCRIPTION
## Description ##

This PR introduces `split_like` layer, which is similar to `reshape_like` layer. The layer takes the first dim of the input shape (lhs), and splits it into two dims, which it gets from the reference shape (rhs).

This layer implements a simple operation, but this operation has a big payoff for high-level frameworks that want to do fast bucketing. If you want to do fast bucketing you have to avoid unrolling / compiling the network more than once. For GPU we have layers like `RNN` layer which make this possible. But an additional requirement is that the sequence length *never* appear in the `shape` parameters of any `Reshape` ops, otherwise we are forced to make new symbols instead of simply reshaping old executors.

Currently, there is a common idiom which unfortunately requires we hardcode the sequence length into a `Reshape`. My `split_like` allows us to implement this idiom without hardcoding sequence length. The idiom I mentioned is a way to efficiently map an operation over a sequence: 

1) take a tensor, with shape `in1 = (seq, batch, d1, d2, ...)`
2) merge the first two dims with `Reshape` using `shape=(-3,-2)` to give `in2 = (seq * batch, d1, d2, ...)`
3) perform some ordinary op or ops that naturally maps over the batch dimension to give `out1 = (seq * batch, e1, e2, ..)`
4) split the first dimension of the output back into two to give `out2 = (seq, batch, e1, e2, ...)`

`seq` doesn't have to come before `batch`, it could be the other way, but the point is the same: in step 4 we need to reverse the split operation that we performed in step 2. Unfortunately, we cannot hard-code either the batch size or the max sequence length into a `Reshape` layer, because if we do, we prevent an existing executor from being resized when we wish change that parameter. But there is no simple way to go from `seq * batch` to `seq, batch` without knowing at least one of them and hardcoding it into the `Reshape`, using current MXNet ops.

split_op makes this easy: you can just use the original tensor `in1` as the reference tensor, giving us `out2 = split_layer(lhs=out1, rhs=in1)`.

When you have a large number of buckets, the performance savings from doing this can be enormous. It is possible to cache the original JSON and attempt to build a template of it such that you can produce new JSON more cheaply, but that is a complicated and hacky prospect compared to having the executor be naturally resizable, which `split_layer` allows.

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
I get `ModuleNotFoundError: No module named 'cpplint'`, but the code is mostly copy-pasted from `reshape_like`, so it is probably ok?
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
`split_like` is almost a direct copy of `reshape_like`, which seems to have no direct test coverage. What should I do? 
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##

1. This seems like the only simple way of achieving executor resizability for the idiom I mentioned, but maybe I'm missing something and it is already possible!

2. Also, I am wondering if we should maybe introduce a `merge_dims` layer that is equivalent to the current `shape=(-3,-2)` spec of `Reshape`. It would be more symmetrical, and the truth is that these two operations "split" and "merge" are all I ever used those codes in `Reshape` for anyway. So if we introduce "merge' we could deprecate those old codes and perhaps remove them in a few versions time? That would also help `Reshape` get better backward shape inference, and keep it simpler for people to understand.