### PR TITLE
[MXNET-175] Raise user warning on mismatch between module data_names and data iter names

### DIFF
--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -492,6 +492,7 @@ class PrefetchingIter(DataIter):
 def _init_data(data, allow_empty, default_name):
     """Convert data into canonical form."""
     assert (data is not None) or allow_empty
+    renamed_data = False
     if data is None:
         data = []
 
@@ -506,6 +507,7 @@ def _init_data(data, allow_empty, default_name):
         else:
             data = OrderedDict( # pylint: disable=redefined-variable-type
                 [('_%d_%s' % (i, default_name), d) for i, d in enumerate(data)])
+        renamed_data = True
     if not isinstance(data, dict):
         raise TypeError("Input must be NDArray, numpy.ndarray, h5py.Dataset " + \
                 "a list of them or dict with them as values")
@@ -517,7 +519,7 @@ def _init_data(data, allow_empty, default_name):
                 raise TypeError(("Invalid type '%s' for %s, "  % (type(v), k)) + \
                                 "should be NDArray, numpy.ndarray or h5py.Dataset")
 
-    return list(sorted(data.items()))
+    return list(sorted(data.items())), renamed_data
 
 def _has_instance(data, dtype):
     """Return True if ``data`` has instance of ``dtype``.
@@ -645,8 +647,8 @@ class NDArrayIter(DataIter):
                  label_name='softmax_label'):
         super(NDArrayIter, self).__init__(batch_size)
 
-        self.data = _init_data(data, allow_empty=False, default_name=data_name)
-        self.label = _init_data(label, allow_empty=True, default_name=label_name)
+        self.data, self.renamedData = _init_data(data, allow_empty=False, default_name=data_name)
+        self.label, _ = _init_data(label, allow_empty=True, default_name=label_name)
 
         if ((_has_instance(self.data, CSRNDArray) or _has_instance(self.label, CSRNDArray)) and
                 (last_batch_handle != 'discard')):

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -647,7 +647,7 @@ class NDArrayIter(DataIter):
                  label_name='softmax_label'):
         super(NDArrayIter, self).__init__(batch_size)
 
-        self.data, self.renamedData = _init_data(data, allow_empty=False, default_name=data_name)
+        self.data, self.renamed_data = _init_data(data, allow_empty=False, default_name=data_name)
         self.label, _ = _init_data(label, allow_empty=True, default_name=label_name)
 
         if ((_has_instance(self.data, CSRNDArray) or _has_instance(self.label, CSRNDArray)) and

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -492,8 +492,6 @@ class PrefetchingIter(DataIter):
 def _init_data(data, allow_empty, default_name):
     """Convert data into canonical form."""
     assert (data is not None) or allow_empty
-
-    renamed_data = False
     if data is None:
         data = []
 
@@ -508,9 +506,6 @@ def _init_data(data, allow_empty, default_name):
         else:
             data = OrderedDict( # pylint: disable=redefined-variable-type
                 [('_%d_%s' % (i, default_name), d) for i, d in enumerate(data)])
-        # This is used to identify if the  data was originally a list, and was
-        # modified to a OrderedDict. Used when doing forward pass.
-        renamed_data = True
     if not isinstance(data, dict):
         raise TypeError("Input must be NDArray, numpy.ndarray, h5py.Dataset " + \
                 "a list of them or dict with them as values")
@@ -522,7 +517,7 @@ def _init_data(data, allow_empty, default_name):
                 raise TypeError(("Invalid type '%s' for %s, "  % (type(v), k)) + \
                                 "should be NDArray, numpy.ndarray or h5py.Dataset")
 
-    return list(sorted(data.items())), renamed_data
+    return list(sorted(data.items()))
 
 def _has_instance(data, dtype):
     """Return True if ``data`` has instance of ``dtype``.
@@ -650,8 +645,8 @@ class NDArrayIter(DataIter):
                  label_name='softmax_label'):
         super(NDArrayIter, self).__init__(batch_size)
 
-        self.data, self.renamed_data = _init_data(data, allow_empty=False, default_name=data_name)
-        self.label, _ = _init_data(label, allow_empty=True, default_name=label_name)
+        self.data = _init_data(data, allow_empty=False, default_name=data_name)
+        self.label = _init_data(label, allow_empty=True, default_name=label_name)
 
         if ((_has_instance(self.data, CSRNDArray) or _has_instance(self.label, CSRNDArray)) and
                 (last_batch_handle != 'discard')):

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -492,6 +492,7 @@ class PrefetchingIter(DataIter):
 def _init_data(data, allow_empty, default_name):
     """Convert data into canonical form."""
     assert (data is not None) or allow_empty
+
     renamed_data = False
     if data is None:
         data = []
@@ -507,6 +508,8 @@ def _init_data(data, allow_empty, default_name):
         else:
             data = OrderedDict( # pylint: disable=redefined-variable-type
                 [('_%d_%s' % (i, default_name), d) for i, d in enumerate(data)])
