### PR TITLE
[MXNET-212] [R] Fix Random Samplers from Uniform and Gaussian distribution in R bindings

### DIFF
--- a/R-package/R/random.R
+++ b/R-package/R/random.R
@@ -49,7 +49,7 @@ mx.runif <- function(shape, min=0, max=1, ctx=NULL) {
   if (!is.numeric(min)) stop("mx.rnorm only accept numeric min")
   if (!is.numeric(max)) stop("mx.rnorm only accept numeric max")
   ret <- mx.nd.internal.empty(shape, ctx)
-  return (mx.nd.internal.sample.uniform(min, max, shape=shape, out=ret))
+  return (mx.nd.internal.random.uniform(min, max, shape=shape, out=ret))
 }
 
 #' Generate nomal distribution with mean and sd.
@@ -73,5 +73,5 @@ mx.rnorm <- function(shape, mean=0, sd=1, ctx=NULL) {
   if (!is.numeric(mean)) stop("mx.rnorm only accept numeric mean")
   if (!is.numeric(sd)) stop("mx.rnorm only accept numeric sd")
   ret <- mx.nd.internal.empty(shape, ctx)
-  return (mx.nd.internal.sample.normal(mean, sd, shape=shape, out=ret))
+  return (mx.nd.internal.random.normal(mean, sd, shape=shape, out=ret))
 }

--- a/R-package/tests/testthat/test_random.R
+++ b/R-package/tests/testthat/test_random.R
@@ -1,0 +1,19 @@
+require(mxnet)
+
+context("random")
+
+test_that("mx.runif", {
+  X <- mx.runif(shape=50000, min=0, max=4, ctx=mx.ctx.default())
+  expect_equal(X>=0, mx.nd.ones(50000))
+  expect_equal(X<=4, mx.nd.ones(50000))
+  sample_mean = mean(as.array(X))
+  expect_equal(sample_mean, 2, tolerance=1e-2)
+})
+
+test_that("mx.rnorm", {
+  X <- mx.rnorm(shape=50000, mean=5, sd=1, ctx=mx.ctx.default())
+  sample_mean = mean(as.array(X))
+  sample_sd = sd(as.array(X))
+  expect_equal(sample_mean, 5, tolerance=1e-2)
+  expect_equal(sample_sd, 1, tolerance=1e-2)
+})

--- a/R-package/tests/testthat/test_random.R
+++ b/R-package/tests/testthat/test_random.R
@@ -3,17 +3,17 @@ require(mxnet)
 context("random")
 
 test_that("mx.runif", {
-  X <- mx.runif(shape=50000, min=0, max=4, ctx=mx.ctx.default())
+  X <- mx.runif(shape=50000, min=0, max=1, ctx=mx.ctx.default())
   expect_equal(X>=0, mx.nd.ones(50000))
-  expect_equal(X<=4, mx.nd.ones(50000))
+  expect_equal(X<=1, mx.nd.ones(50000))
   sample_mean = mean(as.array(X))
-  expect_equal(sample_mean, 2, tolerance=1e-2)
+  expect_equal(sample_mean, 0.5, tolerance=1e-2)
 })
 
 test_that("mx.rnorm", {
-  X <- mx.rnorm(shape=50000, mean=5, sd=1, ctx=mx.ctx.default())
+  X <- mx.rnorm(shape=50000, mean=5, sd=0.1, ctx=mx.ctx.default())
   sample_mean = mean(as.array(X))
   sample_sd = sd(as.array(X))
   expect_equal(sample_mean, 5, tolerance=1e-2)
-  expect_equal(sample_sd, 1, tolerance=1e-2)
+  expect_equal(sample_sd, 0.1, tolerance=1e-2)
 })


### PR DESCRIPTION
## Description ##
Sampling from uniform and normal distribution is currently broken in mxnet's R bindings. Check this issue - https://github.com/apache/incubator-mxnet/issues/9804#issuecomment-379096932, I have given the root cause of the bug in the comments.

This code was working in mxnet v0.10 but is currently broken in mxnet version >= v 1.10.

The change that broke the samplers was introduced in this PR - https://github.com/apache/incubator-mxnet/pull/3334/files#diff-69861896bcb94074f59474beba4e4b90

Marking @tqchen and @piiswrong who were on the above PR so that they can weigh in their thoughts about this change.

- [x] Add tests for the two distributions.

@hetong007 