### PR TITLE
MXNET-295 [Perl] Added support for linalg operators.

### DIFF
--- a/docs/api/perl/index.md
+++ b/docs/api/perl/index.md
@@ -60,10 +60,11 @@ pdl> print mx->nd->array(sequence(2,3))->aspdl ## 3 rows, 2 columns
  [2 3]
  [4 5]
 ]
+```
 
 Export/import to/from sparse MXNet tensors are supported via [PDL::CCS](https://metacpan.org/release/PDL-CCS).
 Please check out the examples directory for the examples on how to use the sparse matrices.
-```
+
  ## Perl API Reference
  * [Module API is a flexible high-level interface for training neural networks.](module.md)
  * [Symbolic API performs operations on NDArrays to assemble neural networks from layers.](symbol.md)

--- a/perl-package/AI-MXNet/Changes
+++ b/perl-package/AI-MXNet/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension AI::MXNet
 
+1.21    Sun Apr  8 12:08:44 PDT 2018
+        - Support for linear algebra operations on symbols and ndarrays.
+
 1.2     Sun Mar  4 16:29:19 PST 2018
         - Support for sparse tensors
 

--- a/perl-package/AI-MXNet/MANIFEST
+++ b/perl-package/AI-MXNet/MANIFEST
@@ -50,6 +50,9 @@ lib/AI/MXNet/Initializer.pm
 lib/AI/MXNet/IO.pm
 lib/AI/MXNet/KVStore.pm
 lib/AI/MXNet/KVStoreServer.pm
+lib/AI/MXNet/LinAlg.pm
+lib/AI/MXNet/LinAlg/NDArray.pm
+lib/AI/MXNet/LinAlg/Symbol.pm
 lib/AI/MXNet/Logging.pm
 lib/AI/MXNet/LRScheduler.pm
 lib/AI/MXNet/Metric.pm

--- a/perl-package/AI-MXNet/META.json
+++ b/perl-package/AI-MXNet/META.json
@@ -45,5 +45,5 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.2"
+   "version" : "1.21"
 }

--- a/perl-package/AI-MXNet/META.yml
+++ b/perl-package/AI-MXNet/META.yml
@@ -25,4 +25,4 @@ requires:
   Mouse: v2.1.0
   PDL: '2.007'
   PDL::CCS: '1.23.4'
-version: '1.2'
+version: '1.21'

--- a/perl-package/AI-MXNet/Makefile.PL
+++ b/perl-package/AI-MXNet/Makefile.PL
@@ -46,7 +46,7 @@ my %WriteMakefileArgs = (
     "GraphViz" => "2.14"
   },
   "TEST_REQUIRES" => {},
-  "VERSION" => "1.2",
+  "VERSION" => "1.21",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/perl-package/AI-MXNet/README
+++ b/perl-package/AI-MXNet/README
@@ -1,5 +1,5 @@
 This archive contains the distribution AI-MXNet,
-version 1.2:
+version 1.21:
 
   Perl interface to MXNet machine learning library
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet.pm
@@ -44,12 +44,13 @@ use AI::MXNet::Visualization;
 use AI::MXNet::RecordIO;
 use AI::MXNet::Image;
 use AI::MXNet::Contrib;
+use AI::MXNet::LinAlg;
 use AI::MXNet::CachedOp;
 use AI::MXNet::AutoGrad;
 use AI::MXNet::Gluon;
 use AI::MXNet::NDArray::Sparse;
 use AI::MXNet::Symbol::Sparse;
