### PR TITLE
Add cuda version check to skip building quantization ops for versions less than 8.0

### DIFF
--- a/src/operator/quantization/quantized_conv.cu
+++ b/src/operator/quantization/quantized_conv.cu
@@ -280,7 +280,8 @@ void QuantizedConvForwardGPU(const nnvm::NodeAttrs& attrs,
   op.Init(param, ctx, {inputs[0].shape_, inputs[1].shape_}, {outputs[0].shape_});
   op.Forward(ctx, inputs, req, outputs);
 #else
-  LOG(FATAL) << "QuantizedConvForward<gpu> only supports cudnnConvolutionForward for now";
+  LOG(FATAL) << "QuantizedConvForward<gpu> only supports cudnnConvolutionForward "
+                "with CUDNN >= 6.0 and CUDA >= 8.0";
 #endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6 && CUDA_VERSION >= 8000
 }
 

--- a/src/operator/quantization/quantized_conv.cu
+++ b/src/operator/quantization/quantized_conv.cu
@@ -49,7 +49,7 @@ struct QuantizedBiasAddKernel {
   }
 };
 
-#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6
+#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6 && CUDA_VERSION >= 8000
 template<typename SrcType, typename DstType, typename CmpType>
 class QuantizedCuDNNConvOp {
  public:
@@ -260,7 +260,7 @@ class QuantizedCuDNNConvOp {
   float alpha_ = 1.0f;
   float beta_ = 0.0f;
 };  // class QuantizedCuDNNConvOp
-#endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6
+#endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6 && CUDA_VERSION >= 8000
 
 void QuantizedConvForwardGPU(const nnvm::NodeAttrs& attrs,
                              const OpContext& ctx,
@@ -270,7 +270,7 @@ void QuantizedConvForwardGPU(const nnvm::NodeAttrs& attrs,
   const ConvolutionParam& param = nnvm::get<ConvolutionParam>(attrs.parsed);
   CHECK_EQ(param.kernel.ndim(), 2U)
     << "QuantizedConvForward<gpu> only supports 2D convolution for now";
-#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6
+#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6 && CUDA_VERSION >= 8000
   typedef QuantizedCuDNNConvOp<int8_t, float, int32_t> QuantizedConvOpInt8;
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local QuantizedConvOpInt8 op;
@@ -281,7 +281,7 @@ void QuantizedConvForwardGPU(const nnvm::NodeAttrs& attrs,
   op.Forward(ctx, inputs, req, outputs);
 #else
   LOG(FATAL) << "QuantizedConvForward<gpu> only supports cudnnConvolutionForward for now";
-#endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6
+#endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6 && CUDA_VERSION >= 8000
 }
 
 NNVM_REGISTER_OP(_contrib_quantized_conv)

--- a/src/operator/quantization/quantized_fully_connected.cu
+++ b/src/operator/quantization/quantized_fully_connected.cu
@@ -30,6 +30,7 @@
 namespace mxnet {
 namespace op {
 
+#if CUDA_VERSION >= 8000
 // value + bias_value * (range1 / limit_range1) * (limit_range2 / range2)
 struct QuantizedBiasAddKernel {
   MSHADOW_XINLINE static void Map(int i, size_t k, int32_t *out,
@@ -49,6 +50,7 @@ struct QuantizedBiasAddKernel {
              float_for_one_out_quant;
   }
 };
+#endif  // CUDA_VERSION >= 8000
 
 template<typename SrcType, typename DstType, typename CmpType>
 void QuantizedFullyConnectedForwardGPU(const nnvm::NodeAttrs& attrs,
@@ -56,6 +58,7 @@ void QuantizedFullyConnectedForwardGPU(const nnvm::NodeAttrs& attrs,
                                        const std::vector<TBlob> &inputs,
                                        const std::vector<OpReqType> &req,
                                        const std::vector<TBlob> &outputs) {
+#if CUDA_VERSION >= 8000
   const FullyConnectedParam& param = nnvm::get<FullyConnectedParam>(attrs.parsed);
   using namespace mshadow;
   using namespace mxnet_op;
@@ -113,6 +116,7 @@ void QuantizedFullyConnectedForwardGPU(const nnvm::NodeAttrs& attrs,
         outputs[1].dptr<float>(), outputs[2].dptr<float>(),
          inputs[7].dptr<float>(),  inputs[8].dptr<float>());
   }
+#endif  // CUDA_VERSION >= 8000
 }
 
 NNVM_REGISTER_OP(_contrib_quantized_fully_connected)

--- a/src/operator/quantization/quantized_fully_connected.cu
+++ b/src/operator/quantization/quantized_fully_connected.cu
@@ -116,6 +116,8 @@ void QuantizedFullyConnectedForwardGPU(const nnvm::NodeAttrs& attrs,
         outputs[1].dptr<float>(), outputs[2].dptr<float>(),
          inputs[7].dptr<float>(),  inputs[8].dptr<float>());
   }
+#else
+  LOG(FATAL) << "QuantizedFullyConnectedForwardGPU only supports CUDA >= 8.0";
 #endif  // CUDA_VERSION >= 8000
 }
 

--- a/src/operator/quantization/quantized_pooling.cu
+++ b/src/operator/quantization/quantized_pooling.cu
@@ -134,7 +134,8 @@ void QuantizedPoolingForwardGPU(const nnvm::NodeAttrs& attrs,
   op.Init(param, {inputs[0].shape_}, {outputs[0].shape_});
   op.Forward(ctx.get_stream<gpu>(), inputs, req, outputs);
 #else
-  LOG(FATAL) << "QuantizedPoolingForward<gpu> only supports cudnnPoolingForward for now";
+  LOG(FATAL) << "QuantizedPoolingForward<gpu> only supports cudnnPoolingForward "
+                "with CUDNN >= 6.0 and CUDA >= 8.0";
 #endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6 && CUDA_VERSION >= 8000
 }
 

--- a/src/operator/quantization/quantized_pooling.cu
+++ b/src/operator/quantization/quantized_pooling.cu
@@ -29,7 +29,7 @@
 namespace mxnet {
 namespace op {
 
-#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6
+#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6 && CUDA_VERSION >= 8000
 template<typename DType>
 class QuantizedCuDNNPoolingOp {
  public:
@@ -115,7 +115,7 @@ class QuantizedCuDNNPoolingOp {
   cudnnTensorDescriptor_t out_desc_;
   cudnnPoolingDescriptor_t pool_desc_;
 };  // class QuantizedCuDNNPoolingOp
-#endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6
+#endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6 && CUDA_VERSION >= 8000
 
 void QuantizedPoolingForwardGPU(const nnvm::NodeAttrs& attrs,
                                 const OpContext& ctx,
@@ -125,7 +125,7 @@ void QuantizedPoolingForwardGPU(const nnvm::NodeAttrs& attrs,
   const PoolingParam& param = nnvm::get<PoolingParam>(attrs.parsed);
   CHECK_EQ(param.kernel.ndim(), 2U)
     << "QuantizedPoolingForward<gpu> only supports 2D convolution for now";
-#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6
+#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6 && CUDA_VERSION >= 8000
 #if DMLC_CXX11_THREAD_LOCAL
   static thread_local QuantizedCuDNNPoolingOp<int8_t> op;
 #else
@@ -135,7 +135,7 @@ void QuantizedPoolingForwardGPU(const nnvm::NodeAttrs& attrs,
   op.Forward(ctx.get_stream<gpu>(), inputs, req, outputs);
 #else
   LOG(FATAL) << "QuantizedPoolingForward<gpu> only supports cudnnPoolingForward for now";
-#endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6
+#endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 6 && CUDA_VERSION >= 8000
 }
 
 NNVM_REGISTER_OP(_contrib_quantized_pooling)


### PR DESCRIPTION

## Description ##
Build would fail if users installed cuda prior to version 8.0. Added cuda version check to prevent build failure.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
