### PR TITLE
Update expected result in osx python install script

### DIFF
--- a/setup-utils/install-mxnet-osx-python.sh
+++ b/setup-utils/install-mxnet-osx-python.sh
@@ -506,8 +506,8 @@ print ((a*2).asnumpy());
 END
 	rm -f mxnet_test.expected
 	cat << END > mxnet_test.expected
-[[ 2.  2.  2.]
- [ 2.  2.  2.]]
+[[2. 2. 2.]
+ [2. 2. 2.]]
 END
 	diff mxnet_test.log mxnet_test.expected
 	if [[ $? = 0 ]]; then


### PR DESCRIPTION
* Change the expected value writtent to file mxnet_test.expected

## Description ##
@gautamkmr @mbaijal
The bash script install-mxnet-osx-python.sh checks for an array created using MXNet. However, the formatting for the expected result is slightly incorrect (extra spaces in a couple of places).

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Installation verified on an OSX machine
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] 1
* The install script (in its final step) checks if the following array was correctly created: mx.nd.ones((2, 3))*2.
* The array checked is formatted as: 
[[ 2.  2.  2.]
 [ 2.  2.  2.]]
* However, it should be formatted as:
[[2. 2. 2.]
  2. 2. 2.]]
- Checked by re-installing MXNet on osx machines a couple of times.
