### PR TITLE
Add documentation generation to PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -554,11 +554,9 @@ try {
   stage('Deploy') {
     node('mxnetlinux-cpu') {
       ws('workspace/docs') {
-        if (env.BRANCH_NAME == "master") {
-          init_git()
-          sh "make clean"
-          sh "make docs"
-        }
+        init_git()
+        sh "make clean"
+        sh "make docs"
       }
     }
   }


### PR DESCRIPTION
At the moment, the Deploy-stage does not generate the html documentation for PRs. It has been shown in cases like
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/master/110/pipeline/
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/master/111/pipeline/
that this step has to be run during PR-stage to avoid issues like these.