### PR TITLE
fix CreateOp of altering shape operations to accept dtypes of uint8 and int32

### DIFF
--- a/src/operator/sequence_last.cc
+++ b/src/operator/sequence_last.cc
@@ -77,13 +77,13 @@ Example::
                       [  22.,   23.,   24.],
                       [  25.,   26.,   27.]]
 
-   // sequence_length y is used
+   // sequence_length is used
    SequenceLast(x, sequence_length=[1,1,1], use_sequence_length=True) =
             [[  1.,   2.,   3.],
              [  4.,   5.,   6.],
              [  7.,   8.,   9.]]
 
-   // sequence_length y is used
+   // sequence_length is used
    SequenceLast(x, sequence_length=[1,2,3], use_sequence_length=True) =
             [[  1.,    2.,   3.],
              [  13.,  14.,  15.],

--- a/src/operator/sequence_last.cc
+++ b/src/operator/sequence_last.cc
@@ -30,7 +30,7 @@ namespace op {
 template <>
 Operator *CreateOp<cpu>(SequenceLastParam param, int dtype) {
   Operator *op = NULL;
-  MSHADOW_REAL_TYPE_SWITCH(dtype, DType,
+  MSHADOW_TYPE_SWITCH(dtype, DType,
                            { op = new SequenceLastOp<cpu, DType>(param); })
   return op;
 }

--- a/src/operator/sequence_last.cc
+++ b/src/operator/sequence_last.cc
@@ -78,13 +78,13 @@ Example::
                       [  25.,   26.,   27.]]
 
    // sequence_length y is used
-   SequenceLast(x, y=[1,1,1], use_sequence_length=True) =
+   SequenceLast(x, sequence_length=[1,1,1], use_sequence_length=True) =
             [[  1.,   2.,   3.],
              [  4.,   5.,   6.],
              [  7.,   8.,   9.]]
 
    // sequence_length y is used
-   SequenceLast(x, y=[1,2,3], use_sequence_length=True) =
+   SequenceLast(x, sequence_length=[1,2,3], use_sequence_length=True) =
             [[  1.,    2.,   3.],
              [  13.,  14.,  15.],
              [  25.,  26.,  27.]]

--- a/src/operator/sequence_last.cu
+++ b/src/operator/sequence_last.cu
@@ -30,7 +30,7 @@ namespace mxnet {
 namespace op {
 template <> Operator *CreateOp<gpu>(SequenceLastParam param, int dtype) {
   Operator *op = NULL;
-  MSHADOW_REAL_TYPE_SWITCH(dtype, DType,
+  MSHADOW_TYPE_SWITCH(dtype, DType,
                            { op = new SequenceLastOp<gpu, DType>(param); })
   return op;
 }

--- a/src/operator/sequence_mask.cc
+++ b/src/operator/sequence_mask.cc
@@ -89,7 +89,7 @@ Example::
 
    // sequence_length [1,1] means 1 of each batch will be kept
    // and other rows are masked with default mask value = 0
-   SequenceMask(x, y=[1,1], use_sequence_length=True) =
+   SequenceMask(x, sequence_length=[1,1], use_sequence_length=True) =
                 [[[  1.,   2.,   3.],
                   [  4.,   5.,   6.]],
 
@@ -101,7 +101,7 @@ Example::
 
    // sequence_length [2,3] means 2 of batch B1 and 3 of batch B2 will be kept
    // and other rows are masked with value = 1
-   SequenceMask(x, y=[2,3], use_sequence_length=True, value=1) =
+   SequenceMask(x, sequence_length=[2,3], use_sequence_length=True, value=1) =
                 [[[  1.,   2.,   3.],
                   [  4.,   5.,   6.]],
 

--- a/src/operator/sequence_mask.cc
+++ b/src/operator/sequence_mask.cc
@@ -30,7 +30,7 @@ namespace op {
 template <>
 Operator *CreateOp<cpu>(SequenceMaskParam param, int dtype) {
   Operator *op = NULL;
-  MSHADOW_REAL_TYPE_SWITCH(dtype, DType,
+  MSHADOW_TYPE_SWITCH(dtype, DType,
                            { op = new SequenceMaskOp<cpu, DType>(param); })
   return op;
 }

--- a/src/operator/sequence_mask.cu
+++ b/src/operator/sequence_mask.cu
@@ -31,7 +31,7 @@ namespace op {
 
 template <> Operator *CreateOp<gpu>(SequenceMaskParam param, int dtype) {
   Operator *op = NULL;
-  MSHADOW_REAL_TYPE_SWITCH(dtype, DType,
+  MSHADOW_TYPE_SWITCH(dtype, DType,
                            { op = new SequenceMaskOp<gpu, DType>(param); })
   return op;
 }

--- a/src/operator/sequence_reverse.cc
+++ b/src/operator/sequence_reverse.cc
@@ -30,7 +30,7 @@ namespace op {
 template <>
 Operator *CreateOp<cpu>(SequenceReverseParam param, int dtype) {
   Operator *op = NULL;
-  MSHADOW_REAL_TYPE_SWITCH(dtype, DType,
+  MSHADOW_TYPE_SWITCH(dtype, DType,
                            { op = new SequenceReverseOp<cpu, DType>(param); })
   return op;
 }
@@ -88,7 +88,7 @@ Example::
 
    // sequence_length [2,2] means 2 rows of
    // both batch B1 and B2 will be reversed.
-   SequenceReverse(x, y=[2,2], use_sequence_length=True) =
+   SequenceReverse(x, sequence_length=[2,2], use_sequence_length=True) =
                      [[[  7.,   8.,   9.],
                        [ 10.,  11.,  12.]],
 
@@ -100,7 +100,7 @@ Example::
 
    // sequence_length [2,3] means 2 of batch B2 and 3 of batch B3
    // will be reversed.
-   SequenceReverse(x, y=[2,3], use_sequence_length=True) =
+   SequenceReverse(x, sequence_length=[2,3], use_sequence_length=True) =
                     [[[  7.,   8.,   9.],
                       [ 16.,  17.,  18.]],
 

--- a/src/operator/sequence_reverse.cu
+++ b/src/operator/sequence_reverse.cu
@@ -30,7 +30,7 @@ namespace mxnet {
 namespace op {
 template <> Operator *CreateOp<gpu>(SequenceReverseParam param, int dtype) {
   Operator *op = NULL;
-  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+  MSHADOW_TYPE_SWITCH(dtype, DType, {
     op = new SequenceReverseOp<gpu, DType>(param);
   })
   return op;

--- a/src/operator/swapaxis.cc
+++ b/src/operator/swapaxis.cc
@@ -32,7 +32,7 @@ namespace op {
 template<>
 Operator* CreateOp<cpu>(SwapAxisParam param, int dtype) {
   Operator *op = NULL;
-  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+  MSHADOW_TYPE_SWITCH(dtype, DType, {
     op = new SwapAxisOp<cpu, DType>(param);
   });
   return op;

--- a/src/operator/swapaxis.cu
+++ b/src/operator/swapaxis.cu
@@ -32,7 +32,7 @@ namespace op {
 template<>
 Operator *CreateOp<gpu>(SwapAxisParam param, int dtype) {
   Operator *op = NULL;
-  MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
+  MSHADOW_TYPE_SWITCH(dtype, DType, {
     op =  new SwapAxisOp<gpu, DType>(param);
   });
   return op;


### PR DESCRIPTION
## Description ##
Same context as https://github.com/apache/incubator-mxnet/pull/9561,
to deal with quantization in future,
operators(sequence_last, sequence_mask, sequence_revert,swapaxis) should have capability to accept uint8 and int32.
Like slice_channel, it can be achieved by changing MSHADOW_REAL_TYPE_SWITCH to MSHADOW_TYPE_SWITCH as concat(https://github.com/apache/incubator-mxnet/blob/d2a856a3a2abb4e72edc301b8b821f0b75f30722/src/operator/concat.cu)
I tested them and it worked well both cpu,gpu setting,

And there was wrong argument y appeared in document of sequence_last,sequence_mask,sequence_reverse instead of right argument sequence_length, so I fixed it also. 