### PR TITLE
Stop ignoring the given name of CompositeEvalMetric

### DIFF
--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -263,7 +263,7 @@ class CompositeEvalMetric(EvalMetric):
     def __init__(self, metrics=None, name='composite',
                  output_names=None, label_names=None):
         super(CompositeEvalMetric, self).__init__(
-            'composite', output_names=output_names, label_names=label_names)
+            name, output_names=output_names, label_names=label_names)
         if metrics is None:
             metrics = []
         self.metrics = [create(i) for i in metrics]


### PR DESCRIPTION
mxnet.metric.CompositeEvalMetric ignores the given name in its constructor.
It shoudn't be ignored.

Before:

```
>>> acc = mx.metric.CompositeEvalMetric(name='composite_xyz')
>>> acc.name
'composite'
```

After:

```
>>> acc = mx.metric.CompositeEvalMetric(name='composite_xyz')
>>> acc.name
'composite_xyz'
```