### PR TITLE
[MXNET-328] Reduce jenkins timeout from 24 to 2h and add timeout to all jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ mx_mkldnn_lib = 'lib/libmxnet.so, lib/libmxnet.a, lib/libiomp5.so, lib/libmkldnn
 // command to start a docker container
 docker_run = 'tests/ci_build/ci_build.sh'
 // timeout in minutes
-max_time = 1440
+max_time = 120
 // assign any caught errors here
 err = null
 
@@ -137,115 +137,141 @@ try {
     parallel 'CPU: CentOS 7': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-centos7-cpu') {
-          init_git()
-          sh "ci/build.py --platform centos7_cpu /work/runtime_functions.sh build_centos7_cpu"
-          pack_lib('centos7_cpu')
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform centos7_cpu /work/runtime_functions.sh build_centos7_cpu"
+            pack_lib('centos7_cpu')
+          }
         }
       }
     },
     'CPU: CentOS 7 MKLDNN': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-centos7-mkldnn') {
-          init_git()
-          sh "ci/build.py --platform centos7_cpu /work/runtime_functions.sh build_centos7_mkldnn"
-          pack_lib('centos7_mkldnn')
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform centos7_cpu /work/runtime_functions.sh build_centos7_mkldnn"
+            pack_lib('centos7_mkldnn')
+          }
         }
       }
     },
     'GPU: CentOS 7': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-centos7-gpu') {
-          init_git()
-          sh "ci/build.py --platform centos7_gpu /work/runtime_functions.sh build_centos7_gpu"
-          pack_lib('centos7_gpu')
+          timeout(time: max_time, unit: 'MINUTES') { 
+            init_git()
+            sh "ci/build.py --platform centos7_gpu /work/runtime_functions.sh build_centos7_gpu"
+            pack_lib('centos7_gpu')
+          }
         }
       }
     },
     'CPU: Openblas': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-cpu-openblas') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_openblas"
-          pack_lib('cpu', mx_dist_lib)
+          timeout(time: max_time, unit: 'MINUTES') { 
+            init_git()
+            sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_openblas"
+            pack_lib('cpu', mx_dist_lib)
+          }
         }
       }
     },
     'CPU: Clang 3.9': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-cpu-clang39') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_clang39"
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_clang39"
+          }
         }
       }
     },
     'CPU: Clang 5': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-cpu-clang50') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_clang50"
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_clang50"
+          }
         }
       }
     },
     'CPU: Clang 3.9 MKLDNN': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-cpu-mkldnn-clang39') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_clang39_mkldnn"
-          pack_lib('mkldnn_cpu_clang3', mx_mkldnn_lib)
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_clang39_mkldnn"
+            pack_lib('mkldnn_cpu_clang3', mx_mkldnn_lib)
+          }
         }
       }
     },
     'CPU: Clang 5 MKLDNN': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-cpu-mkldnn-clang50') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_clang50_mkldnn"
-          pack_lib('mkldnn_cpu_clang5', mx_mkldnn_lib)
+          timeout(time: max_time, unit: 'MINUTES') { 
+            init_git()
+            sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_clang50_mkldnn"
+            pack_lib('mkldnn_cpu_clang5', mx_mkldnn_lib)
+          }
         }
       }
     },
     'CPU: MKLDNN': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-mkldnn-cpu') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_mkldnn"
-          pack_lib('mkldnn_cpu', mx_mkldnn_lib)
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_mkldnn"
+            pack_lib('mkldnn_cpu', mx_mkldnn_lib)
+          }
         }
       }
     },
     'GPU: MKLDNN': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-mkldnn-gpu') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_build_cuda /work/runtime_functions.sh build_ubuntu_gpu_mkldnn"
-          pack_lib('mkldnn_gpu', mx_mkldnn_lib)
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform ubuntu_build_cuda /work/runtime_functions.sh build_ubuntu_gpu_mkldnn"
+            pack_lib('mkldnn_gpu', mx_mkldnn_lib)
+          }  
         }
       }
     },
     'GPU: CUDA9.1+cuDNN7': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-gpu') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_build_cuda /work/runtime_functions.sh build_ubuntu_gpu_cuda91_cudnn7"
-          pack_lib('gpu', mx_dist_lib)
-          stash includes: 'build/cpp-package/example/test_score', name: 'cpp_test_score'
-          stash includes: 'build/cpp-package/example/test_optimizer', name: 'cpp_test_optimizer'
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform ubuntu_build_cuda /work/runtime_functions.sh build_ubuntu_gpu_cuda91_cudnn7"
+            pack_lib('gpu', mx_dist_lib)
+            stash includes: 'build/cpp-package/example/test_score', name: 'cpp_test_score'
+            stash includes: 'build/cpp-package/example/test_optimizer', name: 'cpp_test_optimizer'
+          }
         }
       }
     },
     'Amalgamation MIN': {
       node('mxnetlinux-cpu') {
         ws('workspace/amalgamationmin') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_amalgamation_min"
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_amalgamation_min"
+          }
         }
       }
     },
     'Amalgamation': {
       node('mxnetlinux-cpu') {
         ws('workspace/amalgamation') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_amalgamation"
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_amalgamation"
+          }
         }
       }
     },
