### PR TITLE
Prevent partially update of ParameterDict

### DIFF
--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -661,8 +661,8 @@ class ParameterDict(object):
                 assert self._params[k] is v, \
                     "Cannot update self with other because they have different " \
                     "Parameters with the same name '%s'"%k
-            else:
-                self._params[k] = v
+        for k, v in other.items():
+            self._params[k] = v
 
     def initialize(self, init=initializer.Uniform(), ctx=None, verbose=False,
                    force_reinit=False):

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -661,6 +661,7 @@ class ParameterDict(object):
                 assert self._params[k] is v, \
                     "Cannot update self with other because they have different " \
                     "Parameters with the same name '%s'"%k
+
         for k, v in other.items():
             self._params[k] = v
 


### PR DESCRIPTION
As you can see in the following execution log, `mxnet.gluon.parameter.ParameterDict#update` method partially updates the receiver when the assertion error is occurred by duplicated keys.
Is this intentional processing?

```
$ python
Python 3.6.4 (default, Apr  3 2018, 09:35:44)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from mxnet.gluon.parameter import ParameterDict
>>> pd1 = ParameterDict()
>>> pd2 = ParameterDict()
>>> pd1.get('a')
Parameter a (shape=None, dtype=<class 'numpy.float32'>)
>>> pd1.get('b')
Parameter b (shape=None, dtype=<class 'numpy.float32'>)
>>> pd1.get('c')
Parameter c (shape=None, dtype=<class 'numpy.float32'>)
>>> pd2.get('d')
Parameter d (shape=None, dtype=<class 'numpy.float32'>)
>>> pd2.get('b')
Parameter b (shape=None, dtype=<class 'numpy.float32'>)
>>> pd2.get('e')
Parameter e (shape=None, dtype=<class 'numpy.float32'>)
>>> pd1
(
  Parameter a (shape=None, dtype=<class 'numpy.float32'>)
  Parameter b (shape=None, dtype=<class 'numpy.float32'>)
  Parameter c (shape=None, dtype=<class 'numpy.float32'>)
)
>>> pd2
(
  Parameter d (shape=None, dtype=<class 'numpy.float32'>)
  Parameter b (shape=None, dtype=<class 'numpy.float32'>)
  Parameter e (shape=None, dtype=<class 'numpy.float32'>)
)
>>> pd1.update(pd2)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mrkn/.pyenv/versions/3.6.4/Python.framework/Versions/3.6/lib/python3.6/site-packages/mxnet/gluon/parameter.py", line 557, in update
    "Parameters with the same name %s"%k
AssertionError: Cannot update self with other because they have different Parameters with the same name b
>>> pd1
(
  Parameter a (shape=None, dtype=<class 'numpy.float32'>)
  Parameter b (shape=None, dtype=<class 'numpy.float32'>)
  Parameter c (shape=None, dtype=<class 'numpy.float32'>)
  Parameter d (shape=None, dtype=<class 'numpy.float32'>)
)
>>>
```