### PR TITLE
[MXNET-117] Sparse operator broadcast_mul/div(csr, dense) = csr

### DIFF
--- a/docs/api/python/ndarray/sparse.md
+++ b/docs/api/python/ndarray/sparse.md
@@ -386,6 +386,8 @@ We summarize the interface for each class in the following sections.
     elemwise_add
     elemwise_sub
     elemwise_mul
+    broadcast_mul
+    broadcast_div
     negative
     dot
     add_n

--- a/perl-package/AI-MXNet/lib/AI/MXNet/NDArray/Sparse.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/NDArray/Sparse.pm
@@ -80,10 +80,100 @@ use overload '""' => sub {
                         my $shape_info = join('x', @{ $self->shape });
                         sprintf("\n<%s, %s @%s>", $self->_class_name, $shape_info, $self->context);
                      },
+             '+'  => \&add,
+             '-'  => \&subtract,
+             '*'  => \&multiply,
+             '/'  => \&divide,
              '+=' => \&not_implemented,
              '-=' => \&not_implemented,
              '*=' => \&not_implemented,
              '/=' => \&not_implemented;
+
+method add(AI::MXNet::NDArray|Num $other, $reverse=)
+{
+    if(blessed $other and join(',', @{ $self->shape }) eq join(',', @{ $other->shape }))
+    {
+        return AI::MXNet::NDArray::_ufunc_helper(
+            $self,
+            $other,
+            qw/elemwise_add _plus_scalar/
+        );
+    }
+    else
+    {
+        return AI::MXNet::NDArray::_ufunc_helper(
+            $self,
+            $other,
+            qw/broadcast_add _plus_scalar/
+        );
+    }
+}
+
+
+method subtract(AI::MXNet::NDArray|Num $other, $reverse=)
+{
+    if(blessed $other and join(',', @{ $self->shape }) eq join(',', @{ $other->shape }))
+    {
+        return AI::MXNet::NDArray::_ufunc_helper(
+            $self,
+            $other,
+            qw/elemwise_sub _minus_scalar _rminus_scalar/,
+            $reverse
+        );
+    }
+    else
+    {
+        return AI::MXNet::NDArray::_ufunc_helper(
+            $self,
+            $other,
+            qw/broadcast_sub _minus_scalar _rminus_scalar/,
+            $reverse
+        );
+    }
+}
+
+method multiply(AI::MXNet::NDArray|Num $other, $reverse=)
+{
+    if(blessed $other and join(',', @{ $self->shape }) eq join(',', @{ $other->shape }))
+    {
+        return AI::MXNet::NDArray::_ufunc_helper(
+            $self,
+            $other,
+            qw/elemwise_mul _mul_scalar/,
+        );
+    }
+    else
+    {
+        return AI::MXNet::NDArray::_ufunc_helper(
+            $self,
+            $other,
+            qw/broadcast_mul _mul_scalar/,
+        );
+    }
+}
+
+method divide(AI::MXNet::NDArray|Num $other, $reverse=)
+{
+    if(blessed $other and join(',', @{ $self->shape }) eq join(',', @{ $other->shape }))
+    {
+        return AI::MXNet::NDArray::_ufunc_helper(
+            $self,
+            $other,
+            qw/elemwise_div _div_scalar _rdiv_scalar/,
+            $reverse
+        );
+    }
+    else
+    {
+        return AI::MXNet::NDArray::_ufunc_helper(
+            $self,
+            $other,
+            qw/broadcast_div _div_scalar _rdiv_scalar/,
+            $reverse
+        );
+    }
+}
+
 {
     no warnings 'redefine';
     *_sync_copyfrom = *_at = *_slice = *reshape = *size = \&not_implemented;

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -30,6 +30,7 @@ except ImportError:
 
 import ctypes
 import warnings
+import operator
 from array import array as native_array
 
 __all__ = ["_ndarray_cls", "csr_matrix", "row_sparse_array",
@@ -53,6 +54,7 @@ from .ndarray import _STORAGE_TYPE_STR_TO_ID, _STORAGE_TYPE_ROW_SPARSE, _STORAGE
 from .ndarray import _STORAGE_TYPE_UNDEFINED, _STORAGE_TYPE_DEFAULT
 from .ndarray import zeros as _zeros_ndarray
 from .ndarray import array as _array
+from .ndarray import _ufunc_helper
 
 
 try:
@@ -113,6 +115,18 @@ class BaseSparseNDArray(NDArray):
         # The data content is not displayed since the array usually has big shape
         return '\n<%s %s @%s>' % (self.__class__.__name__,
                                   shape_info, self.context)
+
+    def __add__(self, other):
+        return add(self, other)
+
+    def __sub__(self, other):
+        return subtract(self, other)
+
+    def __mul__(self, other):
+        return multiply(self, other)
+
+    def __div__(self, other):
+        return divide(self, other)
 
     def __iadd__(self, other):
         raise NotImplementedError()
@@ -218,6 +232,7 @@ class BaseSparseNDArray(NDArray):
         NDArray or CSRNDArray or RowSparseNDArray
             The copied array.
         """
+        # pylint: disable= no-member, protected-access
         if isinstance(other, NDArray):
             if other.handle is self.handle:
                 warnings.warn('You are attempting to copy an array to itself', RuntimeWarning)
@@ -229,6 +244,7 @@ class BaseSparseNDArray(NDArray):
             return _internal._copyto(self, out=hret)
         else:
             raise TypeError('copyto does not support type ' + str(type(other)))
+        # pylint: enable= no-member, protected-access
 
     def check_format(self, full_check=True):
         """Check whether the NDArray format is valid.
@@ -342,6 +358,7 @@ class CSRNDArray(BaseSparseNDArray):
         >>> a[-1].asnumpy()
         array([[ 4.,  5.,  6.]], dtype=float32)
         """
+        # pylint: disable= no-member, protected-access
         if isinstance(key, int):
             if key == -1:
                 begin = self.shape[0] - 1
@@ -360,6 +377,7 @@ class CSRNDArray(BaseSparseNDArray):
         if isinstance(key, tuple):
             raise ValueError('Multi-dimension indexing is not supported')
         raise ValueError('Undefined behaviour for {}'.format(key))
+        # pylint: enable= no-member, protected-access
 
     def __setitem__(self, key, value):
         """x.__setitem__(i, y) <=> x[i]=y
@@ -477,9 +495,11 @@ class CSRNDArray(BaseSparseNDArray):
         NDArray or CSRNDArray
             A copy of the array with the chosen storage stype
         """
+        # pylint: disable= no-member, protected-access
         if stype == 'row_sparse':
             raise ValueError("cast_storage from csr to row_sparse is not supported")
         return op.cast_storage(self, stype=stype)
+        # pylint: enable= no-member, protected-access
 
     def copyto(self, other):
         """Copies the value of this array to another array.
@@ -657,6 +677,7 @@ class RowSparseNDArray(BaseSparseNDArray):
                [ 1.,  1.,  1.],
                [ 1.,  1.,  1.]], dtype=float32)
         """
+        # pylint: disable= no-member, protected-access
         if not self.writable:
             raise ValueError('Failed to assign to a readonly RowSparseNDArray')
         if isinstance(key, py_slice):
@@ -679,6 +700,7 @@ class RowSparseNDArray(BaseSparseNDArray):
         else:
             assert(isinstance(key, (int, tuple)))
             raise TypeError('RowSparseNDArray only supports [:] for assignment')
+        # pylint: enable= no-member, protected-access
 
     @property
     def indices(self):
@@ -720,9 +742,11 @@ class RowSparseNDArray(BaseSparseNDArray):
         NDArray or RowSparseNDArray
             A copy of the array with the chosen storage stype
         """
