### PR TITLE
[MXNET-68] Random shuffle implementation

### DIFF
--- a/docs/api/python/ndarray/random.md
+++ b/docs/api/python/ndarray/random.md
@@ -35,6 +35,8 @@ In the rest of this document, we list routines provided by the `ndarray.random` 
     normal
     poisson
     uniform
+	multinomial
+	shuffle
     mxnet.random.seed
 ```
 

--- a/docs/api/python/ndarray/random.md
+++ b/docs/api/python/ndarray/random.md
@@ -35,8 +35,8 @@ In the rest of this document, we list routines provided by the `ndarray.random` 
     normal
     poisson
     uniform
-	multinomial
-	shuffle
+    multinomial
+    shuffle
     mxnet.random.seed
 ```
 

--- a/docs/api/python/symbol/random.md
+++ b/docs/api/python/symbol/random.md
@@ -35,6 +35,8 @@ In the rest of this document, we list routines provided by the `symbol.random` p
     normal
     poisson
     uniform
+	multinomial
+	shuffle
     mxnet.random.seed
 ```
 

--- a/docs/api/python/symbol/random.md
+++ b/docs/api/python/symbol/random.md
@@ -35,8 +35,8 @@ In the rest of this document, we list routines provided by the `symbol.random` p
     normal
     poisson
     uniform
-	multinomial
-	shuffle
+    multinomial
+    shuffle
     mxnet.random.seed
 ```
 

--- a/python/mxnet/ndarray/random.py
+++ b/python/mxnet/ndarray/random.py
@@ -24,7 +24,7 @@ from .ndarray import NDArray
 
 
 __all__ = ['uniform', 'normal', 'poisson', 'exponential', 'gamma', 'multinomial',
-           'negative_binomial', 'generalized_negative_binomial']
+           'negative_binomial', 'generalized_negative_binomial', 'shuffle']
 
 
 def _random_helper(random, sampler, params, shape, dtype, ctx, out, kwargs):
@@ -431,3 +431,35 @@ def multinomial(data, shape=_Null, get_prob=False, out=None, **kwargs):
     <NDArray 2 @cpu(0)>
     """
     return _internal._sample_multinomial(data, shape, get_prob, out=out, **kwargs)
+
+
+def shuffle(data, **kwargs):
+    """Shuffle the elements randomly.
+
+    This shuffles the array along the first axis.
+    The order of the elements in each subarray does not change.
+    For example, if a 2D array is given, the order of the rows randomly changes,
+    but the order of the elements in each row does not change.
+
+    Parameters
+    ----------
+    data : NDArray
+        Input data array.
+    out : NDArray
+        Array to store the result.
+
+    Examples
+    --------
+    >>> data = mx.nd.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+    >>> mx.nd.random.shuffle(data)
+    [[ 0.  1.  2.]
+     [ 6.  7.  8.]
+     [ 3.  4.  5.]]
+    <NDArray 2x3 @cpu(0)>
+    >>> mx.nd.random.shuffle(data)
+    [[ 3.  4.  5.]
+     [ 0.  1.  2.]
+     [ 6.  7.  8.]]
+    <NDArray 2x3 @cpu(0)>
+    """
+    return _internal._shuffle(data, **kwargs)

--- a/python/mxnet/symbol/random.py
+++ b/python/mxnet/symbol/random.py
@@ -23,7 +23,7 @@ from .symbol import Symbol
 
 
 __all__ = ['uniform', 'normal', 'poisson', 'exponential', 'gamma', 'multinomial',
-           'negative_binomial', 'generalized_negative_binomial']
+           'negative_binomial', 'generalized_negative_binomial', 'shuffle']
 
 
 def _random_helper(random, sampler, params, shape, dtype, kwargs):
@@ -247,3 +247,34 @@ def multinomial(data, shape=_Null, get_prob=True, **kwargs):
         reward as head gradient w.r.t. this array to estimate gradient.
     """
     return _internal._sample_multinomial(data, shape, get_prob, **kwargs)
