### PR TITLE
Fix example  example/reinforcement-learning/a3c

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -153,3 +153,4 @@ List of Contributors
 * [Marco de Abreu](https://github.com/marcoabreu)
  - Marco is the creator of the current MXNet CI.
 * [Julian Salazar](https://github.com/JulianSlzr)
+* [Meghna Baijal](https://github.com/mbaijal)

--- a/example/reinforcement-learning/a3c/README.md
+++ b/example/reinforcement-learning/a3c/README.md
@@ -17,4 +17,4 @@ Note this is a generalization of the original algorithm since we use `batch_size
 run `python a3c.py --batch-size=32 --gpus=0` to run training on gpu 0 with batch-size=32.
 
 run `python launcher.py --gpus=0,1 -n 2 python a3c.py` to launch training on 2 gpus (0 and 1), each gpu has two workers.
-
+Note: You might have to update the path to dmlc-core in launcher.py.

--- a/example/reinforcement-learning/a3c/README.md
+++ b/example/reinforcement-learning/a3c/README.md
@@ -7,6 +7,12 @@ The algorithm should be mostly correct. However I cannot reproduce the result in
 
 Note this is a generalization of the original algorithm since we use `batch_size` threads for each worker instead of the original 1 thread.
 
+## Prerequisites
+  - Install OpenAI Gym: `pip install gym`
+  - Install the Atari Env: `pip install gym[atari]`
+  - You may need to install flask: `pip install flask`
+  - You may have to install cv2: `pip install opencv-python`
+
 ## Usage
 run `python a3c.py --batch-size=32 --gpus=0` to run training on gpu 0 with batch-size=32.
 

--- a/example/reinforcement-learning/a3c/a3c.py
+++ b/example/reinforcement-learning/a3c/a3c.py
@@ -26,7 +26,11 @@ import os
 import gym
 from datetime import datetime
 import time
-from importlib import reload
+import sys
+try:
+    from importlib import reload
+except ImportError:
+    pass
 
 parser = argparse.ArgumentParser(description='Traing A3C with OpenAI Gym')
 parser.add_argument('--test', action='store_true', help='run testing', default=False)

--- a/example/reinforcement-learning/a3c/a3c.py
+++ b/example/reinforcement-learning/a3c/a3c.py
@@ -26,6 +26,7 @@ import os
 import gym
 from datetime import datetime
 import time
+from importlib import reload
 
 parser = argparse.ArgumentParser(description='Traing A3C with OpenAI Gym')
 parser.add_argument('--test', action='store_true', help='run testing', default=False)
@@ -139,7 +140,7 @@ def train():
             module.save_params('%s-%04d.params'%(save_model_prefix, epoch))
 
 
-        for _ in range(epoch_size/args.t_max):
+        for _ in range(int(epoch_size/args.t_max)):
             tic = time.time()
             # clear gradients
             for exe in module._exec_group.grad_arrays:

--- a/example/reinforcement-learning/a3c/rl_data.py
+++ b/example/reinforcement-learning/a3c/rl_data.py
@@ -21,7 +21,7 @@ import numpy as np
 import gym
 import cv2
 import math
-import Queue
+import queue
 from threading import Thread
 import time
 import multiprocessing
@@ -62,7 +62,7 @@ def visual(X, show=True):
     buf = np.zeros((h*n, w*n, X.shape[3]), dtype=np.uint8)
     for i in range(N):
         x = i%n
-        y = i/n
+        y = i//n
         buf[h*y:h*(y+1), w*x:w*(x+1), :] = X[i]
     if show:
         cv2.imshow('a', buf)
@@ -88,7 +88,7 @@ class RLDataIter(object):
 
         self.web_viz = web_viz
         if web_viz:
-            self.queue = Queue.Queue()
+            self.queue = queue.Queue()
             self.thread = Thread(target=make_web, args=(self.queue,))
             self.thread.daemon = True
             self.thread.start()
@@ -117,7 +117,7 @@ class RLDataIter(object):
         reward = np.asarray([i[1] for i in new], dtype=np.float32)
         done = np.asarray([i[2] for i in new], dtype=np.float32)
 
-        channels = self.state_.shape[1]/self.input_length
+        channels = self.state_.shape[1]//self.input_length
         state = np.zeros_like(self.state_)
         state[:,:-channels,:,:] = self.state_[:,channels:,:,:]
         for i, (ob, env) in enumerate(zip(new, self.env)):
@@ -151,7 +151,7 @@ class GymDataIter(RLDataIter):
         return gym.make(self.game)
 
     def visual(self):
-        data = self.state_[:4, -self.state_.shape[1]/self.input_length:, :, :]
+        data = self.state_[:4, -self.state_.shape[1]//self.input_length:, :, :]
         return visual(np.asarray(data, dtype=np.uint8), False)
 
 if __name__ == '__main__':

--- a/example/reinforcement-learning/a3c/rl_data.py
+++ b/example/reinforcement-learning/a3c/rl_data.py
@@ -28,11 +28,11 @@ import multiprocessing.pool
 from flask import Flask, render_template, Response
 import signal
 import sys
-is_py2 = sys.version[0] == '2'
-if is_py2:
-    import Queue as queue
-else:
+is_py3 = sys.version[0] == '3'
+if is_py3:
     import queue as queue
+else:
+    import Queue as queue
 
 def make_web(queue):
     app = Flask(__name__)

--- a/example/reinforcement-learning/a3c/rl_data.py
+++ b/example/reinforcement-learning/a3c/rl_data.py
@@ -21,13 +21,18 @@ import numpy as np
 import gym
 import cv2
 import math
-import queue
 from threading import Thread
 import time
 import multiprocessing
 import multiprocessing.pool
 from flask import Flask, render_template, Response
 import signal
+import sys
+is_py2 = sys.version[0] == '2'
+if is_py2:
+    import Queue as queue
+else:
+    import queue as queue
 
 def make_web(queue):
     app = Flask(__name__)


### PR DESCRIPTION
## Description ##
  - This example was not compatible with python3. I made necessary changes. 
  - I also updated the README with the Pre-reqs I needed to make the example work on the CONDA AMI (mxnet_p36/mxnet_p27 envs)
  - I have also verified that the example works with rllab and rllab3 conda envs.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Some changes to a3c.py to make it compatible with both python2 and python3.
- [x] Some changes to rl_data.py to make it compatible with python3.
- [x] Updated README

## Comments ##
  - I have tested on the Deep Learning AMI with Conda (Ubuntu) (ami-405ade3a)
  - I fixed it such that it works with both python 3.x and python 2.x
  - I have not verified the accuracy or validity of results.
