### PR TITLE
Fix row_sparse_pull with single gpu

### DIFF
--- a/src/kvstore/kvstore_local.h
+++ b/src/kvstore/kvstore_local.h
@@ -187,7 +187,11 @@ class KVStoreLocal : public KVStore {
           updater_(key, merged,  &local);
         }
       } else {
-        local = merged.Copy(local.ctx());
+        if (merged.storage_type() != local.storage_type()) {
+          local = merged.Copy(local.ctx());
+        } else {
+          local = merged;
+        }
       }
     }
   }

--- a/tests/python/gpu/test_kvstore_gpu.py
+++ b/tests/python/gpu/test_kvstore_gpu.py
@@ -92,16 +92,16 @@ def test_rsp_push_pull():
     check_rsp_push_pull('device', is_push_cpu=False)
 
 
-def test_kvstore_row_sparse_pull_single_device():
-    kvstore = mx.kv.create('device')
-    grad = mx.nd.random_normal(shape=(10,30),ctx=mx.gpu(0))
-    grad = grad.tostype("row_sparse")
-    copy = grad.copy()
+def test_row_sparse_pull_single_device():
+    kvstore = mx.kv.create('local')
+    copy = mx.nd.random_normal(shape=(4,4), ctx=mx.cpu(0))
+    grad = copy.tostype("row_sparse")
 
-    i = 0
-    kvstore.init(i, grad)
-    kvstore.push(i, grad)
-    kvstore.row_sparse_pull(i, out=grad, row_ids=grad.indices)
+    key = 0
+    kvstore.init(key, grad)
+    idx = grad.indices
+    kvstore.push(key, grad)
+    kvstore.row_sparse_pull(key, out=grad, row_ids=idx)
 
     assert_almost_equal(grad.asnumpy(), copy.asnumpy())
 

--- a/tests/python/gpu/test_kvstore_gpu.py
+++ b/tests/python/gpu/test_kvstore_gpu.py
@@ -93,8 +93,8 @@ def test_rsp_push_pull():
 
 
 def test_row_sparse_pull_single_device():
-    kvstore = mx.kv.create('local')
-    copy = mx.nd.random_normal(shape=(4,4), ctx=mx.cpu(0))
+    kvstore = mx.kv.create('device')
+    copy = mx.nd.random_normal(shape=(4,4), ctx=mx.gpu(0))
     grad = copy.tostype("row_sparse")
 
     key = 0

--- a/tests/python/gpu/test_kvstore_gpu.py
+++ b/tests/python/gpu/test_kvstore_gpu.py
@@ -91,6 +91,21 @@ def test_rsp_push_pull():
     check_rsp_push_pull('device')
     check_rsp_push_pull('device', is_push_cpu=False)
 
+
+def test_kvstore_row_sparse_pull_single_device():
+    kvstore = mx.kv.create('device')
+    grad = mx.nd.random_normal(shape=(10,30),ctx=mx.gpu(0))
+    grad = grad.tostype("row_sparse")
+    copy = grad.copy()
+
+    i = 0
+    kvstore.init(i, grad)
+    kvstore.push(i, grad)
+    kvstore.row_sparse_pull(i, out=grad, row_ids=grad.indices)
+
+    assert_almost_equal(grad.asnumpy(), copy.asnumpy())
+
+
 def test_rsp_push_pull_large_rowid():
     num_rows = 793470
     val = mx.nd.ones((num_rows, 1)).tostype('row_sparse').copyto(mx.gpu())


### PR DESCRIPTION
## Description ##
When using the kvstore on a single device, no copy of the source array would be created when pushing to the kvstore. When row sparse pulling from the kvstore, this would lead to a deadlock as both source and target arrays were identical. For now this PR removes the optimization of not creating a copy.

Thanks @eric-haibin-lin for helping to find the cause.