### PR TITLE
Fix output names of nn operators.

### DIFF
--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -1457,6 +1457,7 @@ void GraphExecutor::ExecuteMonCallback(size_t nid) {
       output_names.emplace_back(std::to_string(i));
     }
   }
+  CHECK_EQ(opnode.exec->out_array.size(), output_names.size());
   for (index_t i = 0; i < opnode.exec->out_array.size(); ++i) {
     NDArray *cpy = new NDArray(opnode.exec->out_array[i]);
     std::string name = inode.source->attrs.name + "_" + output_names[i];

--- a/src/operator/nn/activation.cc
+++ b/src/operator/nn/activation.cc
@@ -150,6 +150,10 @@ The following activation functions are supported:
 )code" ADD_FILELINE)
 .set_attr_parser(ParamParser<ActivationParam>)
 .set_attr<FInferStorageType>("FInferStorageType", ActivationStorageType)
+.set_attr<nnvm::FListInputNames>("FListOutputNames",
+    [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"output"};
+})
 .set_attr<FCompute>("FCompute<cpu>", ActivationCompute<cpu>)
 #if MXNET_USE_MKLDNN == 1
 .set_attr<FComputeEx>("FComputeEx<cpu>", ActivationComputeExCPU)

--- a/src/operator/nn/activation.cc
+++ b/src/operator/nn/activation.cc
@@ -150,7 +150,7 @@ The following activation functions are supported:
 )code" ADD_FILELINE)
 .set_attr_parser(ParamParser<ActivationParam>)
 .set_attr<FInferStorageType>("FInferStorageType", ActivationStorageType)
-.set_attr<nnvm::FListInputNames>("FListOutputNames",
+.set_attr<nnvm::FListOutputNames>("FListOutputNames",
     [](const NodeAttrs& attrs) {
     return std::vector<std::string>{"output"};
 })

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -248,6 +248,10 @@ Example::
   }
   return ret;
 })
+.set_attr<nnvm::FListInputNames>("FListOutputNames",
+    [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"output"};
+})
 #if MXNET_USE_MKLDNN == 1
 .set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -248,7 +248,7 @@ Example::
   }
   return ret;
 })
-.set_attr<nnvm::FListInputNames>("FListOutputNames",
+.set_attr<nnvm::FListOutputNames>("FListOutputNames",
     [](const NodeAttrs& attrs) {
     return std::vector<std::string>{"output"};
 })

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -368,7 +368,11 @@ height, width)*.
 })
 .set_attr<nnvm::FListOutputNames>("FListOutputNames",
     [](const NodeAttrs& attrs) {
-  return std::vector<std::string>{"output"};
+  const PoolingParam &param = nnvm::get<PoolingParam>(attrs.parsed);
+  if (GetNumOutputs(param) == 2)
+    return std::vector<std::string>{"output", "workspace"};
+  else
+    return std::vector<std::string>{"output"};
 })
 .set_attr_parser(PoolingParamParser)
 .set_attr<FInferStorageType>("FInferStorageType", PoolingStorageType)

--- a/src/operator/nn/softmax.cc
+++ b/src/operator/nn/softmax.cc
@@ -96,6 +96,10 @@ Example::
 
 )code" ADD_FILELINE)
 .set_attr_parser(ParamParser<SoftmaxParam>)
+.set_attr<nnvm::FListInputNames>("FListOutputNames",
+    [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"output"};
+})
 .set_attr<FCompute>("FCompute<cpu>", SoftmaxCompute<cpu, mxnet_op::softmax_fwd>)
 #if MXNET_USE_MKLDNN == 1
 .set_attr<FComputeEx>("FComputeEx<cpu>", SoftmaxComputeExCPU)

--- a/src/operator/nn/softmax.cc
+++ b/src/operator/nn/softmax.cc
@@ -96,7 +96,7 @@ Example::
 
 )code" ADD_FILELINE)
 .set_attr_parser(ParamParser<SoftmaxParam>)
-.set_attr<nnvm::FListInputNames>("FListOutputNames",
+.set_attr<nnvm::FListOutputNames>("FListOutputNames",
     [](const NodeAttrs& attrs) {
     return std::vector<std::string>{"output"};
 })

--- a/src/operator/nn/softmax_activation.cc
+++ b/src/operator/nn/softmax_activation.cc
@@ -58,7 +58,7 @@ Example::
 
 )code" ADD_FILELINE)
 .set_attr_parser(ParamParser<SoftmaxActivationParam>)
