### PR TITLE
Tensorboard: Add histogram callback

### DIFF
--- a/python/mxnet/contrib/tensorboard.py
+++ b/python/mxnet/contrib/tensorboard.py
@@ -75,8 +75,9 @@ class LogMetricsCallback(object):
 
     def node_histogram_visualization(self, prefix=None, node_names=None, bins="auto"):
         """Node histogram visualization in TensorBoard.
-        This callback works almost same as `callback.module_checkpoint`, but write TensorBoard event file
-        for visualization. For more usage, please refer https://github.com/dmlc/tensorboard
+        This callback works almost same as `callback.module_checkpoint`,
+        but write TensorBoard event file for visualization.
+        For more usage, please refer https://github.com/dmlc/tensorboard
 
         Parameters
         ----------
@@ -87,20 +88,27 @@ class LogMetricsCallback(object):
             If set 'None', this callback visualize all nodes histogram and distributions.
             Default node_names = None.
         bins : str
-            one of {'tensorflow','auto', 'fd', ...}, this determines how the bins are made. 
-            You can find other options in: https://docs.scipy.org/doc/numpy/reference/generated/numpy.histogram.html
+            one of {'tensorflow','auto', 'fd', ...}, this determines how the bins are made.
+            You can find other options in:
+            https://docs.scipy.org/doc/numpy/reference/generated/numpy.histogram.html
             Default bins = 'auto'
         """
         self.histogram_prefix = prefix
         self.node_names = node_names
         self.bins = bins
 
-        def _callback(iter_no, sym, arg, aux):
+        # pylint: disable=unused-argument
+        def _callback(iter_no, sym=None, arg=None, aux=None):
             """Callback to log node histogram visualization in TensorBoard."""
-            for k,v in arg.items():
+            for k, v in arg.items():
                 if self.node_names is None or k in self.node_names:
-                    name = k
                     if self.histogram_prefix is not None:
                         name = '%s-%s' % (self.histogram_prefix, k)
                     self.summary_writer.add_histogram(name, v, global_step=iter_no, bins=self.bins)
+            for k, v in aux.items():
+                if self.node_names is None or k in self.node_names:
+                    if self.histogram_prefix is not None:
+                        name = '%s-%s' % (self.histogram_prefix, k)
+                    self.summary_writer.add_histogram(name, v, global_step=iter_no, bins=self.bins)
+
         return _callback

--- a/python/mxnet/contrib/tensorboard.py
+++ b/python/mxnet/contrib/tensorboard.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 import logging
 
 
+
 class LogMetricsCallback(object):
     """Log metrics periodically in TensorBoard.
     This callback works almost same as `callback.Speedometer`, but write TensorBoard event file
@@ -71,3 +72,35 @@ class LogMetricsCallback(object):
             if self.prefix is not None:
                 name = '%s-%s' % (self.prefix, name)
             self.summary_writer.add_scalar(name, value)
+
+    def node_histogram_visualization(self, prefix=None, node_names=None, bins="auto"):
+        """Node histogram visualization in TensorBoard.
+        This callback works almost same as `callback.module_checkpoint`, but write TensorBoard event file
+        for visualization. For more usage, please refer https://github.com/dmlc/tensorboard
+
+        Parameters
+        ----------
+        prefix : str
+            Prefix for a metric name of `histograms` and `distributions` value.
+        node_names : list of str, optional
+            Name of nodes list you want to visualize.
+            If set 'None', this callback visualize all nodes histogram and distributions.
+            Default node_names = None.
+        bins : str
+            one of {'tensorflow','auto', 'fd', ...}, this determines how the bins are made. 
+            You can find other options in: https://docs.scipy.org/doc/numpy/reference/generated/numpy.histogram.html
+            Default bins = 'auto'
+        """
+        self.histogram_prefix = prefix
+        self.node_names = node_names
+        self.bins = bins
+
+        def _callback(iter_no, sym, arg, aux):
+            """Callback to log node histogram visualization in TensorBoard."""
+            for k,v in arg.items():
+                if self.node_names is None or k in self.node_names:
+                    name = k
+                    if self.histogram_prefix is not None:
+                        name = '%s-%s' % (self.histogram_prefix, k)
+                    self.summary_writer.add_histogram(name, v, global_step=iter_no, bins=self.bins)
+        return _callback


### PR DESCRIPTION
## Description ##
Add visualize histograms and distributions of each layer in Tensorboard.
You can use `contrib.tensorboard.LogMetricsCallback.node_histogram_visualization` like `callback.module_checkpoint` .
You can specify the names of nodes ( e.g. fc1_bias, default is visualizing all nodes)

<img width="1269" alt="2018-03-02 22 53 13" src="https://user-images.githubusercontent.com/10014831/36973038-bdf62170-20b4-11e8-84ca-e1ad3733aab3.png">
<img width="1270" alt="2018-03-02 22 53 40" src="https://user-images.githubusercontent.com/10014831/36973042-c1f59166-20b4-11e8-8bb2-f831a694692b.png">


## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
