### PR TITLE
Add storage fallback msg to copyfromto

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -354,6 +354,17 @@ inline std::string dev_type_string(const int dev_type) {
   return "unknown";
 }
 
+/*! \brief log message once. Intended for storage fallback warning messages. */
+inline void LogOnce(const std::string& message) {
+  typedef dmlc::ThreadLocalStore<std::unordered_set<std::string>> LogStore;
+  auto log_store = LogStore::Get();
+  if (log_store->find(message) == log_store->end()) {
+    LOG(INFO) << message;
+    log_store->insert(message);
+  }
+}
+
+
 // heuristic to dermine number of threads per GPU
 inline int GetNumThreadPerGPU() {
   // This is resource efficient option.

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -339,6 +339,21 @@ inline std::string stype_string(const int x) {
   return "unknown";
 }
 
+/*! \brief get string representation of device type */
+inline std::string dev_type_string(const int dev_type) {
+  switch (dev_type) {
+    case Context::kCPU:
+      return "cpu";
+    case Context::kGPU:
+      return "gpu";
+    case Context::kCPUPinned:
+      return "cpu_pinned";
+    case Context::kCPUShared:
+      return "cpu_shared";
+  }
+  return "unknown";
+}
+
 // heuristic to dermine number of threads per GPU
 inline int GetNumThreadPerGPU() {
   // This is resource efficient option.

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -533,18 +533,18 @@ void CopyFromTo(const NDArray& from, const NDArray& to, int priority) {
   std::vector<Resource> requested;
   if (from_stype != to_stype) {
     using namespace common;
-    static bool debug = dmlc::GetEnv("MXNET_STORAGE_FALLBACK_DEBUG", false);
     static bool log = dmlc::GetEnv("MXNET_STORAGE_FALLBACK_LOG_VERBOSE", true);
-    std::ostringstream os;
-    os << "\nStorage fallback detected:\n"
-       << "Copy from " << stype_string(from_stype) << " storage type on " << dev_type_string(a)
-       << " to " << stype_string(to_stype) << " storage type on " << dev_type_string(b)
-       << "\nA temporary ndarray with " << stype_string(to_stype)
-       << " storage type will be generated in order to perform the copy. "
-       << STORAGE_FALLBACK_MSG;
-    const std::string warning = os.str();
-    if (debug) throw ::mxnet::op::InferStorageTypeError(warning, -1);
-    if (log) LogOnce(warning);
+    if (log) {
+      std::ostringstream os;
+      os << "\nStorage fallback detected:\n"
+         << "Copy from " << stype_string(from_stype) << " storage type on " << dev_type_string(a)
+         << " to " << stype_string(to_stype) << " storage type on " << dev_type_string(b)
+         << ".\nA temporary ndarray with " << stype_string(to_stype)
+         << " storage type will be generated in order to perform the copy. "
+         << "You can set environment variable "
+         << "MXNET_STORAGE_FALLBACK_LOG_VERBOSE to 0 to suppress this warning.";
+      LogOnce(os.str());
+    }
 
     // request temp resource if cast_storage performs on GPU
     if (a == gpu::kDevMask) {

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -533,33 +533,19 @@ void CopyFromTo(const NDArray& from, const NDArray& to, int priority) {
   std::vector<Resource> requested;
   if (from_stype != to_stype) {
     using namespace common;
-    typedef dmlc::ThreadLocalStore<std::unordered_set<std::string>> LogStore;
-    auto log_store = LogStore::Get();
-    static bool log_verbose = dmlc::GetEnv("MXNET_STORAGE_FALLBACK_LOG_VERBOSE", true);
-    std::ostringstream op_os;
-    op_os << "Copy from " << stype_string(from_stype) << " storage type on " << dev_type_string(a)
-            << " to " << stype_string(to_stype) << " storage type on " << dev_type_string(b);
-    std::string op_str = op_os.str();
-    std::ostringstream warning_os;
-    warning_os << "\nStorage fallback detected:\n" << op_str
+    static bool debug = dmlc::GetEnv("MXNET_STORAGE_FALLBACK_DEBUG", false);
+    static bool log = dmlc::GetEnv("MXNET_STORAGE_FALLBACK_LOG_VERBOSE", true);
+    std::ostringstream os;
+    os << "\nStorage fallback detected:\n"
+       << "Copy from " << stype_string(from_stype) << " storage type on " << dev_type_string(a)
+       << " to " << stype_string(to_stype) << " storage type on " << dev_type_string(b)
        << "\nA temporary ndarray with " << stype_string(to_stype)
        << " storage type will be generated in order to perform the copy. "
-       << "You can set environment variable MXNET_STORAGE_FALLBACK_LOG_VERBOSE "
-       << "to 0 to suppress this warning. If you do not know what caused this error, "
-       << "you can try set environment variable MXNET_STORAGE_FALLBACK_DEBUG to 1. "
-       << "This will give you the series of calls that lead "
-       << "to this error. Remember to set MXNET_STORAGE_FALLBACK_DEBUG back to "
-       << "empty after debugging.";
-    std::string warning = warning_os.str();
-    static bool debug = dmlc::GetEnv("MXNET_STORAGE_FALLBACK_DEBUG", false);
-    if (debug) {
-      throw ::mxnet::op::InferStorageTypeError(warning, -1);
-    } else if (log_verbose) {
-      if (log_store->find(op_str) == log_store->end()) {
-        LOG(INFO) << warning;
-        log_store->insert(op_str);
-      }
-    }
+       << STORAGE_FALLBACK_MSG;
+    const std::string warning = os.str();
+    if (debug) throw ::mxnet::op::InferStorageTypeError(warning, -1);
+    if (log) LogOnce(warning);
+
     // request temp resource if cast_storage performs on GPU
     if (a == gpu::kDevMask) {
       Resource rsc = ResourceManager::Get()->Request(from_ctx,

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -528,7 +528,8 @@ inline void LogStorageFallback(const nnvm::NodeAttrs& attrs,
                                const std::vector<int>* in_attrs,
                                const std::vector<int>* out_attrs) {
   using namespace op;
-  auto op_printed = dmlc::ThreadLocalStore<std::unordered_set<std::string>>::Get();
+  typedef dmlc::ThreadLocalStore<std::unordered_set<std::string>> LogStore;
+  auto log_store = LogStore::Get();
   static bool log_verbose = dmlc::GetEnv("MXNET_STORAGE_FALLBACK_LOG_VERBOSE", true);
   const std::string op_str = operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
   std::ostringstream os;
@@ -538,7 +539,7 @@ inline void LogStorageFallback(const nnvm::NodeAttrs& attrs,
      << "process the given ndarrays with specified storage types, context and parameter. "
      << "Temporary dense ndarrays are generated in order to execute the operator. "
      << "You can set environment variable MXNET_STORAGE_FALLBACK_LOG_VERBOSE "
-     << "to 0 to suppress the warnings. If you do not know what caused this error, "
+     << "to 0 to suppress this warning. If you do not know what caused this error, "
      << "you can try set environment variable MXNET_STORAGE_FALLBACK_DEBUG to 1. "
      << "This will give you the series of calls that lead "
      << "to this error. Remember to set MXNET_STORAGE_FALLBACK_DEBUG back to "
@@ -548,9 +549,9 @@ inline void LogStorageFallback(const nnvm::NodeAttrs& attrs,
   if (debug) {
     throw ::mxnet::op::InferStorageTypeError(warning, -1);
   } else if (log_verbose) {
-    if (op_printed->find(op_str) == op_printed->end()) {
+    if (log_store->find(op_str) == log_store->end()) {
       LOG(INFO) << warning;
-      op_printed->insert(op_str);
+      log_store->insert(op_str);
     }
   }
 }

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -314,16 +314,6 @@ inline bool dispatch_mode_assign(DispatchMode *y, const DispatchMode& x) {
   }
 #endif
 
-/* \brief message for storage fallback event */
-#define STORAGE_FALLBACK_MSG "You can set environment variable "               \
-  "MXNET_STORAGE_FALLBACK_LOG_VERBOSE to 0 to suppress this warning. "         \
-  "If you do not know what caused this error, "                                \
-  "you can try set environment variable MXNET_STORAGE_FALLBACK_DEBUG to 1. "   \
-  "This will give you the series of calls that lead "                          \
-  "to this error. Remember to set MXNET_STORAGE_FALLBACK_DEBUG back to "       \
-  "empty after debugging."
-
-
 /*! \brief assign stype to target_stype, if successful,
  *         assign dispatch_mode to target_dispatch
  */
@@ -537,9 +527,8 @@ inline void LogStorageFallback(const nnvm::NodeAttrs& attrs,
                                const int dev_mask,
                                const std::vector<int>* in_attrs,
                                const std::vector<int>* out_attrs) {
-  static bool debug = dmlc::GetEnv("MXNET_STORAGE_FALLBACK_DEBUG", false);
   static bool log = dmlc::GetEnv("MXNET_STORAGE_FALLBACK_LOG_VERBOSE", true);
-  if (!debug && !log) return;
+  if (!log) return;
   const std::string op_str = op::operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
   std::ostringstream os;
   os << "\nStorage type fallback detected:\n" << op_str
@@ -547,10 +536,9 @@ inline void LogStorageFallback(const nnvm::NodeAttrs& attrs,
      << "You're seeing this warning message because the operator above is unable to "
      << "process the given ndarrays with specified storage types, context and parameter. "
      << "Temporary dense ndarrays are generated in order to execute the operator. "
-     << STORAGE_FALLBACK_MSG;
-  const std::string warning = os.str();
-  if (debug) throw ::mxnet::op::InferStorageTypeError(warning, -1);
-  if (log) common::LogOnce(warning);
+     << "You can set environment variable "
+     << "MXNET_STORAGE_FALLBACK_LOG_VERBOSE to 0 to suppress this warning.";
+  common::LogOnce(os.str());
 }
 
 }  // namespace op

--- a/tests/python/unittest/test_executor.py
+++ b/tests/python/unittest/test_executor.py
@@ -77,40 +77,44 @@ def check_bind_with_uniform(uf, gf, dim, sf=None, lshape=None, rshape=None):
     assert reldiff(rhs_grad.asnumpy(), rhs_grad2) < 1e-6
 
 
-def test_bind(disable_bulk_exec=False):
-    if disable_bulk_exec:
-        prev_bulk_inf_val = mx.test_utils.set_env_var("MXNET_EXEC_BULK_EXEC_INFERENCE", "0", "1")
-        prev_bulk_train_val = mx.test_utils.set_env_var("MXNET_EXEC_BULK_EXEC_TRAIN", "0", "1")
+def test_bind():
+    def check_bind(disable_bulk_exec):
+        if disable_bulk_exec:
+            prev_bulk_inf_val = mx.test_utils.set_env_var("MXNET_EXEC_BULK_EXEC_INFERENCE", "0", "1")
+            prev_bulk_train_val = mx.test_utils.set_env_var("MXNET_EXEC_BULK_EXEC_TRAIN", "0", "1")
 
-    np.random.seed(0)
-    nrepeat = 10
-    maxdim = 4
-    for repeat in range(nrepeat):
-        for dim in range(1, maxdim):
-            check_bind_with_uniform(lambda x, y: x + y,
-                                    lambda g, x, y: (g, g),
-                                    dim)
-            check_bind_with_uniform(lambda x, y: x - y,
-                                    lambda g, x, y: (g, -g),
-                                    dim)
-            check_bind_with_uniform(lambda x, y: x * y,
-                                    lambda g, x, y: (y * g, x * g),
-                                    dim)
-            check_bind_with_uniform(lambda x, y: x / y,
-                                    lambda g, x, y: (g / y, -x * g/ (y**2)),
-                                    dim)
+        np.random.seed(0)
+        nrepeat = 10
+        maxdim = 4
+        for repeat in range(nrepeat):
+            for dim in range(1, maxdim):
+                check_bind_with_uniform(lambda x, y: x + y,
+                                        lambda g, x, y: (g, g),
+                                        dim)
+                check_bind_with_uniform(lambda x, y: x - y,
+                                        lambda g, x, y: (g, -g),
+                                        dim)
+                check_bind_with_uniform(lambda x, y: x * y,
+                                        lambda g, x, y: (y * g, x * g),
+                                        dim)
+                check_bind_with_uniform(lambda x, y: x / y,
+                                        lambda g, x, y: (g / y, -x * g/ (y**2)),
+                                        dim)
 
-            check_bind_with_uniform(lambda x, y: np.maximum(x, y),
-                                    lambda g, x, y: (g * (x>y), g * (y>x)),
-                                    dim,
-                                    sf=mx.symbol.maximum)
-            check_bind_with_uniform(lambda x, y: np.minimum(x, y),
-                                    lambda g, x, y: (g * (x<y), g * (y<x)),
-                                    dim,
-                                    sf=mx.symbol.minimum)
-    if disable_bulk_exec:
-       mx.test_utils.set_env_var("MXNET_EXEC_BULK_EXEC_INFERENCE", prev_bulk_inf_val)
-       mx.test_utils.set_env_var("MXNET_EXEC_BULK_EXEC_TRAIN", prev_bulk_train_val)
+                check_bind_with_uniform(lambda x, y: np.maximum(x, y),
+                                        lambda g, x, y: (g * (x>y), g * (y>x)),
+                                        dim,
+                                        sf=mx.symbol.maximum)
+                check_bind_with_uniform(lambda x, y: np.minimum(x, y),
+                                        lambda g, x, y: (g * (x<y), g * (y<x)),
+                                        dim,
+                                        sf=mx.symbol.minimum)
+        if disable_bulk_exec:
+           mx.test_utils.set_env_var("MXNET_EXEC_BULK_EXEC_INFERENCE", prev_bulk_inf_val)
+           mx.test_utils.set_env_var("MXNET_EXEC_BULK_EXEC_TRAIN", prev_bulk_train_val)
+
+    check_bind(True)
+    check_bind(False)
 
 def test_dot():
     np.random.seed(0)
@@ -154,6 +158,5 @@ def test_reshape():
     assert np.all(exe.outputs[0].asnumpy() == 4)
 
 if __name__ == "__main__":
-    test_bind(disable_bulk_exec=False)
-    test_bind(disable_bulk_exec=True)
-    test_reshape()
+    import nose
+    nose.runmodule()


### PR DESCRIPTION
## Description ##
#8902 
```
ubuntu@ip-172-31-9-180:~/mxnet/python$ MXNET_STORAGE_FALLBACK_DEBUG=1 python
Python 2.7.12 (default, Nov 20 2017, 18:23:56)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import mxnet as mx
>>> def func():
...     a = mx.nd.ones((2,2)).tostype('csr')
...     b = mx.nd.ones((2,2)).tostype('csr')
...     c = a * b
...     d = c + 1
...
>>> func()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 4, in func
  File "mxnet/ndarray/ndarray.py", line 235, in __mul__
    return multiply(self, other)
  File "mxnet/ndarray/ndarray.py", line 2566, in multiply
    None)
  File "mxnet/ndarray/ndarray.py", line 2379, in _ufunc_helper
    return fn_array(lhs, rhs)
  File "<string>", line 46, in broadcast_mul
  File "mxnet/_ctypes/ndarray.py", line 92, in _imperative_invoke
    ctypes.byref(out_stypes)))
  File "mxnet/base.py", line 146, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError:
Storage fallback detected:
operator = broadcast_mul
input storage types = [csr, csr, ]
output storage types = [default, ]
params = {}
context.dev_mask = cpu
The operator with default storage type will be dispatched for execution. You're seeing this warning message because the operator above is unable to process the given ndarrays with specified storage types, context and parameter. Temporary dense ndarrays are generated in order to execute the operator. You can set environment variable MXNET_STORAGE_FALLBACK_LOG_VERBOSE to 0 to suppress the warnings. If you do not know what caused this error, you can try set environment variable MXNET_STORAGE_FALLBACK_DEBUG to 1. This will give you the series of calls that lead to this error. Remember to set MXNET_STORAGE_FALLBACK_DEBUG back to empty after debugging.

```

```
ubuntu@ip-172-31-9-180:~/mxnet/python$ MXNET_STORAGE_FALLBACK_DEBUG=1 python
Python 2.7.12 (default, Nov 20 2017, 18:23:56)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import mxnet as mx
>>> a = mx.nd.ones((2,2)).tostype('csr')
>>> b = mx.nd.ones((2,2))
>>> b.copyto(a)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "mxnet/ndarray/ndarray.py", line 1876, in copyto
    return _internal._copyto(self, out=other)
  File "<string>", line 25, in _copyto
  File "mxnet/_ctypes/ndarray.py", line 92, in _imperative_invoke
    ctypes.byref(out_stypes)))
  File "mxnet/base.py", line 146, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError:
Storage fallback detected:
Copy from default storage type on cpu to csr storage type on cpu
A temporary ndarray with csr storage type will be generated in order to perform the copy. You can set environment variable MXNET_STORAGE_FALLBACK_LOG_VERBOSE to 0 to suppress this warning. If you do not know what caused this error, you can try set environment variable MXNET_STORAGE_FALLBACK_DEBUG to 1. This will give you the series of calls that lead to this error. Remember to set MXNET_STORAGE_FALLBACK_DEBUG back to empty after debugging.
```


## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here


