### PR TITLE
fix the latex formula for LRN operator

### DIFF
--- a/src/operator/nn/lrn.cc
+++ b/src/operator/nn/lrn.cc
@@ -167,7 +167,7 @@ If :math:`a_{x,y}^{i}` is the activity of a neuron computed by applying kernel :
 activity :math:`b_{x,y}^{i}` is given by the expression:
 
 .. math::
-   b_{x,y}^{i} = \frac{a_{x,y}^{i}}{\Bigg({k + \alpha \sum_{j=max(0, i-\frac{n}{2})}^{min(N-1, i+\frac{n}{2})} (a_{x,y}^{j})^{2}}\Bigg)^{\beta}}
+   b_{x,y}^{i} = \frac{a_{x,y}^{i}}{\Bigg({k + \frac{\alpha}{n} \sum_{j=max(0, i-\frac{n}{2})}^{min(N-1, i+\frac{n}{2})} (a_{x,y}^{j})^{2}}\Bigg)^{\beta}}
 
 where the sum runs over :math:`n` "adjacent" kernel maps at the same spatial position, and :math:`N` is the total
 number of kernels in the layer.


### PR DESCRIPTION
## Description ##
Hi.
The latex formula for LRN operator should be
`b_{x,y}^{i} = \frac{a_{x,y}^{i}}{\Bigg({k + \frac{\alpha}{n} \sum_{j=max(0, i-\frac{n}{2})}^{min(N-1, i+\frac{n}{2})} (a_{x,y}^{j})^{2}}\Bigg)^{\beta}}`.
And I wrote a test case to verify it.

## Testing Code
```python
import numpy as np
import mxnet as mx

N, C, H, W = 2,10,5,5

data = np.arange(N*C*H*W).reshape((N, C, H, W))

local_size = 5
alpha = 1e-4
beta = 0.75

pred = np.empty(data.shape)

for n in range(N):
    for h in range(H):
        for w in range(W):
            for c in range(C):
                lo = max(0, c - local_size // 2) 
                hi = min(C-1, c + local_size // 2)
                su = 0.0
                for u in range(lo, hi + 1):
                    if u >= 0 and u < C:
                        su += np.square(data[n,u,h,w])
                nv = local_size
                su *= (alpha / nv)
                su += 1
                pred[n,c,h,w] = data[n,c,h,w] / np.power(su, beta)

mout = mx.nd.LRN(data = mx.nd.array(data), alpha = alpha, beta = beta, knorm = 1, nsize = local_size).asnumpy()
print (np.allclose(mout, pred))
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] **tiny changes.** The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fix the latex formula for LRN operator

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
