### PR TITLE
added more detailed error messages for potri/potrf

### DIFF
--- a/src/operator/linalg_impl.h
+++ b/src/operator/linalg_impl.h
@@ -494,6 +494,9 @@ LINALG_XPU_BATCH_TRMM(gpu, double)
 // for further information about the function and its parameters.
 // Note that this is A = potrf(A), so A is input and output parameter.
 
+static const char *potrf_errstr
+  = "This may happen when the input matrix is either not symmetric or not positive definite.";
+
 template<typename xpu, typename DType>
 inline void check_potrf(const Tensor<xpu, 2, DType>& A, bool lower) {
   // Any checking that helps user debug potential problems.
@@ -507,7 +510,7 @@ void linalg_potrf<cpu, DType>(const Tensor<cpu, 2, DType>& A, bool lower, Stream
   check_potrf(A, lower); \
   int ret(MXNET_LAPACK_##fname(MXNET_LAPACK_ROW_MAJOR, (lower ? 'L' : 'U'), A.size(0),  \
           A.dptr_ , A.stride_)); \
-  CHECK_EQ(ret, 0) << #fname << " failed in lapack on cpu."; \
+  CHECK_EQ(ret, 0) << #fname << " failed in lapack on cpu. " << potrf_errstr; \
 }
 LINALG_CPU_POTRF(spotrf, float)
 LINALG_CPU_POTRF(dpotrf, double)
@@ -589,6 +592,10 @@ LINALG_GPU_BATCH_POTRF(DnDpotrf, double)
 // for further information about the function and its parameters.
 // Note that this is A = potri(A), so A is input and output parameter.
 
+static const char *potri_errstr
+  = "This may happen when the input matrix is not a Cholesky factorization obtained"
+    " by a prior call of the potrf-operator.";
+
 template<typename xpu, typename DType>
 inline void check_potri(const Tensor<xpu, 2, DType>& A, bool lower) {
   // Any checking that helps user debug potential problems.
@@ -601,7 +608,7 @@ void linalg_potri<cpu, DType>(const Tensor<cpu, 2, DType>& A, bool lower, Stream
   check_potri(A, lower); \
   int ret(MXNET_LAPACK_##fname(MXNET_LAPACK_ROW_MAJOR, (lower ? 'L' : 'U'), A.size(0),  \
           A.dptr_ , A.stride_)); \
-  CHECK_EQ(ret, 0) << #fname << " failed in lapack on cpu."; \
+  CHECK_EQ(ret, 0) << #fname << " failed in lapack on cpu. " << potri_errstr; \
 }
 LINALG_CPU_POTRI(spotri, float)
 LINALG_CPU_POTRI(dpotri, double)


### PR DESCRIPTION
## Description ##
Added more detailed error messages for potrf/potri as a response to #10964
We check a lot of conditions upfront, but don't check conditions that are too complex and would actually require writing a complex algorithm just for checking. For potrf, this is whether the input matrix is symmetric and positive definite, for potri this is whether the input matrix is indeed the output of a prior potrf-computation. To help the user in case of an error, we repeat these two unchecked preconditions on the input when displaying the error message. 

There is a limit when we can provide such more useful messages. All cblas-routines do not return any error code (on CPU), so we can realistically cover only lapack routines (which are also the ones that have most complex preconditions). Getting the same type of more elaborate error messages on Cuda is also difficult, specifically as potri on GPU has to be implemented based on blas-routines and not as a single function call. 

As a compromise, we will initially supply such advanced messages for the most common use cases only: potrf/potri on CPU. 


 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
