### PR TITLE
move concurrent/identity blocks to contrib

### DIFF
--- a/python/mxnet/gluon/contrib/nn/__init__.py
+++ b/python/mxnet/gluon/contrib/nn/__init__.py
@@ -16,8 +16,11 @@
 # under the License.
 
 # coding: utf-8
-"""Contrib neural network module."""
+# pylint: disable=wildcard-import
+"""Contrib recurrent neural network module."""
 
-from . import nn
+from . import basic_layers
 
-from . import rnn
+from .basic_layers import *
+
+__all__ = basic_layers.__all__

--- a/python/mxnet/gluon/model_zoo/vision/densenet.py
+++ b/python/mxnet/gluon/model_zoo/vision/densenet.py
@@ -25,7 +25,7 @@ import os
 from ....context import cpu
 from ...block import HybridBlock
 from ... import nn
-from ..custom_layers import HybridConcurrent, Identity
+from ...contrib.nn import HybridConcurrent, Identity
 
 # Helpers
 def _make_dense_block(num_layers, bn_size, growth_rate, dropout, stage_index):
@@ -46,7 +46,7 @@ def _make_dense_layer(growth_rate, bn_size, dropout):
     if dropout:
         new_features.add(nn.Dropout(dropout))
 
-    out = HybridConcurrent(concat_dim=1, prefix='')
+    out = HybridConcurrent(axis=1, prefix='')
     out.add(Identity())
     out.add(new_features)
 

--- a/python/mxnet/gluon/model_zoo/vision/inception.py
+++ b/python/mxnet/gluon/model_zoo/vision/inception.py
@@ -25,7 +25,7 @@ import os
 from ....context import cpu
 from ...block import HybridBlock
 from ... import nn
-from ..custom_layers import HybridConcurrent
+from ...contrib.nn import HybridConcurrent
 
 # Helpers
 def _make_basic_conv(**kwargs):
@@ -51,7 +51,7 @@ def _make_branch(use_pool, *conv_settings):
     return out
 
 def _make_A(pool_features, prefix):
-    out = HybridConcurrent(concat_dim=1, prefix=prefix)
+    out = HybridConcurrent(axis=1, prefix=prefix)
     with out.name_scope():
         out.add(_make_branch(None,
                              (64, 1, None, None)))
@@ -67,7 +67,7 @@ def _make_A(pool_features, prefix):
     return out
 
 def _make_B(prefix):
-    out = HybridConcurrent(concat_dim=1, prefix=prefix)
+    out = HybridConcurrent(axis=1, prefix=prefix)
     with out.name_scope():
         out.add(_make_branch(None,
                              (384, 3, 2, None)))
@@ -79,7 +79,7 @@ def _make_B(prefix):
     return out
 
 def _make_C(channels_7x7, prefix):
-    out = HybridConcurrent(concat_dim=1, prefix=prefix)
+    out = HybridConcurrent(axis=1, prefix=prefix)
     with out.name_scope():
         out.add(_make_branch(None,
                              (192, 1, None, None)))
@@ -98,7 +98,7 @@ def _make_C(channels_7x7, prefix):
     return out
 
 def _make_D(prefix):
