### PR TITLE
Fix a race condition in converting data layouts in MKLDNN.

### DIFF
--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -628,6 +628,11 @@ class NDArray {
     CHECK_EQ(storage_type(), kDefaultStorage);
     ptr_->Reorder2Default();
   }
+  /*
+   * This creates a new NDArray with the reordered data.
+   * This doesn't affect the data of the original NDArray.
+   */
+  NDArray Reorder2Default() const;
 
   void InvalidateMKLDNNData() {
     // Removing mkl_mem_ means the NDArray will store data in the default format.

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -628,11 +628,21 @@ class NDArray {
     CHECK_EQ(storage_type(), kDefaultStorage);
     ptr_->Reorder2Default();
   }
+
   /*
-   * This creates a new NDArray with the reordered data.
-   * This doesn't affect the data of the original NDArray.
+   * These are the async version of the methods above.
+   * It changes the layout of this NDArray, but it happens after all accesses to
+   * the array are complete.
+   */
+  void Reorder2DefaultAsync();
+  void MKLDNNDataReorderAsync(const mkldnn::memory::primitive_desc &desc);
+
+  /*
+   * These create new NDArrays with the reordered data.
+   * They don't affect the data of the original NDArray.
    */
   NDArray Reorder2Default() const;
+  NDArray MKLDNNDataReorder(const mkldnn::memory::primitive_desc &desc) const;
 
   void InvalidateMKLDNNData() {
     // Removing mkl_mem_ means the NDArray will store data in the default format.

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -623,7 +623,10 @@ class NDArray {
   /*
    * Reorder the memory to the specified layout.
    */
-  void MKLDNNDataReorder(const mkldnn::memory::primitive_desc &desc);
+  void MKLDNNDataReorder(const mkldnn::memory::primitive_desc &desc) {
+    CHECK_EQ(storage_type(), kDefaultStorage);
+    ptr_->MKLDNNDataReorder(desc);
+  }
   void Reorder2Default() {
     CHECK_EQ(storage_type(), kDefaultStorage);
     ptr_->Reorder2Default();
@@ -638,11 +641,10 @@ class NDArray {
   void MKLDNNDataReorderAsync(const mkldnn::memory::primitive_desc &desc);
 
   /*
-   * These create new NDArrays with the reordered data.
-   * They don't affect the data of the original NDArray.
+   * This creates a new NDArray with the reordered data.
+   * It doesn't affect the data of the original NDArray.
    */
   NDArray Reorder2Default() const;
-  NDArray MKLDNNDataReorder(const mkldnn::memory::primitive_desc &desc) const;
 
   void InvalidateMKLDNNData() {
     // Removing mkl_mem_ means the NDArray will store data in the default format.
@@ -896,9 +898,11 @@ class NDArray {
     // Have MKL memory reference to the data in the default storage
     // or create memory for MKLDNN.
     void SetMKLMem(const TShape &shape, int dtype);
-    // In the data is stored in MKLDNN layout, we reorder data in mkl_mem_ and
+    // If the data is stored in MKLDNN layout, we reorder data in mkl_mem_ and
     // save the result in shandle.
     void Reorder2Default();
+    // Reroder data to a specified layout.
+    void MKLDNNDataReorder(const mkldnn::memory::primitive_desc &desc);
     bool IsMKLDNN() const;
     bool IsDefault() const;
 #endif

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -523,7 +523,7 @@ NDArray NDArray::MKLDNNDataReorder(const mkldnn::memory::primitive_desc &desc) c
 
   NDArray ret(shape(), ctx(), false, dtype());
   CHECK(ret.ptr_->shandle.size >= desc.get_size());
-  mkldnn::memory mem(desc, ret.ptr_->shandle.dptr);
+  ret.ptr_->mkl_mem_.reset(new mkldnn::memory(desc, ret.ptr_->shandle.dptr));
   mkldnn_mem_ptr this_mem;
   mkldnn::memory::primitive_desc _desc = desc;
   int ndim = shape_.ndim();
@@ -540,7 +540,7 @@ NDArray NDArray::MKLDNNDataReorder(const mkldnn::memory::primitive_desc &desc) c
   }
   // This may be called in MKLDNN operators. We can't use MKLDNNStream here.
   std::vector<mkldnn::primitive> net;
-  net.push_back(mkldnn::reorder(*this_mem, mem));
+  net.push_back(mkldnn::reorder(*this_mem, *ret.ptr_->mkl_mem_));
   mkldnn::stream(mkldnn::stream::kind::eager).submit(net).wait();
   return ret;
 }

--- a/src/operator/nn/mkldnn/mkldnn_base.cc
+++ b/src/operator/nn/mkldnn/mkldnn_base.cc
@@ -281,7 +281,7 @@ void FallBackCompute(FCompute fn, const nnvm::NodeAttrs &attrs,
     } else {
       in_bufs.emplace_back(inputs[i].shape(), inputs[i].ctx(),
                            false, inputs[i].dtype());
-      auto mem = inputs[i].GetMKLDNNData();
+      const mkldnn::memory *mem = inputs[i].GetMKLDNNData();
       in_bufs.back().CopyFrom(*mem);
       in_blobs[i] = in_bufs.back().data();
     }

--- a/src/operator/nn/mkldnn/mkldnn_base.cc
+++ b/src/operator/nn/mkldnn/mkldnn_base.cc
@@ -270,9 +270,24 @@ void FallBackCompute(FCompute fn, const nnvm::NodeAttrs &attrs,
                      const std::vector<OpReqType> &req,
                      const std::vector<NDArray> &outputs) {
   std::vector<TBlob> in_blobs(inputs.size());
+  std::vector<NDArray> in_bufs;
   for (size_t i = 0; i < in_blobs.size(); i++) {
+    // If the input data isn't stored in the default format, we shouldn't
+    // call data() directly, which will change the layout of the NDArray.
+    // Instead, we should save the converted data in another NDArray.
+    // TODO(zhengda) we should use temp space to save the converted data.
+    if (inputs[i].IsDefaultData()) {
       in_blobs[i] = inputs[i].data();
+    } else {
+      in_bufs.emplace_back(inputs[i].shape(), inputs[i].ctx(),
+                           false, inputs[i].dtype());
+      auto mem = inputs[i].GetMKLDNNData();
+      in_bufs.back().CopyFrom(*mem);
+      in_blobs[i] = in_bufs.back().data();
+    }
   }
+  MKLDNNStream::Get()->Submit();
+
   std::vector<TBlob> out_blobs(outputs.size());
   for (size_t i = 0; i < out_blobs.size(); i++) {
     if (req[i] == kWriteTo)

--- a/src/operator/nn/mkldnn/mkldnn_convolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_convolution.cc
@@ -262,8 +262,8 @@ void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx
                                const std::vector<NDArray> &out_data) {
   TmpMemMgr::Get()->Init(ctx.requested[conv::kTempSpace]);
   const ConvolutionParam& param = nnvm::get<ConvolutionParam>(attrs.parsed);
-  MKLDNNConvForward &fwd = GetConvFwd(attrs,
-      ctx.is_train, in_data[conv::kData], in_data[conv::kWeight],
+  NDArray weight = in_data[conv::kWeight];
+  MKLDNNConvForward &fwd = GetConvFwd(attrs, ctx.is_train, in_data[conv::kData], weight,
       param.no_bias ? nullptr : &in_data[conv::kBias], out_data[conv::kOut]);
 
   auto data_mem = in_data[conv::kData].GetMKLDNNDataReorder(fwd.fwd_pd.src_primitive_desc());
@@ -271,16 +271,24 @@ void MKLDNNConvolutionForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx
   if (ctx.is_train) {
     // TODO(zhengda) kvstore doesn't handle MKLDNN correctly. Let's reorder it
     // to the default format for now.
-    if (in_data[conv::kWeight].IsMKLDNNData())
-      const_cast<NDArray &>(in_data[conv::kWeight]).Reorder2Default();
-    weight_mem = GetWeights(in_data[conv::kWeight], fwd.fwd_pd.weights_primitive_desc(),
-                            param.num_group);
+    if (weight.IsMKLDNNData())
+      // This asks the engine to change the layout of the weight array after
+      // it's used.
+      weight.Reorder2DefaultAsync();
+    weight_mem = GetWeights(weight, fwd.fwd_pd.weights_primitive_desc(), param.num_group);
   } else {
     // For inference, we want to reorder the weight array so we don't need to
     // reorder data every time.
-    const_cast<NDArray &>(in_data[conv::kWeight]).MKLDNNDataReorder(
-        fwd.fwd_pd.weights_primitive_desc());
-    weight_mem = in_data[conv::kWeight].GetMKLDNNData();
+    if (weight.IsDefaultData()) {
+      const NDArray tmp_weight = weight;
+      // This is the weight array we should use in this invocation.
+      weight = tmp_weight.MKLDNNDataReorder(fwd.fwd_pd.weights_primitive_desc());
+      // We also need to modify the layout on the original weight array. The
+      // data conversion happens after the weight array is used.
+      const_cast<NDArray &>(in_data[conv::kWeight]).MKLDNNDataReorderAsync(
+          fwd.fwd_pd.weights_primitive_desc());
+    }
+    weight_mem = weight.GetMKLDNNData();
   }
   auto out_mem = CreateMKLDNNMem(out_data[conv::kOut], fwd.fwd_pd.dst_primitive_desc(),
                                  req[conv::kOut]);

--- a/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
@@ -234,21 +234,28 @@ void MKLDNNDeconvForward::SetDataHandle(const DeconvolutionParam& param,
                                         const std::vector<NDArray> &out_data) {
   auto data_mem = in_data[deconv::kData].GetMKLDNNDataReorder(
       fwd_pd.diff_dst_primitive_desc());
+  NDArray weight = in_data[deconv::kWeight];
   const mkldnn::memory *weight_mem;
   if (ctx.is_train) {
     // TODO(zhengda) kvstore doesn't handle MKLDNN correctly. Let's reorder it
     // to the default format for now.
-    if (in_data[deconv::kWeight].IsMKLDNNData())
-      const_cast<NDArray &>(in_data[deconv::kWeight]).Reorder2Default();
-    weight_mem = GetWeights(in_data[deconv::kWeight],
-                            fwd_pd.weights_primitive_desc(),
-                            param.num_group);
+    if (weight.IsMKLDNNData())
+      // This asks the engine to reorder data after the weight array is used.
+      weight.Reorder2DefaultAsync();
+    weight_mem = GetWeights(weight, fwd_pd.weights_primitive_desc(), param.num_group);
   } else {
     // For inference, we want to reorder the weight array so we don't need to
     // reorder data every time.
-    const_cast<NDArray &>(in_data[deconv::kWeight]).MKLDNNDataReorder(
-        fwd_pd.weights_primitive_desc());
-    weight_mem = in_data[deconv::kWeight].GetMKLDNNData();
+    if (weight.IsDefaultData()) {
+      const NDArray tmp_weight = weight;
+      // This is the weight array we should use in this invocation.
+      weight = tmp_weight.MKLDNNDataReorder(fwd_pd.weights_primitive_desc());
+      // We also need to modify the layout on the original weight array. The
+      // data conversion happens after the weight array is used.
+      const_cast<NDArray &>(in_data[deconv::kWeight]).MKLDNNDataReorderAsync(
+          fwd_pd.weights_primitive_desc());
+    }
+    weight_mem = weight.GetMKLDNNData();
   }
   auto out_mem = CreateMKLDNNMem(out_data[deconv::kOut],
       fwd_pd.diff_src_primitive_desc(), req[deconv::kOut]);

--- a/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
+++ b/src/operator/nn/mkldnn/mkldnn_deconvolution.cc
@@ -247,15 +247,14 @@ void MKLDNNDeconvForward::SetDataHandle(const DeconvolutionParam& param,
     // For inference, we want to reorder the weight array so we don't need to
     // reorder data every time.
     if (weight.IsDefaultData()) {
-      const NDArray tmp_weight = weight;
-      // This is the weight array we should use in this invocation.
-      weight = tmp_weight.MKLDNNDataReorder(fwd_pd.weights_primitive_desc());
+      weight_mem = GetWeights(weight, fwd_pd.weights_primitive_desc(), param.num_group);
       // We also need to modify the layout on the original weight array. The
       // data conversion happens after the weight array is used.
-      const_cast<NDArray &>(in_data[deconv::kWeight]).MKLDNNDataReorderAsync(
-          fwd_pd.weights_primitive_desc());
+      weight.MKLDNNDataReorderAsync(fwd_pd.weights_primitive_desc());
+    } else {
+      weight_mem = weight.GetMKLDNNData();
+      CHECK(weight_mem->get_primitive_desc() == fwd_pd.weights_primitive_desc());
     }
-    weight_mem = weight.GetMKLDNNData();
   }
   auto out_mem = CreateMKLDNNMem(out_data[deconv::kOut],
       fwd_pd.diff_src_primitive_desc(), req[deconv::kOut]);

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -90,6 +90,11 @@ void MKLDNNFCForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
   const TShape& oshape = out_data[fullc::kOut].shape();
   NDArray weight = in_data[fullc::kWeight];
   NDArray data = in_data[fullc::kData];
+  // If the input data is a view of an MKLDNN array, we should create a new
+  // NDArray with reordered data.
+  if (data.IsMKLDNNData() && data.IsView())
+    data = in_data[fullc::kData].Reorder2Default();
+
   auto out_md = GetMemDesc(out_data[fullc::kOut]);
   if (data.shape().ndim() != 2 && !param.flatten) {
     data = data.MKLDNNDataReshape(Shape2(ishape.ProdShape(0, ishape.ndim()-1),

--- a/src/operator/tensor/cast_storage-inl.h
+++ b/src/operator/tensor/cast_storage-inl.h
@@ -351,7 +351,12 @@ void CastStorageComputeImpl(const OpContext& ctx,
     CHECK_EQ(output.ctx().dev_type, input.ctx().dev_type);
     // If one of them uses the MKLDNN layout.
     if (input.IsMKLDNNData() || output.IsMKLDNNData()) {
-      auto in_mem = input.GetMKLDNNData();
+      NDArray tmp_input = input;
+      // If the input data is MKLDNN and is a view, we need to reorder the input
+      // data first.
+      if (input.IsMKLDNNData() && input.IsView())
+        tmp_input = input.Reorder2Default();
+      const mkldnn::memory *in_mem = tmp_input.GetMKLDNNData();
       const_cast<NDArray &>(output).CopyFrom(*in_mem);
       MKLDNNStream::Get()->Submit();
     } else {

--- a/src/operator/tensor/elemwise_sum.cc
+++ b/src/operator/tensor/elemwise_sum.cc
@@ -123,9 +123,9 @@ void ElementWiseSumComputeExCPU(const nnvm::NodeAttrs& attrs,
 #if MXNET_USE_MKLDNN == 1
   } else if (IsMKLDNNData(inputs)) {
     MKLDNNSumForward(attrs, ctx, inputs, req[0], outputs[0]);
-#endif
   } else if (common::ContainsOnlyStorage(inputs, kDefaultStorage)) {
     FallBackCompute(ElementWiseSumCompute<cpu>, attrs, ctx, inputs, req, outputs);
+#endif
   } else {
     LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }

--- a/src/operator/tensor/elemwise_sum.cc
+++ b/src/operator/tensor/elemwise_sum.cc
@@ -25,6 +25,7 @@
 #include "./elemwise_sum.h"
 #include "../../ndarray/ndarray_function.h"
 #include "../nn/mkldnn/mkldnn_ops-inl.h"
+#include "../nn/mkldnn/mkldnn_base-inl.h"
 #include "../../common/utils.h"
 
 namespace mxnet {
@@ -124,17 +125,7 @@ void ElementWiseSumComputeExCPU(const nnvm::NodeAttrs& attrs,
     MKLDNNSumForward(attrs, ctx, inputs, req[0], outputs[0]);
 #endif
   } else if (common::ContainsOnlyStorage(inputs, kDefaultStorage)) {
-    // This case happens when we want to create an MKLDNN NDArray but the type
-    // or the shape isn't supported by MKLDNN. In this case, NDArray falls back
-    // to the default storage type and, thus, we have to handle the default
-    // storage in FComputeEx.
-    std::vector<TBlob> in_blobs(inputs.size());
-    std::vector<TBlob> out_blobs(outputs.size());
-    for (size_t i = 0; i < in_blobs.size(); i++)
-      in_blobs[i] = inputs[i].data();
-    for (size_t i = 0; i < out_blobs.size(); i++)
-      out_blobs[i] = outputs[i].data();
-    ElementWiseSumCompute<cpu>(attrs, ctx, in_blobs, req, out_blobs);
+    FallBackCompute(ElementWiseSumCompute<cpu>, attrs, ctx, inputs, req, outputs);
   } else {
     LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
   }

--- a/tests/python/gpu/test_gluon_model_zoo_gpu.py
+++ b/tests/python/gpu/test_gluon_model_zoo_gpu.py
@@ -37,11 +37,10 @@ def download_data():
     return mx.test_utils.download(
         'http://data.mxnet.io/data/val-5k-256.rec', VAL_DATA)
 
-@with_seed()
+@with_seed(1)
 def test_inference():
     all_models = ['resnet50_v1', 'vgg19_bn', 'alexnet', #'inceptionv3',
                   'densenet201', 'squeezenet1.0', 'mobilenet0.25']
-    mx.random.seed(2)
 
     batch_size = 10
     download_data()
@@ -101,13 +100,12 @@ def get_nn_model(name):
 # Seed 1521019752 produced a failure on the Py2 MKLDNN-GPU CI runner
 # on 2/16/2018 that was not reproducible.  Problem could be timing related or
 # based on non-deterministic algo selection.
-@with_seed()
+@with_seed(1)
 def test_training():
     # We use network models without dropout for testing.
     # TODO(zhengda) mobilenet can't pass this test even without MKLDNN.
     all_models = ['resnet18_v1', 'densenet121']
 
-    mx.random.seed(1)
     batch_size = 10
     label = mx.nd.random.uniform(low=0, high=10, shape=(batch_size)).astype('int32')
 


### PR DESCRIPTION
## Description ##
There is a race condition in data layout conversion in the MKLDNN implementation. 
Currently, when NDArray::data() is called, it converts data format (from the MKLDNN format to the default format) inside an NDArray. In the threaded execution engine, while an NDArray is being converted in a thread, the array can also be read by another thread. In this case, the other thread can read wrong data. A similar race condition may also exist in the MKLML integration, which sometimes generates the garbage results.

Please see the details of the error in https://github.com/apache/incubator-mxnet/issues/9820

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
