### PR TITLE
Prepend LD_LIBRARY_PATH to dll_path in find_lib_path

### DIFF
--- a/python/mxnet/libinfo.py
+++ b/python/mxnet/libinfo.py
@@ -43,7 +43,7 @@ def find_lib_path():
             dll_path.append(os.path.join(curr_path, '../../build', vs_configuration))
             dll_path.append(os.path.join(curr_path, '../../windows', vs_configuration))
     elif os.name == "posix" and os.environ.get('LD_LIBRARY_PATH', None):
-        dll_path.extend([p.strip() for p in os.environ['LD_LIBRARY_PATH'].split(":")])
+        dll_path[0:0] = [p.strip() for p in os.environ['LD_LIBRARY_PATH'].split(":")]
     if os.name == 'nt':
         os.environ['PATH'] = os.path.dirname(__file__) + ';' + os.environ['PATH']
         dll_path = [os.path.join(p, 'libmxnet.dll') for p in dll_path]


### PR DESCRIPTION
## Description ##
The paths contained in the LD_LIBRARY_PATH environment variable should have the highest priority while searching for shared libraries.

## Checklist ##
- [x] Passed code style checking.
- [x] Changes are complete.
- [x] To the my best knowledge examples are either not affected by this change.
