### PR TITLE
[REVIEW REQUIRED] Revert PR #9484 & add additional dependency licenses to LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -226,6 +226,7 @@
     9. nnvm - For details, see, nnvm/LICENSE
     10. nnvm-fusion - For details, see, nnvm/plugin/nnvm-fusion/LICENSE
     11. ps-lite - For details, see, ps-lite/LICENSE
+    12. nnvm/tvm - For details, see, nnvm/tvm/LICENSE
 
     ========================================================================
     MIT licenses
@@ -235,13 +236,14 @@
     2. Faster R-CNN - For details, see example/rcnn/LICENSE
     3. tree_lstm - For details, see example/gluon/tree_lstm/LICENSE
     4. OpenMP - For details, see 3rdparty/openmp/LICENSE.txt
+    5. HalideIR - For details, see nnvm/tvm/HalideIR/LICENSE
 
 
     ========================================================================
     NVIDIA Licenses
     ========================================================================
 
-    1. Warp-CTC
+    1. Moderngpu
     For details, see, src/operator/contrib/ctc_include/contrib/moderngpu/LICENSE
 
     /******************************************************************************
@@ -293,6 +295,7 @@
     ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 
 
     ========================================================================
@@ -385,5 +388,12 @@
     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+    4. FindCrypto.cmake
+
+    For Details, see dmlc-core/cmake/Modules/FindCrypto.cmake,
+    Redistribution and use is allowed according to the terms of the BSD license.
+
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -201,7 +201,7 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-    =======================================================================
+    ======================================================================================
     Apache MXNET (incubating) Subcomponents:
 
     The Apache MXNET (incubating) project contains subcomponents with separate copyright
@@ -209,9 +209,9 @@
     subcomponents is subject to the terms and conditions of the following
     licenses.
 
-    ========================================================================
+    =======================================================================================
     Apache-2.0 licenses
-    ========================================================================
+    =======================================================================================
 
     The following components are provided under an Apache 2.0 license.
 
@@ -230,9 +230,9 @@
     13. googlemock scripts/generator - For details, see, 3rdparty/googletest/googlemock/scripts/generator/LICENSE
 
 
-    ========================================================================
+    =======================================================================================
     MIT licenses
-    ========================================================================
+    =======================================================================================
 
     1. Fast R-CNN  - For details, see example/rcnn/LICENSE
     2. Faster R-CNN - For details, see example/rcnn/LICENSE
@@ -241,9 +241,9 @@
     5. HalideIR - For details, see nnvm/tvm/HalideIR/LICENSE
 
 
-    ========================================================================
+    =======================================================================================
     NVIDIA Licenses
-    ========================================================================
+    =======================================================================================
 
     1. Moderngpu
     For details, see, src/operator/contrib/ctc_include/contrib/moderngpu/LICENSE
@@ -300,9 +300,9 @@
 
 
 
-    ========================================================================
+    =======================================================================================
     Other Licenses
-    ========================================================================
+    =======================================================================================
 
     1. Caffe
     For details, see, example/rcnn/LICENSE
@@ -335,7 +335,7 @@
     or otherwise, the contributor releases their content to the
     license and copyright terms herein.
 
-    ========================================================================
+    =======================================================================================
 
     2. MS COCO API
     For details, see, example/rcnn/LICENSE
@@ -364,7 +364,7 @@
     of the authors and should not be interpreted as representing official policies,
     either expressed or implied, of the FreeBSD Project.
 
-    ========================================================================
+    =======================================================================================
 
     3. Sphinx JavaScript utilties for the full-text search
     For details, see, docs/_static/searchtools_custom.js
@@ -392,13 +392,13 @@
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-    ========================================================================
+    =======================================================================================
 
     4. FindCrypto.cmake
     For details, see, dmlc-core/cmake/Modules/FindCrypto.cmake,
     Redistribution and use is allowed according to the terms of the BSD license.
 
-    ========================================================================
+    =======================================================================================
 
     5. Googlemock
     For details, see, 3rdparty/googletest/googlemock/LICENSE
@@ -429,7 +429,7 @@
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-    ========================================================================
+    =======================================================================================
 
     6. Googletest
     For details, see, 3rdparty/googletest/googletest/LICENSE
@@ -460,7 +460,7 @@
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-    ========================================================================
+    =======================================================================================
 
     7. OpenMP Testsuite
     For details, see, 3rdparty/openmp/testsuite/LICENSE
@@ -492,6 +492,20 @@
     LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
     NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    =======================================================================================
+
+    8. Semaphore implementation in blockingconcurrentqueue.h
+    This file uses a semaphore implementation under the terms of its separate zlib license.
+    For details, see, dmlc-core/include/dmlc/blockingconcurrentqueue.h
+
+    =======================================================================================
+
+    9. blockingconcurrentqueue.h
+    This file is Distributed under the terms of the simplified BSD license.
+    For details, see, dmlc-core/include/dmlc/blockingconcurrentqueue.h
+
+    =======================================================================================
 
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -204,40 +204,136 @@
     =======================================================================
     Apache MXNET (incubating) Subcomponents:
 
-    The Apache MXNET (incubating) project contains subcomponents with separate
-    copyright notices and license terms. Your use of the source code for the these
+    The Apache MXNET (incubating) project contains subcomponents with separate copyright
+    notices and license terms. Your use of the source code for the these
     subcomponents is subject to the terms and conditions of the following
-    licenses -
+    licenses.
 
     ========================================================================
-    1. Apache-2.0 license as above, wherever applicable
+    Apache-2.0 licenses
     ========================================================================
 
-    ========================================================================
-    2. MIT license wherever applicable
-    ========================================================================
-    Permission is hereby granted, free of charge, to any person obtaining a
-    copy of this software and associated documentation files (the "Software"),
-    to deal in the Software without restriction, including without limitation
-    the rights to use, copy, modify, merge, publish, distribute, sublicense,
-    and/or sell copies of the Software, and to permit persons to whom the
-    Software is furnished to do so, subject to the following conditions:
+    The following components are provided under an Apache 2.0 license.
 
-    The above copyright notice and this permission notice shall be included
-    in all copies or substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-    OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-    OTHER DEALINGS IN THE SOFTWARE.
-
+    1. MXNet Cpp-package - For details, /cpp-package/LICENSE
+    2. MXNet rcnn - For details, see, example/rcnn/LICENSE
+    3. scala-package - For details, see, scala-package/LICENSE
+    4. Warp-CTC - For details, see, src/operator/contrib/ctc_include/LICENSE
+    5. dlpack - For details, see, dlpack/LICENSE
+    6. dmlc-core - For details, see, dmlc-core/LICENSE
+    7. mshadow - For details, see, mshadow/LICENSE
+    8. nnvm/dmlc-core - For details, see, nnvm/dmlc-core/LICENSE
+    9. nnvm - For details, see, nnvm/LICENSE
+    10. nnvm-fusion - For details, see, nnvm/plugin/nnvm-fusion/LICENSE
+    11. ps-lite - For details, see, ps-lite/LICENSE
 
     ========================================================================
-    3. BSD License wherever applicable
+    MIT licenses
     ========================================================================
+
+    1. Fast R-CNN  - For details, see example/rcnn/LICENSE
+    2. Faster R-CNN - For details, see example/rcnn/LICENSE
+    3. tree_lstm - For details, see example/gluon/tree_lstm/LICENSE
+    4. OpenMP - For details, see 3rdparty/openmp/LICENSE.txt
+
+
+    ========================================================================
+    NVIDIA Licenses
+    ========================================================================
+
+    1. Warp-CTC
+    For details, see, src/operator/contrib/ctc_include/contrib/moderngpu/LICENSE
+
+    /******************************************************************************
+    * Redistribution and use in source and binary forms, with or without
+    * modification, are permitted provided that the following conditions are met:
+    *     * Redistributions of source code must retain the above copyright
+    *       notice, this list of conditions and the following disclaimer.
+    *     * Redistributions in binary form must reproduce the above copyright
+    *       notice, this list of conditions and the following disclaimer in the
+    *       documentation and/or other materials provided with the distribution.
+    *     * Neither the name of the NVIDIA CORPORATION nor the
+    *       names of its contributors may be used to endorse or promote products
+    *       derived from this software without specific prior written permission.
+    *
+    * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+    * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    *
+    ******************************************************************************/
+
+    2. CUB Library
+    For details, see, cub/LICENSE.TXT
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+       *  Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+       *  Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+       *  Neither the name of the NVIDIA CORPORATION nor the
+          names of its contributors may be used to endorse or promote products
+          derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+    ========================================================================
+    Other Licenses
+    ========================================================================
+
+    1. Caffe
+    For details, see, example/rcnn/LICENSE
+
+    LICENSE
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+    ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    CONTRIBUTION AGREEMENT
+
+    By contributing to the BVLC/caffe repository through pull-request, comment,
+    or otherwise, the contributor releases their content to the
+    license and copyright terms herein.
+
+
+    2. MS COCO API
+    For details, see, example/rcnn/LICENSE
+
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
 