@@ -253,18 +279,22 @@ try {
     'GPU: CMake MKLDNN': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-cmake-mkldnn-gpu') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_gpu /work/runtime_functions.sh build_ubuntu_gpu_cmake_mkldnn" //build_cuda
-          pack_lib('cmake_mkldnn_gpu', mx_cmake_mkldnn_lib)
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform ubuntu_gpu /work/runtime_functions.sh build_ubuntu_gpu_cmake_mkldnn" //build_cuda
+            pack_lib('cmake_mkldnn_gpu', mx_cmake_mkldnn_lib)
+          }
         }
       }
     },
     'GPU: CMake': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-cmake-gpu') {
-          init_git()
-          sh "ci/build.py --platform ubuntu_gpu /work/runtime_functions.sh build_ubuntu_gpu_cmake" //build_cuda
-          pack_lib('cmake_gpu', mx_cmake_lib)
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform ubuntu_gpu /work/runtime_functions.sh build_ubuntu_gpu_cmake" //build_cuda
+            pack_lib('cmake_gpu', mx_cmake_lib)
+          }
         }
       }
     },
@@ -337,24 +367,30 @@ try {
     'NVidia Jetson / ARMv8':{
       node('mxnetlinux-cpu') {
         ws('workspace/build-jetson-armv8') {
-          init_git()
-          sh "ci/build.py --platform jetson /work/runtime_functions.sh build_jetson"
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform jetson /work/runtime_functions.sh build_jetson"
+          }
         }
       }
     },
     'Raspberry / ARMv7':{
       node('mxnetlinux-cpu') {
         ws('workspace/build-raspberry-armv7') {
-          init_git()
-          sh "ci/build.py --platform armv7 /work/runtime_functions.sh build_armv7"
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform armv7 /work/runtime_functions.sh build_armv7"
+          }
         }
       }
     },
     'Raspberry / ARMv6l':{
       node('mxnetlinux-cpu') {
         ws('workspace/build-raspberry-armv6') {
-          init_git()
-          sh "ci/build.py --platform armv6 /work/runtime_functions.sh build_armv6"
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            sh "ci/build.py --platform armv6 /work/runtime_functions.sh build_armv6"
+          }
         }
       }
     }
@@ -400,18 +436,22 @@ try {
     'Python2: Quantize GPU': {
       node('mxnetlinux-gpu-p3') {
         ws('workspace/ut-python2-quantize-gpu') {
-          init_git()
-          unpack_lib('gpu', mx_lib)
-          sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh unittest_ubuntu_python2_quantization_gpu"
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('gpu', mx_lib)
+            sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh unittest_ubuntu_python2_quantization_gpu"
+          }
         }
       }
     },
     'Python3: Quantize GPU': {
       node('mxnetlinux-gpu-p3') {
         ws('workspace/ut-python3-quantize-gpu') {
-          init_git()
-          unpack_lib('gpu', mx_lib)
-          sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh unittest_ubuntu_python3_quantization_gpu"
+          timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('gpu', mx_lib)
+            sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh unittest_ubuntu_python3_quantization_gpu"
+          }
         }
       }
     },
