### PR TITLE
Fix minor math equation rendering format in NDArray API doc strings

### DIFF
--- a/src/operator/contrib/krprod.cc
+++ b/src/operator/contrib/krprod.cc
@@ -85,7 +85,7 @@ the (column-wise) Khatri-Rao product is defined as the matrix,
 .. math::
    X = A_1 \otimes \cdots \otimes A_n \in \mathbb{R}^{(M_1 \cdots M_n) \times N},
 
-where the :math:`k`th column is equal to the column-wise outer product
+where the :math:`k` th column is equal to the column-wise outer product
 :math:`{A_1}_k \otimes \cdots \otimes {A_n}_k` where :math:`{A_i}_k` is the kth
 column of the ith matrix.
 

--- a/src/operator/optimizer_op.cc
+++ b/src/operator/optimizer_op.cc
@@ -42,10 +42,11 @@ DMLC_REGISTER_PARAMETER(AdagradParam);
 
 NNVM_REGISTER_OP(signsgd_update)
 .describe(R"code(Update function for SignSGD optimizer.
+
 .. math::
 
  g_t = \nabla J(W_{t-1})\\
- W_t = W_{t-1} - \eta_t \text{sign}(g_t)}
+ W_t = W_{t-1} - \eta_t \text{sign}(g_t)
 
 It updates the weights using::
 
@@ -72,7 +73,7 @@ NNVM_REGISTER_OP(signum_update)
 
  g_t = \nabla J(W_{t-1})\\
  m_t = \beta m_{t-1} + (1 - \beta) g_t\\
- W_t = W_{t-1} - \eta_t \text{sign}(m_t)}
+ W_t = W_{t-1} - \eta_t \text{sign}(m_t)
 
 It updates the weights using::
  state = momentum * state + (1-momentum) * gradient
@@ -398,7 +399,7 @@ available at http://proceedings.mlr.press/v70/zheng17a/zheng17a.pdf.
 
  g_t = \nabla J(W_{t-1})\\
  v_t = \beta_2 v_{t-1} + (1 - \beta_2) g_t^2\\
- d_t = \frac{ (1 - \beta_1^t) }{ \eta_t } (\sqrt{ \frac{ v_t }{ 1 - \beta_2^t } } + \epsilon)
+ d_t = \frac{ 1 - \beta_1^t }{ \eta_t } (\sqrt{ \frac{ v_t }{ 1 - \beta_2^t } } + \epsilon)
  \sigma_t = d_t - \beta_1 d_{t-1}
  z_t = \beta_1 z_{ t-1 } + (1 - \beta_1^t) g_t - \sigma_t W_{t-1}
  W_t = - \frac{ z_t }{ d_t }

--- a/src/operator/regression_output.cc
+++ b/src/operator/regression_output.cc
@@ -131,7 +131,7 @@ The logistic function, also known as the sigmoid function, is computed as
 :math:`\frac{1}{1+exp(-\textbf{x})}`.
 
 Commonly, the sigmoid is used to squash the real-valued output of a linear model
-:math:wTx+b into the [0,1] range so that it can be interpreted as a probability.
+:math:`wTx+b` into the [0,1] range so that it can be interpreted as a probability.
 It is suitable for binary classification or probability prediction tasks.
 
 .. note::


### PR DESCRIPTION
This PR is to fix minor math equation rendering format in [NDArrary API](https://mxnet.incubator.apache.org/api/python/ndarray/ndarray.html).
- khatri_rao
Before:
![image](https://user-images.githubusercontent.com/1680977/38435941-cc7df28a-3a05-11e8-948d-09da983dba48.png)
After:
![image](https://user-images.githubusercontent.com/1680977/38435961-e0b8798c-3a05-11e8-8160-d3209246f5b1.png)

- signsgd_update
Before:
![image](https://user-images.githubusercontent.com/1680977/38436046-2674cef8-3a06-11e8-8e1a-18bdb608acf6.png)
After:
![image](https://user-images.githubusercontent.com/1680977/38436396-1654f164-3a07-11e8-99c6-cb92ae370b1f.png)

- LogisticRegressionOutput
Before:
![image](https://user-images.githubusercontent.com/1680977/38436153-67b1af8a-3a06-11e8-9a10-aa58757a15a9.png)
After:
![image](https://user-images.githubusercontent.com/1680977/38436181-780f8b18-3a06-11e8-8373-7c646d29df10.png)
