### PR TITLE
[MXNET-375] Lp Pooling and Global Lp Pooling

### DIFF
--- a/src/operator/nn/pool.cuh
+++ b/src/operator/nn/pool.cuh
@@ -80,7 +80,9 @@
 
 #include <mxnet/base.h>
 #include <mxnet/operator.h>
+#include "./pool_utils.h"
 #include "../mxnet_op.h"
+#include "../mshadow_op.h"
 #include "../../common/cuda_utils.h"
 
 namespace mxnet {
@@ -208,27 +210,26 @@ __global__ void pool_max_3d_gpu_kernel(const int nthreads, const DType* in_data,
  * \brief avg/sum pooling gpu kernel for 1-D images.
  * Do not call this kernel directly. Use the interface pool().
  */
-template <typename DType>
+template <typename DType, int p = 1>
 __global__ void pool_sum_1d_gpu_kernel(const int nthreads, const DType* in_data, const int channels,
                                        const int width, const int pooled_width, const int kernel_w,
-                                       const int stride_w, const int pad_w,
-                                       DType* out_data, bool getAvg = false) {
+                                       const int stride_w, const int pad_w, DType* out_data,
+                                       const bool getAvg = false) {
   CUDA_KERNEL_LOOP(index, nthreads) {
-	  const int pw = index % pooled_width;
-	  const int c = (index / pooled_width) % channels;
-	  const int n = index / pooled_width / channels;
-	  int wstart = pw * stride_w - pad_w;
-	  int wend = min(wstart + kernel_w, width + pad_w);
-	  const int pool_size = (getAvg? (wend - wstart) : 1);
-	  wstart = max(wstart, 0);
-	  wend = min(wend, width);
-	  DType sum = 0;
-	  const DType* out_slice =
-	 		in_data + (n * channels + c) * width;
+    const int pw = index % pooled_width;
+    const int c = (index / pooled_width) % channels;
+    const int n = index / pooled_width / channels;
+    int wstart = pw * stride_w - pad_w;
+    int wend = min(wstart + kernel_w, width + pad_w);
+    const int pool_size = (getAvg? (wend - wstart) : 1);
+    wstart = max(wstart, 0);
+    wend = min(wend, width);
+    DType sum = 0;
+    const DType* out_slice = in_data + (n * channels + c) * width;
     for (int w = wstart; w < wend; ++w) {
-      sum += out_slice[w];
+      sum += a_pow_p<DType, p>::Map(out_slice[w]) / pool_size;
     }
-    out_data[index] = sum / pool_size;
+    out_data[index] = a_root_p<DType, p>::Map(sum);
   }
 }
 
@@ -236,37 +237,36 @@ __global__ void pool_sum_1d_gpu_kernel(const int nthreads, const DType* in_data,
  * \brief avg/sum pooling gpu kernel for 2-D images.
  * Do not call this kernel directly. Use the interface pool().
  */
-template <typename DType>
+template <typename DType, int p = 1>
 __global__ void pool_sum_2d_gpu_kernel(const int nthreads, const DType* in_data, const int channels,
                                        const int height, const int width,
                                        const int pooled_height, const int pooled_width,
                                        const int kernel_h, const int kernel_w,
                                        const int stride_h, const int stride_w,
-                                       const int pad_h, const int pad_w,
-                                       DType* out_data, bool getAvg = false) {
+                                       const int pad_h, const int pad_w, DType* out_data,
+                                       const bool getAvg = false) {
   CUDA_KERNEL_LOOP(index, nthreads) {
-	  const int pw = index % pooled_width;
-	  const int ph = (index / pooled_width) % pooled_height;
-	  const int c = (index / pooled_width / pooled_height) % channels;
-	  const int n = index / pooled_width / pooled_height / channels;
-	  int hstart = ph * stride_h - pad_h;
-	  int wstart = pw * stride_w - pad_w;
-	  int hend = min(hstart + kernel_h, height + pad_h);
-	  int wend = min(wstart + kernel_w, width + pad_w);
-	  const int pool_size = (getAvg? (hend - hstart) * (wend - wstart) : 1);
-	  hstart = max(hstart, 0);
-	  wstart = max(wstart, 0);
-	  hend = min(hend, height);
-	  wend = min(wend, width);
-	  DType sum = 0;
-	  const DType* out_slice =
-	 		in_data + (n * channels + c) * height * width;
-	  for (int h = hstart; h < hend; ++h) {
-		  for (int w = wstart; w < wend; ++w) {
-		    sum += out_slice[h * width + w];
-		  }
-	  }
-    out_data[index] = sum / pool_size;
+    const int pw = index % pooled_width;
+    const int ph = (index / pooled_width) % pooled_height;
+    const int c = (index / pooled_width / pooled_height) % channels;
+    const int n = index / pooled_width / pooled_height / channels;
+    int hstart = ph * stride_h - pad_h;
+    int wstart = pw * stride_w - pad_w;
+    int hend = min(hstart + kernel_h, height + pad_h);
+    int wend = min(wstart + kernel_w, width + pad_w);
+    const int pool_size = (getAvg? (hend - hstart) * (wend - wstart) : 1);
+    hstart = max(hstart, 0);
+    wstart = max(wstart, 0);
+    hend = min(hend, height);
+    wend = min(wend, width);
+    DType sum = 0;
+    const DType* out_slice = in_data + (n * channels + c) * height * width;
+    for (int h = hstart; h < hend; ++h) {
+      for (int w = wstart; w < wend; ++w) {
+        sum += a_pow_p<DType, p>::Map(out_slice[h * width + w]) / pool_size;
+      }
+    }
+    out_data[index] = a_root_p<DType, p>::Map(sum);
   }
 }
 
@@ -274,7 +274,7 @@ __global__ void pool_sum_2d_gpu_kernel(const int nthreads, const DType* in_data,
  * \brief avg/sum pooling gpu kernel for 3-D images.
  * Do not call this kernel directly. Use the interface pool().
  */
-template <typename DType>
+template <typename DType, int p = 1>
 __global__ void pool_sum_3d_gpu_kernel(const int nthreads, const DType* in_data, const int channels,
                                        const int depth, const int height, const int width,
                                        const int pooled_depth, const int pooled_height,
@@ -282,37 +282,36 @@ __global__ void pool_sum_3d_gpu_kernel(const int nthreads, const DType* in_data,
                                        const int kernel_h, const int kernel_w,
                                        const int stride_d, const int stride_h, const int stride_w,
                                        const int pad_d, const int pad_h, const int pad_w,
-                                       DType* out_data, bool getAvg = false) {
+                                       DType* out_data, const bool getAvg = false) {
   CUDA_KERNEL_LOOP(index, nthreads) {
-	  const int pw = index % pooled_width;
-	  const int ph = (index / pooled_width) % pooled_height;
+    const int pw = index % pooled_width;
+    const int ph = (index / pooled_width) % pooled_height;
     const int pd = (index / pooled_width / pooled_height) % pooled_depth;
-	  const int c = (index / pooled_width / pooled_height / pooled_depth) % channels;
-	  const int n = index / pooled_width / pooled_height / pooled_depth / channels;
+    const int c = (index / pooled_width / pooled_height / pooled_depth) % channels;
+    const int n = index / pooled_width / pooled_height / pooled_depth / channels;
     int dstart = pd * stride_d - pad_d;
-	  int hstart = ph * stride_h - pad_h;
-	  int wstart = pw * stride_w - pad_w;
+    int hstart = ph * stride_h - pad_h;
+    int wstart = pw * stride_w - pad_w;
     int dend = min(dstart + kernel_d, depth + pad_d);
-	  int hend = min(hstart + kernel_h, height + pad_h);
-	  int wend = min(wstart + kernel_w, width + pad_w);
-	  const int pool_size = (getAvg? (dend - dstart) * (hend - hstart) * (wend - wstart) : 1);
+    int hend = min(hstart + kernel_h, height + pad_h);
+    int wend = min(wstart + kernel_w, width + pad_w);
+    const int pool_size = (getAvg? (dend - dstart) * (hend - hstart) * (wend - wstart) : 1);
     dstart = max(dstart, 0);
-	  hstart = max(hstart, 0);
-	  wstart = max(wstart, 0);
+    hstart = max(hstart, 0);
+    wstart = max(wstart, 0);
     dend = min(dend, depth);
-	  hend = min(hend, height);
-	  wend = min(wend, width);
-	  DType sum = 0;
-	  const DType* out_slice =
-	 		in_data + (n * channels + c) * depth * height * width;
+    hend = min(hend, height);
+    wend = min(wend, width);
+    DType sum = 0;
+    const DType* out_slice = in_data + (n * channels + c) * depth * height * width;
     for (int d = dstart; d < dend; ++d) {
       for (int h = hstart; h < hend; ++h) {
         for (int w = wstart; w < wend; ++w) {
-          sum += out_slice[(d * height + h) * width + w];
+          sum += a_pow_p<DType, p>::Map(out_slice[(d * height + h) * width + w]) / pool_size;
         }
       }
     }
-    out_data[index] = sum / pool_size;
+    out_data[index] = a_root_p<DType, p>::Map(sum);
   }
 }
 
@@ -482,34 +481,38 @@ __global__ void unpool_max_3d_gpu_kernel(const int nthreads, const DType* out_gr
  * \brief avg/sum unpooling gpu kernel for 1-D images.
  * Do not call this kernel directly. Use the interface unpool().
  */
-template<typename DType>
+template<typename DType, int p = 1>
 __global__ void unpool_sum_1d_gpu_kernel(const int nthreads, const DType* out_grad,
+                                         const DType* in_data, const DType* out_data,
                                          const int channels, const int width,
                                          const int pooled_width, const int kernel_w,
-                                         const int stride_w, const int pad_w,
-                                         DType* in_grad, bool isAvg = false) {
+                                         const int stride_w, const int pad_w, DType* in_grad,
+                                         const bool isAvg = false) {
   // index is the input image index in NCW
   CUDA_KERNEL_LOOP(index, nthreads) {
-	  // find out the local index
-	  // find out the local offset
-	  const int w = index % width + pad_w;
-	  const int c = (index / width) % channels;
-	  const int n = index / width / channels;
-	  const int pwstart = (w < kernel_w) ? 0 : (w - kernel_w) / stride_w + 1;
-	  const int pwend = min(w / stride_w + 1, pooled_width);
-	  DType gradient = 0;
-	  const DType* out_grad_slice =
+    // find out the local index
+    // find out the local offset
+    const int w = index % width + pad_w;
+    const int c = (index / width) % channels;
+    const int n = index / width / channels;
+    const int pwstart = (w < kernel_w) ? 0 : (w - kernel_w) / stride_w + 1;
+    const int pwend = min(w / stride_w + 1, pooled_width);
+    DType gradient = 0;
+    const DType* out_grad_slice =
       out_grad + (n * channels + c) * pooled_width;
+    const DType* out_data_slice =
+      out_data + (n * channels + c) * pooled_width;
     for (int pw = pwstart; pw < pwend; ++pw) {
       // figure out the pooling size
       int wstart = pw * stride_w - pad_w;
       int wend = min(wstart + kernel_w, width + pad_w);
       int pool_size = (isAvg? (wend - wstart) : 1);
-      gradient += out_grad_slice[pw] / pool_size;
+      gradient +=
+        lp_grad<DType, p>::Map(out_grad_slice[pw], in_data[index], out_data_slice[pw]) / pool_size;
     }
     // if req=kWriteTo, in_grad has already been assigned zero values in unpool()
     // use "+=" here instead of "=" to accommodate when req=kAddTo
-	  in_grad[index] += gradient;
+    in_grad[index] += gradient;
   }
 }
 
@@ -517,43 +520,50 @@ __global__ void unpool_sum_1d_gpu_kernel(const int nthreads, const DType* out_gr
  * \brief avg/sum unpooling gpu kernel for 2-D images.
  * Do not call this kernel directly. Use the interface unpool().
  */
-template<typename DType>
+template<typename DType, int p = 1>
 __global__ void unpool_sum_2d_gpu_kernel(const int nthreads, const DType* out_grad,
+                                         const DType* in_data, const DType* out_data,
                                          const int channels, const int height, const int width,
                                          const int pooled_height, const int pooled_width,
                                          const int kernel_h, const int kernel_w,
                                          const int stride_h, const int stride_w,
-                                         const int pad_h, const int pad_w,
-                                         DType* in_grad, bool isAvg = false) {
+                                         const int pad_h, const int pad_w, DType* in_grad,
+                                         const bool isAvg = false) {
   // index is the input image index in NCHW
   CUDA_KERNEL_LOOP(index, nthreads) {
-	  // find out the local index
-	  // find out the local offset
-	  const int w = index % width + pad_w;
-	  const int h = (index / width) % height + pad_h;
-	  const int c = (index / width / height) % channels;
-	  const int n = index / width / height / channels;
-	  const int phstart = (h < kernel_h) ? 0 : (h - kernel_h) / stride_h + 1;
-	  const int phend = min(h / stride_h + 1, pooled_height);
-	  const int pwstart = (w < kernel_w) ? 0 : (w - kernel_w) / stride_w + 1;
-	  const int pwend = min(w / stride_w + 1, pooled_width);
-	  DType gradient = 0;
-	  const DType* out_grad_slice =
+    // find out the local index
+    // find out the local offset
+    const int w = index % width + pad_w;
+    const int h = (index / width) % height + pad_h;
+    const int c = (index / width / height) % channels;
+    const int n = index / width / height / channels;
+    const int phstart = (h < kernel_h) ? 0 : (h - kernel_h) / stride_h + 1;
+    const int phend = min(h / stride_h + 1, pooled_height);
+    const int pwstart = (w < kernel_w) ? 0 : (w - kernel_w) / stride_w + 1;
+    const int pwend = min(w / stride_w + 1, pooled_width);
+    DType gradient = 0;
+    const DType* out_grad_slice =
       out_grad + (n * channels + c) * pooled_height * pooled_width;
-	  for (int ph = phstart; ph < phend; ++ph) {
-	 	  for (int pw = pwstart; pw < pwend; ++pw) {
-		    // figure out the pooling size
-			  int hstart = ph * stride_h - pad_h;
-			  int wstart = pw * stride_w - pad_w;
-			  int hend = min(hstart + kernel_h, height + pad_h);
-			  int wend = min(wstart + kernel_w, width + pad_w);
-			  int pool_size = (isAvg? (hend - hstart) * (wend - wstart) : 1);
-			  gradient += out_grad_slice[ph * pooled_width + pw] / pool_size;
-		  }
-	  }
+    const DType* out_data_slice =
+      out_data + (n * channels + c) * pooled_height * pooled_width;
+    for (int ph = phstart; ph < phend; ++ph) {
+      for (int pw = pwstart; pw < pwend; ++pw) {
+        // figure out the pooling size
+        int hstart = ph * stride_h - pad_h;
+        int wstart = pw * stride_w - pad_w;
+        int hend = min(hstart + kernel_h, height + pad_h);
+        int wend = min(wstart + kernel_w, width + pad_w);
+        int pool_size = (isAvg? (hend - hstart) * (wend - wstart) : 1);
+        int out_index = ph * pooled_width + pw;
+        gradient +=
+          lp_grad<DType, p>::Map(out_grad_slice[out_index],
+                                 in_data[index],
+                                 out_data_slice[out_index]) / pool_size;
+      }
+    }
     // if req=kWriteTo, in_grad has already been assigned zero values in unpool()
     // use "+=" here instead of "=" to accommodate when req=kAddTo
-	  in_grad[index] += gradient;
+    in_grad[index] += gradient;
   }
 }
 
@@ -561,33 +571,36 @@ __global__ void unpool_sum_2d_gpu_kernel(const int nthreads, const DType* out_gr
  * \brief avg/sum unpooling gpu kernel for 3-D images.
  * Do not call this kernel directly. Use the interface unpool().
  */
-template<typename DType>
+template<typename DType, int p = 1>
 __global__ void unpool_sum_3d_gpu_kernel(const int nthreads, const DType* out_grad,
+                                         const DType* in_data, const DType* out_data,
                                          const int channels, const int depth, const int height,
                                          const int width, const int pooled_depth,
                                          const int pooled_height, const int pooled_width,
                                          const int kernel_d, const int kernel_h,
                                          const int kernel_w, const int stride_d, const int stride_h,
                                          const int stride_w, const int pad_d, const int pad_h,
-                                         const int pad_w, DType* in_grad, bool isAvg = false) {
+                                         const int pad_w, DType* in_grad, const bool isAvg = false) {
   // index is the input image index in NCDHW
   CUDA_KERNEL_LOOP(index, nthreads) {
-	  // find out the local index
-	  // find out the local offset
-	  const int w = index % width + pad_w;
-	  const int h = (index / width) % height + pad_h;
+    // find out the local index
+    // find out the local offset
+    const int w = index % width + pad_w;
+    const int h = (index / width) % height + pad_h;
     const int d = (index / width / height) % depth + pad_d;
-	  const int c = (index / width / height / depth) % channels;
-	  const int n = index / width / height / depth / channels;
+    const int c = (index / width / height / depth) % channels;
+    const int n = index / width / height / depth / channels;
     const int pdstart = (d < kernel_d) ? 0 : (d - kernel_d) / stride_d + 1;
     const int pdend = min(d / stride_d + 1, pooled_depth);
-	  const int phstart = (h < kernel_h) ? 0 : (h - kernel_h) / stride_h + 1;
-	  const int phend = min(h / stride_h + 1, pooled_height);
-	  const int pwstart = (w < kernel_w) ? 0 : (w - kernel_w) / stride_w + 1;
-	  const int pwend = min(w / stride_w + 1, pooled_width);
-	  DType gradient = 0;
-	  const DType* out_grad_slice =
+    const int phstart = (h < kernel_h) ? 0 : (h - kernel_h) / stride_h + 1;
+    const int phend = min(h / stride_h + 1, pooled_height);
+    const int pwstart = (w < kernel_w) ? 0 : (w - kernel_w) / stride_w + 1;
+    const int pwend = min(w / stride_w + 1, pooled_width);
+    DType gradient = 0;
+    const DType* out_grad_slice =
       out_grad + (n * channels + c) * pooled_depth * pooled_height * pooled_width;
+    const DType* out_data_slice =
+      out_data + (n * channels + c) * pooled_depth * pooled_height * pooled_width;
     for (int pd = pdstart; pd < pdend; ++pd) {
       for (int ph = phstart; ph < phend; ++ph) {
         for (int pw = pwstart; pw < pwend; ++pw) {
@@ -599,13 +612,16 @@ __global__ void unpool_sum_3d_gpu_kernel(const int nthreads, const DType* out_gr
           int hend = min(hstart + kernel_h, height + pad_h);
           int wend = min(wstart + kernel_w, width + pad_w);
           int pool_size = (isAvg? (dend - dstart) * (hend - hstart) * (wend - wstart) : 1);
-          gradient += out_grad_slice[(pd * pooled_height + ph) * pooled_width + pw] / pool_size;
+          int out_index = (pd * pooled_height + ph) * pooled_width + pw;
+          gradient += lp_grad<DType, p>::Map(out_grad_slice[out_index],
+                                             in_data[index],
+                                             out_data_slice[out_index]) / pool_size;
         }
       }
     }
     // if req=kWriteTo, in_grad has already been assigned zero values in unpool()
     // use "+=" here instead of "=" to accommodate when req=kAddTo
-	  in_grad[index] += gradient;
+    in_grad[index] += gradient;
   }
 }
 
@@ -621,8 +637,9 @@ __global__ void unpool_sum_3d_gpu_kernel(const int nthreads, const DType* out_gr
  * \param pool_type supported pooling type: max, avg, sum
  * \param req_type operator request type, only support kWriteTo for now
  * \param out_data pointer of the output tensor data in the format of NCW, NCHW, or NCDHW
+ * \param p_value value of p for Lp pooling
  */
-template<typename DType>
+template<typename DType, int p>
 inline void pool(mshadow::Stream<gpu>* s, const DType* in_data, const TShape& ishape,
                  const TShape& oshape, const TShape& kernel, const TShape& pad,
                  const TShape& stride, const int pool_type, OpReqType req_type,
@@ -651,6 +668,13 @@ inline void pool(mshadow::Stream<gpu>* s, const DType* in_data, const TShape& is
                                    oshape.Size(), in_data, ishape[1], ishape[2], oshape[2],
                                    kernel[0], stride[0], pad[0], out_data);
       MSHADOW_CUDA_POST_KERNEL_CHECK(pool_sum_1d_gpu_kernel);
+    } else if (pool_enum::kLpPooling == pool_type) {
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      pool_sum_1d_gpu_kernel<DType, p><<<cuda_get_num_blocks(oshape.Size()), mshadow::cuda::kBaseThreadNum,
+                               0, mshadow::Stream<gpu>::GetStream(s)>>>(
+                                   oshape.Size(), in_data, ishape[1], ishape[2], oshape[2],
+                                   kernel[0], stride[0], pad[0], out_data);
+      MSHADOW_CUDA_POST_KERNEL_CHECK(pool_sum_1d_gpu_kernel);
     } else {
       LOG(FATAL) << "Unknown pooling type " << pool_type;
     }
@@ -674,6 +698,14 @@ inline void pool(mshadow::Stream<gpu>* s, const DType* in_data, const TShape& is
     } else if (pool_enum::kSumPooling == pool_type) {
       // NOLINT_NEXT_LINE(whitespace/operators)
       pool_sum_2d_gpu_kernel<<<cuda_get_num_blocks(oshape.Size()), mshadow::cuda::kBaseThreadNum,
+                               0, mshadow::Stream<gpu>::GetStream(s)>>>(
+                                   oshape.Size(), in_data, ishape[1], ishape[2], ishape[3],
+                                   oshape[2], oshape[3], kernel[0], kernel[1],
+                                   stride[0], stride[1], pad[0], pad[1], out_data);
+      MSHADOW_CUDA_POST_KERNEL_CHECK(pool_sum_2d_gpu_kernel);
+    } else if (pool_enum::kLpPooling == pool_type) {
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      pool_sum_2d_gpu_kernel<DType, p><<<cuda_get_num_blocks(oshape.Size()), mshadow::cuda::kBaseThreadNum,
                                0, mshadow::Stream<gpu>::GetStream(s)>>>(
                                    oshape.Size(), in_data, ishape[1], ishape[2], ishape[3],
                                    oshape[2], oshape[3], kernel[0], kernel[1],
@@ -710,6 +742,15 @@ inline void pool(mshadow::Stream<gpu>* s, const DType* in_data, const TShape& is
                                    kernel[1], kernel[2], stride[0], stride[1], stride[2],
                                    pad[0], pad[1], pad[2], out_data);
       MSHADOW_CUDA_POST_KERNEL_CHECK(pool_sum_3d_gpu_kernel);
+    } else if (pool_enum::kLpPooling == pool_type) {
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      pool_sum_3d_gpu_kernel<DType, p><<<cuda_get_num_blocks(oshape.Size()), mshadow::cuda::kBaseThreadNum,
+                               0, mshadow::Stream<gpu>::GetStream(s)>>>(
+                                   oshape.Size(), in_data, ishape[1], ishape[2], ishape[3],
+                                   ishape[4], oshape[2], oshape[3], oshape[4], kernel[0],
+                                   kernel[1], kernel[2], stride[0], stride[1], stride[2],
+                                   pad[0], pad[1], pad[2], out_data);
+      MSHADOW_CUDA_POST_KERNEL_CHECK(pool_sum_3d_gpu_kernel);
     } else {
       LOG(FATAL) << "Unknown pooling type " << pool_type;
     }
@@ -730,8 +771,9 @@ inline void pool(mshadow::Stream<gpu>* s, const DType* in_data, const TShape& is
  * \param pool_type supported pooling type: max, avg, sum
  * \param req_type operator request type: kNullOp, kNullWriteInplace, kNullWriteTo, kNullAddTo
  * \param in_grad pointer of the gradient of the operator's input tensor
+ * \param p_value value of p for Lp pooling
  */
-template<typename DType>
+template<typename DType, int p>
 inline void unpool(mshadow::Stream<gpu>* s, const DType* out_grad, const DType* in_data,
                    const DType* out_data, const TShape& ishape, const TShape& oshape,
                    const TShape& kernel, const TShape& pad, const TShape& stride,
@@ -754,7 +796,7 @@ inline void unpool(mshadow::Stream<gpu>* s, const DType* out_grad, const DType* 
       // NOLINT_NEXT_LINE(whitespace/operators)
       unpool_sum_1d_gpu_kernel<<<cuda_get_num_blocks(ishape.Size()), mshadow::cuda::kBaseThreadNum,
                                  0, mshadow::Stream<gpu>::GetStream(s)>>>(
-                                     ishape.Size(), out_grad,
+                                     ishape.Size(), out_grad, in_data, out_data,
                                      ishape[1], ishape[2], oshape[2], kernel[0],
                                      stride[0], pad[0], in_grad, true);
       MSHADOW_CUDA_POST_KERNEL_CHECK(unpool_sum_1d_gpu_kernel);
@@ -762,14 +804,22 @@ inline void unpool(mshadow::Stream<gpu>* s, const DType* out_grad, const DType* 
       // NOLINT_NEXT_LINE(whitespace/operators)
       unpool_sum_1d_gpu_kernel<<<cuda_get_num_blocks(ishape.Size()), mshadow::cuda::kBaseThreadNum,
                                  0, mshadow::Stream<gpu>::GetStream(s)>>>(
-                                     ishape.Size(), out_grad,
+                                     ishape.Size(), out_grad, in_data, out_data,
+                                     ishape[1], ishape[2], oshape[2], kernel[0],
+                                     stride[0], pad[0], in_grad);
+      MSHADOW_CUDA_POST_KERNEL_CHECK(unpool_sum_1d_gpu_kernel);
+    } else if (pool_enum::kLpPooling == pool_type) {
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      unpool_sum_1d_gpu_kernel<DType, p><<<cuda_get_num_blocks(ishape.Size()), mshadow::cuda::kBaseThreadNum,
+                                 0, mshadow::Stream<gpu>::GetStream(s)>>>(
+                                     ishape.Size(), out_grad, in_data, out_data,
                                      ishape[1], ishape[2], oshape[2], kernel[0],
                                      stride[0], pad[0], in_grad);
       MSHADOW_CUDA_POST_KERNEL_CHECK(unpool_sum_1d_gpu_kernel);
     } else {
       LOG(FATAL) << "Unknown pooling type " << pool_type;
     }
-  } else  if (kernel.ndim() == 2) {
+  } else if (kernel.ndim() == 2) {
     if (pool_enum::kMaxPooling == pool_type) {
       // NOLINT_NEXT_LINE(whitespace/operators)
       unpool_max_2d_gpu_kernel<<<cuda_get_num_blocks(oshape.Size()), mshadow::cuda::kBaseThreadNum,
@@ -783,7 +833,7 @@ inline void unpool(mshadow::Stream<gpu>* s, const DType* out_grad, const DType* 
       // NOLINT_NEXT_LINE(whitespace/operators)
       unpool_sum_2d_gpu_kernel<<<cuda_get_num_blocks(ishape.Size()), mshadow::cuda::kBaseThreadNum,
                                  0, mshadow::Stream<gpu>::GetStream(s)>>>(
-                                     ishape.Size(), out_grad,
+                                     ishape.Size(), out_grad, in_data, out_data,
                                      ishape[1], ishape[2], ishape[3],
                                      oshape[2], oshape[3], kernel[0], kernel[1],
                                      stride[0], stride[1], pad[0], pad[1], in_grad, true);
@@ -792,7 +842,16 @@ inline void unpool(mshadow::Stream<gpu>* s, const DType* out_grad, const DType* 
       // NOLINT_NEXT_LINE(whitespace/operators)
       unpool_sum_2d_gpu_kernel<<<cuda_get_num_blocks(ishape.Size()), mshadow::cuda::kBaseThreadNum,
                                  0, mshadow::Stream<gpu>::GetStream(s)>>>(
-                                     ishape.Size(), out_grad,
+                                     ishape.Size(), out_grad, in_data, out_data,
+                                     ishape[1], ishape[2], ishape[3],
+                                     oshape[2], oshape[3], kernel[0], kernel[1],
+                                     stride[0], stride[1], pad[0], pad[1], in_grad);
+      MSHADOW_CUDA_POST_KERNEL_CHECK(unpool_sum_2d_gpu_kernel);
+    } else if (pool_enum::kLpPooling == pool_type) {
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      unpool_sum_2d_gpu_kernel<DType, p><<<cuda_get_num_blocks(ishape.Size()), mshadow::cuda::kBaseThreadNum,
+                                 0, mshadow::Stream<gpu>::GetStream(s)>>>(
+                                     ishape.Size(), out_grad, in_data, out_data,
                                      ishape[1], ishape[2], ishape[3],
                                      oshape[2], oshape[3], kernel[0], kernel[1],
                                      stride[0], stride[1], pad[0], pad[1], in_grad);
@@ -815,7 +874,7 @@ inline void unpool(mshadow::Stream<gpu>* s, const DType* out_grad, const DType* 
       // NOLINT_NEXT_LINE(whitespace/operators)
       unpool_sum_3d_gpu_kernel<<<cuda_get_num_blocks(ishape.Size()), mshadow::cuda::kBaseThreadNum,
                                  0, mshadow::Stream<gpu>::GetStream(s)>>>(
-                                     ishape.Size(), out_grad,
+                                     ishape.Size(), out_grad, in_data, out_data,
                                      ishape[1], ishape[2], ishape[3], ishape[4],
                                      oshape[2], oshape[3], oshape[4], kernel[0], kernel[1],
                                      kernel[2], stride[0], stride[1], stride[2], pad[0], pad[1],
@@ -825,7 +884,17 @@ inline void unpool(mshadow::Stream<gpu>* s, const DType* out_grad, const DType* 
       // NOLINT_NEXT_LINE(whitespace/operators)
       unpool_sum_3d_gpu_kernel<<<cuda_get_num_blocks(ishape.Size()), mshadow::cuda::kBaseThreadNum,
                                  0, mshadow::Stream<gpu>::GetStream(s)>>>(
-                                     ishape.Size(), out_grad,
+                                     ishape.Size(), out_grad, in_data, out_data,
+                                     ishape[1], ishape[2], ishape[3], ishape[4],
+                                     oshape[2], oshape[3], oshape[4], kernel[0], kernel[1],
+                                     kernel[2], stride[0], stride[1], stride[2], pad[0], pad[1],
+                                     pad[2], in_grad);
+      MSHADOW_CUDA_POST_KERNEL_CHECK(unpool_sum_3d_gpu_kernel);
+    } else if (pool_enum::kLpPooling == pool_type) {
+      // NOLINT_NEXT_LINE(whitespace/operators)
+      unpool_sum_3d_gpu_kernel<DType, p><<<cuda_get_num_blocks(ishape.Size()), mshadow::cuda::kBaseThreadNum,
+                                 0, mshadow::Stream<gpu>::GetStream(s)>>>(
+                                     ishape.Size(), out_grad, in_data, out_data,
                                      ishape[1], ishape[2], ishape[3], ishape[4],
                                      oshape[2], oshape[3], oshape[4], kernel[0], kernel[1],
                                      kernel[2], stride[0], stride[1], stride[2], pad[0], pad[1],

--- a/src/operator/nn/pool_utils.h
+++ b/src/operator/nn/pool_utils.h
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef MXNET_OPERATOR_NN_POOL_UTILS_H_
+#define MXNET_OPERATOR_NN_POOL_UTILS_H_
+
+#include "../mshadow_op.h"
+
+namespace mxnet {
+namespace op {
+
+template<typename DType, int p>
+struct a_pow_p {
+  static MSHADOW_XINLINE DType Map(const DType a) {
+    return mshadow_op::power::Map(a, DType(p));
+  }
+};
+
+template<typename DType>
+struct a_pow_p<DType, 1> {
+  static MSHADOW_XINLINE DType Map(const DType a) {
+    return a;
+  }
+};
+
+template<typename DType>
+struct a_pow_p<DType, 2> {
+  static MSHADOW_XINLINE DType Map(const DType a) {
+    return a*a;
+  }
+};
+
+template<typename DType>
+struct a_pow_p<DType, 3> {
+  static MSHADOW_XINLINE DType Map(const DType a) {
+    return a*a*a;
+  }
+};
+
+template<typename DType, int p>
+struct a_root_p {
+  static MSHADOW_XINLINE DType Map(const DType a) {
+    return mshadow_op::power::Map(a, DType(1.0 / p));
+  }
+};
+
+template<typename DType>
+struct a_root_p<DType, 1> {
+  static MSHADOW_XINLINE DType Map(const DType a) {
+    return a;
+  }
+};
+
+template<typename DType>
+struct a_root_p<DType, 2> {
+  static MSHADOW_XINLINE DType Map(const DType a) {
+    return mshadow_op::square_root::Map(a);
+  }
+};
+
+template<typename DType>
+struct a_root_p<DType, 3> {
+  static MSHADOW_XINLINE DType Map(const DType a) {
+    return mshadow_op::cube_root::Map(a);
+  }
+};
+
+template<typename DType, int p>
+struct lp_grad {
+  static MSHADOW_XINLINE DType Map(const DType grad, const DType in_data, const DType out_data) {
+    return grad * mshadow_op::power::Map(in_data / out_data, DType(p - 1));
+  }
+};
+
+template<typename DType>
+struct lp_grad<DType, 1> {
+  static MSHADOW_XINLINE DType Map(const DType grad, const DType in_data, const DType out_data) {
+    return grad;
+  }
+};
+
+template<typename DType>
+struct lp_grad<DType, 2> {
+  static MSHADOW_XINLINE DType Map(const DType grad, const DType in_data, const DType out_data) {
+    return grad * in_data / out_data;
+  }
+};
+
+template<typename DType>
+struct lp_grad<DType, 3> {
+  static MSHADOW_XINLINE DType Map(const DType grad, const DType in_data, const DType out_data) {
+    return grad * in_data * in_data / (out_data * out_data);
+  }
+};
+
+}   // namespace op
+}   // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NN_POOL_UTILS_H_

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -92,6 +92,9 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
                          std::vector<TShape> *out_shape) {
   const PoolingParam &param = nnvm::get<PoolingParam>(attrs.parsed);
   CHECK_EQ(in_shape->size(), 1U);
+  if (param.pool_type == pool_enum::kLpPooling) {
+    CHECK(param.p_value.has_value());
+  }
   const TShape &dshape = (*in_shape)[0];
   CHECK_GE(dshape.ndim(), 3U)
       << "Pooling: Input data should be  3D in (batch, channel, x)"
@@ -344,10 +347,22 @@ Three pooling options are supported by ``pool_type``:
 - **avg**: average pooling
 - **max**: max pooling
 - **sum**: sum pooling
+- **lp**: Lp pooling
 
 For 3-D pooling, an additional *depth* dimension is added before
 *height*. Namely the input data will have shape *(batch_size, channel, depth,
 height, width)*.
+
+Notes on Lp pooling:
+
+Lp pooling was first introduced by this paper: https://arxiv.org/pdf/1204.3968.pdf.
+L-1 pooling is simply sum pooling, while L-inf pooling is simply max pooling.
+We can see that Lp pooling stands between those two, in practice the most common value for p is 2.
+
+For each window ``X``, the mathematical expression for Lp pooling is:
+
+..math::
+  f(X) = \sqrt{p}{\sum\limits_{x \in X} x^p}
 
 )code" ADD_FILELINE)
 .set_num_inputs(1)

--- a/src/operator/nn/pooling.cu
+++ b/src/operator/nn/pooling.cu
@@ -66,6 +66,9 @@ void PoolingCompute<gpu>(const nnvm::NodeAttrs& attrs,
         case pool_enum::kSumPooling:
           LOG(WARNING) << "Sum pooling is not supported by cudnn, MXNet sum pooling is applied.";
           break;
+        case pool_enum::kLpPooling:
+          LOG(WARNING) << "Lp pooling is not supported by cudnn, MXNet lp pooling is applied.";
+          break;
       }
     });
   }
@@ -74,7 +77,8 @@ void PoolingCompute<gpu>(const nnvm::NodeAttrs& attrs,
   MSHADOW_REAL_TYPE_SWITCH(inputs[0].type_flag_, DType, {
     if (pool_enum::kMaxPooling == param.pool_type
         || pool_enum::kAvgPooling == param.pool_type
-        || pool_enum::kSumPooling == param.pool_type) {
+        || pool_enum::kSumPooling == param.pool_type
+        || pool_enum::kLpPooling == param.pool_type) {
       PoolingOp<gpu, DType> op;
       op.Init(param);
       op.Forward(ctx, inputs[0], req[0], outputs[0]);
@@ -119,6 +123,9 @@ void PoolingGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
         case pool_enum::kSumPooling:
           LOG(WARNING) << "Sum pooling is not supported by cudnn, MXNet sum pooling is applied.";
           break;
+        case pool_enum::kLpPooling:
+          LOG(WARNING) << "Lp pooling is not supported by cudnn, MXNet Lp pooling is applied.";
+          break;
       }
     });
   }
@@ -127,7 +134,8 @@ void PoolingGradCompute<gpu>(const nnvm::NodeAttrs& attrs,
   MSHADOW_REAL_TYPE_SWITCH(inputs[0].type_flag_, DType, {
     if (pool_enum::kMaxPooling == param.pool_type
         || pool_enum::kAvgPooling == param.pool_type
-        || pool_enum::kSumPooling == param.pool_type) {
+        || pool_enum::kSumPooling == param.pool_type
+        || pool_enum::kLpPooling == param.pool_type) {
       PoolingOp<gpu, DType> op;
       op.Init(param);
       op.Backward(ctx, inputs[ograd_idx], inputs[in_data_idx],

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -903,18 +903,21 @@ def test_pooling_versions():
     test_1d_pooling('sum')
     test_1d_pooling('lp', p_value=1)
     test_1d_pooling('lp', p_value=2)
+    test_1d_pooling('lp', p_value=3)
 
     test_2d_pooling('max')
     test_2d_pooling('avg')
     test_2d_pooling('sum')
     test_2d_pooling('lp', p_value=1)
     test_2d_pooling('lp', p_value=2)
+    test_2d_pooling('lp', p_value=3)
 
     test_3d_pooling('max')
     test_3d_pooling('avg')
     test_3d_pooling('sum')
     test_3d_pooling('lp', p_value=1)
     test_3d_pooling('lp', p_value=2)
+    test_3d_pooling('lp', p_value=3)
 
 
 @with_seed()
@@ -1036,12 +1039,14 @@ def test_global_pooling():
     test_1d_pooling('sum')
     test_1d_pooling('lp', p_value=1)
     test_1d_pooling('lp', p_value=2)
+    test_1d_pooling('lp', p_value=3)
 
     test_2d_pooling('max')
     test_2d_pooling('avg')
     test_2d_pooling('sum')
     test_2d_pooling('lp', p_value=1)
     test_2d_pooling('lp', p_value=2)
+    test_2d_pooling('lp', p_value=3)
 
 
 @with_seed()

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -741,7 +741,7 @@ def test_pooling_with_type():
 @with_seed()
 def test_pooling_versions():
     def test_pooling_versions_helper(pool_op_list, data, kernel, pool_type, pad, stride,
-                                     pooling_convention='valid', global_pool=False):
+                                     pooling_convention='valid', global_pool=False, p_value=2):
         ctx_list = []
         sym_list = []
         # PoolingV1 cpu
@@ -765,140 +765,161 @@ def test_pooling_versions():
             ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
             if not global_pool:
                 sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                               pooling_convention=pooling_convention, name='pool'))
+                                               pooling_convention=pooling_convention, name='pool', p_value=p_value))
             else:
-                sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type, global_pool=True, name='pool'))
+                sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type, global_pool=True, name='pool', p_value=p_value))
         # Pooling gpu
         if 'pool_gpu' in pool_op_list:
             ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
             if not global_pool:
                 sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                               pooling_convention=pooling_convention, cudnn_off=True, name='pool'))
+                                               pooling_convention=pooling_convention, cudnn_off=True, name='pool', p_value=p_value))
             else:
                 sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type, global_pool=True, cudnn_off=True,
-                                               name='pool'))
+                                               name='pool', p_value=p_value))
         # CuDNNPooling
         if 'pool_cudnn' in pool_op_list:
             ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
             if not global_pool:
                 sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                               pooling_convention=pooling_convention, cudnn_off=False, name='pool'))
+                                               pooling_convention=pooling_convention, p_value=p_value, cudnn_off=False, name='pool'))
             else:
-                sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type, global_pool=True, cudnn_off=False,
-                                               name='pool'))
+                sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type, global_pool=True, p_value=p_value,
+                                               cudnn_off=False, name='pool'))
         check_consistency(sym_list, ctx_list)
 
