### PR TITLE
Fix infer storage type

### DIFF
--- a/python/mxnet/operator.py
+++ b/python/mxnet/operator.py
@@ -552,9 +552,9 @@ class CustomOpProp(object):
             "Default infer_storage_type implementation doesnt allow non default stypes: " \
             "found non default stype '%s' for in_stype[%d]. Please implement " \
             "infer_storage_type and infer_storage_type_backward interface " \
-            "in your custom operator if you have non-default input stypes" % (stype, i)
-        return in_stype, [in_stype[0]]*len(self.list_outputs()), \
-            [in_stype[0]]*len(self.list_auxiliary_states())
+            "in your custom operator if you have non-default input/output stypes" % (stype, i)
+        return in_stype, [_STORAGE_TYPE_ID_TO_STR[_STORAGE_TYPE_DEFAULT]]*len(self.list_outputs()), \
+            [_STORAGE_TYPE_ID_TO_STR[_STORAGE_TYPE_DEFAULT]]*len(self.list_auxiliary_states())
 
     def infer_storage_type_backward(self, ograd_stype, in_stype, out_stype, igrad_stype, aux_stype):
         """infer_storage_type_backward interface. Used to infer storage

--- a/python/mxnet/operator.py
+++ b/python/mxnet/operator.py
@@ -553,8 +553,9 @@ class CustomOpProp(object):
             "found non default stype '%s' for in_stype[%d]. Please implement " \
             "infer_storage_type and infer_storage_type_backward interface " \
             "in your custom operator if you have non-default input/output stypes" % (stype, i)
-        return in_stype, [_STORAGE_TYPE_ID_TO_STR[_STORAGE_TYPE_DEFAULT]]*len(self.list_outputs()), \
-            [_STORAGE_TYPE_ID_TO_STR[_STORAGE_TYPE_DEFAULT]]*len(self.list_auxiliary_states())
+        return in_stype, \
+               [_STORAGE_TYPE_ID_TO_STR[_STORAGE_TYPE_DEFAULT]]*len(self.list_outputs()), \
+               [_STORAGE_TYPE_ID_TO_STR[_STORAGE_TYPE_DEFAULT]]*len(self.list_auxiliary_states())
 
     def infer_storage_type_backward(self, ograd_stype, in_stype, out_stype, igrad_stype, aux_stype):
         """infer_storage_type_backward interface. Used to infer storage


### PR DESCRIPTION
## Description ##
Fix infer_storage_type. Please see: https://github.com/apache/incubator-mxnet/issues/10503
Since input list can be empty, indexing for in_stype[0] fails. Since the default implementations for `infer_storage_type` and `infer_storage_type_backward` dont support non-default stypes, forcing stype to be default for output and aux_stypes.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
