### PR TITLE
[MXNET-116] Inference - ObjectDetector and SSDObjectDetectorExample

### DIFF
--- a/scala-package/examples/scripts/inferexample/objectdetector/get_ssd_data.sh
+++ b/scala-package/examples/scripts/inferexample/objectdetector/get_ssd_data.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+set -e
+
+MXNET_ROOT=$(cd "$(dirname $0)/../../../.."; pwd)
+
+data_path=$MXNET_ROOT/examples/scripts/inferexample/models/resnet50_ssd
+
+image_path=$MXNET_ROOT/examples/scripts/inferexample/images
+
+if [ ! -d "$data_path" ]; then
+  mkdir -p "$data_path"
+fi
+
+if [ ! -d "$image_path" ]; then
+  mkdir -p "$image_path"
+fi
+
+if [ ! -f "$data_path" ]; then
+    wget https://s3.amazonaws.com/model-server/models/resnet50_ssd/resnet50_ssd_model-symbol.json -P $data_path
+    wget https://s3.amazonaws.com/model-server/models/resnet50_ssd/resnet50_ssd_model-0000.params -P $data_path
+    wget https://raw.githubusercontent.com/awslabs/mxnet-model-server/master/examples/ssd/synset.txt -P $data_path
+    cd $image_path
+    wget https://cloud.githubusercontent.com/assets/3307514/20012566/cbb53c76-a27d-11e6-9aaa-91939c9a1cd5.jpg -O 000001.jpg
+    wget https://cloud.githubusercontent.com/assets/3307514/20012567/cbb60336-a27d-11e6-93ff-cbc3f09f5c9e.jpg -O dog.jpg
+    wget https://cloud.githubusercontent.com/assets/3307514/20012563/cbb41382-a27d-11e6-92a9-18dab4fd1ad3.jpg -O person.jpg
+fi

--- a/scala-package/examples/scripts/inferexample/objectdetector/get_ssd_data.sh
+++ b/scala-package/examples/scripts/inferexample/objectdetector/get_ssd_data.sh
@@ -43,3 +43,4 @@ if [ ! -f "$data_path" ]; then
     wget https://cloud.githubusercontent.com/assets/3307514/20012567/cbb60336-a27d-11e6-93ff-cbc3f09f5c9e.jpg -O dog.jpg
     wget https://cloud.githubusercontent.com/assets/3307514/20012563/cbb41382-a27d-11e6-92a9-18dab4fd1ad3.jpg -O person.jpg
 fi
+

--- a/scala-package/examples/scripts/inferexample/objectdetector/run_ssd_example.sh
+++ b/scala-package/examples/scripts/inferexample/objectdetector/run_ssd_example.sh
@@ -30,6 +30,6 @@ INPUT_DIR=$3
 
 java -Xmx8G -cp $CLASS_PATH \
 	ml.dmlc.mxnetexamples.inferexample.objectdetector.SSDClassifierExample \
-	--model-dir $MODEL_DIR \
+	--model-path-prefix $MODEL_DIR \
 	--input-image $INPUT_IMG \
 	--input-dir $INPUT_DIR

