### PR TITLE
Fixed armv8 build

### DIFF
--- a/ci/docker/Dockerfile.build.arm64
+++ b/ci/docker/Dockerfile.build.arm64
@@ -21,18 +21,16 @@
 FROM dockcross/linux-arm64
 
 ENV ARCH aarch64
-ENV CC /usr/bin/aarch64-linux-gnu-gcc
-ENV CXX /usr/bin/aarch64-linux-gnu-g++
-ENV FC /usr/bin/aarch64-linux-gnu-gfortran-4.9
 ENV HOSTCC gcc
+ENV TARGET ARMV8
 
-WORKDIR /work
+WORKDIR /work/deps
 
-COPY install/arm64_openblas.sh /work/
-RUN /work/arm64_openblas.sh
-
-ENV LD_LIBRARY_PATH /opt/OpenBLAS/lib
-ENV CPLUS_INCLUDE_PATH /opt/OpenBLAS/include
-WORKDIR /work/mxnet
+# Build OpenBLAS
+RUN git clone --recursive -b v0.2.20 https://github.com/xianyi/OpenBLAS.git && \
+    cd OpenBLAS && \
+    make -j$(nproc) && \
+    make PREFIX=$CROSS_ROOT install
 
 COPY runtime_functions.sh /work/
+WORKDIR /work/mxnet


### PR DESCRIPTION
## Description ##

The paths for cross compiling tools changed. But they are set in the [base image](https://github.com/dockcross/dockcross/commit/88c828b855f15c9df84ece9764e4337727dab313) so no need to override them.

## Checklist ##
### Essentials ###
- [x] The PR title does not start with [MXNET-$JIRA_ID], since it's a minor fix
- [x] Changes are complete

### Changes ###
- [x] Removed compiler override
- [x] Made openblas build consistent with armv6 build

## Comments ##
- Fixes https://github.com/apache/incubator-mxnet/issues/10837
