### PR TITLE
Data-iterator tutorial made python3 compatible.

### DIFF
--- a/docs/tutorials/basic/data.md
+++ b/docs/tutorials/basic/data.md
@@ -104,12 +104,8 @@ The example below shows how to create a Simple iterator.
 class SimpleIter(mx.io.DataIter):
     def __init__(self, data_names, data_shapes, data_gen,
                  label_names, label_shapes, label_gen, num_batches=10):
-        self._data_names = data_names
-        self._data_shapes = data_shapes
-        self._label_names = label_names
-        self._label_shapes = label_shapes
-        self._provide_data = zip(data_names, data_shapes)
-        self._provide_label = zip(label_names, label_shapes)
+        self._provide_data = list(zip(data_names, data_shapes))
+        self._provide_label = list(zip(label_names, label_shapes))
         self.num_batches = num_batches
         self.data_gen = data_gen
         self.label_gen = label_gen
@@ -126,17 +122,17 @@ class SimpleIter(mx.io.DataIter):
 
     @property
     def provide_data(self):
-        return zip(self._data_names, self._data_shapes)
+        return self._provide_data
 
     @property
     def provide_label(self):
-        return zip(self._label_names, self._label_shapes)
+        return self._provide_label
 
     def next(self):
         if self.cur_batch < self.num_batches:
             self.cur_batch += 1
-            data = [mx.nd.array(g(d[1])) for d,g in zip(self.provide_data, self.data_gen)]
-            label = [mx.nd.array(g(d[1])) for d,g in zip(self.provide_label, self.label_gen)]
+            data = [mx.nd.array(g(d[1])) for d,g in zip(self._provide_data, self.data_gen)]
+            label = [mx.nd.array(g(d[1])) for d,g in zip(self._provide_label, self.label_gen)]
             return mx.io.DataBatch(data, label)
         else:
             raise StopIteration


### PR DESCRIPTION
## Description ##
Faced 2 main issues while executing this http://mxnet.incubator.apache.org/tutorials/basic/data.html tutorial on python3:
1. Zip function has changed in python3. It returns an iterator which gets exhausted after it is iterated over. More info: https://stackoverflow.com/questions/31683959/the-zip-function-in-python-3/31684038#31684038
2. Some of the methods in MXNet assume the parameter to be of type string in python2
but as bytes in python3.

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [Y] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [Y] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