+
+
+def shuffle(data, **kwargs):
+    """Shuffle the elements randomly.
+
+    This shuffles the array along the first axis.
+    The order of the elements in each subarray does not change.
+    For example, if a 2D array is given, the order of the rows randomly changes,
+    but the order of the elements in each row does not change.
+
+    Parameters
+    ----------
+    data : NDArray
+        Input data array.
+    Examples
+    --------
+    >>> data = mx.nd.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]])
+    >>> a = mx.sym.Variable('a')
+    >>> b = mx.sym.random.shuffle(a)
+    >>> b.eval(a=data)
+    [[ 0.  1.  2.]
+     [ 6.  7.  8.]
+     [ 3.  4.  5.]]
+    <NDArray 2x3 @cpu(0)>
+    >>> b.eval(a=data)
+    [[ 3.  4.  5.]
+     [ 0.  1.  2.]
+     [ 6.  7.  8.]]
+    <NDArray 2x3 @cpu(0)>
+    """
+    return _internal._shuffle(data, **kwargs)

--- a/src/operator/random/shuffle_op.cc
+++ b/src/operator/random/shuffle_op.cc
@@ -86,7 +86,7 @@ void ShuffleForwardCPU(const nnvm::NodeAttrs& attrs,
   const index_t size = inputs[0].Size();
   const index_t first_axis_len = input_shape[0];
   Stream<cpu> *s = ctx.get_stream<cpu>();
-  MSHADOW_REAL_TYPE_SWITCH(inputs[0].type_flag_, DType, {
+  MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, DType, {
     Tensor<cpu, 1, DType> in = inputs[0].get_with_shape<cpu, 1, DType>(Shape1(size), s);
     Tensor<cpu, 1, DType> out = outputs[0].get_with_shape<cpu, 1, DType>(Shape1(size), s);
     auto& prnd = ctx.requested[0].get_random<cpu, index_t>(ctx.get_stream<cpu>())->GetRndEngine();

--- a/src/operator/random/shuffle_op.cc
+++ b/src/operator/random/shuffle_op.cc
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file shuffle_op.cc
+ * \brief Operator to shuffle elements of an NDArray
+ */
+#if (__GNUC__ > 4 && !defined(__clang__major__)) || (__clang_major__ > 4 && __linux__)
+  #define USE_GNU_PARALLEL_SHUFFLE
+#endif
+
+#include <mxnet/operator_util.h>
+#include <algorithm>
+#include <random>
+#include <vector>
+#ifdef USE_GNU_PARALLEL_SHUFFLE
+  #include <parallel/algorithm>
+#endif
+#include "../elemwise_op_common.h"
+
+namespace mxnet {
+namespace op {
+
+void ShuffleForwardCPU(const nnvm::NodeAttrs& attrs,
+                       const OpContext& ctx,
+                       const std::vector<TBlob>& inputs,
+                       const std::vector<OpReqType>& req,
+                       const std::vector<TBlob>& outputs) {
+  using namespace mxnet_op;
+  if (req[0] == kNullOp) {
+    return;
+  }
+  CHECK_NE(req[0], kAddTo) << "Shuffle does not support AddTo";
+  const TShape input_shape = inputs[0].shape_;
+  const index_t size = inputs[0].Size();
+  const index_t first_axis_len = input_shape[0];
+  const index_t stride = size / first_axis_len;
+  Stream<cpu> *s = ctx.get_stream<cpu>();
+  MSHADOW_REAL_TYPE_SWITCH(inputs[0].type_flag_, DType, {
+    Tensor<cpu, 1, DType> in = inputs[0].get_with_shape<cpu, 1, DType>(Shape1(size), s);
+    Tensor<cpu, 1, DType> out = outputs[0].get_with_shape<cpu, 1, DType>(Shape1(size), s);
+    auto& prnd = ctx.requested[0].get_random<cpu, index_t>(ctx.get_stream<cpu>())->GetRndEngine();
+    auto rand_n = [&prnd](index_t n) {
+      std::uniform_int_distribution<index_t> dist(0, n - 1);
+      return dist(prnd);
+    };
+    if (req[0] != kWriteInplace) {
+      std::copy(in.dptr_, in.dptr_ + size, out.dptr_);
+    }
+    if (input_shape.ndim() == 1) {
+      #ifdef USE_GNU_PARALLEL_SHUFFLE
+      __gnu_parallel::random_shuffle(out.dptr_, out.dptr_ + size, rand_n);
+      #else
+      std::shuffle(out.dptr_, out.dptr_ + size, prnd);
+      #endif
+    } else {
+      // Fisher-Yates shuffling
+      for (index_t i = input_shape[0] - 1; i > 0; --i) {
+        index_t j = rand_n(i + 1);
+        if (i != j) {
+          std::swap_ranges(out.dptr_ + stride * i,
+                           out.dptr_ + stride * (i + 1),
+                           out.dptr_ + stride * j);
+        }
+      }
+    }
+  });
+}
+
+
+// No parameter is declared.
+// No backward computation is registered. Shuffling is not differentiable.
+
+NNVM_REGISTER_OP(_shuffle)
+.add_alias("shuffle")
+.describe(R"code(Randomly shuffle the elements.
+
+This shuffles the array along the first axis.
+The order of the elements in each subarray does not change.
+For example, if a 2D array is given, the order of the rows randomly changes,
+but the order of the elements in each row does not change.
+)code")
+.set_num_inputs(1)
+.set_num_outputs(1)
+.set_attr<nnvm::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const nnvm::NodeAttrs& attrs) {
+    return std::vector<ResourceRequest>{ResourceRequest::kRandom, ResourceRequest::kTempSpace};
+  })
+.set_attr<nnvm::FInplaceOption>("FInplaceOption",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::pair<int, int>>{{0, 0}};
+  })
+.set_attr<FCompute>("FCompute<cpu>", ShuffleForwardCPU)
+.add_argument("data", "NDArray-or-Symbol", "Data to be shuffled.");
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/random/shuffle_op.cc
+++ b/src/operator/random/shuffle_op.cc
@@ -62,8 +62,9 @@ void ShuffleND(DType* const out, const index_t size, const index_t first_axis_le
     std::uniform_int_distribution<index_t> dist(0, n - 1);
     return dist(*prnd);
   };
+  CHECK_GT(first_axis_len, 0U);
   for (index_t i = first_axis_len - 1; i > 0; --i) {
-    index_t j = rand_n(i + 1);
+    const index_t j = rand_n(i + 1);
     if (i != j) {
       std::swap_ranges(out + stride * i, out + stride * (i + 1), out + stride * j);
     }

--- a/src/operator/random/shuffle_op.cc
+++ b/src/operator/random/shuffle_op.cc
@@ -39,16 +39,17 @@ namespace mxnet {
 namespace op {
 
 namespace {
+
   template<typename DType, typename Rand>
   void Shuffle1D(DType* out, index_t size, Rand* prnd) {
     #ifdef USE_GNU_PARALLEL_SHUFFLE
-    auto rand_n = [prnd](index_t n) {
-      std::uniform_int_distribution<index_t> dist(0, n - 1);
-      return dist(*prnd);
-    };
-    __gnu_parallel::random_shuffle(out, out + size, rand_n);
+      auto rand_n = [prnd](index_t n) {
+        std::uniform_int_distribution<index_t> dist(0, n - 1);
+        return dist(*prnd);
+      };
+      __gnu_parallel::random_shuffle(out, out + size, rand_n);
     #else
-    std::shuffle(out, out + size, *prnd);
+      std::shuffle(out, out + size, *prnd);
     #endif
   }
 
@@ -67,6 +68,7 @@ namespace {
       }
     }
   }
+
 }  // namespace
 
 void ShuffleForwardCPU(const nnvm::NodeAttrs& attrs,

--- a/src/operator/random/shuffle_op.cu
+++ b/src/operator/random/shuffle_op.cu
@@ -36,8 +36,8 @@ namespace {
 
 struct CopyForShuffle {
   template<typename DType>
-  MSHADOW_XINLINE static void Map(int i, const DType* in, DType* out,
-                                  const index_t* indices, index_t stride) {
+  MSHADOW_XINLINE static void Map(int i, const DType* const in, DType* out,
+                                  const index_t* indices, const index_t stride) {
     out[i] = in[indices[i / stride] * stride + i % stride];
   }
 };
@@ -54,7 +54,7 @@ void ShuffleForwardGPU(const nnvm::NodeAttrs& attrs,
     return;
   }
   CHECK_NE(req[0], kAddTo) << "Shuffle does not support AddTo";
-  const TShape input_shape = inputs[0].shape_;
+  const TShape& input_shape = inputs[0].shape_;
   const index_t size = inputs[0].Size();
   const index_t first_axis_len = input_shape[0];
   const index_t stride = size / first_axis_len;
@@ -73,7 +73,7 @@ void ShuffleForwardGPU(const nnvm::NodeAttrs& attrs,
       prnd->GetRandInt(keys);
       SortByKey(keys, out, true);
     } else {
-      size_t tmp_space_size = req[0] == kWriteInplace ?
+      const size_t tmp_space_size = req[0] == kWriteInplace ?
         2 * first_axis_len * sizeof(index_t) + size * sizeof(DType) :
         2 * first_axis_len * sizeof(index_t);
       Tensor<gpu, 1, char> tmp_space =

--- a/src/operator/random/shuffle_op.cu
+++ b/src/operator/random/shuffle_op.cu
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file shuffle_op.cc
+ * \brief Operator to shuffle elements of an NDArray
+ */
+#include <mxnet/operator_util.h>
+#include <algorithm>
+#include <random>
+#include <vector>
+#include "../elemwise_op_common.h"
+#include "../tensor/init_op.h"
+
+
+namespace mxnet {
+namespace op {
+
+namespace {
+
+struct CopyForShuffle {
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, const DType* in, DType* out,
+                                  const index_t* indices, index_t stride) {
+    out[i] = in[indices[i / stride] * stride + i % stride];
+  }
+};
+
+}  // namespace
+
+void ShuffleForwardGPU(const nnvm::NodeAttrs& attrs,
+                       const OpContext& ctx,
+                       const std::vector<TBlob>& inputs,
+                       const std::vector<OpReqType>& req,
+                       const std::vector<TBlob>& outputs) {
+  using namespace mxnet_op;
+  if (req[0] == kNullOp) {
+    return;
+  }
+  CHECK_NE(req[0], kAddTo) << "Shuffle does not support AddTo";
+  const TShape input_shape = inputs[0].shape_;
+  const index_t size = inputs[0].Size();
+  const index_t first_axis_len = input_shape[0];
+  const index_t stride = size / first_axis_len;
+  Stream<gpu> *s = ctx.get_stream<gpu>();
+  MSHADOW_REAL_TYPE_SWITCH(inputs[0].type_flag_, DType, {
+    using KeyType = index_t;
+    Tensor<gpu, 1, DType> in = inputs[0].get_with_shape<gpu, 1, DType>(Shape1(size), s);
+    Tensor<gpu, 1, DType> out = outputs[0].get_with_shape<gpu, 1, DType>(Shape1(size), s);
+    Random<gpu, KeyType> *prnd = ctx.requested[0].get_random<gpu, KeyType>(s);
+    if (input_shape.ndim() == 1) {
+      if (req[0] != kWriteInplace) {
+        Copy(out, in, s);
+      }
+      Tensor<gpu, 1, KeyType> keys =
+        ctx.requested[1].get_space_typed<gpu, 1, KeyType>(Shape1(size), s);
+      prnd->GetRandInt(keys);
+      SortByKey(keys, out, true);
+    } else {
+      size_t tmp_space_size = req[0] == kWriteInplace ?
+        2 * first_axis_len * sizeof(index_t) + size * sizeof(DType) :
+        2 * first_axis_len * sizeof(index_t);
+      Tensor<gpu, 1, char> tmp_space =
+        ctx.requested[1].get_space_typed<gpu, 1, char>(Shape1(tmp_space_size), s);
+      char* tmp_space_ptr = tmp_space.dptr_;
+      Tensor<gpu, 1, index_t> indices(reinterpret_cast<index_t*>(tmp_space_ptr),
+                                      Shape1(first_axis_len), s);
+      tmp_space_ptr += sizeof(index_t) * first_axis_len;
+      Kernel<range_fwd, gpu>::Launch(s, first_axis_len, 1, 0U, 1U, kWriteTo, indices.dptr_);
+      Tensor<gpu, 1, KeyType> keys(reinterpret_cast<KeyType*>(tmp_space_ptr),
+                                   Shape1(first_axis_len), s);
+      tmp_space_ptr += sizeof(KeyType) * first_axis_len;
+      prnd->GetRandInt(keys);
+      SortByKey(keys, indices, true);
+      if (req[0] == kWriteInplace) {
+        Tensor<gpu, 1, DType> buf(reinterpret_cast<DType*>(tmp_space_ptr), Shape1(size), s);
+        Copy(buf, in, s);
+        Kernel<CopyForShuffle, gpu>::Launch(s, size, buf.dptr_, out.dptr_, indices.dptr_, stride);
+      } else {
+        Kernel<CopyForShuffle, gpu>::Launch(s, size, in.dptr_, out.dptr_, indices.dptr_, stride);
+      }
+    }
+  });
+}
+
+NNVM_REGISTER_OP(_shuffle)
+.set_attr<FCompute>("FCompute<gpu>", ShuffleForwardGPU);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/random/shuffle_op.cu
+++ b/src/operator/random/shuffle_op.cu
@@ -59,7 +59,7 @@ void ShuffleForwardGPU(const nnvm::NodeAttrs& attrs,
   const index_t first_axis_len = input_shape[0];
   const index_t stride = size / first_axis_len;
   Stream<gpu> *s = ctx.get_stream<gpu>();
-  MSHADOW_REAL_TYPE_SWITCH(inputs[0].type_flag_, DType, {
+  MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, DType, {
     using KeyType = index_t;
     Tensor<gpu, 1, DType> in = inputs[0].get_with_shape<gpu, 1, DType>(Shape1(size), s);
     Tensor<gpu, 1, DType> out = outputs[0].get_with_shape<gpu, 1, DType>(Shape1(size), s);

--- a/src/operator/random/shuffle_op.cu
+++ b/src/operator/random/shuffle_op.cu
@@ -29,7 +29,6 @@
 #include "../elemwise_op_common.h"
 #include "../tensor/init_op.h"
 
-
 namespace mxnet {
 namespace op {
 

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -581,7 +581,7 @@ def test_shuffle():
             ret = mx.nd.random.shuffle(data)
             check_first_axis_shuffle(ret)
         count = {}
-		# Count the number of each outcome
+        # Count the number of each outcome
         for i in range(repeat2):
             ret = mx.nd.random.shuffle(data)
             h = hash(ret.reshape((ret.size,))[::stride])

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -556,12 +556,6 @@ def test_zipfian_generator():
 
 @with_seed()
 def test_shuffle():
-    def hash(arr):
-        ret = 0
-        for i, n in enumerate(arr):
-            ret += int(n.asscalar()) * (arr.size ** i)
-        return ret
-
     def check_first_axis_shuffle(arr):
         stride = int(arr.size / arr.shape[0])
         column0 = arr.reshape((arr.size,))[::stride].sort()
@@ -588,14 +582,14 @@ def test_shuffle():
         stride = int(data.size / data.shape[0])
         for i in range(repeat2):
             ret = mx.nd.random.shuffle(data)
-            h = hash(ret.reshape((ret.size,))[::stride])
+            h = str(ret.reshape((ret.size,))[::stride])
             c = count.get(h, 0)
             count[h] = c + 1
         # Check the total number of possible outcomes.
         assert len(count) == math.factorial(data.shape[0])
         # The outcomes must be uniformly distributed.
         for p in itertools.permutations(range(0, data.size - stride + 1, stride)):
-            assert abs(count[hash(mx.nd.array(p))] / repeat2 - 1 / math.factorial(data.shape[0])) < 0.01
+            assert abs(count[str(mx.nd.array(p))] / repeat2 - 1 / math.factorial(data.shape[0])) < 0.01
         # Check symbol interface
         a = mx.sym.Variable('a')
         b = mx.sym.random.shuffle(a)
@@ -613,7 +607,7 @@ def test_shuffle():
         for i in range(repeat):
             ret = mx.nd.random.shuffle(data)
             check_first_axis_shuffle(ret)
-            h = hash(ret.reshape((ret.size,))[::stride])
+            h = str(ret.reshape((ret.size,))[::stride])
             c = count.get(h, 0)
             count[h] = c + 1
         # The probability of duplicated outcomes is very low for large arrays.

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -589,7 +589,7 @@ def test_shuffle():
         assert len(count) == math.factorial(data.shape[0])
         # The outcomes must be uniformly distributed.
         for p in itertools.permutations(range(0, data.size - stride + 1, stride)):
-            assert abs(count[str(mx.nd.array(p))] / repeat2 - 1 / math.factorial(data.shape[0])) < 0.01
+            assert 1. * abs(count[str(mx.nd.array(p))] / repeat2 - 1. / math.factorial(data.shape[0])) < 0.01
         # Check symbol interface
         a = mx.sym.Variable('a')
         b = mx.sym.random.shuffle(a)

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -596,7 +596,7 @@ def test_shuffle():
         # The outcomes must be uniformly distributed.
         # If `repeat2` is not large enough, this could fail with high probability.
         for p in itertools.permutations(range(0, data.size - stride + 1, stride)):
-            assert 1. * abs(count[str(mx.nd.array(p))] / repeat2 - 1. / math.factorial(data.shape[0])) < 0.01
+            assert abs(1. * count[str(mx.nd.array(p))] / repeat2 - 1. / math.factorial(data.shape[0])) < 0.01
         # Check symbol interface
         a = mx.sym.Variable('a')
         b = mx.sym.random.shuffle(a)


### PR DESCRIPTION
## Description ##

This operator randomly shuffles an NDArray along the first axis. The order of the elements in each subarray does not change. For exmaple, if an NDArray `x` is shuffled, the order of the subarrays `x[i]` randomly changes but the order of the elements in each `x[i]` does not change. This PR is a revise of #9991.

### Implementation

1. In cpu, the shuffling of an 1D array is delegated to `__gnu_parallel::random_shuffle`, which utilizes openmp, for clang on linux and gcc on any OS and delegated to `std::shuffle` for other platforms. For an multidimensional array, the usual Fisher-Yates shuffling is implemented.
2. In gpu, for a multidimensional array, it shuffles the array of indices representing the subarrays and then rearrange the elements of the data array according to the shuffled index array. To shuffle the index array, a random key is generated for each index and then the indices are sorted by the keys. If the given array is 1D, it sorts the array directly with random keys instead of sorting the indices. The sorting is delegated to mshadow's `SortByKey` which again delegates the call to thrust's `sort_by_key`. This implementation is essentially equivalent to `__gnu_parallel::random_shuffle` while the random key generation and sorting are fused in gnu's implementation.

### Note

This operator is modeled on `numpy.random.shuffle`.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
