### PR TITLE
[MXNET-473] Fix for dist_sync_kvstore and test_operator.test_op_roi_align

### DIFF
--- a/src/operator/tensor/elemwise_binary_op-inl.h
+++ b/src/operator/tensor/elemwise_binary_op-inl.h
@@ -552,7 +552,7 @@ void ElemwiseBinaryOp::DnsRspDnsOp(mshadow::Stream<xpu> *s,
   TBlob rsp_data = rsp.data();
   TBlob rsp_indices = rsp.aux_data(rowsparse::kIdx);
 
-  MSHADOW_SGL_DBL_TYPE_SWITCH(rsp_data.type_flag_, DType, {
+  MSHADOW_TYPE_SWITCH(rsp_data.type_flag_, DType, {
     MSHADOW_IDX_TYPE_SWITCH(rsp_indices.type_flag_, IType, {
       MXNET_ASSIGN_REQ_SWITCH(req, Req, {
         if (reverse && std::is_same<OP, mshadow_op::minus>::value) {

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6019,7 +6019,7 @@ def test_context_num_gpus():
         if str(e).find("CUDA") == -1:
             raise e
 
-    
+
 @with_seed()
 def test_op_roi_align():
     # Adapted from https://github.com/wkcn/MobulaOP/blob/master/tests/test_roi_align_op.py
@@ -6146,7 +6146,7 @@ def test_op_roi_align():
         real_output, [dx, drois] = roialign_forward_backward(data.asnumpy(), rois.asnumpy(), pooled_size, spatial_scale, sampling_ratio, dy.asnumpy())
         assert np.allclose(output.asnumpy(), real_output)
         # It seems that the precision between Cfloat and Pyfloat is different.
-        assert np.allclose(data.grad.asnumpy(), dx, atol = 1e-6), np.abs(data.grad.asnumpy() - dx).max()
+        assert np.allclose(data.grad.asnumpy(), dx, atol = 1e-5), np.abs(data.grad.asnumpy() - dx).max()
         assert np.allclose(rois.grad.asnumpy(), drois)
 
     # modified from test_roipooling()


### PR DESCRIPTION
## Description ##
Fix for #11057 #11064

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Change the type switch in elemwise_add/sub between dense and rsp

### Comments ###
@eric-haibin-lin 