### PR TITLE
fix optimizer bug in CPP-Package

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -314,6 +314,7 @@ try {
           make('build_cuda', flag)
           pack_lib('gpu')
           stash includes: 'build/cpp-package/example/test_score', name: 'cpp_test_score'
+          stash includes: 'build/cpp-package/example/test_optimizer', name: 'cpp_test_optimizer'
         }
       }
     },
@@ -658,6 +659,7 @@ try {
           init_git()
           unpack_lib('gpu')
           unstash 'cpp_test_score'
+          unstash 'cpp_test_optimizer'
           timeout(time: max_time, unit: 'MINUTES') {
             sh "${docker_run} gpu --dockerbinary nvidia-docker cpp-package/tests/ci_test.sh"
           }

--- a/cpp-package/example/test_optimizer.cpp
+++ b/cpp-package/example/test_optimizer.cpp
@@ -29,5 +29,4 @@ int main(int argc, char** argv) {
 
   MXNotifyShutdown();
   return ret;
-  return 0;
 }

--- a/cpp-package/example/test_optimizer.cpp
+++ b/cpp-package/example/test_optimizer.cpp
@@ -25,7 +25,9 @@ int main(int argc, char** argv) {
   // Confirm >1 optimizers can be created w/o error
   Optimizer* opt = OptimizerRegistry::Find("sgd");
   opt = OptimizerRegistry::Find("adam");
+  int ret = (opt == 0) ? 1 : 0;
 
   MXNotifyShutdown();
+  return ret;
   return 0;
 }

--- a/cpp-package/example/test_optimizer.cpp
+++ b/cpp-package/example/test_optimizer.cpp
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "mxnet-cpp/MxNetCpp.h"
+
+using namespace std;
+using namespace mxnet::cpp;
+
+int main(int argc, char** argv) {
+  // Confirm >1 optimizers can be created w/o error
+  Optimizer* opt = OptimizerRegistry::Find("sgd");
+  opt = OptimizerRegistry::Find("adam");
+
+  MXNotifyShutdown();
+  return 0;
+}

--- a/cpp-package/include/mxnet-cpp/optimizer.hpp
+++ b/cpp-package/include/mxnet-cpp/optimizer.hpp
@@ -125,13 +125,16 @@ inline float Optimizer::GetWD_(int index) {
 }
 
 inline Optimizer* OptimizerRegistry::Find(const std::string& name) {
-  MXNETCPP_REGISTER_OPTIMIZER(sgd, SGDOptimizer);
-  MXNETCPP_REGISTER_OPTIMIZER(ccsgd, SGDOptimizer);  // For backward compatibility
-  MXNETCPP_REGISTER_OPTIMIZER(rmsprop, RMSPropOptimizer);
-  MXNETCPP_REGISTER_OPTIMIZER(adam, AdamOptimizer);
-  MXNETCPP_REGISTER_OPTIMIZER(adagrad, AdaGradOptimizer);
-  MXNETCPP_REGISTER_OPTIMIZER(adadelta, AdaDeltaOptimizer);
-  MXNETCPP_REGISTER_OPTIMIZER(signum, SignumOptimizer);
+  if (cmap().empty()) {
+    // Optimizers should only be registered once
+    MXNETCPP_REGISTER_OPTIMIZER(sgd, SGDOptimizer);
+    MXNETCPP_REGISTER_OPTIMIZER(ccsgd, SGDOptimizer);  // For backward compatibility
+    MXNETCPP_REGISTER_OPTIMIZER(rmsprop, RMSPropOptimizer);
+    MXNETCPP_REGISTER_OPTIMIZER(adam, AdamOptimizer);
+    MXNETCPP_REGISTER_OPTIMIZER(adagrad, AdaGradOptimizer);
+    MXNETCPP_REGISTER_OPTIMIZER(adadelta, AdaDeltaOptimizer);
+    MXNETCPP_REGISTER_OPTIMIZER(signum, SignumOptimizer);
+  }
   auto it = cmap().find(name);
   if (it == cmap().end())
     return nullptr;

--- a/cpp-package/tests/ci_test.sh
+++ b/cpp-package/tests/ci_test.sh
@@ -22,6 +22,9 @@ export LD_LIBRARY_PATH=$(readlink -f ../../lib):$LD_LIBRARY_PATH
 echo $LD_LIBRARY_PATH
 ls -l ../../lib/
 
+cp ../../build/cpp-package/example/test_optimizer .
+./test_optimizer
+
 cp ../../build/cpp-package/example/test_score .
 ./get_mnist.sh
 ./test_score 0.93


### PR DESCRIPTION
## Description ##
Regards issue #9800. The bug was that CPP-Package won't allow more than one optimizer to be created. See comments for more details. 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
I narrowed my example code down to this snip of code:
```c++
#include "mxnet-cpp/MxNetCpp.h"
int main(int argc, char** argv) {
  Optimizer* opt = OptimizerRegistry::Find("sgd");
  opt = OptimizerRegistry::Find("adam");
  return 0;
}
```
To produce this error:
```c++
terminate called after throwing an instance of 'dmlc::Error'
  what():  [18:02:48] /scratch/cahsin/repo/incubator-mxnet/cpp-package/include/mxnet-cpp/optimizer.hpp:141: Check failed: cmap().count(name) == 0 (1 vs. 0) sgd already registered

Stack trace returned 7 entries:
[bt] (0) ./mlp_cpu(_ZN4dmlc10StackTraceEv+0x42) [0x411b41]
[bt] (1) ./mlp_cpu(_ZN4dmlc15LogMessageFatalD1Ev+0x1b) [0x411db1]
[bt] (2) ./mlp_cpu() [0x41538f]
[bt] (3) ./mlp_cpu() [0x414de8]
[bt] (4) ./mlp_cpu() [0x411231]
[bt] (5) /lib64/libc.so.6(__libc_start_main+0xfd) [0x3449c1ed1d]
[bt] (6) ./mlp_cpu() [0x410ad9]

Aborted (core dumped)
```

I am using adam there as an example, but any two calls to OptimizerRegistry::Find will result in the error. The problem is here:
https://github.com/apache/incubator-mxnet/blob/master/cpp-package/include/mxnet-cpp/optimizer.hpp#L127
```c++
    inline Optimizer* OptimizerRegistry::Find(const std::string& name) {
      MXNETCPP_REGISTER_OPTIMIZER(sgd, SGDOptimizer);
      MXNETCPP_REGISTER_OPTIMIZER(ccsgd, SGDOptimizer);  // For backward compatibility
      MXNETCPP_REGISTER_OPTIMIZER(rmsprop, RMSPropOptimizer);
      MXNETCPP_REGISTER_OPTIMIZER(adam, AdamOptimizer);
      MXNETCPP_REGISTER_OPTIMIZER(adagrad, AdaGradOptimizer);
      MXNETCPP_REGISTER_OPTIMIZER(adadelta, AdaDeltaOptimizer);
      MXNETCPP_REGISTER_OPTIMIZER(signum, SignumOptimizer);
      auto it = cmap().find(name);
      if (it == cmap().end())
        return nullptr;
      return it->second();
    }
```
https://github.com/apache/incubator-mxnet/blob/master/cpp-package/include/mxnet-cpp/optimizer.h#L133
```c++
    #define MXNETCPP_REGISTER_OPTIMIZER(Name, OptimizerType)\
      OptimizerRegistry::__REGISTER__(#Name, [](){return new OptimizerType();})
```
https://github.com/apache/incubator-mxnet/blob/master/cpp-package/include/mxnet-cpp/optimizer.hpp#L141
```c++
    inline int OptimizerRegistry::__REGISTER__(const std::string& name, OptimizerCreator creator) {
      CHECK_EQ(cmap().count(name), 0) << name << " already registered";
      cmap().emplace(name, std::move(creator));
      return 0;
    }
```

This means users can only call ```OptimizerRegistry::Find``` once because every time they want to create an optimizer object, ```OptimizerRegistry::Find``` re-registers everything. This is abnormal. If you look into what the Python API does [optimizer.py](https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/optimizer.py#L113), you observe that ```def register(klass)``` isn't called by ```def create_optimizer(name, **kwargs)```. In fact, when the CPP-Package was first added in [Integrate cpp package (#5251)](https://github.com/apache/incubator-mxnet/blob/21b2da07f6ff10669b7649860b913e17e6184708/cpp-package/include/mxnet-cpp/optimizer.hpp), the registering of optimizers was not placed into the creation:
```c++
std::map<std::string, OptimizerCreator> OptimizerRegistry::cmap_;

MXNETCPP_REGISTER_OPTIMIZER(sgd, SGDOptimizer);
MXNETCPP_REGISTER_OPTIMIZER(ccsgd, SGDOptimizer);  // For backward compatibility

Optimizer* OptimizerRegistry::Find(const std::string& name) {
  auto it = cmap_.find(name);
  if (it == cmap_.end())
    return nullptr;
  return it->second();
}
```
The embedding of register in Find happened with the merge of [[cpp-package] Fix multiple definition issue](https://github.com/apache/incubator-mxnet/pull/5545/files#diff-715b8c623cdceb730bd1f01c9b243d62R67). Since there is a justification for the strange structure, I just put in a small fix that would register the optimizer just once.