### PR TITLE
remove the extra @register

### DIFF
--- a/python/mxnet/optimizer.py
+++ b/python/mxnet/optimizer.py
@@ -893,7 +893,6 @@ class DCASGD(Optimizer):
         weight[:] += mom
 
 @register
-@register
 class NAG(Optimizer):
     """Nesterov accelerated SGD.
 


### PR DESCRIPTION
## Description ##
Two "@register" lead to warning "UserWarning: WARNING: New optimizer mxnet.optimizer.NAG is overriding existing optimizer mxnet.optimizer.NAG Optimizer.opt_registry[name].name))" while importing mxnet.