### PR TITLE
WIP: Test building without explicit MKL disable

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -278,8 +278,6 @@ build_ubuntu_gpu_cmake() {
     cmake \
         -DUSE_CUDA=1               \
         -DUSE_CUDNN=1              \
-        -DUSE_MKLML_MKL=0          \
-        -DUSE_MKLDNN=0             \
         -DCMAKE_BUILD_TYPE=Release \
         -G Ninja                   \
         /work/mxnet


### PR DESCRIPTION
Testing CI when MKL isn't explicitly disabled.  Temporary PR, will be closed in the future without merge.