### PR TITLE
[MXNET-9704] An assertion check for invalid layout

### DIFF
--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -309,7 +309,7 @@ class Conv2D(_Conv):
                  dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0, **kwargs):
-        assert layout == 'NCHW' or layout == 'NHWC',
+        assert layout == 'NCHW' or layout == 'NHWC', \
             "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
@@ -391,7 +391,7 @@ class Conv3D(_Conv):
                  dilation=(1, 1, 1), groups=1, layout='NCDHW', activation=None,
                  use_bias=True, weight_initializer=None, bias_initializer='zeros',
                  in_channels=0, **kwargs):
-        assert layout == 'NCDHW' or layout == 'NDHWC',
+        assert layout == 'NCDHW' or layout == 'NDHWC', \
             "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3
@@ -556,7 +556,7 @@ class Conv2DTranspose(_Conv):
                  output_padding=(0, 0), dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0, **kwargs):
-        assert layout == 'NCHW' or layout == 'NHWC',
+        assert layout == 'NCHW' or layout == 'NHWC', \
             "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
@@ -645,7 +645,7 @@ class Conv3DTranspose(_Conv):
                  output_padding=(0, 0, 0), dilation=(1, 1, 1), groups=1, layout='NCDHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0, **kwargs):
-        assert layout == 'NCDHW' or layout == 'NDHWC',
+        assert layout == 'NCDHW' or layout == 'NDHWC', \
             "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -309,7 +309,8 @@ class Conv2D(_Conv):
                  dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0, **kwargs):
-        assert layout == 'NCHW' or layout == 'NHWC', "Only supports 'NCHW' and 'NHWC' layout for now"
+        assert layout == 'NCHW' or layout == 'NHWC',
+            "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
         assert len(kernel_size) == 2, "kernel_size must be a number or a list of 2 ints"
@@ -390,7 +391,8 @@ class Conv3D(_Conv):
                  dilation=(1, 1, 1), groups=1, layout='NCDHW', activation=None,
                  use_bias=True, weight_initializer=None, bias_initializer='zeros',
                  in_channels=0, **kwargs):
-        assert layout == 'NCDHW' or layout == 'NDHWC', "Only supports 'NCDHW' and 'NDHWC' layout for now"
+        assert layout == 'NCDHW' or layout == 'NDHWC',
+            "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3
         assert len(kernel_size) == 3, "kernel_size must be a number or a list of 3 ints"
@@ -554,7 +556,8 @@ class Conv2DTranspose(_Conv):
                  output_padding=(0, 0), dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0, **kwargs):
-        assert layout == 'NCHW' or layout == 'NHWC', "Only supports 'NCHW' and 'NHWC' layout for now"
+        assert layout == 'NCHW' or layout == 'NHWC',
+            "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
         if isinstance(output_padding, numeric_types):
@@ -642,7 +645,8 @@ class Conv3DTranspose(_Conv):
                  output_padding=(0, 0, 0), dilation=(1, 1, 1), groups=1, layout='NCDHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0, **kwargs):
-        assert layout == 'NCDHW' or layout == 'NDHWC', "Only supports 'NCDHW' and 'NDHWC' layout for now"
+        assert layout == 'NCDHW' or layout == 'NDHWC',
+            "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3
         if isinstance(output_padding, numeric_types):

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -196,7 +196,7 @@ class Conv1D(_Conv):
         layers side by side, each seeing half the input channels, and producing
         half the output channels, and both subsequently concatenated.
     layout: str, default 'NCW'
-        Dimension ordering of data and weight. Can be 'NCW', 'NWC', etc.
+        Dimension ordering of data and weight. Only supports 'NCW' layout for now.
         'N', 'C', 'W' stands for batch, channel, and width (time) dimensions
         respectively. Convolution is applied on the 'W' dimension.
     in_channels : int, default 0
@@ -229,6 +229,7 @@ class Conv1D(_Conv):
                  groups=1, layout='NCW', activation=None, use_bias=True,
                  weight_initializer=None, bias_initializer='zeros',
                  in_channels=0, **kwargs):
