### PR TITLE
add zero-grad for rounding ops

### DIFF
--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -442,7 +442,8 @@ The storage type of ``rint`` output depends upon the input storage type:
    - rint(default) = default
    - rint(row_sparse) = row_sparse
 
-)code" ADD_FILELINE);
+)code" ADD_FILELINE)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
 
 // ceil
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(ceil, cpu, mshadow_op::ceil)
@@ -460,7 +461,8 @@ The storage type of ``ceil`` output depends upon the input storage type:
    - ceil(default) = default
    - ceil(row_sparse) = row_sparse
 
-)code" ADD_FILELINE);
+)code" ADD_FILELINE)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
 
 // floor
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(floor, cpu, mshadow_op::floor)
@@ -478,7 +480,8 @@ The storage type of ``floor`` output depends upon the input storage type:
    - floor(default) = default
    - floor(row_sparse) = row_sparse
 
-)code" ADD_FILELINE);
+)code" ADD_FILELINE)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
 
 // trunc
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(trunc, cpu, mshadow_op::trunc)
@@ -497,7 +500,8 @@ The storage type of ``trunc`` output depends upon the input storage type:
    - trunc(default) = default
    - trunc(row_sparse) = row_sparse
 
-)code" ADD_FILELINE);
+)code" ADD_FILELINE)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
 
 // fix
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(fix, cpu, mshadow_op::fix)
@@ -514,7 +518,8 @@ The storage type of ``fix`` output depends upon the input storage type:
    - fix(default) = default
    - fix(row_sparse) = row_sparse
 
-)code" ADD_FILELINE);
+)code" ADD_FILELINE)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
 
 // square
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(square, cpu, mshadow_op::square)

--- a/tests/python/unittest/test_symbol.py
+++ b/tests/python/unittest/test_symbol.py
@@ -173,6 +173,7 @@ def test_symbol_fluent():
                     'exp', 'expm1', 'log', 'log10', 'log2', 'log1p', 'sqrt', 'rsqrt',
                     'square', 'reciprocal' 'reshape_like', 'cbrt', 'rcbrt', 'relu', 'sigmoid',
                     'softmax', 'log_softmax', 'rint', 'ceil', 'floor', 'trunc', 'fix'])
+
     def check_fluent_regular(func, kwargs, shape=(5, 17, 1), equal_nan=False):
         with mx.name.NameManager():
             data = mx.symbol.Variable('data')

--- a/tests/python/unittest/test_symbol.py
+++ b/tests/python/unittest/test_symbol.py
@@ -172,7 +172,7 @@ def test_symbol_fluent():
                     'degrees', 'radians', 'sinh', 'cosh', 'tanh', 'arcsinh', 'arccosh', 'arctanh',
                     'exp', 'expm1', 'log', 'log10', 'log2', 'log1p', 'sqrt', 'rsqrt',
                     'square', 'reciprocal' 'reshape_like', 'cbrt', 'rcbrt', 'relu', 'sigmoid',
-                    'softmax', 'log_softmax'])
+                    'softmax', 'log_softmax', 'rint', 'ceil', 'floor', 'trunc', 'fix'])
     def check_fluent_regular(func, kwargs, shape=(5, 17, 1), equal_nan=False):
         with mx.name.NameManager():
             data = mx.symbol.Variable('data')


### PR DESCRIPTION
## Description ##
add zero gradients to rounding operators including 'rint', 'ceil', 'floor', 'trunc', and 'fix'.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] register FGradient with MakeZeroGradNodes for 'rint', 'ceil', 'floor', 'trunc', 'fix'