### PR TITLE
Update fit.py

### DIFF
--- a/example/image-classification/common/fit.py
+++ b/example/image-classification/common/fit.py
@@ -238,7 +238,7 @@ def fit(args, network, data_loader, **kwargs):
             # AlexNet will not converge using Xavier
             initializer = mx.init.Normal()
             # VGG will not trend to converge using Xavier-Gaussian
-        elif args.network != None and 'vgg' in args.network:
+        elif args.network and 'vgg' in args.network:
             initializer = mx.init.Xavier()
         else:
             initializer = mx.init.Xavier(

--- a/example/image-classification/common/fit.py
+++ b/example/image-classification/common/fit.py
@@ -238,7 +238,7 @@ def fit(args, network, data_loader, **kwargs):
             # AlexNet will not converge using Xavier
             initializer = mx.init.Normal()
             # VGG will not trend to converge using Xavier-Gaussian
-        elif 'vgg' in args.network:
+        elif args.network != None and 'vgg' in args.network:
             initializer = mx.init.Xavier()
         else:
             initializer = mx.init.Xavier(


### PR DESCRIPTION
## Description ##
args.network is None during finetuing using fine-tune.py file which is provided. Hence, line 241 throws an error while trying to see if 'vgg' is in args.network. Patching it by checking if args.network is None before seeing if 'vgg' is present in network name.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