+        # pylint: disable= no-member, protected-access
         if stype == 'csr':
             raise ValueError("cast_storage from row_sparse to csr is not supported")
         return op.cast_storage(self, stype=stype)
+        # pylint: enable= no-member, protected-access
 
     def copyto(self, other):
         """Copies the value of this array to another array.
@@ -949,6 +973,7 @@ def csr_matrix(arg1, shape=None, ctx=None, dtype=None):
 def _csr_matrix_from_definition(data, indices, indptr, shape=None, ctx=None,
                                 dtype=None, indices_type=None, indptr_type=None):
     """Create a `CSRNDArray` based on data, indices and indptr"""
+    # pylint: disable= no-member, protected-access
     storage_type = 'csr'
     # context
     ctx = Context.default_ctx if ctx is None else ctx
@@ -985,6 +1010,7 @@ def _csr_matrix_from_definition(data, indices, indptr, shape=None, ctx=None,
     check_call(_LIB.MXNDArraySyncCopyFromNDArray(result.handle, indptr.handle, ctypes.c_int(0)))
     check_call(_LIB.MXNDArraySyncCopyFromNDArray(result.handle, indices.handle, ctypes.c_int(1)))
     return result
+    # pylint: enable= no-member, protected-access
 
 def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
     """Creates a `RowSparseNDArray`, a multidimensional row sparse array with a set of \
@@ -1159,6 +1185,284 @@ def _ndarray_cls(handle, writable=True, stype=_STORAGE_TYPE_UNDEFINED):
 _set_ndarray_class(_ndarray_cls)
 
 
