### PR TITLE
Parallelization for ROIpooling OP

### DIFF
--- a/src/operator/roi_pooling.cc
+++ b/src/operator/roi_pooling.cc
@@ -21,7 +21,7 @@
  * Copyright (c) 2015 by Contributors
  * \file roi_pooling.cc
  * \brief roi pooling operator
- * \author Ross Girshick, Kye-Hyeon Kim, Jian Guo
+ * \author Ross Girshick, Kye-Hyeon Kim, Jian Guo, Xinyu Chen
 */
 #include "./roi_pooling-inl.h"
 #include <mshadow/base.h>

--- a/src/operator/roi_pooling.cc
+++ b/src/operator/roi_pooling.cc
@@ -93,8 +93,8 @@ inline void ROIPoolForward(const Tensor<cpu, 4, Dtype> &out,
       for (int ph = 0; ph < pooled_height_; ++ph) {
         for (int pw = 0; pw < pooled_width_; ++pw) {
           // Compute pooling region for this output unit:
-          //  start (included) = floor(ph * roi_height / pooled_height_)
-          //  end (excluded) = ceil((ph + 1) * roi_height / pooled_height_)
+          // start (included) = floor(ph * roi_height / pooled_height_)
+          // end (excluded) = ceil((ph + 1) * roi_height / pooled_height_)
           int hstart = static_cast<int>(floor(static_cast<Dtype>(ph)
                                               * bin_size_h));
           int wstart = static_cast<int>(floor(static_cast<Dtype>(pw)


### PR DESCRIPTION
## Description ##

**What's the problem?**

ROIpooling is used in the Faster-RCNN. It will consume lots of time in the inference path because of the current implementation [(here)](https://github.com/apache/incubator-mxnet/blob/master/src/operator/roi_pooling.cc
) is not parallelized. 

One profiling results as below:

Time   of each OP: | ms | ms/call | calls
-- | -- | -- | --
ROIPooling | **38718.288** | 1548.73152 | 25
Convolution | 9963.628 | 3.724720748 | 2675
Reshape | 0.677 | 0.00677 | 100
Activation | 1089.6 | 0.427294118 | 2550
SoftmaxActivation | 43.279 | 1.73116 | 25
add_n | 1664.403 | 2.017458182 | 825
Pooling | 68.531 | 1.37062 | 50
_contrib_Proposal | 351.051 | 14.04204 | 25
softmax | 0.658 | 0.02632 | 25
FullyConnected | 29.328 | 0.58656 | 50
BatchNorm | 2865.261 | 1.123631765 | 2550




**What we have tried**

We @pengzhao-intel @TaoLv have parallelized this pooling algorithm and got the 20+X performance improvement by OpenMP directives.

![Faster-RCNN](https://user-images.githubusercontent.com/22461308/36769144-6c456376-1c7d-11e8-8968-faf5043287a6.png)


## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Parallelization for ROIpooling
