### PR TITLE
Add CMake CI build job

### DIFF
--- a/tests/ci_build/ci_build.sh
+++ b/tests/ci_build/ci_build.sh
@@ -101,6 +101,11 @@ function upsearch () {
 # reasonable defaults if you run it outside of Jenkins.
 WORKSPACE="${WORKSPACE:-${SCRIPT_DIR}/../../}"
 
+# Set up a default WORKDIR, unless otherwise specified.
+if [[ -z "${WORKDIR}" ]]; then
+    WORKDIR="/workspace"
+fi
+
 # Determine the docker image name
 DOCKER_IMG_NAME="mx-ci.${CONTAINER_TYPE}"
 
@@ -111,16 +116,21 @@ DOCKER_IMG_NAME=$(echo "${DOCKER_IMG_NAME}" | sed -e 's/=/_/g' -e 's/,/-/g')
 # Convert to all lower-case, as per requirement of Docker image names
 DOCKER_IMG_NAME=$(echo "${DOCKER_IMG_NAME}" | tr '[:upper:]' '[:lower:]')
 
-# skip with_the_same_user for non-linux
+# Skip with_the_same_user for non-linux
 uname=`uname`
 if [[ "$uname" == "Linux" ]]; then
-    PRE_COMMAND="tests/ci_build/with_the_same_user"
+    # By convention the root of our source dir is always mapped to the /workspace folder
+    # inside the docker container.  Our working directory when we start the container
+    # is variable, so we should ensure we call commands such as with_the_same_user
+    # with their absolute paths.
+    PRE_COMMAND="/workspace/tests/ci_build/with_the_same_user"
 else
     PRE_COMMAND=""
 fi
 
 # Print arguments.
 echo "WORKSPACE: ${WORKSPACE}"
+echo "WORKDIR: ${WORKDIR}"
 echo "CI_DOCKER_EXTRA_PARAMS: ${CI_DOCKER_EXTRA_PARAMS[@]}"
 echo "COMMAND: ${COMMAND[@]}"
 echo "CONTAINER_TYPE: ${CONTAINER_TYPE}"
@@ -153,9 +163,14 @@ echo "Running '${COMMAND[@]}' inside ${DOCKER_IMG_NAME}..."
 # Turning off MXNET_STORAGE_FALLBACK_LOG_WARNING temporarily per this issue:
 # https://github.com/apache/incubator-mxnet/issues/8980
 
+# By convention always map the root of the MXNet source directory into /workspace.
+# ${WORKSPACE} represents the path to the source folder on the host system.
+# ${WORKDIR} is the working directory we start the container in.  By default this
+# is /workspace, but for example when running cmake it is sometimes /workspace/build.
+
 ${DOCKER_BINARY} run --rm --pid=host \
     -v ${WORKSPACE}:/workspace \
-    -w /workspace \
+    -w ${WORKDIR} \
     -e "CI_BUILD_HOME=${WORKSPACE}" \
     -e "CI_BUILD_USER=$(id -u -n)" \
     -e "CI_BUILD_UID=$(id -u)" \


### PR DESCRIPTION
## Description ##
This PR creates a new build job for CMake on our CI.  The build is currently failing because master doesn't build with cmake.  This fix for the current compilation issues is in: #9321 (I'll rebase after it's merged).

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:NCCL)
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
## Comments ##
- @marcoabreu I noticed this is building with 72 threads on the current fleet.  Would this cause any issues with OOM errors?
  