### PR TITLE
Install jemalloc for armv7, don't use jemalloc on armv6

### DIFF
--- a/ci/docker/Dockerfile.build.armv7
+++ b/ci/docker/Dockerfile.build.armv7
@@ -25,7 +25,7 @@ ENV CC /usr/bin/arm-linux-gnueabihf-gcc
 ENV CXX /usr/bin/arm-linux-gnueabihf-g++
 
 RUN apt-get update && \
-    apt-get install -y libopenblas-dev:armhf && \
+    apt-get install -y libopenblas-dev:armhf libjemalloc-dev:armhf && \
     rm -rf /var/lib/apt/lists/*
 
 COPY runtime_functions.sh /work/

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -91,6 +91,7 @@ build_armv6() {
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DUSE_LAPACK=OFF \
+        -DUSE_JEMALLOC=OFF \
         -Dmxnet_LINKER_LIBS=-lgfortran \
         -G Ninja /work/mxnet
     ninja


### PR DESCRIPTION
## Description ##
Docker CI builds fail due to lack of `libjemalloc.so` within the docker build environment.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] Code is well-documented: 
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
Note that this disables jemalloc on armv6 because I spent 5 minutes trying to build it for armv6, didn't like the look of the errors I was getting, then tried to install it via:

```
dpkg --add-architecture armel
apt update && apt install -y libjemalloc-dev:armel
```

But that wanted to install the whole `gcc` base set of packages within the `armv6` cross-compiler docker image, and I didn't want to then have to fix the fact that the wrong compilers were getting installed within the docker image.  If you want `libjemalloc` on armv6, you should probably do something like the above.