### PR TITLE
Fix R-package version

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -15,7 +15,7 @@ BugReports: https://github.com/dmlc/mxnet/issues
 Imports:
     methods,
     Rcpp (>= 0.12.1),
-    DiagrammeR (=+ 0.9.2),
+    DiagrammeR (== 0.9.2),
     visNetwork (>= 1.0.3),
     data.table,
     jsonlite,

--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -15,7 +15,7 @@ BugReports: https://github.com/dmlc/mxnet/issues
 Imports:
     methods,
     Rcpp (>= 0.12.1),
-    DiagrammeR (>= 0.9.0),
+    DiagrammeR (=+ 0.9.2),
     visNetwork (>= 1.0.3),
     data.table,
     jsonlite,


### PR DESCRIPTION
DiagrammeR has been upgraded to version 1.0, resulting in breaking changes. This PR pins the used version as a temporary fix.