### PR TITLE
Fix typo "weights"

### DIFF
--- a/R-package/R/optimizer.R
+++ b/R-package/R/optimizer.R
@@ -401,7 +401,7 @@ mx.opt.get.updater <- function(optimizer, weights) {
   update <- optimizer$update
 
   update.closure <- function(weight, grad) {
-    ulist <- lapply(seq_along(weights), function(i) {
+    ulist <- lapply(seq_along(weight), function(i) {
       if (!is.null(grad[[i]])) {
         update(i, weight[[i]], grad[[i]], state.list[[i]])
       } else {


### PR DESCRIPTION
There is a typo in mx.opt.get.updater, it's supposed to be weight rather than weights. This typo will yield List Access Error in R

The issue has been discussed in this stream
https://github.com/apache/incubator-mxnet/issues/10878#issuecomment-388607838