### PR TITLE
Fixes for profiler

### DIFF
--- a/src/profiler/profiler.cc
+++ b/src/profiler/profiler.cc
@@ -205,7 +205,6 @@ void Profiler::DumpProfile(bool peform_cleanup) {
   // If aggregate stats aren't enabled, this won't cause a locked instruction
   std::shared_ptr<AggregateStats> ptr_aggregate_stats = aggregate_stats_.get()
                                                         ? aggregate_stats_ : nullptr;
-  bool first_flag = !first_pass && !num_records_emitted_;
   for (uint32_t i = 0; i < dev_num; ++i) {
     DeviceStats &d = profile_stat[i];
     ProfileStat *_opr_stat;
@@ -213,11 +212,7 @@ void Profiler::DumpProfile(bool peform_cleanup) {
       CHECK_NOTNULL(_opr_stat);
       std::unique_ptr<ProfileStat> opr_stat(_opr_stat);  // manage lifecycle
       opr_stat->process_id_ = i;  // lie and set process id to be the device number
-      if (first_flag) {
-        first_flag = false;
-      } else {
-        file << ",\n";
-      }
+      file << ",\n";
       file << std::endl;
       opr_stat->EmitEvents(&file);
       ++num_records_emitted_;
@@ -231,13 +226,7 @@ void Profiler::DumpProfile(bool peform_cleanup) {
   ProfileStat *_profile_stat;
   while (general_stats_.opr_exec_stats_->try_dequeue(_profile_stat)) {
     CHECK_NOTNULL(_profile_stat);
-
-    if (first_flag) {
-      first_flag = false;
-    } else {
-      file << ",";
-    }
-
+    file << ",";
     std::unique_ptr<ProfileStat> profile_stat(_profile_stat);  // manage lifecycle
     CHECK_NE(profile_stat->categories_.c_str()[0], '\0') << "Category must be set";
     // Currently, category_to_pid_ is only accessed here, so it is protected by this->m_ above

--- a/src/profiler/profiler.cc
+++ b/src/profiler/profiler.cc
@@ -212,8 +212,7 @@ void Profiler::DumpProfile(bool peform_cleanup) {
       CHECK_NOTNULL(_opr_stat);
       std::unique_ptr<ProfileStat> opr_stat(_opr_stat);  // manage lifecycle
       opr_stat->process_id_ = i;  // lie and set process id to be the device number
-      file << ",\n";
-      file << std::endl;
+      file << ",\n" << std::endl;
       opr_stat->EmitEvents(&file);
       ++num_records_emitted_;
       if (ptr_aggregate_stats) {

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -130,10 +130,13 @@ struct ProfileStat {
   /* !\brief Process id */
   size_t process_id_ = current_process_id();
 
-  /*! \brief id of thread which operation run on */
+  /*! \brief id of thread which operation run on.
+   * It is converted from hex to an int type by hashing.
+   * Not yet seen a case where this isn't valid
+   * */
   size_t thread_id_ = std::hash<std::thread::id>{}(std::this_thread::get_id());
-  // thread getid returns a hex, hashing it to get a size_t
-  // Not yet seen a case where this isn't valid
+
+
 
   /*! \brief Sub-events (ie begin, end, etc.) */
   SubEvent items_[3];  // Don't use vector in order to avoid memory allocation

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -131,10 +131,10 @@ struct ProfileStat {
   size_t process_id_ = current_process_id();
 
   /*! \brief id of thread which operation run on.
-   * It is converted from hex to an int type by hashing.
-   * Not yet seen a case where this isn't valid
+   *
    * */
-  size_t thread_id_ = std::hash<std::thread::id>{}(std::this_thread::get_id());
+  std::thread::id thread_id_ = std::this_thread::get_id();  // Not yet seen a
+                                                            // case where this isn't valid
 
   /*! \brief Sub-events (ie begin, end, etc.) */
   SubEvent items_[3];  // Don't use vector in order to avoid memory allocation
@@ -211,7 +211,7 @@ struct ProfileStat {
           << "        \"ts\": " << ev.timestamp_ << ",\n";
       EmitExtra(os, idx);
       *os << "        \"pid\": " << process_id_ << ",\n"
-          << "        \"tid\": " << thread_id_ << "\n"
+          << "        \"tid\": " << std::hash<std::thread::id>{}(thread_id_) << "\n"
           << "    }\n";
     }
   }
@@ -796,7 +796,7 @@ struct ProfileTask : public ProfileDuration {
     }
     void EmitExtra(std::ostream *os, size_t idx) override {
       DurationStat::EmitExtra(os, idx);
-      *os << "        \"id\": " << thread_id_ << ",\n";
+      *os << "        \"id\": " << std::hash<std::thread::id>{}(thread_id_) << ",\n";
     }
   };
 

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -131,8 +131,9 @@ struct ProfileStat {
   size_t process_id_ = current_process_id();
 
   /*! \brief id of thread which operation run on */
-  std::thread::id thread_id_ = std::this_thread::get_id();  // Not yet seen a
-                                                            // case where this isn't valid
+  size_t thread_id_ = std::hash<std::thread::id>{}(std::this_thread::get_id());
+  // thread getid returns a hex, hashing it to get a size_t
+  // Not yet seen a case where this isn't valid
 
   /*! \brief Sub-events (ie begin, end, etc.) */
   SubEvent items_[3];  // Don't use vector in order to avoid memory allocation


### PR DESCRIPTION
## Description ##
1. Fixes issue where thread id can be hex, and the hex symbols are not recognized by chrome tracing tool. Using hash to convert it to an integer

2. The json file has some missing commas because of the first_flag condition. The reason for this seems lost at this point. Removing it bring back the comma necessary for a valid json. Verified that it does generate valid jsons by training a network. 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- See description
