### PR TITLE
fix a typo of file "broadcast_reduce_op_value.cc"

### DIFF
--- a/src/operator/tensor/broadcast_reduce_op_value.cc
+++ b/src/operator/tensor/broadcast_reduce_op_value.cc
@@ -77,7 +77,7 @@ Example::
   csr = cast_storage(data, 'csr')
 
   sum(csr, axis=0)
-  [ 8.  2.  2.]
+  [ 8.  3.  1.]
 
   sum(csr, axis=1)
   [ 3.  4.  5.]


### PR DESCRIPTION
fix a typo on the line 80

## Description ##
there is a typo on this file,you can also see the description at the issue:
https://github.com/apache/incubator-mxnet/issues/9272

