### PR TITLE
Fix DataBatch.__str__ for cases where we don't have labels.

### DIFF
--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -168,7 +168,10 @@ class DataBatch(object):
 
     def __str__(self):
         data_shapes = [d.shape for d in self.data]
-        label_shapes = [l.shape for l in self.label]
+        if self.label:
+            label_shapes = [l.shape for l in self.label]
+        else:
+            label_shapes = None
         return "{}: data shapes: {} label shapes: {}".format(
             self.__class__.__name__,
             data_shapes,

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -252,6 +252,17 @@ def test_LibSVMIter():
     check_libSVMIter_synthetic()
     check_libSVMIter_news_data()
 
+
+def test_DataBatch():
+    from nose.tools import ok_
+    from mxnet.io import DataBatch
+    import re
+    batch = DataBatch(data=[mx.nd.ones((2,3))])
+    ok_(re.match('DataBatch: data shapes: \[\(2L?, 3L?\)\] label shapes: None', str(batch)))
+    batch = DataBatch(data=[mx.nd.ones((2,3)), mx.nd.ones((7,8))], label=[mx.nd.ones((4,5))])
+    ok_(re.match('DataBatch: data shapes: \[\(2L?, 3L?\), \(7L?, 8L?\)\] label shapes: \[\(4L?, 5L?\)\]', str(batch)))
+
+
 @unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/7826")
 def test_CSVIter():
     def check_CSVIter_synthetic():


### PR DESCRIPTION
## Description ##
If there's no label, DataBatch throws when printing or converting to str

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change