### PR TITLE
fix nproc arg

### DIFF
--- a/prepare_mkldnn.sh
+++ b/prepare_mkldnn.sh
@@ -89,7 +89,7 @@ if [ ! -f $MKLDNN_LIBFILE ]; then
     if [ -z $MKLROOT ] && [ ! -f $MKLDNN_INSTALLDIR/include/mkl_cblas.h ]; then
         rm -rf external && cd scripts && ./prepare_mkl.sh >&2 && cd ..
         cp -a external/*/* $MKLDNN_INSTALLDIR/.
-    fi 
+    fi
     echo "Building MKLDNN ..." >&2
     cd $MXNET_ROOTDIR
 	g++ --version >&2
@@ -102,7 +102,7 @@ if [ ! -f $MKLDNN_LIBFILE ]; then
     else
       >&2 echo "Can't discover number of cores."
     fi
-    make -C $MKLDNN_BUILDDIR -j$(NUM_PROC) VERBOSE=1 >&2
+    make -C $MKLDNN_BUILDDIR -j${NUM_PROC} VERBOSE=1 >&2
 
     make -C $MKLDNN_BUILDDIR install >&2
     rm -rf $MKLDNN_BUILDDIR
@@ -114,7 +114,7 @@ fi
 MKLDNNROOT=$MKLDNN_INSTALLDIR
 fi
 
-if [ -z $MKLROOT ] && [ -f $MKLDNNROOT/include/mkl_cblas.h ]; then 
+if [ -z $MKLROOT ] && [ -f $MKLDNNROOT/include/mkl_cblas.h ]; then
   MKLROOT=$MKLDNNROOT;
 fi
 


### PR DESCRIPTION
## Description ##

fix nproc arg to make

current version causes error:

`./prepare_mkldnn.sh: line 105: NUM_PROC: command not found`


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
