### PR TITLE
[MXNET-248] Scala Infer API docs editorial pass

### DIFF
--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/imageclassifier/ImageClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/imageclassifier/ImageClassifierExample.scala
@@ -28,8 +28,12 @@ import scala.collection.JavaConverters._
 import java.io.File
 
 /**
-  * Example showing usage of Infer package to do inference on resnet-152 model
-  * Follow instructions in README.md to run this example.
+  * <p>
+  * Example inference showing usage of the Infer package on a resnet-152 model.
+  * @see <a href="https://github.com/apache/incubator-mxnet\
+  * blob/master/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample\
+  * imageclassifier/" target="_blank">Instructions to run this example</a>
+  * </p>
   */
 object ImageClassifierExample {
   private val logger = LoggerFactory.getLogger(classOf[ImageClassifierExample])

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/imageclassifier/ImageClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/imageclassifier/ImageClassifierExample.scala
@@ -33,7 +33,6 @@ import java.io.File
   * @see <a href="https://github.com/apache/incubator-mxnet\
   * blob/master/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample\
   * imageclassifier/" target="_blank">Instructions to run this example</a>
-  * </p>
   */
 object ImageClassifierExample {
   private val logger = LoggerFactory.getLogger(classOf[ImageClassifierExample])

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/SSDClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/SSDClassifierExample.scala
@@ -32,7 +32,6 @@ import java.nio.file.{Files, Paths}
   * @see <a href="https://github.com/apache/incubator-mxnet\
   * blob/master/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample\
   * objectdetector/" target="_blank">Instructions to run this example</a>
-  * </p>
   */
 class SSDClassifierExample {
   @Option(name = "--model-path-prefix", usage = "the input model directory and prefix of the model")

--- a/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/SSDClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample/objectdetector/SSDClassifierExample.scala
@@ -25,6 +25,15 @@ import org.slf4j.LoggerFactory
 import scala.collection.JavaConverters._
 import java.nio.file.{Files, Paths}
 
+/**
+  * <p>
+  * Example single shot detector (SSD) using the Infer package
+  * on a ssd_resnet50_512 model.
+  * @see <a href="https://github.com/apache/incubator-mxnet\
+  * blob/master/scala-package/examples/src/main/scala/ml/dmlc/mxnetexamples/inferexample\
+  * objectdetector/" target="_blank">Instructions to run this example</a>
+  * </p>
+  */
 class SSDClassifierExample {
   @Option(name = "--model-path-prefix", usage = "the input model directory and prefix of the model")
   private val modelPathPrefix: String = "/model/ssd_resnet50_512"

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/Classifier.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/Classifier.scala
@@ -31,7 +31,7 @@ trait ClassifierBase {
     * Takes an array of floats and returns corresponding (Label, Score) tuples
     * @param input            Indexed sequence one-dimensional array of floats
     * @param topK             (Optional) How many result (sorting based on the last axis)
-    *                         elements to return. Default returns unsorted output
+    *                         elements to return. Default returns unsorted output.
     * @return                 Indexed sequence of (Label, Score) tuples
     */
   def classify(input: IndexedSeq[Array[Float]],
@@ -41,7 +41,7 @@ trait ClassifierBase {
     * Takes a sequence of NDArrays and returns (Label, Score) tuples
     * @param input            Indexed sequence of NDArrays
     * @param topK             (Optional) How many result (sorting based on the last axis)
-    *                         elements to return. Default returns unsorted output
+    *                         elements to return. Default returns unsorted output.
     * @return                 Traversable sequence of (Label, Score) tuple
     */
   def classifyWithNDArray(input: IndexedSeq[NDArray],
@@ -78,8 +78,8 @@ class Classifier(modelPathPrefix: String,
   /**
     * Takes flat arrays as input and returns (Label, Score) tuples.
     * @param input            Indexed sequence one-dimensional array of floats
-    * @param topK:            (Optional) How many result (sorting based on the last axis) 
-    *                         elements to return. Default returns unsorted output
+    * @param topK             (Optional) How many result (sorting based on the last axis)
+    *                         elements to return. Default returns unsorted output.
     * @return                 Indexed sequence of (Label, Score) tuples
     */
   override def classify(input: IndexedSeq[Array[Float]],
@@ -103,7 +103,7 @@ class Classifier(modelPathPrefix: String,
     * Also works with batched input.
     * @param input            Indexed sequence of NDArrays
     * @param topK             (Optional) How many result (sorting based on the last axis)
-    *                         elements to return. Default returns unsorted output
+    *                         elements to return. Default returns unsorted output.
     * @return                 Traversable sequence of (Label, Score) tuples
     */
   override def classifyWithNDArray(input: IndexedSeq[NDArray], topK: Option[Int] = None)

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/Classifier.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/Classifier.scala
@@ -28,35 +28,36 @@ import scala.collection.mutable.ListBuffer
 trait ClassifierBase {
 
   /**
-    * Takes an Array of Floats and returns corresponding labels, score tuples.
-    * @param input: IndexedSequence one-dimensional array of Floats.
-    * @param topK: (Optional) How many top_k(sorting will be based on the last axis)
-    *             elements to return, if not passed returns unsorted output.
-    * @return IndexedSequence of (Label, Score) tuples.
+    * Takes an array of floats and returns corresponding (Label, Score) tuples
+    * @param input            Indexed sequence one-dimensional array of floats
+    * @param topK             (Optional) How many result (sorting based on the last axis) \
+    *                         elements to return. Default returns unsorted output
+    * @return                 Indexed sequence of (Label, Score) tuples
     */
   def classify(input: IndexedSeq[Array[Float]],
                topK: Option[Int] = None): IndexedSeq[(String, Float)]
 
   /**
-    * Takes a Sequence of NDArrays and returns Label, Score tuples.
-    * @param input: Indexed Sequence of NDArrays
-    * @param topK: (Optional) How many top_k(sorting will be based on the last axis)
-    *             elements to return, if not passed returns unsorted output.
-    * @return Traversable Sequence of (Label, Score) tuple
+    * Takes a sequence of NDArrays and returns (Label, Score) tuples
+    * @param input            Indexed sequence of NDArrays
+    * @param topK             (Optional) How many result (sorting based on the last axis) \
+    *                         elements to return. Default returns unsorted output
+    * @return                 Traversable sequence of (Label, Score) tuple
     */
   def classifyWithNDArray(input: IndexedSeq[NDArray],
-                          topK: Option[Int] = None): IndexedSeq[IndexedSeq[(String, Float)]]
+              topK: Option[Int] = None): IndexedSeq[IndexedSeq[(String, Float)]]
 }
 
 /**
   * A class for classifier tasks
-  * @param modelPathPrefix PathPrefix from where to load the symbol, parameters and synset.txt
-  *                        Example: file://model-dir/resnet-152(containing resnet-152-symbol.json
-  *                        file://model-dir/synset.txt
-  * @param inputDescriptors Descriptors defining the input node names, shape,
-  *                         layout and Type parameters
-  * @param contexts Device Contexts on which you want to run Inference, defaults to CPU.
-  * @param epoch Model epoch to load, defaults to 0.
+  * @param modelPathPrefix    Path prefix from where to load the model artifacts
+  *                           These include the symbol, parameters, and synset.txt
+  *                           Example: file://model-dir/resnet-152 (containing
+  *                           resnet-152-symbol.json, resnet-152-0000.params, and synset.txt)
+  * @param inputDescriptors   Descriptors defining the input node names, shape,
+  *                           layout and type parameters
+  * @param contexts           Device contexts on which you want to run inference; defaults to CPU
+  * @param epoch              Model epoch to load; defaults to 0
   */
 class Classifier(modelPathPrefix: String,
                  protected val inputDescriptors: IndexedSeq[DataDesc],
@@ -75,11 +76,11 @@ class Classifier(modelPathPrefix: String,
   protected[infer] val handler = MXNetHandler()
 
   /**
-    * Takes a flat arrays as input and returns a List of (Label, tuple)
-    * @param input: IndexedSequence one-dimensional array of Floats.
-    * @param topK: (Optional) How many top_k(sorting will be based on the last axis)
-    *             elements to return, if not passed returns unsorted output.
-    * @return IndexedSequence of (Label, Score) tuples.
+    * Takes flat arrays as input and returns (Label, Score) tuples.
+    * @param input            Indexed sequence one-dimensional array of floats
+    * @param topK:            (Optional) How many result (sorting based on the last axis) \
+    *                         elements to return. Default returns unsorted output
+    * @return                 Indexed sequence of (Label, Score) tuples
     */
   override def classify(input: IndexedSeq[Array[Float]],
                         topK: Option[Int] = None): IndexedSeq[(String, Float)] = {
@@ -98,12 +99,12 @@ class Classifier(modelPathPrefix: String,
   }
 
   /**
-    * Takes input as NDArrays, useful when you want to perform multiple operations on
-    * the input Array or when you want to pass a batch of input.
-    * @param input: Indexed Sequence of NDArrays
-    * @param topK: (Optional) How many top_k(sorting will be based on the last axis)
-    *             elements to return, if not passed returns unsorted output.
-    * @return Traversable Sequence of (Label, Score) tuple
+    * Perform multiple classification operations on NDArrays \
+    * Also works with batched input
+    * @param input            Indexed sequence of NDArrays
+    * @param topK             (Optional) How many result (sorting based on the last axis) \
+    *                         elements to return. Default returns unsorted output
+    * @return                 Traversable sequence of (Label, Score) tuples
     */
   override def classifyWithNDArray(input: IndexedSeq[NDArray], topK: Option[Int] = None)
   : IndexedSeq[IndexedSeq[(String, Float)]] = {

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/Classifier.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/Classifier.scala
@@ -30,7 +30,7 @@ trait ClassifierBase {
   /**
     * Takes an array of floats and returns corresponding (Label, Score) tuples
     * @param input            Indexed sequence one-dimensional array of floats
-    * @param topK             (Optional) How many result (sorting based on the last axis) \
+    * @param topK             (Optional) How many result (sorting based on the last axis)
     *                         elements to return. Default returns unsorted output
     * @return                 Indexed sequence of (Label, Score) tuples
     */
@@ -40,7 +40,7 @@ trait ClassifierBase {
   /**
     * Takes a sequence of NDArrays and returns (Label, Score) tuples
     * @param input            Indexed sequence of NDArrays
-    * @param topK             (Optional) How many result (sorting based on the last axis) \
+    * @param topK             (Optional) How many result (sorting based on the last axis)
     *                         elements to return. Default returns unsorted output
     * @return                 Traversable sequence of (Label, Score) tuple
     */
@@ -78,7 +78,7 @@ class Classifier(modelPathPrefix: String,
   /**
     * Takes flat arrays as input and returns (Label, Score) tuples.
     * @param input            Indexed sequence one-dimensional array of floats
-    * @param topK:            (Optional) How many result (sorting based on the last axis) \
+    * @param topK:            (Optional) How many result (sorting based on the last axis) 
     *                         elements to return. Default returns unsorted output
     * @return                 Indexed sequence of (Label, Score) tuples
     */
@@ -99,10 +99,10 @@ class Classifier(modelPathPrefix: String,
   }
 
   /**
-    * Perform multiple classification operations on NDArrays \
-    * Also works with batched input
+    * Perform multiple classification operations on NDArrays.
+    * Also works with batched input.
     * @param input            Indexed sequence of NDArrays
-    * @param topK             (Optional) How many result (sorting based on the last axis) \
+    * @param topK             (Optional) How many result (sorting based on the last axis)
     *                         elements to return. Default returns unsorted output
     * @return                 Traversable sequence of (Label, Score) tuples
     */

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ImageClassifier.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ImageClassifier.scala
@@ -33,7 +33,7 @@ import javax.imageio.ImageIO
   * Contains helper methods.
   *
   * @param modelPathPrefix    Path prefix from where to load the model artifacts.
-  *                           These include the symbol, parameters, and synset.txt
+  *                           These include the symbol, parameters, and synset.txt. 
   *                           Example: file://model-dir/resnet-152 (containing
   *                           resnet-152-symbol.json, resnet-152-0000.params, and synset.txt).
   * @param inputDescriptors   Descriptors defining the input node names, shape,

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ImageClassifier.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ImageClassifier.scala
@@ -33,7 +33,7 @@ import javax.imageio.ImageIO
   * Contains helper methods.
   *
   * @param modelPathPrefix    Path prefix from where to load the model artifacts.
-  *                           These include the symbol, parameters, and synset.txt. 
+  *                           These include the symbol, parameters, and synset.txt.
   *                           Example: file://model-dir/resnet-152 (containing
   *                           resnet-152-symbol.json, resnet-152-0000.params, and synset.txt).
   * @param inputDescriptors   Descriptors defining the input node names, shape,

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ImageClassifier.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ImageClassifier.scala
@@ -29,16 +29,17 @@ import javax.imageio.ImageIO
 
 
 /**
-  * A class for Image classification tasks.
+  * A class for image classification tasks.
   * Contains helper methods.
   *
-  * @param modelPathPrefix  PathPrefix from where to load the symbol, parameters and synset.txt
-  *                         Example: file://model-dir/resnet-152(containing resnet-152-symbol.json
-  *                         file://model-dir/synset.txt
-  * @param inputDescriptors Descriptors defining the input node names, shape,
-  *                         layout and Type parameters
-  * @param contexts Device Contexts on which you want to run Inference, defaults to CPU.
-  * @param epoch Model epoch to load, defaults to 0.
+  * @param modelPathPrefix    Path prefix from where to load the model artifacts.
+  *                           These include the symbol, parameters, and synset.txt
+  *                           Example: file://model-dir/resnet-152 (containing
+  *                           resnet-152-symbol.json, resnet-152-0000.params, and synset.txt).
+  * @param inputDescriptors   Descriptors defining the input node names, shape,
+  *                           layout and type parameters
+  * @param contexts           Device contexts on which you want to run inference; defaults to CPU
+  * @param epoch              Model epoch to load; defaults to 0
   */
 class ImageClassifier(modelPathPrefix: String,
                       inputDescriptors: IndexedSeq[DataDesc],
@@ -66,9 +67,9 @@ class ImageClassifier(modelPathPrefix: String,
   /**
     * To classify the image according to the provided model
     *
-    * @param inputImage PathPrefix of the input image
-    * @param topK Get top k elements with maximum probability
-    * @return List of list of tuples of (class, probability)
+    * @param inputImage       Path prefix of the input image
+    * @param topK             Number of result elements to return, sorted by probability
+    * @return                 List of list of tuples of (Label, Probability)
     */
   def classifyImage(inputImage: BufferedImage,
                     topK: Option[Int] = None): IndexedSeq[IndexedSeq[(String, Float)]] = {
@@ -88,9 +89,9 @@ class ImageClassifier(modelPathPrefix: String,
   /**
     * To classify batch of input images according to the provided model
     *
-    * @param inputBatch Input batch of Buffered images
-    * @param topK Get top k elements with maximum probability
-    * @return List of list of tuples of (class, probability)
+    * @param inputBatch       Input array of buffered images
+    * @param topK             Number of result elements to return, sorted by probability
+    * @return                 List of list of tuples of (Label, Probability)
     */
   def classifyImageBatch(inputBatch: Traversable[BufferedImage], topK: Option[Int] = None):
   IndexedSeq[IndexedSeq[(String, Float)]] = {
@@ -123,10 +124,10 @@ object ImageClassifier {
   /**
     * Reshape the input image to a new shape
     *
-    * @param img       input image
-    * @param newWidth  rescale to new width
-    * @param newHeight rescale to new height
-    * @return Rescaled BufferedImage
+    * @param img              Input image
+    * @param newWidth         New width for rescaling
+    * @param newHeight        New height for rescaling
+    * @return                 Rescaled BufferedImage
     */
   def reshapeImage(img: BufferedImage, newWidth: Int, newHeight: Int): BufferedImage = {
     val resizedImage = new BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_RGB)
@@ -143,10 +144,11 @@ object ImageClassifier {
     * <p>
     * Note: Caller is responsible to dispose the NDArray
     * returned by this method after the use.
-    *
-    * @param resizedImage BufferedImage to get pixels from
-    * @param inputImageShape Should be same as inputDescriptor shape
-    * @return NDArray pixels array
+    * </p>
+    * @param resizedImage     BufferedImage to get pixels from
+    * @param inputImageShape  Input shape; for example for resnet it is (1,3,224,224).
+                              Should be same as inputDescriptor shape.
+    * @return                 NDArray pixels array
     */
   def bufferedImageToPixels(resizedImage: BufferedImage, inputImageShape: Shape): NDArray = {
     // Get height and width of the image
@@ -184,9 +186,9 @@ object ImageClassifier {
   }
 
   /**
-    * Loading input batch of images
-    * @param inputImagePath Path of single input image
-    * @return BufferedImage Buffered image
+    * Loads an input images from file
+    * @param inputImagePath   Path of single input image
+    * @return                 BufferedImage Buffered image
     */
   def loadImageFromFile(inputImagePath: String): BufferedImage = {
     val img = ImageIO.read(new File(inputImagePath))
@@ -194,9 +196,9 @@ object ImageClassifier {
   }
 
   /**
-    * Loading input batch of images
-    * @param inputImageDirPath
-    * @return List of buffered images
+    * Loads a batch of images from a folder
+    * @param inputImageDirPath  Path to a folder of images
+    * @return                   List of buffered images
     */
   def loadInputBatch(inputImageDirPath: String): List[BufferedImage] = {
     val dir = new File(inputImageDirPath)

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
@@ -30,10 +30,12 @@ import scala.collection.mutable.ListBuffer
   * @param modelPathPrefix    Path prefix from where to load the model artifacts.
   *                           These include the symbol, parameters, and synset.txt.
   *                           Example: file://model-dir/ssd_resnet50_512 (containing
-  *                           ssd_resnet50_512-symbol.json, ssd_resnet50_512-0000.params, and synset.txt)
+  *                           ssd_resnet50_512-symbol.json, ssd_resnet50_512-0000.params,
+  *                           and synset.txt)
   * @param inputDescriptors   Descriptors defining the input node names, shape,
   *                           layout and type parameters
-  * @param contexts           Device contexts on which you want to run inference; defaults to CPU
+  * @param contexts           Device contexts on which you want to run inference.
+  *                           Defaults to CPU.
   * @param epoch              Model epoch to load; defaults to 0
   */
 class ObjectDetector(modelPathPrefix: String,

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
@@ -27,15 +27,14 @@ import scala.collection.mutable.ListBuffer
 /**
   * A class for object detection tasks
   *
-  * @param modelPathPrefix  PathPrefix from where to load the symbol, parameters and synset.txt
-  *                         Example: file://model-dir/ssd_resnet50_512
-  *                         (will resolve both ssd_resnet50_512-symbol.json
-  *                         and ssd_resnet50_512-0000.params)
-  *                         file://model-dir/synset.txt
-  * @param inputDescriptors Descriptors defining the input node names, shape,
-  *                         layout and Type parameters
-  * @param contexts Device Contexts on which you want to run Inference, defaults to CPU.
-  * @param epoch Model epoch to load, defaults to 0.
+  * @param modelPathPrefix    Path prefix from where to load the model artifacts.
+  *                           These include the symbol, parameters, and synset.txt.
+  *                           Example: file://model-dir/ssd_resnet50_512 (containing
+  *                           ssd_resnet50_512-symbol.json, ssd_resnet50_512-0000.params, and synset.txt)
+  * @param inputDescriptors   Descriptors defining the input node names, shape,
+  *                           layout and type parameters
+  * @param contexts           Device contexts on which you want to run inference; defaults to CPU
+  * @param epoch              Model epoch to load; defaults to 0
   */
 class ObjectDetector(modelPathPrefix: String,
                      inputDescriptors: IndexedSeq[DataDesc],
@@ -58,11 +57,12 @@ class ObjectDetector(modelPathPrefix: String,
   protected[infer] val width = imgClassifier.width
 
   /**
-    * To Detect bounding boxes and corresponding labels
+    * Detects objects and returns bounding boxes with corresponding labels
     *
-    * @param inputImage : PathPrefix of the input image
-    * @param topK       : Get top k elements with maximum probability
-    * @return List of List of tuples of (class, [probability, xmin, ymin, xmax, ymax])
+    * @param inputImage       PathPrefix of the input image
+    * @param topK             Get top k elements with maximum probability
+    * @return                 List of List of tuples of
+    *                         (class, [probability, xmin, ymin, xmax, ymax])
     */
   def imageObjectDetect(inputImage: BufferedImage,
                         topK: Option[Int] = None)
@@ -79,10 +79,11 @@ class ObjectDetector(modelPathPrefix: String,
     * Takes input images as NDArrays. Useful when you want to perform multiple operations on
     * the input Array, or when you want to pass a batch of input images.
     *
-    * @param input : Indexed Sequence of NDArrays
-    * @param topK  : (Optional) How many top_k(sorting will be based on the last axis)
-    *              elements to return. If not passed, returns all unsorted output.
-    * @return List of List of tuples of (class, [probability, xmin, ymin, xmax, ymax])
+    * @param input            Indexed Sequence of NDArrays
+    * @param topK             (Optional) How many top_k (sorting will be based on the last axis)
+    *                         elements to return. If not passed, returns all unsorted output.
+    * @return                 List of list of tuples of
+    *                         (class, [probability, xmin, ymin, xmax, ymax])
     */
   def objectDetectWithNDArray(input: IndexedSeq[NDArray], topK: Option[Int])
   : IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
@@ -136,9 +137,9 @@ class ObjectDetector(modelPathPrefix: String,
   /**
     * To classify batch of input images according to the provided model
     *
-    * @param inputBatch Input batch of Buffered images
-    * @param topK       Get top k elements with maximum probability
-    * @return List of list of tuples of (class, probability)
+    * @param inputBatch       Input array of buffered images
+    * @param topK             Number of result elements to return, sorted by probability
+    * @return                 List of list of tuples of (Label, Probability)
     */
   def imageBatchObjectDetect(inputBatch: Traversable[BufferedImage], topK: Option[Int] = None):
   IndexedSeq[IndexedSeq[(String, Array[Float])]] = {

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/ObjectDetector.scala
@@ -57,11 +57,11 @@ class ObjectDetector(modelPathPrefix: String,
   protected[infer] val width = imgClassifier.width
 
   /**
-    * Detects objects and returns bounding boxes with corresponding labels
+    * Detects objects and returns bounding boxes with corresponding class/label
     *
-    * @param inputImage       PathPrefix of the input image
-    * @param topK             Get top k elements with maximum probability
-    * @return                 List of List of tuples of
+    * @param inputImage       Path prefix of the input image
+    * @param topK             Number of result elements to return, sorted by probability
+    * @return                 List of list of tuples of
     *                         (class, [probability, xmin, ymin, xmax, ymax])
     */
   def imageObjectDetect(inputImage: BufferedImage,
@@ -77,7 +77,7 @@ class ObjectDetector(modelPathPrefix: String,
 
   /**
     * Takes input images as NDArrays. Useful when you want to perform multiple operations on
-    * the input Array, or when you want to pass a batch of input images.
+    * the input array, or when you want to pass a batch of input images.
     *
     * @param input            Indexed Sequence of NDArrays
     * @param topK             (Optional) How many top_k (sorting will be based on the last axis)
@@ -139,7 +139,7 @@ class ObjectDetector(modelPathPrefix: String,
     *
     * @param inputBatch       Input array of buffered images
     * @param topK             Number of result elements to return, sorted by probability
-    * @return                 List of list of tuples of (Label, Probability)
+    * @return                 List of list of tuples of (class, probability)
     */
   def imageBatchObjectDetect(inputBatch: Traversable[BufferedImage], topK: Option[Int] = None):
   IndexedSeq[IndexedSeq[(String, Array[Float])]] = {

--- a/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/Predictor.scala
+++ b/scala-package/infer/src/main/scala/ml/dmlc/mxnet/infer/Predictor.scala
@@ -30,37 +30,43 @@ import org.slf4j.LoggerFactory
 private[infer] trait PredictBase {
 
   /**
-   * This method will take input as IndexedSeq one dimensional arrays and creates
+   * Converts indexed sequences of 1-D array to NDArrays.
+   * <p>
+   * This method will take input as IndexedSeq one dimensional arrays and creates the
    * NDArray needed for inference. The array will be reshaped based on the input descriptors.
-   * @param input: A IndexedSequence of Scala one-dimensional array, An IndexedSequence is
-   *             is needed when the model has more than one input
-   * @return IndexedSequence array of outputs.
+   * @param input:            An IndexedSequence of a one-dimensional array.
+                              An IndexedSequence is needed when the model has more than one input.
+   * @return                  Indexed sequence array of outputs
    */
   def predict(input: IndexedSeq[Array[Float]]): IndexedSeq[Array[Float]]
 
   /**
-   * Predict using NDArray as input. This method is useful when the input is a batch of data
+   * Predict using NDArray as input.
+   * <p>
+   * This method is useful when the input is a batch of data
    * or when multiple operations on the input have to performed.
    * Note: User is responsible for managing allocation/deallocation of NDArrays.
-   * @param input: IndexedSequence NDArrays.
-   * @return output of Predictions as NDArrays.
+   * @param input             IndexedSequence NDArrays.
+   * @return                  Output of predictions as NDArrays.
    */
   def predictWithNDArray(input: IndexedSeq[NDArray]): IndexedSeq[NDArray]
 
 }
 
 /**
- * Implementation of predict routines.
+ * Implementation of prediction routines.
  *
- * @param modelPathPrefix PathPrefix from where to load the model.
- *                        Example: file://model-dir/resnet-152(containing resnet-152-symbol.json,
- * @param inputDescriptors Descriptors defining the input node names, shape,
- *                         layout and Type parameters.
- * <p>Note: If the input Descriptors is missing batchSize('N' in layout),
- * a batchSize of 1 is assumed for the model.
- * </p>
- * @param contexts Device Contexts on which you want to run Inference, defaults to CPU.
- * @param epoch Model epoch to load, defaults to 0.
+ * @param modelPathPrefix     Path prefix from where to load the model artifacts.
+ *                            These include the symbol, parameters, and synset.txt
+ *                            Example: file://model-dir/resnet-152 (containing
+ *                            resnet-152-symbol.json, resnet-152-0000.params, and synset.txt).
+ * @param inputDescriptors    Descriptors defining the input node names, shape,
+ *                            layout and type parameters
+ *                            <p>Note: If the input Descriptors is missing batchSize
+ *                            ('N' in layout), a batchSize of 1 is assumed for the model.
+ * @param contexts            Device contexts on which you want to run inference; defaults to CPU
+ * @param epoch               Model epoch to load; defaults to 0
+
  */
 class Predictor(modelPathPrefix: String,
                 protected val inputDescriptors: IndexedSeq[DataDesc],
@@ -97,12 +103,12 @@ class Predictor(modelPathPrefix: String,
   protected[infer] val mod = loadModule()
 
   /**
-   * This method will take input as IndexedSeq one dimensional arrays and creates
-   * NDArray needed for inference. The array will be reshaped based on the input descriptors.
+   * Takes input as IndexedSeq one dimensional arrays and creates the NDArray needed for inference
+   * The array will be reshaped based on the input descriptors.
    *
-   * @param input : A IndexedSequence of Scala one-dimensional array, An IndexedSequence is
-   *              is needed when the model has more than one input
-   * @return IndexedSequence array of outputs.
+   * @param input:            An IndexedSequence of a one-dimensional array.
+                              An IndexedSequence is needed when the model has more than one input.
+   * @return                  Indexed sequence array of outputs
    */
   override def predict(input: IndexedSeq[Array[Float]])
   : IndexedSeq[Array[Float]] = {
@@ -148,11 +154,12 @@ class Predictor(modelPathPrefix: String,
   }
 
   /**
-   * Predict using NDArray as input. This method is useful when the input is a batch of data
+   * Predict using NDArray as input
+   * This method is useful when the input is a batch of data
    * Note: User is responsible for managing allocation/deallocation of input/output NDArrays.
    *
-   * @param inputBatch : IndexedSequence NDArrays.
-   * @return output of Predictions as NDArrays.
+   * @param inputBatch        IndexedSequence NDArrays
+   * @return                  Output of predictions as NDArrays
    */
   override def predictWithNDArray(inputBatch: IndexedSeq[NDArray]): IndexedSeq[NDArray] = {
 


### PR DESCRIPTION
## Preview
http://107.21.90.138/api/scala/docs/index.html#ml.dmlc.mxnet.infer.package

Edited every scala file in the Infer package that had any comments, and added comments to the SSD example.

## Comments
There are quite a variety of scaladoc errors and warnings that need to be resolved, however, the output seems fine.
```
27 warnings found
131 errors found
```
Scala API contributors: please run `make docs` and check the output on the files you contributed or are maintaining, and resolve the issues!
