### PR TITLE
Update MKLML to v0.12

### DIFF
--- a/prepare_mkl.sh
+++ b/prepare_mkl.sh
@@ -84,7 +84,7 @@ elif [ $PLATFORM == "Linux" ]; then
 fi
 ARCHIVE_BASENAME=mklml_${INFIX}_2018.0.1.${VERSION_MATCH}.tgz
 MKL_CONTENT_DIR=`echo $ARCHIVE_BASENAME | rev | cut -d "." -f 2- | rev`
-MKLURL="https://github.com/01org/mkl-dnn/releases/download/v0.11/$ARCHIVE_BASENAME"
+MKLURL="https://github.com/01org/mkl-dnn/releases/download/v0.12/$ARCHIVE_BASENAME"
 # there are diffrent MKL lib to be used for GCC and for ICC
 reg='^[0-9]+$'
 VERSION_LINE=`GetVersionName $MKLROOT`

--- a/tests/ci_build/Dockerfile.build_cuda
+++ b/tests/ci_build/Dockerfile.build_cuda
@@ -20,7 +20,7 @@ COPY install/ubuntu_install_nvidia.sh /install/
 RUN /install/ubuntu_install_nvidia.sh
 
 # Add MKLML libraries
-RUN wget --no-check-certificate -O /tmp/mklml.tgz https://github.com/01org/mkl-dnn/releases/download/v0.11/mklml_lnx_2018.0.1.20171227.tgz
+RUN wget --no-check-certificate -O /tmp/mklml.tgz https://github.com/01org/mkl-dnn/releases/download/v0.12/mklml_lnx_2018.0.1.20171227.tgz
 RUN tar -zxvf /tmp/mklml.tgz && cp -rf mklml_*/* /usr/local/ && rm -rf mklml_*
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib

--- a/tests/ci_build/Dockerfile.cpu_mklml
+++ b/tests/ci_build/Dockerfile.cpu_mklml
@@ -12,7 +12,7 @@ COPY install/ubuntu_install_perl.sh /install/
 RUN /install/ubuntu_install_perl.sh
 
 # Add MKLML library, compatiable with Ubuntu16.04
-RUN wget --no-check-certificate -O /tmp/mklml.tgz https://github.com/01org/mkl-dnn/releases/download/v0.11/mklml_lnx_2018.0.1.20171227.tgz
+RUN wget --no-check-certificate -O /tmp/mklml.tgz https://github.com/01org/mkl-dnn/releases/download/v0.12/mklml_lnx_2018.0.1.20171227.tgz
 RUN tar -zxvf /tmp/mklml.tgz && cp -rf mklml_*/* /usr/local/ && rm -rf mklml_*
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib

--- a/tests/ci_build/Dockerfile.gpu_mklml
+++ b/tests/ci_build/Dockerfile.gpu_mklml
@@ -12,7 +12,7 @@ COPY install/ubuntu_install_scala.sh /install/
 RUN /install/ubuntu_install_scala.sh
 
 # Add MKLML library, compatible with Ubuntu16.04
-RUN wget --no-check-certificate -O /tmp/mklml.tgz https://github.com/01org/mkl-dnn/releases/download/v0.11/mklml_lnx_2018.0.1.20171227.tgz
+RUN wget --no-check-certificate -O /tmp/mklml.tgz https://github.com/01org/mkl-dnn/releases/download/v0.12/mklml_lnx_2018.0.1.20171227.tgz
 RUN tar -zxvf /tmp/mklml.tgz && cp -rf mklml_*/* /usr/local/ && rm -rf mklml_*
 
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib


### PR DESCRIPTION
This PR updates MKLML to v0.12. This is required because v0.11 in #9218 apparently broke some like #9295.