### PR TITLE
[MXNET-291] Fix an ndarray indexing bug with index -1

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -797,7 +797,7 @@ fixed-size items.
         for i, slice_i in enumerate(key):
             if isinstance(slice_i, integer_types):
                 begin.append(slice_i)
-                end.append(slice_i+1)
+                end.append(slice_i+1 if slice_i != -1 else self.shape[i])
                 step.append(1)
             elif isinstance(slice_i, py_slice):
                 if slice_i.step == 0:

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -349,7 +349,7 @@ def test_ndarray_slice():
     A = mx.nd.array(np.random.uniform(-10, 10, shape))
     A2 = A.asnumpy()
     assert same(A[3:8].asnumpy(), A2[3:8])
-    A2[3:8] *= 10;
+    A2[3:8] *= 10
     A[3:8] = A2[3:8]
     assert same(A[3:8].asnumpy(), A2[3:8])
 
@@ -360,11 +360,19 @@ def test_ndarray_slice():
     assert same(A[1,3:4,:,1:5].asnumpy(), A2[1,3:4,:,1:5])
 
     assert A[1,2,3,4,5].asscalar() == A2[1,2,3,4,5]
+    assert A[-1,-2,-3,-4,-5].asscalar() == A2[-1,-2,-3,-4,-5]
 
     a = mx.nd.array([[0, 1], [2, 3]])
     assert (a[[1, 1, 0], [0, 1, 0]].asnumpy() == [2, 3, 0]).all()
     assert (a[mx.nd.array([1, 1, 0]), mx.nd.array([0, 1, 0])].asnumpy() == [2, 3, 0]).all()
 
+    shape = (4, 4)
+    A = mx.nd.random.uniform(shape=shape)
+    A2 = A.asnumpy()
+    for i in range(-3, 0):
+        assert A[i, i].asscalar() == A2[i, i]
+        assert same(A[:, i].asnumpy(), A2[:, i])
+        assert same(A[i, :].asnumpy(), A2[i, :])
 
 @with_seed()
 def test_ndarray_crop():

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -369,7 +369,7 @@ def test_ndarray_slice():
     shape = (4, 4)
     A = mx.nd.random.uniform(shape=shape)
     A2 = A.asnumpy()
-    for i in range(-3, 0):
+    for i in range(-4, 0):
         assert A[i, i].asscalar() == A2[i, i]
         assert same(A[:, i].asnumpy(), A2[:, i])
         assert same(A[i, :].asnumpy(), A2[i, :])


### PR DESCRIPTION
## Description ##
```python
x = mx.nd.array([[1,2,3],[4,5,6]])
print(x[-1,:])  # MXNetError
print(x[:,-1])  # MXNetError
print(x[-1,-1]) # MXNetError
```
This produces MXNetErrors while it is expected to print `[1, 4]`, `[3, 6]` and `6`. The errors are like
```
src/operator/tensor/./matrix_op-inl.h:675: Check failed: b < e (1 vs. 0) slicing with 
begin=[0]=1, end[0]=0, and step[0]=1 is invalid
```
Other negative indices (-2 and -3) work as expected and expressions like `x[-1]` and `x[:,-2:-1]` are also ok. So the error occurs only if -1 is used in a multidimensional index but not a part of a slice expression. This PR fixes the bug.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
