### PR TITLE
Fix Khatri-Rao test build

### DIFF
--- a/src/operator/contrib/krprod.h
+++ b/src/operator/contrib/krprod.h
@@ -29,6 +29,7 @@
 #include <utility>
 #include <vector>
 #include "mshadow/tensor.h"
+#include "../operator_common.h"
 #include "../c_lapack_api.h"
 
 


### PR DESCRIPTION
A recent inclusion of the Khatri-Rao operator breaks `make test`. We add a
missing include to resolve the error.

Fixes Issue #9076

## Description ##

PR #7781 adds the Khatri-Rao operator. The automated testing framework in the PR reported that all tests passed. However, locally running `make test` causes the build error described in Issue #9076 . This small change adds the necessary headers to fix the build issue.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Testing ###

```
$ make
$ make test
$ ./build/tests/cpp/mxnet_unit_tests
$ python -m pytest ./tests/python/unittest/test_contrib_krprod.py
```