### PR TITLE
add where op with sparse condition

### DIFF
--- a/docs/api/python/ndarray/sparse.md
+++ b/docs/api/python/ndarray/sparse.md
@@ -362,6 +362,7 @@ We summarize the interface for each class in the following sections.
 
     slice
     retain
+    where
 ```
 
 ## Mathematical functions

--- a/src/operator/tensor/control_flow_op.cc
+++ b/src/operator/tensor/control_flow_op.cc
@@ -40,7 +40,7 @@ If condition does not have the same shape as x, it must be a 1D array whose size
 the same as x's first dimension size. Each row of the output array is from x's row
 if the corresponding element from condition is true, and from y's row if false.
 
-Note that all non-zero values are interpreted as ``True`` in `condition.
+Note that all non-zero values are interpreted as ``True`` in condition.
 
 Examples::
 

--- a/src/operator/tensor/control_flow_op.cc
+++ b/src/operator/tensor/control_flow_op.cc
@@ -48,13 +48,11 @@ Examples::
   y = [[5, 6], [7, 8]]
   cond = [[0, 1], [-1, 0]]
 
-  where(cond, x, y) = [[1, 2],
-                       [3, 4]]
+  where(cond, x, y) = [[5, 2], [3, 8]]
 
   csr_cond = cast_storage(cond, 'csr')
 
-  where(csr_cond, x, y) = [[5, 2],
-                           [3, 8]]
+  where(csr_cond, x, y) = [[5, 2], [3, 8]]
 
 )code" ADD_FILELINE)
 .set_num_inputs(3)

