### PR TITLE
allow block setattr to reset the prefix when setting new block

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -211,10 +211,13 @@ class Block(object):
         new_block._prefix = prefix
         new_block._empty_prefix = prefix == ''
         new_block._params = self._params._copy(prefix)
+        new_block._name = new_block._prefix[:-1] if new_block._prefix.endswith('_') else new_block._prefix
+        new_block._scope = _BlockScope(new_block)
         for k, v in new_block.__dict__.items():
             if isinstance(v, Block):
                 v_prefix = prefix+v._prefix[len(self._prefix):] # net0's net0_conv_ -> net1_conv_
                 super(Block, new_block).__setattr__(k, v._copy(v_prefix))
+        new_block._children = self._children[:]
         for i, b in enumerate(new_block._children):
             b_prefix = prefix+b._prefix[len(self._prefix):] # net0's net0_conv_ -> net1_conv_
             new_block._children[i] = b._copy(b_prefix)

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -211,7 +211,8 @@ class Block(object):
         new_block._prefix = prefix
         new_block._empty_prefix = prefix == ''
         new_block._params = self._params._copy(prefix)
-        new_block._name = new_block._prefix[:-1] if new_block._prefix.endswith('_') else new_block._prefix
+        new_block._name = new_block._prefix[:-1] if \
+                new_block._prefix.endswith('_') else new_block._prefix
         new_block._scope = _BlockScope(new_block)
         for k, v in new_block.__dict__.items():
             if isinstance(v, Block):

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -210,7 +210,10 @@ class Block(object):
         new_block = copy.copy(self)
         new_block._prefix = prefix
         new_block._empty_prefix = prefix == ''
-        new_block._params = self._params._copy(prefix)
+        new_block._params, name_map = self._params._copy(prefix)
+        if isinstance(self, HybridBlock):
+            for k, v in new_block._reg_params.items():
+                new_block._reg_params[k] = new_block._params[name_map[v.name]]
         new_block._name = new_block._prefix[:-1] if \
                 new_block._prefix.endswith('_') else new_block._prefix
         new_block._scope = _BlockScope(new_block)

--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -209,10 +209,11 @@ class Dense(HybridBlock):
         return act
 
     def __repr__(self):
-        s = '{name}({layout}, {act})'
+        s = '{name}({layout}, {act}, flatten={flatten})'
         shape = self.weight.shape
         return s.format(name=self.__class__.__name__,
                         act=self.act if self.act else 'linear',
+                        flatten=self._flatten,
                         layout='{0} -> {1}'.format(shape[1] if shape[1] else None, shape[0]))
 
 

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -782,10 +782,13 @@ class ParameterDict(object):
 
     def _copy(self, prefix):
         result = ParameterDict(prefix, self._shared)
+        name_map = {}
         for k, v in self._params.items():
             if k.startswith(self._prefix):
                 new_name = prefix+k[len(self._prefix):]
+                name_map[k] = new_name
                 result._params[new_name] = v._shallow_copy(new_name)
             else:
                 result._params[k] = v
-        return result
+                name_map[k] = k
+        return result, name_map

--- a/python/mxnet/gluon/rnn/rnn_layer.py
+++ b/python/mxnet/gluon/rnn/rnn_layer.py
@@ -91,7 +91,8 @@ class _RNNLayer(Block):
             s += ', bidirectional'
         s += ')'
         shape = self.i2h_weight[0].shape
