### PR TITLE
Fixed the 'rm -rfv' command that was not cleaning the versioned master folder

### DIFF
--- a/docs/build_version_doc/build_doc.sh
+++ b/docs/build_version_doc/build_doc.sh
@@ -77,7 +77,7 @@ git submodule update
 echo "Building master"
 make docs || exit 1
 
-rm -rfv "$web_folder/versions/master/*"
+rm -rfv $web_folder/versions/master/*
 cp -a "docs/_build/html/." "$web_folder/versions/master"
 tests/ci_build/ci_build.sh doc python docs/build_version_doc/AddVersion.py --file_path "$web_folder/versions/master"
 


### PR DESCRIPTION
## Description ##
build_doc.sh script was not cleaning up the versioneWeb/versions/master folder due to a wrong syntax used in the script. Removed the double quotes surrounding the recursive removal for the folders under master. This fix should clean up all the not required files and should keep the the latest release version and the master version up-to-date.

Tested the script locally and "make docs" works fine.
