### PR TITLE
[MXNET-435] Dropping rc from the release version in the MXNet home page

### DIFF
--- a/docs/_static/mxnet-theme/index.html
+++ b/docs/_static/mxnet-theme/index.html
@@ -26,8 +26,8 @@
         <a href="http://gluon-crash-course.mxnet.io/">Learn More</a>
       </div>
       <div class="col-lg-4 col-sm-12">
-        <h3>MXNet 1.2.0.rc0 Released</h3>
-        <p>We're excited to announce the release of MXNet 1.2.0.rc0! Check out the release notes for latest updates.</p>
+        <h3>MXNet 1.2.0 Released</h3>
+        <p>We're excited to announce the release of MXNet 1.2.0! Check out the release notes for latest updates.</p>
         <a href="https://cwiki.apache.org/confluence/display/MXNET/Apache+MXNet+%28incubating%29+1.2.0+Release+Notes">Learn More</a>
       </div>
       <div class="col-lg-4 col-sm-12">


### PR DESCRIPTION
## Description ##
Dropping rc from the release version in the MXNet home page.

### Changes ###
- [ x ] In the static index.html, removed rc from the test
