### PR TITLE
[MXNET-368] Fix mxnet::Context hash for 32 bit architectures, where size_t is 32 …

### DIFF
--- a/include/mxnet/base.h
+++ b/include/mxnet/base.h
@@ -365,7 +365,10 @@ constexpr size_t kMKLDNNAlign = 64;
 namespace std {
 template<> struct hash<mxnet::Context> {
   size_t operator()(const mxnet::Context& ctx) const {
-    return (static_cast<size_t>(ctx.dev_type) << 32) | ctx.dev_id;
+    size_t res = 0;
+    res = dmlc::HashCombine(res, static_cast<size_t>(ctx.dev_type));
+    res = dmlc::HashCombine(res, static_cast<size_t>(ctx.dev_id));
+    return res;
   }
 };
 }

--- a/tests/cpp/misc/base.cc
+++ b/tests/cpp/misc/base.cc
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <mxnet/base.h>
+
+using namespace mxnet;
+using namespace std;
+
+/*
+ * Test that different Context have different hash values
+ */
+TEST(ContextHashTest, ContextHashUnique) {
+    set<size_t> hashes;
+    size_t collision_count = 0;
+    size_t total = 0;
+    for (size_t dev_type = 0; dev_type < 32; ++dev_type) {
+        for (size_t dev_id = 0; dev_id < 64; ++dev_id) {
+            auto ctx = Context::Create(static_cast<Context::DeviceType>(dev_type), dev_id);
+            size_t res = std::hash<Context>()(ctx);
+            auto insert_res = hashes.insert(res);
+            if (!insert_res.second)
+                ++collision_count;
+            ++total;
+        }
+    }
+    double collision = collision_count / static_cast<double>(total);
+    cout << "mxnet::Context std::hash collision ratio: " << collision << endl;
+    EXPECT_LE(collision, 0.04);
+}

--- a/tests/cpp/test_main.cc
+++ b/tests/cpp/test_main.cc
@@ -53,19 +53,21 @@ bool csv = false;
 #if MXNET_USE_CUDA
 
 static bool checkForWorkingCuda() {
-  int count = 0;
-  if (cudaSuccess == cudaGetDeviceCount(&count)) {
-    if (count == 0) return -1;
-    for (int device = 0; device < count; ++device) {
+  int device_count = 0;
+  bool workingCuda = false;
+  if (cudaSuccess == cudaGetDeviceCount(&device_count)) {
+    for (int device = 0; device < device_count; ++device) {
       cudaDeviceProp prop;
       if (cudaSuccess == cudaGetDeviceProperties(&prop, device)) {
-        std::printf("%d.%d ", prop.major, prop.minor);
-        return true;
+        std::cout << "Found CUDA Device #: " << device << " properties: " << prop.major
+                  << "." << prop.minor << std::endl;
+        workingCuda = true;
       }
     }
   }
-  std::cerr << "Warning: Could not find working CUDA driver" << std::endl;
-  return false;
+  if (!workingCuda)
+    std::cerr << "Warning: Could not find working CUDA device" << std::endl;
+  return workingCuda;
 }
 #else
 static bool checkForWorkingCuda() {


### PR DESCRIPTION
…bit.

## Description ##
Fix mxnet::Context hash for 32 bit architectures, where size_t is 32 bit. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

