### PR TITLE
Make the numpy version compatible with Official Mac OS system python-2.7.10's numpy

### DIFF
--- a/ci/docker/install/centos7_python.sh
+++ b/ci/docker/install/centos7_python.sh
@@ -32,5 +32,5 @@ curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 python2.7 get-pip.py
 python3.6 get-pip.py
 
-pip2 install nose pylint numpy==1.7.1 nose-timer requests h5py scipy
-pip3 install nose pylint numpy==1.7.1 nose-timer requests h5py scipy
+pip2 install nose pylint numpy nose-timer requests h5py scipy
+pip3 install nose pylint numpy nose-timer requests h5py scipy

--- a/ci/docker/install/centos7_python.sh
+++ b/ci/docker/install/centos7_python.sh
@@ -24,7 +24,7 @@ set -ex
 
  # Python 2.7 is installed by default, install 3.6 on top
 yum -y install https://centos7.iuscommunity.org/ius-release.rpm
-yum -y install python36u
+yum -y install python36u-devel
 yum -y install python-devel
 
 # Install PIP
@@ -32,5 +32,5 @@ curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 python2.7 get-pip.py
 python3.6 get-pip.py
 
-pip2 install nose pylint numpy nose-timer requests h5py scipy
-pip3 install nose pylint numpy nose-timer requests h5py scipy
+pip2 install nose pylint numpy==1.7.1 nose-timer requests h5py scipy
+pip3 install nose pylint numpy==1.7.1 nose-timer requests h5py scipy

--- a/ci/docker/install/centos7_python.sh
+++ b/ci/docker/install/centos7_python.sh
@@ -25,11 +25,12 @@ set -ex
  # Python 2.7 is installed by default, install 3.6 on top
 yum -y install https://centos7.iuscommunity.org/ius-release.rpm
 yum -y install python36u
+yum -y install python-devel
 
 # Install PIP
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 python2.7 get-pip.py
 python3.6 get-pip.py
 
-pip2 install nose pylint numpy nose-timer requests h5py scipy
-pip3 install nose pylint numpy nose-timer requests h5py scipy
+pip2 install nose pylint numpy==1.7.1 nose-timer requests h5py scipy
+pip3 install nose pylint numpy==1.7.1 nose-timer requests h5py scipy

--- a/ci/docker/install/centos7_python.sh
+++ b/ci/docker/install/centos7_python.sh
@@ -25,7 +25,6 @@ set -ex
  # Python 2.7 is installed by default, install 3.6 on top
 yum -y install https://centos7.iuscommunity.org/ius-release.rpm
 yum -y install python36u-devel
-yum -y install python-devel
 
 # Install PIP
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"

--- a/python/setup.py
+++ b/python/setup.py
@@ -28,7 +28,7 @@ if "--inplace" in sys.argv:
 else:
     from setuptools import setup
     from setuptools.extension import Extension
-    kwargs = {'install_requires': ['numpy<=1.15.0,>=1.8.2', 'requests<2.19.0,>=2.18.4', 'graphviz<0.9.0,>=0.8.1'], 'zip_safe': False}
+    kwargs = {'install_requires': ['numpy<=1.15.0,>=1.7.2', 'requests<2.19.0,>=2.18.4', 'graphviz<0.9.0,>=0.8.1'], 'zip_safe': False}
 from setuptools import find_packages
 
 with_cython = False


### PR DESCRIPTION
## Description ##
MAC OS system python-2.7.10 comes with default numpy version 1.8.0.rc1
We have to change the numpy lower bound version something smaller than 1.8.0.rc1

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
