### PR TITLE
Dockerfile to create Jetson TX1 and TX2 compatible builds

### DIFF
--- a/docker_multiarch/Dockerfile.build.jetson
+++ b/docker_multiarch/Dockerfile.build.jetson
@@ -1,0 +1,92 @@
+# -*- mode: dockerfile -*-
+# dockerfile to build libmxnet.so, and a python wheel for the Jetson TX1/TX2
+
+FROM nvidia/cuda:8.0-cudnn5-devel as cudabuilder
+
+FROM dockcross/linux-arm64
+
+ENV ARCH aarch64
+ENV NVCCFLAGS "-m64"
+ENV CUDA_ARCH "-gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62"
+ENV BUILD_OPTS "USE_OPENCV=0 USE_BLAS=openblas USE_SSE=0 USE_CUDA=1 USE_CUDNN=1 ENABLE_CUDA_RTC=0 USE_NCCL=0 USE_CUDA_PATH=/usr/local/cuda/"
+ENV CC /usr/bin/aarch64-linux-gnu-gcc
+ENV CXX /usr/bin/aarch64-linux-gnu-g++
+ENV FC /usr/bin/aarch64-linux-gnu-gfortran-4.9
+ENV HOSTCC gcc
+
+WORKDIR /work
+
+# Build OpenBLAS
+ADD https://api.github.com/repos/xianyi/OpenBLAS/git/refs/heads/master /tmp/openblas_version.json
+RUN git clone https://github.com/xianyi/OpenBLAS.git && \
+    cd OpenBLAS && \
+    make -j$(nproc) TARGET=ARMV8 && \
+    make install && \
+    ln -s /opt/OpenBLAS/lib/libopenblas.so /usr/lib/libopenblas.so && \
+    ln -s /opt/OpenBLAS/lib/libopenblas.a /usr/lib/libopenblas.a && \
+    ln -s /opt/OpenBLAS/lib/libopenblas.a /usr/lib/liblapack.a
+
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/opt/OpenBLAS/lib
+ENV CPLUS_INCLUDE_PATH /opt/OpenBLAS/include
+
+# Setup CUDA build env (including configuring and copying nvcc)
+COPY --from=cudabuilder /usr/local/cuda /usr/local/cuda
+ENV PATH $PATH:/usr/local/cuda/bin
+ENV TARGET_ARCH aarch64
+ENV TARGET_OS linux
+
+# Install ARM depedencies based on Jetpack 3.1
+RUN wget http://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/013/linux-x64/cuda-repo-l4t-8-0-local_8.0.84-1_arm64.deb && \
+    wget http://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/013/linux-x64/libcudnn6_6.0.21-1+cuda8.0_arm64.deb && \
+    dpkg -i cuda-repo-l4t-8-0-local_8.0.84-1_arm64.deb && \
+    dpkg -i libcudnn6_6.0.21-1+cuda8.0_arm64.deb && \
+    apt update -y && \
+    apt install cuda-cudart-cross-aarch64-8-0 cuda-cublas-cross-aarch64-8-0 \
+    cuda-nvml-cross-aarch64-8-0 cuda-nvrtc-cross-aarch64-8-0 cuda-cufft-cross-aarch64-8-0 \
+    cuda-curand-cross-aarch64-8-0 cuda-cusolver-cross-aarch64-8-0 cuda-cusparse-cross-aarch64-8-0 \
+    cuda-misc-headers-cross-aarch64-8-0 cuda-npp-cross-aarch64-8-0 libcudnn6 -y && \
+    cp /usr/local/cuda-8.0/targets/aarch64-linux/lib/*.so /usr/local/cuda/lib64/ && \
+    cp /usr/local/cuda-8.0/targets/aarch64-linux/lib/stubs/*.so /usr/local/cuda/lib64/stubs/ && \
+    cp -r /usr/local/cuda-8.0/targets/aarch64-linux/include/ /usr/local/cuda/include/ && \
+    rm cuda-repo-l4t-8-0-local_8.0.84-1_arm64.deb && rm libcudnn6_6.0.21-1+cuda8.0_arm64.deb
+
+# Build MXNet
+ADD mxnet mxnet
+
+WORKDIR /work/mxnet
+
+# Add ARM specific settings
+ADD arm.crosscompile.mk make/config.mk
+
+# Build and link
+RUN make -j$(nproc) $BUILD_OPTS
+
+# Create a binary wheel for easy installation.
+# When using tool.py output will be in the jetson folder.
+# Scp the .whl file to your target device, and install via
+# pip install
+WORKDIR /work/mxnet/python
+RUN python setup.py  bdist_wheel --universal
+
+# Copy build artifacts to output folder for tool.py script
+RUN mkdir -p /work/build & cp dist/*.whl /work/build && cp ../lib/* /work/build
+
+# Fix pathing issues in the wheel.  We need to move libmxnet.so from the data folder to the root
+# of the wheel, then repackage the wheel.
+# Create a temp dir to do the work.
+WORKDIR /work/build
+RUN apt-get install -y unzip && \
+    mkdir temp && \
+    cp *.whl temp
+
+# Extract the wheel, move the libmxnet.so file, repackage the wheel.
+WORKDIR /work/build/temp
+RUN unzip *.whl &&  \
+    rm *.whl && \
+    mv *.data/data/mxnet/libmxnet.so mxnet && \
+    zip -r ../temp.zip *
+
+# Replace the existing wheel with our fixed version.
+WORKDIR /work/build
+RUN rm -rf temp && \
+    for f in *.whl; do rm "$f" && mv temp.zip "$f"; done


### PR DESCRIPTION
Builds are ARM64 with CUDA 8 support. Dependencies based on Jetpack 3.1.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- No support for CI yet, but we have plans to merge the cross compilation and CI Dockerfiles in the future.
