### PR TITLE
Fix multi worker

### DIFF
--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -119,6 +119,66 @@ def worker_loop(dataset, key_queue, data_queue, batchify_fn):
         batch = batchify_fn([dataset[i] for i in samples])
         data_queue.put((idx, batch))
 
+class _MultiWorkerIter(object):
+    """Interal multi-worker iterator for DataLoader."""
+    def __init__(self, num_workers, dataset, batchify_fn, batch_sampler):
+        assert num_workers > 0, "_MultiWorkerIter is not for {} workers".format(num_workers)
+        self._num_workers = num_workers
+        self._dataset = dataset
+        self._batchify_fn = batchify_fn
+        self._batch_sampler = batch_sampler
+        self._key_queue = Queue()
+        self._data_queue = Queue(2*self._num_workers)
+        self._data_buffer = {}
+        self._index = 0
+        self._shutdown = False
+
+        workers = []
+        for _ in range(self._num_workers):
+            worker = multiprocessing.Process(
+                target=worker_loop,
+                args=(self._dataset, self._key_queue, self._data_queue, self._batchify_fn))
+            worker.daemon = True
+            worker.start()
+            workers.append(worker)
+
+        for idx, batch in enumerate(self._batch_sampler):
+            key_queue.put((idx, batch))
+
+    def __len__(self):
+        return len(self._batch_sampler)
+
+    def __del__(self):
+        self.shutdown()
+
+    def __next__(self):
+        if self._index == len(self._batch_sampler):
+            assert not self._data_buffer, "Data buffer should be empty at this moment"
+            self.shutdown()
+            raise StopIteration
+
+        while True:
+            if self._index in self._data_buffer:
+                batch = self._data_buffer.pop(self._index)
+                self._index += 1
+                return batch
+            idx, batch = self._data_queue.get()
+            self._data_buffer[idx] = batch
+
+    def __iter__(self):
+        return self
+
+    def shutdown(self):
+        if not self._shutdown:
+            for _ in range(self._num_workers):
+                self._key_queue.put((None, None))
+            try:
+                while not self._data_queue.empty():
+                    self._data_queue.get()
+            except IOError:
+                pass
+            self._shutdown = True
+
 
 class DataLoader(object):
     """Loads data from a dataset and returns mini-batches of data.
@@ -201,38 +261,11 @@ class DataLoader(object):
             for batch in self._batch_sampler:
                 yield self._batchify_fn([self._dataset[idx] for idx in batch])
             return
-
-        key_queue = Queue()
-        data_queue = Queue(2*self._num_workers)
-
-        workers = []
-        for _ in range(self._num_workers):
-            worker = multiprocessing.Process(
-                target=worker_loop,
-                args=(self._dataset, key_queue, data_queue, self._batchify_fn))
-            worker.daemon = True
-            worker.start()
-            workers.append(worker)
-
-        idx = 0
-        for idx, batch in enumerate(self._batch_sampler):
-            key_queue.put((idx, batch))
-        num_batches = idx + 1
-
-        data_buffer = {}
-        curr_idx = 0
-        for _ in range(num_batches):
-            idx, batch = data_queue.get()
-            data_buffer[idx] = batch
-            while curr_idx in data_buffer:
-                yield data_buffer.pop(curr_idx)
-                curr_idx += 1
-
-        for _ in range(self._num_workers):
-            key_queue.put((None, None))
-
-        for worker in workers:
-            worker.join()
+        elif self._num_workers > 0:
+            return _MultiWorkerIter(self._num_workers, self._dataset,
+                                    self._batchify_fn, self._batch_sampler)
+        else:
+            raise ValueError("num_workers: {} is not a valid number".format(self._num_workers))
 
     def __len__(self):
         return len(self._batch_sampler)

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -252,7 +252,7 @@ class DataLoader(object):
                              "not be specified if batch_sampler is specified.")
 
         self._batch_sampler = batch_sampler
-        self._num_workers = num_workers
+        self._num_workers = num_workers if num_workers >= 0 else 0
         if batchify_fn is None:
             if num_workers > 0:
                 self._batchify_fn = default_mp_batchify_fn
@@ -266,11 +266,10 @@ class DataLoader(object):
             generator = lambda: [(yield self._batchify_fn([self._dataset[idx] for idx in batch]))
                                  for batch in self._batch_sampler]
             return generator()
-        elif self._num_workers > 0:
-            return _MultiWorkerIter(self._num_workers, self._dataset,
-                                    self._batchify_fn, self._batch_sampler)
-        else:
-            raise ValueError("num_workers: {} is not a valid number".format(self._num_workers))
+
+        # multi-worker
+        return _MultiWorkerIter(self._num_workers, self._dataset,
+                                self._batchify_fn, self._batch_sampler)
 
     def __len__(self):
         return len(self._batch_sampler)

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -173,6 +173,7 @@ class _MultiWorkerIter(object):
         return self
 
     def shutdown(self):
+        """Shutdown internal workers by pushing terminate signals."""
         if not self._shutdown:
             for _ in range(self._num_workers):
                 self._key_queue.put((None, None))

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -152,6 +152,7 @@ class _MultiWorkerIter(object):
         self.shutdown()
 
     def __next__(self):
+        assert not self._shutdown, "call __next__ after shutdown is forbidden"
         if self._index == len(self._batch_sampler):
             assert not self._data_buffer, "Data buffer should be empty at this moment"
             self.shutdown()

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -258,9 +258,10 @@ class DataLoader(object):
 
     def __iter__(self):
         if self._num_workers == 0:
-            for batch in self._batch_sampler:
-                yield self._batchify_fn([self._dataset[idx] for idx in batch])
-            return
+            generator = lambda: [(yield self._batchify_fn([self._dataset[idx] for idx in batch])) for batch in self._batch_sampler]
+            # for batch in self._batch_sampler:
+            #     yield self._batchify_fn([self._dataset[idx] for idx in batch])
+            return generator()
         elif self._num_workers > 0:
             return _MultiWorkerIter(self._num_workers, self._dataset,
                                     self._batchify_fn, self._batch_sampler)

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -165,6 +165,9 @@ class _MultiWorkerIter(object):
             idx, batch = self._data_queue.get()
             self._data_buffer[idx] = batch
 
+    def next(self):
+        return self.__next__()
+
     def __iter__(self):
         return self
 

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -261,9 +261,8 @@ class DataLoader(object):
 
     def __iter__(self):
         if self._num_workers == 0:
-            generator = lambda: [(yield self._batchify_fn([self._dataset[idx] for idx in batch])) for batch in self._batch_sampler]
-            # for batch in self._batch_sampler:
-            #     yield self._batchify_fn([self._dataset[idx] for idx in batch])
+            generator = lambda: [(yield self._batchify_fn([self._dataset[idx] for idx in batch]))
+                                 for batch in self._batch_sampler]
             return generator()
         elif self._num_workers > 0:
             return _MultiWorkerIter(self._num_workers, self._dataset,

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -143,7 +143,7 @@ class _MultiWorkerIter(object):
             workers.append(worker)
 
         for idx, batch in enumerate(self._batch_sampler):
-            key_queue.put((idx, batch))
+            self._key_queue.put((idx, batch))
 
     def __len__(self):
         return len(self._batch_sampler)

--- a/src/storage/cpu_shared_storage_manager.h
+++ b/src/storage/cpu_shared_storage_manager.h
@@ -69,6 +69,7 @@ class CPUSharedStorageManager final : public StorageManager {
 
   void Alloc(Storage::Handle* handle) override;
   void Free(Storage::Handle handle) override {
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
     pool_.erase(handle.dptr);
     FreeImpl(handle);
   }


### PR DESCRIPTION
## Description ##
- Fix race condition for CPUSharedStorageManager->Free
- Launch workers at iter init stage to avoid frequent relaunch

@piiswrong @sxjscience @yajiedesign 


## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
