### PR TITLE
[MXNET-85] Update the OSX Installation guide for Scala Users

### DIFF
--- a/docs/install/osx_setup.md
+++ b/docs/install/osx_setup.md
@@ -1,4 +1,4 @@
-# Installing MXNet froum source on OS X (Mac)
+# Installing MXNet from source on OS X (Mac)
 
 **NOTE:** For prebuild MXNet with Python installation, please refer to the [new install guide](http://mxnet.io/install/index.html).
 
@@ -65,13 +65,18 @@ Install the dependencies, required for MXNet, with the following commands:
 	brew install openblas
 	brew tap homebrew/core
 	brew install opencv
-	# For getting pip
+	# Install Python (if you already have python installed, use "brew reinstall python" instead)
 	brew install python
+	# Get pip
+	easy_install pip
 	# For visualization of network graphs
 	pip install graphviz
 	# Jupyter notebook
 	pip install jupyter
 ```
+
+#### Note
+If you already have Python installed on your Mac, you may face the issue while installing jupyter caused by restricted access in System(see [here](https://stackoverflow.com/questions/33004708/osx-el-capitan-sudo-pip-install-oserror-errno-1-operation-not-permitted)). In that case, use brew resintall python to install another version of Python under homebrew. Use pip2 instead of pip to install the following packages. It also requires you to run a python program using python2 (e.g $ python2 example.py) instead of python.
 
 ### Build MXNet Shared Library
 After you have installed the dependencies, pull the MXNet source code from Git and build MXNet to produce an MXNet library called ```libmxnet.so```.
@@ -167,6 +172,12 @@ You might want to add this command to your ```~/.bashrc``` file. If you do, you 
 For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](http://dmlc.ml/MXNet.jl/latest/user-guide/install/).
 
 ## Install the MXNet Package for Scala
+
+If you haven't installed maven yet, you need to install it now (required by the makefile):
+```bash
+    brew install maven
+```
+
 Before you build MXNet for Scala from source code, you must complete [building the shared library](#build-the-shared-library). After you build the shared library, run the following command from the MXNet source root directory to build the MXNet Scala package:
 
 ```bash

--- a/docs/install/osx_setup.md
+++ b/docs/install/osx_setup.md
@@ -76,7 +76,7 @@ Install the dependencies, required for MXNet, with the following commands:
 ```
 
 #### Note
-If you already have Python installed on your Mac, you may face the issue while installing jupyter caused by restricted access in System(see [here](https://stackoverflow.com/questions/33004708/osx-el-capitan-sudo-pip-install-oserror-errno-1-operation-not-permitted)). In that case, use brew resintall python to install another version of Python under homebrew. Use pip2 instead of pip to install the following packages. It also requires you to run a python program using python2 (e.g $ python2 example.py) instead of python.
+If you already have Python installed on your Mac, you may face the issue while installing jupyter caused by restricted access in System(see [here](https://stackoverflow.com/questions/33004708/osx-el-capitan-sudo-pip-install-oserror-errno-1-operation-not-permitted)). In that case, use brew reinstall python to install another version of Python under homebrew. Use pip2 instead of pip to install the following packages. It also requires you to run a python program using python2 (e.g $ python2 example.py) instead of python.
 
 ### Build MXNet Shared Library
 After you have installed the dependencies, pull the MXNet source code from Git and build MXNet to produce an MXNet library called ```libmxnet.so```.

--- a/docs/install/osx_setup.md
+++ b/docs/install/osx_setup.md
@@ -65,8 +65,6 @@ Install the dependencies, required for MXNet, with the following commands:
 	brew install openblas
 	brew tap homebrew/core
 	brew install opencv
-	# Install Python (if you already have python installed, use "brew reinstall python" instead)
-	brew install python
 	# Get pip
 	easy_install pip
 	# For visualization of network graphs
@@ -74,9 +72,6 @@ Install the dependencies, required for MXNet, with the following commands:
 	# Jupyter notebook
 	pip install jupyter
 ```
-
-#### Note
-If you already have Python installed on your Mac, you may face the issue while installing jupyter caused by restricted access in System(see [here](https://stackoverflow.com/questions/33004708/osx-el-capitan-sudo-pip-install-oserror-errno-1-operation-not-permitted)). In that case, use brew reinstall python to install another version of Python under homebrew. Use pip2 instead of pip to install the following packages. It also requires you to run a python program using python2 (e.g $ python2 example.py) instead of python.
 
 ### Build MXNet Shared Library
 After you have installed the dependencies, pull the MXNet source code from Git and build MXNet to produce an MXNet library called ```libmxnet.so```.


### PR DESCRIPTION
## Description ##
Modification on the setup guide for OSX users @Roshrini @nswamy 

## Checklist ##
### Essentials ###
- [X] Passed code style checking (`make lint`)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Add several changes in the setup document in OSX setup.
Add note for issues in jupyter installation.
Add maven installation as a scala installation requirement.

## Comments ##
N/A
