### PR TITLE
fix parameter overwrite in _generate_symbol_function_code

### DIFF
--- a/python/mxnet/symbol/register.py
+++ b/python/mxnet/symbol/register.py
@@ -173,7 +173,7 @@ def %s(%s):"""%(func_name, ', '.join(signature)))
 
             code.append("""
     name = NameManager.current.get(name, '%s')
-    return _symbol_creator(%d, None, sym_kwargs, keys, vals, name)"""%(
+    return _symbol_creator(%d, None, sym_kwargs, _keys, _vals, name)"""%(
         func_name.lower(), handle.value))
 
     if signature_only:

--- a/python/mxnet/symbol/register.py
+++ b/python/mxnet/symbol/register.py
@@ -143,14 +143,14 @@ def %s(%s):"""%(func_name, ', '.join(signature)))
             code.append("""
     kwargs.update(AttrScope.current.get(attr))
     sym_kwargs = dict()
-    keys = []
-    vals = []
-    for k, v in kwargs.items():
-        if isinstance(v, SymbolBase):
-            sym_kwargs[k] = v
+    _keys = []
+    _vals = []
+    for _k, _v in kwargs.items():
+        if isinstance(_v, SymbolBase):
+            sym_kwargs[_k] = _v
         else:
-            keys.append(k)
-            vals.append(v)""")
+            _keys.append(_k)
+            _vals.append(_v)""")
             # NDArray args
             for name in ndarg_names: # pylint: disable=redefined-argument-from-local
                 code.append("""
@@ -162,14 +162,14 @@ def %s(%s):"""%(func_name, ', '.join(signature)))
             for name in kwarg_names: # pylint: disable=redefined-argument-from-local
                 code.append("""
     if %s is not _Null:
-        keys.append('%s')
-        vals.append(%s)"""%(name, name, name))
+        _keys.append('%s')
+        _vals.append(%s)"""%(name, name, name))
             # dtype
             if dtype_name is not None:
                 code.append("""
     if %s is not _Null:
-        keys.append('%s')
-        vals.append(np.dtype(%s).name)"""%(dtype_name, dtype_name, dtype_name))
+        _keys.append('%s')
+        _vals.append(np.dtype(%s).name)"""%(dtype_name, dtype_name, dtype_name))
 
             code.append("""
     name = NameManager.current.get(name, '%s')


### PR DESCRIPTION
## Description ##
fix bug of parameter overwrited by function local variable in code generate by _generate_symbol_function_code, can be reduce with define k in mx.sym.topk

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [] fix bug of parameter overwrited by function local variable in code generate by _generate_symbol_function_code

