### PR TITLE
Exp backoff for downloads.

### DIFF
--- a/docs/tutorials/basic/data.md
+++ b/docs/tutorials/basic/data.md
@@ -339,7 +339,7 @@ Let's download sample images that we can work with.
 
 
 ```python
-fname = mx.test_utils.download(url='http://data.mxnet.io/data/test_images.tar.gz', dirname='data', overwrite=False)
+fname = mx.utils.download(url='http://data.mxnet.io/data/test_images.tar.gz', dirname='data', overwrite=False)
 tar = tarfile.open(fname)
 tar.extractall(path='./data')
 tar.close()
@@ -380,7 +380,7 @@ Download and unzip
 
 
 ```python
-fname = mx.test_utils.download(url='http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz', dirname='data', overwrite=False)
+fname = mx.utils.download(url='http://www.vision.caltech.edu/Image_Datasets/Caltech101/101_ObjectCategories.tar.gz', dirname='data', overwrite=False)
 tar = tarfile.open(fname)
 tar.extractall(path='./data')
 tar.close()

--- a/docs/tutorials/basic/module.md
+++ b/docs/tutorials/basic/module.md
@@ -43,7 +43,7 @@ logging.getLogger().setLevel(logging.INFO)
 import mxnet as mx
 import numpy as np
 
-fname = mx.test_utils.download('http://archive.ics.uci.edu/ml/machine-learning-databases/letter-recognition/letter-recognition.data')
+fname = mx.utils.download('http://archive.ics.uci.edu/ml/machine-learning-databases/letter-recognition/letter-recognition.data')
 data = np.genfromtxt(fname, delimiter=',')[:,1:]
 label = np.array([ord(l.split(',')[0])-ord('A') for l in open(fname, 'r')])
 

--- a/docs/tutorials/python/predict_image.md
+++ b/docs/tutorials/python/predict_image.md
@@ -26,9 +26,9 @@ a text file for the labels.
 ```python
 import mxnet as mx
 path='http://data.mxnet.io/models/imagenet-11k/'
-[mx.test_utils.download(path+'resnet-152/resnet-152-symbol.json'),
- mx.test_utils.download(path+'resnet-152/resnet-152-0000.params'),
- mx.test_utils.download(path+'synset.txt')]
+[mx.utils.download(path+'resnet-152/resnet-152-symbol.json'),
+ mx.utils.download(path+'resnet-152/resnet-152-0000.params'),
+ mx.utils.download(path+'synset.txt')]
 ```
 
 Next, we load the downloaded model. *Note:* If GPU is available, we can replace all
@@ -60,7 +60,7 @@ Batch = namedtuple('Batch', ['data'])
 
 def get_image(url, show=False):
     # download and show the image
-    fname = mx.test_utils.download(url)
+    fname = mx.utils.download(url)
     img = cv2.cvtColor(cv2.imread(fname), cv2.COLOR_BGR2RGB)
     if img is None:
          return None

--- a/example/gluon/style_transfer/dataset/download_dataset.py
+++ b/example/gluon/style_transfer/dataset/download_dataset.py
@@ -17,7 +17,7 @@
 
 import os, zipfile
 import mxnet
-from mxnet.test_utils import download
+from mxnet.utils import download
 
 def unzip_file(filename, outpath):
     fh = open(filename, 'rb')

--- a/example/gluon/style_transfer/models/download_model.py
+++ b/example/gluon/style_transfer/models/download_model.py
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from mxnet.test_utils import download
+from mxnet.utils import download
 
 download('https://apache-mxnet.s3-accelerate.amazonaws.com/gluon/models/21styles-32f7205c.params', 'models/21styles.params')
 

--- a/example/gluon/super_resolution.py
+++ b/example/gluon/super_resolution.py
@@ -26,7 +26,7 @@ import mxnet.ndarray as F
 from mxnet import gluon
 from mxnet.gluon import nn
 from mxnet import autograd as ag
-from mxnet.test_utils import download
+from mxnet.utils import download
 from mxnet.image import CenterCropAug, ResizeAug
 from mxnet.io import PrefetchingIter
 

