### PR TITLE
[MX-9588] Add micro averaging strategy for F1 metric

### DIFF
--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -477,8 +477,7 @@ class TopKAccuracy(EvalMetric):
 
 class _BinaryClassificationMixin(object):
     """
-    Private class for keeping track of TPR, FPR, TNR, FNR counts for a classification metric. This
-    class is not intended to be instantiated directly, but extended by concrete metric types.
+    Private mixin for keeping track of TPR, FPR, TNR, FNR counts for a classification metric.
     """
 
     def __init__(self):
@@ -489,14 +488,15 @@ class _BinaryClassificationMixin(object):
 
     def _update_binary_stats(self, label, pred):
         """
-        Update various binary classification counts for a single (label, pred) pair.
+        Update various binary classification counts for a single (label, pred)
+        pair.
 
         Parameters
         ----------
-        labels : `NDArray`
+        label : `NDArray`
             The labels of the data.
 
-        preds : `NDArray`
+        pred : `NDArray`
             Predicted values.
         """
         pred = pred.asnumpy()
@@ -539,8 +539,10 @@ class _BinaryClassificationMixin(object):
         else:
             return 0.
 
+    @property
     def _total_examples(self):
-        return self._false_negatives + self._false_positives + self._true_negatives + self._true_positives
+        return self._false_negatives + self._false_positives + \
+               self._true_negatives + self._true_positives
 
     def _reset_stats(self):
         self._false_positives = 0
@@ -591,10 +593,11 @@ class F1(EvalMetric, _BinaryClassificationMixin):
     ('f1', 0.8)
     """
 
-    def __init__(self, name='f1', output_names=None, label_names=None, average="macro"):
+    def __init__(self, name='f1',
+                 output_names=None, label_names=None, average="macro"):
         _BinaryClassificationMixin.__init__(self)
-        EvalMetric.__init__(self,
-                            name, output_names=output_names, label_names=label_names)
+        EvalMetric.__init__(self, name=name,
+                            output_names=output_names, label_names=label_names)
         self.average = average
 
     def update(self, labels, preds):
@@ -612,13 +615,14 @@ class F1(EvalMetric, _BinaryClassificationMixin):
 
         for label, pred in zip(labels, preds):
             self._update_binary_stats(label, pred)
+
         if self.average == "macro":
             self.sum_metric += self._fscore
             self.num_inst += 1
             self._reset_stats()
         else:
-            self.sum_metric = self._fscore * self._total_examples()
-            self.num_inst = self._total_examples()
+            self.sum_metric = self._fscore * self._total_examples
+            self.num_inst = self._total_examples
 
     def reset(self):
         """Resets the internal evaluation result to initial state."""

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -583,9 +583,9 @@ class F1(EvalMetric):
         Name of labels that should be used when updating with update_dict.
         By default include all labels.
     average : str, default 'macro'
-        Strategy to be used for aggregating across micro-batches.
-            "macro": average the F1 scores for each batch
-            "micro": compute a single F1 score across all batches
+        Strategy to be used for aggregating across mini-batches.
+            "macro": average the F1 scores for each batch.
+            "micro": compute a single F1 score across all batches.
 
     Examples
     --------

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -505,7 +505,8 @@ class _BinaryClassificationMixin(object):
 
         check_label_shapes(label, pred)
         if len(numpy.unique(label)) > 2:
-            raise ValueError("F1 currently only supports binary classification.")
+            raise ValueError("%s currently only supports binary classification."
+                             % self.__class__.__name__)
 
         for y_pred, y_true in zip(pred_label, label):
             if y_pred == 1 and y_true == 1:
@@ -578,7 +579,7 @@ class F1(EvalMetric, _BinaryClassificationMixin):
     label_names : list of str, or None
         Name of labels that should be used when updating with update_dict.
         By default include all labels.
-    average : str
+    average : str, default 'macro'
         Strategy to be used for aggregating across micro-batches.
             "macro": average the F1 scores for each batch
             "micro": compute a single F1 score across all batches

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -477,7 +477,9 @@ class TopKAccuracy(EvalMetric):
 
 class _BinaryClassificationMixin(object):
     """
