### PR TITLE
[MXNET-115] Removed forced lapack usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,11 +351,6 @@ endif()
 if(USE_LAPACK AND NOT MSVC)
   add_definitions(-DMXNET_USE_LAPACK=1)
   list(APPEND mxnet_LINKER_LIBS lapack)
-else(USE_LAPACK)
-  # Workaround for Windows until using new Jenkinsfile.
-  if(BLAS STREQUAL "Open" OR BLAS STREQUAL "open" OR USE_BLAS STREQUAL "Open" OR USE_BLAS STREQUAL "open")
-    add_definitions(-DMXNET_USE_LAPACK=1)
-  endif()
 endif()
 
 # ---[ jemalloc


### PR DESCRIPTION
## Description ##

It is breaking the build if the library is not available.

## Checklist ##
### Essentials ###
- [x] The PR title starts with [MXNET-115], where 115 refers to the relevant [JIRA issue](https://issues.apache.org/jira/browse/MXNET-115)
- [x] Changes are complete
- [x] To the my best knowledge, examples are not affected by this change

### Changes ###
- [x] Removed forced define and some mysterious comments
