### PR TITLE
add infer_type for regression ops, fix issues#9847

### DIFF
--- a/src/operator/regression_output.cc
+++ b/src/operator/regression_output.cc
@@ -25,6 +25,7 @@
 #include "./regression_output-inl.h"
 #include "./elemwise_op_common.h"
 
+
 #define MXNET_OPERATOR_REGISTER_REGRESSION_FWD(__name$, __kernel$, __bwdop$)   \
   NNVM_REGISTER_OP(__name$)                                                    \
   .set_num_inputs(2)                                                           \

--- a/src/operator/regression_output.cc
+++ b/src/operator/regression_output.cc
@@ -23,6 +23,7 @@
 */
 
 #include "./regression_output-inl.h"
+#include "./elemwise_op_common.h"
 
 #define MXNET_OPERATOR_REGISTER_REGRESSION_FWD(__name$, __kernel$, __bwdop$)   \
   NNVM_REGISTER_OP(__name$)                                                    \
@@ -33,6 +34,7 @@
       return std::vector<std::string>{"data", "label"};                        \
     })                                                                         \
   .set_attr<nnvm::FInferShape>("FInferShape", RegressionOpShape)               \
+  .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<2, 1>)                \
   .set_attr<nnvm::FGradient>("FGradient", RegressionOpGrad{__bwdop$})          \
   .set_attr<nnvm::FInplaceOption>("FInplaceOption",                            \
   [](const NodeAttrs& attrs){                                                  \
@@ -48,6 +50,7 @@
   .set_num_inputs(2)                                                       \
   .set_num_outputs(2)                                                      \
   .set_attr_parser(ParamParser<RegressionOutputParam>)                     \
+  .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<2, 2>)            \
   .set_attr<nnvm::TIsBackward>("TIsBackward", true)                        \
   .set_attr<nnvm::FInplaceOption>("FInplaceOption",                        \
   [](const NodeAttrs& attrs){                                              \


### PR DESCRIPTION
## Description ##
fix https://github.com/apache/incubator-mxnet/issues/9847

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
