### PR TITLE
Fixing two symbol files for CNN

### DIFF
--- a/example/image-classification/symbols/googlenet.py
+++ b/example/image-classification/symbols/googlenet.py
@@ -65,7 +65,7 @@ def get_symbol(num_classes = 1000, **kwargs):
     pool5 = mx.sym.Pooling(in4e, kernel=(3, 3), stride=(2, 2), pool_type="max")
     in5a = InceptionFactory(pool5, 256, 160, 320, 32, 128, "max", 128, name="in5a")
     in5b = InceptionFactory(in5a, 384, 192, 384, 48, 128, "max", 128, name="in5b")
-    pool6 = mx.sym.Pooling(in5b, kernel=(7, 7), stride=(1,1), pool_type="avg")
+    pool6 = mx.sym.Pooling(in5b, kernel=(7, 7), stride=(1,1), pad=(1, 1), pool_type="avg")
     flatten = mx.sym.Flatten(data=pool6)
     fc1 = mx.sym.FullyConnected(data=flatten, num_hidden=num_classes)
     softmax = mx.symbol.SoftmaxOutput(data=fc1, name='softmax')

--- a/example/image-classification/symbols/vgg.py
+++ b/example/image-classification/symbols/vgg.py
@@ -62,8 +62,12 @@ def get_symbol(num_classes, num_layers=11, batch_norm=False, dtype='float32', **
                 13: ([2, 2, 2, 2, 2], [64, 128, 256, 512, 512]),
                 16: ([2, 2, 3, 3, 3], [64, 128, 256, 512, 512]),
                 19: ([2, 2, 4, 4, 4], [64, 128, 256, 512, 512])}
-    if not vgg_spec.has_key(num_layers):
-        raise ValueError("Invalide num_layers {}. Possible choices are 11,13,16,19.".format(num_layers))
+    if sys.version_info > (3,):
+        if not num_layers in vgg_spec:
+            raise ValueError("Invalide num_layers {}. Possible choices are 11,13,16,19.".format(num_layers))
+    else:
+        if not vgg_spec.has_key(num_layers):
+            raise ValueError("Invalide num_layers {}. Possible choices are 11,13,16,19.".format(num_layers))
     layers, filters = vgg_spec[num_layers]
     data = mx.sym.Variable(name="data")
     if dtype == 'float16':


### PR DESCRIPTION
## Description ##
This PR is trying to fix runtime errors when running benchmark_score.py on CPU machine.


### Changes ###
Under example/image-classification/symbols:
1. vgg.py, original implementation can't run preperly under Python3.x, as "has_key" method not supported by Python3 anymore;
2. google.py, on CPU platform, the input to the last layer (7x7 avg pooling is 6x6, and therefore a runtime error will be triggered, I avoid this issue by add a (1,1) pad with the avg pooling.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


