### PR TITLE
Modified nce-loss README to use image files in dmlc/web-data repo

### DIFF
--- a/example/nce-loss/README.md
+++ b/example/nce-loss/README.md
@@ -63,9 +63,9 @@ The motivation is to design a more robust and scalable word vector system, by re
 
 ### Basics
 
-<img src="https://github.com/zihaolucky/mxnet/blob/example/word2vec-nce-loss-with-subword-representations/example/nce-loss-subword-repr/slide1.png" width="700">
+<img src="https://github.com/dmlc/web-data/blob/master/mxnet/example/nce-loss/images/slide1.png" width="700">
 
-<img src="https://github.com/zihaolucky/mxnet/blob/example/word2vec-nce-loss-with-subword-representations/example/nce-loss-subword-repr/slide2.png" width="700">
+<img src="https://github.com/dmlc/web-data/blob/master/mxnet/example/nce-loss/images/slide2.png" width="700">
 
 Note that this word embedding method uses sub-word units to represent a word, while we still train word2vec model in its original way, the only difference is the vector representation of a word is no longer the word itself, but use several sub-word units' addition.
 


### PR DESCRIPTION
## Description ##
Previously README in nce-loss example referenced a user repo. Modified the file to use image file in dmlc/web-data repo.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage: N/A
- [ ] Code is well-documented: N/A
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] README fix to reference image URL in dmlc/web-data
