### PR TITLE
fix shuffle

### DIFF
--- a/tools/im2rec.py
+++ b/tools/im2rec.py
@@ -72,7 +72,7 @@ def write_list(path_out, image_list):
 def make_list(args):
     image_list = list_image(args.root, args.recursive, args.exts)
     image_list = list(image_list)
-    if args.shuffle is True:
+    if args.no_shuffle is False:
         random.seed(100)
         random.shuffle(image_list)
     N = len(image_list)


### PR DESCRIPTION
## Description ##
 no `args.shuffle` in augment of `im2rec.py`, so change it to `args.no_shuffle`
## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
