### PR TITLE
[Review Required] Adding more file formats to license_header.py (.m, .mk, .R, .cfg)

### DIFF
--- a/cpp-package/cpp-package.mk
+++ b/cpp-package/cpp-package.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 ifndef LINT_LANG
 	LINT_LANG="all"
 endif

--- a/cpp-package/example/example.mk
+++ b/cpp-package/example/example.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 CPPEX_SRC = $(wildcard cpp-package/example/*.cpp)
 CPPEX_EXE = $(patsubst cpp-package/example/%.cpp, build/cpp-package/example/%, $(CPPEX_SRC))
 

--- a/cpp-package/include/mxnet-cpp/CPPLINT.cfg
+++ b/cpp-package/include/mxnet-cpp/CPPLINT.cfg
@@ -1,2 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 filter=-runtime/references
 exclude_files=op.h

--- a/docker_multiarch/arm.crosscompile.android.mk
+++ b/docker_multiarch/arm.crosscompile.android.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #-------------------------------------------------------------------------------
 #  Template configuration for compiling mxnet
 #
@@ -17,7 +34,7 @@
 #-------------------------------------------------------------------------------
 
 #---------------------
-# We do not assign compilers here.  Often when cross-compiling these will already 
+# We do not assign compilers here.  Often when cross-compiling these will already
 # be set correctly.
 #--------------------
 

--- a/docker_multiarch/arm.crosscompile.mk
+++ b/docker_multiarch/arm.crosscompile.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #-------------------------------------------------------------------------------
 #  Template configuration for compiling mxnet
 #
@@ -17,7 +34,7 @@
 #-------------------------------------------------------------------------------
 
 #---------------------
-# We do not assign compilers here.  Often when cross-compiling these will already 
+# We do not assign compilers here.  Often when cross-compiling these will already
 # be set correctly.
 #--------------------
 

--- a/example/captcha/mxnet_captcha.R
+++ b/example/captcha/mxnet_captcha.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(mxnet)
 
 data <- mx.symbol.Variable('data')

--- a/example/gan/CGAN_mnist_R/CGAN_mnist_setup.R
+++ b/example/gan/CGAN_mnist_R/CGAN_mnist_setup.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 require("imager")
 require("dplyr")
 require("readr")
@@ -7,7 +24,7 @@ source("iterators.R")
 
 ######################################################
 ### Data import and preperation
-### First download MNIST train data at Kaggle: 
+### First download MNIST train data at Kaggle:
 ###   https://www.kaggle.com/c/digit-recognizer/data
 ######################################################
 train <- read_csv('data/train.csv')

--- a/example/gan/CGAN_mnist_R/iterators.R
+++ b/example/gan/CGAN_mnist_R/iterators.R
@@ -1,13 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 
 G_iterator<- function(batch_size){
-  
+
   batch<- 0
   batch_per_epoch<-5
-  
+
   reset<- function(){
     batch<<- 0
   }
-  
+
   iter.next<- function(){
     batch<<- batch+1
     if (batch>batch_per_epoch) {
@@ -16,7 +33,7 @@ G_iterator<- function(batch_size){
       return(TRUE)
     }
   }
-  
+
   value<- function(){
     set.seed(123+batch)
     digit<- mx.nd.array(sample(0:9, size = batch_size, replace = T))
@@ -24,19 +41,19 @@ G_iterator<- function(batch_size){
     data<- mx.nd.reshape(data = data, shape = c(1,1,-1, batch_size))
     return(list(data=data, digit=digit))
   }
-  
+
   return(list(reset=reset, iter.next=iter.next, value=value, batch_size=batch_size, batch=batch))
 }
 
 D_iterator<- function(batch_size){
-  
+
   batch<- 0
   batch_per_epoch<-5
-  
+
   reset<- function(){
     batch<<- 0
   }
-  
+
   iter.next<- function(){
     batch<<- batch+1
     if (batch>batch_per_epoch) {
@@ -45,17 +62,17 @@ D_iterator<- function(batch_size){
       return(TRUE)
     }
   }
-  
+
   value<- function(){
     set.seed(123+batch)
     idx<- sample(length(train_label), size = batch_size, replace = T)
     data<- train_data[,,,idx, drop=F]
     label<- mx.nd.array(train_label[idx])
     digit<- mx.nd.one.hot(indices = label, depth = 10)
-    
+
     return(list(data=mx.nd.array(data), digit=digit, label=label))
   }
-  
+
   return(list(reset=reset, iter.next=iter.next, value=value, batch_size=batch_size, batch=batch))
 }
 

--- a/example/image-classification/symbol_alexnet.R
+++ b/example/image-classification/symbol_alexnet.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(mxnet)
 
 get_symbol <- function(num_classes = 1000) {
@@ -11,7 +28,7 @@ get_symbol <- function(num_classes = 1000) {
   conv2 <- mx.symbol.Convolution(data = lrn1, kernel = c(5, 5), pad = c(2, 2), num_filter = 256)
   relu2 <- mx.symbol.Activation(data = conv2, act_type = "relu")
   lrn2 <- mx.symbol.LRN(data = relu2, alpha = 0.0001, beta = 0.75, knorm = 2, nsize = 5)
-  pool2 <- mx.symbol.Pooling(data = lrn2, kernel = c(3, 3), stride = c(2, 2), pool_type = "max")  
+  pool2 <- mx.symbol.Pooling(data = lrn2, kernel = c(3, 3), stride = c(2, 2), pool_type = "max")
   # stage 3
   conv3 <- mx.symbol.Convolution(data = lrn2, kernel = c(3, 3), pad = c(1, 1), num_filter = 384)
   relu3 <- mx.symbol.Activation(data = conv3, act_type = "relu")

--- a/example/image-classification/symbol_googlenet.R
+++ b/example/image-classification/symbol_googlenet.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(mxnet)
 
 ConvFactory <- function(data, num_filter, kernel, stride = c(1, 1), pad = c(0, 0),
@@ -24,11 +41,11 @@ InceptionFactory <- function(data, num_1x1, num_3x3red, num_3x3,
     cd5x5 = ConvFactory(data = cd5x5r, num_filter = num_d5x5, kernel = c(5, 5), pad = c(2, 2),
                         name = paste(name, '_5x5', sep = ''))
     # pool + proj
-    pooling = mx.symbol.Pooling(data = data, kernel = c(3, 3), stride = c(1, 1), 
+    pooling = mx.symbol.Pooling(data = data, kernel = c(3, 3), stride = c(1, 1),
                                 pad = c(1, 1), pool_type = pool,
                                 name = paste(pool, '_pool_', name, '_pool', sep = ''))
 
-    cproj = ConvFactory(data = pooling, num_filter = proj, kernel = c(1, 1), 
+    cproj = ConvFactory(data = pooling, num_filter = proj, kernel = c(1, 1),
                         name = paste(name, '_proj', sep = ''))
     # concat
     concat_lst <- list()
@@ -47,7 +64,7 @@ get_symbol <- function(num_classes = 1000) {
   conv2 <- ConvFactory(pool1, 64, kernel = c(1, 1), stride = c(1, 1), name = "conv2")
   conv3 <- ConvFactory(conv2, 192, kernel = c(3, 3), stride = c(1, 1), pad = c(1, 1), name = "conv3")
   pool3 <- mx.symbol.Pooling(conv3, kernel = c(3, 3), stride = c(2, 2), pool_type = "max")
-  
+
   in3a <- InceptionFactory(pool3, 64, 96, 128, 16, 32, "max", 32, name = "in3a")
   in3b <- InceptionFactory(in3a, 128, 128, 192, 32, 96, "max", 64, name = "in3b")
   pool4 <- mx.symbol.Pooling(in3b, kernel = c(3, 3), stride = c(2, 2), pool_type = "max")

--- a/example/image-classification/symbol_inception-bn-28-small.R
+++ b/example/image-classification/symbol_inception-bn-28-small.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(mxnet)
 
 # Basic Conv + BN + ReLU factory
@@ -19,7 +36,7 @@ DownsampleFactory <- function(data, ch_3x3) {
     data = data, kernel = c(3, 3), stride = c(2, 2), num_filter = ch_3x3, pad =
       c(1, 1)
   )
-  
+
   # pool
   pool = mx.symbol.Pooling(
     data = data, kernel = c(3, 3), stride = c(2, 2), pad = c(1, 1), pool_type =

--- a/example/image-classification/symbol_inception-bn.R
+++ b/example/image-classification/symbol_inception-bn.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(mxnet)
 
 eps = 1e-10 + 1e-5
@@ -9,7 +26,7 @@ ConvFactory <- function(data, num_filter, kernel, stride = c(1, 1),
     conv <- mx.symbol.Convolution(data = data, num_filter = num_filter,
                                   kernel = kernel, stride = stride, pad = pad,
                                   name = paste('conv_', name, suffix, sep = ''))
-    
+
     bn <- mx.symbol.BatchNorm(data = conv, eps = eps, momentum = bn_mom, fix.gamma = fix_gamma, name = paste('bn_', name, suffix, sep = ''))
     act <- mx.symbol.Activation(data = bn, act_type = 'relu', name = paste('relu_', name, suffix, sep = ''))
     return(act)

--- a/example/image-classification/symbol_inception-resnet-v1.R
+++ b/example/image-classification/symbol_inception-resnet-v1.R
@@ -1,25 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Inception resnet v1, suitable for images with around 299 x 299
 #
 # Reference:
-# Szegedy C, Ioffe S, Vanhoucke V. Inception-v4, inception-resnet and 
+# Szegedy C, Ioffe S, Vanhoucke V. Inception-v4, inception-resnet and
 # the impact of residual connections on learning, 2016.
 # Link to the paper: https://arxiv.org/abs/1602.07261
 #
 library(mxnet)
 
-Conv <- function(data, num_filter, kernel=c(1, 1), stride=c(1, 1), pad=c(0, 0), 
+Conv <- function(data, num_filter, kernel=c(1, 1), stride=c(1, 1), pad=c(0, 0),
                  name, suffix="", withRelu=TRUE, withBn=FALSE){
-  conv <- mx.symbol.Convolution(data=data, num_filter=num_filter, kernel=kernel, 
+  conv <- mx.symbol.Convolution(data=data, num_filter=num_filter, kernel=kernel,
                                stride=stride, pad=pad,
                                name=paste0(name, suffix, "_conv2d"))
   if (withBn){
     conv <- mx.symbol.BatchNorm(data=conv, name=paste0(name, suffix, "_bn"))
   }
   if (withRelu){
-    conv <- mx.symbol.Activation(data=conv, act_type="relu", 
+    conv <- mx.symbol.Activation(data=conv, act_type="relu",
                                 name=paste0(name, suffix, "_relu"))
   }
-  
+
   return(conv)
 }
 
@@ -30,22 +47,22 @@ InceptionResnetStem <- function(data,
                                 name){
   stem_3x3 <- Conv(data=data, num_filter=num_1_1, kernel=c(3, 3), stride=c(2, 2),
                   name=paste0(name, "_conv"))
-  stem_3x3 <- Conv(data=stem_3x3, num_filter=num_1_2, kernel=c(3, 3), 
+  stem_3x3 <- Conv(data=stem_3x3, num_filter=num_1_2, kernel=c(3, 3),
                   name=paste0(name, "_stem"), suffix="_conv_1")
-  stem_3x3 <- Conv(data=stem_3x3, num_filter=num_1_3, kernel=c(3, 3), 
+  stem_3x3 <- Conv(data=stem_3x3, num_filter=num_1_3, kernel=c(3, 3),
                   name=paste0(name, "_stem"), suffix="_conv_2")
-  pool1 <- mx.symbol.Pooling(data=stem_3x3, kernel=c(3, 3), stride=c(2, 2), 
+  pool1 <- mx.symbol.Pooling(data=stem_3x3, kernel=c(3, 3), stride=c(2, 2),
                             pool_type="max", name=paste0("max_", name, "_pool1"))
-  stem_1_3x3 <- Conv(data=pool1, num_filter=num_2_1, name=paste0(name, "_stem_1"), 
+  stem_1_3x3 <- Conv(data=pool1, num_filter=num_2_1, name=paste0(name, "_stem_1"),
                     suffix="_conv_1")
-  stem_1_3x3 <- Conv(data=stem_1_3x3, num_filter=num_2_2, kernel=c(3, 3), 
+  stem_1_3x3 <- Conv(data=stem_1_3x3, num_filter=num_2_2, kernel=c(3, 3),
                     name=paste0(name, "_stem_1"), suffix="_conv_2")
-  stem_1_3x3 <- Conv(data=stem_1_3x3, num_filter=num_2_3, kernel=c(3, 3), 
-                    pad=c(1, 1), stride=c(2, 2), name=paste0(name, "_stem_1"), 
+  stem_1_3x3 <- Conv(data=stem_1_3x3, num_filter=num_2_3, kernel=c(3, 3),
+                    pad=c(1, 1), stride=c(2, 2), name=paste0(name, "_stem_1"),
                     suffix="_conv_3", withRelu=FALSE)
   bn1 <- mx.symbol.BatchNorm(data=stem_1_3x3, name=paste0(name, "_bn1"))
   act1 <- mx.symbol.Activation(data=bn1, act_type="relu", name=paste0(name, "_relu1"))
-  
+
   return(act1)
 }
 
@@ -57,17 +74,17 @@ InceptionResnetA <- function(data,
                              name,
                              scaleResidual=TRUE){
   init <- data
-  
+
   a1 <- Conv(data=data, num_filter=num_1_1, name=paste0(name, "_a_1"), suffix="_conv")
-  
+
   a2 <- Conv(data=data, num_filter=num_2_1, name=paste0(name, "_a_2"), suffix="_conv_1")
-  a2 <- Conv(data=a2, num_filter=num_2_2, kernel=c(3, 3), pad=c(1, 1), 
+  a2 <- Conv(data=a2, num_filter=num_2_2, kernel=c(3, 3), pad=c(1, 1),
             name=paste0(name, "_a_2"), suffix="_conv_2")
-  
+
   a3 <- Conv(data=data, num_filter=num_3_1, name=paste0(name, "_a_3"), suffix="_conv_1")
-  a3 <- Conv(data=a3, num_filter=num_3_2, kernel=c(3, 3), pad=c(1, 1), 
+  a3 <- Conv(data=a3, num_filter=num_3_2, kernel=c(3, 3), pad=c(1, 1),
             name=paste0(name, "_a_3"), suffix="_conv_2")
-  a3 <- Conv(data=a3, num_filter=num_3_3, kernel=c(3, 3), pad=c(1, 1), 
+  a3 <- Conv(data=a3, num_filter=num_3_3, kernel=c(3, 3), pad=c(1, 1),
             name=paste0(name, "_a_3"), suffix="_conv_3")
   # concat
   merge_lst <- list()
@@ -75,17 +92,17 @@ InceptionResnetA <- function(data,
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_a_concat1")
   merge <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
-  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_a_liner_conv"), 
+
+  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_a_liner_conv"),
               withRelu=FALSE)
   if(scaleResidual){
     conv <- conv*0.1
   }
-  
+
   out <- init + conv
   bn <- mx.symbol.BatchNorm(data=out, name=paste0(name, "_a_bn1"))
   act <- mx.symbol.Activation(data=bn, act_type="relu", name=paste0(name, "_a_relu1"))
-  
+
   return(act)
 }
 
@@ -96,31 +113,31 @@ InceptionResnetB <- function(data,
                              name,
                              scaleResidual=TRUE){
   init <- data
-  
+
   b1 <- Conv(data=data, num_filter=num_1_1, name=paste0(name, "_b_1"), suffix="_conv")
-  
+
   b2 <- Conv(data=data, num_filter=num_2_1, name=paste0(name, "_b_2"), suffix="_conv_1")
-  b2 <- Conv(data=b2, num_filter=num_2_2, kernel=c(1, 7), pad=c(0, 3), 
+  b2 <- Conv(data=b2, num_filter=num_2_2, kernel=c(1, 7), pad=c(0, 3),
             name=paste0(name, "_b_2"), suffix="_conv_2")
-  b2 <- Conv(data=b2, num_filter=num_2_3, kernel=c(7, 1), pad=c(3, 0), 
+  b2 <- Conv(data=b2, num_filter=num_2_3, kernel=c(7, 1), pad=c(3, 0),
             name=paste0(name, "_b_2"), suffix="_conv_3")
-  
+
   merge_lst <- list()
   merge_lst <- c(b1, b2)
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_b_concat1")
   merge <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
-  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_b_liner_conv"), 
+
+  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_b_liner_conv"),
               withRelu=FALSE)
   if(scaleResidual){
     conv <- conv*0.1
   }
-  
+
   out <- init + conv
   bn <- mx.symbol.BatchNorm(data=out, name=paste0(name, "_b_bn1"))
   act <- mx.symbol.Activation(data=bn, act_type="relu", name=paste0(name, "_b_relu1"))
-  
+
   return(act)
 }
 
@@ -130,33 +147,33 @@ InceptionResnetC <- function(data,
                              proj,
                              name,
                              scaleResidual=TRUE){
-  
+
   init <- data
-  
+
   c1 <- Conv(data=data, num_filter=num_1_1, name=paste0(name, "_c_1"), suffix="_conv")
-  
+
   c2 <- Conv(data=data, num_filter=num_2_1, name=paste0(name, "_c_2"), suffix="_conv_1")
-  c2 <- Conv(data=c2, num_filter=num_2_2, kernel=c(1, 3), pad=c(0, 1), 
+  c2 <- Conv(data=c2, num_filter=num_2_2, kernel=c(1, 3), pad=c(0, 1),
             name=paste0(name, "_c_2"), suffix="_conv_2")
-  c2 <- Conv(data=c2, num_filter=num_2_3, kernel=c(3, 1), pad=c(1, 0), 
+  c2 <- Conv(data=c2, num_filter=num_2_3, kernel=c(3, 1), pad=c(1, 0),
             name=paste0(name, "_c_2"), suffix="_conv_3")
-  
+
   merge_lst <- list()
   merge_lst <- c(c1, c2)
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_c_concat1")
   merge <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
-  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_b_liner_conv"), 
+
+  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_b_liner_conv"),
               withRelu=FALSE)
   if(scaleResidual){
     conv <- conv*0.1
   }
-  
+
   out <- init + conv
   bn <- mx.symbol.BatchNorm(data=out, name=paste0(name, "_c_bn1"))
   act <- mx.symbol.Activation(data=bn, act_type="relu", name=paste0(name, "_c_relu1"))
-  
+
   return(act)
 }
 
@@ -164,28 +181,28 @@ ReductionResnetA <- function(data,
                              num_2_1,
                              num_3_1, num_3_2, num_3_3,
                              name){
-  
-  ra1 <- mx.symbol.Pooling(data=data, kernel=c(3, 3), stride=c(2, 2), 
+
+  ra1 <- mx.symbol.Pooling(data=data, kernel=c(3, 3), stride=c(2, 2),
                           pool_type="max", name=paste0("max_", name, "_pool1"))
-  
-  ra2 <- Conv(data=data, num_filter=num_2_1, kernel=c(3, 3), stride=c(2, 2), 
+
+  ra2 <- Conv(data=data, num_filter=num_2_1, kernel=c(3, 3), stride=c(2, 2),
              name=paste0(name, "_ra_2"), suffix="_conv", withRelu=FALSE)
-  
+
   ra3 <- Conv(data=data, num_filter=num_3_1, name=paste0(name, "_ra_3"), suffix="_conv_1")
-  ra3 <- Conv(data=ra3, num_filter=num_3_2, kernel=c(3, 3), pad=c(1, 1), 
+  ra3 <- Conv(data=ra3, num_filter=num_3_2, kernel=c(3, 3), pad=c(1, 1),
              name=paste0(name, "_ra_3"), suffix="_conv_2")
-  ra3 <- Conv(data=ra3, num_filter=num_3_3, kernel=c(3, 3), stride=c(2, 2), 
+  ra3 <- Conv(data=ra3, num_filter=num_3_3, kernel=c(3, 3), stride=c(2, 2),
              name=paste0(name, "_ra_3"), suffix="_conv_3", withRelu=FALSE)
-  
+
   merge_lst <- list()
   merge_lst <- c(ra1, ra2, ra3)
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_ra_concat1")
   m <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
+
   m <- mx.symbol.BatchNorm(data=m, name=paste0(name, "_ra_bn1"))
   m <- mx.symbol.Activation(data=m, act_type="relu", name=paste0(name, "_ra_relu1"))
-  
+
   return(m)
 }
 
@@ -194,32 +211,32 @@ ReductionResnetB <- function(data,
                              num_3_1, num_3_2,
                              num_4_1, num_4_2, num_4_3,
                              name){
-  rb1 <- mx.symbol.Pooling(data=data, kernel=c(3, 3), stride=c(2, 2), 
+  rb1 <- mx.symbol.Pooling(data=data, kernel=c(3, 3), stride=c(2, 2),
                           pool_type="max", name=paste0("max_", name, "_pool1"))
-  
+
   rb2 <- Conv(data=data, num_filter=num_2_1, name=paste0(name, "_rb_2"), suffix="_conv_1")
-  rb2 <- Conv(data=rb2, num_filter=num_2_2, kernel=c(3, 3), stride=c(2, 2), 
+  rb2 <- Conv(data=rb2, num_filter=num_2_2, kernel=c(3, 3), stride=c(2, 2),
              name=paste0(name, "_rb_2"), suffix="_conv_2", withRelu=FALSE)
-  
+
   rb3 <- Conv(data=data, num_filter=num_3_1, name=paste0(name, "_rb_3"), suffix="_conv_1")
-  rb3 <- Conv(data=rb3, num_filter=num_3_2, kernel=c(3, 3), stride=c(2, 2), 
+  rb3 <- Conv(data=rb3, num_filter=num_3_2, kernel=c(3, 3), stride=c(2, 2),
              name=paste0(name, "_rb_3"), suffix="_conv_2", withRelu=FALSE)
-  
+
   rb4 <- Conv(data=data, num_filter=num_4_1, name=paste0(name, "_rb_4"), suffix="_conv_1")
-  rb4 <- Conv(data=rb4, num_filter=num_4_2, kernel=c(3, 3), pad=c(1, 1), 
+  rb4 <- Conv(data=rb4, num_filter=num_4_2, kernel=c(3, 3), pad=c(1, 1),
              name=paste0(name, "_rb_4"), suffix="_conv_2")
-  rb4 <- Conv(data=rb4, num_filter=num_4_3, kernel=c(3, 3), stride=c(2, 2), 
+  rb4 <- Conv(data=rb4, num_filter=num_4_3, kernel=c(3, 3), stride=c(2, 2),
              name=paste0(name, "_rb_4"), suffix="_conv_3", withRelu=FALSE)
-  
+
   merge_lst <- list()
   merge_lst <- c(rb1, rb2, rb3, rb4)
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_rb_concat1")
   m <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
+
   m <- mx.symbol.BatchNorm(data=m, name=paste0(name, "_rb_bn1"))
   m <- mx.symbol.Activation(data=m, act_type="relu", name=paste0(name, "_rb_relu1"))
-  
+
   return(m)
 }
 
@@ -242,7 +259,7 @@ circle_in3a <- function(data,
                             scaleResidual=scale)
   }
   return(in3a)
-  
+
 }
 
 circle_in2b <- function(data,
@@ -285,10 +302,10 @@ circle_in2c <- function(data,
 
 # create inception-resnet-v1
 get_symbol <- function(num_classes=1000, scale=TRUE){
-  
+
   # input shape 229*229*3
   data <- mx.symbol.Variable(name="data")
-  
+
   # stage stem
   num_1_1 <- 32
   num_1_2 <- 32
@@ -296,12 +313,12 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
   num_2_1 <- 80
   num_2_2 <- 192
   num_2_3 <- 256
-  
+
   in_stem <- InceptionResnetStem(data,
                                 num_1_1, num_1_2, num_1_3,
                                 num_2_1, num_2_2, num_2_3,
                                 "stem_stage")
-  
+
   # stage 5 x Inception Resnet A
   num_1_1 <- 32
   num_2_1 <- 32
@@ -310,7 +327,7 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
   num_3_2 <- 32
   num_3_3 <- 32
   proj <- 256
-  
+
   in3a <- circle_in3a(in_stem,
                      num_1_1,
                      num_2_1, num_2_2,
@@ -319,25 +336,25 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
                      "in3a",
                      scale,
                      5)
-  
+
   # stage Reduction Resnet A
   num_1_1 <- 384
   num_2_1 <- 192
   num_2_2 <- 192
   num_2_3 <- 256
-  
+
   re3a <- ReductionResnetA(in3a,
                           num_1_1,
                           num_2_1, num_2_2, num_2_3,
                           "re3a")
-  
+
   # stage 10 x Inception Resnet B
   num_1_1 <- 128
   num_2_1 <- 128
   num_2_2 <- 128
   num_2_3 <- 128
   proj <- 896
-  
+
   in2b <- circle_in2b(re3a,
                      num_1_1,
                      num_2_1, num_2_2, num_2_3,
@@ -345,7 +362,7 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
                      "in2b",
                      scale,
                      10)
-  
+
   # stage Reduction Resnet B
   num_1_1 <- 256
   num_1_2 <- 384
@@ -354,20 +371,20 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
   num_3_1 <- 256
   num_3_2 <- 256
   num_3_3 <- 256
-  
+
   re4b <- ReductionResnetB(in2b,
                           num_1_1, num_1_2,
                           num_2_1, num_2_2,
                           num_3_1, num_3_2, num_3_3,
                           "re4b")
-  
+
   # stage 5 x Inception Resnet C
   num_1_1 <- 128
   num_2_1 <- 192
   num_2_2 <- 192
   num_2_3 <- 192
   proj <-  1792
-  
+
   in2c <- circle_in2c(re4b,
                      num_1_1,
                      num_2_1, num_2_2, num_2_3,
@@ -375,19 +392,19 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
                      "in2c",
                      scale,
                      5)
-  
+
   # stage Average Pooling
-  pool <- mx.symbol.Pooling(data=in2c, kernel=c(8, 8), stride=c(1, 1), 
+  pool <- mx.symbol.Pooling(data=in2c, kernel=c(8, 8), stride=c(1, 1),
                            pool_type="avg", name="global_pool")
-  
+
   # stage Dropout
   dropout <- mx.symbol.Dropout(data=pool, p=0.2)
   # dropout =  mx.symbol.Dropout(data=pool, p=0.8)
   flatten <- mx.symbol.Flatten(data=dropout, name="flatten")
-  
+
   # output
   fc1 <- mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes, name="fc1")
   softmax <- mx.symbol.SoftmaxOutput(data=fc1, name="softmax")
-  
+
   return(softmax)
 }

--- a/example/image-classification/symbol_inception-resnet-v2.R
+++ b/example/image-classification/symbol_inception-resnet-v2.R
@@ -1,25 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Inception resnet v2, suitable for images with around 299 x 299
 #
 # Reference:
-# Szegedy C, Ioffe S, Vanhoucke V. Inception-v4, inception-resnet and 
+# Szegedy C, Ioffe S, Vanhoucke V. Inception-v4, inception-resnet and
 # the impact of residual connections on learning, 2016.
 # Link to the paper: https://arxiv.org/abs/1602.07261
 #
 library(mxnet)
 
-Conv <- function(data, num_filter, kernel=c(1, 1), stride=c(1, 1), pad=c(0, 0), 
+Conv <- function(data, num_filter, kernel=c(1, 1), stride=c(1, 1), pad=c(0, 0),
                  name, suffix="", withRelu=TRUE, withBn=FALSE){
-  conv <- mx.symbol.Convolution(data=data, num_filter=num_filter, kernel=kernel, 
+  conv <- mx.symbol.Convolution(data=data, num_filter=num_filter, kernel=kernel,
                                 stride=stride, pad=pad,
                                 name=paste0(name, suffix, "_conv2d"))
   if (withBn){
     conv <- mx.symbol.BatchNorm(data=conv, name=paste0(name, suffix, "_bn"))
   }
   if (withRelu){
-    conv <- mx.symbol.Activation(data=conv, act_type="relu", 
+    conv <- mx.symbol.Activation(data=conv, act_type="relu",
                                  name=paste0(name, suffix, "_relu"))
   }
-  
+
   return(conv)
 }
 
@@ -33,16 +50,16 @@ InceptionResnetStem <- function(data,
                                 name){
   stem_3x3 <- Conv(data=data, num_filter=num_1_1, kernel=c(3, 3), stride=c(2, 2),
                    name=paste0(name, "_conv"))
-  stem_3x3 <- Conv(data=stem_3x3, num_filter=num_1_2, kernel=c(3, 3), 
+  stem_3x3 <- Conv(data=stem_3x3, num_filter=num_1_2, kernel=c(3, 3),
                    name=paste0(name, "_stem"), suffix="_conv")
   stem_3x3 <- Conv(data=stem_3x3, num_filter=num_1_3, kernel=c(3, 3), pad=c(1,1),
                    name=paste0(name, "_stem"), suffix="_conv_1")
 
-  
-  pool1 <- mx.symbol.Pooling(data=stem_3x3, kernel=c(3, 3), stride=c(2, 2), 
+
+  pool1 <- mx.symbol.Pooling(data=stem_3x3, kernel=c(3, 3), stride=c(2, 2),
                              pool_type="max", name=paste0("max_", name, "_pool1"))
-  
-  stem_1_3x3 <- Conv(data=stem_3x3, num_filter=num_2_1, kernel=c(3, 3), stride=c(2, 2), 
+
+  stem_1_3x3 <- Conv(data=stem_3x3, num_filter=num_2_1, kernel=c(3, 3), stride=c(2, 2),
                      name=paste0(name, "_stem_1"), suffix="_conv_1")
 
   merge_lst <- list()
@@ -50,16 +67,16 @@ InceptionResnetStem <- function(data,
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_concat1")
   concat1 <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
+
   stem_1_1x1 <- Conv(data=concat1, num_filter=num_3_1, name=paste0(name, "_stem_1"), suffix='_conv_2')
-  stem_1_3x3 <- Conv(data=stem_1_1x1, num_filter=num_3_2, kernel=c(3, 3), 
+  stem_1_3x3 <- Conv(data=stem_1_1x1, num_filter=num_3_2, kernel=c(3, 3),
                      name=paste0(name, "_stem_1"), suffix='_conv_3')
   stem_2_1x1 <- Conv(data=concat1, num_filter=num_4_1, name=paste0(name, "_stem_2"), suffix='_conv_1')
   stem_2_7x1 <- Conv(data=stem_2_1x1, num_filter=num_4_2, kernel=c(7, 1), pad=c(3, 0),
                      name=paste0(name, "_stem_2"), suffix='_conv_2')
   stem_2_1x7 <- Conv(data=stem_2_7x1, num_filter=num_4_3, kernel=c(1, 7), pad=c(0, 3),
                      name=paste0(name, "_stem_2"), suffix='_conv_3')
-  stem_2_3x3 <- Conv(data=stem_2_1x7, num_filter=num_4_4, kernel=c(3, 3), 
+  stem_2_3x3 <- Conv(data=stem_2_1x7, num_filter=num_4_4, kernel=c(3, 3),
                      name=paste0(name, "_stem_2"), suffix='_conv_4')
 
   merge_lst <- list()
@@ -67,13 +84,13 @@ InceptionResnetStem <- function(data,
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_concat2")
   concat2 <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
-  pool2 <- mx.symbol.Pooling(data=concat2, kernel=c(3, 3), stride=c(2, 2), 
+
+  pool2 <- mx.symbol.Pooling(data=concat2, kernel=c(3, 3), stride=c(2, 2),
                              pool_type="max", name=paste0("max_", name, "_pool2"))
-  
+
   stem_3_3x3 <- Conv(data=concat2, num_filter=num_5_1, kernel=c(3, 3), stride=c(2, 2),
                      name=paste0(name, "_stem_3"), suffix='_conv_1', withRelu=FALSE)
-  
+
   merge_lst <- list()
   merge_lst <- c(pool2, stem_3_3x3)
   merge_lst$num.args <- length(merge_lst)
@@ -82,7 +99,7 @@ InceptionResnetStem <- function(data,
 
   bn1 <- mx.symbol.BatchNorm(data=concat3, name=paste0(name, "_bn1"))
   act1 <- mx.symbol.Activation(data=bn1, act_type="relu", name=paste0(name, "_relu1"))
-  
+
   return(act1)
 }
 
@@ -94,17 +111,17 @@ InceptionResnetV2A <- function(data,
                              name,
                              scaleResidual=TRUE){
   init <- data
-  
+
   a1 <- Conv(data=data, num_filter=num_1_1, name=paste0(name, "_a_1"), suffix="_conv")
-  
+
   a2 <- Conv(data=data, num_filter=num_2_1, name=paste0(name, "_a_2"), suffix="_conv_1")
-  a2 <- Conv(data=a2, num_filter=num_2_2, kernel=c(3, 3), pad=c(1, 1), 
+  a2 <- Conv(data=a2, num_filter=num_2_2, kernel=c(3, 3), pad=c(1, 1),
              name=paste0(name, "_a_2"), suffix="_conv_2")
-  
+
   a3 <- Conv(data=data, num_filter=num_3_1, name=paste0(name, "_a_3"), suffix="_conv_1")
-  a3 <- Conv(data=a3, num_filter=num_3_2, kernel=c(3, 3), pad=c(1, 1), 
+  a3 <- Conv(data=a3, num_filter=num_3_2, kernel=c(3, 3), pad=c(1, 1),
              name=paste0(name, "_a_3"), suffix="_conv_2")
-  a3 <- Conv(data=a3, num_filter=num_3_3, kernel=c(3, 3), pad=c(1, 1), 
+  a3 <- Conv(data=a3, num_filter=num_3_3, kernel=c(3, 3), pad=c(1, 1),
              name=paste0(name, "_a_3"), suffix="_conv_3")
 
   merge_lst <- list()
@@ -112,17 +129,17 @@ InceptionResnetV2A <- function(data,
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_a_concat1")
   merge <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
-  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_a_liner_conv"), 
+
+  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_a_liner_conv"),
                withRelu=FALSE)
   if(scaleResidual){
     conv <- conv*0.1
   }
-  
+
   out <- init + conv
   bn <- mx.symbol.BatchNorm(data=out, name=paste0(name, "_a_bn1"))
   act <- mx.symbol.Activation(data=bn, act_type="relu", name=paste0(name, "_a_relu1"))
-  
+
   return(act)
 }
 
@@ -133,31 +150,31 @@ InceptionResnetV2B <- function(data,
                              name,
                              scaleResidual=TRUE){
   init <- data
-  
+
   b1 <- Conv(data=data, num_filter=num_1_1, name=paste0(name, "_b_1"), suffix="_conv")
-  
+
   b2 <- Conv(data=data, num_filter=num_2_1, name=paste0(name, "_b_2"), suffix="_conv_1")
-  b2 <- Conv(data=b2, num_filter=num_2_2, kernel=c(1, 7), pad=c(0, 3), 
+  b2 <- Conv(data=b2, num_filter=num_2_2, kernel=c(1, 7), pad=c(0, 3),
              name=paste0(name, "_b_2"), suffix="_conv_2")
-  b2 <- Conv(data=b2, num_filter=num_2_3, kernel=c(7, 1), pad=c(3, 0), 
+  b2 <- Conv(data=b2, num_filter=num_2_3, kernel=c(7, 1), pad=c(3, 0),
              name=paste0(name, "_b_2"), suffix="_conv_3")
-  
+
   merge_lst <- list()
   merge_lst <- c(b1, b2)
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_b_concat1")
   merge <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
-  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_b_liner_conv"), 
+
+  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_b_liner_conv"),
                withRelu=FALSE)
   if(scaleResidual){
     conv <- conv*0.1
   }
-  
+
   out <- init + conv
   bn <- mx.symbol.BatchNorm(data=out, name=paste0(name, "_b_bn1"))
   act <- mx.symbol.Activation(data=bn, act_type="relu", name=paste0(name, "_b_relu1"))
-  
+
   return(act)
 }
 
@@ -167,33 +184,33 @@ InceptionResnetV2C <- function(data,
                              proj,
                              name,
                              scaleResidual=TRUE){
-  
+
   init <- data
-  
+
   c1 <- Conv(data=data, num_filter=num_1_1, name=paste0(name, "_c_1"), suffix="_conv")
-  
+
   c2 <- Conv(data=data, num_filter=num_2_1, name=paste0(name, "_c_2"), suffix="_conv_1")
-  c2 <- Conv(data=c2, num_filter=num_2_2, kernel=c(1, 3), pad=c(0, 1), 
+  c2 <- Conv(data=c2, num_filter=num_2_2, kernel=c(1, 3), pad=c(0, 1),
              name=paste0(name, "_c_2"), suffix="_conv_2")
-  c2 <- Conv(data=c2, num_filter=num_2_3, kernel=c(3, 1), pad=c(1, 0), 
+  c2 <- Conv(data=c2, num_filter=num_2_3, kernel=c(3, 1), pad=c(1, 0),
              name=paste0(name, "_c_2"), suffix="_conv_3")
-  
+
   merge_lst <- list()
   merge_lst <- c(c1, c2)
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_c_concat1")
   merge <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
-  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_b_liner_conv"), 
+
+  conv <- Conv(data=merge, num_filter=proj, name=paste0(name, "_b_liner_conv"),
                withRelu=FALSE)
   if(scaleResidual){
     conv <- conv*0.1
   }
-  
+
   out <- init + conv
   bn <- mx.symbol.BatchNorm(data=out, name=paste0(name, "_c_bn1"))
   act <- mx.symbol.Activation(data=bn, act_type="relu", name=paste0(name, "_c_relu1"))
-  
+
   return(act)
 }
 
@@ -201,28 +218,28 @@ ReductionResnetV2A <- function(data,
                              num_2_1,
                              num_3_1, num_3_2, num_3_3,
                              name){
-  
-  ra1 <- mx.symbol.Pooling(data=data, kernel=c(3, 3), stride=c(2, 2), 
+
+  ra1 <- mx.symbol.Pooling(data=data, kernel=c(3, 3), stride=c(2, 2),
                            pool_type="max", name=paste0("max_", name, "_pool1"))
-  
-  ra2 <- Conv(data=data, num_filter=num_2_1, kernel=c(3, 3), stride=c(2, 2), 
+
+  ra2 <- Conv(data=data, num_filter=num_2_1, kernel=c(3, 3), stride=c(2, 2),
               name=paste0(name, "_ra_2"), suffix="_conv", withRelu=FALSE)
-  
+
   ra3 <- Conv(data=data, num_filter=num_3_1, name=paste0(name, "_ra_3"), suffix="_conv_1")
-  ra3 <- Conv(data=ra3, num_filter=num_3_2, kernel=c(3, 3), pad=c(1, 1), 
+  ra3 <- Conv(data=ra3, num_filter=num_3_2, kernel=c(3, 3), pad=c(1, 1),
               name=paste0(name, "_ra_3"), suffix="_conv_2")
-  ra3 <- Conv(data=ra3, num_filter=num_3_3, kernel=c(3, 3), stride=c(2, 2), 
+  ra3 <- Conv(data=ra3, num_filter=num_3_3, kernel=c(3, 3), stride=c(2, 2),
               name=paste0(name, "_ra_3"), suffix="_conv_3", withRelu=FALSE)
-  
+
   merge_lst <- list()
   merge_lst <- c(ra1, ra2, ra3)
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_ra_concat1")
   m <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
+
   m <- mx.symbol.BatchNorm(data=m, name=paste0(name, "_ra_bn1"))
   m <- mx.symbol.Activation(data=m, act_type="relu", name=paste0(name, "_ra_relu1"))
-  
+
   return(m)
 }
 
@@ -231,32 +248,32 @@ ReductionResnetV2B <- function(data,
                              num_3_1, num_3_2,
                              num_4_1, num_4_2, num_4_3,
                              name){
-  rb1 <- mx.symbol.Pooling(data=data, kernel=c(3, 3), stride=c(2, 2), 
+  rb1 <- mx.symbol.Pooling(data=data, kernel=c(3, 3), stride=c(2, 2),
                            pool_type="max", name=paste0("max_", name, "_pool1"))
-  
+
   rb2 <- Conv(data=data, num_filter=num_2_1, name=paste0(name, "_rb_2"), suffix="_conv_1")
-  rb2 <- Conv(data=rb2, num_filter=num_2_2, kernel=c(3, 3), stride=c(2, 2), 
+  rb2 <- Conv(data=rb2, num_filter=num_2_2, kernel=c(3, 3), stride=c(2, 2),
               name=paste0(name, "_rb_2"), suffix="_conv_2", withRelu=FALSE)
-  
+
   rb3 <- Conv(data=data, num_filter=num_3_1, name=paste0(name, "_rb_3"), suffix="_conv_1")
-  rb3 <- Conv(data=rb3, num_filter=num_3_2, kernel=c(3, 3), stride=c(2, 2), 
+  rb3 <- Conv(data=rb3, num_filter=num_3_2, kernel=c(3, 3), stride=c(2, 2),
               name=paste0(name, "_rb_3"), suffix="_conv_2", withRelu=FALSE)
-  
+
   rb4 <- Conv(data=data, num_filter=num_4_1, name=paste0(name, "_rb_4"), suffix="_conv_1")
-  rb4 <- Conv(data=rb4, num_filter=num_4_2, kernel=c(3, 3), pad=c(1, 1), 
+  rb4 <- Conv(data=rb4, num_filter=num_4_2, kernel=c(3, 3), pad=c(1, 1),
               name=paste0(name, "_rb_4"), suffix="_conv_2")
-  rb4 <- Conv(data=rb4, num_filter=num_4_3, kernel=c(3, 3), stride=c(2, 2), 
+  rb4 <- Conv(data=rb4, num_filter=num_4_3, kernel=c(3, 3), stride=c(2, 2),
               name=paste0(name, "_rb_4"), suffix="_conv_3", withRelu=FALSE)
-  
+
   merge_lst <- list()
   merge_lst <- c(rb1, rb2, rb3, rb4)
   merge_lst$num.args <- length(merge_lst)
   merge_lst$name <- paste0(name, "_rb_concat1")
   m <- mxnet:::mx.varg.symbol.Concat(merge_lst)
-  
+
   m <- mx.symbol.BatchNorm(data=m, name=paste0(name, "_rb_bn1"))
   m <- mx.symbol.Activation(data=m, act_type="relu", name=paste0(name, "_rb_relu1"))
-  
+
   return(m)
 }
 
@@ -279,7 +296,7 @@ circle_in3a <- function(data,
                              scaleResidual=scale)
   }
   return(in3a)
-  
+
 }
 
 circle_in2b <- function(data,
@@ -322,10 +339,10 @@ circle_in2c <- function(data,
 
 # create inception-resnet-v1
 get_symbol <- function(num_classes=1000, scale=TRUE){
-  
+
   # input shape 229*229*3
   data <- mx.symbol.Variable(name="data")
-  
+
   # stage stem
   num_1_1 <- 32
   num_1_2 <- 32
@@ -338,7 +355,7 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
   num_4_3 <- 64
   num_4_4 <- 96
   num_5_1 <- 192
-  
+
   in_stem <- InceptionResnetStem(data,
                                  num_1_1, num_1_2, num_1_3,
                                  num_2_1,
@@ -346,7 +363,7 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
                                  num_4_1, num_4_2, num_4_3, num_4_4,
                                  num_5_1,
                                  "stem_stage")
-  
+
   # stage 5 x Inception Resnet A
   num_1_1 <- 32
   num_2_1 <- 32
@@ -355,7 +372,7 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
   num_3_2 <- 48
   num_3_3 <- 64
   proj <- 384
-  
+
   in3a <- circle_in3a(in_stem,
                       num_1_1,
                       num_2_1, num_2_2,
@@ -364,25 +381,25 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
                       "in3a",
                       scale,
                       5)
-  
+
   # stage Reduction Resnet A
   num_1_1 <- 384
   num_2_1 <- 256
   num_2_2 <- 256
   num_2_3 <- 384
-  
+
   re3a <- ReductionResnetV2A(in3a,
                            num_1_1,
                            num_2_1, num_2_2, num_2_3,
                            "re3a")
-  
+
   # stage 10 x Inception Resnet B
   num_1_1 <- 192
   num_2_1 <- 128
   num_2_2 <- 160
   num_2_3 <- 192
   proj <- 1152
-  
+
   in2b <- circle_in2b(re3a,
                       num_1_1,
                       num_2_1, num_2_2, num_2_3,
@@ -390,7 +407,7 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
                       "in2b",
                       scale,
                       10)
-  
+
   # stage Reduction Resnet B
   num_1_1 <- 256
   num_1_2 <- 384
@@ -399,20 +416,20 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
   num_3_1 <- 256
   num_3_2 <- 288
   num_3_3 <- 320
-  
+
   re4b <- ReductionResnetV2B(in2b,
                            num_1_1, num_1_2,
                            num_2_1, num_2_2,
                            num_3_1, num_3_2, num_3_3,
                            "re4b")
-  
+
   # stage 5 x Inception Resnet C
   num_1_1 <- 192
   num_2_1 <- 192
   num_2_2 <- 224
   num_2_3 <- 256
   proj <-  2144
-  
+
   in2c <- circle_in2c(re4b,
                       num_1_1,
                       num_2_1, num_2_2, num_2_3,
@@ -420,19 +437,19 @@ get_symbol <- function(num_classes=1000, scale=TRUE){
                       "in2c",
                       scale,
                       5)
-  
+
   # stage Average Pooling
-  pool <- mx.symbol.Pooling(data=in2c, kernel=c(8, 8), stride=c(1, 1), 
+  pool <- mx.symbol.Pooling(data=in2c, kernel=c(8, 8), stride=c(1, 1),
                             pool_type="avg", name="global_pool")
-  
+
   # stage Dropout
   dropout <- mx.symbol.Dropout(data=pool, p=0.2)
   # dropout =  mx.symbol.Dropout(data=pool, p=0.8)
   flatten <- mx.symbol.Flatten(data=dropout, name="flatten")
-  
+
   # output
   fc1 <- mx.symbol.FullyConnected(data=flatten, num_hidden=num_classes, name="fc1")
   softmax <- mx.symbol.SoftmaxOutput(data=fc1, name="softmax")
-  
+
   return(softmax)
 }

--- a/example/image-classification/symbol_lenet.R
+++ b/example/image-classification/symbol_lenet.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(mxnet)
 
 get_symbol <- function(num_classes = 1000) {
@@ -7,7 +24,7 @@ get_symbol <- function(num_classes = 1000) {
 
   tanh1 <- mx.symbol.Activation(data = conv1, act_type = "tanh")
   pool1 <- mx.symbol.Pooling(data = tanh1, pool_type = "max", kernel = c(2, 2), stride = c(2, 2))
-  
+
   # second conv
   conv2 <- mx.symbol.Convolution(data = pool1, kernel = c(5, 5), num_filter = 50)
   tanh2 <- mx.symbol.Activation(data = conv2, act_type = "tanh")

--- a/example/image-classification/symbol_mlp.R
+++ b/example/image-classification/symbol_mlp.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(mxnet)
 
 get_symbol <- function(num_classes = 1000) {

--- a/example/image-classification/symbol_resnet-28-small.R
+++ b/example/image-classification/symbol_resnet-28-small.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(mxnet)
 
 conv_factory <- function(data, num_filter, kernel, stride,
@@ -21,7 +38,7 @@ residual_factory <- function(data, num_filter, dim_match) {
     identity_data = data
     conv1 = conv_factory(data = data, num_filter = num_filter, kernel = c(3, 3),
                          stride = c(1, 1), pad = c(1, 1), act_type = 'relu', conv_type = 0)
-    
+
     conv2 = conv_factory(data = conv1, num_filter = num_filter, kernel = c(3, 3),
                          stride = c(1, 1), pad = c(1, 1), conv_type = 1)
     new_data = identity_data + conv2
@@ -32,7 +49,7 @@ residual_factory <- function(data, num_filter, dim_match) {
                          stride = c(2, 2), pad = c(1, 1), act_type = 'relu', conv_type = 0)
     conv2 = conv_factory(data = conv1, num_filter = num_filter, kernel = c(3, 3),
                          stride = c(1, 1), pad = c(1, 1), conv_type = 1)
-    
+
     # adopt project method in the paper when dimension increased
     project_data = conv_factory(data = data, num_filter = num_filter, kernel = c(1, 1),
                                 stride = c(2, 2), pad = c(0, 0), conv_type = 1)
@@ -47,8 +64,8 @@ residual_net <- function(data, n) {
   for (i in 1:n) {
     data = residual_factory(data = data, num_filter = 16, dim_match = TRUE)
   }
-  
-  
+
+
   #second 2n layers
   for (i in 1:n) {
     if (i == 1) {

--- a/example/image-classification/symbol_resnet-v2.R
+++ b/example/image-classification/symbol_resnet-v2.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 ###
 # Reproducing parper:
 # Kaiming He, Xiangyu Zhang, Shaoqing Ren, Jian Sun. "Identity Mappings in Deep Residual Networks"
@@ -7,53 +24,53 @@ library(mxnet)
 
 residual_unit <- function(data, num_filter, stride, dim_match, name, bottle_neck=TRUE, bn_mom=0.9, workspace=512){
   if(bottle_neck){
-    bn1 <- mx.symbol.BatchNorm(data=data, fix_gamma=FALSE, eps=2e-5, 
+    bn1 <- mx.symbol.BatchNorm(data=data, fix_gamma=FALSE, eps=2e-5,
                                momentum=bn_mom, name=paste0(name,'_bn1'))
-    act1 <- mx.symbol.Activation(data=bn1, act_type='relu', 
+    act1 <- mx.symbol.Activation(data=bn1, act_type='relu',
                                  name=paste0(name, '_relu1'))
-    conv1 <- mx.symbol.Convolution(data=act1, num_filter=as.integer(num_filter*0.25), 
+    conv1 <- mx.symbol.Convolution(data=act1, num_filter=as.integer(num_filter*0.25),
                                    kernel=c(1,1), stride=c(1,1), pad=c(0,0),
-                                   no_bias=TRUE, workspace=workspace, 
+                                   no_bias=TRUE, workspace=workspace,
                                    name=paste0(name,'_conv1'))
-    bn2 <- mx.symbol.BatchNorm(data=conv1, fix_gamma=FALSE, eps=2e-5, 
+    bn2 <- mx.symbol.BatchNorm(data=conv1, fix_gamma=FALSE, eps=2e-5,
                                momentum=bn_mom, name=paste0(name, '_bn2'))
     act2 <- mx.symbol.Activation(data=bn2, act_type='relu', name=paste0(name, '_relu2'))
-    conv2 <- mx.symbol.Convolution(data=act2, num_filter=as.integer(num_filter*0.25), 
+    conv2 <- mx.symbol.Convolution(data=act2, num_filter=as.integer(num_filter*0.25),
                                    kernel=c(3,3), stride=stride, pad=c(1,1),
-                                   no_bias=TRUE, workspace=workspace, 
+                                   no_bias=TRUE, workspace=workspace,
                                    name=paste0(name, '_conv2'))
-    bn3 <- mx.symbol.BatchNorm(data=conv2, fix_gamma=FALSE, eps=2e-5, 
+    bn3 <- mx.symbol.BatchNorm(data=conv2, fix_gamma=FALSE, eps=2e-5,
                                momentum=bn_mom, name=paste0(name, '_bn3'))
     act3 <- mx.symbol.Activation(data=bn3, act_type='relu', name=paste0(name,'_relu3'))
-    conv3 <- mx.symbol.Convolution(data=act3, num_filter=num_filter, kernel=c(1,1), 
+    conv3 <- mx.symbol.Convolution(data=act3, num_filter=num_filter, kernel=c(1,1),
                                    stride=c(1,1), pad=c(0,0), no_bias=TRUE,
                                    workspace=workspace, name=paste0(name, '_conv3'))
     if (dim_match){
       shortcut <- data
     } else{
-      shortcut <- mx.symbol.Convolution(data=act1, num_filter=num_filter, 
+      shortcut <- mx.symbol.Convolution(data=act1, num_filter=num_filter,
                                         kernel=c(1,1), stride=stride, no_bias=TRUE,
                                         workspace=workspace, name=paste0(name,'_sc'))
     }
     return (conv3 + shortcut)
   } else{
-    bn1 <- mx.symbol.BatchNorm(data=data, fix_gamma=FALSE, momentum=bn_mom, 
+    bn1 <- mx.symbol.BatchNorm(data=data, fix_gamma=FALSE, momentum=bn_mom,
                                eps=2e-5, name=paste0(name,'_bn1'))
     act1 <- mx.symbol.Activation(data=bn1, act_type='relu', name=paste0(name, '_relu1'))
-    conv1 <- mx.symbol.Convolution(data=act1, num_filter=num_filter, kernel=c(3,3), 
-                                   stride=stride, pad=c(1,1), no_bias=TRUE, 
+    conv1 <- mx.symbol.Convolution(data=act1, num_filter=num_filter, kernel=c(3,3),
+                                   stride=stride, pad=c(1,1), no_bias=TRUE,
                                    workspace=workspace, name=paste0(name,'_conv1'))
-    bn2 <- mx.symbol.BatchNorm(data=conv1, fix_gamma=FALSE, momentum=bn_mom, 
+    bn2 <- mx.symbol.BatchNorm(data=conv1, fix_gamma=FALSE, momentum=bn_mom,
                                eps=2e-5, name=paste0(name, '_bn2'))
-    act2 <- mx.symbol.Activation(data=bn2, act_type='relu', 
+    act2 <- mx.symbol.Activation(data=bn2, act_type='relu',
                                  name=paste0(name, '_relu2'))
-    conv2 <- mx.symbol.Convolution(data=act2, num_filter=num_filter, kernel=c(3,3), 
-                                   stride=c(1,1), pad=c(1,1), no_bias=TRUE, 
+    conv2 <- mx.symbol.Convolution(data=act2, num_filter=num_filter, kernel=c(3,3),
+                                   stride=c(1,1), pad=c(1,1), no_bias=TRUE,
                                    workspace=workspace, name=paste0(name, '_conv2'))
     if (dim_match){
       shortcut = data
     } else {
-      shortcut <- mx.symbol.Convolution(data=act1, num_filter=num_filter, kernel=c(1,1), 
+      shortcut <- mx.symbol.Convolution(data=act1, num_filter=num_filter, kernel=c(1,1),
                                         stride=stride, no_bias=TRUE,
                                         workspace=workspace, name=paste0(name,'_sc'))
     }
@@ -63,41 +80,41 @@ residual_unit <- function(data, num_filter, stride, dim_match, name, bottle_neck
 
 
 
-resnet <- function(units, num_stage, filter_list, num_class, bottle_neck=TRUE, 
+resnet <- function(units, num_stage, filter_list, num_class, bottle_neck=TRUE,
                    bn_mom=0.9, workspace=512){
   num_unit <- length(units)
   if(num_unit != num_stage) stop("Number of units different from num_stage")
   data <- mx.symbol.Variable(name='data')
-  data <- mx.symbol.BatchNorm(data=data, fix_gamma=TRUE, eps=2e-5, momentum=bn_mom, 
+  data <- mx.symbol.BatchNorm(data=data, fix_gamma=TRUE, eps=2e-5, momentum=bn_mom,
                               name='bn_data')
-  body <- mx.symbol.Convolution(data=data, num_filter=filter_list[1], kernel=c(7, 7), 
+  body <- mx.symbol.Convolution(data=data, num_filter=filter_list[1], kernel=c(7, 7),
                                 stride=c(2,2), pad=c(3, 3),
                                 no_bias=TRUE, name="conv0", workspace=workspace)
-  body <- mx.symbol.BatchNorm(data=body, fix_gamma=FALSE, eps=2e-5, 
+  body <- mx.symbol.BatchNorm(data=body, fix_gamma=FALSE, eps=2e-5,
                               momentum=bn_mom, name='bn0')
   body <- mx.symbol.Activation(data=body, act_type='relu', name='relu0')
-  body <- mx.symbol.Pooling(data=body, kernel=c(3, 3), stride=c(2,2), 
+  body <- mx.symbol.Pooling(data=body, kernel=c(3, 3), stride=c(2,2),
                             pad=c(1,1), pool_type='max')
-  
-  
+
+
   for(i in 1:num_stage){
     if(i==1) stride <- c(1,1)
     else stride <- c(2,2)
     body <- residual_unit(body, filter_list[i+1], stride, FALSE,
-                          name=paste0('stage', i, '_unit1') , 
+                          name=paste0('stage', i, '_unit1') ,
                           bottle_neck=bottle_neck, workspace=workspace)
                           for(j in 1:(units[i]-1)){
-                            body <- residual_unit(body, filter_list[i+1], c(1,1), 
+                            body <- residual_unit(body, filter_list[i+1], c(1,1),
                                                   TRUE, name=paste0('stage',i, '_unit', j + 1),
-                                                  bottle_neck=bottle_neck, 
+                                                  bottle_neck=bottle_neck,
                                                   workspace=workspace)
                           }
   }
-  bn1 <- mx.symbol.BatchNorm(data=body, fix_gamma=FALSE, eps=2e-5, 
+  bn1 <- mx.symbol.BatchNorm(data=body, fix_gamma=FALSE, eps=2e-5,
                              momentum=bn_mom, name='bn1')
   relu1 <- mx.symbol.Activation(data=bn1, act_type='relu', name='relu1')
   # Although kernel is not used here when global_pool=TRUE, we should put one
-  pool1 <-  mx.symbol.Pooling(data=relu1, global_pool=TRUE, kernel=c(7, 7), 
+  pool1 <-  mx.symbol.Pooling(data=relu1, global_pool=TRUE, kernel=c(7, 7),
                               pool_type='avg', name='pool1')
   flat <- mx.symbol.Flatten(data=pool1)
   fc1 <- mx.symbol.FullyConnected(data=flat, num_hidden=num_class, name='fc1')
@@ -117,13 +134,13 @@ get_symbol <- function(num_class, depth=18){
   } else if (depth == 152){
     units = c(3, 8, 36, 3)
   } else if (depth == 200){
-    units = c(3, 24, 36, 3) 
+    units = c(3, 24, 36, 3)
   } else if (depth == 269){
     units = c(3, 30, 48, 8)
   } else{
     stop(paste0("no experiments done on depth ", depth))
   }
-  
+
   if (depth >=50){
     filter_list <- c(64, 256, 512, 1024, 2048)
     bottle_neck <- TRUE
@@ -133,8 +150,8 @@ get_symbol <- function(num_class, depth=18){
   }
   bn_mom <- 0.9 #momentum of batch normalization
   workspace <- 500
-  symbol <- resnet(units=units, num_stage=4, filter_list=filter_list, 
-                   num_class=num_class, bottle_neck=bottle_neck, 
+  symbol <- resnet(units=units, num_stage=4, filter_list=filter_list,
+                   num_class=num_class, bottle_neck=bottle_neck,
                    bn_mom=bn_mom, workspace=workspace)
   return(symbol)
 }

--- a/example/image-classification/symbol_resnet.R
+++ b/example/image-classification/symbol_resnet.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(mxnet)
 
 get_conv <- function(name, data, num_filter, kernel, stride,
@@ -24,7 +41,7 @@ make_block <- function(name, data, num_filter, dim_match, bn_momentum) {
                      num_filter = num_filter, kernel = c(3, 3), stride = c(2, 2),
                      pad = c(1, 1), with_relu = TRUE, bn_momentum = bn_momentum)
   }
-  
+
   conv2 = get_conv(name = paste(name, '_conv2', sep = ''), data = conv1,
                    num_filter = num_filter, kernel = c(3, 3), stride = c(1, 1),
                    pad = c(1, 1), with_relu = FALSE, bn_momentum = bn_momentum)
@@ -32,7 +49,7 @@ make_block <- function(name, data, num_filter, dim_match, bn_momentum) {
     shortcut = data
   } else {
     shortcut = mx.symbol.Convolution(name = paste(name, '_proj', sep = ''),
-                                     data = data, num_filter = num_filter, kernel = c(2, 2), 
+                                     data = data, num_filter = num_filter, kernel = c(2, 2),
                                      stride = c(2, 2), pad = c(0, 0), no_bias = TRUE)
   }
   fused = shortcut + conv2
@@ -57,7 +74,7 @@ get_body <- function(data, num_level, num_block, num_filter, bn_momentum) {
 get_symbol <- function(num_class, num_level = 3, num_block = 9,
                        num_filter = 16, bn_momentum = 0.9, pool_kernel = c(8, 8)) {
   data = mx.symbol.Variable(name = 'data')
-  zscore = mx.symbol.BatchNorm(name = 'zscore', data = data, 
+  zscore = mx.symbol.BatchNorm(name = 'zscore', data = data,
                                fix_gamma = TRUE, momentum = bn_momentum)
   conv = get_conv(name = 'conv0', data = zscore, num_filter = num_filter,
                   kernel = c(3, 3), stride = c(1, 1), pad = c(1, 1),

--- a/example/image-classification/symbol_vgg.R
+++ b/example/image-classification/symbol_vgg.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(mxnet)
 
 get_symbol <- function(num_classes = 1000) {

--- a/example/image-classification/train_cifar10.R
+++ b/example/image-classification/train_cifar10.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 require(mxnet)
 require(argparse)
 
@@ -12,7 +29,7 @@ get_iterator <- function(data.shape) {
     rand.mirror     = TRUE,
     mean.img        = paste0(data_dir, "mean.bin")
   )
-  
+
   val <- mx.io.ImageRecordIter(
     path.imgrec     = paste0(data_dir, "test.rec"),
     path.imglist    = paste0(data_dir, "test.lst"),

--- a/example/image-classification/train_imagenet.R
+++ b/example/image-classification/train_imagenet.R
@@ -1,4 +1,21 @@
-# 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+#
 # This file shows how to train ImageNet dataset with several Convolutional Neural Network architectures in R.
 # More information: https://blogs.technet.microsoft.com/machinelearning/2016/11/15/imagenet-deep-neural-network-training-using-microsoft-r-server-and-azure-gpu-vms/
 #
@@ -25,7 +42,7 @@ get_iterator <- function(args) {
     rand.crop       = TRUE,
     rand.mirror     = TRUE
   )
-  
+
   val = mx.io.ImageRecordIter(
     path.imgrec     = file.path(args$data_dir, args$val_dataset),
     batch.size      = args$batch_size,
@@ -57,7 +74,7 @@ parse_args <- function() {
                       help='times the lr with a factor for every lr-factor-epoch epoch')
   parser$add_argument('--lr-factor-epoch', type='double', default=1,
                       help='the number of epoch to factor the lr, could be .5')
-  parser$add_argument('--lr-multifactor', type='character', 
+  parser$add_argument('--lr-multifactor', type='character',
                       help='the epoch at which the lr is changed, e.g "15,30,45"')
   parser$add_argument('--mom', type='double', default=.9,
                       help='momentum for sgd')
@@ -77,7 +94,7 @@ parse_args <- function() {
                       help='the number of training examples')
   parser$add_argument('--num-classes', type='integer', default=1000,
                       help='the number of classes')
-  parser$add_argument('--log-file', type='character', 
+  parser$add_argument('--log-file', type='character',
                       help='the name of log file')
   parser$add_argument('--log-dir', type='character', default="/tmp/",
                       help='directory of the log file')

--- a/example/image-classification/train_mnist.R
+++ b/example/image-classification/train_mnist.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 require(argparse)
 require(mxnet)
 
@@ -120,10 +137,10 @@ if (args$network == 'mlp') {
 data_loader <- get_iterator(data_shape)
 data <- data_loader(args)
 train <- data$train
-val <- data$value 
+val <- data$value
 
 if (is.null(args$gpus)) {
-  devs <- mx.cpu()  
+  devs <- mx.cpu()
 } else {
   devs <- lapply(unlist(strsplit(args$gpus, ",")), function(i) {
     mx.gpu(as.integer(i))

--- a/example/image-classification/train_model.R
+++ b/example/image-classification/train_model.R
@@ -1,10 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 require(mxnet)
 
 train_model.fit <- function(args, network, data_loader) {
-    
+
     # log
     if(!is.null(args$log_file)){
-      sink(file.path(args$log_dir, args$log_file), append = FALSE, 
+      sink(file.path(args$log_dir, args$log_file), append = FALSE,
            type=c("output", "message"))
       cat(paste0("Starting computation of ", args$network, " at ", Sys.time(), "\n"))
     }
@@ -35,11 +52,11 @@ train_model.fit <- function(args, network, data_loader) {
     # data
     data <- data_loader(args)
     train <- data$train
-    val <- data$value 
-    
+    val <- data$value
+
     # devices
     if (is.null(args$gpus)) {
-        devs <- mx.cpu()  
+        devs <- mx.cpu()
     } else {
         devs <- lapply(unlist(strsplit(args$gpus, ",")), function(i) {
             mx.gpu(as.integer(i))
@@ -53,7 +70,7 @@ train_model.fit <- function(args, network, data_loader) {
         step <- as.integer(strsplit(args$lr_multifactor,",")[[1]])
         step.updated <- step - begin.round + 1
         step.updated <- step.updated[step.updated > 0]
-        step_batch <- epoch_size*step.updated 
+        step_batch <- epoch_size*step.updated
         lr_scheduler <- mx.lr_scheduler.MultiFactorScheduler(step=step_batch, factor_val=args$lr_factor)
       } else{
         lr_scheduler <- mx.lr_scheduler.FactorScheduler(

--- a/example/kaggle-ndsb2/Train.R
+++ b/example/kaggle-ndsb2/Train.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Train.R for Second Annual Data Science Bowl
 # Deep learning model with GPU support
 # Please refer to https://mxnet.readthedocs.org/en/latest/build.html#r-package-installation

--- a/example/recommenders/demo-MF.R
+++ b/example/recommenders/demo-MF.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 library(mxnet)
 DF <- read.table("./ml-100k/u.data", header = F, sep = "\t")
 names(DF) <- c("user", "item", "score", "time")

--- a/example/rnn/bucket_R/aclImdb_lstm_classification.R
+++ b/example/rnn/bucket_R/aclImdb_lstm_classification.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 require("mxnet")
 
 corpus_bucketed_train <- readRDS(file = "data/corpus_bucketed_train.rds")
@@ -10,22 +27,22 @@ batch.size <- 64
 
 num.round <- 16
 
-train.data <- mx.io.bucket.iter(buckets = corpus_bucketed_train$buckets, batch.size = batch.size, 
+train.data <- mx.io.bucket.iter(buckets = corpus_bucketed_train$buckets, batch.size = batch.size,
   data.mask.element = 0, shuffle = TRUE)
 
-eval.data <- mx.io.bucket.iter(buckets = corpus_bucketed_test$buckets, batch.size = batch.size, 
+eval.data <- mx.io.bucket.iter(buckets = corpus_bucketed_test$buckets, batch.size = batch.size,
   data.mask.element = 0, shuffle = FALSE)
 
 mx.set.seed(0)
-optimizer <- mx.opt.create("adadelta", rho = 0.92, epsilon = 1e-06, wd = 2e-04, clip_gradient = NULL, 
+optimizer <- mx.opt.create("adadelta", rho = 0.92, epsilon = 1e-06, wd = 2e-04, clip_gradient = NULL,
   rescale.grad = 1/batch.size)
 
 bucket_list <- unique(c(train.data$bucket.names, eval.data$bucket.names))
 
 symbol_buckets <- sapply(bucket_list, function(seq) {
-  rnn.graph(config = "seq-to-one", cell_type = "lstm", 
-            num_rnn_layer = 1, num_embed = 2, num_hidden = 6, 
-            num_decode = 2, input_size = vocab, dropout = 0.5, 
+  rnn.graph(config = "seq-to-one", cell_type = "lstm",
+            num_rnn_layer = 1, num_embed = 2, num_hidden = 6,
+            num_decode = 2, input_size = vocab, dropout = 0.5,
             ignore_label = -1, loss_output = "softmax",
             output_last_state = F, masking = T)
 })
@@ -33,9 +50,9 @@ symbol_buckets <- sapply(bucket_list, function(seq) {
 model_sentiment_lstm <- mx.model.buckets(symbol = symbol_buckets,
                           train.data = train.data, eval.data = eval.data,
                           num.round = num.round, ctx = devices, verbose = FALSE,
-                          metric = mx.metric.accuracy, optimizer = optimizer,  
+                          metric = mx.metric.accuracy, optimizer = optimizer,
                           initializer = initializer,
-                          batch.end.callback = NULL, 
+                          batch.end.callback = NULL,
                           epoch.end.callback = epoch.end.callback)
 
 mx.model.save(model_sentiment_lstm, prefix = "model_sentiment_lstm", iteration = num.round)

--- a/example/rnn/bucket_R/data_preprocessing_seq_to_one.R
+++ b/example/rnn/bucket_R/data_preprocessing_seq_to_one.R
@@ -1,6 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # download the IMDB dataset
 if (!file.exists("data/aclImdb_v1.tar.gz")) {
-  download.file("http://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz", 
+  download.file("http://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz",
                 "data/aclImdb_v1.tar.gz")
   untar("data/aclImdb_v1.tar.gz", exdir = "data/")
 }
@@ -40,7 +57,7 @@ test_raw <- c(negative_test_raw, positive_test_raw)
 text_pre_process <- function(corpus, count_threshold = 10, dic = NULL) {
   raw_vec <- corpus
   raw_vec <- stri_enc_toascii(str = raw_vec)
-  
+
   ### perform some preprocessing
   raw_vec <- str_replace_all(string = raw_vec, pattern = "[^[:print:]]", replacement = "")
   raw_vec <- str_to_lower(string = raw_vec)
@@ -48,12 +65,12 @@ text_pre_process <- function(corpus, count_threshold = 10, dic = NULL) {
   raw_vec <- str_replace_all(string = raw_vec, pattern = "\\bbr\\b", replacement = "")
   raw_vec <- str_replace_all(string = raw_vec, pattern = "\\s+", replacement = " ")
   raw_vec <- str_trim(string = raw_vec)
-  
+
   ### Split raw sequence vectors into lists of word vectors (one list element per
   ### sequence)
-  word_vec_list <- stri_split_boundaries(raw_vec, type = "word", skip_word_none = T, 
+  word_vec_list <- stri_split_boundaries(raw_vec, type = "word", skip_word_none = T,
     skip_word_number = F, simplify = F)
-  
+
   ### Build vocabulary
   if (is.null(dic)) {
     word_vec_unlist <- unlist(word_vec_list)
@@ -63,77 +80,77 @@ text_pre_process <- function(corpus, count_threshold = 10, dic = NULL) {
     stopwords <- c(letters, "an", "the", "br")
     word_keep <- setdiff(word_keep, stopwords)
   } else word_keep <- names(dic)[!dic == 0]
-  
+
   ### Clean the sentences to keep only the curated list of words
   word_vec_list <- lapply(word_vec_list, function(x) x[x %in% word_keep])
-  
+
   # sentence_vec<- stri_split_boundaries(raw_vec, type='sentence', simplify = T)
   word_vec_length <- lapply(word_vec_list, length) %>% unlist()
-  
+
   ### Build dictionnary
   dic <- 1:length(word_keep)
   names(dic) <- word_keep
   dic <- c(`¤` = 0, dic)
-  
+
   ### reverse dictionnary
   rev_dic <- names(dic)
   names(rev_dic) <- dic
-  
+
   return(list(word_vec_list = word_vec_list, dic = dic, rev_dic = rev_dic))
 }
 
-################################################################ 
+################################################################
 make_bucket_data <- function(word_vec_list, labels, dic, seq_len = c(225), right_pad = T) {
   ### Trunc sequence to max bucket length
   word_vec_list <- lapply(word_vec_list, head, n = max(seq_len))
-  
+
   word_vec_length <- lapply(word_vec_list, length) %>% unlist()
-  bucketID <- cut(word_vec_length, breaks = c(0, seq_len, Inf), include.lowest = T, 
+  bucketID <- cut(word_vec_length, breaks = c(0, seq_len, Inf), include.lowest = T,
     labels = F)
-  
+
   ### Right or Left side Padding Pad sequences to their bucket length with
   ### dictionnary 0-label
   word_vec_list_pad <- lapply(1:length(word_vec_list), function(x) {
     length(word_vec_list[[x]]) <- seq_len[bucketID[x]]
     word_vec_list[[x]][is.na(word_vec_list[[x]])] <- names(dic[1])
-    if (right_pad == F) 
+    if (right_pad == F)
       word_vec_list[[x]] <- rev(word_vec_list[[x]])
     return(word_vec_list[[x]])
   })
-  
+
   ### Assign sequences to buckets and unroll them in order to be reshaped into arrays
-  unrolled_arrays <- lapply(1:length(seq_len), function(x) unlist(word_vec_list_pad[bucketID == 
+  unrolled_arrays <- lapply(1:length(seq_len), function(x) unlist(word_vec_list_pad[bucketID ==
     x]))
-  
+
   ### Assign labels to their buckets
   bucketed_labels <- lapply(1:length(seq_len), function(x) labels[bucketID == x])
   names(bucketed_labels) <- as.character(seq_len)
-  
+
   ### Assign the dictionnary to each bucket terms
   unrolled_arrays_dic <- lapply(1:length(seq_len), function(x) dic[unrolled_arrays[[x]]])
-  
+
   # Reshape into arrays having each sequence into a row
   features <- lapply(1:length(seq_len), function(x) {
-    array(unrolled_arrays_dic[[x]], 
+    array(unrolled_arrays_dic[[x]],
           dim = c(seq_len[x], length(unrolled_arrays_dic[[x]])/seq_len[x]))
   })
-  
+
   names(features) <- as.character(seq_len)
-  
+
   ### Combine data and labels into buckets
-  buckets <- lapply(1:length(seq_len), function(x) c(list(data = features[[x]]), 
+  buckets <- lapply(1:length(seq_len), function(x) c(list(data = features[[x]]),
     list(label = bucketed_labels[[x]])))
   names(buckets) <- as.character(seq_len)
-  
+
   ### reverse dictionnary
   rev_dic <- names(dic)
   names(rev_dic) <- dic
-  
+
   return(list(buckets = buckets, dic = dic, rev_dic = rev_dic))
 }
 
 
-corpus_preprocessed_train <- text_pre_process(corpus = train_raw, count_threshold = 10, 
+corpus_preprocessed_train <- text_pre_process(corpus = train_raw, count_threshold = 10,
   dic = NULL)
 
 corpus_preprocessed_test <- text_pre_process(corpus = test_raw, dic = corpus_preprocessed_train$dic)
@@ -142,32 +159,32 @@ seq_length_dist <- unlist(lapply(corpus_preprocessed_train$word_vec_list, length
 quantile(seq_length_dist, 0:20/20)
 
 # Save bucketed corpus
-corpus_bucketed_train <- make_bucket_data(word_vec_list = corpus_preprocessed_train$word_vec_list, 
-                                          labels = rep(0:1, each = 12500), 
-                                          dic = corpus_preprocessed_train$dic, 
-                                          seq_len = c(100, 150, 250, 400, 600), 
+corpus_bucketed_train <- make_bucket_data(word_vec_list = corpus_preprocessed_train$word_vec_list,
+                                          labels = rep(0:1, each = 12500),
+                                          dic = corpus_preprocessed_train$dic,
+                                          seq_len = c(100, 150, 250, 400, 600),
                                           right_pad = T)
 
-corpus_bucketed_test <- make_bucket_data(word_vec_list = corpus_preprocessed_test$word_vec_list, 
-                                         labels = rep(0:1, each = 12500), 
-                                         dic = corpus_preprocessed_test$dic, 
-                                         seq_len = c(100, 150, 250, 400, 600), 
+corpus_bucketed_test <- make_bucket_data(word_vec_list = corpus_preprocessed_test$word_vec_list,
+                                         labels = rep(0:1, each = 12500),
+                                         dic = corpus_preprocessed_test$dic,
+                                         seq_len = c(100, 150, 250, 400, 600),
                                          right_pad = T)
 
 saveRDS(corpus_bucketed_train, file = "data/corpus_bucketed_train.rds")
 saveRDS(corpus_bucketed_test, file = "data/corpus_bucketed_test.rds")
 
 # Save non bucketed corpus
-corpus_single_train <- make_bucket_data(word_vec_list = corpus_preprocessed_train$word_vec_list, 
-                                          labels = rep(0:1, each = 12500), 
-                                          dic = corpus_preprocessed_train$dic, 
-                                          seq_len = c(600), 
+corpus_single_train <- make_bucket_data(word_vec_list = corpus_preprocessed_train$word_vec_list,
+                                          labels = rep(0:1, each = 12500),
+                                          dic = corpus_preprocessed_train$dic,
+                                          seq_len = c(600),
                                           right_pad = T)
 
-corpus_single_test <- make_bucket_data(word_vec_list = corpus_preprocessed_test$word_vec_list, 
-                                         labels = rep(0:1, each = 12500), 
-                                         dic = corpus_preprocessed_test$dic, 
-                                         seq_len = c(600), 
+corpus_single_test <- make_bucket_data(word_vec_list = corpus_preprocessed_test$word_vec_list,
+                                         labels = rep(0:1, each = 12500),
+                                         dic = corpus_preprocessed_test$dic,
+                                         seq_len = c(600),
                                          right_pad = T)
 
 saveRDS(corpus_single_train, file = "data/corpus_single_train.rds")

--- a/example/rnn/old/lstm_ptb.R
+++ b/example/rnn/old/lstm_ptb.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # PennTreeBank Language Model using lstm, you can replace mx.lstm by mx.gru/ mx.rnn to use gru/rnn model
 # The data file can be found at:
 # https://github.com/dmlc/web-data/tree/master/mxnet/ptb
@@ -89,18 +106,18 @@ X.val.label <- get.label(X.val.data)
 X.train <- list(data=X.train.data, label=X.train.label)
 X.val <- list(data=X.val.data, label=X.val.label)
 
-model <- mx.lstm(X.train, X.val, 
+model <- mx.lstm(X.train, X.val,
                  ctx=mx.gpu(0),
-                 num.round=num.round, 
+                 num.round=num.round,
                  update.period=update.period,
-                 num.lstm.layer=num.lstm.layer, 
+                 num.lstm.layer=num.lstm.layer,
                  seq.len=seq.len,
-                 num.hidden=num.hidden, 
-                 num.embed=num.embed, 
+                 num.hidden=num.hidden,
+                 num.embed=num.embed,
                  num.label=vocab,
-                 batch.size=batch.size, 
+                 batch.size=batch.size,
                  input.size=vocab,
-                 initializer=mx.init.uniform(0.01), 
+                 initializer=mx.init.uniform(0.01),
                  learning.rate=learning.rate,
                  wd=wd)
 

--- a/example/speech_recognition/deepspeech.cfg
+++ b/example/speech_recognition/deepspeech.cfg
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [common]
 # method can be one of the followings - train,predict,load
 mode = train

--- a/example/speech_recognition/default.cfg
+++ b/example/speech_recognition/default.cfg
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 [common]
 # method can be one of the followings - train,predict,load
 mode = train

--- a/make/config.mk
+++ b/make/config.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #-------------------------------------------------------------------------------
 #  Template configuration for compiling mxnet
 #

--- a/make/osx.mk
+++ b/make/osx.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #-------------------------------------------------------------------------------
 #  Template configuration for compiling mxnet
 #

--- a/make/readthedocs.mk
+++ b/make/readthedocs.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 #--------------------------------------------------------
 # Configuration for document generation with less deps
 # The library may not run, but doc generation could work

--- a/matlab/+mxnet/model.m
+++ b/matlab/+mxnet/model.m
@@ -1,3 +1,20 @@
+% Licensed to the Apache Software Foundation (ASF) under one
+% or more contributor license agreements.  See the NOTICE file
+% distributed with this work for additional information
+% regarding copyright ownership.  The ASF licenses this file
+% to you under the Apache License, Version 2.0 (the
+% "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing,
+% software distributed under the License is distributed on an
+% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+% KIND, either express or implied.  See the License for the
+% specific language governing permissions and limitations
+% under the License.
+
 classdef model < handle
 %MODEL MXNet model, supports load and forward
 

--- a/matlab/+mxnet/private/callmxnet.m
+++ b/matlab/+mxnet/private/callmxnet.m
@@ -1,3 +1,20 @@
+% Licensed to the Apache Software Foundation (ASF) under one
+% or more contributor license agreements.  See the NOTICE file
+% distributed with this work for additional information
+% regarding copyright ownership.  The ASF licenses this file
+% to you under the Apache License, Version 2.0 (the
+% "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing,
+% software distributed under the License is distributed on an
+% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+% KIND, either express or implied.  See the License for the
+% specific language governing permissions and limitations
+% under the License.
+
 function callmxnet(func, varargin)
 %CALLMXNET call mxnet functions
 
@@ -7,7 +24,7 @@ if ~libisloaded('libmxnet')
   cd(mxnet_root);
   mxnet_root = pwd;
   cd(cur_pwd);
-  
+
   assert(exist([mxnet_root, '/lib/libmxnet.so'   ], 'file') == 2 || ...
          exist([mxnet_root, '/lib/libmxnet.dylib'], 'file') == 2 || ...
          exist([mxnet_root, '/lib/libmxnet.dll'  ], 'file') == 2, ...

--- a/matlab/+mxnet/private/parse_json.m
+++ b/matlab/+mxnet/private/parse_json.m
@@ -1,3 +1,20 @@
+% Licensed to the Apache Software Foundation (ASF) under one
+% or more contributor license agreements.  See the NOTICE file
+% distributed with this work for additional information
+% regarding copyright ownership.  The ASF licenses this file
+% to you under the Apache License, Version 2.0 (the
+% "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing,
+% software distributed under the License is distributed on an
+% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+% KIND, either express or implied.  See the License for the
+% specific language governing permissions and limitations
+% under the License.
+
 function data = parse_json(fname,varargin)
 %PARSE_JSON parse a JSON (JavaScript Object Notation) file or string
 %

--- a/matlab/demo.m
+++ b/matlab/demo.m
@@ -1,3 +1,20 @@
+% Licensed to the Apache Software Foundation (ASF) under one
+% or more contributor license agreements.  See the NOTICE file
+% distributed with this work for additional information
+% regarding copyright ownership.  The ASF licenses this file
+% to you under the Apache License, Version 2.0 (the
+% "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing,
+% software distributed under the License is distributed on an
+% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+% KIND, either express or implied.  See the License for the
+% specific language governing permissions and limitations
+% under the License.
+
 %% Assumes model symbol and parameters already downloaded using .sh script
 
 %% Load the model

--- a/matlab/tests/prepare_data.m
+++ b/matlab/tests/prepare_data.m
@@ -1,3 +1,20 @@
+% Licensed to the Apache Software Foundation (ASF) under one
+% or more contributor license agreements.  See the NOTICE file
+% distributed with this work for additional information
+% regarding copyright ownership.  The ASF licenses this file
+% to you under the Apache License, Version 2.0 (the
+% "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing,
+% software distributed under the License is distributed on an
+% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+% KIND, either express or implied.  See the License for the
+% specific language governing permissions and limitations
+% under the License.
+
 %% download cifar10 dataset
 system('wget https://www.cs.toronto.edu/~kriz/cifar-10-matlab.tar.gz')
 system('tar -xzvf cifar-10-matlab.tar.gz')

--- a/matlab/tests/test_prediction.m
+++ b/matlab/tests/test_prediction.m
@@ -1,3 +1,20 @@
+% Licensed to the Apache Software Foundation (ASF) under one
+% or more contributor license agreements.  See the NOTICE file
+% distributed with this work for additional information
+% regarding copyright ownership.  The ASF licenses this file
+% to you under the Apache License, Version 2.0 (the
+% "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing,
+% software distributed under the License is distributed on an
+% "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+% KIND, either express or implied.  See the License for the
+% specific language governing permissions and limitations
+% under the License.
+
 %% prepare
 
 addpath('..')

--- a/plugin/caffe/caffe.mk
+++ b/plugin/caffe/caffe.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 CFLAGS += -I$(CAFFE_PATH)/include -I$(CAFFE_PATH)/build/src -I$(CAFFE_PATH)/build/include
 LDFLAGS += -lprotobuf -lboost_system -lboost_thread -lboost_filesystem -lgflags -lglog -L$(CAFFE_PATH)/build/lib -lcaffe
 

--- a/plugin/opencv/opencv.mk
+++ b/plugin/opencv/opencv.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 OPENCV_SRC = $(wildcard plugin/opencv/*.cc)
 PLUGIN_OBJ += $(patsubst %.cc, build/%.o, $(OPENCV_SRC))
 OPENCV_CUSRC = $(wildcard plugin/opencv/*.cu)

--- a/plugin/sframe/plugin.mk
+++ b/plugin/sframe/plugin.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 SFRMAE_SRC = plugin/sframe/iter_sframe.cc
 PLUGIN_OBJ += build/plugin/sframe/iter_sframe.o
 CFLAGS += -I$(SFRAME_PATH)/oss_src/unity/lib/

--- a/plugin/torch/torch.mk
+++ b/plugin/torch/torch.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 CFLAGS += -I$(TORCH_PATH)/install/include -I$(TORCH_PATH)/install/include/TH -I$(TORCH_PATH)/install/include/THC/ -DMXNET_USE_TORCH=1
 LDFLAGS += -L$(TORCH_PATH)/install/lib -lluajit -lluaT -lTH -lTHC
 

--- a/plugin/warpctc/warpctc.mk
+++ b/plugin/warpctc/warpctc.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 CFLAGS += -I$(WARPCTC_PATH)/include
 LDFLAGS += -L$(WARPCTC_PATH)/build -lwarpctc
 

--- a/tests/cpp/unittest.mk
+++ b/tests/cpp/unittest.mk
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 TEST_SRC = $(shell find tests/cpp/ -name "*.cc")
 TEST_OBJ = $(patsubst %.cc, build/%.o, $(TEST_SRC))
 TEST = build/tests/cpp/mxnet_unit_tests

--- a/tests/travis/r_vignettes.R
+++ b/tests/travis/r_vignettes.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 fnames <- list.files("R-package/vignettes/", pattern="*.Rmd")
 sapply(fnames, function(x){
 	knitr::purl(paste0("R-package/vignettes/", x))

--- a/tools/license_header.py
+++ b/tools/license_header.py
@@ -75,7 +75,7 @@ _WHITE_LIST = ['R-package/',
 _LANGS = {'.cc':'*', '.h':'*', '.cu':'*', '.cuh':'*', '.py':'#',
           '.pm':'#', '.scala':'*', '.cc':'*', '.sh':'#', '.cmake':'#',
           '.java':'*', '.sh':'#', '.cpp':'*', '.hpp':'*', '.c':'*',
-          '.bat':'rem', '.pl':'#'}
+          '.bat':'rem', '.pl':'#', '.m':'%', '.R':'#', '.mk':'#'}
 
 # Previous license header, which will be removed
 _OLD_LICENSE = re.compile('.*Copyright.*by Contributors')

--- a/tools/license_header.py
+++ b/tools/license_header.py
@@ -75,7 +75,7 @@ _WHITE_LIST = ['R-package/',
 _LANGS = {'.cc':'*', '.h':'*', '.cu':'*', '.cuh':'*', '.py':'#',
           '.pm':'#', '.scala':'*', '.cc':'*', '.sh':'#', '.cmake':'#',
           '.java':'*', '.sh':'#', '.cpp':'*', '.hpp':'*', '.c':'*',
-          '.bat':'rem', '.pl':'#', '.m':'%', '.R':'#', '.mk':'#'}
+          '.bat':'rem', '.pl':'#', '.m':'%', '.R':'#', '.mk':'#', '.cfg':'#'}
 
 # Previous license header, which will be removed
 _OLD_LICENSE = re.compile('.*Copyright.*by Contributors')


### PR DESCRIPTION
## Fixing Apache RAT failures - Part 1##
PLEASE HELP REVIEW! @bhavinthaker @gautamkmr 
Added some file formats to the license_header.py script and then added the Apache license to the files that were failing the updated check. 

For further details, Refer to this wiki - 
https://cwiki.apache.org/confluence/display/MXNET/MXNet+Source+Licenses

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] The main change is adding this to the license_header.py - `'.m':'%', '.R':'#', '.mk':'#' `
- [ ] Added Apache License Header to all .R, .mk and .m files using the license_header.py script

## Please Review the following - ##
- [ ] correct comment markers are used for the new formats
- [ ] It is ok to add a license to these files (nothing will break)
- [ ] the updated files do fall under the Apache license
- [ ] Please help make sure that NO CODE has been affected in this PR (only blank spaces and comments)

## Comments - ##
Also To be added to the script (in a separate PR after release)
- .proto
- Makefile
- .pyx

