### PR TITLE
[MXNET-130]disable cpu/gpu consistency test for Proposal OP and Multi Proposal OP

### DIFF
--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1657,7 +1657,14 @@ def test_cross_device_autograd():
 
     assert_almost_equal(dx, x.grad.asnumpy())
 
+@unittest.skip('''
+  Proposal (gpu) uses stable sort to sort anchors, but Proposal (cpu) uses unstable sort.
+  So we skip the cpu/gpu consistency test for Proposal Operator and MultiProposal Operator.
 
+  http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/PR-10161/5/pipeline/549/#step-919-log-1763
+
+  Temporarily disabled until fixed.
+''')
 @with_seed()
 def test_multi_proposal_op():
     # paramters

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1657,14 +1657,7 @@ def test_cross_device_autograd():
 
     assert_almost_equal(dx, x.grad.asnumpy())
 
-@unittest.skip('''
-  Proposal (gpu) uses stable sort to sort anchors, but Proposal (cpu) uses unstable sort.
-  So we skip the cpu/gpu consistency test for Proposal Operator and MultiProposal Operator.
-
-  http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/PR-10161/5/pipeline/549/#step-919-log-1763
-
-  Temporarily disabled until fixed.
-''')
+@unittest.skip("JIRA issue: https://issues.apache.org/jira/projects/MXNET/issues/MXNET-130")
 @with_seed()
 def test_multi_proposal_op():
     # paramters


### PR DESCRIPTION
## Description ##
I'm sorry that I made a mistake in the CPU/GPU consistency test for Proposal Operator and Multi Proposal Operator.

I disable cpu/gpu consistency test for Proposal OP and Multi Proposal OP temporarily until fixed.

Unit Test Detail:
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/PR-10161/5/pipeline/549#step-919-log-1763


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
