### PR TITLE
Check padding size for global pooling

### DIFF
--- a/src/operator/mkl/mkl_pooling-inl.h
+++ b/src/operator/mkl/mkl_pooling-inl.h
@@ -86,6 +86,7 @@ class MKLPoolingOp : public Operator {
     pad_w_ = param_.pad[1];
     if (global_pooling_) {
       stride_h_ = stride_w_ = 1;
+      pad_h_ = pad_w_ = 0;
     } else {
       stride_h_ = param_.stride[0];
       stride_w_ = param_.stride[1];

--- a/src/operator/nn/cudnn/cudnn_pooling-inl.h
+++ b/src/operator/nn/cudnn/cudnn_pooling-inl.h
@@ -213,8 +213,8 @@ class CuDNNPoolingOp : public Operator {
                                                nan_prop_,
                                                param_.global_pool ? dshape[2] : param_.kernel[0],
                                                param_.global_pool ? dshape[3] : param_.kernel[1],
-                                               param_.pad[0],
-                                               param_.pad[1],
+                                               param_.global_pool ? 0 : param_.pad[0],
+                                               param_.global_pool ? 0 : param_.pad[1],
                                                param_.global_pool ? 1 : param_.stride[0],
                                                param_.global_pool ? 1 :param_.stride[1]));
         #else
@@ -222,8 +222,8 @@ class CuDNNPoolingOp : public Operator {
                                                mode_,
                                                param_.global_pool ? dshape[2] : param_.kernel[0],
                                                param_.global_pool ? dshape[3] : param_.kernel[1],
-                                               param_.pad[0],
-                                               param_.pad[1],
+                                               param_.global_pool ? 0 : param_.pad[0],
+                                               param_.global_ppol ? 0 : param_.pad[1],
                                                param_.global_pool ? 1 : param_.stride[0],
                                                param_.global_pool ? 1 : param_.stride[1]));
         #endif

