### PR TITLE
Fix Python error on --model-prefix parameter used and make the param can be periodically saved

### DIFF
--- a/example/image-classification/common/fit.py
+++ b/example/image-classification/common/fit.py
@@ -67,11 +67,8 @@ def _load_model(args, rank=0):
 def _save_model(args, rank=0):
     if args.model_prefix is None:
         return None
-    dst_dir = os.path.dirname(args.model_prefix)
-    if not os.path.isdir(dst_dir):
-        os.mkdir(dst_dir)
     return mx.callback.do_checkpoint(args.model_prefix if rank == 0 else "%s-%d" % (
-        args.model_prefix, rank))
+        args.model_prefix, rank), period=args.save_period)
 
 
 def add_fit_args(parser):
@@ -111,6 +108,7 @@ def add_fit_args(parser):
                        help='show progress for every n batches')
     train.add_argument('--model-prefix', type=str,
                        help='model prefix')
+    train.add_argument('--save-period', type=int, default=0, help='params saving period')
     parser.add_argument('--monitor', dest='monitor', type=int, default=0,
                         help='log network parameters every N iters if larger than 0')
     train.add_argument('--load-epoch', type=int,

--- a/example/image-classification/common/fit.py
+++ b/example/image-classification/common/fit.py
@@ -108,7 +108,7 @@ def add_fit_args(parser):
                        help='show progress for every n batches')
     train.add_argument('--model-prefix', type=str,
                        help='model prefix')
-    train.add_argument('--save-period', type=int, default=0, help='params saving period')
+    train.add_argument('--save-period', type=int, default=1, help='params saving period')
     parser.add_argument('--monitor', dest='monitor', type=int, default=0,
                         help='log network parameters every N iters if larger than 0')
     train.add_argument('--load-epoch', type=int,


### PR DESCRIPTION
## Description ##
This PR fixes a Python run time error (which breaking the params saving functionality) when --model-prefix parameter, and make the params can be saved periodically by introducing a new parameter "--save-period", but not always saved every epoch. 

After applying this PR, the params will be saved under the current working path, this is to match the behavior of the corresponding params loading function "_load_model" in fit.py, which will find the *.params file under the current working path.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
example/image-classification/common/fit.py

## Comments ##
After applying this PR, the params will be saved under the current working path, this is to match the behavior of the corresponding params loading function "_load_model" in fit.py, which will find the *.params file under the current working path.
