### PR TITLE
[MXNET-155] Add support for np.int32 and np.int64 as basic index types

### DIFF
--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -37,14 +37,14 @@ __all__ = ['MXNetError']
 if sys.version_info[0] == 3:
     string_types = str,
     numeric_types = (float, int, np.generic)
-    integer_types = int
+    integer_types = (int, np.int32, np.int64)
     # this function is needed for python3
     # to convert ctypes.char_p .value back to python str
     py_str = lambda x: x.decode('utf-8')
 else:
     string_types = basestring,
     numeric_types = (float, int, long, np.generic)
-    integer_types = (int, long)
+    integer_types = (int, long, np.int32, np.int64)
     py_str = lambda x: x
 
 class _NullType(object):

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -28,7 +28,6 @@ except ImportError:
     from builtins import slice as py_slice
 
 from array import array as native_array
-import sys
 import ctypes
 import warnings
 import operator

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -28,12 +28,13 @@ except ImportError:
     from builtins import slice as py_slice
 
 from array import array as native_array
+import sys
 import ctypes
 import warnings
 import operator
 from functools import reduce # pylint: disable=redefined-builtin
 import numpy as np
-from ..base import _LIB, numeric_types, integer_types
+from ..base import _LIB, numeric_types
 from ..base import c_array, c_array_buf, c_handle_array, mx_real_t
 from ..base import mx_uint, NDArrayHandle, check_call
 from ..base import ctypes2buffer
@@ -101,6 +102,11 @@ _GRAD_REQ_MAP = {
 _NDARRAY_UNSUPPORTED_INDEXING = -1
 _NDARRAY_BASIC_INDEXING = 0
 _NDARRAY_ADVANCED_INDEXING = 1
+
+if sys.version_info[0] == 3:
+    _index_types = (int, np.int32, np.int64)
+else:
+    _index_types = (int, long, np.int32, np.int64)
 
 
 def _new_empty_handle():
@@ -519,7 +525,7 @@ fixed-size items.
             slices and integers."""
             return not isinstance(index, py_slice)
 
-        if isinstance(key, (NDArray, np.ndarray, list, integer_types, py_slice)):
+        if isinstance(key, (NDArray, np.ndarray, list, _index_types, py_slice)):
             key = (key,)
 
         assert isinstance(key, tuple),\
@@ -546,7 +552,7 @@ fixed-size items.
                 idx_i = arange(start, stop, step, ctx=self.context, dtype=dtype)
                 basic_indices.append(i)
                 is_advanced_index = False
-            elif isinstance(idx_i, integer_types):
+            elif isinstance(idx_i, _index_types):
                 start, stop, step = _get_index_range(idx_i, idx_i+1, shape[i], 1)
                 idx_i = arange(start, stop, step, ctx=self.context, dtype=dtype)
                 advanced_indices.append(i)
@@ -681,7 +687,7 @@ fixed-size items.
         an integer, or a slice, or a tuple of integers and slices. No restrictions
         on the values of slices' steps."""
         shape = self.shape
-        if isinstance(key, integer_types):
+        if isinstance(key, _index_types):
             sliced_arr = self._at(key)
             sliced_arr[:] = value
             return
@@ -731,7 +737,7 @@ fixed-size items.
                                                      shape[i], slice_i.step)
                 dim_size = _get_dim_size(start, stop, step)
                 vshape.append(dim_size)
-            elif isinstance(slice_i, integer_types):
+            elif isinstance(slice_i, _index_types):
                 begin.append(slice_i)
                 end.append(slice_i+1)
                 steps.append(1)
@@ -768,7 +774,7 @@ fixed-size items.
         """This function is called when key is a slice, or an integer,
         or a tuple of slices or integers"""
         shape = self.shape
