### PR TITLE
[MXNET-407] Better error handling of NDArray setitem autograd

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -765,7 +765,8 @@ fixed-size items.
         indices = self._get_index_nd(key)
         vshape = _get_oshape_of_gather_nd_op(self.shape, indices.shape)
         value_nd = self._prepare_value_nd(value, vshape)
-        _internal._scatter_set_nd(data=value_nd, indices=indices, shape=self.shape, out=self)
+        _internal._scatter_set_nd(lhs=self, rhs=value_nd, indices=indices,
+                                  shape=self.shape, out=self)
 
     def _get_nd_basic_indexing(self, key):
         """This function is called when key is a slice, or an integer,

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -682,17 +682,20 @@ fixed-size items.
         on the values of slices' steps."""
         shape = self.shape
         if isinstance(key, integer_types):
-            sliced_arr = self._at(key)
-            sliced_arr[:] = value
-            return
-        elif isinstance(key, py_slice):
-            if key.step is None or key.step == 1:  # trivial step
-                if key.start is not None or key.stop is not None:
-                    sliced_arr = self._slice(key.start, key.stop)
-                    sliced_arr[:] = value
-                    return
-                # assign value to the whole NDArray
-                # may need to broadcast first
+            if key < 0:
+                key += shape[0]
+            if key < 0 or key >= shape[0]:
+                if key < 0:
+                    key -= shape[0]
+                raise IndexError('index %d is out of bounds for axis 0 with size %d'
+                                 % (key, shape[0]))
+            key = py_slice(key, key+1)  # key must be >= 0 here
+
+        if isinstance(key, py_slice):
+            assign_to_self = key.step is None or key.step == 1
+            assign_to_self &= key.start is None or key.start == 0
+            assign_to_self &= key.stop is None or key.stop == shape[0]
+            if assign_to_self:  # trivial case, assign value to self
                 if isinstance(value, NDArray):
                     if value.handle is not self.handle:
                         if value.shape != shape:
@@ -709,7 +712,7 @@ fixed-size items.
                     value_nd = self._prepare_value_nd(value, shape)
                     value_nd.copyto(self)
                 return
-            else:  # non-trivial step, use _slice_assign or _slice_assign_scalar
+            else:  # non-trivial case, use _slice_assign or _slice_assign_scalar
                 key = (key,)
 
         assert isinstance(key, tuple), "key=%s must be a tuple of slices and integers" % str(key)

--- a/src/imperative/imperative.cc
+++ b/src/imperative/imperative.cc
@@ -194,7 +194,7 @@ void Imperative::RecordOp(
       << "will cause undefined behavior when evaluating gradients. "
       << "Please call backward first to clear the graph or do this out side of "
       << "a record section. Also note that you cannot use inplace operations "
-      << "like +=, *=, relu(x, out=x), etc inside a record section.";
+      << "like +=, *=, relu(x, out=x), y[idx]=x, etc inside a record section.";
   }
 
   bool need_grad = false;

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -668,7 +668,9 @@ Examples::
 NNVM_REGISTER_OP(_scatter_set_nd)
 .describe(R"code(This operator has the same functionality as scatter_nd
 except that it does not reset the elements not indexed by the input
-index `NDArray` in the input data `NDArray`.
+index `NDArray` in the input data `NDArray`. output should be explicitly
+given and be the same as lhs.
+
 .. note:: This operator is for internal use only.
 
 Examples::
@@ -676,21 +678,62 @@ Examples::
   data = [2, 3, 0]
   indices = [[1, 1, 0], [0, 1, 0]]
   out = [[1, 1], [1, 1]]
-  scatter_nd(data=data, indices=indices, out=out)
+  _scatter_set_nd(lhs=out, rhs=data, indices=indices, out=out)
   out = [[0, 1], [2, 3]]
 
 )code")
 .set_num_outputs(1)
-.set_num_inputs(2)
+.set_num_inputs(3)
 .set_attr_parser(ParamParser<ScatterNDParam>)
 .set_attr<nnvm::FListInputNames>("FListInputNames",
   [](const NodeAttrs& attrs) {
-    return std::vector<std::string>{"data", "indices"};
+    return std::vector<std::string>{"lhs", "rhs", "indices"};
   })
