### PR TITLE
[MXNET-357][WIP] New Scala API Design (NDArray)

### DIFF
--- a/scala-package/macros/src/main/scala/org/apache/mxnet/NDArrayMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/NDArrayMacro.scala
@@ -52,18 +52,6 @@ private[mxnet] object NDArrayMacro {
       else ndarrayFunctions.filter(!_._1.startsWith("_contrib_"))
     }
 
-    val AST_NDARRAY_TYPE = Select(Select(Select(
-      Ident(TermName("org")), TermName("apache")), TermName("mxnet")), TypeName("NDArray"))
-    val AST_TYPE_MAP_STRING_ANY = AppliedTypeTree(Ident(TypeName("Map")),
-      List(Ident(TypeName("String")), Ident(TypeName("Any"))))
-    val AST_TYPE_ANY_VARARG = AppliedTypeTree(
-      Select(
-        Select(Ident(termNames.ROOTPKG), TermName("scala")),
-        TypeName("<repeated>")
-      ),
-      List(Ident(TypeName("Any")))
-    )
-
     val functionDefs = newNDArrayFunctions flatMap { case (funcName, funcProp) =>
       val functionScope = {
         if (isContrib) Modifiers()
@@ -75,45 +63,15 @@ private[mxnet] object NDArrayMacro {
         if (isContrib) funcName.substring(funcName.indexOf("_contrib_") + "_contrib_".length())
         else funcName
       }
-
+      val termName = TermName(funcName)
       // It will generate definition something like,
       Seq(
+        // scalastyle:off
         // def transpose(kwargs: Map[String, Any] = null)(args: Any*)
-        DefDef(functionScope, TermName(newName), List(),
-          List(
-            List(
-              ValDef(Modifiers(Flag.PARAM | Flag.DEFAULTPARAM), TermName("kwargs"),
-                AST_TYPE_MAP_STRING_ANY, Literal(Constant(null)))
-            ),
-            List(
-              ValDef(Modifiers(), TermName("args"), AST_TYPE_ANY_VARARG, EmptyTree)
-            )
-          ), TypeTree(),
-          Apply(
-            Ident(TermName("genericNDArrayFunctionInvoke")),
-            List(
-              Literal(Constant(funcName)),
-              Ident(TermName("args")),
-              Ident(TermName("kwargs"))
-            )
-          )
-        ),
+        q"def $termName(kwargs: Map[String, Any] = null)(args: Any*) = {genericNDArrayFunctionInvoke($funcName, args, kwargs)}",
         // def transpose(args: Any*)
-        DefDef(functionScope, TermName(newName), List(),
-          List(
-            List(
-              ValDef(Modifiers(), TermName("args"), AST_TYPE_ANY_VARARG, EmptyTree)
-            )
-          ), TypeTree(),
-          Apply(
-            Ident(TermName("genericNDArrayFunctionInvoke")),
-            List(
-              Literal(Constant(funcName)),
-              Ident(TermName("args")),
-              Literal(Constant(null))
-            )
-          )
-        )
+        q"def $termName(args: Any*) = {genericNDArrayFunctionInvoke($funcName, args, null)}"
+        // scalastyle:on
       )
     }
 


### PR DESCRIPTION
## Description ##
See [full design document](https://cwiki.apache.org/confluence/display/MXNET/MXNet+Scala+API+Usability+Improvement)
@nswamy @yzhliu 
This PR is the Addition for new NDArray functions of Scala API
## Checklist ##
### Essentials ###
- [x] Use QuasiQuote to replace original API Implementation (Reduce lines)
- [ ] MakeAtomicFunction change to support String type parameter type in
- [ ] User New namespace for New API (temporarily <Functioname>New)
- [ ] Default args using None to pass in as default
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