+def add(lhs, rhs):
+    """Returns element-wise sum of the input arrays with broadcasting.
+
+    Equivalent to ``lhs + rhs``, ``mx.nd.broadcast_add(lhs, rhs)`` and
+    ``mx.nd.broadcast_plus(lhs, rhs)``.
+
+    .. note::
+
+        If the corresponding dimensions of two arrays have the same size or one of them has size 1,
+        then the arrays are broadcastable to a common shape.abs
+
+    Parameters
+    ----------
+    lhs : scalar or array
+        First array to be added.
+    rhs : scalar or array
+         Second array to be added.
+        If ``lhs.shape != rhs.shape``, they must be
+        broadcastable to a common shape.
+
+    Returns
+    -------
+    NDArray
+        The element-wise sum of the input arrays.
+
+    Examples
+    --------
+    >>> x = mx.nd.ones((2,3))
+    >>> y = mx.nd.arange(2).reshape((2,1))
+    >>> z = mx.nd.arange(2).reshape((1,2))
+    >>> x.asnumpy()
+    array([[ 1.,  1.,  1.],
+           [ 1.,  1.,  1.]], dtype=float32)
+    >>> y.asnumpy()
+    array([[ 0.],
+           [ 1.]], dtype=float32)
+    >>> z.asnumpy()
+    array([[ 0.,  1.]], dtype=float32)
+    >>> (x+2).asnumpy()
+    array([[ 3.,  3.,  3.],
+           [ 3.,  3.,  3.]], dtype=float32)
+    >>> (x+y).asnumpy()
+    array([[ 1.,  1.,  1.],
+           [ 2.,  2.,  2.]], dtype=float32)
+    >>> mx.nd.add(x,y).asnumpy()
+    array([[ 1.,  1.,  1.],
+           [ 2.,  2.,  2.]], dtype=float32)
+    >>> (z + y).asnumpy()
+    array([[ 0.,  1.],
+           [ 1.,  2.]], dtype=float32)
+    """
+    # pylint: disable= no-member, protected-access
+    if isinstance(lhs, NDArray) and isinstance(rhs, NDArray) and lhs.shape == rhs.shape:
+        return _ufunc_helper(
+            lhs,
+            rhs,
+            op.elemwise_add,
+            operator.add,
+            _internal._plus_scalar,
+            None)
+
+    return _ufunc_helper(
+        lhs,
+        rhs,
+        op.broadcast_add,
+        operator.add,
+        _internal._plus_scalar,
+        None)
+    # pylint: enable= no-member, protected-access
+
+
+def subtract(lhs, rhs):
+    """Returns element-wise difference of the input arrays with broadcasting.
+
+    Equivalent to ``lhs - rhs``, ``mx.nd.broadcast_sub(lhs, rhs)`` and
+    ``mx.nd.broadcast_minus(lhs, rhs)``.
+
+    .. note::
+
+        If the corresponding dimensions of two arrays have the same size or one of them has size 1,
+        then the arrays are broadcastable to a common shape.
+
+    Parameters
+    ----------
+    lhs : scalar or array
+        First array to be subtracted.
+    rhs : scalar or array
+         Second array to be subtracted.
+        If ``lhs.shape != rhs.shape``, they must be
+        broadcastable to a common shape.__spec__
+
+    Returns
+    -------
+    NDArray
+        The element-wise difference of the input arrays.
+
+    Examples
+    --------
+    >>> x = mx.nd.ones((2,3))
+    >>> y = mx.nd.arange(2).reshape((2,1))
+    >>> z = mx.nd.arange(2).reshape((1,2))
+    >>> x.asnumpy()
+    array([[ 1.,  1.,  1.],
+           [ 1.,  1.,  1.]], dtype=float32)
+    >>> y.asnumpy()
+    array([[ 0.],
+           [ 1.]], dtype=float32)
+    >>> z.asnumpy()
+    array([[ 0.,  1.]], dtype=float32)
+    >>> (x-2).asnumpy()
+    array([[-1., -1., -1.],
+           [-1., -1., -1.]], dtype=float32)
+    >>> (x-y).asnumpy()
+    array([[ 1.,  1.,  1.],
+           [ 0.,  0.,  0.]], dtype=float32)
+    >>> mx.nd.subtract(x,y).asnumpy()
+    array([[ 1.,  1.,  1.],
+           [ 0.,  0.,  0.]], dtype=float32)
+    >>> (z-y).asnumpy()
+    array([[ 0.,  1.],
+           [-1.,  0.]], dtype=float32)
+    """
+    # pylint: disable= no-member, protected-access
+    if isinstance(lhs, NDArray) and isinstance(rhs, NDArray) and lhs.shape == rhs.shape:
+        return _ufunc_helper(
+            lhs,
+            rhs,
+            op.elemwise_sub,
+            operator.sub,
+            _internal._minus_scalar,
+            None)
+
+    return _ufunc_helper(
+        lhs,
+        rhs,
+        op.broadcast_sub,
+        operator.sub,
+        _internal._minus_scalar,
+        None)
+    # pylint: enable= no-member, protected-access
+
+
+def multiply(lhs, rhs):
+    """Returns element-wise product of the input arrays with broadcasting.
+
+        Equivalent to ``lhs * rhs`` and ``mx.nd.broadcast_mul(lhs, rhs)``.
+
+    .. note::
+
+        If the corresponding dimensions of two arrays have the same size or one of them has size 1,
+        then the arrays are broadcastable to a common shape.
+
+    Parameters
+    ----------
+    lhs : scalar or array
+        First array to be multiplied.
+    rhs : scalar or array
+         Second array to be multiplied.
+        If ``lhs.shape != rhs.shape``, they must be
+        broadcastable to a common shape.
+
+    Returns
+    -------
+    NDArray
+        The element-wise multiplication of the input arrays.
+
+    Examples
+    --------
+    >>> x = mx.nd.ones((2,3))
+    >>> y = mx.nd.arange(2).reshape((2,1))
+    >>> z = mx.nd.arange(2).reshape((1,2))
+    >>> x.asnumpy()
+    array([[ 1.,  1.,  1.],
+           [ 1.,  1.,  1.]], dtype=float32)
+    >>> y.asnumpy()
+    array([[ 0.],
+           [ 1.]], dtype=float32)
+    >>> z.asnumpy()
+    array([[ 0.,  1.]], dtype=float32)
+    >>> (x*2).asnumpy()
+    array([[ 2.,  2.,  2.],
+           [ 2.,  2.,  2.]], dtype=float32)
+    >>> (x*y).asnumpy()
+    array([[ 0.,  0.,  0.],
+           [ 1.,  1.,  1.]], dtype=float32)
+    >>> mx.nd.multiply(x, y).asnumpy()
+    array([[ 0.,  0.,  0.],
+           [ 1.,  1.,  1.]], dtype=float32)
+    >>> (z*y).asnumpy()
+    array([[ 0.,  0.],
+           [ 0.,  1.]], dtype=float32)
+    """
+    # pylint: disable= no-member, protected-access
+    if isinstance(lhs, NDArray) and isinstance(rhs, NDArray) and lhs.shape == rhs.shape:
+        return _ufunc_helper(
+            lhs,
+            rhs,
+            op.elemwise_mul,
+            operator.mul,
+            _internal._mul_scalar,
+            None)
+
+    return _ufunc_helper(
+        lhs,
+        rhs,
+        op.broadcast_mul,
+        operator.mul,
+        _internal._mul_scalar,
+        None)
+    # pylint: enable= no-member, protected-access
+
+
+def divide(lhs, rhs):
+    """Returns element-wise division of the input arrays with broadcasting.
+
+    Equivalent to ``lhs / rhs`` and ``mx.nd.broadcast_div(lhs, rhs)``.
+
+    .. note::
+
+        If the corresponding dimensions of two arrays have the same size or one of them has size 1,
+        then the arrays are broadcastable to a common shape.
+
+    Parameters
+    ----------
+    lhs : scalar or array
+        First array in division.
+    rhs : scalar or array
+         Second array in division.
+        The arrays to be divided. If ``lhs.shape != rhs.shape``, they must be
+        broadcastable to a common shape.
+
+    Returns
+    -------
+    NDArray
+        The element-wise division of the input arrays.
+
+    Examples
+    --------
+    >>> x = mx.nd.ones((2,3))*6
+    >>> y = mx.nd.ones((2,1))*2
+    >>> x.asnumpy()
+    array([[ 6.,  6.,  6.],
+           [ 6.,  6.,  6.]], dtype=float32)
+    >>> y.asnumpy()
+    array([[ 2.],
+           [ 2.]], dtype=float32)
+    >>> x/2
+    <NDArray 2x3 @cpu(0)>
+    >>> (x/3).asnumpy()
+    array([[ 2.,  2.,  2.],
+           [ 2.,  2.,  2.]], dtype=float32)
+    >>> (x/y).asnumpy()
+    array([[ 3.,  3.,  3.],
+           [ 3.,  3.,  3.]], dtype=float32)
+    >>> mx.nd.divide(x,y).asnumpy()
+    array([[ 3.,  3.,  3.],
+           [ 3.,  3.,  3.]], dtype=float32)
+    """
+    # pylint: disable= no-member, protected-access
+    if isinstance(lhs, NDArray) and isinstance(rhs, NDArray) and lhs.shape == rhs.shape:
+        return _ufunc_helper(
+            lhs,
+            rhs,
+            op.elemwise_div,
+            operator.div,
+            _internal._div_scalar,
+            None)
+
+    return _ufunc_helper(
+        lhs,
+        rhs,
+        op.broadcast_div,
+        operator.div,
+        _internal._div_scalar,
+        None)
+    # pylint: enable= no-member, protected-access
+
+
 def zeros(stype, shape, ctx=None, dtype=None, **kwargs):
     """Return a new array of given shape and type, filled with zeros.
 
@@ -1184,6 +1488,7 @@ def zeros(stype, shape, ctx=None, dtype=None, **kwargs):
     >>> mx.nd.sparse.zeros('row_sparse', (1,2), ctx=mx.cpu(), dtype='float16').asnumpy()
     array([[ 0.,  0.]], dtype=float16)
     """
