### PR TITLE
[MXNET-171] Fix a bug that was causing training accuracy to be printed as nan sometimes

### DIFF
--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -22,7 +22,6 @@
 import time
 import logging
 import warnings
-from copy import deepcopy
 
 from .. import metric
 from .. import ndarray

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -22,6 +22,7 @@
 import time
 import logging
 import warnings
+from copy import deepcopy
 
 from .. import metric
 from .. import ndarray
@@ -523,8 +524,9 @@ class BaseModule(object):
                     monitor.toc_print()
 
                 if batch_end_callback is not None:
+                    arg_eval_metric = eval_metric if not end_of_batch else deepcopy(eval_metric)
                     batch_end_params = BatchEndParam(epoch=epoch, nbatch=nbatch,
-                                                     eval_metric=eval_metric,
+                                                     eval_metric=arg_eval_metric,
                                                      locals=locals())
                     for callback in _as_list(batch_end_callback):
                         callback(batch_end_params)

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -525,7 +525,7 @@ class BaseModule(object):
 
                 if batch_end_callback is not None:
                     batch_end_params = BatchEndParam(epoch=epoch, nbatch=nbatch,
-                                                     eval_metric =
+                                                     eval_metric=
                                                      deepcopy(eval_metric) if end_of_batch
                                                      else eval_metric,
                                                      locals=locals())

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -523,18 +523,19 @@ class BaseModule(object):
                 if monitor is not None:
                     monitor.toc_print()
 
+                if end_of_batch:
+                    eval_name_vals = eval_metric.get_name_value()
+
                 if batch_end_callback is not None:
                     batch_end_params = BatchEndParam(epoch=epoch, nbatch=nbatch,
-                                                     eval_metric=
-                                                     deepcopy(eval_metric) if end_of_batch
-                                                     else eval_metric,
+                                                     eval_metric=eval_metric,
                                                      locals=locals())
                     for callback in _as_list(batch_end_callback):
                         callback(batch_end_params)
                 nbatch += 1
 
             # one epoch of training is finished
-            for name, val in eval_metric.get_name_value():
+            for name, val in eval_name_vals:
                 self.logger.info('Epoch[%d] Train-%s=%f', epoch, name, val)
             toc = time.time()
             self.logger.info('Epoch[%d] Time cost=%.3f', epoch, (toc-tic))

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -524,9 +524,10 @@ class BaseModule(object):
                     monitor.toc_print()
 
                 if batch_end_callback is not None:
-                    arg_eval_metric = eval_metric if not end_of_batch else deepcopy(eval_metric)
                     batch_end_params = BatchEndParam(epoch=epoch, nbatch=nbatch,
-                                                     eval_metric=arg_eval_metric,
+                                                     eval_metric =
+                                                     deepcopy(eval_metric) if end_of_batch
+                                                     else eval_metric,
                                                      locals=locals())
                     for callback in _as_list(batch_end_callback):
                         callback(batch_end_params)


### PR DESCRIPTION
## Description ##
Fix a bug (issue #4253) that was causing training accuracy to be printed as nan sometimes

The "Epoch[x] Train-accuracy=xxx" line printed at the end of every epoch gives the impression that the accuracy metric is for the entire epoch. In reality, it is NOT.

For example if an epoch consists of 101 batches and we were printing metrics every 10 batch because callback was created that way, what will be printed as 'Train-accuracy=xxx' at the end of an epoch is actually just the accuracy from a single batch (101'st batch). Printing this as 'Epoch[x] Train-accuracy=xxx' is very misleading.

Ideally we should remove this misleading print statement. But then, I'm sure there is a lot of existing scripts out there that look for this statement. We can't remove this without breaking those scripts. Since this will be a breaking change, let's do it in a major version change.

For now, to avoid the nan error, we can avoid resetting the metrics when processing callback for the last batch. It will be reset at the beginning of the next epoch anyway.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
