### PR TITLE
Removing a broken tutorial from the nightly tests

### DIFF
--- a/tests/nightly/test_tutorial_config.txt
+++ b/tests/nightly/test_tutorial_config.txt
@@ -4,4 +4,3 @@ basic/module
 basic/data
 python/linear-regression
 python/mnist
-python/predict_image


### PR DESCRIPTION
## Description ##
The predict image tutorial is broken: https://github.com/apache/incubator-mxnet/issues/9532
It is causing the nightly test build to also fail, so I'm removing it from the config until #9532 can be fixed.


## Comments ##
Since we've added a bunch of tutorials in this last release, we need to update this file to cover those tutorials. However, I'm not sure how these tests work and if the tutorials have the requisite code blocks to facilitate being part of the nightly test suite.

If there's nothing special to be added to the tutorials themselves, then kick this back to me for adding the other tutorials to this config.
