### PR TITLE
Re-enable all op segments when in batch mode

### DIFF
--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -1348,72 +1348,100 @@ void GraphExecutor::InitOpSegs() {
   bool prefer_bulk_exec_inference = dmlc::GetEnv("MXNET_EXEC_BULK_EXEC_INFERENCE", true);
   // Whether to perform bulk exec for training
   bool prefer_bulk_exec = dmlc::GetEnv("MXNET_EXEC_BULK_EXEC_TRAIN", 1);
-  // The maximum number of node in a segment executed in bulk
-  size_t num_nodes_threshold = dmlc::GetEnv("MXNET_EXEC_BULK_EXEC_MAX_NODE_TRAIN", 15);
-  if (prefer_bulk_exec_inference && num_forward_nodes_ == total_num_nodes) {
-    // Bulk the whole graph for inference
-    cached_seg_opr_[0] = this->CreateCachedSegOpr(0, num_forward_nodes_);
-    return;
+
+  bool is_training = num_forward_nodes_ != total_num_nodes;
+
+  if (prefer_bulk_exec  && is_training) {
+    this->BulkTrainingOpSegs(total_num_nodes);
   }
 
-  if (prefer_bulk_exec) {
-    // create forward segments for training
-    size_t topo_start = 0;
-    for (size_t nid = 0; nid < num_forward_nodes_; nid++) {
-      auto &node = graph_.indexed_graph()[nid].source;
-      auto &op_node = op_nodes_[nid];
-      // check if the segment relies on external input, or exceeds maxinum number of node,
-      // or requires async ops
-      if (node->is_variable() || nid - topo_start > num_nodes_threshold ||
-          op_node.exec->exec_type() != ExecType::kSync) {
-        // create a new segment for the previous nodes if the current one cannot be bulked
-        cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, nid);
-        topo_start = nid + 1;
-      }
-    }
-    // the last segmenet
-    if (topo_start != num_forward_nodes_) {
-      cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, num_forward_nodes_);
-    }
-
-    // create backward segments for training
-    // get all gradient variables
-    std::unordered_set<engine::VarHandle> grad_vars;
-    for (auto &kv : grad_store_) {
-      grad_vars.insert(kv.second.var());
-    }
-    auto &idx = graph_.indexed_graph();
-    topo_start = num_forward_nodes_;
-    for (size_t nid = num_forward_nodes_; nid < total_num_nodes; nid++) {
-      auto &op_node = op_nodes_[nid];
-      if (op_node.skip_exec_node || op_node.exec == nullptr) {
-        continue;
-      }
-      if (idx[nid].source->is_variable() || nid - topo_start > num_nodes_threshold ||
-          op_node.exec->exec_type() != ExecType::kSync) {
-        cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, nid);
-        topo_start = nid + 1;
-      } else {
-        // If it produces output gradient, don't include it in the segment
-        bool output_gradient = false;
-        for (auto &out_arr : op_node.exec->out_array) {
-          if (grad_vars.find(out_arr.var()) != grad_vars.end()) {
-            output_gradient = true;
-          }
-        }
-        if (output_gradient) {
-          cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, nid);
-          topo_start = nid + 1;
-        }
-      }
-    }
-    // last segment for backward
-    if (topo_start < total_num_nodes) {
-      cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, total_num_nodes);
-    }
+  if (prefer_bulk_exec_inference && !is_training) {
+    this->BulkInferenceOpSegs();
   }
 
   return;
