### PR TITLE
[MXNET-362] ensure same mkldnn engine is used for consistency

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -67,7 +67,8 @@ class CpuEngine {
  public:
   static CpuEngine *Get() {
     // I's thread-safe in C++11.
-    static thread_local CpuEngine myInstance;
+    // ensure same mkldnn engine is used across threads
+    static CpuEngine myInstance;
     return &myInstance;
   }
   CpuEngine(CpuEngine const &) = delete;             // Copy construct

--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -93,7 +93,10 @@ def test_mkldnn_model():
 
 def test_mkldnn_engine_threading():
     """
-    This test will trigger mkldnn engine on different thread of execution
+    This test will trigger mkldnn engine on different thread of execution.
+    The test will first kickoff simple model calculation, and then uses a 
+    gluon data iterator to trigger different thread context, and executes
+    the model on this new thread.
     """
 
     import mxnet as mx
@@ -112,6 +115,7 @@ def test_mkldnn_engine_threading():
     # trigger mkldnn execution thread
     y = net(nd.array(np.ones(X))).asnumpy()
 
+    # Use Gluon dataloader to trigger different thread.
     # below line triggers different execution thread
     for _ in val_data:
         y = net(nd.array(np.ones(X))).asnumpy()

--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -94,7 +94,7 @@ def test_mkldnn_model():
 def test_mkldnn_engine_threading():
     """
     This test will trigger mkldnn engine on different thread of execution.
-    The test will first kickoff simple model calculation, and then uses a 
+    The test will first kickoff simple model calculation, and then uses a
     gluon data iterator to trigger different thread context, and executes
     the model on this new thread.
     """
@@ -139,7 +139,7 @@ def test_mkldnn_ndarray_slice():
         y = net(x)
 
         # trigger computation on ndarray slice
-        assert_almost_equal(y[0].asnumpy()[0,0,0], 0.3376348)
+        assert_almost_equal(y[0].asnumpy()[0, 0, 0], 0.3376348)
 
 if __name__ == '__main__':
     test_mkldnn_install()


### PR DESCRIPTION
## Description ##
Gluon data iterators may trigger different thread for execution context, this causes mkl-dnn engine to be inconsistent. Following snippet reproduces this issue.

```python
import numpy as np
import mxnet as mx
from mxnet import gluon, nd
 
net = gluon.nn.HybridSequential()
with net.name_scope():
    net.add(gluon.nn.Conv2D(channels=32, kernel_size=3, activation=None))
net.collect_params().initialize(mx.init.Xavier(magnitude=2.24), ctx=mx.cpu())
 
val_data = gluon.data.DataLoader(
    gluon.data.vision.CIFAR10(train=False),
    batch_size=32, shuffle=False,num_workers=1)
 
# output should be 0.57521844
X = (32,3,32,32)
y = net(nd.array(np.ones(X))).asnumpy()
print(y[0][0][0][0])
 
# below line works!
# for _ in range(1):
# below line causes bug
for _ in val_data:
    y = net(nd.array(np.ones(X))).asnumpy()
    print(y[0][0][0][0])
    break
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
