### PR TITLE
ensure kv store is initialized when saving states

### DIFF
--- a/python/mxnet/gluon/trainer.py
+++ b/python/mxnet/gluon/trainer.py
@@ -209,7 +209,7 @@ class Trainer(object):
             Path to output states file.
         """
         assert self._optimizer is not None
-        
+
         if not self._kv_initialized:
             self._init_kvstore()
 

--- a/python/mxnet/gluon/trainer.py
+++ b/python/mxnet/gluon/trainer.py
@@ -209,6 +209,9 @@ class Trainer(object):
             Path to output states file.
         """
         assert self._optimizer is not None
+        
+        if not self._kv_initialized:
+            self._init_kvstore()
 
         if self._update_on_kvstore:
             self._kvstore.save_optimizer_states(fname, dump_optimizer=True)


### PR DESCRIPTION
## Description ##

Minor bugfix for calling `save_states()` on newly created trainer.  Currently you get:
```
>       if self._update_on_kvstore:
E       AttributeError: 'Trainer' object has no attribute '_update_on_kvstore'
```
