### PR TITLE
Make numpy functions return Symbol instead of numpy object array

### DIFF
--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -56,6 +56,9 @@ class Symbol(SymbolBase):
     # pylint: disable=no-member
     __slots__ = []
 
+    # Make numpy functions return Symbol instead of numpy object array
+    __array_priority__ = 1000.0
+
     def __repr__(self):
         """Gets a string representation of the symbol."""
         name = self.name


### PR DESCRIPTION
## Description ##
@piiswrong 

Fix comes from Eric (@piiswrong) from similar issue with NDArray

Seen error would be something like:

Traceback (most recent call last):
  File "../../python/troubleshoot.py", line 157, in <module>
    train(net, batch_size=8*1024, hybridize=True, ctx=ctx)
  File "../../python/troubleshoot.py", line 62, in train
    losses = [p50_p90_mixed_QL_mask_oos(Y, net(X)) for X, Y in zip(data, label)]
  File "/home/coolivie/src/DeepLearning/mxnet/python/mxnet/gluon/block.py", line 306, in __call__
    return self.forward(*args)
  File "/home/coolivie/src/DeepLearning/mxnet/python/mxnet/gluon/block.py", line 511, in forward
    return self._call_cached_op(x, *args)
  File "/home/coolivie/src/DeepLearning/mxnet/python/mxnet/gluon/block.py", line 417, in _call_cached_op
    self._build_cache(*args)
  File "/home/coolivie/src/DeepLearning/mxnet/python/mxnet/gluon/block.py", line 382, in _build_cache
    inputs, out = self._get_graph(*args)
  File "/home/coolivie/src/DeepLearning/mxnet/python/mxnet/gluon/block.py", line 374, in _get_graph
    out = self.hybrid_forward(symbol, *grouped_inputs, **params)  # pylint: disable=no-value-for-parameter
  File "../../python/troubleshoot.py", line 130, in hybrid_forward
    x = self.output(x)
  File "/home/coolivie/src/DeepLearning/mxnet/python/mxnet/gluon/block.py", line 306, in __call__
    return self.forward(*args)
  File "/home/coolivie/src/DeepLearning/mxnet/python/mxnet/gluon/block.py", line 523, in forward
    "Symbol or NDArray, but got %s"%type(x)
AssertionError: HybridBlock requires the first argument to forward be either Symbol or NDArray, but got <type 'numpy.ndarray'>


## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
