### PR TITLE
[MXNET-166] add unknown dtype to resolve segfaults when inputType is -1 and type …

### DIFF
--- a/scala-package/core/src/main/scala/ml/dmlc/mxnet/DType.scala
+++ b/scala-package/core/src/main/scala/ml/dmlc/mxnet/DType.scala
@@ -24,6 +24,7 @@ object DType extends Enumeration {
   val Float16 = Value(2, "float16")
   val UInt8 = Value(3, "uint8")
   val Int32 = Value(4, "int32")
+  val Unknown = Value(-1, "unknown")
   private[mxnet] def numOfBytes(dtype: DType): Int = {
     dtype match {
       case DType.UInt8 => 1
@@ -31,6 +32,7 @@ object DType extends Enumeration {
       case DType.Float16 => 2
       case DType.Float32 => 4
       case DType.Float64 => 8
+      case DType.Unknown => 0
     }
   }
 }


### PR DESCRIPTION
…is unknown

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
