### PR TITLE
[MX-307] Upgrade timeout to 10 minutes per test

### DIFF
--- a/tests/tutorials/test_tutorials.py
+++ b/tests/tutorials/test_tutorials.py
@@ -44,9 +44,9 @@ from nbconvert.preprocessors import ExecutePreprocessor
 import sys
 
 
-# Maximum 7 minutes per test
+# Maximum 10 minutes per test
 # Reaching timeout causes a test failure
-TIME_OUT = 7*60
+TIME_OUT = 10*60
 # Pin to ipython version 4
 IPYTHON_VERSION = 4
 temp_dir = 'tmp_notebook'


### PR DESCRIPTION
That might be useful on a very slow day, but any tests runs in less than 2 minutes locally. There was one instance of failure because of timeout after 7 min. If it happens again, it is actually a hang rather than a timeout.