### PR TITLE
support setattr for some specified paramter of ParameterDict

### DIFF
--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -593,10 +593,10 @@ class ParameterDict(object):
         for i in self.values():
             i.reset_ctx(ctx)
 
-    def setattr(self, name, value):
-        """Set an attribute to a new value for all Parameters.
+    def setattr(self, name, value, selected_param_names="all"):
+        """Set an attribute to a new value for all(default) or some selected Parameters.
 
-        For example, set grad_req to null if you don't need gradient w.r.t a
+        For example, set grad_req to null if you don't need gradient w.r.t all
         model's Parameters::
 
             model.collect_params().setattr('grad_req', 'null')
@@ -605,15 +605,27 @@ class ParameterDict(object):
 
             model.collect_params().setattr('lr_mult', 0.5)
 
+        or set grad_req to null if you don't need gradient w.r.t  model's
+        Parameters in ['conv1_weight', 'conv1_bias']::
+
+            model.collect_params().setattr('grad_req', 'null', ['conv1_weight', 'conv1_bias'])
+
         Parameters
         ----------
         name : str
             Name of the attribute.
         value : valid type for attribute name
             The new value for the attribute.
+        selected_param_names : str or list
+            The selected paramters to be setattr.
         """
-        for i in self.values():
-            setattr(i, name, value)
+        if selected_param_names == "all":
+            selected_param_names = self.keys()
+        elif isinstance(selected_param_names, str):
+            selected_param_names = [selected_param_names]
+        for k, v in self.items():
+            if k in selected_param_names:
+                setattr(v, name, value)
 
     def save(self, filename, strip_prefix=''):
         """Save parameters to file.


### PR DESCRIPTION
## Description ##
Somewhat  similar with ```fixed_param_names``` in ```mx.mod.Module()```, which can set attr of some specified paramter.


## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
```selected_param_names``` may be not a good parameter name, better name is welcome.

  