### PR TITLE
Fix for batch_norm gradient without cudnn.

### DIFF
--- a/src/operator/nn/batch_norm.cu
+++ b/src/operator/nn/batch_norm.cu
@@ -708,7 +708,7 @@ void BatchNormGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
     })
   }
 #else
-  MSHADOW_REAL_TYPE_SWITCH_EX(out_grad[0].type_flag_, DType, AccReal, {
+  MSHADOW_REAL_TYPE_SWITCH_EX(outputs[0].type_flag_, DType, AccReal, {
     BatchNormBackward<gpu, DType, AccReal>(ctx, param, inputs, req, outputs);
   });
 #endif


### PR DESCRIPTION
## Description ##
Using `MXNET_USE_CUDNN = 0` does not currently compile as `out_grad` is not available in `BatchNormGradCompute `. This was mostly a typo/copy paste error.