+        # This is used to identify if the  data was originally a list, and was
+        # modified to a OrderedDict. Used when doing forward pass.
         renamed_data = True
     if not isinstance(data, dict):
         raise TypeError("Input must be NDArray, numpy.ndarray, h5py.Dataset " + \

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -97,6 +97,12 @@ def _get_relevant_data(eval_data, data_names):
         for k, _ in relevant_eval_data.data:
             if k not in data_names:
                 del data_dict[k]
+
+        if len(data_dict) == 0:
+            msg = "Data provided in  data_names don't match names specified by NDArrayIterator" \
+                  " (%s vs. %s)"%(str(data_names), str(dict(eval_data.data).keys()))
+            raise ValueError(msg)
+
         relevant_eval_data.data = list(data_dict.items())
         return relevant_eval_data
 

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -363,6 +363,19 @@ class BaseModule(object):
             eval_data.reset()
 
         output_list = []
+        # If data provided is a dict. This makes sure that only relevant data items
+        # matching the data names, provided during bind time, are send for eval.
+        orig_eval_data = None
+
+        if not eval_data.renamedData and eval_data.data and isinstance(eval_data.data[0], tuple):
+            # Keeping a copy of original data.
+            orig_eval_data = eval_data.data
+            data_dict = dict(eval_data.data)
+
+            for k, _ in eval_data.data:
+                if k not in self.data_names:
+                    del data_dict[k]
+            eval_data.data = list(data_dict.items())
 
         for nbatch, eval_batch in enumerate(eval_data):
             if num_batch is not None and nbatch == num_batch:

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -25,6 +25,7 @@ import warnings
 
 from .. import metric
 from .. import ndarray
+from .. import io
 
 from ..context import cpu
 from ..model import BatchEndParam
@@ -244,10 +245,13 @@ class BaseModule(object):
         eval_metric.reset()
         actual_num_batch = 0
 
-        # If data provided is a dict. This makes sure that only relevant data items
+        # If NDArrayIter data provided is a dict. This makes sure that only relevant data items
         # matching the data names, provided during bind time, are send for eval.
         orig_eval_data = None
-        if not eval_data.renamed_data and eval_data.data and isinstance(eval_data.data[0], tuple):
+        if isinstance(eval_data, io.NDArrayIter) and \
+                not eval_data.renamed_data and \
+                eval_data.data and \
+                isinstance(eval_data.data[0], tuple):
             # Keeping a copy of original data.
             orig_eval_data = eval_data.data
             data_dict = dict(eval_data.data)
@@ -381,10 +385,13 @@ class BaseModule(object):
 
         output_list = []
 
-        # If data provided is a dict. This makes sure that only relevant data items
+        # If NDArrayIter data provided is a dict. This makes sure that only relevant data items
         # matching the data names, provided during bind time, are send for eval.
         orig_eval_data = None
-        if not eval_data.renamed_data and eval_data.data and isinstance(eval_data.data[0], tuple):
+        if isinstance(eval_data, io.NDArrayIter) and \
+                not eval_data.renamed_data and \
+                eval_data.data and \
+                isinstance(eval_data.data[0], tuple):
             # Keeping a copy of original data.
             orig_eval_data = eval_data.data
             data_dict = dict(eval_data.data)

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -25,6 +25,7 @@ import warnings
 
 from .. import metric
 from .. import ndarray
+from .. import io
 
 from ..context import cpu
 from ..model import BatchEndParam
@@ -80,11 +81,13 @@ def _parse_data_desc(data_names, label_names, data_shapes, label_shapes):
 
 def _check_data_names(eval_data, data_names):
     """ Check if iterator data names match the data names provided in module"""
-    if len(eval_data.data) and isinstance(eval_data.data[0], tuple):
-        if dict(eval_data.data).keys() != data_names:
-            msg = "Data provided in data_names don't match names specified by iterator" \
-                  " (%s vs. %s)"%(str(data_names), str(dict(eval_data.data).keys()))
-            warnings.warn(msg)
+    if isinstance(eval_data, io.NDArrayIter) and \
+            not eval_data.renamed_data and \
+            len(eval_data.data) and isinstance(eval_data.data[0], tuple) and \
+            dict(eval_data.data).keys() != data_names:
+        msg = "Data provided in data_names don't match names specified by iterator" \
+              " (%s vs. %s)"%(str(data_names), str(dict(eval_data.data).keys()))
+        warnings.warn(msg)
 
 
 class BaseModule(object):

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -387,6 +387,10 @@ class BaseModule(object):
 
             output_list.append(outputs)
 
+        # restoring original user data if changed:
+        if orig_eval_data is not None:
+            eval_data.data = orig_eval_data
+
         if len(output_list) == 0:
             return output_list
 

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -82,7 +82,6 @@ def _parse_data_desc(data_names, label_names, data_shapes, label_shapes):
 
 
 def _get_relevant_data(eval_data, data_names):
-
     # If NDArrayIter data provided is a dict. This makes sure that only relevant data items
     # matching the data names, provided during bind time, are send in forward pass.
     if isinstance(eval_data, io.NDArrayIter) and \

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -313,39 +313,6 @@ def test_CSVIter():
 
     check_CSVIter_synthetic()
 
-
-def test_DictData_NDIterator():
-    train_iter = mx.io.NDArrayIter({
-        'i2': mx.nd.ones((5, 4, 3, 3)),
-        'i0': mx.nd.zeros(5, ),
-        'i1': mx.nd.ones(5, ),
-        'i3': mx.nd.ones((5, 4, 3, 3))
-    }, batch_size=5)
-
-    net = mx.sym.var('i1')
-    mod = mx.module.Module(net, ['i1'], None)
-    mod.bind([('i1', (5,))], None)
-    mod.init_params()
-    mod.predict(train_iter)
-    assert_almost_equal(mod.get_outputs()[0].asnumpy(), np.ones(shape=(5,)))
-
-    # checking for incorrect data
-    net = mx.sym.var('invalidData')
-    mod = mx.module.Module(net, ['invalidData'], None)
-    mod.bind([('invalidData', (5,))])
-    mod.init_params()
-    assertRaises(ValueError, mod.predict, train_iter)
-
-    # check for picking non-consecutive data
-    net = mx.sym.add_n(mx.sym.var('i2'), mx.sym.var('i3'))
-    mod = mx.module.Module(net, ['i2', 'i3'], None)
-    mod.bind([('i2', (5, 4, 3, 3)), ('i3', (5, 4, 3, 3))])
-    mod.init_params()
-    mod.predict(train_iter)
-    assert_almost_equal(mod.get_outputs()[0].asnumpy(), 2*np.ones(shape=(5, 4, 3, 3)))
-
-
-
 if __name__ == "__main__":
     test_NDArrayIter()
     if h5py:
@@ -355,4 +322,3 @@ if __name__ == "__main__":
     test_LibSVMIter()
     test_NDArrayIter_csr()
     test_CSVIter()
-    test_DictData_NDIterator()

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -316,8 +316,10 @@ def test_CSVIter():
 
 def test_DictData_NDIterator():
     train_iter = mx.io.NDArrayIter({
+        'i2': mx.nd.ones((5, 4, 3, 3)),
         'i0': mx.nd.zeros(5, ),
         'i1': mx.nd.ones(5, ),
+        'i3': mx.nd.ones((5, 4, 3, 3))
     }, batch_size=5)
 
     net = mx.sym.var('i1')
@@ -326,6 +328,23 @@ def test_DictData_NDIterator():
     mod.init_params()
     mod.predict(train_iter)
     assert_almost_equal(mod.get_outputs()[0].asnumpy(), np.ones(shape=(5,)))
+
+    # checking for incorrect data
+    net = mx.sym.var('invalidData')
+    mod = mx.module.Module(net, ['invalidData'], None)
+    mod.bind([('invalidData', (5,))])
+    mod.init_params()
+    assertRaises(ValueError, mod.predict, train_iter)
+
+    # check for picking non-consecutive data
+    net = mx.sym.add_n(mx.sym.var('i2'), mx.sym.var('i3'))
+    mod = mx.module.Module(net, ['i2', 'i3'], None)
+    mod.bind([('i2', (5, 4, 3, 3)), ('i3', (5, 4, 3, 3))])
+    mod.init_params()
+    mod.predict(train_iter)
+    assert_almost_equal(mod.get_outputs()[0].asnumpy(), 2*np.ones(shape=(5, 4, 3, 3)))
+
+
 
 if __name__ == "__main__":
     test_NDArrayIter()

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -313,6 +313,20 @@ def test_CSVIter():
 
     check_CSVIter_synthetic()
 
+
+def test_DictData_NDIterator():
+    train_iter = mx.io.NDArrayIter({
+        'i0': mx.nd.zeros(5, ),
+        'i1': mx.nd.ones(5, ),
+    }, batch_size=5)
+
+    net = mx.sym.var('i1')
+    mod = mx.module.Module(net, ['i1'], None)
+    mod.bind([('i1', (5,))], None)
+    mod.init_params()
+    mod.predict(train_iter)
+    assert_almost_equal(mod.get_outputs()[0].asnumpy(), np.ones(shape=(5,)))
+
 if __name__ == "__main__":
     test_NDArrayIter()
     if h5py:
@@ -322,3 +336,4 @@ if __name__ == "__main__":
     test_LibSVMIter()
     test_NDArrayIter_csr()
     test_CSVIter()
+    test_DictData_NDIterator()


### PR DESCRIPTION
## Description ##
dataiter data_names  should match module data names.
Raising a warning if it does not match.

Related github issue:
https://github.com/apache/incubator-mxnet/issues/10045

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###



## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

@sandeep-krishnamurthy @nswamy @lupesko @anirudh2290 
