### PR TITLE
Fix broken website build and update version number

### DIFF
--- a/docs/build_version_doc/build_all_version.sh
+++ b/docs/build_version_doc/build_all_version.sh
@@ -21,7 +21,10 @@
 # Built files are stored in $built
 # Version numbers are stored in $tag_list.
 # Version numbers are ordered from latest to old and final one is master.
-tag_list="1.0.0 0.12.1 0.12.0 0.11.0 master"
+set -e
+set -x
+
+tag_list="1.1.0 1.0.0 0.12.1 0.12.0 0.11.0 master"
 
 mxnet_url="https://github.com/apache/incubator-mxnet.git"
 mxnet_folder="apache_mxnet"

--- a/docs/build_version_doc/build_doc.sh
+++ b/docs/build_version_doc/build_doc.sh
@@ -16,7 +16,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+set -e
+set -x
 
 web_url="$1"
 web_folder="VersionedWeb"
@@ -57,7 +58,7 @@ then
     cat $tag_list_file
     tests/ci_build/ci_build.sh doc python docs/build_version_doc/AddVersion.py --file_path "docs/_build/html/" --current_version "$latest_tag"
     tests/ci_build/ci_build.sh doc python docs/build_version_doc/AddPackageLink.py \
-                                          --file_path "docs/_build/html/get_started/install.html" --current_version "$latest_tag"
+                                          --file_path "docs/_build/html/install/index.html" --current_version "$latest_tag"
     cp -a "docs/_build/html/." "$local_build"
     cp $tag_list_file "$local_build/tag.txt"
     rm -rf "$web_folder/.git"


### PR DESCRIPTION
Update website build script to point to the right file
Add 1.1.0 to build_all_versions.sh
Made build scripts fail fast with set -xe