### PR TITLE
migrating docs build and publish job to secure nodes

### DIFF
--- a/docs/Jenkinsfile
+++ b/docs/Jenkinsfile
@@ -47,13 +47,13 @@ def init_git() {
 
 try {
   stage('Build Docs') {
-    node('mxnetlinux-cpu') {
+    node('restricted-mxnetlinux-cpu') {
       ws('workspace/docs') {
         init_git()
         timeout(time: max_time, unit: 'MINUTES') {
             sh "ci/build.py -p ubuntu_cpu /work/runtime_functions.sh build_docs ${params.tags_to_build} ${params.tag_list} ${params.tag_default} ${params.domain}"
             archiveArtifacts 'docs/build_version_doc/artifacts.tgz'
-            build 'website build - test publish'
+            build 'restricted-website-publish'
         }
       }
     }
@@ -62,13 +62,13 @@ try {
   // set build status to success at the end
   currentBuild.result = "SUCCESS"
 } catch (caughtError) {
-  node("mxnetlinux-cpu") {
+  node("restricted-mxnetlinux-cpu") {
     sh "echo caught ${caughtError}"
     err = caughtError
     currentBuild.result = "FAILURE"
   }
 } finally {
-  node("mxnetlinux-cpu") {
+  node("restricted-mxnetlinux-cpu") {
     // Only send email if master failed
     if (currentBuild.result == "FAILURE" && env.BRANCH_NAME == "master") {
       emailext body: 'Build for MXNet branch ${BRANCH_NAME} has broken. Please view the build at ${BUILD_URL}', replyTo: '${EMAIL}', subject: '[BUILD FAILED] Branch ${BRANCH_NAME} build ${BUILD_NUMBER}', to: '${EMAIL}'


### PR DESCRIPTION
## Description ##
Migrating docs build to secure/restricted jenkins nodes.
- [x] Created a new jenkins job called [restricted-website-publish](http://jenkins.mxnet-ci.amazon-ml.com/job/restricted-website-publish/)
- [x] Updated nodes in Jenkinsfile `node('restricted-mxnetlinux-cpu')`
- [x] Updated Jenkinsfile to call new job `restricted-website-publish`

## Comments
I would assume that the config in the Jenkins job for `Restrict where this project can be run` would be updated from `mxnetlinux-cpu` to `restricted-mxnetlinux-cpu`. However, I get an error if I try to do this:
```
There’s no agent/cloud that matches this assignment. Did you mean ‘mxnetlinux-cpu’ instead of ‘restricted-mxnetlinux-cpu’?
```
Once I get clarity on this, I can clone the build job and configure it to use the restricted naming.

@marcoabreu  - what are your thoughts on this?