### PR TITLE
Fix the version on website mainpage

### DIFF
--- a/docs/_static/mxnet-theme/index.html
+++ b/docs/_static/mxnet-theme/index.html
@@ -23,7 +23,7 @@
       <div class="col-lg-4 col-sm-12">
         <h3>Apache MXNet 1.1.0 Released</h3>
         <p>We're excited to announce the release of MXNet 1.1.0! Check out the release notes for latest updates.</p>
-        <a href="https://github.com/apache/incubator-mxnet/releases/tag/1.0.1">Learn More</a>
+        <a href="https://github.com/apache/incubator-mxnet/releases/tag/1.1.0">Learn More</a>
       </div>
       <div class="col-lg-4 col-sm-12">
         <h3>MXNet Model Server</h3>

--- a/docs/_static/mxnet-theme/index.html
+++ b/docs/_static/mxnet-theme/index.html
@@ -21,8 +21,8 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-4 col-sm-12">
-        <h3>Apache MXNet 1.0.1 Released</h3>
-        <p>We're excited to announce the release of MXNet 1.0.1! Check out the release notes for latest updates.</p>
+        <h3>Apache MXNet 1.1.0 Released</h3>
+        <p>We're excited to announce the release of MXNet 1.1.0! Check out the release notes for latest updates.</p>
         <a href="https://github.com/apache/incubator-mxnet/releases/tag/1.0.1">Learn More</a>
       </div>
       <div class="col-lg-4 col-sm-12">

--- a/docs/_static/mxnet-theme/index.html
+++ b/docs/_static/mxnet-theme/index.html
@@ -21,9 +21,9 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-4 col-sm-12">
-        <h3>Apache MXNet 1.1.0 Released</h3>
-        <p>We're excited to announce the release of MXNet 1.1.0! Check out the release notes for latest updates.</p>
-        <a href="https://github.com/apache/incubator-mxnet/releases/tag/1.1.0">Learn More</a>
+        <h3>Apache MXNet 1.0 Released</h3>
+        <p>We're excited to announce the release of MXNet 1.0! Check out the release notes for latest updates.</p>
+        <a href="https://github.com/apache/incubator-mxnet/releases/tag/1.0.0">Learn More</a>
       </div>
       <div class="col-lg-4 col-sm-12">
         <h3>MXNet Model Server</h3>


### PR DESCRIPTION
PR #9535 modified the version of MXNet on the index page which leads to a broken link. This should only be updated when the voting for the new version passes. Reverting it now. @thinksanky @aaronmarkham 