### PR TITLE
Revert "Temporarily disable test with failing http connection (#9333)"

### DIFF
--- a/R-package/tests/testthat/test_model.R
+++ b/R-package/tests/testthat/test_model.R
@@ -172,7 +172,6 @@ test_that("Fine-tune", {
 })                                       
 
 test_that("Matrix Factorization", {
-  skip("Disabled due to an unavailible http server.  Tracked here: https://git.io/vNkrE")
   GetMovieLens()
   DF <- read.table("./data/ml-100k/u.data", header = F, sep = "\t")
   names(DF) <- c("user", "item", "score", "time")


### PR DESCRIPTION
This reverts commit 8ad77f3ed8eced5e98661a3828dd22104f356d4e.

## Description ##
For the time being the server seems to be stable again, so I'm opening this PR to optionally allow commiters to re-enable the tests.

I feel this test should be refactored such that future web server outages don't break the build.  The test seems to be mostly setting up declarative code.  During a quick review I noticed that there's for example no asserts in the majority of these tests.  It would be great if someone could verify that these tests are actually testing their respective intended units of work.

If merged this addresses issue: https://github.com/apache/incubator-mxnet/issues/9332
