### PR TITLE
revert acc changes

### DIFF
--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -380,10 +380,11 @@ class Accuracy(EvalMetric):
         Parameters
         ----------
         labels : list of `NDArray`
-            The labels of the data.
+            The labels of the data with class indices as values, one per sample.
 
         preds : list of `NDArray`
-            Predicted values.
+            Prediction values for samples. Each prediction value can either be the class index,
+            or a vector of likelihoods for all classes.
         """
         check_label_shapes(labels, preds)
 

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -399,7 +399,7 @@ class Accuracy(EvalMetric):
             if pred_label.context != label.context:
                 pred_label = pred_label.as_in_context(label.context)
 
-            self.sum_metric += (pred_label.reshape((-1,)) == label.reshape((-1,))).sum().asscalar()
+            self.sum_metric += (pred_label.flatten() == label.flatten()).sum().asscalar()
             self.num_inst += numpy.prod(pred_label.shape)
 
 

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -28,7 +28,6 @@ import numpy
 from .base import numeric_types, string_types
 from . import ndarray
 from . import registry
-from .context import cpu
 
 
 def check_label_shapes(labels, preds, shape=0):
@@ -389,7 +388,6 @@ class Accuracy(EvalMetric):
         """
         check_label_shapes(labels, preds)
 
-        results = []
         for label, pred_label in zip(labels, preds):
             if pred_label.shape != label.shape:
                 pred_label = ndarray.argmax(pred_label, axis=self.axis)
@@ -401,10 +399,8 @@ class Accuracy(EvalMetric):
             if pred_label.context != label.context:
                 pred_label = pred_label.as_in_context(label.context)
 
-            self.num_inst += pred_label.size
-            results.append((pred_label.reshape((-1,)) == label.reshape((-1,)))
-                           .sum().as_in_context(cpu()))
-        self.sum_metric += ndarray.add_n(*results).asscalar()
+            self.sum_metric += (pred_label.reshape((-1,)) == label.reshape((-1,))).sum().asscalar()
+            self.num_inst += numpy.prod(pred_label.shape)
 
 
 @register

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -380,27 +380,23 @@ class Accuracy(EvalMetric):
         Parameters
         ----------
         labels : list of `NDArray`
-            The labels of the data with class indices as values, one per sample.
+            The labels of the data.
 
         preds : list of `NDArray`
-            Prediction values for samples. Each prediction value can either be the class index,
-            or a vector of likelihoods for all classes.
+            Predicted values.
         """
         check_label_shapes(labels, preds)
 
         for label, pred_label in zip(labels, preds):
             if pred_label.shape != label.shape:
                 pred_label = ndarray.argmax(pred_label, axis=self.axis)
-            pred_label = pred_label.astype('int32')
-            label = label.astype('int32')
+            pred_label = pred_label.asnumpy().astype('int32')
+            label = label.asnumpy().astype('int32')
 
             check_label_shapes(label, pred_label)
 
-            if pred_label.context != label.context:
-                pred_label = pred_label.as_in_context(label.context)
-
-            self.sum_metric += (pred_label.flatten() == label.flatten()).sum().asscalar()
-            self.num_inst += numpy.prod(pred_label.shape)
+            self.sum_metric += (pred_label.flat == label.flat).sum()
+            self.num_inst += len(pred_label.flat)
 
 
 @register


### PR DESCRIPTION
## Description ##
Using ndarray for metric negatively impacts the performance for volta GPU and no simple workaround is available, so rolling back the change until underlying issue is addressed.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change