### PR TITLE
[fix issue#9976] The assignment problem in NDArray

### DIFF
--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -325,6 +325,10 @@ class NDArray {
   inline Engine::VarHandle var() const {
     return ptr_->var;
   }
+  /*! \return byte offset in chunk of the ndarray*/
+  inline size_t byte_offset() const {
+    return byte_offset_;
+  }
   /*!
    * \brief save the content into binary stream
    * \param strm the output stream

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -1128,7 +1128,7 @@ void CopyFromToImpl(const NDArray& from, const NDArray& to,
 }
 
 void CopyFromTo(const NDArray& from, const NDArray& to, int priority) {
-  if (from.var() == to.var()) {
+  if (from.var() == to.var() && from.byte_offset() == to.byte_offset()) {
     // skip to copy to itself
     return;
   }

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1100,38 +1100,34 @@ def test_assign_float_value_to_ndarray():
     assert same(a, b.asnumpy())
 
 @with_seed()
-def test_ndarray_assignment():
+def test_assign_a_row_to_ndarray():
+    """Test case from https://github.com/apache/incubator-mxnet/issues/9976"""
     H, W = 10, 10
-    a_np = np.random.random((H, W))
+    dtype = np.float32
+    a_np = np.random.random((H, W)).astype(dtype)
     a_nd = mx.nd.array(a_np)
-    a_nd_id = id(a_nd)
 
     # assign directly
     a_np[0] = a_np[1]
     a_nd[0] = a_nd[1]
-    assert np.allclose(a_np, a_nd.asnumpy())
-    assert id(a_nd) == a_nd_id
+    assert same(a_np, a_nd.asnumpy())
 
     # assign a list
-    v = np.random.random(W).tolist()
+    v = np.random.random(W).astype(dtype).tolist()
     a_np[1] = v
     a_nd[1] = v 
-    assert np.allclose(a_np, a_nd.asnumpy())
-    assert id(a_nd) == a_nd_id
+    assert same(a_np, a_nd.asnumpy())
 
     # assign a np.ndarray
-    v = np.random.random(W)
+    v = np.random.random(W).astype(dtype)
     a_np[2] = v
     a_nd[2] = v 
-    assert np.allclose(a_np, a_nd.asnumpy())
-    assert id(a_nd) == a_nd_id
+    assert same(a_np, a_nd.asnumpy())
 
     # assign by slice 
     a_np[0, :] = a_np[1]
     a_nd[0, :] = a_nd[1]
-    assert np.allclose(a_np, a_nd.asnumpy())
-    assert id(a_nd) == a_nd_id
-
+    assert same(a_np, a_nd.asnumpy())
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1099,7 +1099,7 @@ def test_assign_float_value_to_ndarray():
     b[0] = a[0]
     assert same(a, b.asnumpy())
 
-@with_seed
+@with_seed()
 def test_ndarray_assignment():
     H, W = 10, 10
     a_np = np.random.random((H, W))

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1099,6 +1099,39 @@ def test_assign_float_value_to_ndarray():
     b[0] = a[0]
     assert same(a, b.asnumpy())
 
+@with_seed
+def test_ndarray_assignment():
+    H, W = 10, 10
+    a_np = np.random.random((H, W))
+    a_nd = mx.nd.array(a_np)
+    a_nd_id = id(a_nd)
+
+    # assign directly
+    a_np[0] = a_np[1]
+    a_nd[0] = a_nd[1]
+    assert same(a_np, a_nd.asnumpy())
+    assert same(id(a_nd), a_nd_id)
+
+    # assign a list
+    v = np.random.random(W).tolist()
+    a_np[1] = v
+    a_nd[1] = v 
+    assert same(a_np, a_nd.asnumpy())
+    assert same(id(a_nd), a_nd_id)
+
+    # assign a np.ndarray
+    v = np.random.random(W)
+    a_np[2] = v
+    a_nd[2] = v 
+    assert same(a_np, a_nd.asnumpy())
+    assert same(id(a_nd), a_nd_id)
+
+    # assign by slice 
+    a_np[0, :] = a_np[1]
+    a_nd[0, :] = a_nd[1]
+    assert same(a_np, a_nd.asnumpy())
+    assert same(id(a_nd), a_nd_id)
+
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1109,28 +1109,28 @@ def test_ndarray_assignment():
     # assign directly
     a_np[0] = a_np[1]
     a_nd[0] = a_nd[1]
-    assert same(a_np, a_nd.asnumpy())
-    assert same(id(a_nd), a_nd_id)
+    assert np.allclose(a_np, a_nd.asnumpy())
+    assert id(a_nd) == a_nd_id
 
     # assign a list
     v = np.random.random(W).tolist()
     a_np[1] = v
     a_nd[1] = v 
-    assert same(a_np, a_nd.asnumpy())
-    assert same(id(a_nd), a_nd_id)
+    assert np.allclose(a_np, a_nd.asnumpy())
+    assert id(a_nd) == a_nd_id
 
     # assign a np.ndarray
     v = np.random.random(W)
     a_np[2] = v
     a_nd[2] = v 
-    assert same(a_np, a_nd.asnumpy())
-    assert same(id(a_nd), a_nd_id)
+    assert np.allclose(a_np, a_nd.asnumpy())
+    assert id(a_nd) == a_nd_id
 
     # assign by slice 
     a_np[0, :] = a_np[1]
     a_nd[0, :] = a_nd[1]
-    assert same(a_np, a_nd.asnumpy())
-    assert same(id(a_nd), a_nd_id)
+    assert np.allclose(a_np, a_nd.asnumpy())
+    assert id(a_nd) == a_nd_id
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
Fix #9976 (https://github.com/apache/incubator-mxnet/issues/9976)

```python
>>> a = mx.nd.array(np.arange(12).reshape((3,4)))
>>> a

[[ 0.  1.  2.  3.]
 [ 4.  5.  6.  7.]
 [ 8.  9. 10. 11.]]
<NDArray 3x4 @cpu(0)>
>>> a[0]=a[1]     #   HERE
>>> a

[[ 0.  1.  2.  3.]
 [ 4.  5.  6.  7.]
 [ 8.  9. 10. 11.]]
<NDArray 3x4 @cpu(0)>
```

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add `byte_offset()` function for NDArray
- [x] Fix the assignment problem in NDArray. https://github.com/apache/incubator-mxnet/blob/master/src/ndarray/ndarray.cc#L1131

## Comments ##
- Is it necessary to add `byte_offset()` function for NDArray?
- Is it necessary to add `is_itself()` function for NDArray?
