### PR TITLE
Increase git timeout for CI (fixes #9070)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ def init_git() {
   deleteDir()
   retry(5) {
     try {
-      timeout(time: 2, unit: 'MINUTES') {
+      timeout(time: 15, unit: 'MINUTES') {
         checkout scm
         sh 'git submodule update --init'
         sh 'git clean -d -f'        

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ def init_git() {
   deleteDir()
   retry(5) {
     try {
+      // Make sure wait long enough for quote. Important: Don't increase the amount of 
+      // retries as this will increase the amount of requests and worsen the throttling
       timeout(time: 15, unit: 'MINUTES') {
         checkout scm
         sh 'git submodule update --init'


### PR DESCRIPTION
This patch increases the timeout of init_git in the Jenkinsfile. This is required because GitHub tends to rate limit our CI if the load is high. In order to give the slaves more time to receive a quota, increase the timeout. Otherwise, the execution would fail during high load.

It's important to have high timeout time instead of retries due to the fact that otherwise we'd spam GitHub with even more requests and worsen the situation.