-        mapping = '{0} -> {1}'.format(shape[1] if shape[1] else None, shape[0])
+        mapping = '{0} -> {1}'.format(shape[1] if shape[1] else None,
+                                      shape[0] // self._gates)
         return s.format(name=self.__class__.__name__,
                         mapping=mapping,
                         **self.__dict__)

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -881,7 +881,16 @@ def test_dropout():
         check_dropout_axes(0.25, nshape, axes = (0, 2, 3))
         check_dropout_axes(0.25, nshape, axes = (1, 2, 3))
 
-
+@with_seed()
+def test_new_child_prefix():
+    net1 = mx.gluon.model_zoo.vision.alexnet(pretrained=True, prefix='net1_')
+    net2 = mx.gluon.model_zoo.vision.alexnet(2, prefix='net2_')
+    net2.features = net1.features
+    assert net2.features.prefix == 'net2_'
+    net2(mx.random.uniform(shape=(1, 3, 224, 224)))
+    net2.save_params('test_new_child_prefix.params')
+    net2.load_params('test_new_child_prefix.params')
+    net2(mx.random.uniform(shape=(1, 3, 224, 224)))
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -885,12 +885,19 @@ def test_dropout():
 def test_new_child_prefix():
     net1 = mx.gluon.model_zoo.vision.alexnet(pretrained=True, prefix='net1_')
     net2 = mx.gluon.model_zoo.vision.alexnet(2, prefix='net2_')
+    x = mx.random.uniform(shape=(1, 3, 224, 224))
+    y1_1 = net1(x)
     net2.features = net1.features
     assert net2.features.prefix == 'net2_'
-    net2(mx.random.uniform(shape=(1, 3, 224, 224)))
+    y2_1 = net2(x)
     net2.save_params('test_new_child_prefix.params')
     net2.load_params('test_new_child_prefix.params')
-    net2(mx.random.uniform(shape=(1, 3, 224, 224)))
+    y2_2 = net2(x)
+    net1.save_params('test_new_child_prefix.params')
+    net1.load_params('test_new_child_prefix.params')
+    y1_2 = net1(x)
+    assert_almost_equal(y1_1.asnumpy(), y1_2.asnumpy())
+    assert_almost_equal(y2_1.asnumpy(), y2_2.asnumpy())
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -893,10 +893,10 @@ def test_new_child_prefix():
     assert net2.first.prefix == 'net2_'
     y2_1 = net2(x)
     net2.save_params('test_new_child_prefix.params')
-    net2.load_params('test_new_child_prefix.params')
+    net2.load_params('test_new_child_prefix.params', ctx=mx.context.current_context())
     y2_2 = net2(x)
     net1.save_params('test_new_child_prefix.params')
-    net1.load_params('test_new_child_prefix.params')
+    net1.load_params('test_new_child_prefix.params', ctx=mx.context.current_context())
     y1_2 = net1(x)
     assert_almost_equal(y1_1.asnumpy(), y1_2.asnumpy())
     assert_almost_equal(y2_1.asnumpy(), y2_2.asnumpy())

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -550,17 +550,6 @@ def test_block_attr_param():
 
 
 @with_seed()
-def test_block_attr_regular():
-    b = gluon.Block()
-
-    # set block attribute also sets _children
-    b.c = gluon.Block()
-    c2 = gluon.Block()
-    b.c = c2
-    assert b.c is c2 and b._children[0] is c2
-
-
-@with_seed()
 def test_block_attr_list_of_block():
     class Model1(gluon.Block):
         def __init__(self, **kwargs):
@@ -693,8 +682,9 @@ def test_hybrid_stale_cache():
     net.initialize()
     net(mx.nd.ones((2,3,5)))
 
-    net.fc2 = mx.gluon.nn.Dense(10, weight_initializer='zeros',
-                                bias_initializer='ones', flatten=True)
+    with net.name_scope():
+        net.fc2 = mx.gluon.nn.Dense(10, weight_initializer='zeros',
+                                    bias_initializer='ones', flatten=True)
     net.initialize()
     assert net(mx.nd.ones((2,3,5))).shape == (2, 10)
 
@@ -883,12 +873,24 @@ def test_dropout():
 
 @with_seed()
 def test_new_child_prefix():
-    net1 = mx.gluon.model_zoo.vision.alexnet(pretrained=True, prefix='net1_')
-    net2 = mx.gluon.model_zoo.vision.alexnet(2, prefix='net2_')
+    class TestBlock(mx.gluon.nn.HybridSequential):
+        def __init__(self, classes, **kwargs):
+            super(TestBlock, self).__init__(**kwargs)
+            with self.name_scope():
+                self.first = mx.gluon.nn.Dense(10)
+                self.second = mx.gluon.nn.HybridSequential()
+                with self.second.name_scope():
+                    self.second.add(mx.gluon.nn.Dense(15))
+                    self.second.add(mx.gluon.nn.Dense(classes))
+
+    net1 = TestBlock(9, prefix='net1_')
+    net2 = TestBlock(2, prefix='net2_')
+    net1.initialize()
+    net2.initialize()
     x = mx.random.uniform(shape=(1, 3, 224, 224))
     y1_1 = net1(x)
-    net2.features = net1.features
-    assert net2.features.prefix == 'net2_'
+    net2.first = net1.first
+    assert net2.first.prefix == 'net2_'
     y2_1 = net2(x)
     net2.save_params('test_new_child_prefix.params')
     net2.load_params('test_new_child_prefix.params')


### PR DESCRIPTION
## Description ##
allow use cases like `block1.features = block2.features` to be able to save and load on `block1` by overriding prefix

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] make shallow copies of block when overriding prefix
- [x] make shallow copies of parameters when overriding prefix