### PR TITLE
[MXNET-249] Add inplace support to mkldnn sum

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -54,18 +54,32 @@ void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
   std::vector<mkldnn::memory::primitive_desc> in_pds(inputs.size());
   std::vector<float> scales(inputs.size(), 1);
   in_prims.reserve(inputs.size());
+  bool pd_same = true;
   for (size_t i = 0; i < inputs.size(); i++) {
     auto in_mem = inputs[i].GetMKLDNNData();
     in_prims.push_back(*in_mem);
     in_pds[i] = in_mem->get_primitive_desc();
+    pd_same = pd_same && (in_pds[i] == in_pds[0]);
   }
   mkldnn::sum::primitive_desc pdesc(scales, in_pds);
 
-  auto out_mem = CreateMKLDNNMem(out_data, pdesc.dst_primitive_desc(), req);
-  MKLDNNStream *stream = MKLDNNStream::Get();
-  stream->RegisterPrim(mkldnn::sum(pdesc, in_prims, *out_mem.second));
-  CommitOutput(out_data, out_mem);
-  stream->Submit();
+  if (req == kWriteTo) {
+    auto out_mem = const_cast<NDArray&>(out_data).CreateMKLDNNData(pdesc.dst_primitive_desc());
+    MKLDNNStream *stream = MKLDNNStream::Get();
+    stream->RegisterPrim(mkldnn::sum(pdesc, in_prims, *out_mem));
+    stream->Submit();
+  } else if (req == kWriteInplace && pd_same && (pdesc.dst_primitive_desc() == in_pds[0])) {
+    auto out_mem = const_cast<NDArray&>(out_data).CreateMKLDNNData(pdesc.dst_primitive_desc());
+    MKLDNNStream *stream = MKLDNNStream::Get();
+    stream->RegisterPrim(mkldnn::sum(pdesc, in_prims, *out_mem));
+    stream->Submit();
+  } else {
+    auto out_mem = CreateMKLDNNMem(out_data, pdesc.dst_primitive_desc(), req);
+    MKLDNNStream *stream = MKLDNNStream::Get();
+    stream->RegisterPrim(mkldnn::sum(pdesc, in_prims, *out_mem.second));
+    CommitOutput(out_data, out_mem);
+    stream->Submit();
+  }
 }
 
 }  // namespace op

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -49,6 +49,10 @@ void Sum(const mkldnn::memory &arr1, const mkldnn::memory &arr2,
 void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
                       const std::vector<NDArray> &inputs, const OpReqType &req,
                       const NDArray &out_data) {
+  if (req == kNullOp) {
+    return;
+  }
+
   TmpMemMgr::Get()->Init(ctx.requested[0]);
   std::vector<mkldnn::primitive::at> in_prims;
   std::vector<mkldnn::memory::primitive_desc> in_pds(inputs.size());

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -63,7 +63,6 @@ void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
     auto in_mem = inputs[i].GetMKLDNNData();
     in_prims.push_back(*in_mem);
     in_pds[i] = in_mem->get_primitive_desc();
-    // pd_same = pd_same && (in_pds[i] == in_pds[0]);
   }
 
   mkldnn::sum::primitive_desc pdesc(scales, in_pds);

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -63,7 +63,7 @@ void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
     auto in_mem = inputs[i].GetMKLDNNData();
     in_prims.push_back(*in_mem);
     in_pds[i] = in_mem->get_primitive_desc();
-    pd_same = pd_same && (in_pds[i] == in_pds[0]);
+    // pd_same = pd_same && (in_pds[i] == in_pds[0]);
   }
 
   mkldnn::sum::primitive_desc pdesc(scales, in_pds);


### PR DESCRIPTION
## Description ##
If `req==kWriteTo`, mkldnn sum can be performed on inputs and output directly. If `req==kWriteInplace`, a more strict limit is applied to mkldnn sum:
1. <del>all inputs should have same layout</del> => output should have same memory address with inputs[0]
2. <del>output should have same layout with inputs</del> => output should have same layout with inputs[0]

In other conditions, an additional memory is needed to do mkldnn sum and result will be copied back to output tensor after the computation is finished.

@zheng-da @pengzhao-intel @ashokei 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
