### PR TITLE
[MXNET-364] Fix docs for sparse broadcast operators

### DIFF
--- a/docs/api/python/ndarray/sparse.md
+++ b/docs/api/python/ndarray/sparse.md
@@ -386,6 +386,8 @@ We summarize the interface for each class in the following sections.
     elemwise_add
     elemwise_sub
     elemwise_mul
+    broadcast_add
+    broadcast_sub
     broadcast_mul
     broadcast_div
     negative

--- a/docs/api/python/symbol/sparse.md
+++ b/docs/api/python/symbol/sparse.md
@@ -97,6 +97,10 @@ In the rest of this document, we list sparse related routines provided by the
     elemwise_add
     elemwise_sub
     elemwise_mul
+    broadcast_add
+    broadcast_sub
+    broadcast_mul
+    broadcast_div
     negative
     dot
     add_n

--- a/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
@@ -29,6 +29,8 @@
 namespace mxnet {
 namespace op {
 MXNET_OPERATOR_REGISTER_BINARY_BROADCAST(broadcast_add)
+MXNET_ADD_SPARSE_OP_ALIAS(broadcast_add)
+MXNET_ADD_SPARSE_OP_ALIAS(broadcast_plus)
 .add_alias("broadcast_plus")
 .describe(R"code(Returns element-wise sum of the input arrays with broadcasting.
 
@@ -49,6 +51,7 @@ Example::
                            [ 2.,  2.,  2.]]
 
 Supported sparse operations:
+
    broadcast_add(csr, dense(1D)) = dense
    broadcast_add(dense(1D), csr) = dense
 
@@ -74,6 +77,8 @@ NNVM_REGISTER_OP(_backward_broadcast_add)
                                                                 mshadow_op::identity>);
 
 MXNET_OPERATOR_REGISTER_BINARY_BROADCAST(broadcast_sub)
+MXNET_ADD_SPARSE_OP_ALIAS(broadcast_sub)
+MXNET_ADD_SPARSE_OP_ALIAS(broadcast_minus)
 .add_alias("broadcast_minus")
 .describe(R"code(Returns element-wise difference of the input arrays with broadcasting.
 
@@ -94,6 +99,7 @@ Example::
                             [ 0.,  0.,  0.]]
 
 Supported sparse operations:
+
    broadcast_sub/minus(csr, dense(1D)) = dense
    broadcast_sub/minus(dense(1D), csr) = dense
 
@@ -119,6 +125,7 @@ NNVM_REGISTER_OP(_backward_broadcast_sub)
                                                                 mshadow_op::negation>);
 
 MXNET_OPERATOR_REGISTER_BINARY_BROADCAST(broadcast_mul)
+MXNET_ADD_SPARSE_OP_ALIAS(broadcast_mul)
 .describe(R"code(Returns element-wise product of the input arrays with broadcasting.
 
 Example::
@@ -133,6 +140,7 @@ Example::
                           [ 1.,  1.,  1.]]
 
 Supported sparse operations:
+
    broadcast_mul(csr, dense(1D)) = csr (CPU only)
 
 )code" ADD_FILELINE)
@@ -158,6 +166,7 @@ NNVM_REGISTER_OP(_backward_broadcast_mul)
                                                               mshadow_op::left>);
 
 MXNET_OPERATOR_REGISTER_BINARY_BROADCAST(broadcast_div)
+MXNET_ADD_SPARSE_OP_ALIAS(broadcast_div)
 .describe(R"code(Returns element-wise division of the input arrays with broadcasting.
 
 Example::
@@ -172,6 +181,7 @@ Example::
                           [ 2.,  2.,  2.]]
 
 Supported sparse operations:
+
    broadcast_div(csr, dense(1D)) = csr (CPU only)
 
 )code" ADD_FILELINE)


### PR DESCRIPTION
## Description ##
As title

## Checklist ##
### Essentials ###
- [x] The PR title starts with [MXNET-364]
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fix doc problems for broadcast operators

## Comments ##
