### PR TITLE
FTML optimizer implementation

### DIFF
--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -25,7 +25,7 @@ import numpy
 from .base import py_str
 from .ndarray import (NDArray, zeros, clip, sqrt, cast, maximum, abs as NDabs)
 from .ndarray import (sgd_update, sgd_mom_update, adam_update, rmsprop_update, rmspropalex_update,
-                      mp_sgd_update, mp_sgd_mom_update, square, ftrl_update)
+                      mp_sgd_update, mp_sgd_mom_update, square, ftrl_update, ftml_update)
 from .ndarray import _internal
 from .ndarray import op
 from .ndarray import sparse
@@ -529,6 +529,7 @@ class SGD(Optimizer):
         self._update_impl(index, weight, grad, state,
                           multi_precision=use_multi_precision)
 
+
 @register
 class FTML(Optimizer):
     """The FTML optimizer.
@@ -542,9 +543,12 @@ class FTML(Optimizer):
 
     Parameters
     ----------
-    beta1: float, 0 < beta < 1. Generally close to 0.5.
-    beta2: float, 0 < beta < 1. Generally close to 1.
-    epsilon: float >= 0. Fuzz factor.
+    beta1 : float, optional
+        0 < beta1 < 1. Generally close to 0.5.
+    beta2 : float, optional
+        0 < beta2 < 1. Generally close to 1.
+    epsilon : float, optional
+        Small value to avoid division by 0.
     """
     def __init__(self, beta1=0.6, beta2=0.999, epsilon=1e-8, **kwargs):
         super(FTML, self).__init__(**kwargs)
@@ -565,22 +569,14 @@ class FTML(Optimizer):
         wd = self._get_wd(index)
         t = self._index_update_count[index]
 
-        grad = grad * self.rescale_grad
-        if self.clip_gradient is not None:
-            grad = clip(grad, -self.clip_gradient, self.clip_gradient)
-        # get previous states
+        kwargs = {'beta1': self.beta1, 'beta2': self.beta2, 'epsilon': self.epsilon,
+                  'rescale_grad': self.rescale_grad, 't': t}
+        if self.clip_gradient:
+            kwargs['clip_grad'] = self.clip_gradient
+
         prev_d, prev_v, prev_z = state
-        # compute states
-        v_t = self.beta2 * prev_v + (1 - self.beta2) * square(grad)
-        d_t = (1 - pow(self.beta1, t)) / lr * (sqrt(v_t / (1 - pow(self.beta2, t))) + self.epsilon)
-        sigma_t = d_t - self.beta1 * prev_d
-        z_t = self.beta1 * prev_z + (1 - self.beta1) * grad - sigma_t * weight
-        # update weight
-        weight[:] = - z_t / d_t - lr * wd * weight
-        # update states
-        prev_d[:] = d_t
-        prev_v[:] = v_t
-        prev_z[:] = z_t
+        ftml_update(weight, grad, prev_d, prev_v, prev_z, out=weight,
+                    lr=lr, wd=wd, **kwargs)
 
 # pylint: enable=line-too-long
 @register

--- a/src/operator/optimizer_op-inl.h
+++ b/src/operator/optimizer_op-inl.h
@@ -485,6 +485,95 @@ inline void SGDMomUpdateEx(const nnvm::NodeAttrs& attrs,
   }
 }
 