--- a/src/operator/nn/pooling-inl.h
+++ b/src/operator/nn/pooling-inl.h
@@ -97,6 +97,12 @@ class PoolingOp : public Operator {
     CHECK_EQ(out_data.size(), 1U);
     Stream<xpu> *s = ctx.get_stream<xpu>();
     const TShape& ishape = in_data[pool_enum::kData].shape_;
+    TShape padding = param_.pad;
+    if (param_.global_pool) {
+      for (int i = 0; i < padding.ndim(); i++) {
+        padding[i] = 0;
+      }
+    }
 
     pool(s, in_data[pool_enum::kData].dptr<DType>(),
          in_data[pool_enum::kData].shape_,
@@ -104,7 +110,7 @@ class PoolingOp : public Operator {
          param_.global_pool?
            TShape(ishape.data()+ishape.ndim()-param_.kernel.ndim(), ishape.data()+ishape.ndim())
            : param_.kernel,
-         param_.pad,
+         padding,
          param_.global_pool? TShape(param_.kernel.ndim()) : param_.stride,
          param_.pool_type,
          req[pool_enum::kOut],
@@ -126,6 +132,12 @@ class PoolingOp : public Operator {
     CHECK_EQ(in_grad.size(), 1U);
     Stream<xpu> *s = ctx.get_stream<xpu>();
     const TShape& ishape = in_data[pool_enum::kData].shape_;
+    TShape padding = param_.pad;
+    if (param_.global_pool) {
+      for (int i = 0; i < padding.ndim(); i++) {
+        padding[i] = 0;
+      }
+    }
 
     unpool(s, out_grad[pool_enum::kOut].dptr<DType>(),
            in_data[pool_enum::kData].dptr<DType>(),
@@ -135,7 +147,7 @@ class PoolingOp : public Operator {
            param_.global_pool?
              TShape(ishape.data()+ishape.ndim()-param_.kernel.ndim(), ishape.data()+ishape.ndim())
              : param_.kernel,
-           param_.pad,
+           padding,
            param_.global_pool? TShape(param_.kernel.ndim()) : param_.stride,
            param_.pool_type,
            req[pool_enum::kData],

--- a/src/operator/nn/pooling-inl.h
+++ b/src/operator/nn/pooling-inl.h
@@ -99,7 +99,7 @@ class PoolingOp : public Operator {
     const TShape& ishape = in_data[pool_enum::kData].shape_;
     TShape padding = param_.pad;
     if (param_.global_pool) {
-      for (int i = 0; i < padding.ndim(); i++) {
+      for (index_t i = 0; i < padding.ndim(); i++) {
         padding[i] = 0;
       }
     }
@@ -134,7 +134,7 @@ class PoolingOp : public Operator {
     const TShape& ishape = in_data[pool_enum::kData].shape_;
     TShape padding = param_.pad;
     if (param_.global_pool) {
-      for (int i = 0; i < padding.ndim(); i++) {
+      for (index_t i = 0; i < padding.ndim(); i++) {
         padding[i] = 0;
       }
     }

--- a/src/operator/pooling_v1-inl.h
+++ b/src/operator/pooling_v1-inl.h
@@ -106,7 +106,7 @@ class PoolingV1Op : public Operator {
     // reset padding size for global pooling
     TShape padding = param_.pad;
     if (param_.global_pool) {
-        padding[0] = padding[1] = 0;
+      padding[0] = padding[1] = 0;
     }
 
     Tensor<xpu, 4, DType> data = in_data[pool_v1_enum::kData].get<xpu, 4, DType>(s);
@@ -159,7 +159,7 @@ class PoolingV1Op : public Operator {
     // reset padding size for global pooling
     TShape padding = param_.pad;
     if (param_.global_pool) {
-        padding[0] = padding[1] = 0;
+      padding[0] = padding[1] = 0;
     }
 
     Stream<xpu> *s = ctx.get_stream<xpu>();

--- a/src/operator/pooling_v1-inl.h
+++ b/src/operator/pooling_v1-inl.h
@@ -102,6 +102,13 @@ class PoolingV1Op : public Operator {
     if (param_.kernel.ndim() == 3) {
       LOG(FATAL) << "3D kernel not implemented";
     }
+
+    // reset padding size for global pooling
+    TShape padding = param_.pad;
+    if (param_.global_pool) {
+        padding[0] = padding[1] = 0;
+    }
+
     Tensor<xpu, 4, DType> data = in_data[pool_v1_enum::kData].get<xpu, 4, DType>(s);
     Tensor<xpu, 4, DType> out = out_data[pool_v1_enum::kOut].get<xpu, 4, DType>(s);
     mshadow::Shape<2> out_shape = Shape2(out.shape_[2], out.shape_[3]);
@@ -109,7 +116,7 @@ class PoolingV1Op : public Operator {
         || param_.pool_type == pool_v1_enum::kSumPooling) {
       Assign(out,
              req[pool_v1_enum::kOut],
-             pool<Reducer>(pad(data, param_.pad[0], param_.pad[1]),
+             pool<Reducer>(pad(data, padding[0], padding[1]),
                            out_shape,
                            param_.global_pool ? data.shape_[2] : param_.kernel[0],
                            param_.global_pool ? data.shape_[3] : param_.kernel[1],
@@ -121,7 +128,7 @@ class PoolingV1Op : public Operator {
              scalar<DType>(1.0f / (param_.global_pool ?
                       data.shape_[2] * data.shape_[3] :
                       param_.kernel[0] * param_.kernel[1])) * \
-             pool<Reducer>(pad(data, param_.pad[0], param_.pad[1]),
+             pool<Reducer>(pad(data, padding[0], padding[1]),
                            out_shape,
                            param_.global_pool ? data.shape_[2] : param_.kernel[0],
                            param_.global_pool ? data.shape_[3] : param_.kernel[1],
@@ -148,6 +155,13 @@ class PoolingV1Op : public Operator {
     if (param_.kernel.ndim() == 3) {
       LOG(FATAL) << "3D kernel not implemented";
     }
+
+    // reset padding size for global pooling
+    TShape padding = param_.pad;
+    if (param_.global_pool) {
+        padding[0] = padding[1] = 0;
+    }
+
     Stream<xpu> *s = ctx.get_stream<xpu>();
     Tensor<xpu, 4, DType> grad = out_grad[pool_v1_enum::kOut].get<xpu, 4, DType>(s);
     Tensor<xpu, 4, DType> data = in_data[pool_v1_enum::kData].get<xpu, 4, DType>(s);
@@ -159,7 +173,7 @@ class PoolingV1Op : public Operator {
     if (param_.pool_type == pool_v1_enum::kMaxPooling
         || param_.pool_type == pool_v1_enum::kSumPooling) {
       Assign(input_grad, req[pool_v1_enum::kData],
-             crop(unpool<Reducer>(pad(data, param_.pad[0], param_.pad[1]),
+             crop(unpool<Reducer>(pad(data, padding[0], padding[1]),
                                   pad(output_data, 0, 0),
                                   pad(grad, 0, 0),
                                   param_.global_pool ? in_shape[0] : param_.kernel[0],
@@ -167,14 +181,14 @@ class PoolingV1Op : public Operator {
                                   param_.global_pool ? 1 : param_.stride[0],
                                   param_.global_pool ? 1 : param_.stride[1]),
                   in_shape,
-                  param_.pad[0],
-                  param_.pad[1]));
+                  padding[0],
+                  padding[1]));
     } else if (param_.pool_type == pool_v1_enum::kAvgPooling) {
       Assign(input_grad, req[pool_v1_enum::kData],
              scalar<DType>(1.0f / (param_.global_pool ?
                       data.shape_[2] * data.shape_[3] :
                       param_.kernel[0] * param_.kernel[1])) * \
-             crop(unpool<Reducer>(pad(data, param_.pad[0], param_.pad[1]),
+             crop(unpool<Reducer>(pad(data, padding[0], padding[1]),
                                   pad(output_data, 0, 0),
                                   pad(grad, 0, 0),
                                   param_.global_pool ? in_shape[0] : param_.kernel[0],
@@ -182,8 +196,8 @@ class PoolingV1Op : public Operator {
                                   param_.global_pool ? 1 : param_.stride[0],
                                   param_.global_pool ? 1 : param_.stride[1]),
                   in_shape,
-                  param_.pad[0],
-                  param_.pad[1]));
+                  padding[0],
+                  padding[1]));
     }
   }
 

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -875,6 +875,98 @@ def test_pooling_versions():
     test_3d_pooling('sum')
 
 
+def test_global_pooling():
+    def test_1d_pooling(pool_type):
+        data = (2, 3, 20)
+        kernel = (4,)
+        pad = (2,)
+        stride = (2,)
+    
+        ctx_list = []
+        sym_list = []
+    
+        pooling_convention = 'valid'
+    
+        ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+    
+        ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+    
+        ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=False, name='pool'))
+    
+        ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=False, name='pool'))
+    
+        ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=True, name='pool'))
+    
+        ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=True, name='pool'))
+    
+        check_consistency(sym_list, ctx_list)
+    
+    def test_2d_pooling(pool_type):
+        data = (2, 3, 20, 20)
+        kernel = (4, 4)
+        pad = (2, 2)
+        stride = (2, 2)
+    
+        ctx_list = []
+        sym_list = []
+    
+        pooling_convention = 'valid'
+    
+        ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling_v1(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+    
+        ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling_v1(kernel=kernel, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+    
+        ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+    
+        ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+    
+        ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=False, name='pool'))
+    
+        ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=False, name='pool'))
+    
+        ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=True, name='pool'))
+    
+        ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+        sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
+                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=True, name='pool'))
+    
+        check_consistency(sym_list, ctx_list)
+
+    test_1d_pooling('max')
+    test_1d_pooling('avg')
+    test_1d_pooling('sum')
+
+    test_2d_pooling('max')
+    test_2d_pooling('avg')
+    test_2d_pooling('sum')
+
+
 def test_upsampling_with_type():
     sym = mx.sym.UpSampling(scale=2, num_filter=2, name='up', sample_type='nearest', num_args=1)
     ctx_list = [{'ctx': mx.gpu(0), 'up_arg0': (2, 2, 2, 10), 'type_dict': {'up_arg0': np.float64}},


### PR DESCRIPTION
## Description ##
Check padding size for global pooling. #9714 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Check padding size for pooling, cudnn pooling and pooling_v1
- add python test case for global pooling with user padding size and stride size

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
