### PR TITLE
Revert "header updates to clarify use of CODEOWNERS (#9426)"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,17 +1,4 @@
 # Owners of Apache MXNet
-# Please see documentation of use of CODEOWNERS file at
-# https://help.github.com/articles/about-codeowners/ and 
-# https://github.com/blog/2392-introducing-code-owners
-# 
-# The first owner listed for a package is considered the maintainer for a package.
-# Anybody can add themselves or a team (see https://help.github.com/articles/about-teams/)
-# as additional owners to get notified about changes in a specific package.
-#
-# By default the package maintainer should merge PR after appropriate review.
-# A PR which received 2 +1 (or LGTM) comments can be merged by any committer.
-# In the future we might consider adopting required reviews 
-# (see https://help.github.com/articles/about-pull-request-reviews/)
-
 
 # Global owners
 *			@apache/mxnet-committers


### PR DESCRIPTION
This reverts commit 63394de90cd5f600100380093e2d5636dd91c18a.

This PR was merged in error

## Description ##
This PR was part of an incomplete discussion and merged in error

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
