### PR TITLE
[MXNET-35] simplify import of citation metadata

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -1,0 +1,23 @@
+@article{DBLP:journals/corr/ChenLLLWWXXZZ15,
+  author    = {Tianqi Chen and
+               Mu Li and
+               Yutian Li and
+               Min Lin and
+               Naiyan Wang and
+               Minjie Wang and
+               Tianjun Xiao and
+               Bing Xu and
+               Chiyuan Zhang and
+               Zheng Zhang},
+  title     = {MXNet: {A} Flexible and Efficient Machine Learning Library for Heterogeneous
+               Distributed Systems},
+  journal   = {CoRR},
+  volume    = {abs/1512.01274},
+  year      = {2015},
+  url       = {http://arxiv.org/abs/1512.01274},
+  archivePrefix = {arXiv},
+  eprint    = {1512.01274},
+  timestamp = {Wed, 07 Jun 2017 14:40:48 +0200},
+  biburl    = {http://dblp.org/rec/bib/journals/corr/ChenLLLWWXXZZ15},
+  bibsource = {dblp computer science bibliography, http://dblp.org}
+}


### PR DESCRIPTION
This is a copy of the BibTeX snippet from https://arxiv.org/abs/1512.01274 incorporated into the repo as suggested in https://www.software.ac.uk/blog/2013-09-02-encouraging-citation-software-introducing-citation-files. Adding it here may make it simpler for people to cite your software. How about it?

Also, it would be possible edit this PR to:

- [ ] use `@software{...`, even though it's may still be treated as `@misc` by BibLaTeX
- [ ] add a DOI through https://guides.github.com/activities/citable-code/
- [ ] point [`Reference Paper`](https://github.com/apache/incubator-mxnet#reference-paper) to this file

I'm leaving out the rest of the checklist from the PR template, because this PR does not add or change actual code.