### PR TITLE
Fix __repr__ for gluon.Parameter

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -152,3 +152,4 @@ List of Contributors
 * [Andre Tamm](https://github.com/andretamm)
 * [Marco de Abreu](https://github.com/marcoabreu)
  - Marco is the creator of the current MXNet CI.
+* [Julian Salazar](https://github.com/JulianSlzr)

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -117,7 +117,7 @@ class Parameter(object):
 
     def __repr__(self):
         s = 'Parameter {name} (shape={shape}, dtype={dtype})'
-        return s.format(**self.__dict__)
+        return s.format(name=self.name, shape=self.shape, dtype=self.dtype)
 
     @property
     def grad_req(self):

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -70,6 +70,23 @@ def test_parameter_sharing():
     net3.load_params('net1.params', mx.cpu())
 
 
+def test_parameter_str():
+    class Net(gluon.Block):
+        def __init__(self, **kwargs):
+            super(Net, self).__init__(**kwargs)
+            with self.name_scope():
+                self.dense0 = nn.Dense(10, in_units=5, use_bias=False)
+
+    net = Net(prefix='net1_')
+    lines = str(net.collect_params()).splitlines()
+
+    assert lines[0] == 'net1_ ('
+    assert 'net1_dense0_weight' in lines[1]
+    assert '(10, 5)' in lines[1]
+    assert 'numpy.float32' in lines[1]
+    assert lines[2] == ')'
+
+
 def test_basic():
     model = nn.Sequential()
     model.add(nn.Dense(128, activation='tanh', in_units=10, flatten=False))


### PR DESCRIPTION
## Description ##
Printing `gluon.Parameter` (`__repr__`) gives an error; this resolves the issue.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [n/a] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Update `gluon.Parameter.__repr__`

## Comments ##
Printing any `gluon.parameters` (e.g., `print(net.collect_params())`) will give:
```
.../site-packages/mxnet/gluon/parameter.py", line 120, in __repr__
    return s.format(**self.__dict__)
KeyError: 'shape'
```
instead of 
```
model0_ (
...
  Parameter model0_dense1_weight (shape=(10, 0), dtype=<class 'numpy.float32'>)
  Parameter model0_dense1_bias (shape=(10,), dtype=<class 'numpy.float32'>)
)
```
This regression in 1.0.0 due to [this change](https://github.com/apache/incubator-mxnet/commit/1852e2f47d68bb4c2373a359a2a8671b59cd14e5#diff-89ace34cda0f147e8dd6010b0a19be90R110), though `__repr__` was also at fault for using `self.__dict__` directly instead of the properties.