+        assert layout == 'NCW', "Only supports 'NCW' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)
         assert len(kernel_size) == 1, "kernel_size must be a number or a list of 1 ints"
@@ -271,9 +272,9 @@ class Conv2D(_Conv):
         layers side by side, each seeing half the input channels, and producing
         half the output channels, and both subsequently concatenated.
     layout : str, default 'NCHW'
-        Dimension ordering of data and weight. Can be 'NCHW', 'NHWC', etc.
-        'N', 'C', 'H', 'W' stands for batch, channel, height, and width
-        dimensions respectively. Convolution is applied on the 'H' and
+        Dimension ordering of data and weight. Only supports 'NCHW' and 'NHWC'
+        layout for now. 'N', 'C', 'H', 'W' stands for batch, channel, height,
+        and width dimensions respectively. Convolution is applied on the 'H' and
         'W' dimensions.
     in_channels : int, default 0
         The number of input channels to this layer. If not specified,
@@ -293,12 +294,12 @@ class Conv2D(_Conv):
 
     Inputs:
         - **data**: 4D input tensor with shape
-          `(batch_size, in_channels, height, width)` when `layout` is `NCW`.
+          `(batch_size, in_channels, height, width)` when `layout` is `NCHW`.
           For other layouts shape is permuted accordingly.
 
     Outputs:
         - **out**: 4D output tensor with shape
-          `(batch_size, channels, out_height, out_width)` when `layout` is `NCW`.
+          `(batch_size, channels, out_height, out_width)` when `layout` is `NCHW`.
           out_height and out_width are calculated as::
 
               out_height = floor((height+2*padding[0]-dilation[0]*(kernel_size[0]-1)-1)/stride[0])+1
@@ -308,6 +309,7 @@ class Conv2D(_Conv):
                  dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0, **kwargs):
+        assert layout == 'NCHW' or layout == 'NHWC', "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
         assert len(kernel_size) == 2, "kernel_size must be a number or a list of 2 ints"
@@ -350,9 +352,9 @@ class Conv3D(_Conv):
         layers side by side, each seeing half the input channels, and producing
         half the output channels, and both subsequently concatenated.
     layout : str, default 'NCDHW'
-        Dimension ordering of data and weight. Can be 'NCDHW', 'NDHWC', etc.
-        'N', 'C', 'H', 'W', 'D' stands for batch, channel, height, width and
-        depth dimensions respectively. Convolution is applied on the 'D',
+        Dimension ordering of data and weight. Only supports 'NCDHW' and 'NDHWC'
+        layout for now. 'N', 'C', 'H', 'W', 'D' stands for batch, channel, height,
+        width and depth dimensions respectively. Convolution is applied on the 'D',
         'H' and 'W' dimensions.
     in_channels : int, default 0
         The number of input channels to this layer. If not specified,
@@ -372,12 +374,12 @@ class Conv3D(_Conv):
 
     Inputs:
         - **data**: 5D input tensor with shape
-          `(batch_size, in_channels, depth, height, width)` when `layout` is `NCW`.
+          `(batch_size, in_channels, depth, height, width)` when `layout` is `NCDHW`.
           For other layouts shape is permuted accordingly.
 
     Outputs:
         - **out**: 5D output tensor with shape
-          `(batch_size, channels, out_depth, out_height, out_width)` when `layout` is `NCW`.
+          `(batch_size, channels, out_depth, out_height, out_width)` when `layout` is `NCDHW`.
           out_depth, out_height and out_width are calculated as::
 
               out_depth = floor((depth+2*padding[0]-dilation[0]*(kernel_size[0]-1)-1)/stride[0])+1
@@ -388,6 +390,7 @@ class Conv3D(_Conv):
                  dilation=(1, 1, 1), groups=1, layout='NCDHW', activation=None,
                  use_bias=True, weight_initializer=None, bias_initializer='zeros',
                  in_channels=0, **kwargs):
