### PR TITLE
Overload ndarrayiter

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
@@ -58,7 +58,7 @@ class NDArrayIter (data: IndexedSeq[(String, NDArray)], label: IndexedSeq[(Strin
 
     // discard final part if lastBatchHandle equals discard
     if (lastBatchHandle.equals("discard")) {
-      val dataSize = data(0)_.2.shape(0)
+      val dataSize = data(0)._2.shape(0)
       require(dataBatchSize <= dataSize,
         "batch_size need to be smaller than data size when not padding.")
       val keepSize = dataSize - dataSize % dataBatchSize

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
@@ -38,9 +38,9 @@ import scala.collection.immutable.ListMap
  * the size of data does not match batch_size. Roll over is intended
  * for training and can cause problems if used for prediction.
  */
-class NDArrayIter (data: IndexedSeq[(String, NDArray)], label: IndexedSeq[(String, NDArray)] = IndexedSeq.empty,
-                  private val dataBatchSize: Int = 1, shuffle: Boolean = false,
-                  lastBatchHandle: String = "pad") extends DataIter {
+class NDArrayIter (data: IndexedSeq[(String, NDArray)], label: IndexedSeq[(String, NDArray)],
+                  private val dataBatchSize: Int, shuffle: Boolean,
+                  lastBatchHandle: String) extends DataIter {
   private val logger = LoggerFactory.getLogger(classOf[NDArrayIter])
 
 
@@ -90,39 +90,9 @@ class NDArrayIter (data: IndexedSeq[(String, NDArray)], label: IndexedSeq[(Strin
       lastBatchHandle)
   }
 
-  def this(
-      data: IndexedSeq[(String, NDArray)], 
-      label: IndexedSeq[NDArray] = IndexedSeq.empty,
-      dataBatchSize: Int = 1, 
-      shuffle: Boolean = false,
-      lastBatchHandle: String = "pad",
-      labelName: String = "label") = {
-    this(
-      data,
-      IO.initData(label, true, labelName),
-      dataBatchSize,
-      shuffle,
-      lastBatchHandle)
-  }
-
-  def this(
-      data: IndexedSeq[NDArray], 
-      label: IndexedSeq[(String, NDArray)] = IndexedSeq.empty,
-      dataBatchSize: Int = 1, 
-      shuffle: Boolean = false,
-      lastBatchHandle: String = "pad",
-      dataName: String = "data") = {
-    this(
-      IO.initData(data, false, dataName),
-      label,
-      dataBatchSize,
-      shuffle,
-      lastBatchHandle)
-  }
-
   val initData: IndexedSeq[(String, NDArray)] = _dataList
   val initLabel: IndexedSeq[(String, NDArray)] = _labelList
-  val numData = _dataList(0).shape(0)
+  val numData = _dataList(0)._2.shape(0)
   val numSource = initData.size
   var cursor = -dataBatchSize
 
@@ -217,7 +187,7 @@ class NDArrayIter (data: IndexedSeq[(String, NDArray)], label: IndexedSeq[(Strin
    * @return the data of current batch
    */
   override def getData(): IndexedSeq[NDArray] = {
-    _getData(_dataList)
+    _getData(_dataList.map(_._2))
   }
 
   /**
@@ -225,7 +195,7 @@ class NDArrayIter (data: IndexedSeq[(String, NDArray)], label: IndexedSeq[(Strin
    * @return the label of current batch
    */
   override def getLabel(): IndexedSeq[NDArray] = {
-    _getData(_labelList)
+    _getData(_labelList.map(_._2))
   }
 
   /**

--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
@@ -77,7 +77,7 @@ class NDArrayIter (data: IndexedSeq[(String, NDArray)], label: IndexedSeq[(Strin
   def this(
       data: IndexedSeq[NDArray], 
       label: IndexedSeq[NDArray] = IndexedSeq.empty,
-      private val dataBatchSize: Int = 1, 
+      dataBatchSize: Int = 1, 
       shuffle: Boolean = false,
       lastBatchHandle: String = "pad",
       dataName: String = "data", 
@@ -93,7 +93,7 @@ class NDArrayIter (data: IndexedSeq[(String, NDArray)], label: IndexedSeq[(Strin
   def this(
       data: IndexedSeq[(String, NDArray)], 
       label: IndexedSeq[NDArray] = IndexedSeq.empty,
-      private val dataBatchSize: Int = 1, 
+      dataBatchSize: Int = 1, 
       shuffle: Boolean = false,
       lastBatchHandle: String = "pad",
       labelName: String = "label") = {
@@ -108,7 +108,7 @@ class NDArrayIter (data: IndexedSeq[(String, NDArray)], label: IndexedSeq[(Strin
   def this(
       data: IndexedSeq[NDArray], 
       label: IndexedSeq[(String, NDArray)] = IndexedSeq.empty,
-      private val dataBatchSize: Int = 1, 
+      dataBatchSize: Int = 1, 
       shuffle: Boolean = false,
       lastBatchHandle: String = "pad",
       dataName: String = "data") = {


### PR DESCRIPTION
For multiple inputs or multiple labels in NDArrayIter, these data type is IndexedSeq[NDArray], which is not flexible to design neural network like Python API because the naming rule here is dataname_0, dataname_1, etc.

We modify the constructor to receive IndexedSeq[(String, NDArray)] type to allow assigning custom names. 
In order to compatible with the old argument version, we overload the constructor.
