### PR TITLE
Fix bug for Dropout with axes, also adding unit test

### DIFF
--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -259,7 +259,7 @@ class DropoutOp {
             return;
           }
           // initialize the mask
-          LaunchRNG<BernoulliKernel, xpu>(s, pgen, out.Size(),
+          LaunchRNG<BernoulliKernel, xpu>(s, pgen, mask.Size(),
                                           mask.dptr<DType>(),
                                           this->pkeep_);
           // broadcast mul


### PR DESCRIPTION
## Description ##
1) Fix bug/typo in previous PR https://github.com/apache/incubator-mxnet/pull/9931
2) Add unit test for new feature Dropout with axes (variational dropout)

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Dropout operator with axes, unit tests

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
