### PR TITLE
adding context parameter to infer api- imageclassifier and objectdetector

### DIFF
--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ImageClassifier.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ImageClassifier.scala
@@ -17,7 +17,7 @@
 
 package ml.dmlc.mxnet.infer
 
-import ml.dmlc.mxnet.{DataDesc, NDArray, Shape}
+import ml.dmlc.mxnet.{Context, DataDesc, NDArray, Shape}
 
 import scala.collection.mutable.ListBuffer
 
@@ -39,11 +39,11 @@ import javax.imageio.ImageIO
   *                         layout and Type parameters
   */
 class ImageClassifier(modelPathPrefix: String,
-                      inputDescriptors: IndexedSeq[DataDesc])
+                      inputDescriptors: IndexedSeq[DataDesc],
+                      contexts: Array[Context] = Context.cpu(),
+                      epoch: Option[Int] = Some(0))
                       extends Classifier(modelPathPrefix,
-                      inputDescriptors) {
-
-  val classifier: Classifier = getClassifier(modelPathPrefix, inputDescriptors)
+                      inputDescriptors, contexts, epoch) {
 
   protected[infer] val inputLayout = inputDescriptors.head.layout
 
@@ -108,8 +108,10 @@ class ImageClassifier(modelPathPrefix: String,
     result
   }
 
-  def getClassifier(modelPathPrefix: String, inputDescriptors: IndexedSeq[DataDesc]): Classifier = {
-    new Classifier(modelPathPrefix, inputDescriptors)
+  def getClassifier(modelPathPrefix: String, inputDescriptors: IndexedSeq[DataDesc],
+                    contexts: Array[Context] = Context.cpu(),
+                    epoch: Option[Int] = Some(0)): Classifier = {
+    new Classifier(modelPathPrefix, inputDescriptors, contexts, epoch)
   }
 }
 

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ImageClassifier.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ImageClassifier.scala
@@ -37,6 +37,8 @@ import javax.imageio.ImageIO
   *                         file://model-dir/synset.txt
   * @param inputDescriptors Descriptors defining the input node names, shape,
   *                         layout and Type parameters
+  * @param contexts Device Contexts on which you want to run Inference, defaults to CPU.
+  * @param epoch Model epoch to load, defaults to 0.
   */
 class ImageClassifier(modelPathPrefix: String,
                       inputDescriptors: IndexedSeq[DataDesc],

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
@@ -34,6 +34,8 @@ import scala.collection.mutable.ListBuffer
   *                         file://model-dir/synset.txt
   * @param inputDescriptors Descriptors defining the input node names, shape,
   *                         layout and Type parameters
+  * @param contexts Device Contexts on which you want to run Inference, defaults to CPU.
+  * @param epoch Model epoch to load, defaults to 0.
   */
 class ObjectDetector(modelPathPrefix: String,
                      inputDescriptors: IndexedSeq[DataDesc],

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
@@ -16,12 +16,14 @@
  */
 
 package ml.dmlc.mxnet.infer
+
 // scalastyle:off
 import java.awt.image.BufferedImage
 // scalastyle:on
-import ml.dmlc.mxnet.NDArray
-import ml.dmlc.mxnet.DataDesc
+
+import ml.dmlc.mxnet.{Context, DataDesc, NDArray}
 import scala.collection.mutable.ListBuffer
+
 /**
   * A class for object detection tasks
   *
@@ -34,9 +36,12 @@ import scala.collection.mutable.ListBuffer
   *                         layout and Type parameters
   */
 class ObjectDetector(modelPathPrefix: String,
-                     inputDescriptors: IndexedSeq[DataDesc]) {
+                     inputDescriptors: IndexedSeq[DataDesc],
+                     contexts: Array[Context] = Context.cpu(),
+                     epoch: Option[Int] = Some(0)) {
 
-  val imgClassifier: ImageClassifier = getImageClassifier(modelPathPrefix, inputDescriptors)
+  val imgClassifier: ImageClassifier =
+    getImageClassifier(modelPathPrefix, inputDescriptors, contexts, epoch)
 
   val inputShape = imgClassifier.inputShape
 
@@ -54,7 +59,7 @@ class ObjectDetector(modelPathPrefix: String,
     * To Detect bounding boxes and corresponding labels
     *
     * @param inputImage : PathPrefix of the input image
-    * @param topK : Get top k elements with maximum probability
+    * @param topK       : Get top k elements with maximum probability
     * @return List of List of tuples of (class, [probability, xmin, ymin, xmax, ymax])
     */
   def imageObjectDetect(inputImage: BufferedImage,
@@ -71,9 +76,10 @@ class ObjectDetector(modelPathPrefix: String,
   /**
     * Takes input images as NDArrays. Useful when you want to perform multiple operations on
     * the input Array, or when you want to pass a batch of input images.
+    *
     * @param input : Indexed Sequence of NDArrays
-    * @param topK : (Optional) How many top_k(sorting will be based on the last axis)
-    *             elements to return. If not passed, returns all unsorted output.
+    * @param topK  : (Optional) How many top_k(sorting will be based on the last axis)
+    *              elements to return. If not passed, returns all unsorted output.
     * @return List of List of tuples of (class, [probability, xmin, ymin, xmax, ymax])
     */
   def objectDetectWithNDArray(input: IndexedSeq[NDArray], topK: Option[Int])
@@ -90,10 +96,10 @@ class ObjectDetector(modelPathPrefix: String,
     batchResult.toIndexedSeq
   }
 
-  private def sortAndReformat(predictResultND : NDArray, topK: Option[Int])
+  private def sortAndReformat(predictResultND: NDArray, topK: Option[Int])
   : IndexedSeq[(String, Array[Float])] = {
     val predictResult: ListBuffer[Array[Float]] = ListBuffer[Array[Float]]()
-    val accuracy : ListBuffer[Float] = ListBuffer[Float]()
+    val accuracy: ListBuffer[Float] = ListBuffer[Float]()
 
     // iterating over the all the predictions
     val length = predictResultND.shape(0)
@@ -110,7 +116,7 @@ class ObjectDetector(modelPathPrefix: String,
       handler.execute(r.dispose())
     }
     var result = IndexedSeq[(String, Array[Float])]()
-    if(topK.isDefined) {
+    if (topK.isDefined) {
       var sortedIndices = accuracy.zipWithIndex.sortBy(-_._1).map(_._2)
       sortedIndices = sortedIndices.take(topK.get)
       // takeRight(5) would provide the output as Array[Accuracy, Xmin, Ymin, Xmax, Ymax
@@ -127,8 +133,9 @@ class ObjectDetector(modelPathPrefix: String,
 
   /**
     * To classify batch of input images according to the provided model
+    *
     * @param inputBatch Input batch of Buffered images
-    * @param topK Get top k elements with maximum probability
+    * @param topK       Get top k elements with maximum probability
     * @return List of list of tuples of (class, probability)
     */
   def imageBatchObjectDetect(inputBatch: Traversable[BufferedImage], topK: Option[Int] = None):
@@ -148,9 +155,11 @@ class ObjectDetector(modelPathPrefix: String,
     result
   }
 
-  def getImageClassifier(modelPathPrefix: String, inputDescriptors: IndexedSeq[DataDesc]):
+  def getImageClassifier(modelPathPrefix: String, inputDescriptors: IndexedSeq[DataDesc],
+                         contexts: Array[Context] = Context.cpu(),
+                         epoch: Option[Int] = Some(0)):
   ImageClassifier = {
-    new ImageClassifier(modelPathPrefix, inputDescriptors)
+    new ImageClassifier(modelPathPrefix, inputDescriptors, contexts, epoch)
   }
 
 }

--- a/scala-package/infer/src/test/scala/ml/dmlc/mxnet/infer/ObjectDetectorSuite.scala
+++ b/scala-package/infer/src/test/scala/ml/dmlc/mxnet/infer/ObjectDetectorSuite.scala
@@ -23,7 +23,7 @@ import java.awt.image.BufferedImage
 // scalastyle:on
 import ml.dmlc.mxnet.Context
 import ml.dmlc.mxnet.DataDesc
-import ml.dmlc.mxnet.{NDArray, Shape}
+import ml.dmlc.mxnet.{Context, NDArray, Shape}
 import org.mockito.Matchers.any
 import org.mockito.Mockito
 import org.scalatest.BeforeAndAfterAll
@@ -36,7 +36,8 @@ class ObjectDetectorSuite extends ClassifierSuite with BeforeAndAfterAll {
     extends ObjectDetector(modelPathPrefix, inputDescriptors) {
 
     override def getImageClassifier(modelPathPrefix: String, inputDescriptors:
-    IndexedSeq[DataDesc]): ImageClassifier = {
+        IndexedSeq[DataDesc], contexts: Array[Context] = Context.cpu(),
+        epoch: Option[Int] = Some(0)): ImageClassifier = {
       new MyImageClassifier(modelPathPrefix, inputDescriptors)
     }
 
@@ -44,13 +45,15 @@ class ObjectDetectorSuite extends ClassifierSuite with BeforeAndAfterAll {
 
   class MyImageClassifier(modelPathPrefix: String,
                      protected override val inputDescriptors: IndexedSeq[DataDesc])
-    extends ImageClassifier(modelPathPrefix, inputDescriptors) {
+    extends ImageClassifier(modelPathPrefix, inputDescriptors, Context.cpu(), Some(0)) {
 
     override def getPredictor(): MyClassyPredictor = {
       Mockito.mock(classOf[MyClassyPredictor])
     }
 
-    override def getClassifier(modelPathPrefix: String, inputDescriptors: IndexedSeq[DataDesc]):
+    override def getClassifier(modelPathPrefix: String, inputDescriptors: IndexedSeq[DataDesc],
+                               contexts: Array[Context] = Context.cpu(),
+                               epoch: Option[Int] = Some(0)):
     Classifier = {
       new MyClassifier(modelPathPrefix, inputDescriptors)
     }


### PR DESCRIPTION
## Description ##
adding context parameter to infer api- imageclassifier and objectdetector
@nswamy @lanking520 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
