### PR TITLE
[MXNET-129] Pin gcc version to gcc 4.8

### DIFF
--- a/ci/docker/install/centos7_core.sh
+++ b/ci/docker/install/centos7_core.sh
@@ -31,7 +31,7 @@ yum -y install openblas-devel
 yum -y install lapack-devel
 yum -y install opencv-devel
 yum -y install openssl-devel
-yum -y install gcc-c++
+yum -y install gcc-c++-4.8.*
 yum -y install make
 yum -y install cmake
 yum -y install wget


### PR DESCRIPTION
## Description ##
Pins the GCC version used on CentOS 7 to 4.8 as specified on our homepage.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [ ] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Pin gcc version to gcc 4.8

## Comments ##
See https://github.com/apache/incubator-mxnet/issues/10168 for reference. This PR does not resolve that issue but just makes the CentOS 7 environment compliant with our requirements. The actual issue (MKLDNN-test) is getting resolved by @TaoLv.