### PR TITLE
Cherry-picked from master branch(Remove finalizers from Scala API (#8887))

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -146,3 +146,6 @@ List of Contributors
 * [Xizhou Zhu](https://github.com/einsiedler0408/)
 * [Jean Kossaifi](https://github.com/JeanKossaifi/)
 * [Kenta Kubo](https://github.com/kkk669/)
+* [Manu Seth](https://github.com/mseth10/)
+* [Calum Leslie](https://github.com/calumleslie)
+* [Andre Tamm](https://github.com/andretamm)

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Executor.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Executor.scala
@@ -18,6 +18,7 @@
 package ml.dmlc.mxnet
 
 import ml.dmlc.mxnet.Base._
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -34,7 +35,6 @@ object Executor {
  * Symbolic Executor component of MXNet <br />
  * <b>
  * WARNING: it is your responsibility to clear this object through dispose().
- * NEVER rely on the GC strategy
  * </b>
  *
  * @author Yizhi Liu
@@ -44,9 +44,8 @@ object Executor {
  * @param symbol
  * @see Symbol.bind : to create executor
  */
-// scalastyle:off finalize
 class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
-                              private[mxnet] val symbol: Symbol) {
+                              private[mxnet] val symbol: Symbol) extends WarnIfNotDisposed {
   private[mxnet] var argArrays: Array[NDArray] = null
   private[mxnet] var gradArrays: Array[NDArray] = null
   private[mxnet] var auxArrays: Array[NDArray] = null
@@ -58,12 +57,10 @@ class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
   private[mxnet] var _ctx: Context = null
   private[mxnet] var _gradsReq: Iterable[_] = null
   private[mxnet] var _group2ctx: Map[String, Context] = null
+  private val logger: Logger = LoggerFactory.getLogger(classOf[Executor])
 
   private var disposed = false
-
-  override protected def finalize(): Unit = {
-    dispose()
-  }
+  protected def isDisposed = disposed
 
   def dispose(): Unit = {
     if (!disposed) {
@@ -306,4 +303,3 @@ class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
     str.value
   }
 }
-// scalastyle:on finalize

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStore.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/KVStore.scala
@@ -20,7 +20,7 @@ package ml.dmlc.mxnet
 import java.io._
 
 import ml.dmlc.mxnet.Base._
-import org.slf4j.{LoggerFactory, Logger}
+import org.slf4j.{Logger, LoggerFactory}
 
 /**
  * Key value store interface of MXNet for parameter synchronization.
@@ -37,7 +37,6 @@ object KVStore {
    * Create a new KVStore. <br />
    * <b>
    * WARNING: it is your responsibility to clear this object through dispose().
-   * NEVER rely on the GC strategy
    * </b>
    *
    * @param name : {'local', 'dist'}
@@ -53,15 +52,11 @@ object KVStore {
   }
 }
 
-// scalastyle:off finalize
-class KVStore(private[mxnet] val handle: KVStoreHandle) {
+class KVStore(private[mxnet] val handle: KVStoreHandle) extends WarnIfNotDisposed {
   private val logger: Logger = LoggerFactory.getLogger(classOf[KVStore])
   private var updaterFunc: MXKVStoreUpdater = null
   private var disposed = false
-
-  override protected def finalize(): Unit = {
-    dispose()
-  }
+  protected def isDisposed = disposed
 
   /**
    * Release the native memory.
@@ -306,4 +301,3 @@ class KVStore(private[mxnet] val handle: KVStoreHandle) {
     }
   }
 }
-// scalastyle:off finalize

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/Symbol.scala
@@ -27,17 +27,12 @@ import scala.collection.mutable.{ArrayBuffer, ListBuffer}
  * Symbolic configuration API of mxnet. <br />
  * <b>
  * WARNING: it is your responsibility to clear this object through dispose().
- * NEVER rely on the GC strategy
  * </b>
  */
-// scalastyle:off finalize
-class Symbol private(private[mxnet] val handle: SymbolHandle) {
+class Symbol private(private[mxnet] val handle: SymbolHandle) extends WarnIfNotDisposed {
   private val logger: Logger = LoggerFactory.getLogger(classOf[Symbol])
   private var disposed = false
-
-  override protected def finalize(): Unit = {
-    dispose()
-  }
+  protected def isDisposed = disposed
 
   /**
    * Release the native memory.
@@ -828,7 +823,6 @@ class Symbol private(private[mxnet] val handle: SymbolHandle) {
   }
 }
 
-// scalastyle:on finalize
 @AddSymbolFunctions(false)
 object Symbol {
   private type SymbolCreateNamedFunc = Map[String, Any] => Symbol

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/MXDataIter.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/MXDataIter.scala
@@ -18,7 +18,7 @@
 package ml.dmlc.mxnet.io
 
 import ml.dmlc.mxnet.Base._
-import ml.dmlc.mxnet.{DataPack, DataBatch, DataIter, NDArray, Shape}
+import ml.dmlc.mxnet.{DataBatch, DataIter, DataPack, NDArray, Shape, WarnIfNotDisposed}
 import ml.dmlc.mxnet.IO._
 import org.slf4j.LoggerFactory
 
@@ -29,10 +29,11 @@ import scala.collection.mutable.ListBuffer
  * DataIter built in MXNet.
  * @param handle the handle to the underlying C++ Data Iterator
  */
-// scalastyle:off finalize
 private[mxnet] class MXDataIter(private[mxnet] val handle: DataIterHandle,
                                 dataName: String = "data",
-                                labelName: String = "label") extends DataIter {
+                                labelName: String = "label")
+  extends DataIter with WarnIfNotDisposed {
+
   private val logger = LoggerFactory.getLogger(classOf[MXDataIter])
 
   // use currentBatch to implement hasNext
@@ -57,9 +58,7 @@ private[mxnet] class MXDataIter(private[mxnet] val handle: DataIterHandle,
     }
 
   private var disposed = false
-  override protected def finalize(): Unit = {
-    dispose()
-  }
+  protected def isDisposed = disposed
 
   /**
    * Release the native memory.
@@ -169,7 +168,6 @@ private[mxnet] class MXDataIter(private[mxnet] val handle: DataIterHandle,
   override def batchSize: Int = _batchSize
 }
 
-// scalastyle:on finalize
 private[mxnet] class MXDataPack(iterName: String, params: Map[String, String]) extends DataPack {
   /**
     * get data iterator

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
@@ -145,8 +145,12 @@ class NDArrayIter (data: IndexedSeq[NDArray], label: IndexedSeq[NDArray] = Index
   private def _padData(ndArray: NDArray): NDArray = {
     val padNum = cursor + dataBatchSize - numData
     val newArray = NDArray.zeros(ndArray.slice(0, dataBatchSize).shape)
-    newArray.slice(0, dataBatchSize - padNum).set(ndArray.slice(cursor, numData))
-    newArray.slice(dataBatchSize - padNum, dataBatchSize).set(ndArray.slice(0, padNum))
+    val batch = ndArray.slice(cursor, numData)
+    val padding = ndArray.slice(0, padNum)
+    newArray.slice(0, dataBatchSize - padNum).set(batch).dispose()
+    newArray.slice(dataBatchSize - padNum, dataBatchSize).set(padding).dispose()
+    batch.dispose()
+    padding.dispose()
     newArray
   }
 

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/util/WarnIfNotDisposed.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/util/WarnIfNotDisposed.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.mxnet
+
+import org.slf4j.{Logger, LoggerFactory}
+import scala.util.Try
+import scala.collection._
+
+private object WarnIfNotDisposed {
+  private val traceProperty = "mxnet.traceLeakedObjects"
+
+  private val logger: Logger = LoggerFactory.getLogger(classOf[WarnIfNotDisposed])
+
+  // This set represents the list of classes we've logged a warning about if we're not running
+  // in tracing mode. This is used to ensure we only log once.
+  // Don't need to synchronize on this set as it's usually used from a single finalizer thread.
+  private val classesWarned = mutable.Set.empty[String]
+
+  lazy val tracingEnabled = {
+    val value = Try(System.getProperty(traceProperty).toBoolean).getOrElse(false)
+    if (value) {
+      logger.info("Leaked object tracing is enabled (property {} is set)", traceProperty)
+    }
+    value
+  }
+}
+
+// scalastyle:off finalize
+protected trait WarnIfNotDisposed {
+  import WarnIfNotDisposed.logger
+  import WarnIfNotDisposed.traceProperty
+  import WarnIfNotDisposed.classesWarned
+
+  protected def isDisposed: Boolean
+
+  protected val creationTrace: Option[Array[StackTraceElement]] = if (tracingEnabled) {
+    Some(Thread.currentThread().getStackTrace())
+  } else {
+    None
+  }
+
+  override protected def finalize(): Unit = {
+    if (!isDisposed) logDisposeWarning()
+
+    super.finalize()
+  }
+
+  // overridable for testing
+  protected def tracingEnabled = WarnIfNotDisposed.tracingEnabled
+
+  protected def logDisposeWarning(): Unit = {
+    // The ":Any" casts below are working around the Slf4j Java API having overloaded methods that
+    // Scala doesn't resolve automatically.
+    if (creationTrace.isDefined) {
+      logger.warn(
+        "LEAK: An instance of {} was not disposed. Creation point of this resource was:\n\t{}",
+        getClass(), creationTrace.get.mkString("\n\t"): Any)
+    } else {
+      // Tracing disabled but we still warn the first time we see a leak to ensure the code author
+      // knows. We could warn every time but this can be very noisy.
+      val className = getClass().getName()
+      if (!classesWarned.contains(className)) {
+        logger.warn(
+          "LEAK: [one-time warning] An instance of {} was not disposed. " + //
+          "Set property {} to true to enable tracing",
+          className, traceProperty: Any)
+
+        classesWarned += className
+      }
+    }
+  }
+}
+// scalastyle:on finalize

--- a/scala-package/core/src/test/scala/ml/dmlc/mxnet/util/WarnIfNotDiposedSuite.scala
+++ b/scala-package/core/src/test/scala/ml/dmlc/mxnet/util/WarnIfNotDiposedSuite.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.mxnet
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+// scalastyle:off finalize
+class Leakable(enableTracing: Boolean = false, markDisposed: Boolean = false)
+    extends WarnIfNotDisposed {
+  def isDisposed: Boolean = markDisposed
+  override protected def tracingEnabled = enableTracing
+
+  var warningWasLogged: Boolean = false
+  def getCreationTrace: Option[Array[StackTraceElement]] = creationTrace
+
+  override def finalize(): Unit = super.finalize()
+  override protected def logDisposeWarning() = {
+    warningWasLogged = true
+  }
+}
+// scalastyle:on finalize
+
+class WarnIfNotDisposedSuite extends FunSuite with BeforeAndAfterAll {
+  test("trace collected if tracing enabled") {
+    val leakable = new Leakable(enableTracing = true)
+
+    val trace = leakable.getCreationTrace
+    assert(trace.isDefined)
+    assert(trace.get.exists(el => el.getClassName() == getClass().getName()))
+  }
+
+  test("trace not collected if tracing disabled") {
+    val leakable = new Leakable(enableTracing = false)
+    assert(!leakable.getCreationTrace.isDefined)
+  }
+
+  test("no warning logged if object disposed") {
+    val notLeaked = new Leakable(markDisposed = true)
+    notLeaked.finalize()
+    assert(!notLeaked.warningWasLogged)
+  }
+
+  test("warning logged if object not disposed") {
+    val leaked = new Leakable(markDisposed = false)
+    leaked.finalize()
+    assert(leaked.warningWasLogged)
+  }
+}


### PR DESCRIPTION
* [scala] Remove finalizers for leakable resources

Finalizers always run in a separate thread which is not controlled by the user.
Since MXNet cannot be safely accessed from multiple threads, this causes memory
corruption. It is not safe to use finalizers in this way.

This change also adds some leaked object tracing, to allow leaks to be tracked.
It's easy to leak objects and despite warnings in the documentation leaks are
common (even within the Scala API itself). The leak tracing is activated by a
system property, as its runtime cost may be significant.

With the system property unset, the *first* leak of a type will be reported
(without a trace) as a prompt to the developer to investigate.

Co-authored-by: Andre Tamm <tammtamm@amazon.com>

* [scala] Fix various resource leaks

These leaks were diagnosed with the leak detection added in the previous
commit. This is not an exhaustive clean up but it allows predicting with a
model from Scala at scale (hundreds of millions of comparisons) without a
reported leak, as well as removing the most common errors when training using
the Module code.

Co-authored-by: Andre Tamm <tammtamm@amazon.com>

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