@@ -263,5 +359,31 @@
     either expressed or implied, of the FreeBSD Project.
 
 
+    3. Sphinx JavaScript utilties for the full-text search
+
+    For details, see, docs/_static/searchtools_custom.js
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+    * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -227,6 +227,8 @@
     10. nnvm-fusion - For details, see, nnvm/plugin/nnvm-fusion/LICENSE
     11. ps-lite - For details, see, ps-lite/LICENSE
     12. nnvm/tvm - For details, see, nnvm/tvm/LICENSE
+    13. googlemock scripts/generator - For details, see, 3rdparty/googletest/googlemock/scripts/generator/LICENSE
+
 
     ========================================================================
     MIT licenses
@@ -272,7 +274,7 @@
     ******************************************************************************/
 
     2. CUB Library
-    For details, see, cub/LICENSE.TXT
+    For details, see, 3rdparty/cub/LICENSE.TXT
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
@@ -333,6 +335,7 @@
     or otherwise, the contributor releases their content to the
     license and copyright terms herein.
 
+    ========================================================================
 
     2. MS COCO API
     For details, see, example/rcnn/LICENSE
@@ -361,9 +364,9 @@
     of the authors and should not be interpreted as representing official policies,
     either expressed or implied, of the FreeBSD Project.
 
+    ========================================================================
 
     3. Sphinx JavaScript utilties for the full-text search
