### PR TITLE
host files needed by caffe converter in s3

### DIFF
--- a/tools/caffe_converter/convert_caffe_modelzoo.py
+++ b/tools/caffe_converter/convert_caffe_modelzoo.py
@@ -23,7 +23,9 @@ from convert_model import convert_model
 from convert_mean import convert_mean
 import mxnet as mx
 
-_mx_caffe_model = 'http://data.mxnet.io/models/imagenet/test/caffe/'
+apache_repo_url = 'https://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/'
+repo_url = os.environ.get('MXNET_GLUON_REPO', apache_repo_url)
+_mx_caffe_model_root = '{repo}caffe/models/'.format(repo=repo_url)
 
 """Dictionary for model meta information
 
@@ -41,53 +43,69 @@ Optionly it takes
 model_meta_info = {
     # pylint: disable=line-too-long
     'bvlc_alexnet' : {
-        'prototxt' : 'https://raw.githubusercontent.com/BVLC/caffe/master/models/bvlc_alexnet/deploy.prototxt',
-        'caffemodel' : 'http://dl.caffe.berkeleyvision.org/bvlc_alexnet.caffemodel',
-        'mean' : 'https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/caffe/imagenet_mean.binaryproto',
+        'prototxt' : (_mx_caffe_model_root + 'bvlc_alexnet/deploy.prototxt',
+                      'cb77655eb4db32c9c47699c6050926f9e0fc476a'),
+        'caffemodel' : (_mx_caffe_model_root + 'bvlc_alexnet/bvlc_alexnet.caffemodel',
+                        '9116a64c0fbe4459d18f4bb6b56d647b63920377'),
+        'mean' : (_mx_caffe_model_root + 'bvlc_alexnet/imagenet_mean.binaryproto',
+                  '63e4652e656abc1e87b7a8339a7e02fca63a2c0c'),
         'top-1-acc' : 0.571,
         'top-5-acc' : 0.802
     },
     'bvlc_googlenet' : {
-        'prototxt' : 'https://raw.githubusercontent.com/BVLC/caffe/master/models/bvlc_googlenet/deploy.prototxt',
-        'caffemodel' : 'http://dl.caffe.berkeleyvision.org/bvlc_googlenet.caffemodel',
+        'prototxt' : (_mx_caffe_model_root + 'bvlc_googlenet/deploy.prototxt',
+                      '7060345c8012294baa60eeb5901d2d3fd89d75fc'),
+        'caffemodel' : (_mx_caffe_model_root + 'bvlc_googlenet/bvlc_googlenet.caffemodel',
+                        '405fc5acd08a3bb12de8ee5e23a96bec22f08204'),
         'mean' : (123, 117, 104),
         'top-1-acc' : 0.687,
         'top-5-acc' : 0.889
     },
     'vgg-16' : {
-        'prototxt' : 'https://gist.githubusercontent.com/ksimonyan/211839e770f7b538e2d8/raw/c3ba00e272d9f48594acef1f67e5fd12aff7a806/VGG_ILSVRC_16_layers_deploy.prototxt',
-        # 'caffemodel' : 'http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_16_layers.caffemodel',
-        'caffemodel' : 'http://data.mxnet.io/models/imagenet/test/caffe/VGG_ILSVRC_16_layers.caffemodel',
+        'prototxt' : (_mx_caffe_model_root + 'vgg/VGG_ILSVRC_16_layers_deploy.prototxt',
+                      '2734e5500f1445bd7c9fee540c99f522485247bd'),
+        'caffemodel' : (_mx_caffe_model_root + 'vgg/VGG_ILSVRC_16_layers.caffemodel',
+                        '9363e1f6d65f7dba68c4f27a1e62105cdf6c4e24'),
         'mean': (123.68, 116.779, 103.939),
         'top-1-acc' : 0.734,
         'top-5-acc' : 0.914
     },
     'vgg-19' : {
-        'prototxt' : 'https://gist.githubusercontent.com/ksimonyan/3785162f95cd2d5fee77/raw/bb2b4fe0a9bb0669211cf3d0bc949dfdda173e9e/VGG_ILSVRC_19_layers_deploy.prototxt',
-        # 'caffemodel' : 'http://www.robots.ox.ac.uk/~vgg/software/very_deep/caffe/VGG_ILSVRC_19_layers.caffemodel',
-        'caffemodel' : 'http://data.mxnet.io/models/imagenet/test/caffe/VGG_ILSVRC_19_layers.caffemodel',
+        'prototxt' : (_mx_caffe_model_root + 'vgg/VGG_ILSVRC_19_layers_deploy.prototxt',
+                      '132d2f60b3d3b1c2bb9d3fdb0c8931a44f89e2ae'),
+        'caffemodel' : (_mx_caffe_model_root + 'vgg/VGG_ILSVRC_19_layers.caffemodel',
+                        '239785e7862442717d831f682bb824055e51e9ba'),
         'mean' : (123.68, 116.779, 103.939),
         'top-1-acc' : 0.731,
         'top-5-acc' : 0.913
     },
     'resnet-50' : {
-        'prototxt' : _mx_caffe_model+'ResNet-50-deploy.prototxt',
-        'caffemodel' : _mx_caffe_model+'ResNet-50-model.caffemodel',
-        'mean' : _mx_caffe_model+'ResNet_mean.binaryproto',
+        'prototxt' : (_mx_caffe_model_root + 'resnet/ResNet-50-deploy.prototxt',
+                      '5d6fd5aeadd8d4684843c5028b4e5672b9e51638'),
+        'caffemodel' : (_mx_caffe_model_root + 'resnet/ResNet-50-model.caffemodel',
+                        'b7c79ccc21ad0479cddc0dd78b1d20c4d722908d'),
+        'mean' : (_mx_caffe_model_root + 'resnet/ResNet_mean.binaryproto',
+                  '0b056fd4444f0ae1537af646ba736edf0d4cefaf'),
         'top-1-acc' : 0.753,
         'top-5-acc' : 0.922
     },
     'resnet-101' : {
-        'prototxt' : _mx_caffe_model+'ResNet-101-deploy.prototxt',
-        'caffemodel' : _mx_caffe_model+'ResNet-101-model.caffemodel',
-        'mean' : _mx_caffe_model+'ResNet_mean.binaryproto',
+        'prototxt' : (_mx_caffe_model_root + 'resnet/ResNet-101-deploy.prototxt',
+                      'c165d6b6ccef7cc39ee16a66f00f927f93de198b'),
+        'caffemodel' : (_mx_caffe_model_root + 'resnet/ResNet-101-model.caffemodel',
+                        '1dbf5f493926bb9b6b3363b12d5133c0f8b78904'),
+        'mean' : (_mx_caffe_model_root + 'resnet/ResNet_mean.binaryproto',
+                  '0b056fd4444f0ae1537af646ba736edf0d4cefaf'),
         'top-1-acc' : 0.764,
         'top-5-acc' : 0.929
     },
     'resnet-152' : {
-        'prototxt' : _mx_caffe_model+'ResNet-152-deploy.prototxt',
-        'caffemodel' : _mx_caffe_model+'ResNet-152-model.caffemodel',
-        'mean' : _mx_caffe_model+'ResNet_mean.binaryproto',
+        'prototxt' : (_mx_caffe_model_root + 'resnet/ResNet-152-deploy.prototxt',
+                      'ae15aade2304af8a774c5bfb1d32457f119214ef'),
+        'caffemodel' : (_mx_caffe_model_root + 'resnet/ResNet-152-model.caffemodel',
+                        '251edb93604ac8268c7fd2227a0f15144310e1aa'),
+        'mean' : (_mx_caffe_model_root + 'resnet/ResNet_mean.binaryproto',
+                  '0b056fd4444f0ae1537af646ba736edf0d4cefaf'),
         'top-1-acc' : 0.77,
         'top-5-acc' : 0.933
     },
@@ -95,21 +113,32 @@ model_meta_info = {
 
 def get_model_meta_info(model_name):
     """returns a dict with model information"""
-    return dict(dict(model_meta_info)[model_name])
+    return model_meta_info[model_name].copy()
 
 def download_caffe_model(model_name, meta_info, dst_dir='./model'):
     """Download caffe model into disk by the given meta info """
     if not os.path.isdir(dst_dir):
         os.mkdir(dst_dir)
     model_name = os.path.join(dst_dir, model_name)
+
     assert 'prototxt' in meta_info, "missing prototxt url"
-    prototxt = mx.test_utils.download(meta_info['prototxt'], model_name+'_deploy.prototxt')
+    proto_url, proto_sha1 = meta_info['prototxt']
+    prototxt = mx.gluon.utils.download(proto_url,
+                                       model_name+'_deploy.prototxt',
+                                       sha1_hash=proto_sha1)
+
     assert 'caffemodel' in meta_info, "mssing caffemodel url"
-    caffemodel = mx.test_utils.download(meta_info['caffemodel'], model_name+'.caffemodel')
+    caffemodel_url, caffemodel_sha1 = meta_info['caffemodel']
+    caffemodel = mx.gluon.utils.download(caffemodel_url,
+                                         model_name+'.caffemodel',
+                                         sha1_hash=caffemodel_sha1)
     assert 'mean' in meta_info, 'no mean info'
     mean = meta_info['mean']
-    if isinstance(mean, str):
-        mean = mx.test_utils.download(mean, model_name+'_mean.binaryproto')
+    if isinstance(mean[0], str):
+        mean_url, mean_sha1 = mean
+        mean = mx.gluon.utils.download(mean_url,
+                                       model_name+'_mean.binaryproto',
+                                       sha1_hash=mean_sha1)
     return (prototxt, caffemodel, mean)
 
 def convert_caffe_model(model_name, meta_info, dst_dir='./model'):


### PR DESCRIPTION
## Description ##
Fixes #8283 by hosting the files by ourselves. Added file integrity check to avoid repeated download.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] host caffe files from s3
- [x] use file integrity check to avoid repeated downloads.

## Comments ##
- Checked that licenses permit redistribution.