### PR TITLE
[MXNET-315] Fix the version select in the navbar to be independent of order

### DIFF
--- a/docs/build_version_doc/AddVersion.py
+++ b/docs/build_version_doc/AddVersion.py
@@ -27,6 +27,7 @@ parser.add_argument('--current_version', type=str, default='master',
                         help='Current version')
 parser.add_argument('--root_url', type=str, default='https://mxnet.incubator.apache.org/',
                         help='Root URL')
+parser.add_argument('--default_tag', type=str, default='master', help='Default Tag')
 
 if __name__ == '__main__':
     args = parser.parse_args()
@@ -46,7 +47,7 @@ if __name__ == '__main__':
                          'style="position: relative">' \
                          '<a href="#" tabindex="-1">Versions(%s)</a><ul class="dropdown-menu">' % (args.current_version)
     for i, tag in enumerate(tag_list):
-        url = root_url if i == 0 else root_url + 'versions/%s/index.html' % (tag)
+        url = root_url if tag == args.default_tag else root_url + 'versions/%s/index.html' % (tag)
         version_str += '<li><a class="main-nav-link" href=%s>%s</a></li>' % (url, tag)
         version_str_mobile += '<li><a tabindex="-1" href=%s>%s</a></li>' % (url, tag)
     version_str += '</ul></span>'

--- a/docs/build_version_doc/update_all_version.sh
+++ b/docs/build_version_doc/update_all_version.sh
@@ -93,7 +93,7 @@ function update_mxnet_css {
 for tag in $tag_list; do
     # This Python script is expecting the tag_list.txt and it will use that as the entries to populate
 
-    python AddVersion.py --root_url "$root_url" --file_path "$built/versions/$tag" --current_version "$tag" || exit 1
+    python AddVersion.py --root_url "$root_url" --file_path "$built/versions/$tag" --current_version "$tag" --default_tag "$tag_default" || exit 1
 
     # Patch any fixes to all versions except 0.11.0.
     # Version 0.11.0 has old theme and does not make use of the current mxnet.css


### PR DESCRIPTION
## Description ##
Fix the version select in the navbar to be independent of the order versions listed. Currently, the default version is taken to be the version at the top of the navbar. Changed the AddVersion script to take it as a parameter.

### Changes ###
- [  x ] Updated update_all_version.sh to pass the default tag as a parameter to AddVersion
- [  x ] Use the default tag parameter to decide the root url

Tested manually by Krishnan and Aaron at http://54.210.6.225/ .
