### PR TITLE
[Doc/Test Fix] Fix documentation of embedding layer + Fix LayerNorm Test

### DIFF
--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -353,7 +353,7 @@ class BatchNorm(HybridBlock):
 
 class Embedding(HybridBlock):
     r"""Turns non-negative integers (indexes/tokens) into dense vectors
-    of fixed size. eg. [[4], [20]] -> [[0.25, 0.1], [0.6, -0.2]]
+    of fixed size. eg. [4, 20] -> [[0.25, 0.1], [0.6, -0.2]]
 
 
     Parameters
@@ -369,10 +369,10 @@ class Embedding(HybridBlock):
 
 
     Inputs:
-        - **data**: 2D tensor with shape: `(x1, x2)`.
+        - **data**: (N-1)-D tensor with shape: `(x1, x2, ..., xN-1)`.
 
     Output:
-        - **out**: 3D tensor with shape: `(x1, x2, output_dim)`.
+        - **out**: N-D tensor with shape: `(x1, x2, ..., xN-1, output_dim)`.
     """
     def __init__(self, input_dim, output_dim, dtype='float32',
                  weight_initializer=None, **kwargs):

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2445,7 +2445,7 @@ def check_layer_normalization(in_shape, axis, eps, dtype=np.float32):
     for req in ['write', 'add']:
         check_numeric_gradient(out_s, {'data': data, 'gamma': gamma, 'beta': beta},
                                grad_nodes={'data': req, 'gamma': req, 'beta': req},
-                               numeric_eps=1e-2, rtol=1e-2, atol=1e-3)
+                               numeric_eps=1e-3, rtol=1e-2, atol=1e-3)
 
 def test_layer_norm():
     for dtype in [np.float16, np.float32, np.float64]:

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2452,7 +2452,7 @@ def test_layer_norm():
         for in_shape in [(10, 6, 5), (5, 5)]:
             for axis in range(-len(in_shape), len(in_shape)):
                 for eps in [1E-3, 1E-4]:
-                    check_layer_normalization(in_shape, axis, eps)
+                    check_layer_normalization(in_shape, axis, eps, dtype=dtype)
 
 
 # Numpy Implementation of Sequence Ops

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2420,9 +2420,9 @@ def check_layer_normalization(in_shape, axis, eps, dtype=np.float32):
             axis += data.ndim
         broadcast_shape = [1 for _ in range(data.ndim)]
         broadcast_shape[axis] = data.shape[axis]
-        mean = data.mean(axis=axis, keepdims=True)
-        var = data.var(axis=axis, keepdims=True)
-        std = np.sqrt(var + eps)
+        mean = data.mean(axis=axis, keepdims=True).astype(dtype)
+        var = data.var(axis=axis, keepdims=True).astype(dtype)
+        std = np.sqrt(var + eps).astype(dtype)
         out = np.reshape(gamma, broadcast_shape) * (data - mean) / std + \
               np.reshape(beta, broadcast_shape)
         return out

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2441,7 +2441,7 @@ def check_layer_normalization(in_shape, axis, eps, dtype=np.float32):
     exe.arg_dict['beta'][:] = beta
     out_nd = exe.forward()[0]
     out = npy_layer_norm(data, gamma, beta, axis, eps)
-    assert_allclose(out, out_nd.asnumpy(), 1E-3, 1E-3)
+    assert_almost_equal(out, out_nd.asnumpy(), 1E-3, 1E-3)
     for req in ['write', 'add']:
         check_numeric_gradient(out_s, {'data': data, 'gamma': gamma, 'beta': beta},
                                grad_nodes={'data': req, 'gamma': req, 'beta': req},
@@ -2449,7 +2449,7 @@ def check_layer_normalization(in_shape, axis, eps, dtype=np.float32):
 
 def test_layer_norm():
     for dtype in [np.float16, np.float32, np.float64]:
-        for in_shape in [(10, 6, 5), (5, 5)]:
+        for in_shape in [(10, 6, 5), (10, 10)]:
             for axis in range(-len(in_shape), len(in_shape)):
                 for eps in [1E-2, 1E-3]:
                     check_layer_normalization(in_shape, axis, eps, dtype=dtype)

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2441,7 +2441,7 @@ def check_layer_normalization(in_shape, axis, eps, dtype=np.float32):
     exe.arg_dict['beta'][:] = beta
     out_nd = exe.forward()[0]
     out = npy_layer_norm(data, gamma, beta, axis, eps)
-    assert_allclose(out, out_nd.asnumpy(), 1E-4, 1E-4)
+    assert_allclose(out, out_nd.asnumpy(), 1E-3, 1E-3)
     for req in ['write', 'add']:
         check_numeric_gradient(out_s, {'data': data, 'gamma': gamma, 'beta': beta},
                                grad_nodes={'data': req, 'gamma': req, 'beta': req},
@@ -2451,7 +2451,7 @@ def test_layer_norm():
     for dtype in [np.float16, np.float32, np.float64]:
         for in_shape in [(10, 6, 5), (5, 5)]:
             for axis in range(-len(in_shape), len(in_shape)):
-                for eps in [1E-3, 1E-4]:
+                for eps in [1E-2, 1E-3]:
                     check_layer_normalization(in_shape, axis, eps, dtype=dtype)
 
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2445,7 +2445,7 @@ def check_layer_normalization(in_shape, axis, eps, dtype=np.float32):
     for req in ['write', 'add']:
         check_numeric_gradient(out_s, {'data': data, 'gamma': gamma, 'beta': beta},
                                grad_nodes={'data': req, 'gamma': req, 'beta': req},
-                               numeric_eps=1e-3, rtol=1e-2, atol=1e-3)
+                               numeric_eps=1e-2, rtol=1e-2, atol=1e-3)
 
 def test_layer_norm():
     for dtype in [np.float16, np.float32, np.float64]:


### PR DESCRIPTION
## Description ##
1. Fix the doc. Embedding layer supports (N-1)-D array to N-D array. This makes it consistent with the doc in Symbol/NDArray http://mxnet.incubator.apache.org/api/python/ndarray/ndarray.html#mxnet.ndarray.Embedding
2. Fix flaky layer_norm test, fixes https://github.com/apache/incubator-mxnet/issues/10114