+    # pylint: disable= no-member, protected-access
     if stype == 'default':
         return _zeros_ndarray(shape, ctx=ctx, dtype=dtype, **kwargs)
     if ctx is None:
@@ -1195,6 +1500,7 @@ def zeros(stype, shape, ctx=None, dtype=None, **kwargs):
         raise ValueError("unknown storage type" + stype)
     out = _ndarray_cls(_new_alloc_handle(stype, shape, ctx, True, dtype, aux_types))
     return _internal._zeros(shape=shape, ctx=ctx, dtype=dtype, out=out, **kwargs)
+    # pylint: enable= no-member, protected-access
 
 
 def empty(stype, shape, ctx=None, dtype=None):

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -35,7 +35,7 @@ from array import array as native_array
 
 __all__ = ["_ndarray_cls", "csr_matrix", "row_sparse_array",
            "BaseSparseNDArray", "CSRNDArray", "RowSparseNDArray",
-           "multiply", "divide"]
+           "add", "subtract", "multiply", "divide"]
 
 import numpy as np
 from ..base import NotSupportedForSparseNDArray
@@ -1215,29 +1215,28 @@ def add(lhs, rhs):
 
     Examples
     --------
-    >>> x = mx.nd.ones((2,3)).tostype('csr')
-    >>> y = mx.nd.arange(2).reshape((2,1))
-    >>> z = mx.nd.arange(2).reshape((1,2))
-    >>> x.asnumpy()
+    >>> a = mx.nd.ones((2,3)).tostype('csr')
+    >>> b = mx.nd.ones((2,3)).tostype('csr')
+    >>> a.asnumpy()
     array([[ 1.,  1.,  1.],
            [ 1.,  1.,  1.]], dtype=float32)
