### PR TITLE
fix trainer: init kvstore before load states

### DIFF
--- a/python/mxnet/gluon/trainer.py
+++ b/python/mxnet/gluon/trainer.py
@@ -223,6 +223,9 @@ class Trainer(object):
         fname : str
             Path to input states file.
         """
+        if not self._kv_initialized:
+            self._init_kvstore()
+
         if self._update_on_kvstore:
             self._kvstore.load_optimizer_states(fname)
             self._optimizer = self._kvstore._updater.optimizer


### PR DESCRIPTION
init kvstore before load states.

```python
trainer = gl.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.01, ...}
trainer.load_states('/path/to/xxx.states')
```