### PR TITLE
[MXNET-210]give warning for variables with same name in graph visualization

### DIFF
--- a/ci/docker/install/arm64_openblas.sh
+++ b/ci/docker/install/arm64_openblas.sh
@@ -32,5 +32,4 @@ make install
 ln -s /opt/OpenBLAS/lib/libopenblas.so /usr/lib/libopenblas.so
 ln -s /opt/OpenBLAS/lib/libopenblas.a /usr/lib/libopenblas.a
 ln -s /opt/OpenBLAS/lib/libopenblas.a /usr/lib/liblapack.a
-pip install graphviz
 popd

--- a/ci/docker/install/arm64_openblas.sh
+++ b/ci/docker/install/arm64_openblas.sh
@@ -32,4 +32,5 @@ make install
 ln -s /opt/OpenBLAS/lib/libopenblas.so /usr/lib/libopenblas.so
 ln -s /opt/OpenBLAS/lib/libopenblas.a /usr/lib/libopenblas.a
 ln -s /opt/OpenBLAS/lib/libopenblas.a /usr/lib/liblapack.a
+pip install graphviz
 popd

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import
 import re
 import copy
 import json
-import logging
+import warnings
 from .symbol import Symbol
 
 def _str2tuple(string):
@@ -254,13 +254,13 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs
     nodes = conf["nodes"]
     # check if multiple nodes have the same name
     if len(nodes) != len(set([node["name"] for node in nodes])):
-        seen = set()
-        seen_add = seen.add
+        seen_nodes = set()
         # find all repeated names
-        repeated = set(node['name'] for node in nodes if node['name'] in seen
-                       or seen_add(node['name']))
-        logging.warning("There are multiple variables with the same name in your graph, "
-                        "this may result in cyclic graph. Repeated names: %s", ','.join(repeated))
+        repeated = set(node['name'] for node in nodes if node['name'] in seen_nodes
+                       or seen_nodes.add(node['name']))
+        warning_message = "There are multiple variables with the same name in your graph, " \
+                          "this may result in cyclic graph. Repeated names: " + ','.join(repeated)
+        warnings.warn(warning_message, RuntimeWarning)
     # default attributes of node
     node_attr = {"shape": "box", "fixedsize": "true",
                  "width": "1.3", "height": "0.8034", "style": "filled"}

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -254,7 +254,8 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs
     nodes = conf["nodes"]
     # check if multiple nodes have the same name
     if len(nodes) != len(set([node["name"] for node in nodes])):
-        logging.warning("There are multiple variables with the same name in your graph, this may result in cyclic graph")
+        logging.warning("There are multiple variables with the same name in your graph, "
+                        "this may result in cyclic graph")
     # default attributes of node
     node_attr = {"shape": "box", "fixedsize": "true",
                  "width": "1.3", "height": "0.8034", "style": "filled"}

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -254,8 +254,13 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs
     nodes = conf["nodes"]
     # check if multiple nodes have the same name
     if len(nodes) != len(set([node["name"] for node in nodes])):
+        seen = set()
+        seen_add = seen.add
+        # find all repeated names
+        repeated = set(node['name'] for node in nodes if node['name'] in seen
+                       or seen_add(node['name']))
         logging.warning("There are multiple variables with the same name in your graph, "
-                        "this may result in cyclic graph")
+                        "this may result in cyclic graph. Repeated names: %s", ','.join(repeated))
     # default attributes of node
     node_attr = {"shape": "box", "fixedsize": "true",
                  "width": "1.3", "height": "0.8034", "style": "filled"}

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import
 import re
 import copy
 import json
-
+import logging
 from .symbol import Symbol
 
 def _str2tuple(string):
@@ -252,6 +252,9 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs
         shape_dict = dict(zip(interals.list_outputs(), out_shapes))
     conf = json.loads(symbol.tojson())
     nodes = conf["nodes"]
+    # check if multiple nodes have the same name
+    if len(nodes) != len(set([node["name"] for node in nodes])):
+        logging.warning("There are multiple variables with the same name in your graph, this may result in cyclic graph")
     # default attributes of node
     node_attr = {"shape": "box", "fixedsize": "true",
                  "width": "1.3", "height": "0.8034", "style": "filled"}

--- a/tests/python/unittest/test_viz.py
+++ b/tests/python/unittest/test_viz.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import mxnet as mx
+import warnings
 
 def test_print_summary():
     data = mx.sym.Variable('data')
@@ -32,5 +33,19 @@ def test_print_summary():
     shape["data"]=(1,3,28,28)
     mx.viz.print_summary(sc1, shape)
 
+def test_plot_network():
+    # Test warnings for cyclic graph
+    net = mx.sym.Variable('data')
+    net = mx.sym.FullyConnected(data=net, name='fc', num_hidden=128)
+    net = mx.sym.Activation(data=net, name='relu1', act_type="relu")
+    net = mx.sym.FullyConnected(data=net, name='fc', num_hidden=10)
+    net = mx.sym.SoftmaxOutput(data=net, name='out')
+    with warnings.catch_warnings(record=True) as w:
+        digraph = mx.viz.plot_network(net, shape={'data': (100, 200)},
+                                      node_attrs={"fixedsize": "false"})
+    assert len(w) == 1
+    assert "There are multiple variables with the same name in your graph" in str(w[-1].message)
+
 if __name__ == "__main__":
-    test_print_summary()
+    import nose
+    nose.runmodule()

--- a/tests/python/unittest/test_viz.py
+++ b/tests/python/unittest/test_viz.py
@@ -15,9 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import mxnet as mx
-import warnings
 import unittest
+import warnings
+
+import mxnet as mx
+
 
 def test_print_summary():
     data = mx.sym.Variable('data')
@@ -56,7 +58,7 @@ def test_plot_network():
     assert len(w) == 1
     assert "There are multiple variables with the same name in your graph" in str(w[-1].message)
     assert "fc" in str(w[-1].message)
-    
+
 if __name__ == "__main__":
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_viz.py
+++ b/tests/python/unittest/test_viz.py
@@ -45,7 +45,8 @@ def test_plot_network():
                                       node_attrs={"fixedsize": "false"})
     assert len(w) == 1
     assert "There are multiple variables with the same name in your graph" in str(w[-1].message)
-
+    assert "fc" in str(w[-1].message)
+    
 if __name__ == "__main__":
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_viz.py
+++ b/tests/python/unittest/test_viz.py
@@ -17,6 +17,7 @@
 
 import mxnet as mx
 import warnings
+import unittest
 
 def test_print_summary():
     data = mx.sym.Variable('data')
@@ -33,6 +34,15 @@ def test_print_summary():
     shape["data"]=(1,3,28,28)
     mx.viz.print_summary(sc1, shape)
 
+def graphviz_exists():
+    try:
+        import graphviz
+    except ImportError:
+        return False
+    else:
+        return True
+
+@unittest.skipIf(not graphviz_exists(), "Skip test_plot_network as Graphviz could not be imported")
 def test_plot_network():
     # Test warnings for cyclic graph
     net = mx.sym.Variable('data')


### PR DESCRIPTION
## Description ##
[Issue 9898](https://github.com/apache/incubator-mxnet/issues/9890)
MXNet allow to use same name for variables, it could cause confusion

- Add warning when variables with same name could lead to cyclic graph in visualization
- We should still allow to use same name, as suggested in #2036

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-210](https://issues.apache.org/jira/browse/MXNET-210) 
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Check if there are nodes with the same name in graph, gave warning to prevent confusion in visualization

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
