### PR TITLE
Better even_split=False support in gluon.split_data()

### DIFF
--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -74,12 +74,13 @@ def split_data(data, num_slice, batch_axis=0, even_split=True):
         slices = ndarray.split(data, num_outputs=num_slice, axis=batch_axis)
     else:
         # First `rem` slices will have an extra sample
-        slices = [ndarray.slice_axis(data, batch_axis, i*(step+1), (i+1)*(step+1)) for i in range(rem)]
+        slices = [ndarray.slice_axis(data, batch_axis, i*(step+1), (i+1)*(step+1))
+                  for i in range(rem)]
         offset = rem*(step+1)
         # Create the remaining slices
         if step > 0:
-            slices += [ndarray.slice_axis(data, batch_axis, offset+i*step, offset+(i+1)*step) 
-                        for i in range(num_slice-rem)]
+            slices += [ndarray.slice_axis(data, batch_axis, offset+i*step, offset+(i+1)*step)
+                       for i in range(num_slice-rem)]
     return slices
 
 

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -56,13 +56,10 @@ def split_data(data, num_slice, batch_axis=0, even_split=True):
     Returns
     -------
     list of NDArray
-        Return value is a list even if `num_slice` is 1.
+        Return value is a list even if `num_slice` is 1. When `even_split`
+        is `False` this may be shorter than `num_slice`.
     """
     size = data.shape[batch_axis]
-    if size < num_slice:
-        raise ValueError(
-            "Too many slices for data with shape %s. Arguments are " \
-            "num_slice=%d and batch_axis=%d."%(str(data.shape), num_slice, batch_axis))
     if even_split and size % num_slice != 0:
         raise ValueError(
             "data with shape %s cannot be evenly split into %d slices along axis %d. " \
@@ -71,16 +68,18 @@ def split_data(data, num_slice, batch_axis=0, even_split=True):
                 str(data.shape), num_slice, batch_axis, num_slice))
 
     step = size // num_slice
-    if batch_axis == 0:
-        slices = [data[i*step:(i+1)*step] if i < num_slice - 1 else data[i*step:size]
-                  for i in range(num_slice)]
-    elif even_split:
+    rem = size % num_slice
+
+    if rem == 0:
         slices = ndarray.split(data, num_outputs=num_slice, axis=batch_axis)
     else:
-        slices = [ndarray.slice_axis(data, batch_axis, i*step, (i+1)*step)
-                  if i < num_slice - 1 else
-                  ndarray.slice_axis(data, batch_axis, i*step, size)
-                  for i in range(num_slice)]
+        # First `rem` slices will have an extra sample
+        slices = [ndarray.slice_axis(data, batch_axis, i*(step+1), (i+1)*(step+1)) for i in range(rem)]
+        offset = rem*(step+1)
+        # Create the remaining slices
+        if step > 0:
+            slices += [ndarray.slice_axis(data, batch_axis, offset+i*step, offset+(i+1)*step) 
+                        for i in range(num_slice-rem)]
     return slices
 
 

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -404,9 +404,11 @@ def test_deferred_init():
     layer(x)
 
 
-def check_split_data(x, num_slice, batch_axis, **kwargs):
+def check_split_data(x, num_slice, batch_axis, slice_shapes, **kwargs):
     res = gluon.utils.split_data(x, num_slice, batch_axis, **kwargs)
-    assert len(res) == num_slice
+    assert len(res) == len(slice_shapes)
+    for res_slice, slice_shape in zip(res, slice_shapes):
+        assert res_slice.shape == slice_shape
     mx.test_utils.assert_almost_equal(mx.nd.concat(*res, dim=batch_axis).asnumpy(),
                                       x.asnumpy())
 
@@ -415,15 +417,16 @@ def check_split_data(x, num_slice, batch_axis, **kwargs):
 def test_split_data():
     x = mx.nd.random.uniform(shape=(128, 33, 64))
 
-    check_split_data(x, 8, 0)
-    check_split_data(x, 3, 1)
-    check_split_data(x, 4, 1, even_split=False)
-    check_split_data(x, 15, 1, even_split=False)
+    check_split_data(x, 8, 0, ((16, 33, 64),)*8)
+    check_split_data(x, 3, 1, ((128, 11, 64),)*3)
+    check_split_data(x, 4, 1, ((128, 9, 64),) + ((128, 8, 64),)*3, even_split=False)
+    check_split_data(x, 15, 1, ((128, 3, 64),)*3 + ((128, 2, 64),)*12, even_split=False)
+    check_split_data(x, 70, 2, ((128, 33, 1),)*64, even_split=False)
     try:
-        check_split_data(x, 4, 1)
+        check_split_data(x, 4, 1, ((128, 9, 64),) + ((128, 8, 64),)*3)
     except ValueError:
         return
-    assert False, "Should have failed"
+    assert False, "Should have failed because even_split=True"
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
When someone uses `even_split=False`, it means they want the data to be processed irrespective of how divisible the amount of data is. Suppose you have 8 GPUs. The old code would:
- Error out if the last batch only had 7 samples
- If you had 64+7 samples, one expects 7 GPUs w/ 9 and 1 GPU w/ 8; however, you got 7 GPUs w/ 8 and 1 GPU w/ 15.

This address both issues.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Support `size < num_slice` case
- [x] Use `ndarray.split()` when divisible, not just when `even_split=True`
- [x] More evenly distribute splits

## Comments ##
**One may be concerned by returning less than `num_slice` lists when `even_split=False`.** However, this is not a problem idiomatically. E.g., if `num_slice = len(context)`, the expression `zip(context, split)` would truncate to the length of `split <= num_slice`; note that `split_and_load` works as-is after changing `split_data`.