### PR TITLE
Specify lint-versions and fix docker build issues due to nvidia-384

### DIFF
--- a/tests/ci_build/Dockerfile.lint
+++ b/tests/ci_build/Dockerfile.lint
@@ -1,6 +1,5 @@
 # For lint test
 FROM ubuntu:16.04
 
-# Sudo is not present on ubuntu16.04
 RUN apt-get update && apt-get install -y python-pip sudo
-RUN pip install cpplint pylint
+RUN pip install cpplint==1.3.0 pylint==1.8.2

--- a/tests/ci_build/install/ubuntu_install_nvidia.sh
+++ b/tests/ci_build/install/ubuntu_install_nvidia.sh
@@ -28,4 +28,4 @@ add-apt-repository -y ppa:graphics-drivers
 # Retrieve ppa:graphics-drivers and install nvidia-drivers.
 # Note: DEBIAN_FRONTEND required to skip the interactive setup steps
 apt update && \
-    DEBIAN_FRONTEND=noninteractive apt install -y nvidia-384
+    DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends cuda-8-0


### PR DESCRIPTION
## Description ##
Specify and fix pylint as well as cpplint versions in order to provide a consistent behaviour. Otherwise, new slaves (having no docker cache present) might use a newer version of linting and produce different results. Linting reports for the latest version have been fixed in #9660.

Due to Nvidias update regarding the spectre vulnerability, we were not able to use the nvidia-384 package inside our Dockerfiles. Instead, we're now switching to the cuda-8-0 package, which matches our general CI setup to support CUDA 8.0.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Set CppLint to 1.3.0
- Set PyLint to 1.8.2
- Get CUDA stubs in build_cuda from cuda-8-0 instead of nvidia-384.

## Comments ##

