### PR TITLE
Dropped Sergey's explicit copyright note per email 

### DIFF
--- a/perl-package/AI-MXNet/README
+++ b/perl-package/AI-MXNet/README
@@ -3,7 +3,5 @@ version 1.1:
 
   Perl interface to MXNet machine learning library
 
-Copyright (C) 2017 by Sergey Kolychev <sergeykolychev.github@gmail.com>
-
 This library is licensed under Apache 2.0 license https://www.apache.org/licenses/LICENSE-2.0
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet.pm
@@ -196,8 +196,6 @@ AI::MXNet - Perl interface to MXNet machine learning library
 
 =head1 COPYRIGHT & LICENSE
 
-    Copyright (C) 2017 by Sergey Kolychev <sergeykolychev.github@gmail.com>
-
     This library is licensed under Apache 2.0 license https://www.apache.org/licenses/LICENSE-2.0
 
 =cut

--- a/perl-package/AI-MXNetCAPI/README
+++ b/perl-package/AI-MXNetCAPI/README
@@ -19,7 +19,5 @@ It's used by AI::MXNet
 
 COPYRIGHT AND LICENCE
 
-Copyright (C) 2017 by Sergey Kolychev <sergeykolychev.github@gmail.com>
-
 This library is licensed under Apache 2.0 license https://www.apache.org/licenses/LICENSE-2.0
 

--- a/perl-package/AI-MXNetCAPI/lib/AI/MXNetCAPI.pm
+++ b/perl-package/AI-MXNetCAPI/lib/AI/MXNetCAPI.pm
@@ -45,8 +45,6 @@ Sergey Kolychev, <sergeykolychev.github@gmail.com>
 
 =head1 COPYRIGHT & LICENSE
 
-Copyright 2017 Sergey Kolychev.
-
 This library is licensed under Apache 2.0 license.
 
 See https://www.apache.org/licenses/LICENSE-2.0 for more information.

--- a/perl-package/AI-NNVMCAPI/README
+++ b/perl-package/AI-NNVMCAPI/README
@@ -19,8 +19,6 @@ It's used by AI::MXNet.
 
 COPYRIGHT AND LICENCE
 
-Copyright (C) 2017 by Sergey Kolychev <sergeykolychev.github@gmail.com>
-
 This library is licensed under Apache 2.0 license https://www.apache.org/licenses/LICENSE-2.0
 
 

--- a/perl-package/AI-NNVMCAPI/lib/AI/NNVMCAPI.pm
+++ b/perl-package/AI-NNVMCAPI/lib/AI/NNVMCAPI.pm
@@ -45,8 +45,6 @@ Sergey Kolychev, <sergeykolychev.github@gmail.com>
 
 =head1 COPYRIGHT & LICENSE
 
-Copyright 2017 Sergey Kolychev.
-
 This library is licensed under Apache 2.0 license.
 
 See https://www.apache.org/licenses/LICENSE-2.0 for more information.

--- a/perl-package/README.md
+++ b/perl-package/README.md
@@ -16,5 +16,4 @@ Installation
 
 License
 -------
-Copyright (C) 2017 by Sergey Kolychev <sergeykolychev.github@gmail.com>
 This library is licensed under Apache 2.0 license https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
Email: https://lists.apache.org/thread.html/3cc041b688e9efd235ebfad8336917b7e1566b4acceff7783cf09c3c@%3Cdev.mxnet.apache.org%3E

## Description ##
Dropping explicit copyright note in favour of entry in AUTHORs with copyright holder's permission.

## Checklist ##

Documentation only change. Reviewed diff by eye.