### PR TITLE
Fix Gluon Language Model for python3

### DIFF
--- a/example/gluon/word_language_model/train.py
+++ b/example/gluon/word_language_model/train.py
@@ -78,21 +78,21 @@ val_dataset, test_dataset = [contrib.data.text.WikiText2('./data', segment,
                                                          seq_len=args.bptt)
                              for segment in ['validation', 'test']]
 
-nbatch_train = len(train_dataset) / args.batch_size
+nbatch_train = len(train_dataset) // args.batch_size
 train_data = gluon.data.DataLoader(train_dataset,
                                    batch_size=args.batch_size,
                                    sampler=contrib.data.IntervalSampler(len(train_dataset),
                                                                         nbatch_train),
                                    last_batch='discard')
 
-nbatch_val = len(val_dataset) / args.batch_size
+nbatch_val = len(val_dataset) // args.batch_size
 val_data = gluon.data.DataLoader(val_dataset,
                                  batch_size=args.batch_size,
                                  sampler=contrib.data.IntervalSampler(len(val_dataset),
                                                                       nbatch_val),
                                  last_batch='discard')
 
-nbatch_test = len(test_dataset) / args.batch_size
+nbatch_test = len(test_dataset) // args.batch_size
 test_data = gluon.data.DataLoader(test_dataset,
                                   batch_size=args.batch_size,
                                   sampler=contrib.data.IntervalSampler(len(test_dataset),


### PR DESCRIPTION
## Description ##
Small fix of the gluon-lm example in python3. The division in python3 will return a float. The line here (https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/gluon/contrib/data/sampler.py#L57) will raise an error 
```log
  File "train.py", line 193, in <module>
    train()
  File "train.py", line 151, in train
    for i, (data, target) in enumerate(train_data):
  File "/home/ubuntu/mxnet/python/mxnet/gluon/data/dataloader.py", line 201, in __iter__
    for batch in self._batch_sampler:
  File "/home/ubuntu/mxnet/python/mxnet/gluon/data/sampler.py", line 112, in __iter__
    for i in self._sampler:
  File "/home/ubuntu/mxnet/python/mxnet/gluon/contrib/data/sampler.py", line 57, in __iter__
    for i in range(self._interval if self._rollover else 1):
TypeError: 'float' object cannot be interpreted as an integer

```

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Use `//`
