### PR TITLE
Make sure build_doc only builds target version

### DIFF
--- a/docs/build_version_doc/build_doc.sh
+++ b/docs/build_version_doc/build_doc.sh
@@ -121,19 +121,16 @@ then
     echo " ******************************************  " 
     echo " Successfully built new release $latest_tag "
     echo " ******************************************  " 
+else
+    # Build latest master
+    echo " ********** Building Master ************ "
+
+    make docs || exit 1
+
+    rm -rfv $web_folder/versions/master/*
+    cp -a "docs/_build/html/." "$web_folder/versions/master"
+    tests/ci_build/ci_build.sh doc python docs/build_version_doc/AddVersion.py --file_path "$web_folder/versions/master"
 fi
-
-# Build latest master
-echo " ********** Building Master ************ "
-git checkout master
-git checkout -- .
-git submodule update
-
-make docs || exit 1
-
-rm -rfv $web_folder/versions/master/*
-cp -a "docs/_build/html/." "$web_folder/versions/master"
-tests/ci_build/ci_build.sh doc python docs/build_version_doc/AddVersion.py --file_path "$web_folder/versions/master"
 
 # Update version list for all previous version website
 if [ $latest_tag != ${tag_list[0]} ]


### PR DESCRIPTION
build_doc attempts to try building the passed version as well as master, resulting in two builds.

The target of this script is to build only exactly one version - the passed tag OR the master. The current design is not able to handle multiple builds as "make docs" pollutes the directory. While it might be feasible to clean it up, I don't think it's necessary because this script only build the target version and nothing else.