### PR TITLE
Update build status link to new CI in the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Apache MXNet (incubating) for Deep Learning
 =====
 
-[![Build Status](https://builds.apache.org/job/incubator-mxnet/job/master/badge/icon)](https://builds.apache.org/job/incubator-mxnet/job/master/)
+[![Build Status](https://builds.apache.org/job/incubator-mxnet/job/master/badge/icon)](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/)
 [![Documentation Status](https://builds.apache.org/job/incubator-mxnet-build-site/badge/icon)](https://mxnet.incubator.apache.org/)
 [![GitHub license](http://dmlc.github.io/img/apache2.svg)](./LICENSE)
 


### PR DESCRIPTION
## Description ##
@marcoabreu 
The top level README file still points to the old CI (builds.apache.org) status page. I have updated this to the new CI. 

Note: This README.md still contains two more broken links to build.apache.org which should be updated. (These are logos from the apache build page but I do not know what they used to be)

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] updated one link in the README.md file


## Comments ##
Two more broken links exist in this file. If I am unable to fix it as a part of this PR, I will create a github issue for it. 
