### PR TITLE
[MXNET-258] Improve flaky test_random.test_shuffle

### DIFF
--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -554,8 +554,8 @@ def test_zipfian_generator():
     mx.test_utils.assert_almost_equal(exp_cnt_sampled.asnumpy(), exp_cnt[sampled_classes].asnumpy(), rtol=1e-1, atol=1e-2)
     mx.test_utils.assert_almost_equal(exp_cnt_true.asnumpy(), exp_cnt[true_classes].asnumpy(), rtol=1e-1, atol=1e-2)
 
-# See issue #10277 for the fixed seed.
-@with_seed(1485655931)
+# See issue #10277 (https://github.com/apache/incubator-mxnet/issues/10277) for the fixed seed.
+@with_seed(1)
 def test_shuffle():
     def check_first_axis_shuffle(arr):
         stride = int(arr.size / arr.shape[0])

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -554,6 +554,7 @@ def test_zipfian_generator():
     mx.test_utils.assert_almost_equal(exp_cnt_sampled.asnumpy(), exp_cnt[sampled_classes].asnumpy(), rtol=1e-1, atol=1e-2)
     mx.test_utils.assert_almost_equal(exp_cnt_true.asnumpy(), exp_cnt[true_classes].asnumpy(), rtol=1e-1, atol=1e-2)
 
+# See issue #10277 for the fixed seed.
 @with_seed(1)
 def test_shuffle():
     def check_first_axis_shuffle(arr):

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -554,7 +554,7 @@ def test_zipfian_generator():
     mx.test_utils.assert_almost_equal(exp_cnt_sampled.asnumpy(), exp_cnt[sampled_classes].asnumpy(), rtol=1e-1, atol=1e-2)
     mx.test_utils.assert_almost_equal(exp_cnt_true.asnumpy(), exp_cnt[true_classes].asnumpy(), rtol=1e-1, atol=1e-2)
 
-@with_seed()
+@with_seed(1)
 def test_shuffle():
     def check_first_axis_shuffle(arr):
         stride = int(arr.size / arr.shape[0])

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -554,8 +554,8 @@ def test_zipfian_generator():
     mx.test_utils.assert_almost_equal(exp_cnt_sampled.asnumpy(), exp_cnt[sampled_classes].asnumpy(), rtol=1e-1, atol=1e-2)
     mx.test_utils.assert_almost_equal(exp_cnt_true.asnumpy(), exp_cnt[true_classes].asnumpy(), rtol=1e-1, atol=1e-2)
 
-# See issue #10277 (https://github.com/apache/incubator-mxnet/issues/10277) for the fixed seed.
-@with_seed(1485655931)
+# Issue #10277 (https://github.com/apache/incubator-mxnet/issues/10277) discusses this test.
+@with_seed(1)
 def test_shuffle():
     def check_first_axis_shuffle(arr):
         stride = int(arr.size / arr.shape[0])

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -555,7 +555,7 @@ def test_zipfian_generator():
     mx.test_utils.assert_almost_equal(exp_cnt_true.asnumpy(), exp_cnt[true_classes].asnumpy(), rtol=1e-1, atol=1e-2)
 
 # Issue #10277 (https://github.com/apache/incubator-mxnet/issues/10277) discusses this test.
-@with_seed(1)
+@with_seed()
 def test_shuffle():
     def check_first_axis_shuffle(arr):
         stride = int(arr.size / arr.shape[0])

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -555,7 +555,7 @@ def test_zipfian_generator():
     mx.test_utils.assert_almost_equal(exp_cnt_true.asnumpy(), exp_cnt[true_classes].asnumpy(), rtol=1e-1, atol=1e-2)
 
 # See issue #10277 (https://github.com/apache/incubator-mxnet/issues/10277) for the fixed seed.
-@with_seed(1)
+@with_seed(1485655931)
 def test_shuffle():
     def check_first_axis_shuffle(arr):
         stride = int(arr.size / arr.shape[0])
@@ -597,7 +597,8 @@ def test_shuffle():
         # The outcomes must be uniformly distributed.
         # If `repeat2` is not large enough, this could fail with high probability.
         for p in itertools.permutations(range(0, data.size - stride + 1, stride)):
-            assert abs(1. * count[str(mx.nd.array(p))] / repeat2 - 1. / math.factorial(data.shape[0])) < 0.01
+            err = abs(1. * count[str(mx.nd.array(p))] / repeat2 - 1. / math.factorial(data.shape[0]))
+            assert err < 0.01, "The absolute error {} is larger than the tolerance.".format(err)
         # Check symbol interface
         a = mx.sym.Variable('a')
         b = mx.sym.random.shuffle(a)
@@ -623,9 +624,9 @@ def test_shuffle():
         assert len(count) == repeat
 
     # Test small arrays with different shapes
-    testSmall(mx.nd.arange(0, 3), 100, 20000)
-    testSmall(mx.nd.arange(0, 9).reshape((3, 3)), 100, 20000)
-    testSmall(mx.nd.arange(0, 18).reshape((3, 2, 3)), 100, 20000)
+    testSmall(mx.nd.arange(0, 3), 100, 40000)
+    testSmall(mx.nd.arange(0, 9).reshape((3, 3)), 100, 40000)
+    testSmall(mx.nd.arange(0, 18).reshape((3, 2, 3)), 100, 40000)
     # Test larger arrays
     testLarge(mx.nd.arange(0, 100000).reshape((10, 10000)), 10)
     testLarge(mx.nd.arange(0, 100000).reshape((10000, 10)), 10)

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -555,7 +555,7 @@ def test_zipfian_generator():
     mx.test_utils.assert_almost_equal(exp_cnt_true.asnumpy(), exp_cnt[true_classes].asnumpy(), rtol=1e-1, atol=1e-2)
 
 # See issue #10277 for the fixed seed.
-@with_seed(1)
+@with_seed(1485655931)
 def test_shuffle():
     def check_first_axis_shuffle(arr):
         stride = int(arr.size / arr.shape[0])


### PR DESCRIPTION
## Description ##

This sets a random seed for `test_random.test_shuffle`. As discussed in #10277, the test requires too long running time to be both strict and not flaky. Fixing the seed for the random numbers would be a practical workaround assuming that the random number sequence by the seed is not special.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