-    def test_1d_pooling(pool_type):
+    def test_1d_pooling(pool_type, p_value=2):
         data = (2, 3, 20)
         kernel = (4,)
         pad = (0,)
         stride = (1,)
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='valid', global_pool=False)
+                                     pooling_convention='valid', global_pool=False, p_value=p_value)
 
         pad = (2,)
         stride = (2,)
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='valid', global_pool=False)
+                                     pooling_convention='valid', global_pool=False, p_value=p_value)
 
         pad = (0,)
         stride = (1,)
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='full', global_pool=False)
+                                     pooling_convention='full', global_pool=False, p_value=p_value)
 
         pad = (2,)
         stride = (2,)
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='full', global_pool=False)
+                                     pooling_convention='full', global_pool=False, p_value=p_value)
 
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     global_pool=True)
+                                     global_pool=True, p_value=p_value)
 
-    def test_2d_pooling(pool_type):
+    def test_2d_pooling(pool_type, p_value=2):
         data = (2, 3, 20, 20)
         kernel = (4, 5)
         pad = (0, 0)
         stride = (1, 1)
-        test_pooling_versions_helper(pool_op_list=['pool_v1_cpu', 'pool_v1_gpu', 'pool_cpu', 'pool_gpu', 'pool_cudnn'],
-                                     data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='valid', global_pool=False)
+        if pool_type == 'lp':
+            test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu'],
+                                         data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                         pooling_convention='valid', global_pool=False, p_value=p_value)
+        else:
+            test_pooling_versions_helper(pool_op_list=['pool_v1_cpu', 'pool_v1_gpu', 'pool_cpu', 'pool_gpu', 'pool_cudnn'],
+                                         data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                         pooling_convention='valid', global_pool=False)
 
         # pool_v1 has bugs when pad is not 0, do not test PoolingV1 here
         pad = (2, 3)
         stride = (2, 3)
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu', 'pool_cudnn'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='valid', global_pool=False)
+                                     pooling_convention='valid', global_pool=False, p_value=p_value)
 
         pad = (0, 0)
         stride = (1, 1)
