### PR TITLE
[MXNET-173]fix acc metric shape miss match

### DIFF
--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -417,11 +417,14 @@ class Accuracy(EvalMetric):
                 pred_label = ndarray.argmax(pred_label, axis=self.axis)
             pred_label = pred_label.asnumpy().astype('int32')
             label = label.asnumpy().astype('int32')
+            # flatten before checking shapes to avoid shape miss match
+            label = label.flat
+            pred_label = pred_label.flat
 
             labels, preds = check_label_shapes(label, pred_label)
 
-            self.sum_metric += (pred_label.flat == label.flat).sum()
-            self.num_inst += len(pred_label.flat)
+            self.sum_metric += (pred_label == label).sum()
+            self.num_inst += len(pred_label)
 
 
 @register

--- a/tests/python/unittest/test_metric.py
+++ b/tests/python/unittest/test_metric.py
@@ -62,7 +62,7 @@ def test_acc_2d_label():
     metric.update([label], [pred])
     _, acc = metric.get()
     expected_acc = (np.argmax(pred, axis=1).asnumpy() == label.asnumpy().ravel()).sum() / \
-                   label.asnumpy().ravel().size
+                   float(label.asnumpy().ravel().size)
     assert acc == expected_acc
 
 def test_f1():

--- a/tests/python/unittest/test_metric.py
+++ b/tests/python/unittest/test_metric.py
@@ -56,12 +56,13 @@ def test_acc():
 
 def test_acc_2d_label():
     # label maybe provided in 2d arrays in custom data iterator
-    pred = mx.nd.array([[0.3, 0.7], [0, 1.], [0.4, 0.6],  [0.8, 0.2],[0.3, 0.5],[0.6, 0.4]])
-    label = mx.nd.array([[0, 1, 1], [1, 0 , 1]])
+    pred = mx.nd.array([[0.3, 0.7], [0, 1.], [0.4, 0.6], [0.8, 0.2], [0.3, 0.5], [0.6, 0.4]])
+    label = mx.nd.array([[0, 1, 1], [1, 0, 1]])
     metric = mx.metric.create('acc')
     metric.update([label], [pred])
     _, acc = metric.get()
-    expected_acc = ( np.argmax(pred, axis=1).asnumpy() == label.asnumpy().ravel()).sum() / label.asnumpy().ravel().size
+    expected_acc = (np.argmax(pred, axis=1).asnumpy() == label.asnumpy().ravel()).sum() / \
+                   label.asnumpy().ravel().size
     assert acc == expected_acc
 
 def test_f1():

--- a/tests/python/unittest/test_metric.py
+++ b/tests/python/unittest/test_metric.py
@@ -54,6 +54,16 @@ def test_acc():
     expected_acc = (np.argmax(pred, axis=1) == label).sum().asscalar() / label.size
     assert acc == expected_acc
 
+def test_acc_2d_label():
+    # label maybe provided in 2d arrays in custom data iterator
+    pred = mx.nd.array([[0.3, 0.7], [0, 1.], [0.4, 0.6],  [0.8, 0.2],[0.3, 0.5],[0.6, 0.4]])
+    label = mx.nd.array([[0, 1, 1], [1, 0 , 1]])
+    metric = mx.metric.create('acc')
+    metric.update([label], [pred])
+    _, acc = metric.get()
+    expected_acc = ( np.argmax(pred, axis=1).asnumpy() == label.asnumpy().ravel()).sum() / label.asnumpy().ravel().size
+    assert acc == expected_acc
+
 def test_f1():
     microF1 = mx.metric.create("f1", average="micro")
     macroF1 = mx.metric.F1(average="macro")


### PR DESCRIPTION
## Description ##
fix issue #2116 
This only happens when label is provided in 2D array through custom data iterator, it was not affecting major use cases because most of the time, the labels are provided in 1D or built in iterators.
The root cause is label and pred_label  in 'acc' metric have different shapes during [check_label_shapes](https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/metric.py#L33). It's similar to 'ce' metric which works fine because it [ravel the  label shape](https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/metric.py#L1008) before check.
Flatten label and pred_label for equal comparison, and 'acc' needed flattened result anyway

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-173](https://issues.apache.org/jira/browse/MXNET-173)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Flatten pre_label and label for equal comparison, the metric need to return flattened result anyway

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
