### PR TITLE
Fix CODEOWNERS syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,16 +4,16 @@
 *			@apache/mxnet-committers
 
 # Owners of language bindings
-R-package/*		@thirdwing
-scala-package/*		@javelinjs
-perl-package/*		@sergeykolychev
+/R-package/		@thirdwing
+/scala-package/		@javelinjs
+/perl-package/		@sergeykolychev
 
 # CMake owners
 CMakeLists.txt		@cjolivier01
-cmake/*			@cjolivier01
+/cmake/			@cjolivier01
 
 # Owners of MXNet CI
-tests/ci_build/*    @marcoabreu
+/tests/ci_build/    @marcoabreu
 Jenkinsfile         @marcoabreu
 .travis.yml         @marcoabreu
 appveyor.yml        @marcoabreu


### PR DESCRIPTION
According to https://github.com/apache/incubator-mxnet, the notation /dir/ is necessary in order to cover all subdirectories. At the moment, only files on the first level are being checked.

 @szha 