### PR TITLE
[MXNET-420] broadcast_mul/div between csr and 1D dense on GPU

### DIFF
--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -88,16 +88,13 @@ inline bool BinaryBroadcastMulStorageType(const nnvm::NodeAttrs& attrs,
   const int rhs_stype = in_attrs->at(1);
   int& out_stype = out_attrs->at(0);
   bool dispatched = false;
-  // For GPU, directly fallback
-  const auto dispatch_ex = (dev_mask == mshadow::gpu::kDevMask)? DispatchMode::kFComputeFallback :
-                           DispatchMode::kFComputeEx;
   if (!dispatched && common::ContainsOnlyStorage(*in_attrs, kDefaultStorage)) {
     dispatched = storage_type_assign(&out_stype, kDefaultStorage,
                                      dispatch_mode, DispatchMode::kFCompute);
   }
   if (!dispatched && lhs_stype == kCSRStorage && rhs_stype == kDefaultStorage) {
     dispatched = storage_type_assign(&out_stype, kCSRStorage,
-                                     dispatch_mode, dispatch_ex);
+                                     dispatch_mode, DispatchMode::kFComputeEx);
   }
   if (!dispatched) {
     dispatched = dispatch_fallback(out_attrs, dispatch_mode);
@@ -229,17 +226,26 @@ struct binary_broadcast_kernel {
   }
 };
 
-template<int req, typename OP>
+template<int req, typename OP, bool col_vec>
 struct csr_dns_csr_broadcast_kernel {
-  template <typename DType, typename CType, typename RType>
+  template<typename DType, typename CType, typename RType>
   MSHADOW_XINLINE static void Map(int row, const DType *csr_data, const CType *csr_indices,
                                   const RType *csr_indptr, const DType *dns,
-                                  DType *out, const nnvm::dim_t row_length, bool col_vec) {
+                                  DType *out, const nnvm::dim_t row_length) {
     const nnvm::dim_t curr_row_i = csr_indptr[row];
     const nnvm::dim_t next_row_i = csr_indptr[row + 1];
     for (nnvm::dim_t iter = curr_row_i; iter < next_row_i; iter++) {
       KERNEL_ASSIGN(out[iter], req, OP::Map(csr_data[iter],
                     (col_vec)? dns[row] : dns[csr_indices[iter]]));
+    }
+  }
+
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, const DType *csr_data, const DType* scalar_ptr,
+                                  DType *out, const nnvm::dim_t nnz) {
+    const DType scale = scalar_ptr[0];
+    if (i < nnz) {
+      KERNEL_ASSIGN(out[i], req, OP::Map(csr_data[i], scale));
     }
   }
 };
@@ -322,19 +328,26 @@ void BinaryBroadcastCsrDnsCsrImpl(const OpContext& ctx,
           MXNET_ASSIGN_REQ_SWITCH(req, req_type, {
             if ((dns.shape().ndim() == 2 && dns.shape()[0] == 1 && dns.shape()[1] == 1) ||
                 (dns.shape().ndim() == 1 && dns.shape()[0] == 1)) {
-              Kernel<op_with_req<OP, req_type>, xpu>::Launch(
-                s, nnz, output.data().dptr<DType>(), csr.data().dptr<DType>(),
-                dns.data().dptr<DType>()[0]);
+              Kernel<csr_dns_csr_broadcast_kernel<req_type, OP, false>, xpu>::Launch(
+                s, nnz, csr.data().dptr<DType>(), dns.data().dptr<DType>(),
+                output.data().dptr<DType>(), nnz);
             } else {
-              Kernel<csr_dns_csr_broadcast_kernel<req_type, OP>, xpu>::Launch(
-                s, num_rows, csr.data().dptr<DType>(), csr.aux_data(kIdx).dptr<CType>(),
-                csr.aux_data(kIndPtr).dptr<RType>(), dns.data().dptr<DType>(),
-                output.data().dptr<DType>(), csr.shape()[1], col_vec);
+              if (col_vec) {
+                Kernel<csr_dns_csr_broadcast_kernel<req_type, OP, true>, xpu>::Launch(
+                  s, num_rows, csr.data().dptr<DType>(), csr.aux_data(kIdx).dptr<CType>(),
+                  csr.aux_data(kIndPtr).dptr<RType>(), dns.data().dptr<DType>(),
+                  output.data().dptr<DType>(), csr.shape()[1]);
+              } else {
+                Kernel<csr_dns_csr_broadcast_kernel<req_type, OP, false>, xpu>::Launch(
+                  s, num_rows, csr.data().dptr<DType>(), csr.aux_data(kIdx).dptr<CType>(),
+                  csr.aux_data(kIndPtr).dptr<RType>(), dns.data().dptr<DType>(),
+                  output.data().dptr<DType>(), csr.shape()[1]);
+              }
             }
             Copy(output.aux_data(kIdx).FlatTo1D<xpu, CType>(),
-                 csr.aux_data(kIdx).FlatTo1D<xpu, CType>());
+                 csr.aux_data(kIdx).FlatTo1D<xpu, CType>(), s);
             Copy(output.aux_data(kIndPtr).FlatTo1D<xpu, RType>(),
-                 csr.aux_data(kIndPtr).FlatTo1D<xpu, RType>());
+                 csr.aux_data(kIndPtr).FlatTo1D<xpu, RType>(), s);
           });
         });
       });

