### PR TITLE
Change the cuda version for docs test script

### DIFF
--- a/tests/jenkins/run_test_installation_docs.sh
+++ b/tests/jenkins/run_test_installation_docs.sh
@@ -302,13 +302,13 @@ echo
 echo "### Testing Virtualenv ###"
 echo "${virtualenv_commands}"
 echo
-nvidia-docker run --rm nvidia/cuda:7.5-cudnn5-devel bash -c "${virtualenv_commands}"
+nvidia-docker run --rm nvidia/cuda:9.0-cudnn7-devel bash -c "${virtualenv_commands}"
 
 echo
 echo "### Testing Pip ###"
 echo "${pip_commands}"
 echo
-nvidia-docker run --rm nvidia/cuda:7.5-cudnn5-devel bash -c "${pip_commands}"
+nvidia-docker run --rm nvidia/cuda:9.0-cudnn7-devel bash -c "${pip_commands}"
 
 echo
 echo "### Testing Docker ###"
@@ -320,4 +320,4 @@ echo
 echo "### Testing Build From Source ###"
 echo "${buildfromsource_commands}"
 echo
-nvidia-docker run --rm nvidia/cuda:7.5-cudnn5-devel bash -c "${buildfromsource_commands}"
+nvidia-docker run --rm nvidia/cuda:9.0-cudnn7-devel bash -c "${buildfromsource_commands}"


### PR DESCRIPTION
## Description ##
Installation Guide Nightly test is failing due to old cuda version. 
Update the CUDA version from 7.5 to 9.0. 

@aaronmarkham @b0noI  Can you please review soon!
@anirudh2290 This needs to make it into 1.2 release

NOTE: I have not updated the cuda version to 9.1 since the slaves on the old(nightly) CI do not have the correct nvidia drivers. These tests are being migrated to the official CI in the coming weeks. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Updated cuda from 7.5 to 9.0
- [ ] Updated Cudnn from 5 to 7

## Comments ##
- We will know whether this change fixes the nightly test as expected only after the PR is merged and I run the nightly test.
