### PR TITLE
Jetson build with cmake and CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ if(USE_CUDA AND NOT USE_OLDCMAKECUDA)
         (${CMAKE_GENERATOR} MATCHES "Visual Studio.*")
         OR (${CMAKE_GENERATOR} MATCHES "Xcode.*")
         OR (${CMAKE_GENERATOR} STREQUAL "Unix Makefiles")
+        OR (${CMAKE_GENERATOR} MATCHES "Ninja")
       ) AND (
         (${CMAKE_VERSION} VERSION_GREATER "3.9.0") OR (${CMAKE_VERSION} VERSION_EQUAL "3.9.0")
       )
@@ -102,7 +103,7 @@ else(MSVC)
   else()
     set(SUPPORT_MSSE2 FALSE)
   endif()
-  set(CMAKE_C_FLAGS "-Wall -Wno-unknown-pragmas -fPIC -Wno-sign-compare")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-unknown-pragmas -fPIC -Wno-sign-compare")
   if ("${CMAKE_CXX_COMPILER_ID}" MATCHES ".*Clang$")
     set(CMAKE_C_FLAGS "-Wno-braced-scalar-init")
   endif()
@@ -198,7 +199,9 @@ if(USE_CUDA)
     if(CUDA_TOOLSET STREQUAL "")
       set(CUDA_TOOLSET "${CUDA_VERSION_STRING}")
     endif()
+  if(NOT CMAKE_GENERATOR_TOOLSET AND CUDA_TOOLSET)
     set(CMAKE_GENERATOR_TOOLSET "cuda=${CUDA_TOOLSET},host=x64")
+  endif()
   else()
     set(FIRST_CUDA FALSE)
   endif()
@@ -325,7 +328,10 @@ if(USE_OPENMP)
   find_package(OpenMP REQUIRED)
   # This should build on Windows, but there's some problem and I don't have a Windows box, so
   # could a Windows user please fix?
-  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/openmp/CMakeLists.txt AND SYSTEM_ARCHITECTURE STREQUAL "x86_64" AND NOT MSVC)
+  if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/openmp/CMakeLists.txt
+      AND SYSTEM_ARCHITECTURE STREQUAL "x86_64"
+      AND NOT MSVC
+      AND NOT CMAKE_CROSSCOMPILING)
     # Intel/llvm OpenMP: https://github.com/llvm-mirror/openmp
     set(OPENMP_STANDALONE_BUILD TRUE)
     set(LIBOMP_ENABLE_SHARED TRUE)

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -32,14 +32,16 @@ ENV TARGET ARMV8
 WORKDIR /work
 
 # Build OpenBLAS
-ADD https://api.github.com/repos/xianyi/OpenBLAS/git/refs/tags/v0.2.20 openblas_version.json
 RUN git clone --recursive -b v0.2.20 https://github.com/xianyi/OpenBLAS.git && \
     cd OpenBLAS && \
     make -j$(nproc) && \
     PREFIX=${CROSS_ROOT} make install
 
-# Setup CUDA build env (including configuring and copying nvcc)
-COPY --from=cudabuilder /usr/local/cuda /usr/local/cuda
+ENV OpenBLAS_HOME=${CROSS_ROOT}
+ENV OpenBLAS_DIR=${CROSS_ROOT}
+
+COPY --from=cudabuilder /usr/local/cuda-9.0 /usr/local/cuda-9.0
+
 ENV TARGET_ARCH aarch64
 ENV TARGET_OS linux
 
@@ -55,12 +57,21 @@ RUN JETPACK_DOWNLOAD_PREFIX=http://developer.download.nvidia.com/devzone/devcent
     apt-key add /var/cuda-repo-9-0-local/7fa2af80.pub && \
     dpkg -i $ARM_CUDNN_INSTALLER_PACKAGE && \
     dpkg -i $ARM_CUDNN_DEV_INSTALLER_PACKAGE && \
-    apt update -y && apt install -y unzip cuda-libraries-dev-9-0 libcudnn7-dev
+    apt update -y
 
-ENV PATH $PATH:/usr/local/cuda/bin
+RUN apt install -yf unzip cuda-libraries-dev-9-0 libcudnn7-dev
+
+RUN ln -s cuda-9.0 /usr/local/cuda
+
+ENV CUDA_PATH=/usr/local/cuda
+ENV CUDA_BIN_PATH=${CUDA_PATH}/bin
+ENV CUDA_LIB_PATH=${CUDA_PATH}/lib64
+
+ENV PATH ${PATH}:${CUDA_BIN_PATH}
+
+RUN ln -s ${CUDA_LIB_PATH}/stubs/libcuda.so ${CUDA_LIB_PATH}/libcuda.so
+
 ENV NVCCFLAGS "-m64"
-ENV CUDA_ARCH "-gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62"
-ENV NVCC /usr/local/cuda/bin/nvcc
 
 COPY runtime_functions.sh /work/
 WORKDIR /work/mxnet


### PR DESCRIPTION
## Description ##

Changed jetson build to cmake.

## Checklist ##
### Essentials ###
- [x] The PR title does not start with [MXNET-$JIRA_ID], since it's a minor change
- [x] Changes are complete
- [x] To the my best knowledge, examples are not affected by this change

### Changes ###
- [x] Added Ninja to possible generators when using CUDA
- [x] Fixed passing CMAKE_C_FLAGS issue
- [x] Disabled CMAKE_GENERATOR_TOOLSET override (actually I think this override should be removed completely, according to the manual this is [undefined behaviour](https://cmake.org/cmake/help/v3.10/variable/CMAKE_GENERATOR_TOOLSET.html))
- [x] Disabled OpenMP build from 3rdparty when cross compiling
- [x] Made 1 cuda directory in the Docker image

## Comments ##
- Tested on Jetson TX2
