### PR TITLE
Fix Example example/dec/dec.py

### DIFF
--- a/example/deep-embedded-clustering/README.md
+++ b/example/deep-embedded-clustering/README.md
@@ -1,0 +1,9 @@
+# DEC Implementation
+This is based on the paper `Unsupervised deep embedding for clustering analysis` by  Junyuan Xie, Ross Girshick, and Ali Farhadi
+
+## Prerequisite
+  - Install Scikit-learn: `python -m pip install --user sklearn`
+  - Install SciPy: `python -m pip install --user scipy`
+
+## Usage
+run `python dec.py`

--- a/example/deep-embedded-clustering/dec.py
+++ b/example/deep-embedded-clustering/dec.py
@@ -82,8 +82,8 @@ class DECModel(model.MXModel):
 
     def setup(self, X, num_centers, alpha, save_to='dec_model'):
         sep = X.shape[0]*9/10
-        X_train = X[:sep]
-        X_val = X[sep:]
+        X_train = X[:int(sep)]
+        X_val = X[int(sep):]
         ae_model = AutoEncoderModel(self.xpu, [X.shape[1],500,500,2000,10], pt_dropout=0.2)
         if not os.path.exists(save_to+'_pt.arg'):
             ae_model.layerwise_pretrain(X_train, 256, 50000, 'sgd', l_rate=0.1, decay=0.0,

--- a/example/deep-embedded-clustering/dec.py
+++ b/example/deep-embedded-clustering/dec.py
@@ -81,9 +81,9 @@ class DECModel(model.MXModel):
             return ['data', 'mu', 'label']
 
     def setup(self, X, num_centers, alpha, save_to='dec_model'):
-        sep = X.shape[0]*9/10
-        X_train = X[:int(sep)]
-        X_val = X[int(sep):]
+        sep = X.shape[0]*9//10
+        X_train = X[:sep]
+        X_val = X[sep:]
         ae_model = AutoEncoderModel(self.xpu, [X.shape[1],500,500,2000,10], pt_dropout=0.2)
         if not os.path.exists(save_to+'_pt.arg'):
             ae_model.layerwise_pretrain(X_train, 256, 50000, 'sgd', l_rate=0.1, decay=0.0,


### PR DESCRIPTION
## Description ##
The example has no README, no description, and does not run with python 3. 
@piiswrong can you please verify that the changes I have made are valid.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [x] For user-facing API changes, API doc string has been updated. For new C++ functions in header files, their functionalities and arguments are well-documented. 
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Renamed the folder from dec to deep-embedded-clustering
- [x] Added a README.md 
- [x] Was incompatible with python 3.x. Added a type conversion where needed. 

## Comments ##
 - I have tested on the `Deep Learning AMI with Conda (Ubuntu) (ami-405ade3a)`
 - I have verified that the change for python 3.x does not break the example on python 2.x
 - I have not verified the accuracy or validity of results.
