### PR TITLE
Fix flaky test R

### DIFF
--- a/R-package/tests/testthat/test_model.R
+++ b/R-package/tests/testthat/test_model.R
@@ -174,9 +174,6 @@ test_that("Fine-tune", {
 test_that("Matrix Factorization", {
   
   # Use fake random data instead of GetMovieLens() to remove external dependency
-  # GetMovieLens()
-  # DF <- read.table("./data/ml-100k/u.data", header = F, sep = "\t")
-  # names(DF) <- c("user", "item", "score", "time")
   set.seed(123)
   user <- sample(943, size = 100000, replace = T)
   item <- sample(1682, size = 100000, replace = T)

--- a/R-package/tests/testthat/test_model.R
+++ b/R-package/tests/testthat/test_model.R
@@ -172,9 +172,17 @@ test_that("Fine-tune", {
 })                                       
 
 test_that("Matrix Factorization", {
-  GetMovieLens()
-  DF <- read.table("./data/ml-100k/u.data", header = F, sep = "\t")
-  names(DF) <- c("user", "item", "score", "time")
+  
+  # Use fake random data instead of GetMovieLens() to remove external dependency
+  # GetMovieLens()
+  # DF <- read.table("./data/ml-100k/u.data", header = F, sep = "\t")
+  # names(DF) <- c("user", "item", "score", "time")
+  set.seed(123)
+  user <- sample(943, size = 100000, replace = T)
+  item <- sample(1682, size = 100000, replace = T)
+  score <- sample(5, size = 100000, replace = T)
+  DF <- data.frame(user, item, score)
+  
   max_user <- max(DF$user)
   max_item <- max(DF$item)
   DF_mat_x <- data.matrix(t(DF[, 1:2]))


### PR DESCRIPTION
Fix the flaky test as reported by #9332 and #9412. 
Uses a fix seed to generate random data since the test is only to validate the custom iterator. 