### PR TITLE
Fixes #9210: Cosine Loss Formula

### DIFF
--- a/example/recommenders/recotools.py
+++ b/example/recommenders/recotools.py
@@ -28,6 +28,7 @@ def CosineLoss(a, b, label):
     dot = mx.symbol.sum_axis(dot, axis=1)
     dot = mx.symbol.Flatten(dot)
     cosine = 1 - dot
+    cosine = cosine / 2
     return mx.symbol.MAERegressionOutput(data=cosine, label=label)
 
 def SparseRandomProjection(indexes, values, input_dim, output_dim, ngram=1):


### PR DESCRIPTION
## Description ##
Fixes #9210 
- `cosine = 1 - dot` was bounded between 0 and 2.
- I have divided cosine by 2 so that it becomes bounded between the values 0 and 1.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Feature1, tests, (and when applicable, API doc)
- [x] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
