### PR TITLE
[MXNET-327] Fix docker disk-space leak by rearranging ubuntu_build_cuda

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu_build_cuda
+++ b/ci/docker/Dockerfile.build.ubuntu_build_cuda
@@ -41,13 +41,15 @@ COPY install/ubuntu_clang.sh /work/
 RUN /work/ubuntu_clang.sh
 COPY install/ubuntu_mklml.sh /work/
 RUN /work/ubuntu_mklml.sh
-COPY install/ubuntu_adduser.sh /work/
-RUN /work/ubuntu_adduser.sh
 
 # Special case because the CPP-Package requires the CUDA runtime libs
-# and not only stubs..
+# and not only stubs (which are provided by the base image)
 COPY install/ubuntu_nvidia.sh /work/
 RUN /work/ubuntu_nvidia.sh
+
+# Keep this at the end since this command is not cachable
+COPY install/ubuntu_adduser.sh /work/
+RUN /work/ubuntu_adduser.sh
 
 COPY runtime_functions.sh /work/
 


### PR DESCRIPTION
## Description ##
This PR fixes the docker disk-space leak which was caused by our CI constantly re-creating docker layers and invalidating the cache. The reason for this was that the ```nvidia-install``` script was executed after the uncacheable ```add_user``` script. This result in every single run creating a new layer. While this is usally no problem since the following layers are very small and compressed into a single layer, this caused problems if a big layer like ```Nvidia-install``` is being re-created during every single run.

Also, this speeds up the spin-up time of GPU build jobs. Considering the fact that the GPU build job is on our critical path, this will reduce the overall runtime of a CI job by about 5 minutes.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Reduced disk-space consumption on Ubuntu CPU slaves
- Higher execution speed of all jobs that build with CUDA. 

