### PR TITLE
[MXNET-367] update mkldnn to v0.14 and disable building test examples

### DIFF
--- a/ci/docker/install/ubuntu_mklml.sh
+++ b/ci/docker/install/ubuntu_mklml.sh
@@ -21,5 +21,5 @@
 # the whole docker cache for the image
 
 set -ex
-wget --no-check-certificate -O /tmp/mklml.tgz https://github.com/intel/mkl-dnn/releases/download/v0.12/mklml_lnx_2018.0.1.20171227.tgz
+wget --no-check-certificate -O /tmp/mklml.tgz https://github.com/intel/mkl-dnn/releases/download/v0.14/mklml_lnx_2018.0.3.20180406.tgz
 tar -zxvf /tmp/mklml.tgz && cp -rf mklml_*/* /usr/local/ && rm -rf mklml_*

--- a/prepare_mkl.sh
+++ b/prepare_mkl.sh
@@ -58,16 +58,16 @@ MXNET_ROOT=`dirname $0`
 USE_MKLML=0
 # NOTE: if you update the following line, please also update the dockerfile at
 # tests/ci_build/Dockerfile.mkl
-VERSION_MATCH=20171227
+VERSION_MATCH=20180406
 PLATFORM=$(uname)
 if [ $PLATFORM == "Darwin" ]; then
     INFIX=mac
 elif [ $PLATFORM == "Linux" ]; then
     INFIX=lnx
 fi
-ARCHIVE_BASENAME=mklml_${INFIX}_2018.0.1.${VERSION_MATCH}.tgz
+ARCHIVE_BASENAME=mklml_${INFIX}_2018.0.3.${VERSION_MATCH}.tgz
 MKL_CONTENT_DIR=`echo $ARCHIVE_BASENAME | rev | cut -d "." -f 2- | rev`
-MKLURL="https://github.com/01org/mkl-dnn/releases/download/v0.12/$ARCHIVE_BASENAME"
+MKLURL="https://github.com/intel/mkl-dnn/releases/download/v0.14/$ARCHIVE_BASENAME"
 # there are diffrent MKL lib to be used for GCC and for ICC
 reg='^[0-9]+$'
 VERSION_LINE=`GetVersionName $MKLROOT`

--- a/prepare_mkldnn.sh
+++ b/prepare_mkldnn.sh
@@ -57,6 +57,7 @@
 
 MXNET_ROOTDIR="$(pwd)"
 MKLDNN_ROOTDIR="$MXNET_ROOTDIR/3rdparty/mkldnn/"
+MKLDNN_VERSION="v0.14"
 MKLDNN_SRCDIR="$MKLDNN_ROOTDIR/src"
 MKLDNN_BUILDDIR="$MKLDNN_ROOTDIR/build"
 MKLDNN_INSTALLDIR="$MKLDNN_ROOTDIR/install"
@@ -93,7 +94,8 @@ if [ ! -f $MKLDNN_LIBFILE ]; then
     echo "Building MKLDNN ..." >&2
     cd $MXNET_ROOTDIR
 	g++ --version >&2
-    cmake $MKLDNN_ROOTDIR -DCMAKE_INSTALL_PREFIX=$MKLDNN_INSTALLDIR -B$MKLDNN_BUILDDIR -DARCH_OPT_FLAGS="-mtune=generic" >&2
+    git reset --hard $MKLDNN_VERSION >&2
+    cmake $MKLDNN_ROOTDIR -DCMAKE_INSTALL_PREFIX=$MKLDNN_INSTALLDIR -B$MKLDNN_BUILDDIR -DARCH_OPT_FLAGS="-mtune=generic" -DWITH_TEST=OFF -DWITH_EXAMPLE=OFF >&2
     NUM_PROC=1
     if [[ ! -z $(command -v nproc) ]]; then
       NUM_PROC=$(nproc)

--- a/prepare_mkldnn.sh
+++ b/prepare_mkldnn.sh
@@ -57,7 +57,6 @@
 
 MXNET_ROOTDIR="$(pwd)"
 MKLDNN_ROOTDIR="$MXNET_ROOTDIR/3rdparty/mkldnn/"
-MKLDNN_VERSION="v0.14"
 MKLDNN_SRCDIR="$MKLDNN_ROOTDIR/src"
 MKLDNN_BUILDDIR="$MKLDNN_ROOTDIR/build"
 MKLDNN_INSTALLDIR="$MKLDNN_ROOTDIR/install"
@@ -94,7 +93,6 @@ if [ ! -f $MKLDNN_LIBFILE ]; then
     echo "Building MKLDNN ..." >&2
     cd $MXNET_ROOTDIR
 	g++ --version >&2
-    git reset --hard $MKLDNN_VERSION >&2
     cmake $MKLDNN_ROOTDIR -DCMAKE_INSTALL_PREFIX=$MKLDNN_INSTALLDIR -B$MKLDNN_BUILDDIR -DARCH_OPT_FLAGS="-mtune=generic" -DWITH_TEST=OFF -DWITH_EXAMPLE=OFF >&2
     NUM_PROC=1
     if [[ ! -z $(command -v nproc) ]]; then


### PR DESCRIPTION
## Description ##
updated mkldnn submodule to latest release version, and disabled unnecessary build steps for mkldnn-examples/test

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
