### PR TITLE
[MXNET-128] added load from buffer functions

### DIFF
--- a/cpp-package/include/mxnet-cpp/ndarray.h
+++ b/cpp-package/include/mxnet-cpp/ndarray.h
@@ -398,6 +398,32 @@ class NDArray {
   */
   static std::vector<NDArray> LoadToList(const std::string &file_name);
   /*!
+  * \brief Load NDArrays from buffer.
+  * \param buffer Pointer to buffer.
+  * \param size Size of buffer
+  * \param array_list a list of NDArrays returned, do not fill the list if
+  * nullptr is given.
+  * \param array_map a map from names to NDArrays returned, do not fill the map
+  * if nullptr is given or no names is stored in binary file.
+  */
+  static void LoadFromBuffer(const void *buffer, size_t size,
+                   std::vector<NDArray> *array_list = nullptr,
+                   std::map<std::string, NDArray> *array_map = nullptr);
+  /*!
+  * \brief Load map of NDArrays from buffer.
+  * \param buffer Pointer to buffer.
+  * \param size Size of buffer
+  * \return a list of NDArrays.
+  */
+  static std::map<std::string, NDArray> LoadFromBufferToMap(const void *buffer, size_t size);
+  /*!
+  * \brief Load list of NDArrays from buffer.
+  * \param buffer Pointer to buffer.
+  * \param size Size of buffer
+  * \return a map from names to NDArrays.
+  */
+  static std::vector<NDArray> LoadFromBufferToList(const void *buffer, size_t size);
+  /*!
   * \brief save a map of string->NDArray to binary file.
   * \param file_name name of the binary file.
   * \param array_map a map from names to NDArrays.

--- a/cpp-package/include/mxnet-cpp/ndarray.h
+++ b/cpp-package/include/mxnet-cpp/ndarray.h
@@ -411,14 +411,14 @@ class NDArray {
                    std::map<std::string, NDArray> *array_map = nullptr);
   /*!
   * \brief Load map of NDArrays from buffer.
-  * \param buffer Pointer to buffer. 
+  * \param buffer Pointer to buffer. (ie contents of param file)
   * \param size Size of buffer
   * \return a list of NDArrays.
   */
   static std::map<std::string, NDArray> LoadFromBufferToMap(const void *buffer, size_t size);
   /*!
   * \brief Load list of NDArrays from buffer.
-  * \param buffer Pointer to buffer.
+  * \param buffer Pointer to buffer. (ie contents of param file)
   * \param size Size of buffer
   * \return a map from names to NDArrays.
   */

--- a/cpp-package/include/mxnet-cpp/ndarray.h
+++ b/cpp-package/include/mxnet-cpp/ndarray.h
@@ -399,7 +399,7 @@ class NDArray {
   static std::vector<NDArray> LoadToList(const std::string &file_name);
   /*!
   * \brief Load NDArrays from buffer.
-  * \param buffer Pointer to buffer.
+  * \param buffer Pointer to buffer. (ie contents of param file)
   * \param size Size of buffer
   * \param array_list a list of NDArrays returned, do not fill the list if
   * nullptr is given.
@@ -411,7 +411,7 @@ class NDArray {
                    std::map<std::string, NDArray> *array_map = nullptr);
   /*!
   * \brief Load map of NDArrays from buffer.
-  * \param buffer Pointer to buffer.
+  * \param buffer Pointer to buffer. 
   * \param size Size of buffer
   * \return a list of NDArrays.
   */

--- a/cpp-package/include/mxnet-cpp/ndarray.hpp
+++ b/cpp-package/include/mxnet-cpp/ndarray.hpp
@@ -255,6 +255,7 @@ inline void NDArray::Load(const std::string &file_name,
                          &out_names),
            0);
   if (array_list != nullptr) {
+    array_list->reserve(out_size);
     for (mx_uint i = 0; i < out_size; ++i) {
       array_list->push_back(NDArray(out_arr[i]));
     }
@@ -291,6 +292,60 @@ inline std::vector<NDArray> NDArray::LoadToList(const std::string &file_name) {
   CHECK_EQ(MXNDArrayLoad(file_name.c_str(), &out_size, &out_arr, &out_name_size,
                          &out_names),
            0);
+  array_list.reserve(out_size);
+  for (mx_uint i = 0; i < out_size; ++i) {
+    array_list.push_back(NDArray(out_arr[i]));
+  }
+  return array_list;
+}
+inline void NDArray::LoadFromBuffer(const void *buffer, size_t size,
+                          std::vector<NDArray> *array_list,
+                          std::map<std::string, NDArray> *array_map) {
+  mx_uint out_size, out_name_size;
+  NDArrayHandle *out_arr;
+  const char **out_names;
+  CHECK_EQ(MXNDArrayLoadFromBuffer(buffer, size, &out_size, &out_arr, &out_name_size,
+                         &out_names),
+           0);
+  if (array_list != nullptr) {
+    array_list->reserve(out_size);
+    for (mx_uint i = 0; i < out_size; ++i) {
+      array_list->push_back(NDArray(out_arr[i]));
+    }
+  }
+  if (array_map != nullptr && out_name_size > 0) {
+    CHECK_EQ(out_name_size, out_size);
+    for (mx_uint i = 0; i < out_size; ++i) {
+      (*array_map)[out_names[i]] = NDArray(out_arr[i]);
+    }
+  }
+}
+inline std::map<std::string, NDArray> NDArray::LoadFromBufferToMap(
+    const void *buffer, size_t size) {
+  std::map<std::string, NDArray> array_map;
+  mx_uint out_size, out_name_size;
+  NDArrayHandle *out_arr;
+  const char **out_names;
+  CHECK_EQ(MXNDArrayLoadFromBuffer(buffer, size, &out_size, &out_arr, &out_name_size,
+                         &out_names),
+           0);
+  if (out_name_size > 0) {
+    CHECK_EQ(out_name_size, out_size);
+    for (mx_uint i = 0; i < out_size; ++i) {
+      array_map[out_names[i]] = NDArray(out_arr[i]);
+    }
+  }
+  return array_map;
+}
+inline std::vector<NDArray> NDArray::LoadFromBufferToList(const void *buffer, size_t size) {
+  std::vector<NDArray> array_list;
+  mx_uint out_size, out_name_size;
+  NDArrayHandle *out_arr;
+  const char **out_names;
+  CHECK_EQ(MXNDArrayLoadFromBuffer(buffer, size, &out_size, &out_arr, &out_name_size,
+                         &out_names),
+           0);
+  array_list.reserve(out_size);
   for (mx_uint i = 0; i < out_size; ++i) {
     array_list.push_back(NDArray(out_arr[i]));
   }


### PR DESCRIPTION
## Description ##
(resubmitted due to merge issues)

Added load from function buffers for CPP package

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Added equivalent functions for the loading, from buffers instead of files

## Comments ##
- Duplicates functionality from Python wrapper