### PR TITLE
[MXNET-117] [WIP] [DO NOT MERGE] Sparse operator broadcast_mul/div(csr, dense) = csr

### DIFF
--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -77,22 +77,22 @@ inline bool BinaryBroadcastShape(const nnvm::NodeAttrs& attrs,
   return true;
 }
 
-inline bool BinaryBroadcastStorageTypeCsr(const nnvm::NodeAttrs& attrs,
+inline bool BinaryBroadcastMulStorageType(const nnvm::NodeAttrs& attrs,
                                           const int dev_mask,
                                           DispatchMode* dispatch_mode,
                                           std::vector<int>* in_attrs,
                                           std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 2U);
   CHECK_EQ(out_attrs->size(), 1U);
-  const int in1_stype = in_attrs->at(0);
-  const int in2_stype = in_attrs->at(1);
+  const int lhs_stype = in_attrs->at(0);
+  const int rhs_stype = in_attrs->at(1);
   int& out_stype = out_attrs->at(0);
   bool dispatched = false;
-  if (!dispatched && in1_stype == kDefaultStorage && in2_stype == kDefaultStorage) {
+  if (!dispatched && lhs_stype == kDefaultStorage && rhs_stype == kDefaultStorage) {
     dispatched = storage_type_assign(&out_stype, kDefaultStorage,
                                      dispatch_mode, DispatchMode::kFCompute);
   }
-  if (!dispatched && in1_stype == kCSRStorage && in2_stype == kDefaultStorage) {
+  if (!dispatched && lhs_stype == kCSRStorage && rhs_stype == kDefaultStorage) {
     dispatched = storage_type_assign(&out_stype, kCSRStorage,
                                      dispatch_mode, DispatchMode::kFComputeEx);
   }
@@ -188,8 +188,8 @@ struct csr_dns_csr_broadcast_kernel {
   MSHADOW_XINLINE static void Map(int row, const DType *csr_data, const CType *csr_indices,
                                   const RType *csr_indptr, const DType *dns,
                                   DType *out, const nnvm::dim_t row_length, bool col_vec) {
-    nnvm::dim_t curr_row_i = csr_indptr[row];
-    nnvm::dim_t next_row_i = csr_indptr[row + 1];
+    const nnvm::dim_t curr_row_i = csr_indptr[row];
+    const nnvm::dim_t next_row_i = csr_indptr[row + 1];
     for (nnvm::dim_t iter = curr_row_i; iter < next_row_i; iter++) {
       KERNEL_ASSIGN(out[iter], req, OP::Map(csr_data[iter],
                     (col_vec)? dns[row] : dns[csr_indices[iter]]));
@@ -228,7 +228,7 @@ void BinaryBroadcastCompute(const nnvm::NodeAttrs& attrs,
 }
 
 template<typename xpu, typename OP>
-void BinaryBroadCastCsrDnsCsrImpl(const OpContext& ctx,
+void BinaryBroadcastCsrDnsCsrImpl(const OpContext& ctx,
                                   const NDArray& csr,
                                   const NDArray& dns,
                                   const OpReqType req,
@@ -236,33 +236,36 @@ void BinaryBroadCastCsrDnsCsrImpl(const OpContext& ctx,
   using namespace mshadow;
   using namespace mxnet_op;
   using namespace csr;
+  CHECK(req != kAddTo && req != kWriteInplace);
   CHECK_EQ(dns.shape().ndim(), 1) << "input dense should be a vector";
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
   bool col_vec = (dns.shape()[0] == csr.shape()[0])? true : false;
-  if (!csr.storage_initialized()) {
-    FillZerosCsrImpl(s, output);
-    return;
-  }
-  const nnvm::dim_t nnz = csr.storage_shape()[0];
-  const nnvm::dim_t num_rows = output.shape()[0];
-  output.CheckAndAlloc({Shape1(num_rows + 1), Shape1(nnz)});
+  if (csr.storage_initialized()) {
+    const nnvm::dim_t nnz = csr.storage_shape()[0];
+    const nnvm::dim_t num_rows = output.shape()[0];
+    output.CheckAndAlloc({Shape1(num_rows + 1), Shape1(nnz)});
 
-  MSHADOW_TYPE_SWITCH(output.dtype(), DType, {
-    MSHADOW_IDX_TYPE_SWITCH(output.aux_type(kIdx), CType, {
-      MSHADOW_IDX_TYPE_SWITCH(output.aux_type(kIndPtr), RType, {
-        MXNET_ASSIGN_REQ_SWITCH(req, req_type, {
-          Kernel<csr_dns_csr_broadcast_kernel<req_type, OP>, xpu>::Launch(
-            s, num_rows, csr.data().dptr<DType>(), csr.aux_data(kIdx).dptr<CType>(),
-            csr.aux_data(kIndPtr).dptr<RType>(), dns.data().dptr<DType>(),
-            output.data().dptr<DType>(), csr.shape()[1], col_vec);
-          Copy(output.aux_data(kIdx).FlatTo1D<xpu, CType>(),
-               csr.aux_data(kIdx).FlatTo1D<xpu, CType>());
-          Copy(output.aux_data(kIndPtr).FlatTo1D<xpu, RType>(),
-               csr.aux_data(kIndPtr).FlatTo1D<xpu, RType>());
+    MSHADOW_TYPE_SWITCH(output.dtype(), DType, {
+      MSHADOW_IDX_TYPE_SWITCH(output.aux_type(kIdx), CType, {
+        MSHADOW_IDX_TYPE_SWITCH(output.aux_type(kIndPtr), RType, {
+          MXNET_ASSIGN_REQ_SWITCH(req, req_type, {
+            Kernel<csr_dns_csr_broadcast_kernel<req_type, OP>, xpu>::Launch(
+              s, num_rows, csr.data().dptr<DType>(), csr.aux_data(kIdx).dptr<CType>(),
+              csr.aux_data(kIndPtr).dptr<RType>(), dns.data().dptr<DType>(),
+              output.data().dptr<DType>(), csr.shape()[1], col_vec);
+            Copy(output.aux_data(kIdx).FlatTo1D<xpu, CType>(),
+                 csr.aux_data(kIdx).FlatTo1D<xpu, CType>());
+            Copy(output.aux_data(kIndPtr).FlatTo1D<xpu, RType>(),
+                 csr.aux_data(kIndPtr).FlatTo1D<xpu, RType>());
+          });
         });
       });
     });
-  });
+  // If input csr is an empty matrix, fill zeros and return
+  } else {
+    FillZerosCsrImpl(s, output);
+    return;
+  }
 }
 
 template<typename xpu, typename OP>
@@ -275,25 +278,28 @@ void BinaryBroadcastComputeCsrEx(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(outputs.size(), 1U);
   CHECK_EQ(req.size(), 1U);
   CHECK_LE(inputs[1].shape().ndim(), 2U) << "input dense matrix should have less than 2 dimensions";
-  const auto in1_stype = inputs[0].storage_type();
-  const auto in2_stype = inputs[1].storage_type();
-  const auto out_stype = outputs[0].storage_type();
-  if (!(inputs[1].shape().ndim() == 1U)) {
-    ElemwiseBinaryOp::ComputeEx<xpu, OP>(attrs, ctx, inputs, req, outputs);
-  } else {
+  const NDArray& lhs = inputs[0];
+  const NDArray& rhs = inputs[1];
+  const NDArray& out = outputs[0];
+  const auto lhs_stype = lhs.storage_type();
+  const auto rhs_stype = rhs.storage_type();
+  const auto out_stype = out.storage_type();
+  // if (!(inputs[1].shape().ndim() == 1U)) {
+  //   ElemwiseBinaryOp::ComputeEx<xpu, OP>(attrs, ctx, inputs, req, outputs);
+  // } else {
     if (req[0] != kNullOp) {
       // broadcast(CSR, Dense(1D)) = CSR
-      if (in1_stype == kCSRStorage && in2_stype == kDefaultStorage && out_stype == kCSRStorage) {
-        BinaryBroadCastCsrDnsCsrImpl<xpu, OP>(ctx, inputs[0], inputs[1], req[0], outputs[0]);
+      if (lhs_stype == kCSRStorage && rhs_stype == kDefaultStorage && out_stype == kCSRStorage) {
+        BinaryBroadcastCsrDnsCsrImpl<xpu, OP>(ctx, lhs, rhs, req[0], out);
       // broadcast(CSR, Dense(1D)) = Dense
-      //} else if (in1_stype == kCSRStorage && in2_stype == kDefaultStorage &&
+      //} else if (lhs_stype == kCSRStorage && rhs_stype == kDefaultStorage &&
       //           out_stype == kDefaultStorage) {
-      //  BinaryBroadCastCsrDnsDnsImpl(ctx, inputs[0], input[1], req[0], outputs[0]);
+      //  BinaryBroadCastCsrDnsDnsImpl(ctx, lhs, rhs, req[0], out);
       } else {
         LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
       }
     }
-  }
+  // }
 }
 
 template<typename xpu, typename LOP, typename ROP>

--- a/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
@@ -122,6 +122,8 @@ Example::
 
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::mul>)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeCsrEx<cpu, op::mshadow_op::mul>)
+.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastStorageTypeCsr)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_broadcast_mul"});
 
 
@@ -156,6 +158,8 @@ Example::
 
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::div>)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeCsrEx<cpu, op::mshadow_op::div>)
+.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastStorageTypeCsr)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_broadcast_div"});
 
 NNVM_REGISTER_OP(_backward_broadcast_div)

--- a/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
@@ -120,10 +120,13 @@ Example::
    broadcast_mul(x, y) = [[ 0.,  0.,  0.],
                           [ 1.,  1.,  1.]]
 
+Supported sparse operations:
+   broadcast_mul(csr, dense(1D)) = csr
+
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::mul>)
 .set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeCsrEx<cpu, op::mshadow_op::mul>)
-.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastStorageTypeCsr)
+.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastMulStorageType)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_broadcast_mul"});
 
 
@@ -156,10 +159,13 @@ Example::
    broadcast_div(x, y) = [[ 3.,  3.,  3.],
                           [ 2.,  2.,  2.]]
 
+Supported sparse operations:
+   broadcast_div(csr, dense(1D)) = csr
+
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::div>)
 .set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeCsrEx<cpu, op::mshadow_op::div>)
-.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastStorageTypeCsr)
+.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastMulStorageType)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_broadcast_div"});
 
 NNVM_REGISTER_OP(_backward_broadcast_div)


### PR DESCRIPTION
## Description ##
Add a sparse operator on CPU that supports broadcast_mul/div(csr, dense) = csr operations.

## Checklist ##
### Essentials ###
- [x] The PR title starts with [MXNET-117]
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add support for broadcast_mul/div(csr, 1Ddense) = csr
- [ ] Add support for broadcast_mul/div(csr, 2Ddense) = csr

## Comments ##
Example for broadcast_mul/div(csr, 1Ddense) = csr
import mxnet as mx
a = mx.nd.array([[0,0,3],[0,2,0],[1,0,0]]).tostype('csr')
b = mx.nd.array([1,2,3])
mx.nd.broadcast_mul(a,b).asnumpy()
array([[ 0.,  0.,  3.],
           [ 0.,  4.,  0.],
           [ 3.,  0.,  0.]], dtype=float32)

