### PR TITLE
Squeeze op

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -1882,6 +1882,7 @@ inline bool SqueezeShape(const nnvm::NodeAttrs& attrs,
       CHECK_EQ(dshape[axes[i]], 1)
         << "cannot select an axis to squeeze out which has size="
         << dshape[axes[i]] << " not equal to one";
+      CHECK_NE(oshape[axes[i]], 0) << "duplicate value in axis";
       oshape[axes[i]] = 0;
     }
   } else {

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -1852,8 +1852,11 @@ inline uint32_t SqueezeShapeHelper(TShape* shape) {
   CHECK(shape != nullptr);
   uint32_t count = 0;
   for (uint32_t i = 0; i < shape->ndim(); ++i) {
-    if ((*shape)[i] == 0) ++count;
-    else std::swap((*shape)[i], (*shape)[i-count]);
+    if ((*shape)[i] == 0) {
+      ++count;
+    } else {
+      std::swap((*shape)[i], (*shape)[i-count]);
+    }
   }
   return shape->ndim() - count;
 }

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -1902,20 +1902,6 @@ inline bool SqueezeShape(const nnvm::NodeAttrs& attrs,
   return true;
 }
 
-template<typename xpu>
-void SqueezeCompute(const nnvm::NodeAttrs& attrs,
-                    const OpContext& ctx,
-                    const std::vector<TBlob>& inputs,
-                    const std::vector<OpReqType>& req,
-                    const std::vector<TBlob>& outputs) {
-  CHECK_EQ(inputs.size(), 1U);
-  CHECK_EQ(outputs.size(), 1U);
-  CHECK_EQ(req.size(), 1U);
-  TBlob out_data = outputs[0];
-  out_data.shape_ = inputs[0].shape_;
-  UnaryOp::IdentityCompute<xpu>(attrs, ctx, inputs, req, {out_data});
-}
-
 }  // namespace op
 }  // namespace mxnet
 

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -742,7 +742,8 @@ NNVM_REGISTER_OP(_backward_stack)
 
 NNVM_REGISTER_OP(squeeze)
 .describe(R"code(Remove single-dimensional entries from the shape of an array.
-Same behavior as numpy.squeeze.
+Same behavior of defining the output tensor shape as numpy.squeeze for the most of cases.
+See the following note for exception.
 
 Examples::
 
@@ -751,6 +752,10 @@ Examples::
   squeeze(data, axis=0) = [[0], [1], [2]]
   squeeze(data, axis=2) = [[0, 1, 2]]
   squeeze(data, axis=(0, 2)) = [0, 1, 2]
+
+.. Note::
+  The output of this operator will keep at least one dimension not removed. For example,
+  squeeze([[[4]]]) = [4], while in numpy.squeeze, the output will become a scalar.
 )code")
 .set_num_inputs(1)
 .set_num_outputs(1)

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -766,7 +766,7 @@ Examples::
   })
 .set_attr<nnvm::FInferShape>("FInferShape", SqueezeShape)
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)
-.set_attr<FCompute>("FCompute<cpu>", SqueezeCompute<cpu>)
+.set_attr<FCompute>("FCompute<cpu>", UnaryOp::IdentityCompute<cpu>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_squeeze"})
 .add_argument("data", "NDArray-or-Symbol[]", "data to squeeze")
 .add_arguments(StackParam::__FIELDS__());
@@ -776,7 +776,7 @@ NNVM_REGISTER_OP(_backward_squeeze)
 .set_num_outputs(1)
 .set_attr_parser(ParamParser<SqueezeParam>)
 .set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_attr<FCompute>("FCompute<cpu>", SqueezeCompute<cpu>);
+.set_attr<FCompute>("FCompute<cpu>", UnaryOp::IdentityCompute<cpu>);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/matrix_op.cu
+++ b/src/operator/tensor/matrix_op.cu
@@ -200,10 +200,10 @@ NNVM_REGISTER_OP(_backward_stack)
 .set_attr<FCompute>("FCompute<gpu>", StackOpBackward<gpu>);
 
 NNVM_REGISTER_OP(squeeze)
-.set_attr<FCompute>("FCompute<gpu>", SqueezeCompute<gpu>);
+.set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
 
 NNVM_REGISTER_OP(_backward_squeeze)
-.set_attr<FCompute>("FCompute<gpu>", SqueezeCompute<gpu>);
+.set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/matrix_op.cu
+++ b/src/operator/tensor/matrix_op.cu
@@ -198,5 +198,12 @@ NNVM_REGISTER_OP(stack)
 
 NNVM_REGISTER_OP(_backward_stack)
 .set_attr<FCompute>("FCompute<gpu>", StackOpBackward<gpu>);
+
+NNVM_REGISTER_OP(squeeze)
+.set_attr<FCompute>("FCompute<gpu>", SqueezeCompute<gpu>);
+
+NNVM_REGISTER_OP(_backward_squeeze)
+.set_attr<FCompute>("FCompute<gpu>", SqueezeCompute<gpu>);
+
 }  // namespace op
 }  // namespace mxnet


### PR DESCRIPTION
## Description ##
This PR implemented squeeze op in MXNet as numpy.squeeze. Requested by @szha .
https://docs.scipy.org/doc/numpy/reference/generated/numpy.squeeze.html

@eric-haibin-lin 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change