### PR TITLE
Support single array input for metric

### DIFF
--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -793,6 +793,8 @@ class MAE(EvalMetric):
 
             if len(label.shape) == 1:
                 label = label.reshape(label.shape[0], 1)
+            if len(pred.shape) == 1:
+                pred = pred.reshape(pred.shape[0], 1)
 
             self.sum_metric += numpy.abs(label - pred).mean()
             self.num_inst += 1 # numpy.prod(label.shape)
@@ -851,6 +853,8 @@ class MSE(EvalMetric):
 
             if len(label.shape) == 1:
                 label = label.reshape(label.shape[0], 1)
+            if len(pred.shape) == 1:
+                pred = pred.reshape(pred.shape[0], 1)
 
             self.sum_metric += ((label - pred)**2.0).mean()
             self.num_inst += 1 # numpy.prod(label.shape)
@@ -909,6 +913,8 @@ class RMSE(EvalMetric):
 
             if len(label.shape) == 1:
                 label = label.reshape(label.shape[0], 1)
+            if len(pred.shape) == 1:
+                pred = pred.reshape(pred.shape[0], 1)
 
             self.sum_metric += numpy.sqrt(((label - pred)**2.0).mean())
             self.num_inst += 1

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -31,6 +31,23 @@ from . import registry
 
 
 def check_label_shapes(labels, preds, wrap=False, shape=False):
+    """Helper function for checking shape of label and prediction
+
+    Parameters
+    ----------
+    labels : list of `NDArray`
+        The labels of the data.
+
+    preds : list of `NDArray`
+        Predicted values.
+
+    wrap : boolean
+        If True, wrap labels/preds in a list if they are single NDArray
+
+    shape : boolean
+        If True, check the shape of labels and preds;
+        Otherwise only check their length.
+    """
     if not shape:
         label_shape, pred_shape = len(labels), len(preds)
     else:
@@ -39,7 +56,7 @@ def check_label_shapes(labels, preds, wrap=False, shape=False):
     if label_shape != pred_shape:
         raise ValueError("Shape of labels {} does not match shape of "
                          "predictions {}".format(label_shape, pred_shape))
-    
+
     if wrap:
         if isinstance(labels, ndarray.ndarray.NDArray):
             labels = [labels]

--- a/tests/python/unittest/test_metric.py
+++ b/tests/python/unittest/test_metric.py
@@ -122,7 +122,7 @@ def test_pearsonr():
 
 def test_single_input():
     pred = mx.nd.array([[1,2,3,4]])
-    label = pred+0.1
+    label = pred + 0.1
 
     mse = mx.metric.create('mse')
     mse.update(label, pred)

--- a/tests/python/unittest/test_metric.py
+++ b/tests/python/unittest/test_metric.py
@@ -120,6 +120,27 @@ def test_pearsonr():
     _, pearsonr = metric.get()
     assert pearsonr == pearsonr_expected
 
+def test_single_input():
+    pred = mx.nd.array([[1,2,3,4]])
+    label = pred+0.1
+
+    mse = mx.metric.create('mse')
+    mse.update(label, pred)
+    _, mse_res = mse.get()
+    np.testing.assert_almost_equal(mse_res, 0.01)
+
+    mae = mx.metric.create('mae')
+    mae.update(label, pred)
+    mae.get()
+    _, mae_res = mae.get()
+    np.testing.assert_almost_equal(mae_res, 0.1)
+
+    rmse = mx.metric.create('rmse')
+    rmse.update(label, pred)
+    rmse.get()
+    _, rmse_res = rmse.get()
+    np.testing.assert_almost_equal(rmse_res, 0.1)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_metric.py
+++ b/tests/python/unittest/test_metric.py
@@ -120,7 +120,7 @@ def test_pearsonr():
     _, pearsonr = metric.get()
     assert pearsonr == pearsonr_expected
 
-def test_single_input():
+def test_single_array_input():
     pred = mx.nd.array([[1,2,3,4]])
     label = pred + 0.1
 


### PR DESCRIPTION
## Description ##
Fix #9865 by reshaping both `label` and `pred`.

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
