### PR TITLE
support profile can be saved to s3 

### DIFF
--- a/src/profiler/profiler.cc
+++ b/src/profiler/profiler.cc
@@ -244,7 +244,6 @@ void Profiler::DumpProfile(bool peform_cleanup) {
   }
 
   if (last_pass) {
-    std::cout<<"last---------------"<<std::endl;
     *file << "\n" << std::endl;
     *file << "    ]," << std::endl;
     *file << "    \"displayTimeUnit\": \"ms\"" << std::endl;

--- a/src/profiler/profiler.cc
+++ b/src/profiler/profiler.cc
@@ -102,7 +102,6 @@ Profiler::~Profiler() {
 }
 
 Profiler* Profiler::Get(std::shared_ptr<Profiler> *sp) {
-#if MXNET_USE_PROFILER
   static std::mutex mtx;
   static std::shared_ptr<Profiler> prof = nullptr;
   if (!prof) {
@@ -115,9 +114,6 @@ Profiler* Profiler::Get(std::shared_ptr<Profiler> *sp) {
     *sp = prof;
   }
   return prof.get();
-#else
-  return nullptr;
-#endif
 }
 
 void Profiler::SetState(ProfilerState state) {

--- a/src/profiler/profiler.cc
+++ b/src/profiler/profiler.cc
@@ -95,9 +95,14 @@ Profiler::~Profiler() {
     thread_group_->join_all();
     thread_group_.reset();
   }
+  delete file;
+  delete fo;
+  file = nullptr;
+  fo = nullptr;
 }
 
 Profiler* Profiler::Get(std::shared_ptr<Profiler> *sp) {
+#if MXNET_USE_PROFILER
   static std::mutex mtx;
   static std::shared_ptr<Profiler> prof = nullptr;
   if (!prof) {
@@ -110,6 +115,9 @@ Profiler* Profiler::Get(std::shared_ptr<Profiler> *sp) {
     *sp = prof;
   }
   return prof.get();
+#else
+  return nullptr;
+#endif
 }
 
 void Profiler::SetState(ProfilerState state) {
@@ -137,6 +145,8 @@ void Profiler::SetConfig(int mode,
   if (!this->filename_.empty()) {
     ::unlink(this->filename_.c_str());
   }
+  this->fo = dmlc::Stream::Create(this->filename_.c_str(), "w");
+  this->file = new dmlc::ostream(this->fo);
   SetContinuousProfileDump(continuous_dump, dump_period);
   // Adjust whether storing aggregate stats as necessary
   if (aggregate_stats) {
@@ -171,17 +181,11 @@ void Profiler::DumpProfile(bool peform_cleanup) {
   if (peform_cleanup) {
     SetContinuousProfileDump(false, 1.0f);
   }
-  std::ofstream file;
   const bool first_pass = ++profile_dump_count_ == 1;
   const bool last_pass = peform_cleanup || !continuous_dump_;
-  if (!first_pass && continuous_dump_) {
-    file.open(filename_, std::ios::app|std::ios::out);
-  } else {
-    file.open(filename_, std::ios::trunc|std::ios::out);
-  }
   if (first_pass || !continuous_dump_) {
-    file << "{" << std::endl;
-    file << "    \"traceEvents\": [" << std::endl;
+    *file << "{" << std::endl;
+    *file << "    \"traceEvents\": [" << std::endl;
   }
 
   const size_t dev_num = DeviceCount();
@@ -189,10 +193,10 @@ void Profiler::DumpProfile(bool peform_cleanup) {
   if (first_pass) {
     for (uint32_t pid = 0; pid < dev_num; ++pid) {
        if (pid) {
-         file << ",\n";
+         *file << ",\n";
        }
       const DeviceStats &d = profile_stat[pid];
-      this->EmitPid(&file, d.dev_name_, pid);
+      this->EmitPid(file, d.dev_name_, pid);
       process_ids_.emplace(pid);
     }
   }
@@ -208,8 +212,8 @@ void Profiler::DumpProfile(bool peform_cleanup) {
       CHECK_NOTNULL(_opr_stat);
       std::unique_ptr<ProfileStat> opr_stat(_opr_stat);  // manage lifecycle
       opr_stat->process_id_ = i;  // lie and set process id to be the device number
-      file << ",\n" << std::endl;
-      opr_stat->EmitEvents(&file);
+      *file << ",\n" << std::endl;
+      opr_stat->EmitEvents(file);
       ++num_records_emitted_;
       if (ptr_aggregate_stats) {
         ptr_aggregate_stats->OnProfileStat(*_opr_stat);
@@ -221,7 +225,7 @@ void Profiler::DumpProfile(bool peform_cleanup) {
   ProfileStat *_profile_stat;
   while (general_stats_.opr_exec_stats_->try_dequeue(_profile_stat)) {
     CHECK_NOTNULL(_profile_stat);
-    file << ",";
+    *file << ",";
     std::unique_ptr<ProfileStat> profile_stat(_profile_stat);  // manage lifecycle
     CHECK_NE(profile_stat->categories_.c_str()[0], '\0') << "Category must be set";
     // Currently, category_to_pid_ is only accessed here, so it is protected by this->m_ above
@@ -231,12 +235,12 @@ void Profiler::DumpProfile(bool peform_cleanup) {
       const size_t this_pid = hash_fn(profile_stat->categories_.c_str());
       iter = category_to_pid_.emplace(std::make_pair(profile_stat->categories_.c_str(),
                                                      this_pid)).first;
-      EmitPid(&file, profile_stat->categories_.c_str(), iter->second);
-      file << ",\n";
+      EmitPid(file, profile_stat->categories_.c_str(), iter->second);
+      *file << ",\n";
     }
     profile_stat->process_id_ = iter->second;
-    file << std::endl;
-    profile_stat->EmitEvents(&file);
+    *file << std::endl;
+    profile_stat->EmitEvents(file);
     ++num_records_emitted_;
     if (ptr_aggregate_stats) {
       ptr_aggregate_stats->OnProfileStat(*profile_stat);
@@ -244,10 +248,12 @@ void Profiler::DumpProfile(bool peform_cleanup) {
   }
 
   if (last_pass) {
-    file << "\n" << std::endl;
-    file << "    ]," << std::endl;
-    file << "    \"displayTimeUnit\": \"ms\"" << std::endl;
-    file << "}" << std::endl;
+    std::cout<<"last---------------"<<std::endl;
+    *file << "\n" << std::endl;
+    *file << "    ]," << std::endl;
+    *file << "    \"displayTimeUnit\": \"ms\"" << std::endl;
+    *file << "}" << std::endl;
+    (*file).set_stream(nullptr);
   }
   enable_output_ = continuous_dump_ && !last_pass;  // If we're appending, then continue.
                                                     // Otherwise, profiling stops.

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -391,6 +391,14 @@ class Profiler {
     return aggregate_stats_.get() != nullptr;
   }
 
+ /*!
+  * \brief Whether aggregate stats are currently being recorded
+  * \return true if aggregate stats are currently being recorded
+  */
+ inline bool AggregateRunning() const {
+   return GetState() == kRunning && AggregateEnabled();
+ }
+
  public:
   /*!
    * \brief Constructor

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -391,13 +391,13 @@ class Profiler {
     return aggregate_stats_.get() != nullptr;
   }
 
- /*!
-  * \brief Whether aggregate stats are currently being recorded
-  * \return true if aggregate stats are currently being recorded
-  */
- inline bool AggregateRunning() const {
-   return GetState() == kRunning && AggregateEnabled();
- }
+  /*!
+   * \brief Whether aggregate stats are currently being recorded
+   * \return true if aggregate stats are currently being recorded
+   */
+  inline bool AggregateRunning() const {
+    return GetState() == kRunning && AggregateEnabled();
+  }
 
  public:
   /*!

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -391,14 +391,6 @@ class Profiler {
     return aggregate_stats_.get() != nullptr;
   }
 
-  /*!
-   * \brief Whether aggregate stats are currently being recorded
-   * \return true if aggregate stats are currently being recorded
-   */
-  inline bool AggregateRunning() const {
-    return GetState() == kRunning && AggregateEnabled();
-  }
-
  public:
   /*!
    * \brief Constructor
@@ -481,6 +473,10 @@ class Profiler {
   std::shared_ptr<dmlc::ThreadGroup> thread_group_ = std::make_shared<dmlc::ThreadGroup>();
   /* !\brief pids */
   std::unordered_set<uint32_t> process_ids_;
+  /* !\brief dmlc stream */
+  dmlc::Stream *fo = nullptr;
+  /* !\brief dmlc ostream */
+  dmlc::ostream *file = nullptr;
 };
 
 #ifdef MXNET_USE_VTUNE


### PR DESCRIPTION
We use dmlc::ostream to replace std::ostream.
This will make profile file can be saved to s3 file system.