### PR TITLE
[MXNET-137]fix parameters name inconsistent for Proposal OP and Multi Proposal OP

### DIFF
--- a/src/operator/contrib/multi_proposal.cc
+++ b/src/operator/contrib/multi_proposal.cc
@@ -497,7 +497,7 @@ DMLC_REGISTER_PARAMETER(MultiProposalParam);
 
 MXNET_REGISTER_OP_PROPERTY(_contrib_MultiProposal, MultiProposalProp)
 .describe("Generate region proposals via RPN")
-.add_argument("cls_score", "NDArray-or-Symbol", "Score of how likely proposal is object.")
+.add_argument("cls_prob", "NDArray-or-Symbol", "Score of how likely proposal is object.")
 .add_argument("bbox_pred", "NDArray-or-Symbol", "BBox Predicted deltas from anchors for proposals")
 .add_argument("im_info", "NDArray-or-Symbol", "Image size and scale.")
 .add_arguments(MultiProposalParam::__FIELDS__());

--- a/src/operator/contrib/proposal.cc
+++ b/src/operator/contrib/proposal.cc
@@ -459,7 +459,7 @@ DMLC_REGISTER_PARAMETER(ProposalParam);
 
 MXNET_REGISTER_OP_PROPERTY(_contrib_Proposal, ProposalProp)
 .describe("Generate region proposals via RPN")
-.add_argument("cls_score", "NDArray-or-Symbol", "Score of how likely proposal is object.")
+.add_argument("cls_prob", "NDArray-or-Symbol", "Score of how likely proposal is object.")
 .add_argument("bbox_pred", "NDArray-or-Symbol", "BBox Predicted deltas from anchors for proposals")
 .add_argument("im_info", "NDArray-or-Symbol", "Image size and scale.")
 .add_arguments(ProposalParam::__FIELDS__());

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1703,7 +1703,7 @@ def test_multi_proposal_op():
         '''
         cls_prob, bbox_pred, im_info = get_new_data(batch_size, mx.cpu(0))
         rois_cpu, score_cpu = op(
-                cls_score = cls_prob,
+                cls_prob = cls_prob,
                 bbox_pred = bbox_pred,
                 im_info = im_info,
                 feature_stride = feature_stride,
@@ -1722,7 +1722,7 @@ def test_multi_proposal_op():
         im_info_gpu = im_info.as_in_context(gpu_ctx)
 
         rois_gpu, score_gpu = op(
-                cls_score = cls_prob_gpu,
+                cls_prob = cls_prob_gpu,
                 bbox_pred = bbox_pred_gpu,
                 im_info = im_info_gpu,
                 feature_stride = feature_stride,

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5267,7 +5267,7 @@ def test_multi_proposal_op():
     rpn_min_size = 16
 
     batch_size = 20
-    feat_len = 14
+    feat_len = (1000 + 15) // 16
     H, W = feat_len, feat_len
     num_anchors = len(scales) * len(ratios)
     count_anchors = H * W * num_anchors
@@ -5301,7 +5301,7 @@ def test_multi_proposal_op():
         single_score = []
         for i in range(batch_size):
             rois, score = mx.nd.contrib.Proposal(
-                    cls_score = get_sub(cls_prob, i),
+                    cls_prob = get_sub(cls_prob, i),
                     bbox_pred = get_sub(bbox_pred, i),
                     im_info = get_sub(im_info, i),
                     feature_stride = feature_stride,
@@ -5315,7 +5315,7 @@ def test_multi_proposal_op():
             single_score.append(score)
 
         multi_proposal, multi_score = mx.nd.contrib.MultiProposal(
-                cls_score = cls_prob,
+                cls_prob = cls_prob,
                 bbox_pred = bbox_pred,
                 im_info = im_info,
                 feature_stride = feature_stride,


### PR DESCRIPTION
## Description ##
Hi, there.
There is parameters name inconsistent in Proposal OP and Multi Proposal OP.
Proposal OP:
[cls_prob](https://github.com/apache/incubator-mxnet/blob/master/src/operator/contrib/proposal-inl.h#L160) vs [cls_score](https://github.com/apache/incubator-mxnet/blob/master/src/operator/contrib/proposal.cc#L462)

Multi Proposal OP:
[cls_prob](https://github.com/apache/incubator-mxnet/blob/master/src/operator/contrib/multi_proposal-inl.h#L162) vs [cls_score](https://github.com/apache/incubator-mxnet/blob/master/src/operator/contrib/multi_proposal.cc#L500)

It seems that the parameter name should be `cls_prob` rather than `cls_score`.
[The parameter prompt](https://github.com/apache/incubator-mxnet/blob/master/src/operator/contrib/proposal-inl.h#L107)
[Faster R-CNN example](https://github.com/apache/incubator-mxnet/blob/master/example/rcnn/rcnn/symbol/symbol_resnet.py#L193)

So I replace `cls_score` with `cls_prob`, and I change the parameter name in the unittest for Proposal OP and Multi Proposal OP.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Replace the parameter name `cls_score` with `cls_prob` in Proposal OP and Multi Proposal OP
- [x] Change the parameter name `cls_score` in the unit-test for Proposal OP and Multi Proposal OP 
