### PR TITLE
[MXNET-257] Do not copy when casting as same type

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -1854,7 +1854,8 @@ fixed-size items.
         Returns
         -------
         NDArray, CSRNDArray or RowSparseNDArray
-            The copied array after casting to the specified type.
+            The copied array after casting to the specified type,
+            If the type is the same, return the same array
 
         Examples
         --------
@@ -1863,6 +1864,10 @@ fixed-size items.
         >>> y.dtype
         <type 'numpy.int32'>
         """
+
+        if np.dtype(dtype) == self.dtype:
+            return self
+
         res = empty(self.shape, ctx=self.context, dtype=dtype)
         self.copyto(res)
         return res

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -1843,19 +1843,25 @@ fixed-size items.
             raise ValueError("The current array is not a scalar")
         return self.asnumpy()[0]
 
-    def astype(self, dtype):
+    def astype(self, dtype, copy=True):
         """Returns a copy of the array after casting to a specified type.
 
         Parameters
         ----------
         dtype : numpy.dtype or str
             The type of the returned array.
+        copy : bool
+            Default `True`. By default, astype always returns a newly
+            allocated ndarray on the same context. If this is set to
+            False, and the dtype requirement is satisfied,
+            the input ndarray is returned instead of a copy.
 
         Returns
         -------
         NDArray, CSRNDArray or RowSparseNDArray
-            The copied array after casting to the specified type,
-            If the type is the same, return the same array
+            The copied array after casting to the specified type, or
+            the same array if copy=False and dtype is the same as the input
+            array.
 
         Examples
         --------
@@ -1865,7 +1871,7 @@ fixed-size items.
         <type 'numpy.int32'>
         """
 
-        if np.dtype(dtype) == self.dtype:
+        if not copy and np.dtype(dtype) == self.dtype:
             return self
 
         res = empty(self.shape, ctx=self.context, dtype=dtype)

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -179,12 +179,17 @@ class BaseSparseNDArray(NDArray):
         """
         return self.tostype('default').asnumpy()
 
-    def astype(self, dtype):
+    def astype(self, dtype, copy=True):
         """Returns a copy of the array after casting to a specified type.
         Parameters
         ----------
         dtype : numpy.dtype or str
             The type of the returned array.
+        copy : bool
+            Default `True`. By default, astype always returns a newly
+            allocated ndarray on the same context. If this is set to
+            False, and the dtype requirement is satisfied,
+            the input ndarray is returned instead of a copy.
         Examples
         --------
         >>> x = mx.nd.sparse.zeros('row_sparse', (2,3), dtype='float32')
@@ -192,6 +197,9 @@ class BaseSparseNDArray(NDArray):
         >>> y.dtype
         <type 'numpy.int32'>
         """
+        if not copy and np.dtype(dtype) == self.dtype:
+            return self
+
         res = zeros(shape=self.shape, ctx=self.context,
                     dtype=dtype, stype=self.stype)
         self.copyto(res)

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1142,17 +1142,28 @@ def test_ndarray_astype():
     # Test that a new ndarray has been allocated
     assert (id(x) != id(y))
 
-    # test that it works whether with 'dtype' or
-    # np.dtype
-    x = mx.nd.zeros((2, 3), dtype='int32')
-    y = x.astype(np.float32)
+    x = mx.nd.zeros((2, 3), dtype='int32', copy=False)
+    y = x.astype('float32')
     assert (y.dtype==np.float32)
     # Test that a new ndarray has been allocated
     assert (id(x) != id(y))
 
-
     x = mx.nd.zeros((2, 3), dtype='int32')
     y = x.astype('int32')
+    assert (y.dtype==np.float32)
+    # Test that a new ndarray has been allocated
+    # even though they have same dtype
+    assert (id(x) != id(y))
+
+    # Test that a new ndarray has not been allocated
+    x = mx.nd.zeros((2, 3), dtype='int32', copy=False)
+    y = x.astype('int32')
+    assert (id(x) == id(y))
+    
+    # Test the string version 'int32'
+    # has the same behaviour as the np.int32
+    x = mx.nd.zeros((2, 3), dtype='int32', copy=False)
+    y = x.astype(np.int32)
     assert (id(x) == id(y))
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1134,6 +1134,27 @@ def test_assign_a_row_to_ndarray():
     a_nd[0, :] = a_nd[1]
     assert same(a_np, a_nd.asnumpy())
 
