### PR TITLE
Fix warning in sequence_last-inl.h

### DIFF
--- a/src/operator/optimizer_op-inl.h
+++ b/src/operator/optimizer_op-inl.h
@@ -917,7 +917,6 @@ inline void AdamStdUpdateRspRspRspImpl(const AdamParam& param,
   using namespace mxnet_op;
   using namespace rowsparse;
   CHECK_RSP_ALL_ROWS_NON_ZERO(weight, "AdamStdUpdate", "weights");
-  mshadow::Stream<xpu>* s = ctx.get_stream<xpu>();
   TBlob out_blob = out->data();
   // reuse dns rsp implementation when storage_shape == shape
   AdamStdUpdateDnsRspDnsImpl<xpu>(param, ctx, weight.data(), grad, mean.data(),

--- a/src/operator/sequence_last-inl.h
+++ b/src/operator/sequence_last-inl.h
@@ -198,7 +198,6 @@ class SequenceLastOp : public Operator {
     auto dsize = in_data[seq_last::kData].Size();
 
     auto batch = (axis != 0) ? d0 : d1;
-    auto max_seq_len = in_data[seq_last::kData].size(axis);
     auto rest_size = dsize / (d0 * d1);
 
     Tensor<xpu, 3, DType> data_grad =


### PR DESCRIPTION
Fix a complier warning (unused variable) in `sequence_last-inl.h` 
@sbodenstein 