### PR TITLE
correct comments to copy and copyto

### DIFF
--- a/cpp-package/include/mxnet-cpp/ndarray.h
+++ b/cpp-package/include/mxnet-cpp/ndarray.h
@@ -291,15 +291,15 @@ class NDArray {
   */
   void SyncCopyToCPU(std::vector<mx_float> *data, size_t size = 0);
   /*!
-  * \brief Copy the content of current array to other.
-  * \param other the new context of this NDArray
-  * \return the new copy
+  * \brief copy the content of current array to a target array.
+  * \param other the target NDArray
+  * \return the target NDarray
   */
   NDArray CopyTo(NDArray * other) const;
   /*!
-  * \brief return a new copy this NDArray
-  * \param other the target NDArray
-  * \return the copy target NDarray
+  * \brief return a new copy to this NDArray
+  * \param Context the new context of this NDArray
+  * \return the new copy
   */
   NDArray Copy(const Context &) const;
   /*!


### PR DESCRIPTION
## Description ##
The comments to Copy and CopyTo were incorrect and this is obvious when you look at the arguments to the functions and the implementations in ndarray.hpp.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change