### PR TITLE
add three pretrained english fasttext embedding

### DIFF
--- a/python/mxnet/contrib/text/_constants.py
+++ b/python/mxnet/contrib/text/_constants.py
@@ -341,4 +341,7 @@ FAST_TEXT_FILE_SHA1 = \
      'wiki.diq.vec': '77f3c370d1d77806fafe368cf788af550ff607dd',
      'wiki.zea.vec': 'ee12db26aab3f2b3b2745a298ef414e7aeb5a058',
      'wiki.za.vec': 'e3a0e58bd2e5b1891c71f1f7e37ff71997a20361',
-     'wiki.zu.vec': '4b244b9697a8280e6646842c5fc81bb3a6bc8ec7'}
+     'wiki.zu.vec': '4b244b9697a8280e6646842c5fc81bb3a6bc8ec7',
+     'wiki-news-300d-1M.vec': '11cac9efe6f599e659be182f5766d6fbd5b1cab9',
+     'wiki-news-300d-1M-subword.vec': '717a3058e0ba5ef3cde52c3df0d4f0f60b0a113a',
+     'crawl-300d-2M.vec': '9b556504d099a6c01f3dd76b88775d02cb2f1946'}

--- a/tests/python/unittest/test_contrib_text.py
+++ b/tests/python/unittest/test_contrib_text.py
@@ -781,14 +781,14 @@ def test_composite_embedding_with_two_embeddings():
 
 def test_get_and_pretrain_file_names():
     assert len(text.embedding.get_pretrained_file_names(
-        embedding_name='fasttext')) == 294
+        embedding_name='fasttext')) == 297
 
     assert len(text.embedding.get_pretrained_file_names(embedding_name='glove')) == 10
 
     reg = text.embedding.get_pretrained_file_names(embedding_name=None)
 
     assert len(reg['glove']) == 10
-    assert len(reg['fasttext']) == 294
+    assert len(reg['fasttext']) == 297
 
     assertRaises(KeyError, text.embedding.get_pretrained_file_names, 'unknown$$')
 


### PR DESCRIPTION
## Description ##
Add three word-embeddings from fasttext for english.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add 3 embeddings to available pretrained

## Comments ##
- Tested offline. The embeddings are large so it's not suitable for adding to CI.