### PR TITLE
Random shuffle implementation

### DIFF
--- a/docs/api/python/ndarray/random.md
+++ b/docs/api/python/ndarray/random.md
@@ -35,6 +35,8 @@ In the rest of this document, we list routines provided by the `ndarray.random` 
     normal
     poisson
     uniform
+    multinomial
+    shuffle
     mxnet.random.seed
 ```
 

--- a/docs/api/python/symbol/random.md
+++ b/docs/api/python/symbol/random.md
@@ -35,6 +35,8 @@ In the rest of this document, we list routines provided by the `symbol.random` p
     normal
     poisson
     uniform
+    multinomial
+    shuffle
     mxnet.random.seed
 ```
 

--- a/python/mxnet/ndarray/random.py
+++ b/python/mxnet/ndarray/random.py
@@ -24,7 +24,7 @@ from .ndarray import NDArray
 
 
 __all__ = ['uniform', 'normal', 'poisson', 'exponential', 'gamma', 'multinomial',
-           'negative_binomial', 'generalized_negative_binomial']
+           'negative_binomial', 'generalized_negative_binomial', 'shuffle']
 
 
 def _random_helper(random, sampler, params, shape, dtype, ctx, out, kwargs):
@@ -431,3 +431,32 @@ def multinomial(data, shape=_Null, get_prob=False, out=None, **kwargs):
     <NDArray 2 @cpu(0)>
     """
     return _internal._sample_multinomial(data, shape, get_prob, out=out, **kwargs)
+
+
+def shuffle(data, out=None, **kwargs):
+    """Shuffle the elements randomly.
+
+    This shuffles the elements along the last axis, i.e., for each element,
+    all indices except the last one are preserved but the last one changes randomly.
+
+    Parameters
+    ----------
+    data : NDArray
+        Input data array.
+    out : NDArray
+        Array to store the result.
+	    For in-place shuffle, set this to the same array assigned to `data`.
+
+    Examples
+    --------
+    >>> data = mx.nd.array([[0, 1, 2], [3, 4, 5]])
+    >>> mx.nd.random.shuffle(data)
+    [[ 0.  2.  1.]
+     [ 5.  4.  3.]]
+    <NDArray 2x3 @cpu(0)>
+    >>> mx.nd.random.shuffle(data)
+    [[ 1.  2.  0.]
+     [ 3.  5.  4.]]
+    <NDArray 2x3 @cpu(0)>
+    """
+    return _internal._shuffle(data, out, **kwargs)

--- a/python/mxnet/symbol/random.py
+++ b/python/mxnet/symbol/random.py
@@ -247,3 +247,30 @@ def multinomial(data, shape=_Null, get_prob=True, **kwargs):
         reward as head gradient w.r.t. this array to estimate gradient.
     """
     return _internal._sample_multinomial(data, shape, get_prob, **kwargs)
+
+def shuffle(data, **kwargs):
+    """Shuffle the elements randomly.
+
+    This shuffles the elements along the last axis, i.e., for each element,
+    all indices except the last one are preserved but the last one changes randomly.
+
+    Parameters
+    ----------
+    data : NDArray
+        Input data array.
+
+    Examples
+    --------
+    >>> data = mx.nd.array([[0, 1, 2], [3, 4, 5]])
+    >>> a = mx.sym.Variable('a')
+    >>> b = mx.sym.random.shuffle(a)
+    >>> b.eval(a=data)
+    [[ 0.  2.  1.]
+     [ 5.  4.  3.]]
+    <NDArray 2x3 @cpu(0)>
+    >>> b.eval(a=data)
+    [[ 1.  2.  0.]
+     [ 3.  5.  4.]]
+    <NDArray 2x3 @cpu(0)>
+    """
+    return _internal._shuffle(data, **kwargs)

