### PR TITLE
Fixing a symbol file for image-classification example

### DIFF
--- a/example/image-classification/symbols/googlenet.py
+++ b/example/image-classification/symbols/googlenet.py
@@ -65,7 +65,7 @@ def get_symbol(num_classes = 1000, **kwargs):
     pool5 = mx.sym.Pooling(in4e, kernel=(3, 3), stride=(2, 2), pool_type="max")
     in5a = InceptionFactory(pool5, 256, 160, 320, 32, 128, "max", 128, name="in5a")
     in5b = InceptionFactory(in5a, 384, 192, 384, 48, 128, "max", 128, name="in5b")
-    pool6 = mx.sym.Pooling(in5b, kernel=(7, 7), stride=(1,1), pool_type="avg")
+    pool6 = mx.sym.Pooling(in5b, kernel=(7, 7), stride=(1,1), global_pool=True, pool_type="avg")
     flatten = mx.sym.Flatten(data=pool6)
     fc1 = mx.sym.FullyConnected(data=flatten, num_hidden=num_classes)
     softmax = mx.symbol.SoftmaxOutput(data=fc1, name='softmax')


### PR DESCRIPTION
## Description ##
This PR is trying to fix a runtime error when running benchmark_score.py on CPU machine.

The existing implementation of GoogleNet symbol under:
example/image-classification/symbols/googlenet.py will introduce a run time error when input shape set as 3*224*224, per the error message below and topo of GoogleNet, I use global_pool option to avoid this issue.
src/operator/nn/./pooling-inl.h:215: Check failed: param_.kernel[0] <= dshape[2] + 2 * param_.pad[0] kernel size (7) exceeds input (6 padded to 6)

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
example/image-classification/symbols/google.py, on CPU platform, the input to the last layer (7x7 avg pooling is 6x6, and therefore a runtime error will be triggered, I avoid this issue by using global_pool option. 

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