+        assert layout == 'NCDHW' or layout == 'NDHWC', "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3
         assert len(kernel_size) == 3, "kernel_size must be a number or a list of 3 ints"
@@ -431,7 +434,7 @@ class Conv1DTranspose(_Conv):
         layers side by side, each seeing half the input channels, and producing
         half the output channels, and both subsequently concatenated.
     layout : str, default 'NCW'
-        Dimension ordering of data and weight. Can be 'NCW', 'NWC', etc.
+        Dimension ordering of data and weight. Only supports 'NCW' layout for now.
         'N', 'C', 'W' stands for batch, channel, and width (time) dimensions
         respectively. Convolution is applied on the 'W' dimension.
     in_channels : int, default 0
@@ -464,6 +467,7 @@ class Conv1DTranspose(_Conv):
                  dilation=1, groups=1, layout='NCW', activation=None, use_bias=True,
                  weight_initializer=None, bias_initializer='zeros',
                  in_channels=0, **kwargs):
+        assert layout == 'NCW', "Only supports 'NCW' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)
         if isinstance(output_padding, numeric_types):
@@ -513,9 +517,9 @@ class Conv2DTranspose(_Conv):
         layers side by side, each seeing half the input channels, and producing
         half the output channels, and both subsequently concatenated.
     layout : str, default 'NCHW'
-        Dimension ordering of data and weight. Can be 'NCHW', 'NHWC', etc.
-        'N', 'C', 'H', 'W' stands for batch, channel, height, and width
-        dimensions respectively. Convolution is applied on the 'H' and
+        Dimension ordering of data and weight. Only supports 'NCHW' and 'NHWC'
+        layout for now. 'N', 'C', 'H', 'W' stands for batch, channel, height,
+        and width dimensions respectively. Convolution is applied on the 'H' and
         'W' dimensions.
     in_channels : int, default 0
         The number of input channels to this layer. If not specified,
@@ -535,12 +539,12 @@ class Conv2DTranspose(_Conv):
 
     Inputs:
         - **data**: 4D input tensor with shape
-          `(batch_size, in_channels, height, width)` when `layout` is `NCW`.
+          `(batch_size, in_channels, height, width)` when `layout` is `NCHW`.
           For other layouts shape is permuted accordingly.
 
     Outputs:
         - **out**: 4D output tensor with shape
-          `(batch_size, channels, out_height, out_width)` when `layout` is `NCW`.
+          `(batch_size, channels, out_height, out_width)` when `layout` is `NCHW`.
           out_height and out_width are calculated as::
 
               out_height = (height-1)*strides[0]-2*padding[0]+kernel_size[0]+output_padding[0]
@@ -550,6 +554,7 @@ class Conv2DTranspose(_Conv):
                  output_padding=(0, 0), dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0, **kwargs):
+        assert layout == 'NCHW' or layout == 'NHWC', "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
         if isinstance(output_padding, numeric_types):
@@ -599,10 +604,10 @@ class Conv3DTranspose(_Conv):
         layers side by side, each seeing half the input channels, and producing
         half the output channels, and both subsequently concatenated.
     layout : str, default 'NCDHW'
-        Dimension ordering of data and weight. Can be 'NCDHW', 'NDHWC', etc.
-        'N', 'C', 'H', 'W', 'D' stands for batch, channel, height, width and
-        depth dimensions respectively. Convolution is applied on the 'D',
-        'H', and 'W' dimensions.
+        Dimension ordering of data and weight. Only supports 'NCDHW' and 'NDHWC'
+        layout for now. 'N', 'C', 'H', 'W', 'D' stands for batch, channel, height,
+        width and depth dimensions respectively. Convolution is applied on the 'D',
+        'H' and 'W' dimensions.
     in_channels : int, default 0
         The number of input channels to this layer. If not specified,
         initialization will be deferred to the first time `forward` is called