-    >>> y.asnumpy()
-    array([[ 0.],
-           [ 1.]], dtype=float32)
-    >>> z.asnumpy()
-    array([[ 0.,  1.]], dtype=float32)
-    >>> (x+2).asnumpy()
-    array([[ 3.,  3.,  3.],
-           [ 3.,  3.,  3.]], dtype=float32)
-    >>> (x+y).asnumpy()
+    >>> b.asnumpy()
     array([[ 1.,  1.,  1.],
+           [ 1.,  1.,  1.]], dtype=float32)
+    >>> (a+b).asnumpy()
+    array([[ 2.,  2.,  2.],
            [ 2.,  2.,  2.]], dtype=float32)
-    >>> mx.nd.add(x,y).asnumpy()
+    >>> c = mx.nd.ones((2,3)).tostype('row_sparse')
+    >>> d = mx.nd.ones((2,3)).tostype('row_sparse')
+    >>> c.asnumpy()
     array([[ 1.,  1.,  1.],
+           [ 1.,  1.,  1.]], dtype=float32)
+    >>> d.asnumpy()
+    array([[ 1.,  1.,  1.],
+           [ 1.,  1.,  1.]], dtype=float32)
+    >>> (c+d).asnumpy()
+    array([[ 2.,  2.,  2.],
            [ 2.,  2.,  2.]], dtype=float32)
-    >>> (z + y).asnumpy()
-    array([[ 0.,  1.],
-           [ 1.,  2.]], dtype=float32)
     """
     # pylint: disable= no-member, protected-access
     if isinstance(lhs, NDArray) and isinstance(rhs, NDArray) and lhs.shape == rhs.shape:
@@ -1288,29 +1287,28 @@ def subtract(lhs, rhs):
 
     Examples
     --------
-    >>> x = mx.nd.ones((2,3)).tostype('csr')
-    >>> y = mx.nd.arange(2).reshape((2,1))
-    >>> z = mx.nd.arange(2).reshape((1,2))
-    >>> x.asnumpy()
+    >>> a = mx.nd.ones((2,3)).tostype('csr')
+    >>> b = mx.nd.ones((2,3)).tostype('csr')
+    >>> a.asnumpy()
     array([[ 1.,  1.,  1.],
            [ 1.,  1.,  1.]], dtype=float32)
-    >>> y.asnumpy()
-    array([[ 0.],
-           [ 1.]], dtype=float32)
-    >>> z.asnumpy()
-    array([[ 0.,  1.]], dtype=float32)
-    >>> (x-2).asnumpy()
-    array([[-1., -1., -1.],
-           [-1., -1., -1.]], dtype=float32)
-    >>> (x-y).asnumpy()
+    >>> b.asnumpy()
     array([[ 1.,  1.,  1.],
+           [ 1.,  1.,  1.]], dtype=float32)
+    >>> (a-b).asnumpy()
+    array([[ 0.,  0.,  0.],
            [ 0.,  0.,  0.]], dtype=float32)
-    >>> mx.nd.subtract(x,y).asnumpy()
+    >>> c = mx.nd.ones((2,3)).tostype('row_sparse')
+    >>> d = mx.nd.ones((2,3)).tostype('row_sparse')
+    >>> c.asnumpy()
     array([[ 1.,  1.,  1.],
+           [ 1.,  1.,  1.]], dtype=float32)
+    >>> d.asnumpy()
+    array([[ 1.,  1.,  1.],
+           [ 1.,  1.,  1.]], dtype=float32)
+    >>> (c-d).asnumpy()
+    array([[ 0.,  0.,  0.],
            [ 0.,  0.,  0.]], dtype=float32)
-    >>> (z-y).asnumpy()
-    array([[ 0.,  1.],
-           [-1.,  0.]], dtype=float32)
     """
     # pylint: disable= no-member, protected-access
     if isinstance(lhs, NDArray) and isinstance(rhs, NDArray) and lhs.shape == rhs.shape:
@@ -1377,13 +1375,13 @@ def multiply(lhs, rhs):
     >>> (x*y).asnumpy()
     array([[ 0.,  0.,  0.],
            [ 1.,  1.,  1.]], dtype=float32)
-    >>> mx.nd.multiply(x, y).asnumpy()
+    >>> mx.nd.sparse.multiply(x, y).asnumpy()
     array([[ 0.,  0.,  0.],
            [ 1.,  1.,  1.]], dtype=float32)
     >>> (x*z).asnumpy()
     array([[ 0.,  1.,  2.],
            [ 0.,  1.,  2.]], dtype=float32)
-    >>> mx.nd.multiply(x, z).asnumpy()
+    >>> mx.nd.sparse.multiply(x, z).asnumpy()
     array([[ 0.,  1.,  2.],
            [ 0.,  1.,  2.]], dtype=float32)
     >>> z = z.reshape((1, 3))
@@ -1392,7 +1390,7 @@ def multiply(lhs, rhs):
     >>> (x*z).asnumpy()
     array([[ 0.,  1.,  2.],
            [ 0.,  1.,  2.]], dtype=float32)
