### PR TITLE
temporary fix to update the verionsioning of 1.1.0 that is skipped du…

### DIFF
--- a/docs/build_version_doc/build_doc.sh
+++ b/docs/build_version_doc/build_doc.sh
@@ -49,12 +49,12 @@ then
 fi
 
 # Build new released tag
-if [ $latest_tag != ${tag_list[0]} ]
+if [ $latest_tag == ${tag_list[0]} ] # this is a temporary fix changed from != to == (SHOULD BE REMOVED LATER)
 then
     echo "Building new tag"
     git submodule update
     make docs || exit 1
-    echo -e "$latest_tag\n$(cat $tag_list_file)" > "$tag_list_file"
+    #echo -e "$latest_tag\n$(cat $tag_list_file)" > "$tag_list_file"
     cat $tag_list_file
     tests/ci_build/ci_build.sh doc python docs/build_version_doc/AddVersion.py --file_path "docs/_build/html/" --current_version "$latest_tag"
     tests/ci_build/ci_build.sh doc python docs/build_version_doc/AddPackageLink.py \
@@ -83,7 +83,7 @@ cp -a "docs/_build/html/." "$web_folder/versions/master"
 tests/ci_build/ci_build.sh doc python docs/build_version_doc/AddVersion.py --file_path "$web_folder/versions/master"
 
 # Update version list for all previous version website
-if [ $latest_tag != ${tag_list[0]} ]
+if [ $latest_tag == ${tag_list[0]} ] # this is a temporary fix changed from != to == (SHOULD BE REMOVED LATER)
 then
     total=${#tag_list[*]}
     for (( i=0; i<=$(( $total -1 )); i++ ))


### PR DESCRIPTION

## Description ##
Because of missed process in building new versioned mxnet we are in a situation that the versioned folder is not being built for 1.1.0. Due to this issue, once users switch to "master" they cannot switch back to "1.1.0" as the link does not exist.

* This PR is only to mitigate the issue at the moment.
* After merging this this code, the nightly job needs to  be run manually, validate the website.
* After testing revert the code back to original state.