### PR TITLE
Fix names of extract-layers of resnet101

### DIFF
--- a/example/ssd/symbol/symbol_factory.py
+++ b/example/ssd/symbol/symbol_factory.py
@@ -86,7 +86,7 @@ def get_config(network, data_shape, **kwargs):
         num_layers = 101
         image_shape = '3,224,224'
         network = 'resnet'
-        from_layers = ['_plus12', '_plus15', '', '', '', '']
+        from_layers = ['_plus29', '_plus32', '', '', '', '']
         num_filters = [-1, -1, 512, 256, 256, 128]
         strides = [-1, -1, 2, 2, 2, 2]
         pads = [-1, -1, 1, 1, 1, 1]


### PR DESCRIPTION


## Description ##
After running resnet50 and resnet101 in example/ssd, the size of .params file for these two models are:

| Model      | Size of .params file |
| :--:           | :--: |
|resnet50   | 119MB |
|resnet101  | 69MB |

Commands:

`python train.py --network resnet50`
`python train.py --network resnet101`

It shows the number of parameters for resnet101 is smaller than resnet50, which seems very weird.

### Changes ###
- The names of extract-layers for resnet101 in symbol/symbol_factory.py

## Comments ##
For resnet50, the numbers of layers for different stages are [3, 4, 6, 3], so the extract-layers for SSD are 3+4+6-1=12 and 3+4+6+3-1=15，as the code in symbol_factory.py:
`from_layers = ['_plus12', '_plus15', '', '', '', '']`
The numbers of layers for resnet101 are [3, 4, 23, 3],  so the extract-layers for SSD should be 3+4+23-1=29 and 3+4+23+3-1=32.
The right code for resnet101 should be:
`from_layers = ['_plus29', '_plus32', '', '', '', '']`
