### PR TITLE
raise err in io.NDArrayIter for invalid usecase

### DIFF
--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -515,17 +515,10 @@ def _init_data(data, allow_empty, default_name):
     return list(data.items())
 
 def _has_instance(data, dtype):
-    """return True if data has instance of dtype"""
-    if isinstance(data, dtype):
-        return True
-    if isinstance(data, list):
-        for v in data:
-            if isinstance(v, dtype):
-                return True
-    if isinstance(data, dict):
-        for v in data.values():
-            if isinstance(v, dtype):
-                return True
+    """return True if data has instance of dtype after _init_data"""
+    for item in data:
+        if isinstance(item[1], dtype):
+            return True
     return False
 
 def _shuffle(data, idx):
@@ -544,7 +537,7 @@ def _shuffle(data, idx):
 
 class NDArrayIter(DataIter):
     """Returns an iterator for ``mx.nd.NDArray``, ``numpy.ndarray``, ``h5py.Dataset``
-    or ``mx.nd.sparse.CSRNDArray``.
+    ``mx.nd.sparse.CSRNDArray`` or ``scipy.sparse.csr_matrix``.
 
     Example usage:
     ----------
@@ -644,12 +637,13 @@ class NDArrayIter(DataIter):
                  label_name='softmax_label'):
         super(NDArrayIter, self).__init__(batch_size)
 
-        if ((_has_instance(data, CSRNDArray) or _has_instance(label, CSRNDArray)) and
+        self.data = _init_data(data, allow_empty=False, default_name=data_name)
+        self.label = _init_data(label, allow_empty=True, default_name=label_name)
+
+        if ((_has_instance(self.data, CSRNDArray) or _has_instance(self.label, CSRNDArray)) and
                 (last_batch_handle != 'discard')):
             raise NotImplementedError("`NDArrayIter` only supports ``CSRNDArray``" \
                                       " with `last_batch_handle` set to `discard`.")
-        self.data = _init_data(data, allow_empty=False, default_name=data_name)
-        self.label = _init_data(label, allow_empty=True, default_name=label_name)
 
         self.idx = np.arange(self.data[0][1].shape[0])
         # shuffle data

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -515,9 +515,12 @@ def _init_data(data, allow_empty, default_name):
     return list(data.items())
 
 def _has_instance(data, dtype):
-    """return True if data has instance of dtype after _init_data"""
+    """Return True if ``data`` has instance of ``dtype``.
+    This function is called after _init_data.
+    ``data`` is a list of (str, NDArray)"""
     for item in data:
-        if isinstance(item[1], dtype):
+        _, arr = item
+        if isinstance(arr, dtype):
             return True
     return False
 

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -162,9 +162,14 @@ def test_NDArrayIter_csr():
     csr, _ = rand_sparse_ndarray(shape, 'csr')
     dns = csr.asnumpy()
 
-    # CSRNDArray with last_batch_handle not equal to 'discard' will throw NotImplementedError
-    assertRaises(NotImplementedError, mx.io.NDArrayIter, {'data': csr}, dns, batch_size,
-                 last_batch_handle='pad')
+    # CSRNDArray or scipy.sparse.csr_matrix with last_batch_handle not equal to 'discard' will throw NotImplementedError
+    assertRaises(NotImplementedError, mx.io.NDArrayIter, {'data': csr}, dns, batch_size)
+    try:
+        import scipy.sparse as spsp
+        train_data = spsp.csr_matrix(dns)
+        assertRaises(NotImplementedError, mx.io.NDArrayIter, {'data': train_data}, dns, batch_size)
+    except ImportError:
+        pass
 
     # CSRNDArray with shuffle
     csr_iter = iter(mx.io.NDArrayIter({'csr_data': csr, 'dns_data': dns}, dns, batch_size,


### PR DESCRIPTION
## Description ##
fix https://github.com/apache/incubator-mxnet/issues/9211

cc @eric-haibin-lin @dingran

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] unittest

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
