### PR TITLE
[MXNET-259] Performance improvement of random.shuffle

### DIFF
--- a/src/operator/random/shuffle_op.cc
+++ b/src/operator/random/shuffle_op.cc
@@ -30,6 +30,7 @@
 #include <algorithm>
 #include <random>
 #include <vector>
+#include <cstring>
 #ifdef USE_GNU_PARALLEL_SHUFFLE
   #include <parallel/algorithm>
 #endif
@@ -55,18 +56,24 @@ void Shuffle1D(DType* const out, const index_t size, Rand* const prnd) {
 
 template<typename DType, typename Rand>
 void ShuffleND(DType* const out, const index_t size, const index_t first_axis_len,
-                Rand* const prnd) {
+                Rand* const prnd, const OpContext& ctx) {
   // Fisher-Yates shuffling
+  using namespace mxnet_op;
   const index_t stride = size / first_axis_len;
   auto rand_n = [prnd](index_t n) {
     std::uniform_int_distribution<index_t> dist(0, n - 1);
     return dist(*prnd);
   };
   CHECK_GT(first_axis_len, 0U);
+  const size_t stride_bytes = sizeof(DType) * stride;
+  Tensor<cpu, 1, char> buf =
+    ctx.requested[1].get_space_typed<cpu, 1, char>(Shape1(stride_bytes), ctx.get_stream<cpu>());
   for (index_t i = first_axis_len - 1; i > 0; --i) {
     const index_t j = rand_n(i + 1);
     if (i != j) {
-      std::swap_ranges(out + stride * i, out + stride * (i + 1), out + stride * j);
+      std::memcpy(buf.dptr_, out + stride * i, stride_bytes);
+      std::memcpy(out + stride * i, out + stride * j, stride_bytes);
+      std::memcpy(out + stride * j, buf.dptr_, stride_bytes);
     }
   }
 }
@@ -97,7 +104,7 @@ void ShuffleForwardCPU(const nnvm::NodeAttrs& attrs,
     if (input_shape.ndim() == 1) {
       Shuffle1D(out.dptr_, size, &prnd);
     } else {
-      ShuffleND(out.dptr_, size, first_axis_len, &prnd);
+      ShuffleND(out.dptr_, size, first_axis_len, &prnd, ctx);
     }
   });
 }


### PR DESCRIPTION
## Description ##

For multidimensional arrays on CPU, `mx.random.shuffle` implements Fisher-Yates algorithm which needs `n` number of swaps of two memory ranges where `n` is the length of the first axis. Previously the swap is performed by `std::swap_ranges`. This PR replaces it with a manual swap using `std::memcpy`. This brings a good performance gain. For example, shuffling of arrays with shape `(1000, 10000)` is almost ten times faster in linux/g++-6.4.1 and linux/clang++-6.0. (1D arrays on CPU and arrays on GPU are not in the scope of this PR.)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
