### PR TITLE
[MXNET-356] Fix for the search results issues

### DIFF
--- a/docs/_static/searchtools_custom.js
+++ b/docs/_static/searchtools_custom.js
@@ -458,6 +458,16 @@ var Search = {
             } else {
                 // normal html builders
                 var baseURL = 'https://' + window.location.hostname + '/';
+                var urlHref = window.location.href;
+                var urlSplits = urlHref.split("/");
+                versionString = '';
+                for (var idx = 0; idx < urlSplits.length; ++idx) {
+                    if(urlSplits[idx] == 'versions') {
+                        versionString = 'versions/' + urlSplits[idx + 1] + '/';
+                        break;
+                    }
+                }
+                baseURL = baseURL.concat(versionString);
                 listItem.append($('<a/>').attr('href',
                 baseURL + item[0] + DOCUMENTATION_OPTIONS.FILE_SUFFIX +
                 highlightstring + item[2]).html(item[1]));
@@ -513,8 +523,8 @@ var Search = {
             displayNextItem();
           });
         } else if (DOCUMENTATION_OPTIONS.HAS_SOURCE) {
-          $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + '_sources/' + item[0] + '.txt',
-                  dataType: "text",
+          $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + item[0] + '.html',
+                  dataType: "html",
                   complete: function(jqxhr, textstatus) {
                     var data = jqxhr.responseText;
                     if (data !== '' && data !== undefined) {

--- a/docs/_static/searchtools_custom.js
+++ b/docs/_static/searchtools_custom.js
@@ -523,8 +523,8 @@ var Search = {
             displayNextItem();
           });
         } else if (DOCUMENTATION_OPTIONS.HAS_SOURCE) {
-          $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + item[0] + '.html',
-                  dataType: "html",
+          $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + item[0] + '.txt',
+                  dataType: "txt",
                   complete: function(jqxhr, textstatus) {
                     var data = jqxhr.responseText;
                     if (data !== '' && data !== undefined) {

--- a/docs/_static/searchtools_custom.js
+++ b/docs/_static/searchtools_custom.js
@@ -459,8 +459,8 @@ var Search = {
                 // normal html builders
                 var baseURL = 'https://' + window.location.hostname + '/';
                 var urlHref = window.location.href;
-                var urlSplits = urlHref.split("/");
-                versionString = '';
+                let urlSplits = urlHref.split("/");
+                let versionString = '';
                 for (var idx = 0; idx < urlSplits.length; ++idx) {
                     if(urlSplits[idx] == 'versions') {
                         versionString = 'versions/' + urlSplits[idx + 1] + '/';
@@ -523,8 +523,8 @@ var Search = {
             displayNextItem();
           });
         } else if (DOCUMENTATION_OPTIONS.HAS_SOURCE) {
-          $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + item[0] + '.txt',
-                  dataType: "txt",
+          $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + '_sources/' + item[0] + '.txt',
+                  dataType: "text",
                   complete: function(jqxhr, textstatus) {
                     var data = jqxhr.responseText;
                     if (data !== '' && data !== undefined) {


### PR DESCRIPTION
## Description ##
There are two issues with the MXNet search result lists: first, when accessed as the drop-down for an earlier version, the URL in the drop-down redirects to the corresponding page in the default version. Second, in the search results after pressing enter, there are entries with HTTP 404 error.

### Changes ###
- [ x ] This changes reads the current version (if it exists) to add it as a part of the URL given in the search results drop-down.
- [ x ] In the search results page corrected the search preview target page from txt to html

Preview - http://54.210.6.225/
