### PR TITLE
CUDNN not training on backward pass similar to pytorch

### DIFF
--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1787,6 +1787,7 @@ def test_incorrect_gpu():
     # Try setting dev_id to a really big number
     assert_raises(MXNetError, mx.nd.ones, (2,2), ctx=mx.gpu(100001))
 
+@with_seed()
 def test_batchnorm_backwards_notrain():
     for ctx in [mx.cpu(0), mx.gpu(0)]:
         for cudnn_o in [False, True]:

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -27,6 +27,7 @@ import unittest
 from nose.tools import assert_raises
 from mxnet.test_utils import check_consistency, set_default_context, assert_almost_equal
 from mxnet.base import MXNetError
+from mxnet import autograd
 from numpy.testing import assert_allclose
 
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
@@ -1786,7 +1787,23 @@ def test_incorrect_gpu():
     # Try setting dev_id to a really big number
     assert_raises(MXNetError, mx.nd.ones, (2,2), ctx=mx.gpu(100001))
 
+def test_batchnorm_backwards_notrain():
+    for ctx in [mx.cpu(0), mx.gpu(0)]:
+        for cudnn_o in [False, True]:
+            B,C,H,W = 4,3,2,2
+            x = mx.nd.random.poisson(1,shape=(B,C,H,W)).as_in_context(ctx)
+            gamma = mx.nd.random.normal(shape=(C)).as_in_context(ctx)
+            beta = mx.nd.random.normal(shape=(C)).as_in_context(ctx)
+            mean = mx.nd.random.normal(shape=(C)).as_in_context(ctx)
+            std = mx.nd.random.normal(shape=(C)).as_in_context(ctx)
+            x.attach_grad()
+
+            with autograd.record(False):
+                y = mx.ndarray.BatchNorm(x, gamma, beta, mean, std.square(),
+                                         fix_gamma=False, cudnn_off=cudnn_o)
+                loss=y.square().sum()
+            loss.backward(train_mode=False)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()
-


### PR DESCRIPTION
Pytorch fix: https://github.com/pytorch/pytorch/issues/4284

Issue: https://github.com/apache/incubator-mxnet/issues/9648

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
