### PR TITLE
Add clang jobs to the CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,6 +168,42 @@ try {
         }
       }
     },
+    'CPU: Clang 3.9': {
+      node('mxnetlinux-cpu') {
+        ws('workspace/build-cpu-clang') {
+          init_git()
+          def flag = """ \
+            USE_PROFILER=1                \
+            USE_CPP_PACKAGE=1             \
+            USE_BLAS=openblas             \
+            USE_OPENMP=0                  \
+            CXX=clang++-3.9               \
+            CC=clang-3.9                  \
+            -j\$(nproc)
+            """
+          make("cpu_clang", flag)
+          pack_lib('cpu_clang')
+        }
+      }
+    },
+    'CPU: Clang 5': {
+      node('mxnetlinux-cpu') {
+        ws('workspace/build-cpu-clang') {
+          init_git()
+          def flag = """ \
+            USE_PROFILER=1                \
+            USE_CPP_PACKAGE=1             \
+            USE_BLAS=openblas             \
+            USE_OPENMP=1                  \
+            CXX=clang++-5.0               \
+            CC=clang-5.0                  \
+            -j\$(nproc)
+            """
+          make("cpu_clang", flag)
+          pack_lib('cpu_clang')
+        }
+      }
+    },
     'CPU: MKLML': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-mklml-cpu') {

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -240,7 +240,7 @@ void Imread(const nnvm::NodeAttrs& attrs,
   Engine::Get()->PushSync([ndout, buff, fsize, param](RunContext ctx){
       ImdecodeImpl(param.flag, param.to_rgb, buff, fsize,
                    const_cast<NDArray*>(&ndout));
-      delete buff;
+      delete[] buff;
     }, ndout.ctx(), {}, {ndout.var()},
     FnProperty::kNormal, 0, PROFILER_MESSAGE("Imread"));
 #else

--- a/tests/ci_build/Dockerfile.cpu_clang
+++ b/tests/ci_build/Dockerfile.cpu_clang
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+
+COPY install/ubuntu_install_core.sh /install/
+RUN /install/ubuntu_install_core.sh
+COPY install/ubuntu_install_python.sh /install/
+RUN /install/ubuntu_install_python.sh
+COPY install/ubuntu_install_scala.sh /install/
+RUN /install/ubuntu_install_scala.sh
+COPY install/ubuntu_install_r.sh /install/
+RUN /install/ubuntu_install_r.sh
+COPY install/ubuntu_install_perl.sh /install/
+RUN /install/ubuntu_install_perl.sh
+
+# Install clang 3.9 (the same version as in XCode 8.*) and 5.0 (latest major release)
+RUN wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" && \
+    apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" && \
+    apt-get update && \
+    apt-get install -y clang-3.9 clang-5.0 && \
+    clang-3.9 --version && \
+    clang-5.0 --version


### PR DESCRIPTION
## Description ##
This PR adds a new job that tests the build with clang 3.8.  The hope is that it will catch any errors that could cause failing builds for users of clang (for example MacOS users).

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- We're still discussing this patch on the dev list.  Let's not merge until we've come to a consensus.  I'll update the PR when we do.
- I've turned off warnings as errors for this build.  Clang has few warnings that would fail the build, including some from external headers.
  