### PR TITLE
[MXNET-293] Navigation updates

### DIFF
--- a/docs/_static/js/navbar.js
+++ b/docs/_static/js/navbar.js
@@ -1,5 +1,5 @@
 var searchBox = $("#search-input-wrap");
-var TITLE = ['/install/', '/gluon/' , '/api/', '/docs/', '/github/', '/community/', ];
+var TITLE = ['/install/', '/api/', '/docs/', '/community/' ];
 var DOC_TITLE = ['/faq/', '/tutorials/', '/architecture/', '/model_zoo/'];
 var APISubmenu, versionSubmenu, docSubmenu;
 $("#burgerMenu").children().each(function () {

--- a/docs/_static/js/navbar.js
+++ b/docs/_static/js/navbar.js
@@ -1,5 +1,5 @@
 var searchBox = $("#search-input-wrap");
-var TITLE = ['/install/', '/api/', '/docs/', '/community/' ];
+var TITLE = ['/install/', '/gluon/', '/api/', '/docs/', '/community/' ];
 var DOC_TITLE = ['/faq/', '/tutorials/', '/architecture/', '/model_zoo/'];
 var APISubmenu, versionSubmenu, docSubmenu;
 $("#burgerMenu").children().each(function () {

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -7,7 +7,14 @@
       <nav id="main-nav" class='nav-bar'>
         <a class="main-nav-link" href="{{url_root}}install/index.html">Install</a>
 
-        
+        <span id="dropdown-menu-position-anchor">
+          <a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">Gluon <span class="caret"></span></a>
+          <ul id="package-dropdown-menu" class="dropdown-menu navbar-menu">
+            <li><a class="main-nav-link" href="{{url_root}}gluon/index.html">About</a></li>
+            <li><a class="main-nav-link" href="http://gluon.mxnet.io">Tutorials</a></li>
+          </ul>
+        </span>
+ 
         <span id="dropdown-menu-position-anchor">
           <a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">API <span class="caret"></span></a>
           <ul id="package-dropdown-menu" class="dropdown-menu navbar-menu">

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -7,15 +7,8 @@
       <nav id="main-nav" class='nav-bar'>
         <a class="main-nav-link" href="{{url_root}}install/index.html">Install</a>
 
-        <span id="dropdown-menu-position-anchor">
-          <a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">Gluon <span class="caret"></span></a>
-          <ul id="package-dropdown-menu" class="dropdown-menu navbar-menu">
-            <li><a class="main-nav-link" href="{{url_root}}gluon/index.html">About</a></li>
-            <li><a class="main-nav-link" href="http://gluon.mxnet.io">Tutorials</a></li>
-          </ul>
-        </span>
         
-     <span id="dropdown-menu-position-anchor">
+        <span id="dropdown-menu-position-anchor">
           <a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">API <span class="caret"></span></a>
           <ul id="package-dropdown-menu" class="dropdown-menu navbar-menu">
             <li><a class="main-nav-link" href="{{url_root}}api/python/index.html">Python</a></li>
@@ -27,12 +20,12 @@
           </ul>
         </span>
 
-         <span id="dropdown-menu-position-anchor-docs">
+        <span id="dropdown-menu-position-anchor-docs">
           <a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">Docs <span class="caret"></span></a>
           <ul id="package-dropdown-menu-docs" class="dropdown-menu navbar-menu">
             <li><a class="main-nav-link" href="{{url_root}}tutorials/index.html">Tutorials</a>
             <li><a class="main-nav-link" href="{{url_root}}faq/index.html">FAQ</a></li>
-            <li><a class="main-nav-link" href="{{url_root}}versions/master/api/python/contrib/onnx.html">ONNX</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/python/contrib/onnx.html">ONNX</a></li>
             <li><a class="main-nav-link" href="{{url_root}}architecture/index.html">Architecture</a></li>
             <li><a class="main-nav-link" href="https://github.com/apache/incubator-mxnet/tree/master/example">Examples</a></li>
             <li><a class="main-nav-link" href="{{url_root}}api/python/gluon/model_zoo.html">Model Zoo</a></li>

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -12,34 +12,34 @@
           <a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">API <span class="caret"></span></a>
           <ul id="package-dropdown-menu" class="dropdown-menu navbar-menu">
             <li><a class="main-nav-link" href="{{url_root}}api/python/index.html">Python</a></li>
-            <li><a class="main-nav-link" href="{{url_root}}api/scala/index.html">Scala</a></li>
-            <li><a class="main-nav-link" href="{{url_root}}api/r/index.html">R</a></li>
-            <li><a class="main-nav-link" href="{{url_root}}api/julia/index.html">Julia</a></li>
             <li><a class="main-nav-link" href="{{url_root}}api/c++/index.html">C++</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/scala/index.html">Scala</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/julia/index.html">Julia</a></li>
             <li><a class="main-nav-link" href="{{url_root}}api/perl/index.html">Perl</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/r/index.html">R</a></li>
           </ul>
         </span>
 
         <span id="dropdown-menu-position-anchor-docs">
           <a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">Docs <span class="caret"></span></a>
           <ul id="package-dropdown-menu-docs" class="dropdown-menu navbar-menu">
-            <li><a class="main-nav-link" href="{{url_root}}tutorials/index.html">Tutorials</a>
             <li><a class="main-nav-link" href="{{url_root}}faq/index.html">FAQ</a></li>
-            <li><a class="main-nav-link" href="{{url_root}}api/python/contrib/onnx.html">ONNX</a></li>
-            <li><a class="main-nav-link" href="{{url_root}}architecture/index.html">Architecture</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}tutorials/index.html">Tutorials</a>
             <li><a class="main-nav-link" href="https://github.com/apache/incubator-mxnet/tree/master/example">Examples</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}architecture/index.html">Architecture</a></li>
             <li><a class="main-nav-link" href="{{url_root}}api/python/gluon/model_zoo.html">Model Zoo</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/python/contrib/onnx.html">ONNX</a></li>
           </ul>
         </span>
 
         <span id="dropdown-menu-position-anchor-community">
           <a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">Community <span class="caret"></span></a>
           <ul id="package-dropdown-menu-community" class="dropdown-menu navbar-menu">
-            <li><a class="main-nav-link" href="{{url_root}}community/index.html">Community</a></li>
+            <li><a class="main-nav-link" href="http://discuss.mxnet.io">Forum</a></li>
             <li><a class="main-nav-link" href="https://github.com/dmlc/mxnet">Github</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}community/index.html">Community</a></li>
             <li><a class="main-nav-link" href="{{url_root}}community/contribute.html">Contribute</a></li>
             <li><a class="main-nav-link" href="{{url_root}}community/powered_by.html">Powered By</a></li>
-            <li><a class="main-nav-link" href="http://discuss.mxnet.io">Discuss</a></li>
           </ul>
         </span>
       </nav>

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -36,7 +36,7 @@
           <a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">Community <span class="caret"></span></a>
           <ul id="package-dropdown-menu-community" class="dropdown-menu navbar-menu">
             <li><a class="main-nav-link" href="http://discuss.mxnet.io">Forum</a></li>
-            <li><a class="main-nav-link" href="https://github.com/dmlc/mxnet">Github</a></li>
+            <li><a class="main-nav-link" href="https://github.com/apache/incubator-mxnet">Github</a></li>
             <li><a class="main-nav-link" href="{{url_root}}community/index.html">Community</a></li>
             <li><a class="main-nav-link" href="{{url_root}}community/contribute.html">Contribute</a></li>
             <li><a class="main-nav-link" href="{{url_root}}community/powered_by.html">Powered By</a></li>

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -32,19 +32,18 @@
           <ul id="package-dropdown-menu-docs" class="dropdown-menu navbar-menu">
             <li><a class="main-nav-link" href="{{url_root}}tutorials/index.html">Tutorials</a>
             <li><a class="main-nav-link" href="{{url_root}}faq/index.html">FAQ</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}versions/master/api/python/contrib/onnx.html">ONNX</a></li>
             <li><a class="main-nav-link" href="{{url_root}}architecture/index.html">Architecture</a></li>
             <li><a class="main-nav-link" href="https://github.com/apache/incubator-mxnet/tree/master/example">Examples</a></li>
