### PR TITLE
Remove unnecessary RuntimeError

### DIFF
--- a/tests/python/gpu/test_forward.py
+++ b/tests/python/gpu/test_forward.py
@@ -44,17 +44,12 @@ def _dump_images(shape):
 def _get_data(shape):
     hash_test_img = "355e15800642286e7fe607d87c38aeeab085b0cc"
     hash_inception_v3 = "91807dfdbd336eb3b265dd62c2408882462752b9"
-    fname = utils.download("http://data.mxnet.io/data/test_images_%d_%d.npy" % (shape),
-                           path="data/test_images_%d_%d.npy" % (shape),
-                           sha1_hash=hash_test_img)
-    if not utils.check_sha1(fname, hash_test_img):
-        raise RuntimeError("File %s not downloaded completely" % ("test_images_%d_%d.npy"%(shape)))
-
-    fname = utils.download("http://data.mxnet.io/data/inception-v3-dump.npz",
-                           path='data/inception-v3-dump.npz',
-                           sha1_hash=hash_inception_v3)
-    if not utils.check_sha1(fname, hash_inception_v3):
-        raise RuntimeError("File %s not downloaded completely" % ("inception-v3-dump.npz"))
+    utils.download("http://data.mxnet.io/data/test_images_%d_%d.npy" % (shape),
+                   path="data/test_images_%d_%d.npy" % (shape),
+                   sha1_hash=hash_test_img)
+    utils.download("http://data.mxnet.io/data/inception-v3-dump.npz",
+                   path='data/inception-v3-dump.npz',
+                   sha1_hash=hash_inception_v3)
 
 def test_consistency(dump=False):
     shape = (299, 299)

--- a/tests/python/gpu/test_forward.py
+++ b/tests/python/gpu/test_forward.py
@@ -19,6 +19,7 @@ import os
 import numpy as np
 import mxnet as mx
 from mxnet.test_utils import *
+from mxnet.gluon import utils
 
 def _get_model():
     if not os.path.exists('model/Inception-7-symbol.json'):
@@ -41,8 +42,19 @@ def _dump_images(shape):
     np.save('data/test_images_%d_%d.npy'%shape, imgs)
 
 def _get_data(shape):
-    download("http://data.mxnet.io/data/test_images_%d_%d.npy" % (shape), dirname='data')
-    download("http://data.mxnet.io/data/inception-v3-dump.npz", dirname="data")
+    hash_test_img = "355e15800642286e7fe607d87c38aeeab085b0cc"
+    hash_inception_v3 = "91807dfdbd336eb3b265dd62c2408882462752b9"
+    fname = utils.download("http://data.mxnet.io/data/test_images_%d_%d.npy" % (shape),
+                           path="data/test_images_%d_%d.npy" % (shape),
+                           sha1_hash=hash_test_img)
+    if not utils.check_sha1(fname, hash_test_img):
+        raise RuntimeError("File %s not downloaded completely" % ("test_images_%d_%d.npy"%(shape)))
+
+    fname = utils.download("http://data.mxnet.io/data/inception-v3-dump.npz",
+                           path='data/inception-v3-dump.npz',
+                           sha1_hash=hash_inception_v3)
+    if not utils.check_sha1(fname, hash_inception_v3):
+        raise RuntimeError("File %s not downloaded completely" % ("inception-v3-dump.npz"))
 
 def test_consistency(dump=False):
     shape = (299, 299)


### PR DESCRIPTION
## Description ##
utils.download already raises an Exception if the checksum doesn't match. Not needed to do it twice. 

@szha @eric-haibin-lin 

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
