### PR TITLE
[MXNET-282] Fix R documentation

### DIFF
--- a/docs/api/julia/index.md
+++ b/docs/api/julia/index.md
@@ -1,5 +1,7 @@
 # MXNet - Julia API
 
+See the [MXNet Julia Reference Manual](https://media.readthedocs.org/pdf/mxnet-test/latest/mxnet-test.pdf).
+
 MXNet supports the Julia programming language. The MXNet Julia package brings flexible and efficient GPU
 computing and the state-of-art deep learning to Julia.
 

--- a/docs/api/r/index.md
+++ b/docs/api/r/index.md
@@ -1,7 +1,5 @@
 # MXNet - R API
 
-See the [MXNet R Reference Manual](https://media.readthedocs.org/pdf/mxnet-test/latest/mxnet-test.pdf).
-
 MXNet supports the R programming language. The MXNet R package brings flexible and efficient GPU
 computing and state-of-art deep learning to R. It enables you to write seamless tensor/matrix computation with multiple GPUs in R. It also lets you construct and customize the state-of-art deep learning models in R,
   and apply them to tasks, such as image classification and data science challenges.
@@ -23,6 +21,5 @@ You can perform tensor or matrix computation in R:
 ```
 ## Resources
 
-* [MXNet R Reference Manual](https://media.readthedocs.org/pdf/mxnet-test/latest/mxnet-test.pdf)
 * [MXNet for R Tutorials](../../tutorials/r/index.html)
 


### PR DESCRIPTION
## Description ##
R documentation reference manual now points to Julia reference manual.

Fixes these isues - https://github.com/apache/incubator-mxnet/issues/6161 https://github.com/apache/incubator-mxnet/issues/7483

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- @hetong007 