-.set_attr<nnvm::FListInputNames>("FListOutputNames",
+.set_attr<nnvm::FListOutputNames>("FListOutputNames",
     [](const NodeAttrs& attrs) {
     return std::vector<std::string>{"output"};
 })

--- a/src/operator/nn/softmax_activation.cc
+++ b/src/operator/nn/softmax_activation.cc
@@ -58,6 +58,10 @@ Example::
 
 )code" ADD_FILELINE)
 .set_attr_parser(ParamParser<SoftmaxActivationParam>)
+.set_attr<nnvm::FListInputNames>("FListOutputNames",
+    [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"output"};
+})
 .set_attr<FCompute>("FCompute<cpu>", SoftmaxActivationCompute<cpu>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseOut{"_backward_SoftmaxActivation"})
 .add_arguments(SoftmaxActivationParam::__FIELDS__());

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -132,7 +132,7 @@ NNVM_REGISTER_OP(UpSampling)
     [](const NodeAttrs& attrs) {
   return ListArguments(nnvm::get<UpSamplingParam>(attrs.parsed));
 })
-.set_attr<nnvm::FListInputNames>("FListOutputNames",
+.set_attr<nnvm::FListOutputNames>("FListOutputNames",
     [](const NodeAttrs& attrs) {
     return std::vector<std::string>{"output"};
 })

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -132,6 +132,10 @@ NNVM_REGISTER_OP(UpSampling)
     [](const NodeAttrs& attrs) {
   return ListArguments(nnvm::get<UpSamplingParam>(attrs.parsed));
 })
+.set_attr<nnvm::FListInputNames>("FListOutputNames",
+    [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"output"};
+})
 .set_attr<nnvm::FInferShape>("FInferShape", UpSamplingShape)
 .set_attr<nnvm::FInferType>("FInferType", UpSamplingType)
 .set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5419,7 +5419,10 @@ def test_quadratic_function():
 
 
 def test_op_output_names_monitor():
+    def eprint(*args, **kwargs):
+        print(*args, file=sys.stderr, **kwargs)
     def check_name(op_sym, expected_names):
+        eprint(expected_names)
         output_names = []
 
         def get_output_names_callback(name, arr):

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5464,7 +5464,6 @@ def test_op_output_names_monitor():
                             name='pooling')
     check_name(us_sym, ['pooling_output'])
 
-
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5419,10 +5419,7 @@ def test_quadratic_function():
 
 
 def test_op_output_names_monitor():
-    def eprint(*args, **kwargs):
-        print(*args, file=sys.stderr, **kwargs)
     def check_name(op_sym, expected_names):
-        eprint(expected_names)
         output_names = []
 
         def get_output_names_callback(name, arr):
@@ -5459,7 +5456,7 @@ def test_op_output_names_monitor():
     sa_sym = mx.sym.SoftmaxActivation(data, name='softmax')
     check_name(sa_sym, ['softmax_output'])
 
-    us_sym = mx.sym.UpSampling(data, scale=2, sample_type='bilinear',
+    us_sym = mx.sym.UpSampling(data, scale=2, sample_type='nearest',
                                name='upsampling')
     check_name(us_sym, ['upsampling_output'])
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5444,6 +5444,21 @@ def test_op_output_names_monitor():
     lrn_sym = mx.sym.LRN(data, nsize=1, name='lrn')
     check_name(lrn_sym, ['lrn_output', 'lrn_tmp_norm'])
 
+    act_sym = mx.sym.Activation(data, act_type='relu', name='act')
+    check_name(act_sym, ['act_output'])
+
+    cc_sym = mx.sym.concat(data, data, dim=0, name='concat')
+    check_name(cc_sym, ['concat_output'])
+
+    sm_sym = mx.sym.softmax(data, name='softmax')
+    check_name(sm_sym, ['softmax_output'])
+
+    sa_sym = mx.sym.SoftmaxActivation(data, name='softmax')
+    check_name(sa_sym, ['softmax_output'])
+
+    us_sym = mx.sym.UpSampling(data, name='upsampling')
+    check_name(us_sym, ['upsampling_output'])
+
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5456,7 +5456,8 @@ def test_op_output_names_monitor():
     sa_sym = mx.sym.SoftmaxActivation(data, name='softmax')
     check_name(sa_sym, ['softmax_output'])
 
-    us_sym = mx.sym.UpSampling(data, name='upsampling')
+    us_sym = mx.sym.UpSampling(data, scale=2, sample_type='bilinear',
+                               name='upsampling')
     check_name(us_sym, ['upsampling_output'])
 
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5460,6 +5460,10 @@ def test_op_output_names_monitor():
                                name='upsampling')
     check_name(us_sym, ['upsampling_output'])
 
+    us_sym = mx.sym.Pooling(data, kernel=(2, 2), pool_type='avg',
+                            name='pooling')
+    check_name(us_sym, ['pooling_output'])
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
For the backward compatibility, the output names are added for the operators refactored from the old operator interface.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change