### PR TITLE
[MXNET-121] Update the release number in the ONNX install script.

### DIFF
--- a/ci/docker/install/ubuntu_onnx.sh
+++ b/ci/docker/install/ubuntu_onnx.sh
@@ -27,8 +27,17 @@ set -e
 set -x
 
 echo "Installing libprotobuf-dev and protobuf-compiler ..."
-apt-get install -y libprotobuf-dev protobuf-compiler
+apt-get install autoconf automake libtool curl make g++ unzip
+git clone --recursive https://github.com/google/protobuf.git
+cd protobuf
+git checkout 80a37e0782d2d702d52234b62dd4b9ec74fd2c95
+./autogen.sh
+./configure --prefix=/usr
+make
+make check
+make install 
+ldconfig
 
 echo "Installing pytest, pytest-cov, protobuf, Pillow, ONNX and tabulate ..."
-pip2 install pytest==3.4.0 pytest-cov==2.5.1 protobuf==3.0.0 onnx==1.0.1 Pillow==5.0.0 tabulate==0.7.5
-pip3 install pytest==3.4.0 pytest-cov==2.5.1 protobuf==3.0.0 onnx==1.0.1 Pillow==5.0.0 tabulate==0.7.5
+pip2 install pytest==3.4.0 pytest-cov==2.5.1 protobuf==3.4.0 onnx==1.1.0 Pillow==5.0.0 tabulate==0.7.5
+pip3 install pytest==3.4.0 pytest-cov==2.5.1 protobuf==3.4.0 onnx==1.1.0 Pillow==5.0.0 tabulate==0.7.5


### PR DESCRIPTION
## Description ##
It installs the latest ONNX release in the CI pipeline. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Installs the latest ONNX release in the Mxnet CI pipeline.

## Comments ##
- Instead of doing a apt-get install for libprotobuf-dev and protobuf-compiler, we are now building these two packages from source, because ONNX v1.1.0 requires libprotoc v3.4.0 but the apt-get command installs v2.6.
