### PR TITLE
[MXNET-150] Fix the build status icons in the root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Apache MXNet (incubating) for Deep Learning
 =====
 
-[![Build Status](https://builds.apache.org/job/incubator-mxnet/job/master/badge/icon)](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/)
-[![Documentation Status](https://builds.apache.org/job/incubator-mxnet-build-site/badge/icon)](https://mxnet.incubator.apache.org/)
+[![Build Status](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/badge/icon)](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/)
+[![Documentation Status](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet-build-site/badge/icon)](https://mxnet.incubator.apache.org/)
 [![GitHub license](http://dmlc.github.io/img/apache2.svg)](./LICENSE)
 
 ![banner](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/banner.png)


### PR DESCRIPTION
## Description ##
Fix the build status icons in the root README. These icons were not changed when we moved to the new CI and is now broken.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