@@ -621,12 +626,12 @@ class Conv3DTranspose(_Conv):
 
     Inputs:
         - **data**: 5D input tensor with shape
-          `(batch_size, in_channels, depth, height, width)` when `layout` is `NCW`.
+          `(batch_size, in_channels, depth, height, width)` when `layout` is `NCDHW`.
           For other layouts shape is permuted accordingly.
 
     Outputs:
         - **out**: 5D output tensor with shape
-          `(batch_size, channels, out_depth, out_height, out_width)` when `layout` is `NCW`.
+          `(batch_size, channels, out_depth, out_height, out_width)` when `layout` is `NCDHW`.
           out_depth, out_height and out_width are calculated as::
 
             out_depth = (depth-1)*strides[0]-2*padding[0]+kernel_size[0]+output_padding[0]
@@ -637,6 +642,7 @@ class Conv3DTranspose(_Conv):
                  output_padding=(0, 0, 0), dilation=(1, 1, 1), groups=1, layout='NCDHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0, **kwargs):
+        assert layout == 'NCDHW' or layout == 'NDHWC', "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3
         if isinstance(output_padding, numeric_types):
@@ -694,7 +700,7 @@ class MaxPool1D(_Pooling):
         If padding is non-zero, then the input is implicitly
         zero-padded on both sides for padding number of points.
     layout : str, default 'NCW'
-        Dimension ordering of data and weight. Can be 'NCW', 'NWC', etc.
+        Dimension ordering of data and weight. Only supports 'NCW' layout for now.
         'N', 'C', 'W' stands for batch, channel, and width (time) dimensions
         respectively. Pooling is applied on the W dimension.
     ceil_mode : bool, default False
@@ -716,7 +722,7 @@ class MaxPool1D(_Pooling):
     """
     def __init__(self, pool_size=2, strides=None, padding=0, layout='NCW',
                  ceil_mode=False, **kwargs):
-        assert layout == 'NCW', "Only supports NCW layout for now"
+        assert layout == 'NCW', "Only supports 'NCW' layout for now"
         if isinstance(pool_size, numeric_types):
             pool_size = (pool_size,)
         assert len(pool_size) == 1, "pool_size must be a number or a list of 1 ints"
@@ -739,7 +745,7 @@ class MaxPool2D(_Pooling):
         If padding is non-zero, then the input is implicitly
         zero-padded on both sides for padding number of points.
     layout : str, default 'NCHW'
-        Dimension ordering of data and weight. Can be 'NCHW', 'NHWC', etc.
+        Dimension ordering of data and weight. Only supports 'NCHW' layout for now.
         'N', 'C', 'H', 'W' stands for batch, channel, height, and width
         dimensions respectively. padding is applied on 'H' and 'W' dimension.
     ceil_mode : bool, default False
@@ -748,12 +754,12 @@ class MaxPool2D(_Pooling):
 
     Inputs:
         - **data**: 4D input tensor with shape
-          `(batch_size, in_channels, height, width)` when `layout` is `NCW`.
+          `(batch_size, in_channels, height, width)` when `layout` is `NCHW`.
           For other layouts shape is permuted accordingly.
 
     Outputs:
         - **out**: 4D output tensor with shape
-          `(batch_size, channels, out_height, out_width)` when `layout` is `NCW`.
+          `(batch_size, channels, out_height, out_width)` when `layout` is `NCHW`.
           out_height and out_width are calculated as::
 
               out_height = floor((height+2*padding[0]-pool_size[0])/strides[0])+1
@@ -764,7 +770,7 @@ class MaxPool2D(_Pooling):
     """
     def __init__(self, pool_size=(2, 2), strides=None, padding=0, layout='NCHW',
                  ceil_mode=False, **kwargs):
-        assert layout == 'NCHW', "Only supports NCHW layout for now"
+        assert layout == 'NCHW', "Only supports 'NCHW' layout for now"
         if isinstance(pool_size, numeric_types):
             pool_size = (pool_size,)*2
         assert len(pool_size) == 2, "pool_size must be a number or a list of 2 ints"
