### PR TITLE
Fix the gradient of gather_nd

### DIFF
--- a/src/common/cuda_utils.h
+++ b/src/common/cuda_utils.h
@@ -481,7 +481,7 @@ static inline __device__ void atomicAdd(mshadow::half::half_t *address,
 
 // Overload atomicAdd to work for signed int64 on all architectures
 static inline  __device__  void atomicAdd(int64_t *address, int64_t val) {
-  atomicAdd(reinterpret_cast<unsigned int64_t*>(address), static_cast<unsigned int64_t>(val));
+  atomicAdd(reinterpret_cast<unsigned long long*>(address), static_cast<unsigned long long>(val));
 }
 
 template <typename DType>

--- a/src/common/cuda_utils.h
+++ b/src/common/cuda_utils.h
@@ -479,6 +479,11 @@ static inline __device__ void atomicAdd(mshadow::half::half_t *address,
   } while (assumed != old);
 }
 
+// Overload atomicAdd to work for signed int64 on all architectures
+static inline  __device__  void atomicAdd(int64_t *address, int64_t val) {
+  atomicAdd(reinterpret_cast<unsigned int64_t*>(address), static_cast<unsigned int64_t>(val));
+}
+
 template <typename DType>
 __device__ inline DType ldg(const DType* address) {
 #if __CUDA_ARCH__ >= 350

--- a/src/common/cuda_utils.h
+++ b/src/common/cuda_utils.h
@@ -481,7 +481,7 @@ static inline __device__ void atomicAdd(mshadow::half::half_t *address,
 
 // Overload atomicAdd to work for signed int64 on all architectures
 static inline  __device__  void atomicAdd(int64_t *address, int64_t val) {
-  atomicAdd(reinterpret_cast<unsigned long long*>(address), static_cast<unsigned long long>(val));
+  atomicAdd(reinterpret_cast<unsigned long long*>(address), static_cast<unsigned long long>(val)); // NOLINT
 }
 
 template <typename DType>

--- a/src/operator/mxnet_op.h
+++ b/src/operator/mxnet_op.h
@@ -132,6 +132,50 @@ inline int get_num_threads<cpu>(const int N) {
     LOG(FATAL) << "ndim=" << NDim << "too large "; \
   }
 
+#define MXNET_NO_INT8_TYPE_SWITCH(type, DType, ...)        \
+  switch (type) {                                          \
+  case mshadow::kFloat32:                                  \
+    {                                                      \
+      typedef float DType;                                 \
+      {__VA_ARGS__}                                        \
+    }                                                      \
+    break;                                                 \
+  case mshadow::kFloat64:                                  \
+    {                                                      \
+      typedef double DType;                                \
+      {__VA_ARGS__}                                        \
+    }                                                      \
+    break;                                                 \
+  case mshadow::kFloat16:                                  \
+    {                                                      \
+      typedef mshadow::half::half_t DType;                 \
+      {__VA_ARGS__}                                        \
+    }                                                      \
+    break;                                                 \
+  case mshadow::kUint8:                                    \
+    LOG(FATAL) << "This operation does not "               \
+                  "support int8 or uint8";                 \
+    break;                                                 \
+  case mshadow::kInt8:                                     \
+    LOG(FATAL) << "This operation does not "               \
+                  "support int8 or uint8";                 \
+    break;                                                 \
+  case mshadow::kInt32:                                    \
+    {                                                      \
+      typedef int32_t DType;                               \
+      {__VA_ARGS__}                                        \
+    }                                                      \
+    break;                                                 \
+  case mshadow::kInt64:                                    \
+    {                                                      \
+      typedef int64_t DType;                               \
+      {__VA_ARGS__}                                        \
+    }                                                      \
+    break;                                                 \
+  default:                                                 \
+    LOG(FATAL) << "Unknown type enum " << type;            \
+  }
+
 
 /*!
  * \brief assign the val to out according

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -136,25 +136,6 @@ inline void SparseEmbeddingOpBackwardRspImpl<cpu>(const OpContext& ctx,
   });
 }
 
-
-template<typename DType, typename IType>
-inline void ScatterNDAccForwardImpl(int N, int M, int K,
-                                    const mshadow::Shape<10> strides,
-                                    DType* out,
-                                    const DType* data,
-                                    const IType* indices,
-                                    mshadow::Stream<cpu> *s) {
-  for (int i = 0; i < N; i++) {
-    int offset = 0;
-    for (int j = 0; j < M; ++j) {
-      offset += strides[j] * static_cast<int>(indices[j*N + i]);
-    }
-    for (int j = 0; j < K; ++j) {
-      out[offset + j] += data[i * K + j];
-    }
-  }
-}
-
 DMLC_REGISTER_PARAMETER(EmbeddingParam);
 DMLC_REGISTER_PARAMETER(TakeParam);
 DMLC_REGISTER_PARAMETER(OneHotParam);

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -136,6 +136,25 @@ inline void SparseEmbeddingOpBackwardRspImpl<cpu>(const OpContext& ctx,
   });
 }
 
+
+template<typename DType, typename IType>
+inline void ScatterNDAccForwardImpl(int N, int M, int K,
+                                    const mshadow::Shape<10> strides,
+                                    DType* out,
+                                    const DType* data,
+                                    const IType* indices,
+                                    mshadow::Stream<cpu> *s) {
+  for (int i = 0; i < N; i++) {
+    int offset = 0;
+    for (int j = 0; j < M; ++j) {
+      offset += strides[j] * static_cast<int>(indices[j*N + i]);
+    }
+    for (int j = 0; j < K; ++j) {
+      out[offset + j] += data[i * K + j];
+    }
+  }
+}
+
 DMLC_REGISTER_PARAMETER(EmbeddingParam);
 DMLC_REGISTER_PARAMETER(TakeParam);
 DMLC_REGISTER_PARAMETER(OneHotParam);

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -138,7 +138,7 @@ inline void SparseEmbeddingOpBackwardRspImpl<cpu>(const OpContext& ctx,
 
 
 template<typename DType, typename IType>
-inline typename std::enable_if<(not std::is_same<DType, mshadow::half::half_t>::value), void>::type
+inline typename std::enable_if<(!std::is_same<DType, mshadow::half::half_t>::value), void>::type
 ScatterNDAccForwardImpl(int N, int M, int K,
                         const mshadow::Shape<10> strides,
                         DType* out,

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -144,14 +144,12 @@ inline void ScatterNDAccForwardImpl(int N, int M, int K,
                                     const DType* data,
                                     const IType* indices,
                                     mshadow::Stream<cpu> *s) {
-#pragma omp parallel for
   for (int i = 0; i < N; i++) {
     int offset = 0;
     for (int j = 0; j < M; ++j) {
       offset += strides[j] * static_cast<int>(indices[j*N + i]);
     }
     for (int j = 0; j < K; ++j) {
-#pragma omp atomic
       out[offset + j] += data[i * K + j];
     }
   }

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -144,12 +144,14 @@ inline void ScatterNDAccForwardImpl(int N, int M, int K,
                                     const DType* data,
                                     const IType* indices,
                                     mshadow::Stream<cpu> *s) {
+#pragma omp parallel for
   for (int i = 0; i < N; i++) {
     int offset = 0;
     for (int j = 0; j < M; ++j) {
       offset += strides[j] * static_cast<int>(indices[j*N + i]);
     }
     for (int j = 0; j < K; ++j) {
+#pragma omp atomic
       out[offset + j] += data[i * K + j];
     }
   }

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -548,8 +548,10 @@ The elements in output is defined as follows::
 
 all other entries in output are 0.
 
-WARNING!!! If the indices have duplicates, the result will be non-deterministic and
- the gradient of `scatter_nd` will not be correct!!
+.. warning::
+
+    If the indices have duplicates, the result will be non-deterministic and
+    the gradient of `scatter_nd` will not be correct!!
 
 
 Examples::

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -483,8 +483,7 @@ Examples::
 
 NNVM_REGISTER_OP(gather_nd)
 .describe(R"code(Gather elements or slices from `data` and store to a tensor whose
-shape is defined by `indices`. `gather_nd` and `scatter_nd_acc` are inverse functions
-to each other.
+shape is defined by `indices`.
 
 Given `data` with shape `(X_0, X_1, ..., X_{N-1})` and indices with shape
 `(M, Y_0, ..., Y_{K-1})`, the output will have shape `(Y_0, ..., Y_{K-1}, X_M, ..., X_{N-1})`,
@@ -516,7 +515,7 @@ Examples::
 .set_attr<nnvm::FGradient>("FGradient",
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
     auto p = nnvm::Node::Create();
-    p->attrs.op = nnvm::Op::Get("scatter_nd_acc");
+    p->attrs.op = nnvm::Op::Get("_backward_gather_nd");
     p->attrs.name = n->attrs.name + "_backward";
     p->inputs.push_back(ograds[0]);
     p->inputs.push_back(n->inputs[1]);
@@ -592,7 +591,8 @@ Examples::
 .add_arguments(ScatterNDParam::__FIELDS__());
 
 NNVM_REGISTER_OP(_backward_gather_nd)
-.describe(R"code(Accumulates data according to indices and get the result.
+.describe(R"code(Accumulates data according to indices and get the result. It's the backward of
+`gather_nd`.
 
 Given `data` with shape `(Y_0, ..., Y_{K-1}, X_M, ..., X_{N-1})` and indices with shape
 `(M, Y_0, ..., Y_{K-1})`, the output will have shape `(X_0, X_1, ..., X_{N-1})`,

--- a/src/operator/tensor/indexing_op.cu
+++ b/src/operator/tensor/indexing_op.cu
@@ -179,6 +179,37 @@ inline void SparseEmbeddingOpBackwardRspImpl<gpu>(const OpContext& ctx,
   });
 }
 
+template<typename DType, typename IType>
+__global__ void ScatterNDAccForwardImplKernel(int N, int M, int K,
+                                         const mshadow::Shape<10> strides,
+                                         DType* out,
+                                         const DType* data,
+                                         const IType* indices) {
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < N; i += blockDim.x * gridDim.x) {
+    int offset = 0;
+    for (int j = 0; j < M; ++j) {
+      offset += strides[j] * static_cast<int>(indices[j*N + i]);
+    }
+    for (int j = 0; j < K; ++j) {
+      atomicAdd(out + (offset + j), data[i * K + j]);
+    }
+  }
+}
+
+template<typename DType, typename IType>
+inline void ScatterNDAccForwardImpl(int N, int M, int K,
+                                    const mshadow::Shape<10> strides,
+                                    DType* out,
+                                    const DType* data,
+                                    const IType* indices,
+                                    mshadow::Stream<gpu> *s) {
+  using namespace mshadow::cuda;
+  int ngrid = std::min(kMaxGridNum, (N + kBaseThreadNum - 1) / kBaseThreadNum);
+  ScatterNDAccForwardImplKernel
+    <<<ngrid, kBaseThreadNum, 0, mshadow::Stream<gpu>::GetStream(s) >>>(
+      N, M, K, strides, out, data, indices);
+}
+
 NNVM_REGISTER_OP(Embedding)
 .set_attr<FCompute>("FCompute<gpu>", EmbeddingOpForward<gpu>);
 
@@ -208,6 +239,9 @@ NNVM_REGISTER_OP(gather_nd)
 
 NNVM_REGISTER_OP(scatter_nd)
 .set_attr<FCompute>("FCompute<gpu>", ScatterNDForward<gpu>);
+
+NNVM_REGISTER_OP(scatter_nd_acc)
+.set_attr<FCompute>("FCompute<gpu>", ScatterNDAccForward<gpu>);
 
 NNVM_REGISTER_OP(_scatter_set_nd)
 .set_attr<FCompute>("FCompute<gpu>", ScatterSetNDForward<gpu>);

--- a/src/operator/tensor/indexing_op.cu
+++ b/src/operator/tensor/indexing_op.cu
@@ -179,6 +179,49 @@ inline void SparseEmbeddingOpBackwardRspImpl<gpu>(const OpContext& ctx,
   });
 }
 
+template<typename DType, typename IType>
+__global__ void ScatterNDAccForwardImplKernel(int N, int M, int K,
+                                              const mshadow::Shape<10> strides,
+                                              DType* out,
+                                              const DType* data,
+                                              const IType* indices) {
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < N; i += blockDim.x * gridDim.x) {
+    int offset = 0;
+    for (int j = 0; j < M; ++j) {
+      offset += strides[j] * static_cast<int>(indices[j*N + i]);
+    }
+    for (int j = 0; j < K; ++j) {
+      atomicAdd(out + (offset + j), data[i * K + j]);
+    }
+  }
+}
+
+struct scatter_nd_acc_gpu {
+  template<typename DType, typename IType>
+  MSHADOW_XINLINE static void Map(int i, int N, int M, int K,
+                                  const mshadow::Shape<10> strides,
+                                  DType* out, const DType* data,
+                                  const IType* indices) {
+    int offset = 0;
+    for (int j = 0; j < M; ++j) {
+      offset += strides[j] * static_cast<int>(indices[j*N + i]);
+    }
+    for (int j = 0; j < K; ++j) {
+      atomicAdd(out + (offset + j), data[i * K + j]);
+    }
+  }
+};
+
+template<typename DType, typename IType>
+inline void ScatterNDAccForwardImpl(int N, int M, int K,
+                                    const mshadow::Shape<10> strides,
+                                    DType* out,
+                                    const DType* data,
+                                    const IType* indices,
+                                    mshadow::Stream<gpu> *s) {
+  mxnet_op::Kernel<scatter_nd_acc_gpu, gpu>::Launch(s, N, N, M, K, strides, out, data, indices);
+}
+
 NNVM_REGISTER_OP(Embedding)
 .set_attr<FCompute>("FCompute<gpu>", EmbeddingOpForward<gpu>);
 

--- a/src/operator/tensor/indexing_op.cu
+++ b/src/operator/tensor/indexing_op.cu
@@ -179,49 +179,6 @@ inline void SparseEmbeddingOpBackwardRspImpl<gpu>(const OpContext& ctx,
   });
 }
 
-template<typename DType, typename IType>
-__global__ void ScatterNDAccForwardImplKernel(int N, int M, int K,
-                                              const mshadow::Shape<10> strides,
-                                              DType* out,
-                                              const DType* data,
-                                              const IType* indices) {
-  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < N; i += blockDim.x * gridDim.x) {
-    int offset = 0;
-    for (int j = 0; j < M; ++j) {
-      offset += strides[j] * static_cast<int>(indices[j*N + i]);
-    }
-    for (int j = 0; j < K; ++j) {
-      atomicAdd(out + (offset + j), data[i * K + j]);
-    }
-  }
-}
-
-struct scatter_nd_acc_gpu {
-  template<typename DType, typename IType>
-  MSHADOW_XINLINE static void Map(int i, int N, int M, int K,
-                                  const mshadow::Shape<10> strides,
-                                  DType* out, const DType* data,
-                                  const IType* indices) {
-    int offset = 0;
-    for (int j = 0; j < M; ++j) {
-      offset += strides[j] * static_cast<int>(indices[j*N + i]);
-    }
-    for (int j = 0; j < K; ++j) {
-      atomicAdd(out + (offset + j), data[i * K + j]);
-    }
-  }
-};
-
-template<typename DType, typename IType>
-inline void ScatterNDAccForwardImpl(int N, int M, int K,
-                                    const mshadow::Shape<10> strides,
-                                    DType* out,
-                                    const DType* data,
-                                    const IType* indices,
-                                    mshadow::Stream<gpu> *s) {
-  mxnet_op::Kernel<scatter_nd_acc_gpu, gpu>::Launch(s, N, N, M, K, strides, out, data, indices);
-}
-
 NNVM_REGISTER_OP(Embedding)
 .set_attr<FCompute>("FCompute<gpu>", EmbeddingOpForward<gpu>);
 

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -1131,14 +1131,62 @@ void ScatterNDForward(const nnvm::NodeAttrs& attrs,
   int K = oshape.ProdShape(M, oshape.ndim());
   mshadow::Shape<10> strides;
   for (int i = M-1, stride = K; i >= 0; stride *= oshape[i], --i) strides[i] = stride;
+  if (kWriteTo == req[0]) {
+    Fill<true>(s, outputs[0], req[0], 0);
+  }
   MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, DType, {  // output data type switch
-    if (kWriteTo == req[0]) {
-      Fill<true>(s, outputs[0], req[0], 0);
-    }
     MSHADOW_TYPE_SWITCH(inputs[1].type_flag_, IType, {  // indices data type switch
       mxnet_op::Kernel<scatter_nd, xpu>::Launch(
         s, N, req[0], N, M, K, strides, outputs[0].dptr<DType>(),
         inputs[0].dptr<DType>(), inputs[1].dptr<IType>());
+    });
+  });
+}
+
+template<typename DType, typename IType>
+inline void ScatterNDAccForwardImpl(int N, int M, int K,
+                                    const mshadow::Shape<10> strides,
+                                    DType* out,
+                                    const DType* data,
+                                    const IType* indices,
+                                    mshadow::Stream<cpu> *s);
+
+template<typename DType, typename IType>
+inline void ScatterNDAccForwardImpl(int N, int M, int K,
+                                    const mshadow::Shape<10> strides,
+                                    DType* out,
+                                    const DType* data,
+                                    const IType* indices,
+                                    mshadow::Stream<gpu> *s);
+
+template<typename xpu>
+void ScatterNDAccForward(const nnvm::NodeAttrs& attrs,
+                         const OpContext& ctx,
+                         const std::vector<TBlob>& inputs,
+                         const std::vector<OpReqType>& req,
+                         const std::vector<TBlob>& outputs) {
+  using namespace mshadow;
+  CHECK_EQ(inputs.size(), 2U);
+  CHECK_EQ(outputs.size(), 1U);
+  if (req[0] == kNullOp) return;
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  const TShape& oshape = outputs[0].shape_;
+  const TShape& ishape = inputs[1].shape_;
+  int M = ishape[0];
+  int N = ishape.Size() / M;
+  int K = oshape.ProdShape(M, oshape.ndim());
+  mshadow::Shape<10> strides;
+  for (int i = M-1, stride = K; i >= 0; stride *= oshape[i], --i) strides[i] = stride;
+  if (kWriteTo == req[0]) {
+    Fill<true>(s, outputs[0], req[0], 0);
+  }
+  MXNET_NO_INT8_TYPE_SWITCH(inputs[0].type_flag_, DType, {  // output data type switch
+    MSHADOW_TYPE_SWITCH(inputs[1].type_flag_, IType, {  // indices data type switch
+      ScatterNDAccForwardImpl(N, M, K, strides,
+                              outputs[0].dptr<DType>(),
+                              inputs[0].dptr<DType>(),
+                              inputs[1].dptr<IType>(),
+                              s);
     });
   });
 }

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -1144,7 +1144,7 @@ void ScatterNDForward(const nnvm::NodeAttrs& attrs,
 }
 
 template<typename DType, typename IType>
-inline typename std::enable_if<(not std::is_same<DType, mshadow::half::half_t>::value), void>::type
+inline typename std::enable_if<(!std::is_same<DType, mshadow::half::half_t>::value), void>::type
 ScatterNDAccForwardImpl(int N, int M, int K,
                         const mshadow::Shape<10> strides,
                         DType* out,

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -1154,7 +1154,7 @@ struct scatter_nd_acc {
       offset += strides[j] * static_cast<int>(indices[j*N + i]);
     }
     for (int j = 0; j < K; ++j) {
-#if __CUDA__ 
+#ifdef __CUDACC__
       atomicAdd(out + (offset + j), data[i * K + j]);
 #else
       out[offset + j] += data[i * K + j];

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -1145,36 +1145,36 @@ void ScatterNDForward(const nnvm::NodeAttrs& attrs,
 
 template<typename DType, typename IType>
 inline typename std::enable_if<(!std::is_same<DType, mshadow::half::half_t>::value), void>::type
-ScatterNDAccForwardImpl(int N, int M, int K,
-                        const mshadow::Shape<10> strides,
-                        DType* out,
-                        const DType* data,
-                        const IType* indices,
-                        mshadow::Stream<cpu> *s);
+GatherNDBackwardImpl(int N, int M, int K,
+                     const mshadow::Shape<10> strides,
+                     DType* out,
+                     const DType* data,
+                     const IType* indices,
+                     mshadow::Stream<cpu> *s);
 
 template<typename DType, typename IType>
 inline typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value, void>::type
-ScatterNDAccForwardImpl(int N, int M, int K,
-                        const mshadow::Shape<10> strides,
-                        DType* out,
-                        const DType* data,
-                        const IType* indices,
-                        mshadow::Stream<cpu> *s);
+GatherNDBackwardImpl(int N, int M, int K,
+                     const mshadow::Shape<10> strides,
+                     DType* out,
+                     const DType* data,
+                     const IType* indices,
+                     mshadow::Stream<cpu> *s);
 
 template<typename DType, typename IType>
-inline void ScatterNDAccForwardImpl(int N, int M, int K,
-                                    const mshadow::Shape<10> strides,
-                                    DType* out,
-                                    const DType* data,
-                                    const IType* indices,
-                                    mshadow::Stream<gpu> *s);
+inline void GatherNDBackwardImpl(int N, int M, int K,
+                                 const mshadow::Shape<10> strides,
+                                 DType* out,
+                                 const DType* data,
+                                 const IType* indices,
+                                 mshadow::Stream<gpu> *s);
 
 template<typename xpu>
-void ScatterNDAccForward(const nnvm::NodeAttrs& attrs,
-                         const OpContext& ctx,
-                         const std::vector<TBlob>& inputs,
-                         const std::vector<OpReqType>& req,
-                         const std::vector<TBlob>& outputs) {
+void GatherNDBackward(const nnvm::NodeAttrs& attrs,
+                      const OpContext& ctx,
+                      const std::vector<TBlob>& inputs,
+                      const std::vector<OpReqType>& req,
+                      const std::vector<TBlob>& outputs) {
   using namespace mshadow;
   CHECK_EQ(inputs.size(), 2U);
   CHECK_EQ(outputs.size(), 1U);
@@ -1192,11 +1192,11 @@ void ScatterNDAccForward(const nnvm::NodeAttrs& attrs,
   }
   MXNET_NO_INT8_TYPE_SWITCH(inputs[0].type_flag_, DType, {  // output data type switch
     MSHADOW_TYPE_SWITCH(inputs[1].type_flag_, IType, {  // indices data type switch
-      ScatterNDAccForwardImpl(N, M, K, strides,
-                              outputs[0].dptr<DType>(),
-                              inputs[0].dptr<DType>(),
-                              inputs[1].dptr<IType>(),
-                              s);
+      GatherNDBackwardImpl(N, M, K, strides,
+                           outputs[0].dptr<DType>(),
+                           inputs[0].dptr<DType>(),
+                           inputs[1].dptr<IType>(),
+                           s);
     });
   });
 }

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -1144,12 +1144,22 @@ void ScatterNDForward(const nnvm::NodeAttrs& attrs,
 }
 
 template<typename DType, typename IType>
-inline void ScatterNDAccForwardImpl(int N, int M, int K,
-                                    const mshadow::Shape<10> strides,
-                                    DType* out,
-                                    const DType* data,
-                                    const IType* indices,
-                                    mshadow::Stream<cpu> *s);
+inline typename std::enable_if<(not std::is_same<DType, mshadow::half::half_t>::value), void>::type
+ScatterNDAccForwardImpl(int N, int M, int K,
+                        const mshadow::Shape<10> strides,
+                        DType* out,
+                        const DType* data,
+                        const IType* indices,
+                        mshadow::Stream<cpu> *s);
+
+template<typename DType, typename IType>
+inline typename std::enable_if<std::is_same<DType, mshadow::half::half_t>::value, void>::type
+ScatterNDAccForwardImpl(int N, int M, int K,
+                        const mshadow::Shape<10> strides,
+                        DType* out,
+                        const DType* data,
+                        const IType* indices,
+                        mshadow::Stream<cpu> *s);
 
 template<typename DType, typename IType>
 inline void ScatterNDAccForwardImpl(int N, int M, int K,

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -1154,7 +1154,7 @@ struct scatter_nd_acc {
       offset += strides[j] * static_cast<int>(indices[j*N + i]);
     }
     for (int j = 0; j < K; ++j) {
-#ifdef __CUDACC__
+#if __CUDA__ 
       atomicAdd(out + (offset + j), data[i * K + j]);
 #else
       out[offset + j] += data[i * K + j];

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -1143,21 +1143,25 @@ void ScatterNDForward(const nnvm::NodeAttrs& attrs,
   });
 }
 
-template<typename DType, typename IType>
-inline void ScatterNDAccForwardImpl(int N, int M, int K,
-                                    const mshadow::Shape<10> strides,
-                                    DType* out,
-                                    const DType* data,
-                                    const IType* indices,
-                                    mshadow::Stream<cpu> *s);
-
-template<typename DType, typename IType>
-inline void ScatterNDAccForwardImpl(int N, int M, int K,
-                                    const mshadow::Shape<10> strides,
-                                    DType* out,
-                                    const DType* data,
-                                    const IType* indices,
-                                    mshadow::Stream<gpu> *s);
+struct scatter_nd_acc {
+  template<typename DType, typename IType>
+  MSHADOW_XINLINE static void Map(int i, int N, int M, int K,
+                                  const mshadow::Shape<10> strides,
+                                  DType* out, const DType* data,
+                                  const IType* indices) {
+    int offset = 0;
+    for (int j = 0; j < M; ++j) {
+      offset += strides[j] * static_cast<int>(indices[j*N + i]);
+    }
+    for (int j = 0; j < K; ++j) {
+#if __CUDA__ 
+      atomicAdd(out + (offset + j), data[i * K + j]);
+#else
+      out[offset + j] += data[i * K + j];
+#endif
+    }
+  }
+};
 
 template<typename xpu>
 void ScatterNDAccForward(const nnvm::NodeAttrs& attrs,
@@ -1182,11 +1186,10 @@ void ScatterNDAccForward(const nnvm::NodeAttrs& attrs,
   }
   MXNET_NO_INT8_TYPE_SWITCH(inputs[0].type_flag_, DType, {  // output data type switch
     MSHADOW_TYPE_SWITCH(inputs[1].type_flag_, IType, {  // indices data type switch
-      ScatterNDAccForwardImpl(N, M, K, strides,
-                              outputs[0].dptr<DType>(),
-                              inputs[0].dptr<DType>(),
-                              inputs[1].dptr<IType>(),
-                              s);
+      mxnet_op::Kernel<scatter_nd_acc, xpu>::Launch(s, N, N, M, K, strides,
+                                                    outputs[0].dptr<DType>(),
+                                                    inputs[0].dptr<DType>(),
+                                                    inputs[1].dptr<IType>());
     });
   });
 }

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4315,21 +4315,23 @@ def test_scatter_gather_nd():
         npdata = np.zeros_like(data.asnumpy())
         npdata[npidx] = y.asnumpy()
         assert (npdata == data.grad.asnumpy()).all()
-        assert (mx.nd.scatter_nd(y, idx, shape=data.shape).asnumpy() == data.grad.asnumpy()).all()
+        assert (mx.nd.scatter_nd_acc(y, idx, shape=data.shape).asnumpy() == data.grad.asnumpy()).all()
+    for dtype in ['int32', 'float16', 'float32', 'float64']:
+        data = mx.nd.arange(360, dtype=dtype).reshape((3,4,5,6))
+        idx = mx.nd.array([[1,1,2], [3, 3, 0], [3,2,1]], dtype='int32')
+        check(data, idx)
 
-    data = mx.nd.arange(360, dtype='int32').reshape((3,4,5,6))
-    idx = mx.nd.array([[1,1,2], [3, 3, 0], [3,2,1]], dtype='int32')
+        idx = mx.nd.array([[1,1,2], [3,3,0], [3,2,1], [5,2,4]], dtype='int32')
 
-    check(data, idx)
+        check(data, idx)
 
-    idx = mx.nd.array([[1,1,2], [3,3,0], [3,2,1], [5,2,4]], dtype='int32')
+        data = mx.nd.array([2, 3, 0])
+        idx = mx.nd.array([[1, 1, 0], [0, 1, 0]])
+        assert (mx.nd.scatter_nd(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [2, 3]]).all()
 
-    check(data, idx)
-
-    data = mx.nd.array([2, 3, 0])
-    idx = mx.nd.array([[1, 1, 0], [0, 1, 0]])
-
-    assert (mx.nd.scatter_nd(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [2, 3]]).all()
+        data = mx.nd.array([2, 3, 0])
+        idx = mx.nd.array([[1, 1, 0], [1, 1, 0]])
+        assert (mx.nd.scatter_nd_acc(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, 5]]).all()
 
 def compare_forw_backw_unary_op(
         name, forward_mxnet_call, forward_numpy_call,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4325,13 +4325,13 @@ def test_scatter_gather_nd():
 
         check(data, idx)
 
-        data = mx.nd.array([2, 3, 0])
-        idx = mx.nd.array([[1, 1, 0], [0, 1, 0]])
+        data = mx.nd.array([2, 3, 0], dtype=dtype)
+        idx = mx.nd.array([[1, 1, 0], [0, 1, 0]], dtype=dtype)
         assert (mx.nd.scatter_nd(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [2, 3]]).all()
 
-        data = mx.nd.array([2, 3, 0])
-        idx = mx.nd.array([[1, 1, 0], [1, 1, 0]])
-        assert (mx.nd.scatter_nd_acc(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, 5]]).all()
+        data = mx.nd.array([2, -3, 0], dtype=dtype)
+        idx = mx.nd.array([[1, 1, 0], [1, 1, 0]], dtype=dtype)
+        assert (mx.nd.scatter_nd_acc(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, -1]]).all()
 
 def compare_forw_backw_unary_op(
         name, forward_mxnet_call, forward_numpy_call,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4315,7 +4315,7 @@ def test_scatter_gather_nd():
         npdata = np.zeros_like(data.asnumpy())
         npdata[npidx] = y.asnumpy()
         assert (npdata == data.grad.asnumpy()).all()
-        assert (mx.nd.scatter_nd_acc(y, idx, shape=data.shape).asnumpy() == data.grad.asnumpy()).all()
+        assert (mx.nd._backward_gather_nd(y, idx, shape=data.shape).asnumpy() == data.grad.asnumpy()).all()
     for dtype in ['int32', 'int64', 'float16', 'float32', 'float64']:
         data = mx.nd.arange(360, dtype=dtype).reshape((3,4,5,6))
         idx = mx.nd.array([[1,1,2], [3, 3, 0], [3,2,1]], dtype='int32')
@@ -4331,16 +4331,16 @@ def test_scatter_gather_nd():
 
         data = mx.nd.array([2, 3, 0], dtype=dtype)
         idx = mx.nd.array([[1, 1, 0], [1, 1, 0]], dtype='int32')
-        assert (mx.nd.scatter_nd_acc(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, 5]]).all()
+        assert (mx.nd._backward_gather_nd(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, 5]]).all()
         data_npy = np.random.randint(0, 10, (100,))
         data = mx.nd.array(data_npy, dtype=dtype)
         idx = mx.nd.zeros(shape=(1, 100), dtype='int32')
-        assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asscalar() == data_npy.sum())
+        assert (mx.nd._backward_gather_nd(data, idx, shape=(1,)).asscalar() == data_npy.sum())
         if dtype == 'int64':
             data = mx.nd.array([2123162361283621, -31231236374787,
                                 -112372937128970, -1378278798172378], dtype=dtype)
             idx = mx.nd.array([[0, 0, 0, 0]], dtype='int32')
-            assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asscalar() == data.asnumpy().sum())
+            assert (mx.nd._backward_gather_nd(data, idx, shape=(1,)).asscalar() == data.asnumpy().sum())
 
 def compare_forw_backw_unary_op(
         name, forward_mxnet_call, forward_numpy_call,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4332,7 +4332,9 @@ def test_scatter_gather_nd():
             data = mx.nd.array([212316236123621, -31231236374787,
                                 -112372937128970, -13782787981728], dtype=dtype)
             idx = mx.nd.array([[0, 0, 0, 0]], dtype='int32')
-            assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asnumpy()[0] == data.asnumpy().sum())
+            scatter_nd_ret = mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asscalar()
+            npy_ret = data.asnumpy().sum()
+            assert (scatter_nd_ret == npy_ret), "scatter_nd_acc={}, npy={}".format(scatter_nd_ret, npy_ret)
 
 def compare_forw_backw_unary_op(
         name, forward_mxnet_call, forward_numpy_call,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4332,7 +4332,7 @@ def test_scatter_gather_nd():
         data = mx.nd.array([2, 3, 0], dtype=dtype)
         idx = mx.nd.array([[1, 1, 0], [1, 1, 0]], dtype='int32')
         assert (mx.nd.scatter_nd_acc(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, 5]]).all()
-        data_npy = np.random.uniform(0, 100, size=(100,)).astype(dtype)
+        data_npy = np.random.randint(0, 10, (100,))
         data = mx.nd.array(data_npy, dtype=dtype)
         idx = mx.nd.zeros(shape=(1, 100), dtype='int32')
         assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asscalar() == data_npy.sum())

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4329,8 +4329,8 @@ def test_scatter_gather_nd():
         idx = mx.nd.array([[1, 1, 0], [0, 1, 0]], dtype='int32')
         assert (mx.nd.scatter_nd(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [2, 3]]).all()
         if dtype == 'int64':
-            data = mx.nd.array([2123162361283621, -31231236374787,
-                                -112372937128970, -1378278798172378], dtype=dtype)
+            data = mx.nd.array([212316236123621, -31231236374787,
+                                -112372937128970, -13782787981728], dtype=dtype)
             idx = mx.nd.array([[0, 0, 0, 0]], dtype='int32')
             assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asnumpy()[0] == data.asnumpy().sum())
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4332,7 +4332,15 @@ def test_scatter_gather_nd():
             data = mx.nd.array([2123162361283621, -31231236374787,
                                 -112372937128970, -1378278798172378], dtype=dtype)
             idx = mx.nd.array([[0, 0, 0, 0]], dtype='int32')
-            assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asnumpy()[0] == data.asnumpy().sum())
+            assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asscalar() == data.asnumpy().sum())
+        else:
+            data = mx.nd.array([2, 3, 0], dtype=dtype)
+            idx = mx.nd.array([[1, 1, 0], [1, 1, 0]], dtype='int32')
+            assert (mx.nd.scatter_nd_acc(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, 5]]).all()
+            data_npy = np.random.uniform(0, 100, size=(100,)).astype(dtype)
+            data = mx.nd.array(data_npy, dtype=dtype)
+            idx = mx.nd.zeros(shape=(100,), dtype='int32')
+            assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asscalar() == data_npy.sum())
 
 def compare_forw_backw_unary_op(
         name, forward_mxnet_call, forward_numpy_call,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4328,11 +4328,11 @@ def test_scatter_gather_nd():
         data = mx.nd.array([2, 3, 0], dtype=dtype)
         idx = mx.nd.array([[1, 1, 0], [0, 1, 0]], dtype='int32')
         assert (mx.nd.scatter_nd(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [2, 3]]).all()
-
-        data = mx.nd.array([2123162361283621, -31231236374787,
-                            -112372937128970, -1378278798172378], dtype=dtype)
-        idx = mx.nd.array([[0, 0, 0, 0]], dtype='int32')
-        assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asnumpy()[0] == data.asnumpy().sum())
+        if dtype == 'int64':
+            data = mx.nd.array([2123162361283621, -31231236374787,
+                                -112372937128970, -1378278798172378], dtype=dtype)
+            idx = mx.nd.array([[0, 0, 0, 0]], dtype='int32')
+            assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asnumpy()[0] == data.asnumpy().sum())
 
 def compare_forw_backw_unary_op(
         name, forward_mxnet_call, forward_numpy_call,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4316,7 +4316,7 @@ def test_scatter_gather_nd():
         npdata[npidx] = y.asnumpy()
         assert (npdata == data.grad.asnumpy()).all()
         assert (mx.nd.scatter_nd_acc(y, idx, shape=data.shape).asnumpy() == data.grad.asnumpy()).all()
-    for dtype in ['int32', 'float16', 'float32', 'float64']:
+    for dtype in ['int32', 'int64', 'float16', 'float32', 'float64']:
         data = mx.nd.arange(360, dtype=dtype).reshape((3,4,5,6))
         idx = mx.nd.array([[1,1,2], [3, 3, 0], [3,2,1]], dtype='int32')
         check(data, idx)
@@ -4326,12 +4326,13 @@ def test_scatter_gather_nd():
         check(data, idx)
 
         data = mx.nd.array([2, 3, 0], dtype=dtype)
-        idx = mx.nd.array([[1, 1, 0], [0, 1, 0]], dtype=dtype)
+        idx = mx.nd.array([[1, 1, 0], [0, 1, 0]], dtype='int32')
         assert (mx.nd.scatter_nd(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [2, 3]]).all()
 
-        data = mx.nd.array([2, -3, 0], dtype=dtype)
-        idx = mx.nd.array([[1, 1, 0], [1, 1, 0]], dtype=dtype)
-        assert (mx.nd.scatter_nd_acc(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, -1]]).all()
+        data = mx.nd.array([2123162361283621, -31231236374787,
+                            -112372937128970, -1378278798172378], dtype=dtype)
+        idx = mx.nd.array([[0, 0, 0, 0]], dtype='int32')
+        assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asnumpy()[0] == data.asnumpy().sum())
 
 def compare_forw_backw_unary_op(
         name, forward_mxnet_call, forward_numpy_call,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4328,19 +4328,19 @@ def test_scatter_gather_nd():
         data = mx.nd.array([2, 3, 0], dtype=dtype)
         idx = mx.nd.array([[1, 1, 0], [0, 1, 0]], dtype='int32')
         assert (mx.nd.scatter_nd(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [2, 3]]).all()
+
+        data = mx.nd.array([2, 3, 0], dtype=dtype)
+        idx = mx.nd.array([[1, 1, 0], [1, 1, 0]], dtype='int32')
+        assert (mx.nd.scatter_nd_acc(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, 5]]).all()
+        data_npy = np.random.uniform(0, 100, size=(100,)).astype(dtype)
+        data = mx.nd.array(data_npy, dtype=dtype)
+        idx = mx.nd.zeros(shape=(100,), dtype='int32')
+        assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asscalar() == data_npy.sum())
         if dtype == 'int64':
             data = mx.nd.array([2123162361283621, -31231236374787,
                                 -112372937128970, -1378278798172378], dtype=dtype)
             idx = mx.nd.array([[0, 0, 0, 0]], dtype='int32')
             assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asscalar() == data.asnumpy().sum())
-        else:
-            data = mx.nd.array([2, 3, 0], dtype=dtype)
-            idx = mx.nd.array([[1, 1, 0], [1, 1, 0]], dtype='int32')
-            assert (mx.nd.scatter_nd_acc(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, 5]]).all()
-            data_npy = np.random.uniform(0, 100, size=(100,)).astype(dtype)
-            data = mx.nd.array(data_npy, dtype=dtype)
-            idx = mx.nd.zeros(shape=(100,), dtype='int32')
-            assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asscalar() == data_npy.sum())
 
 def compare_forw_backw_unary_op(
         name, forward_mxnet_call, forward_numpy_call,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4329,8 +4329,8 @@ def test_scatter_gather_nd():
         idx = mx.nd.array([[1, 1, 0], [0, 1, 0]], dtype='int32')
         assert (mx.nd.scatter_nd(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [2, 3]]).all()
         if dtype == 'int64':
-            data = mx.nd.array([212316236123621, -31231236374787,
-                                -112372937128970, -13782787981728], dtype=dtype)
+            data = mx.nd.array([2123162361283621, -31231236374787,
+                                -112372937128970, -1378278798172378], dtype=dtype)
             idx = mx.nd.array([[0, 0, 0, 0]], dtype='int32')
             assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asnumpy()[0] == data.asnumpy().sum())
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4315,7 +4315,7 @@ def test_scatter_gather_nd():
         npdata = np.zeros_like(data.asnumpy())
         npdata[npidx] = y.asnumpy()
         assert (npdata == data.grad.asnumpy()).all()
-        assert (mx.nd._backward_gather_nd(y, idx, shape=data.shape).asnumpy() == data.grad.asnumpy()).all()
+        assert (mx.nd._internal._backward_gather_nd(y, idx, shape=data.shape).asnumpy() == data.grad.asnumpy()).all()
     for dtype in ['int32', 'int64', 'float16', 'float32', 'float64']:
         data = mx.nd.arange(360, dtype=dtype).reshape((3,4,5,6))
         idx = mx.nd.array([[1,1,2], [3, 3, 0], [3,2,1]], dtype='int32')
@@ -4331,16 +4331,16 @@ def test_scatter_gather_nd():
 
         data = mx.nd.array([2, 3, 0], dtype=dtype)
         idx = mx.nd.array([[1, 1, 0], [1, 1, 0]], dtype='int32')
-        assert (mx.nd._backward_gather_nd(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, 5]]).all()
+        assert (mx.nd._internal._backward_gather_nd(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, 5]]).all()
         data_npy = np.random.randint(0, 10, (100,))
         data = mx.nd.array(data_npy, dtype=dtype)
         idx = mx.nd.zeros(shape=(1, 100), dtype='int32')
-        assert (mx.nd._backward_gather_nd(data, idx, shape=(1,)).asscalar() == data_npy.sum())
+        assert (mx.nd._internal._backward_gather_nd(data, idx, shape=(1,)).asscalar() == data_npy.sum())
         if dtype == 'int64':
             data = mx.nd.array([2123162361283621, -31231236374787,
                                 -112372937128970, -1378278798172378], dtype=dtype)
             idx = mx.nd.array([[0, 0, 0, 0]], dtype='int32')
-            assert (mx.nd._backward_gather_nd(data, idx, shape=(1,)).asscalar() == data.asnumpy().sum())
+            assert (mx.nd._internal._backward_gather_nd(data, idx, shape=(1,)).asscalar() == data.asnumpy().sum())
 
 def compare_forw_backw_unary_op(
         name, forward_mxnet_call, forward_numpy_call,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4334,7 +4334,7 @@ def test_scatter_gather_nd():
         assert (mx.nd.scatter_nd_acc(data, idx, shape=(2, 2)).asnumpy() == [[0, 0], [0, 5]]).all()
         data_npy = np.random.uniform(0, 100, size=(100,)).astype(dtype)
         data = mx.nd.array(data_npy, dtype=dtype)
-        idx = mx.nd.zeros(shape=(100,), dtype='int32')
+        idx = mx.nd.zeros(shape=(1, 100), dtype='int32')
         assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asscalar() == data_npy.sum())
         if dtype == 'int64':
             data = mx.nd.array([2123162361283621, -31231236374787,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4332,9 +4332,7 @@ def test_scatter_gather_nd():
             data = mx.nd.array([212316236123621, -31231236374787,
                                 -112372937128970, -13782787981728], dtype=dtype)
             idx = mx.nd.array([[0, 0, 0, 0]], dtype='int32')
-            scatter_nd_ret = mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asscalar()
-            npy_ret = data.asnumpy().sum()
-            assert (scatter_nd_ret == npy_ret), "scatter_nd_acc={}, npy={}".format(scatter_nd_ret, npy_ret)
+            assert (mx.nd.scatter_nd_acc(data, idx, shape=(1,)).asnumpy()[0] == data.asnumpy().sum())
 
 def compare_forw_backw_unary_op(
         name, forward_mxnet_call, forward_numpy_call,


### PR DESCRIPTION
## Description ##
Add _backward_gather_nd, which accumulates the value when the indices are same. Should solve https://github.com/apache/incubator-mxnet/issues/9172

## Checklist ##
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add new type switch macro that can be used when int8 is not supported
- [x] atomicAdd support for int64
- [x] Add _backward_gather_nd
- [x] Set the gradient of gather_nd to _backward_gather_nd

## Comments ##
I use atomicAdd to implement the operator. The current CPU implementation does not used openmp. Also, int8 and uint8 are not supported.
  