--- a/src/operator/random/shuffle_op.cc
+++ b/src/operator/random/shuffle_op.cc
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file shuffle_op.cc
+ * \brief Operator to shuffle elements of an NDArray
+ */
+#include <random>
+#include <algorithm>
+#ifdef __GNUC__
+  #include <parallel/algorithm>
+#endif
+#include "./shuffle_op.h"
+
+namespace mxnet {
+namespace op {
+
+struct ShuffleCPUImpl {
+  template<typename DType>
+  static void shuffle(const OpContext& ctx,
+                      mshadow::Tensor<cpu, 1, DType> out,
+                      size_t n_batches,
+                      size_t n_elements) {
+    using namespace mxnet_op;
+    auto& prnd = ctx.requested[0].get_random<cpu, size_t>(ctx.get_stream<cpu>())->GetRndEngine();
+    for (size_t i = 0; i < n_batches; ++i) {
+      #ifdef __GNUC__
+        __gnu_parallel::random_shuffle(out.dptr_ + i * n_elements,
+                                       out.dptr_ + (i + 1) * n_elements,
+                                       [&prnd](size_t n) {
+                                         std::uniform_int_distribution<size_t> dist(0, n - 1);
+                                         return dist(prnd);
+                                       });
+      #else
+        std::shuffle(out.dptr_ + i * n_elements,
+                     out.dptr_ + (i + 1) * n_elements,
+                     prnd);
+      #endif
+    }
+  }
+};
+
+// No parameter is declared.
+// No backward computation is registered. Shuffling is not differentiable.
+
+NNVM_REGISTER_OP(_shuffle)
+.add_alias("shuffle")
+.describe(R"code(Randomly shuffle the elements.
+
+This shuffles the elements along the last axis, i.e., for each element,
+all indices except the last one are preserved but the last one changes randomly.
+)code")
+.set_num_inputs(1)
+.set_num_outputs(1)
+.set_attr<nnvm::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const nnvm::NodeAttrs& attrs) {
+    return std::vector<ResourceRequest>{ResourceRequest::kRandom, ResourceRequest::kTempSpace};
+  })
+.set_attr<nnvm::FInplaceOption>("FInplaceOption",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::pair<int, int>>{{0, 0}};
+  })
+.set_attr<FCompute>("FCompute<cpu>", ShuffleForward<cpu, ShuffleCPUImpl>)
+.add_argument("data", "NDArray-or-Symbol", "Data to be shuffled.");
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/random/shuffle_op.cu
+++ b/src/operator/random/shuffle_op.cu
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file shuffle_op.cu
+ * \brief Operator to shuffle elements of an NDArray
+ */
+#include "./shuffle_op.h"
+
+namespace mxnet {
+namespace op {
+
+// Note that the outcomes may not be distributed uniformly if the batch size is very large.
+struct ShuffleGPUImpl {
+  using KeyType = double;  // `float` does not provide enough precision
+
+  struct AddBatchIndexKernel {
+    template<typename DType>
+    MSHADOW_XINLINE static void Map(int i, DType* keys, size_t n_elements) {
+      keys[i] += i / n_elements;
+    }
+  };
+
+  template<typename DType>
+  static void shuffle(const OpContext& ctx,
+                      mshadow::Tensor<gpu, 1, DType> out,
+                      size_t n_batches,
+                      size_t n_elements) {
+    using namespace mxnet_op;
+    Stream<gpu> *s = ctx.get_stream<gpu>();
+    size_t size = n_batches * n_elements;
+    Random<gpu, KeyType> *prnd = ctx.requested[0].get_random<gpu, KeyType>(s);
+    Tensor<gpu, 1, KeyType> keys =
+      ctx.requested[1].get_space_typed<gpu, 1, KeyType>(Shape1(size), s);
+    prnd->SampleUniform(&keys, 0, 1);
+    if (n_batches > 1) {
+      Kernel<AddBatchIndexKernel, gpu>::Launch(s, size, keys.dptr_, n_elements);
+    }
+    SortByKey(keys, out, true);
+  }
+};
+
+NNVM_REGISTER_OP(_shuffle)
+.set_attr<FCompute>("FCompute<gpu>", ShuffleForward<gpu, ShuffleGPUImpl>);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/random/shuffle_op.h
+++ b/src/operator/random/shuffle_op.h
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file shuffle_op.h
+ * \brief Operator to shuffle elements of an NDArray
+ */
+#ifndef MXNET_OPERATOR_RANDOM_SHUFFLE_OP_H_
+#define MXNET_OPERATOR_RANDOM_SHUFFLE_OP_H_
+
+#include <mxnet/operator_util.h>
+#include <vector>
+#include "../mshadow_op.h"
+#include "../mxnet_op.h"
+#include "../operator_common.h"
+#include "../elemwise_op_common.h"
+
+namespace mxnet {
+namespace op {
+
+template<typename xpu, typename ShuffleImpl>
+void ShuffleForward(const nnvm::NodeAttrs& attrs,
+                    const OpContext& ctx,
+                    const std::vector<TBlob>& inputs,
+                    const std::vector<OpReqType>& req,
+                    const std::vector<TBlob>& outputs) {
+  using namespace mxnet_op;
+  if (req[0] == kNullOp) {
+    return;
+  }
+  CHECK_NE(req[0], kAddTo) << "Shuffle does not support AddTo";
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+  const TShape input_shape = inputs[0].shape_;
+  const size_t n_elements = input_shape[input_shape.ndim() - 1];
+  const size_t n_batches = inputs[0].Size() / n_elements;
+  const size_t size = inputs[0].Size();
+  MSHADOW_REAL_TYPE_SWITCH(inputs[0].type_flag_, DType, {
+    Tensor<xpu, 1, DType> in = inputs[0].get_with_shape<xpu, 1, DType>(Shape1(size), s);
+    Tensor<xpu, 1, DType> out = outputs[0].get_with_shape<xpu, 1, DType>(Shape1(size), s);
+    if (req[0] != kWriteInplace) {
+      Copy(out, in, s);
+    }
+    ShuffleImpl::shuffle(ctx, out, n_batches, n_elements);
+  });
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_RANDOM_SHUFFLE_OP_H_


### PR DESCRIPTION
## Description ##

This operator randomly shuffles the elements of an NDArray along the last axis, i.e., it performs a batched shuffling. For example, if you shuffle a matrix (2D array), the elements in each row are shuffled inside the row and the shufflings in different rows are statistically independent. So, for each element, all indices except the last one perserved but the last one changes randomly. 

### Motivation

1. Random shuffle is a widely used operation so that most of the random number APIs, such as those of numpy or C++, have it while mxnet lacks the operation. It would be useful especially for the shuffling of the arrays in gpu.
2. If this PR is accepted I'd like to open a separate PR which removes the dependency of mxnet python API on the *global* random number generators of python and numpy. I think that the dependency is not sound because it introduces an unnecessary coupling between mxnet and other parts of a user's environment. This can be a source of subtle technical or mathematical bugs. Personally I have spent some amount of meaningless time to figure out the source of an unexpected randomness due to the coupling. The dependency has confused many newcomers, for example, see #9978, #9335, #7124 and #736. To replace random number generations through the global generators of python and numpy with the generations through the operations of `mx.nd.random`, we need to copy the data back and forth between a numpy array and an NDArray or a python list and an NDArray, but I think that the overhead from this is not significant and avoiding the coupling is much more important. When I actually tried the replacing, the only obstacle was that mxnet does not support the random shuffling. So I implemented it. However, I think that the suffling is useful regardless of this motivation and so opened a separate PR.

### Implementation

1. In cpu, the shuffling is delegated to `__gnu_parallel::random_shuffle` for gcc and to `std::shuffle` for other compilers. The shufflings in a batch are processed sequentially one by one.
2. In gpu, a random key of `double` type is generated for each element of the array and then the elements are sorted by the keys. The keys for `n`-th batch is distributed in the range `[n, n + 1]` and the entire array is sorted by the keys at once. The sorting is delegated to mxnet's `SortByKey` which again delegates the call to thrust's `sort_by_key`. If both of the batch size and the length of the last axis are very large, the qualitiy of the shuffling could be bad in this implementation, i.e., the outcomes may not be uniformly distributed. It is because, as `n` grows,  the number of floating point numbers in `[n, n+1]` becomes smaller and so the probability that there are duplicated keys grows. However, I believe that it hardly causes a problem in practice. If this is not acceptable, an alternative implementation is to process the shufflings in a batch sequentially. However, this alternative shows very poor performance comparing to the current implementation even when the batch size is some hundreds.
3. Inplace shuffling is allowed. 

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
