### PR TITLE
[MXNET-135] mx.image.imread support s3

### DIFF
--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -217,28 +217,27 @@ void Imread(const nnvm::NodeAttrs& attrs,
             std::vector<NDArray>* outputs) {
 #if MXNET_USE_OPENCV
   const auto& param = nnvm::get<ImreadParam>(attrs.parsed);
-  dmlc::Stream *fi = dmlc::Stream::Create(param.filename.c_str(), "r", true);
-  CHECK(fi != NULL) << "Imread: '" << param.filename
+  std::unique_ptr<dmlc::Stream> fi(dmlc::Stream::Create(param.filename.c_str(), "r", true));
+  CHECK(fi.get() != NULL) << "Imread: '" << param.filename
     << "' couldn't open file: " << strerror(errno);
-  std::vector<char*> buff_vec;
+  std::vector<std::unique_ptr<char> > buff_vec;
   std::vector<int> buff_size;
-  int ptr = 0, single_buff_size = 10000;
+  int single_buff_size = 1000000;
   size_t size, fsize = 0;
   char* single_buff = new char[single_buff_size];
-  while ((size = fi->Read(single_buff, single_buff_size)) != 0) {
+  while ((size = fi.get()->Read(single_buff, single_buff_size)) != 0) {
     fsize += size;
-    buff_vec.push_back(single_buff);
+    buff_vec.push_back(std::unique_ptr<char>(single_buff));
     buff_size.push_back(size);
     single_buff = new char[single_buff_size];
   }
   CHECK(fsize != 0) << "Failed reading image file: '" << param.filename << "' "
     << strerror(errno);
   std::shared_ptr<uint8_t> buff(new uint8_t[fsize], std::default_delete<uint8_t[]>());
-  for (size_t i = 0; i < buff_vec.size(); i++) {
-    memcpy(buff.get() + ptr, buff_vec[i], buff_size[i]);
-    ptr += buff_size[i];
+  for (size_t i = 0, offset = 0; i < buff_vec.size(); i++) {
+    memcpy(buff.get() + offset, buff_vec[i].get(), buff_size[i]);
+    offset += buff_size[i];
   }
-  delete fi;
 
   TShape oshape(3);
   oshape[2] = param.flag == 0 ? 1 : 3;

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -219,11 +219,11 @@ void Imread(const nnvm::NodeAttrs& attrs,
   const auto& param = nnvm::get<ImreadParam>(attrs.parsed);
   dmlc::Stream *fi = dmlc::Stream::Create(param.filename.c_str(), "r", true);
   CHECK(fi != NULL) << "Imread: '" << param.filename
-      << "' couldn't open file: " << strerror(errno);	
+    << "' couldn't open file: " << strerror(errno);
   std::vector<char*> buff_vec;
   std::vector<int> buff_size;
   int ptr = 0, single_buff_size = 10000;
-  size_t size, fsize = 0; 
+  size_t size, fsize = 0;
   char* single_buff = new char[single_buff_size];
   while ((size = fi->Read(single_buff, single_buff_size)) != 0) {
     fsize += size;
@@ -232,7 +232,7 @@ void Imread(const nnvm::NodeAttrs& attrs,
     single_buff = new char[single_buff_size];
   }
   CHECK(fsize != 0) << "Failed reading image file: '" << param.filename << "' "
-             << strerror(errno);
+    << strerror(errno);
   std::shared_ptr<uint8_t> buff(new uint8_t[fsize], std::default_delete<uint8_t[]>());
   for (size_t i = 0; i < buff_vec.size(); i++) {
     memcpy(buff.get() + ptr, buff_vec[i], buff_size[i]);

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -217,17 +217,28 @@ void Imread(const nnvm::NodeAttrs& attrs,
             std::vector<NDArray>* outputs) {
 #if MXNET_USE_OPENCV
   const auto& param = nnvm::get<ImreadParam>(attrs.parsed);
-
-  std::ifstream file(param.filename, std::ios::binary | std::ios::ate);
-  // if file is not open we get bad alloc after tellg
-  CHECK(file.is_open()) << "Imread: '" << param.filename
-      << "' couldn't open file: " << strerror(errno);
-  size_t fsize = file.tellg();
-  file.seekg(0, std::ios::beg);
+  dmlc::Stream *fi = dmlc::Stream::Create(param.filename.c_str(), "r", true);
+  CHECK(fi != NULL) << "Imread: '" << param.filename
+      << "' couldn't open file: " << strerror(errno);	
+  std::vector<char*> buff_vec;
+  std::vector<int> buff_size;
+  int ptr = 0, single_buff_size = 10000;
+  size_t size, fsize = 0; 
+  char* single_buff = new char[single_buff_size];
+  while ((size = fi->Read(single_buff, single_buff_size)) != 0) {
+    fsize += size;
+    buff_vec.push_back(single_buff);
+    buff_size.push_back(size);
+    single_buff = new char[single_buff_size];
+  }
+  CHECK(fsize != 0) << "Failed reading image file: '" << param.filename << "' "
+             << strerror(errno);
   std::shared_ptr<uint8_t> buff(new uint8_t[fsize], std::default_delete<uint8_t[]>());
-  file.read(reinterpret_cast<char*>(buff.get()), fsize);
-  CHECK(file.good()) << "Failed reading image file: '" << param.filename << "' "
-            << strerror(errno);
+  for (size_t i = 0; i < buff_vec.size(); i++) {
+    memcpy(buff.get() + ptr, buff_vec[i], buff_size[i]);
+    ptr += buff_size[i];
+  }
+  delete fi;
 
   TShape oshape(3);
   oshape[2] = param.flag == 0 ? 1 : 3;

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -222,14 +222,17 @@ void Imread(const nnvm::NodeAttrs& attrs,
     << "' couldn't open file: " << strerror(errno);
   std::vector<std::unique_ptr<char> > buff_vec;
   std::vector<int> buff_size;
-  int single_buff_size = 1000000;
+  int single_buff_size = 1000;
   size_t size, fsize = 0;
-  char* single_buff = new char[single_buff_size];
-  while ((size = fi.get()->Read(single_buff, single_buff_size)) != 0) {
+  while (true) {
+    std::unique_ptr<char> single_buff(new char[single_buff_size]);
+    size = fi.get()->Read(single_buff.get(), single_buff_size);
+    if (size == 0) {
+      break;
+    }
     fsize += size;
-    buff_vec.push_back(std::unique_ptr<char>(single_buff));
+    buff_vec.push_back(std::move(single_buff));
     buff_size.push_back(size);
-    single_buff = new char[single_buff_size];
   }
   CHECK(fsize != 0) << "Failed reading image file: '" << param.filename << "' "
     << strerror(errno);


### PR DESCRIPTION
In current mxnet version, mx.image.imread can only read file in local file system.
We used dmlc::Stream to read date, it can read file from many other file systems.