-our $VERSION = '1.2';
+our $VERSION = '1.21';
 
 sub import
 {
@@ -63,6 +64,7 @@ sub import
             package $short_name;
             no warnings 'redefine';
             sub nd { 'AI::MXNet::NDArray' }
+            sub ndarray { 'AI::MXNet::NDArray' }
             sub sym { 'AI::MXNet::Symbol' }
             sub symbol { 'AI::MXNet::Symbol' }
             sub init { 'AI::MXNet::Initializer' }
@@ -88,6 +90,7 @@ sub import
             sub img { 'AI::MXNet::Image' }
             sub image { 'AI::MXNet::Image' }
             sub contrib { 'AI::MXNet::Contrib' }
+            sub linalg { 'AI::MXNet::LinAlg' }
             sub autograd { 'AI::MXNet::AutoGrad' }
             sub name { '$short_name' }
             sub rtc { '$short_name' }

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/BasicLayers.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/BasicLayers.pm
@@ -42,7 +42,7 @@ use AI::MXNet::Function::Parameters;
 use AI::MXNet::Gluon::Mouse;
 extends 'AI::MXNet::Gluon::Block';
 
-=head
+=head2
 
     Adds block on top of the stack.
 =cut
@@ -104,7 +104,7 @@ package AI::MXNet::Gluon::NN::HybridSequential;
 use AI::MXNet::Gluon::Mouse;
 extends 'AI::MXNet::Gluon::HybridBlock';
 
-=head
+=head2
 
     Adds block on top of the stack.
 =cut

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/ConvLayers.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/ConvLayers.pm
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+use strict;
+use warnings;
 package AI::MXNet::Gluon::NN::Conv;
 use AI::MXNet::Function::Parameters;
 use AI::MXNet::Symbol;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Parameter.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Parameter.pm
@@ -665,7 +665,7 @@ method _get_impl($name)
     return undef;
 }
 
-=head get
+=head2 get
 
         Retrieves a 'AI::MXNet::Gluon::Parameter' with name '$self->prefix.$name'. If not found,
         'get' will first try to retrieve it from 'shared' dict. If still not

--- a/perl-package/AI-MXNet/lib/AI/MXNet/LinAlg.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/LinAlg.pm
@@ -15,15 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
-package AI::MXNet::Contrib;
+package AI::MXNet::LinAlg;
 use strict;
 use warnings;
-use AI::MXNet::Contrib::Symbol;
-use AI::MXNet::Contrib::NDArray;
+use AI::MXNet::LinAlg::Symbol;
+use AI::MXNet::LinAlg::NDArray;
 
-sub sym    { 'AI::MXNet::Contrib::Symbol'  }
-sub symbol { 'AI::MXNet::Contrib::Symbol'  }
-sub nd     { 'AI::MXNet::Contrib::NDArray' }
-sub ndarray { 'AI::MXNet::Contrib::NDArray' }
+sub sym    { 'AI::MXNet::LinAlg::Symbol'  }
+sub symbol { 'AI::MXNet::LinAlg::Symbol'  }
+sub nd     { 'AI::MXNet::LinAlg::NDArray' }
+sub ndarray { 'AI::MXNet::LinAlg::NDArray' }
 
 1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/LinAlg/NDArray.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/LinAlg/NDArray.pm
@@ -15,15 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-package AI::MXNet::Contrib;
+package AI::MXNet::LinAlg::NDArray;
 use strict;
 use warnings;
-use AI::MXNet::Contrib::Symbol;
-use AI::MXNet::Contrib::NDArray;
 
-sub sym    { 'AI::MXNet::Contrib::Symbol'  }
-sub symbol { 'AI::MXNet::Contrib::Symbol'  }
-sub nd     { 'AI::MXNet::Contrib::NDArray' }
-sub ndarray { 'AI::MXNet::Contrib::NDArray' }
+sub AUTOLOAD {
+    my $sub = $AI::MXNet::LinAlg::NDArray::AUTOLOAD;
+    $sub =~ s/.*:://;
+    $sub = "_linalg_$sub";
+    shift;
+    return AI::MXNet::NDArray->$sub(@_);
+}
 
 1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/LinAlg/Symbol.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/LinAlg/Symbol.pm
@@ -15,15 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-package AI::MXNet::Contrib;
+package AI::MXNet::LinAlg::Symbol;
 use strict;
 use warnings;
-use AI::MXNet::Contrib::Symbol;
-use AI::MXNet::Contrib::NDArray;
 
