### PR TITLE
Enable the reporting of cross-entropy or nll loss value when training CNN network using the models defined by example/image-classification

### DIFF
--- a/example/image-classification/common/fit.py
+++ b/example/image-classification/common/fit.py
@@ -117,6 +117,8 @@ def add_fit_args(parser):
                        help='load the model on an epoch using the model-load-prefix')
     train.add_argument('--top-k', type=int, default=0,
                        help='report the top-k accuracy. 0 means no report.')
+    train.add_argument('--loss', type=str,
+                       help='show the cross-entropy or nll loss. ce strands for cross-entropy, nll-loss stands for likelihood loss')
     train.add_argument('--test-io', type=int, default=0,
                        help='1 means test reading speed without training')
     train.add_argument('--dtype', type=str, default='float32',
@@ -259,6 +261,23 @@ def fit(args, network, data_loader, **kwargs):
     if args.top_k > 0:
         eval_metrics.append(mx.metric.create(
             'top_k_accuracy', top_k=args.top_k))
+
+    supported_loss = ['ce', 'nll_loss']
+    if len(args.loss) > 0:
+        # ce or nll loss is only applicable to softmax output
+        loss_type_list = args.loss.split(',')
+        if 'softmax_output' in network.list_outputs():
+            for loss_type in loss_type_list:
+                loss_type = loss_type.strip()
+                if loss_type == 'nll':
+                    loss_type = 'nll_loss'
+                if loss_type not in supported_loss:
+                    logging.warning(loss_type + ' is not an valid loss type, only cross-entropy or ' \
+                                    'negative likelihood loss is supported!')
+                else:
+                    eval_metrics.append(mx.metric.create(loss_type))
+        else:
+            logging.warning("The output is not softmax_output, loss argument will be skipped!")
 
     # callbacks that run after each batch
     batch_end_callbacks = [mx.callback.Speedometer(

--- a/example/image-classification/common/fit.py
+++ b/example/image-classification/common/fit.py
@@ -117,7 +117,7 @@ def add_fit_args(parser):
                        help='load the model on an epoch using the model-load-prefix')
     train.add_argument('--top-k', type=int, default=0,
                        help='report the top-k accuracy. 0 means no report.')
-    train.add_argument('--loss', type=str,
+    train.add_argument('--loss', type=str, default='',
                        help='show the cross-entropy or nll loss. ce strands for cross-entropy, nll-loss stands for likelihood loss')
     train.add_argument('--test-io', type=int, default=0,
                        help='1 means test reading speed without training')


### PR DESCRIPTION
## Description ##
MxNET already implements the loss computation at Python layer (in python/mxnet/metric.py)
For most of the CNN models used for image-classification, as softmax is commonly used as the output, the cross-entropy or likelihood loss value is helpful to monitor the convergence trend during training.
The current implementation of example/image-classification/fit.py already provides an extensible implementation to report some useful information during training, such as accuracy. This PR utilizes this design and enabling the report of cross-entropy or nll loss value during training.

My understanding is: the cross-entropy loss and (negative) likelihood loss are most common used for softmax output, and therefore I choose reporting either cross-entropy or negative likelihood loss as long as the output layer is the softmax.

The current implementation of this PR is add a string-type argument, that is the "--loss", and the corresponding type loss will be reported accordingly. _(if the user want to report more than one type of loss value, it can be a list, such as 'ce, nll'. )_

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
All the code changes are in example/image-classification/common/fit.py
A new argument '--loss' is introduced, and it can be set as either a string or a list corresponding to type(s) of the loss value accordingly.
Taking the example/image-classification/train_cifar10.py as an example, the cross-entropy loss value will be reported if the below bold code line added,
parser.set_defaults(
    ......
    **loss = 'ce'**
    ......
)

The output log will be the following pattern:

INFO:root:Epoch[0] Batch [380] Speed: 504.42 samples/sec accuracy=0.087109 top_k_accuracy_5=0.469531 **cross-entropy=2.305971**
INFO:root:Epoch[0] Train-accuracy=0.098437
INFO:root:Epoch[0] Train-top_k_accuracy_5=0.506250
INFO:root:Epoch[0] **Train-cross-entropy=2.304529**
INFO:root:Epoch[0] Time cost=100.989
INFO:root:Epoch[0] Validation-accuracy=0.098101
INFO:root:Epoch[0] Validation-top_k_accuracy_5=0.486946
INFO:root:Epoch[0] **Validation-cross-entropy=2.302873**

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
