### PR TITLE
[MXNET-363] fix race condition in sparse dot(csr.T, dense) on gpu

### DIFF
--- a/src/operator/tensor/dot-inl.cuh
+++ b/src/operator/tensor/dot-inl.cuh
@@ -32,8 +32,6 @@
 #include "./util/tensor_util-inl.h"
 #include "./util/tensor_util-inl.cuh"
 #include "./indexing_op.h"
-#include "./init_op.h"
-#include "./sort_op.h"
 
 
 namespace mxnet {

--- a/src/operator/tensor/dot-inl.cuh
+++ b/src/operator/tensor/dot-inl.cuh
@@ -655,19 +655,18 @@ struct DotCsrTransDnsRspKernel {
                                              const DType* val_array,
                                              const IType* idx_array,
                                              const nnvm::dim_t row_length) {
-    using nnvm::dim_t;
     int tid = thread_id / row_length;
-    const dim_t offset = thread_id % row_length;
+    const nnvm::dim_t offset = thread_id % row_length;
     if (tid == 0 || sorted_indices[tid - 1] != sorted_indices[tid]) {
       DType acc = 0;
-      const dim_t src_row_idx = sorted_indices[tid];
-      const dim_t dst_row_idx = lookup_table[src_row_idx];
-      const dim_t out_offset = dst_row_idx * row_length + offset;
+      const IType src_row_idx = sorted_indices[tid];
+      const IType dst_row_idx = lookup_table[src_row_idx];
+      const IType out_offset = dst_row_idx * row_length + offset;
       do {
-        const dim_t idx = original_idx[tid];
+        const IType idx = original_idx[tid];
         const DType val = val_array[idx];
         const DType col_idx = idx_array[idx];
-        const dim_t rhs_offset = col_idx * row_length + offset;
+        const IType rhs_offset = col_idx * row_length + offset;
         acc += rhs[rhs_offset] * val;
         tid++;
       } while (tid < nnz && sorted_indices[tid - 1] == sorted_indices[tid]);

--- a/src/operator/tensor/dot-inl.cuh
+++ b/src/operator/tensor/dot-inl.cuh
@@ -719,11 +719,6 @@ inline void DotCsrDnsRspImpl(const OpContext& ctx,
   const dim_t num_rows_l = lhs.shape()[0];
   const dim_t num_cols_l = lhs.shape()[1];
   const dim_t num_cols_r = rhs.shape_[1];
-  const dim_t threads_per_warp = mxnet_op::cuda_get_device_prop().warpSize;
-  // TODO: remove kernel dependency on warpSize=32
-  if (threads_per_warp != 32) {
-    LOG(FATAL) << "DotCsrDnsRspImpl GPU kernels expect warpSize=32";
-  }
   CHECK_EQ(ret->aux_type(rowsparse::kIdx), col_idx_l.type_flag_)
     << "Mismatch indices dtype detected";
   MSHADOW_SGL_DBL_TYPE_SWITCH(data_l.type_flag_, DType, {  // data type
@@ -739,7 +734,7 @@ inline void DotCsrDnsRspImpl(const OpContext& ctx,
           IType* lookup_table_ptr = nullptr;
           char* temp_storage_ptr = nullptr;
 
-          // estimate temp space for unique. TODO(haibin) refactor unique code
+          // estimate temp space for unique.
           const size_t nnr_bytes = sizeof(size_t);
           size_t unique_temp_bytes = 0;
           size_t *null_ptr = nullptr;

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -42,7 +42,6 @@
 #include "./util/tensor_util-inl.h"
 #include "../mxnet_op.h"
 #include "./sort_op.h"
-#include "./dot-inl.h"
 #include "./init_op.h"
 #include "./matrix_op-inl.h"
 #include "../../engine/openmp.h"

--- a/src/operator/tensor/util/tensor_util-inl.h
+++ b/src/operator/tensor/util/tensor_util-inl.h
@@ -76,6 +76,20 @@ struct FillRspRowIdxKernel {
   }
 };
 
+/*
+ * \brief the kernel to generate a lookup table for positions of row ids
+ * \param i thread id
+ * \param out output table
+ * \param data the input row id in sorted order
+ */
+struct MarkLookupTable {
+  template<typename IType, typename DType>
+  MSHADOW_XINLINE static void Map(int i, IType* out, const DType* data) {
+    out[static_cast<nnvm::dim_t>(data[i])] = i;
+  }
+};
+
+
 }  // namespace op
 }  // namespace mxnet
 

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1336,22 +1336,9 @@ def test_sparse_dot():
     test_sparse_dot_zero_output(rand_shape_2d(50, 200), False, 40)
     test_sparse_dot_zero_output(rand_shape_2d(50, 200), True, 40)
 
-@with_seed(0)
-def test_sparse_dot_determinism():
-    def check_dot_determinism(lhs_stype, rhs_stype, lhs_density, rhs_density, transpose_a, transpose_b):
-        lhs_shape = (32, 1000)
-        rhs_shape = (32, 64)
-        lhs = rand_ndarray(lhs_shape, lhs_stype, density=lhs_density)
-        rhs = rand_ndarray(rhs_shape, rhs_stype, density=rhs_density)
-        res1 = mx.nd.sparse.dot(lhs, rhs, transpose_a=transpose_a, transpose_b=transpose_b)
-        res2 = mx.nd.sparse.dot(lhs, rhs, transpose_a=transpose_a, transpose_b=transpose_b)
-        assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=0.0, atol=0.0)
-    check_dot_determinism('csr', 'default', 0.5, 1.0, True, False)
-
-
 @with_seed()
 def test_sparse_dot_determinism():
-    def test_dot_determinism(lhs_stype, rhs_stype, lhs_density, rhs_density, transpose_a, transpose_b):
+    def test_dot_determinism(lhs_stype, rhs_stype, lhs_density, rhs_density, transpose_a, transpose_b, forward_stype):
         lhs_row = rnd.randint(50, 100)
         lhs_col = rnd.randint(50, 100)
         if transpose_a:
@@ -1364,18 +1351,17 @@ def test_sparse_dot_determinism():
                 rhs_shape = (rnd.randint(50, 100), lhs_col)
             else:
                 rhs_shape = (lhs_col, rnd.randint(50, 100))
-        if default_context() == mx.cpu():
-            forward_stype = 'csr'
-        else:
-            forward_stype = 'default'
         lhs_shape = (lhs_row, lhs_col)
         lhs = rand_ndarray(lhs_shape, lhs_stype, density=lhs_density)
         rhs = rand_ndarray(rhs_shape, rhs_stype, density=rhs_density)
         res1 = mx.nd.sparse.dot(lhs, rhs, transpose_a=transpose_a, transpose_b=transpose_b, forward_stype=forward_stype)
         res2 = mx.nd.sparse.dot(lhs, rhs, transpose_a=transpose_a, transpose_b=transpose_b, forward_stype=forward_stype)
         assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=0.0, atol=0.0)
-    test_dot_determinism('default', 'csr', 1.0, 0.1, False, False)
-    test_dot_determinism('default', 'csr', 1.0, 0.1, False, True)
+
+    test_dot_determinism('csr', 'default', 0.1, 1.0, True, False, 'row_sparse')
+    forward_stype = 'csr' if default_context() == mx.cpu() else 'default'
+    test_dot_determinism('default', 'csr', 1.0, 0.1, False, False, forward_stype)
+    test_dot_determinism('default', 'csr', 1.0, 0.1, False, True, forward_stype)
 
 
 @with_seed()

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1336,6 +1336,18 @@ def test_sparse_dot():
     test_sparse_dot_zero_output(rand_shape_2d(50, 200), False, 40)
     test_sparse_dot_zero_output(rand_shape_2d(50, 200), True, 40)
 
+@with_seed(0)
+def test_sparse_dot_determinism():
+    def check_dot_determinism(lhs_stype, rhs_stype, lhs_density, rhs_density, transpose_a, transpose_b):
+        lhs_shape = (32, 1000)
+        rhs_shape = (32, 64)
+        lhs = rand_ndarray(lhs_shape, lhs_stype, density=lhs_density)
+        rhs = rand_ndarray(rhs_shape, rhs_stype, density=rhs_density)
+        res1 = mx.nd.sparse.dot(lhs, rhs, transpose_a=transpose_a, transpose_b=transpose_b)
+        res2 = mx.nd.sparse.dot(lhs, rhs, transpose_a=transpose_a, transpose_b=transpose_b)
+        assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=0.0, atol=0.0)
+    check_dot_determinism('csr', 'default', 0.5, 1.0, True, False)
+
 
 @with_seed()
 def test_sparse_dot_determinism():


### PR DESCRIPTION
## Description ##
Use sort in dot(csr.T, dense) to ensure deterministic result. 
After benchmarking with synthetic uniform sparse data, the performance is almost the same as the previous version. Below please find the script. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

Benchmark script:
```
def measure_cost(repeat, f, *args, **kwargs):
    # start bench
    start = time.time()
    results = []
    for i in range(repeat):
        results.append(f(*args, **kwargs))
    for result in results:
        result.wait_to_read()
    end = time.time()
    diff = end - start
    return diff / repeat

def main():
    shape_lhs = (256, 1000000)
    shape_rhs = (256, 512)
    rhs = rand_ndarray(shape_rhs, 'default')
    for density in [0.01, 0.005, 0.001]:
        lhs = rand_ndarray(shape_lhs, 'csr', density=density)
        lhs_dns = lhs.tostype('default')
        mx.nd.waitall()
        # warmup
        check = mx.nd.dot(lhs, rhs, transpose_a=True)
        check_dns = mx.nd.dot(lhs_dns, rhs, transpose_a=True)
        assert_almost_equal(check.asnumpy(), check_dns.asnumpy(), atol=1e-5, rtol=1e-4)
        mx.nd.waitall()
        sparse_cost = 0.0
        dns_cost = 0.0
        for i in range(1):
            sparse_cost += measure_cost(5, mx.nd.dot, lhs, rhs, transpose_a=True)
            dns_cost += measure_cost(5, mx.nd.dot, lhs_dns, rhs, transpose_a=True)

        print("%.2f %%" % (density*100), dns_cost, sparse_cost, dns_cost / sparse_cost)
        mx.nd.waitall()
        sparse_cost = 0.0
        dns_cost = 0.0
        for i in range(1):
            sparse_cost += measure_cost(50, mx.nd.dot, lhs, rhs, transpose_a=True)
            dns_cost += measure_cost(50, mx.nd.dot, lhs_dns, rhs, transpose_a=True)
        print("%.2f %%" % (density*100), dns_cost, sparse_cost, dns_cost / sparse_cost)

if __name__ == "__main__":
    main()
```
#10709