-        test_pooling_versions_helper(pool_op_list=['pool_v1_cpu', 'pool_v1_gpu', 'pool_cpu', 'pool_gpu', 'pool_cudnn'],
-                                     data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='full', global_pool=False)
+        if pool_type == 'lp':
+            test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu', 'pool_cudnn'],
+                                         data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                         pooling_convention='full', global_pool=False, p_value=p_value)
+        else:
+            test_pooling_versions_helper(pool_op_list=['pool_v1_cpu', 'pool_v1_gpu', 'pool_cpu', 'pool_gpu', 'pool_cudnn'],
+                                         data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                         pooling_convention='full', global_pool=False)
 
         # pool_v1 has bugs when pad is not 0, do not test PoolingV1 here
         pad = (2, 3)
         stride = (2, 3)
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu', 'pool_cudnn'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='full', global_pool=False)
+                                     pooling_convention='full', global_pool=False, p_value=p_value)
 
-        test_pooling_versions_helper(pool_op_list=['pool_v1_cpu', 'pool_v1_gpu', 'pool_cpu', 'pool_gpu', 'pool_cudnn'],
-                                     data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     global_pool=True)
+        if pool_type == 'lp':
+            test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu', 'pool_cudnn'],
+                                         data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                         global_pool=True, p_value=p_value)
+        else:
+            test_pooling_versions_helper(pool_op_list=['pool_v1_cpu', 'pool_v1_gpu', 'pool_cpu', 'pool_gpu', 'pool_cudnn'],
+                                         data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                         global_pool=True)
 
