### PR TITLE
[MXNET-287] ARMv6 build with 8-10 times bigger file size

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -88,9 +88,10 @@ build_armv6() {
         -DUSE_CUDA=OFF \
         -DUSE_OPENCV=OFF \
         -DUSE_SIGNAL_HANDLER=ON \
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DCMAKE_BUILD_TYPE=Release \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DUSE_LAPACK=OFF \
+        -DBUILD_CPP_EXAMPLES=OFF \
         -Dmxnet_LINKER_LIBS=-lgfortran \
         -G Ninja /work/mxnet
     ninja


### PR DESCRIPTION
## Description ##

Debug information and examples were included in the build.

## Checklist ##
### Essentials ###
- [x] The PR title starts with [MXNET-287](https://issues.apache.org/jira/projects/MXNET/issues/MXNET-287)
- [x] Changes are complete
- [x] To the my best knowledge, examples are not affected by this change

### Changes ###
- [x] Removed debug info
- [x] Removed examples

### Comments ###

Size went down from 318M to 33M for libmxnet.so.
