### PR TITLE
[MXNET-127] Fix 1.1.0 fine-tune FAQ

### DIFF
--- a/docs/faq/finetune.md
+++ b/docs/faq/finetune.md
@@ -61,8 +61,8 @@ for i in 256_ObjectCategories/*; do
     done
 done
 
-python ~/mxnet/tools/im2rec.py --list True --recursive True caltech-256-60-train caltech_256_train_60/
-python ~/mxnet/tools/im2rec.py --list True --recursive True caltech-256-60-val 256_ObjectCategories/
+python ~/mxnet/tools/im2rec.py --list --recursive caltech-256-60-train caltech_256_train_60/
+python ~/mxnet/tools/im2rec.py --list --recursive caltech-256-60-val 256_ObjectCategories/
 python ~/mxnet/tools/im2rec.py --resize 256 --quality 90 --num-thread 16 caltech-256-60-val 256_ObjectCategories/
 python ~/mxnet/tools/im2rec.py --resize 256 --quality 90 --num-thread 16 caltech-256-60-train caltech_256_train_60/
 ```


### PR DESCRIPTION
This Finetune FAQ is broken for 1.1.0 on the website (already fixed in master)

```
!which python
/home/ubuntu/anaconda3/envs/mxnet_p36/bin/python

import mxnet as mx
mx.__version__
'1.1.0'

!python /home/ubuntu/anaconda3/envs/mxnet_p36/lib/python3.6/site-packages/mxnet/tools/im2rec.py --help
usage: im2rec.py [-h] [--list] [--exts EXTS [EXTS ...]] [--chunks CHUNKS]
                 [--train-ratio TRAIN_RATIO] [--test-ratio TEST_RATIO]
                 [--recursive] [--no-shuffle] [--pass-through]
                 [--resize RESIZE] [--center-crop] [--quality QUALITY]
                 [--num-thread NUM_THREAD] [--color {-1,0,1}]
                 [--encoding {.jpg,.png}] [--pack-label]
                 prefix root
```

@aaronmarkham @simoncorstonoliver 