### PR TITLE
Rename kvstore/utils.* to kvstore/kvstore_utils.*

### DIFF
--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -34,7 +34,7 @@
 #include "gradient_compression.h"
 #include "../ndarray/ndarray_function.h"
 #include "../operator/tensor/sparse_retain-inl.h"
-#include "./utils.h"
+#include "./kvstore_utils.h"
 namespace mxnet {
 namespace kvstore {
 /**

--- a/src/kvstore/kvstore_local.h
+++ b/src/kvstore/kvstore_local.h
@@ -34,7 +34,7 @@
 #include <functional>
 #include <algorithm>
 #include "./comm.h"
-#include "./utils.h"
+#include "./kvstore_utils.h"
 
 namespace mxnet {
 namespace kvstore {

--- a/src/kvstore/kvstore_utils.cc
+++ b/src/kvstore/kvstore_utils.cc
@@ -18,11 +18,11 @@
  */
 
 /*!
- * \file utils.cc
+ * \file kvstore_utils.cc
  * \brief cpu implementation of util functions
  */
 
-#include "./utils.h"
+#include "./kvstore_utils.h"
 #include "../common/utils.h"
 
 namespace mxnet {

--- a/src/kvstore/kvstore_utils.cu
+++ b/src/kvstore/kvstore_utils.cu
@@ -19,7 +19,7 @@
 
 /*!
  *  Copyright (c) 2017 by Contributors
- * \file utils.cu
+ * \file kvstore_utils.cu
  * \brief gpu implementation of util functions
  */
 #if defined(_MSC_VER) && __CUDACC_VER_MAJOR__ == 8 && __CUDACC_VER_BUILD__ != 44
@@ -32,10 +32,10 @@
 #else
 #undef SORT_WITH_THRUST
 #endif
-#include "./utils.h"
-#include "../common/utils.h"
+#include "./kvstore_utils.h"
 #include <cub/cub.cuh>
 #include <mxnet/resource.h>
+#include "../common/utils.h"
 
 namespace mxnet {
 namespace kvstore {

--- a/src/kvstore/kvstore_utils.h
+++ b/src/kvstore/kvstore_utils.h
@@ -18,11 +18,11 @@
  */
 
 /*!
- * \file utils.h
+ * \file kvstore_utils.h
  * \brief Basic utilility functions.
  */
-#ifndef MXNET_KVSTORE_UTILS_H_
-#define MXNET_KVSTORE_UTILS_H_
+#ifndef MXNET_KVSTORE_KVSTORE_UTILS_H_
+#define MXNET_KVSTORE_KVSTORE_UTILS_H_
 
 #include <dmlc/logging.h>
 #include <mxnet/ndarray.h>
@@ -44,4 +44,4 @@ void UniqueImpl(const Resource& rsc, mshadow::Stream<xpu> *s,
 }  // namespace kvstore
 }  // namespace mxnet
 
-#endif  // MXNET_KVSTORE_UTILS_H_
+#endif  // MXNET_KVSTORE_KVSTORE_UTILS_H_


### PR DESCRIPTION
Using an old version of GCC (e.g. 4.9) as the host compiler for nvcc causes compilation failures in multi-threaded builds when there are multiple CUDA source files with the same name.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change

@ZiyueHuang  @eric-haibin-lin 
#8732: `src/common/utils.cu` and `src/kvstore/utils.cu`