-    def test_3d_pooling(pool_type):
+    def test_3d_pooling(pool_type, p_value=2):
         data = (2, 3, 20, 20, 20)
         kernel = (4, 5, 3)
         pad = (0, 0, 0)
         stride = (1, 1, 1)
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu', 'pool_cudnn'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='valid', global_pool=False)
+                                     pooling_convention='valid', global_pool=False, p_value=p_value)
 
         pad = (2, 3, 3)
         stride = (2, 3, 1)
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu', 'pool_cudnn'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='valid', global_pool=False)
+                                     pooling_convention='valid', global_pool=False, p_value=p_value)
 
         pad = (0, 0, 0)
         stride = (1, 1, 1)
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu', 'pool_cudnn'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='full', global_pool=False)
+                                     pooling_convention='full', global_pool=False, p_value=p_value)
 
         pad = (2, 3, 3)
         stride = (2, 3, 1)
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu', 'pool_cudnn'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     pooling_convention='full', global_pool=False)
+                                     pooling_convention='full', global_pool=False, p_value=p_value)
 
         test_pooling_versions_helper(pool_op_list=['pool_cpu', 'pool_gpu', 'pool_cudnn'],
                                      data=data, kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                     global_pool=True)
+                                     global_pool=True, p_value=p_value)
 
     test_1d_pooling('max')
     test_1d_pooling('avg')
     test_1d_pooling('sum')
