### PR TITLE
Random seed setting

### DIFF
--- a/src/common/random_generator.cu
+++ b/src/common/random_generator.cu
@@ -55,6 +55,7 @@ void RandGenerator<gpu, float>::Seed(mshadow::Stream<gpu> *s, uint32_t seed) {
           states_,
           RandGenerator<gpu, float>::kNumRandomStates,
           seed);
+  s->Wait();
 }
 
 }  // namespace random

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -122,7 +122,7 @@ def check_with_device(device, dtype):
         ret1 = ndop(**params).asnumpy()
         mx.random.seed(128)
         ret2 = ndop(**params).asnumpy()
-        assert device.device_type == 'gpu' or same(ret1, ret2), \
+        assert same(ret1, ret2), \
                 "ndarray test: `%s` should give the same result with the same seed" % name
 
         for check_name, check_func, tol in symbdic['checks']:
@@ -135,7 +135,7 @@ def check_with_device(device, dtype):
         ret1 = ndop(**params).asnumpy()
         mx.random.seed(128)
         ret2 = ndop(**params).asnumpy()
-        assert device.device_type == 'gpu' or same(ret1, ret2), \
+        assert same(ret1, ret2), \
                 "ndarray test: `%s` should give the same result with the same seed" % name
         for i in range(2):
             for j in range(2):
@@ -161,7 +161,7 @@ def check_with_device(device, dtype):
         mx.random.seed(128)
         yexec.forward()
         un2 = (yexec.outputs[0] - x).copyto(device)
-        assert device.device_type == 'gpu' or same(un1.asnumpy(), un2.asnumpy()), \
+        assert same(un1.asnumpy(), un2.asnumpy()), \
                 "symbolic test: `%s` should give the same result with the same seed" % name
 
         ret1 = un1.asnumpy()
@@ -195,6 +195,75 @@ def test_random():
     check_with_device(mx.context.current_context(), 'float16')
     check_with_device(mx.context.current_context(), 'float32')
     check_with_device(mx.context.current_context(), 'float64')
+
+
+# Set seed variously based on `start_seed` and `num_init_seeds`, then set seed finally to `final_seed`
+def set_seed_variously(init_seed, num_init_seeds, final_seed):
+    end_seed = init_seed + num_init_seeds
+    for seed in range(init_seed, end_seed):
+        mx.random.seed(seed)
+    mx.random.seed(final_seed)
+    return end_seed
+
+# Tests that seed setting of std (non-parallel) rng is synchronous w.r.t. rng use before and after.
+def test_random_seed_setting():
+    ctx = mx.context.current_context()
+    seed_to_test = 1234
+    num_temp_seeds = 25
+    probs = [0.125, 0.25, 0.25, 0.0625, 0.125, 0.1875]
+    num_samples = 100000
+    for dtype in ['float16', 'float32', 'float64']:
+        seed = set_seed_variously(1, num_temp_seeds, seed_to_test)
+        samples1 = mx.nd.random.multinomial(data=mx.nd.array(probs, ctx=ctx, dtype=dtype),
+                                            shape=num_samples)
+        seed = set_seed_variously(seed, num_temp_seeds, seed_to_test)
+        samples2 = mx.nd.random.multinomial(data=mx.nd.array(probs, ctx=ctx, dtype=dtype),
+                                            shape=num_samples)
+        samples1np = samples1.asnumpy()
+        set_seed_variously(seed, num_temp_seeds, seed_to_test+1)
+        samples2np = samples2.asnumpy()
+        assert same(samples1np, samples2np), \
+            "seed-setting test: `multinomial` should give the same result with the same seed"
+
+
+# Tests that seed setting of parallel rng is synchronous w.r.t. rng use before and after.
+def test_parallel_random_seed_setting():
+    ctx = mx.context.current_context()
+    seed_to_test = 1234
+    num_temp_seeds = 25
+    for dtype in ['float16', 'float32', 'float64']:
+        # To flush out a possible race condition, run multiple times
+        for _ in range(20):
+            # Create enough samples such that we get a meaningful distribution.
+            shape = (200, 200)
+            params = { 'low': -1.5, 'high': 3.0 }
+            params.update(shape=shape, dtype=dtype, ctx=ctx)
+
+            # check directly
+            seed = set_seed_variously(1, num_temp_seeds, seed_to_test)
+            ret1 = mx.nd.random.uniform(**params)
+            seed = set_seed_variously(seed, num_temp_seeds, seed_to_test)
+            ret2 = mx.nd.random.uniform(**params)
+            seed = set_seed_variously(seed, num_temp_seeds, seed_to_test)
+            assert same(ret1.asnumpy(), ret2.asnumpy()), \
+                "ndarray seed-setting test: `uniform` should give the same result with the same seed"
+
+            # check symbolic
+            X = mx.sym.Variable("X")
+            Y = mx.sym.random.uniform(**params) + X
+            x = mx.nd.zeros(shape, dtype=dtype, ctx=ctx)
+            xgrad = mx.nd.zeros(shape, dtype=dtype, ctx=ctx)
+            yexec = Y.bind(ctx, {'X' : x}, {'X': xgrad})
+            seed = set_seed_variously(seed, num_temp_seeds, seed_to_test)
+            yexec.forward(is_train=True)
+            yexec.backward(yexec.outputs[0])
+            un1 = (yexec.outputs[0] - x).copyto(ctx)
+            seed = set_seed_variously(seed, num_temp_seeds, seed_to_test)
+            yexec.forward()
+            set_seed_variously(seed, num_temp_seeds, seed_to_test)
+            un2 = (yexec.outputs[0] - x).copyto(ctx)
+            assert same(un1.asnumpy(), un2.asnumpy()), \
+                "symbolic seed-setting test: `uniform` should give the same result with the same seed"
 
 
 def test_sample_multinomial():


### PR DESCRIPTION
## Description ##

I observed failures in "nosetests test_operator_gpu.py:test_random" in the check for repeatable sequences given identical seeds.  These failures are due to a lack of synchronization (i.e. race) between the setting of the seed by the gpu and a subsequent request for random numbers.  The test failures were only occasional and occurred more repeatably on the older, slower GPUs.

The first commit of this PR adds two new tests designed to accentuate the problem.  The test_random.py:test_parallel_random_seed_setting test targets the 'ResourceParallelRandom' that was recently added and fails consistently on multiple generations of GPUs.  The test_random.py:test_random_seed_setting test targets the legacy 'ResourceRandom' and does not exhibit any failures, suggesting the race issue is only present in the new parallel random generator.

The second commit of the PR adds the needed synchronization to ResourceParallelRandom and remedies the failure of the included test.  Since no failure was ever seen in ResourceRandom, I refrained from adding a similar synchronization where none is apparently needed.  I can add such a synchronization blindly if desired.

@piiswrong @szha @yzhliu might have some interest in this PR.

## Checklist ##
### Essentials ###
- [X] Passed code style checking (`make lint`)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
