### PR TITLE
refactor logging in infer storage pass

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -369,25 +369,25 @@ inline std::string operator_stype_string(const nnvm::NodeAttrs& attrs,
                                          const int dev_mask,
                                          const std::vector<int>& in_attrs,
                                          const std::vector<int>& out_attrs) {
-  std::string result = "";
-  result += "operator = " + attrs.op->name + "\n";
-  result += "input storage types = [";
-  for (const auto attr : in_attrs) {
-    result += stype_string(attr) + ", ";
+  std::ostringstream os;
+  os << "operator = " << attrs.op->name
+     << "\ninput storage types = [";
+  for (const int attr : in_attrs) {
+    os << stype_string(attr) << ", ";
   }
-  result += "]\n";
-  result += "output storage types = [";
-  for (const auto attr : out_attrs) {
-    result += stype_string(attr) + ", ";
+  os << "]\n"
+     << "output storage types = [";
+  for (const int attr : out_attrs) {
+    os << stype_string(attr) << ", ";
   }
-  result += "]\n";
-  result += "params = {";
+  os << "]\n"
+     << "params = {";
   for (auto kv : attrs.dict) {
-    result += "\"" + kv.first + "\" : " + kv.second + ", ";
+    os << "\"" << kv.first << "\" : " << kv.second << ", ";
   }
-  result += "}\n";
-  result += "context.dev_mask = " + dev_type_string(dev_mask);
-  return result;
+  os << "}\n"
+     << "context.dev_mask = " << dev_type_string(dev_mask);
+  return os.str();
 }
 
 /*! \brief get string representation of the operator */
@@ -428,7 +428,7 @@ inline void LogStorageFallback(const nnvm::NodeAttrs& attrs,
   if (!log) return;
   const std::string op_str = operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
   std::ostringstream os;
-  const std::string warning = "\nThe operator with default storage type will be dispatched "
+  const char* warning = "\nThe operator with default storage type will be dispatched "
     "for execution. You're seeing this warning message because the operator above is unable "
     "to process the given ndarrays with specified storage types, context and parameter. "
     "Temporary dense ndarrays are generated in order to execute the operator. "

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -399,6 +399,8 @@ inline std::string operator_string(const nnvm::NodeAttrs& attrs,
   std::string result = "";
   std::vector<int> in_stypes;
   std::vector<int> out_stypes;
+  in_stypes.reserve(inputs.size());
+  out_stypes.reserve(outputs.size());
   auto xform = [](const NDArray arr) -> int { return arr.storage_type(); };
   std::transform(inputs.begin(), inputs.end(), std::back_inserter(in_stypes), xform);
   std::transform(outputs.begin(), outputs.end(), std::back_inserter(out_stypes), xform);
@@ -426,13 +428,13 @@ inline void LogStorageFallback(const nnvm::NodeAttrs& attrs,
   if (!log) return;
   const std::string op_str = operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
   std::ostringstream os;
-  os << "\nStorage type fallback detected:\n" << op_str
-     << "\nThe operator with default storage type will be dispatched for execution. "
-     << "You're seeing this warning message because the operator above is unable to "
-     << "process the given ndarrays with specified storage types, context and parameter. "
-     << "Temporary dense ndarrays are generated in order to execute the operator. "
-     << "You can set environment variable "
-     << "MXNET_STORAGE_FALLBACK_LOG_VERBOSE to 0 to suppress this warning.";
+  const std::string warning = "\nThe operator with default storage type will be dispatched "
+    "for execution. You're seeing this warning message because the operator above is unable "
+    "to process the given ndarrays with specified storage types, context and parameter. "
+    "Temporary dense ndarrays are generated in order to execute the operator. "
+    "You can set environment variable MXNET_STORAGE_FALLBACK_LOG_VERBOSE to "
+    "0 to suppress this warning.";
+  os << "\nStorage type fallback detected:\n" << op_str << warning;
   LogOnce(os.str());
 }
 

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -373,12 +373,12 @@ inline std::string operator_stype_string(const nnvm::NodeAttrs& attrs,
   result += "operator = " + attrs.op->name + "\n";
   result += "input storage types = [";
   for (const auto attr : in_attrs) {
-    result += common::stype_string(attr) + ", ";
+    result += stype_string(attr) + ", ";
   }
   result += "]\n";
   result += "output storage types = [";
   for (const auto attr : out_attrs) {
-    result += common::stype_string(attr) + ", ";
+    result += stype_string(attr) + ", ";
   }
   result += "]\n";
   result += "params = {";
@@ -386,7 +386,7 @@ inline std::string operator_stype_string(const nnvm::NodeAttrs& attrs,
     result += "\"" + kv.first + "\" : " + kv.second + ", ";
   }
   result += "}\n";
-  result += "context.dev_mask = " + common::dev_type_string(dev_mask);
+  result += "context.dev_mask = " + dev_type_string(dev_mask);
   return result;
 }
 

--- a/src/executor/infer_graph_attr_pass.cc
+++ b/src/executor/infer_graph_attr_pass.cc
@@ -50,7 +50,7 @@ bool ApplyOpInferAttr<int, FInferStorageType>(const nnvm::Graph& g,
                                               std::vector<int>* out_attrs,
                                               DispatchMode* dispatch_mode) {
   const DevMaskVector& dev_masks = g.GetAttr<DevMaskVector>("dev_mask");
-  static bool success = finfer(attrs, dev_masks[nid], dispatch_mode, in_attrs, out_attrs);
+  const bool success = finfer(attrs, dev_masks[nid], dispatch_mode, in_attrs, out_attrs);
   if (!success) {
     LOG(FATAL) << "Operator not implemented: "
                << common::operator_stype_string(attrs, dev_masks[nid], *in_attrs, *out_attrs);
@@ -58,7 +58,7 @@ bool ApplyOpInferAttr<int, FInferStorageType>(const nnvm::Graph& g,
   if (*dispatch_mode == DispatchMode::kFComputeFallback) {
     common::LogStorageFallback(attrs, dev_masks[nid], in_attrs, out_attrs);
   }
-  return success;
+  return true;
 }
 
 /*!\brief

--- a/src/executor/infer_graph_attr_pass.cc
+++ b/src/executor/infer_graph_attr_pass.cc
@@ -50,7 +50,15 @@ bool ApplyOpInferAttr<int, FInferStorageType>(const nnvm::Graph& g,
                                               std::vector<int>* out_attrs,
                                               DispatchMode* dispatch_mode) {
   const DevMaskVector& dev_masks = g.GetAttr<DevMaskVector>("dev_mask");
-  return finfer(attrs, dev_masks[nid], dispatch_mode, in_attrs, out_attrs);
+  static bool success = finfer(attrs, dev_masks[nid], dispatch_mode, in_attrs, out_attrs);
+  if (!success) {
+    LOG(FATAL) << "Operator not implemented: "
+               << common::operator_stype_string(attrs, dev_masks[nid], *in_attrs, *out_attrs);
+  }
+  if (*dispatch_mode == DispatchMode::kFComputeFallback) {
+    common::LogStorageFallback(attrs, dev_masks[nid], in_attrs, out_attrs);
+  }
+  return success;
 }
 
 /*!\brief
@@ -357,7 +365,6 @@ inline bool DefaultStorageType(const nnvm::NodeAttrs& attrs,
   if (*dispatch_mode == DispatchMode::kUndefined) {
     if (fallback) {
       *dispatch_mode = DispatchMode::kFComputeFallback;
-      op::LogStorageFallback(attrs, dev_mask, iattr, oattr);
     } else {
       *dispatch_mode = DispatchMode::kFCompute;
     }

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -147,10 +147,8 @@ inline void SetShapeType(const Context& ctx,
     infer_stype_success = exec::DefaultStorageType(attrs, ctx.dev_mask(), dispatch_mode,
                                                    &in_storage_types, &out_storage_types);
   }
-  if (!infer_stype_success) {
-    LOG(FATAL) << "Operator not implemented: "
-      << common::operator_stype_string(attrs, ctx.dev_mask(), in_storage_types, out_storage_types);
-  }
+  CHECK(infer_stype_success) << "Operator not implemented: "
+     << common::operator_stype_string(attrs, ctx.dev_mask(), in_storage_types, out_storage_types);
   if (*dispatch_mode == DispatchMode::kFComputeFallback) {
     common::LogStorageFallback(attrs, ctx.dev_mask(), &in_storage_types, &out_storage_types);
   }

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -138,15 +138,23 @@ inline void SetShapeType(const Context& ctx,
   for (auto& i : outputs) {
     out_storage_types.push_back(i->storage_type());
   }
+  bool infer_stype_success;
   if (inferstorage.count(attrs.op)) {
-    CHECK(inferstorage[attrs.op](attrs, ctx.dev_mask(), dispatch_mode,
-                                 &in_storage_types, &out_storage_types));
+    infer_stype_success = inferstorage[attrs.op](attrs, ctx.dev_mask(), dispatch_mode,
+                                                 &in_storage_types, &out_storage_types);
   } else {
     // if infer storage attr is not present, apply the default infer storage function
-    bool success = exec::DefaultStorageType(attrs, ctx.dev_mask(), dispatch_mode,
-                                            &in_storage_types, &out_storage_types);
-    CHECK(success);
+    infer_stype_success = exec::DefaultStorageType(attrs, ctx.dev_mask(), dispatch_mode,
+                                                   &in_storage_types, &out_storage_types);
   }
+  if (!infer_stype_success) {
+    LOG(FATAL) << "Operator not implemented: "
+      << common::operator_stype_string(attrs, ctx.dev_mask(), in_storage_types, out_storage_types);
+  }
+  if (*dispatch_mode == DispatchMode::kFComputeFallback) {
+    common::LogStorageFallback(attrs, ctx.dev_mask(), &in_storage_types, &out_storage_types);
+  }
+
   CHECK_EQ(out_storage_types.size(), outputs.size());
   CHECK(*dispatch_mode != DispatchMode::kUndefined);
 

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -480,11 +480,14 @@ inline void ParamParser(nnvm::NodeAttrs* attrs) {
           << ") == " << param << ".shape[0] (" << rsp.shape()[0] << ").";          \
   }
 
-#define LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs)                      \
-  {                                                                                \
-    LOG(FATAL) << "Not implemented: "                                              \
-               << common::operator_string(attrs, ctx, inputs, req, outputs);       \
-  }
+inline void LogUnimplementedOp(const nnvm::NodeAttrs& attrs,
+                               const OpContext &ctx,
+                               const std::vector<NDArray> &inputs,
+                               const std::vector<OpReqType> &req,
+                               const std::vector<NDArray> &outputs) {
+    using common::operator_string;
+    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+}
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -350,11 +350,12 @@ inline bool storage_type_assign(StorageTypeVector* stypes,
 
 /*! \brief update the stype vector to default storage and dispatch_mode to fallback
  */
-inline void dispatch_fallback(StorageTypeVector* stypes, DispatchMode* dispatch) {
+inline bool dispatch_fallback(StorageTypeVector* stypes, DispatchMode* dispatch) {
   for (auto& stype : *stypes) {
     type_assign(&stype, kDefaultStorage);
   }
   DISPATCH_MODE_ASSIGN_CHECK(dispatch, 0, DispatchMode::kFComputeFallback);
+  return true;
 }
 
 // make a new node with operator op_name. Inputs are not filled.
@@ -479,67 +480,11 @@ inline void ParamParser(nnvm::NodeAttrs* attrs) {
           << ") == " << param << ".shape[0] (" << rsp.shape()[0] << ").";          \
   }
 
-/*! \brief get string representation of the operator stypes */
-inline std::string operator_stype_string(const nnvm::NodeAttrs& attrs,
-                                         const int dev_mask,
-                                         const std::vector<int>& in_attrs,
-                                         const std::vector<int>& out_attrs) {
-  std::string result = "";
-  result += "operator = " + attrs.op->name + "\n";
-  result += "input storage types = [";
-  for (const auto attr : in_attrs) {
-    result += common::stype_string(attr) + ", ";
+#define LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs)                      \
+  {                                                                                \
+    LOG(FATAL) << "Not implemented: "                                              \
+               << common::operator_string(attrs, ctx, inputs, req, outputs);       \
   }
-  result += "]\n";
-  result += "output storage types = [";
-  for (const auto attr : out_attrs) {
-    result += common::stype_string(attr) + ", ";
-  }
-  result += "]\n";
-  result += "params = {";
-  for (auto kv : attrs.dict) {
-    result += "\"" + kv.first + "\" : " + kv.second + ", ";
-  }
-  result += "}\n";
-  result += "context.dev_mask = " + common::dev_type_string(dev_mask);
-  return result;
-}
-
-/*! \brief get string representation of the operator */
-inline std::string operator_string(const nnvm::NodeAttrs& attrs,
-                                  const OpContext& ctx,
-                                  const std::vector<NDArray>& inputs,
-                                  const std::vector<OpReqType>& req,
-                                  const std::vector<NDArray>& outputs) {
-  std::string result = "";
-  std::vector<int> in_stypes;
-  std::vector<int> out_stypes;
-  auto xform = [](const NDArray arr) -> int { return arr.storage_type(); };
-  std::transform(inputs.begin(), inputs.end(), std::back_inserter(in_stypes), xform);
-  std::transform(outputs.begin(), outputs.end(), std::back_inserter(out_stypes), xform);
-  result += operator_stype_string(attrs, ctx.run_ctx.ctx.dev_mask(), in_stypes, out_stypes);
-  return result;
-}
-
-/*! \brief log storage fallback event
- */
-inline void LogStorageFallback(const nnvm::NodeAttrs& attrs,
-                               const int dev_mask,
-                               const std::vector<int>* in_attrs,
-                               const std::vector<int>* out_attrs) {
-  static bool log = dmlc::GetEnv("MXNET_STORAGE_FALLBACK_LOG_VERBOSE", true);
-  if (!log) return;
-  const std::string op_str = op::operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
-  std::ostringstream os;
-  os << "\nStorage type fallback detected:\n" << op_str
-     << "\nThe operator with default storage type will be dispatched for execution. "
-     << "You're seeing this warning message because the operator above is unable to "
-     << "process the given ndarrays with specified storage types, context and parameter. "
-     << "Temporary dense ndarrays are generated in order to execute the operator. "
-     << "You can set environment variable "
-     << "MXNET_STORAGE_FALLBACK_LOG_VERBOSE to 0 to suppress this warning.";
-  common::LogOnce(os.str());
-}
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/optimizer_op-inl.h
+++ b/src/operator/optimizer_op-inl.h
@@ -197,7 +197,7 @@ inline void SGDUpdateEx(const nnvm::NodeAttrs& attrs,
     NDArray out = outputs[0];
     SGDUpdateRspRspImpl<xpu>(param, ctx, inputs[0], inputs[1], req[0], &out);
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -496,10 +496,9 @@ inline bool StdOptStorageType(const nnvm::NodeAttrs& attrs,
   }
 
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  return true;
+  return dispatched;
 }
 
 template<int req>
@@ -584,7 +583,7 @@ inline void SGDMomUpdateEx(const nnvm::NodeAttrs& attrs,
              out_stype == kRowSparseStorage) {
     SGDMomStdUpdateRspRspDnsImpl<xpu>(param, ctx, weight, grad, mom, req[0], &out);
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -881,7 +880,7 @@ inline void AdamUpdateEx(const nnvm::NodeAttrs& attrs,
      AdamUpdateRspRspRspImpl<xpu>(param, ctx, inputs[0], inputs[1], inputs[2],
                                   inputs[3], req[0], &out);
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -1276,7 +1275,7 @@ inline void FtrlUpdateEx(const nnvm::NodeAttrs& attrs,
      FtrlUpdateRspRspRspImpl<xpu>(param, ctx, inputs[0], inputs[1], inputs[2],
                                   inputs[3], req[0], &out);
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/optimizer_op-inl.h
+++ b/src/operator/optimizer_op-inl.h
@@ -197,7 +197,7 @@ inline void SGDUpdateEx(const nnvm::NodeAttrs& attrs,
     NDArray out = outputs[0];
     SGDUpdateRspRspImpl<xpu>(param, ctx, inputs[0], inputs[1], req[0], &out);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -583,7 +583,7 @@ inline void SGDMomUpdateEx(const nnvm::NodeAttrs& attrs,
              out_stype == kRowSparseStorage) {
     SGDMomStdUpdateRspRspDnsImpl<xpu>(param, ctx, weight, grad, mom, req[0], &out);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -880,7 +880,7 @@ inline void AdamUpdateEx(const nnvm::NodeAttrs& attrs,
      AdamUpdateRspRspRspImpl<xpu>(param, ctx, inputs[0], inputs[1], inputs[2],
                                   inputs[3], req[0], &out);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -1275,7 +1275,7 @@ inline void FtrlUpdateEx(const nnvm::NodeAttrs& attrs,
      FtrlUpdateRspRspRspImpl<xpu>(param, ctx, inputs[0], inputs[1], inputs[2],
                                   inputs[3], req[0], &out);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -679,7 +679,7 @@ void SumOpForwardEx(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
     NDArray output = outputs[0];
     SumCsrImpl<xpu, normalize>(attrs, s, ctx, inputs[0], req[0], &output);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -374,13 +374,9 @@ inline bool SumOpForwardInferStorageType(const nnvm::NodeAttrs& attrs,
   if (!dispatched) {
     // If input is csr, but keepdims or exclude is set or summing along a axis
     // different from 0 or 1
-    dispatch_fallback(out_attrs, dispatch_mode);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  if (*dispatch_mode == DispatchMode::kFComputeFallback) {
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
-  }
-
-  return true;
+  return dispatched;
 }
 
 template<typename xpu, typename reducer>
@@ -683,8 +679,7 @@ void SumOpForwardEx(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
     NDArray output = outputs[0];
     SumCsrImpl<xpu, normalize>(attrs, s, ctx, inputs[0], req[0], &output);
   } else {
-    LOG(FATAL) << "Not implemented: "
-               << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/cast_storage-inl.h
+++ b/src/operator/tensor/cast_storage-inl.h
@@ -397,11 +397,7 @@ inline bool CastStorageInferStorageType(const nnvm::NodeAttrs& attrs,
     dispatched = storage_type_assign(out_attrs, param_stype,
                                      dispatch_mode, DispatchMode::kFComputeEx);
   }
-  if (!dispatched) {
-    LOG(FATAL) << "Not implemented: "
-               << operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 template<typename xpu>

--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -1066,7 +1066,7 @@ void DotForwardEx(const nnvm::NodeAttrs& attrs,
     NDArray ret = outputs[0];
     DotDnsCsrCsrImpl<xpu>(ctx, inputs[0].data(), inputs[1], req[0], &ret);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -1108,7 +1108,7 @@ void DotBackwardEx(const nnvm::NodeAttrs& attrs,
     TBlob ret = outputs[1].data();
     DotCsrRspDnsImpl(ctx, xpu(), inputs[1], inputs[0], req[1], !param.transpose_a, &ret);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -244,12 +244,9 @@ inline bool DotForwardInferStorageType(const nnvm::NodeAttrs& attrs,
                                      dispatch_ex);
   }
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  if (static_cast<DispatchMode>(*dispatch_mode) == DispatchMode::kFComputeFallback) {
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 inline bool DotBackwardInferStorageType(const nnvm::NodeAttrs& attrs,
@@ -294,10 +291,9 @@ inline bool DotBackwardInferStorageType(const nnvm::NodeAttrs& attrs,
     }
   }
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  return true;
+  return dispatched;
 }
 
 /*!
@@ -1070,7 +1066,7 @@ void DotForwardEx(const nnvm::NodeAttrs& attrs,
     NDArray ret = outputs[0];
     DotDnsCsrCsrImpl<xpu>(ctx, inputs[0].data(), inputs[1], req[0], &ret);
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -1112,7 +1108,7 @@ void DotBackwardEx(const nnvm::NodeAttrs& attrs,
     TBlob ret = outputs[1].data();
     DotCsrRspDnsImpl(ctx, xpu(), inputs[1], inputs[0], req[1], !param.transpose_a, &ret);
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/elemwise_binary_op.cc
+++ b/src/operator/tensor/elemwise_binary_op.cc
@@ -46,12 +46,9 @@ bool ElemwiseBinaryOp::SparseSparseWithDenseResult(const nnvm::NodeAttrs& attrs,
     dispatched = storage_type_assign(&out_stype, kDefaultStorage, dispatch_mode, dispatch_ex);
   }
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  if (*dispatch_mode == DispatchMode::kFComputeFallback) {
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 bool ElemwiseBinaryOp::BackwardUseInStorageType(const nnvm::NodeAttrs& attrs,
@@ -78,12 +75,9 @@ bool ElemwiseBinaryOp::BackwardUseInStorageType(const nnvm::NodeAttrs& attrs,
     }
   }
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  if (*dispatch_mode == DispatchMode::kFComputeFallback) {
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 }  // namespace op

--- a/src/operator/tensor/elemwise_binary_op.h
+++ b/src/operator/tensor/elemwise_binary_op.h
@@ -400,7 +400,7 @@ class ElemwiseBinaryOp : public OpBase {
         });
       });
     } else {
-      LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+      LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
     }
   }
 
@@ -442,7 +442,7 @@ class ElemwiseBinaryOp : public OpBase {
     } else if (lhs_stype == kCSRStorage && rhs_stype == kCSRStorage) {
       ComputeEx<xpu, OP>(attrs, ctx, inputs, req, outputs);
     } else {
-      LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+      LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
     }
   }
 
@@ -487,7 +487,7 @@ class ElemwiseBinaryOp : public OpBase {
         DCHECK_LT(fabs(static_cast<float>(LOP::Map(0))), 1e-5f);
         UnaryOp::ComputeEx<xpu, LOP>(attrs, ctx, inputs, req, {outputs[0]});
       } else {
-        LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+        LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
       }
     }
     // rhs grad
@@ -498,7 +498,7 @@ class ElemwiseBinaryOp : public OpBase {
         DCHECK_LT(fabs(static_cast<float>(ROP::Map(0))), 1e-5f);
         UnaryOp::ComputeEx<xpu, ROP>(attrs, ctx, inputs, req, {outputs[1]});
       } else {
-        LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+        LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
       }
     }
   }

--- a/src/operator/tensor/elemwise_binary_op.h
+++ b/src/operator/tensor/elemwise_binary_op.h
@@ -300,12 +300,9 @@ class ElemwiseBinaryOp : public OpBase {
       }
     }
     if (!dispatched) {
-      dispatch_fallback(out_attrs, dispatch_mode);
+      dispatched = dispatch_fallback(out_attrs, dispatch_mode);
     }
-    if (*dispatch_mode == DispatchMode::kFComputeFallback) {
-      LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
-    }
-    return true;
+    return dispatched;
   }
 
   /*!
@@ -403,7 +400,7 @@ class ElemwiseBinaryOp : public OpBase {
         });
       });
     } else {
-      LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+      LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
     }
   }
 
@@ -445,7 +442,7 @@ class ElemwiseBinaryOp : public OpBase {
     } else if (lhs_stype == kCSRStorage && rhs_stype == kCSRStorage) {
       ComputeEx<xpu, OP>(attrs, ctx, inputs, req, outputs);
     } else {
-      LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+      LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
     }
   }
 
@@ -490,7 +487,7 @@ class ElemwiseBinaryOp : public OpBase {
         DCHECK_LT(fabs(static_cast<float>(LOP::Map(0))), 1e-5f);
         UnaryOp::ComputeEx<xpu, LOP>(attrs, ctx, inputs, req, {outputs[0]});
       } else {
-        LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+        LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
       }
     }
     // rhs grad
@@ -501,7 +498,7 @@ class ElemwiseBinaryOp : public OpBase {
         DCHECK_LT(fabs(static_cast<float>(ROP::Map(0))), 1e-5f);
         UnaryOp::ComputeEx<xpu, ROP>(attrs, ctx, inputs, req, {outputs[1]});
       } else {
-        LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+        LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
       }
     }
   }

--- a/src/operator/tensor/elemwise_binary_scalar_op.h
+++ b/src/operator/tensor/elemwise_binary_scalar_op.h
@@ -269,7 +269,7 @@ class BinaryScalarOp : public UnaryOp {
         });
       });
     } else {
-      LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+      LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
     }
   }
 

--- a/src/operator/tensor/elemwise_binary_scalar_op.h
+++ b/src/operator/tensor/elemwise_binary_scalar_op.h
@@ -269,7 +269,7 @@ class BinaryScalarOp : public UnaryOp {
         });
       });
     } else {
-      LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+      LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
     }
   }
 

--- a/src/operator/tensor/elemwise_binary_scalar_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_scalar_op_basic.cc
@@ -74,12 +74,9 @@ static bool BinaryScalarStorageTypeWithDenseResultStorageType(const NodeAttrs& a
       dispatch_mode, dispatch_ex);
   }
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  if (static_cast<DispatchMode>(*dispatch_mode) == DispatchMode::kFComputeFallback) {
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 static bool BinaryScalarStorageType(const nnvm::NodeAttrs& attrs,
@@ -118,10 +115,9 @@ static bool BinaryScalarStorageType(const nnvm::NodeAttrs& attrs,
     }
   }
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  return true;
+  return dispatched;
 }
 
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SCALAR_SUPPORT_WITH_DENSE_RESULT(_plus_scalar)

--- a/src/operator/tensor/elemwise_scatter_op.cc
+++ b/src/operator/tensor/elemwise_scatter_op.cc
@@ -23,18 +23,6 @@
 namespace mxnet {
 namespace op {
 
-static bool fail_storage_type_inference(const NodeAttrs& attrs,
-                                        const int dev_mask,
-                                        DispatchMode* dispatch_mode,
-                                        std::vector<int>* in_attrs,
-                                        std::vector<int>* out_attrs) {
-  dispatch_fallback(out_attrs, dispatch_mode);
-  if (*dispatch_mode == DispatchMode::kFComputeFallback) {
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
-  }
-  return true;
-}
-
 static bool StorageTypeRspOrDenseOutput(const NodeAttrs& attrs,
                                         const int dev_mask,
                                         DispatchMode* dispatch_mode,
@@ -57,7 +45,7 @@ static bool StorageTypeRspOrDenseOutput(const NodeAttrs& attrs,
       return true;
     }
   }
-  return fail_storage_type_inference(attrs, dev_mask, dispatch_mode, in_attrs, out_attrs);
+  return dispatch_fallback(out_attrs, dispatch_mode);
 }
 
 static bool StorageTypeScatteredScalarOp(const NodeAttrs& attrs,
@@ -74,7 +62,7 @@ static bool StorageTypeScatteredScalarOp(const NodeAttrs& attrs,
                                                   : DispatchMode::kFComputeEx)) {
     return true;
   }
-  return fail_storage_type_inference(attrs, dev_mask, dispatch_mode, in_attrs, out_attrs);
+  return dispatch_fallback(out_attrs, dispatch_mode);
 }
 
 /*! \brief _scatter_elemwise_div */

--- a/src/operator/tensor/elemwise_sum.cc
+++ b/src/operator/tensor/elemwise_sum.cc
@@ -84,7 +84,7 @@ bool ElementWiseSumForwardInferStorageType(const nnvm::NodeAttrs& attrs,
 }
 
 void ElementWiseSumComputeExCPU(const nnvm::NodeAttrs& attrs,
-                                const OpContext& op_ctx,
+                                const OpContext& ctx,
                                 const std::vector<NDArray>& inputs,
                                 const std::vector<OpReqType>& req,
                                 const std::vector<NDArray>& outputs) {
@@ -94,20 +94,20 @@ void ElementWiseSumComputeExCPU(const nnvm::NodeAttrs& attrs,
   if (req[0] == kNullOp) return;
   CHECK_EQ(req[0], kWriteTo) << "ElementWiseSumComputeExCPU only supports req = kWriteTo";
   if (inputs[0].storage_type() == kRowSparseStorage) {
-    mshadow::Stream<cpu>* s = op_ctx.get_stream<cpu>();
-    Resource rsc = ResourceManager::Get()->Request(op_ctx.run_ctx.get_ctx(),
+    mshadow::Stream<cpu>* s = ctx.get_stream<cpu>();
+    Resource rsc = ResourceManager::Get()->Request(ctx.run_ctx.get_ctx(),
         ResourceRequest(ResourceRequest::kTempSpace));
     NDArray out_nd = outputs[0];
     mxnet::ndarray::ElementwiseSum<cpu>(s, rsc, inputs, &out_nd);
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, op_ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 
 NNVM_REGISTER_OP(add_n)
+MXNET_ADD_SPARSE_OP_ALIAS(add_n)
+MXNET_ADD_SPARSE_OP_ALIAS(ElementWiseSum)
 .add_alias("ElementWiseSum")
-.add_alias("_sparse_add_n")
-.add_alias("_sparse_ElementWiseSum")
 .describe(R"doc(Adds all input arguments element-wise.
 
 .. math::

--- a/src/operator/tensor/elemwise_sum.cc
+++ b/src/operator/tensor/elemwise_sum.cc
@@ -100,7 +100,7 @@ void ElementWiseSumComputeExCPU(const nnvm::NodeAttrs& attrs,
     NDArray out_nd = outputs[0];
     mxnet::ndarray::ElementwiseSum<cpu>(s, rsc, inputs, &out_nd);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/elemwise_sum.cu
+++ b/src/operator/tensor/elemwise_sum.cu
@@ -43,8 +43,7 @@ void ElementWiseSumComputeExGPU(const nnvm::NodeAttrs& attrs,
     NDArray out_nd = outputs[0];
     mxnet::ndarray::ElementwiseSum<gpu>(s, op_ctx.requested[0], inputs, &out_nd);
   } else {
-    LOG(FATAL) << "Not implemented: "
-               << operator_string(attrs, op_ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/elemwise_sum.cu
+++ b/src/operator/tensor/elemwise_sum.cu
@@ -29,7 +29,7 @@ namespace mxnet {
 namespace op {
 
 void ElementWiseSumComputeExGPU(const nnvm::NodeAttrs& attrs,
-                                const OpContext& op_ctx,
+                                const OpContext& ctx,
                                 const std::vector<NDArray>& inputs,
                                 const std::vector<OpReqType>& req,
                                 const std::vector<NDArray>& outputs) {
@@ -39,9 +39,9 @@ void ElementWiseSumComputeExGPU(const nnvm::NodeAttrs& attrs,
   if (req[0] == kNullOp) return;
   CHECK_EQ(req[0], kWriteTo) << "ElementWiseSumComputeExGPU only supports req = kWriteTo";
   if (inputs[0].storage_type() == kRowSparseStorage) {
-    mshadow::Stream<gpu>* s = op_ctx.get_stream<gpu>();
+    mshadow::Stream<gpu>* s = ctx.get_stream<gpu>();
     NDArray out_nd = outputs[0];
-    mxnet::ndarray::ElementwiseSum<gpu>(s, op_ctx.requested[0], inputs, &out_nd);
+    mxnet::ndarray::ElementwiseSum<gpu>(s, ctx.requested[0], inputs, &out_nd);
   } else {
     LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }

--- a/src/operator/tensor/elemwise_sum.cu
+++ b/src/operator/tensor/elemwise_sum.cu
@@ -43,7 +43,7 @@ void ElementWiseSumComputeExGPU(const nnvm::NodeAttrs& attrs,
     NDArray out_nd = outputs[0];
     mxnet::ndarray::ElementwiseSum<gpu>(s, ctx.requested[0], inputs, &out_nd);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/elemwise_unary_op.h
+++ b/src/operator/tensor/elemwise_unary_op.h
@@ -318,7 +318,7 @@ class UnaryOp : public OpBase {
     if (in_stype == out_stype && (in_stype == kRowSparseStorage || in_stype == kCSRStorage)) {
       MapToFCompute<xpu>(attrs, ctx, inputs, req, outputs, IdentityCompute<xpu>);
     } else {
-      LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+      LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
     }
   }
 
@@ -338,7 +338,7 @@ class UnaryOp : public OpBase {
       // csr, _ -> csr, or rsp, _ -> rsp
       OpBase::CopyNDArray(ctx.get_stream<xpu>(), &outputs[0], req[0], inputs[0]);
     } else {
-      LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+      LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
     }
   }
 };

--- a/src/operator/tensor/elemwise_unary_op.h
+++ b/src/operator/tensor/elemwise_unary_op.h
@@ -318,7 +318,7 @@ class UnaryOp : public OpBase {
     if (in_stype == out_stype && (in_stype == kRowSparseStorage || in_stype == kCSRStorage)) {
       MapToFCompute<xpu>(attrs, ctx, inputs, req, outputs, IdentityCompute<xpu>);
     } else {
-      LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+      LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
     }
   }
 
@@ -338,7 +338,7 @@ class UnaryOp : public OpBase {
       // csr, _ -> csr, or rsp, _ -> rsp
       OpBase::CopyNDArray(ctx.get_stream<xpu>(), &outputs[0], req[0], inputs[0]);
     } else {
-      LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+      LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
     }
   }
 };

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -62,10 +62,9 @@ static bool IdentityAttrLikeRhsStorageType(const nnvm::NodeAttrs& attrs,
                                      dispatch_mode, DispatchMode::kFComputeEx);
   }
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  return true;
+  return dispatched;
 }
 
 // relu

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -194,12 +194,7 @@ inline bool SparseEmbeddingOpForwardStorageType(const nnvm::NodeAttrs& attrs,
     dispatched = storage_type_assign(&out_stype, kDefaultStorage,
                                      dispatch_mode, DispatchMode::kFComputeEx);
   }
-  if (!dispatched) {
-    // nothing to fallback on
-    LOG(FATAL) << "Not implemented: "
-               << operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 
@@ -224,12 +219,7 @@ inline bool SparseEmbeddingOpBackwardStorageType(const nnvm::NodeAttrs& attrs,
       dispatched = true;
     }
   }
-  if (!dispatched) {
-    // nothing to fallback on
-    LOG(FATAL) << "Not implemented: "
-               << operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 /*! \brief name the struct Take instead of take
  * to avoid conflict with the take function in mshadow
@@ -410,7 +400,7 @@ void SparseEmbeddingOpForwardEx(const nnvm::NodeAttrs& attrs,
       out_stype == kDefaultStorage) {
     SparseEmbeddingOpForwardRspImpl<xpu>(ctx, data.data(), weight, req[0], out.data());
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -597,7 +587,7 @@ void SparseEmbeddingOpBackwardEx(const nnvm::NodeAttrs& attrs,
     SparseEmbeddingOpBackwardRspImpl<xpu>(ctx, ograd.data(), data.data(),
                                           req[embedding::kWeight], weight_grad);
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -400,7 +400,7 @@ void SparseEmbeddingOpForwardEx(const nnvm::NodeAttrs& attrs,
       out_stype == kDefaultStorage) {
     SparseEmbeddingOpForwardRspImpl<xpu>(ctx, data.data(), weight, req[0], out.data());
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -587,7 +587,7 @@ void SparseEmbeddingOpBackwardEx(const nnvm::NodeAttrs& attrs,
     SparseEmbeddingOpBackwardRspImpl<xpu>(ctx, ograd.data(), data.data(),
                                           req[embedding::kWeight], weight_grad);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/init_op.h
+++ b/src/operator/tensor/init_op.h
@@ -187,10 +187,9 @@ inline bool InitStorageType(const nnvm::NodeAttrs& attrs,
                                      dispatch_mode, DispatchMode::kFComputeEx);
   }
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  return true;
+  return dispatched;
 }
 
 /*!
@@ -345,7 +344,7 @@ void FillComputeZerosEx(const nnvm::NodeAttrs& attrs,
   } else if (stype == kCSRStorage) {
     FillZerosCsrImpl(s, outputs[0]);
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/init_op.h
+++ b/src/operator/tensor/init_op.h
@@ -344,7 +344,7 @@ void FillComputeZerosEx(const nnvm::NodeAttrs& attrs,
   } else if (stype == kCSRStorage) {
     FillZerosCsrImpl(s, outputs[0]);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -417,13 +417,10 @@ inline bool SliceForwardInferStorageType(const nnvm::NodeAttrs& attrs,
   }
 
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
-  }
-  if (*dispatch_mode == DispatchMode::kFComputeFallback) {
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
 
-  return true;
+  return dispatched;
 }
 
 // slice the indptr of a csr

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -516,11 +516,10 @@ parameter values:
       // otherwise, output is dense (print warning anyway)
       if (!storage_type_assign(&(*out_attrs)[0], kDefaultStorage,
                               dispatch_mode, DispatchMode::kFComputeFallback)) {
-        dispatch_fallback(out_attrs, dispatch_mode);
+        dispatched = dispatch_fallback(out_attrs, dispatch_mode);
       }
-      LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
     }
-    return true;
+    return dispatched;
   })
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_clip" })
 .add_argument("data", "NDArray-or-Symbol", "Input array.")

--- a/src/operator/tensor/sparse_retain-inl.h
+++ b/src/operator/tensor/sparse_retain-inl.h
@@ -85,11 +85,7 @@ inline bool SparseRetainForwardInferStorageType(const nnvm::NodeAttrs& attrs,
     dispatched = storage_type_assign(&out_stype, kRowSparseStorage,
                                      dispatch_mode, DispatchMode::kFComputeEx);
   }
-  if (!dispatched) {
-    LOG(FATAL) << "Not implemented: "
-               << operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 inline bool SparseRetainBackwardInferStorageType(const nnvm::NodeAttrs& attrs,
@@ -111,11 +107,7 @@ inline bool SparseRetainBackwardInferStorageType(const nnvm::NodeAttrs& attrs,
       dispatched = true;
     }
   }
-  if (!dispatched) {
-    LOG(FATAL) << "Not implemented: "
-               << operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 /*!

--- a/src/operator/tensor/square_sum-inl.h
+++ b/src/operator/tensor/square_sum-inl.h
@@ -63,12 +63,7 @@ inline bool SquareSumForwardInferStorageType(const nnvm::NodeAttrs& attrs,
       dispatched = storage_type_assign(&out_stype, kDefaultStorage,
                                        dispatch_mode, DispatchMode::kFComputeEx);
   }
-  if (!dispatched) {
-    // nothing to fallback on
-    LOG(FATAL) << "Not implemented: "
-               << operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 // infer storage function for _backward_square_sum operator on cpu
@@ -88,12 +83,7 @@ inline bool SquareSumBackwardInferStorageType(const nnvm::NodeAttrs& attrs,
     dispatched = storage_type_assign(&grad_stype, kRowSparseStorage,
                                      dispatch_mode, DispatchMode::kFComputeEx);
   }
-  if (!dispatched) {
-    // nothing to fallback on
-    LOG(FATAL) << "Not implemented: "
-               << operator_stype_string(attrs, dev_mask, *in_attrs, *out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 /*!
@@ -493,7 +483,7 @@ void SquareSumOpForwardEx(const nnvm::NodeAttrs& attrs,
     NDArray output = outputs[0];
     SquareSumRspImpl(attrs, s, inputs[0], req[0], &output);
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -515,7 +505,7 @@ void SquareSumOpBackwardEx(const nnvm::NodeAttrs& attrs,
     NDArray output = outputs[0];
     SquareSumRspGradImpl<xpu>(attrs, ctx, inputs[0], inputs[1], req[0], &output);
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
   }
 }
 

--- a/src/operator/tensor/square_sum-inl.h
+++ b/src/operator/tensor/square_sum-inl.h
@@ -483,7 +483,7 @@ void SquareSumOpForwardEx(const nnvm::NodeAttrs& attrs,
     NDArray output = outputs[0];
     SquareSumRspImpl(attrs, s, inputs[0], req[0], &output);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -505,7 +505,7 @@ void SquareSumOpBackwardEx(const nnvm::NodeAttrs& attrs,
     NDArray output = outputs[0];
     SquareSumRspGradImpl<xpu>(attrs, ctx, inputs[0], inputs[1], req[0], &output);
   } else {
-    LOG_UNIMPLMENTED_OP(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 


### PR DESCRIPTION
## Description ##
This PR moves the logging of storage fallback message and other error messages from individual operator's FInferStorage to a common place, by checking the value of `dispatch_mode` and return code of FInferStorage.

@reminisce @anirudh2290 @cjolivier01 

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