@@ -787,7 +793,7 @@ class MaxPool3D(_Pooling):
         If padding is non-zero, then the input is implicitly
         zero-padded on both sides for padding number of points.
     layout : str, default 'NCDHW'
-        Dimension ordering of data and weight. Can be 'NCDHW', 'NDHWC', etc.
+        Dimension ordering of data and weight. Only supports 'NCDHW' layout for now.
         'N', 'C', 'H', 'W', 'D' stands for batch, channel, height, width and
         depth dimensions respectively. padding is applied on 'D', 'H' and 'W'
         dimension.
@@ -802,7 +808,7 @@ class MaxPool3D(_Pooling):
 
     Outputs:
         - **out**: 5D output tensor with shape
-          `(batch_size, channels, out_depth, out_height, out_width)` when `layout` is `NCW`.
+          `(batch_size, channels, out_depth, out_height, out_width)` when `layout` is `NCDHW`.
           out_depth, out_height and out_width are calculated as::
 
               out_depth = floor((depth+2*padding[0]-pool_size[0])/strides[0])+1
@@ -814,7 +820,7 @@ class MaxPool3D(_Pooling):
     """
     def __init__(self, pool_size=(2, 2, 2), strides=None, padding=0,
                  ceil_mode=False, layout='NCDHW', **kwargs):
-        assert layout == 'NCDHW', "Only supports NCDHW layout for now"
+        assert layout == 'NCDHW', "Only supports 'NCDHW' layout for now"
         if isinstance(pool_size, numeric_types):
             pool_size = (pool_size,)*3
         assert len(pool_size) == 3, "pool_size must be a number or a list of 3 ints"
@@ -836,7 +842,7 @@ class AvgPool1D(_Pooling):
         If padding is non-zero, then the input is implicitly
         zero-padded on both sides for padding number of points.
     layout : str, default 'NCW'
-        Dimension ordering of data and weight. Can be 'NCW', 'NWC', etc.
+        Dimension ordering of data and weight. Only supports 'NCW' layout for now.
         'N', 'C', 'W' stands for batch, channel, and width (time) dimensions
         respectively. padding is applied on 'W' dimension.
     ceil_mode : bool, default False
@@ -858,7 +864,7 @@ class AvgPool1D(_Pooling):
     """
     def __init__(self, pool_size=2, strides=None, padding=0, layout='NCW',
                  ceil_mode=False, **kwargs):
-        assert layout == 'NCW', "Only supports NCW layout for now"
+        assert layout == 'NCW', "Only supports 'NCW' layout for now"
         if isinstance(pool_size, numeric_types):
             pool_size = (pool_size,)
         assert len(pool_size) == 1, "pool_size must be a number or a list of 1 ints"
@@ -880,7 +886,7 @@ class AvgPool2D(_Pooling):
         If padding is non-zero, then the input is implicitly
         zero-padded on both sides for padding number of points.
     layout : str, default 'NCHW'
-        Dimension ordering of data and weight. Can be 'NCHW', 'NHWC', etc.
+        Dimension ordering of data and weight. Only supports 'NCHW' layout for now.
         'N', 'C', 'H', 'W' stands for batch, channel, height, and width
         dimensions respectively. padding is applied on 'H' and 'W' dimension.
     ceil_mode : bool, default False
@@ -889,12 +895,12 @@ class AvgPool2D(_Pooling):
 
     Inputs:
         - **data**: 4D input tensor with shape
-          `(batch_size, in_channels, height, width)` when `layout` is `NCW`.
+          `(batch_size, in_channels, height, width)` when `layout` is `NCHW`.
           For other layouts shape is permuted accordingly.
 
     Outputs:
         - **out**: 4D output tensor with shape
-          `(batch_size, channels, out_height, out_width)` when `layout` is `NCW`.
+          `(batch_size, channels, out_height, out_width)` when `layout` is `NCHW`.
           out_height and out_width are calculated as::
 
               out_height = floor((height+2*padding[0]-pool_size[0])/strides[0])+1
