### PR TITLE
fixed calling error while preparing data in ssd

### DIFF
--- a/example/ssd/tools/prepare_coco.sh
+++ b/example/ssd/tools/prepare_coco.sh
@@ -19,4 +19,4 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 python $DIR/prepare_dataset.py --dataset coco --set train2014,valminusminival2014 --target $DIR/../data/train.lst  --root $DIR/../data/coco
-python $DIR/prepare_dataset.py --dataset coco --set minival2014 --target $DIR/../data/val.lst --shuffle False --root $DIR/../data/coco
+python $DIR/prepare_dataset.py --dataset coco --set minival2014 --target $DIR/../data/val.lst --root $DIR/../data/coco --no-shuffle

--- a/example/ssd/tools/prepare_dataset.py
+++ b/example/ssd/tools/prepare_dataset.py
@@ -104,6 +104,9 @@ def parse_args():
                         type=str)
     parser.add_argument('--no-shuffle', dest='shuffle', help='shuffle list',
                         action='store_false')
+    parser.add_argument('--num-thread', dest='num_thread', type=int, default=1,
+                        help='number of thread to use while runing im2rec.py')
+
     args = parser.parse_args()
     return args
 
@@ -122,9 +125,14 @@ if __name__ == '__main__':
 
     print("List file {} generated...".format(args.target))
 
-    subprocess.check_call(["python",
-        os.path.join(curr_path, "../../../tools/im2rec.py"),
-        os.path.abspath(args.target), os.path.abspath(args.root_path),
-        "--shuffle", str(int(args.shuffle)), "--pack-label", "1"])
+    cmd_arguments = ["python",
+                    os.path.join(curr_path, "../../../tools/im2rec.py"),
+                    os.path.abspath(args.target), os.path.abspath(args.root_path),
+                    "--pack-label", "--num-thread", str(args.num_thread)]
+
+    if not args.shuffle:
+        cmd_arguments.append("--no-shuffle")
+
+    subprocess.check_call(cmd_arguments)
 
     print("Record file {} generated...".format(args.target.split('.')[0] + '.rec'))

--- a/example/ssd/tools/prepare_pascal.sh
+++ b/example/ssd/tools/prepare_pascal.sh
@@ -19,4 +19,4 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 python $DIR/prepare_dataset.py --dataset pascal --year 2007,2012 --set trainval --target $DIR/../data/train.lst
-python $DIR/prepare_dataset.py --dataset pascal --year 2007 --set test --target $DIR/../data/val.lst --shuffle False
+python $DIR/prepare_dataset.py --dataset pascal --year 2007 --set test --target $DIR/../data/val.lst --no-shuffle


### PR DESCRIPTION
fixed calling error while calling im2rec.py in prepare_dataset.py
add threads support in prepare_dataset.py

## Description ##
Since the im2rec.py is changed, the calling method in prepare_dataset.py in ssd is invalid. Thus, modified the code to allow converting data correctly. Also, added threads support to improve converting speed.

## Checklist ##
### Essentials ###
- [ ] Passed code style checking (`make lint`)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
