### PR TITLE
Fixed Android build

### DIFF
--- a/src/storage/cpu_shared_storage_manager.h
+++ b/src/storage/cpu_shared_storage_manager.h
@@ -20,11 +20,6 @@
 #ifndef MXNET_STORAGE_CPU_SHARED_STORAGE_MANAGER_H_
 #define MXNET_STORAGE_CPU_SHARED_STORAGE_MANAGER_H_
 
-#if MXNET_USE_CUDA
-  #include <cuda_runtime.h>
-#endif  // MXNET_USE_CUDA
-#include <mxnet/base.h>
-
 #ifndef _WIN32
 #include <sys/mman.h>
 #include <sys/fcntl.h>
@@ -46,8 +41,6 @@
 #include <limits>
 
 #include "./storage_manager.h"
-#include "../common/cuda_utils.h"
-
 
 namespace mxnet {
 namespace storage {

--- a/src/storage/cpu_shared_storage_manager.h
+++ b/src/storage/cpu_shared_storage_manager.h
@@ -20,6 +20,8 @@
 #ifndef MXNET_STORAGE_CPU_SHARED_STORAGE_MANAGER_H_
 #define MXNET_STORAGE_CPU_SHARED_STORAGE_MANAGER_H_
 
+#if !defined(ANDROID) && !defined(__ANDROID__)
+
 #ifndef _WIN32
 #include <sys/mman.h>
 #include <sys/fcntl.h>
@@ -227,5 +229,7 @@ inline void CPUSharedStorageManager::CheckAndRealFree() {
 #endif  // _WIN32
 }  // namespace storage
 }  // namespace mxnet
+
+#endif  // !defined(ANDROID) && !defined(__ANDROID__)
 
 #endif  // MXNET_STORAGE_CPU_SHARED_STORAGE_MANAGER_H_

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -51,7 +51,13 @@ class StorageImpl : public Storage {
   static void ActivateDevice(Context ctx) {
     switch (ctx.dev_type) {
       case Context::kCPU:
-      case Context::kCPUShared: break;
+        break;
+      case Context::kCPUShared: {
+#if defined(ANDROID) || defined(__ANDROID__)
+        LOG(FATAL) << "Unimplemented device";
+#endif  // defined(ANDROID) || defined(__ANDROID__)
+      }
+        break;
       case Context::kGPU:
       case Context::kCPUPinned: {
 #if MXNET_USE_CUDA
@@ -88,7 +94,9 @@ void StorageImpl::Alloc(Storage::Handle* handle) {
             break;
           }
           case Context::kCPUShared: {
+#if !defined(ANDROID) && !defined(__ANDROID__)
             ptr = new storage::CPUSharedStorageManager();
+#endif  // !defined(ANDROID) && !defined(__ANDROID__)
             break;
           }
           case Context::kCPUPinned: {

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -175,7 +175,11 @@ void StorageImpl::SharedIncrementRefCount(Storage::Handle handle) {
       LOG(FATAL) << "Cannot increment ref count before allocating any shared memory.";
       return nullptr;
     });
+#if defined(ANDROID) || defined(__ANDROID__)
+  LOG(FATAL) << "Shared memory not implemented on Android";
+#else
   dynamic_cast<storage::CPUSharedStorageManager*>(manager.get())->IncrementRefCount(handle);
+#endif  // defined(ANDROID) || defined(__ANDROID__)
 }
 
 std::shared_ptr<Storage> Storage::_GetSharedRef() {


### PR DESCRIPTION
## Description ##

POSIX shared memory functions are not available on Android.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Examples are either not affected by this change

### Changes ###
- [x] Defined guards for shared memory builds
- [x] Added an not implemented guard for access attempts
- [x] Removed not used CUDA include

### Issues ###
Android build broken https://github.com/apache/incubator-mxnet/issues/9646