### PR TITLE
Update dependencies / Makefile + add Maven profile to support build with Scala 2.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 ROOTDIR = $(CURDIR)
 
+SCALA_VERSION_PROFILE := scala-2.11
+
 ifeq ($(OS),Windows_NT)
 	UNAME_S := Windows
 else
@@ -503,30 +505,30 @@ rpkgtest:
 
 scalaclean:
 	(cd $(ROOTDIR)/scala-package; \
-		mvn clean -P$(SCALA_PKG_PROFILE))
+		mvn clean -P$(SCALA_PKG_PROFILE),$(SCALA_VERSION_PROFILE))
 
 scalapkg:
 	(cd $(ROOTDIR)/scala-package; \
-		mvn package -P$(SCALA_PKG_PROFILE) -Dcxx="$(CXX)" \
+		mvn package -P$(SCALA_PKG_PROFILE),$(SCALA_VERSION_PROFILE) -Dcxx="$(CXX)" \
 			-Dcflags="$(CFLAGS)" -Dldflags="$(LDFLAGS)" \
 			-Dcurrent_libdir="$(ROOTDIR)/lib" \
 			-Dlddeps="$(LIB_DEP) $(ROOTDIR)/lib/libmxnet.a")
 
 scalatest:
 	(cd $(ROOTDIR)/scala-package; \
-		mvn verify -P$(SCALA_PKG_PROFILE) -Dcxx="$(CXX)" \
+		mvn verify -P$(SCALA_PKG_PROFILE),$(SCALA_VERSION_PROFILE) -Dcxx="$(CXX)" \
 			-Dcflags="$(CFLAGS)" -Dldflags="$(LDFLAGS)" \
 			-Dlddeps="$(LIB_DEP) $(ROOTDIR)/lib/libmxnet.a" $(SCALA_TEST_ARGS))
 
 scalainstall:
 	(cd $(ROOTDIR)/scala-package; \
-		mvn install -P$(SCALA_PKG_PROFILE) -DskipTests -Dcxx="$(CXX)" \
+		mvn install -P$(SCALA_PKG_PROFILE),$(SCALA_VERSION_PROFILE) -DskipTests -Dcxx="$(CXX)" \
 			-Dcflags="$(CFLAGS)" -Dldflags="$(LDFLAGS)" \
 			-Dlddeps="$(LIB_DEP) $(ROOTDIR)/lib/libmxnet.a")
 
 scaladeploy:
 	(cd $(ROOTDIR)/scala-package; \
-		mvn deploy -Prelease,$(SCALA_PKG_PROFILE) -DskipTests -Dcxx="$(CXX)" \
+		mvn deploy -Prelease,$(SCALA_PKG_PROFILE),$(SCALA_VERSION_PROFILE) -DskipTests -Dcxx="$(CXX)" \
 			-Dcflags="$(CFLAGS)" -Dldflags="$(LDFLAGS)" \
 			-Dlddeps="$(LIB_DEP) $(ROOTDIR)/lib/libmxnet.a")
 

--- a/scala-package/dev/change-scala-version.sh
+++ b/scala-package/dev/change-scala-version.sh
@@ -39,7 +39,10 @@ export -f sed_i
 BASEDIR=$(dirname $0)/..
 find "$BASEDIR" -name 'pom.xml' -not -path '*target*' -print \
   -exec bash -c "sed_i 's/\(artifactId.*\)_'$FROM_VERSION'/\1_'$TO_VERSION'/g' {}" \;
- 
+
+find "$BASEDIR/.." -name 'Makefile' -not -path '*target*' -print \
+  -exec bash -c "sed_i 's/'$FROM_VERSION'/'$TO_VERSION'/g' {}" \;
+
 # Also update <scala.binary.version> in parent POM
 # Match any scala binary version to ensure idempotency
 sed_i '1,/<scala\.binary\.version>[0-9]*\.[0-9]*</s/<scala\.binary\.version>[0-9]*\.[0-9]*</<scala.binary.version>'$TO_VERSION'</' \

--- a/scala-package/examples/pom.xml
+++ b/scala-package/examples/pom.xml
@@ -124,17 +124,17 @@
     <dependency>
       <groupId>com.sksamuel.scrimage</groupId>
       <artifactId>scrimage-core_2.11</artifactId>
-      <version>2.1.5</version>
+      <version>2.1.8</version>
     </dependency>
     <dependency>
       <groupId>com.sksamuel.scrimage</groupId>
       <artifactId>scrimage-io-extra_2.11</artifactId>
-      <version>2.1.5</version>
+      <version>2.1.8</version>
     </dependency>
     <dependency>
       <groupId>com.sksamuel.scrimage</groupId>
       <artifactId>scrimage-filters_2.11</artifactId>
-      <version>2.1.5</version>
+      <version>2.1.8</version>
     </dependency>
     <dependency>
       <groupId>nu.pattern</groupId>

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -112,6 +112,11 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>scala-2.11</id>
+    </profile>
+
     <profile>
       <id>scala-2.12</id>
       <properties>

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -112,6 +112,39 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>scala-2.12</id>
+      <properties>
+        <scala.version>2.12.4</scala.version>
+        <scala.binary.version>2.12</scala.binary.version>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-versions</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <bannedDependencies>
+                      <excludes combine.children="append">
+                        <exclude>*:*_2.11</exclude>
+                        <exclude>*:*_2.10</exclude>
+                      </excludes>
+                    </bannedDependencies>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
   <distributionManagement>
@@ -329,7 +362,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.binary.version}</artifactId>
-      <version>2.2.4</version>
+      <version>3.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -340,7 +373,7 @@
     <dependency>
       <groupId>org.scalacheck</groupId>
       <artifactId>scalacheck_${scala.binary.version}</artifactId>
-      <version>1.11.3</version>
+      <version>1.13.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -47,11 +47,6 @@
     </developer>
   </developers>
 
-  <properties>
-    <scala.version>2.11.8</scala.version>
-    <scala.binary.version>2.11</scala.binary.version>
-  </properties>
-
   <packaging>pom</packaging>
   <modules>
     <module>init</module>
@@ -115,6 +110,36 @@
 
     <profile>
       <id>scala-2.11</id>
+      <properties>
+        <scala.version>2.11.8</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-versions</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <bannedDependencies>
+                      <excludes combine.children="append">
+                        <exclude>*:*_2.12</exclude>
+                        <exclude>*:*_2.10</exclude>
+                      </excludes>
+                    </bannedDependencies>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
 
     <profile>

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -47,6 +47,11 @@
     </developer>
   </developers>
 
+  <properties>
+    <scala.version>2.11.8</scala.version>
+    <scala.binary.version>2.11</scala.binary.version>
+  </properties>
+
   <packaging>pom</packaging>
   <modules>
     <module>init</module>


### PR DESCRIPTION
## Description ##
Update Maven poms in MXNet scala-package and Makefile to enable build against Scala 2.12

## Checklist ##
### Essentials ###
Passes `make scalapkg` and `make scalatest` against Scala 2.11. 
Passes  `make scalapkg` and `make scalatest` against Scala 2.12 (see comments for details).

No changes to code, tests or examples.

### Changes ###
Update Maven poms in MXNet scala-package and Makefile to enable build against Scala 2.12

## Comments ##
To build / test against Scala 2.12: 
1) run ```dev/change-scala-version.sh 2.11 2.12```
2) modify the SCALA_VERSION_PROFILE var in Makefile (to scala-2.12)
3) Exclude spark target, as we are waiting on Spark / Scala 2.12 compatibility there.

