### PR TITLE
bug fix for contrib wikitext2

### DIFF
--- a/python/mxnet/gluon/contrib/data/text.py
+++ b/python/mxnet/gluon/contrib/data/text.py
@@ -66,7 +66,7 @@ class _WikiText(_LanguageModelDataset):
                     if line]
         for line in raw_data:
             line.append(C.EOS_TOKEN)
-        raw_data = self.vocabulary.to_indices([x for x in line for line in raw_data if x])
+        raw_data = self.vocabulary.to_indices([x for line in raw_data for x in line if x])
         data = raw_data[0:-1]
         label = raw_data[1:]
         return np.array(data, dtype=np.int32), np.array(label, dtype=np.int32)

--- a/tests/python/unittest/test_gluon_contrib.py
+++ b/tests/python/unittest/test_gluon_contrib.py
@@ -184,13 +184,13 @@ def test_datasets():
     wikitext2_val = contrib.data.text.WikiText2(root='data/wikitext-2', segment='validation',
                                                 vocab=wikitext2_train.vocabulary)
     wikitext2_test = contrib.data.text.WikiText2(root='data/wikitext-2', segment='test')
-    assert len(wikitext2_train) == 42780
-    assert len(wikitext2_train.vocabulary) == 33278
-    assert len(wikitext2_train.frequencies) == 33277
-    assert len(wikitext2_val) == 632
-    assert len(wikitext2_val.vocabulary) == 33278
-    assert len(wikitext2_val.frequencies) == 13776
-    assert len(wikitext2_test) == 15941
+    assert len(wikitext2_train) == 59305,  len(wikitext2_train)
+    assert len(wikitext2_train.vocabulary) == 33278, len(wikitext2_train.vocabulary)
+    assert len(wikitext2_train.frequencies) == 33277, len(wikitext2_train.frequencies)
+    assert len(wikitext2_val) == 6181, len(wikitext2_val)
+    assert len(wikitext2_val.vocabulary) == 33278, len(wikitext2_val.vocabulary)
+    assert len(wikitext2_val.frequencies) == 13776, len(wikitext2_val.frequencies)
+    assert len(wikitext2_test) == 6974, len(wikitext2_test)
     assert len(wikitext2_test.vocabulary) == 14143, len(wikitext2_test.vocabulary)
     assert len(wikitext2_test.frequencies) == 14142, len(wikitext2_test.frequencies)
     assert wikitext2_test.frequencies['English'] == 32


### PR DESCRIPTION
## Description ##
Fix a bug that causes the wikitext corpus to have wrong iteration order.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fix wikitext2 sample iteration order