### PR TITLE
workaround for install page display issue

### DIFF
--- a/docs/build_version_doc/AddVersion.py
+++ b/docs/build_version_doc/AddVersion.py
@@ -57,6 +57,9 @@ if __name__ == '__main__':
         for name in files:
             if not name.endswith('.html'):
                 continue
+            if 'install' in path:
+                print("Skipping this path: {}".format(path))
+                continue
             with open(os.path.join(path, name), 'r') as html_file:
                 content = bs(html_file, 'html.parser')
             navbar = content.find(id="main-nav")
@@ -74,7 +77,7 @@ if __name__ == '__main__':
                 outstr = str(content).replace('&lt;', '<').replace('&gt;', '>')
             # Fix link
             if args.current_version == tag_list[0]:
-                print("Fixing" + os.path.join(path, name))
+                print("Fixing " + os.path.join(path, name))
                 outstr = outstr.replace('https://mxnet.io', 'https://mxnet.incubator.apache.org')
                 outstr = outstr.replace('http://mxnet.io', 'https://mxnet.incubator.apache.org')
             else:


### PR DESCRIPTION
## Description ##
Disables the versions dropdown on the install page when the dropdown is being injected. This is a temporary workaround while we can find a better solution for the display problems.

## Background ##
The versions dropdown is injected in post build processing and this step breaks the page causing the wrong divs to be displayed.
