### PR TITLE
[MXNET-101] Fix flaky test_leaky_relu

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -498,7 +498,7 @@ def test_leaky_relu():
         neg_indices = x < 0
         out = x.copy()
         if act_type == 'elu':
-            out[neg_indices] = slope * (np.exp(out[neg_indices]) - 1.)
+            out[neg_indices] = slope * np.expm1(out[neg_indices])
         elif act_type == 'leaky':
             out[neg_indices] = slope * out[neg_indices]
         return out
@@ -516,7 +516,7 @@ def test_leaky_relu():
     for dtype in [np.float16, np.float32, np.float64]:
         xa = np.random.uniform(low=-1.0,high=1.0,size=shape).astype(dtype)
         eps = 1e-4
-        rtol = 1e-4
+        rtol = 1e-2
         atol = 1e-3
         xa[abs(xa) < eps] = 1.0
         for act_type in ['elu', 'leaky']:
@@ -558,7 +558,7 @@ def test_prelu():
     for dtype in [np.float16, np.float32, np.float64]:
         for gam in [np.array([0.1, 0.2, 0.3, 0.4], dtype=dtype)]:
             xa = np.random.uniform(low=-1.0,high=1.0,size=shape).astype(dtype)
-            rtol = 1e-3
+            rtol = 1e-2
             atol = 1e-3
             eps = 1e-4
             xa[abs(xa) < eps] = 1.0


### PR DESCRIPTION
## Description ##
Get rid of flaky behavior of test_leaky_relu mentioned in #10421.

## Checklist ##
### Essentials ###
- [x] The PR title starts with [MXNET-101]
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Loosen overly strict rtol for test_leaky_relu and test_prelu

## Comments ##
Also changed the code used to compute the reference value for elu case from "exp() - 1" to "expm1()" to match what we use in src/operator/mshadow_op.h.