+}
+
+void GraphExecutor::BulkTrainingOpSegs(size_t total_num_nodes) {
+  // The maximum number of node in a segment executed in bulk
+  size_t num_nodes_threshold = dmlc::GetEnv("MXNET_EXEC_BULK_EXEC_MAX_NODE_TRAIN", 15);
+
+  // create forward segments for training
+  size_t topo_start = 0;
+  for (size_t nid = 0; nid < num_forward_nodes_; nid++) {
+    auto &node = graph_.indexed_graph()[nid].source;
+    auto &op_node = op_nodes_[nid];
+    // check if the segment relies on external input, or exceeds maxinum number of node,
+    // or requires async ops
+    if (node->is_variable() || nid - topo_start > num_nodes_threshold ||
+        op_node.exec->exec_type() != ExecType::kSync) {
+      // create a new segment for the previous nodes if the current one cannot be bulked
+      cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, nid);
+      topo_start = nid + 1;
+    }
+  }
+  // the last segment
+  if (topo_start != num_forward_nodes_) {
+    cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, num_forward_nodes_);
+  }
+
+  // create backward segments for training
+  // get all gradient variables
+  std::unordered_set<engine::VarHandle> grad_vars;
+  for (auto &kv : grad_store_) {
+    grad_vars.insert(kv.second.var());
+  }
+  auto &idx = graph_.indexed_graph();
+  topo_start = num_forward_nodes_;
+  for (size_t nid = num_forward_nodes_; nid < total_num_nodes; nid++) {
+    auto &op_node = op_nodes_[nid];
+    if (op_node.skip_exec_node || op_node.exec == nullptr) {
+      continue;
+    }
+    if (idx[nid].source->is_variable() || nid - topo_start > num_nodes_threshold ||
+        op_node.exec->exec_type() != ExecType::kSync) {
+      cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, nid);
+      topo_start = nid + 1;
+    } else {
+      // If it produces output gradient, don't include it in the segment
+      bool output_gradient = false;
+      for (auto &out_arr : op_node.exec->out_array) {
+        if (grad_vars.find(out_arr.var()) != grad_vars.end()) {
+          output_gradient = true;
+        }
+      }
+      if (output_gradient) {
+        cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, nid);
+        topo_start = nid + 1;
+      }
+    }
+  }
+  // last segment for backward
+  if (topo_start < total_num_nodes) {
+    cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, total_num_nodes);
+  }
+}
+
+void GraphExecutor::BulkInferenceOpSegs() {
+  // Attempt to bulk the whole graph for inference.  We will only create new segments when
+  // required for non-kSync operations.
+  size_t topo_start = 0;
+  for (size_t nid = 0; nid < num_forward_nodes_; nid++) {
+    auto &node = graph_.indexed_graph()[nid].source;
+    auto &op_node = op_nodes_[nid];
+
+    // Variables do not need to be segmented at inference time.
+    if (node->is_variable()) continue;
+
+    if (op_node.exec->exec_type() != ExecType::kSync) {
+      cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, nid);
+      topo_start = nid + 1;
+    }
+  }
+  // The last segment
+  if (topo_start != num_forward_nodes_) {
+    cached_seg_opr_[topo_start] = this->CreateCachedSegOpr(topo_start, num_forward_nodes_);
+  }
 }
 
 void GraphExecutor::ExecuteMonCallback(size_t nid) {

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -1351,8 +1351,9 @@ void GraphExecutor::InitOpSegs() {
   // The maximum number of node in a segment executed in bulk
   size_t num_nodes_threshold = dmlc::GetEnv("MXNET_EXEC_BULK_EXEC_MAX_NODE_TRAIN", 15);
   if (prefer_bulk_exec_inference && num_forward_nodes_ == total_num_nodes) {
-    // bulk the whole graph for inference
-    num_nodes_threshold = std::numeric_limits<size_t>::max();
+    // Bulk the whole graph for inference
+    cached_seg_opr_[0] = this->CreateCachedSegOpr(0, num_forward_nodes_);
+    return;
   }
 
   if (prefer_bulk_exec) {

--- a/src/executor/graph_executor.h
+++ b/src/executor/graph_executor.h
@@ -197,6 +197,10 @@ class GraphExecutor : public Executor {
   CachedSegOpr CreateCachedSegOpr(size_t topo_start, size_t topo_end);
   // run the monitor callback for node `nid`
   void ExecuteMonCallback(size_t nid);
+  // peform bulking and segmentation on an inference graph
+  void BulkInferenceOpSegs();
+  // perform bulking and segmentation on a training graph
+  void BulkTrainingOpSegs(size_t total_num_nodes);
 
   // internal graph
   nnvm::Graph graph_;


### PR DESCRIPTION
## Description ##
This patch fixes a performance regression that is causing a roughly 20% slowdown in some inference scenarios.  I haven't investigated in depth how wide spread this issue is, but at a minimum it's affecting inference with a resnet model and a batch size of 1.

I'm not totally familiar with the commit that makes the change, but to me it looks like the regression occurred because of a refactor in the graph executor that improves readability.  The performance problems occur because we introduce a number of cudaStreamSyncronize calls which lower our overall gpu utilization (likely due to a restricted execution plan that leads to a lower overall SM occupancy).  It's not clear to me if this would cause any issues when running inference in a non-GPU environment.

It is possible that the change in operator segmentation behaviour was intended and has other useful implications.  If so we should be able to modify the code so that we get both the intended benefits, and the faster performance.

## Investigation ##
After verifying the regression on a demonstration model we did some high level measurements to see if any trends emerged.  We saw two stats that helped diagnose the issue.   First the gpu usage during inference dropping from ~95% to ~85%.  Second we had a large increase in the number of cudaStreamSynchronize calls.

0.9.5  cuda calls:
```
Time(%)      Time     Calls       Avg       Min       Max  Name
 30.59%  16.6780s      2401  6.9463ms  5.7920us  31.420ms  cudaStreamSynchronize
 22.59%  12.3190s    105146  117.16us  22.368us  12.287ms  cudaLaunch
 17.10%  9.32475s        16  582.80ms  195.55us  4.66099s  cudaStreamCreateWithFlags
```
0.12 cuda calls:
```
==2726== API calls:
Time(%)      Time     Calls       Avg       Min       Max  Name
 46.13%  37.5542s     48601  772.70us  5.1200us  5.5922ms  cudaStreamSynchronize
 17.72%  14.4214s    102946  140.09us  22.432us  9.2845ms  cudaLaunch
 11.32%  9.21538s        16  575.96ms  222.94us  4.60608s  cudaStreamCreateWithFlags
...
```

Note the number of cudaStreamSynchronize calls increases from 2401 to 48601.  Once this PR has been applied our models return to exactly 2401 calls.

We verified that the cudaStreamSynchronize calls were responsible for the low GPU utilization with some further profiling.  The following images show a timeline view of one inference call through the model.  A timespan is highlighted at the top of the timeline to show relative performance.  Gaps in the compute row show the relative utilization of the GPU.  I've also added a little instrumentation that adds our existing profiling names to nvidia's tool's timeline (very small change, will PR it separately after Chris's awesome profiling work is merged).  This also highlights the difference in behaviour when we're segmenting operators.  The 0.9.5 and 1.0 (with this PR)  builds both group operators together into a single segment for a single inference.  The 0.12 build breaks operators apart into several segments.

0.9.5:
![0 9 5_with_tracing](https://user-images.githubusercontent.com/7443219/33946102-2c9979e4-e021-11e7-9e31-1e0baa0d690c.png)

0.12:
![0 12_with_tracing](https://user-images.githubusercontent.com/7443219/33946110-34296d18-e021-11e7-8d18-6d40b797405c.png)

1.0 with PR applied:
![1 0_with_fix_and_tracing](https://user-images.githubusercontent.com/7443219/33946125-3b93cb98-e021-11e7-82ab-440211a6fb0b.png)

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Performance regression fix.  While refactoring this function it appears we introduced an unexpected side-effect: a number of cudaStreamSyncCalls which caused a slowdown in performance.

## Comments ##
- This needs to be reviewed by someone with familiarity with this graph executor.  Tests are passing, and the performance tests I've run have been sped up by a factor of ~20%, but I would like to have a discussion around the performance implications of this change.  Could this negatively affect some aspect of MXNet performance (for example CPU inference, large batched prediction, etc?).  
-  This change also groups together several operators into the same reported segment from the profiler.  Is this the right thing to do from the users's perspective?  