-        if isinstance(key, integer_types):
+        if isinstance(key, _index_types):
             if key > shape[0] - 1:
                 raise IndexError(
                     'index {} is out of bounds for axis 0 with size {}'.format(
@@ -795,7 +801,7 @@ fixed-size items.
         kept_axes = []  # axes where slice_i is a slice
         i = -1
         for i, slice_i in enumerate(key):
-            if isinstance(slice_i, integer_types):
+            if isinstance(slice_i, _index_types):
                 begin.append(slice_i)
                 end.append(slice_i+1)
                 step.append(1)
@@ -2109,18 +2115,18 @@ def _get_indexing_dispatch_code(key):
     elif isinstance(key, list):
         # TODO(junwu): Add support for nested lists besides integer list
         for i in key:
-            if not isinstance(i, integer_types):
+            if not isinstance(i, _index_types):
                 raise TypeError('Indexing NDArray only supports a list of integers as index'
                                 ' when key is of list type, received element=%s of type=%s'
                                 % (str(i), str(type(i))))
         return _NDARRAY_ADVANCED_INDEXING
-    elif isinstance(key, (integer_types, py_slice)):
+    elif isinstance(key, (_index_types, py_slice)):
         return _NDARRAY_BASIC_INDEXING
     elif isinstance(key, tuple):
         for idx in key:
             if isinstance(idx, (NDArray, np.ndarray, list, tuple)):
                 return _NDARRAY_ADVANCED_INDEXING
-            elif not isinstance(idx, (py_slice, integer_types)):
+            elif not isinstance(idx, (py_slice, _index_types)):
                 raise ValueError("NDArray does not support slicing with key %s of type %s."
                                  % (str(idx), str(type(idx))))
         return _NDARRAY_BASIC_INDEXING

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1053,35 +1053,103 @@ def test_ndarray_indexing():
         x_grad[index] = value
         assert same(x_grad.asnumpy(), x.grad.asnumpy())
 
+    def np_int(index, int_type=np.int32):
+        def convert(num):
+            if num is None:
+                return num
+            else:
+                return int_type(num)
+
+        if isinstance(index, slice):
+            return slice(convert(index.start), convert(index.stop), convert(index.step))
+        elif isinstance(index, tuple):  # tuple of slices and integers
+            ret = []
+            for elem in index:
+                if isinstance(elem, slice):
+                    ret.append(slice(convert(elem.start), convert(elem.stop), convert(elem.step)))
+                else:
+                    ret.append(convert(elem))
+            return tuple(ret)
+        else:
+            assert False
+
     shape = (8, 16, 9, 9)
     np_array = np.arange(np.prod(shape), dtype='int32').reshape(shape)
     # index_list is a list of tuples. The tuple's first element is the index, the second one is a boolean value
     # indicating whether we should expect the result as a scalar compared to numpy.
-    index_list = [(0, False), (5, False), (-1, False),
-                  (slice(5), False), (slice(1, 5), False), (slice(1, 5, 2), False),
-                  (slice(7, 0, -1), False), (slice(None, 6), False), (slice(None, 6, 3), False),
-                  (slice(1, None), False), (slice(1, None, 3), False), (slice(None, None, 2), False),
-                  (slice(None, None, -1), False), (slice(None, None, -2), False),
+    index_list = [(0, False), (np.int32(0), False), (np.int64(0), False),
+                  (5, False), (np.int32(5), False), (np.int64(5), False),
+                  (-1, False), (np.int32(-1), False), (np.int64(-1), False),
+                  (slice(5), False), (np_int(slice(5), np.int32), False), (np_int(slice(5), np.int64), False),
+                  (slice(1, 5), False), (np_int(slice(1, 5), np.int32), False), (np_int(slice(1, 5), np.int64), False),
+                  (slice(1, 5, 2), False), (np_int(slice(1, 5, 2), np.int32), False),
+                  (np_int(slice(1, 5, 2), np.int64), False),
+                  (slice(7, 0, -1), False), (np_int(slice(7, 0, -1)), False),
+                  (np_int(slice(7, 0, -1), np.int64), False),
+                  (slice(None, 6), False), (np_int(slice(None, 6)), False),
+                  (np_int(slice(None, 6), np.int64), False),
+                  (slice(None, 6, 3), False), (np_int(slice(None, 6, 3)), False),
+                  (np_int(slice(None, 6, 3), np.int64), False),
+                  (slice(1, None), False), (np_int(slice(1, None)), False),
+                  (np_int(slice(1, None), np.int64), False),
+                  (slice(1, None, 3), False), (np_int(slice(1, None, 3)), False),
+                  (np_int(slice(1, None, 3), np.int64), False),
+                  (slice(None, None, 2), False), (np_int(slice(None, None, 2)), False),
+                  (np_int(slice(None, None, 2), np.int64), False),
+                  (slice(None, None, -1), False),
+                  (np_int(slice(None, None, -1)), False), (np_int(slice(None, None, -1), np.int64), False),
+                  (slice(None, None, -2), False),
+                  (np_int(slice(None, None, -2), np.int32), False), (np_int(slice(None, None, -2), np.int64), False),
                   ((slice(None), slice(None), 1, 8), False),
+                  (np_int((slice(None), slice(None), 1, 8)), False),
+                  (np_int((slice(None), slice(None), 1, 8), np.int64), False),
+                  ((slice(None), slice(None), 1, 8), False),
+                  (np_int((slice(None), slice(None), 1, 8)), False),
+                  (np_int((slice(None), slice(None), 1, 8), np.int64), False),
                   ((slice(None), 2, slice(1, 5), 1), False),
-                  ((1, 2, 3), False), ((1, 2, 3, 4), True),
+                  (np_int((slice(None), 2, slice(1, 5), 1)), False),
+                  (np_int((slice(None), 2, slice(1, 5), 1), np.int64), False),
+                  ((1, 2, 3), False),
+                  (np_int((1, 2, 3)), False),
+                  (np_int((1, 2, 3), np.int64), False),
+                  ((1, 2, 3, 4), True),
+                  (np_int((1, 2, 3, 4)), True),
+                  (np_int((1, 2, 3, 4), np.int64), True),
                   ((slice(None, None, -1), 2, slice(1, 5), 1), False),
+                  (np_int((slice(None, None, -1), 2, slice(1, 5), 1)), False),
+                  (np_int((slice(None, None, -1), 2, slice(1, 5), 1), np.int64), False),
                   ((slice(None, None, -1), 2, slice(1, 7, 2), 1), False),
+                  (np_int((slice(None, None, -1), 2, slice(1, 7, 2), 1)), False),
+                  (np_int((slice(None, None, -1), 2, slice(1, 7, 2), 1), np.int64), False),
                   ((slice(1, 8, 2), slice(14, 2, -2), slice(3, 8), slice(0, 7, 3)), False),
+                  (np_int((slice(1, 8, 2), slice(14, 2, -2), slice(3, 8), slice(0, 7, 3))), False),
+                  (np_int((slice(1, 8, 2), slice(14, 2, -2), slice(3, 8), slice(0, 7, 3)), np.int64), False),
                   ((slice(1, 8, 2), 1, slice(3, 8), 2), False),
+                  (np_int((slice(1, 8, 2), 1, slice(3, 8), 2)), False),
+                  (np_int((slice(1, 8, 2), 1, slice(3, 8), 2), np.int64), False),
                   ([1], False), ([1, 2], False), ([2, 1, 3], False), ([7, 5, 0, 3, 6, 2, 1], False),
                   (np.array([6, 3], dtype=np.int32), False),
                   (np.array([[3, 4], [0, 6]], dtype=np.int32), False),
                   (np.array([[7, 3], [2, 6], [0, 5], [4, 1]], dtype=np.int32), False),
+                  (np.array([[7, 3], [2, 6], [0, 5], [4, 1]], dtype=np.int64), False),
                   (np.array([[2], [0], [1]], dtype=np.int32), False),
+                  (np.array([[2], [0], [1]], dtype=np.int64), False),
                   (mx.nd.array([4, 7], dtype=np.int32), False),
+                  (mx.nd.array([4, 7], dtype=np.int64), False),
                   (mx.nd.array([[3, 6], [2, 1]], dtype=np.int32), False),
+                  (mx.nd.array([[3, 6], [2, 1]], dtype=np.int64), False),
                   (mx.nd.array([[7, 3], [2, 6], [0, 5], [4, 1]], dtype=np.int32), False),
+                  (mx.nd.array([[7, 3], [2, 6], [0, 5], [4, 1]], dtype=np.int64), False),
                   ((1, [2, 3]), False), ((1, [2, 3], np.array([[3], [0]], dtype=np.int32)), False),
+                  ((1, [2, 3]), False), ((1, [2, 3], np.array([[3], [0]], dtype=np.int64)), False),
                   ((1, [2], np.array([[5], [3]], dtype=np.int32), slice(None)), False),
+                  ((1, [2], np.array([[5], [3]], dtype=np.int64), slice(None)), False),
                   ((1, [2, 3], np.array([[6], [0]], dtype=np.int32), slice(2, 5)), False),
+                  ((1, [2, 3], np.array([[6], [0]], dtype=np.int64), slice(2, 5)), False),
                   ((1, [2, 3], np.array([[4], [7]], dtype=np.int32), slice(2, 5, 2)), False),
+                  ((1, [2, 3], np.array([[4], [7]], dtype=np.int64), slice(2, 5, 2)), False),
                   ((1, [2], np.array([[3]], dtype=np.int32), slice(None, None, -1)), False),
+                  ((1, [2], np.array([[3]], dtype=np.int64), slice(None, None, -1)), False),
                   ((1, [2], np.array([[3]], dtype=np.int32), np.array([[5, 7], [2, 4]], dtype=np.int64)), False),
                   ((1, [2], mx.nd.array([[4]], dtype=np.int32), mx.nd.array([[1, 3], [5, 7]], dtype='int64')),
                    False),

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -638,6 +638,17 @@ def test_create_row_sparse():
         rsp_copy = mx.nd.array(rsp_created)
         assert(same(rsp_copy.asnumpy(), rsp_created.asnumpy()))
 
+        # add this test since we added np.int32 and np.int64 to integer_types
+        if len(shape) == 2:
+            for np_int_type in (np.int32, np.int64):
+                shape = list(shape)
+                shape = [np_int_type(x) for x in shape]
+                arg1 = tuple(shape)
+                mx.nd.sparse.row_sparse_array(arg1, tuple(shape))
+                shape[0] += 1
+                assert_exception(mx.nd.sparse.row_sparse_array, ValueError, arg1, tuple(shape))
+
+
 
 @with_seed()
 def test_create_sparse_nd_infer_shape():


### PR DESCRIPTION
## Description ##
Support np.int32 and np.int64 as basic index types. Those types were not defined as index types previously.

Issue#: https://github.com/apache/incubator-mxnet/issues/9772

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