--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -228,10 +228,18 @@ struct binary_broadcast_kernel {
 
 template<int req, typename OP, bool col_vec>
 struct csr_dns_csr_broadcast_kernel {
+  /*!
+   * \brief Map function for broadcast between csr and 1D vector
+   * \param row          global thread id/assigned row id
+   * \param csr_data     ptr to data buffer of csr matrix
+   * \param csr_indices  ptr to indices buffer of csr matrix
+   * \param csr_indptr   ptr to indptr buffer of csr matrix
+   * \param dns          ptr to data buffer of the dense vector
+   * \param out          ptr to the data buffer of the result csr matrix
+   */
   template<typename DType, typename CType, typename RType>
   MSHADOW_XINLINE static void Map(int row, const DType *csr_data, const CType *csr_indices,
-                                  const RType *csr_indptr, const DType *dns,
-                                  DType *out, const nnvm::dim_t row_length) {
+                                  const RType *csr_indptr, const DType *dns, DType *out) {
     const nnvm::dim_t curr_row_i = csr_indptr[row];
     const nnvm::dim_t next_row_i = csr_indptr[row + 1];
     for (nnvm::dim_t iter = curr_row_i; iter < next_row_i; iter++) {
@@ -240,6 +248,14 @@ struct csr_dns_csr_broadcast_kernel {
     }
   }
 
+  /*!
+   * \brief Map function for broadcast between csr and a scalar
+   * \param i           global thread id
+   * \param csr_data    ptr to data buffer of csr matrix
+   * \param scalar_ptr  ptr to data buffer of the scalar tensor, only the 0-th element is used
+   * \param out         ptr to the data buffer of output csr matrix
+   * \param nnz         number of non-zero elements in input csr matrix
+   */
   template<typename DType>
   MSHADOW_XINLINE static void Map(int i, const DType *csr_data, const DType* scalar_ptr,
                                   DType *out, const nnvm::dim_t nnz) {
@@ -326,22 +342,25 @@ void BinaryBroadcastCsrDnsCsrImpl(const OpContext& ctx,
       MSHADOW_IDX_TYPE_SWITCH(output.aux_type(kIdx), CType, {
         MSHADOW_IDX_TYPE_SWITCH(output.aux_type(kIndPtr), RType, {
           MXNET_ASSIGN_REQ_SWITCH(req, req_type, {
+            // broadcast_mul/div between csr and a scalar case
             if ((dns.shape().ndim() == 2 && dns.shape()[0] == 1 && dns.shape()[1] == 1) ||
                 (dns.shape().ndim() == 1 && dns.shape()[0] == 1)) {
               Kernel<csr_dns_csr_broadcast_kernel<req_type, OP, false>, xpu>::Launch(
                 s, nnz, csr.data().dptr<DType>(), dns.data().dptr<DType>(),
                 output.data().dptr<DType>(), nnz);
             } else {
+              // broadcast_mul/div between csr and column vector
               if (col_vec) {
                 Kernel<csr_dns_csr_broadcast_kernel<req_type, OP, true>, xpu>::Launch(
                   s, num_rows, csr.data().dptr<DType>(), csr.aux_data(kIdx).dptr<CType>(),
                   csr.aux_data(kIndPtr).dptr<RType>(), dns.data().dptr<DType>(),
-                  output.data().dptr<DType>(), csr.shape()[1]);
+                  output.data().dptr<DType>());
+              // broadcast_mul/div between csr and row vector
               } else {
                 Kernel<csr_dns_csr_broadcast_kernel<req_type, OP, false>, xpu>::Launch(
                   s, num_rows, csr.data().dptr<DType>(), csr.aux_data(kIdx).dptr<CType>(),
                   csr.aux_data(kIndPtr).dptr<RType>(), dns.data().dptr<DType>(),
-                  output.data().dptr<DType>(), csr.shape()[1]);
+                  output.data().dptr<DType>());
               }
             }
             Copy(output.aux_data(kIdx).FlatTo1D<xpu, CType>(),

--- a/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_broadcast_op_basic.cc
@@ -141,7 +141,7 @@ Example::
 
 Supported sparse operations:
 
-   broadcast_mul(csr, dense(1D)) = csr (CPU only)
+   broadcast_mul(csr, dense(1D)) = csr
 
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::mul>)
@@ -182,7 +182,7 @@ Example::
 
 Supported sparse operations:
 
-   broadcast_div(csr, dense(1D)) = csr (CPU only)
+   broadcast_div(csr, dense(1D)) = csr
 
 )code" ADD_FILELINE)
 .set_attr<FCompute>("FCompute<cpu>", BinaryBroadcastCompute<cpu, op::mshadow_op::div>)

--- a/src/operator/tensor/elemwise_binary_broadcast_op_basic.cu
+++ b/src/operator/tensor/elemwise_binary_broadcast_op_basic.cu
@@ -45,14 +45,16 @@ NNVM_REGISTER_OP(_backward_broadcast_sub)
                                                                 mshadow_op::negation>);
 
 NNVM_REGISTER_OP(broadcast_mul)
-.set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastCompute<gpu, op::mshadow_op::mul>);
+.set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastCompute<gpu, op::mshadow_op::mul>)
+.set_attr<FComputeEx>("FComputeEx<gpu>", BinaryBroadcastComputeSparseEx<gpu, op::mshadow_op::mul>);
 
 NNVM_REGISTER_OP(_backward_broadcast_mul)
 .set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastBackwardUseIn<gpu, mshadow_op::right,
                                                                 mshadow_op::left>);
 
 NNVM_REGISTER_OP(broadcast_div)
-.set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastCompute<gpu, op::mshadow_op::div>);
+.set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastCompute<gpu, op::mshadow_op::div>)
+.set_attr<FComputeEx>("FComputeEx<gpu>", BinaryBroadcastComputeSparseEx<gpu, op::mshadow_op::div>);
 
 NNVM_REGISTER_OP(_backward_broadcast_div)
 .set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastBackwardUseIn<gpu, mshadow_op::div_grad,


### PR DESCRIPTION
## Description ##
As title

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add support on GPU for broadcast_mul/div between csr and 1D dense vector
