### PR TITLE
fix NAG if multi_precision = true

### DIFF
--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -129,10 +129,11 @@ class Optimizer(object):
         assert(isinstance(klass, type))
         name = klass.__name__.lower()
         if name in Optimizer.opt_registry:
-            warnings.warn('WARNING: New optimizer %s.%s is overriding existing '
-                          'optimizer %s.%s', klass.__module__, klass.__name__,
-                          Optimizer.opt_registry[name].__module__,
-                          Optimizer.opt_registry[name].__name__)
+            warnings.warn('WARNING: New optimizer %s.%s is overriding '
+                          'existing optimizer %s.%s' %
+                          (klass.__module__, klass.__name__,
+                           Optimizer.opt_registry[name].__module__,
+                           Optimizer.opt_registry[name].__name__))
         Optimizer.opt_registry[name] = klass
         return klass
 
@@ -892,7 +893,8 @@ class DCASGD(Optimizer):
         weight[:] += mom
 
 @register
-class NAG(SGD):
+@register
+class NAG(Optimizer):
     """Nesterov accelerated SGD.
 
     This optimizer updates each weight by::
@@ -900,10 +902,26 @@ class NAG(SGD):
         state = momentum * state + grad + wd * weight
         weight = weight - (lr * (grad + momentum * state))
 
-    This optimizer accepts the same arguments as :class:`.SGD`.
+    Parameters
+    ----------
+    momentum : float, optional
+       The momentum value.
+    multi_precision: bool, optional
+       Flag to control the internal precision of the optimizer.
+       ``False`` results in using the same precision as the weights (default),
+       ``True`` makes internal 32-bit copy of the weights and applies gradients \
+                in 32-bit precision even if actual weights used in the model have lower precision.\
+                Turning this on can improve convergence and accuracy when training with float16.
     """
-    def __init__(self, **kwargs):
+    def __init__(self, momentum=0.0, **kwargs):
         super(NAG, self).__init__(**kwargs)
+        self.momentum = momentum
+
+    def create_state(self, index, weight):
+        momentum = None
+        if self.momentum != 0.0:
+            momentum = zeros(weight.shape, weight.context, dtype=weight.dtype)
+        return momentum
 
     def update(self, index, weight, grad, state):
         assert(isinstance(weight, NDArray))


### PR DESCRIPTION
## Description ##
NAG inherits SGD, but not override SGD's `update_multi_precision` which calls `_update_impl` in SGD.

NAG should not inherit SGD also because parameter `lazy_update` makes no sense in NAG.

Thanks for @huangzehao reporting this issue.

cc @eric-haibin-lin @sxjscience 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] unittest


## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