--- a/scala-package/examples/scripts/inferexample/objectdetector/run_ssd_example.sh
+++ b/scala-package/examples/scripts/inferexample/objectdetector/run_ssd_example.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+MXNET_ROOT=$(cd "$(dirname $0)/../../../../../"; pwd)
+CLASS_PATH=$MXNET_ROOT/scala-package/assembly/osx-x86_64-cpu/target/*:$MXNET_ROOT/scala-package/examples/target/*:$MXNET_ROOT/scala-package/examples/target/classes/lib/*:$MXNET_ROOT/scala-package/infer/target/*
+
+# model dir and prefix
+MODEL_DIR=$1
+# input image
+INPUT_IMG=$2
+# which input image dir
+INPUT_DIR=$3
+
+java -Xmx8G -cp $CLASS_PATH \
+	ml.dmlc.mxnetexamples.inferexample.objectdetector.SSDClassifierExample \
+	--model-dir $MODEL_DIR \
+	--input-image $INPUT_IMG \
+	--input-dir $INPUT_DIR

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/README.md
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/README.md
@@ -1,8 +1,8 @@
 # Single Shot Multi Object Detection using Scala Inference API
 
-In this example, you will learn how to use Scala Inference API to import pre-trained Single Shot Multi Object Detection (SSD) MXNet model.
+In this example, you will learn how to use Scala Inference API to run Inference on pre-trained Single Shot Multi Object Detection (SSD) MXNet model.
 
-The pre-trained model is trained on the [Pascal VOC 2012 dataset](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/index.html). The network is a SSD model built on Resnet50 as base network to extract image features. The model is trained to detect the following entities (classes): ['aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus', 'car', 'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse', 'motorbike', 'person', 'pottedplant', 'sheep', 'sofa', 'train', 'tvmonitor']. For more details about the model, you can refer to the [MXNet SSD example](https://github.com/apache/incubator-mxnet/tree/master/example/ssd).
+The model is trained on the [Pascal VOC 2012 dataset](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/index.html). The network is a SSD model built on Resnet50 as base network to extract image features. The model is trained to detect the following entities (classes): ['aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus', 'car', 'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse', 'motorbike', 'person', 'pottedplant', 'sheep', 'sofa', 'train', 'tvmonitor']. For more details about the model, you can refer to the [MXNet SSD example](https://github.com/apache/incubator-mxnet/tree/master/example/ssd).
 
 
 ## Contents
@@ -44,9 +44,9 @@ Alternatively use the following links to download the Symbol and Params files vi
 In the pre-trained model, the `input_name` is `data` and shape is `(1, 3, 512, 512)`.
 This shape translates to: a batch of `1` image, the image has color and uses `3` channels (RGB), and the image has the dimensions of `512` pixels in height by `512` pixels in width.
 
-The signature also specifies `image/jpeg` as the expected input type, since this example's image pre-processor only supports the handling of binary JPEG images.
+`image/jpeg` is the expected input type, since this example's image pre-processor only supports the handling of binary JPEG images.
 
-The signature specifies the output shape is `(1, 6132, 6)`. As with the input, the `1` is the number of images. `6132` is the number of prediction results, and `6` is for the size of each prediction. Each prediction contains the following components:
+The output shape is `(1, 6132, 6)`. As with the input, the `1` is the number of images. `6132` is the number of prediction results, and `6` is for the size of each prediction. Each prediction contains the following components:
 - `Class`
 - `Accuracy`
 - `Xmin`
@@ -98,11 +98,11 @@ Class: dog
 Probabilties: 0.8226818
 (Coord:,83.82353,179.13998,206.63783,476.7875)
 ```
-The first output came from the image `dog.jpg`, with top3 prediction picked.
+the outputs come from the the input image, with top3 predictions picked.
 
 
 ## Infer API Details
-This example uses ObjectDetector class provided by MXNet's scala package Infer APIs. It provides methods to load the images, create NDArray out of BufferedImage and run prediction using Classifier and Predictor APIs.
+This example uses ObjectDetector class provided by MXNet's scala package Infer APIs. It provides methods to load the images, create NDArray out of Java BufferedImage and run prediction using Classifier and Predictor APIs.
 
 
 ## References

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/README.md
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/README.md
@@ -1,0 +1,116 @@
+# Single Shot Multi Object Detection using Scala Inference API
+
+In this example, you will learn how to use Scala Inference API to import pre-trained Single Shot Multi Object Detection (SSD) MXNet model.
+
+The pre-trained model is trained on the [Pascal VOC 2012 dataset](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/index.html). The network is a SSD model built on Resnet50 as base network to extract image features. The model is trained to detect the following entities (classes): ['aeroplane', 'bicycle', 'bird', 'boat', 'bottle', 'bus', 'car', 'cat', 'chair', 'cow', 'diningtable', 'dog', 'horse', 'motorbike', 'person', 'pottedplant', 'sheep', 'sofa', 'train', 'tvmonitor']. For more details about the model, you can refer to the [MXNet SSD example](https://github.com/apache/incubator-mxnet/tree/master/example/ssd).
+
+
+## Contents
+
+1. [Prerequisites](#prerequisites)
+2. [Download artifacts](#download-artifacts)
+3. [Setup datapath and parameters](#setup-datapath-and-parameters)
+4. [Run the image inference example](#run-the-image-inference-example)
+5. [Infer APIs](#infer-api-details)
+6. [Next steps](#next-steps)
+
+
+## Prerequisites
+
+1. MXNet
+2. MXNet Scala Package
+3. [IntelliJ IDE (or alternative IDE) project setup](http://mxnet.incubator.apache.org/tutorials/scala/mxnet_scala_on_intellij.html) with the MXNet Scala Package
+4. wget
+
+
+## Setup Guide
+
+### Download Artifacts
+#### Step 1
+You can download the files using the script `get_ssd_data.sh`. It will download and place the model files in a `model` folder and the test image files in a `image` folder in the current directory.
+From the `scala-package/examples/scripts/inferexample/imageclassifier/` folder run:
+
+```bash
+./get_resnet_data.sh
+```
+
+**Note**: You may need to run `chmod +x get_resnet_data.sh` before running this script.
+
+Alternatively use the following links to download the Symbol and Params files via your browser:
+- [resnet50_ssd_model-symbol.json](https://s3.amazonaws.com/model-server/models/resnet50_ssd/resnet50_ssd_model-symbol.json)
+- [resnet50_ssd_model-0000.params](https://s3.amazonaws.com/model-server/models/resnet50_ssd/resnet50_ssd_model-0000.params)
+- [synset.txt](https://github.com/awslabs/mxnet-model-server/blob/master/examples/ssd/synset.txt)
+
+In the pre-trained model, the `input_name` is `data` and shape is `(1, 3, 512, 512)`.
+This shape translates to: a batch of `1` image, the image has color and uses `3` channels (RGB), and the image has the dimensions of `512` pixels in height by `512` pixels in width.
+
+The signature also specifies `image/jpeg` as the expected input type, since this example's image pre-processor only supports the handling of binary JPEG images.
+
+The signature specifies the output shape is `(1, 6132, 6)`. As with the input, the `1` is the number of images. `6132` is the number of prediction results, and `6` is for the size of each prediction. Each prediction contains the following components:
+- `Class`
+- `Accuracy`
+- `Xmin`
+- `Ymin`
+- `Xmax`
+- `Ymax`
+
+
+### Setup Datapath and Parameters
+#### Step 2
+The code `Line 31: val baseDir = System.getProperty("user.dir")` in the example will automatically searches the work directory you have defined. Please put the files in your [work directory](https://stackoverflow.com/questions/16239130/java-user-dir-property-what-exactly-does-it-mean). <!-- how do you define the work directory? -->
+
+Alternatively, if you would like to use your own path, please change line 31 into your own path
+```scala
+val baseDir = <Your Own Path>
+```
+
+The followings is the parameters defined for this example, you can find more information in the `class SSDClassifierExample`.
+
+| Argument                      | Comments                                 |
+| ----------------------------- | ---------------------------------------- |
+| `model-dir`                   | Folder path with prefix to the model (including json, params, and any synset file). |
+| `input-image`                 | The image to run inference on. |
+| `input-dir`                   | The directory of images to run inference on. |
+
+
+## How to Run Inference
+After the previous steps, you should be able to run the code using the following script that will pass all of the required parameters to the Infer API.
+
+From the `scala-package/examples/scripts/inferexample/objectdetector/` folder run:
+
+```bash
+./run_ssd_example.sh ../model/resnet50_ssd_model ../image/dog.jpg ../image
+```
+
+**Notes**:
+* These are relative paths to this script.
+* You may need to run `chmod +x run_ssd_example.sh` before running this script.
+
+The example should give expected output as shown below:
+```
+Class: car
+Probabilties: 0.99847263
+(Coord:,312.21335,72.0291,456.01443,150.66176)
+Class: bicycle
+Probabilties: 0.90473825
+(Coord:,155.95807,149.96362,383.8369,418.94513)
+Class: dog
+Probabilties: 0.8226818
+(Coord:,83.82353,179.13998,206.63783,476.7875)
+```
+The first output came from the image `dog.jpg`, with top3 prediction picked.
+
+
+## Infer API Details
+This example uses ObjectDetector class provided by MXNet's scala package Infer APIs. It provides methods to load the images, create NDArray out of BufferedImage and run prediction using Classifier and Predictor APIs.
+
+
+## References
+This documentation used the model and inference setup guide from the [MXNet Model Server SSD example](https://github.com/awslabs/mxnet-model-server/blob/master/examples/ssd/README.md).
+
+
+## Next Steps
+
+Check out the following related tutorials and examples for the Infer API:
+
+* [Image Classification with the MXNet Scala Infer API](../imageclassifier/README.md)

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/README.md
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/README.md
@@ -68,7 +68,7 @@ The followings is the parameters defined for this example, you can find more inf
 
 | Argument                      | Comments                                 |
 | ----------------------------- | ---------------------------------------- |
-| `model-dir`                   | Folder path with prefix to the model (including json, params, and any synset file). |
+| `model-path-prefix`                   | Folder path with prefix to the model (including json, params, and any synset file). |
 | `input-image`                 | The image to run inference on. |
 | `input-dir`                   | The directory of images to run inference on. |
 

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/SSDClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/SSDClassifierExample.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
 import java.nio.file.{Files, Paths}
 
 class SSDClassifierExample {
-  @Option(name = "--model-dir", usage = "the input model directory and prefix of the model")
+  @Option(name = "--model-path-prefix", usage = "the input model directory and prefix of the model")
   private val modelPathPrefix: String = "/model/ssd_resnet50_512"
   @Option(name = "--input-image", usage = "the input image")
   private val inputImagePath: String = "/images/dog.jpg"

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/SSDClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/SSDClassifierExample.scala
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.mxnetexamples.inferexample.objectdetector
+
+import ml.dmlc.mxnet.{DType, Shape, DataDesc}
+import ml.dmlc.mxnet.infer._
+import org.kohsuke.args4j.{CmdLineParser, Option}
+import org.slf4j.LoggerFactory
+
+import scala.collection.JavaConverters._
+import java.nio.file.{Files, Paths}
+
+class SSDClassifierExample {
+  @Option(name = "--model-dir", usage = "the input model directory and prefix of the model")
+  private val modelPathPrefix: String = "/model/ssd_resnet50_512"
+  @Option(name = "--input-image", usage = "the input image")
+  private val inputImagePath: String = "/images/dog.jpg"
+  @Option(name = "--input-dir", usage = "the input batch of images directory")
+  private val inputImageDir: String = "/images/"
+}
+
+object SSDClassifierExample {
+
+  private val logger = LoggerFactory.getLogger(classOf[SSDClassifierExample])
+  private type SSDOut = (String, Array[Float])
+
+  def runObjectDetectionSingle(modelPathPrefix: String, inputImagePath: String):
+  IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
+    val dType = DType.Float32
+    val inputShape = Shape(1, 3, 512, 512)
+    // ssd detections, numpy.array([[id, score, x1, y1, x2, y2]...])
+    val outputShape = Shape(1, 6132, 6)
+    val inputDescriptors = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
+    val img = ImageClassifier.loadImageFromFile(inputImagePath)
+    val objDetector = new ObjectDetector(modelPathPrefix, inputDescriptors)
+    val output = objDetector.imageObjectDetect(img, Some(3))
+
+    output
+  }
+
+  def runObjectDetectionBatch(modelPathPrefix: String, inputImageDir: String):
+  IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
+    val dType = DType.Float32
+    val inputShape = Shape(1, 3, 512, 512)
+    // ssd detections, numpy.array([[id, score, x1, y1, x2, y2]...])
+    val outputShape = Shape(1, 6132, 6)
+    val inputDescriptors = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
+    val imgList = ImageClassifier.loadInputBatch(inputImageDir)
+    val objDetector = new ObjectDetector(modelPathPrefix, inputDescriptors)
+    val outputList = objDetector.imageBatchObjectDetect(imgList, Some(1))
+    outputList
+  }
+
+  def main(args: Array[String]): Unit = {
+    val inst = new SSDClassifierExample
+    val parser : CmdLineParser = new CmdLineParser(inst)
+    parser.parseArgument(args.toList.asJava)
+    val baseDir = System.getProperty("user.dir")
+    val mdprefixDir = baseDir + inst.modelPathPrefix
+    val imgPath = baseDir + inst.inputImagePath
+    val imgDir = baseDir + inst.inputImageDir
+    if (!checkExist(Array(mdprefixDir + "-symbol.json", imgDir, imgPath))) {
+      logger.error("Model or input image path does not exist")
+      sys.exit(1)
+    }
+
+    try {
+      val inputShape = Shape(1, 3, 512, 512)
+      val outputShape = Shape(1, 6132, 6)
+
+      val width = inputShape(2)
+      val height = inputShape(3)
+      var outputStr : String = "\n"
+
+      val output = runObjectDetectionSingle(mdprefixDir, imgPath)
+
+
+      for (ele <- output) {
+        for (i <- ele) {
+          outputStr += "Class: " + i._1 + "\n"
+          val arr = i._2
+          outputStr += "Probabilties: " + arr(0) + "\n"
+          val coord = Array[Float](
+            arr(1) * width, arr(2) * height,
+            arr(3) * width, arr(4) * height
+          )
+          outputStr += "Coord:" + coord.mkString(",") + "\n"
+        }
+      }
+      logger.info(outputStr)
+
+      val outputList = runObjectDetectionBatch(mdprefixDir, imgDir)
+
+      outputStr = "\n"
+      for (idx <- outputList.indices) {
+        outputStr += "*** Image " + (idx + 1) + "***" + "\n"
+        for (i <- outputList(idx)) {
+          outputStr += "Class: " + i._1 + "\n"
+          val arr = i._2
+          outputStr += "Probabilties: " + arr(0) + "\n"
+          val coord = Array[Float](
+            arr(1) * width, arr(2) * height,
+            arr(3) * width, arr(4) * height
+          )
+          outputStr += "Coord:" + coord.mkString(",") + "\n"
+        }
+      }
+      logger.info(outputStr)
+
+    } catch {
+      case ex: Exception => {
+        logger.error(ex.getMessage, ex)
+        parser.printUsage(System.err)
+        sys.exit(1)
+      }
+    }
+    sys.exit(0)
+  }
+
+
+  def checkExist(arr : Array[String]) : Boolean = {
+    var exist : Boolean = true
+    for (item <- arr) {
+      exist = Files.exists(Paths.get(item)) && exist
+      if (!exist) {
+        logger.error("Cannot find: " + item)
+      }
+    }
+    exist
+  }
+
+}

--- a/scala-package/examples/src/test/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/ObjectDetectorExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/ObjectDetectorExampleSuite.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.mxnetexamples.inferexample.objectdetector
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.slf4j.LoggerFactory
+import scala.sys.process.Process
+
+class ObjectDetectorExampleSuite extends FunSuite with BeforeAndAfterAll {
+  private val logger = LoggerFactory.getLogger(classOf[ObjectDetectorExampleSuite])
+
+  test("testObjectDetectionExample") {
+    logger.info("Downloading resnetssd model")
+    val tempDirPath = System.getProperty("java.io.tmpdir")
+
+    logger.info("tempDirPath: %s".format(tempDirPath))
+
+    val modelBase = "https://s3.amazonaws.com/model-server/models/resnet50_ssd/"
+    val synsetBase = "https://raw.githubusercontent.com/awslabs/mxnet-model-server/master/examples/"
+    val imageBase = "https://cloud.githubusercontent.com/assets/3307514/"
+
+    Process("wget " + modelBase + "resnet50_ssd_model-symbol.json " + "-P " +
+      tempDirPath + "resnetssd/ -q") !
+
+
+    Process("wget " + modelBase + "resnet50_ssd_model-0000.params " +
+      "-P " + tempDirPath + "resnetssd/ -q") !
+
+
+    Process("wget  " + synsetBase + "ssd/synset.txt " + "-P" +
+      tempDirPath + "resnetssd/ -q") !
+
+    Process("wget " +
+      imageBase + "20012567/cbb60336-a27d-11e6-93ff-cbc3f09f5c9e.jpg " +
+      "-P " + tempDirPath + "inputImages/") !
+
+
+    val modelDirPath = tempDirPath + "resnetssd/"
+    val inputImagePath = tempDirPath +
+      "inputImages/cbb60336-a27d-11e6-93ff-cbc3f09f5c9e.jpg"
+    val inputImageDir = tempDirPath + "inputImages/"
+
+    val output = SSDClassifierExample.runObjectDetectionSingle(modelDirPath + "resnet50_ssd_model",
+      inputImagePath)
+
+    assert(output(0)(0)._1 === "car")
+
+    val outputList = SSDClassifierExample.runObjectDetectionBatch(
+      modelDirPath + "resnet50_ssd_model",
+      inputImageDir)
+
+    assert(output(0)(0)._1 === "car")
+
+    Process("rm -rf " + modelDirPath + " " + inputImageDir) !
+  }
+}

--- a/scala-package/examples/src/test/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/ObjectDetectorExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/ObjectDetectorExampleSuite.scala
@@ -17,8 +17,11 @@
 
 package ml.dmlc.mxnetexamples.inferexample.objectdetector
 
+import java.io.File
+
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.slf4j.LoggerFactory
+
 import scala.sys.process.Process
 
 class ObjectDetectorExampleSuite extends FunSuite with BeforeAndAfterAll {
@@ -50,10 +53,10 @@ class ObjectDetectorExampleSuite extends FunSuite with BeforeAndAfterAll {
       "-P " + tempDirPath + "inputImages/") !
 
 
-    val modelDirPath = tempDirPath + "resnetssd/"
-    val inputImagePath = tempDirPath +
+    val modelDirPath = tempDirPath + File.separator + "resnetssd/"
+    val inputImagePath = tempDirPath + File.separator +
       "inputImages/dog-ssd.jpg"
-    val inputImageDir = tempDirPath + "inputImages/"
+    val inputImageDir = tempDirPath + File.separator + "inputImages/"
 
     val output = SSDClassifierExample.runObjectDetectionSingle(modelDirPath + "resnet50_ssd_model",
       inputImagePath)

--- a/scala-package/examples/src/test/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/ObjectDetectorExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/ObjectDetectorExampleSuite.scala
@@ -38,19 +38,19 @@ class ObjectDetectorExampleSuite extends FunSuite with BeforeAndAfterAll {
     val imageBase = "https://s3.amazonaws.com/model-server/inputs/"
 
     Process("wget " + modelBase + "resnet50_ssd_model-symbol.json " + "-P " +
-      tempDirPath + "resnetssd/ -q") !
+      tempDirPath + "/resnetssd/ -q") !
 
 
     Process("wget " + modelBase + "resnet50_ssd_model-0000.params " +
-      "-P " + tempDirPath + "resnetssd/ -q") !
+      "-P " + tempDirPath + "/resnetssd/ -q") !
 
 
     Process("wget  " + synsetBase + "ssd/synset.txt " + "-P" +
-      tempDirPath + "resnetssd/ -q") !
+      tempDirPath + "/resnetssd/ -q") !
 
     Process("wget " +
       imageBase + "dog-ssd.jpg " +
-      "-P " + tempDirPath + "inputImages/") !
+      "-P " + tempDirPath + "/inputImages/") !
 
 
     val modelDirPath = tempDirPath + File.separator + "resnetssd/"

--- a/scala-package/examples/src/test/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/ObjectDetectorExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/ObjectDetectorExampleSuite.scala
@@ -32,7 +32,7 @@ class ObjectDetectorExampleSuite extends FunSuite with BeforeAndAfterAll {
 
     val modelBase = "https://s3.amazonaws.com/model-server/models/resnet50_ssd/"
     val synsetBase = "https://raw.githubusercontent.com/awslabs/mxnet-model-server/master/examples/"
-    val imageBase = "https://cloud.githubusercontent.com/assets/3307514/"
+    val imageBase = "https://s3.amazonaws.com/model-server/inputs/"
 
     Process("wget " + modelBase + "resnet50_ssd_model-symbol.json " + "-P " +
       tempDirPath + "resnetssd/ -q") !
@@ -46,13 +46,13 @@ class ObjectDetectorExampleSuite extends FunSuite with BeforeAndAfterAll {
       tempDirPath + "resnetssd/ -q") !
 
     Process("wget " +
-      imageBase + "20012567/cbb60336-a27d-11e6-93ff-cbc3f09f5c9e.jpg " +
+      imageBase + "dog-ssd.jpg " +
       "-P " + tempDirPath + "inputImages/") !
 
 
     val modelDirPath = tempDirPath + "resnetssd/"
     val inputImagePath = tempDirPath +
-      "inputImages/cbb60336-a27d-11e6-93ff-cbc3f09f5c9e.jpg"
+      "inputImages/dog-ssd.jpg"
     val inputImageDir = tempDirPath + "inputImages/"
 
     val output = SSDClassifierExample.runObjectDetectionSingle(modelDirPath + "resnet50_ssd_model",

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.mxnet.infer
+// scalastyle:off
+import java.awt.image.BufferedImage
+// scalastyle:on
+import ml.dmlc.mxnet.NDArray
+import ml.dmlc.mxnet.DataDesc
+import scala.collection.mutable.ListBuffer
+/**
+  * A class for object detection tasks
+  *
+  * @param modelPathPrefix  PathPrefix from where to load the symbol, parameters and synset.txt
+  *                         Example: file://model-dir/ssd_resnet50_512
+  *                         (will resolve both ssd_resnet50_512-symbol.json
+  *                         and ssd_resnet50_512-0000.params)
+  *                         file://model-dir/synset.txt
+  * @param inputDescriptors Descriptors defining the input node names, shape,
+  *                         layout and Type parameters
+  */
+class ObjectDetector(modelPathPrefix: String,
+                     inputDescriptors: IndexedSeq[DataDesc]) {
+
+  val classifier: Classifier = getClassifier(modelPathPrefix, inputDescriptors)
+
+  val inputLayout = inputDescriptors(0).layout
+
+  val inputShape = inputDescriptors(0).shape
+
+  val handler = classifier.handler
+
+  val predictor = classifier.predictor
+
+  val synset = classifier.synset
+
+  // Considering 'NCHW' as default layout when not provided
+  // Else get axis according to the layout
+  val height = inputShape(if (inputLayout.indexOf('H')<0) 2 else inputLayout.indexOf('H'))
+  val width = inputShape(if (inputLayout.indexOf('W')<0) 3 else inputLayout.indexOf('W'))
+
+  /**
+    * To Detect bounding boxes and corresponding labels
+    *
+    * @param inputImage : PathPrefix of the input image
+    * @param topK : Get top k elements with maximum probability
+    * @return List of List of tuples of (class, [probability, xmin, ymin, xmax, ymax])
+    */
+  def imageObjectDetect(inputImage: BufferedImage,
+                        topK: Option[Int] = None)
+  : IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
+
+    val scaledImage = ImageClassifier.reshapeImage(inputImage, width, height)
+    val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape)
+    val output = objectDetectWithNDArray(IndexedSeq(pixelsNDArray), topK)
+    handler.execute(pixelsNDArray.dispose())
+    output
+  }
+
+  /**
+    * Takes input images as NDArrays. Useful when you want to perform multiple operations on
+    * the input Array, or when you want to pass a batch of input images.
+    * @param input : Indexed Sequence of NDArrays
+    * @param topK : (Optional) How many top_k(sorting will be based on the last axis)
+    *             elements to return. If not passed, returns all unsorted output.
+    * @return List of List of tuples of (class, [probability, xmin, ymin, xmax, ymax])
+    */
+  def objectDetectWithNDArray(input: IndexedSeq[NDArray], topK: Option[Int])
+  : IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
+
+    val predictResult = predictor.predictWithNDArray(input)(0)
+    var batchResult = ListBuffer[IndexedSeq[(String, Array[Float])]]()
+    for (i <- 0 until predictResult.shape(0)) {
+      val r = predictResult.at(i)
+      batchResult += sortAndReformat(r, topK)
+      handler.execute(r.dispose())
+    }
+    handler.execute(predictResult.dispose())
+    batchResult.toIndexedSeq
+  }
+
+  private def sortAndReformat(predictResultND : NDArray, topK: Option[Int])
+  : IndexedSeq[(String, Array[Float])] = {
+    val predictResult: ListBuffer[Array[Float]] = ListBuffer[Array[Float]]()
+    val accuracy : ListBuffer[Float] = ListBuffer[Float]()
+
+    // iterating over the all the predictions
+    val length = predictResultND.shape(0)
+
+    for (i <- 0 until length) {
+      val r = predictResultND.at(i)
+      val tempArr = r.toArray
+      if (tempArr(0) != -1.0) {
+        predictResult += tempArr
+        accuracy += tempArr(1)
+      } else {
+        // Ignore the minus 1 part
+      }
+      handler.execute(r.dispose())
+    }
+    var result = IndexedSeq[(String, Array[Float])]()
+    if(topK.isDefined) {
+      var sortedIndices = accuracy.zipWithIndex.sortBy(-_._1).map(_._2)
+      sortedIndices = sortedIndices.take(topK.get)
+      // takeRight(5) would provide the output as Array[Accuracy, Xmin, Ymin, Xmax, Ymax
+      result = sortedIndices.map(idx
+      => (synset(predictResult(idx)(0).toInt),
+          predictResult(idx).takeRight(5))).toIndexedSeq
+    } else {
+      result = predictResult.map(ele
+      => (synset(ele(0).toInt), ele.takeRight(5))).toIndexedSeq
+    }
+
+    result
+  }
+
+  /**
+    * To classify batch of input images according to the provided model
+    * @param inputBatch Input batch of Buffered images
+    * @param topK Get top k elements with maximum probability
+    * @return List of list of tuples of (class, probability)
+    */
+  def imageBatchObjectDetect(inputBatch: Traversable[BufferedImage], topK: Option[Int] = None):
+  IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
+
+    val imageBatch = ListBuffer[NDArray]()
+    for (image <- inputBatch) {
+      val scaledImage = ImageClassifier.reshapeImage(image, width, height)
+      val pixelsNdarray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape)
+      imageBatch += pixelsNdarray
+    }
+    val op = NDArray.concatenate(imageBatch)
+
+    val result = objectDetectWithNDArray(IndexedSeq(op), topK)
+    handler.execute(op.dispose())
+    for (ele <- imageBatch) {
+      handler.execute(ele.dispose())
+    }
+    result
+  }
+
+  def getClassifier(modelPathPrefix: String, inputDescriptors: IndexedSeq[DataDesc]): Classifier = {
+    new Classifier(modelPathPrefix, inputDescriptors)
+  }
+
+}

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
@@ -36,22 +36,22 @@ import scala.collection.mutable.ListBuffer
 class ObjectDetector(modelPathPrefix: String,
                      inputDescriptors: IndexedSeq[DataDesc]) {
 
-  val classifier: Classifier = getClassifier(modelPathPrefix, inputDescriptors)
+  val imgClassifier: ImageClassifier = getImageClassifier(modelPathPrefix, inputDescriptors)
 
   val inputLayout = inputDescriptors(0).layout
 
   val inputShape = inputDescriptors(0).shape
 
-  val handler = classifier.handler
+  val handler = imgClassifier.handler
 
-  val predictor = classifier.predictor
+  val predictor = imgClassifier.predictor
 
-  val synset = classifier.synset
+  val synset = imgClassifier.synset
 
-  // Considering 'NCHW' as default layout when not provided
-  // Else get axis according to the layout
-  val height = inputShape(if (inputLayout.indexOf('H')<0) 2 else inputLayout.indexOf('H'))
-  val width = inputShape(if (inputLayout.indexOf('W')<0) 3 else inputLayout.indexOf('W'))
+  val height = imgClassifier.height
+
+  val width = imgClassifier.width
+
 
   /**
     * To Detect bounding boxes and corresponding labels
@@ -147,14 +147,13 @@ class ObjectDetector(modelPathPrefix: String,
 
     val result = objectDetectWithNDArray(IndexedSeq(op), topK)
     handler.execute(op.dispose())
-    for (ele <- imageBatch) {
-      handler.execute(ele.dispose())
-    }
+    handler.execute(imageBatch.foreach(_.dispose()))
     result
   }
 
-  def getClassifier(modelPathPrefix: String, inputDescriptors: IndexedSeq[DataDesc]): Classifier = {
-    new Classifier(modelPathPrefix, inputDescriptors)
+  def getImageClassifier(modelPathPrefix: String, inputDescriptors: IndexedSeq[DataDesc]):
+  ImageClassifier = {
+    new ImageClassifier(modelPathPrefix, inputDescriptors)
   }
 
 }

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
@@ -38,9 +38,7 @@ class ObjectDetector(modelPathPrefix: String,
 
   val imgClassifier: ImageClassifier = getImageClassifier(modelPathPrefix, inputDescriptors)
 
-  val inputLayout = inputDescriptors(0).layout
-
-  val inputShape = inputDescriptors(0).shape
+  val inputShape = imgClassifier.inputShape
 
   val handler = imgClassifier.handler
 
@@ -51,7 +49,6 @@ class ObjectDetector(modelPathPrefix: String,
   val height = imgClassifier.height
 
   val width = imgClassifier.width
-
 
   /**
     * To Detect bounding boxes and corresponding labels

--- a/scala-package/infer/src/test/scala/ml/dmlc/mxnet/infer/ObjectDetectorSuite.scala
+++ b/scala-package/infer/src/test/scala/ml/dmlc/mxnet/infer/ObjectDetectorSuite.scala
@@ -35,16 +35,30 @@ class ObjectDetectorSuite extends ClassifierSuite with BeforeAndAfterAll {
                          inputDescriptors: IndexedSeq[DataDesc])
     extends ObjectDetector(modelPathPrefix, inputDescriptors) {
 
-    override def getClassifier(modelPathPrefix: String, inputDescriptors:
-    IndexedSeq[DataDesc]): Classifier = {
-      new MyClassifier(modelPathPrefix, inputDescriptors)
+    override def getImageClassifier(modelPathPrefix: String, inputDescriptors:
+    IndexedSeq[DataDesc]): ImageClassifier = {
+      new MyImageClassifier(modelPathPrefix, inputDescriptors)
     }
 
   }
 
+  class MyImageClassifier(modelPathPrefix: String,
+                     protected override val inputDescriptors: IndexedSeq[DataDesc])
+    extends ImageClassifier(modelPathPrefix, inputDescriptors) {
+
+    override def getPredictor(): MyClassyPredictor = {
+      Mockito.mock(classOf[MyClassyPredictor])
+    }
+
+    override def getClassifier(modelPathPrefix: String, inputDescriptors: IndexedSeq[DataDesc]):
+    Classifier = {
+      new MyClassifier(modelPathPrefix, inputDescriptors)
+    }
+  }
+
   class MyClassifier(modelPathPrefix: String,
                      protected override val inputDescriptors: IndexedSeq[DataDesc])
-    extends Classifier(modelPathPrefix, inputDescriptors, Context.cpu(), Some(0)) {
+    extends Classifier(modelPathPrefix, inputDescriptors) {
 
     override def getPredictor(): MyClassyPredictor = {
       Mockito.mock(classOf[MyClassyPredictor])

--- a/scala-package/infer/src/test/scala/ml/dmlc/mxnet/infer/ObjectDetectorSuite.scala
+++ b/scala-package/infer/src/test/scala/ml/dmlc/mxnet/infer/ObjectDetectorSuite.scala
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ml.dmlc.mxnet.infer
+
+
+// scalastyle:off
+import java.awt.image.BufferedImage
+// scalastyle:on
+import ml.dmlc.mxnet.Context
+import ml.dmlc.mxnet.DataDesc
+import ml.dmlc.mxnet.{NDArray, Shape}
+import org.mockito.Matchers.any
+import org.mockito.Mockito
+import org.scalatest.BeforeAndAfterAll
+
+
+class ObjectDetectorSuite extends ClassifierSuite with BeforeAndAfterAll {
+
+  class MyObjectDetector(modelPathPrefix: String,
+                         inputDescriptors: IndexedSeq[DataDesc])
+    extends ObjectDetector(modelPathPrefix, inputDescriptors) {
+
+    override def getClassifier(modelPathPrefix: String, inputDescriptors:
+    IndexedSeq[DataDesc]): Classifier = {
+      new MyClassifier(modelPathPrefix, inputDescriptors)
+    }
+
+  }
+
+  class MyClassifier(modelPathPrefix: String,
+                     protected override val inputDescriptors: IndexedSeq[DataDesc])
+    extends Classifier(modelPathPrefix, inputDescriptors, Context.cpu(), Some(0)) {
+
+    override def getPredictor(): MyClassyPredictor = {
+      Mockito.mock(classOf[MyClassyPredictor])
+    }
+    def getSynset(): IndexedSeq[String] = synset
+  }
+
+  test("objectDetectWithInputImage") {
+    val inputDescriptor = IndexedSeq[DataDesc](new DataDesc(modelPath, Shape(1, 3, 512, 512)))
+    val inputImage = new BufferedImage(512, 512, BufferedImage.TYPE_INT_RGB)
+    val testObjectDetector: ObjectDetector =
+      new MyObjectDetector(modelPath, inputDescriptor)
+
+    val predictRaw: IndexedSeq[Array[Array[Float]]] =
+      IndexedSeq[Array[Array[Float]]](Array(
+        Array(1.0f, 0.42f, 0.45f, 0.66f, 0.72f, 0.88f),
+        Array(2.0f, 0.88f, 0.21f, 0.33f, 0.45f, 0.66f),
+        Array(3.0f, 0.62f, 0.50f, 0.42f, 0.68f, 0.99f)
+      ))
+    val predictResultND: NDArray =
+      NDArray.array(predictRaw.flatten.flatten.toArray, Shape(1, 3, 6))
+
+    val synset = testObjectDetector.synset
+
+    val predictResult: IndexedSeq[IndexedSeq[(String, Array[Float])]] =
+      IndexedSeq[IndexedSeq[(String, Array[Float])]](
+        IndexedSeq[(String, Array[Float])](
+          (synset(2), Array(0.88f, 0.21f, 0.33f, 0.45f, 0.66f)),
+          (synset(3), Array(0.62f, 0.50f, 0.42f, 0.68f, 0.99f)),
+          (synset(1), Array(0.42f, 0.45f, 0.66f, 0.72f, 0.88f))
+        )
+      )
+
+    Mockito.doReturn(IndexedSeq(predictResultND)).when(testObjectDetector.predictor)
+      .predictWithNDArray(any(classOf[IndexedSeq[NDArray]]))
+
+    val result: IndexedSeq[IndexedSeq[(String, Array[Float])]] =
+      testObjectDetector.imageObjectDetect(inputImage, Some(3))
+
+    for (idx <- predictResult(0).indices) {
+      assert(predictResult(0)(idx)._1 == result(0)(idx)._1)
+      for (arridx <- predictResult(0)(idx)._2.indices) {
+        assert(predictResult(0)(idx)._2(arridx) == result(0)(idx)._2(arridx))
+      }
+    }
+  }
+
+  test("objectDetectWithBatchImages") {
+    val inputDescriptor = IndexedSeq[DataDesc](new DataDesc(modelPath, Shape(1, 3, 512, 512)))
+    val inputImage = new BufferedImage(224, 224, BufferedImage.TYPE_INT_RGB)
+    val imageBatch = IndexedSeq[BufferedImage](inputImage, inputImage)
+
+    val testObjectDetector: ObjectDetector =
+      new MyObjectDetector(modelPath, inputDescriptor)
+
+    val predictRaw: IndexedSeq[Array[Array[Float]]] =
+      IndexedSeq[Array[Array[Float]]](
+        Array(
+          Array(1.0f, 0.42f, 0.45f, 0.66f, 0.72f, 0.88f),
+          Array(2.0f, 0.88f, 0.21f, 0.33f, 0.45f, 0.66f),
+          Array(3.0f, 0.62f, 0.50f, 0.42f, 0.68f, 0.99f)
+        ),
+        Array(
+          Array(0.0f, 0.42f, 0.45f, 0.66f, 0.72f, 0.88f),
+          Array(2.0f, 0.23f, 0.21f, 0.33f, 0.45f, 0.66f),
+          Array(2.0f, 0.94f, 0.50f, 0.42f, 0.68f, 0.99f)
+        )
+      )
+    val predictResultND: NDArray =
+      NDArray.array(predictRaw.flatten.flatten.toArray, Shape(2, 3, 6))
+
+    val synset = testObjectDetector.synset
+
+    val predictResult: IndexedSeq[IndexedSeq[(String, Array[Float])]] =
+      IndexedSeq[IndexedSeq[(String, Array[Float])]](
+        IndexedSeq[(String, Array[Float])](
+          (synset(2), Array(0.88f, 0.21f, 0.33f, 0.45f, 0.66f)),
+          (synset(3), Array(0.62f, 0.50f, 0.42f, 0.68f, 0.99f)),
+          (synset(1), Array(0.42f, 0.45f, 0.66f, 0.72f, 0.88f))
+        ),
+        IndexedSeq[(String, Array[Float])](
+          (synset(2), Array(0.94f, 0.50f, 0.42f, 0.68f, 0.99f)),
+          (synset(0), Array(0.42f, 0.45f, 0.66f, 0.72f, 0.88f)),
+          (synset(2), Array(0.23f, 0.21f, 0.33f, 0.45f, 0.66f))
+        )
+      )
+
+    Mockito.doReturn(IndexedSeq(predictResultND)).when(testObjectDetector.predictor)
+      .predictWithNDArray(any(classOf[IndexedSeq[NDArray]]))
+
+    val result: IndexedSeq[IndexedSeq[(String, Array[Float])]] =
+      testObjectDetector.imageBatchObjectDetect(imageBatch, Some(3))
+    for (preidx <- predictResult.indices) {
+      for (idx <- predictResult(preidx).indices) {
+        assert(predictResult(preidx)(idx)._1 == result(preidx)(idx)._1)
+        for (arridx <- predictResult(preidx)(idx)._2.indices) {
+          assert(predictResult(preidx)(idx)._2(arridx) == result(preidx)(idx)._2(arridx))
+        }
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
## Description ##
Add Object Detection Class for MXNet Inference API, also add test and example to it. This code is fully tested with SSD model.
@Roshrini @nswamy @aaronmarkham 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

