### PR TITLE
Change the definition of dropout in op_translations

### DIFF
--- a/python/mxnet/contrib/onnx/_import/op_translations.py
+++ b/python/mxnet/contrib/onnx/_import/op_translations.py
@@ -270,7 +270,7 @@ def local_response_norm(op_name, attrs, inputs):
                                                         'size' : 'nsize'})
     return 'LRN', new_attrs, inputs
 
-def dropout(op_name, attrs, inputs):
+def dropout(attrs, inputs, cls):
     """Dropout Regularization."""
     new_attrs = translation_utils._fix_attribute_names(attrs,
                                                        {'ratio': 'p'})


### PR DESCRIPTION
## Description ##
Make the definition of dropout method be consistent to the others in op_translations.

## Comments ##
- Is the definition of local_response_norm wrong as well?
Suggestion: line 266 def local_response_norm(op_name, attrs, inputs) to def local_response_norm(attrs, inputs, cls)