### PR TITLE
Fixed divison by zero bug in DistanceWeightedSampling in gluon example

### DIFF
--- a/example/gluon/embedding_learning/model.py
+++ b/example/gluon/embedding_learning/model.py
@@ -110,7 +110,10 @@ class DistanceWeightedSampling(HybridBlock):
             mask[i:i+k, i:i+k] = 0
 
         weights = weights * F.array(mask) * (distance < self.nonzero_loss_cutoff)
-        weights = weights / F.sum(weights, axis=1, keepdims=True)
+        weight_norm = F.sum(weights, axis=1, keepdims=True)
+        # we need to change all zero elements to 1 to avoid division by zero
+        weight_norm = F.where(weight_norm == 0, F.ones_like(weight_norm), weight_norm)
+        weights = weights / weight_norm
 
         a_indices = []
         p_indices = []

--- a/example/gluon/embedding_learning/model.py
+++ b/example/gluon/embedding_learning/model.py
@@ -220,6 +220,8 @@ class MarginLoss(gluon.loss.Loss):
         neg_loss = F.maximum(beta - d_an + self._margin, 0.0)
 
         pair_cnt = float(F.sum((pos_loss > 0.0) + (neg_loss > 0.0)).asscalar())
+        if pair_cnt == 0.0:
+            return F.zeros(1)
 
         # Normalize based on the number of pairs.
         loss = (F.sum(pos_loss + neg_loss) + beta_reg_loss) / pair_cnt

--- a/example/gluon/embedding_learning/model.py
+++ b/example/gluon/embedding_learning/model.py
@@ -219,10 +219,11 @@ class MarginLoss(gluon.loss.Loss):
         pos_loss = F.maximum(d_ap - beta + self._margin, 0.0)
         neg_loss = F.maximum(beta - d_an + self._margin, 0.0)
 
-        pair_cnt = float(F.sum((pos_loss > 0.0) + (neg_loss > 0.0)).asscalar())
+        pair_cnt = F.sum((pos_loss > 0.0) + (neg_loss > 0.0))
         if pair_cnt == 0.0:
-            return F.zeros(1)
-
-        # Normalize based on the number of pairs.
-        loss = (F.sum(pos_loss + neg_loss) + beta_reg_loss) / pair_cnt
+            # When poss_loss and neg_loss is zero then total loss is zero as well
+            loss = F.sum(pos_loss + neg_loss)
+        else:
+            # Normalize based on the number of pairs.
+            loss = (F.sum(pos_loss + neg_loss) + beta_reg_loss) / pair_cnt
         return gluon.loss._apply_weighting(F, loss, self._weight, None)


### PR DESCRIPTION
## Description ##
Sample selection for training is based on a vector of computed probabilities that come from distance weights. In the current implementation these weights can become zero (especially at random initialization) when distances to all other neighbors are zero.
Zero weights lead to nan bugs in the model, this commit is supposed to fix it by changing those zero weights not being divided by zero any longer.

This example project has no unit test. :(

