### PR TITLE
[MXNET-87] Add JIRA info to docs

### DIFF
--- a/docs/community/contribute.md
+++ b/docs/community/contribute.md
@@ -6,6 +6,22 @@ After your patch has been merged, remember to add your name to [CONTRIBUTORS.md]
 
 ## Code Contribution
 
+Before you start coding…
+
+… please make sure there is a JIRA issue that corresponds to your contribution. This is a general rule that the MXNet community follows for all code contributions, including bug fixes, improvements, or new features, with an exception for trivial hot fixes. If you would like to fix a bug that you found or if you would like to add a new feature or improvement to MXNet, please follow the [File a bug report or Propose an improvement or a new feature](http://mxnet.io/community/index.html) guidelines to open an issue in [MXNet’s JIRA](http://issues.apache.org/jira/browse/MXNet) before starting with the implementation.
+
+If the description of a JIRA issue indicates that its resolution will touch sensible parts of the code base, be sufficiently complex, or add significant amounts of new code, the MXNet community might request a design document (most contributions should not require a design document). The purpose of this document is to ensure that the overall approach to address the issue is sensible and agreed upon by the community. JIRA issues that require a design document are tagged with the requires-design-doc label. The label can be attached by any community member who feels that a design document is necessary. A good description helps to decide whether a JIRA issue requires a design document or not. The design document must be added or attached to or link from the JIRA issue and cover the following aspects:
+
+- Overview of the general approach<br/>
+- List of API changes (changed interfaces, new and deprecated configuration parameters, changed behavior, …)<br/>
+- Main components and classes to be touched<br/>
+- Known limitations of the proposed approach<br/>
+
+A design document can be added by anybody, including the reporter of the issue or the person working on it.<br/>
+
+Contributions for JIRA issues that require a design document will not be added to MXNet’s code base before a design document has been accepted by the community with lazy consensus. Please check if a design document is required before starting to code.
+
+
 ### Core Library
 
 - Follow the [Google C++ Style Guide](https://google.github.io/styleguide/cppguide.html) for C++ code.

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -2,8 +2,17 @@
 ## Questions about Using MXNet
 If you need help with using MXNet, have questions about applying it to a particular kind of problem, or have a discussion topic, please use our [forum](https://discuss.mxnet.io).
 
-## Issue Tracker
-We track bugs and new feature requests in the MXNet Github repo in the issues folder: [mxnet/issues](https://github.com/apache/incubator-mxnet/issues).
+## File a bug report
+Please let us know if you experienced a problem with MXNet and file a bug report. Open [MXNet’s JIRA](http://issues.apache.org/jira/browse/MXNet) and click on the blue `Create` button at the top. Please give detailed information about the problem you encountered and, if possible, add a description that helps to reproduce the problem.<p/>
+Issues may also be entered on github: [mxnet/issues](https://github.com/apache/incubator-mxnet/issues).  Github issues are syn'd to JIRA periodically. Thank you very much.
+
+## Propose an improvement or a new feature
+Our community is constantly looking for feedback to improve Apache MXNet. If you have an idea how to improve MXNet or have a new feature in mind that would be beneficial for MXNet users, please open an issue in [MXNet’s JIRA](http://issues.apache.org/jira/browse/MXNet). The improvement or new feature should be described in appropriate detail and include the scope and its requirements if possible. Detailed information is important for a few reasons:<br/>
+- It ensures your requirements are met when the improvement or feature is implemented.<br/> 
+- It helps to estimate the effort and to design a solution that addresses your needs. <br/>
+- It allows for constructive discussions that might arise around this issue.
+
+Detailed information is also required, if you plan to contribute the improvement or feature you proposed yourself. Please read the [contributions](http://mxnet.io/community/contribute.html) guide in this case as well.
 
 ## Contributors
 MXNet has been developed and is used by a group of active community members. Contribute to improving it! For more information, see [contributions](http://mxnet.io/community/contribute.html).

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -4,7 +4,7 @@ If you need help with using MXNet, have questions about applying it to a particu
 
 ## File a bug report
 Please let us know if you experienced a problem with MXNet and file a bug report. Open [MXNet’s JIRA](http://issues.apache.org/jira/browse/MXNet) and click on the blue `Create` button at the top. Please give detailed information about the problem you encountered and, if possible, add a description that helps to reproduce the problem.<p/>
-Issues may also be entered on github: [mxnet/issues](https://github.com/apache/incubator-mxnet/issues).  Github issues are syn'd to JIRA periodically. Thank you very much.
+Issues may also be entered on github: [mxnet/issues](https://github.com/apache/incubator-mxnet/issues).  Github issues are synced to JIRA periodically. Thank you very much.
 
 ## Propose an improvement or a new feature
 Our community is constantly looking for feedback to improve Apache MXNet. If you have an idea how to improve MXNet or have a new feature in mind that would be beneficial for MXNet users, please open an issue in [MXNet’s JIRA](http://issues.apache.org/jira/browse/MXNet). The improvement or new feature should be described in appropriate detail and include the scope and its requirements if possible. Detailed information is important for a few reasons:<br/>


### PR DESCRIPTION
## Description ##

Much of this shamelessly stolen from: https://flink.apache.org/how-to-contribute.html

JIRA: https://issues.apache.org/jira/browse/MXNET-87

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
