### PR TITLE
Make versions of python dependencies like numpy, deterministic.

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -240,10 +240,10 @@ $ make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas
 
 **Build the MXNet Python binding**
 
-**Step 1** Install prerequisites - python, setup-tools, python-pip and numpy.
+**Step 1** Install prerequisites - python, setup-tools, python-pip and libfortran (required for Numpy).
 
 ```bash
-$ sudo apt-get install -y python-dev python-setuptools python-numpy python-pip
+$ sudo apt-get install -y python-dev python-setuptools python-pip libgfortran3
 ```
 
 **Step 2** Install the MXNet Python binding.
@@ -468,10 +468,10 @@ $ make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/
 
 **Install the MXNet Python binding**
 
-**Step 1** Install prerequisites - python, setup-tools, python-pip and numpy.
+**Step 1** Install prerequisites - python, setup-tools, python-pip and libfortran (required for Numpy)..
 
 ```bash
-$ sudo apt-get install -y python-dev python-setuptools python-numpy python-pip
+$ sudo apt-get install -y python-dev python-setuptools python-pip libgfortran3
 ```
 
 **Step 2** Install the MXNet Python binding.

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,7 +28,7 @@ if "--inplace" in sys.argv:
 else:
     from setuptools import setup
     from setuptools.extension import Extension
-    kwargs = {'install_requires': ['numpy<=1.13.3', 'requests==2.18.4', 'graphviz==0.8.1'], 'zip_safe': False}
+    kwargs = {'install_requires': ['numpy<=1.13.3,>=1.8.2', 'requests==2.18.4', 'graphviz==0.8.1'], 'zip_safe': False}
 from setuptools import find_packages
 
 with_cython = False

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,7 +28,7 @@ if "--inplace" in sys.argv:
 else:
     from setuptools import setup
     from setuptools.extension import Extension
-    kwargs = {'install_requires': ['numpy', 'requests', 'graphviz'], 'zip_safe': False}
+    kwargs = {'install_requires': ['numpy<=1.13.3', 'requests==2.18.4', 'graphviz==0.8.1'], 'zip_safe': False}
 from setuptools import find_packages
 
 with_cython = False


### PR DESCRIPTION
## Description ##

Dependencies listed in python setup.py did not have version numbers. It was always pulling the latest available version. This was causing a non-deterministic (untested) versions of dependencies like "Numpy" to be installed when users were building from source.

For example, one of the users tried to checkout v0.12.1 and build from source, but it installed numpy v1.14.0.rc1 causing unknown issues and failures.

In this PR, capping on the known tested versions of the dependencies.

@szha - Can you please review this PR? Also, I am guessing Pip packages are capped with known dependency versions rather than taking latest.

## Checklist ##
- [X] Passed code style checking (`make lint`)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

