### PR TITLE
[MXNET-406] support init/pull dense weight, push row_sparse grad in kvstore

### DIFF
--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -426,7 +426,8 @@ class CommCPU : public Comm {
       }
       return sparse_merged;
     }
-  private:
+
+   private:
     /// \brief the sparse merged value
     NDArray sparse_merged;
   };
@@ -759,7 +760,8 @@ class CommDevice : public Comm {
       }
       return sparse_merged;
     }
-  private:
+
+   private:
     /// \brief the sparse merged value for reduce and rowsparse broadcast operations
     NDArray sparse_merged;
   };

--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -513,9 +513,7 @@ class CommDevice : public Comm {
         // initialize buffer for copying during reduce
         buf.copy_buf.resize(src.size());
         for (size_t j = 0; j < src.size(); ++j) {
-          buf.copy_buf[j] = NDArray(
-            src[0].storage_type(), buf.merged.shape(), buf.merged.ctx(),
-            true, buf.merged.dtype());
+          buf.copy_buf[j] = NDArray(stype, src[0].shape(), pinned_ctx_, true, src[0].dtype());
         }
       }
       CHECK(src[0].storage_type() == buf.copy_buf[0].storage_type())

--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -745,7 +745,6 @@ class CommDevice : public Comm {
       // check if sparse_merged is initialized
       if (sparse_merged.is_none()) {
         CHECK(!merged.is_none());
-        LOG(INFO) << "init sparse-merged on " << merged.ctx();
         sparse_merged = NDArray(kRowSparseStorage, merged.shape(), merged.ctx(),
                                 true, merged.dtype());
       }

--- a/src/kvstore/comm.h
+++ b/src/kvstore/comm.h
@@ -245,9 +245,12 @@ class CommCPU : public Comm {
           NDArray(kRowSparseStorage, src.shape(), src.ctx(), true,
                   src.dtype(), src.aux_types());
       if (!is_diff_var) {
-        common::LogOnce("The output of row_sparse_pull on key " + std::to_string(key) +
+        common::LogOnce("The output of row_sparse_pull() on key " + std::to_string(key) +
                         "refers to the same NDArray as the one stored in KVStore."
-                        "Incorrect result may be generated.");
+                        "Performing row_sparse_pull() with such output is going to change the "
+                        "data stored in KVStore. Incorrect result may be generated "
+                        "next time row_sparse_pull() is called. To avoid such an issue,"
+                        "consider create a new NDArray buffer to store the output.");
       }
       Engine::Get()->PushAsync(
         [=](RunContext rctx, Engine::CallbackOnComplete on_complete) {
@@ -619,9 +622,12 @@ class CommDevice : public Comm {
           NDArray(kRowSparseStorage, out->shape(), src.ctx(), true,
                   out->dtype(), out->aux_types());
       if (!is_diff_var) {
-        common::LogOnce("The output of row_sparse_pull on key " + std::to_string(key) +
+        common::LogOnce("The output of row_sparse_pull() on key " + std::to_string(key) +
                         "refers to the same NDArray as the one stored in KVStore."
-                        "Incorrect result may be generated.");
+                        "Performing row_sparse_pull() with such output is going to change the "
+                        "data stored in KVStore. Incorrect result may be generated "
+                        "next time row_sparse_pull() is called. To avoid such an issue,"
+                        "consider create a new NDArray buffer to store the output.");
       }
 
       Engine::Get()->PushAsync([=](RunContext rctx, Engine::CallbackOnComplete on_complete) {

--- a/src/kvstore/kvstore_local.h
+++ b/src/kvstore/kvstore_local.h
@@ -276,8 +276,8 @@ class KVStoreLocal : public KVStore {
       // invalid, print warning messages once
       if (this->warnings_printed_.find(key) == this->warnings_printed_.end()) {
         LOG(INFO) << "Warning: non-default weights detected during kvstore pull. "
-                  << "This call has been ignored. "
-                  << "Please make sure to use row_sparse_pull with row_ids.";
+                     "This call has been ignored. Please make sure to use"
+                     "kv.row_sparse_pull() or module.prepare() with row_ids.";
         this->warnings_printed_.insert(key);
       }
       return false;

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -1297,7 +1297,7 @@ void ElementwiseSum(const std::vector<NDArray> &source, NDArray *out, int priori
       CHECK_EQ(source[i].ctx().dev_mask(), Context::kCPU)
           << "operands context mismatch";
     } else {
-      CHECK(source[i].ctx() == out->ctx())
+      CHECK_EQ(source[i].ctx(), out->ctx())
           << "operands context mismatch";
     }
   }


### PR DESCRIPTION
## Description ##
Current to use sparse gradient, the weight has to be "row_sparse", too. For distributed training, the following operations are done on kvstore
```
kv.init(row_sparse_weight)
kv.push(row_sparse_grad)
kv.row_sparse_pull(row_sparse_weight)
```

However, one might want to have row_sparse grad when weight is dense. Instead the kvstore operations are the following, which is implemented in this PR:
```
kv.init(dense_weight)
kv.push(row_sparse_grad)
kv.pull(dense_weight)
```

@rahul003 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
