### PR TITLE
[MXNET-472] Add ccache support to CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,9 +187,11 @@ try {
       node('mxnetlinux-cpu') {
         ws('workspace/build-cpu-openblas') {
           timeout(time: max_time, unit: 'MINUTES') { 
-            init_git()
-            docker_run('ubuntu_cpu', 'build_ubuntu_cpu_openblas', false)
-            pack_lib('cpu', mx_dist_lib)
+            withEnv(['CCACHE_DIR=/tmp/jenkins_ccache']) {
+                init_git()
+                docker_run('ubuntu_cpu', 'build_ubuntu_cpu_openblas', false)
+                pack_lib('cpu', mx_dist_lib)
+            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,9 +154,9 @@ try {
       node('mxnetlinux-cpu') {
         ws('workspace/build-centos7-cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-             init_git()
-             docker_run('centos7_cpu', 'build_centos7_cpu', false)
-             pack_lib('centos7_cpu')
+            init_git()
+            docker_run('centos7_cpu', 'build_centos7_cpu', false)
+            pack_lib('centos7_cpu')
           }
         }
       }
@@ -187,9 +187,9 @@ try {
       node('mxnetlinux-cpu') {
         ws('workspace/build-cpu-openblas') {
           timeout(time: max_time, unit: 'MINUTES') { 
-             init_git()
-             docker_run('ubuntu_cpu', 'build_ubuntu_cpu_openblas', false)
-             pack_lib('cpu', mx_dist_lib)
+            init_git()
+            docker_run('ubuntu_cpu', 'build_ubuntu_cpu_openblas', false)
+            pack_lib('cpu', mx_dist_lib)
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -154,9 +154,9 @@ try {
       node('mxnetlinux-cpu') {
         ws('workspace/build-centos7-cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            init_git()
-            docker_run('centos7_cpu', 'build_centos7_cpu', false)
-            pack_lib('centos7_cpu')
+             init_git()
+             docker_run('centos7_cpu', 'build_centos7_cpu', false)
+             pack_lib('centos7_cpu')
           }
         }
       }
@@ -187,11 +187,9 @@ try {
       node('mxnetlinux-cpu') {
         ws('workspace/build-cpu-openblas') {
           timeout(time: max_time, unit: 'MINUTES') { 
-            withEnv(['CCACHE_DIR=/tmp/jenkins_ccache']) {
-                init_git()
-                docker_run('ubuntu_cpu', 'build_ubuntu_cpu_openblas', false)
-                pack_lib('cpu', mx_dist_lib)
-            }
+             init_git()
+             docker_run('ubuntu_cpu', 'build_ubuntu_cpu_openblas', false)
+             pack_lib('cpu', mx_dist_lib)
           }
         }
       }

--- a/Makefile
+++ b/Makefile
@@ -477,7 +477,7 @@ endif
 $(PS_PATH)/build/libps.a: PSLITE
 
 PSLITE:
-	$(MAKE) CXX=$(CXX) DEPS_PATH=$(DEPS_PATH) -C $(PS_PATH) ps
+	$(MAKE) CXX="$(CXX)" DEPS_PATH="$(DEPS_PATH)" -C $(PS_PATH) ps
 
 $(DMLC_CORE)/libdmlc.a: DMLCCORE
 

--- a/ci/build.py
+++ b/ci/build.py
@@ -130,6 +130,7 @@ def container_run(platform: str,
     local_build_folder = buildir()
     # We need to create it first, otherwise it will be created by the docker daemon with root only permissions
     os.makedirs(local_build_folder, exist_ok=True)
+    os.makedirs(local_ccache_dir, exist_ok=True)
     runlist = [docker_binary, 'run', '--rm', '-t',
         '--shm-size={}'.format(shared_memory_size),
         '-v', "{}:/work/mxnet".format(mx_root), # mount mxnet root

--- a/ci/build.py
+++ b/ci/build.py
@@ -33,6 +33,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from copy import deepcopy
 from itertools import chain
 from subprocess import call, check_call
@@ -120,7 +121,9 @@ def default_ccache_dir() -> str:
         ccache_dir = os.path.realpath(os.environ['CCACHE_DIR'])
         os.makedirs(ccache_dir, exist_ok=True)
         return ccache_dir
-    return os.path.join(buildir(), "ccache")
+    #return os.path.join(buildir(), "ccache")
+    # Share ccache across containers (should we have a separate dir per platform?)
+    return os.path.join(tempfile.gettempdir(), "ci_ccache")
 
 def container_run(platform: str,
                   docker_binary: str,

--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -20,6 +20,8 @@
 
 FROM dockcross/linux-armv6
 
+RUN apt update && apt install -y ccache
+
 ENV ARCH armv6l
 ENV FC=/usr/bin/${CROSS_TRIPLE}-gfortran
 ENV HOSTCC gcc

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -63,5 +63,9 @@ ENV NVCCFLAGS "-m64"
 ENV CUDA_ARCH "-gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62"
 ENV NVCC /usr/local/cuda/bin/nvcc
 
+# we need to install latest ccache that contains fixes for working with nvcc
+
+RUN apt update && apt install -y ccache
+
 COPY runtime_functions.sh /work/
 WORKDIR /work/mxnet

--- a/ci/docker/install/centos7_core.sh
+++ b/ci/docker/install/centos7_core.sh
@@ -37,3 +37,4 @@ yum -y install cmake
 yum -y install wget
 yum -y install unzip
 yum -y install ninja-build
+yum -y install ccache

--- a/ci/docker/install/ubuntu_core.sh
+++ b/ci/docker/install/ubuntu_core.sh
@@ -40,4 +40,5 @@ apt-get install -y \
     software-properties-common \
     sudo \
     unzip \
-    wget
+    wget \
+    ccache

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -199,8 +199,6 @@ build_centos7_mkldnn() {
 build_centos7_gpu() {
     set -ex
     cd /work/mxnet
-    export CC="ccache gcc"
-    export CXX="ccache g++"
     make \
         DEV=1 \
         USE_LAPACK=1 \
@@ -254,45 +252,45 @@ build_ubuntu_cpu_clang50() {
 }
 
 build_ubuntu_cpu_clang39_mkldnn() {
+    # mkldnn gets compiled with a script 
+    # and compilation fails with clang-3.9
     set -ex
-    export CC="ccache clang-3.9"
-    export CXX="ccache clang++-3.9"
     make \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
         USE_OPENMP=0                  \
+        CC="ccache clang-3.9"         \
+        CXX="ccache clang++-3.9"      \
         -j$(nproc)
 }
 
 build_ubuntu_cpu_clang50_mkldnn() {
     set -ex
-    export CC="ccache clang-5.0"
-    export CXX="ccache clang++-5.0"
     make \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
         USE_OPENMP=1                  \
+        CC="ccache clang-5.0"         \
+        CXX="ccache clang++-5.0"      \
         -j$(nproc)
 }
 
 build_ubuntu_cpu_mkldnn() {
     set -ex
-    export CC="ccache gcc"
-    export CXX="ccache g++"
     make  \
         DEV=1                         \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
+        CC="ccache gcc"               \
+        CXX="ccache g++"              \
         -j$(nproc)
 }
 
 build_ubuntu_gpu_mkldnn() {
     set -ex
-    export CC="ccache gcc"
-    export CXX="ccache g++"
     make  \
         DEV=1                         \
         USE_CPP_PACKAGE=1             \
@@ -306,8 +304,6 @@ build_ubuntu_gpu_mkldnn() {
 
 build_ubuntu_gpu_cuda91_cudnn7() {
     set -ex
-    export CC="ccache gcc"
-    export CXX="ccache g++"
     make  \
         DEV=1                         \
         USE_BLAS=openblas             \
@@ -336,8 +332,6 @@ build_ubuntu_amalgamation_min() {
 build_ubuntu_gpu_cmake_mkldnn() {
     set -ex
     cd /work/build
-    export CC="ccache gcc"
-    export CXX="ccache g++"
     cmake \
         -DUSE_CUDA=1               \
         -DUSE_CUDNN=1              \
@@ -356,8 +350,6 @@ build_ubuntu_gpu_cmake_mkldnn() {
 build_ubuntu_gpu_cmake() {
     set -ex
     cd /work/build
-    export CC="ccache gcc"
-    export CXX="ccache g++"
     cmake \
         -DUSE_CUDA=1               \
         -DUSE_CUDNN=1              \
@@ -408,7 +400,7 @@ unittest_ubuntu_python3_cpu() {
 
 unittest_ubuntu_python3_cpu_mkldnn() {
     set -ex
-    export PYTHONPATH=./python/ 
+    export PYTHONPATH=./python/
     # MXNET_MKLDNN_DEBUG is buggy and produces false positives
     # https://github.com/apache/incubator-mxnet/issues/10026
     #export MXNET_MKLDNN_DEBUG=1  # Ignored if not present

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -38,23 +38,7 @@ clean_repo() {
 build_jetson() {
     set -ex
     pushd .
-
-
-    # workaround for old version of ccache that has a bug working with nvcc
-
-    echo '#!/bin/sh\nccache ${CC} "$@"\n' > cc
-    echo '#!/bin/sh\nccache ${CXX} "$@"\n' > cxx
-
-    chmod +x cc
-    chmod +x cxx
-
-    export DIR=$(pwd)
-
-    export CC="${DIR}/cc"
-    export CXX="${DIR}/cxx"
-
     mv make/config.mk make/config.tmp
-
     cp -f make/crosscompile.jetson.mk make/config.mk
     make -j$(nproc)
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -171,6 +171,8 @@ build_android_arm64() {
 build_centos7_cpu() {
     set -ex
     cd /work/mxnet
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     make \
         DEV=1 \
         USE_LAPACK=1 \
@@ -183,6 +185,8 @@ build_centos7_cpu() {
 build_centos7_mkldnn() {
     set -ex
     cd /work/mxnet
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     make \
         DEV=1 \
         USE_LAPACK=1 \
@@ -195,6 +199,8 @@ build_centos7_mkldnn() {
 build_centos7_gpu() {
     set -ex
     cd /work/mxnet
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     make \
         DEV=1 \
         USE_LAPACK=1 \
@@ -225,54 +231,56 @@ build_ubuntu_cpu_openblas() {
 
 build_ubuntu_cpu_clang39() {
     set -ex
+    export CC="ccache clang-3.9"
+    export CXX="ccache clang++-3.9"
     make \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_OPENMP=0                  \
         USE_DIST_KVSTORE=1            \
-        CXX=clang++-3.9               \
-        CC=clang-3.9                  \
         -j$(nproc)
 }
 
 build_ubuntu_cpu_clang50() {
     set -ex
+    export CC="ccache clang-5.0"
+    export CXX="ccache clang++-5.0"
     make \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_OPENMP=1                  \
         USE_DIST_KVSTORE=1            \
-        CXX=clang++-5.0               \
-        CC=clang-5.0                  \
         -j$(nproc)
 }
 
 build_ubuntu_cpu_clang39_mkldnn() {
     set -ex
+    export CC="ccache clang-3.9"
+    export CXX="ccache clang++-3.9"
     make \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
         USE_OPENMP=0                  \
-        CXX=clang++-3.9               \
-        CC=clang-3.9                  \
         -j$(nproc)
 }
 
 build_ubuntu_cpu_clang50_mkldnn() {
     set -ex
+    export CC="ccache clang-5.0"
+    export CXX="ccache clang++-5.0"
     make \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
         USE_OPENMP=1                  \
-        CXX=clang++-5.0               \
-        CC=clang-5.0                  \
         -j$(nproc)
 }
 
 build_ubuntu_cpu_mkldnn() {
     set -ex
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     make  \
         DEV=1                         \
         USE_CPP_PACKAGE=1             \
@@ -283,6 +291,8 @@ build_ubuntu_cpu_mkldnn() {
 
 build_ubuntu_gpu_mkldnn() {
     set -ex
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     make  \
         DEV=1                         \
         USE_CPP_PACKAGE=1             \
@@ -296,6 +306,8 @@ build_ubuntu_gpu_mkldnn() {
 
 build_ubuntu_gpu_cuda91_cudnn7() {
     set -ex
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     make  \
         DEV=1                         \
         USE_BLAS=openblas             \
@@ -324,6 +336,8 @@ build_ubuntu_amalgamation_min() {
 build_ubuntu_gpu_cmake_mkldnn() {
     set -ex
     cd /work/build
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     cmake \
         -DUSE_CUDA=1               \
         -DUSE_CUDNN=1              \
@@ -342,6 +356,8 @@ build_ubuntu_gpu_cmake_mkldnn() {
 build_ubuntu_gpu_cmake() {
     set -ex
     cd /work/build
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     cmake \
         -DUSE_CUDA=1               \
         -DUSE_CUDNN=1              \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -38,8 +38,16 @@ clean_repo() {
 build_jetson() {
     set -ex
     pushd .
-    mv make/crosscompile.jetson.mk make/config.mk
+
+    export CC="ccache ${CC}"
+    export CXX="ccache ${CXX}"
+
+    mv make/config.mk make/config.tmp
+
+    cp -f make/crosscompile.jetson.mk make/config.mk
     make -j$(nproc)
+
+    mv make/config.tmp make/config.mk
 
     export MXNET_LIBRARY_PATH=`pwd`/libmxnet.so
     cd /work/mxnet/python
@@ -62,6 +70,7 @@ build_jetson() {
 build_armv6() {
     set -ex
     pushd .
+
     cd /work/build
 
     # Lapack functionality will be included and statically linked to openblas.
@@ -73,6 +82,7 @@ build_armv6() {
 
     cmake \
         -DCMAKE_TOOLCHAIN_FILE=$CROSS_ROOT/Toolchain.cmake \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DUSE_CUDA=OFF \
         -DUSE_OPENCV=OFF \
         -DUSE_OPENMP=OFF \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -223,8 +223,14 @@ build_centos7_gpu() {
         -j$(nproc)
 }
 
+build_ubuntu_cpu() {
+    build_ubuntu_cpu_openblas
+}
+
 build_ubuntu_cpu_openblas() {
     set -ex
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     make \
         DEV=1                         \
         USE_CPP_PACKAGE=1             \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -39,8 +39,19 @@ build_jetson() {
     set -ex
     pushd .
 
-    export CC="ccache ${CC}"
-    export CXX="ccache ${CXX}"
+
+    # workaround for old version of ccache that has a bug working with nvcc
+
+    echo '#!/bin/sh\nccache ${CC} "$@"\n' > cc
+    echo '#!/bin/sh\nccache ${CXX} "$@"\n' > cxx
+
+    chmod +x cc
+    chmod +x cxx
+
+    export DIR=$(pwd)
+
+    export CC="${DIR}/cc"
+    export CXX="${DIR}/cxx"
 
     mv make/config.mk make/config.tmp
 

--- a/make/config.mk
+++ b/make/config.mk
@@ -37,8 +37,8 @@
 # choice of compiler
 #--------------------
 
-export CC = gcc
-export CXX = g++
+#export CC = gcc
+#export CXX = g++
 export NVCC = nvcc
 
 # whether compile with options for MXNet developer

--- a/prepare_mkldnn.sh
+++ b/prepare_mkldnn.sh
@@ -17,7 +17,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# set -ex
 #
 # All modification made by Intel Corporation: © 2016 Intel Corporation
 #
@@ -54,6 +53,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
+set -e
 
 MXNET_ROOTDIR="$(pwd)"
 MKLDNN_ROOTDIR="$MXNET_ROOTDIR/3rdparty/mkldnn/"


### PR DESCRIPTION
## Description ##
Add ccache support to CPU builds. GPU builds need a recent ccache, since the version in ubuntu is too old and doesn't support nvcc


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)