### PR TITLE
fix CreateOp of slice_channel to accept dtypes of uint8 and int32

### DIFF
--- a/src/operator/slice_channel.cu
+++ b/src/operator/slice_channel.cu
@@ -31,7 +31,7 @@ namespace op {
 template<>
 Operator* CreateOp<gpu>(SliceChannelParam param, int dtype) {
   Operator* op = nullptr;
-  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+  MSHADOW_TYPE_SWITCH(dtype, DType, {
     op = new SliceChannelOp<gpu, DType>(param);
   })
   return op;


### PR DESCRIPTION
## Description ##
To deal with quantization in future, 
operators like slice_channel(split) should have capability to accept uint8 and int32.
In slice_channel, it can be achieved by changing MSHADOW_REAL_TYPE_SWITCH to MSHADOW_TYPE_SWITCH as concat(https://github.com/apache/incubator-mxnet/blob/d2a856a3a2abb4e72edc301b8b821f0b75f30722/src/operator/concat.cu)
Is there any reason to use MSHADOW_REAL_TYPE_SWITCH for splitting symbol?