-sub sym    { 'AI::MXNet::Contrib::Symbol'  }
-sub symbol { 'AI::MXNet::Contrib::Symbol'  }
-sub nd     { 'AI::MXNet::Contrib::NDArray' }
-sub ndarray { 'AI::MXNet::Contrib::NDArray' }
+sub AUTOLOAD {
+    my $sub = $AI::MXNet::LinAlg::Symbol::AUTOLOAD;
+    $sub =~ s/.*:://;
+    $sub = "_linalg_$sub";
+    shift;
+    return AI::MXNet::Symbol->$sub(@_);
+}
 
 1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/NDArray.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/NDArray.pm
@@ -1599,5 +1599,6 @@ EOV
 sub contrib { 'AI::MXNet::Contrib::NDArray' }
 sub random  { 'AI::MXNet::Random' }
 sub sparse  { 'AI::MXNet::NDArray::Sparse' }
+sub linalg  { 'AI::MXNet::LinAlg::NDArray' }
 
 __PACKAGE__->meta->make_immutable;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Symbol.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Symbol.pm
@@ -1498,5 +1498,6 @@ sub  _ufunc_helper
 sub contrib { 'AI::MXNet::Contrib::Symbol' }
 sub random  { 'AI::MXNet::Symbol::Random' }
 sub sparse  { 'AI::MXNet::Symbol::Sparse' }
+sub linalg  { 'AI::MXNet::LinAlg::Symbol' }
 
 1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/TestUtils.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/TestUtils.pm
@@ -29,7 +29,7 @@ use base qw(Exporter);
 @AI::MXNet::TestUtils::EXPORT_OK = qw(same reldiff almost_equal GetMNIST_ubyte
                                       GetCifar10 pdl_maximum pdl_minimum mlp2 conv dies_ok
                                       check_consistency zip assert enumerate same_array dies_like allclose rand_shape_2d
-                                      rand_shape_3d rand_sparse_ndarray random_arrays rand_ndarray randint);
+                                      rand_shape_3d rand_sparse_ndarray random_arrays rand_ndarray randint pdl);
 use constant default_numerical_threshold => 1e-6;
 =head1 NAME
 

--- a/perl-package/AI-MXNet/t/test_ndarray.t
+++ b/perl-package/AI-MXNet/t/test_ndarray.t
@@ -18,8 +18,8 @@
 use strict;
 use warnings;
 use AI::MXNet qw(mx);
-use AI::MXNet::TestUtils qw(almost_equal same);
-use Test::More tests => 17;
+use AI::MXNet::TestUtils qw(almost_equal same pdl);
+use Test::More tests => 19;
 
 sub test_ndarray_reshape
 {
@@ -139,8 +139,29 @@ sub test_ndarray_slice
     ok(($a->slice([mx->nd->array([1, 1, 0]), mx->nd->array([0, 1, 0])])->aspdl == mx->nd->array([2, 3, 0])->aspdl)->all);
 }
 
+sub test_linalg_gemm2
+{
+    # Single matrix multiply
+    my $A = mx->nd->array([[1.0, 1.0], [1.0, 1.0]]);
+    my $B = mx->nd->array([[1.0, 1.0], [1.0, 1.0], [1.0, 1.0]]);
+    ok(almost_equal(
+        mx->nd->linalg->gemm2($A, $B, transpose_b=>1, alpha=>2.0)->aspdl,
+        pdl([[4.0, 4.0, 4.0], [4.0, 4.0, 4.0]])
+    ));
+
+    # Batch matrix multiply
+    $A = mx->nd->array([[[1.0, 1.0]], [[0.1, 0.1]]]);
+    $B = mx->nd->array([[[1.0, 1.0]], [[0.1, 0.1]]]);
+    ok(almost_equal(
+        mx->nd->linalg->gemm2($A, $B, transpose_b=>1, alpha=>2.0)->aspdl,
+        pdl([[[4.0]], [[0.04]]])
+    ));
+}
+
 test_ndarray_slice();
 test_ndarray_reshape();
 test_moveaxis();
 test_output();
 test_cached();
+test_linalg_gemm2();
+


### PR DESCRIPTION
## Description ##
Added support for linear algebra operations on symbols/ndarrays for Perl API

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
