### PR TITLE
[MXNET-145] Remove global PRNGs of numpy and python used in mx.image package

### DIFF
--- a/python/mxnet/image/detection.py
+++ b/python/mxnet/image/detection.py
@@ -120,7 +120,8 @@ class DetRandomSelectAug(DetAugmenter):
             return (src, label)
         else:
             tmp_idx = nd.arange(len(self.aug_list), dtype=np.int32)
-            self.aug_list = [self.aug_list[i] for i in random.shuffle(tmp_idx, out=tmp_idx).asnumpy()]
+            self.aug_list = [self.aug_list[i] for i in
+                             random.shuffle(tmp_idx, out=tmp_idx).asnumpy()]
             return self.aug_list[0](src, label)
 
 


### PR DESCRIPTION
## Description ##

This PR replaces global random number generators of numpy and python used in mx.image package with mxnet's random number generators. This is a sequel of PR #10260.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