+
+struct FTMLParam : public dmlc::Parameter<FTMLParam> {
+  float lr;
+  float beta1;
+  float beta2;
+  double epsilon;
+  int t;
+  float wd;
+  float rescale_grad;
+  float clip_grad;
+  DMLC_DECLARE_PARAMETER(FTMLParam) {
+    DMLC_DECLARE_FIELD(lr)
+    .describe("Learning rate.");
+    DMLC_DECLARE_FIELD(beta1)
+    .set_default(0.6f)
+    .set_range(0.0f, 1.0f)
+    .describe("Generally close to 0.5.");
+    DMLC_DECLARE_FIELD(beta2)
+    .set_default(0.999f)
+    .set_range(0.0f, 1.0f)
+    .describe("Generally close to 1.");
+    DMLC_DECLARE_FIELD(epsilon)
+    .set_default(1e-8f)
+    .describe("Epsilon to prevent div 0.");
+    DMLC_DECLARE_FIELD(t)
+    .describe("Number of update.");
+    DMLC_DECLARE_FIELD(wd)
+    .set_default(0.0f)
+    .describe("Weight decay augments the objective function with a "
+              "regularization term that penalizes large weights. "
+              "The penalty scales with the square of the magnitude of each weight.");
+    DMLC_DECLARE_FIELD(rescale_grad)
+    .set_default(1.0f)
+    .describe("Rescale gradient to grad = rescale_grad*grad.");
+    DMLC_DECLARE_FIELD(clip_grad)
+    .set_default(-1.0f)
+    .describe("Clip gradient to the range of [-clip_gradient, clip_gradient] "
+              "If clip_gradient <= 0, gradient clipping is turned off. "
+              "grad = max(min(grad, clip_gradient), -clip_gradient).");
+  }
+};
+
+
+struct FTMLKernel {
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, DType* out, DType* weight, DType* grad,
+    DType* d, DType* v, DType* z, const DType lr, const DType beta1,
+    const DType beta2, const DType epsilon, const DType t,
+    const DType wd, const DType rescale_grad, const DType clip_grad,
+    const OpReqType req) {
+    using namespace mshadow_op;
+    const DType grad_i = clip_grad >= 0.0f
+        ? (clip::Map(rescale_grad * grad[i], clip_grad) + wd * weight[i])
+        : (rescale_grad * grad[i] + wd * weight[i]);
+    v[i] = beta2 * v[i] + (1 - beta2) * square::Map(grad_i);
+    const DType d_t = (1 - power::Map(beta1, t)) / lr *
+        (square_root::Map(v[i] / (1 - power::Map(beta2, t))) + epsilon);
+    z[i] = beta1 * z[i] + (1 - beta1) * grad_i - (d_t - beta1 * d[i]) * weight[i];
+    d[i] = d_t;
+    KERNEL_ASSIGN(out[i], req, - z[i] / d_t);
+  }
+};
+
+
+template<typename xpu>
+inline void FTMLUpdate(const nnvm::NodeAttrs& attrs,
+                       const OpContext &ctx,
+                       const std::vector<TBlob> &inputs,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &outputs) {
+  using namespace mxnet_op;
+  FTMLParam param = nnvm::get<FTMLParam>(attrs.parsed);
+  Stream<xpu>* s = ctx.get_stream<xpu>();
+  MSHADOW_REAL_TYPE_SWITCH(inputs[0].type_flag_, DType, {
+    DType* weight_data = inputs[0].dptr<DType>();
+    DType* grad_data = inputs[1].dptr<DType>();
+    DType* d_data = inputs[2].dptr<DType>();
+    DType* v_data = inputs[3].dptr<DType>();
+    DType* z_data = inputs[4].dptr<DType>();
+    DType* out_data = outputs[0].dptr<DType>();
+    Kernel<FTMLKernel, xpu>::Launch(s, inputs[0].shape_.Size(), out_data,
+      weight_data, grad_data, d_data, v_data, z_data, static_cast<DType>(param.lr),
+      static_cast<DType>(param.beta1), static_cast<DType>(param.beta2),
+      static_cast<DType>(param.epsilon), static_cast<DType>(param.t), static_cast<DType>(param.wd),
+      static_cast<DType>(param.rescale_grad), static_cast<DType>(param.clip_grad),
+      req[0]);
+  });
+}
+
 struct AdamParam : public dmlc::Parameter<AdamParam> {
   float lr;
   float beta1;

--- a/src/operator/optimizer_op-inl.h
+++ b/src/operator/optimizer_op-inl.h
@@ -537,7 +537,7 @@ struct FTMLKernel {
     const OpReqType req) {
     using namespace mshadow_op;
     const DType grad_i = clip_grad >= 0.0f
-        ? (clip::Map(rescale_grad * grad[i], clip_grad) + wd * weight[i])
+        ? clip::Map(rescale_grad * grad[i] + wd * weight[i], clip_grad)
         : (rescale_grad * grad[i] + wd * weight[i]);
     v[i] = beta2 * v[i] + (1 - beta2) * square::Map(grad_i);
     const DType d_t = (1 - power::Map(beta1, t)) / lr *

--- a/src/operator/optimizer_op.cu
+++ b/src/operator/optimizer_op.cu
@@ -42,6 +42,9 @@ NNVM_REGISTER_OP(mp_sgd_update)
 NNVM_REGISTER_OP(mp_sgd_mom_update)
 .set_attr<FCompute>("FCompute<gpu>", MP_SGDMomUpdate<gpu>);
 
+NNVM_REGISTER_OP(ftml_update)
+.set_attr<FCompute>("FCompute<gpu>", FTMLUpdate<gpu>);
+
 NNVM_REGISTER_OP(adam_update)
 .set_attr<FCompute>("FCompute<gpu>", AdamUpdate<gpu>)
 .set_attr<FComputeEx>("FComputeEx<gpu>", AdamUpdateEx<gpu>);

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -357,10 +357,9 @@ class PyFTML(mx.optimizer.Optimizer):
         wd = self._get_wd(index)
         t = self._index_update_count[index]
 
-        grad = grad * self.rescale_grad
+        grad = grad * self.rescale_grad + wd * weight
         if self.clip_gradient is not None:
             grad = mx.nd.clip(grad, -self.clip_gradient, self.clip_gradient)
-        grad += wd * weight 
         # get previous states
         prev_d, prev_v, prev_z = state
         # compute states

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -333,6 +333,75 @@ def test_sparse_sgd():
                             compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, dtype,
                                               w_stype='row_sparse', g_stype='row_sparse')
 
+
+# FTML
+
+class PyFTML(mx.optimizer.Optimizer):
+    """python reference implemenation of FTML"""
+    def __init__(self, beta1=0.6, beta2=0.999, epsilon=1e-8, **kwargs):
+        super(PyFTML, self).__init__(**kwargs)
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.epsilon = epsilon
+
+    def create_state(self, index, weight):
+        return (mx.nd.zeros(weight.shape, weight.context, dtype=weight.dtype), # d_0
+                mx.nd.zeros(weight.shape, weight.context, dtype=weight.dtype), # v_0
+                mx.nd.zeros(weight.shape, weight.context, dtype=weight.dtype)) # z_0
+
+    def update(self, index, weight, grad, state):
+        assert(isinstance(weight, mx.nd. NDArray))
+        assert(isinstance(grad, mx.nd.NDArray))
+        self._update_count(index)
+        lr = self._get_lr(index)
+        wd = self._get_wd(index)
+        t = self._index_update_count[index]
+
+        grad = grad * self.rescale_grad
+        if self.clip_gradient is not None:
+            grad = mx.nd.clip(grad, -self.clip_gradient, self.clip_gradient)
+        grad += wd * weight 
+        # get previous states
+        prev_d, prev_v, prev_z = state
+        # compute states
+        v_t = self.beta2 * prev_v + (1 - self.beta2) * mx.nd.square(grad)
+        d_t = (1 - pow(self.beta1, t)) / lr * (mx.nd.sqrt(v_t / (1 - pow(self.beta2, t))) + self.epsilon)
+        sigma_t = d_t - self.beta1 * prev_d
+        z_t = self.beta1 * prev_z + (1 - self.beta1) * grad - sigma_t * weight
+        # update weight
+        weight[:] = - z_t / d_t
+        # update states
+        prev_d[:] = d_t
+        prev_v[:] = v_t
+        prev_z[:] = z_t
+
+
+def test_ftml():
+    mx.random.seed(0)
+    opt1 = PyFTML
+    opt2 = mx.optimizer.FTML
+    shape = (3, 4, 5)
+    beta1_options = [{}, {'beta1': 0.5}, {'beta1': 0.7}]
+    beta2_options = [{}, {'beta2': 0.8}, {'beta2': 0.9}]
+    cg_options = [{}, {'clip_gradient': 0.4}, {'clip_gradient': 0.5}]
+    rg_options = [{}, {'rescale_grad': 0.14}, {'rescale_grad': 0.8}]
+    wd_options = [{}, {'wd': 0.03}, {'wd': 0.05}, {'wd': 0.07}]
+    for dtype in [np.float32]:
+        for beta1_option in beta1_options:
+            for beta2_option in beta2_options:
+                for cg_option in cg_options:
+                    for rg_option in rg_options:
+                        for wd_option in wd_options:
+                            kwarg = {}
+                            kwarg.update(beta1_option)
+                            kwarg.update(beta2_option)
+                            kwarg.update(cg_option)
+                            kwarg.update(rg_option)
+                            kwarg.update(wd_option)
+                            compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, dtype)
+
+
+
 # ADAM
 
 class PyAdam(mx.optimizer.Optimizer):
@@ -675,4 +744,3 @@ def test_nadam():
 if __name__ == '__main__':
     import nose
     nose.runmodule()
-


### PR DESCRIPTION
## Description ##
FTML optimizer implementation, requested in https://github.com/apache/incubator-mxnet/issues/9182

The default values of `beta1, beta2, epsilon` is the same with https://github.com/keras-team/keras-contrib/pull/110.

How to add test to verify the correctness of implementation? @sxjscience 

Here is the [test](https://github.com/keras-team/keras-contrib/blob/master/tests/keras_contrib/optimizers/ftml_test.py) for FTML in keras-contrib. Is that OK?

I have done only one experiment, FTML (val acc : 0.756210 at 10th epoch) can converge faster than momentum SGD (val acc : 0.684095 at 10th epoch) on cifar10, both using `lr = 0.001, wd = 0` and `resnet18_v1`. 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