-    >>> mx.nd.multiply(x, z).asnumpy()
+    >>> mx.nd.sparse.multiply(x, z).asnumpy()
     array([[ 0.,  1.,  2.],
            [ 0.,  1.,  2.]], dtype=float32)
     """
@@ -1463,13 +1461,13 @@ def divide(lhs, rhs):
     >>> (x/y).asnumpy()
     array([[ 6.,  6.,  6.],
            [ 3.,  3.,  3.]], dtype=float32)
-    >>> mx.nd.divide(x,y).asnumpy()
+    >>> mx.nd.sparse.divide(x,y).asnumpy()
     array([[ 6.,  6.,  6.],
            [ 3.,  3.,  3.]], dtype=float32)
     >>> (x/z).asnumpy()
     array([[ 6.,  3.,  2.],
            [ 6.,  3.,  2.]], dtype=float32)
-    >>> mx.nd.divide(x,z).asnumpy()
+    >>> mx.nd.sprase.divide(x,z).asnumpy()
     array([[ 6.,  3.,  2.],
            [ 6.,  3.,  2.]], dtype=float32)
     >>> z = z.reshape((1,3))
@@ -1478,7 +1476,7 @@ def divide(lhs, rhs):
     >>> (x/z).asnumpy()
     array([[ 6.,  3.,  2.],
            [ 6.,  3.,  2.]], dtype=float32)
-    >>> mx.nd.divide(x,z).asnumpy()
+    >>> mx.nd.sparse.divide(x,z).asnumpy()
     array([[ 6.,  3.,  2.],
            [ 6.,  3.,  2.]], dtype=float32)
     """
@@ -1488,7 +1486,7 @@ def divide(lhs, rhs):
             lhs,
             rhs,
             op.elemwise_div,
-            operator.div,
+            operator.truediv,
             _internal._div_scalar,
             None)
 

--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -89,17 +89,15 @@ inline bool BinaryBroadcastMulStorageType(const nnvm::NodeAttrs& attrs,
   int& out_stype = out_attrs->at(0);
   bool dispatched = false;
   // For GPU, directly fallback
-  if (dev_mask == mshadow::gpu::kDevMask) {
-    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
-    return dispatched;
-  }
-  if (!dispatched && lhs_stype == kDefaultStorage && rhs_stype == kDefaultStorage) {
+  const auto dispatch_ex = (dev_mask == mshadow::gpu::kDevMask)? DispatchMode::kFComputeFallback :
+                           DispatchMode::kFComputeEx;
+  if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)) {
     dispatched = storage_type_assign(&out_stype, kDefaultStorage,
                                      dispatch_mode, DispatchMode::kFCompute);
   }
   if (!dispatched && lhs_stype == kCSRStorage && rhs_stype == kDefaultStorage) {
     dispatched = storage_type_assign(&out_stype, kCSRStorage,
-                                     dispatch_mode, DispatchMode::kFComputeEx);
+                                     dispatch_mode, dispatch_ex);
   }
   if (!dispatched) {
     dispatched = dispatch_fallback(out_attrs, dispatch_mode);

--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -241,7 +241,13 @@ void BinaryBroadcastCsrDnsCsrImpl(const OpContext& ctx,
   using namespace csr;
   CHECK(req != kAddTo && req != kWriteInplace);
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  bool col_vec = (dns.shape()[0] == csr.shape()[0])? true : false;
+  bool col_vec;
+  if (dns.shape().ndim() == 1) {
+    col_vec = false;
+  } else {
+    col_vec = (dns.shape()[0] == csr.shape()[0])? true : false;
+  }
+
   if (csr.storage_initialized()) {
     const nnvm::dim_t nnz = csr.storage_shape()[0];
     const nnvm::dim_t num_rows = output.shape()[0];

--- a/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
@@ -122,6 +122,8 @@ Example::
 
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::mul>)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeCsrEx<cpu, op::mshadow_op::mul>)
+.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastStorageTypeCsr)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_broadcast_mul"});
 
 
@@ -156,6 +158,8 @@ Example::
 
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::div>)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeCsrEx<cpu, op::mshadow_op::div>)
+.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastStorageTypeCsr)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_broadcast_div"});
 
 NNVM_REGISTER_OP(_backward_broadcast_div)

--- a/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
@@ -120,10 +120,13 @@ Example::
    broadcast_mul(x, y) = [[ 0.,  0.,  0.],
                           [ 1.,  1.,  1.]]
 
+Supported sparse operations:
+   broadcast_mul(csr, dense(1D)) = csr
+
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::mul>)
 .set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeCsrEx<cpu, op::mshadow_op::mul>)
-.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastStorageTypeCsr)
+.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastMulStorageType)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_broadcast_mul"});
 
 
@@ -156,10 +159,13 @@ Example::
    broadcast_div(x, y) = [[ 3.,  3.,  3.],
                           [ 2.,  2.,  2.]]
 
+Supported sparse operations:
+   broadcast_div(csr, dense(1D)) = csr
+
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::div>)
 .set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeCsrEx<cpu, op::mshadow_op::div>)
-.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastStorageTypeCsr)
+.set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastMulStorageType)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_broadcast_div"});
 
 NNVM_REGISTER_OP(_backward_broadcast_div)

--- a/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
@@ -125,7 +125,7 @@ Supported sparse operations:
 
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::mul>)
-.set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeCsrEx<cpu, op::mshadow_op::mul>)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeEx<cpu, op::mshadow_op::mul>)
 .set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastMulStorageType)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_broadcast_mul"});
 
