### PR TITLE
Fix test_sparse_operator failures due to out-of-bounds ref.

### DIFF
--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -362,7 +362,7 @@ inline bool SumOpForwardInferStorageType(const nnvm::NodeAttrs& attrs,
                                      DispatchMode::kFCompute);
   }
 
-  if (!dispatched && in_stype == kCSRStorage &&
+  if (!dispatched && in_stype == kCSRStorage && param.axis.ndim() == 1 &&
       (param.axis[0] == 0 || param.axis[0] == 1) && !param.keepdims &&
       !param.exclude) {
     // If input is csr and axis is 0 or 1, and neither of keepdims or exclude


### PR DESCRIPTION
## Description ##

One of our python2 mxnet containers showed test failures in test_sparse_operator.py:test_sparse_storage_fallback  .  The root cause was traced to an out-of-bounds array reference of the 'axis' shape.  The only supported axis shapes for the given 'csr' storage type reduction are (0,) and (1,).  A check that the axis shape dimension is 1 before accessing shape[0] was added, solving the problem.

## Checklist ##
### Essentials ###
- [X] Passed code style checking (`make lint`)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
