### PR TITLE
fix SSDClassifierExample

### DIFF
--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/README.md
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/README.md
@@ -79,7 +79,7 @@ After the previous steps, you should be able to run the code using the following
 From the `scala-package/examples/scripts/inferexample/objectdetector/` folder run:
 
 ```bash
-./run_ssd_example.sh ../model/resnet50_ssd_model ../image/dog.jpg ../image
+./run_ssd_example.sh ../models/resnet50_ssd_model ../images/dog.jpg ../images
 ```
 
 **Notes**:

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
@@ -108,10 +108,9 @@ object SSDClassifierExample {
     val inst = new SSDClassifierExample
     val parser : CmdLineParser = new CmdLineParser(inst)
     parser.parseArgument(args.toList.asJava)
-    val baseDir = System.getProperty("user.dir")
-    val mdprefixDir = baseDir + inst.modelPathPrefix
-    val imgPath = baseDir + inst.inputImagePath
-    val imgDir = baseDir + inst.inputImageDir
+    val mdprefixDir = inst.modelPathPrefix
+    val imgPath = inst.inputImagePath
+    val imgDir = inst.inputImageDir
     if (!checkExist(Array(mdprefixDir + "-symbol.json", imgDir, imgPath))) {
       logger.error("Model or input image path does not exist")
       sys.exit(1)


### PR DESCRIPTION
## Description ##
fix SSDClassifierExample, Existing code always looks against the user.dir regardless of the user input.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
