### PR TITLE
[MXNET-326] fix filter layout in DepthwiseConv2dBackwardFilterKernel

### DIFF
--- a/src/operator/nn/depthwise_convolution_tf.cuh
+++ b/src/operator/nn/depthwise_convolution_tf.cuh
@@ -458,7 +458,6 @@ DepthwiseConv2dBackwardFilterKernel(const DepthwiseArgs args,
             (filter_width * f_h);
         CUDA_UNROLL for (int f_w = 0; f_w < filter_width; ++f_w) {
           const int in_col = in_col_start + f_w;
-          const int addr_temp = filter_width * f_h;
 
           if (in_row >= 0 && in_row < in_height && in_col >= 0 && in_col < in_width) {
             const int input_offset = input_offset_temp + in_col;

--- a/src/operator/nn/depthwise_convolution_tf.cuh
+++ b/src/operator/nn/depthwise_convolution_tf.cuh
@@ -434,12 +434,15 @@ DepthwiseConv2dBackwardFilterKernel(const DepthwiseArgs args,
         const int input_offset_temp =
             (out_b * in_channel * in_height * in_width) +
             (in_c * in_height * in_width) + (in_row * in_width);
+        const int filter_backprop_temp =
+            (in_channel * filter_width * filter_height) +
+            (filter_width * f_h);
 
         CUDA_UNROLL for (int f_w = 0; f_w < filter_width; ++f_w) {
           const int in_col = in_col_start + f_w;
           const int input_offset = input_offset_temp + in_col;
           DType partial_sum = ldg(input + input_offset) * out_bp;
-          DType* addr = filter_backprop + (in_c + in_channel * (f_w + filter_width * f_h));
+          DType* addr = filter_backprop + (filter_backprop_temp + f_w);
           atomicAdd(addr, partial_sum);
         }
       }
@@ -450,6 +453,9 @@ DepthwiseConv2dBackwardFilterKernel(const DepthwiseArgs args,
         const int input_offset_temp =
             (out_b * in_channel * in_height * in_width) +
             (in_c * in_height * in_width) + (in_row * in_width);
+        const int filter_backprop_temp =
+            (in_channel * filter_width * filter_height) +
+            (filter_width * f_h);
         CUDA_UNROLL for (int f_w = 0; f_w < filter_width; ++f_w) {
           const int in_col = in_col_start + f_w;
           const int addr_temp = filter_width * f_h;
@@ -457,7 +463,7 @@ DepthwiseConv2dBackwardFilterKernel(const DepthwiseArgs args,
           if (in_row >= 0 && in_row < in_height && in_col >= 0 && in_col < in_width) {
             const int input_offset = input_offset_temp + in_col;
             DType partial_sum = ldg(input + input_offset) * out_bp;
-            DType* addr = filter_backprop + (in_c + in_channel * (f_w + addr_temp));
+            DType* addr = filter_backprop + (filter_backprop_temp + f_w);
             // Potentially many threads can add to the same address so we have
             // to use atomic add here.
             // TODO(jmchen): If atomic add turns out to be slow, we can:

--- a/src/operator/nn/depthwise_convolution_tf.cuh
+++ b/src/operator/nn/depthwise_convolution_tf.cuh
@@ -435,7 +435,7 @@ DepthwiseConv2dBackwardFilterKernel(const DepthwiseArgs args,
             (out_b * in_channel * in_height * in_width) +
             (in_c * in_height * in_width) + (in_row * in_width);
         const int filter_backprop_temp =
-            (in_channel * filter_width * filter_height) +
+            (in_c * filter_width * filter_height) +
             (filter_width * f_h);
 
         CUDA_UNROLL for (int f_w = 0; f_w < filter_width; ++f_w) {
@@ -454,7 +454,7 @@ DepthwiseConv2dBackwardFilterKernel(const DepthwiseArgs args,
             (out_b * in_channel * in_height * in_width) +
             (in_c * in_height * in_width) + (in_row * in_width);
         const int filter_backprop_temp =
-            (in_channel * filter_width * filter_height) +
+            (in_c * filter_width * filter_height) +
             (filter_width * f_h);
         CUDA_UNROLL for (int f_w = 0; f_w < filter_width; ++f_w) {
           const int in_col = in_col_start + f_w;

--- a/src/operator/nn/mkldnn/mkldnn_base.cc
+++ b/src/operator/nn/mkldnn/mkldnn_base.cc
@@ -239,6 +239,7 @@ mkldnn_memory_format_t GetDefaultFormat(const mkldnn::memory::desc &desc) {
       case mkldnn_gOihw8o:
       case mkldnn_Goihw8g:
       case mkldnn_gOihw16o:
+      case mkldnn_Goihw16g:
       case mkldnn_gOhwi8o:
       case mkldnn_gOhwi16o:
       case mkldnn_gOhIw16o4i:

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -77,4 +77,11 @@ TEST(MKLDNN_UTIL_FUNC, AlignMem) {
   LOG(INFO) << "Skipped for GCC " << __GNUC__ << "." << __GNUC_MINOR__;
 #endif
 }
+
+TEST(MKLDNN_UTIL_FUNC, MemFormat) {
+  // Check whether the number of format is correct.
+  CHECK_EQ(mkldnn_format_last, 56);
+  CHECK_EQ(mkldnn_nchw, 5);
+  CHECK_EQ(mkldnn_oihw, 12);
+}
 #endif

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1259,7 +1259,6 @@ def test_convolution_grouping():
             np.testing.assert_allclose(arr1.asnumpy(), arr2.asnumpy(), rtol=1e-3, atol=1e-4)
 
 
-@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/8712")
 @with_seed()
 def test_depthwise_convolution():
     for dim in [1,2]:

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1139,6 +1139,7 @@ def test_nearest_upsampling():
                     check_nearest_upsampling_with_shape(shapes, scale, root_scale)
 
 
+@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/8044")
 @with_seed()
 def test_batchnorm_training():
     def check_batchnorm_training(stype):

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1139,7 +1139,6 @@ def test_nearest_upsampling():
                     check_nearest_upsampling_with_shape(shapes, scale, root_scale)
 
 
-@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/8044")
 @with_seed()
 def test_batchnorm_training():
     def check_batchnorm_training(stype):


### PR DESCRIPTION
## Description ##
the filter layout should be NCHW, while the exsiting code write as NHWC, which is wrong.
this change fix it.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
