### PR TITLE
Some changes to numpy_ops examples

### DIFF
--- a/example/numpy-ops/custom_softmax.py
+++ b/example/numpy-ops/custom_softmax.py
@@ -82,10 +82,12 @@ train, val = MNISTIterator(batch_size=100, input_shape = (784,))
 logging.basicConfig(level=logging.DEBUG)
 
 # MXNET_CPU_WORKER_NTHREADS must be greater than 1 for custom op to work on CPU
-model = mx.model.FeedForward(
-    ctx = mx.cpu(0), symbol = mlp, num_epoch = 20,
-    learning_rate = 0.1, momentum = 0.9, wd = 0.00001)
+context=mx.cpu()
+# Uncomment this line to train on GPU
+# context=mx.gpu(0)
 
-model.fit(X=train, eval_data=val,
-          batch_end_callback=mx.callback.Speedometer(100,100))
+mod = mx.mod.Module(mlp, context=context)
 
+mod.fit(train_data=train, eval_data=val, optimizer='sgd',
+    optimizer_params={'learning_rate':0.1, 'momentum': 0.9, 'wd': 0.00001},
+    num_epoch=10, batch_end_callback=mx.callback.Speedometer(100, 100))

--- a/example/numpy-ops/numpy_softmax.py
+++ b/example/numpy-ops/numpy_softmax.py
@@ -76,9 +76,13 @@ train, val = MNISTIterator(batch_size=100, input_shape = (784,))
 
 logging.basicConfig(level=logging.DEBUG)
 
-model = mx.model.FeedForward(
-    ctx = mx.cpu(), symbol = mlp, num_epoch = 20,
-    learning_rate = 0.1, momentum = 0.9, wd = 0.00001)
+# MXNET_CPU_WORKER_NTHREADS must be greater than 1 for custom op to work on CPU
+context=mx.cpu()
+# Uncomment this line to train on GPU instead of CPU
+# context=mx.gpu(0)
 
-model.fit(X=train, eval_data=val)
+mod = mx.mod.Module(mlp, context=context)
 
+mod.fit(train_data=train, eval_data=val, optimizer='sgd',
+    optimizer_params={'learning_rate':0.1, 'momentum': 0.9, 'wd': 0.00001},
+    num_epoch=10, batch_end_callback=mx.callback.Speedometer(100, 100))

--- a/example/numpy-ops/weighted_logistic_regression.py
+++ b/example/numpy-ops/weighted_logistic_regression.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import os
 import numpy as np
 import mxnet as mx
 
@@ -26,7 +25,8 @@ class WeightedLogisticRegression(mx.operator.CustomOp):
     def forward(self, is_train, req, in_data, out_data, aux):
         self.assign(out_data[0], req[0], mx.nd.divide(1, (1 + mx.nd.exp(- in_data[0]))))
     def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
-        in_grad[0][:] = ((out_data[0] - 1) * in_data[1] * self.pos_grad_scale + out_data[0] * (1 - in_data[1]) * self.neg_grad_scale) / out_data[0].shape[1]
+        in_grad[0][:] = ((out_data[0] - 1) * in_data[1] * self.pos_grad_scale
+                         + out_data[0] * (1 - in_data[1]) * self.neg_grad_scale) / out_data[0].shape[1]
 
 @mx.operator.register("weighted_logistic_regression")
 class WeightedLogisticRegressionProp(mx.operator.CustomOpProp):
@@ -48,23 +48,39 @@ if __name__ == '__main__':
     m, n = 2, 5
     pos, neg = 1, 0.1
     data = mx.sym.Variable('data')
-    wlr = mx.sym.Custom(data, pos_grad_scale = pos, neg_grad_scale = neg, name = 'wlr', op_type = 'weighted_logistic_regression')
-    lr = mx.sym.LogisticRegressionOutput(data, name = 'lr')
-    exe1 = wlr.simple_bind(ctx = mx.gpu(1), data = (2 * m, n))
-    exe2 = lr.simple_bind(ctx = mx.gpu(1), data = (2 * m, n))
+
+    wlr = mx.sym.Custom(data, pos_grad_scale=pos, neg_grad_scale=neg, name='wlr',
+                        op_type='weighted_logistic_regression')
+    lr = mx.sym.LogisticRegressionOutput(data, name='lr')
+
+    # MXNET_CPU_WORKER_NTHREADS must be greater than 1 for custom op to work on CPU
+    context = mx.cpu()
+    # Uncomment this line to compute on GPU
+    # context=mx.gpu(0)
+
+    exe1 = wlr.simple_bind(ctx=context, data=(2 * m, n))
+    exe2 = lr.simple_bind(ctx=context, data=(2 * m, n))
+
     exe1.arg_dict['data'][:] = np.ones([2 * m, n])
     exe2.arg_dict['data'][:] = np.ones([2 * m, n])
+
     exe1.arg_dict['wlr_label'][:] = np.vstack([np.ones([m, n]), np.zeros([m, n])])
     exe2.arg_dict['lr_label'][:] = np.vstack([np.ones([m, n]), np.zeros([m, n])])
-    exe1.forward(is_train = True)
-    exe2.forward(is_train = True)
-    print('wlr output:')
+
+    exe1.forward(is_train=True)
+    exe2.forward(is_train=True)
+
+    print('Weighted Logistic Regression output:')
     print(exe1.outputs[0].asnumpy())
-    print('lr output:')
+
+    print('Logistic Regression output:')
     print(exe2.outputs[0].asnumpy())
+
     exe1.backward()
     exe2.backward()
-    print('wlr grad:')
+
+    print('Weighted Logistic Regression gradients:')
     print(exe1.grad_dict['data'].asnumpy())
-    print('lr grad:')
+
+    print('Logistic Regression gradients:')
     print(exe2.grad_dict['data'].asnumpy())


### PR DESCRIPTION
## Description ##
Some changes to numpy_ops examples:
- Use module API instead of the deprecated model API
- Reduce the number of epochs to 10 (which is sufficient)
- Use CPU by default. Make it easy for user to switch to GPU is needed.
- When using GPU, use GPU 0 and not GPU 1. Many machines will have only one GPU

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] For user-facing API changes, API doc string has been updated. 
- [x] For new C++ functions in header files, their functionalities and arguments are documented. 
- [x] For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
