### PR TITLE
Avoid unnecessary copy in ndarray.astype

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -1844,7 +1844,9 @@ fixed-size items.
         return self.asnumpy()[0]
 
     def astype(self, dtype):
-        """Returns a copy of the array after casting to a specified type.
+        """Returns a copy of the array after casting to a specified type
+        if the type of array is different from the argument dtype.
+        Else, returns the same array.
 
         Parameters
         ----------
@@ -1863,9 +1865,12 @@ fixed-size items.
         >>> y.dtype
         <type 'numpy.int32'>
         """
-        res = empty(self.shape, ctx=self.context, dtype=dtype)
-        self.copyto(res)
-        return res
+        if self.dtype == np.dtype(dtype):
+            return self
+        else:
+            res = empty(self.shape, ctx=self.context, dtype=dtype)
+            self.copyto(res)
+            return res
 
     def copyto(self, other):
         """Copies the value of this array to another array.


### PR DESCRIPTION
## Description ##
Avoid copy during narray.astype(dtype) when array is already of required dtype.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

