### PR TITLE
Add label_from_zero_one argument to LogisticLoss

### DIFF
--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -619,7 +619,7 @@ class LogisticLoss(Loss):
         L = \sum_i \log(1 + \exp(- {pred}_i \cdot {label}_i))
 
     where `pred` is the classifier prediction and `label` is the target tensor
-    containing values -1 or 1 (0 or 1 if `label_from_zero_one` is set).
+    containing values -1 or 1 (0 or 1 if `label_format` is binary).
      `pred` and `label` can have arbitrary shape as long as they have the same number of elements.
 
     Parameters

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -643,11 +643,14 @@ class LogisticLoss(Loss):
         - **loss**: loss tensor with shape (batch_size,). Dimenions other than
           batch_axis are averaged out.
     """
-    def __init__(self, weight=None, batch_axis=0, **kwargs):
+    def __init__(self, weight=None, batch_axis=0, use_zero_one=False, **kwargs):
         super(LogisticLoss, self).__init__(weight, batch_axis, **kwargs)
+        self._use_zero_one = use_zero_one
 
     def hybrid_forward(self, F, pred, label, sample_weight=None):
         label = _reshape_like(F, label, pred)
+        if self._use_zero_one:
+            label = 2 * label - 1  # Transform label to be either -1 or 1
         loss = F.log(1.0 + F.exp(-pred * label))
         loss = _apply_weighting(F, loss, self._weight, sample_weight)
         return F.mean(loss, axis=self._batch_axis, exclude=True)

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -619,8 +619,8 @@ class LogisticLoss(Loss):
         L = \sum_i \log(1 + \exp(- {pred}_i \cdot {label}_i))
 
     where `pred` is the classifier prediction and `label` is the target tensor
-    containing values -1 or 1. `pred` and `label` can have arbitrary shape as
-    long as they have the same number of elements.
+    containing values -1 or 1 (0 or 1 if `use_zero_one` is set).
+     `pred` and `label` can have arbitrary shape as long as they have the same number of elements.
 
     Parameters
     ----------
@@ -628,6 +628,8 @@ class LogisticLoss(Loss):
         Global scalar weight for loss.
     batch_axis : int, default 0
         The axis that represents mini-batch.
+    use_zero_one : bool, default False
+        Whether the labels are either 0 or 1. If not set, the labels should contain -1 or 1.
 
 
     Inputs:

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -619,7 +619,7 @@ class LogisticLoss(Loss):
         L = \sum_i \log(1 + \exp(- {pred}_i \cdot {label}_i))
 
     where `pred` is the classifier prediction and `label` is the target tensor
-    containing values -1 or 1 (0 or 1 if `use_zero_one` is set).
+    containing values -1 or 1 (0 or 1 if `label_from_zero_one` is set).
      `pred` and `label` can have arbitrary shape as long as they have the same number of elements.
 
     Parameters
@@ -628,8 +628,8 @@ class LogisticLoss(Loss):
         Global scalar weight for loss.
     batch_axis : int, default 0
         The axis that represents mini-batch.
-    use_zero_one : bool, default False
-        Whether the labels are either 0 or 1. If not set, the labels should contain -1 or 1.
+    label_from_zero_one : bool, default False
+        Whether the labels are either 0 or 1. If not set, the labels should be either -1 or 1.
 
 
     Inputs:
@@ -645,13 +645,13 @@ class LogisticLoss(Loss):
         - **loss**: loss tensor with shape (batch_size,). Dimenions other than
           batch_axis are averaged out.
     """
-    def __init__(self, weight=None, batch_axis=0, use_zero_one=False, **kwargs):
+    def __init__(self, weight=None, batch_axis=0, label_from_zero_one=False, **kwargs):
         super(LogisticLoss, self).__init__(weight, batch_axis, **kwargs)
-        self._use_zero_one = use_zero_one
+        self._label_from_zero_one = label_from_zero_one
 
     def hybrid_forward(self, F, pred, label, sample_weight=None):
         label = _reshape_like(F, label, pred)
-        if self._use_zero_one:
+        if self._label_from_zero_one:
             label = 2 * label - 1  # Transform label to be either -1 or 1
         loss = F.log(1.0 + F.exp(-pred * label))
         loss = _apply_weighting(F, loss, self._weight, sample_weight)

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -628,9 +628,10 @@ class LogisticLoss(Loss):
         Global scalar weight for loss.
     batch_axis : int, default 0
         The axis that represents mini-batch.
-    label_from_zero_one : bool, default False
-        Whether the labels are either 0 or 1. If not set, the labels should be either -1 or 1.
-
+    label_format : str, default 'signed'
+        Can be either 'signed' or 'binary'. If the label_format is 'signed', all label values should
+        be either -1 or 1. If the label_format is 'binary', all label values should be either
+        0 or 1.
 
     Inputs:
         - **pred**: prediction tensor with arbitrary shape.
@@ -645,13 +646,16 @@ class LogisticLoss(Loss):
         - **loss**: loss tensor with shape (batch_size,). Dimenions other than
           batch_axis are averaged out.
     """
-    def __init__(self, weight=None, batch_axis=0, label_from_zero_one=False, **kwargs):
+    def __init__(self, weight=None, batch_axis=0, label_format='signed', **kwargs):
         super(LogisticLoss, self).__init__(weight, batch_axis, **kwargs)
-        self._label_from_zero_one = label_from_zero_one
+        self._label_format = label_format
+        if self._label_format not in ["signed", "binary"]:
+            raise ValueError("label_format can only be signed or binary, recieved %s."
+                             % label_format)
 
     def hybrid_forward(self, F, pred, label, sample_weight=None):
         label = _reshape_like(F, label, pred)
-        if self._label_from_zero_one:
+        if self._label_format == 'binary':
             label = 2 * label - 1  # Transform label to be either -1 or 1
         loss = F.log(1.0 + F.exp(-pred * label))
         loss = _apply_weighting(F, loss, self._weight, sample_weight)


### PR DESCRIPTION
## Description ##
Add the `use_zero_one` argument to LogisticLoss. This handles the case where the labels are either 0 or 1.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] use_zero_one flag
