### PR TITLE
[MXNET-342] Fix the multi worker Dataloader

### DIFF
--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -30,6 +30,7 @@ import numpy as np
 
 from . import sampler as _sampler
 from ... import nd, context
+from . import RecordFileDataset
 
 
 def rebuild_ndarray(*args):
@@ -112,6 +113,9 @@ def default_mp_batchify_fn(data):
 
 def worker_loop(dataset, key_queue, data_queue, batchify_fn):
     """Worker loop for multiprocessing DataLoader."""
+    if isinstance(dataset, RecordFileDataset):
+        dataset.reload_recordfile()
+
     while True:
         idx, samples = key_queue.get()
         if idx is None:

--- a/python/mxnet/gluon/data/dataset.py
+++ b/python/mxnet/gluon/data/dataset.py
@@ -173,8 +173,15 @@ class RecordFileDataset(Dataset):
         Path to rec file.
     """
     def __init__(self, filename):
-        idx_file = os.path.splitext(filename)[0] + '.idx'
-        self._record = recordio.MXIndexedRecordIO(idx_file, filename, 'r')
+        self._filename = filename
+        self.reload_recordfile()
+
+    def reload_recordfile(self):
+        """
+        Reload the record file.
+        """
+        idx_file = os.path.splitext(self._filename)[0] + '.idx'
+        self._record = recordio.MXIndexedRecordIO(idx_file, self._filename, 'r')
 
     def __getitem__(self, idx):
         return self._record.read_idx(self._record.keys[idx])

--- a/python/mxnet/gluon/data/dataset.py
+++ b/python/mxnet/gluon/data/dataset.py
@@ -178,7 +178,7 @@ class RecordFileDataset(Dataset):
 
     def reload_recordfile(self):
         """
-        Reload the record file.
+        Reload the record file to open a new file description
         """
         idx_file = os.path.splitext(self._filename)[0] + '.idx'
         self._record = recordio.MXIndexedRecordIO(idx_file, self._filename, 'r')

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -72,6 +72,28 @@ def test_recordimage_dataset():
         assert x.shape[0] == 1 and x.shape[3] == 3
         assert y.asscalar() == i
 
+
+@with_seed()
+def test_recordimage_dataset_withdataloader():
+    recfile = prepare_record()
+    dataset = gluon.data.vision.ImageRecordDataset(recfile)
+    loader = gluon.data.DataLoader(dataset, 1)
+
+    for i, (x, y) in enumerate(loader):
+        assert x.shape[0] == 1 and x.shape[3] == 3
+        assert y.asscalar() == i
+
+@with_seed()
+def test_recordimage_dataset_withdataloader_multiworker():
+    recfile = prepare_record()
+    dataset = gluon.data.vision.ImageRecordDataset(recfile)
+    loader = gluon.data.DataLoader(dataset, 1, num_workers=5)
+
+    for i, (x, y) in enumerate(loader):
+        assert x.shape[0] == 1 and x.shape[3] == 3
+        assert y.asscalar() == i
+
+
 @with_seed()
 def test_sampler():
     seq_sampler = gluon.data.SequentialSampler(10)
@@ -103,13 +125,6 @@ def test_image_folder_dataset():
     dataset = gluon.data.vision.ImageFolderDataset('data/test_images')
     assert dataset.synsets == ['test_images']
     assert len(dataset.items) == 16
-
-
-class Dataset(gluon.data.Dataset):
-    def __len__(self):
-        return 100
-    def __getitem__(self, key):
-        return mx.nd.full((10,), key)
 
 @unittest.skip("Somehow fails with MKL. Cannot reproduce locally")
 def test_multi_worker():

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -73,15 +73,6 @@ def test_recordimage_dataset():
         assert y.asscalar() == i
 
 
-@with_seed()
-def test_recordimage_dataset_withdataloader():
-    recfile = prepare_record()
-    dataset = gluon.data.vision.ImageRecordDataset(recfile)
-    loader = gluon.data.DataLoader(dataset, 1)
-
-    for i, (x, y) in enumerate(loader):
-        assert x.shape[0] == 1 and x.shape[3] == 3
-        assert y.asscalar() == i
 
 @with_seed()
 def test_recordimage_dataset_withdataloader_multiworker():
@@ -125,6 +116,13 @@ def test_image_folder_dataset():
     dataset = gluon.data.vision.ImageFolderDataset('data/test_images')
     assert dataset.synsets == ['test_images']
     assert len(dataset.items) == 16
+
+
+class Dataset(gluon.data.Dataset):
+    def __len__(self):
+        return 100
+    def __getitem__(self, key):
+        return mx.nd.full((10,), key)
 
 @unittest.skip("Somehow fails with MKL. Cannot reproduce locally")
 def test_multi_worker():

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -72,8 +72,6 @@ def test_recordimage_dataset():
         assert x.shape[0] == 1 and x.shape[3] == 3
         assert y.asscalar() == i
 
-
-
 @with_seed()
 def test_recordimage_dataset_with_data_loader_multiworker():
     # This test is pointless on Windows because Windows doesn't fork
@@ -85,8 +83,7 @@ def test_recordimage_dataset_with_data_loader_multiworker():
         for i, (x, y) in enumerate(loader):
             assert x.shape[0] == 1 and x.shape[3] == 3
             assert y.asscalar() == i
-
-
+            
 @with_seed()
 def test_sampler():
     seq_sampler = gluon.data.SequentialSampler(10)

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -75,14 +75,16 @@ def test_recordimage_dataset():
 
 
 @with_seed()
-def test_recordimage_dataset_withdataloader_multiworker():
-    recfile = prepare_record()
-    dataset = gluon.data.vision.ImageRecordDataset(recfile)
-    loader = gluon.data.DataLoader(dataset, 1, num_workers=5)
+def test_recordimage_dataset_with_data_loader_multiworker():
+    # This test is pointless on Windows because Windows doesn't fork
+    if platform.system() != 'Windows':
+        recfile = prepare_record()
+        dataset = gluon.data.vision.ImageRecordDataset(recfile)
+        loader = gluon.data.DataLoader(dataset, 1, num_workers=5)
 
-    for i, (x, y) in enumerate(loader):
-        assert x.shape[0] == 1 and x.shape[3] == 3
-        assert y.asscalar() == i
+        for i, (x, y) in enumerate(loader):
+            assert x.shape[0] == 1 and x.shape[3] == 3
+            assert y.asscalar() == i
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##

[MXNET-342](https://issues.apache.org/jira/browse/MXNET-342)

Fix https://github.com/apache/incubator-mxnet/issues/9974

DataLoader was not compatible with ImageRecordDataset as the file descriptors ~~was (probably) closed on forking (close_fds=True by default)~~. 

The code in DataLoader use the `multiprocessing` package, which does not close the file descriptors, as it is simply calling `os.fork()`. The problem is that the recordIter is calling `lseek` on the file descriptors of each fork, all pointing to the same open file description. Since all the forked processes share the same open file description, they are all trying to set the value of `lseek` at the same time, thus creating a crash, as they can't be reading the same file at different position using a single open file description.

see https://stackoverflow.com/questions/4277289/are-file-descriptors-shared-when-forking
and https://stackoverflow.com/questions/11733481/can-anyone-explain-a-simple-description-regarding-file-descriptor-after-fork for more information of the distinction between `file descriptor` and `file description`

Now it reloads the record in each worker so that each individual process gets its own open file description.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