-    Private mixin for keeping track of TPR, FPR, TNR, FNR counts for a classification metric.
+    Private mixin for classification metrics. True/false positive rate and true/false negative
+    rate are sufficient statistics for various concrete metrics. This class provides the machinery
+    to track those statistics across mini-batches of (label, prediction) pairs.
     """
 
     def __init__(self):

--- a/tests/python/unittest/test_metric.py
+++ b/tests/python/unittest/test_metric.py
@@ -88,7 +88,7 @@ def test_f1():
     assert microF1.num_inst == 4
     assert macroF1.num_inst == 1
     # f1 = 2 * tp / (2 * tp + fp + fn)
-    fscore1 = 2 * (1) / (2 * 1 + 1 + 0)
+    fscore1 = 2. * (1) / (2 * 1 + 1 + 0)
     np.testing.assert_almost_equal(microF1.get()[1], fscore1)
     np.testing.assert_almost_equal(macroF1.get()[1], fscore1)
 
@@ -96,10 +96,10 @@ def test_f1():
     macroF1.update([label21, label22], [pred21, pred22])
     assert microF1.num_inst == 6
     assert macroF1.num_inst == 2
-    fscore2 = 2 * (1) / (2 * 1 + 0 + 0)
-    fscore_total = 2 * (1 + 1) / (2 * (1 + 1) + (1 + 0) + (0 + 0))
+    fscore2 = 2. * (1) / (2 * 1 + 0 + 0)
+    fscore_total = 2. * (1 + 1) / (2 * (1 + 1) + (1 + 0) + (0 + 0))
     np.testing.assert_almost_equal(microF1.get()[1], fscore_total)
-    np.testing.assert_almost_equal(macroF1.get()[1], (fscore1 + fscore2) / 2)
+    np.testing.assert_almost_equal(macroF1.get()[1], (fscore1 + fscore2) / 2.)
 
 def test_perplexity():
     pred = mx.nd.array([[0.8, 0.2], [0.2, 0.8], [0, 1.]])

--- a/tests/python/unittest/test_metric.py
+++ b/tests/python/unittest/test_metric.py
@@ -27,8 +27,8 @@ def check_metric(metric, *args, **kwargs):
     assert metric.get_config() == metric2.get_config()
 
 def test_f1():
-    microF1 = mx.metric.F1()
-    macroF1 = mx.metric.F1().macro()
+    microF1 = mx.metric.F1(average="micro")
+    macroF1 = mx.metric.F1(average="macro")
 
     assert np.isnan(macroF1.get()[1])
     assert np.isnan(microF1.get()[1])
@@ -61,17 +61,17 @@ def test_f1():
     assert macroF1.num_inst == 1
     # f1 = 2 * tp / (2 * tp + fp + fn)
     fscore1 = 2 * (1) / (2 * 1 + 1 + 0)
-    assert microF1.get()[1] == fscore1
-    assert macroF1.get()[1] == fscore1
+    np.testing.assert_almost_equal(microF1.get()[1], fscore1)
+    np.testing.assert_almost_equal(macroF1.get()[1], fscore1)
 
     microF1.update([label21, label22], [pred21, pred22])
     macroF1.update([label21, label22], [pred21, pred22])
     assert microF1.num_inst == 6
     assert macroF1.num_inst == 2
     fscore2 = 2 * (1) / (2 * 1 + 0 + 0)
-    assert macroF1.get()[1] == (fscore1 + fscore2) / 2
     fscore_total = 2 * (1 + 1) / (2 * (1 + 1) + (1 + 0) + (0 + 0))
-    assert microF1.get()[1] == fscore_total
+    np.testing.assert_almost_equal(microF1.get()[1], fscore_total)
+    np.testing.assert_almost_equal(macroF1.get()[1], (fscore1 + fscore2) / 2)
 
 
 def test_metrics():

--- a/tests/python/unittest/test_metric.py
+++ b/tests/python/unittest/test_metric.py
@@ -19,8 +19,6 @@ import mxnet as mx
 import numpy as np
 import json
 
-from sklearn.metrics import f1_score as scikit_f1
-
 def check_metric(metric, *args, **kwargs):
     metric = mx.metric.create(metric, *args, **kwargs)
     str_metric = json.dumps(metric.get_config())
@@ -57,22 +55,22 @@ def test_acc():
     assert acc == expected_acc
 
 def test_f1():
-    micro_f1 = mx.metric.create("f1", average="micro")
-    macro_f1 = mx.metric.F1(average="macro")
+    microF1 = mx.metric.create("f1", average="micro")
+    macroF1 = mx.metric.F1(average="macro")
 
-    assert np.isnan(macro_f1.get()[1])
-    assert np.isnan(micro_f1.get()[1])
+    assert np.isnan(macroF1.get()[1])
+    assert np.isnan(microF1.get()[1])
 
     # check divide by zero
     pred = mx.nd.array([[0.9, 0.1],
                         [0.8, 0.2]])
     label = mx.nd.array([0, 0])
-    macro_f1.update([label], [pred])
-    micro_f1.update([label], [pred])
-    assert macro_f1.get()[1] == 0.0
-    assert micro_f1.get()[1] == 0.0
-    macro_f1.reset()
-    micro_f1.reset()
+    macroF1.update([label], [pred])
+    microF1.update([label], [pred])
+    assert macroF1.get()[1] == 0.0
+    assert microF1.get()[1] == 0.0
+    macroF1.reset()
+    microF1.reset()
 
     pred11 = mx.nd.array([[0.1, 0.9],
                           [0.5, 0.5]])
@@ -85,28 +83,23 @@ def test_f1():
     pred22 = mx.nd.array([[0.2, 0.8]])
     label22 = mx.nd.array([1])
 
-    micro_f1.update([label11, label12], [pred11, pred12])
-    macro_f1.update([label11, label12], [pred11, pred12])
-    assert micro_f1.num_inst == 4
-    assert macro_f1.num_inst == 1
-    np_pred1 = np.concatenate([mx.nd.argmax(pred11, axis=1).asnumpy(),
-                              mx.nd.argmax(pred12, axis=1).asnumpy()])
-    np_label1 = np.concatenate([label11.asnumpy(), label12.asnumpy()])
-    np.testing.assert_almost_equal(micro_f1.get()[1], scikit_f1(np_label1, np_pred1))
-    np.testing.assert_almost_equal(macro_f1.get()[1], scikit_f1(np_label1, np_pred1))
+    microF1.update([label11, label12], [pred11, pred12])
+    macroF1.update([label11, label12], [pred11, pred12])
+    assert microF1.num_inst == 4
+    assert macroF1.num_inst == 1
+    # f1 = 2 * tp / (2 * tp + fp + fn)
+    fscore1 = 2. * (1) / (2 * 1 + 1 + 0)
+    np.testing.assert_almost_equal(microF1.get()[1], fscore1)
+    np.testing.assert_almost_equal(macroF1.get()[1], fscore1)
 
-    micro_f1.update([label21, label22], [pred21, pred22])
-    macro_f1.update([label21, label22], [pred21, pred22])
-    assert micro_f1.num_inst == 6
-    assert macro_f1.num_inst == 2
-    np_pred2 = np.concatenate([mx.nd.argmax(pred21, axis=1).asnumpy(),
-                               mx.nd.argmax(pred22, axis=1).asnumpy()])
-    np_pred_total = np.concatenate([np_pred1, np_pred2])
-    np_label2 = np.concatenate([label21.asnumpy(), label22.asnumpy()])
-    np_label_total = np.concatenate([np_label1, np_label2])
-    np.testing.assert_almost_equal(micro_f1.get()[1], scikit_f1(np_label_total, np_pred_total))
-    np.testing.assert_almost_equal(macro_f1.get()[1], (scikit_f1(np_label1, np_pred1) +
-                                                      scikit_f1(np_label2, np_pred2)) / 2)
+    microF1.update([label21, label22], [pred21, pred22])
+    macroF1.update([label21, label22], [pred21, pred22])
+    assert microF1.num_inst == 6
+    assert macroF1.num_inst == 2
+    fscore2 = 2. * (1) / (2 * 1 + 0 + 0)
+    fscore_total = 2. * (1 + 1) / (2 * (1 + 1) + (1 + 0) + (0 + 0))
+    np.testing.assert_almost_equal(microF1.get()[1], fscore_total)
+    np.testing.assert_almost_equal(macroF1.get()[1], (fscore1 + fscore2) / 2.)
 
 def test_perplexity():
     pred = mx.nd.array([[0.8, 0.2], [0.2, 0.8], [0, 1.]])

--- a/tests/python/unittest/test_metric.py
+++ b/tests/python/unittest/test_metric.py
@@ -26,54 +26,6 @@ def check_metric(metric, *args, **kwargs):
 
     assert metric.get_config() == metric2.get_config()
 
-def test_f1():
-    microF1 = mx.metric.F1(average="micro")
-    macroF1 = mx.metric.F1(average="macro")
-
-    assert np.isnan(macroF1.get()[1])
-    assert np.isnan(microF1.get()[1])
-
-    # check divide by zero
-    pred = mx.nd.array([[0.9, 0.1],
-                        [0.8, 0.2]])
-    label = mx.nd.array([0, 0])
-    macroF1.update([label], [pred])
-    microF1.update([label], [pred])
-    assert macroF1.get()[1] == 0.0
-    assert microF1.get()[1] == 0.0
-    macroF1.reset()
-    microF1.reset()
-
-    pred11 = mx.nd.array([[0.1, 0.9],
-                         [0.5, 0.5]])
-    label11 = mx.nd.array([1, 0])
-    pred12 = mx.nd.array([[0.85, 0.15],
-                          [1.0, 0.0]])
-    label12 = mx.nd.array([1, 0])
-    pred21 = mx.nd.array([[0.6, 0.4]])
-    label21 = mx.nd.array([0])
-    pred22 = mx.nd.array([[0.2, 0.8]])
-    label22 = mx.nd.array([1])
-
-    microF1.update([label11, label12], [pred11, pred12])
-    macroF1.update([label11, label12], [pred11, pred12])
-    assert microF1.num_inst == 4
-    assert macroF1.num_inst == 1
-    # f1 = 2 * tp / (2 * tp + fp + fn)
-    fscore1 = 2 * (1) / (2 * 1 + 1 + 0)
-    np.testing.assert_almost_equal(microF1.get()[1], fscore1)
-    np.testing.assert_almost_equal(macroF1.get()[1], fscore1)
-
-    microF1.update([label21, label22], [pred21, pred22])
-    macroF1.update([label21, label22], [pred21, pred22])
-    assert microF1.num_inst == 6
-    assert macroF1.num_inst == 2
-    fscore2 = 2 * (1) / (2 * 1 + 0 + 0)
-    fscore_total = 2 * (1 + 1) / (2 * (1 + 1) + (1 + 0) + (0 + 0))
-    np.testing.assert_almost_equal(microF1.get()[1], fscore_total)
-    np.testing.assert_almost_equal(macroF1.get()[1], (fscore1 + fscore2) / 2)
-
-
 def test_metrics():
     check_metric('acc', axis=0)
     check_metric('f1')
@@ -103,18 +55,51 @@ def test_acc():
     assert acc == expected_acc
 
 def test_f1():
-    pred = mx.nd.array([[0.3, 0.7], [1., 0], [0.4, 0.6], [0.6, 0.4], [0.9, 0.1]])
-    label = mx.nd.array([0, 1, 1, 1, 1])
-    positives = np.argmax(pred, axis=1).sum().asscalar()
-    true_positives = (np.argmax(pred, axis=1) == label).sum().asscalar()
-    precision = true_positives / positives
-    overall_positives = label.sum().asscalar()
-    recall = true_positives / overall_positives
-    f1_expected = 2 * (precision * recall) / (precision + recall)
-    metric = mx.metric.create('f1')
-    metric.update([label], [pred])
-    _, f1 = metric.get()
-    assert f1 == f1_expected
+    microF1 = mx.metric.create("f1", average="micro")
+    macroF1 = mx.metric.F1(average="macro")
+
+    assert np.isnan(macroF1.get()[1])
+    assert np.isnan(microF1.get()[1])
+
+    # check divide by zero
+    pred = mx.nd.array([[0.9, 0.1],
+                        [0.8, 0.2]])
+    label = mx.nd.array([0, 0])
+    macroF1.update([label], [pred])
+    microF1.update([label], [pred])
+    assert macroF1.get()[1] == 0.0
+    assert microF1.get()[1] == 0.0
+    macroF1.reset()
+    microF1.reset()
+
+    pred11 = mx.nd.array([[0.1, 0.9],
+                          [0.5, 0.5]])
+    label11 = mx.nd.array([1, 0])
+    pred12 = mx.nd.array([[0.85, 0.15],
+                          [1.0, 0.0]])
+    label12 = mx.nd.array([1, 0])
+    pred21 = mx.nd.array([[0.6, 0.4]])
+    label21 = mx.nd.array([0])
+    pred22 = mx.nd.array([[0.2, 0.8]])
+    label22 = mx.nd.array([1])
+
+    microF1.update([label11, label12], [pred11, pred12])
+    macroF1.update([label11, label12], [pred11, pred12])
+    assert microF1.num_inst == 4
+    assert macroF1.num_inst == 1
+    # f1 = 2 * tp / (2 * tp + fp + fn)
+    fscore1 = 2 * (1) / (2 * 1 + 1 + 0)
+    np.testing.assert_almost_equal(microF1.get()[1], fscore1)
+    np.testing.assert_almost_equal(macroF1.get()[1], fscore1)
+
+    microF1.update([label21, label22], [pred21, pred22])
+    macroF1.update([label21, label22], [pred21, pred22])
+    assert microF1.num_inst == 6
+    assert macroF1.num_inst == 2
+    fscore2 = 2 * (1) / (2 * 1 + 0 + 0)
+    fscore_total = 2 * (1 + 1) / (2 * (1 + 1) + (1 + 0) + (0 + 0))
+    np.testing.assert_almost_equal(microF1.get()[1], fscore_total)
+    np.testing.assert_almost_equal(macroF1.get()[1], (fscore1 + fscore2) / 2)
 
 def test_perplexity():
     pred = mx.nd.array([[0.8, 0.2], [0.2, 0.8], [0, 1.]])

--- a/tests/python/unittest/test_metric.py
+++ b/tests/python/unittest/test_metric.py
@@ -26,6 +26,53 @@ def check_metric(metric, *args, **kwargs):
 
     assert metric.get_config() == metric2.get_config()
 
+def test_f1():
+    microF1 = mx.metric.F1()
+    macroF1 = mx.metric.F1().macro()
+
+    assert np.isnan(macroF1.get()[1])
+    assert np.isnan(microF1.get()[1])
+
+    # check divide by zero
+    pred = mx.nd.array([[0.9, 0.1],
+                        [0.8, 0.2]])
+    label = mx.nd.array([0, 0])
+    macroF1.update([label], [pred])
+    microF1.update([label], [pred])
+    assert macroF1.get()[1] == 0.0
+    assert microF1.get()[1] == 0.0
+    macroF1.reset()
+    microF1.reset()
+
+    pred11 = mx.nd.array([[0.1, 0.9],
+                         [0.5, 0.5]])
+    label11 = mx.nd.array([1, 0])
+    pred12 = mx.nd.array([[0.85, 0.15],
+                          [1.0, 0.0]])
+    label12 = mx.nd.array([1, 0])
+    pred21 = mx.nd.array([[0.6, 0.4]])
+    label21 = mx.nd.array([0])
+    pred22 = mx.nd.array([[0.2, 0.8]])
+    label22 = mx.nd.array([1])
+
+    microF1.update([label11, label12], [pred11, pred12])
+    macroF1.update([label11, label12], [pred11, pred12])
+    assert microF1.num_inst == 4
+    assert macroF1.num_inst == 1
+    # f1 = 2 * tp / (2 * tp + fp + fn)
+    fscore1 = 2 * (1) / (2 * 1 + 1 + 0)
+    assert microF1.get()[1] == fscore1
+    assert macroF1.get()[1] == fscore1
+
+    microF1.update([label21, label22], [pred21, pred22])
+    macroF1.update([label21, label22], [pred21, pred22])
+    assert microF1.num_inst == 6
+    assert macroF1.num_inst == 2
+    fscore2 = 2 * (1) / (2 * 1 + 0 + 0)
+    assert macroF1.get()[1] == (fscore1 + fscore2) / 2
+    fscore_total = 2 * (1 + 1) / (2 * (1 + 1) + (1 + 0) + (0 + 0))
+    assert microF1.get()[1] == fscore_total
+
 
 def test_metrics():
     check_metric('acc', axis=0)


### PR DESCRIPTION
## Description ##
This PR adds a mixin class that F1 and other metrics like precision and recall can leverage in the future. It also provides a new option for the F1 metric called `average` which defines how the metric will be aggregated across mini batches. 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Approach

The "micro" vs "macro" update strategy is not specific to F1 score. The macro update just takes an average of averages, which can be done for any metric. It may be best to design an abstraction where any metric can have the micro/macro update option, but I couldn't see a good way to do that here that would:

* be easy to use for end users AND
* maintain backward compatibility AND
* maintain current semantics

For now, the behavior for each type of update is hard coded into the `update` method of the `F1` class. We can discuss the approach.

Please let me know if I have missed or overlooked anything :)