### PR TITLE
Add back kvstore unit test

### DIFF
--- a/tests/python/unittest/test_kvstore.py
+++ b/tests/python/unittest/test_kvstore.py
@@ -61,7 +61,6 @@ def test_single_kv_pair():
     check_single_kv_pair(init_kv(), 3)
     check_single_kv_pair(init_kv_with_str(), 'a')
 
-@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/9384")
 def test_row_sparse_pull():
     kv = init_kv_with_str('row_sparse')
     kv.init('e', mx.nd.ones(shape).tostype('row_sparse'))


### PR DESCRIPTION
`test_row_sparse_pull` is working correctly on CPU. It was mistakenly disabled by a previous PR. The non-working one is in `gpu/test_kvstore.py`, which is disabled already. Now adding this test back. 