### PR TITLE
Temporarily disable test with failing http connection

### DIFF
--- a/R-package/tests/testthat/test_model.R
+++ b/R-package/tests/testthat/test_model.R
@@ -172,6 +172,7 @@ test_that("Fine-tune", {
 })                                       
 
 test_that("Matrix Factorization", {
+  skip("Disabled due to an unavailible http server.  Tracked here: https://git.io/vNkrE")
   GetMovieLens()
   DF <- read.table("./data/ml-100k/u.data", header = F, sep = "\t")
   names(DF) <- c("user", "item", "score", "time")


### PR DESCRIPTION
Disable test Matrix Factorization from the R package.

## Description ##
This PR disables another test which is failing due to a remote http call.  The site it's attempting to reach seems to be down globally.

Applicable Issue: #9332 

  