### PR TITLE
add SameType as default type inference function in imperative mode

### DIFF
--- a/src/executor/exec_pass.h
+++ b/src/executor/exec_pass.h
@@ -189,6 +189,13 @@ bool DefaultStorageType(const nnvm::NodeAttrs& attrs,
                         std::vector<int> *iattr,
                         std::vector<int> *oattr);
 
+/*! \brief The default type inference function, which assigns all undefined
+ *         types to the same type of one of the inputs or outputs.
+ */
+bool SameType(const nnvm::NodeAttrs& attrs,
+              std::vector<int> *iattr,
+              std::vector<int> *oattr);
+
 }  // namespace exec
 }  // namespace mxnet
 

--- a/src/executor/exec_pass.h
+++ b/src/executor/exec_pass.h
@@ -178,24 +178,6 @@ Graph InferStorageType(Graph&& graph,
                        StorageTypeVector&& storage_type_inputs = StorageTypeVector(),
                        const std::string& storage_type_attr_key = "");
 
-/*! \brief The default storage type inference function, which assigns all undefined
- *         storage types to kDefaultStorage. If all of input and output storage types
- *         are kDefaultStorage, DispatchMode::kFCompute is assigned to dispatch_mode. Otherwise,
- *         DispatchMode::kFComputeFallback is assigned to dispatch_mode.
- */
-bool DefaultStorageType(const nnvm::NodeAttrs& attrs,
-                        const int dev_mask,
-                        DispatchMode* dispatch_mode,
-                        std::vector<int> *iattr,
-                        std::vector<int> *oattr);
-
-/*! \brief The default type inference function, which assigns all undefined
- *         types to the same type of one of the inputs or outputs.
- */
-bool SameType(const nnvm::NodeAttrs& attrs,
-              std::vector<int> *iattr,
-              std::vector<int> *oattr);
-
 }  // namespace exec
 }  // namespace mxnet
 

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -120,11 +120,11 @@ inline void SetShapeType(const Context& ctx,
   for (auto& i : outputs) {
     out_types.push_back(i->dtype());
   }
-  bool infer_type_success;
+  bool infer_type_success = false;
   if (infertype.count(attrs.op)) {
     infer_type_success = infertype[attrs.op](attrs, &in_types, &out_types);
   } else {
-    infer_type_success = exec::SameType(attrs, &in_types, &out_types);
+    infer_type_success = common::SameType(attrs, &in_types, &out_types);
   }
   CHECK(infer_type_success) << "Operator " << attrs.op->name << " is missing FInferType attribute";
   CHECK_EQ(out_types.size(), outputs.size());
@@ -142,13 +142,13 @@ inline void SetShapeType(const Context& ctx,
   for (auto& i : outputs) {
     out_storage_types.push_back(i->storage_type());
   }
-  bool infer_stype_success;
+  bool infer_stype_success = false;
   if (inferstorage.count(attrs.op)) {
     infer_stype_success = inferstorage[attrs.op](attrs, ctx.dev_mask(), dispatch_mode,
                                                  &in_storage_types, &out_storage_types);
   } else {
     // if infer storage attr is not present, apply the default infer storage function
-    infer_stype_success = exec::DefaultStorageType(attrs, ctx.dev_mask(), dispatch_mode,
+    infer_stype_success = common::DefaultStorageType(attrs, ctx.dev_mask(), dispatch_mode,
                                                    &in_storage_types, &out_storage_types);
   }
   CHECK(infer_stype_success) << "Operator not implemented: "

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -120,9 +120,13 @@ inline void SetShapeType(const Context& ctx,
   for (auto& i : outputs) {
     out_types.push_back(i->dtype());
   }
-  CHECK(infertype.count(attrs.op))
-    << "Operator " << attrs.op->name << " is missing FInferType attribute";
-  CHECK(infertype[attrs.op](attrs, &in_types, &out_types));
+  bool infer_type_success;
+  if (infertype.count(attrs.op)) {
+    infer_type_success = infertype[attrs.op](attrs, &in_types, &out_types);
+  } else {
+    infer_type_success = exec::SameType(attrs, &in_types, &out_types);
+  }
+  CHECK(infer_type_success) << "Operator " << attrs.op->name << " is missing FInferType attribute";
   CHECK_EQ(out_types.size(), outputs.size());
 
   // infer storage type


### PR DESCRIPTION
## Description ##
Add SameType as default type inference function in imperative mode (this is the same way in symbolic mode).

Test locally by removing the `FInferType` attr in Regression operators, before this PR the script below will fail

```
import mxnet as mx
import numpy as np

in_shape = (10, 10, 10)
ctx = mx.cpu()
data = mx.nd.ones(in_shape)
out = mx.nd.LinearRegressionOutput(data=data, label=data)
print out.asnumpy()
```

cc @eric-haibin-lin @reminisce 

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
