### PR TITLE
enabling multithreading in broadcast_reduce

### DIFF
--- a/src/operator/tensor/broadcast_reduce-inl.h
+++ b/src/operator/tensor/broadcast_reduce-inl.h
@@ -197,6 +197,7 @@ void seq_reduce_compute(const int N, const int M, const bool addto,
                         const DType *big, DType *small, const Shape<ndim> bshape,
                         const Shape<ndim> sshape, const Shape<ndim> rshape,
                         const Shape<ndim> rstride) {
+  #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
   for (int idx = 0; idx < N; ++idx) {
     seq_reduce_assign<Reducer, ndim, DType, OP>(idx, M, addto, big, small, bshape, sshape, rshape,
       rstride);
@@ -266,6 +267,7 @@ void seq_reduce_compute(const int N, const int M, const bool addto,
                         const Shape<ndim> lhs_shape, const Shape<ndim> lhs_stride,
                         const Shape<ndim> rhs_shape, const Shape<ndim> rhs_stride,
                         const Shape<ndim>& lhs_shape0, const Shape<ndim>& rhs_shape0) {
+  #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
   for (int idx = 0; idx < N; ++idx) {
     seq_reduce_assign<Reducer, ndim, DType, OP1, OP2>(idx, M, addto, big, lhs, rhs, small,
       big_shape, lhs_shape0, rhs_shape0, small_shape, rshape, lhs_shape, rhs_shape, rstride,


### PR DESCRIPTION
## Description ##
Add multithreading on CPU for the class of broadcast_reduce operators. For unknown reasons, this class of operators does not use any internal threading so far and therefore was observed to become a serious runtime bottleneck in an application. Threading is done on the level of sequences to be reduced, not within a single reduce sequence. This pattern is in line with the one that we are already doing in elemwise_binary_broadcast_op.h (where we achieve threading when starting the binary_broadcast_kernel). 
With this change, this class of operators shows good threading whenever we reduce over multiple sequences and matches the runtime characteristics of elemwise_binary_broadcast.

## Checklist ##
### Essentials ###
- [x ] Passed code style checking (`make lint`)
- [x ] Changes are complete (i.e. I finished coding on this PR)
- [ x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