@@ -905,7 +911,7 @@ class AvgPool2D(_Pooling):
     """
     def __init__(self, pool_size=(2, 2), strides=None, padding=0,
                  ceil_mode=False, layout='NCHW', **kwargs):
-        assert layout == 'NCHW', "Only supports NCHW layout for now"
+        assert layout == 'NCHW', "Only supports 'NCHW' layout for now"
         if isinstance(pool_size, numeric_types):
             pool_size = (pool_size,)*2
         assert len(pool_size) == 2, "pool_size must be a number or a list of 2 ints"
@@ -937,12 +943,12 @@ class AvgPool3D(_Pooling):
 
     Inputs:
         - **data**: 5D input tensor with shape
-          `(batch_size, in_channels, depth, height, width)` when `layout` is `NCW`.
+          `(batch_size, in_channels, depth, height, width)` when `layout` is `NCDHW`.
           For other layouts shape is permuted accordingly.
 
     Outputs:
         - **out**: 5D output tensor with shape
-          `(batch_size, channels, out_depth, out_height, out_width)` when `layout` is `NCW`.
+          `(batch_size, channels, out_depth, out_height, out_width)` when `layout` is `NCDHW`.
           out_depth, out_height and out_width are calculated as::
 
               out_depth = floor((depth+2*padding[0]-pool_size[0])/strides[0])+1
@@ -954,7 +960,7 @@ class AvgPool3D(_Pooling):
     """
     def __init__(self, pool_size=(2, 2, 2), strides=None, padding=0,
                  ceil_mode=False, layout='NCDHW', **kwargs):
-        assert layout == 'NCDHW', "Only supports NCDHW layout for now"
+        assert layout == 'NCDHW', "Only supports 'NCDHW' layout for now"
         if isinstance(pool_size, numeric_types):
             pool_size = (pool_size,)*3
         assert len(pool_size) == 3, "pool_size must be a number or a list of 3 ints"
@@ -965,7 +971,7 @@ class AvgPool3D(_Pooling):
 class GlobalMaxPool1D(_Pooling):
     """Global max pooling operation for temporal data."""
     def __init__(self, layout='NCW', **kwargs):
-        assert layout == 'NCW', "Only supports NCW layout for now"
+        assert layout == 'NCW', "Only supports 'NCW' layout for now"
         super(GlobalMaxPool1D, self).__init__(
             (1,), None, 0, True, True, 'max', **kwargs)
 
@@ -973,7 +979,7 @@ class GlobalMaxPool1D(_Pooling):
 class GlobalMaxPool2D(_Pooling):
     """Global max pooling operation for spatial data."""
     def __init__(self, layout='NCHW', **kwargs):
-        assert layout == 'NCHW', "Only supports NCHW layout for now"
+        assert layout == 'NCHW', "Only supports 'NCHW' layout for now"
         super(GlobalMaxPool2D, self).__init__(
             (1, 1), None, 0, True, True, 'max', **kwargs)
 
@@ -981,7 +987,7 @@ class GlobalMaxPool2D(_Pooling):
 class GlobalMaxPool3D(_Pooling):
     """Global max pooling operation for 3D data."""
     def __init__(self, layout='NCDHW', **kwargs):
-        assert layout == 'NCDHW', "Only supports NCDHW layout for now"
+        assert layout == 'NCDHW', "Only supports 'NCDHW' layout for now"
         super(GlobalMaxPool3D, self).__init__(
             (1, 1, 1), None, 0, True, True, 'max', **kwargs)
 
@@ -989,7 +995,7 @@ class GlobalMaxPool3D(_Pooling):
 class GlobalAvgPool1D(_Pooling):
     """Global average pooling operation for temporal data."""
     def __init__(self, layout='NCW', **kwargs):