--- a/src/operator/tensor/control_flow_op.cc
+++ b/src/operator/tensor/control_flow_op.cc
@@ -29,7 +29,7 @@ namespace op {
 
 NNVM_REGISTER_OP(where)
 MXNET_ADD_SPARSE_OP_ALIAS(where)
-.MXNET_DESCRIBE(R"code(Return the elements, either from x or y, depending on the condition.
+.describe(R"code(Return the elements, either from x or y, depending on the condition.
 
 Given three ndarrays, condition, x, and y, return an ndarray with the elements from x or y,
 depending on the elements from condition are true or false. x and y must have the same shape.

--- a/src/operator/tensor/control_flow_op.cc
+++ b/src/operator/tensor/control_flow_op.cc
@@ -56,7 +56,7 @@ Examples::
   where(csr_cond, x, y) = [[5, 2],
                            [3, 8]]
 
-)code")
+)code" ADD_FILELINE)
 .set_num_inputs(3)
 .set_num_outputs(1)
 .set_attr<nnvm::FListInputNames>("FListInputNames",

--- a/src/operator/tensor/control_flow_op.cc
+++ b/src/operator/tensor/control_flow_op.cc
@@ -28,16 +28,35 @@ namespace mxnet {
 namespace op {
 
 NNVM_REGISTER_OP(where)
-.MXNET_DESCRIBE("Given three ndarrays, condition, x, and y, return an ndarray"
-                " with the elements from x or y, depending on the elements"
-                " from condition are true or false. x and y must have the same"
-                " shape. If condition has the same shape as x, each element"
-                " in the output array is from x if the corresponding element"
-                " in the condition is true, and from y if false. If condition"
-                " does not have the same shape as x, it must be a 1D array"
-                " whose size is the same as x's first dimension size. Each"
-                " row of the output array is from x's row if the corresponding"
-                " element from condition is true, and from y's row if false.")
+MXNET_ADD_SPARSE_OP_ALIAS(where)
+.MXNET_DESCRIBE(R"code(Return the elements, either from x or y, depending on the condition.
+
+Given three ndarrays, condition, x, and y, return an ndarray with the elements from x or y,
+depending on the elements from condition are true or false. x and y must have the same shape.
+If condition has the same shape as x, each element in the output array is from x if the
+corresponding element in the condition is true, and from y if false.
+
+If condition does not have the same shape as x, it must be a 1D array whose size is
+the same as x's first dimension size. Each row of the output array is from x's row
+if the corresponding element from condition is true, and from y's row if false.
+
+Note that all non-zero values are interpreted as ``True`` in `condition.
+
+Examples::
+
+  x = [[1, 2], [3, 4]]
+  y = [[5, 6], [7, 8]]
+  cond = [[0, 1], [-1, 0]]
+
+  where(cond, x, y) = [[1, 2],
+                       [3, 4]]
+
+  csr_cond = cast_storage(cond, 'csr')
+
+  where(csr_cond, x, y) = [[5, 2],
+                           [3, 8]]
+
+)code")
 .set_num_inputs(3)
 .set_num_outputs(1)
 .set_attr<nnvm::FListInputNames>("FListInputNames",
@@ -46,7 +65,9 @@ NNVM_REGISTER_OP(where)
   })
 .set_attr<nnvm::FInferShape>("FInferShape", WhereOpShape)
 .set_attr<nnvm::FInferType>("FInferType", WhereOpType)
+.set_attr<FInferStorageType>("FInferStorageType", WhereOpForwardStorageType)
 .set_attr<FCompute>("FCompute<cpu>", WhereOpForward<cpu>)
+.set_attr<FComputeEx>("FComputeEx<cpu>", WhereOpForwardEx<cpu>)
 .set_attr<nnvm::FGradient>("FGradient",
   // Use the following lambda function instead of ElemwiseGradUseIn
   // for best efficiency. grad[condition] = 0; to calculate grad[x] and grad[y]
@@ -83,7 +104,10 @@ NNVM_REGISTER_OP(_backward_where)
 .set_num_inputs(2)
 .set_num_outputs(2)
 .set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_attr<FCompute>("FCompute<cpu>", WhereOpBackward<cpu>);
+.set_attr<FInferStorageType>("FInferStorageType", WhereOpBackwardStorageType)
+.set_attr<FCompute>("FCompute<cpu>", WhereOpBackward<cpu>)
+.set_attr<FComputeEx>("FComputeEx<cpu>", WhereOpBackwardEx<cpu>);
+
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/control_flow_op.cu
+++ b/src/operator/tensor/control_flow_op.cu
@@ -28,10 +28,12 @@ namespace mxnet {
 namespace op {
 
 NNVM_REGISTER_OP(where)
-.set_attr<FCompute>("FCompute<gpu>", WhereOpForward<gpu>);
+.set_attr<FCompute>("FCompute<gpu>", WhereOpForward<gpu>)
+.set_attr<FComputeEx>("FComputeEx<gpu>", WhereOpForwardEx<gpu>);
 
 NNVM_REGISTER_OP(_backward_where)
-.set_attr<FCompute>("FCompute<gpu>", WhereOpBackward<gpu>);
+.set_attr<FCompute>("FCompute<gpu>", WhereOpBackward<gpu>)
+.set_attr<FComputeEx>("FComputeEx<gpu>", WhereOpBackwardEx<gpu>);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/control_flow_op.h
+++ b/src/operator/tensor/control_flow_op.h
@@ -31,6 +31,7 @@
 #include "../mxnet_op.h"
 #include "../operator_common.h"
 #include "../elemwise_op_common.h"
+#include "../tensor/init_op.h"
 
 namespace mxnet {
 namespace op {
@@ -50,6 +51,35 @@ struct where {
     KERNEL_ASSIGN(out[i], req, (0 != cond[i]? x[i] : y[i]));
   }
 };
+
+/*! \brief Choose elements from x or y depending on condition.
+ * The condition, x, and y have the same shape.
+ * The returned array is formed by elements from x or y
+ * depending on the elements of condition.
+ * The condition is a csr matrix, while x and y are both dense.
+ */
+template<int req>
+struct where_csr {
+  // DType is the output data type
+  // CType is condition data type
+  // i is for i-th row in the output
+  template<typename DType, typename CType, typename IType>
+  MSHADOW_XINLINE static void Map(int i, DType* out, const IType* cond_idx,
+                                  const IType* cond_indptr, const CType* cond_data,
+                                  const nnvm::dim_t num_cols, const DType* x) {
+    using nnvm::dim_t;
+    dim_t offset = i * num_cols;
+    for (dim_t j = cond_indptr[i]; j < cond_indptr[i + 1]; j++) {
+      const CType data = cond_data[j];
+      if (data != 0) {
+        const IType col_idx = cond_idx[j];
+        dim_t out_idx = offset + col_idx;
+        KERNEL_ASSIGN(out[out_idx], req, x[out_idx]);
+      }
+    }
+  }
+};
+
 
 /*! \brief Choose elements from x or y depending on condition
  * The condition is a vector whose size is the same as the
@@ -86,6 +116,37 @@ struct where_backward {
       ((0 == cond[i])^negate)? grad_in[i] : static_cast<DType>(0));
   }
 };
+
+/*!
+ * \brief Template for calculating grad[x] and grad[y].
+ * template argument req is OpReqType; negate indicates
+ * whether the output is grad_x (negate=true)
+ * or grad_y (negate=false).
+ * cond is a csr matrix, while others are dense ones.
+ */
+template<int req, bool negate>
+struct where_backward_csr {
+  // DType is the output data type
+  // CType is condition data type
+  // IType is condition aux data type
+  template<typename DType, typename CType, typename IType>
+  MSHADOW_XINLINE static void Map(int i, DType* grad_out,
+                                  const DType* grad_in,
+                                  const CType* cond_data,
+                                  const IType* cond_idx,
+                                  const IType* cond_indptr,
+                                  const nnvm::dim_t num_cols) {
+    const IType offset = i * num_cols;
+    const DType zero = static_cast<DType>(0);
+    for (IType j = cond_indptr[i]; j < cond_indptr[i + 1]; j++) {
+      IType col = cond_idx[j];
+      IType grad_offset = offset + col;
+      KERNEL_ASSIGN(grad_out[grad_offset], req,
+        ((0 == cond_data[j])^negate)? grad_in[grad_offset] : zero);
+    }
+  }
+};
+
 
 /*!
  * \brief Template for calculating grad[x] and grad[y].
@@ -152,6 +213,69 @@ inline bool WhereOpType(const nnvm::NodeAttrs& attrs,
   return true;
 }
 
+inline bool WhereOpForwardStorageType(const nnvm::NodeAttrs& attrs,
+                                      const int dev_mask,
+                                      DispatchMode* dispatch_mode,
+                                      std::vector<int>* in_attrs,
+                                      std::vector<int>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 3U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  const auto cond_stype = in_attrs->at(0);
+  const auto x_stype = in_attrs->at(1);
+  const auto y_stype = in_attrs->at(2);
+  auto& out_stype = out_attrs->at(0);
+  bool dispatched = false;
+  if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)) {
+    // dns, dns -> dns
+    dispatched = storage_type_assign(&out_stype, kDefaultStorage, dispatch_mode,
+                                     DispatchMode::kFCompute);
+  }
+  if (!dispatched && cond_stype == kCSRStorage && x_stype == kDefaultStorage &&
+      y_stype == kDefaultStorage) {
+    // csr, dns, dns -> dns
+    dispatched = storage_type_assign(&out_stype, kDefaultStorage,
+                                     dispatch_mode, DispatchMode::kFComputeEx);
+  }
+  if (!dispatched) {
+    dispatch_fallback(out_attrs, dispatch_mode);
+  }
+  if (static_cast<DispatchMode>(*dispatch_mode) == DispatchMode::kFComputeFallback) {
+    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
+  }
+  return true;
+}
+
+inline bool WhereOpBackwardStorageType(const nnvm::NodeAttrs& attrs,
+                                       const int dev_mask,
+                                       DispatchMode* dispatch_mode,
+                                       std::vector<int>* in_attrs,
+                                       std::vector<int>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 2U);
+  CHECK_EQ(out_attrs->size(), 2U);
+  const auto in_grad_stype = in_attrs->at(0);
+  const auto cond_stype = in_attrs->at(1);
+  bool dispatched = false;
+  if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)) {
+    // dns, dns -> dns, dns
+    dispatched = storage_type_assign(out_attrs, kDefaultStorage,
+                                     dispatch_mode, DispatchMode::kFCompute);
+  }
+  if (!dispatched && cond_stype == kCSRStorage && in_grad_stype == kDefaultStorage) {
+    // dns, csr -> dns, dns
+    dispatched = storage_type_assign(out_attrs, kDefaultStorage,
+                                     dispatch_mode, DispatchMode::kFComputeEx);
+  }
+  if (!dispatched) {
+    dispatch_fallback(out_attrs, dispatch_mode);
+  }
+  if (static_cast<DispatchMode>(*dispatch_mode) == DispatchMode::kFComputeFallback) {
+    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
+  }
+  return true;
+}
+
+
+
 template<typename xpu>
 void WhereOpForward(const nnvm::NodeAttrs& attrs,
                     const OpContext& ctx,
@@ -183,6 +307,62 @@ void WhereOpForward(const nnvm::NodeAttrs& attrs,
       });
     });
   });
+}
+
+template<typename xpu>
+void WhereOpForwardCsrImpl(mshadow::Stream<xpu> *s,
+                           const NDArray& cond,
+                           const TBlob& x,
+                           const TBlob& y,
+                           const OpReqType req,
+                           const TBlob& out) {
+  using namespace mxnet_op;
+  using namespace csr;
+  if (out.Size() == 0 || req == kNullOp) return;
+  CHECK(cond.shape() == x.shape_)
+    << "WhereOpForwardCsrImpl only supports inputs of same 2-D shapes";
+  CHECK(req == kWriteInplace || req == kWriteTo)
+    << "WhereOpForwardCsrImpl doesn't support req = " << req;
+  MSHADOW_TYPE_SWITCH(out.type_flag_, DType, {
+    MSHADOW_TYPE_SWITCH(cond.dtype(), CType, {
+      MSHADOW_TYPE_SWITCH(cond.aux_type(kIdx), IType, {
+        MXNET_ASSIGN_REQ_SWITCH(req, req_type, {
+          mshadow::Copy(out.FlatTo1D<xpu, DType>(s), y.FlatTo1D<xpu, DType>(s), s);
+          // no condition is satisfied
+          if (!cond.storage_initialized()) return;
+          IType* cond_idx = cond.aux_data(kIdx).dptr<IType>();
+          IType* cond_indptr = cond.aux_data(kIndPtr).dptr<IType>();
+          CType* cond_data = cond.data().dptr<CType>();
+          Kernel<where_csr<req_type>, xpu>::Launch(s, cond.shape()[0], out.dptr<DType>(),
+                 cond_idx, cond_indptr, cond_data, cond.shape()[1], x.dptr<DType>());
+        });
+      });
+    });
+  });
+}
+
+template<typename xpu>
+void WhereOpForwardEx(const nnvm::NodeAttrs& attrs,
+                      const OpContext& ctx,
+                      const std::vector<NDArray>& inputs,
+                      const std::vector<OpReqType>& req,
+                      const std::vector<NDArray>& outputs) {
+  CHECK_EQ(inputs.size(), 3U);
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+  const auto& cond_stype = inputs[0].storage_type();
+  const auto& x_stype = inputs[1].storage_type();
+  const auto& y_stype = inputs[2].storage_type();
+  const auto& out_stype = outputs[0].storage_type();
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  CHECK_NE(inputs[0].shape().ndim(), 1) << "WhereOpForwardEx with 1-D cond is not implemented";
+  if (cond_stype == kCSRStorage && x_stype == kDefaultStorage &&
+      y_stype == kDefaultStorage && out_stype == kDefaultStorage) {
+    WhereOpForwardCsrImpl(s, inputs[0], inputs[1].data(), inputs[2].data(), req[0],
+                          outputs[0].data());
+  } else {
+    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+  }
 }
 
 /*!
@@ -237,6 +417,83 @@ void WhereOpBackward(const nnvm::NodeAttrs& attrs,
       });
     });
   });
+}
+
+template<typename xpu>
+void WhereOpBackwardCsrImpl(mshadow::Stream<xpu> *s,
+                            const TBlob& grad_in,
+                            const NDArray& cond,
+                            const std::vector<OpReqType>& req,
+                            const TBlob& grad_x,
+                            const TBlob& grad_y) {
+  using namespace mxnet_op;
+  using namespace csr;
+  if (grad_in.Size() == 0) return;
+  CHECK(cond.shape() == grad_x.shape_)
+    << "WhereOpForwardCsrImpl only supports inputs of same 2-D shapes";
+  CHECK_NE(req[0], kAddTo) << "WhereOpForwardCsrImpl doesn't support kAddTo";
+  CHECK_NE(req[1], kAddTo) << "WhereOpForwardCsrImpl doesn't support kAddTo";
+  MSHADOW_TYPE_SWITCH(grad_in.type_flag_, DType, {
+    MSHADOW_TYPE_SWITCH(cond.dtype(), CType, {
+      MSHADOW_IDX_TYPE_SWITCH(cond.aux_type(kIdx), IType, {
+        if (req[0] != kNullOp) {
+          Fill<false>(s, grad_x, req[0], 0);
+          // some conditions are satisfied
+          if (cond.storage_initialized()) {
+            const IType* cond_indptr = cond.aux_data(kIndPtr).dptr<IType>();
+            const IType* cond_idx = cond.aux_data(kIdx).dptr<IType>();
+            const CType* cond_data = cond.data().dptr<CType>();
+            MXNET_ASSIGN_REQ_SWITCH(req[0], req_type_x, {
+              Kernel<where_backward_csr<req_type_x, true>, xpu>::Launch(s, cond.shape()[0],
+                grad_x.dptr<DType>(), grad_in.dptr<DType>(), cond_data, cond_idx,
+                cond_indptr, cond.shape()[1]);
+            });
+          }
+        }
+        if (req[1] != kNullOp) {
+          mshadow::Copy(grad_y.FlatTo1D<xpu, DType>(s), grad_in.FlatTo1D<xpu, DType>(s), s);
+          CHECK_EQ(req[1], kWriteTo);
+          if (cond.storage_initialized()) {
+            const IType* cond_indptr = cond.aux_data(kIndPtr).dptr<IType>();
+            const IType* cond_idx = cond.aux_data(kIdx).dptr<IType>();
+            const CType* cond_data = cond.data().dptr<CType>();
+            MXNET_ASSIGN_REQ_SWITCH(req[1], req_type_y, {
+              Kernel<where_backward_csr<req_type_y, false>, xpu>::Launch(s, cond.shape()[0],
+                grad_y.dptr<DType>(), grad_in.dptr<DType>(), cond_data, cond_idx,
+                cond_indptr, cond.shape()[1]);
+              ;
+            });
+          }
+        }
+      });
+    });
+  });
+}
+
+template<typename xpu>
+void WhereOpBackwardEx(const nnvm::NodeAttrs& attrs,
+                       const OpContext& ctx,
+                       const std::vector<NDArray>& inputs,
+                       const std::vector<OpReqType>& req,
+                       const std::vector<NDArray>& outputs) {
+  CHECK_EQ(inputs.size(), 2U);
+  CHECK_EQ(req.size(), 2U);
+  CHECK_EQ(outputs.size(), 2U);
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  if (inputs[1].shape().ndim() == 1) {
+    LOG(FATAL) << "WhereOpBackwardEx with 1-D cond is not implemented";
+  }
+  const auto grad_in_stype = inputs[0].storage_type();
+  const auto cond_stype = inputs[1].storage_type();
+  const auto grad_x_stype = outputs[0].storage_type();
+  const auto grad_y_stype = outputs[1].storage_type();
+  if (grad_in_stype == kDefaultStorage && cond_stype == kCSRStorage &&
+      grad_x_stype == kDefaultStorage && grad_y_stype == kDefaultStorage) {
+    WhereOpBackwardCsrImpl(s, inputs[0].data(), inputs[1], req, outputs[0].data(),
+                           outputs[1].data());
+  } else {
+    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+  }
 }
 
 }  // namespace op

--- a/src/operator/tensor/control_flow_op.h
+++ b/src/operator/tensor/control_flow_op.h
@@ -344,9 +344,9 @@ void WhereOpForwardEx(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(inputs.size(), 3U);
   CHECK_EQ(outputs.size(), 1U);
   CHECK_EQ(req.size(), 1U);
-  const auto& cond_stype = inputs[0].storage_type();
-  const auto& x_stype = inputs[1].storage_type();
-  const auto& y_stype = inputs[2].storage_type();
+  const int cond_stype = inputs[0].storage_type();
+  const int x_stype = inputs[1].storage_type();
+  const int y_stype = inputs[2].storage_type();
   const auto& out_stype = outputs[0].storage_type();
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
   CHECK_NE(inputs[0].shape().ndim(), 1) << "WhereOpForwardEx with 1-D cond is not implemented";

--- a/src/operator/tensor/control_flow_op.h
+++ b/src/operator/tensor/control_flow_op.h
@@ -461,7 +461,6 @@ void WhereOpBackwardCsrImpl(mshadow::Stream<xpu> *s,
               Kernel<where_backward_csr<req_type_y, false>, xpu>::Launch(s, cond.shape()[0],
                 grad_y.dptr<DType>(), grad_in.dptr<DType>(), cond_data, cond_idx,
                 cond_indptr, cond.shape()[1]);
-              ;
             });
           }
         }

--- a/src/operator/tensor/control_flow_op.h
+++ b/src/operator/tensor/control_flow_op.h
@@ -68,12 +68,12 @@ struct where_csr {
                                   const IType* cond_indptr, const CType* cond_data,
                                   const nnvm::dim_t num_cols, const DType* x) {
     using nnvm::dim_t;
-    dim_t offset = i * num_cols;
+    const dim_t offset = i * num_cols;
     for (dim_t j = cond_indptr[i]; j < cond_indptr[i + 1]; j++) {
       const CType data = cond_data[j];
       if (data != 0) {
         const IType col_idx = cond_idx[j];
-        dim_t out_idx = offset + col_idx;
+        const dim_t out_idx = offset + col_idx;
         KERNEL_ASSIGN(out[out_idx], req, x[out_idx]);
       }
     }
@@ -139,8 +139,8 @@ struct where_backward_csr {
     const IType offset = i * num_cols;
     const DType zero = static_cast<DType>(0);
     for (IType j = cond_indptr[i]; j < cond_indptr[i + 1]; j++) {
-      IType col = cond_idx[j];
-      IType grad_offset = offset + col;
+      const IType col = cond_idx[j];
+      const IType grad_offset = offset + col;
       KERNEL_ASSIGN(grad_out[grad_offset], req,
         ((0 == cond_data[j])^negate)? grad_in[grad_offset] : zero);
     }
@@ -220,9 +220,9 @@ inline bool WhereOpForwardStorageType(const nnvm::NodeAttrs& attrs,
                                       std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 3U);
   CHECK_EQ(out_attrs->size(), 1U);
-  const auto cond_stype = in_attrs->at(0);
-  const auto x_stype = in_attrs->at(1);
-  const auto y_stype = in_attrs->at(2);
+  const int cond_stype = in_attrs->at(0);
+  const int x_stype = in_attrs->at(1);
+  const int y_stype = in_attrs->at(2);
   auto& out_stype = out_attrs->at(0);
   bool dispatched = false;
   if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)) {

--- a/src/operator/tensor/control_flow_op.h
+++ b/src/operator/tensor/control_flow_op.h
@@ -237,12 +237,9 @@ inline bool WhereOpForwardStorageType(const nnvm::NodeAttrs& attrs,
                                      dispatch_mode, DispatchMode::kFComputeEx);
   }
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  if (static_cast<DispatchMode>(*dispatch_mode) == DispatchMode::kFComputeFallback) {
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 inline bool WhereOpBackwardStorageType(const nnvm::NodeAttrs& attrs,
@@ -266,12 +263,9 @@ inline bool WhereOpBackwardStorageType(const nnvm::NodeAttrs& attrs,
                                      dispatch_mode, DispatchMode::kFComputeEx);
   }
   if (!dispatched) {
-    dispatch_fallback(out_attrs, dispatch_mode);
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
   }
-  if (static_cast<DispatchMode>(*dispatch_mode) == DispatchMode::kFComputeFallback) {
-    LogStorageFallback(attrs, dev_mask, in_attrs, out_attrs);
-  }
-  return true;
+  return dispatched;
 }
 
 
@@ -361,7 +355,7 @@ void WhereOpForwardEx(const nnvm::NodeAttrs& attrs,
     WhereOpForwardCsrImpl(s, inputs[0], inputs[1].data(), inputs[2].data(), req[0],
                           outputs[0].data());
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 
@@ -491,7 +485,7 @@ void WhereOpBackwardEx(const nnvm::NodeAttrs& attrs,
     WhereOpBackwardCsrImpl(s, inputs[0].data(), inputs[1], req, outputs[0].data(),
                            outputs[1].data());
   } else {
-    LOG(FATAL) << "Not implemented: " << operator_string(attrs, ctx, inputs, req, outputs);
+    LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }
 }
 


### PR DESCRIPTION
## Description ##
support sparse.where with condition being csr ndarray
#9464 need to be merged first
@reminisce 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
