### PR TITLE
[MXNET-294] Fix element wise multiply for csr ndarrays

### DIFF
--- a/src/operator/tensor/elemwise_binary_op-inl.h
+++ b/src/operator/tensor/elemwise_binary_op-inl.h
@@ -295,8 +295,10 @@ void ElemwiseBinaryOp::CsrCsrOp(mshadow::Stream<cpu> *s,
   if (!same_lhs_rhs) {
     rhs_row = Tensor<cpu, 1, DType>(lhs_row.dptr_ + nr_cols, Shape1(nr_cols));
     OpBase::FillDense<DType>(s, rhs_row.shape_.Size(), DType(0), req, rhs_row.dptr_);
+  } else {
+    rhs_row = lhs_row;
   }
-
+ 
   // Column indices
   const Tensor<cpu, 1, IType> col_indices_l = lhs.aux_data(csr::kIdx).FlatTo1D<cpu, IType>(s);
   const Tensor<cpu, 1, IType> col_indices_r = rhs.aux_data(csr::kIdx).FlatTo1D<cpu, IType>(s);
@@ -351,7 +353,7 @@ void ElemwiseBinaryOp::CsrCsrOp(mshadow::Stream<cpu> *s,
     // scan through columns where A or B has
     // contributed a non-zero entry
     for (IType jj = 0; jj < length; jj++) {
-      const DType result = OP::Map(lhs_row[head], (same_lhs_rhs ? lhs_row[head] : rhs_row[head]));
+      const DType result = OP::Map(lhs_row[head], rhs_row[head]);
       if (result != 0) {
         col_indices_out[nnz] = head;
         data_out[nnz] = result;

--- a/src/operator/tensor/elemwise_binary_op-inl.h
+++ b/src/operator/tensor/elemwise_binary_op-inl.h
@@ -255,6 +255,7 @@ void ElemwiseBinaryOp::CsrCsrOp(mshadow::Stream<cpu> *s,
   using namespace mshadow;
   using namespace mxnet_op;
   using namespace mshadow::expr;
+
   const auto nr_rows = static_cast<size_t>(lhs.shape()[0]);
   if (!nr_rows) {
     return;
@@ -354,6 +355,7 @@ void ElemwiseBinaryOp::CsrCsrOp(mshadow::Stream<cpu> *s,
     // contributed a non-zero entry
     for (IType jj = 0; jj < length; jj++) {
       const DType result = OP::Map(lhs_row[head], rhs_row[head]);
+
       if (result != 0) {
         col_indices_out[nnz] = head;
         data_out[nnz] = result;

--- a/src/operator/tensor/elemwise_binary_op-inl.h
+++ b/src/operator/tensor/elemwise_binary_op-inl.h
@@ -299,7 +299,7 @@ void ElemwiseBinaryOp::CsrCsrOp(mshadow::Stream<cpu> *s,
   } else {
     rhs_row = lhs_row;
   }
- 
+
   // Column indices
   const Tensor<cpu, 1, IType> col_indices_l = lhs.aux_data(csr::kIdx).FlatTo1D<cpu, IType>(s);
   const Tensor<cpu, 1, IType> col_indices_r = rhs.aux_data(csr::kIdx).FlatTo1D<cpu, IType>(s);

--- a/src/operator/tensor/elemwise_binary_op-inl.h
+++ b/src/operator/tensor/elemwise_binary_op-inl.h
@@ -292,7 +292,6 @@ void ElemwiseBinaryOp::CsrCsrOp(mshadow::Stream<cpu> *s,
   OpBase::FillDense<IType>(s, next.shape_.Size(), IType(-1), req, next.dptr_);
   OpBase::FillDense<DType>(s, lhs_row.shape_.Size(), DType(0),  req, lhs_row.dptr_);
 
-
   if (!same_lhs_rhs) {
     rhs_row = Tensor<cpu, 1, DType>(lhs_row.dptr_ + nr_cols, Shape1(nr_cols));
     OpBase::FillDense<DType>(s, rhs_row.shape_.Size(), DType(0), req, rhs_row.dptr_);

--- a/src/operator/tensor/elemwise_binary_op-inl.h
+++ b/src/operator/tensor/elemwise_binary_op-inl.h
@@ -292,9 +292,7 @@ void ElemwiseBinaryOp::CsrCsrOp(mshadow::Stream<cpu> *s,
 
   OpBase::FillDense<IType>(s, next.shape_.Size(), IType(-1), req, next.dptr_);
   OpBase::FillDense<DType>(s, lhs_row.shape_.Size(), DType(0),  req, lhs_row.dptr_);
-  if (!same_lhs_rhs) {
-    OpBase::FillDense<DType>(s, rhs_row.shape_.Size(), DType(0), req, rhs_row.dptr_);
-  }
+  OpBase::FillDense<DType>(s, rhs_row.shape_.Size(), DType(0), req, rhs_row.dptr_);
 
   // Column indices
   const Tensor<cpu, 1, IType> col_indices_l = lhs.aux_data(csr::kIdx).FlatTo1D<cpu, IType>(s);
@@ -349,7 +347,6 @@ void ElemwiseBinaryOp::CsrCsrOp(mshadow::Stream<cpu> *s,
     // contributed a non-zero entry
     for (IType jj = 0; jj < length; jj++) {
       const DType result = OP::Map(lhs_row[head], rhs_row[head]);
-
       if (result != 0) {
         col_indices_out[nnz] = head;
         data_out[nnz] = result;

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -261,6 +261,7 @@ def test_sparse_nd_binary():
             lhs_nd = mx.nd.array(lhs).tostype(stype)
             rhs_nd = mx.nd.array(rhs).tostype(stype)
             assert_allclose(fn(lhs, rhs), fn(lhs_nd, rhs_nd).asnumpy(), rtol=1e-4, atol=1e-4)
+            assert_allclose(fn(lhs, lhs), fn(lhs_nd, lhs_nd).asnumpy(), rtol=1e-4, atol=1e-4)
 
     stypes = ['row_sparse', 'csr']
     for stype in stypes:


### PR DESCRIPTION
## Description ##
Fixes Issue https://github.com/apache/incubator-mxnet/issues/10431
[JIRA](https://issues.apache.org/jira/browse/MXNET-294?filter=-6)

Tensor value was being used without initialization causing garbage values to crop up and make the product wrong.

First use with `+=` 
https://github.com/apache/incubator-mxnet/blob/6f6a1dc4d350dcec3058abbe4ca5123b5fce536e/src/operator/tensor/elemwise_binary_op-inl.h#L339

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Initialize tensor

## Comments ##
- There is already a test for this. 

@eric-haibin-lin @anirudh2290 @cjolivier01 Please review