### PR TITLE
add option to exclude matched parameter names in collect params

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -261,7 +261,7 @@ class Block(object):
         children's parameters)."""
         return self._params
 
-    def collect_params(self, select=None):
+    def collect_params(self, select=None, exclude=False):
         """Returns a :py:class:`ParameterDict` containing this :py:class:`Block` and all of its
         children's Parameters(default), also can returns the select :py:class:`ParameterDict`
         which match some given regular expressions.
@@ -279,7 +279,9 @@ class Block(object):
         Parameters
         ----------
         select : str
-            regular expressions
+            Regular expressions.
+        exclude : bool
+            If True, this method only returns parameters that do not match the select expression.
 
         Returns
         -------
@@ -292,9 +294,10 @@ class Block(object):
             ret.update(self.params)
         else:
             pattern = re.compile(select)
-            ret.update({name:value for name, value in self.params.items() if pattern.match(name)})
+            ret.update({name:value for name, value in self.params.items()
+                        if exclude != bool(pattern.match(name))})
         for cld in self._children.values():
-            ret.update(cld.collect_params(select=select))
+            ret.update(cld.collect_params(select=select, exclude=exclude))
         return ret
 
     def _collect_params_with_prefix(self, prefix=''):

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -148,7 +148,7 @@ def test_parameter_str():
 
 
 @with_seed()
-def test_collect_paramters():
+def test_collect_parameters():
     net = nn.HybridSequential(prefix="test_")
     with net.name_scope():
         net.add(nn.Conv2D(10, 3))
@@ -158,6 +158,8 @@ def test_collect_paramters():
     assert set(net.collect_params('.*weight').keys()) == \
         set(['test_conv0_weight', 'test_dense0_weight'])
     assert set(net.collect_params('test_conv0_bias|test_dense0_bias').keys()) == \
+        set(['test_conv0_bias', 'test_dense0_bias'])
+    assert set(net.collect_params('.*weight', exclude=True).keys()) == \
         set(['test_conv0_bias', 'test_dense0_bias'])
 
 @with_seed()


### PR DESCRIPTION
## Description ##
in gluon.block.collect_params, add option to exclude matched parameter names

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] in gluon.block.collect_params, add option to exclude matched parameter names