### PR TITLE
[MXNET-352] Document behavior of mx.initializer.Constant

### DIFF
--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -161,7 +161,7 @@ class Initializer(object):
         Parameters
         ----------
         name : str
-            Name of corrosponding NDArray.
+            Name of corresponding NDArray.
 
         arr : NDArray
             NDArray to be initialized.

--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -432,7 +432,7 @@ class Constant(Initializer):
     ----------
     value : float, NDArray
         Value to set.
-        
+
     Example
     ----------
     >>> init = mx.init.Constant(np.identity(512))
@@ -448,7 +448,7 @@ class Constant(Initializer):
      [ 0.  0.  0. ...,  0.  1.  0.]
      [ 0.  0.  0. ...,  0.  0.  1.]]
      <NDArray 512x512 @cpu(0)>]
-     
+
     >>> init = mx.init.Constant(42)
     >>> layer = gluon.nn.Dense(5, in_units=5, use_bias=False)
     >>> layer.collect_params().initialize(init)

--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -426,7 +426,7 @@ class One(Initializer):
 class Constant(Initializer):
     """Initializes the weights to a given value.
     The value passed in can be a scalar or a ndarray that matches the shape
-    of the parameter to be set. 
+    of the parameter to be set.
 
     Parameters
     ----------

--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -424,12 +424,42 @@ class One(Initializer):
 
 @register
 class Constant(Initializer):
-    """Initializes the weights to a scalar value.
+    """Initializes the weights to a given value.
+    The value passed in can be a scalar or a ndarray that matches the shape
+    of the parameter to be set. 
 
     Parameters
     ----------
-    value : float
-        Fill value.
+    value : float, NDArray
+        Value to set.
+        
+    Example
+    ----------
+    >>> init = mx.init.Constant(np.identity(512))
+    >>> layer = gluon.nn.Dense(512, in_units=512, use_bias=False)
+    >>> layer.collect_params().initialize(init)
+    >>> [layer.params[k].data() for k in layer.params]
+    [
+    [[ 1.  0.  0. ...,  0.  0.  0.]
+     [ 0.  1.  0. ...,  0.  0.  0.]
+     [ 0.  0.  1. ...,  0.  0.  0.]
+     ...,
+     [ 0.  0.  0. ...,  1.  0.  0.]
+     [ 0.  0.  0. ...,  0.  1.  0.]
+     [ 0.  0.  0. ...,  0.  0.  1.]]
+     <NDArray 512x512 @cpu(0)>]
+     
+    >>> init = mx.init.Constant(42)
+    >>> layer = gluon.nn.Dense(5, in_units=5, use_bias=False)
+    >>> layer.collect_params().initialize(init)
+    >>> [layer.params[k].data() for k in layer.params]
+    [
+    [[ 42.  42.  42.  42.  42.]
+     [ 42.  42.  42.  42.  42.]
+     [ 42.  42.  42.  42.  42.]
+     [ 42.  42.  42.  42.  42.]
+     [ 42.  42.  42.  42.  42.]]
+    <NDArray 5x5 @cpu(0)>,
     """
     def __init__(self, value):
         super(Constant, self).__init__(value=value)

--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -425,41 +425,13 @@ class One(Initializer):
 @register
 class Constant(Initializer):
     """Initializes the weights to a given value.
-    The value passed in can be a scalar or a ndarray that matches the shape
+    The value passed in can be a scalar or a NDarray that matches the shape
     of the parameter to be set.
 
     Parameters
     ----------
     value : float, NDArray
         Value to set.
-
-    Example
-    ----------
-    >>> init = mx.init.Constant(np.identity(512))
-    >>> layer = gluon.nn.Dense(512, in_units=512, use_bias=False)
-    >>> layer.collect_params().initialize(init)
-    >>> [layer.params[k].data() for k in layer.params]
-    [
-    [[ 1.  0.  0. ...,  0.  0.  0.]
-     [ 0.  1.  0. ...,  0.  0.  0.]
-     [ 0.  0.  1. ...,  0.  0.  0.]
-     ...,
-     [ 0.  0.  0. ...,  1.  0.  0.]
-     [ 0.  0.  0. ...,  0.  1.  0.]
-     [ 0.  0.  0. ...,  0.  0.  1.]]
-     <NDArray 512x512 @cpu(0)>]
-
-    >>> init = mx.init.Constant(42)
-    >>> layer = gluon.nn.Dense(5, in_units=5, use_bias=False)
-    >>> layer.collect_params().initialize(init)
-    >>> [layer.params[k].data() for k in layer.params]
-    [
-    [[ 42.  42.  42.  42.  42.]
-     [ 42.  42.  42.  42.  42.]
-     [ 42.  42.  42.  42.  42.]
-     [ 42.  42.  42.  42.  42.]
-     [ 42.  42.  42.  42.  42.]]
-    <NDArray 5x5 @cpu(0)>]
     """
     def __init__(self, value):
         super(Constant, self).__init__(value=value)

--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -459,7 +459,7 @@ class Constant(Initializer):
      [ 42.  42.  42.  42.  42.]
      [ 42.  42.  42.  42.  42.]
      [ 42.  42.  42.  42.  42.]]
-    <NDArray 5x5 @cpu(0)>,
+    <NDArray 5x5 @cpu(0)>]
     """
     def __init__(self, value):
         super(Constant, self).__init__(value=value)

--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -653,7 +653,7 @@ class Bilinear(Initializer):
 
 @register
 class LSTMBias(Initializer):
-    """Initialize all bias of an LSTMCell to 0.0 except for
+    """Initialize all biases of an LSTMCell to 0.0 except for
     the forget gate whose bias is set to custom value.
 
     Parameters


### PR DESCRIPTION
## Description ##
As I was looking for a way to initialize the value of my weights to a given specific value, I couldn't find any straightforward way to do that without hacking into the parameters and setting the value directly. 
Turns out you can use the `mx.initializer.Constant`, even though the documentation stated that it can only accept scalar. If you give a NDArray of the right shape, you can initialize your weights using the `Constant` initializer, which is much cleaner than setting the data directly since you don't have to play around the names of the layers and parameters.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
