### PR TITLE
Add Marco de Abreu to CODEOWNERS related to CI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,3 +12,8 @@ perl-package/*		@sergeykolychev
 CMakeLists.txt		@cjolivier01
 cmake/*			@cjolivier01
 
+# Owners of MXNet CI
+tests/ci_build/*    @marcoabreu
+Jenkinsfile         @marcoabreu
+.travis.yml         @marcoabreu
+appveyor.yml        @marcoabreu


### PR DESCRIPTION
There have been unreviewed changes like https://github.com/apache/incubator-mxnet/commit/d0388d00d5959d96341129a40ab21264476dfda6 to CI-related files. This change, for example, requires rebuilding of the docker image cache. In order to be notified of cases like this, I'd like to add myself as a code owner.