### PR TITLE
Update shape.h

### DIFF
--- a/cpp-package/include/mxnet-cpp/shape.h
+++ b/cpp-package/include/mxnet-cpp/shape.h
@@ -170,7 +170,7 @@ struct Shape {
       data_heap_[1] = s2;
       data_heap_[2] = s3;
       data_heap_[3] = s4;
-      data_heap_[5] = s5;
+      data_heap_[4] = s5;
     }
   }
   /*!


### PR DESCRIPTION
In line 173 of ./cpp-package/include/mxnet-cpp/shape.h whether the num 5 is a error?

## Description ##
(Brief description on what this PR is about)
I maybe find a writing error in /cpp-package/include/mxnet-cpp/shape.h.
if kStackCache is less than 5, the code in line 173 will out of memory.

## Checklist ##
Sorry, I don't take any test yet.