-.set_attr<nnvm::FInferShape>("FInferShape", ScatterNDShape)
-.set_attr<nnvm::FInferType>("FInferType", ScatterNDType)
+.set_attr<nnvm::FInferShape>("FInferShape",
+  [](const nnvm::NodeAttrs& attrs,
+     std::vector<TShape> *in_attrs,
+     std::vector<TShape> *out_attrs) {
+    CHECK_EQ(in_attrs->size(), 3U);
+    CHECK_EQ(out_attrs->size(), 1U);
+    SHAPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
+    std::vector<TShape> tmp_in_attrs = {in_attrs->at(1), in_attrs->at(2)};
+    if (!ScatterNDShape(attrs, &tmp_in_attrs, out_attrs)) {
+      return false;
+    }
+    SHAPE_ASSIGN_CHECK(*in_attrs, 1, tmp_in_attrs[0]);
+    SHAPE_ASSIGN_CHECK(*in_attrs, 2, tmp_in_attrs[1]);
+    SHAPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
+    return true;
+  })
+.set_attr<nnvm::FInferType>("FInferType",
+  [](const nnvm::NodeAttrs& attrs,
+     std::vector<int> *in_attrs,
+     std::vector<int> *out_attrs) {
+    CHECK_EQ(in_attrs->size(), 3U);
+    CHECK_EQ(out_attrs->size(), 1U);
+    TYPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
+    TYPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
+    std::vector<int> tmp_in_attrs = {in_attrs->at(1), in_attrs->at(2)};
+    if (!ScatterNDType(attrs, &tmp_in_attrs, out_attrs)) {
+      return false;
+    }
+    TYPE_ASSIGN_CHECK(*in_attrs, 1, tmp_in_attrs[0]);
+    TYPE_ASSIGN_CHECK(*in_attrs, 2, tmp_in_attrs[1]);
+    TYPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
+    return true;
+  })
 .set_attr<FCompute>("FCompute<cpu>", ScatterSetNDForward<cpu>)
-.add_argument("data", "NDArray-or-Symbol", "data")
+.set_attr<nnvm::FInplaceOption>("FInplaceOption",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::pair<int, int> >{{0, 0}};
+  })
+.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+  [](const NodeAttrs& attrs){
+    return std::vector<bool>{true};
+  })
+.add_argument("lhs", "NDArray-or-Symbol", "source input")
+.add_argument("rhs", "NDArray-or-Symbol", "value to assign")
 .add_argument("indices", "NDArray-or-Symbol", "indices")
 .add_arguments(ScatterNDParam::__FIELDS__());
 

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -1111,7 +1111,7 @@ inline bool ScatterNDType(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(out_attrs->size(), 1U);
   TYPE_ASSIGN_CHECK(*out_attrs, 0, (*in_attrs)[0]);
   TYPE_ASSIGN_CHECK(*in_attrs, 0, (*out_attrs)[0]);
-  return true;
+  return in_attrs->at(0) != -1 && in_attrs->at(1) != -1;
 }
 
 struct scatter_nd {
@@ -1228,7 +1228,10 @@ void ScatterSetNDForward(const nnvm::NodeAttrs& attrs,
                          const std::vector<TBlob>& inputs,
                          const std::vector<OpReqType>& req,
                          const std::vector<TBlob>& outputs) {
-  ScatterNDForward<xpu>(attrs, ctx, inputs, {kWriteInplace}, outputs);
+  CHECK_EQ(inputs.size(), 3U);
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(inputs[0].dptr_, outputs[0].dptr_);
+  ScatterNDForward<xpu>(attrs, ctx, {inputs[1], inputs[2]}, {kWriteInplace}, outputs);
 }
 
 }  // namespace op


### PR DESCRIPTION
## Description ##
`NDArray` inplace assignment is prohibited in autograd due to the ambiguity of its backward pass. However, the error message before this PR is not clear to Gluon users. Before this PR, if users write code like:
```python
import mxnet as mx
from mxnet import autograd

a = mx.nd.ones((1, 2))
a.attach_grad()
b = mx.nd.arange(4).reshape((2, 2))

with autograd.record():
    b[1] = a[0]

b.backward()
```
they would receive an error message saying "Cannot differentiate node because it is not in a computational graph", which is confusing and unhelpful in identifying the root cause of the line in python code. This is because `b[1]` would create a temporary `NDArray` as a slice of `b` and the assignment operation would create autograd info on the temporary `NDArray` instead of `b`. Therefore, the following sanity check could not catch this inplace assignment.

This PR fixes this issue by
1. Not creating temporary arrays when slicing along `axis=0` in `NDArray.__setitem__`.
2. Enforcing passing the same input and output `NDArray` object to `_scatter_set_nd` for `NDArray.__setitem__` using advanced indexing.

After this PR, users writing the code like
```python
with autograd.record():
    b[1] = a[0]
    b[[1]] = a[0]
```
would receive the error message "Inplace operations (+=, -=, x[:]=, etc) are not supported when recording with autograd" and the line numbers referencing inplace assignments.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
