### PR TITLE
Doc update - clarify that mx.nd.flatten != np.nd.flatten

### DIFF
--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -191,6 +191,9 @@ NNVM_REGISTER_OP(Flatten)
 For an input array with shape ``(d1, d2, ..., dk)``, `flatten` operation reshapes
 the input array into an output array of shape ``(d1, d2*...*dk)``.
 
+Note that the bahavior of this function is different from numpy.ndarray.flatten,
+which behaves similar to mxnet.ndarray.reshape((-1,)).
+
 Example::
 
     x = [[


### PR DESCRIPTION
Added comment for clarity that numpy.ndarray.flatten behaves differently than nd.flatten

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage: N/A
- [ ] Code is well-documented: N/A
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Documentation update of mx.nd.flatten
