### PR TITLE
Symbol __getitem__ using list_outputs() is too expensive

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1058,7 +1058,7 @@ MXNET_DLL int MXSymbolListOutputs(SymbolHandle symbol,
  * \param out_size number of outputs
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXSymbolGetOutputCount(SymbolHandle symbol,
+MXNET_DLL int MXSymbolGetNumOutputs(SymbolHandle symbol,
                                      mx_uint *output_count);
 
 /*!

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1051,6 +1051,16 @@ MXNET_DLL int MXSymbolListArguments(SymbolHandle symbol,
 MXNET_DLL int MXSymbolListOutputs(SymbolHandle symbol,
                                   mx_uint *out_size,
                                   const char ***out_str_array);
+
+/*!
+ * \brief Get number of outputs of the symbol.
+ * \param symbol The symbol
+ * \param out_size number of outputs
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXSymbolGetOutputCount(SymbolHandle symbol,
+                                     mx_uint *output_count);
+
 /*!
  * \brief Get a symbol that contains all the internals.
  * \param symbol The symbol
@@ -1077,6 +1087,7 @@ MXNET_DLL int MXSymbolGetChildren(SymbolHandle symbol,
 MXNET_DLL int MXSymbolGetOutput(SymbolHandle symbol,
                                 mx_uint index,
                                 SymbolHandle *out);
+
 /*!
  * \brief List auxiliary states in the symbol.
  * \param symbol the symbol

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -491,7 +491,7 @@ class Symbol(SymbolBase):
             Indexing key
 
         """
-        output_count = self.output_count()
+        output_count = len(self)
         if isinstance(index, py_slice):
             start = 0 if index.start is None else index.start
             stop = output_count if index.stop is None else index.stop
@@ -747,7 +747,7 @@ class Symbol(SymbolBase):
             self.handle, ctypes.byref(size), ctypes.byref(sarr)))
         return [py_str(sarr[i]) for i in range(size.value)]
 
-    def output_count(self):
+    def __len__(self):
         """Get number of outputs for the symbol.
 
         Example
@@ -755,15 +755,15 @@ class Symbol(SymbolBase):
         >>> a = mx.sym.var('a')
         >>> b = mx.sym.var('b')
         >>> c = a + b
-        >>> c.output_count()
+        >>> len(c)
 
         Returns
         -------
-        output_count: Number of outputs
+        len(self): Number of outputs
             Number of outputs
         """
         output_count = mx_uint()
-        check_call(_LIB.MXSymbolGetOutputCount(self.handle, ctypes.byref(output_count)))
+        check_call(_LIB.MXSymbolGetNumOutputs(self.handle, ctypes.byref(output_count)))
         return int(output_count.value)
 
     def list_auxiliary_states(self):

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -764,7 +764,7 @@ class Symbol(SymbolBase):
         """
         output_count = mx_uint()
         check_call(_LIB.MXSymbolGetNumOutputs(self.handle, ctypes.byref(output_count)))
-        return int(output_count.value)
+        return output_count.value
 
     def list_auxiliary_states(self):
         """Lists all the auxiliary states in the symbol.

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -491,14 +491,16 @@ class Symbol(SymbolBase):
             Indexing key
 
         """
-        output_names = self.list_outputs()
+        output_count = self.output_count()
         if isinstance(index, py_slice):
             start = 0 if index.start is None else index.start
-            stop = len(output_names) if index.stop is None else index.stop
+            stop = output_count if index.stop is None else index.stop
             step = 1 if index.step is None else index.step
             return Group([self[i] for i in range(start, stop, step)])
 
         if isinstance(index, string_types):
+            # Returning this list of names is expensive. Some symbols may have hundreds of outputs
+            output_names = self.list_outputs()
             idx = None
             for i, name in enumerate(output_names):
                 if name == index:
@@ -511,7 +513,7 @@ class Symbol(SymbolBase):
 
         if not isinstance(index, int):
             raise TypeError('Symbol only support integer index to fetch i-th output')
-        if index >= len(output_names):
+        if index >= output_count:
             # Important, python determines the end by this exception
             raise IndexError
         handle = SymbolHandle()
@@ -744,6 +746,25 @@ class Symbol(SymbolBase):
         check_call(_LIB.MXSymbolListOutputs(
             self.handle, ctypes.byref(size), ctypes.byref(sarr)))
         return [py_str(sarr[i]) for i in range(size.value)]
+
+    def output_count(self):
+        """Get number of outputs for the symbol.
+
+        Example
+        -------
+        >>> a = mx.sym.var('a')
+        >>> b = mx.sym.var('b')
+        >>> c = a + b
+        >>> c.output_count()
+
+        Returns
+        -------
+        output_count: Number of outputs
+            Number of outputs
+        """
+        output_count = mx_uint()
+        check_call(_LIB.MXSymbolGetOutputCount(self.handle, ctypes.byref(output_count)))
+        return int(output_count.value)
 
     def list_auxiliary_states(self):
         """Lists all the auxiliary states in the symbol.

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -310,6 +310,11 @@ int MXSymbolListOutputs(SymbolHandle symbol,
   return NNSymbolListOutputNames(symbol, out_size, out_str_array);
 }
 
+int MXSymbolGetOutputCount(SymbolHandle symbol,
+                           mx_uint *output_count) {
+  return NNSymbolGetOutputCount(symbol, output_count);
+}
+
 int MXSymbolCompose(SymbolHandle sym,
                     const char *name,
                     mx_uint num_args,

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -310,9 +310,9 @@ int MXSymbolListOutputs(SymbolHandle symbol,
   return NNSymbolListOutputNames(symbol, out_size, out_str_array);
 }
 
-int MXSymbolGetOutputCount(SymbolHandle symbol,
+int MXSymbolGetNumOutputs(SymbolHandle symbol,
                            mx_uint *output_count) {
-  return NNSymbolGetOutputCount(symbol, output_count);
+  return NNSymbolGetNumOutputs(symbol, output_count);
 }
 
 int MXSymbolCompose(SymbolHandle sym,

--- a/tests/python/unittest/test_symbol.py
+++ b/tests/python/unittest/test_symbol.py
@@ -46,6 +46,7 @@ def test_symbol_compose():
     composed = net2(fc3_data=net1, name='composed')
     multi_out = mx.symbol.Group([composed, net1])
     assert len(multi_out.list_outputs()) == 2
+    assert multi_out.output_count() == 2
 
 
 def test_symbol_copy():
@@ -72,7 +73,9 @@ def test_symbol_children():
     net1 = mx.symbol.FullyConnected(data=oldfc, name='fc2', num_hidden=100)
 
     assert net1.get_children().list_outputs() == ['fc1_output', 'fc2_weight', 'fc2_bias']
+    assert net1.get_children().output_count() == 3
     assert net1.get_children().get_children().list_outputs() == ['data', 'fc1_weight', 'fc1_bias']
+    assert net1.get_children().get_children().output_count() == 3
     assert net1.get_children()['fc2_weight'].list_arguments() == ['fc2_weight']
     assert net1.get_children()['fc2_weight'].get_children() is None
 

--- a/tests/python/unittest/test_symbol.py
+++ b/tests/python/unittest/test_symbol.py
@@ -46,7 +46,7 @@ def test_symbol_compose():
     composed = net2(fc3_data=net1, name='composed')
     multi_out = mx.symbol.Group([composed, net1])
     assert len(multi_out.list_outputs()) == 2
-    assert multi_out.output_count() == 2
+    assert len(multi_out) == 2
 
 
 def test_symbol_copy():
@@ -73,9 +73,9 @@ def test_symbol_children():
     net1 = mx.symbol.FullyConnected(data=oldfc, name='fc2', num_hidden=100)
 
     assert net1.get_children().list_outputs() == ['fc1_output', 'fc2_weight', 'fc2_bias']
-    assert net1.get_children().output_count() == 3
+    assert len(net1.get_children()) == 3
     assert net1.get_children().get_children().list_outputs() == ['data', 'fc1_weight', 'fc1_bias']
-    assert net1.get_children().get_children().output_count() == 3
+    assert len(net1.get_children().get_children()) == 3
     assert net1.get_children()['fc2_weight'].list_arguments() == ['fc2_weight']
     assert net1.get_children()['fc2_weight'].get_children() is None
 


### PR DESCRIPTION
Symbol __getitem__ using list_outputs() is too expensive, when it only cares about the output count in most cases

## Description ##

Dependency: https://github.com/dmlc/nnvm/pull/270

Profile hotspot, expensive call of Symbol.list_outputs()

![list_outputs_profiling](https://user-images.githubusercontent.com/11234557/33741873-f55916ee-db5a-11e7-95b9-241c49cee65f.png)


## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
