### PR TITLE
ProfileObjectType no longer used

### DIFF
--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -492,25 +492,12 @@ class Profiler {
  *                                       |___/             |__/
  */
 
-enum ProfileObjectType {
-  kDomain,
-  kCounter,
-  kTask,
-  kEvent,
-  kFrame
-};
-
 class ProfileObject {
  public:
   /*!
    * \brief Virtual destructor for child classes
    */
   virtual ~ProfileObject() {}
-  /*!
-   * \brief Return profiling object object type (i.e. kTask, kEvent, ...)
-   * \return Profiling object type
-   */
-  virtual ProfileObjectType type() const = 0;
 };
 
 /*!
@@ -533,7 +520,6 @@ struct ProfileDomain : public ProfileObject {
    * \return Domain name
    */
   const char *name() const { return name_.c_str(); }
-  ProfileObjectType type() const override { return kDomain; }
   VTUNE_ONLY_CODE(inline vtune::VTuneDomain *dom() { return vtune_domain_.get(); });
  private:
   /*! \brief Name of the domain */
@@ -558,7 +544,7 @@ struct ProfileCounter : public ProfileObject {
     CHECK_NOTNULL(domain);
     VTUNE_ONLY_CODE(vtune_.reset(new vtune::VTuneCounter(name, domain->dom())));
   }
-  ~ProfileCounter() {}
+  ~ProfileCounter() override {}
   /*! \brief operator: ++object */
   inline uint64_t operator ++() {
     return IncrementValue(1);
@@ -605,8 +591,6 @@ struct ProfileCounter : public ProfileObject {
     SetValue(v);
     return *this;
   }
-
-  ProfileObjectType type() const override { return kCounter; }
 
  protected:
   /*!
@@ -781,8 +765,6 @@ struct ProfileTask : public ProfileDuration {
     SendStat();
   }
 
-  ProfileObjectType type() const override { return kTask; }
-
  protected:
   /*!
    * \brief Task statistic object
@@ -861,8 +843,6 @@ struct ProfileEvent  : public ProfileDuration {
     categories_.set(categories);
   }
 
-  ProfileObjectType type() const override { return kEvent; }
-
  protected:
   /*!
    * \brief Event statistic object
@@ -930,8 +910,6 @@ struct ProfileFrame : public ProfileDuration {
     VTUNE_ONLY_CODE(vtune_frame_->stop());
     SendStat();
   }
-
-  ProfileObjectType type() const override { return kFrame; }
 
  protected:
   /*!


### PR DESCRIPTION
## Description ##
This was created during development but then its use was deprecated. It's not actually used at all anymore, so removing it.

Leaving ProfileObject in for now based soley on its virtual destructor, but may remove at a later date.

## Checklist ##
### Essentials ###
- [x] Passed code style checking (`make lint`)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
