### PR TITLE
Adding test for forward backward compatibility

### DIFF
--- a/load_inference.py
+++ b/load_inference.py
@@ -1,0 +1,33 @@
+import mxnet as mx
+mnist = mx.test_utils.get_mnist()
+batch_size = 100
+train_iter = mx.io.NDArrayIter(mnist['train_data'], mnist['train_label'], batch_size, shuffle=True)
+val_iter = mx.io.NDArrayIter(mnist['test_data'], mnist['test_label'], batch_size)
+data = mx.sym.var('data')
+# Flatten the data from 4-D shape into 2-D (batch_size, num_channel*width*height)
+data = mx.sym.flatten(data=data)
+# The first fully-connected layer and the corresponding activation function
+fc1  = mx.sym.FullyConnected(data=data, num_hidden=128)
+act1 = mx.sym.Activation(data=fc1, act_type="relu")
+
+# The second fully-connected layer and the corresponding activation function
+fc2  = mx.sym.FullyConnected(data=act1, num_hidden = 64)
+act2 = mx.sym.Activation(data=fc2, act_type="relu")
+# MNIST has 10 classes
+fc3  = mx.sym.FullyConnected(data=act2, num_hidden=10)
+# Softmax with cross entropy loss
+mlp  = mx.sym.SoftmaxOutput(data=fc3, name='softmax')
+import logging
+logging.getLogger().setLevel(logging.DEBUG)  # logging to stdout
+# create a trainable module on CPU
+mlp_model = mx.mod.Module(symbol=mlp, context=mx.cpu())
+mlp_model.bind(data_shapes=train_iter.provide_data, label_shapes=train_iter.provide_label)
+mlp_model.load_params('mymodel')
+test_iter = mx.io.NDArrayIter(mnist['test_data'], None, batch_size)
+prob = mlp_model.predict(test_iter)
+assert prob.shape == (10000, 10)
+test_iter = mx.io.NDArrayIter(mnist['test_data'], mnist['test_label'], batch_size)
+# predict accuracy of mlp
+acc = mx.metric.Accuracy()
+mlp_model.score(test_iter, acc)
+print(acc)

--- a/train_models.py
+++ b/train_models.py
@@ -1,0 +1,36 @@
+# Example taken from https://mxnet.incubator.apache.org/tutorials/python/mnist.html
+import mxnet as mx
+mnist = mx.test_utils.get_mnist()
+batch_size = 100
+train_iter = mx.io.NDArrayIter(mnist['train_data'], mnist['train_label'], batch_size, shuffle=True)
+val_iter = mx.io.NDArrayIter(mnist['test_data'], mnist['test_label'], batch_size)
+data = mx.sym.var('data')
+# Flatten the data from 4-D shape into 2-D (batch_size, num_channel*width*height)
+data = mx.sym.flatten(data=data)
+# The first fully-connected layer and the corresponding activation function
+fc1  = mx.sym.FullyConnected(data=data, num_hidden=128)
+act1 = mx.sym.Activation(data=fc1, act_type="relu")
+
+# The second fully-connected layer and the corresponding activation function
+fc2  = mx.sym.FullyConnected(data=act1, num_hidden = 64)
+act2 = mx.sym.Activation(data=fc2, act_type="relu")
+# MNIST has 10 classes
+fc3  = mx.sym.FullyConnected(data=act2, num_hidden=10)
+# Softmax with cross entropy loss
+mlp  = mx.sym.SoftmaxOutput(data=fc3, name='softmax')
+import logging
+logging.getLogger().setLevel(logging.DEBUG)  # logging to stdout
+# create a trainable module on CPU
+mlp_model = mx.mod.Module(symbol=mlp, context=mx.cpu())
+mlp_model.fit(train_iter,  # train data
+              eval_data=val_iter,  # validation data
+              optimizer='sgd',  # use SGD to train
+              optimizer_params={'learning_rate':0.1},  # use fixed learning rate
+              eval_metric='acc',  # report accuracy during training
+              batch_end_callback = mx.callback.Speedometer(batch_size, 100), # output progress for each 100 data batches
+              num_epoch=1)  # train for at most 1 dataset passes modified
+
+
+# save a model to mymodel-symbol.json and mymodel-0100.params
+filename='mymodel'
+mlp_model.save_params(filename)


### PR DESCRIPTION
## Description ##
This should not be merged. This change is for my local repo to set up a test.
This test does training on latest version of MXNet and run the inference on old version of MXNet. This way we basically make sure that if we break anything in new release. If so we can add that in release notes. 

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
