### PR TITLE
fix build error in clang-900.0.38 in mac

### DIFF
--- a/src/operator/l2_normalization-inl.h
+++ b/src/operator/l2_normalization-inl.h
@@ -96,7 +96,7 @@ class L2NormalizationOp : public Operator {
       Tensor<xpu, 1> norm = out_data[l2_normalization::kNorm].get<xpu, 1, real_t>(s);
       norm = sumall_except_dim<0>(F<mxnet::op::mshadow_op::square>(data));
       norm = F<mxnet::op::mshadow_op::square_root>(norm + param_.eps);
-      out = data / broadcast<0>(norm, out.shape_);
+      out = data / mshadow::expr::broadcast<0>(norm, out.shape_);
     } else if (param_.mode == l2_normalization::kChannel) {
       CHECK_GE(orig_shape.ndim(), 3U);
       Shape<3> dshape = Shape3(orig_shape[0], orig_shape[1],
@@ -159,8 +159,8 @@ class L2NormalizationOp : public Operator {
         .get_space<xpu>(mshadow::Shape1(data.shape_[0]), s);
       temp = sumall_except_dim<0>(grad_out * data);
       Assign(grad_in, req[l2_normalization::kData],
-        (grad_out - data * broadcast<0>(temp, data.shape_)) /
-        broadcast<0>(norm, data.shape_));
+        (grad_out - data * mshadow::expr::broadcast<0>(temp, data.shape_)) /
+        mshadow::expr::broadcast<0>(norm, data.shape_));
     } else if (param_.mode == l2_normalization::kChannel) {
       CHECK_GE(orig_shape.ndim(), 3U);
       Shape<3> dshape = Shape3(orig_shape[0], orig_shape[1],


### PR DESCRIPTION
## Description ##
I make new amalgamation, build failed in mac with clang-900.0.38. the error is

```
error: unexpected namespace name 'broadcast': expected expression
``` 
I change the code as pr, now it builds ok and the result is right.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
