### PR TITLE
[MXNET-145]  Remove the dependences of mx.io and mx.initializer on the numpy's global random number generator

### DIFF
--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -530,9 +530,9 @@ class Orthogonal(Initializer):
         nout = arr.shape[0]
         nin = np.prod(arr.shape[1:])
         if self.rand_type == "uniform":
-            tmp = np.random.uniform(-1.0, 1.0, (nout, nin))
+            tmp = random.uniform(-1.0, 1.0, shape=(nout, nin)).asnumpy()
         elif self.rand_type == "normal":
-            tmp = np.random.normal(0.0, 1.0, (nout, nin))
+            tmp = random.normal(0.0, 1.0, shape=(nout, nin)).asnumpy()
         u, _, v = np.linalg.svd(tmp, full_matrices=False) # pylint: disable=invalid-name
         if u.shape == tmp.shape:
             res = u

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -539,7 +539,7 @@ def _shuffle(data, idx):
         elif isinstance(v, CSRNDArray):
             shuffle_data.append((k, sparse_array(v.asscipy()[idx.asnumpy()], v.context)))
         else:
-            shuffle_data.append((k, v[idx]))
+            shuffle_data.append((k, v[idx.as_in_context(v.context)]))
 
     return shuffle_data
 

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -39,6 +39,8 @@ from .ndarray.sparse import array as sparse_array
 from .ndarray import _ndarray_cls
 from .ndarray import array
 from .ndarray import concatenate
+from .ndarray import arange
+from .ndarray.random import shuffle as random_shuffle
 
 class DataDesc(namedtuple('DataDesc', ['name', 'shape'])):
     """DataDesc is used to store name, shape, type and layout
@@ -535,9 +537,9 @@ def _shuffle(data, idx):
         if (isinstance(v, h5py.Dataset) if h5py else False):
             shuffle_data.append((k, v))
         elif isinstance(v, CSRNDArray):
-            shuffle_data.append((k, sparse_array(v.asscipy()[idx], v.context)))
+            shuffle_data.append((k, sparse_array(v.asscipy()[idx.asnumpy()], v.context)))
         else:
-            shuffle_data.append((k, array(v.asnumpy()[idx], v.context)))
+            shuffle_data.append((k, v[idx]))
 
     return shuffle_data
 
@@ -651,10 +653,10 @@ class NDArrayIter(DataIter):
             raise NotImplementedError("`NDArrayIter` only supports ``CSRNDArray``" \
                                       " with `last_batch_handle` set to `discard`.")
 
-        self.idx = np.arange(self.data[0][1].shape[0])
+        self.idx = arange(self.data[0][1].shape[0])
         # shuffle data
         if shuffle:
-            np.random.shuffle(self.idx)
+            random_shuffle(self.idx, out=self.idx)
             self.data = _shuffle(self.data, self.idx)
             self.label = _shuffle(self.label, self.idx)
 


### PR DESCRIPTION
## Description ##

This PR removes the dependences of `mx.io` and `mx.initializer` on the numpy's global random number generator. The dependences are not sound as they introduce unnecessary coupling with user's environment and confuse newcomers about seeding. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- If this PR is accepted, I'll make similar PRs removing the dependences on python's and numpy's global random number generators from `rnn/io`, `gluon`'s samplers and so on.

