### PR TITLE
[MXNET-146] Docs build updates: added some deps; clarified developer builds

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,91 +1,54 @@
-# MXNet documentation
+# MXNet Documentation
 
-## How to build MXNet website
+The website is hosted at http://mxnet.incubator.apache.org/.
+http://mxnet.io redirects to this site and advised to use links with http://mxnet.incubator.apache.org/ instead of http://mxnet.io/.
 
-MXNet Documentation Website is built with [sphinx 1.5.1](http://www.sphinx-doc.org/en/1.5.1/intro.html).
+MXNet Documentation Website is built with [Sphinx](http://www.sphinx-doc.org) and a variety of plugins including [pandoc](https://pandoc.org/), [recommonmark](https://github.com/rtfd/recommonmark), a custom Sphinx plugin ([mxdoc.py](https://github.com/apache/incubator-mxnet/blob/master/docs/mxdoc.py)).
 
-A built version of document is available at http://mxnet.io
 
-To build the documents locally, we need to first install [docker](https://docker.com).
-Then use the following commands to clone and
-build the documents.
+## How to Build the MXNet Website for Development and QA
 
-```bash
-git clone --recursive https://github.com/apache/incubator-mxnet.git mxnet
-cd mxnet && make docs
-```
+* [Dependencies](build_doc_version/README.md#dependencies)
+* [Developer Build Instructions](build_doc_version/README.md#developer-instructions)
+* [Full Site Build Instructions](build_doc_version/README.md#full-website-build)
 
-In case docker method is not available, there is an alternate method:
-```bash
-sudo pip install sphinx==1.5.1 CommonMark==0.5.4 breathe mock==1.0.1 recommonmark pypandoc
-cd mxnet/docs && make html USE_OPENMP=0
-```
 
-The results will be available at `docs/_build/html/`.
+## File Structure
 
-Note:
+* Static files such as **css**, **javascript** and **html** templates are under the `_static` folder:
+  - Javascript files are under `_static/js` folder
+  - Layout templates and landing page html file are under `_static/mxnet-theme` folder
+  - `_static/mxnet.css` contains all MXNet website styles
 
-- If C++ codes have been changed, we suggest to remove the previous results to
-  trigger the rebuild for all pages, namely run `make clean_docs`.
-- If C++ code fails to build, run `make clean`
-- If CSS or javascript are changed, we often need to do a *force refresh* in the
-  browser to clear the cache.
-- If search doesn't work, we need to `make clean` and rebuild.
-  
-## File structure
+* Page contents originate as markdown files. Sphinx converts markdown files to html through an `rst` intermediate format. Each content folder should contain an index file as landing page.
 
-1. Static files such as css, javascript and html templates are under `_static` folder:
-- Javascript files are under `_static/js` folder.
-- Layout templates and landing page html file are under `_static/mxnet-theme` folder.
-- `_static/mxnet.css` contains all MXNet website styles.
+* There are some utility scripts to help building website, such as `mxdoc.py` and `build_version_doc/`. They are used to manipulate website contents during building. Refer to [Developer Build Instructions](build_doc_version/README.md#developer-instructions) for more information.
 
-2. Sphinx converts markdowns files to html. Page contents are markdown files. Each content folder 
-contains an index file as landing page.
 
-3. There are some utility scripts to help building website, such as `mxdoc.py` and `build_version_doc/`.
-They are used to manipulate website contents during building.
+## Production Website Building Process
 
-## Production website building process
+**IMPORTANT**: this is currently offline.
 
-[Apache Jenkins MXNet website building job](https://builds.apache.org/job/incubator-mxnet-build-site/) is used to build MXNet website. 
-There are two ways to trigger this job. 
-First is nightly build for master branch. 
+[Apache Jenkins MXNet website building job](https://builds.apache.org/job/incubator-mxnet-build-site/) is used to build MXNet website.
+There are two ways to trigger this job.
+First is nightly build for master branch.
 Second is manually trigger job when a new version is released. This will build for new version.
 
-The job will fetch mxnet repository, build MXNet website and push all static files to [host repository](https://github.com/apache/incubator-mxnet-site.git). 
+The job will fetch mxnet repository, build MXNet website and push all static files to [host repository](https://github.com/apache/incubator-mxnet-site.git).
 The host repo is hooked with [Apache gitbox](https://gitbox.apache.org/repos/asf?p=incubator-mxnet-site.git;a=summary) to host website.
 
-## Build versioning website
+## Build Versioning Website
 
-`make docs` doesn't add any version information. Version information is added by [Apache Jenkins MXNet website building job](https://builds.apache.org/job/incubator-mxnet-build-site/).
-Landing page will point to the latest released version. Older versions and master version are placed under versions folder. 
-After completing website update and testing it locally, we also need to build and test versioning website.
+**IMPORTANT**: Refer to [Full Site Build Instructions](build_doc_version/README.md#full-website-build) for a working site build with the versions dropdown in the UI.
 
-Python Beautifulsoup is the dependency:
 
-```bash
-sudo pip install beautifulsoup4
-```
 
-The essenitial part of adding version is to use `AddPackageLink.py` to add Apache source packages and 
-`AddVersion.py` to update all version related information on website. These two scripts are used in `build_doc.sh` and `build_all_version`. 
+`build_doc.sh` is used by Apache Jenkins MXNet website building job to incremental adding of versions. We don't need it for local website development. **Currently offline due to site rendering problems.**
 
-`build_doc.sh` is used by Apache Jenkins MXNet webiste building job to incremental adding version. We don't need it 
-for local website development. 
 
-`build_all_version.sh` is to rebuild versioning website locally and is useful to verify versioning website locally. 
-We need to specify which versions to be built. This can be set in `tag_list` variable at the beginning of the script. 
-Version order should be from latest to oldest and placing master at the end. We may also want to modify `mxnet_url` 
-variable to our own repository for local testing. Another use case is to completely rebuild website with specific versions. 
-Although this will not happen often, we can use it to rebuld whole website and push to [host repo](https://github.com/apache/incubator-mxnet-site.git).
+## Troubleshooting
 
-```bash
-./build_all_version.sh
-```
-
-## Develop notes
-
-1. `AddVersion.py` depends on Beautiful library, which requires target html files to have close tags. Although open tag html can still be rendered by browser, it will be problematic for Beautifulsoup. 
-
-2. `AddVersion.py` and `AddPackageLink.py` manipulates contents for website. If there are layout changes, it may break these two scripts. We need to change scripts respectively.
-
+- If C++ code has been changed, remove the previous results to trigger the rebuild for all pages. To do this, run `make clean_docs`.
+- If C++ code fails to build, run `make clean`.
+- If CSS or javascript are changed, clear the cache in the browser with a *forced refresh*.
+- If search doesn't work, run `make clean` and then `make docs`.

--- a/docs/build_version_doc/Dockerfile
+++ b/docs/build_version_doc/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y \
     doxygen \
     git \
     libatlas-base-dev \
+    libjemalloc-dev \
     liblapack-dev \
     libopenblas-dev \
     libopencv-dev \

--- a/docs/build_version_doc/README.md
+++ b/docs/build_version_doc/README.md
@@ -168,14 +168,14 @@ For example, for a simple local development build, from the MXNet root folder:
 
 ```bash
 cd docs/_build/html
-sudo cp -a . /var/www/html/
+sudo cp -r . /var/www/html/
 ```
 
 Or if you're using the output from the [Full Website Build](#full-website-build), from the `build_doc_version` folder:
 
 ```bash
 cd VersionedWeb
-sudo cp -a . /var/www/html/
+sudo cp -r . /var/www/html/
 ```
 
 **Note**: When generating docs, many files and folders can be deleted or renamed, so it is a good practice to purge the web server directory first, or else you will have old files hanging around potentially introducing errors or hiding broken links.

--- a/docs/build_version_doc/README.md
+++ b/docs/build_version_doc/README.md
@@ -29,6 +29,9 @@ If you need to build <= v0.12.0, then use a Python 2 environment to avoid errors
 
 ### Ubuntu 16.04 Dependencies for Docs Generation
 
+This script is available for you to run directly on Ubuntu from the source repository.
+Run `./setup_docs_ubuntu.sh`.
+
 ```
 sudo apt-get update
 sudo apt-get install -y \
@@ -36,6 +39,8 @@ sudo apt-get install -y \
     ca-certificates \
     curl \
     doxygen \
+    git \
+    libjemalloc-dev \
     pandoc \
     software-properties-common
 
@@ -62,12 +67,26 @@ sudo apt-get install -y \
   sbt \
   scala
 
+# Optionally setup Apache2
+sudo apt-get install -y apache2
+sudo ufw allow 'Apache Full'
+# turn on mod_rewrite
+sudo a2enmod rewrite
+
+echo 'To enable redirects you need to edit /etc/apache2/apache2.conf '
+echo '--> Change directives for Directory for /var/www/html using the following: '
+echo '       AllowOverride all '
+echo '--> Then restart apache with: '
+echo '       sudo systemctl restart apache2'
+
 # Cleanup
 sudo apt autoremove -y
 ```
 
-### Script Usage for Manual Generation
-The scripts can be run stand-alone or in conjunction, but `build_all_version.sh` should be run first.
+### Full Website Build
+The following three scripts will help you build multiple version tags and deploy a full site build that with each available API version. If you just want to run master or your current fork's branch you should skip ahead to the [Developer Instructions](#developer-instructions).
+
+The full site build scripts can be run stand-alone or in conjunction, but `build_all_version.sh` should be run first.
 
 ### build_all_version.sh
 This will checkout each tag provided as an argument and build the docs in the `apache_mxnet` folder. The output is copied to the `VersionedWeb` folder and each version will have a subfolder in `VersionedWeb/versions/`.
@@ -98,10 +117,82 @@ Takes the same three arguments that update_all_version.sh takes.
 It will execute `build_all_version.sh` first, then execute `update_all_version.sh` next.
 
 **Example Usage**:
-./build_site_tag.sh "1.1.0 master" 1.0.0 http://mxnet.incubator.apache.org/
+./build_site_tag.sh "1.1.0 master" 1.1.0 http://mxnet.incubator.apache.org/
 Then run a web server on the outputted `VersionedWeb` folder.
 
-## Docker Usage ##
+
+## Developer Instructions
+
+### Build Docs for Your Current Branch
+From the MXNet source root run:
+
+```bash
+make docs USE_OPENMP=1
+```
+
+The files from `make docs` are viewable in `docs/_build/html/`.
+
+
+### Serving Your Development Version
+
+You can view the generated docs with whatever web server you prefer. The Ubuntu setup script described earlier provides instructions for Apache2. MacOS comes preinstalled with Apache.
+
+#### Serve the Website with Apache2
+
+```bash
+sudo apt-get install -y apache2
+sudo ufw allow 'Apache Full'
+```
+Copy your `docs/_build/html/` files to where your Apache server will pick them up. If you used the default Ubuntu setup, then this will be `/var/www/html`.
+
+For example, for a simple local development build, from the MXNet root folder:
+
+```bash
+cd docs/_build/html
+sudo cp -a . /var/www/html/
+```
+
+Or if you're using the output from the [Full Website Build](#full-website-build), from the `build_doc_version` folder:
+
+```bash
+cd VersionedWeb
+sudo cp -a . /var/www/html/
+```
+
+**Note**: When generating docs, many files and folders can be deleted or renamed, so it is a good practice to purge the web server directory first, or else you will have old files hanging around potentially introducing errors or hiding broken links.
+
+#### Serve the Website with Python3
+Python has a simple web server that you can use for a quick check on your site build. If your SSH tunnel breaks, the site will stop working, so if you plan to share your work as preview in a PR, use Apache2 instead.
+
+From the MXNet source root run:
+
+```bash
+cd docs/_build/html
+python3 -m http.server
+```
+
+### Enabling Redirects
+The website uses redirects with `mod_rewrite` for content and folders that have moved. To simulate this locally you need to configure Apache to allow the rewrite module.
+
+```bash
+sudo a2enmod rewrite
+```
+
+To enable redirects for the folder with the website you need to edit `/etc/apache2/apache2.conf`.
+Change directives for `Directory` for `/var/www/html`, or wherever the build files reside, using the following:
+
+```
+AllowOverride all
+```
+
+Then restart Apache on Ubuntu with:
+
+```bash
+sudo systemctl restart apache2
+```
+
+
+## Docker Usage
 
 The `Dockerfile` will build all of the docs when you create the docker image. You can also run the scripts listed above to regenerate any tag or collection of tags.
 

--- a/docs/build_version_doc/setup_docs_ubuntu.sh
+++ b/docs/build_version_doc/setup_docs_ubuntu.sh
@@ -29,6 +29,9 @@ sudo apt-get install -y \
     ca-certificates \
     curl \
     doxygen \
+    git \
+    libjemalloc-dev \
+    pandoc \
     software-properties-common
 
 pip install --user \
@@ -41,9 +44,6 @@ pip install --user \
     recommonmark==0.4.0 \
     sphinx==1.5.6
 
-# Recommonmark/Sphinx errors: https://github.com/sphinx-doc/sphinx/issues/3800
-
-
 # Setup scala
 echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
@@ -52,11 +52,17 @@ sudo apt-get install -y \
   sbt \
   scala
 
+# Optionally setup Apache2
+sudo apt-get install -y apache2
+sudo ufw allow 'Apache Full'
+# turn on mod_rewrite
+sudo a2enmod rewrite
+
+echo 'To enable redirects you need to edit /etc/apache2/apache2.conf '
+echo '--> Change directives for Directory for /var/www/html using the following: '
+echo '       AllowOverride all '
+echo '--> Then restart apache with: '
+echo '       sudo systemctl restart apache2'
+
 # Cleanup
 sudo apt autoremove -y
-
-# Make docs using the manual way
-# cd .. && make html USE_OPENMP=0
-# using the docker way
-# sudo make docs
-


### PR DESCRIPTION
## Description ##
Found some additional dependencies that should help reduce build errors. 

Updated the accompanying docs on using a variety of methods to build and serve the docs.

### Changes ###
- [x] libjemalloc-dev and pandoc added to setup script
- [x] optional apache2 added with instructions on mod_rewrite; also added python web server info
- [x] developer build instructions (vs full website build)
