### PR TITLE
Btaskaya/stringformatting

### DIFF
--- a/python/mxnet/ndarray/register.py
+++ b/python/mxnet/ndarray/register.py
@@ -68,19 +68,19 @@ def _generate_ndarray_function_code(handle, name, func_name, signature_only=Fals
         name, atype = arg_names[i], arg_types[i]
         if name == 'dtype':
             dtype_name = name
-            signature.append('%s=_Null'%name)
+            signature.append('{}=_Null'.format(name))
         elif atype.startswith('NDArray') or atype.startswith('Symbol'):
             assert not arr_name, \
                 "Op can only have one argument with variable " \
                 "size and it must be the last argument."
             if atype.endswith('[]'):
-                ndsignature.append('*%s'%name)
+                ndsignature.append('*{}'.format(name))
                 arr_name = name
             else:
-                ndsignature.append('%s=None'%name)
+                ndsignature.append('{}=None'.format(name))
                 ndarg_names.append(name)
         else:
-            signature.append('%s=_Null'%name)
+            signature.append('{}=_Null'.format(name))
             kwarg_names.append(name)
     signature.append('out=None')
     signature.append('name=None')
@@ -90,7 +90,7 @@ def _generate_ndarray_function_code(handle, name, func_name, signature_only=Fals
     code = []
     if arr_name:
         code.append("""
-def %s(*%s, **kwargs):"""%(func_name, arr_name))
+def {}(*{}, **kwargs):""".formatting(func_name, arr_name))
         if not signature_only:
             code.append("""
     ndargs = []
@@ -101,8 +101,8 @@ def %s(*%s, **kwargs):"""%(func_name, arr_name))
         ndargs.append(i)""".format(arr_name))
             if dtype_name is not None:
                 code.append("""
-    if '%s' in kwargs:
-        kwargs['%s'] = np.dtype(kwargs['%s']).name"""%(
+    if '{0}' in kwargs:
+        kwargs['{0}'] = np.dtype(kwargs['{0}']).name""".format(
             dtype_name, dtype_name, dtype_name))
             code.append("""
     _ = kwargs.pop('name', None)
@@ -111,7 +111,7 @@ def %s(*%s, **kwargs):"""%(func_name, arr_name))
     vals = list(kwargs.values())""")
     else:
         code.append("""
-def %s(%s):"""%(func_name, ', '.join(signature)))
+def {}({}):""".format(func_name, ', '.join(signature)))
         if not signature_only:
             code.append("""
     ndargs = []
@@ -127,19 +127,19 @@ def %s(%s):"""%(func_name, ', '.join(signature)))
             # kwargs
             for name in kwarg_names: # pylint: disable=redefined-argument-from-local
                 code.append("""
-    if %s is not _Null:
-        keys.append('%s')
-        vals.append(%s)"""%(name, name, name))
+    if {0} is not _Null:
+        keys.append('{0}')
+        vals.append({0})""".format(name))
             # dtype
             if dtype_name is not None:
                 code.append("""
-    if %s is not _Null:
-        keys.append('%s')
-        vals.append(np.dtype(%s).name)"""%(dtype_name, dtype_name, dtype_name))
+    if {0} is not _Null:
+        keys.append('{0}')
+        vals.append(np.dtype({0}).name)""".format(dtype_name, dtype_name, dtype_name))
 
     if not signature_only:
         code.append("""
-    return _imperative_invoke(%d, ndargs, keys, vals, out)"""%(
+    return _imperative_invoke({:d}, ndargs, keys, vals, out)""".format(
         handle.value))
     else:
         code.append("""

--- a/python/mxnet/registry.py
+++ b/python/mxnet/registry.py
@@ -67,20 +67,20 @@ def get_register_func(base_class, nickname):
     def register(klass, name=None):
         """Register functions"""
         assert issubclass(klass, base_class), \
-            "Can only register subclass of %s"%base_class.__name__
+            "Can only register subclass of {}".format(base_class.__name__)
         if name is None:
             name = klass.__name__.lower()
         if name in registry:
             warnings.warn(
-                "\033[91mNew %s %s.%s registered with name %s is"
-                "overriding existing %s %s.%s\033[0m"%(
+                "\033[91mNew {0} {1}.{2} registered with name {3} is"
+                "overriding existing {0} {4}.{5}\033[0m".format(
                     nickname, klass.__module__, klass.__name__, name,
-                    nickname, registry[name].__module__, registry[name].__name__),
+                    registry[name].__module__, registry[name].__name__),
                 UserWarning, stacklevel=2)
         registry[name] = klass
         return klass
 
-    register.__doc__ = "Register %s to the %s factory"%(nickname, nickname)
+    register.__doc__ = "Register {0} to the {0} factory".format(nickname)
     return register
 
 
@@ -139,13 +139,13 @@ def get_create_func(base_class, nickname):
 
         if isinstance(name, base_class):
             assert len(args) == 0 and len(kwargs) == 0, \
-                "%s is already an instance. Additional arguments are invalid"%(nickname)
+                "{} is already an instance. Additional arguments are invalid".format(nickname)
             return name
 
         if isinstance(name, dict):
             return create(**name)
 
-        assert isinstance(name, string_types), "%s must be of string type"%nickname
+        assert isinstance(name, string_types), "{} must be of string type".format(nickname)
 
         if name.startswith('['):
             assert not args and not kwargs
@@ -158,18 +158,18 @@ def get_create_func(base_class, nickname):
 
         name = name.lower()
         assert name in registry, \
-            "%s is not registered. Please register with %s.register first"%(
+            "{} is not registered. Please register with {}.register first".format(
                 str(name), nickname)
         return registry[name](*args, **kwargs)
 
-    create.__doc__ = """Create a %s instance from config.
+    create.__doc__ = """Create a {0} instance from config.
 
 Parameters
 ----------
-%s : str or %s instance
+{0} : str or {1} instance
     class name of desired instance. If is a instance,
     it will be returned directly.
 **kwargs : dict
-    arguments to be passed to constructor"""%(nickname, nickname, base_class.__name__)
+    arguments to be passed to constructor"""%(nickname, base_class.__name__)
 
     return create


### PR DESCRIPTION
## Description ##
According to PEP3101, old type string formattings (%s) should re-writed as new type string formatting ("{}" and ".format()")

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Old Type String Formattings converted New Type String Formattings in python/mxnet

## Comments ##
-  PEP3101 generally says .format() is a better way to formatting strings.
