### PR TITLE
[MXNET-357] New Scala API Design (Symbol)

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/NewSymbol.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NewSymbol.scala
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.mxnet
+@AddNewSymbolFunctions(false)
+object NewSymbol {
+}

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
@@ -830,7 +830,7 @@ object Symbol {
   private val functions: Map[String, SymbolFunction] = initSymbolModule()
   private val bindReqMap = Map("null" -> 0, "write" -> 1, "add" -> 3)
 
-  val api = NewSymbol
+  val api = SymbolAPI
 
   def pow(sym1: Symbol, sym2: Symbol): Symbol = {
     Symbol.createFromListedSymbols("_Power")(Array(sym1, sym2))

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
@@ -830,6 +830,8 @@ object Symbol {
   private val functions: Map[String, SymbolFunction] = initSymbolModule()
   private val bindReqMap = Map("null" -> 0, "write" -> 1, "add" -> 3)
 
+  val api = NewSymbol
+
   def pow(sym1: Symbol, sym2: Symbol): Symbol = {
     Symbol.createFromListedSymbols("_Power")(Array(sym1, sym2))
   }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/SymbolAPI.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/SymbolAPI.scala
@@ -15,6 +15,6 @@
  * limitations under the License.
  */
 package org.apache.mxnet
-@AddNewSymbolFunctions(false)
-object NewSymbol {
+@AddSymbolAPIs(false)
+object SymbolAPI {
 }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/SymbolAPI.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/SymbolAPI.scala
@@ -15,6 +15,12 @@
  * limitations under the License.
  */
 package org.apache.mxnet
+
+
 @AddSymbolAPIs(false)
+/**
+  * typesafe Symbol API: Symbol.api._
+  * Main code will be generated during compile time through Macros
+  */
 object SymbolAPI {
 }

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/imclassification/TrainMnist.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/imclassification/TrainMnist.scala
@@ -31,12 +31,12 @@ object TrainMnist {
   def getMlp: Symbol = {
     val data = Symbol.Variable("data")
 
-    val fc1 = Symbol.FullyConnectedNew(data = Some(data), num_hidden = 128, name = "fc1")
-    val act1 = Symbol.ActivationNew(data = Some(fc1), "relu", name = "relu")
-    val fc2 = Symbol.FullyConnectedNew(Some(act1), None, None, 64, name = "fc2")
-    val act2 = Symbol.ActivationNew(data = Some(fc2), "relu", name = "relu2")
-    val fc3 = Symbol.FullyConnectedNew(Some(act2), None, None, 10, name = "fc3")
-    val mlp = Symbol.SoftmaxOutputNew(name = "softmax", data = Some(fc3))
+    val fc1 = Symbol.api.FullyConnected(data = Some(data), num_hidden = 128, name = "fc1")
+    val act1 = Symbol.api.Activation (data = Some(fc1), "relu", name = "relu")
+    val fc2 = Symbol.api.FullyConnected(Some(act1), None, None, 64, name = "fc2")
+    val act2 = Symbol.api.Activation(data = Some(fc2), "relu", name = "relu2")
+    val fc3 = Symbol.api.FullyConnected(Some(act2), None, None, 10, name = "fc3")
+    val mlp = Symbol.api.SoftmaxOutput(name = "softmax", data = Some(fc3))
     mlp
   }
 
@@ -47,23 +47,23 @@ object TrainMnist {
   def getLenet: Symbol = {
     val data = Symbol.Variable("data")
     // first conv
-    val conv1 = Symbol.ConvolutionNew(data = Some(data), kernel = Shape(5, 5), num_filter = 20)
-    val tanh1 = Symbol.tanhNew(data = Some(conv1))
-    val pool1 = Symbol.PoolingNew(data = Some(tanh1), pool_type = Some("max"),
+    val conv1 = Symbol.api.Convolution(data = Some(data), kernel = Shape(5, 5), num_filter = 20)
+    val tanh1 = Symbol.api.tanh(data = Some(conv1))
+    val pool1 = Symbol.api.Pooling(data = Some(tanh1), pool_type = Some("max"),
       kernel = Some(Shape(2, 2)), stride = Some(Shape(2, 2)))
     // second conv
-    val conv2 = Symbol.ConvolutionNew(data = Some(pool1), kernel = Shape(5, 5), num_filter = 50)
-    val tanh2 = Symbol.tanhNew(data = Some(conv2))
-    val pool2 = Symbol.PoolingNew(data = Some(tanh2), pool_type = Some("max"),
+    val conv2 = Symbol.api.Convolution(data = Some(pool1), kernel = Shape(5, 5), num_filter = 50)
+    val tanh2 = Symbol.api.tanh(data = Some(conv2))
+    val pool2 = Symbol.api.Pooling(data = Some(tanh2), pool_type = Some("max"),
       kernel = Some(Shape(2, 2)), stride = Some(Shape(2, 2)))
     // first fullc
-    val flatten = Symbol.FlattenNew(data = Some(pool2))
-    val fc1 = Symbol.FullyConnectedNew(data = Some(flatten), num_hidden = 500)
-    val tanh3 = Symbol.tanhNew(data = Some(fc1))
+    val flatten = Symbol.api.Flatten(data = Some(pool2))
+    val fc1 = Symbol.api.FullyConnected(data = Some(flatten), num_hidden = 500)
+    val tanh3 = Symbol.api.tanh(data = Some(fc1))
     // second fullc
-    val fc2 = Symbol.FullyConnectedNew(data = Some(tanh3), num_hidden = 10)
+    val fc2 = Symbol.api.FullyConnected(data = Some(tanh3), num_hidden = 10)
     // loss
-    val lenet = Symbol.SoftmaxOutputNew(name = "softmax", data = Some(fc2))
+    val lenet = Symbol.api.SoftmaxOutput(name = "softmax", data = Some(fc2))
     lenet
   }
 

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/imclassification/TrainMnist.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/imclassification/TrainMnist.scala
@@ -30,40 +30,38 @@ object TrainMnist {
   // multi-layer perceptron
   def getMlp: Symbol = {
     val data = Symbol.Variable("data")
-    val fc1 = Symbol.FullyConnected(name = "fc1")()(Map("data" -> data, "num_hidden" -> 128))
-    val act1 = Symbol.Activation(name = "relu1")()(Map("data" -> fc1, "act_type" -> "relu"))
-    val fc2 = Symbol.FullyConnected(name = "fc2")()(Map("data" -> act1, "num_hidden" -> 64))
-    val act2 = Symbol.Activation(name = "relu2")()(Map("data" -> fc2, "act_type" -> "relu"))
-    val fc3 = Symbol.FullyConnected(name = "fc3")()(Map("data" -> act2, "num_hidden" -> 10))
-    val mlp = Symbol.SoftmaxOutput(name = "softmax")()(Map("data" -> fc3))
+
+    val fc1 = Symbol.FullyConnectedNew(data = Some(data), num_hidden = 128, name =  "fc1")
+    val act1 = Symbol.ActivationNew(data = Some(fc1), "relu", name = "relu")
+    val fc2 = Symbol.FullyConnectedNew(Some(act1), None, None, 64, name = "fc2")
+    val act2 = Symbol.ActivationNew(data = Some(fc2), "relu", name = "relu2")
+    val fc3 = Symbol.FullyConnectedNew(Some(act2), None, None, 10, name = "fc3")
+    val mlp = Symbol.SoftmaxOutputNew(name = "softmax", data = Some(fc3))
     mlp
   }
 
   // LeCun, Yann, Leon Bottou, Yoshua Bengio, and Patrick
   // Haffner. "Gradient-based learning applied to document recognition."
   // Proceedings of the IEEE (1998)
+
   def getLenet: Symbol = {
     val data = Symbol.Variable("data")
     // first conv
-    val conv1 = Symbol.Convolution()()(
-      Map("data" -> data, "kernel" -> "(5, 5)", "num_filter" -> 20))
-    val tanh1 = Symbol.Activation()()(Map("data" -> conv1, "act_type" -> "tanh"))
-    val pool1 = Symbol.Pooling()()(Map("data" -> tanh1, "pool_type" -> "max",
-                                       "kernel" -> "(2, 2)", "stride" -> "(2, 2)"))
+    val conv1 = Symbol.ConvolutionNew(data = Some(data), kernel = Shape(5, 5), num_filter = 20)
+    val tanh1 = Symbol.tanhNew(data = Some(conv1))
+    val pool1 = Symbol.PoolingNew(data = Some(tanh1), pool_type = Some("max"), kernel = Some(Shape(2, 2)), stride = Some(Shape(2, 2)))
     // second conv
-    val conv2 = Symbol.Convolution()()(
-      Map("data" -> pool1, "kernel" -> "(5, 5)", "num_filter" -> 50))
-    val tanh2 = Symbol.Activation()()(Map("data" -> conv2, "act_type" -> "tanh"))
-    val pool2 = Symbol.Pooling()()(Map("data" -> tanh2, "pool_type" -> "max",
-                                       "kernel" -> "(2, 2)", "stride" -> "(2, 2)"))
+    val conv2 = Symbol.ConvolutionNew(data = Some(pool1), kernel = Shape(5, 5), num_filter = 50)
+    val tanh2 = Symbol.tanhNew(data = Some(conv2))
+    val pool2 = Symbol.PoolingNew(data = Some(tanh2), pool_type = Some("max"), kernel = Some(Shape(2, 2)), stride = Some(Shape(2, 2)))
     // first fullc
-    val flatten = Symbol.Flatten()()(Map("data" -> pool2))
-    val fc1 = Symbol.FullyConnected()()(Map("data" -> flatten, "num_hidden" -> 500))
-    val tanh3 = Symbol.Activation()()(Map("data" -> fc1, "act_type" -> "tanh"))
+    val flatten = Symbol.FlattenNew(data = Some(pool2))
+    val fc1 = Symbol.FullyConnectedNew(data = Some(flatten), num_hidden = 500)
+    val tanh3 = Symbol.tanhNew(data = Some(fc1))
     // second fullc
-    val fc2 = Symbol.FullyConnected()()(Map("data" -> tanh3, "num_hidden" -> 10))
+    val fc2 = Symbol.FullyConnectedNew(data = Some(tanh3), num_hidden = 10)
     // loss
-    val lenet = Symbol.SoftmaxOutput(name = "softmax")()(Map("data" -> fc2))
+    val lenet = Symbol.SoftmaxOutputNew(name = "softmax", data = Some(fc2))
     lenet
   }
 

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/imclassification/TrainMnist.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/imclassification/TrainMnist.scala
@@ -31,7 +31,7 @@ object TrainMnist {
   def getMlp: Symbol = {
     val data = Symbol.Variable("data")
 
-    val fc1 = Symbol.FullyConnectedNew(data = Some(data), num_hidden = 128, name =  "fc1")
+    val fc1 = Symbol.FullyConnectedNew(data = Some(data), num_hidden = 128, name = "fc1")
     val act1 = Symbol.ActivationNew(data = Some(fc1), "relu", name = "relu")
     val fc2 = Symbol.FullyConnectedNew(Some(act1), None, None, 64, name = "fc2")
     val act2 = Symbol.ActivationNew(data = Some(fc2), "relu", name = "relu2")
@@ -49,11 +49,13 @@ object TrainMnist {
     // first conv
     val conv1 = Symbol.ConvolutionNew(data = Some(data), kernel = Shape(5, 5), num_filter = 20)
     val tanh1 = Symbol.tanhNew(data = Some(conv1))
-    val pool1 = Symbol.PoolingNew(data = Some(tanh1), pool_type = Some("max"), kernel = Some(Shape(2, 2)), stride = Some(Shape(2, 2)))
+    val pool1 = Symbol.PoolingNew(data = Some(tanh1), pool_type = Some("max"),
+      kernel = Some(Shape(2, 2)), stride = Some(Shape(2, 2)))
     // second conv
     val conv2 = Symbol.ConvolutionNew(data = Some(pool1), kernel = Shape(5, 5), num_filter = 50)
     val tanh2 = Symbol.tanhNew(data = Some(conv2))
-    val pool2 = Symbol.PoolingNew(data = Some(tanh2), pool_type = Some("max"), kernel = Some(Shape(2, 2)), stride = Some(Shape(2, 2)))
+    val pool2 = Symbol.PoolingNew(data = Some(tanh2), pool_type = Some("max"),
+      kernel = Some(Shape(2, 2)), stride = Some(Shape(2, 2)))
     // first fullc
     val flatten = Symbol.FlattenNew(data = Some(pool2))
     val fc1 = Symbol.FullyConnectedNew(data = Some(flatten), num_hidden = 500)

--- a/scala-package/init/src/main/scala/org/apache/mxnet/init/Base.scala
+++ b/scala-package/init/src/main/scala/org/apache/mxnet/init/Base.scala
@@ -37,7 +37,11 @@ object Base {
 
   @throws(classOf[UnsatisfiedLinkError])
   private def tryLoadInitLibrary(): Unit = {
-    val baseDir = System.getProperty("user.dir") + "/init-native"
+    // val baseDir = System.getProperty("user.dir") + "/init-native"
+    var baseDir = System.getProperty("user.dir") + "/init-native"
+    if (System.getenv().containsKey("BASEDIR")) {
+      baseDir = sys.env("BASEDIR")
+    }
     val os = System.getProperty("os.name")
     // ref: http://lopica.sourceforge.net/os.html
     if (os.startsWith("Linux")) {

--- a/scala-package/init/src/main/scala/org/apache/mxnet/init/Base.scala
+++ b/scala-package/init/src/main/scala/org/apache/mxnet/init/Base.scala
@@ -38,8 +38,8 @@ object Base {
   @throws(classOf[UnsatisfiedLinkError])
   private def tryLoadInitLibrary(): Unit = {
     var baseDir = System.getProperty("user.dir") + "/init-native"
-    if (System.getenv().containsKey("MXNET_SCALA_MACRO_BASEDIR")) {
-      baseDir = sys.env("MXNET_SCALA_MACRO_BASEDIR")
+    if (System.getenv().containsKey("MXNET_BASEDIR")) {
+      baseDir = sys.env("MXNET_BASEDIR")
     }
     val os = System.getProperty("os.name")
     // ref: http://lopica.sourceforge.net/os.html

--- a/scala-package/init/src/main/scala/org/apache/mxnet/init/Base.scala
+++ b/scala-package/init/src/main/scala/org/apache/mxnet/init/Base.scala
@@ -39,7 +39,7 @@ object Base {
   private def tryLoadInitLibrary(): Unit = {
     var baseDir = System.getProperty("user.dir") + "/init-native"
     if (System.getenv().containsKey("MXNET_BASEDIR")) {
-      baseDir = sys.env("MXNET_BASEDIR")
+      baseDir = sys.env("MXNET_BASEDIR") + "/scala-package/init-native"
     }
     val os = System.getProperty("os.name")
     // ref: http://lopica.sourceforge.net/os.html

--- a/scala-package/init/src/main/scala/org/apache/mxnet/init/Base.scala
+++ b/scala-package/init/src/main/scala/org/apache/mxnet/init/Base.scala
@@ -38,8 +38,10 @@ object Base {
   @throws(classOf[UnsatisfiedLinkError])
   private def tryLoadInitLibrary(): Unit = {
     var baseDir = System.getProperty("user.dir") + "/init-native"
+    // TODO(lanKing520) Update this to use relative path to the MXNet director.
+    // TODO(lanking520) baseDir = sys.env("MXNET_BASEDIR") + "/scala-package/init-native"
     if (System.getenv().containsKey("MXNET_BASEDIR")) {
-      baseDir = sys.env("MXNET_BASEDIR") + "/scala-package/init-native"
+      baseDir = sys.env("MXNET_BASEDIR")
     }
     val os = System.getProperty("os.name")
     // ref: http://lopica.sourceforge.net/os.html

--- a/scala-package/init/src/main/scala/org/apache/mxnet/init/Base.scala
+++ b/scala-package/init/src/main/scala/org/apache/mxnet/init/Base.scala
@@ -37,10 +37,9 @@ object Base {
 
   @throws(classOf[UnsatisfiedLinkError])
   private def tryLoadInitLibrary(): Unit = {
-    // val baseDir = System.getProperty("user.dir") + "/init-native"
     var baseDir = System.getProperty("user.dir") + "/init-native"
-    if (System.getenv().containsKey("BASEDIR")) {
-      baseDir = sys.env("BASEDIR")
+    if (System.getenv().containsKey("MXNET_SCALA_MACRO_BASEDIR")) {
+      baseDir = sys.env("MXNET_SCALA_MACRO_BASEDIR")
     }
     val os = System.getProperty("os.name")
     // ref: http://lopica.sourceforge.net/os.html

--- a/scala-package/macros/pom.xml
+++ b/scala-package/macros/pom.xml
@@ -75,7 +75,7 @@
         <artifactId>scalatest-maven-plugin</artifactId>
         <configuration>
           <environmentVariables>
-            <BASEDIR>${project.parent.basedir}/init-native</BASEDIR>
+            <MXNET_SCALA_MACRO_BASEDIR>${project.parent.basedir}/init-native</MXNET_SCALA_MACRO_BASEDIR>
           </environmentVariables>
           <argLine>
             -Djava.library.path=${project.parent.basedir}/native/${platform}/target \

--- a/scala-package/macros/pom.xml
+++ b/scala-package/macros/pom.xml
@@ -52,4 +52,42 @@
       <type>${libtype}</type>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>META-INF/*.SF</exclude>
+            <exclude>META-INF/*.DSA</exclude>
+            <exclude>META-INF/*.RSA</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <configuration>
+          <environmentVariables>
+            <BASEDIR>${project.parent.basedir}/init-native</BASEDIR>
+          </environmentVariables>
+          <argLine>
+            -Djava.library.path=${project.parent.basedir}/native/${platform}/target \
+            -Dlog4j.configuration=file://${project.basedir}/src/test/resources/log4j.properties
+          </argLine>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.scalastyle</groupId>
+        <artifactId>scalastyle-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/scala-package/macros/pom.xml
+++ b/scala-package/macros/pom.xml
@@ -75,7 +75,7 @@
         <artifactId>scalatest-maven-plugin</artifactId>
         <configuration>
           <environmentVariables>
-            <MXNET_SCALA_MACRO_BASEDIR>${project.parent.basedir}/init-native</MXNET_SCALA_MACRO_BASEDIR>
+            <MXNET_BASEDIR>${project.parent.basedir}/init-native</MXNET_BASEDIR>
           </environmentVariables>
           <argLine>
             -Djava.library.path=${project.parent.basedir}/native/${platform}/target \

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
@@ -183,7 +183,7 @@ private[mxnet] object SymbolImplMacros {
   }
 
   // Convert C++ Types to Scala Types
-  private def typeConversion(in : String, argType : String = "") : String = {
+  def typeConversion(in : String, argType : String = "") : String = {
     in match {
       case "Shape(tuple)" | "ShapeorNone" => "org.apache.mxnet.Shape"
       case "Symbol" | "NDArray" | "NDArray-or-Symbol" => "org.apache.mxnet.Symbol"
@@ -212,7 +212,7 @@ private[mxnet] object SymbolImplMacros {
     * @param argType Raw arguement Type description
     * @return (Scala_Type, isOptional)
     */
-  private def argumentCleaner(argType : String) : (String, Boolean) = {
+  def argumentCleaner(argType : String) : (String, Boolean) = {
     val spaceRemoved = argType.replaceAll("\\s+", "")
     var commaRemoved : Array[String] = new Array[String](0)
     // Deal with the case e.g: stype : {'csr', 'default', 'row_sparse'}

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
@@ -89,6 +89,8 @@ private[mxnet] object SymbolImplMacros {
       case q"new AddSymbolAPIs($b)" => c.eval[Boolean](c.Expr(b))
     }
 
+    // TODO: Put Symbol.api.foo --> Stable APIs
+    // Symbol.contrib.bar--> Contrib APIs
     val newSymbolFunctions = {
       if (isContrib) symbolFunctions.filter(
         func => func.name.startsWith("_contrib_") || !func.name.startsWith("_"))
@@ -125,6 +127,7 @@ private[mxnet] object SymbolImplMacros {
       argDef += "name : String = null"
       argDef += "attr : Map[String, String] = null"
       // scalastyle:off
+      // TODO: Seq() here allows user to place Symbols rather than normal arguments to run, need to fix if old API deprecated
       impl += "org.apache.mxnet.Symbol.createSymbolGeneral(\"" + symbolfunction.name + "\", name, attr, Seq(), map.toMap)"
       // scalastyle:on
       // Combine and build the function string

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
@@ -56,6 +56,7 @@ private[mxnet] object SymbolImplMacros {
         val funcName = symbolfunction.name
         val tName = TermName(funcName)
         q"""
+            @Deprecated
             def $tName(name : String = null, attr : Map[String, String] = null)
             (args : org.apache.mxnet.Symbol*)(kwargs : Map[String, Any] = null)
              : org.apache.mxnet.Symbol = {

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
@@ -177,6 +177,9 @@ private[mxnet] object SymbolImplMacros {
     }
     // Optional Field
     if (commaRemoved.length >= 3) {
+      // arg: Type, optional, default = Null
+      require(commaRemoved(1).equals("optional"))
+      require(commaRemoved(2).startsWith("default="))
       (typeConversion(commaRemoved(0), argType), true)
     } else if (commaRemoved.length == 2 || commaRemoved.length == 1) {
       val tempType = typeConversion(commaRemoved(0), argType)

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
@@ -57,8 +57,9 @@ private[mxnet] object SymbolImplMacros {
     }
 
     val newSymbolFunctions = {
-      if (isContrib) symbolFunctions.filter(_.name.startsWith("_contrib_"))
-      else symbolFunctions.filter(!_.name.startsWith("_contrib_"))
+      if (isContrib) symbolFunctions.filter(
+        func => func.name.startsWith("_contrib_") || !func.name.startsWith("_"))
+      else symbolFunctions.filter(!_.name.startsWith("_"))
     }
 
     var functionDefs = List[DefDef]()

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
@@ -66,8 +66,8 @@ private[mxnet] object SymbolImplMacros {
 
 
     val newFunctionDefs : List[DefDef] = newSymbolFunctions map { symbolfunction =>
-      // TODO: Implement the codeGen
 
+      // Construct argument field
       var argDef = ListBuffer[String]()
       symbolfunction.listOfArgs.foreach(symbolarg => {
         val currArgName = if (symbolarg.argName.equals("var")) "vari" else symbolarg.argName
@@ -80,7 +80,7 @@ private[mxnet] object SymbolImplMacros {
       })
       argDef += "name : String = null"
       argDef += "attr : Map[String, String] = null"
-
+      // Construct Implementation field
       var impl = ListBuffer[String]()
       impl += "val map = scala.collection.mutable.Map[String, Any]()"
       symbolfunction.listOfArgs.foreach({ symbolarg =>
@@ -92,7 +92,7 @@ private[mxnet] object SymbolImplMacros {
         impl += base
       })
       impl += "createSymbolGeneral(\"" + symbolfunction.name + "\", name, attr, Seq(), map.toMap)"
-
+      // Combine and build the function string
       val returnType = "Symbol"
       var finalStr = s"def ${symbolfunction.name}New"
       finalStr += s" (${argDef.mkString(",")}) : Symbol"
@@ -158,7 +158,6 @@ private[mxnet] object SymbolImplMacros {
     if (spaceRemoved.charAt(0)== '{') {
       val endIdx = spaceRemoved.indexOf('}')
       commaRemoved = spaceRemoved.substring(endIdx + 1).split(",")
-      // commaRemoved(0) = spaceRemoved.substring(0, endIdx+1)
       commaRemoved(0) = "string"
     } else {
       commaRemoved = spaceRemoved.split(",")
@@ -166,8 +165,6 @@ private[mxnet] object SymbolImplMacros {
     // Optional Field
     if (commaRemoved.length >= 3) {
       (typeConversion(commaRemoved(0), argType), true)
-      // TODO: Qing: do we set default value on our side?
-      // optionalField = " = " + conversion(typeConv, commaRemoved(2).split("=")(1))
     } else if (commaRemoved.length == 2 || commaRemoved.length == 1) {
       val tempType = typeConversion(commaRemoved(0), argType)
       val tempOptional = tempType.equals("Symbol")

--- a/scala-package/macros/src/test/resources/log4j.properties
+++ b/scala-package/macros/src/test/resources/log4j.properties
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# for development debugging
+log4j.rootLogger = debug, stdout
+
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target = System.out
+log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} [%t] [%c] [%p] - %m%n

--- a/scala-package/macros/src/test/scala/org/apache/mxnet/MacrosSuite.scala
+++ b/scala-package/macros/src/test/scala/org/apache/mxnet/MacrosSuite.scala
@@ -25,13 +25,6 @@ class MacrosSuite extends FunSuite with BeforeAndAfterAll {
   private val logger = LoggerFactory.getLogger(classOf[MacrosSuite])
 
 
-  override def beforeAll() {
-  }
-
-  override def afterAll(): Unit = {
-
-  }
-
   test("MacrosSuite-testArgumentCleaner") {
     val input = List(
       "Symbol, optional, default = Null",

--- a/scala-package/macros/src/test/scala/org/apache/mxnet/MacrosSuite.scala
+++ b/scala-package/macros/src/test/scala/org/apache/mxnet/MacrosSuite.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.mxnet
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import org.slf4j.LoggerFactory
+
+class MacrosSuite extends FunSuite with BeforeAndAfterAll {
+
+  private val logger = LoggerFactory.getLogger(classOf[MacrosSuite])
+
+
+  override def beforeAll() {
+  }
+
+  override def afterAll(): Unit = {
+
+  }
+
+  test("MacrosSuite-testArgumentCleaner") {
+    val input = List(
+      "Symbol, optional, default = Null",
+      "int, required",
+      "Shape(tuple), optional, default = []",
+      "{'csr', 'default', 'row_sparse'}, optional, default = 'csr'",
+      ", required"
+    )
+    val output = List(
+      ("org.apache.mxnet.Symbol", true),
+      ("Int", false),
+      ("org.apache.mxnet.Shape", true),
+      ("String", true),
+      ("Any", false)
+    )
+
+    for (idx <- input.indices) {
+      val result = SymbolImplMacros.argumentCleaner(input(idx))
+      assert(result._1 === output(idx)._1 && result._2 === output(idx)._2)
+    }
+  }
+
+}


### PR DESCRIPTION
## Description ##
See [full design document](https://cwiki.apache.org/confluence/display/MXNET/MXNet+Scala+API+Usability+Improvement)
@nswamy @yzhliu 
This PR is the Addition for new Symbol functions of Scala API
## Checklist ##
### Essentials ###
- [x] Use QuasiQuote to replace original API Implementation (Reduce lines)
- [x] MakeAtomicFunction change to support String type parameter type in
- [x] User New namespace for New API (temporarily Symbol.api.function_name)
- [x] Default args using None to pass in as default
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
