### PR TITLE
fix FileNotFoundError error in diagnose.py

### DIFF
--- a/tools/diagnose.py
+++ b/tools/diagnose.py
@@ -110,7 +110,7 @@ def check_mxnet():
             print('Commit Hash   :', ch)
     except ImportError:
         print('No MXNet installed.')
-    except FileNotFoundError:
+    except IOError:
         print('Hashtag not found. Not installed from pre-built package.')
     except Exception as e:
         import traceback


### PR DESCRIPTION
FileNotFoundError not available in python2.7, use IOError instead.

## Description ##

What happens with old code:
```
----------Python Info----------
('Version      :', '2.7.13')
('Compiler     :', 'GCC 4.8.2 20140120 (Red Hat 4.8.2-15)')
('Build        :', ('default', 'Dec 19 2017 13:31:54'))
('Arch         :', ('64bit', 'ELF'))
------------Pip Info-----------
('Version      :', '9.0.1')
('Directory    :', '/scratch/cahsin/pythondir27/lib/python2.7/site-packages/pip')
----------MXNet Info-----------
('Version      :', '1.0.0')
('Directory    :', '/scratch/cahsin/repo/mxnet/python/mxnet')
Traceback (most recent call last):
  File "/scratch/cahsin/repo/mxnet/tools/diagnose.py", line 171, in <module>
    check_mxnet()
  File "/scratch/cahsin/repo/mxnet/tools/diagnose.py", line 113, in check_mxnet
    except FileNotFoundError:
NameError: global name 'FileNotFoundError' is not defined
```

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change