### PR TITLE
Removing the PYTHONPATH inserts from the examples to avoid portabiliity issues.

### DIFF
--- a/example/ctc/lstm.py
+++ b/example/ctc/lstm.py
@@ -20,7 +20,6 @@ import sys
 
 from mxnet.symbol_doc import SymbolDoc
 
-sys.path.insert(0, "../../python")
 import mxnet as mx
 import numpy as np
 from collections import namedtuple

--- a/example/ctc/lstm_ocr.py
+++ b/example/ctc/lstm_ocr.py
@@ -19,7 +19,7 @@
 # pylint: disable=superfluous-parens, no-member, invalid-name
 from __future__ import print_function
 import sys, random
-sys.path.insert(0, "../../python")
+
 import numpy as np
 import mxnet as mx
 

--- a/example/ctc/ocr_predict.py
+++ b/example/ctc/ocr_predict.py
@@ -21,8 +21,6 @@
 from __future__ import print_function
 import sys, os
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-sys.path.append("../../amalgamation/python/")
-sys.path.append("../../python/")
 
 from mxnet_predict import Predictor
 import mxnet as mx


### PR DESCRIPTION
## Description ##
The test scripts contain sys.path() that insert relative PYTHONPATH. This makes the examples less portable.

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [y] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [y] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
