### PR TITLE
[MXNET-360]auto convert str to bytes in img.imdecode when py3

### DIFF
--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -21,13 +21,14 @@
 
 from __future__ import absolute_import, print_function
 
+import sys
 import os
 import random
 import logging
 import json
 import warnings
 import numpy as np
-import sys
+
 
 try:
     import cv2

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -27,6 +27,7 @@ import logging
 import json
 import warnings
 import numpy as np
+import sys
 
 try:
     import cv2
@@ -133,8 +134,10 @@ def imdecode(buf, *args, **kwargs):
     <NDArray 224x224x3 @cpu(0)>
     """
     if not isinstance(buf, nd.NDArray):
-        if sys.version_info[0] == 3 and not (isinstance(buf, bytes) or isinstance(buf, np.ndarray)):
-            raise ValueError('buf must bytes or numpy.ndarray,if you input str,please convert it to bytes')
+        if sys.version_info[0] == 3 \
+                and not (isinstance(buf, bytes) or isinstance(buf, np.ndarray)):
+            raise ValueError('buf must bytes or numpy.ndarray,'
+                             'if you input str,please convert it to bytes')
         buf = nd.array(np.frombuffer(buf, dtype=np.uint8), dtype=np.uint8)
     return _internal._cvimdecode(buf, *args, **kwargs)
 

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -133,6 +133,8 @@ def imdecode(buf, *args, **kwargs):
     <NDArray 224x224x3 @cpu(0)>
     """
     if not isinstance(buf, nd.NDArray):
+        if sys.version_info[0] == 3 and not (isinstance(buf, bytes) or isinstance(buf, np.ndarray)):
+            raise ValueError('buf must bytes or numpy.ndarray,if you input str,please convert it to bytes')
         buf = nd.array(np.frombuffer(buf, dtype=np.uint8), dtype=np.uint8)
     return _internal._cvimdecode(buf, *args, **kwargs)
 

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -136,8 +136,8 @@ def imdecode(buf, *args, **kwargs):
     """
     if not isinstance(buf, nd.NDArray):
         if sys.version_info[0] == 3 and not isinstance(buf, (bytes, np.ndarray)):
-            raise ValueError('buf must bytes or numpy.ndarray,'
-                             'if you input str,please convert it to bytes')
+            raise ValueError('buf must be of type bytes or numpy.ndarray,'
+                             'if you would like to input type str, please convert to bytes')
         buf = nd.array(np.frombuffer(buf, dtype=np.uint8), dtype=np.uint8)
     return _internal._cvimdecode(buf, *args, **kwargs)
 

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -135,8 +135,7 @@ def imdecode(buf, *args, **kwargs):
     <NDArray 224x224x3 @cpu(0)>
     """
     if not isinstance(buf, nd.NDArray):
-        if sys.version_info[0] == 3 \
-                and not (isinstance(buf, bytes) or isinstance(buf, np.ndarray)):
+        if sys.version_info[0] == 3 and not isinstance(buf, (bytes, np.ndarray)):
             raise ValueError('buf must bytes or numpy.ndarray,'
                              'if you input str,please convert it to bytes')
         buf = nd.array(np.frombuffer(buf, dtype=np.uint8), dtype=np.uint8)


### PR DESCRIPTION
## Description ##
auto convert str to bytes in img.imdecode when py3

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###


## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