@@ -164,7 +164,7 @@ Supported sparse operations:
 
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::div>)
-.set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeCsrEx<cpu, op::mshadow_op::div>)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BinaryBroadcastComputeEx<cpu, op::mshadow_op::div>)
 .set_attr<FInferStorageType>("FInferStorageType", BinaryBroadcastMulStorageType)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_broadcast_div"});
 

--- a/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
@@ -121,7 +121,7 @@ Example::
                           [ 1.,  1.,  1.]]
 
 Supported sparse operations:
-   broadcast_mul(csr, dense(1D)) = csr
+   broadcast_mul(csr, dense(1D)) = csr (CPU only)
 
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::mul>)
@@ -160,7 +160,7 @@ Example::
                           [ 2.,  2.,  2.]]
 
 Supported sparse operations:
-   broadcast_div(csr, dense(1D)) = csr
+   broadcast_div(csr, dense(1D)) = csr (CPU only)
 
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::div>)

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1679,6 +1679,30 @@ def test_sparse_embedding():
 
 
 @with_seed()
+def test_sparse_broadcast_mul_div():
+    from scipy.sparse import random, csr_matrix
+    def check_broadcast_mul(mx_lhs, mx_rhs, np_lhs, np_rhs, dtype):
+        assert_almost_equal(mx.nd.broadcast_mul(mx_lhs, mx_rhs).asnumpy(), np.multiply(np_lhs, np_rhs), atol=1e-4)
+    def check_broadcast_div(mx_lhs, mx_rhs, np_lhs, np_rhs, dtype):
+        assert_almost_equal(mx.nd.broadcast_div(mx_lhs, mx_rhs).asnumpy(), np.divide(np_lhs, np_rhs), atol=1e-4)
+    shape = (4,3)
+    np_lhs = random(shape[0], shape[1], density=0.25, dtype=np.float32).tocsr()
+    mx_lhs = mx.nd.sparse.csr_matrix((np_lhs.data, np_lhs.indices, np_lhs.indptr), shape=shape)
+    np_lhs = np_lhs.todense()
+    np_rhs_row_2D = np.array([[3,2,1]], dtype=np.float32)
+    np_rhs_row_1D = np.array([3,2,1], dtype=np.float32)
+    np_rhs_col = np.array([[4,3,2,1]], dtype=np.float32).T
+    mx_rhs_row_2D = mx.nd.array(np_rhs_row_2D)
+    mx_rhs_row_1D = mx.nd.array(np_rhs_row_1D)
+    mx_rhs_col = mx.nd.array(np_rhs_col)
+    check_broadcast_mul(mx_lhs, mx_rhs_row_2D, np_lhs, np_rhs_row_2D, np.float32)
+    check_broadcast_mul(mx_lhs, mx_rhs_row_1D, np_lhs, np_rhs_row_1D, np.float32)
+    check_broadcast_mul(mx_lhs, mx_rhs_col, np_lhs, np_rhs_col, np.float32)
+    check_broadcast_div(mx_lhs, mx_rhs_row_2D, np_lhs, np_rhs_row_2D, np.float32)
+    check_broadcast_div(mx_lhs, mx_rhs_row_1D, np_lhs, np_rhs_row_1D, np.float32)
+    check_broadcast_div(mx_lhs, mx_rhs_col, np_lhs, np_rhs_col, np.float32)
+
+@with_seed()
 def test_scatter_ops():
     def csr_get_seen_points(name, csr_array, verbose=False):
         """Get a unique list of points int he CSR array as well as a

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1680,27 +1680,24 @@ def test_sparse_embedding():
 
 @with_seed()
 def test_sparse_broadcast_mul_div():
-    from scipy.sparse import random, csr_matrix
     def check_broadcast_mul(mx_lhs, mx_rhs, np_lhs, np_rhs, dtype):
-        assert_almost_equal(mx.nd.broadcast_mul(mx_lhs, mx_rhs).asnumpy(), np.multiply(np_lhs, np_rhs), atol=1e-4)
+        assert_almost_equal(mx.nd.sparse.multiply(mx_lhs, mx_rhs).asnumpy(), np.multiply(np_lhs, np_rhs), atol=1e-4)
     def check_broadcast_div(mx_lhs, mx_rhs, np_lhs, np_rhs, dtype):
-        assert_almost_equal(mx.nd.broadcast_div(mx_lhs, mx_rhs).asnumpy(), np.divide(np_lhs, np_rhs), atol=1e-4)
-    shape = (4,3)
-    np_lhs = random(shape[0], shape[1], density=0.25, dtype=np.float32).tocsr()
-    mx_lhs = mx.nd.sparse.csr_matrix((np_lhs.data, np_lhs.indices, np_lhs.indptr), shape=shape)
-    np_lhs = np_lhs.todense()
-    np_rhs_row_2D = np.array([[3,2,1]], dtype=np.float32)
-    np_rhs_row_1D = np.array([3,2,1], dtype=np.float32)
-    np_rhs_col = np.array([[4,3,2,1]], dtype=np.float32).T
-    mx_rhs_row_2D = mx.nd.array(np_rhs_row_2D)
-    mx_rhs_row_1D = mx.nd.array(np_rhs_row_1D)
-    mx_rhs_col = mx.nd.array(np_rhs_col)
-    check_broadcast_mul(mx_lhs, mx_rhs_row_2D, np_lhs, np_rhs_row_2D, np.float32)
-    check_broadcast_mul(mx_lhs, mx_rhs_row_1D, np_lhs, np_rhs_row_1D, np.float32)
-    check_broadcast_mul(mx_lhs, mx_rhs_col, np_lhs, np_rhs_col, np.float32)
-    check_broadcast_div(mx_lhs, mx_rhs_row_2D, np_lhs, np_rhs_row_2D, np.float32)
-    check_broadcast_div(mx_lhs, mx_rhs_row_1D, np_lhs, np_rhs_row_1D, np.float32)
-    check_broadcast_div(mx_lhs, mx_rhs_col, np_lhs, np_rhs_col, np.float32)
+        assert_almost_equal(mx.nd.sparse.divide(mx_lhs, mx_rhs).asnumpy(), np.divide(np_lhs, np_rhs), atol=1e-4)
+    stype = 'csr'
+    for num_rows in range(2, 6):
+        for num_cols in range(2, 6):
+            shape = (num_rows, num_cols)
+            density = random.uniform(0.15, 0.25)
+            mx_lhs = rand_ndarray(shape, stype, density)
+            np_lhs = mx_lhs.asnumpy()
+            mx_rhs_row_2D = rand_ndarray((1, num_cols), 'default')
+            mx_rhs_row_1D = mx_rhs_row_2D.reshape((num_cols))
+            mx_rhs_col = rand_ndarray((num_rows, 1), 'default')
+            for mx_rhs in [mx_rhs_row_2D, mx_rhs_row_1D, mx_rhs_col]:
+                np_rhs = mx_rhs.asnumpy()
+                check_broadcast_mul(mx_lhs, mx_rhs, np_lhs, np_rhs, np.float32)
+                check_broadcast_div(mx_lhs, mx_rhs, np_lhs, np_rhs, np.float32)
 
 @with_seed()
 def test_scatter_ops():

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1685,19 +1685,21 @@ def test_sparse_broadcast_mul_div():
     def check_broadcast_div(mx_lhs, mx_rhs, np_lhs, np_rhs, dtype):
         assert_almost_equal(mx.nd.sparse.divide(mx_lhs, mx_rhs).asnumpy(), np.divide(np_lhs, np_rhs), atol=1e-4)
     stype = 'csr'
-    for num_rows in range(2, 6):
-        for num_cols in range(2, 6):
-            shape = (num_rows, num_cols)
-            density = random.uniform(0.15, 0.25)
-            mx_lhs = rand_ndarray(shape, stype, density)
-            np_lhs = mx_lhs.asnumpy()
-            mx_rhs_row_2D = rand_ndarray((1, num_cols), 'default')
-            mx_rhs_row_1D = mx_rhs_row_2D.reshape((num_cols))
-            mx_rhs_col = rand_ndarray((num_rows, 1), 'default')
-            for mx_rhs in [mx_rhs_row_2D, mx_rhs_row_1D, mx_rhs_col]:
-                np_rhs = mx_rhs.asnumpy()
-                check_broadcast_mul(mx_lhs, mx_rhs, np_lhs, np_rhs, np.float32)
-                check_broadcast_div(mx_lhs, mx_rhs, np_lhs, np_rhs, np.float32)
+    shape = rand_shape_2d()
+    num_rows = shape[0]
+    num_cols = shape[1]
+    for density in [0.1 * i for i in range(10)]:
+        mx_lhs = rand_ndarray(shape, stype, density)
+        np_lhs = mx_lhs.asnumpy()
+        mx_rhs_row_2D = rand_ndarray((1, num_cols), 'default')
+        mx_rhs_row_1D = mx_rhs_row_2D.reshape((num_cols))
+        mx_rhs_col = rand_ndarray((num_rows, 1), 'default')
+        mx_rhs_scalar_2D = rand_ndarray((1, 1), 'default')
+        mx_rhs_scalar_1D = mx_rhs_scalar_2D.reshape((1, ))
+        for mx_rhs in [mx_rhs_row_2D, mx_rhs_row_1D, mx_rhs_col, mx_rhs_scalar_2D, mx_rhs_scalar_1D]:
+            np_rhs = mx_rhs.asnumpy()
+            check_broadcast_mul(mx_lhs, mx_rhs, np_lhs, np_rhs, np.float32)
+            check_broadcast_div(mx_lhs, mx_rhs, np_lhs, np_rhs, np.float32)
 
 @with_seed()
 def test_scatter_ops():


### PR DESCRIPTION
## Description ##
Add a sparse operator on CPU that supports broadcast_mul/div(csr, dense) = csr operations.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-117]
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add support for broadcast_mul/div(csr, 1Ddense) = csr
- [x] Add support for broadcast_mul/div(csr, 2Ddense) = csr
- [x] Add test for broadcast_mul/div(csr, 1Ddense) = csr
- [x] Add test for broadcast_mul/div(csr, 2Ddense) = csr
## Comments ##
Duplicate PR with #10150, getting a new PR due to renaming of my branch
Example for broadcast_mul/div(csr, 1Ddense) = csr
import mxnet as mx
a = mx.nd.array([[0,0,3],[0,2,0],[1,0,0]]).tostype('csr')
b = mx.nd.array([1,2,3])
mx.nd.broadcast_mul(a,b).asnumpy()
array([[ 0.,  0.,  3.],
           [ 0.,  4.,  0.],
           [ 3.,  0.,  0.]], dtype=float32)