### PR TITLE
Fix failed test with opencv 3.4.1

### DIFF
--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -110,9 +110,9 @@ class TestImage(unittest.TestCase):
             for _ in range(3):
                 new_size = np.random.randint(1, 1000)
                 if h > w:
-                    new_h, new_w = new_size * h / w, new_size
+                    new_h, new_w = int(new_size * h / w), new_size
                 else:
-                    new_h, new_w = new_size, new_size * w / h
+                    new_h, new_w = new_size, int(new_size * w / h)
                 for interp in range(0, 2):
                     # area-based/lanczos don't match with cv2?
                     cv_resized = cv2.resize(cv_img, (new_w, new_h), interpolation=interp)


### PR DESCRIPTION
## Description ##

Fix a test which causes an error with opencv 3.4.1. I'm not sure which version of opencv is used in mxnet's testing environment but the `test_resize_short` in `test_image.py` causes the following error on my Arch linux system with opencv 3.4.1 and python 3.6.4.
```
======================================================================
ERROR: test_resize_short (test_image.TestImage)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/pds/pds131/asitdepends/Tmp/mxnet/incubator-mxnet/tests/python/unittest/test_image.py", line 118, in test_resize_short
    cv_resized = cv2.resize(cv_img, (new_w, new_h), interpolation=interp)
TypeError: integer argument expected, got float
----------------------------------------------------------------------
```
This PR fixes it.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
