### PR TITLE
fix print_summary bug and add groups of convolution

### DIFF
--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -134,26 +134,26 @@ def print_summary(symbol, shape=None, line_length=120, positions=[.44, .64, .74,
                             pre_filter = pre_filter + int(shape[0])
         cur_param = 0
         if op == 'Convolution':
-            if ("no_bias" in node["attrs"]) and node["attrs"]["no_bias"] == 'True':
+            if "no_bias" in node["attrs"] and bool(node["attrs"]["no_bias"]):
                 num_group = int(node["attrs"]["num_group"]) if \
-                   ("num_group" in node["attrs"]) else 1
-                cur_param = (pre_filter * int(node["attrs"]["num_filter"])) \
+                   "num_group" in node["attrs"] else 1
+                cur_param = pre_filter * int(node["attrs"]["num_filter"]) \
                    // num_group
                 for k in _str2tuple(node["attrs"]["kernel"]):
                     cur_param *= int(k)
             else:
                 num_group = int(node["attrs"]["num_group"]) if \
-                   ("num_group" in node["attrs"]) else 1
-                cur_param = (pre_filter * int(node["attrs"]["num_filter"])) \
+                   "num_group" in node["attrs"] else 1
+                cur_param = pre_filter * int(node["attrs"]["num_filter"]) \
                    // num_group
                 for k in _str2tuple(node["attrs"]["kernel"]):
                     cur_param *= int(k)
                 cur_param += int(node["attrs"]["num_filter"])
         elif op == 'FullyConnected':
-            if ("no_bias" in node["attrs"]) and node["attrs"]["no_bias"] == 'True':
-                cur_param = pre_filter * (int(node["attrs"]["num_hidden"]))
+            if ("no_bias" in node["attrs"]) and bool(node["attrs"]["no_bias"]):
+                cur_param = pre_filter * int(node["attrs"]["num_hidden"])
             else:
-                cur_param = (pre_filter+1) * (int(node["attrs"]["num_hidden"]))
+                cur_param = (pre_filter+1) * int(node["attrs"]["num_hidden"])
         elif op == 'BatchNorm':
             key = node["name"] + "_output"
             if show_shape:

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -135,13 +135,17 @@ def print_summary(symbol, shape=None, line_length=120, positions=[.44, .64, .74,
         cur_param = 0
         if op == 'Convolution':
             if ("no_bias" in node["attrs"]) and node["attrs"]["no_bias"] == 'True':
+                num_group = int(node["attrs"]["num_group"]) if \
+                   ("num_group" in node["attrs"]) else 1
                 cur_param = (pre_filter * int(node["attrs"]["num_filter"])) \
-                   // int(node["attrs"]["num_group"])
+                   // num_group
                 for k in _str2tuple(node["attrs"]["kernel"]):
                     cur_param *= int(k)
             else:
+                num_group = int(node["attrs"]["num_group"]) if \
+                   ("num_group" in node["attrs"]) else 1
                 cur_param = (pre_filter * int(node["attrs"]["num_filter"])) \
-                   // int(node["attrs"]["num_group"])
+                   // num_group
                 for k in _str2tuple(node["attrs"]["kernel"]):
                     cur_param *= int(k)
                 cur_param += int(node["attrs"]["num_filter"])

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -135,11 +135,13 @@ def print_summary(symbol, shape=None, line_length=120, positions=[.44, .64, .74,
         cur_param = 0
         if op == 'Convolution':
             if ("no_bias" in node["attrs"]) and node["attrs"]["no_bias"] == 'True':
-                cur_param = (pre_filter * int(node["attrs"]["num_filter"])) // int(node["attrs"]["num_group"])
+                cur_param = (pre_filter * int(node["attrs"]["num_filter"])) \
+                   // int(node["attrs"]["num_group"])
                 for k in _str2tuple(node["attrs"]["kernel"]):
                     cur_param *= int(k)
             else:
-                cur_param = (pre_filter * int(node["attrs"]["num_filter"])) // int(node["attrs"]["num_group"])
+                cur_param = (pre_filter * int(node["attrs"]["num_filter"])) \
+                   // int(node["attrs"]["num_group"])
                 for k in _str2tuple(node["attrs"]["kernel"]):
                     cur_param *= int(k)
                 cur_param += int(node["attrs"]["num_filter"])

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -134,7 +134,7 @@ def print_summary(symbol, shape=None, line_length=120, positions=[.44, .64, .74,
                             pre_filter = pre_filter + int(shape[0])
         cur_param = 0
         if op == 'Convolution':
-            if "no_bias" in node["attrs"] and eval(node["attrs"]["no_bias"]):
+            if "no_bias" in node["attrs"] and node["attrs"]["no_bias"] == 'True':
                 num_group = int(node["attrs"]["num_group"]) if \
                    "num_group" in node["attrs"] else 1
                 cur_param = pre_filter * int(node["attrs"]["num_filter"]) \
@@ -150,7 +150,7 @@ def print_summary(symbol, shape=None, line_length=120, positions=[.44, .64, .74,
                     cur_param *= int(k)
                 cur_param += int(node["attrs"]["num_filter"])
         elif op == 'FullyConnected':
-            if ("no_bias" in node["attrs"]) and eval(node["attrs"]["no_bias"]):
+            if "no_bias" in node["attrs"] and node["attrs"]["no_bias"] == 'True':
                 cur_param = pre_filter * int(node["attrs"]["num_hidden"])
             else:
                 cur_param = (pre_filter+1) * int(node["attrs"]["num_hidden"])

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -135,15 +135,13 @@ def print_summary(symbol, shape=None, line_length=120, positions=[.44, .64, .74,
         cur_param = 0
         if op == 'Convolution':
             if "no_bias" in node["attrs"] and node["attrs"]["no_bias"] == 'True':
-                num_group = int(node['attrs'].get('num_group', '1')) if \
-                   "num_group" in node["attrs"] else 1
+                num_group = int(node['attrs'].get('num_group', '1'))
                 cur_param = pre_filter * int(node["attrs"]["num_filter"]) \
                    // num_group
                 for k in _str2tuple(node["attrs"]["kernel"]):
                     cur_param *= int(k)
             else:
-                num_group = int(node['attrs'].get('num_group', '1')) if \
-                   "num_group" in node["attrs"] else 1
+                num_group = int(node['attrs'].get('num_group', '1'))
                 cur_param = pre_filter * int(node["attrs"]["num_filter"]) \
                    // num_group
                 for k in _str2tuple(node["attrs"]["kernel"]):

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -134,17 +134,17 @@ def print_summary(symbol, shape=None, line_length=120, positions=[.44, .64, .74,
                             pre_filter = pre_filter + int(shape[0])
         cur_param = 0
         if op == 'Convolution':
-            if ("no_bias" in node["attrs"]) and int(node["attrs"]["no_bias"]):
-                cur_param = pre_filter * int(node["attrs"]["num_filter"])
+            if ("no_bias" in node["attrs"]) and node["attrs"]["no_bias"] == 'True':
+                cur_param = (pre_filter * int(node["attrs"]["num_filter"])) // int(node["attrs"]["num_group"])
                 for k in _str2tuple(node["attrs"]["kernel"]):
                     cur_param *= int(k)
             else:
-                cur_param = pre_filter * int(node["attrs"]["num_filter"])
+                cur_param = (pre_filter * int(node["attrs"]["num_filter"])) // int(node["attrs"]["num_group"])
                 for k in _str2tuple(node["attrs"]["kernel"]):
                     cur_param *= int(k)
                 cur_param += int(node["attrs"]["num_filter"])
         elif op == 'FullyConnected':
-            if ("no_bias" in node["attrs"]) and int(node["attrs"]["no_bias"]):
+            if ("no_bias" in node["attrs"]) and node["attrs"]["no_bias"] == 'True':
                 cur_param = pre_filter * (int(node["attrs"]["num_hidden"]))
             else:
                 cur_param = (pre_filter+1) * (int(node["attrs"]["num_hidden"]))

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -135,14 +135,14 @@ def print_summary(symbol, shape=None, line_length=120, positions=[.44, .64, .74,
         cur_param = 0
         if op == 'Convolution':
             if "no_bias" in node["attrs"] and node["attrs"]["no_bias"] == 'True':
-                num_group = int(node["attrs"]["num_group"]) if \
+                num_group = int(node['attrs'].get('num_group', '1')) if \
                    "num_group" in node["attrs"] else 1
                 cur_param = pre_filter * int(node["attrs"]["num_filter"]) \
                    // num_group
                 for k in _str2tuple(node["attrs"]["kernel"]):
                     cur_param *= int(k)
             else:
-                num_group = int(node["attrs"]["num_group"]) if \
+                num_group = int(node['attrs'].get('num_group', '1')) if \
                    "num_group" in node["attrs"] else 1
                 cur_param = pre_filter * int(node["attrs"]["num_filter"]) \
                    // num_group

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -134,7 +134,7 @@ def print_summary(symbol, shape=None, line_length=120, positions=[.44, .64, .74,
                             pre_filter = pre_filter + int(shape[0])
         cur_param = 0
         if op == 'Convolution':
-            if "no_bias" in node["attrs"] and bool(node["attrs"]["no_bias"]):
+            if "no_bias" in node["attrs"] and eval(node["attrs"]["no_bias"]):
                 num_group = int(node["attrs"]["num_group"]) if \
                    "num_group" in node["attrs"] else 1
                 cur_param = pre_filter * int(node["attrs"]["num_filter"]) \
@@ -150,7 +150,7 @@ def print_summary(symbol, shape=None, line_length=120, positions=[.44, .64, .74,
                     cur_param *= int(k)
                 cur_param += int(node["attrs"]["num_filter"])
         elif op == 'FullyConnected':
-            if ("no_bias" in node["attrs"]) and bool(node["attrs"]["no_bias"]):
+            if ("no_bias" in node["attrs"]) and eval(node["attrs"]["no_bias"]):
                 cur_param = pre_filter * int(node["attrs"]["num_hidden"])
             else:
                 cur_param = (pre_filter+1) * int(node["attrs"]["num_hidden"])


### PR DESCRIPTION
## Description ##
1. Bug fixed: invalid literal for int() with base 10: 'True'
2. Convolution param number calculation now support channel group. We will get right param number when calculating CNN with group conv such as Mobilenet, Shufflenet and Xception.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
