### PR TITLE
Allow user to pass specific environment variables for server/worker/both through launch.py

### DIFF
--- a/tools/launch.py
+++ b/tools/launch.py
@@ -35,11 +35,15 @@ def dmlc_opts(opts):
             '--num-servers', str(opts.num_servers),
             '--cluster', opts.launcher,
             '--host-file', opts.hostfile,
-            '--sync-dst-dir', opts.sync_dst_dir,
-            '--envs-server', opts.envs_server,
-            '--envs-worker', opts.envs_worker,
-            '--envs', opts.envs]
-    args += opts.command;
+            '--sync-dst-dir', opts.sync_dst_dir]
+
+    # convert to dictionary
+    dopts = vars(opts)
+    for key in ['env_server', 'env_worker', 'env']:
+        for v in dopts[key]:
+            args.append('--' + key.replace("_","-"))
+            args.append(v)
+    args += opts.command
     try:
         from dmlc_tracker import opts
     except ImportError:
@@ -67,21 +71,19 @@ def main():
     parser.add_argument('--launcher', type=str, default='ssh',
                         choices = ['local', 'ssh', 'mpi', 'sge', 'yarn'],
                         help = 'the launcher to use')
-    parser.add_argument('--envs-server', type=str, default='',
-                        help = 'Given a pair of environment_variable:value, sets those values of \
-                        environment variables for the server processes. This overrides values of \
+    parser.add_argument('--env-server', action='append', default=[],
+                        help = 'Given a pair of environment_variable:value, sets this value of \
+                        environment variable for the server processes. This overrides values of \
                         those environment variable on the machine where this script is run from. \
-                        Example OMP_NUM_THREADS:3,MXNET_PROFILER_MODE:1')
-    parser.add_argument('--envs-worker', type=str, default='',
-                        help = 'Given a list of comma separated pairs of environment_variable:value, \
-                        sets those values of environment variables for the worker processes. \
-                        This overrides values of those environment variable on the machine \
-                        where the job script is run from.\
-                        Example OMP_NUM_THREADS:3,MXNET_PROFILER_MODE:1')
-    parser.add_argument('--envs', type=str, default='',
-                        help = 'given a list of comma separated environment variables, passes their \
+                        Example OMP_NUM_THREADS:3')
+    parser.add_argument('--env-worker', action='append', default=[],
+                        help = 'Given a pair of environment_variable:value, sets this value of \
+                        environment variable for the worker processes. This overrides values of \
+                        those environment variable on the machine where this script is run from. \
+                        Example OMP_NUM_THREADS:3')
+    parser.add_argument('--env', action='append', default=[],
+                        help = 'given a environment variable, passes their \
                         values from current system to all workers and servers. \
-                        Example OMP_NUM_THREADS,MXNET_PROFILER_MODE \
                         Not necessary when launcher is local as in that case \
                         all environment variables which are set are copied.')
     parser.add_argument('command', nargs='+',

--- a/tools/launch.py
+++ b/tools/launch.py
@@ -35,7 +35,10 @@ def dmlc_opts(opts):
             '--num-servers', str(opts.num_servers),
             '--cluster', opts.launcher,
             '--host-file', opts.hostfile,
-            '--sync-dst-dir', opts.sync_dst_dir]
+            '--sync-dst-dir', opts.sync_dst_dir,
+            '--envs-server', opts.envs_server,
+            '--envs-worker', opts.envs_worker,
+            '--envs', opts.envs]
     args += opts.command;
     try:
         from dmlc_tracker import opts
@@ -64,6 +67,23 @@ def main():
     parser.add_argument('--launcher', type=str, default='ssh',
                         choices = ['local', 'ssh', 'mpi', 'sge', 'yarn'],
                         help = 'the launcher to use')
+    parser.add_argument('--envs-server', type=str, default='',
+                        help = 'Given a pair of environment_variable:value, sets those values of \
+                        environment variables for the server processes. This overrides values of \
+                        those environment variable on the machine where this script is run from. \
+                        Example OMP_NUM_THREADS:3,MXNET_PROFILER_MODE:1')
+    parser.add_argument('--envs-worker', type=str, default='',
+                        help = 'Given a list of comma separated pairs of environment_variable:value, \
+                        sets those values of environment variables for the worker processes. \
+                        This overrides values of those environment variable on the machine \
+                        where the job script is run from.\
+                        Example OMP_NUM_THREADS:3,MXNET_PROFILER_MODE:1')
+    parser.add_argument('--envs', type=str, default='',
+                        help = 'given a list of comma separated environment variables, passes their \
+                        values from current system to all workers and servers. \
+                        Example OMP_NUM_THREADS,MXNET_PROFILER_MODE \
+                        Not necessary when launcher is local as in that case \
+                        all environment variables which are set are copied.')
     parser.add_argument('command', nargs='+',
                         help = 'command for launching the program')
     args, unknown = parser.parse_known_args()


### PR DESCRIPTION
## Description ##
Sometimes user might want to pass a specific environment variable when launching a distributed training job using launch.py. I have found it very helpful to set variables like PYTHONPATH or one of the [many MXNet environment variables](https://mxnet.incubator.apache.org/how_to/env_var.html). 
Also we might sometimes want to set a variable like OMP_NUM_THREADS or MXNET_CPU_WORKER_NTHREADS only for server processes. And others for worker processes only.

This PR allows user to pass such variables easily
**Requires this PR in dmlc-core to be merged https://github.com/dmlc/dmlc-core/pull/346**

- For both server and worker processes
```... --env VARIABLE1```
Picks value of the environment variable which is set when launch.py is called. If a variable passed doesn't have value set, raises an error to ensure user isn't making a mistake.

- For server processes only
```... --env-server VARIABLE:VALUE```

- For worker processes only
```... --env-worker VARIABLE:VALUE```

Passing multiple such arguments is allowed
For example ```--env VARIABLE1 --env VARIABLE2```

Supports cluster types of `local` and `ssh`

@anirudh2290 This is a better version of something I had sent earlier that you had reviewed

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Refer description

## Comments ##
This doesn't break anything which is already there. 
If someone doesn't want to use it, it doesn't affect them. But I believe this would be very useful