### PR TITLE
add doc for gluon contrib

### DIFF
--- a/docs/api/python/gluon/contrib.md
+++ b/docs/api/python/gluon/contrib.md
@@ -24,22 +24,60 @@ In the rest of this document, we list routines provided by the `gluon.contrib` p
 
 ## Contrib
 
+### Neural network
+
 ```eval_rst
-.. currentmodule:: mxnet.gluon.contrib
+.. currentmodule:: mxnet.gluon.contrib.nn
 
 .. autosummary::
     :nosignatures:
 
-    rnn.VariationalDropoutCell
-    rnn.Conv1DRNNCell
-    rnn.Conv2DRNNCell
-    rnn.Conv3DRNNCell
-    rnn.Conv1DLSTMCell
-    rnn.Conv2DLSTMCell
-    rnn.Conv3DLSTMCell
-    rnn.Conv1DGRUCell
-    rnn.Conv2DGRUCell
-    rnn.Conv3DGRUCell
+    Concurrent
+    HybridConcurrent
+    Identity
+```
+
+### Recurrent neural network
+
+```eval_rst
+.. currentmodule:: mxnet.gluon.contrib.rnn
+
+.. autosummary::
+    :nosignatures:
+
+    VariationalDropoutCell
+    Conv1DRNNCell
+    Conv2DRNNCell
+    Conv3DRNNCell
+    Conv1DLSTMCell
+    Conv2DLSTMCell
+    Conv3DLSTMCell
+    Conv1DGRUCell
+    Conv2DGRUCell
+    Conv3DGRUCell
+```
+
+### Data
+
+```eval_rst
+.. currentmodule:: mxnet.gluon.contrib.data
+
+.. autosummary::
+    :nosignatures:
+
+    IntervalSampler
+```
+
+#### Text dataset
+
+```eval_rst
+.. currentmodule:: mxnet.gluon.contrib.data.text
+
+.. autosummary::
+    :nosignatures:
+
+    WikiText2
+    WikiText103
 ```
 
 ## API Reference
@@ -52,7 +90,19 @@ In the rest of this document, we list routines provided by the `gluon.contrib` p
     :members:
     :imported-members:
 
+.. automodule:: mxnet.gluon.contrib.nn
+    :members:
+    :imported-members:
+
 .. automodule:: mxnet.gluon.contrib.rnn
+    :members:
+    :imported-members:
+
+.. automodule:: mxnet.gluon.contrib.data
+    :members:
+    :imported-members:
+
+.. automodule:: mxnet.gluon.contrib.data.text
     :members:
     :imported-members:
 

--- a/python/mxnet/gluon/contrib/data/text.py
+++ b/python/mxnet/gluon/contrib/data/text.py
@@ -108,7 +108,7 @@ class WikiText2(_WikiText):
 
     Parameters
     ----------
-    root : str, default '~/.mxnet/datasets/cifar10'
+    root : str, default '~/.mxnet/datasets/wikitext-2'
         Path to temp folder for storing data.
     segment : str, default 'train'
         Dataset segment. Options are 'train', 'validation', 'test'.
@@ -146,7 +146,7 @@ class WikiText103(_WikiText):
 
     Parameters
     ----------
-    root : str, default '~/.mxnet/datasets/cifar10'
+    root : str, default '~/.mxnet/datasets/wikitext-103'
         Path to temp folder for storing data.
     segment : str, default 'train'
         Dataset segment. Options are 'train', 'validation', 'test'.


### PR DESCRIPTION
## Description ##
add api doc that was missed in previous PRs.
doc is rendered at http://mxnet-doc.s3-accelerate.dualstack.amazonaws.com/api/python/gluon/contrib.html

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] add api doc entries for gluon.contrib