### PR TITLE
[MKLDNN] reorder the mem format for the AddBack mode in case src & dst is different

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_base.cc
+++ b/src/operator/nn/mkldnn/mkldnn_base.cc
@@ -128,8 +128,14 @@ void CommitOutput(const NDArray &arr, const mkldnn_output_t &res) {
   if (res.first == CopyBack) {
     const_cast<NDArray &>(arr).CopyFrom(*res.second);
   } else if (res.first == AddBack) {
-    auto mem = arr.GetMKLDNNData(res.second->get_primitive_desc());
-    CHECK(mem != nullptr);
+    const mkldnn::memory *mem = arr.GetMKLDNNData();
+    auto arr_desc = mem->get_primitive_desc();
+    auto res_desc = res.second->get_primitive_desc();
+    if (arr_desc == res_desc) {
+        mem = arr.GetMKLDNNData(res_desc);
+    } else {
+        mem = arr.GetMKLDNNDataReorder(res_desc);
+    }
     // We have to allocate new memory for the sum result.
     auto sum_res = TmpMemMgr::Get()->Alloc(
         res.second->get_primitive_desc());


### PR DESCRIPTION
## Description ##
For MKL-DNN backend, the case is not covered that the src format is not as same as dst format for the AddBack mode. So the crash is observed in [example/reinforcement-learning/a3c](https://github.com/apache/incubator-mxnet/tree/master/example/reinforcement-learning/a3c). 

Therefore, the fix is to reorder the src format to dst format when the difference is detected.

The A3C case can pass with the fix. And verified the performance by [benchmark_score.py](https://github.com/apache/incubator-mxnet/blob/master/example/image-classification/benchmark_score.py), there's no performance effect. 

@zheng-da @TaoLv 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