-
     For details, see, docs/_static/searchtools_custom.js
 
     Redistribution and use in source and binary forms, with or without
@@ -389,11 +392,106 @@
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+    ========================================================================
 
     4. FindCrypto.cmake
-
-    For Details, see dmlc-core/cmake/Modules/FindCrypto.cmake,
+    For details, see, dmlc-core/cmake/Modules/FindCrypto.cmake,
     Redistribution and use is allowed according to the terms of the BSD license.
+
+    ========================================================================
+
+    5. Googlemock
+    For details, see, 3rdparty/googletest/googlemock/LICENSE
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+        * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    ========================================================================
+
+    6. Googletest
+    For details, see, 3rdparty/googletest/googletest/LICENSE
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+        * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+    ========================================================================
+
+    7. OpenMP Testsuite
+    For details, see, 3rdparty/openmp/testsuite/LICENSE
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    o Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+
+    o Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    o Neither the name of the University of Houston System nor the names of its
+      contributors may be used to
+      endorse or promote products derived from this software without specific
+      prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+    TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+    LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+    NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 


### PR DESCRIPTION
@hen @eric-haibin-lin Please Review these changes. 

1. This reverted commit 8930d96b265560a797c5554a9617f607cea7740f.
2. Revisited some comments from previous release which are now relevant and made appropriate changes. 
based on [points 8-11 and 13 to 19 in this wiki, section E] (https://cwiki.apache.org/confluence/display/MXNET/MXNet+Source+Licenses)
3. ran a search for additional dependencies with a separate license (around 27 ) and added to LICENSE file. 

## Description ##
As discussed on the general vote thread, reverted the LICENSE file to previous version and added some more packages to various licenses as needed. 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 

### Changes ###
- [x] Reverts PR #9484 
- [x] Added some packages to various licenses. 
   - Added HalideIR to LICENSE (MIT)
   - Added googlemock scripts/generator to LICENSE (Apache)
   - Fixed error which named moderngpu license as warp-ctc
   - Added FindCrypto.cmake to Other licenses with link
   - Added Googlemock to LICENSE with text and link
   - Added Googletest to LICENSE with text and link
   - Added OpenMP testsuite to LICENSE with text and link
   - Added blockingconcurrentqueue to LICENSE (BSD)
   - Added Semaphore Implementaion of blockingconcurrentqueue to LICENSE (zlib license)



 