--- a/example/gluon/tree_lstm/scripts/download.py
+++ b/example/gluon/tree_lstm/scripts/download.py
@@ -30,7 +30,7 @@ import os
 import shutil
 import zipfile
 import gzip
-from mxnet.test_utils import download
+from mxnet.utils import download
 
 def unzip(filepath):
     print("Extracting: " + filepath)

--- a/example/image-classification/test_score.py
+++ b/example/image-classification/test_score.py
@@ -25,7 +25,7 @@ from score import score
 
 VAL_DATA='data/val-5k-256.rec'
 def download_data():
-    return mx.test_utils.download(
+    return mx.utils.download(
         'http://data.mxnet.io/data/val-5k-256.rec', VAL_DATA)
 
 def test_imagenet1k_resnet(**kwargs):

--- a/example/mxnet_adversarial_vae/convert_data.py
+++ b/example/mxnet_adversarial_vae/convert_data.py
@@ -29,7 +29,7 @@ from PIL import Image
 import scipy.io
 import scipy.misc
 import numpy as np
-from mxnet.test_utils import *
+from mxnet.utils import download
 
 logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 
@@ -95,7 +95,7 @@ def parse_args():
 
 def main():
     args = parse_args()
-    download(DEFAULT_DATASET_URL, fname=args.dataset, dirname=args.save_path, overwrite=False)
+    download(DEFAULT_DATASET_URL, path=args.save_path + args.dataset, overwrite=False)
     convert_mat_to_images(args)
 
 if __name__ == '__main__':

--- a/python/mxnet/__init__.py
+++ b/python/mxnet/__init__.py
@@ -75,6 +75,7 @@ from . import image
 from . import image as img
 
 from . import test_utils
+from . import utils
 
 from . import rnn
 

--- a/python/mxnet/gluon/contrib/data/text.py
+++ b/python/mxnet/gluon/contrib/data/text.py
@@ -28,7 +28,7 @@ import numpy as np
 
 from . import _constants as C
 from ...data import dataset
-from ...utils import download, check_sha1
+from ....utils import download, check_sha1
 from ....contrib import text
 from .... import nd
 

--- a/python/mxnet/gluon/data/vision/datasets.py
+++ b/python/mxnet/gluon/data/vision/datasets.py
@@ -29,7 +29,7 @@ import warnings
 import numpy as np
 
 from .. import dataset
-from ...utils import download, check_sha1
+from .... utils import download, check_sha1
 from .... import nd, image, recordio
 
 

--- a/python/mxnet/gluon/model_zoo/model_store.py
+++ b/python/mxnet/gluon/model_zoo/model_store.py
@@ -22,7 +22,7 @@ __all__ = ['get_model_file', 'purge']
 import os
 import zipfile
 
-from ..utils import download, check_sha1
+from ... utils import download, check_sha1
 
 _model_sha1 = {name: checksum for checksum, name in [
     ('44335d1f0046b328243b32a26a4fbd62d9057b45', 'alexnet'),

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -35,6 +35,7 @@ import numpy as np
 
 from .. import ndarray
 
+
 def split_data(data, num_slice, batch_axis=0, even_split=True):
     """Splits an NDArray into `num_slice` slices along `batch_axis`.
     Usually used for data parallelism where each slices is sent
@@ -61,13 +62,13 @@ def split_data(data, num_slice, batch_axis=0, even_split=True):
     size = data.shape[batch_axis]
     if size < num_slice:
         raise ValueError(
-            "Too many slices for data with shape %s. Arguments are " \
-            "num_slice=%d and batch_axis=%d."%(str(data.shape), num_slice, batch_axis))
+            "Too many slices for data with shape %s. Arguments are "
+            "num_slice=%d and batch_axis=%d." % (str(data.shape), num_slice, batch_axis))
     if even_split and size % num_slice != 0:
         raise ValueError(
-            "data with shape %s cannot be evenly split into %d slices along axis %d. " \
-            "Use a batch size that's multiple of %d or set even_split=False to allow " \
-            "uneven partitioning of data."%(
+            "data with shape %s cannot be evenly split into %d slices along axis %d. "
+            "Use a batch size that's multiple of %d or set even_split=False to allow "
+            "uneven partitioning of data." % (
                 str(data.shape), num_slice, batch_axis, num_slice))
 
     step = size // num_slice
@@ -131,14 +132,14 @@ def clip_global_norm(arrays, max_norm):
     return total_norm
 
 
-def _indent(s_, numSpaces):
+def _indent(s_, num_spaces):
     """Indent string
     """
     s = s_.split('\n')
     if len(s) == 1:
         return s_
     first = s.pop(0)
-    s = [first] + [(numSpaces * ' ') + line for line in s]
+    s = [first] + [(num_spaces * ' ') + line for line in s]
     s = '\n'.join(s)
     return s
 
@@ -202,19 +203,19 @@ def download(url, path=None, overwrite=False, sha1_hash=None):
         if not os.path.exists(dirname):
             os.makedirs(dirname)
 
-        print('Downloading %s from %s...'%(fname, url))
+        print('Downloading %s from %s...' % (fname, url))
         r = requests.get(url, stream=True)
         if r.status_code != 200:
-            raise RuntimeError("Failed downloading url %s"%url)
+            raise RuntimeError("Failed downloading url %s" % url)
         with open(fname, 'wb') as f:
             for chunk in r.iter_content(chunk_size=1024):
-                if chunk: # filter out keep-alive new chunks
+                if chunk:  # filter out keep-alive new chunks
                     f.write(chunk)
 
         if sha1_hash and not check_sha1(fname, sha1_hash):
-            raise UserWarning('File {} is downloaded but the content hash does not match. ' \
-                              'The repo may be outdated or download may be incomplete. ' \
-                              'If the "repo_url" is overridden, consider switching to ' \
+            raise UserWarning('File {} is downloaded but the content hash does not match. '
+                              'The repo may be outdated or download may be incomplete. '
+                              'If the "repo_url" is overridden, consider switching to '
                               'the default repo.'.format(fname))
 
     return fname

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -18,19 +18,9 @@
 # coding: utf-8
 # pylint: disable=
 """Parallelization utility optimizer."""
-__all__ = ['split_data', 'split_and_load', 'clip_global_norm',
-           'check_sha1', 'download']
+__all__ = ['split_data', 'split_and_load', 'clip_global_norm']
 
-import os
-import hashlib
 import warnings
-try:
-    import requests
-except ImportError:
-    class requests_failed_to_import(object):
-        pass
-    requests = requests_failed_to_import
-
 import numpy as np
 
 from .. import ndarray
@@ -144,78 +134,3 @@ def _indent(s_, num_spaces):
     return s
 
 
-def check_sha1(filename, sha1_hash):
-    """Check whether the sha1 hash of the file content matches the expected hash.
-
-    Parameters
-    ----------
-    filename : str
-        Path to the file.
-    sha1_hash : str
-        Expected sha1 hash in hexadecimal digits.
-
-    Returns
-    -------
-    bool
-        Whether the file content matches the expected hash.
-    """
-    sha1 = hashlib.sha1()
-    with open(filename, 'rb') as f:
-        while True:
-            data = f.read(1048576)
-            if not data:
-                break
-            sha1.update(data)
-
-    return sha1.hexdigest() == sha1_hash
-
-
-def download(url, path=None, overwrite=False, sha1_hash=None):
-    """Download an given URL
-
-    Parameters
-    ----------
-    url : str
-        URL to download
-    path : str, optional
-        Destination path to store downloaded file. By default stores to the
-        current directory with same name as in url.
-    overwrite : bool, optional
-        Whether to overwrite destination file if already exists.
-    sha1_hash : str, optional
-        Expected sha1 hash in hexadecimal digits. Will ignore existing file when hash is specified
-        but doesn't match.
-
-    Returns
-    -------
-    str
-        The file path of the downloaded file.
-    """
-    if path is None:
-        fname = url.split('/')[-1]
-    elif os.path.isdir(path):
-        fname = os.path.join(path, url.split('/')[-1])
-    else:
-        fname = path
-
-    if overwrite or not os.path.exists(fname) or (sha1_hash and not check_sha1(fname, sha1_hash)):
-        dirname = os.path.dirname(os.path.abspath(os.path.expanduser(fname)))
-        if not os.path.exists(dirname):
-            os.makedirs(dirname)
-
-        print('Downloading %s from %s...' % (fname, url))
-        r = requests.get(url, stream=True)
-        if r.status_code != 200:
-            raise RuntimeError("Failed downloading url %s" % url)
-        with open(fname, 'wb') as f:
-            for chunk in r.iter_content(chunk_size=1024):
-                if chunk:  # filter out keep-alive new chunks
-                    f.write(chunk)
-
-        if sha1_hash and not check_sha1(fname, sha1_hash):
-            raise UserWarning('File {} is downloaded but the content hash does not match. '
-                              'The repo may be outdated or download may be incomplete. '
-                              'If the "repo_url" is overridden, consider switching to '
-                              'the default repo.'.format(fname))
-
-    return fname

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -44,6 +44,7 @@ except ImportError:
     # in rare cases requests may be not installed
     pass
 import mxnet as mx
+from .utils import create_dir
 from .context import Context
 from .ndarray.ndarray import _STORAGE_TYPE_STR_TO_ID
 from .ndarray import array
@@ -1364,59 +1365,6 @@ def list_gpus():
             pass
     return range(len([i for i in re.split('\n') if 'GPU' in i]))
 
-def download(url, fname=None, dirname=None, overwrite=False):
-    """Download an given URL
-
-    Parameters
-    ----------
-
-    url : str
-        URL to download
-    fname : str, optional
-        filename of the downloaded file. If None, then will guess a filename
-        from url.
-    dirname : str, optional
-        output directory name. If None, then guess from fname or use the current
-        directory
-    overwrite : bool, optional
-        Default is false, which means skipping download if the local file
-        exists. If true, then download the url to overwrite the local file if
-        exists.
-
-    Returns
-    -------
-    str
-        The filename of the downloaded file
-    """
-    if fname is None:
-        fname = url.split('/')[-1]
-
-    if dirname is None:
-        dirname = os.path.dirname(fname)
-    else:
-        fname = os.path.join(dirname, fname)
-    if dirname != "":
-        if not os.path.exists(dirname):
-            try:
-                logging.info('create directory %s', dirname)
-                os.makedirs(dirname)
-            except OSError as exc:
-                if exc.errno != errno.EEXIST:
-                    raise OSError('failed to create ' + dirname)
-
-    if not overwrite and os.path.exists(fname):
-        logging.info("%s exists, skipping download", fname)
-        return fname
-
-    r = requests.get(url, stream=True)
-    assert r.status_code == 200, "failed to open %s" % url
-    with open(fname, 'wb') as f:
-        for chunk in r.iter_content(chunk_size=1024):
-            if chunk: # filter out keep-alive new chunks
-                f.write(chunk)
-    logging.info("downloaded %s into %s successfully", url, fname)
-    return fname
-
 def get_mnist():
     """Download and load the MNIST dataset
 
@@ -1426,10 +1374,10 @@ def get_mnist():
         A dict containing the data
     """
     def read_data(label_url, image_url):
-        with gzip.open(mx.test_utils.download(label_url)) as flbl:
+        with gzip.open(mx.utils.download(label_url)) as flbl:
             struct.unpack(">II", flbl.read(8))
             label = np.fromstring(flbl.read(), dtype=np.int8)
-        with gzip.open(mx.test_utils.download(image_url), 'rb') as fimg:
+        with gzip.open(mx.utils.download(image_url), 'rb') as fimg:
             _, _, rows, cols = struct.unpack(">IIII", fimg.read(16))
             image = np.fromstring(fimg.read(), dtype=np.uint8).reshape(len(label), rows, cols)
             image = image.reshape(image.shape[0], 1, 28, 28).astype(np.float32)/255

--- a/python/mxnet/utils.py
+++ b/python/mxnet/utils.py
@@ -1,0 +1,151 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Utility functions applicable to all areas of code (tests, tutorials, gluon, etc)."""
+
+__all__ = ['check_sha1', 'download', 'create_dir']
+
+import errno
+import logging
+import time
+import os
+import hashlib
+
+try:
+    import requests
+except ImportError:
+    class requests_failed_to_import(object):
+        pass
+    requests = requests_failed_to_import
+
+
+def check_sha1(filename, sha1_hash):
+    """Check whether the sha1 hash of the file content matches the expected hash.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the file.
+    sha1_hash : str
+        Expected sha1 hash in hexadecimal digits.
+
+    Returns
+    -------
+    bool
+        Whether the file content matches the expected hash.
+    """
+    sha1 = hashlib.sha1()
+    with open(filename, 'rb') as f:
+        while True:
+            data = f.read(1048576)
+            if not data:
+                break
+            sha1.update(data)
+
+    return sha1.hexdigest() == sha1_hash
+
+
+def _download_retry_with_backoff(fname, url, max_attempts=4):
+    """Downloads a url with backoff applied, automatically re-requesting after a failure.
+    :param fname : str
+        Name of the target file being downloaded.
+    :param url : str
+        URL to download.
+    :param max_attempts : int, optional
+        The number of requests to attempt before throwing a RequestException.
+    :return:
+        A streaming request object.
+    """
+    attempts = 1
+    backoff_coef = 50.0
+    while True:
+        try:
+            print('Downloading %s from %s...' % (fname, url))
+            r = requests.get(url, stream=True)
+
+            # If the remote server returned an error, raise a descriptive HTTPError.
+            # For non-error http codes (e.g. 200, 206) do nothing.
+            r.raise_for_status()
+            return r
+        except requests.exceptions.RequestException:
+            # Likely non-2** result, possibly timeout or redirection failure.
+            attempts = attempts + 1
+            if attempts > max_attempts:
+                print('Downloading %s from %s, failed after #%d attempts' % (fname, url, attempts))
+                raise
+
+            # Apply backoff with default values borrowed from the popular Boto3 lib.
+            time.sleep((backoff_coef * (2 ** attempts)) / 1000.0)
+
+
+def download(url, path=None, overwrite=False, sha1_hash=None):
+    """Download a given URL
+
+    Parameters
+    ----------
+    url : str
+        URL to download
+    path : str, optional
+        Destination path to store downloaded file. By default stores to the
+        current directory with same name as in url.
+    overwrite : bool, optional
+        Whether to overwrite destination file if already exists.
+    sha1_hash : str, optional
+        Expected sha1 hash in hexadecimal digits. Will ignore existing file when hash is specified
+        but doesn't match.
+
+    Returns
+    -------
+    str
+        The file path of the downloaded file.
+    """
+    if path is None:
+        fname = url.split('/')[-1]
+    elif os.path.isdir(path):
+        fname = os.path.join(path, url.split('/')[-1])
+    else:
+        fname = path
+
+    if overwrite or not os.path.exists(fname) or (sha1_hash and not check_sha1(fname, sha1_hash)):
+        dirname = os.path.dirname(os.path.abspath(os.path.expanduser(fname)))
+        if not os.path.exists(dirname):
+            os.makedirs(dirname)
+
+        r = _download_retry_with_backoff(fname, url)
+        with open(fname, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=1024):
+                if chunk:  # filter out keep-alive new chunks
+                    f.write(chunk)
+
+        if sha1_hash and not check_sha1(fname, sha1_hash):
+            raise UserWarning('File {} is downloaded but the content hash does not match. '
+                              'The repo may be outdated or download may be incomplete. '
+                              'If the "repo_url" is overridden, consider switching to '
+                              'the default repo.'.format(fname))
+
+    return fname
+
+
+def create_dir(dirname):
+    if not os.path.exists(dirname):
+        try:
+            logging.info('create directory %s', dirname)
+            os.makedirs(dirname)
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise OSError('failed to create ' + dirname)
+    return

--- a/tests/python/README.md
+++ b/tests/python/README.md
@@ -1,6 +1,6 @@
 Python Test Case
 ================
-This folder contains test cases for mxnet in python.
+This folder contains test cases for MXNet in python.
 
 * [common](common) contains common utils for all test modules.
   - From subfolders, import with ```from ..common import get_data```
@@ -8,3 +8,6 @@ This folder contains test cases for mxnet in python.
   - These are basic tests that must pass for every commit.
 * [train](train) contains tests that runs on real network training.
   - These tests can be time consuming.
+
+The file 'requirements.test.txt' contains all dependencies need to run unit tests.  It can be
+installed with the command 'pip install -r requirements.test.txt'.

--- a/tests/python/gpu/test_forward.py
+++ b/tests/python/gpu/test_forward.py
@@ -18,13 +18,14 @@
 import os
 import numpy as np
 import mxnet as mx
-from mxnet.test_utils import *
-from mxnet.gluon import utils
+from mxnet.test_utils import check_consistency
+from mxnet.utils import create_dir, download
 
 def _get_model():
     if not os.path.exists('model/Inception-7-symbol.json'):
-        download('http://data.mxnet.io/models/imagenet/inception-v3.tar.gz', dirname='model')
-        os.system("cd model; tar -xf inception-v3.tar.gz --strip-components 1")
+        create_dir('model')
+        download('http://data.mxnet.io/models/imagenet/inception-v3.tar.gz', 'model')
+        os.system("pwd; cd model; tar -xf inception-v3.tar.gz --strip-components 1")
 
 def _dump_images(shape):
     import skimage.io
@@ -44,12 +45,12 @@ def _dump_images(shape):
 def _get_data(shape):
     hash_test_img = "355e15800642286e7fe607d87c38aeeab085b0cc"
     hash_inception_v3 = "91807dfdbd336eb3b265dd62c2408882462752b9"
-    utils.download("http://data.mxnet.io/data/test_images_%d_%d.npy" % (shape),
-                   path="data/test_images_%d_%d.npy" % (shape),
-                   sha1_hash=hash_test_img)
-    utils.download("http://data.mxnet.io/data/inception-v3-dump.npz",
-                   path='data/inception-v3-dump.npz',
-                   sha1_hash=hash_inception_v3)
+    download("http://data.mxnet.io/data/test_images_%d_%d.npy" % (shape),
+             path="data/test_images_%d_%d.npy" % (shape),
+             sha1_hash=hash_test_img)
+    download("http://data.mxnet.io/data/inception-v3-dump.npz",
+             path='data/inception-v3-dump.npz',
+             sha1_hash=hash_inception_v3)
 
 def test_consistency(dump=False):
     shape = (299, 299)

--- a/tests/python/requirements.test.txt
+++ b/tests/python/requirements.test.txt
@@ -1,0 +1,7 @@
+mock
+nose
+numpy
+requests
+requests-mock
+scikit-image
+scipy

--- a/tests/python/unittest/test_download_utils.py
+++ b/tests/python/unittest/test_download_utils.py
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import mxnet as mx
+import mock
+import requests
+import requests_mock
+from nose.tools import *
+
+DATASET_URL = 'http://fakeyannlecun.com/fake.dataset.tar.gz'
+DATASET_FILENAME = 'fake.dataset.tar.gz'
+
+
+@raises(requests.exceptions.HTTPError)
+def test_fake_yann_http_error():
+    # Patch requests so we don't actually issue an http request.
+    with requests_mock.mock() as request_mock:
+        # Patch time so we don't waste time retrying.
+        with mock.patch('time.sleep'):
+            request_mock.get(DATASET_URL, text='Not Found', status_code=404)
+            mx.utils.download(DATASET_URL, overwrite=True)
+
+
+def test_fake_yann_success():
+    # Patch requests so we don't actually issue an http request.
+    with requests_mock.mock() as m:
+        m.get(DATASET_URL, text='data')
+        result = mx.utils.download(DATASET_URL, overwrite=True)
+        assert result == DATASET_FILENAME
+
+
+if __name__ == '__main__':
+
+    import nose
+    nose.runmodule()

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -42,7 +42,7 @@ def prepare_record():
     if not os.path.isdir("data/test_images"):
         os.makedirs('data/test_images')
     if not os.path.isdir("data/test_images/test_images"):
-        gluon.utils.download("http://data.mxnet.io/data/test_images.tar.gz", "data/test_images.tar.gz")
+        mx.utils.download("http://data.mxnet.io/data/test_images.tar.gz", "data/test_images.tar.gz")
         tarfile.open('data/test_images.tar.gz').extractall('data/test_images/')
     if not os.path.exists('data/test.rec'):
         imgs = os.listdir('data/test_images/test_images')

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -17,17 +17,18 @@
 
 import mxnet as mx
 import numpy as np
-from mxnet.test_utils import *
 from common import assertRaises
 import shutil
 import tempfile
 import unittest
+from mxnet.utils import *
 
 from nose.tools import raises
 
 def _get_data(url, dirname):
     import os, tarfile
-    download(url, dirname=dirname, overwrite=False)
+    create_dir(dirname)
+    download(url, dirname)
     fname = os.path.join(dirname, url.split('/')[-1])
     tar = tarfile.open(fname)
     source_images = [os.path.join(dirname, x.name) for x in tar.getmembers() if x.isfile()]

--- a/tools/caffe_converter/convert_caffe_modelzoo.py
+++ b/tools/caffe_converter/convert_caffe_modelzoo.py
@@ -123,22 +123,22 @@ def download_caffe_model(model_name, meta_info, dst_dir='./model'):
 
     assert 'prototxt' in meta_info, "missing prototxt url"
     proto_url, proto_sha1 = meta_info['prototxt']
-    prototxt = mx.gluon.utils.download(proto_url,
-                                       model_name+'_deploy.prototxt',
-                                       sha1_hash=proto_sha1)
+    prototxt = mx.utils.download(proto_url,
+                                 model_name+'_deploy.prototxt',
+                                 sha1_hash=proto_sha1)
 
     assert 'caffemodel' in meta_info, "mssing caffemodel url"
     caffemodel_url, caffemodel_sha1 = meta_info['caffemodel']
-    caffemodel = mx.gluon.utils.download(caffemodel_url,
-                                         model_name+'.caffemodel',
-                                         sha1_hash=caffemodel_sha1)
+    caffemodel = mx.utils.download(caffemodel_url,
+                                   model_name+'.caffemodel',
+                                   sha1_hash=caffemodel_sha1)
     assert 'mean' in meta_info, 'no mean info'
     mean = meta_info['mean']
     if isinstance(mean[0], str):
         mean_url, mean_sha1 = mean
-        mean = mx.gluon.utils.download(mean_url,
-                                       model_name+'_mean.binaryproto',
-                                       sha1_hash=mean_sha1)
+        mean = mx.utils.download(mean_url,
+                                 model_name+'_mean.binaryproto',
+                                 sha1_hash=mean_sha1)
     return (prototxt, caffemodel, mean)
 
 def convert_caffe_model(model_name, meta_info, dst_dir='./model'):

--- a/tools/coreml/test/test_mxnet_image.py
+++ b/tools/coreml/test/test_mxnet_image.py
@@ -32,7 +32,7 @@ URL = 'http://data.mxnet.io/data/val-5k-256.rec'
 
 
 def download_data():
-    return mx.test_utils.download(URL, VAL_DATA)
+    return mx.utils.download(URL, VAL_DATA)
 
 
 def read_image(data_val, label_name):

--- a/tools/coreml/test/test_mxnet_models.py
+++ b/tools/coreml/test/test_mxnet_models.py
@@ -93,7 +93,7 @@ class ModelsTest(unittest.TestCase):
         if files is not None:
             print("Downloading files from urls: %s" % (files))
             for url in files:
-                mx.test_utils.download(url)
+                mx.utils.download(url)
                 print("Downloaded %s" % (url))
 
         module = self._load_model(


### PR DESCRIPTION
## Description ##
The primary goal of this PR was to add exponential backoff to our http request.  This should be a good feature for customers with slow Internet connections, but I also hope it will help mitigate test issues such as: #9669.

I noticed that we have a lot of duplicate code between test_utils.download and gluon.download.  I've attempted to combine these two functions, but can roll it back if they had a good reason to be separated.

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 

Note examples are affected by this change.  I've updated them so that they do not reference download functions that no longer exist.

## Comments ##
- The tests require a new test dependency: requests_mock. Which may need to be added to the CI.  Due to this, this PR may require a little iteration before test work properly.  No rush to get it merged.
- I've created a requirements.test.txt file for convenient installation of test deps.
