### PR TITLE
Fix typo in image.py

### DIFF
--- a/python/mxnet/ndarray/image.py
+++ b/python/mxnet/ndarray/image.py
@@ -19,7 +19,7 @@
 # pylint: disable=wildcard-import, unused-wildcard-import
 """Image NDArray API of MXNet."""
 try:
-    from .gen_iamge import *
+    from .gen_image import *
 except ImportError:
     pass
 


### PR DESCRIPTION
Fix typo in image.py

## Description ##
There is a typo in `image.py` so that IDE can't auto-complete functions in `gen_image.py`

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fix typo
