### PR TITLE
Update conv_layers.py documentation

### DIFF
--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -420,15 +420,19 @@ class Conv1DTranspose(_Conv):
     channels : int
         The dimensionality of the output space, i.e. the number of output
         channels (filters) in the convolution.
-    kernel_size :int or tuple/list of 3 int
+    kernel_size :int or tuple/list of 1 int
         Specifies the dimensions of the convolution window.
-    strides : int or tuple/list of 3 int,
+    strides : int or tuple/list of 1 int
         Specify the strides of the convolution.
-    padding : int or a tuple/list of 3 int,
+    padding : int or a tuple/list of 1 int,
         If padding is non-zero, then the input is implicitly zero-padded
         on both sides for padding number of points
-    dilation : int or tuple/list of 3 int
-        Specifies the dilation rate to use for dilated convolution.
+    output_padding: int or a tuple/list of 1 int
+        Controls the amount of implicit zero-paddings on both sides of the
+        output for output_padding number of points for each dimension.
+    dilation : int or tuple/list of 1 int
+        Controls the spacing between the kernel points; also known as the
+        à trous algorithm
     groups : int
         Controls the connections between inputs and outputs.
         At groups=1, all inputs are convolved to all outputs.
@@ -503,15 +507,19 @@ class Conv2DTranspose(_Conv):
     channels : int
         The dimensionality of the output space, i.e. the number of output
         channels (filters) in the convolution.
-    kernel_size :int or tuple/list of 3 int
+    kernel_size :int or tuple/list of 2 int
         Specifies the dimensions of the convolution window.
-    strides : int or tuple/list of 3 int,
+    strides : int or tuple/list of 2 int
         Specify the strides of the convolution.
-    padding : int or a tuple/list of 3 int,
+    padding : int or a tuple/list of 2 int,
         If padding is non-zero, then the input is implicitly zero-padded
         on both sides for padding number of points
-    dilation : int or tuple/list of 3 int
-        Specifies the dilation rate to use for dilated convolution.
+    output_padding: int or a tuple/list of 2 int
+        Controls the amount of implicit zero-paddings on both sides of the
+        output for output_padding number of points for each dimension.
+    dilation : int or tuple/list of 2 int
+        Controls the spacing between the kernel points; also known as the 
+        à trous algorithm
     groups : int
         Controls the connections between inputs and outputs.
         At groups=1, all inputs are convolved to all outputs.
@@ -593,13 +601,17 @@ class Conv3DTranspose(_Conv):
         channels (filters) in the convolution.
     kernel_size :int or tuple/list of 3 int
         Specifies the dimensions of the convolution window.
-    strides : int or tuple/list of 3 int,
+    strides : int or tuple/list of 3 int
         Specify the strides of the convolution.
     padding : int or a tuple/list of 3 int,
         If padding is non-zero, then the input is implicitly zero-padded
         on both sides for padding number of points
+    output_padding: int or a tuple/list of 3 int
+        Controls the amount of implicit zero-paddings on both sides of the
+        output for output_padding number of points for each dimension.
     dilation : int or tuple/list of 3 int
-        Specifies the dilation rate to use for dilated convolution.
+        Controls the spacing between the kernel points; also known as the 
+        à trous algorithm.
     groups : int
         Controls the connections between inputs and outputs.
         At groups=1, all inputs are convolved to all outputs.


### PR DESCRIPTION
## Description ##
The `output_padding` parameter was missing from the doc string, wrong tuple size were used.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
