### PR TITLE
add deprecated profiler_set_state()

### DIFF
--- a/python/mxnet/profiler.py
+++ b/python/mxnet/profiler.py
@@ -58,7 +58,7 @@ def set_config(**kwargs):
 
 
 def profiler_set_config(mode='symbolic', filename='profile.json'):
-    """Set up the configure of profiler.
+    """Set up the configure of profiler (Deprecated).
 
     Parameters
     ----------
@@ -68,7 +68,7 @@ def profiler_set_config(mode='symbolic', filename='profile.json'):
     filename : string, optional
         The name of output trace file. Defaults to 'profile.json'.
     """
-    warnings.warn('profiler.profiler_set_config() is deprecated. ' \
+    warnings.warn('profiler.profiler_set_config() is deprecated. '
                   'Please use profiler.set_config() instead')
     keys = c_str_array([key for key in ["profile_" + mode, "filename"]])
     values = c_str_array([str(val) for val in [True, filename]])
@@ -89,6 +89,19 @@ def set_state(state='stop'):
     check_call(_LIB.MXSetProfilerState(ctypes.c_int(state2int[state])))
 
 
+def profiler_set_state(state='stop'):
+    """Set up the profiler state to 'run' or 'stop' (Deprecated).
+
+    Parameters
+    ----------
+    state : string, optional
+        Indicates whether to run the profiler, can
+        be 'stop' or 'run'. Default is `stop`.
+    """
+    warnings.warn('profiler.profiler_set_state() is deprecated. '
+                  'Please use profiler.set_state() instead')
+    set_state(state)
+
 def dump(finished=True):
     """Dump profile and stop profiler. Use this to save profile
     in advance in case your program cannot exit normally.
@@ -106,7 +119,7 @@ def dump(finished=True):
 def dump_profile():
     """Dump profile and stop profiler. Use this to save profile
     in advance in case your program cannot exit normally."""
-    warnings.warn('profiler.dump_profile() is deprecated. ' \
+    warnings.warn('profiler.dump_profile() is deprecated. '
                   'Please use profiler.dump() instead')
     dump(True)
 


### PR DESCRIPTION
## Description ##
add deprecated profiler_set_state()

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
