### PR TITLE
Fix mem alignment.

### DIFF
--- a/include/mxnet/base.h
+++ b/include/mxnet/base.h
@@ -366,7 +366,7 @@ inline std::ostream& operator<<(std::ostream &out, const Context &ctx) {
 #define ADD_FILELINE "\n\nDefined in " __FILE__ ":L" STRINGIZE(__LINE__)
 
 #if MXNET_USE_MKLDNN == 1
-static constexpr size_t MKLDNNAlign = 64;
+constexpr size_t kMKLDNNAlign = 64;
 #endif
 
 }  // namespace mxnet

--- a/include/mxnet/base.h
+++ b/include/mxnet/base.h
@@ -365,6 +365,10 @@ inline std::ostream& operator<<(std::ostream &out, const Context &ctx) {
 #define MXNET_DESCRIBE(...) describe(__VA_ARGS__ "\n\nFrom:" __FILE__ ":" STRINGIZE(__LINE__))
 #define ADD_FILELINE "\n\nDefined in " __FILE__ ":L" STRINGIZE(__LINE__)
 
+#if MXNET_USE_MKLDNN == 1
+static constexpr size_t MKLDNNAlign = 64;
+#endif
+
 }  // namespace mxnet
 
 #include "./tensor_blob.h"

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -227,7 +227,7 @@ class TmpMemMgr {
   size_t curr_size;
   // This estimate the required temp memory size in an operator.
   size_t est_size;
-  const size_t alignment = MKLDNNAlign;
+  const size_t alignment = kMKLDNNAlign;
 
  public:
   static TmpMemMgr *Get() {

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -227,7 +227,7 @@ class TmpMemMgr {
   size_t curr_size;
   // This estimate the required temp memory size in an operator.
   size_t est_size;
-  const size_t alignment = 4096;
+  const size_t alignment = MKLDNNAlign;
 
  public:
   static TmpMemMgr *Get() {

--- a/src/storage/cpu_device_storage.h
+++ b/src/storage/cpu_device_storage.h
@@ -57,7 +57,7 @@ class CPUDeviceStorage {
 #if MXNET_USE_MKLDNN == 1
   // MKLDNN requires special alignment. 64 is used by the MKLDNN library in
   // memory allocation.
-  static constexpr size_t alignment_ = MKLDNNAlign;
+  static constexpr size_t alignment_ = kMKLDNNAlign;
 #else
   static constexpr size_t alignment_ = 16;
 #endif

--- a/src/storage/cpu_device_storage.h
+++ b/src/storage/cpu_device_storage.h
@@ -55,9 +55,9 @@ class CPUDeviceStorage {
    * \brief Alignment of allocation.
    */
 #if MXNET_USE_MKLDNN == 1
-  // MKLDNN requires special alignment. 4096 is used by the MKLDNN library in
+  // MKLDNN requires special alignment. 64 is used by the MKLDNN library in
   // memory allocation.
-  static constexpr size_t alignment_ = 4096;
+  static constexpr size_t alignment_ = 64;
 #else
   static constexpr size_t alignment_ = 16;
 #endif

--- a/src/storage/cpu_device_storage.h
+++ b/src/storage/cpu_device_storage.h
@@ -57,7 +57,7 @@ class CPUDeviceStorage {
 #if MXNET_USE_MKLDNN == 1
   // MKLDNN requires special alignment. 64 is used by the MKLDNN library in
   // memory allocation.
-  static constexpr size_t alignment_ = 64;
+  static constexpr size_t alignment_ = MKLDNNAlign;
 #else
   static constexpr size_t alignment_ = 16;
 #endif


### PR DESCRIPTION
## Description ##
This is to fix the memory alignment for the memory allocator. When we allocate memory for MKLDNN, we only need to make the memory address aligned to 64. This change also seems to fix a memory error in the test of https://github.com/apache/incubator-mxnet/pull/10021

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