-            <li><a class="main-nav-link" href="{{url_root}}api/python/gluon/model_zoo.html">Gluon Model Zoo</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/python/gluon/model_zoo.html">Model Zoo</a></li>
           </ul>
         </span>
-
-
-        <a class="main-nav-link" href="https://github.com/dmlc/mxnet">Github</a>
 
         <span id="dropdown-menu-position-anchor-community">
           <a href="#" class="main-nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="true">Community <span class="caret"></span></a>
           <ul id="package-dropdown-menu-community" class="dropdown-menu navbar-menu">
             <li><a class="main-nav-link" href="{{url_root}}community/index.html">Community</a></li>
+            <li><a class="main-nav-link" href="https://github.com/dmlc/mxnet">Github</a></li>
             <li><a class="main-nav-link" href="{{url_root}}community/contribute.html">Contribute</a></li>
             <li><a class="main-nav-link" href="{{url_root}}community/powered_by.html">Powered By</a></li>
             <li><a class="main-nav-link" href="http://discuss.mxnet.io">Discuss</a></li>


### PR DESCRIPTION
## Description ##
Updates to the website navigation to be in line with the new organization.

### Changes ###
- [ x ] Add ONNX to Docs
- [ x  ] Remove Gluon
- [  x ] Move Github to Community
- [  x ] Rename Gluon Model Zoo --> Model Zoo

Preview link -http://54.210.6.225/