### PR TITLE
[MXNET-307] Add utility to get im2rec.py path

### DIFF
--- a/docs/tutorials/basic/data.md
+++ b/docs/tutorials/basic/data.md
@@ -391,8 +391,9 @@ Now let's convert them into record io format using the `im2rec.py` utility scrip
 First, we need to make a list that contains all the image files and their categories:
 
 ```python
-mxnet_path = os.path.dirname(mx.__file__)
-im2rec_path = os.path.join(mxnet_path, 'tools','im2rec.py')
+
+                   
+im2rec_path = mx.test_utils.get_im2rec_path()
 data_path = os.path.join('data','101_ObjectCategories')
 prefix_path = os.path.join('data','caltech')
 

--- a/docs/tutorials/basic/data.md
+++ b/docs/tutorials/basic/data.md
@@ -391,8 +391,6 @@ Now let's convert them into record io format using the `im2rec.py` utility scrip
 First, we need to make a list that contains all the image files and their categories:
 
 ```python
-
-                   
 im2rec_path = mx.test_utils.get_im2rec_path()
 data_path = os.path.join('data','101_ObjectCategories')
 prefix_path = os.path.join('data','caltech')

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1750,9 +1750,8 @@ def get_im2rec_path(home_env="MXNET_HOME"):
     if home_env in os.environ:
         mxnet_path = os.environ[home_env]
     else:
-        # Else use currently imported mxnet as reference 
+        # Else use currently imported mxnet as reference
         mxnet_path = os.path.dirname(mx.__file__)
-        
     # If MXNet was installed through pip, the location of im2rec.py
     im2rec_path = os.path.join(mxnet_path, 'tools', 'im2rec.py')
     if os.path.isfile(im2rec_path):

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1732,6 +1732,37 @@ def mean_check(generator, mu, sigma, nsamples=1000000):
           (sample_mean < mu + 3 * sigma / np.sqrt(nsamples))
     return ret
 
+def get_im2rec_path(home_env="MXNET_HOME"):
+    """Get path to the im2rec.py tool
+
+    Parameters
+    ----------
+
+    home_env : str
+        Env variable that holds the path to the MXNET folder
+
+    Returns
+    -------
+    str
+        The path to im2rec.py
+    """
+    # Check first if the path to MXNET is passed as an env variable
+    if home_env in os.environ:
+        mxnet_path = os.environ[home_env]
+    else:
+        # Else use currently imported mxnet as reference 
+        mxnet_path = os.path.dirname(mx.__file__)
+        
+    # If MXNet was installed through pip, the location of im2rec.py
+    im2rec_path =  os.path.join(mxnet_path, 'tools', 'im2rec.py')
+    if os.path.isfile(im2rec_path):
+        return im2rec_path
+    # If MXNet has been built locally
+    im2rec_path =  os.path.join(mxnet_path, '..', '..', 'tools', 'im2rec.py')
+    if os.path.isfile(im2rec_path):
+        return im2rec_path
+    raise IOError('Could not find path to tools/im2rec.py')
+
 def var_check(generator, sigma, nsamples=1000000):
     """Test the generator by matching the variance.
     It will need a large number of samples and is not recommended to use

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1754,11 +1754,11 @@ def get_im2rec_path(home_env="MXNET_HOME"):
         mxnet_path = os.path.dirname(mx.__file__)
         
     # If MXNet was installed through pip, the location of im2rec.py
-    im2rec_path =  os.path.join(mxnet_path, 'tools', 'im2rec.py')
+    im2rec_path = os.path.join(mxnet_path, 'tools', 'im2rec.py')
     if os.path.isfile(im2rec_path):
         return im2rec_path
     # If MXNet has been built locally
-    im2rec_path =  os.path.join(mxnet_path, '..', '..', 'tools', 'im2rec.py')
+    im2rec_path = os.path.join(mxnet_path, '..', '..', 'tools', 'im2rec.py')
     if os.path.isfile(im2rec_path):
         return im2rec_path
     raise IOError('Could not find path to tools/im2rec.py')


### PR DESCRIPTION
## Description ##

Add a utility to get the path to the `im2rec.py` tool
update the basic/data.md tutorial

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