@@ -454,9 +494,9 @@ try {
     'Python3: CentOS 7 CPU': {
       node('mxnetlinux-cpu') {
         ws('workspace/build-centos7-cpu') {
-          init_git()
-          unpack_lib('centos7_cpu')
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('centos7_cpu')
             sh "ci/build.py --platform centos7_cpu /work/runtime_functions.sh unittest_centos7_cpu"
           }
         }
@@ -465,9 +505,9 @@ try {
     'Python3: CentOS 7 GPU': {
       node('mxnetlinux-gpu') {
         ws('workspace/build-centos7-gpu') {
-          init_git()
-          unpack_lib('centos7_gpu')
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('centos7_gpu')
             sh "ci/build.py --nvidiadocker --platform centos7_gpu /work/runtime_functions.sh unittest_centos7_gpu"
           }
         }
@@ -476,9 +516,9 @@ try {
     'Scala: CPU': {
       node('mxnetlinux-cpu') {
         ws('workspace/ut-scala-cpu') {
-          init_git()
-          unpack_lib('cpu', mx_dist_lib)
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('cpu', mx_dist_lib)
             sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh unittest_ubuntu_cpu_scala"
           }
         }
@@ -487,9 +527,9 @@ try {
     'Scala: GPU': {
       node('mxnetlinux-gpu') {
         ws('workspace/ut-scala-gpu') {
-          init_git()
-          unpack_lib('gpu', mx_dist_lib)
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('gpu', mx_dist_lib)
             sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh unittest_ubuntu_gpu_scala"
           }
         }
@@ -498,9 +538,9 @@ try {
     'Perl: CPU': {
       node('mxnetlinux-cpu') {
         ws('workspace/ut-perl-cpu') {
-          init_git()
-          unpack_lib('cpu')
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('cpu')
             sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh unittest_ubuntu_cpugpu_perl"
           }
         }
@@ -509,9 +549,9 @@ try {
     'Perl: GPU': {
       node('mxnetlinux-gpu') {
         ws('workspace/ut-perl-gpu') {
-          init_git()
-          unpack_lib('gpu')
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('gpu')
             sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh unittest_ubuntu_cpugpu_perl"
           }
         }
@@ -520,9 +560,9 @@ try {
     'Cpp: GPU': {
       node('mxnetlinux-gpu') {
         ws('workspace/ut-cpp-gpu') {
-          init_git()
-          unpack_lib('cmake_gpu', mx_cmake_lib)
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('cmake_gpu', mx_cmake_lib)
             sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh unittest_ubuntu_gpu_cpp"
           }
         }
@@ -531,9 +571,9 @@ try {
     'R: CPU': {
       node('mxnetlinux-cpu') {
         ws('workspace/ut-r-cpu') {
-          init_git()
-          unpack_lib('cpu')
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('cpu')
             sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh unittest_ubuntu_cpu_R"
           }
         }
@@ -542,9 +582,9 @@ try {
     'R: GPU': {
       node('mxnetlinux-gpu') {
         ws('workspace/ut-r-gpu') {
-          init_git()
-          unpack_lib('gpu')
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('gpu')
             sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh unittest_ubuntu_gpu_R"
           }
         }
@@ -629,9 +669,9 @@ try {
     parallel 'Onnx CPU': {
       node('mxnetlinux-cpu') {
         ws('workspace/it-onnx-cpu') {
-          init_git()
-          unpack_lib('cpu')
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('cpu')
             sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh integrationtest_ubuntu_cpu_onnx"
           }
         }
@@ -640,9 +680,9 @@ try {
     'Python GPU': {
       node('mxnetlinux-gpu') {
         ws('workspace/it-python-gpu') {
-          init_git()
-          unpack_lib('gpu')
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('gpu')
             sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh integrationtest_ubuntu_gpu_python"
           }
         }
@@ -651,9 +691,9 @@ try {
     'Caffe GPU': {
       node('mxnetlinux-gpu') {
         ws('workspace/it-caffe') {
-          init_git()
-          unpack_lib('gpu')
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('gpu')
             sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh integrationtest_ubuntu_gpu_caffe"
           }
         }
@@ -662,11 +702,11 @@ try {
     'cpp-package GPU': {
       node('mxnetlinux-gpu') {
         ws('workspace/it-cpp-package') {
-          init_git()
-          unpack_lib('gpu')
-          unstash 'cpp_test_score'
-          unstash 'cpp_test_optimizer'
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('gpu')
+            unstash 'cpp_test_score'
+            unstash 'cpp_test_optimizer'
             sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh integrationtest_ubuntu_gpu_cpp_package"
           }
         }
@@ -675,9 +715,9 @@ try {
     'dist-kvstore tests GPU': {
       node('mxnetlinux-gpu') {
         ws('workspace/it-dist-kvstore') {
-          init_git()
-          unpack_lib('gpu')
           timeout(time: max_time, unit: 'MINUTES') {
+            init_git()
+            unpack_lib('gpu')
             sh "ci/build.py --nvidiadocker --platform ubuntu_gpu /work/runtime_functions.sh integrationtest_ubuntu_gpu_dist_kvstore"
           }
         }
@@ -688,8 +728,8 @@ try {
   stage('Deploy') {
     node('mxnetlinux-cpu') {
       ws('workspace/docs') {
-        init_git()
         timeout(time: max_time, unit: 'MINUTES') {
+          init_git()
           sh "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh deploy_docs"
           sh "tests/ci_build/deploy/ci_deploy_doc.sh ${env.BRANCH_NAME} ${env.BUILD_NUMBER}"
         }        


### PR DESCRIPTION
## Description ##
Reduce the CI timeout from 24h to 2h and add timeout to all jobs which were not covered.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Timeout from 24h to 2h
- Add timeout to jobs without timeout

## Comments ##

