### PR TITLE
fix MobileNetV2 structure according to 1801.04381 v3

### DIFF
--- a/python/mxnet/gluon/model_zoo/vision/mobilenet.py
+++ b/python/mxnet/gluon/model_zoo/vision/mobilenet.py
@@ -150,7 +150,7 @@ class MobileNetV2(nn.HybridBlock):
                 channels_group = [int(x * multiplier) for x in [16] + [24] * 2 + [32] * 3
                                   + [64] * 4 + [96] * 3 + [160] * 3 + [320]]
                 ts = [1] + [6] * 16
-                strides = [1, 2] * 2 + [1] * 6 + [2, 1, 1] * 2 + [1]
+                strides = [1, 2] * 2 + [1, 1, 2] + [1] * 6 + [2] + [1] * 3
 
                 for in_c, c, t, s in zip(in_channels_group, channels_group, ts, strides):
                     self.features.add(LinearBottleneck(in_channels=in_c, channels=c,

--- a/python/mxnet/gluon/model_zoo/vision/mobilenet.py
+++ b/python/mxnet/gluon/model_zoo/vision/mobilenet.py
@@ -23,7 +23,7 @@ __all__ = ['MobileNet', 'MobileNetV2', 'mobilenet1_0', 'mobilenet_v2_1_0', 'mobi
            'mobilenet_v2_0_25', 'get_mobilenet', 'get_mobilenet_v2']
 
 __modify__ = 'dwSun'
-__modified_date__ = '18/01/31'
+__modified_date__ = '18/04/18'
 
 import os
 
@@ -33,17 +33,29 @@ from ...block import HybridBlock
 
 
 # Helpers
+class RELU6(nn.HybridBlock):
+    """Relu6 used in MobileNetV2."""
+
+    def __init__(self, **kwargs):
+        super(RELU6, self).__init__(**kwargs)
+
+    def hybrid_forward(self, F, x):
+        return F.clip(x, 0, 6, name="relu6")
+
+
 # pylint: disable= too-many-arguments
-def _add_conv(out, channels=1, kernel=1, stride=1, pad=0, num_group=1, active=True):
+def _add_conv(out, channels=1, kernel=1, stride=1, pad=0,
+              num_group=1, active=True, relu6=False):
     out.add(nn.Conv2D(channels, kernel, stride, pad, groups=num_group, use_bias=False))
     out.add(nn.BatchNorm(scale=True))
     if active:
-        out.add(nn.Activation('relu'))
+        out.add(RELU6() if relu6 else nn.Activation('relu'))
 
 
-def _add_conv_dw(out, dw_channels, channels, stride):
-    _add_conv(out, channels=dw_channels, kernel=3, stride=stride, pad=1, num_group=dw_channels)
-    _add_conv(out, channels=channels)
+def _add_conv_dw(out, dw_channels, channels, stride, relu6=False):
+    _add_conv(out, channels=dw_channels, kernel=3, stride=stride,
+              pad=1, num_group=dw_channels, relu6=relu6)
+    _add_conv(out, channels=channels, relu6=relu6)
 
 
 class LinearBottleneck(nn.HybridBlock):
@@ -70,10 +82,10 @@ class LinearBottleneck(nn.HybridBlock):
         with self.name_scope():
             self.out = nn.HybridSequential()
 
-            _add_conv(self.out, in_channels * t)
+            _add_conv(self.out, in_channels * t, relu6=True)
             _add_conv(self.out, in_channels * t, kernel=3, stride=stride,
-                      pad=1, num_group=in_channels * t)
-            _add_conv(self.out, channels, active=False)
+                      pad=1, num_group=in_channels * t, relu6=True)
+            _add_conv(self.out, channels, active=False, relu6=True)
 
     def hybrid_forward(self, F, x):
         out = self.out(x)
@@ -143,7 +155,7 @@ class MobileNetV2(nn.HybridBlock):
             self.features = nn.HybridSequential(prefix='features_')
             with self.features.name_scope():
                 _add_conv(self.features, int(32 * multiplier), kernel=3,
-                          stride=2, pad=1)
+                          stride=2, pad=1, relu6=True)
 
                 in_channels_group = [int(x * multiplier) for x in [32] + [16] + [24] * 2
                                      + [32] * 3 + [64] * 4 + [96] * 3 + [160] * 3]
@@ -157,7 +169,7 @@ class MobileNetV2(nn.HybridBlock):
                                                        t=t, stride=s))
 
                 last_channels = int(1280 * multiplier) if multiplier > 1.0 else 1280
-                _add_conv(self.features, last_channels)
+                _add_conv(self.features, last_channels, relu6=True)
 
                 self.features.add(nn.GlobalAvgPool2D())
 


### PR DESCRIPTION
## Description ##
fix net structure according to 1801.04381 v3.
relu -> relu6 in MobileNetV2.

## Checklist ##
- [ Y ] Changes are complete (i.e. I finished coding on this PR)
- [ Y ] All changes have test coverage:
- [ Y ] Code is well-documented: 
- [ Y ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