+    test_1d_pooling('lp', p_value=1)
+    test_1d_pooling('lp', p_value=2)
 
     test_2d_pooling('max')
     test_2d_pooling('avg')
     test_2d_pooling('sum')
+    test_2d_pooling('lp', p_value=1)
+    test_2d_pooling('lp', p_value=2)
 
     test_3d_pooling('max')
     test_3d_pooling('avg')
     test_3d_pooling('sum')
+    test_3d_pooling('lp', p_value=1)
+    test_3d_pooling('lp', p_value=2)
 
 
 @with_seed()
 def test_global_pooling():
-    def test_1d_pooling(pool_type):
+    def test_1d_pooling(pool_type, p_value=2):
         data = (2, 3, 20)
         kernel = (4,)
         pad = (2,)
@@ -911,43 +932,43 @@ def test_global_pooling():
 
         ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, name='pool', p_value=p_value))
 
         ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, name='pool', p_value=p_value))
 
         ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, name='pool', p_value=p_value))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=False, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=False, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=False, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=False, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=False, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=False, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=True, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=True, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=True, name='pool'))
 
         check_consistency(sym_list, ctx_list)
 
-    def test_2d_pooling(pool_type):
+    def test_2d_pooling(pool_type, p_value=2):
         data = (2, 3, 20, 20)
         kernel = (4, 4)
         pad = (2, 2)
