### PR TITLE
Set the autotune default to 1 in docs

### DIFF
--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -110,7 +110,7 @@ When USE_PROFILER is enabled in Makefile or CMake, the following environments ca
 ## Other Environment Variables
 
 * MXNET_CUDNN_AUTOTUNE_DEFAULT
-  - Values: 0(false) or 1(true) ```(default=0)```
+  - Values: 0(false) or 1(true) ```(default=1)```
   - The default value of cudnn auto tunning for convolution layers.
   - Auto tuning is turned off by default. For benchmarking, set this to 1 to turn it on by default.
 


### PR DESCRIPTION
From the usages I see, the default value is 1.  

https://github.com/apache/incubator-mxnet/blob/2cc2aa2272881326c8a50c6204aedd71e1821c3f/src/operator/nn/cudnn/cudnn_convolution-inl.h#L100
and 
https://github.com/apache/incubator-mxnet/blob/2cc2aa2272881326c8a50c6204aedd71e1821c3f/src/operator/nn/cudnn/cudnn_deconvolution-inl.h#L97

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Feature1, tests, (and when applicable, API doc)
- [x] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
