### PR TITLE
make array.reshape compatible with numpy

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -926,12 +926,12 @@ fixed-size items.
             self.handle, mx_uint(idx), ctypes.byref(handle)))
         return NDArray(handle=handle, writable=self.writable)
 
-    def reshape(self, shape):
+    def reshape(self, *shape):
         """Returns a **view** of this array with a new shape without altering any data.
 
         Parameters
         ----------
-        shape : tuple of int
+        shape : tuple of int, or n ints
             The new shape should not change the array size, namely
             ``np.prod(new_shape)`` should be equal to ``np.prod(self.shape)``.
 
@@ -963,11 +963,18 @@ fixed-size items.
         array([[ 0.,  1.],
                [ 2.,  3.],
                [ 4.,  5.]], dtype=float32)
+        >>> y = x.reshape(3,2)
+        >>> y.asnumpy()
+        array([[ 0.,  1.],
+               [ 2.,  3.],
+               [ 4.,  5.]], dtype=float32)
         >>> y[:] = -1
         >>> x.asnumpy()
         array([[-1., -1., -1.],
                [-1., -1., -1.]], dtype=float32)
         """
+        if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
+            shape = shape[0]
         handle = NDArrayHandle()
 
         # Actual reshape

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -975,12 +975,15 @@ fixed-size items.
         """
         if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
             shape = shape[0]
-        elif not len(shape):
+        elif not shape:
             for key, value in kwargs.items():
                 if key == 'shape':
                     shape = value
                 else:
                     raise TypeError("'%s' is an invalid keyword argument for this function"%key)
+        else:
+            assert not kwargs,\
+                "Specifying both positional and keyword arguments is not allowed in reshape."
         handle = NDArrayHandle()
 
         # Actual reshape

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -976,11 +976,11 @@ fixed-size items.
         if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
             shape = shape[0]
         elif not shape:
-            for key, value in kwargs.items():
-                if key == 'shape':
-                    shape = value
-                else:
-                    raise TypeError("'%s' is an invalid keyword argument for this function"%key)
+            shape = kwargs.get('shape')
+            assert shape, "Shape must be provided."
+            if len(kwargs) != 1:
+                raise TypeError("Only 'shape' is supported as keyword argument. Got: {}."
+                                .format(', '.join(kwargs.keys())))
         else:
             assert not kwargs,\
                 "Specifying both positional and keyword arguments is not allowed in reshape."

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -926,7 +926,7 @@ fixed-size items.
             self.handle, mx_uint(idx), ctypes.byref(handle)))
         return NDArray(handle=handle, writable=self.writable)
 
-    def reshape(self, *shape):
+    def reshape(self, *shape, **kwargs):
         """Returns a **view** of this array with a new shape without altering any data.
 
         Parameters
@@ -975,6 +975,12 @@ fixed-size items.
         """
         if len(shape) == 1 and isinstance(shape[0], (list, tuple)):
             shape = shape[0]
+        elif not len(shape):
+            for key, value in kwargs.items():
+                if key == 'shape':
+                    shape = value
+                else:
+                    raise TypeError("'%s' is an invalid keyword argument for this function"%key)
         handle = NDArrayHandle()
 
         # Actual reshape

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -138,7 +138,7 @@ class BaseSparseNDArray(NDArray):
     def _slice(self, start, stop):
         raise NotSupportedForSparseNDArray(self._slice, None, start, stop)
 
-    def reshape(self, shape):
+    def reshape(self, *shape):
         raise NotSupportedForSparseNDArray(self.reshape, None, shape)
 
     @property

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -138,7 +138,7 @@ class BaseSparseNDArray(NDArray):
     def _slice(self, start, stop):
         raise NotSupportedForSparseNDArray(self._slice, None, start, stop)
 
-    def reshape(self, *shape):
+    def reshape(self, *shape, **kwargs):
         raise NotSupportedForSparseNDArray(self.reshape, None, shape)
 
     @property

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -154,6 +154,11 @@ def test_ndarray_reshape():
                              [5, 6],
                              [7, 8]])
     assert same(tensor.reshape((-1, 2)).asnumpy(), true_res.asnumpy())
+    assert same(tensor.reshape(4, 2).asnumpy(), true_res.asnumpy())
+    assert same(tensor.reshape(-1, 2).asnumpy(), true_res.asnumpy())
+    true_res = mx.nd.arange(8) + 1
+    assert same(tensor.reshape(-1).asnumpy(), true_res.asnumpy())
+    assert same(tensor.reshape(8).asnumpy(), true_res.asnumpy())
 
 
 def test_ndarray_choose():


### PR DESCRIPTION
## Description ##
Allow n ints as input to array.reshape.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Allow n ints as input to array.reshape.