### PR TITLE
Fix R build crash in CI

### DIFF
--- a/R-package/DESCRIPTION
+++ b/R-package/DESCRIPTION
@@ -15,7 +15,7 @@ BugReports: https://github.com/dmlc/mxnet/issues
 Imports:
     methods,
     Rcpp (>= 0.12.1),
-    DiagrammeR (>= 0.9.0),
+    DiagrammeR (>= 1.0.0),
     visNetwork (>= 1.0.3),
     data.table,
     jsonlite,

--- a/R-package/R/viz.graph.R
+++ b/R-package/R/viz.graph.R
@@ -8,7 +8,6 @@
 #' @importFrom stringr str_trim
 #' @importFrom jsonlite fromJSON
 #' @importFrom DiagrammeR create_graph
-#' @importFrom DiagrammeR set_global_graph_attrs 
 #' @importFrom DiagrammeR add_global_graph_attrs
 #' @importFrom DiagrammeR create_node_df
 #' @importFrom DiagrammeR create_edge_df
@@ -143,7 +142,7 @@ graph.viz <- function(symbol, shape=NULL, direction="TD", type="graph", graph.wi
   }
   
   graph<- create_graph(nodes_df = nodes_df_new, edges_df = edge_df_new, directed = TRUE) %>% 
-    set_global_graph_attrs("layout", value = "dot", attr_type = "graph") %>% 
+    add_global_graph_attrs("layout", value = "dot", attr_type = "graph") %>% 
     add_global_graph_attrs("rankdir", value = direction, attr_type = "graph")
   
   if (type=="vis"){


### PR DESCRIPTION
Fix for #9957 
Resolves the deprecated function in DiagrammeR package used in graph.viz. 
Graph nodes are now of fixed size rather than adapting to wrap the whole text, I will check for a solution to this in the next days. 