### PR TITLE
fix hard-coded in_channels in gluon model zoo resnet

### DIFF
--- a/python/mxnet/gluon/model_zoo/vision/resnet.py
+++ b/python/mxnet/gluon/model_zoo/vision/resnet.py
@@ -249,10 +249,9 @@ class ResNetV1(HybridBlock):
         with self.name_scope():
             self.features = nn.HybridSequential(prefix='')
             if thumbnail:
-                self.features.add(_conv3x3(channels[0], 1, 3))
+                self.features.add(_conv3x3(channels[0], 1, 0))
             else:
-                self.features.add(nn.Conv2D(channels[0], 7, 2, 3, use_bias=False,
-                                            in_channels=3))
+                self.features.add(nn.Conv2D(channels[0], 7, 2, 3, use_bias=False))
                 self.features.add(nn.BatchNorm())
                 self.features.add(nn.Activation('relu'))
                 self.features.add(nn.MaxPool2D(3, 2, 1))
@@ -306,10 +305,9 @@ class ResNetV2(HybridBlock):
             self.features = nn.HybridSequential(prefix='')
             self.features.add(nn.BatchNorm(scale=False, center=False))
             if thumbnail:
-                self.features.add(_conv3x3(channels[0], 1, 3))
+                self.features.add(_conv3x3(channels[0], 1, 0))
             else:
-                self.features.add(nn.Conv2D(channels[0], 7, 2, 3, use_bias=False,
-                                            in_channels=3))
+                self.features.add(nn.Conv2D(channels[0], 7, 2, 3, use_bias=False))
                 self.features.add(nn.BatchNorm())
                 self.features.add(nn.Activation('relu'))
                 self.features.add(nn.MaxPool2D(3, 2, 1))


### PR DESCRIPTION
## Description ##
Remove the hard-coded `in_channels=3` in resnet in gluon model zoo. Thanks @gmono for identifying the issue in #9336.
 
## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] For resnet v1 and v2, set `in_channels` to 0.

## Comments ##
- Fully backward compatible.
  