### PR TITLE
hide kvstore api from api index

### DIFF
--- a/docs/api/python/executor/executor.md
+++ b/docs/api/python/executor/executor.md
@@ -3,7 +3,7 @@
 The executor and executor manager are internal classes for managing symbolic
 graph execution. This document is only intended for reference for advanced users.
 
-.. note:: Direct interaction with executor and executor manager is dangerous and not recommended.
+.. note:: Direct interactions with executor and executor manager are dangerous and not recommended.
 
 ## Executor
 

--- a/docs/api/python/executor/executor.md
+++ b/docs/api/python/executor/executor.md
@@ -3,6 +3,8 @@
 The executor and executor manager are internal classes for managing symbolic
 graph execution. This document is only intended for reference for advanced users.
 
+.. note:: Direct interaction with Executor and Executor Manager is dangerous and not recommended.
+
 ## Executor
 
 ```eval_rst

--- a/docs/api/python/executor/executor.md
+++ b/docs/api/python/executor/executor.md
@@ -3,7 +3,7 @@
 The executor and executor manager are internal classes for managing symbolic
 graph execution. This document is only intended for reference for advanced users.
 
-.. note:: Direct interaction with Executor and Executor Manager is dangerous and not recommended.
+.. note:: Direct interaction with executor and executor manager is dangerous and not recommended.
 
 ## Executor
 

--- a/docs/api/python/index.md
+++ b/docs/api/python/index.md
@@ -86,15 +86,6 @@ Code examples are placed throughout the API documentation and these can be run a
    gluon/contrib.md
 ```
 
-## KVStore API
-
-```eval_rst
-.. toctree::
-   :maxdepth: 1
-
-   kvstore/kvstore.md
-```
-
 ## IO API
 
 ```eval_rst

--- a/docs/api/python/kvstore/kvstore.md
+++ b/docs/api/python/kvstore/kvstore.md
@@ -1,5 +1,7 @@
 # KVStore API
 
+.. note:: Direct interaction with ``KVStore`` is dangerous and not recommended.
+
 ## Basic Push and Pull
 
 Provides basic operation over multiple devices (GPUs) on a single device.

--- a/docs/api/python/kvstore/kvstore.md
+++ b/docs/api/python/kvstore/kvstore.md
@@ -1,6 +1,6 @@
 # KVStore API
 
-.. note:: Direct interaction with ``KVStore`` is dangerous and not recommended.
+.. note:: Direct interactions with ``KVStore`` are dangerous and not recommended.
 
 ## Basic Push and Pull
 


### PR DESCRIPTION
## Description ##
The kvstore in MXNet is implemented with lots of assumption and is dangerous to expose the API to users. We should consider changing it to private APIs in MXNet 2.0.

Currently the API documentation doesn't explain all the edge cases in KVStore implementation. We should discourage users from using kvstore directly (and usually, they don't have to). 

@rahul003 @mli 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