-        assert layout == 'NCW', "Only supports NCW layout for now"
+        assert layout == 'NCW', "Only supports 'NCW' layout for now"
         super(GlobalAvgPool1D, self).__init__(
             (1,), None, 0, True, True, 'avg', **kwargs)
 
@@ -997,7 +1003,7 @@ class GlobalAvgPool1D(_Pooling):
 class GlobalAvgPool2D(_Pooling):
     """Global average pooling operation for spatial data."""
     def __init__(self, layout='NCHW', **kwargs):
-        assert layout == 'NCHW', "Only supports NCHW layout for now"
+        assert layout == 'NCHW', "Only supports 'NCHW' layout for now"
         super(GlobalAvgPool2D, self).__init__(
             (1, 1), None, 0, True, True, 'avg', **kwargs)
 
@@ -1005,7 +1011,7 @@ class GlobalAvgPool2D(_Pooling):
 class GlobalAvgPool3D(_Pooling):
     """Global max pooling operation for 3D data."""
     def __init__(self, layout='NCDHW', **kwargs):
-        assert layout == 'NCDHW', "Only supports NCDHW layout for now"
+        assert layout == 'NCDHW', "Only supports 'NCDHW' layout for now"
         super(GlobalAvgPool3D, self).__init__(
             (1, 1, 1), None, 0, True, True, 'avg', **kwargs)
 


### PR DESCRIPTION
## Description ##
a fix for issue #9704
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
  I don't know how to test for this one. A nasty testing script is posted downside.
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
This link is broken. Please update it.
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] assertion check for invalid layout of conv and pooling layers.

## Comments ##
  Assertion check for conv and pooling with documents updates. The pooling assertions was added by someone else before. I'm not sure if other layouts are supported too. 

@gianlucacorrado @zhreshold @anjishnu

a nasty debug script is posted here. feel free to modify it.
``` python
import sys
sys.path.insert(0,'../incubator-mxnet/python')
from mxnet import nd
from mxnet.gluon import nn
from mxnet import gluon

a = nd.zeros((5,2,10))
conv1 = nn.Conv1D(5,1)
conv1t = nn.Conv1DTranspose(5,1)
pool1_ave = nn.AvgPool1D()
pool1_max = nn.MaxPool1D()
pool1_ave_g = nn.GlobalAvgPool1D()
pool1_max_g = nn.GlobalMaxPool1D()
conv1.initialize()
conv1t.initialize()
print(conv1(a).shape)
print(conv1t(a).shape)
print(pool1_ave(a).shape)
print(pool1_max(a).shape)
print(pool1_ave_g(a).shape)
print(pool1_max_g(a).shape)

a = nd.zeros((5,2,10,10))
conv2 = nn.Conv2D(5, (1,1))
conv2t = nn.Conv2DTranspose(5,(1,1), layout='NHWC')
pool2_ave = nn.AvgPool2D()
pool2_max = nn.MaxPool2D()
pool2_ave_g = nn.GlobalAvgPool2D()
pool2_max_g = nn.GlobalMaxPool2D()
conv2.initialize()
conv2t.initialize()
print(conv2(a).shape)
print(conv2t(a).shape)
print(pool2_ave(a).shape)
print(pool2_max(a).shape)
print(pool2_ave_g(a).shape)
print(pool2_max_g(a).shape)

a = nd.zeros((5,2,10,10,10))
conv3 = nn.Conv3D(5, (1,1,1))
conv3t = nn.Conv3DTranspose(5,(1,1,1), layout='NDHWC')
pool3_ave = nn.AvgPool3D()
pool3_max = nn.MaxPool3D()
pool3_ave_g = nn.GlobalAvgPool3D()
pool3_max_g = nn.GlobalMaxPool3D()
conv3.initialize()
conv3t.initialize()
print(conv3(a).shape)
print(conv3t(a).shape)
print(pool3_ave(a).shape)
print(pool3_max(a).shape)
print(pool3_ave_g(a).shape)
print(pool3_max_g(a).shape)

```
