### PR TITLE
Modify NDArrayIter constructor to receive tuple (i.e. dict in Python)…

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/io/NDArrayIter.scala
@@ -38,15 +38,14 @@ import scala.collection.immutable.ListMap
  * the size of data does not match batch_size. Roll over is intended
  * for training and can cause problems if used for prediction.
  */
-class NDArrayIter (data: IndexedSeq[NDArray], label: IndexedSeq[NDArray] = IndexedSeq.empty,
-                  private val dataBatchSize: Int = 1, shuffle: Boolean = false,
-                  lastBatchHandle: String = "pad",
-                  dataName: String = "data", labelName: String = "label") extends DataIter {
+class NDArrayIter (data: IndexedSeq[(String, NDArray)], label: IndexedSeq[(String, NDArray)],
+                  private val dataBatchSize: Int, shuffle: Boolean,
+                  lastBatchHandle: String) extends DataIter {
   private val logger = LoggerFactory.getLogger(classOf[NDArrayIter])
 
 
-  private val (_dataList: IndexedSeq[NDArray],
-  _labelList: IndexedSeq[NDArray]) = {
+  private val (_dataList: IndexedSeq[(String, NDArray)],
+  _labelList: IndexedSeq[(String, NDArray)]) = {
     // data should not be null and size > 0
     require(data != null && data.size > 0,
       "data should not be null and data.size should not be zero")
@@ -59,13 +58,13 @@ class NDArrayIter (data: IndexedSeq[NDArray], label: IndexedSeq[NDArray] = Index
 
     // discard final part if lastBatchHandle equals discard
     if (lastBatchHandle.equals("discard")) {
-      val dataSize = data(0).shape(0)
+      val dataSize = data(0)._2.shape(0)
       require(dataBatchSize <= dataSize,
         "batch_size need to be smaller than data size when not padding.")
       val keepSize = dataSize - dataSize % dataBatchSize
-      val dataList = data.map(ndArray => {ndArray.slice(0, keepSize)})
+      val dataList = data.map { case(name, ndArray) => (name, {ndArray.slice(0, keepSize)}) }
       if (!label.isEmpty) {
-        val labelList = label.map(ndArray => {ndArray.slice(0, keepSize)})
+        val labelList = label.map { case(name, ndArray) => (name, {ndArray.slice(0, keepSize)}) }
         (dataList, labelList)
       } else {
         (dataList, label)
@@ -75,10 +74,25 @@ class NDArrayIter (data: IndexedSeq[NDArray], label: IndexedSeq[NDArray] = Index
     }
   }
 
+  def this(
+      data: IndexedSeq[NDArray],
+      label: IndexedSeq[NDArray] = IndexedSeq.empty,
+      dataBatchSize: Int = 1,
+      shuffle: Boolean = false,
+      lastBatchHandle: String = "pad",
+      dataName: String = "data",
+      labelName: String = "label") = {
+    this(
+      IO.initData(data, false, dataName),
+      IO.initData(label, true, labelName),
+      dataBatchSize,
+      shuffle,
+      lastBatchHandle)
+  }
 
-  val initData: IndexedSeq[(String, NDArray)] = IO.initData(_dataList, false, dataName)
-  val initLabel: IndexedSeq[(String, NDArray)] = IO.initData(_labelList, true, labelName)
-  val numData = _dataList(0).shape(0)
+  val initData: IndexedSeq[(String, NDArray)] = _dataList
+  val initLabel: IndexedSeq[(String, NDArray)] = _labelList
+  val numData = _dataList(0)._2.shape(0)
   val numSource = initData.size
   var cursor = -dataBatchSize
 
@@ -173,7 +187,7 @@ class NDArrayIter (data: IndexedSeq[NDArray], label: IndexedSeq[NDArray] = Index
    * @return the data of current batch
    */
   override def getData(): IndexedSeq[NDArray] = {
-    _getData(_dataList)
+    _getData(_dataList.map(_._2))
   }
 
   /**
@@ -181,7 +195,7 @@ class NDArrayIter (data: IndexedSeq[NDArray], label: IndexedSeq[NDArray] = Index
    * @return the label of current batch
    */
   override def getLabel(): IndexedSeq[NDArray] = {
-    _getData(_labelList)
+    _getData(_labelList.map(_._2))
   }
 
   /**


### PR DESCRIPTION
## Description ##
For multiple inputs or multiple labels in NDArrayIter, they are assigned IndexedSeq[NDArray] type, which is not flexible to design neural network like Python API because the naming rule here is dataname_0, dataname_1, etc. In more complex network you may want to give a meaningful names like "user" and "item" in Matrix Factorization example.

We modify the constructor to receive IndexedSeq[(String, NDArray)] type to allow assigning custom names. We can initialize the NDArrayIter like this:
```scala
val trainData1 = IndexedSeq(("user", NDArray.array(Array(1,2,3,4,5,6,3,2,7,1,6,9), shape = Shape(6,2))))
val trainData2 = IndexedSeq(("item", NDArray.array(Array(1,2,3,4,5,6,3,2,6,1,6,9), shape = Shape(6,2))))
val trainLabel = IndexedSeq(("label", NDArray.array(Array(5,11,17,7,9,24), shape = Shape(6))))
val trainIter = new NDArrayIter(
  trainData1 ++ trainData2,
  trainLabel, 
  1, 
  false,
  "pad")
```

In order to compatible with the old argument version, we overload the constructor.