-    out = HybridConcurrent(concat_dim=1, prefix=prefix)
+    out = HybridConcurrent(axis=1, prefix=prefix)
     with out.name_scope():
         out.add(_make_branch(None,
                              (192, 1, None, None),
@@ -112,7 +112,7 @@ def _make_D(prefix):
     return out
 
 def _make_E(prefix):
-    out = HybridConcurrent(concat_dim=1, prefix=prefix)
+    out = HybridConcurrent(axis=1, prefix=prefix)
     with out.name_scope():
         out.add(_make_branch(None,
                              (320, 1, None, None)))
@@ -121,7 +121,7 @@ def _make_E(prefix):
         out.add(branch_3x3)
         branch_3x3.add(_make_branch(None,
                                     (384, 1, None, None)))
-        branch_3x3_split = HybridConcurrent(concat_dim=1, prefix='')
+        branch_3x3_split = HybridConcurrent(axis=1, prefix='')
         branch_3x3_split.add(_make_branch(None,
                                           (384, (1, 3), None, (0, 1))))
         branch_3x3_split.add(_make_branch(None,
@@ -133,7 +133,7 @@ def _make_E(prefix):
         branch_3x3dbl.add(_make_branch(None,
                                        (448, 1, None, None),
                                        (384, 3, None, 1)))
-        branch_3x3dbl_split = HybridConcurrent(concat_dim=1, prefix='')
+        branch_3x3dbl_split = HybridConcurrent(axis=1, prefix='')
         branch_3x3dbl.add(branch_3x3dbl_split)
         branch_3x3dbl_split.add(_make_branch(None,
                                              (384, (1, 3), None, (0, 1))))

--- a/python/mxnet/gluon/model_zoo/vision/squeezenet.py
+++ b/python/mxnet/gluon/model_zoo/vision/squeezenet.py
@@ -25,14 +25,14 @@ import os
 from ....context import cpu
 from ...block import HybridBlock
 from ... import nn
-from ..custom_layers import HybridConcurrent
+from ...contrib.nn import HybridConcurrent
 
 # Helpers
 def _make_fire(squeeze_channels, expand1x1_channels, expand3x3_channels):
     out = nn.HybridSequential(prefix='')
     out.add(_make_fire_conv(squeeze_channels, 1))
 
-    paths = HybridConcurrent(concat_dim=1, prefix='')
+    paths = HybridConcurrent(axis=1, prefix='')
     paths.add(_make_fire_conv(expand1x1_channels, 1))
     paths.add(_make_fire_conv(expand3x3_channels, 3, 1))
     out.add(paths)

--- a/tests/python/unittest/test_gluon_contrib.py
+++ b/tests/python/unittest/test_gluon_contrib.py
@@ -18,6 +18,8 @@
 from __future__ import print_function
 import mxnet as mx
 from mxnet.gluon import contrib
+from mxnet.gluon import nn
+from mxnet.gluon.contrib.nn import Concurrent, HybridConcurrent, Identity
 from mxnet.test_utils import almost_equal
 import numpy as np
 from numpy.testing import assert_allclose
@@ -136,6 +138,39 @@ def test_vardrop():
 
     check_vardrop(0.5, 0.5, 0.5)
     check_vardrop(0.5, 0, 0.5)
+
+
+def test_concurrent():
+    model = HybridConcurrent(axis=1)
+    model.add(nn.Dense(128, activation='tanh', in_units=10))
+    model.add(nn.Dense(64, activation='tanh', in_units=10))
+    model.add(nn.Dense(32, in_units=10))
+    model2 = Concurrent(axis=1)
+    model2.add(nn.Dense(128, activation='tanh', in_units=10))
+    model2.add(nn.Dense(64, activation='tanh', in_units=10))
+    model2.add(nn.Dense(32, in_units=10))
+
+    # symbol
+    x = mx.sym.var('data')
+    y = model(x)
+    assert len(y.list_arguments()) == 7
+
+    # ndarray
+    model.initialize(mx.init.Xavier(magnitude=2.24))
+    model2.initialize(mx.init.Xavier(magnitude=2.24))
+    x = model(mx.nd.zeros((32, 10)))
+    x2 = model2(mx.nd.zeros((32, 10)))
+    assert x.shape == (32, 224)
+    assert x2.shape == (32, 224)
+    x.wait_to_read()
+    x2.wait_to_read()
+
+
+def test_identity():
+    model = Identity()
+    x = mx.nd.random.uniform(shape=(128, 33, 64))
+    mx.test_utils.assert_almost_equal(model(x).asnumpy(),
+                                      x.asnumpy())
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_gluon_model_zoo.py
+++ b/tests/python/unittest/test_gluon_model_zoo.py
@@ -17,38 +17,11 @@
 
 from __future__ import print_function
 import mxnet as mx
-from mxnet.gluon import nn
-from mxnet.gluon.model_zoo.custom_layers import HybridConcurrent, Identity
 from mxnet.gluon.model_zoo.vision import get_model
 import sys
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
-
-def test_concurrent():
-    model = HybridConcurrent(concat_dim=1)
-    model.add(nn.Dense(128, activation='tanh', in_units=10))
-    model.add(nn.Dense(64, activation='tanh', in_units=10))
-    model.add(nn.Dense(32, in_units=10))
-
-    # symbol
-    x = mx.sym.var('data')
-    y = model(x)
-    assert len(y.list_arguments()) == 7
-
-    # ndarray
-    model.collect_params().initialize(mx.init.Xavier(magnitude=2.24))
-    x = model(mx.nd.zeros((32, 10)))
-    assert x.shape == (32, 224)
-    x.wait_to_read()
-
-
-def test_identity():
-    model = Identity()
-    x = mx.nd.random.uniform(shape=(128, 33, 64))
-    mx.test_utils.assert_almost_equal(model(x).asnumpy(),
-                                      x.asnumpy())
-
 
 def test_models():
     all_models = ['resnet18_v1', 'resnet34_v1', 'resnet50_v1', 'resnet101_v1', 'resnet152_v1',
@@ -62,7 +35,7 @@ def test_models():
     pretrained_to_test = set(['squeezenet1.1'])
 
     for model_name in all_models:
-        test_pretrain = model_name in pretrained_to_test
+        test_pretrain = True #model_name in pretrained_to_test
         model = get_model(model_name, pretrained=test_pretrain, root='model/')
         data_shape = (2, 3, 224, 224) if 'inception' not in model_name else (2, 3, 299, 299)
         eprint('testing forward for %s'%model_name)


### PR DESCRIPTION
## Description ##
Move Concurrent/HybridConcurrent/Identity blocks from custom_layers in model zoo to gluon.contrib. Identity block simply passes the input through. Concurrent blocks can be used to concatenate outputs from child blocks on the specified axis. These blocks are useful in implementing residual paths commonly seen in networks through constructor.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Move Concurrent/HybridConcurrent/Identity blocks from custom_layers in model zoo to gluon.contrib