@@ -958,53 +979,54 @@ def test_global_pooling():
 
         pooling_convention = 'valid'
 
-        ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
-        sym_list.append(mx.sym.Pooling_v1(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+        if pool_type != 'lp':
+            ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+            sym_list.append(mx.sym.Pooling_v1(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
+                                              pooling_convention=pooling_convention, global_pool=True, name='pool'))
 
-        ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
-        sym_list.append(mx.sym.Pooling_v1(kernel=kernel, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+            ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+            sym_list.append(mx.sym.Pooling_v1(kernel=kernel, pool_type=pool_type,
+                                              pooling_convention=pooling_convention, global_pool=True, name='pool'))
 
-        ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
-        sym_list.append(mx.sym.Pooling_v1(pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+            ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
+            sym_list.append(mx.sym.Pooling_v1(pool_type=pool_type,
+                                              pooling_convention=pooling_convention, global_pool=True, name='pool'))
 
         ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, name='pool'))
 
         ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, name='pool'))
 
         ctx_list.append({'ctx': mx.cpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=False, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=False, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=False, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=False, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=False, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=False, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=True, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=True, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, cudnn_off=True, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=True, name='pool'))
 
 
         check_consistency(sym_list, ctx_list)
@@ -1012,10 +1034,14 @@ def test_global_pooling():
     test_1d_pooling('max')
     test_1d_pooling('avg')
     test_1d_pooling('sum')
+    test_1d_pooling('lp', p_value=1)
+    test_1d_pooling('lp', p_value=2)
 
     test_2d_pooling('max')
     test_2d_pooling('avg')
     test_2d_pooling('sum')
+    test_2d_pooling('lp', p_value=1)
+    test_2d_pooling('lp', p_value=2)
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
We follow the same implementation as PyTorch's implementation:
https://github.com/pytorch/pytorch/blob/master/torch/nn/functional.py#L445-L465

## Checklist ##
### Essentials ###
- [x] The PR title starts with [MXNET-375]
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Support Lp Pooling
- [x] Unit tests for Lp Pooling

## Comments ##
- For bridging the gap between MXNet and ONNX operators
Comparison of performance of Avgpool:
(before &nbsp;&nbsp;&nbsp;&nbsp; after)
1D Pooling on CPU:
0.039776878356933595&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0.049250895977020266
2D Pooling on CPU:
0.018903429508209228&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0.01837245225906372
3D Pooling on CPU:
0.9366579866409301&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0.915347421169281
1D Pooling on GPU:
0.002552490234375&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0.0024517107009887694
2D Pooling on GPU:
0.0012897467613220215&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0.001228764057159424
3D Pooling on GPU:
0.048471152782440186&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;0.048865692615509035
Script used:
```python
import mxnet as mx
from mxnet.test_utils import check_speed, rand_ndarray, rand_shape_nd

def get_params(dim):
    if dim == 1:
        return (50, 3, 20000), (16, ), (0, ), (2, )
    if dim == 2:
        return (50, 3, 45, 45), (16, 16), (0, 0), (2, 2)
    if dim == 3:
        return (50, 3, 32, 32, 32), (16, 16, 16), (0, 0, 0), (2, 2, 2)

def main():
    for n_dim in range(3, 6):
        test_shape, kernel, pad, stride = get_params(n_dim - 2)
        test_input = rand_ndarray(test_shape, 'default')
        data = mx.sym.Variable('data')
        sym = mx.sym.Pooling(data=data, kernel=kernel, pad=pad, stride=stride, pool_type='avg', cudnn_off=True)
        for context in [mx.cpu(), mx.gpu()]:
            print(check_speed(sym, location={'data':test_input}, ctx=context, N=100))


if __name__ == '__main__':
    main()
```