### PR TITLE
Correctly set the device context to CPU at symbolic mode when --gpus not set

### DIFF
--- a/example/gluon/image_classification.py
+++ b/example/gluon/image_classification.py
@@ -255,7 +255,10 @@ def main():
         data = mx.sym.var('data')
         out = net(data)
         softmax = mx.sym.SoftmaxOutput(out, name='softmax')
-        mod = mx.mod.Module(softmax, context=[mx.gpu(i) for i in range(num_gpus)] if num_gpus > 0 else [mx.cpu()])
+        if mx.cpu() in context:
+            mod = mx.mod.Module(softmax, context=mx.cpu())
+        else:
+            mod = mx.mod.Module(softmax, context=[mx.gpu(i) for i in range(num_gpus)])
         kv = mx.kv.create(opt.kvstore)
         train_data, val_data = get_data_iters(dataset, batch_size, kv.num_workers, kv.rank)
         mod.fit(train_data,


### PR DESCRIPTION
## Description ##
This PR fixes an issue on example/gluon/image_classification.py
When using argument --mode symbolic and not set --gpus, it assumed the script will run on CPU, while actually the device is not correctly set to mx.cpu()

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- example/gluon/image_classification

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
