### PR TITLE
[MXNET-187] Disallow Pre-Kepler (i.e. Fermi) architectures

### DIFF
--- a/src/common/cuda_utils.h
+++ b/src/common/cuda_utils.h
@@ -53,6 +53,21 @@ extern __cuda_fake_struct blockIdx;
 #include <cublas_v2.h>
 #include <curand.h>
 
+/*!
+ * \brief When compiling a __device__ function, check that the architecture is >= Kepler (3.0)
+ *        Note that __CUDA_ARCH__ is not defined outside of a __device__ function
+ */
+#ifdef __CUDACC__
+inline __device__ bool __is_supported_cuda_architecture() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 300
+#error "Fermi and earlier GPU architectures are not supported (architecture versions less than 3.0)"
+  return false;
+#else
+  return true;
+#endif  // __CUDA_ARCH__ < 300
+}
+#endif  // __CUDACC__
+
 namespace mxnet {
 namespace common {
 /*! \brief common utils for cuda */


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