+@with_seed()
+def test_ndarray_astype():
+    x = mx.nd.zeros((2, 3), dtype='int32')
+    y = x.astype('float32')
+    assert (y.dtype==np.float32)
+    # Test that a new ndarray has been allocated
+    assert (id(x) != id(y))
+
+    # test that it works whether with 'dtype' or
+    # np.dtype
+    x = mx.nd.zeros((2, 3), dtype='int32')
+    y = x.astype(np.float32)
+    assert (y.dtype==np.float32)
+    # Test that a new ndarray has been allocated
+    assert (id(x) != id(y))
+
+
+    x = mx.nd.zeros((2, 3), dtype='int32')
+    y = x.astype('int32')
+    assert (id(x) == id(y))
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1142,28 +1142,28 @@ def test_ndarray_astype():
     # Test that a new ndarray has been allocated
     assert (id(x) != id(y))
 
-    x = mx.nd.zeros((2, 3), dtype='int32', copy=False)
-    y = x.astype('float32')
+    x = mx.nd.zeros((2, 3), dtype='int32')
+    y = x.astype('float32', copy=False)
     assert (y.dtype==np.float32)
     # Test that a new ndarray has been allocated
     assert (id(x) != id(y))
 
     x = mx.nd.zeros((2, 3), dtype='int32')
     y = x.astype('int32')
-    assert (y.dtype==np.float32)
+    assert (y.dtype==np.int32)
     # Test that a new ndarray has been allocated
     # even though they have same dtype
     assert (id(x) != id(y))
 
     # Test that a new ndarray has not been allocated
-    x = mx.nd.zeros((2, 3), dtype='int32', copy=False)
-    y = x.astype('int32')
+    x = mx.nd.zeros((2, 3), dtype='int32')
+    y = x.astype('int32', copy=False)
     assert (id(x) == id(y))
     
     # Test the string version 'int32'
     # has the same behaviour as the np.int32
-    x = mx.nd.zeros((2, 3), dtype='int32', copy=False)
-    y = x.astype(np.int32)
+    x = mx.nd.zeros((2, 3), dtype='int32')
+    y = x.astype(np.int32, copy=False)
     assert (id(x) == id(y))
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -23,6 +23,7 @@ from common import setup_module, with_seed, random_seed
 from mxnet.base import mx_real_t
 from numpy.testing import assert_allclose
 import numpy.random as rnd
+import numpy as np
 from common import assertRaises
 from mxnet.ndarray.sparse import RowSparseNDArray, CSRNDArray
 
@@ -441,6 +442,37 @@ def test_sparse_nd_astype():
         x = mx.nd.zeros(shape=rand_shape_2d(), stype=stype, dtype='float32')
         y = x.astype('int32')
         assert(y.dtype == np.int32), y.dtype
+
+
+@with_seed()
+def test_sparse_nd_astype_copy():
+    stypes = ['row_sparse', 'csr']
+    for stype in stypes:
+        x = mx.nd.zeros(shape=rand_shape_2d(), stype=stype, dtype='int32')
+        y = x.astype('float32')
+        assert (y.dtype == np.float32)
+        # Test that a new ndarray has been allocated
+        assert (id(x) != id(y))
+
+        y = x.astype('float32', copy=False)
+        assert (y.dtype == np.float32)
+        # Test that a new ndarray has been allocated
+        assert (id(x) != id(y))
+
+        y = x.astype('int32')
+        assert (y.dtype == np.int32)
+        # Test that a new ndarray has been allocated
+        # even though they have same dtype
+        assert (id(x) != id(y))
+
+        # Test that a new ndarray has not been allocated
+        y = x.astype('int32', copy=False)
+        assert (id(x) == id(y))
+
+        # Test the string version 'int32'
+        # has the same behaviour as the np.int32
+        y = x.astype(np.int32, copy=False)
+        assert (id(x) == id(y))
 
 
 @with_seed(0)


### PR DESCRIPTION
[MXNET-257](https://issues.apache.org/jira/browse/MXNET-257)

## Description ##
Currently there is a copy even when the data has already the correct type when calling 'astype'.
I am not sure why, so if it's on purpose please enlighten me 😄 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
