### PR TITLE
[MXNET-286] Removed OpenMP from armv6 builds

### DIFF
--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -28,7 +28,6 @@ ENV TARGET ARMV6
 WORKDIR /work/deps
 
 # Build OpenBLAS
-ADD https://api.github.com/repos/xianyi/OpenBLAS/git/refs/tags/v0.2.20 openblas_version.json
 RUN git clone --recursive -b v0.2.20 https://github.com/xianyi/OpenBLAS.git && \
     cd OpenBLAS && \
     make -j$(nproc) && \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -87,6 +87,7 @@ build_armv6() {
         -DCMAKE_TOOLCHAIN_FILE=$CROSS_ROOT/Toolchain.cmake \
         -DUSE_CUDA=OFF \
         -DUSE_OPENCV=OFF \
+        -DUSE_OPENMP=OFF \
         -DUSE_SIGNAL_HANDLER=ON \
         -DCMAKE_BUILD_TYPE=Release \
         -DUSE_MKL_IF_AVAILABLE=OFF \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -83,6 +83,8 @@ build_armv6() {
     # file tries to add -llapack. Lapack functionality though, requires -lgfortran
     # to be linked additionally.
 
+    # We do not need OpenMP, since most armv6 systems have only 1 core
+
     cmake \
         -DCMAKE_TOOLCHAIN_FILE=$CROSS_ROOT/Toolchain.cmake \
         -DUSE_CUDA=OFF \


### PR DESCRIPTION
## Description ##

Switched OpenMP off for armv6 builds.

## Checklist ##
### Essentials ###
- [x] The PR does not start with [MXNET-$JIRA_ID] since it's minor
- [x] Changes are complete

### Changes ###
- [x] Switched USE_OPENMP off (most armv6 systems have only 1 core)
- [x] Removed github API call for version caching for OpenBLAS since ci might hit the limits very quickly ([only 60 per hr](https://developer.github.com/changes/2012-10-14-rate-limit-changes/))

## Comments ##
- This should fix https://github.com/apache/incubator-mxnet/issues/10230
