### PR TITLE
Disable test libsvm iter 

### DIFF
--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -191,6 +191,7 @@ def test_NDArrayIter_csr():
         assert_almost_equal(batch.data[0].asnumpy(), expected)
         begin += batch_size
 
+@unittest.skip("test fails intermittently due to external dependency. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/9604")
 def test_LibSVMIter():
 
     def check_libSVMIter_synthetic():


### PR DESCRIPTION
We need to move it to s3 hosting. 