### PR TITLE
fix wide&deep

### DIFF
--- a/example/sparse/wide_deep/README.md
+++ b/example/sparse/wide_deep/README.md
@@ -4,4 +4,4 @@ The example demonstrates how to train [wide and deep model](https://arxiv.org/ab
 
 The final accuracy should be around 85%.
 
-- `python wide_deep_classification.py`
+- `python train.py`

--- a/example/sparse/wide_deep/model.py
+++ b/example/sparse/wide_deep/model.py
@@ -49,9 +49,9 @@ def wide_deep_model(num_linear_features, num_embed_features, num_cont_features,
 
     hidden = mx.symbol.concat(*features, dim=1)
     hidden = mx.symbol.FullyConnected(data=hidden, num_hidden=hidden_units[1])
-    hideen = mx.symbol.Activation(data=hidden, act_type='relu')
+    hidden = mx.symbol.Activation(data=hidden, act_type='relu')
     hidden = mx.symbol.FullyConnected(data=hidden, num_hidden=hidden_units[2])
-    hideen = mx.symbol.Activation(data=hidden, act_type='relu')
+    hidden = mx.symbol.Activation(data=hidden, act_type='relu')
     deep_out = mx.symbol.FullyConnected(data=hidden, num_hidden=2)
 
     out = mx.symbol.SoftmaxOutput(linear_out + deep_out, label, name='model')


### PR DESCRIPTION
## Description ##
fix wrong name in wide&deep example.
Final val acc is around 85%

```
python train.py
2018-01-04 08:31:16,394 Namespace(batch_size=100, cuda=False, log_interval=100, lr=0.001, num_epoch=10, optimizer='adam')
2018-01-04 08:31:17,483 Training started ...
2018-01-04 08:31:18,045 Epoch[0] Batch [100]	Speed: 18404.21 samples/sec	accuracy=0.782500
2018-01-04 08:31:18,602 Epoch[0] Batch [200]	Speed: 17960.93 samples/sec	accuracy=0.805900
2018-01-04 08:31:19,136 Epoch[0] Batch [300]	Speed: 18731.01 samples/sec	accuracy=0.836500
2018-01-04 08:31:19,983 epoch 0, accuracy = 0.843950617284
2018-01-04 08:31:19,989 Saved checkpoint to "checkpoint-0000.params"
2018-01-04 08:31:19,993 Saved optimizer state to "checkpoint-0000.states"
2018-01-04 08:31:20,532 Epoch[1] Batch [100]	Speed: 18666.05 samples/sec	accuracy=0.835400
2018-01-04 08:31:21,049 Epoch[1] Batch [200]	Speed: 19363.37 samples/sec	accuracy=0.844300
2018-01-04 08:31:21,586 Epoch[1] Batch [300]	Speed: 18625.41 samples/sec	accuracy=0.847000
2018-01-04 08:31:22,430 epoch 1, accuracy = 0.85037037037
2018-01-04 08:31:22,437 Saved checkpoint to "checkpoint-0001.params"
2018-01-04 08:31:22,441 Saved optimizer state to "checkpoint-0001.states"
2018-01-04 08:31:22,993 Epoch[2] Batch [100]	Speed: 18188.73 samples/sec	accuracy=0.843000
2018-01-04 08:31:23,542 Epoch[2] Batch [200]	Speed: 18215.66 samples/sec	accuracy=0.849500
2018-01-04 08:31:24,107 Epoch[2] Batch [300]	Speed: 17709.80 samples/sec	accuracy=0.846200
2018-01-04 08:31:24,954 epoch 2, accuracy = 0.846543209877
2018-01-04 08:31:24,960 Saved checkpoint to "checkpoint-0002.params"
2018-01-04 08:31:24,963 Saved optimizer state to "checkpoint-0002.states"
2018-01-04 08:31:25,494 Epoch[3] Batch [100]	Speed: 18926.82 samples/sec	accuracy=0.843200
2018-01-04 08:31:26,013 Epoch[3] Batch [200]	Speed: 19257.54 samples/sec	accuracy=0.848300
2018-01-04 08:31:26,517 Epoch[3] Batch [300]	Speed: 19850.32 samples/sec	accuracy=0.854000
2018-01-04 08:31:27,345 epoch 3, accuracy = 0.847160493827
2018-01-04 08:31:27,351 Saved checkpoint to "checkpoint-0003.params"
2018-01-04 08:31:27,354 Saved optimizer state to "checkpoint-0003.states"
2018-01-04 08:31:27,868 Epoch[4] Batch [100]	Speed: 19549.62 samples/sec	accuracy=0.848300
2018-01-04 08:31:28,411 Epoch[4] Batch [200]	Speed: 18433.86 samples/sec	accuracy=0.851000
2018-01-04 08:31:28,928 Epoch[4] Batch [300]	Speed: 19351.20 samples/sec	accuracy=0.856300
2018-01-04 08:31:29,786 epoch 4, accuracy = 0.847098765432
2018-01-04 08:31:29,791 Saved checkpoint to "checkpoint-0004.params"
2018-01-04 08:31:29,795 Saved optimizer state to "checkpoint-0004.states"
2018-01-04 08:31:30,327 Epoch[5] Batch [100]	Speed: 18892.66 samples/sec	accuracy=0.848300
2018-01-04 08:31:30,853 Epoch[5] Batch [200]	Speed: 19013.75 samples/sec	accuracy=0.849800
2018-01-04 08:31:31,372 Epoch[5] Batch [300]	Speed: 19268.64 samples/sec	accuracy=0.859200
2018-01-04 08:31:32,205 epoch 5, accuracy = 0.849382716049
2018-01-04 08:31:32,211 Saved checkpoint to "checkpoint-0005.params"
2018-01-04 08:31:32,215 Saved optimizer state to "checkpoint-0005.states"
2018-01-04 08:31:32,723 Epoch[6] Batch [100]	Speed: 19776.68 samples/sec	accuracy=0.851000
2018-01-04 08:31:33,242 Epoch[6] Batch [200]	Speed: 19271.31 samples/sec	accuracy=0.853300
2018-01-04 08:31:33,777 Epoch[6] Batch [300]	Speed: 18675.22 samples/sec	accuracy=0.859400
2018-01-04 08:31:34,587 epoch 6, accuracy = 0.84987654321
2018-01-04 08:31:34,592 Saved checkpoint to "checkpoint-0006.params"
2018-01-04 08:31:34,596 Saved optimizer state to "checkpoint-0006.states"
2018-01-04 08:31:35,118 Epoch[7] Batch [100]	Speed: 19269.87 samples/sec	accuracy=0.851500
2018-01-04 08:31:35,615 Epoch[7] Batch [200]	Speed: 20107.65 samples/sec	accuracy=0.852300
2018-01-04 08:31:36,163 Epoch[7] Batch [300]	Speed: 18262.51 samples/sec	accuracy=0.859200
2018-01-04 08:31:36,979 epoch 7, accuracy = 0.850679012346
2018-01-04 08:31:36,984 Saved checkpoint to "checkpoint-0007.params"
2018-01-04 08:31:36,987 Saved optimizer state to "checkpoint-0007.states"
2018-01-04 08:31:37,529 Epoch[8] Batch [100]	Speed: 18537.02 samples/sec	accuracy=0.853200
2018-01-04 08:31:38,090 Epoch[8] Batch [200]	Speed: 17838.41 samples/sec	accuracy=0.854300
2018-01-04 08:31:38,619 Epoch[8] Batch [300]	Speed: 18902.09 samples/sec	accuracy=0.859900
2018-01-04 08:31:39,445 epoch 8, accuracy = 0.849691358025
2018-01-04 08:31:39,451 Saved checkpoint to "checkpoint-0008.params"
2018-01-04 08:31:39,454 Saved optimizer state to "checkpoint-0008.states"
2018-01-04 08:31:39,975 Epoch[9] Batch [100]	Speed: 19294.07 samples/sec	accuracy=0.853200
2018-01-04 08:31:40,511 Epoch[9] Batch [200]	Speed: 18670.72 samples/sec	accuracy=0.855900
2018-01-04 08:31:41,022 Epoch[9] Batch [300]	Speed: 19576.13 samples/sec	accuracy=0.860100
2018-01-04 08:31:41,832 epoch 9, accuracy = 0.850185185185
2018-01-04 08:31:41,837 Saved checkpoint to "checkpoint-0009.params"
2018-01-04 08:31:41,841 Saved optimizer state to "checkpoint-0009.states"
2018-01-04 08:31:41,841 Training completed.
```
cc @eric-haibin-lin 

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
