### PR TITLE
[Review Required] Fixing Licenses in the Docs folder wherever possible

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,5 +1,22 @@
 # Doxyfile 1.8.8
 
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # This file describes the settings to be used by the documentation system
 # doxygen (www.doxygen.org) for a project.
 #

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Makefile for Sphinx documentation
 #
 

--- a/docs/api/r/Makefile
+++ b/docs/api/r/Makefile
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # This is the makefile for compiling Rmarkdown files into the md file with results.
 PKGROOT=../../R-package
 


### PR DESCRIPTION
## Description ##
Fixing Licenses in the Docs/ folder wherever possible
@bhavinthaker @marcoabreu  Please Review.

Note: For details, Please refer to this wiki - https://cwiki.apache.org/confluence/display/MXNET/MXNet+Source+Licenses

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Added License to the scripts in the Docs folder so that RAT does not fail
- [x] Apache RAT Checks will be excluded from the docs/_static/* files. 

## Please Review the following - ##
- [ ] correct comment markers are used for the new formats
- [ ] It is ok to add a license to these files (nothing will break)
- [ ] the updated files do fall under the Apache license
- [ ] Please help make sure that NO CODE has been affected in this PR (only blank spaces and comments)

