### PR TITLE
[MXNET-346] Fix flaky test for hard sigmoid

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -601,7 +601,7 @@ def test_hard_sigmoid():
     for dtype in [np.float16, np.float32, np.float64]:
         if dtype is np.float16:
             rtol = 1e-2
-            atol = 1e-4
+            atol = 1e-3
         else:
             rtol = 1e-3
             atol = 1e-5
@@ -611,9 +611,10 @@ def test_hard_sigmoid():
         xa[xa == -2.5] = xa[xa == -2.5] - 1e-2
         ya = fhardsigmoid(xa)
         grad_xa = fhardsigmoid_grad(xa, np.ones(shape))
-        check_numeric_gradient(y, [xa], numeric_eps=1e-3, rtol=rtol, atol=atol)
-        check_symbolic_forward(y, [xa], [ya], rtol=rtol, atol=atol)
-        check_symbolic_backward(y, [xa], [np.ones(shape)], [grad_xa], rtol=rtol, atol=atol)
+        if dtype is not np.float16:
+            check_numeric_gradient(y, [xa], numeric_eps=1e-3, rtol=rtol, atol=atol, dtype=dtype)
+        check_symbolic_forward(y, [xa], [ya], rtol=rtol, atol=atol, dtype=dtype)
+        check_symbolic_backward(y, [xa], [np.ones(shape)], [grad_xa], rtol=rtol, atol=atol, dtype=dtype)
 
 @with_seed()
 def test_softsign():


### PR DESCRIPTION
## Description ##
Same as title.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-346]
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fix flaky hard sigmoid unit test with dtype match in check_forward/backward/gradient

## Comments ##
@piiswrong