### PR TITLE
[MXNET-185] Improved error message

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -460,8 +460,9 @@ class HybridBlock(Block):
     def _finish_deferred_init(self, hybrid, *args):
         try:
             self.infer_shape(*args)
-        except Exception as e:
-            raise ValueError('Deferred initialization failed because shape of parameters cannot be inferred')
+        except Exception:
+            raise ValueError("Deferred initialization failed because "\
+                             "shape of parameters cannot be inferred")
         if hybrid:
             for is_arg, i in self._cached_op_args:
                 if not is_arg:

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -461,9 +461,9 @@ class HybridBlock(Block):
         try:
             self.infer_shape(*args)
         except Exception as e:
-           error_msg = "Deferred initialization failed because shape"\
+            error_msg = "Deferred initialization failed because shape"\
                        " of {} cannot be inferred \n {}".format(self._name, e)
-           raise ValueError(error_msg)
+            raise ValueError(error_msg)
 
         if hybrid:
             for is_arg, i in self._cached_op_args:

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -520,11 +520,11 @@ class HybridBlock(Block):
                 **{i.name: getattr(j, attr) for i, j in zip(inputs, args)})
             if arg_attrs is None:
                 raise ValueError(w[0].message)
-            sdict = {i: j for i, j in zip(out.list_arguments(), arg_attrs)}
-            sdict.update({name : attr for name, attr in \
-                 zip(out.list_auxiliary_states(), aux_attrs)})
-            for i in self.collect_params().values():
-                setattr(i, attr, sdict[i.name])
+        sdict = {i: j for i, j in zip(out.list_arguments(), arg_attrs)}
+        sdict.update({name : attr for name, attr in \
+             zip(out.list_auxiliary_states(), aux_attrs)})
+        for i in self.collect_params().values():
+            setattr(i, attr, sdict[i.name])
 
     def infer_shape(self, *args):
         """Infers shape of Parameters from inputs."""

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -458,7 +458,10 @@ class HybridBlock(Block):
                                 for name in out.list_inputs()]
 
     def _finish_deferred_init(self, hybrid, *args):
-        self.infer_shape(*args)
+        try:
+            self.infer_shape(*args)
+        except Exception as e:
+            raise ValueError('Deferred initialization failed because shape of parameters cannot be inferred')
         if hybrid:
             for is_arg, i in self._cached_op_args:
                 if not is_arg:

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -520,12 +520,12 @@ class HybridBlock(Block):
                 **{i.name: getattr(j, attr) for i, j in zip(inputs, args)})
             if arg_attrs is None:
                 raise ValueError("Failed to  {} attribute for {}"
-                                     "\n {} ".format(infer_fn,out,w[0].message))
+                                 "\n {} ".format(infer_fn, out, w[0].message))
             sdict = {i: j for i, j in zip(out.list_arguments(), arg_attrs)}
             sdict.update({name : attr for name, attr in \
                  zip(out.list_auxiliary_states(), aux_attrs)})
             for i in self.collect_params().values():
-                 setattr(i, attr, sdict[i.name])
+                setattr(i, attr, sdict[i.name])
 
     def infer_shape(self, *args):
         """Infers shape of Parameters from inputs."""

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -513,9 +513,9 @@ class HybridBlock(Block):
 
     def _infer_attrs(self, infer_fn, attr, *args):
         """Generic infer attributes."""
+        inputs, out = self._get_graph(*args)
+        args, _ = _flatten(args)
         with warnings.catch_warnings(record=True) as w:
-            inputs, out = self._get_graph(*args)
-            args, _ = _flatten(args)
             arg_attrs, _, aux_attrs = getattr(out, infer_fn)(
                 **{i.name: getattr(j, attr) for i, j in zip(inputs, args)})
             if arg_attrs is None:
@@ -529,6 +529,7 @@ class HybridBlock(Block):
     def infer_shape(self, *args):
         """Infers shape of Parameters from inputs."""
         self._infer_attrs('infer_shape', 'shape', *args)
+
     def infer_type(self, *args):
         """Infers data type of Parameters from inputs."""
         self._infer_attrs('infer_type', 'dtype', *args)

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -462,7 +462,7 @@ class HybridBlock(Block):
             self.infer_shape(*args)
         except Exception as e:
             error_msg = "Deferred initialization failed because shape"\
-                        " of {} cannot be inferred \n {}".format(self._name, e)
+                        " cannot be inferred \n {}".format(e)
             raise ValueError(error_msg)
 
         if hybrid:
@@ -519,8 +519,7 @@ class HybridBlock(Block):
             arg_attrs, _, aux_attrs = getattr(out, infer_fn)(
                 **{i.name: getattr(j, attr) for i, j in zip(inputs, args)})
             if arg_attrs is None:
-                raise ValueError("Failed to  {} attribute for {}"
-                                 "\n {} ".format(infer_fn, out, w[0].message))
+                raise ValueError(w[0].message)
             sdict = {i: j for i, j in zip(out.list_arguments(), arg_attrs)}
             sdict.update({name : attr for name, attr in \
                  zip(out.list_auxiliary_states(), aux_attrs)})

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -460,9 +460,11 @@ class HybridBlock(Block):
     def _finish_deferred_init(self, hybrid, *args):
         try:
             self.infer_shape(*args)
-        except Exception:
-            raise ValueError("Deferred initialization failed because "\
-                             "shape of parameters cannot be inferred")
+        except Exception as e:
+           error_msg = "Deferred initialization failed because shape"\
+                        " of {} cannot be inferred \n {}".format(self._name,e)
+           raise ValueError(error_msg)
+
         if hybrid:
             for is_arg, i in self._cached_op_args:
                 if not is_arg:
@@ -515,6 +517,9 @@ class HybridBlock(Block):
         args, _ = _flatten(args)
         arg_attrs, _, aux_attrs = getattr(out, infer_fn)(
             **{i.name: getattr(j, attr) for i, j in zip(inputs, args)})
+        if arg_attrs is None:
+            raise ValueError("Failed to obtain shape for %s"%(out))
+
         sdict = {i: j for i, j in zip(out.list_arguments(), arg_attrs)}
         sdict.update({name : attr for name, attr in \
                       zip(out.list_auxiliary_states(), aux_attrs)})

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -462,7 +462,7 @@ class HybridBlock(Block):
             self.infer_shape(*args)
         except Exception as e:
            error_msg = "Deferred initialization failed because shape"\
-                        " of {} cannot be inferred \n {}".format(self._name,e)
+                       " of {} cannot be inferred \n {}".format(self._name, e)
            raise ValueError(error_msg)
 
         if hybrid:


### PR DESCRIPTION
## Description ##
Issue #9842
The error due to custom function shape inference failure on deferred initialization is not well reported.
The PR improves error message when deferred initialisation fails due to failed shape inference.
It was pointed put by @piiswrong  that the issue(Issue #9842 ) is not a bug and he has already suggested the way to fix it. However, we needed  improved messaging and this PR is about the error message

- [ Y] Changes are complete (i.e. I finished coding on this PR)
- [ Y] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change