### PR TITLE
raise warning when we detect Block inside nested list/dict

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -181,6 +181,7 @@ class Block(object):
 
     def __setattr__(self, name, value):
         """Registers parameters."""
+
         if hasattr(self, name):
             existing = getattr(self, name)
             if isinstance(existing, (Parameter, Block)) and not isinstance(value, type(existing)):

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -181,7 +181,6 @@ class Block(object):
 
     def __setattr__(self, name, value):
         """Registers parameters."""
-
         if hasattr(self, name):
             existing = getattr(self, name)
             if isinstance(existing, (Parameter, Block)) and not isinstance(value, type(existing)):
@@ -199,6 +198,33 @@ class Block(object):
             self.register_child(value)
 
         super(Block, self).__setattr__(name, value)
+
+    def _check_container_with_block(self):
+        def _find_block_in_container(data):
+            # Find whether a nested container structure contains Blocks
+            if isinstance(data, (list, tuple)):
+                for ele in data:
+                    if _find_block_in_container(ele):
+                        return True
+                return False
+            elif isinstance(data, dict):
+                for _, v in data.items():
+                    if _find_block_in_container(v):
+                        return True
+                return False
+            elif isinstance(data, Block):
+                return True
+            else:
+                return False
+        for k, v in self.__dict__.items():
+            if isinstance(v, (list, tuple, dict)) and not (k.startswith('__') or k == '_children'):
+                if _find_block_in_container(v):
+                    warnings.warn('"{name}" is a container with Blocks. '
+                                  'Note that Blocks inside the list, tuple or dict will not be '
+                                  'registered automatically. Make sure to register them using '
+                                  'register_child() or switching to '
+                                  'nn.Sequential/nn.HybridSequential instead. '
+                                  .format(name=self.__class__.__name__ + "." + k))
 
     def _alias(self):
         return self.__class__.__name__.lower()
@@ -252,6 +278,8 @@ class Block(object):
         -------
         The selected :py:class:`ParameterDict`
         """
+        # We need to check here because blocks inside containers are not supported.
+        self._check_container_with_block()
         ret = ParameterDict(self._params.prefix)
         if not select:
             ret.update(self.params)

--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -90,7 +90,7 @@ class HybridSequential(HybridBlock):
 
     Example::
 
-        net = nn.Sequential()
+        net = nn.HybridSequential()
         # use net's name_scope to give child Blocks appropriate names.
         with net.name_scope():
             net.add(nn.Dense(10, activation='relu'))

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -475,6 +475,50 @@ def test_block_attr_regular():
     b.c = c2
     assert b.c is c2 and b._children[0] is c2
 
+def test_block_attr_list_of_block():
+    class Model1(gluon.Block):
+        def __init__(self, **kwargs):
+            super(Model1, self).__init__(**kwargs)
+            with self.name_scope():
+                self.layers = [nn.Dense(i * 10) for i in range(6)]
+
+    class Model2(gluon.Block):
+        def __init__(self, **kwargs):
+            super(Model2, self).__init__(**kwargs)
+            with self.name_scope():
+                self.layers = dict()
+                self.layers['a'] = [nn.Dense(10), nn.Dense(10)]
+
+    class Model3(gluon.Block):
+        def __init__(self, **kwargs):
+            super(Model3, self).__init__(**kwargs)
+            with self.name_scope():
+                self.layers = nn.Sequential()
+                self.layers.add(*[nn.Dense(i * 10) for i in range(6)])
+
+    class Model4(gluon.Block):
+        def __init__(self, **kwargs):
+            super(Model4, self).__init__(**kwargs)
+            with self.name_scope():
+                self.data = {'a': '4', 'b': 123}
+
+    with warnings.catch_warnings(record=True) as w:
+        model = Model1()
+        model.collect_params()
+        assert len(w) > 0
+    with warnings.catch_warnings(record=True) as w:
+        model = Model2()
+        model.collect_params()
+        assert len(w) > 0
+    with warnings.catch_warnings(record=True) as w:
+        model = Model3()
+        model.collect_params()
+        assert len(w) == 0
+    with warnings.catch_warnings(record=True) as w:
+        model = Model4()
+        model.collect_params()
+        assert len(w) == 0
+
 def test_sequential_warning():
     with warnings.catch_warnings(record=True) as w:
         b = gluon.nn.Sequential()


### PR DESCRIPTION
Since we do not automatically register the Blocks inside a list/dict, the code will have bugs if the user tries to insert class attributes like `self.layers = [Block, Block, ...]` or `self.layers = {'a': Block, 'b': Block}`.

Now, we generate warning when the user calls `Block.collect_params()` and we find some containers contain the Blocks. The warning message will recommend the users to register the Blocks manually or use `nn.Sequential` instead.

Example:
```python
import mxnet as mx
from mxnet import gluon
from mxnet.gluon import nn

class Model(gluon.Block):
    def __init__(self, **kwargs):
        super(Model, self).__init__(**kwargs)
        with self.name_scope():
            self.layers = [nn.Dense(i * 10) for i in range(6)]

model = Model()
model.collect_params()
```

```
/home/ubuntu/mxnet/python/mxnet/gluon/block.py:225: UserWarning: Find "Model.layers" to be a container with Blocks. Note that Blocks inside the list, tuple or dict will not be registered automatically! Make sure to register them using register_child() or use nn.Sequential instead.
```
## Description ##
Raise warnings when we detect the pattern: Block under nested list/dict

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add warning, tests
