### PR TITLE
Refactor dropout operator to use ParallelRandom generator and also react deterministically when seeding

### DIFF
--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -99,7 +99,7 @@ class DropoutOp : public Operator {
                                          const double pkeep,
                                          const std::vector<TBlob> &in_data,
                                          const std::vector<TBlob> &out_data) {
-    // BernoulliGenerate expects an array int, so for types smaller than int, the mast buffer
+    // BernoulliGenerate expects an array int, so for types smaller than int, the mask buffer
     // will be too small, so we can;t use MKL in those cases
     if (sizeof(DType) >= sizeof(int)) {
       Tensor<xpu, 2, DType> mask = out_data[dropout::kMask].FlatTo2D<xpu, DType>(s);

--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -34,9 +34,9 @@
 #include <string>
 #include <utility>
 #include <algorithm>
-#include "../../engine/openmp.h"
-#include "../operator_common.h"
+#include "../mxnet_op.h"
 #include "../mshadow_op.h"
+#include "../random/sampler.h"
 
 #if defined(USE_MKL) && defined(_OPENMP)
 #include <omp.h>
@@ -54,28 +54,6 @@ enum DropoutOpMode {kTraining, kAlways};
 
 namespace mxnet {
 namespace op {
-
-#if defined(USE_MKL) && defined(_OPENMP)
-static void bernoulli_generate(int n, double p, int* r) {
-  const int seed = 17 + rand() % 4096;  // NOLINT(runtime/threadsafe_fn)
-  const int nthr = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
-# pragma omp parallel num_threads(nthr)
-  {
-    const int ithr = omp_get_thread_num();
-    const int avg_amount = (n + nthr - 1) / nthr;
-    const int my_offset = ithr * avg_amount;
-    const int my_amount = std::min(my_offset + avg_amount, n) - my_offset;
-    if (my_amount > 0) {
-      VSLStreamStatePtr stream;
-      vslNewStream(&stream, VSL_BRNG_MCG31, seed);
-      vslSkipAheadStream(stream, my_offset);
-      viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF, stream, my_amount,
-        r + my_offset, p);
-      vslDeleteStream(&stream);
-    }
-  }
-}
-#endif  // USE_MKL && _OPENMP
 
 struct DropoutParam : public dmlc::Parameter<DropoutParam> {
   float p;
@@ -95,9 +73,40 @@ struct DropoutParam : public dmlc::Parameter<DropoutParam> {
 template<typename xpu, typename DType>
 class DropoutOp : public Operator {
  public:
+  /*!
+   * \brief Dropout kernel, compute dropout tensor
+   */
+  struct DropoutKernel {
+    /*!
+     * \brief Dropout kernel function
+     * \param id Thread number (0-based representing count)
+     * \param gen Random number generator
+     * \param N Total number of items in the output
+     * \param step Step between items, related to parallelism
+     * \param dropout_out Output dropout values
+     * \param mask_out  Output mask (is multiplied to create dropout output, may be 0)
+     * \param input_data Input data to perform the dropout on
+     * \param pkeep Dropout rate (keep when the generated random number is less than this value)
+     */
+    MSHADOW_XINLINE static void Map(int id,
+                                    RandGenerator<xpu, DType> gen,
+                                    const int N,
+                                    const int step,
+                                    DType *dropout_out,
+                                    DType *mask_out,
+                                    const DType *input_data,
+                                    const real_t pkeep) {
+      RNG_KERNEL_LOOP(xpu, DType, id, gen, N, step, {
+        const real_t rand_num = static_cast<real_t>(genImpl.uniform());
+        mask_out[i] = mshadow_op::threshold::Map<real_t>(rand_num, pkeep) * (1.0f / pkeep);
+        dropout_out[i] = input_data[i] * mask_out[i];
+      });
+    }
+  };
+
   explicit DropoutOp(DropoutParam param) {
     this->pkeep_ = 1.0f - param.p;
-    this->mode_ = param.mode;
+    this->mode_ = static_cast<dropout::DropoutOpMode>(param.mode);
   }
 
   virtual void Forward(const OpContext &ctx,
@@ -105,36 +114,34 @@ class DropoutOp : public Operator {
                        const std::vector<OpReqType> &req,
                        const std::vector<TBlob> &out_data,
                        const std::vector<TBlob> &aux_states) {
-    using namespace mshadow;
-    using namespace mshadow::expr;
-    CHECK_EQ(in_data.size(), 1U);
-    if (ctx.is_train) {
-      CHECK_EQ(out_data.size(), 2U);
-    }
-    Stream<xpu> *s = ctx.get_stream<xpu>();
-    Tensor<xpu, 2, DType> data = in_data[dropout::kData].FlatTo2D<xpu, DType>(s);
-    Tensor<xpu, 2, DType> out = out_data[dropout::kOut].FlatTo2D<xpu, DType>(s);
-    if (ctx.is_train || mode_ == dropout::kAlways) {
-      Tensor<xpu, 2, DType> mask = out_data[dropout::kMask].FlatTo2D<xpu, DType>(s);
-#if !defined(__CUDACC__) && defined(USE_MKL) && defined(_OPENMP)
-      DType* outptr = out.dptr_;
-      DType* dataptr = data.dptr_;
-      auto maskptr = reinterpret_cast<int*>(mask.dptr_);
-      int count = mask.shape_[0]*mask.shape_[1];
-      bernoulli_generate(count, this->pkeep_, maskptr);
-      const float pk_1 = 1.0f / pkeep_;
-      #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
-      for (int i = 0; i < count; ++i) {
-        outptr[i] = dataptr[i] * maskptr[i] * pk_1;
+    if(req[dropout::kOut] != kNullOp) {
+      CHECK_EQ(in_data.size(), 1U);
+      if (ctx.is_train) {
+        CHECK_EQ(out_data.size(), 2U);
       }
-#else
-      Random<xpu> *prnd = ctx.requested[dropout::kRandom].get_random<xpu, real_t>(s);
-      mask = tcast<DType>(F<mshadow_op::threshold>(
-             prnd->uniform(mask.shape_), pkeep_) * (1.0f / pkeep_));
-      Assign(out, req[dropout::kOut], data * mask);
-#endif  // USE_MKL && _OPENMP
-    } else {
-      Assign(out, req[dropout::kOut], F<mshadow_op::identity>(data));
+      Stream<xpu> *s = ctx.get_stream<xpu>();
+      const TBlob &out = out_data[dropout::kOut];
+      if (ctx.is_train || mode_ == dropout::kAlways) {
+        const TBlob &mask = out_data[dropout::kMask];
+        CHECK(req[dropout::kOut] != kAddTo);
+        RandGenerator<xpu, DType> *pgen = ctx.requested[0].get_parallel_random<xpu, DType>();
+        LaunchRNG<DropoutKernel, xpu>(s, pgen, out.Size(),
+                                      out.dptr<DType>(),
+                                      mask.dptr<DType>(),
+                                      in_data[dropout::kData].dptr<DType>(),
+                                      this->pkeep_);
+
+      } else {
+        const TBlob& data = in_data[dropout::kData];
+        if(req[dropout::kOut] == kWriteTo) {
+          mxnet_op::copy(s, out, data);
+        } else {
+          MXNET_ASSIGN_REQ_SWITCH(req[dropout::kOut], Req, {
+            mxnet_op::Kernel<mxnet_op::op_with_req<mshadow_op::identity, Req>, xpu>::Launch(
+              s, out.Size(), out.dptr<DType>(), data.dptr<DType>());
+          });
+        }
+      }
     }
   }
 
@@ -150,32 +157,32 @@ class DropoutOp : public Operator {
     CHECK_EQ(out_grad.size(), 1U);
     CHECK_EQ(in_grad.size(), 1U);
     Stream<xpu> *s = ctx.get_stream<xpu>();
-    Tensor<xpu, 2, DType> grad = out_grad[dropout::kOut].FlatTo2D<xpu, DType>(s);
-    Tensor<xpu, 2, DType> mask = out_data[dropout::kMask].FlatTo2D<xpu, DType>(s);
-    Tensor<xpu, 2, DType> gdata = in_grad[dropout::kData].FlatTo2D<xpu, DType>(s);
+    const TBlob& gdata = in_grad[dropout::kData];
+    const TBlob& grad = out_grad[dropout::kOut];
     if (ctx.is_train || mode_ == dropout::kAlways) {
-#if !defined(__CUDACC__) && defined(USE_MKL) && defined(_OPENMP)
-      DType* ingradptr = gdata.dptr_;
-      DType* outgradptr = grad.dptr_;
-      auto maskptr = reinterpret_cast<int*>(mask.dptr_);
-      int count = mask.shape_[0]*mask.shape_[1];
-      const float pk_1 = 1.0f / pkeep_;
-      #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
-      for (int i = 0; i < count; ++i) {
-        ingradptr[i] = outgradptr[i] * maskptr[i] * pk_1;
-      }
-#else  // USE_MKL && _OPENMP
-      CHECK_EQ(grad.shape_.Size(), mask.shape_.Size());
-      Assign(gdata, req[dropout::kData], grad * mask);
-#endif  // USE_MKL && _OPENMP
+      const TBlob& mask = out_data[dropout::kMask];
+      CHECK_EQ(grad.Size(), mask.Size());
+      MXNET_ASSIGN_REQ_SWITCH(req[dropout::kData], Req, {
+        mxnet_op::Kernel<mxnet_op::op_with_req<mshadow_op::mul, Req>, xpu>::Launch(
+          s, gdata.Size(), gdata.dptr<DType>(), grad.dptr<DType>(), mask.dptr<DType>());
+      });
     } else {
-      Assign(gdata, req[dropout::kData], F<mshadow_op::identity>(grad));
+      if(req[dropout::kData] == kWriteTo) {
+        mxnet_op::copy(s, gdata, grad);
+      } else {
+        MXNET_ASSIGN_REQ_SWITCH(req[dropout::kData], Req, {
+          mxnet_op::Kernel<mxnet_op::op_with_req<mshadow_op::identity, Req>, xpu>::Launch(
+            s, gdata.Size(), gdata.dptr<DType>(), grad.dptr<DType>());
+        });
+      }
     }
   }
 
  private:
+  /*! \brief Dropout rate (keep when the generated random number is less than this value) */
   real_t pkeep_;
-  int mode_;
+  /*! \brief Dropout mode */
+  dropout::DropoutOpMode mode_;
 };  // class DropoutOp
 
 
@@ -254,9 +261,8 @@ class DropoutProp : public OperatorProperty {
     return {{in_data[dropout::kData], out_data[dropout::kOut]}};
   }
 
-  std::vector<ResourceRequest> ForwardResource(
-    const std::vector<TShape> &in_shape) const override {
-    return {ResourceRequest::kRandom};
+  std::vector<ResourceRequest> ForwardResource(const std::vector<TShape> &in_shape) const override {
+    return { ResourceRequest::kParallelRandom };
   }
 
   int NumVisibleOutputs() const override {

--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -72,6 +72,29 @@ struct DropoutParam : public dmlc::Parameter<DropoutParam> {
 
 template<typename xpu, typename DType>
 class DropoutOp : public Operator {
+#if defined(USE_MKL) && defined(_OPENMP)
+  static void bernoulli_generate(common::random::RandGenerator<cpu, DType> gen,
+                                 int n, double p, int* r) {
+    typename RandGenerator<xpu, DType>::Impl genImpl(&gen, 1);
+    const int seed = 17 + genImpl.rand() % 4096;  // NOLINT(runtime/threadsafe_fn)
+    const int nthr = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
+#pragma omp parallel num_threads(nthr)
+    {
+      const int ithr = omp_get_thread_num();
+      const int avg_amount = (n + nthr - 1) / nthr;
+      const int my_offset = ithr * avg_amount;
+      const int my_amount = std::min(my_offset + avg_amount, n) - my_offset;
+      if (my_amount > 0) {
+        VSLStreamStatePtr stream;
+        vslNewStream(&stream, VSL_BRNG_MCG31, seed + my_offset);
+        vslSkipAheadStream(stream, my_offset);
+        viRngBernoulli(VSL_RNG_METHOD_BERNOULLI_ICDF, stream, my_amount, r + my_offset, p);
+        vslDeleteStream(&stream);
+      }
+    }
+  }
+#endif  // defined(USE_MKL) && defined(_OPENMP) && defined(MKL_DROPOUT)
+
  public:
   /*!
    * \brief Dropout kernel, compute dropout tensor
@@ -122,15 +145,31 @@ class DropoutOp : public Operator {
       Stream<xpu> *s = ctx.get_stream<xpu>();
       const TBlob &out = out_data[dropout::kOut];
       if (ctx.is_train || mode_ == dropout::kAlways) {
+        RandGenerator<xpu, DType> *pgen = ctx.requested[0].get_parallel_random<xpu, DType>();
+        CHECK_NOTNULL(pgen);
+#if !defined(__CUDACC__) && defined(USE_MKL) && defined(_OPENMP)
+        Tensor<xpu, 2, DType> mask = out_data[dropout::kMask].FlatTo2D<xpu, DType>(s);
+        Tensor<xpu, 2, DType> data = in_data[dropout::kData].FlatTo2D<xpu, DType>(s);
+        Tensor<xpu, 2, DType> out = out_data[dropout::kOut].FlatTo2D<xpu, DType>(s);
+        DType* outptr = out.dptr_;
+        DType* dataptr = data.dptr_;
+        auto maskptr = reinterpret_cast<int*>(mask.dptr_);
+        int count = mask.shape_[0]*mask.shape_[1];
+        bernoulli_generate(*pgen, count, this->pkeep_, maskptr);
+        const float pk_1 = 1.0f / pkeep_;
+        #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+        for (int i = 0; i < count; ++i) {
+          outptr[i] = dataptr[i] * maskptr[i] * pk_1;
+        }
+#else  // MKL
         const TBlob &mask = out_data[dropout::kMask];
         CHECK(req[dropout::kOut] != kAddTo);
-        RandGenerator<xpu, DType> *pgen = ctx.requested[0].get_parallel_random<xpu, DType>();
         LaunchRNG<DropoutKernel, xpu>(s, pgen, out.Size(),
                                       out.dptr<DType>(),
                                       mask.dptr<DType>(),
                                       in_data[dropout::kData].dptr<DType>(),
                                       this->pkeep_);
-
+#endif  // MKL
       } else {
         const TBlob& data = in_data[dropout::kData];
         if (req[dropout::kOut] == kWriteTo) {
@@ -157,16 +196,33 @@ class DropoutOp : public Operator {
     CHECK_EQ(out_grad.size(), 1U);
     CHECK_EQ(in_grad.size(), 1U);
     Stream<xpu> *s = ctx.get_stream<xpu>();
-    const TBlob& gdata = in_grad[dropout::kData];
-    const TBlob& grad = out_grad[dropout::kOut];
     if (ctx.is_train || mode_ == dropout::kAlways) {
+#if !defined(__CUDACC__) && defined(USE_MKL) && defined(_OPENMP)
+      Tensor<xpu, 2, DType> grad = out_grad[dropout::kOut].FlatTo2D<xpu, DType>(s);
+      Tensor<xpu, 2, DType> mask = out_data[dropout::kMask].FlatTo2D<xpu, DType>(s);
+      Tensor<xpu, 2, DType> gdata = in_grad[dropout::kData].FlatTo2D<xpu, DType>(s);
+      DType* ingradptr = gdata.dptr_;
+      const DType* outgradptr = grad.dptr_;
+      auto maskptr = reinterpret_cast<int*>(mask.dptr_);
+      int count = mask.shape_[0]*mask.shape_[1];
+      const float pk_1 = 1.0f / pkeep_;
+#pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+      for (int i = 0; i < count; ++i) {
+        ingradptr[i] = outgradptr[i] * maskptr[i] * pk_1;
+      }
+#else  // MKL
+      const TBlob& gdata = in_grad[dropout::kData];
+      const TBlob& grad = out_grad[dropout::kOut];
       const TBlob& mask = out_data[dropout::kMask];
       CHECK_EQ(grad.Size(), mask.Size());
       MXNET_ASSIGN_REQ_SWITCH(req[dropout::kData], Req, {
         mxnet_op::Kernel<mxnet_op::op_with_req<mshadow_op::mul, Req>, xpu>::Launch(
           s, gdata.Size(), gdata.dptr<DType>(), grad.dptr<DType>(), mask.dptr<DType>());
       });
+#endif  // MKL
     } else {
+      const TBlob& gdata = in_grad[dropout::kData];
+      const TBlob& grad = out_grad[dropout::kOut];
       if (req[dropout::kData] == kWriteTo) {
         mxnet_op::copy(s, gdata, grad);
       } else {

--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -93,7 +93,86 @@ class DropoutOp : public Operator {
       }
     }
   }
-#endif  // defined(USE_MKL) && defined(_OPENMP) && defined(MKL_DROPOUT)
+
+  // MKL forward pass
+  static bool MSHADOW_CINLINE MKLForward(mshadow::Stream<cpu> *s, RandGenerator<cpu, DType> *pgen,
+                                         const double pkeep,
+                                         const std::vector<TBlob> &in_data,
+                                         const std::vector<TBlob> &out_data) {
+    // BernoulliGenerate expects an array int, so for types smaller than int, the mast buffer
+    // will be too small, so we can;t use MKL in those cases
+    if (sizeof(DType) >= sizeof(int)) {
+      Tensor<xpu, 2, DType> mask = out_data[dropout::kMask].FlatTo2D<xpu, DType>(s);
+      Tensor<xpu, 2, DType> data = in_data[dropout::kData].FlatTo2D<xpu, DType>(s);
+      Tensor<xpu, 2, DType> out = out_data[dropout::kOut].FlatTo2D<xpu, DType>(s);
+      DType *outptr = out.dptr_;
+      DType *dataptr = data.dptr_;
+      auto maskptr = reinterpret_cast<int *>(mask.dptr_);
+      int count = mask.shape_[0] * mask.shape_[1];
+      BernoulliGenerate(*pgen, count, pkeep, maskptr);
+      const float pk_1 = 1.0f / pkeep;
+#pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+      for (int i = 0; i < count; ++i) {
+        outptr[i] = dataptr[i] * maskptr[i] * pk_1;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  // MKL backward pass
+  static bool MSHADOW_CINLINE MKLBackward(mshadow::Stream<cpu> *s, const double pkeep,
+                                          const std::vector<TBlob> &in_grad,
+                                          const std::vector<TBlob> &out_data,
+                                          const std::vector<TBlob> &out_grad) {
+    if (sizeof(DType) >= sizeof(int)) {
+      Tensor<xpu, 2, DType> grad = out_grad[dropout::kOut].FlatTo2D<xpu, DType>(s);
+      Tensor<xpu, 2, DType> mask = out_data[dropout::kMask].FlatTo2D<xpu, DType>(s);
+      Tensor<xpu, 2, DType> gdata = in_grad[dropout::kData].FlatTo2D<xpu, DType>(s);
+      DType *ingradptr = gdata.dptr_;
+      const DType *outgradptr = grad.dptr_;
+      auto maskptr = reinterpret_cast<int *>(mask.dptr_);
+      int count = mask.shape_[0] * mask.shape_[1];
+      const float pk_1 = 1.0f / pkeep;
+#pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+      for (int i = 0; i < count; ++i) {
+        ingradptr[i] = outgradptr[i] * maskptr[i] * pk_1;
+      }
+      return true;
+    }
+    return false;
+  }
+
+#ifdef __CUDACC__
+  // GPU never uses MKL
+  static bool MSHADOW_CINLINE MKLForward(mshadow::Stream<gpu> *s, RandGenerator<gpu, DType> *pgen,
+                                         const double pkeep,
+                                         const std::vector<TBlob> &in_data,
+                                         const std::vector<TBlob> &out_data) {
+    return false;
+  }
+  static bool MSHADOW_CINLINE MKLBackward(mshadow::Stream<gpu> *s, const double pkeep,
+                                          const std::vector<TBlob> &in_grad,
+                                          const std::vector<TBlob> &out_data,
+                                          const std::vector<TBlob> &out_grad) {
+    return false;
+  }
+#endif  // __CUDACC__
+
+#else  // #if defined(USE_MKL) && defined(_OPENMP)
+  static bool MSHADOW_CINLINE MKLForward(mshadow::Stream<xpu> *s, RandGenerator<xpu, DType> *pgen,
+                                const double pkeep,
+                                const std::vector<TBlob> &in_data,
+                                const std::vector<TBlob> &out_data) {
+    return false;
+  }
+  static bool MSHADOW_CINLINE MKLBackward(mshadow::Stream<xpu> *s, const double pkeep,
+                                          const std::vector<TBlob> &in_grad,
+                                          const std::vector<TBlob> &out_data,
+                                          const std::vector<TBlob> &out_grad) {
+    return false;
+  }
+#endif  // #if defined(USE_MKL) && defined(_OPENMP)
 
  public:
   /*!
@@ -144,40 +223,17 @@ class DropoutOp : public Operator {
       }
       Stream<xpu> *s = ctx.get_stream<xpu>();
       const TBlob &out = out_data[dropout::kOut];
-      if (ctx.is_train || mode_ == dropout::kAlways) {
+      if (ctx.is_train || this->mode_ == dropout::kAlways) {
         RandGenerator<xpu, DType> *pgen = ctx.requested[0].get_parallel_random<xpu, DType>();
         CHECK_NOTNULL(pgen);
-        const int can_use_mkl = sizeof(DType) >= sizeof(int) ? 1 : 0;
-        switch (can_use_mkl) {
-          case 1:
-#if !defined(__CUDACC__) && defined(USE_MKL) && defined(_OPENMP)
-            {
-              Tensor<xpu, 2, DType> mask = out_data[dropout::kMask].FlatTo2D<xpu, DType>(s);
-              Tensor<xpu, 2, DType> data = in_data[dropout::kData].FlatTo2D<xpu, DType>(s);
-              Tensor<xpu, 2, DType> out = out_data[dropout::kOut].FlatTo2D<xpu, DType>(s);
-              DType* outptr = out.dptr_;
-              DType* dataptr = data.dptr_;
-              auto maskptr = reinterpret_cast<int*>(mask.dptr_);
-              int count = mask.shape_[0]*mask.shape_[1];
-              BernoulliGenerate(*pgen, count, this->pkeep_, maskptr);
-              const float pk_1 = 1.0f / pkeep_;
-#pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
-              for (int i = 0; i < count; ++i) {
-                outptr[i] = dataptr[i] * maskptr[i] * pk_1;
-              }
-            }
-            break;
-#endif  // MKL
-          default: {
-            const TBlob &mask = out_data[dropout::kMask];
-            CHECK(req[dropout::kOut] != kAddTo);
-            LaunchRNG<DropoutKernel, xpu>(s, pgen, out.Size(),
-                                          out.dptr<DType>(),
-                                          mask.dptr<DType>(),
-                                          in_data[dropout::kData].dptr<DType>(),
-                                          this->pkeep_);
-            break;
-          }
+        if (!MKLForward(s, pgen, this->pkeep_, in_data, out_data)) {
+          const TBlob &mask = out_data[dropout::kMask];
+          CHECK(req[dropout::kOut] != kAddTo);
+          LaunchRNG<DropoutKernel, xpu>(s, pgen, out.Size(),
+                                        out.dptr<DType>(),
+                                        mask.dptr<DType>(),
+                                        in_data[dropout::kData].dptr<DType>(),
+                                        this->pkeep_);
         }
       } else {
         const TBlob& data = in_data[dropout::kData];
@@ -206,36 +262,15 @@ class DropoutOp : public Operator {
     CHECK_EQ(in_grad.size(), 1U);
     Stream<xpu> *s = ctx.get_stream<xpu>();
     if (ctx.is_train || mode_ == dropout::kAlways) {
-      const int can_use_mkl = sizeof(DType) >= sizeof(int) ? 1 : 0;
-      switch (can_use_mkl) {
-        case 1:
-#if !defined(__CUDACC__) && defined(USE_MKL) && defined(_OPENMP)
-          {
-            Tensor<xpu, 2, DType> grad = out_grad[dropout::kOut].FlatTo2D<xpu, DType>(s);
-            Tensor<xpu, 2, DType> mask = out_data[dropout::kMask].FlatTo2D<xpu, DType>(s);
-            Tensor<xpu, 2, DType> gdata = in_grad[dropout::kData].FlatTo2D<xpu, DType>(s);
-            DType* ingradptr = gdata.dptr_;
-            const DType* outgradptr = grad.dptr_;
-            auto maskptr = reinterpret_cast<int*>(mask.dptr_);
-            int count = mask.shape_[0]*mask.shape_[1];
-            const float pk_1 = 1.0f / pkeep_;
-#pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
-            for (int i = 0; i < count; ++i) {
-              ingradptr[i] = outgradptr[i] * maskptr[i] * pk_1;
-            }
-          }
-          break;
-#endif  // MKL
-        default: {
-          const TBlob &gdata = in_grad[dropout::kData];
-          const TBlob &grad = out_grad[dropout::kOut];
-          const TBlob &mask = out_data[dropout::kMask];
-          CHECK_EQ(grad.Size(), mask.Size());
-          MXNET_ASSIGN_REQ_SWITCH(req[dropout::kData], Req, {
-            mxnet_op::Kernel<mxnet_op::op_with_req<mshadow_op::mul, Req>, xpu>::Launch(
-              s, gdata.Size(), gdata.dptr<DType>(), grad.dptr<DType>(), mask.dptr<DType>());
-          });
-        }
+      if (!MKLBackward(s, this->pkeep_, in_grad, out_data, out_grad)) {
+        const TBlob &gdata = in_grad[dropout::kData];
+        const TBlob &grad = out_grad[dropout::kOut];
+        const TBlob &mask = out_data[dropout::kMask];
+        CHECK_EQ(grad.Size(), mask.Size());
+        MXNET_ASSIGN_REQ_SWITCH(req[dropout::kData], Req, {
+          mxnet_op::Kernel<mxnet_op::op_with_req<mshadow_op::mul, Req>, xpu>::Launch(
+            s, gdata.Size(), gdata.dptr<DType>(), grad.dptr<DType>(), mask.dptr<DType>());
+        });
       }
     } else {
       const TBlob& gdata = in_grad[dropout::kData];

--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -114,7 +114,7 @@ class DropoutOp : public Operator {
                        const std::vector<OpReqType> &req,
                        const std::vector<TBlob> &out_data,
                        const std::vector<TBlob> &aux_states) {
-    if(req[dropout::kOut] != kNullOp) {
+    if (req[dropout::kOut] != kNullOp) {
       CHECK_EQ(in_data.size(), 1U);
       if (ctx.is_train) {
         CHECK_EQ(out_data.size(), 2U);
@@ -133,7 +133,7 @@ class DropoutOp : public Operator {
 
       } else {
         const TBlob& data = in_data[dropout::kData];
-        if(req[dropout::kOut] == kWriteTo) {
+        if (req[dropout::kOut] == kWriteTo) {
           mxnet_op::copy(s, out, data);
         } else {
           MXNET_ASSIGN_REQ_SWITCH(req[dropout::kOut], Req, {
@@ -167,7 +167,7 @@ class DropoutOp : public Operator {
           s, gdata.Size(), gdata.dptr<DType>(), grad.dptr<DType>(), mask.dptr<DType>());
       });
     } else {
-      if(req[dropout::kData] == kWriteTo) {
+      if (req[dropout::kData] == kWriteTo) {
         mxnet_op::copy(s, gdata, grad);
       } else {
         MXNET_ASSIGN_REQ_SWITCH(req[dropout::kData], Req, {

--- a/src/operator/nn/dropout.cc
+++ b/src/operator/nn/dropout.cc
@@ -25,6 +25,7 @@
 */
 
 #include "./dropout-inl.h"
+#include "../operator_common.h"
 
 namespace mxnet {
 namespace op {

--- a/src/operator/optimizer_op-inl.h
+++ b/src/operator/optimizer_op-inl.h
@@ -463,7 +463,7 @@ inline void SGDMomUpdateRspRspRspImpl(const SGDMomParam& param,
                                  mom.data(), req, &out_blob);
 }
 
-/*! 
+/*!
  * \brief Storge type inference function in optimizer.
  * \param n_rsp     The number of inputs that should be of row_sparse storage type
  *                  if kFComputeEx is dispatched

--- a/tests/cpp/include/test_legacy_op.h
+++ b/tests/cpp/include/test_legacy_op.h
@@ -508,13 +508,6 @@ class LegacyOperatorExecutor : public OperatorDataInitializer<DType>
         if (ctx.dev_mask() == Context::kCPU) {
           common::random::RandGenerator<cpu, DType>::AllocState(
             rm.get_parallel_random<cpu, DType>());
-        } else {
-#if MXNET_USE_CUDA
-          common::random::RandGenerator<gpu, DType>::AllocState(
-            rm.get_parallel_random<cpu, DType>());
-#else
-          CHECK(false);  // shouldn't get here
-#endif  // MXNET_USE_CUDA
         }
         opContext_.requested.emplace_back(rm);
       } else {

--- a/tests/cpp/operator/dropout_perf.cc
+++ b/tests/cpp/operator/dropout_perf.cc
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ *  \file dropout_perf.cc
+ *  \brief Perf/profile run of DropoutOp
+ *  \author Chris Olivier
+ */
+
+#include <gtest/gtest.h>
+#include <mxnet/tensor_blob.h>
+#include "../include/test_op_runner.h"
+#include "../include/test_legacy_op.h"
+#include "../../src/operator/nn/dropout-inl.h"
+
+using namespace mxnet;
+
+typedef std::vector<std::pair<std::string, std::string> > kwargs_t;
+const kwargs_t basic_dropout_args = { };
+
+/*!
+ * \brief Generic bidirectional sanity test
+ */
+TEST(DROPOUT_PERF, ExecuteBidirectional) {
+  TShape shape({5, 5});
+  kwargs_t kwargs = basic_dropout_args;
+  kwargs.push_back({"mode", "always"});
+  test::op::LegacyOpRunner<mxnet::op::DropoutProp, float, float> runner;
+  runner.RunBidirectional(false, { shape }, kwargs, 1);
+}
+
+/*!
+ * \brief DropoutOp timing test for CPU
+ */
+TEST(DROPOUT_PERF, TimingCPU) {
+  kwargs_t kwargs = basic_dropout_args;
+// Which math function is arbitrary since it will have roughly constant timing among approaches
+  kwargs.push_back({"mode", "always"});
+  test::op::LegacyOpRunner<mxnet::op::DropoutProp, float, float> runner;
+  runner.RunBidirectional(false,
+                          { TShape({10, 10, 10, 10}) },
+                          kwargs, 1);  // prime code and cache
+  std::vector <TShape> shapes;
+  if (test::performance_run) {
+    shapes = {
+      {1,  1, 28,  28},
+      {1,  3, 28,  28},
+      {50, 1, 18,  32},
+      {50, 3, 18,  32},
+      {20, 3, 128, 128}
+    };
+  } else {
+    shapes = {
+      {1,  1, 28,  28},
+      {50, 3, 18,  32},
+    };
+  }
+  for (const TShape &shape : shapes) {
+    runner.TimingTest("Dropout Operator CPU", false, false, kwargs, 2, 10, { shape });
+  }
+}
+
+#if MXNET_USE_CUDA == 1
+/*!
+ * \brief DropoutOp timing test for GPU
+ */
+TEST(DROPOUT_PERF, TimingGPU) {
+  kwargs_t kwargs = basic_dropout_args;
+  // Which math function is arbitrary since it will have roughly constant timing among approaches
+  kwargs.push_back({"mode", "always"});
+  test::OperatorRunner<mxnet::op::DropoutProp,
+    test::op::LegacyOperatorExecutor<float, float>> runner;
+  runner.RunBidirectional(true,
+                          { TShape({10, 10, 10, 10}) },
+                          kwargs, 1);  // prime code and cache
+  std::vector <TShape> shapes = {
+    {1,  1, 28,  28},
+    {1,  3, 28,  28},
+    {50, 1, 18,  32},
+    {50, 3, 18,  32},
+    {20, 3, 128, 128}
+  };
+  for (const TShape &shape : shapes) {
+    runner.TimingTest("Dropout Operator GPU", true, false, kwargs, 2, 10, { shape });
+  }
+}
+#endif  // MXNET_USE_CUDA == 1
+


### PR DESCRIPTION
## Description ##

Fix for: https://discuss.mxnet.io/t/ensuring-the-same-result-with-dropout-using-random-seed/392/8

@nswamy 
@yzhliu 

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

  