### PR TITLE
added function for loading content of nd_array files from a buffer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -157,3 +157,4 @@ List of Contributors
 * [Tao Hu](https://github.com/dongzhuoyao)
 * [Sorokin Evgeniy](https://github.com/TheTweak)
 * [dwSun](https://github.com/dwSun/)
+* [David Braude](https://github.com/dabraude/)

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -507,7 +507,7 @@ MXNET_DLL int MXNDArrayLoad(const char* fname,
  * manner to MXNDArrayLoad, however, it loads from
  * buffer containing the contents of a file, rather than
  * from a specified file.
- * \param nd_file pointer to the start of the ndarray file content
+ * \param ndarray_buffer pointer to the start of the ndarray file content
  * \param size size of the file
  * \param out_size number of narray loaded.
  * \param out_arr head of the returning narray handles.
@@ -515,7 +515,7 @@ MXNET_DLL int MXNDArrayLoad(const char* fname,
  * \param out_names the names of returning NDArrays, can be NULL
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXNDArrayLoadFileContent(const void *nd_file,
+MXNET_DLL int MXNDArrayLoadFromBuffer(const void *ndarray_buffer,
                             size_t size,
                             mx_uint *out_size,
                             NDArrayHandle** out_arr,

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -500,6 +500,28 @@ MXNET_DLL int MXNDArrayLoad(const char* fname,
                             NDArrayHandle** out_arr,
                             mx_uint *out_name_size,
                             const char*** out_names);
+
+/*!
+ * \brief Load list / dictionary of narrays from file content loaded into memory.
+ * This will load a list of ndarrays in a similar
+ * manner to MXNDArrayLoad, however, it loads from
+ * buffer containing the contents of a file, rather than
+ * from a specified file.
+ * \param nd_file pointer to the start of the ndarray file content
+ * \param size size of the file
+ * \param out_size number of narray loaded.
+ * \param out_arr head of the returning narray handles.
+ * \param out_name_size size of output name arrray.
+ * \param out_names the names of returning NDArrays, can be NULL
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXNDArrayLoadFileContent(const void *nd_file,
+                            size_t size,
+                            mx_uint *out_size,
+                            NDArrayHandle** out_arr,
+                            mx_uint *out_name_size,
+                            const char*** out_names);
+
 /*!
  * \brief Perform a synchronize copy from a continugous CPU memory region.
  *

--- a/python/mxnet/ndarray/__init__.py
+++ b/python/mxnet/ndarray/__init__.py
@@ -27,7 +27,7 @@ from . import register
 from .op import *
 from .ndarray import *
 # pylint: enable=wildcard-import
-from .utils import load, save, zeros, empty, array
+from .utils import load, load_frombuffer, save, zeros, empty, array
 from .sparse import _ndarray_cls
 from .ndarray import _GRAD_REQ_MAP
 

--- a/python/mxnet/ndarray/utils.py
+++ b/python/mxnet/ndarray/utils.py
@@ -190,7 +190,7 @@ def load_frombuffer(buf):
     Parameters
     ----------
     buf : str
-        Buffer containing contents of a file as a string.
+        Buffer containing contents of a file as a string or bytes.
 
     Returns
     -------
@@ -198,13 +198,13 @@ def load_frombuffer(buf):
     dict of str to NDArray, RowSparseNDArray or CSRNDArray
         Loaded data.
     """
-    if not isinstance(buf, string_types):
-        raise TypeError('buf required to be a string')
+    if not isinstance(buf, string_types + tuple([bytes])):
+        raise TypeError('buf required to be a string or bytes')
     out_size = mx_uint()
     out_name_size = mx_uint()
     handles = ctypes.POINTER(NDArrayHandle)()
     names = ctypes.POINTER(ctypes.c_char_p)()
-    check_call(_LIB.MXNDArrayLoadFromBuffer(c_str(buf),
+    check_call(_LIB.MXNDArrayLoadFromBuffer(buf,
                                             mx_uint(len(buf)),
                                             ctypes.byref(out_size),
                                             ctypes.byref(handles),

--- a/python/mxnet/ndarray/utils.py
+++ b/python/mxnet/ndarray/utils.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     spsp = None
 
-__all__ = ['zeros', 'empty', 'array', 'load', 'save']
+__all__ = ['zeros', 'empty', 'array', 'load', 'load_frombuffer', 'save']
 
 
 def zeros(shape, ctx=None, dtype=None, stype=None, **kwargs):
@@ -169,6 +169,43 @@ def load(fname):
     handles = ctypes.POINTER(NDArrayHandle)()
     names = ctypes.POINTER(ctypes.c_char_p)()
     check_call(_LIB.MXNDArrayLoad(c_str(fname),
+                                  ctypes.byref(out_size),
+                                  ctypes.byref(handles),
+                                  ctypes.byref(out_name_size),
+                                  ctypes.byref(names)))
+    if out_name_size.value == 0:
+        return [_ndarray_cls(NDArrayHandle(handles[i])) for i in range(out_size.value)]
+    else:
+        assert out_name_size.value == out_size.value
+        return dict(
+            (py_str(names[i]), _ndarray_cls(NDArrayHandle(handles[i])))
+            for i in range(out_size.value))
+
+
+def load_frombuffer(buf):
+    """Loads an array dictionary or list from a buffer
+
+    See more details in ``save``.
+
+    Parameters
+    ----------
+    buf : str, bytes, bytearray
+        The filename.
+
+    Returns
+    -------
+    list of NDArray, RowSparseNDArray or CSRNDArray, or \
+    dict of str to NDArray, RowSparseNDArray or CSRNDArray
+        Loaded data.
+    """
+    if not isinstance(buf, string_types + (bytes, bytearray)):
+        raise TypeError('buf required to be a string, bytes, or bytearray')
+    out_size = mx_uint()
+    out_name_size = mx_uint()
+    handles = ctypes.POINTER(NDArrayHandle)()
+    names = ctypes.POINTER(ctypes.c_char_p)()
+    check_call(_LIB.MXNDArrayLoadFromBuffer(c_str(bytes(buf)),
+                                  mx_uint(len(buf)),
                                   ctypes.byref(out_size),
                                   ctypes.byref(handles),
                                   ctypes.byref(out_name_size),

--- a/python/mxnet/ndarray/utils.py
+++ b/python/mxnet/ndarray/utils.py
@@ -205,11 +205,11 @@ def load_frombuffer(buf):
     handles = ctypes.POINTER(NDArrayHandle)()
     names = ctypes.POINTER(ctypes.c_char_p)()
     check_call(_LIB.MXNDArrayLoadFromBuffer(c_str(bytes(buf)),
-                                  mx_uint(len(buf)),
-                                  ctypes.byref(out_size),
-                                  ctypes.byref(handles),
-                                  ctypes.byref(out_name_size),
-                                  ctypes.byref(names)))
+                                            mx_uint(len(buf)),
+                                            ctypes.byref(out_size),
+                                            ctypes.byref(handles),
+                                            ctypes.byref(out_name_size),
+                                            ctypes.byref(names)))
     if out_name_size.value == 0:
         return [_ndarray_cls(NDArrayHandle(handles[i])) for i in range(out_size.value)]
     else:

--- a/python/mxnet/ndarray/utils.py
+++ b/python/mxnet/ndarray/utils.py
@@ -189,8 +189,8 @@ def load_frombuffer(buf):
 
     Parameters
     ----------
-    buf : str, bytes, bytearray
-        The filename.
+    buf : str
+        Buffer containing contents of a file as a string.
 
     Returns
     -------
@@ -198,13 +198,13 @@ def load_frombuffer(buf):
     dict of str to NDArray, RowSparseNDArray or CSRNDArray
         Loaded data.
     """
-    if not isinstance(buf, string_types + (bytes, bytearray)):
-        raise TypeError('buf required to be a string, bytes, or bytearray')
+    if not isinstance(buf, string_types):
+        raise TypeError('buf required to be a string')
     out_size = mx_uint()
     out_name_size = mx_uint()
     handles = ctypes.POINTER(NDArrayHandle)()
     names = ctypes.POINTER(ctypes.c_char_p)()
-    check_call(_LIB.MXNDArrayLoadFromBuffer(c_str(bytes(buf)),
+    check_call(_LIB.MXNDArrayLoadFromBuffer(c_str(buf),
                                             mx_uint(len(buf)),
                                             ctypes.byref(out_size),
                                             ctypes.byref(handles),

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -336,7 +336,7 @@ int MXNDArrayLoadFromBuffer(const void *ndarray_buffer,
   std::vector<std::string> &names = ret->ret_vec_str;
   {
     std::unique_ptr<dmlc::MemoryFixedSizeStream> fi(new dmlc::MemoryFixedSizeStream(
-            reinterpret_cast<void*>(ndarray_buffer), size));
+            const_cast<void*>(ndarray_buffer), size));
     mxnet::NDArray::Load(fi.get(), &data, &names);
   }
   ret->ret_handles.resize(data.size());

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -335,8 +335,8 @@ int MXNDArrayLoadFromBuffer(const void *ndarray_buffer,
   std::vector<NDArray> data;
   std::vector<std::string> &names = ret->ret_vec_str;
   {
-    std::unique_ptr<dmlc::MemoryFixedSizeStream> fi(
-        new dmlc::MemoryFixedSizeStream((void*)ndarray_buffer, size));
+    std::unique_ptr<dmlc::MemoryFixedSizeStream> fi(new dmlc::MemoryFixedSizeStream(
+            reinterpret_cast<void*>(ndarray_buffer), size));
     mxnet::NDArray::Load(fi.get(), &data, &names);
   }
   ret->ret_handles.resize(data.size());

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -322,6 +322,38 @@ int MXNDArrayLoad(const char* fname,
   API_END();
 }
 
+int MXNDArrayLoadFileContent(const void *nd_file,
+                            size_t size,
+                            mx_uint *out_size,
+                            NDArrayHandle** out_arr,
+                            mx_uint *out_name_size,
+                            const char*** out_names) {
+  MXAPIThreadLocalEntry *ret = MXAPIThreadLocalStore::Get();
+  ret->ret_vec_str.clear();
+  API_BEGIN();
+  std::vector<NDArray> data;
+  std::vector<std::string> &names = ret->ret_vec_str;
+  {
+    std::unique_ptr<dmlc::MemoryFixedSizeStream> fi(new dmlc::MemoryFixedSizeStream((void*)nd_file, size)); // NOLINT(*)
+    mxnet::NDArray::Load(fi.get(), &data, &names);
+  }
+  ret->ret_handles.resize(data.size());
+  for (size_t i = 0; i < data.size(); ++i) {
+    NDArray *ptr = new NDArray();
+    *ptr = data[i];
+    ret->ret_handles[i] = ptr;
+  }
+  ret->ret_vec_charp.resize(names.size());
+  for (size_t i = 0; i < names.size(); ++i) {
+    ret->ret_vec_charp[i] = names[i].c_str();
+  }
+  *out_size = static_cast<mx_uint>(data.size());
+  *out_arr = dmlc::BeginPtr(ret->ret_handles);
+  *out_name_size = static_cast<mx_uint>(names.size());
+  *out_names = dmlc::BeginPtr(ret->ret_vec_charp);
+  API_END();
+}
+
 int MXNDArrayFree(NDArrayHandle handle) {
   API_BEGIN();
   delete static_cast<NDArray*>(handle);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -322,7 +322,7 @@ int MXNDArrayLoad(const char* fname,
   API_END();
 }
 
-int MXNDArrayLoadFileContent(const void *nd_file,
+int MXNDArrayLoadFromBuffer(const void *ndarray_buffer,
                             size_t size,
                             mx_uint *out_size,
                             NDArrayHandle** out_arr,
@@ -331,10 +331,12 @@ int MXNDArrayLoadFileContent(const void *nd_file,
   MXAPIThreadLocalEntry *ret = MXAPIThreadLocalStore::Get();
   ret->ret_vec_str.clear();
   API_BEGIN();
+  CHECK_NOTNULL(ndarray_buffer);
   std::vector<NDArray> data;
   std::vector<std::string> &names = ret->ret_vec_str;
   {
-    std::unique_ptr<dmlc::MemoryFixedSizeStream> fi(new dmlc::MemoryFixedSizeStream((void*)nd_file, size)); // NOLINT(*)
+    std::unique_ptr<dmlc::MemoryFixedSizeStream> fi(
+        new dmlc::MemoryFixedSizeStream((void*)ndarray_buffer, size));
     mxnet::NDArray::Load(fi.get(), &data, &names);
   }
   ret->ret_handles.resize(data.size());

--- a/tests/python/unittest/common.py
+++ b/tests/python/unittest/common.py
@@ -26,6 +26,7 @@ sys.path.insert(0, os.path.join(curr_path, '../../../python'))
 import models
 from contextlib import contextmanager
 from nose.tools import make_decorator
+import tempfile
 
 def assertRaises(expected_exception, func, *args, **kwargs):
     try:
@@ -225,3 +226,18 @@ def setup_module():
     #  the 'with_seed()' decoration.  Inform the user of this once here at the module level.
     if os.getenv('MXNET_TEST_SEED') is not None:
         logger.warn('*** test-level seed set: all "@with_seed()" tests run deterministically ***')
+
+try:
+    from tempfile import TemporaryDirectory
+except:
+    import shutil
+    # really simple implementation of TemporaryDirectory
+    class TemporaryDirectory(object):
+        def __init__(self, suffix='', prefix='', dir=''):
+            self._dirname = tempfile.mkdtemp(suffix, prefix, dir)
+
+        def __enter__(self):
+            return self._dirname
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            shutil.rmtree(self._dirname)

--- a/tests/python/unittest/common.py
+++ b/tests/python/unittest/common.py
@@ -19,6 +19,7 @@ import sys, os, logging
 import mxnet as mx
 import numpy as np
 import random
+import shutil
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.append(os.path.join(curr_path, '../common/'))
 sys.path.insert(0, os.path.join(curr_path, '../../../python'))
@@ -230,7 +231,6 @@ def setup_module():
 try:
     from tempfile import TemporaryDirectory
 except:
-    import shutil
     # really simple implementation of TemporaryDirectory
     class TemporaryDirectory(object):
         def __init__(self, suffix='', prefix='', dir=''):

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -295,27 +295,29 @@ def test_ndarray_legacy_load():
 @with_seed()
 def test_buffer_load():
     nrepeat = 10
-    tmpfile = tempfile.NamedTemporaryFile()
-    fname = tmpfile.name
     for repeat in range(nrepeat):
         data = []
         # test load_buffer as list
         for i in range(10):
             data.append(random_ndarray(np.random.randint(1, 5)))
-        tmpfile.seek(0)
+        tmpfile = tempfile.NamedTemporaryFile()
+        fname = tmpfile.name
         mx.nd.save(fname, data)
         tmpfile.seek(0)
         buf_data = tmpfile.read()
+        tmpfile.close()
         data2 = mx.nd.load_frombuffer(buf_data)
         assert len(data) == len(data2)
         for x, y in zip(data, data2):
             assert np.sum(x.asnumpy() != y.asnumpy()) == 0
         # test load_buffer as dict
         dmap = {'ndarray xx %s' % i : x for i, x in enumerate(data)}
-        tmpfile.seek(0)
+        tmpfile = tempfile.NamedTemporaryFile()
+        fname = tmpfile.name
         mx.nd.save(fname, data)
         tmpfile.seek(0)
         buf_dmap = tmpfile.read()
+        tmpfile.close()
         dmap2 = mx.nd.load_frombuffer(buf_dmap)
         assert len(dmap2) == len(dmap)
         for k, x in dmap.items():
@@ -324,10 +326,12 @@ def test_buffer_load():
         # test load_buffer as ndarray
         # we expect the single ndarray to be converted into a list containing the ndarray
         single_ndarray = data[0]
-        tmpfile.seek(0)
+        tmpfile = tempfile.NamedTemporaryFile()
+        fname = tmpfile.name
         mx.nd.save(fname, data)
         tmpfile.seek(0)
         buf_single_ndarray = tmpfile.read()
+        tmpfile.close()
         single_ndarray_loaded = mx.nd.load_frombuffer(buf_single_ndarray)
         assert len(single_ndarray_loaded) == 1
         single_ndarray_loaded = single_ndarray_loaded[0]

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -290,6 +290,7 @@ def test_ndarray_legacy_load():
     for i in range(len(data)):
         assert same(data[i].asnumpy(), legacy_data[i].asnumpy())
 
+
 @with_seed()
 def test_buffer_load():
     nrepeat = 10
@@ -330,7 +331,6 @@ def test_buffer_load():
         assertRaises(mx.base.MXNetError,  mx.nd.load_frombuffer, buf_single_ndarray[:-10])
         
     os.remove(fname)
-
 
 
 @with_seed()

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -313,7 +313,7 @@ def test_buffer_load():
                     assert np.sum(x.asnumpy() != y.asnumpy()) == 0
                 # test garbage values
                 assertRaises(mx.base.MXNetError,  mx.nd.load_frombuffer, buf_data[:-10])
-        os.remove(fname)
+            os.remove(fname)
 
         # test load_buffer as dict
         dmap = {'ndarray xx %s' % i : x for i, x in enumerate(data)}
@@ -330,7 +330,7 @@ def test_buffer_load():
                     assert np.sum(x.asnumpy() != y.asnumpy()) == 0
                 # test garbage values
                 assertRaises(mx.base.MXNetError,  mx.nd.load_frombuffer, buf_dmap[:-10])
-        os.remove(fname)
+            os.remove(fname)
 
         # we expect the single ndarray to be converted into a list containing the ndarray
         single_ndarray = data[0]
@@ -346,8 +346,7 @@ def test_buffer_load():
                 assert np.sum(single_ndarray.asnumpy() != single_ndarray_loaded.asnumpy()) == 0
                 # test garbage values
                 assertRaises(mx.base.MXNetError,  mx.nd.load_frombuffer, buf_single_ndarray[:-10])
-
-        os.remove(fname)
+            os.remove(fname)
 
 @with_seed()
 def test_ndarray_slice():

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -301,7 +301,7 @@ def test_buffer_load():
         for i in range(10):
             data.append(random_ndarray(np.random.randint(1, 5)))
         mx.nd.save(fname, data)
-        buf_data = open(fname, 'rb').read()
+        buf_data = str(open(fname, 'rb').read())
         data2 = mx.nd.load_frombuffer(buf_data)
         assert len(data) == len(data2)
         for x, y in zip(data, data2):
@@ -309,7 +309,7 @@ def test_buffer_load():
         # test load_buffer as dict
         dmap = {'ndarray xx %s' % i : x for i, x in enumerate(data)}
         mx.nd.save(fname, dmap)
-        buf_dmap = open(fname, 'rb').read()
+        buf_dmap = str(open(fname, 'rb').read())
         dmap2 = mx.nd.load_frombuffer(buf_dmap)
         assert len(dmap2) == len(dmap)
         for k, x in dmap.items():
@@ -319,17 +319,17 @@ def test_buffer_load():
         # we expect the single ndarray to be converted into a list containing the ndarray
         single_ndarray = data[0]
         mx.nd.save(fname, single_ndarray)
-        buf_single_ndarray = open(fname, 'rb').read()
+        buf_single_ndarray = str(open(fname, 'rb').read())
         single_ndarray_loaded = mx.nd.load_frombuffer(buf_single_ndarray)
         assert len(single_ndarray_loaded) == 1
         single_ndarray_loaded = single_ndarray_loaded[0]
         assert np.sum(single_ndarray.asnumpy() != single_ndarray_loaded.asnumpy()) == 0
-        
+
         # test garbage values
         assertRaises(mx.base.MXNetError,  mx.nd.load_frombuffer, buf_data[:-10])
         assertRaises(mx.base.MXNetError,  mx.nd.load_frombuffer, buf_dmap[:-10])
         assertRaises(mx.base.MXNetError,  mx.nd.load_frombuffer, buf_single_ndarray[:-10])
-        
+
     os.remove(fname)
 
 

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -296,7 +296,7 @@ def test_ndarray_legacy_load():
 @with_seed()
 def test_buffer_load():
     nrepeat = 10
-    tmp = tempfile.NamedTemporaryFile(mode='wb', dir=os.path.join(os.getcwd()))
+    tmp = tempfile.NamedTemporaryFile(mode='wb')
     fname = tmp.name
     for repeat in range(nrepeat):
         data = []

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -29,8 +29,6 @@ from mxnet.test_utils import np_reduce
 from mxnet.test_utils import same
 from numpy.testing import assert_allclose
 import mxnet.autograd
-import tempfile
-import shutil
 
 def check_with_uniform(uf, arg_shapes, dim=None, npuf=None, rmin=-10, type_list=[np.float32]):
     """check function consistency with uniform random numbers"""

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -301,7 +301,7 @@ def test_buffer_load():
         for i in range(10):
             data.append(random_ndarray(np.random.randint(1, 5)))
         mx.nd.save(fname, data)
-        buf_data = str(open(fname, 'rb').read())
+        buf_data = open(fname, 'rb').read()
         data2 = mx.nd.load_frombuffer(buf_data)
         assert len(data) == len(data2)
         for x, y in zip(data, data2):
@@ -309,7 +309,7 @@ def test_buffer_load():
         # test load_buffer as dict
         dmap = {'ndarray xx %s' % i : x for i, x in enumerate(data)}
         mx.nd.save(fname, dmap)
-        buf_dmap = str(open(fname, 'rb').read())
+        buf_dmap = open(fname, 'rb').read()
         dmap2 = mx.nd.load_frombuffer(buf_dmap)
         assert len(dmap2) == len(dmap)
         for k, x in dmap.items():
@@ -319,7 +319,7 @@ def test_buffer_load():
         # we expect the single ndarray to be converted into a list containing the ndarray
         single_ndarray = data[0]
         mx.nd.save(fname, single_ndarray)
-        buf_single_ndarray = str(open(fname, 'rb').read())
+        buf_single_ndarray = open(fname, 'rb').read()
         single_ndarray_loaded = mx.nd.load_frombuffer(buf_single_ndarray)
         assert len(single_ndarray_loaded) == 1
         single_ndarray_loaded = single_ndarray_loaded[0]


### PR DESCRIPTION
## Description ##
Adds a function for loading the content of an NDArray file.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Added function MXNDArrayLoadFileContent


## Comments ##
- As far as I can determine it is not possible for the current API to be able to load the content of an NDArray file without knowing a lot of details about the file format, saving the dtypes, and using both the c_api.h and the c_predict_api.h. 
- The symbol loading API allows you to load from a file by name or by a string containing the JSON content so this would put it inline with that.
- required for issue #9827
- Not sure if you are happy with the names but that is the best I could come up with.

