### PR TITLE
cuda archs for TX1 and TX2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ endif
 # be JIT-compiled by the updated driver from the included PTX.
 ifeq ($(USE_CUDA), 1)
 ifeq ($(CUDA_ARCH),)
-	KNOWN_CUDA_ARCHS := 30 35 50 52 60 61 70
+	KNOWN_CUDA_ARCHS := 30 35 50 52 63 60 61 62 70
 	# Run nvcc on a zero-length file to check architecture-level support.
 	# Create args to include SASS in the fat binary for supported levels.
 	CUDA_ARCH := $(foreach arch,$(KNOWN_CUDA_ARCHS), \

--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,7 @@ endif
 # be JIT-compiled by the updated driver from the included PTX.
 ifeq ($(USE_CUDA), 1)
 ifeq ($(CUDA_ARCH),)
-	KNOWN_CUDA_ARCHS := 30 35 50 52 63 60 61 62 70
+	KNOWN_CUDA_ARCHS := 30 35 50 52 53 60 61 62 70
 	# Run nvcc on a zero-length file to check architecture-level support.
 	# Create args to include SASS in the fat binary for supported levels.
 	CUDA_ARCH := $(foreach arch,$(KNOWN_CUDA_ARCHS), \


### PR DESCRIPTION
## Description ##
Add cuda archs for Jetson TX1 and TX2

Note also that one needs to add USE_F16C=0 to the make options to get this to work on Jetson. Suggest to add this to the MXnet installation documentation. Currently, people with TX1/TX2 would follow the given instructions, and are greeted with compile errors, and then spend a lot of time on StackOverflow. Here's the magic incantation version for TX1/TX2 with JetPack 3.2 (16.04) with CUDA 9.0, just leaving this on GitHub comments in hopes that people googling "mxnet jetson compile error" will find this comment:
make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 USE_F16C=0

That USE_F16C=0 needs to be done in addition to the cuda arch additions in this commit below.

(Suggestion: I wish all this F16C stuff were automatically detected and would "just work" ... especially on TX1/TX2, some of NVIDIA's most popular pieces of hardware ... people trying to work on ML shouldn't have to spend time dealing with installation problems. Ideally would be nice if it were officially supported to just be able to sudo pip3 install mxnet-cu90==1.2.0 on a TX2 and start deploying models within minutes).