### PR TITLE
allow user to define unknown token symbol

### DIFF
--- a/python/mxnet/rnn/io.py
+++ b/python/mxnet/rnn/io.py
@@ -27,7 +27,7 @@ import numpy as np
 from ..io import DataIter, DataBatch, DataDesc
 from .. import ndarray
 
-def encode_sentences(sentences, vocab=None, invalid_label=-1, invalid_key='\n', start_label=0):
+def encode_sentences(sentences, vocab=None, invalid_label=-1, invalid_key='\n', start_label=0, unknown_token=None):
     """Encode sentences and (optionally) build a mapping
     from string tokens to integer indices. Unknown keys
     will be added to vocabulary.
@@ -46,6 +46,9 @@ def encode_sentences(sentences, vocab=None, invalid_label=-1, invalid_key='\n', 
         of sentence by default.
     start_label : int
         lowest index.
+    unknown_token: str
+        Symbol to represent unknown token.
+        If not specified, unknown token will be skipped.
 
     Returns
     -------
@@ -58,6 +61,8 @@ def encode_sentences(sentences, vocab=None, invalid_label=-1, invalid_key='\n', 
     if vocab is None:
         vocab = {invalid_key: invalid_label}
         new_vocab = True
+    elif unknown_token:
+        new_vocab = True
     else:
         new_vocab = False
     res = []
@@ -68,6 +73,8 @@ def encode_sentences(sentences, vocab=None, invalid_label=-1, invalid_key='\n', 
                 assert new_vocab, "Unknown token %s"%word
                 if idx == invalid_label:
                     idx += 1
+                if unknown_token:
+                    word = unknown_token
                 vocab[word] = idx
                 idx += 1
             coded.append(vocab[word])


### PR DESCRIPTION
## Description ##
Add new feature for issue [#10068](https://github.com/apache/incubator-mxnet/issues/10068). It allows unknown token to be added to vocab if user provides a vocabulary and specifies a symbol(e.g. 'UNK'). Along with new default behaviour as ignoring the unknown token, instead of the present way which throwing an error. 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, allow unknown token to be added to vocab if user provides a vocabulary and specifies a symbol(e.g. 'UNK'); 
- [ ] Feature 2, new default behaviour is ignoring the unknown token, instead of throwing an error. 

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
