### PR TITLE
[MXNET-311] Change the docker image for Installation Guide Test - needs sudo

### DIFF
--- a/tests/jenkins/run_test_installation_docs.sh
+++ b/tests/jenkins/run_test_installation_docs.sh
@@ -298,17 +298,20 @@ LINUX_PYTHON_GPU_END_LINENO=$(grep -n "END - Linux Python GPU Installation Instr
 
 set_instruction_set ${LINUX_PYTHON_GPU_START_LINENO} ${LINUX_PYTHON_GPU_END_LINENO}
 
+
+# mxnet/base-cuda9 is a simple Docker Image with 'nvidia/cuda:9.0-cudnn7-devel' and 'apt-get install sudo'.
+
 echo
 echo "### Testing Virtualenv ###"
 echo "${virtualenv_commands}"
 echo
-nvidia-docker run --rm nvidia/cuda:9.0-cudnn7-devel bash -c "${virtualenv_commands}"
+nvidia-docker run --rm mxnet/base-cuda9 bash -c "${virtualenv_commands}"
 
 echo
 echo "### Testing Pip ###"
 echo "${pip_commands}"
 echo
-nvidia-docker run --rm nvidia/cuda:9.0-cudnn7-devel bash -c "${pip_commands}"
+nvidia-docker run --rm mxnet/base-cuda9 bash -c "${pip_commands}"
 
 echo
 echo "### Testing Docker ###"
@@ -320,4 +323,4 @@ echo
 echo "### Testing Build From Source ###"
 echo "${buildfromsource_commands}"
 echo
-nvidia-docker run --rm nvidia/cuda:9.0-cudnn7-devel bash -c "${buildfromsource_commands}"
+nvidia-docker run --rm mxnet/base-cuda9 bash -c "${buildfromsource_commands}"


### PR DESCRIPTION
## Description ##
The installation guide test used to pull a Cuda docker image from dockerhub and run tests inside this container. Earlier this test was running in cuda7.5 containers which had 'sudo' installed inside it. I changed this to cuda9 a couple of days back. 

However, the latest cuda docker images - `nvidia/cuda:9.0-cudnn7-devel` and `nvidia/cuda:8.0-cudnn5-devel` do not have `sudo` installed which is needed by the scripts in the mxnet installation page. 

Hence I have created a simple docker image on the host called mxnet/base-cuda9 which only has the following - 
1. `nvidia/cuda:9.0-cudnn7-devel`
2. `sudo`

Please Note: 
1. These tests are going to run on the official MXNet CI soon and these docker images will not be needed at that point since I plan to fix the script itself.
2. The dockerfile and docker Image are only present on the Jenkins setup where this nightly test is running. Please add a comment below if you would like me to add this image to the MXNet dockerhub repo. 


@anirudh2290 This needs to go into 1.2 to make a nightly test pass. 
@gautamkmr @b0noI Can you please review!

## Checklist ##
### Essentials ###

- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Created a new docker image on the slave where these nightly tests run, I can publish this image to dockerhub if needed. 
- [x] Changed the installation guide GPU tests to run in this new docker container

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
