### PR TITLE
Change type of 'lr_refactor_ratio' to 'float' or else the learning-rate-refactor will never work

### DIFF
--- a/example/ssd/train.py
+++ b/example/ssd/train.py
@@ -72,7 +72,7 @@ def parse_args():
                         help='blue mean value')
     parser.add_argument('--lr-steps', dest='lr_refactor_step', type=str, default='80, 160',
                         help='refactor learning rate at specified epochs')
-    parser.add_argument('--lr-factor', dest='lr_refactor_ratio', type=str, default=0.1,
+    parser.add_argument('--lr-factor', dest='lr_refactor_ratio', type=float, default=0.1,
                         help='ratio to refactor learning rate')
     parser.add_argument('--freeze', dest='freeze_pattern', type=str, default="^(conv1_|conv2_).*",
                         help='freeze layer pattern')


### PR DESCRIPTION
## Description ##
When training SSD with shell command:

`python train.py --lr-steps '20, 40, 60, 80, 100, 120, 140, 160, 180, 200, 220' --lr-factor 0.5`

It didn't change learning-rate for any epoch.

### Changes ###
- Change type of 'lr_refactor_ratio' from 'str' to 'float'

## Comments ##
- If we use "--lr-factor 0.5" in shell, the python code will consider lr_refactor_ratio' as "0.5" (string) and in the code below:
> 
    assert lr_refactor_ratio > 0
    iter_refactor = [int(r) for r in lr_refactor_step.split(',') if r.strip()]
    if lr_refactor_ratio >= 1:
        return (learning_rate, None)
    else:
        lr = learning_rate

The "0.5" >= 1  is true in Python, so the function "get_lr_scheduler()" will always return 'None' as lr_scheduler.