### PR TITLE
[MXNET-73] Armv6 ci build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,9 @@ else(MSVC)
   endif()
 endif(MSVC)
 
-set(mxnet_LINKER_LIBS "")
+if(NOT mxnet_LINKER_LIBS)
+  set(mxnet_LINKER_LIBS "")
+endif(NOT mxnet_LINKER_LIBS)
 
 if(USE_GPROF)
   message(STATUS "Using GPROF")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -339,7 +339,7 @@ try {
         }
       }
     },
-    'Raspberry / ARMv7':{
+    'Raspberry / ARMv6l':{
       node('mxnetlinux-cpu') {
         ws('workspace/build-raspberry-armv6') {
           init_git()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -338,6 +338,14 @@ try {
           sh "ci/build.py --build --platform armv7 /work/runtime_functions.sh build_armv7"
         }
       }
+    },
+    'Raspberry / ARMv7':{
+      node('mxnetlinux-cpu') {
+        ws('workspace/build-raspberry-armv6') {
+          init_git()
+          sh "ci/build.py --build --platform armv6 /work/runtime_functions.sh build_armv6"
+        }
+      }
     }
   } // End of stage('Build')
 

--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -1,0 +1,47 @@
+# -*- mode: dockerfile -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Dockerfile to build MXNet for ARMv6
+
+FROM dockcross/linux-armv6
+
+ENV ARCH armv6l
+ENV CC /usr/bin/arm-linux-gnueabihf-gcc
+ENV CXX /usr/bin/arm-linux-gnueabihf-g++
+ENV FC /usr/bin/arm-linux-gnueabihf-gfortran
+ENV HOSTCC gcc
+
+WORKDIR /work/deps
+
+# Build OpenBLAS
+ADD https://api.github.com/repos/xianyi/OpenBLAS/git/refs/heads/master openblas_version.json
+RUN git clone https://github.com/xianyi/OpenBLAS.git && \
+    cd OpenBLAS && \
+    make -j$(nproc) TARGET=ARMV6 && \
+    make PREFIX=/opt/OpenBLAS install
+#    ln -s /opt/OpenBLAS/lib/libopenblas.so /work/deps/OpenBLAS/libopenblas.so && \
+#    ln -s /opt/OpenBLAS/lib/libopenblas.a /work/deps/OpenBLAS/libopenblas.a && \
+#    ln -s /opt/OpenBLAS/lib/libopenblas.a /work/deps/OpenBLAS/liblapack.a && \
+#    ln -s /opt/OpenBLAS/lib/libopenblas.a /usr/lib/liblapack.a
+
+ENV LD_LIBRARY_PATH /opt/OpenBLAS/lib
+ENV CPLUS_INCLUDE_PATH /opt/OpenBLAS/include
+ENV C_INCLUDE_PATH /opt/OpenBLAS/include
+
+COPY runtime_functions.sh /work/
+WORKDIR /work/mxnet

--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -26,13 +26,12 @@ ENV CXX /usr/bin/arm-linux-gnueabihf-g++
 ENV FC /usr/bin/arm-linux-gnueabihf-gfortran
 ENV HOSTCC gcc
 ENV TARGET ARMV6
-ENV BUILD_RELAPACK 1
 
 WORKDIR /work/deps
 
 # Build OpenBLAS
-ADD https://api.github.com/repos/xianyi/OpenBLAS/git/refs/heads/master openblas_version.json
-RUN git clone --recursive https://github.com/xianyi/OpenBLAS.git && \
+ADD https://api.github.com/repos/xianyi/OpenBLAS/git/refs/tags/v0.2.9 openblas_version.json
+RUN git clone --recursive -b v0.2.9 https://github.com/xianyi/OpenBLAS.git && \
     cd OpenBLAS && \
     make -j$(nproc) && \
     make PREFIX=$CROSS_ROOT install

--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -25,23 +25,17 @@ ENV CC /usr/bin/arm-linux-gnueabihf-gcc
 ENV CXX /usr/bin/arm-linux-gnueabihf-g++
 ENV FC /usr/bin/arm-linux-gnueabihf-gfortran
 ENV HOSTCC gcc
+ENV TARGET ARMV6
+ENV BUILD_RELAPACK 1
 
 WORKDIR /work/deps
 
 # Build OpenBLAS
 ADD https://api.github.com/repos/xianyi/OpenBLAS/git/refs/heads/master openblas_version.json
-RUN git clone https://github.com/xianyi/OpenBLAS.git && \
+RUN git clone --recursive https://github.com/xianyi/OpenBLAS.git && \
     cd OpenBLAS && \
-    make -j$(nproc) TARGET=ARMV6 && \
-    make PREFIX=/opt/OpenBLAS install
-#    ln -s /opt/OpenBLAS/lib/libopenblas.so /work/deps/OpenBLAS/libopenblas.so && \
-#    ln -s /opt/OpenBLAS/lib/libopenblas.a /work/deps/OpenBLAS/libopenblas.a && \
-#    ln -s /opt/OpenBLAS/lib/libopenblas.a /work/deps/OpenBLAS/liblapack.a && \
-#    ln -s /opt/OpenBLAS/lib/libopenblas.a /usr/lib/liblapack.a
-
-ENV LD_LIBRARY_PATH /opt/OpenBLAS/lib
-ENV CPLUS_INCLUDE_PATH /opt/OpenBLAS/include
-ENV C_INCLUDE_PATH /opt/OpenBLAS/include
+    make -j$(nproc) && \
+    make PREFIX=$CROSS_ROOT install
 
 COPY runtime_functions.sh /work/
 WORKDIR /work/mxnet

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -73,6 +73,26 @@ build_jetson() {
     popd
 }
 
+build_armv6() {
+    set -ex
+    pushd .
+    cd /work/build
+    cmake\
+        -DUSE_CUDA=OFF\
+        -DUSE_OPENCV=OFF\
+        -DUSE_OPENMP=OFF\
+        -DUSE_SIGNAL_HANDLER=ON\
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo\
+        -DUSE_MKL_IF_AVAILABLE=OFF\
+        -G Ninja /work/mxnet
+    ninja
+    export MXNET_LIBRARY_PATH=`pwd`/libmxnet.so
+    cd /work/mxnet/python
+    python setup.py bdist_wheel --universal
+    cp dist/*.whl /work/build
+    popd
+}
+
 build_armv7() {
     set -ex
     pushd .

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -77,13 +77,15 @@ build_armv6() {
     set -ex
     pushd .
     cd /work/build
-    cmake\
-        -DUSE_CUDA=OFF\
-        -DUSE_OPENCV=OFF\
-        -DUSE_OPENMP=OFF\
-        -DUSE_SIGNAL_HANDLER=ON\
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo\
-        -DUSE_MKL_IF_AVAILABLE=OFF\
+    cmake \
+	-DCMAKE_TOOLCHAIN_FILE=$CROSS_ROOT/Toolchain.cmake \
+        -DUSE_CUDA=OFF \
+        -DUSE_OPENCV=OFF \
+        -DUSE_SIGNAL_HANDLER=ON \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DUSE_MKL_IF_AVAILABLE=OFF \
+	-DUSE_LAPACK=OFF \
+	-Dmxnet_LINKER_LIBS=-lgfortran \
         -G Ninja /work/mxnet
     ninja
     export MXNET_LIBRARY_PATH=`pwd`/libmxnet.so

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -77,15 +77,21 @@ build_armv6() {
     set -ex
     pushd .
     cd /work/build
+
+    # Lapack functionality will be included and statically linked to openblas.
+    # But USE_LAPACK needs to be set to OFF, otherwise the main CMakeLists.txt
+    # file tries to add -llapack. Lapack functionality though, requires -lgfortran
+    # to be linked additionally.
+
     cmake \
-	-DCMAKE_TOOLCHAIN_FILE=$CROSS_ROOT/Toolchain.cmake \
+        -DCMAKE_TOOLCHAIN_FILE=$CROSS_ROOT/Toolchain.cmake \
         -DUSE_CUDA=OFF \
         -DUSE_OPENCV=OFF \
         -DUSE_SIGNAL_HANDLER=ON \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DUSE_MKL_IF_AVAILABLE=OFF \
-	-DUSE_LAPACK=OFF \
-	-Dmxnet_LINKER_LIBS=-lgfortran \
+        -DUSE_LAPACK=OFF \
+        -Dmxnet_LINKER_LIBS=-lgfortran \
         -G Ninja /work/mxnet
     ninja
     export MXNET_LIBRARY_PATH=`pwd`/libmxnet.so


### PR DESCRIPTION
## Description ##

[[MXNET-73]](https://issues.apache.org/jira/browse/MXNET-73) Armv6 ci build with cmake. 

## Checklist ##
### Essentials ###
- [x] Changes are complete
- [x] To the my best knowledge, examples are not affected by this change

### Changes ###
- [x] Dockerfile with cross compilation to arm
- [x] Compilation of OpenBLAS
- [x] cmake based build of mxnet

## Comments ##
- Unfortunately USE_LAPACK switch does not work at the moment (undefined references while linking mxnet). Now the define is forced on all platforms, if switched off multiple unit tests break [MXNET-115](https://issues.apache.org/jira/browse/MXNET-115)
- If used with USE_LAPACK it requires a separate llapack library which is not available, because lapack is linked by default into the OpenBLAS so file.
- Unfortunately OpenBLAS has a bug that prevents -static-libgfortran to work properly, leaving the only option to supply openblas -lgfortran for linker option
