### PR TITLE
Limit the test_nccl.py to run on 8 GPUs

### DIFF
--- a/tests/python/gpu/test_nccl.py
+++ b/tests/python/gpu/test_nccl.py
@@ -21,7 +21,15 @@ import unittest
 
 shapes = [(10), (100), (1000), (10000), (100000), (2,2), (2,3,4,5,6,7,8)]
 keys = [1,2,3,4,5,6,7]
-gpus = range(1,1+len(mx.test_utils.list_gpus()))
+num_gpus = len(mx.test_utils.list_gpus())
+
+
+if num_gpus > 8 :
+    print("The machine has {} gpus. We will run the test on 8 gpus.".format(num_gpus))
+    print("There is a limit for all PCI-E hardware on creating number of P2P peers. The limit is 8.")
+    num_gpus = 8;
+
+gpus = range(1,1+num_gpus)
 
 @unittest.skip("Test requires NCCL library installed and enabled during build")
 def test_nccl_pushpull():


### PR DESCRIPTION
## Description ##
This change limits the test_nccl.py script to run 8 GPUs only. This is due to a hardware limit on number of P2P peers that can be created. The limit is 8.

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
