### PR TITLE
added mac gpu install; refactored windows install

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -730,7 +730,7 @@ Alternatively, you may follow the [CUDA installation instructions for macOS](htt
 
 3. Run `xcode-select --install` to install all command line tools, compilers, etc.
 
-4. Run sudo xcodebuild -license accept to accept Xcode's licensing terms.
+4. Run `sudo xcodebuild -license accept` to accept Xcode's licensing terms.
 
 5. Install CUDA for macOS. Specific steps are provided in NVIDIA's [CUDA installation instructions](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html#installation).
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -706,7 +706,7 @@ $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/inst
 $ export PATH=/usr/local/bin:/usr/local/sbin:$PATH
 
 # Install python development tools - python2.7, pip, python-setuptools
-$ brew install python
+$ brew install python pkg-config graphviz
 ```
 
 **Step 2**  Install optional components - OpenCV
@@ -721,18 +721,20 @@ brew install opencv
 
 **Step 3**  Install CUDA and cuDNN
 
-The following instructions are for CUDA 9.1 and cuDNN 7 for MacOS X 10.12+ and a CUDA-capable GPU. They summarize confirmed successful builds in [#9217](https://github.com/apache/incubator-mxnet/issues/9217).
-Alternatively, you may follow the [CUDA installation instructions for Mac OS X](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html).
+The following instructions are for CUDA 9.1 and cuDNN 7 for macOS 10.12+ and a CUDA-capable GPU. They summarize confirmed successful builds in [#9217](https://github.com/apache/incubator-mxnet/issues/9217).
+Alternatively, you may follow the [CUDA installation instructions for macOS](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html).
 
-1. [Download Xcode 8.3.3 from Apple](https://download.developer.apple.com/Developer_Tools/Xcode_8.3.3/Xcode8.3.3.xip). This is the version [NVIDIA specifies in its instructions for Mac OS X](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html). Unzip and rename to `Xcode8.3.3.app`.
+1. [Download Xcode 8.3.3 from Apple](https://developer.apple.com/download/more/). This is the version [NVIDIA specifies in its instructions for macOS](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html). Unzip and rename to `Xcode8.3.3.app`.
 
 2. Run `sudo xcode-select -s /Applications/Xcode8.3.3.app` or to wherever you have placed Xcode.
 
 3. Run `xcode-select --install` to install all command line tools, compilers, etc.
 
-4. Install CUDA for MacOS X. Specific steps are provided in NVIDIA's [CUDA installation instructions](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html#installation).
+4. Run sudo xcodebuild -license accept to accept Xcode's licensing terms.
 
-5. [Download](http://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#download-mac) and [install](http://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#installmac) cuDNN for MacOS X. You will need to [create a free developer account](https://developer.nvidia.com/accelerated-computing-developer) with NVIDIA prior to getting the download link.
+5. Install CUDA for macOS. Specific steps are provided in NVIDIA's [CUDA installation instructions](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html#installation).
+
+6. [Download](http://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#download-mac) and [install](http://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#installmac) cuDNN for macOS. You will need to [create a free developer account](https://developer.nvidia.com/accelerated-computing-developer) with NVIDIA prior to getting the download link.
 
 **Step 4**  Build MXNet
 
@@ -757,7 +759,7 @@ Alternatively, you may follow the [CUDA installation instructions for Mac OS X](
 
 7. Do `cd python`.
 
-8. Run `sudo python setup.py install`.
+8. Run `sudo pip install -e .` **Note**: the `.` is part of the command.
 
 </div>
 </div>

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -698,6 +698,29 @@ Try the **Build from Source** option for now.
 
 <div class="build-from-source">
 
+**Step 1**  Install prerequisites - Homebrew, python development tools.
+
+```bash
+# Install Homebrew
+$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+$ export PATH=/usr/local/bin:/usr/local/sbin:$PATH
+
+# Install python development tools - python2.7, pip, python-setuptools
+$ brew install python
+```
+
+**Step 2**  Install optional components - OpenCV
+
+If you want to use OpenCV you should install it first, then build MXNet with the `USE_OPENCV=1` option in the later steps.
+
+```bash
+brew tap homebrew/science
+brew install opencv
+
+```
+
+**Step 3**  Install CUDA and cuDNN
+
 The following instructions are for CUDA 9.1 and cuDNN 7 for MacOS X 10.12+ and a CUDA-capable GPU. They summarize confirmed successful builds in [#9217](https://github.com/apache/incubator-mxnet/issues/9217).
 Alternatively, you may follow the [CUDA installation instructions for Mac OS X](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html).
 
@@ -709,28 +732,32 @@ Alternatively, you may follow the [CUDA installation instructions for Mac OS X](
 
 4. Install CUDA for MacOS X. Specific steps are provided in NVIDIA's [CUDA installation instructions](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html#installation).
 
-5. Run `git clone --recursive https://github.com/apache/incubator-mxnet.git mxnet` to get the latest version.
+5. [Download](http://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#download-mac) and [install](http://docs.nvidia.com/deeplearning/sdk/cudnn-install/index.html#installmac) cuDNN for MacOS X. You will need to [create a free developer account](https://developer.nvidia.com/accelerated-computing-developer) with NVIDIA prior to getting the download link.
 
-6. Run `cd mxnet`.
+**Step 4**  Build MXNet
 
-7. Edit the `make/osx.mk` file to set the following parameters:
+1. Run `git clone --recursive https://github.com/apache/incubator-mxnet.git mxnet` to get the latest version.
+
+2. Run `cd mxnet`.
+
+3. Edit the `make/osx.mk` file to set the following parameters:
 
     ```
     USE_CUDA = 1
     USE_CUDA_PATH = /usr/local/cuda
     USE_CUDNN = 1
-    USE_OPENCV = 0
+    USE_OPENCV = 0   # set to 1 if you want to build with OpenCV
     ```
 
-8. Copy the `mxnet/make/osx.mk` to `mxnet/config.mk`
+4. Copy the `make/osx.mk` to `config.mk`
 
-9. Run `make`. If you previously attempted to compile you might want to do make clean_all first. You can also run `make -j` with the number of processors you have to compile with multithreading. There'll be plenty of warnings, but there should be no errors.
+5. Run `make`. If you previously attempted to compile you might want to do `make clean_all` first. You can also run `make -j` with the number of processors you have to compile with multithreading. There'll be plenty of warnings, but there should be no errors.
 
-10. Once finished, you should have a file called `libmxnet.so` in `mxnet/lib/`.
+6. Once finished, you should have a file called `libmxnet.so` in `lib/`.
 
-11. Do `cd python`.
+7. Do `cd python`.
 
-12. Run `sudo python setup.py install`.
+8. Run `sudo python setup.py install`.
 
 </div>
 </div>
@@ -1036,9 +1063,9 @@ These commands produce a library called ```mxnet.dll``` in the ```./build/Releas
 
 
 &nbsp;
-Next, we install ```graphviz``` library that we use for visualizing network graphs you build on MXNet. We will also install [Jupyter Notebook](http://jupyter.readthedocs.io/)  used for running MXNet tutorials and examples.
-- Install ```graphviz``` by downloading MSI installer from [Graphviz Download Page](https://graphviz.gitlab.io/_pages/Download/Download_windows.html).
-**Note** Make sure to add graphviz executable path to PATH environment variable. Refer [here for more details](http://stackoverflow.com/questions/35064304/runtimeerror-make-sure-the-graphviz-executables-are-on-your-systems-path-aft)
+Next, we install the ```graphviz``` library that we use for visualizing network graphs that you build on MXNet. We will also install [Jupyter Notebook](http://jupyter.readthedocs.io/) which is used for running MXNet tutorials and examples.
+- Install the ```graphviz``` by downloading the installer from the [Graphviz Download Page](https://graphviz.gitlab.io/_pages/Download/Download_windows.html).
+**Note** Make sure to add the `graphviz` executable path to the PATH environment variable. Refer [here for more details](http://stackoverflow.com/questions/35064304/runtimeerror-make-sure-the-graphviz-executables-are-on-your-systems-path-aft)
 
 
 &nbsp;

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -44,7 +44,7 @@ Indicate your preferred configuration. Then, follow the customized commands to i
 
 <!-- Linux Python GPU Options -->
 
-<div class="linux macos">
+<div class="linux macos windows">
 <div class="python">
 <div class="cpu gpu">
 <div class="btn-group opt-group" role="group">
@@ -689,11 +689,50 @@ $ bash install-mxnet-osx-python.sh
   <div class="python">
     <div class="gpu">
 
-More details and verified installation instructions for macOS, with GPUs, coming soon.
+<div class="pip virtualenv docker">
+</br>
 
+Try the **Build from Source** option for now.
 
-*MXNet* is expected to be compatible on macOS with NVIDIA GPUs. Please install CUDA 9.0 and cuDNN 7, prior to installing GPU version of *MXNet*.
+</div>
 
+<div class="build-from-source">
+
+The following instructions are for CUDA 9.1 and cuDNN 7 for MacOS X 10.12+ and a CUDA-capable GPU. They summarize confirmed successful builds in [#9217](https://github.com/apache/incubator-mxnet/issues/9217).
+Alternatively, you may follow the [CUDA installation instructions for Mac OS X](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html).
+
+1. [Download Xcode 8.3.3 from Apple](https://download.developer.apple.com/Developer_Tools/Xcode_8.3.3/Xcode8.3.3.xip). This is the version [NVIDIA specifies in its instructions for Mac OS X](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html). Unzip and rename to `Xcode8.3.3.app`.
+
+2. Run `sudo xcode-select -s /Applications/Xcode8.3.3.app` or to wherever you have placed Xcode.
+
+3. Run `xcode-select --install` to install all command line tools, compilers, etc.
+
+4. Install CUDA for MacOS X. Specific steps are provided in NVIDIA's [CUDA installation instructions](https://docs.nvidia.com/cuda/cuda-installation-guide-mac-os-x/index.html#installation).
+
+5. Run `git clone --recursive https://github.com/apache/incubator-mxnet.git mxnet` to get the latest version.
+
+6. Run `cd mxnet`.
+
+7. Edit the `make/osx.mk` file to set the following parameters:
+
+    ```
+    USE_CUDA = 1
+    USE_CUDA_PATH = /usr/local/cuda
+    USE_CUDNN = 1
+    USE_OPENCV = 0
+    ```
+
+8. Copy the `mxnet/make/osx.mk` to `mxnet/config.mk`
+
+9. Run `make`. If you previously attempted to compile you might want to do make clean_all first. You can also run `make -j` with the number of processors you have to compile with multithreading. There'll be plenty of warnings, but there should be no errors.
+
+10. Once finished, you should have a file called `libmxnet.so` in `mxnet/lib/`.
+
+11. Do `cd python`.
+
+12. Run `sudo python setup.py install`.
+
+</div>
 </div>
 </div>
 </div>
@@ -938,11 +977,93 @@ Follow the installation instructions [in this guide](./osx_setup.md) to set up M
 </div>
 
 <div class="windows">
-  <div class="python scala julia perl">
-    <div class="gpu">
+  <div class="python">
+  <div class="cpu">
+  <div class="pip">
+<br/>
+
+**Step 1**  Install Python.
+
+[Anaconda](https://www.anaconda.com/download/) is recommended.
+
+**Step 2**  Install *MXNet*.
+
+```bash
+$ pip install mxnet
+```
+
+</div>
+</div>
+
+  <div class="gpu">
+
+<div class="pip">
+<br/>
+
+**Step 1**  Install Python.
+
+[Anaconda](https://www.anaconda.com/download/) is recommended.
+
+**Step 2**  Install *MXNet* with GPU support using CUDA 9.0.
+
+```bash
+$ pip install mxnet-cu90
+```
+
+Refer to [#8671](https://github.com/apache/incubator-mxnet/issues/8671) for status on CUDA 9.1 support.
+
+</div>
+<div class="build-from-source">
+<br/>
+To build and install MXNet yourself, you need the following dependencies. Install the required dependencies:
+
+1. If [Microsoft Visual Studio 2015](https://www.visualstudio.com/downloads/) is not already installed, download and install it. You can download and install the free community edition.
+2. Download and install [CMake](https://cmake.org/) if it is not already installed.
+3. Download and install [OpenCV](http://sourceforge.net/projects/opencvlibrary/files/opencv-win/3.0.0/opencv-3.0.0.exe/download).
+4. Unzip the OpenCV package.
+5. Set the environment variable ```OpenCV_DIR``` to point to the ```OpenCV build directory```.
+6. If you don't have the Intel Math Kernel Library (MKL) installed, download and install [OpenBlas](http://sourceforge.net/projects/openblas/files/v0.2.14/).
+7. Set the environment variable ```OpenBLAS_HOME``` to point to the ```OpenBLAS``` directory that contains the ```include``` and ```lib``` directories. Typically, you can find the directory in ```C:\Program files (x86)\OpenBLAS\```.
+8. Download and install [CUDA](https://developer.nvidia.com/cuda-downloads?target_os=Windows&target_arch=x86_64) and [cuDNN](https://developer.nvidia.com/cudnn). To get access to the download link, register as an NVIDIA community user.
+
+After you have installed all of the required dependencies, build the MXNet source code:
+
+1. Download the MXNet source code from [GitHub](https://github.com/apache/incubator-mxnet).
+2. Use [CMake](https://cmake.org/) to create a Visual Studio solution in ```./build```.
+3. In Visual Studio, open the solution file,```.sln```, and compile it.
+These commands produce a library called ```mxnet.dll``` in the ```./build/Release/``` or ```./build/Debug``` folder.
+
+
+
+&nbsp;
+Next, we install ```graphviz``` library that we use for visualizing network graphs you build on MXNet. We will also install [Jupyter Notebook](http://jupyter.readthedocs.io/)  used for running MXNet tutorials and examples.
+- Install ```graphviz``` by downloading MSI installer from [Graphviz Download Page](https://graphviz.gitlab.io/_pages/Download/Download_windows.html).
+**Note** Make sure to add graphviz executable path to PATH environment variable. Refer [here for more details](http://stackoverflow.com/questions/35064304/runtimeerror-make-sure-the-graphviz-executables-are-on-your-systems-path-aft)
+
+
+&nbsp;
+</div>
+</div>
+</div>
+
+<div class="windows">
+  <div class="scala julia perl">
+    <div class="cpu gpu">
 
 Follow the installation instructions [in this guide](./windows_setup.md) to set up MXNet.
 
+</div>
+</div>
+</div>
+
+<div class="windows">
+  <div class="python">
+    <div class="cpu">
+      <div class="virtualenv docker build-from-source">
+
+Follow the installation instructions [in this guide](./windows_setup.md) to set up MXNet.
+
+</div>
 </div>
 </div>
 </div>
@@ -1012,7 +1133,7 @@ If you are getting build errors in which the compiler is being killed, it is lik
 
 **Step 2** Install MXNet Python Bindings
 
-To install python bindings run the following commands in the MXNet directory:
+To install Python bindings run the following commands in the MXNet directory:
 
 ```bash
     cd python
@@ -1094,7 +1215,7 @@ Executing this command creates a file called ```libmxnet.so``` in the mxnet/lib 
 
 **Step 2** Install MXNet Python Bindings
 
-To install python bindings run the following commands in the MXNet directory:
+To install Python bindings run the following commands in the MXNet directory:
 
 ```bash
     cd python
@@ -1119,6 +1240,9 @@ You are now ready to run MXNet on your NVIDIA Jetson TX2 device.
 </div>
 
 <br/>
+
+<!-- This # tag restarts the page and allows reuse
+ of the div classes for validation sections, etc -->
 
 # Validate MXNet Installation
 
@@ -1179,6 +1303,75 @@ Run a short *MXNet* python program to create a 2X3 matrix of ones, multiply each
 array([[ 3.,  3.,  3.],
        [ 3.,  3.,  3.]], dtype=float32)
 ```
+</div>
+</div>
+</div>
+
+<!-- Validate Windows CPU pip install -->
+
+<div class="windows">
+  <div class="python">
+    <div class="cpu">
+      <div class="pip">
+
+Run a short *MXNet* python program to create a 2X3 matrix of ones, multiply each element in the matrix by 2 followed by adding 1. We expect the output to be a 2X3 matrix with all elements being 3.
+
+```python
+>>> import mxnet as mx
+>>> a = mx.nd.ones((2, 3))
+>>> b = a * 2 + 1
+>>> b.asnumpy()
+array([[ 3.,  3.,  3.],
+       [ 3.,  3.,  3.]], dtype=float32)
+```
+
+</div>
+</div>
+</div>
+</div>
+
+<!-- Mac OS GPU installation validation -->
+
+<div class="macos">
+  <div class="python">
+    <div class="gpu">
+
+<div class="pip virtualenv docker">
+</br>
+
+Will be available soon.
+
+</div>
+
+<div class="build-from-source">
+</br>
+
+From the MXNet root directory run: `python example/image-classification/train_mnist.py --network lenet --gpus 0` to test GPU training.
+
+</div>
+</div>
+</div>
+</div>
+
+<!-- Windows GPU installation validation -->
+
+<div class="windows">
+  <div class="python">
+    <div class="gpu">
+
+<div class="virtualenv docker">
+</br>
+
+Will be available soon.
+
+</div>
+
+<div class="pip build-from-source">
+</br>
+
+From the MXNet root directory run: `python example/image-classification/train_mnist.py --network lenet --gpus 0` to test GPU training.
+
+</div>
 </div>
 </div>
 </div>
@@ -1246,15 +1439,10 @@ array([[ 3.,  3.,  3.],
 </div>
 </div>
 
-<div class="macos">
-  <div class="python">
-    <div class="gpu">
 
-More details and verified validation instructions for macOS, with GPUs, coming soon.
 
-</div>
-</div>
-</div>
+
+
 
 <!-- Linux Clean up -->
 <div class="linux">
@@ -1450,77 +1638,28 @@ Will be available soon.
 </div>
 </div>
 
+<!-- Windows MXNet Installation validation -->
 <div class="windows">
   <div class="python">
-  <div class="cpu">
-  </div>
-    <div class="gpu">
+    <div class="cpu">
 
-
-**Prerequisites**
-
-Install the following NVIDIA libraries to setup *MXNet* with GPU support:
-
-1. Install CUDA 9.0 following the NVIDIA's [installation guide](http://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows).
-2. Install cuDNN 7 for CUDA 9.0 following the NVIDIA's [installation guide](https://developer.nvidia.com/cudnn). You may need to register with NVIDIA for downloading the cuDNN library.
-
-**Note:** Make sure to add CUDA install path to `PATH`.
-
-<div class="pip">
+<div class="build-from-source virtualenv docker">
 <br/>
-
-**Step 1**  Install python.
-
-Recommend install ```Anaconda3``` [here](https://www.anaconda.com/download/)
-
-**Step 2**  Install *MXNet* with GPU support using CUDA 9.0
-
-```bash
-$ pip install mxnet-cu90
-```
-
-</div>
-<div class="build-from-source">
-<br/>
-To build and install MXNet yourself, you need the following dependencies. Install the required dependencies:
-
-1. If [Microsoft Visual Studio 2015](https://www.visualstudio.com/downloads/) is not already installed, download and install it. You can download and install the free community edition.
-2. Download and Install [CMake](https://cmake.org/) if it is not already installed.
-3. Download and install [OpenCV](http://sourceforge.net/projects/opencvlibrary/files/opencv-win/3.0.0/opencv-3.0.0.exe/download).
-4. Unzip the OpenCV package.
-5. Set the environment variable ```OpenCV_DIR``` to point to the ```OpenCV build directory```.
-6. If you don't have the Intel Math Kernel Library (MKL) installed, download and install [OpenBlas](http://sourceforge.net/projects/openblas/files/v0.2.14/).
-7. Set the environment variable ```OpenBLAS_HOME``` to point to the ```OpenBLAS``` directory that contains the ```include``` and ```lib``` directories. Typically, you can find the directory in ```C:\Program files (x86)\OpenBLAS\```.
-8. Download and install [CuDNN](https://developer.nvidia.com/cudnn). To get access to the download link, register as an NVIDIA community user.
-
-After you have installed all of the required dependencies, build the MXNet source code:
-
-1. Download the MXNet source code from [GitHub](https://github.com/apache/incubator-mxnet).
-2. Use [CMake](https://cmake.org/) to create a Visual Studio solution in ```./build```.
-3. In Visual Studio, open the solution file,```.sln```, and compile it.
-These commands produce a library called ```mxnet.dll``` in the ```./build/Release/``` or ```./build/Debug``` folder.
-
-
-
-&nbsp;
-Next, we install ```graphviz``` library that we use for visualizing network graphs you build on MXNet. We will also install [Jupyter Notebook](http://jupyter.readthedocs.io/)  used for running MXNet tutorials and examples.
-- Install ```graphviz``` by downloading MSI installer from [Graphviz Download Page](https://graphviz.gitlab.io/_pages/Download/Download_windows.html).
-**Note** Make sure to add graphviz executable path to PATH environment variable. Refer [here for more details](http://stackoverflow.com/questions/35064304/runtimeerror-make-sure-the-graphviz-executables-are-on-your-systems-path-aft)
-
-
-&nbsp;
+Will be available soon.
 </div>
 
-  </div>
-  </div>
-    <div class="scala julia perl">
-    <div class="cpu gpu">
+</div>
+</div>
+
+<div class="scala julia perl">
+<div class="cpu gpu">
 
 Will be available soon.
 
-  </div>
-  </div>
 </div>
+</div>
+</div>
+<!-- End Windows Installation validation -->
 
 <div class="devices">
   <div class="raspberry-pi">


### PR DESCRIPTION
## Description ##
- Fixed install selector issues where certain Windows instructions were failing to appear.
- Added Mac OS GPU installation info

The install page is far from ideal - super difficult to maintain - but this should at least improve usability.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
Out of the scope of this PR.
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Windows
   - Fixed config so Windows pip, virtualenv, docker, and build from source selector appears.
   - Windows > Python > GPU > build from source instructions are available now under the appropriate heading.
   - Windows > Python > CPU > pip install added
- Mac
   - Mac > Python > GPU > Build from Source - Added Mac OS X GPU build from source instructions.
- Various adjustments to repair validation sections.

## Comments ##
Documents #9217 for at least a non-OpenCV build. Mac + GPU + OpenCV is uncertain.
Fixes #9146 (broken selector)

Existing PR #8619 - will need to rebase with this update and should probably just add updated installation info to the existing section in this file instead of the separate windows_setup.md file.

Windows CPU Build From Source needs validation and improved information since the existing docs really seem to focus on GPU builds only.
