### PR TITLE
[MXNET-472]  ccache for docker builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,7 @@ python/.eggs
 *DartConfiguration.tcl
 tests/Makefile
 tests/mxnet_unit_tests
+
+# generated wrappers for ccache
+cc
+cxx

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ include $(DMLC_CORE)/make/dmlc.mk
 
 # all tge possible warning tread
 WARNFLAGS= -Wall -Wsign-compare
-CFLAGS = -DMSHADOW_FORCE_STREAM $(WARNFLAGS)
+CFLAGS += -DMSHADOW_FORCE_STREAM $(WARNFLAGS)
 
 ifeq ($(DEV), 1)
 	CFLAGS += -g -Werror
@@ -93,7 +93,7 @@ else
 	CFLAGS += -O3 -DNDEBUG=1
 endif
 CFLAGS += -I$(TPARTYDIR)/mshadow/ -I$(TPARTYDIR)/dmlc-core/include -fPIC -I$(NNVM_PATH)/include -I$(DLPACK_PATH)/include -I$(NNVM_PATH)/tvm/include -Iinclude $(MSHADOW_CFLAGS)
-LDFLAGS = -pthread $(MSHADOW_LDFLAGS) $(DMLC_LDFLAGS)
+LDFLAGS += -pthread $(MSHADOW_LDFLAGS) $(DMLC_LDFLAGS)
 ifeq ($(DEBUG), 1)
 	NVCCFLAGS += -std=c++11 -Xcompiler -D_FORCE_INLINES -g -G -O0 -ccbin $(CXX) $(MSHADOW_NVCCFLAGS)
 else
@@ -477,7 +477,7 @@ endif
 $(PS_PATH)/build/libps.a: PSLITE
 
 PSLITE:
-	$(MAKE) CXX=$(CXX) DEPS_PATH=$(DEPS_PATH) -C $(PS_PATH) ps
+	$(MAKE) CXX="$(CXX)" DEPS_PATH="$(DEPS_PATH)" -C $(PS_PATH) ps
 
 $(DMLC_CORE)/libdmlc.a: DMLCCORE
 

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ include $(DMLC_CORE)/make/dmlc.mk
 
 # all tge possible warning tread
 WARNFLAGS= -Wall -Wsign-compare
-CFLAGS += -DMSHADOW_FORCE_STREAM $(WARNFLAGS)
+CFLAGS = -DMSHADOW_FORCE_STREAM $(WARNFLAGS)
 
 ifeq ($(DEV), 1)
 	CFLAGS += -g -Werror
@@ -93,7 +93,7 @@ else
 	CFLAGS += -O3 -DNDEBUG=1
 endif
 CFLAGS += -I$(TPARTYDIR)/mshadow/ -I$(TPARTYDIR)/dmlc-core/include -fPIC -I$(NNVM_PATH)/include -I$(DLPACK_PATH)/include -I$(NNVM_PATH)/tvm/include -Iinclude $(MSHADOW_CFLAGS)
-LDFLAGS += -pthread $(MSHADOW_LDFLAGS) $(DMLC_LDFLAGS)
+LDFLAGS = -pthread $(MSHADOW_LDFLAGS) $(DMLC_LDFLAGS)
 ifeq ($(DEBUG), 1)
 	NVCCFLAGS += -std=c++11 -Xcompiler -D_FORCE_INLINES -g -G -O0 -ccbin $(CXX) $(MSHADOW_NVCCFLAGS)
 else

--- a/ci/README.md
+++ b/ci/README.md
@@ -54,7 +54,7 @@ The artifacts are located in the build/ directory in the project root. In case
 
 ## Add a platform
 
-To add a platform, you should add the appropiate dockerfile in
+To add a platform, you should add the appropriate dockerfile in
 docker/Dockerfile.build.<platform> and add a shell function named
 build_<platform> to the file docker/runtime_functions.sh with build
 instructions for that platform.
@@ -63,3 +63,9 @@ instructions for that platform.
 Due to current limitations of the CMake build system creating artifacts in the
 source 3rdparty folder of the parent mxnet sources concurrent builds of
 different platforms is NOT SUPPORTED.
+
+## ccache
+For all builds a directory from the host system is mapped where ccache will store cached 
+compiled object files (defaults to /tmp/ci_ccache). This will speed up rebuilds 
+significantly. You can set this directory explicitly by setting CCACHE_DIR environment 
+variable. All ccache instances are currently set to be 10 Gigabytes max in size.

--- a/ci/build.py
+++ b/ci/build.py
@@ -40,7 +40,7 @@ from subprocess import call, check_call
 from typing import *
 
 
-def get_platforms(path: Optional[str]="docker"):
+def get_platforms(path: Optional[str] = "docker"):
     """Get a list of architectures given our dockerfiles"""
     dockerfiles = glob.glob(os.path.join(path, "Dockerfile.build.*"))
     dockerfiles = list(filter(lambda x: x[-1] != '~', dockerfiles))
@@ -88,6 +88,7 @@ def build_docker(platform: str, docker_binary: str) -> None:
         raise FileNotFoundError('Unable to find docker image id matching with {}'.format(tag))
     return image_id
 
+
 def _get_local_image_id(docker_binary, docker_tag):
     """
     Get the image id of the local docker layer with the passed tag
@@ -102,8 +103,10 @@ def _get_local_image_id(docker_binary, docker_tag):
 
 def get_mxnet_root() -> str:
     curpath = os.path.abspath(os.path.dirname(__file__))
+
     def is_mxnet_root(path: str) -> bool:
         return os.path.exists(os.path.join(path, ".mxnet_root"))
+
     while not is_mxnet_root(curpath):
         parent = os.path.abspath(os.path.join(curpath, os.pardir))
         if parent == curpath:
@@ -115,6 +118,7 @@ def get_mxnet_root() -> str:
 def buildir() -> str:
     return os.path.join(get_mxnet_root(), "build")
 
+
 def default_ccache_dir() -> str:
     if 'CCACHE_DIR' in os.environ:
         ccache_dir = os.path.realpath(os.environ['CCACHE_DIR'])
@@ -122,6 +126,7 @@ def default_ccache_dir() -> str:
         return ccache_dirpython
     # Share ccache across containers (should we have a separate dir per platform?)
     return os.path.join(tempfile.gettempdir(), "ci_ccache")
+
 
 def container_run(platform: str,
                   docker_binary: str,
@@ -139,11 +144,11 @@ def container_run(platform: str,
     logging.info("Using ccache directory: %s", local_ccache_dir)
     runlist = [docker_binary, 'run', '--rm', '-t',
                '--shm-size={}'.format(shared_memory_size),
-               '-v', "{}:/work/mxnet".format(mx_root), # mount mxnet root
-               '-v', "{}:/work/build".format(local_build_folder), # mount mxnet/build for storing build artifacts
+               '-v', "{}:/work/mxnet".format(mx_root),  # mount mxnet root
+               '-v', "{}:/work/build".format(local_build_folder),  # mount mxnet/build for storing build artifacts
                '-v', "{}:/work/ccache".format(local_ccache_dir),
                '-u', '{}:{}'.format(os.getuid(), os.getgid()),
-               '-e', "CCACHE_DIR=/work/ccache", # this path is inside the container as /work/ccache is mounted
+               '-e', "CCACHE_DIR=/work/ccache",  # this path is inside the container as /work/ccache is mounted
                tag]
     runlist.extend(command)
     cmd = ' '.join(runlist)
@@ -171,6 +176,7 @@ def container_run(platform: str,
 def list_platforms() -> str:
     print("\nSupported platforms:\n{}".format('\n'.join(get_platforms())))
 
+
 def main() -> int:
     # We need to be in the same directory than the script so the commands in the dockerfiles work as
     # expected. But the script can be invoked from a different path
@@ -178,13 +184,14 @@ def main() -> int:
     os.chdir(base)
 
     logging.getLogger().setLevel(logging.INFO)
+
     def script_name() -> str:
         return os.path.split(sys.argv[0])[1]
+
     logging.basicConfig(format='{}: %(asctime)-15s %(message)s'.format(script_name()))
 
-
     parser = argparse.ArgumentParser(description="""Utility for building and testing MXNet on docker
-    containers""",epilog="")
+    containers""", epilog="")
     parser.add_argument("-p", "--platform",
                         help="platform",
                         type=str)

--- a/ci/build.py
+++ b/ci/build.py
@@ -33,6 +33,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from copy import deepcopy
 from itertools import chain
 from subprocess import call, check_call
@@ -71,12 +72,12 @@ def build_docker(platform: str, docker_binary: str) -> None:
     tag = get_docker_tag(platform)
     logging.info("Building container tagged '%s' with %s", tag, docker_binary)
     cmd = [docker_binary, "build",
-        "-f", get_dockerfile(platform),
-        "--rm=false",  # Keep intermediary layers to prime the build cache
-        "--build-arg", "USER_ID={}".format(os.getuid()),
-        "--cache-from", tag,
-        "-t", tag,
-        "docker"]
+           "-f", get_dockerfile(platform),
+           "--rm=false",  # Keep intermediary layers to prime the build cache
+           "--build-arg", "USER_ID={}".format(os.getuid()),
+           "--cache-from", tag,
+           "-t", tag,
+           "docker"]
     logging.info("Running command: '%s'", ' '.join(cmd))
     check_call(cmd)
 
@@ -87,6 +88,31 @@ def build_docker(platform: str, docker_binary: str) -> None:
         raise FileNotFoundError('Unable to find docker image id matching with {}'.format(tag))
     return image_id
 
+def build_ccache(platform: str, docker_binary: str) -> None:
+    """
+    Build a ccache container for the given platform
+    :param platform: Platform
+    :param docker_binary: docker binary to use (docker/nvidia-docker)
+    :return: Id of the top level image
+    """
+
+    tag = "ccache/build.{}".format(platform)
+    logging.info("Building ccache container tagged '%s' with %s", tag, docker_binary)
+    cmd = [docker_binary, "build",
+           "-f", get_dockerfile("{}.ccache".format(platform)),
+           "--rm=true", # We only need the binary
+           "--cache-from", tag,
+           "-t", tag,
+           "docker"]
+    logging.info("Running command: '%s'", ' '.join(cmd))
+    check_call(cmd)
+
+    # Get image id by reading the tag. It's guaranteed (except race condition) that the tag exists. Otherwise, the
+    # check_call would have failed
+    image_id = _get_local_image_id(docker_binary=docker_binary, docker_tag=tag)
+    if not image_id:
+        raise FileNotFoundError('Unable to find docker image id matching with {}'.format(tag))
+    return image_id
 
 def _get_local_image_id(docker_binary, docker_tag):
     """
@@ -115,10 +141,18 @@ def get_mxnet_root() -> str:
 def buildir() -> str:
     return os.path.join(get_mxnet_root(), "build")
 
+def default_ccache_dir() -> str:
+    if 'CCACHE_DIR' in os.environ:
+        ccache_dir = os.path.realpath(os.environ['CCACHE_DIR'])
+        os.makedirs(ccache_dir, exist_ok=True)
+        return ccache_dirpython
+    # Share ccache across containers (should we have a separate dir per platform?)
+    return os.path.join(tempfile.gettempdir(), "ci_ccache")
 
 def container_run(platform: str,
                   docker_binary: str,
                   shared_memory_size: str,
+                  local_ccache_dir: str,
                   command: List[str],
                   dry_run: bool = False,
                   into_container: bool = False) -> str:
@@ -127,12 +161,16 @@ def container_run(platform: str,
     local_build_folder = buildir()
     # We need to create it first, otherwise it will be created by the docker daemon with root only permissions
     os.makedirs(local_build_folder, exist_ok=True)
+    os.makedirs(local_ccache_dir, exist_ok=True)
+    logging.info("Using ccache directory: %s", local_ccache_dir)
     runlist = [docker_binary, 'run', '--rm', '-t',
-        '--shm-size={}'.format(shared_memory_size),
-        '-v', "{}:/work/mxnet".format(mx_root), # mount mxnet root
-        '-v', "{}:/work/build".format(local_build_folder), # mount mxnet/build for storing build artifacts
-        '-u', '{}:{}'.format(os.getuid(), os.getgid()),
-        tag]
+               '--shm-size={}'.format(shared_memory_size),
+               '-v', "{}:/work/mxnet".format(mx_root), # mount mxnet root
+               '-v', "{}:/work/build".format(local_build_folder), # mount mxnet/build for storing build artifacts
+               '-v', "{}:/work/ccache".format(local_ccache_dir),
+               '-u', '{}:{}'.format(os.getuid(), os.getgid()),
+               '-e', "CCACHE_DIR=/work/ccache", # this path is inside the container as /work/ccache is mounted
+               tag]
     runlist.extend(command)
     cmd = ' '.join(runlist)
     if not dry_run and not into_container:
@@ -166,11 +204,10 @@ def main() -> int:
     os.chdir(base)
 
     logging.getLogger().setLevel(logging.INFO)
-
     def script_name() -> str:
         return os.path.split(sys.argv[0])[1]
-
     logging.basicConfig(format='{}: %(asctime)-15s %(message)s'.format(script_name()))
+
 
     parser = argparse.ArgumentParser(description="""Utility for building and testing MXNet on docker
     containers""",epilog="")
@@ -219,6 +256,11 @@ def main() -> int:
                         help="command to run in the container",
                         nargs='*', action='append', type=str)
 
+    parser.add_argument("--ccache-dir",
+                        default=default_ccache_dir(),
+                        help="Ccache directory",
+                        type=str)
+
     args = parser.parse_args()
     command = list(chain(*args.command))
     docker_binary = get_docker_binary(args.nvidiadocker)
@@ -234,21 +276,24 @@ def main() -> int:
             import docker_cache
             logging.info('Docker cache download is enabled')
             docker_cache.load_docker_cache(bucket_name=args.docker_cache_bucket, docker_tag=tag)
+        # prepare ccache
+        build_ccache("ubuntu", docker_binary)
+        build_ccache("centos7", docker_binary)
         build_docker(platform, docker_binary)
         if args.build_only:
             logging.warning("Container was just built. Exiting due to build-only.")
             return 0
 
         if command:
-            container_run(platform, docker_binary, shared_memory_size, command)
+            container_run(platform, docker_binary, shared_memory_size, args.ccache_dir, command)
         elif args.print_docker_run:
-            print(container_run(platform, docker_binary, shared_memory_size, [], True))
+            print(container_run(platform, docker_binary, shared_memory_size, args.ccache_dir, [], True))
         elif args.into_container:
-            container_run(platform, docker_binary, shared_memory_size, [], False, True)
+            container_run(platform, docker_binary, shared_memory_size, args.ccache_dir, [], False, True)
         else:
             cmd = ["/work/mxnet/ci/docker/runtime_functions.sh", "build_{}".format(platform)]
             logging.info("No command specified, trying default build: %s", ' '.join(cmd))
-            container_run(platform, docker_binary, shared_memory_size, cmd)
+            container_run(platform, docker_binary, shared_memory_size, args.ccache_dir, cmd)
 
     elif args.all:
         platforms = get_platforms()
@@ -266,7 +311,7 @@ def main() -> int:
             build_platform = "build_{}".format(platform)
             cmd = ["/work/mxnet/ci/docker/runtime_functions.sh", build_platform]
             shutil.rmtree(buildir(), ignore_errors=True)
-            container_run(platform, docker_binary, shared_memory_size, cmd)
+            container_run(platform, docker_binary, shared_memory_size, args.ccache_dir, cmd)
             plat_buildir = os.path.join(get_mxnet_root(), build_platform)
             shutil.move(buildir(), plat_buildir)
             logging.info("Built files left in: %s", plat_buildir)

--- a/ci/build.py
+++ b/ci/build.py
@@ -88,32 +88,6 @@ def build_docker(platform: str, docker_binary: str) -> None:
         raise FileNotFoundError('Unable to find docker image id matching with {}'.format(tag))
     return image_id
 
-def build_ccache(platform: str, docker_binary: str) -> None:
-    """
-    Build a ccache container for the given platform
-    :param platform: Platform
-    :param docker_binary: docker binary to use (docker/nvidia-docker)
-    :return: Id of the top level image
-    """
-
-    tag = "ccache/build.{}".format(platform)
-    logging.info("Building ccache container tagged '%s' with %s", tag, docker_binary)
-    cmd = [docker_binary, "build",
-           "-f", get_dockerfile("{}.ccache".format(platform)),
-           "--rm=true", # We only need the binary
-           "--cache-from", tag,
-           "-t", tag,
-           "docker"]
-    logging.info("Running command: '%s'", ' '.join(cmd))
-    check_call(cmd)
-
-    # Get image id by reading the tag. It's guaranteed (except race condition) that the tag exists. Otherwise, the
-    # check_call would have failed
-    image_id = _get_local_image_id(docker_binary=docker_binary, docker_tag=tag)
-    if not image_id:
-        raise FileNotFoundError('Unable to find docker image id matching with {}'.format(tag))
-    return image_id
-
 def _get_local_image_id(docker_binary, docker_tag):
     """
     Get the image id of the local docker layer with the passed tag
@@ -277,8 +251,6 @@ def main() -> int:
             logging.info('Docker cache download is enabled')
             docker_cache.load_docker_cache(bucket_name=args.docker_cache_bucket, docker_tag=tag)
         # prepare ccache
-        build_ccache("ubuntu", docker_binary)
-        build_ccache("centos7", docker_binary)
         build_docker(platform, docker_binary)
         if args.build_only:
             logging.warning("Container was just built. Exiting due to build-only.")

--- a/ci/docker/Dockerfile.build.android_arm64
+++ b/ci/docker/Dockerfile.build.android_arm64
@@ -20,6 +20,9 @@
 
 FROM ccache/build.ubuntu as ccachebuilder
 
+COPY install/ubuntu_install_ccache.sh /work/
+RUN /work/ubuntu_install_ccache.sh
+
 FROM dockcross/base:latest
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 

--- a/ci/docker/Dockerfile.build.android_arm64
+++ b/ci/docker/Dockerfile.build.android_arm64
@@ -18,8 +18,14 @@
 #
 # Dockerfile to build MXNet for Android ARM64/ARMv8
 
+FROM ccache/build.ubuntu as ccachebuilder
+
 FROM dockcross/base:latest
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
+
+COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
+ENV CCACHE_MAXSIZE 10G
+ENV CCACHE_DIR /work/ccache
 
 # The cross-compiling emulator
 RUN apt-get update && apt-get install -y \

--- a/ci/docker/Dockerfile.build.android_arm64
+++ b/ci/docker/Dockerfile.build.android_arm64
@@ -27,8 +27,6 @@ FROM dockcross/base:latest
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
 
 # The cross-compiling emulator
 RUN apt-get update && apt-get install -y \

--- a/ci/docker/Dockerfile.build.android_arm64
+++ b/ci/docker/Dockerfile.build.android_arm64
@@ -26,6 +26,7 @@ RUN /work/ubuntu_install_ccache.sh
 FROM dockcross/base:latest
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 
+# extract ccache binary into latest context
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 
 # The cross-compiling emulator

--- a/ci/docker/Dockerfile.build.android_armv7
+++ b/ci/docker/Dockerfile.build.android_armv7
@@ -18,8 +18,14 @@
 #
 # Dockerfile to build MXNet for Android ARMv7
 
+FROM ccache/build.ubuntu as ccachebuilder
+
 FROM dockcross/base:latest
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
+
+COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
+ENV CCACHE_MAXSIZE 10G
+ENV CCACHE_DIR /work/ccache
 
 # The cross-compiling emulator
 RUN apt-get update && apt-get install -y \

--- a/ci/docker/Dockerfile.build.android_armv7
+++ b/ci/docker/Dockerfile.build.android_armv7
@@ -20,6 +20,9 @@
 
 FROM ccache/build.ubuntu as ccachebuilder
 
+COPY install/ubuntu_install_ccache.sh /work/
+RUN /work/ubuntu_install_ccache.sh
+
 FROM dockcross/base:latest
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 

--- a/ci/docker/Dockerfile.build.android_armv7
+++ b/ci/docker/Dockerfile.build.android_armv7
@@ -27,8 +27,6 @@ FROM dockcross/base:latest
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
 
 # The cross-compiling emulator
 RUN apt-get update && apt-get install -y \

--- a/ci/docker/Dockerfile.build.android_armv7
+++ b/ci/docker/Dockerfile.build.android_armv7
@@ -26,6 +26,7 @@ RUN /work/ubuntu_install_ccache.sh
 FROM dockcross/base:latest
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 
+# extract ccache binary into latest context
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 
 # The cross-compiling emulator

--- a/ci/docker/Dockerfile.build.arm64
+++ b/ci/docker/Dockerfile.build.arm64
@@ -18,7 +18,10 @@
 #
 # Dockerfile to build MXNet for ARM64/ARMv8
 
-FROM ccache/build.ubuntu as ccachebuilder
+FROM ubuntu:16.04 as ccachebuilder
+
+COPY install/ubuntu_install_ccache.sh /work/
+RUN /work/ubuntu_install_ccache.sh
 
 # Temporary fix due to https://github.com/apache/incubator-mxnet/issues/10837
 #FROM dockcross/linux-arm64

--- a/ci/docker/Dockerfile.build.arm64
+++ b/ci/docker/Dockerfile.build.arm64
@@ -28,8 +28,6 @@ RUN /work/ubuntu_install_ccache.sh
 FROM mxnetci/dockcross-linux-arm64:05082018
 
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
 
 ENV ARCH aarch64
 ENV FC /usr/bin/${CROSS_TRIPLE}-gfortran

--- a/ci/docker/Dockerfile.build.arm64
+++ b/ci/docker/Dockerfile.build.arm64
@@ -18,9 +18,15 @@
 #
 # Dockerfile to build MXNet for ARM64/ARMv8
 
+FROM ccache/build.ubuntu as ccachebuilder
+
 # Temporary fix due to https://github.com/apache/incubator-mxnet/issues/10837
 #FROM dockcross/linux-arm64
 FROM mxnetci/dockcross-linux-arm64:05082018
+
+COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
+ENV CCACHE_MAXSIZE 10G
+ENV CCACHE_DIR /work/ccache
 
 ENV ARCH aarch64
 ENV FC /usr/bin/${CROSS_TRIPLE}-gfortran

--- a/ci/docker/Dockerfile.build.arm64
+++ b/ci/docker/Dockerfile.build.arm64
@@ -27,6 +27,7 @@ RUN /work/ubuntu_install_ccache.sh
 #FROM dockcross/linux-arm64
 FROM mxnetci/dockcross-linux-arm64:05082018
 
+# extract ccache binary into latest context
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 
 ENV ARCH aarch64

--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -18,7 +18,10 @@
 #
 # Dockerfile to build MXNet for ARMv6
 
-FROM ccache/build.ubuntu as ccachebuilder
+FROM ubuntu:16.04 as ccachebuilder
+
+COPY install/ubuntu_install_ccache.sh /work/
+RUN /work/ubuntu_install_ccache.sh
 
 FROM dockcross/linux-armv6
 

--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -26,8 +26,6 @@ RUN /work/ubuntu_install_ccache.sh
 FROM dockcross/linux-armv6
 
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
 
 ENV ARCH armv6l
 ENV HOSTCC gcc

--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -25,6 +25,7 @@ RUN /work/ubuntu_install_ccache.sh
 
 FROM dockcross/linux-armv6
 
+# extract ccache binary into latest context
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 
 ENV ARCH armv6l

--- a/ci/docker/Dockerfile.build.armv7
+++ b/ci/docker/Dockerfile.build.armv7
@@ -18,7 +18,10 @@
 #
 # Dockerfile to build MXNet for Android ARMv7
 
-FROM ccache/build.ubuntu as ccachebuilder
+FROM ubuntu:16.04 as ccachebuilder
+
+COPY install/ubuntu_install_ccache.sh /work/
+RUN /work/ubuntu_install_ccache.sh
 
 FROM dockcross/linux-armv7
 

--- a/ci/docker/Dockerfile.build.armv7
+++ b/ci/docker/Dockerfile.build.armv7
@@ -18,7 +18,13 @@
 #
 # Dockerfile to build MXNet for Android ARMv7
 
+FROM ccache/build.ubuntu as ccachebuilder
+
 FROM dockcross/linux-armv7
+
+COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
+ENV CCACHE_MAXSIZE 10G
+ENV CCACHE_DIR /work/ccache
 
 ENV ARCH armv71
 ENV CC /usr/bin/arm-linux-gnueabihf-gcc

--- a/ci/docker/Dockerfile.build.armv7
+++ b/ci/docker/Dockerfile.build.armv7
@@ -25,6 +25,7 @@ RUN /work/ubuntu_install_ccache.sh
 
 FROM dockcross/linux-armv7
 
+# extract ccache binary into latest context
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 
 ENV ARCH armv71

--- a/ci/docker/Dockerfile.build.armv7
+++ b/ci/docker/Dockerfile.build.armv7
@@ -26,8 +26,6 @@ RUN /work/ubuntu_install_ccache.sh
 FROM dockcross/linux-armv7
 
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
 
 ENV ARCH armv71
 ENV CC /usr/bin/arm-linux-gnueabihf-gcc

--- a/ci/docker/Dockerfile.build.centos7.ccache
+++ b/ci/docker/Dockerfile.build.centos7.ccache
@@ -16,27 +16,27 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Dockerfile to build MXNet for ARMv6
+# Dockerfile to build ccache for ubuntu based images
 
-FROM ccache/build.ubuntu as ccachebuilder
+FROM centos:7
 
-FROM dockcross/linux-armv6
-
-COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
-
-ENV ARCH armv6l
-ENV HOSTCC gcc
-ENV TARGET ARMV6
+# Multipackage installation does not fail in yum
+RUN yum -y install epel-release && \
+    yum -y install git \
+    yum -y install ssh \
+    yum -y install autoconf \
+    yum -y install wget \
+    yum -y install make \
+    yum -y install google-perftools \
+    yum -y install asciidoc \
+    yum -y install gcc-c++-4.8.*
 
 WORKDIR /work/deps
 
-# Build OpenBLAS
-RUN git clone --recursive -b v0.2.20 https://github.com/xianyi/OpenBLAS.git && \
-    cd OpenBLAS && \
+# build ccache
+RUN git clone --recursive -b v3.4.2 https://github.com/ccache/ccache.git && \
+    cd ccache && \
+    ./autogen.sh && \
+    ./configure && \
     make -j$(nproc) && \
-    make PREFIX=$CROSS_ROOT install
-
-COPY runtime_functions.sh /work/
-WORKDIR /work/mxnet
+    make install

--- a/ci/docker/Dockerfile.build.centos7_cpu
+++ b/ci/docker/Dockerfile.build.centos7_cpu
@@ -18,11 +18,8 @@
 #
 # Dockerfile to build and run MXNet on CentOS 7 for CPU
 
-FROM ccache/build.centos7 as ccachebuilder
-
 FROM centos:7
 
-COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 ENV CCACHE_MAXSIZE 10G
 ENV CCACHE_DIR /work/ccache
 
@@ -30,6 +27,8 @@ WORKDIR /work/deps
 
 COPY install/centos7_core.sh /work/
 RUN /work/centos7_core.sh
+COPY install/centos7_install_ccache.sh /work/
+RUN /work/centos7_install_ccache.sh
 COPY install/centos7_python.sh /work/
 RUN /work/centos7_python.sh
 COPY install/ubuntu_mklml.sh /work/

--- a/ci/docker/Dockerfile.build.centos7_cpu
+++ b/ci/docker/Dockerfile.build.centos7_cpu
@@ -20,9 +20,6 @@
 
 FROM centos:7
 
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
-
 WORKDIR /work/deps
 
 COPY install/centos7_core.sh /work/

--- a/ci/docker/Dockerfile.build.centos7_cpu
+++ b/ci/docker/Dockerfile.build.centos7_cpu
@@ -18,7 +18,13 @@
 #
 # Dockerfile to build and run MXNet on CentOS 7 for CPU
 
+FROM ccache/build.centos7 as ccachebuilder
+
 FROM centos:7
+
+COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
+ENV CCACHE_MAXSIZE 10G
+ENV CCACHE_DIR /work/ccache
 
 WORKDIR /work/deps
 

--- a/ci/docker/Dockerfile.build.centos7_gpu
+++ b/ci/docker/Dockerfile.build.centos7_gpu
@@ -18,7 +18,13 @@
 #
 # Dockerfile to build and run MXNet on CentOS 7 for GPU
 
+FROM ccache/build.centos7 as ccachebuilder
+
 FROM nvidia/cuda:9.1-cudnn7-devel-centos7
+
+COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
+ENV CCACHE_MAXSIZE 10G
+ENV CCACHE_DIR /work/ccache
 
 WORKDIR /work/deps
 

--- a/ci/docker/Dockerfile.build.centos7_gpu
+++ b/ci/docker/Dockerfile.build.centos7_gpu
@@ -18,11 +18,8 @@
 #
 # Dockerfile to build and run MXNet on CentOS 7 for GPU
 
-FROM ccache/build.centos7 as ccachebuilder
-
 FROM nvidia/cuda:9.1-cudnn7-devel-centos7
 
-COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 ENV CCACHE_MAXSIZE 10G
 ENV CCACHE_DIR /work/ccache
 
@@ -30,6 +27,8 @@ WORKDIR /work/deps
 
 COPY install/centos7_core.sh /work/
 RUN /work/centos7_core.sh
+COPY install/centos7_install_ccache.sh /work/
+RUN /work/centos7_install_ccache.sh
 COPY install/centos7_python.sh /work/
 RUN /work/centos7_python.sh
 

--- a/ci/docker/Dockerfile.build.centos7_gpu
+++ b/ci/docker/Dockerfile.build.centos7_gpu
@@ -20,9 +20,6 @@
 
 FROM nvidia/cuda:9.1-cudnn7-devel-centos7
 
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
-
 WORKDIR /work/deps
 
 COPY install/centos7_core.sh /work/

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -24,7 +24,9 @@ FROM nvidia/cuda:9.0-cudnn7-devel as cudabuilder
 
 FROM ccache/build.ubuntu as ccachebuilder
 
-FROM dockcross/linux-arm64
+# Temporary fix due to https://github.com/apache/incubator-mxnet/issues/10837
+# FROM dockcross/linux-arm64
+FROM mxnetci/dockcross-linux-arm64:05082018
 
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 ENV CCACHE_MAXSIZE 10G
@@ -32,6 +34,7 @@ ENV CCACHE_DIR /work/ccache
 
 ENV ARCH aarch64
 ENV HOSTCC gcc
+ENV FC /usr/bin/${CROSS_TRIPLE}-gfortran
 ENV TARGET ARMV8
 
 WORKDIR /work

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -22,7 +22,10 @@
 
 FROM nvidia/cuda:9.0-cudnn7-devel as cudabuilder
 
-FROM ccache/build.ubuntu as ccachebuilder
+FROM ubuntu:16.04 as ccachebuilder
+
+COPY install/ubuntu_install_ccache.sh /work/
+RUN /work/ubuntu_install_ccache.sh
 
 # Temporary fix due to https://github.com/apache/incubator-mxnet/issues/10837
 # FROM dockcross/linux-arm64

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -31,6 +31,7 @@ RUN /work/ubuntu_install_ccache.sh
 # FROM dockcross/linux-arm64
 FROM mxnetci/dockcross-linux-arm64:05082018
 
+# extract ccache binary into latest context
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 
 ENV ARCH aarch64

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -22,12 +22,15 @@
 
 FROM nvidia/cuda:9.0-cudnn7-devel as cudabuilder
 
-# Temporary fix due to https://github.com/apache/incubator-mxnet/issues/10837
-# FROM dockcross/linux-arm64
-FROM mxnetci/dockcross-linux-arm64:05082018
+FROM ccache/build.ubuntu as ccachebuilder
+
+FROM dockcross/linux-arm64
+
+COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
+ENV CCACHE_MAXSIZE 10G
+ENV CCACHE_DIR /work/ccache
 
 ENV ARCH aarch64
-ENV FC /usr/bin/${CROSS_TRIPLE}-gfortran
 ENV HOSTCC gcc
 ENV TARGET ARMV8
 
@@ -38,6 +41,9 @@ RUN git clone --recursive -b v0.2.20 https://github.com/xianyi/OpenBLAS.git && \
     cd OpenBLAS && \
     make -j$(nproc) && \
     PREFIX=${CROSS_ROOT} make install
+
+ENV OpenBLAS_HOME=${CROSS_ROOT}
+ENV OpenBLAS_DIR=${CROSS_ROOT}
 
 # Setup CUDA build env (including configuring and copying nvcc)
 COPY --from=cudabuilder /usr/local/cuda /usr/local/cuda

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -32,8 +32,6 @@ RUN /work/ubuntu_install_ccache.sh
 FROM mxnetci/dockcross-linux-arm64:05082018
 
 COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
 
 ENV ARCH aarch64
 ENV HOSTCC gcc

--- a/ci/docker/Dockerfile.build.ubuntu.ccache
+++ b/ci/docker/Dockerfile.build.ubuntu.ccache
@@ -16,27 +16,31 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# Dockerfile to build MXNet for ARMv6
+# Dockerfile to build ccache for ubuntu based images
 
-FROM ccache/build.ubuntu as ccachebuilder
+FROM ubuntu:16.04
 
-FROM dockcross/linux-armv6
-
-COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
-
-ENV ARCH armv6l
-ENV HOSTCC gcc
-ENV TARGET ARMV6
+RUN apt update && \
+    apt install -y --no-install-recommends \
+        git \
+        ssh \
+        apt-transport-https \
+        build-essential \
+        ca-certificates \
+        autoconf \
+        google-perftools \
+        asciidoc \
+        libxslt1-dev \
+        docbook-xsl \
+        xsltproc \
+        libxml2-utils
 
 WORKDIR /work/deps
 
-# Build OpenBLAS
-RUN git clone --recursive -b v0.2.20 https://github.com/xianyi/OpenBLAS.git && \
-    cd OpenBLAS && \
+# build ccache
+RUN git clone --recursive -b v3.4.2 https://github.com/ccache/ccache.git && \
+    cd ccache && \
+    ./autogen.sh && \
+    ./configure && \
     make -j$(nproc) && \
-    make PREFIX=$CROSS_ROOT install
-
-COPY runtime_functions.sh /work/
-WORKDIR /work/mxnet
+    make install

--- a/ci/docker/Dockerfile.build.ubuntu_build_cuda
+++ b/ci/docker/Dockerfile.build.ubuntu_build_cuda
@@ -21,7 +21,13 @@
 # package generation, requiring the actual CUDA library to be
 # present
 
+FROM ccache/build.ubuntu as ccachebuilder
+
 FROM nvidia/cuda:9.1-cudnn7-devel
+
+COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
+ENV CCACHE_MAXSIZE 10G
+ENV CCACHE_DIR /work/ccache
 
 WORKDIR /work/deps
 

--- a/ci/docker/Dockerfile.build.ubuntu_build_cuda
+++ b/ci/docker/Dockerfile.build.ubuntu_build_cuda
@@ -21,11 +21,8 @@
 # package generation, requiring the actual CUDA library to be
 # present
 
-FROM ccache/build.ubuntu as ccachebuilder
-
 FROM nvidia/cuda:9.1-cudnn7-devel
 
-COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 ENV CCACHE_MAXSIZE 10G
 ENV CCACHE_DIR /work/ccache
 
@@ -33,6 +30,8 @@ WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/
 RUN /work/ubuntu_core.sh
+COPY install/ubuntu_install_ccache.sh /work/
+RUN /work/ubuntu_install_ccache.sh
 COPY install/ubuntu_python.sh /work/
 RUN /work/ubuntu_python.sh
 COPY install/ubuntu_scala.sh /work/

--- a/ci/docker/Dockerfile.build.ubuntu_build_cuda
+++ b/ci/docker/Dockerfile.build.ubuntu_build_cuda
@@ -23,9 +23,6 @@
 
 FROM nvidia/cuda:9.1-cudnn7-devel
 
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
-
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/

--- a/ci/docker/Dockerfile.build.ubuntu_cpu
+++ b/ci/docker/Dockerfile.build.ubuntu_cpu
@@ -20,9 +20,6 @@
 
 FROM ubuntu:16.04
 
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
-
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/

--- a/ci/docker/Dockerfile.build.ubuntu_cpu
+++ b/ci/docker/Dockerfile.build.ubuntu_cpu
@@ -18,11 +18,8 @@
 #
 # Dockerfile to build and run MXNet on Ubuntu 16.04 for CPU
 
-FROM ccache/build.ubuntu as ccachebuilder
-
 FROM ubuntu:16.04
 
-COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 ENV CCACHE_MAXSIZE 10G
 ENV CCACHE_DIR /work/ccache
 
@@ -30,6 +27,8 @@ WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/
 RUN /work/ubuntu_core.sh
+COPY install/ubuntu_install_ccache.sh /work/
+RUN /work/ubuntu_install_ccache.sh
 COPY install/ubuntu_python.sh /work/
 RUN /work/ubuntu_python.sh
 COPY install/ubuntu_scala.sh /work/

--- a/ci/docker/Dockerfile.build.ubuntu_cpu
+++ b/ci/docker/Dockerfile.build.ubuntu_cpu
@@ -18,7 +18,13 @@
 #
 # Dockerfile to build and run MXNet on Ubuntu 16.04 for CPU
 
+FROM ccache/build.ubuntu as ccachebuilder
+
 FROM ubuntu:16.04
+
+COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
+ENV CCACHE_MAXSIZE 10G
+ENV CCACHE_DIR /work/ccache
 
 WORKDIR /work/deps
 

--- a/ci/docker/Dockerfile.build.ubuntu_gpu
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu
@@ -20,9 +20,6 @@
 
 FROM nvidia/cuda:9.1-cudnn7-devel
 
-ENV CCACHE_MAXSIZE 10G
-ENV CCACHE_DIR /work/ccache
-
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/

--- a/ci/docker/Dockerfile.build.ubuntu_gpu
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu
@@ -18,11 +18,8 @@
 #
 # Dockerfile to run MXNet on Ubuntu 16.04 for CPU
 
-FROM ccache/build.ubuntu as ccachebuilder
-
 FROM nvidia/cuda:9.1-cudnn7-devel
 
-COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
 ENV CCACHE_MAXSIZE 10G
 ENV CCACHE_DIR /work/ccache
 
@@ -30,6 +27,8 @@ WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/
 RUN /work/ubuntu_core.sh
+COPY install/ubuntu_install_ccache.sh /work/
+RUN /work/ubuntu_install_ccache.sh
 COPY install/ubuntu_python.sh /work/
 RUN /work/ubuntu_python.sh
 COPY install/ubuntu_scala.sh /work/

--- a/ci/docker/Dockerfile.build.ubuntu_gpu
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu
@@ -18,7 +18,13 @@
 #
 # Dockerfile to run MXNet on Ubuntu 16.04 for CPU
 
+FROM ccache/build.ubuntu as ccachebuilder
+
 FROM nvidia/cuda:9.1-cudnn7-devel
+
+COPY --from=ccachebuilder /usr/local/bin/ccache /usr/local/bin/ccache
+ENV CCACHE_MAXSIZE 10G
+ENV CCACHE_DIR /work/ccache
 
 WORKDIR /work/deps
 

--- a/ci/docker/install/centos7_install_ccache.sh
+++ b/ci/docker/install/centos7_install_ccache.sh
@@ -1,4 +1,5 @@
-# -*- mode: dockerfile -*-
+#!/bin/bash
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,32 +16,32 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-# Dockerfile to build ccache for ubuntu based images
 
-FROM ubuntu:16.04
+# Script to build ccache for centos7 based images
 
-RUN apt update && \
-    apt install -y --no-install-recommends \
-        git \
-        ssh \
-        apt-transport-https \
-        build-essential \
-        ca-certificates \
-        autoconf \
-        google-perftools \
-        asciidoc \
-        libxslt1-dev \
-        docbook-xsl \
-        xsltproc \
-        libxml2-utils
+set -ex
 
-WORKDIR /work/deps
+pushd .
 
-# build ccache
-RUN git clone --recursive -b v3.4.2 https://github.com/ccache/ccache.git && \
-    cd ccache && \
-    ./autogen.sh && \
-    ./configure && \
-    make -j$(nproc) && \
-    make install
+yum -y install epel-release
+yum -y install git
+yum -y install ssh
+yum -y install autoconf
+yum -y install wget
+yum -y install make
+yum -y install google-perftools
+yum -y install asciidoc
+yum -y install gcc-c++-4.8.*
+
+cd /work
+
+git clone --recursive -b v3.4.2 https://github.com/ccache/ccache.git
+
+cd ccache
+
+./autogen.sh
+./configure
+make -j$(nproc)
+make install
+
+popd

--- a/ci/docker/install/centos7_install_ccache.sh
+++ b/ci/docker/install/centos7_install_ccache.sh
@@ -25,7 +25,6 @@ pushd .
 
 yum -y install epel-release
 yum -y install git
-yum -y install ssh
 yum -y install autoconf
 yum -y install wget
 yum -y install make

--- a/ci/docker/install/centos7_install_ccache.sh
+++ b/ci/docker/install/centos7_install_ccache.sh
@@ -45,3 +45,8 @@ make -j$(nproc)
 make install
 
 popd
+
+rm -rf /work/ccache
+
+export CCACHE_MAXSIZE=${CCACHE_MAXSIZE:=10G}
+export CCACHE_DIR=${CCACHE_DIR:=/work/ccache}

--- a/ci/docker/install/centos7_install_ccache.sh
+++ b/ci/docker/install/centos7_install_ccache.sh
@@ -32,7 +32,8 @@ yum -y install google-perftools
 yum -y install asciidoc
 yum -y install gcc-c++-4.8.*
 
-cd /work
+mkdir -p /work/deps
+cd /work/deps
 
 git clone --recursive -b v3.4.2 https://github.com/ccache/ccache.git
 
@@ -43,9 +44,10 @@ cd ccache
 make -j$(nproc)
 make install
 
-popd
+cd /work/deps
+rm -rf /work/deps/ccache
 
-rm -rf /work/ccache
+popd
 
 export CCACHE_MAXSIZE=${CCACHE_MAXSIZE:=10G}
 export CCACHE_DIR=${CCACHE_DIR:=/work/ccache}

--- a/ci/docker/install/ubuntu_install_ccache.sh
+++ b/ci/docker/install/ubuntu_install_ccache.sh
@@ -52,3 +52,6 @@ make install
 popd
 
 rm -rf /work/ccache
+
+export CCACHE_MAXSIZE=${CCACHE_MAXSIZE:=10G}
+export CCACHE_DIR=${CCACHE_DIR:=/work/ccache}

--- a/ci/docker/install/ubuntu_install_ccache.sh
+++ b/ci/docker/install/ubuntu_install_ccache.sh
@@ -38,7 +38,8 @@ apt install -y --no-install-recommends \
     xsltproc \
     libxml2-utils
 
-cd /work
+mkdir -p /work/deps
+cd /work/deps
 
 git clone --recursive -b v3.4.2 https://github.com/ccache/ccache.git
 
@@ -49,9 +50,10 @@ cd ccache
 make -j$(nproc)
 make install
 
-popd
+cd /work/deps
+rm -rf /work/deps/ccache
 
-rm -rf /work/ccache
+popd
 
 export CCACHE_MAXSIZE=${CCACHE_MAXSIZE:=10G}
 export CCACHE_DIR=${CCACHE_DIR:=/work/ccache}

--- a/ci/docker/install/ubuntu_install_ccache.sh
+++ b/ci/docker/install/ubuntu_install_ccache.sh
@@ -1,4 +1,5 @@
-# -*- mode: dockerfile -*-
+#!/bin/bash
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,28 +16,39 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-# Dockerfile to build ccache for ubuntu based images
 
-FROM centos:7
+# Script to build ccache for ubuntu based images
 
-# Multipackage installation does not fail in yum
-RUN yum -y install epel-release && \
-    yum -y install git \
-    yum -y install ssh \
-    yum -y install autoconf \
-    yum -y install wget \
-    yum -y install make \
-    yum -y install google-perftools \
-    yum -y install asciidoc \
-    yum -y install gcc-c++-4.8.*
+set -ex
 
-WORKDIR /work/deps
+pushd .
 
-# build ccache
-RUN git clone --recursive -b v3.4.2 https://github.com/ccache/ccache.git && \
-    cd ccache && \
-    ./autogen.sh && \
-    ./configure && \
-    make -j$(nproc) && \
-    make install
+apt update
+apt install -y --no-install-recommends \
+    git \
+    ssh \
+    apt-transport-https \
+    build-essential \
+    ca-certificates \
+    autoconf \
+    google-perftools \
+    asciidoc \
+    libxslt1-dev \
+    docbook-xsl \
+    xsltproc \
+    libxml2-utils
+
+cd /work
+
+git clone --recursive -b v3.4.2 https://github.com/ccache/ccache.git
+
+cd ccache
+
+./autogen.sh
+./configure
+make -j$(nproc)
+make install
+
+popd
+
+rm -rf /work/ccache

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -47,11 +47,11 @@ build_ccache_wrappers() {
     fi
 
     if [ -z ${CXX+x} ]; then
-        echo "No \$CXX set, defaulting to g++";
-        export CXX=g++
+       echo "No \$CXX set, defaulting to g++";
+       export CXX=g++
     fi
 
-    # this function is nessesary for cuda enabled make based builds, since nvcc needs just an exacutable for -ccbin
+    # this function is nessesary for cuda enabled make based builds, since nvcc needs just an executable for -ccbin
 
     echo -e "#!/bin/sh\n/usr/local/bin/ccache ${CC} \"\$@\"\n" >> cc
     echo -e "#!/bin/sh\n/usr/local/bin/ccache ${CXX} \"\$@\"\n" >> cxx
@@ -210,8 +210,9 @@ build_android_arm64() {
 
 build_centos7_cpu() {
     set -ex
-    build_ccache_wrappers
     cd /work/mxnet
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     make \
         DEV=1 \
         USE_LAPACK=1 \
@@ -223,8 +224,9 @@ build_centos7_cpu() {
 
 build_centos7_mkldnn() {
     set -ex
-    build_ccache_wrappers
     cd /work/mxnet
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     make \
         DEV=1 \
         USE_LAPACK=1 \
@@ -236,8 +238,9 @@ build_centos7_mkldnn() {
 
 build_centos7_gpu() {
     set -ex
-    build_ccache_wrappers
     cd /work/mxnet
+    # unfortunately this build has problems in 3rdparty dependencies with ccache and make
+    # build_ccache_wrappers
     make \
         DEV=1 \
         USE_LAPACK=1 \
@@ -250,9 +253,14 @@ build_centos7_gpu() {
         -j$(nproc)
 }
 
+build_ubuntu_cpu() {
+    build_ubuntu_cpu_openblas
+}
+
 build_ubuntu_cpu_openblas() {
     set -ex
-    build_ccache_wrappers
+    export CC="ccache gcc"
+    export CXX="ccache g++"
     make \
         DEV=1                         \
         USE_CPP_PACKAGE=1             \
@@ -352,7 +360,8 @@ build_ubuntu_gpu_mkldnn() {
 
 build_ubuntu_gpu_cuda91_cudnn7() {
     set -ex
-    build_ccache_wrappers
+    # unfortunately this build has problems in 3rdparty dependencies with ccache and make
+    # build_ccache_wrappers
     make \
         DEV=1                         \
         USE_BLAS=openblas             \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -31,6 +31,25 @@ clean_repo() {
     git submodule update --init --recursive
 }
 
+# this function is nessesary for cuda enabled make based builds, since nvcc needs just an exacutable for -ccbin
+build_ccache_wrappers() {
+    set -ex
+
+    rm -f cc
+    rm -f cxx
+
+    touch cc
+    touch cxx
+
+    echo -e "#!/bin/sh\n/usr/local/bin/ccache ${CC} \"\$@\"\n" >> cc
+    echo -e "#!/bin/sh\n/usr/local/bin/ccache ${CXX} \"\$@\"\n" >> cxx
+
+    chmod +x cc
+    chmod +x cxx
+
+    export CC=`pwd`/cc
+    export CXX=`pwd`/cxx
+}
 
 # Build commands: Every platform in docker/Dockerfile.build.<platform> should have a corresponding
 # function here with the same suffix:
@@ -38,6 +57,8 @@ clean_repo() {
 build_jetson() {
     set -ex
     pushd .
+
+    build_ccache_wrappers
 
     cp -f make/crosscompile.jetson.mk ./config.mk
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -41,6 +41,16 @@ build_ccache_wrappers() {
     touch cc
     touch cxx
 
+    if [ -z ${CC+x} ]; then
+        echo "No \$CC set, defaulting to gcc";
+        export CC=gcc
+    fi
+
+    if [ -z ${CXX+x} ]; then
+        echo "No \$CXX set, defaulting to g++";
+        export CXX=g++
+    fi
+
     # this function is nessesary for cuda enabled make based builds, since nvcc needs just an exacutable for -ccbin
 
     echo -e "#!/bin/sh\n/usr/local/bin/ccache ${CC} \"\$@\"\n" >> cc
@@ -343,7 +353,7 @@ build_ubuntu_gpu_mkldnn() {
 build_ubuntu_gpu_cuda91_cudnn7() {
     set -ex
     build_ccache_wrappers
-    make  \
+    make \
         DEV=1                         \
         USE_BLAS=openblas             \
         USE_CUDA=1                    \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -31,7 +31,7 @@ clean_repo() {
     git submodule update --init --recursive
 }
 
-# this function is nessesary for cuda enabled make based builds, since nvcc needs just an exacutable for -ccbin
+# wrap compiler calls with ccache
 build_ccache_wrappers() {
     set -ex
 
@@ -40,6 +40,8 @@ build_ccache_wrappers() {
 
     touch cc
     touch cxx
+
+    # this function is nessesary for cuda enabled make based builds, since nvcc needs just an exacutable for -ccbin
 
     echo -e "#!/bin/sh\n/usr/local/bin/ccache ${CC} \"\$@\"\n" >> cc
     echo -e "#!/bin/sh\n/usr/local/bin/ccache ${CXX} \"\$@\"\n" >> cxx
@@ -97,6 +99,7 @@ build_armv6() {
     cmake \
         -DCMAKE_TOOLCHAIN_FILE=$CROSS_ROOT/Toolchain.cmake \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DUSE_CUDA=OFF \
         -DUSE_OPENCV=OFF \
         -DUSE_OPENMP=OFF \
@@ -119,7 +122,9 @@ build_armv7() {
     set -ex
     pushd .
     cd /work/build
-    cmake\
+    cmake \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DUSE_CUDA=OFF\
         -DUSE_OPENCV=OFF\
         -DUSE_OPENMP=OFF\
@@ -137,7 +142,9 @@ build_armv7() {
 
 build_amzn_linux_cpu() {
     cd /work/build
-    cmake\
+    cmake \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DUSE_CUDA=OFF\
         -DUSE_OPENCV=ON\
         -DUSE_OPENMP=ON\
@@ -152,7 +159,9 @@ build_amzn_linux_cpu() {
 }
 
 build_arm64() {
-    cmake\
+    cmake \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DUSE_CUDA=OFF\
         -DUSE_OPENCV=OFF\
         -DUSE_OPENMP=OFF\
@@ -170,7 +179,9 @@ build_arm64() {
 build_android_arm64() {
     set -ex
     cd /work/build
-    cmake\
+    cmake \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DUSE_CUDA=OFF\
         -DUSE_SSE=OFF\
         -DUSE_LAPACK=OFF\
@@ -189,6 +200,7 @@ build_android_arm64() {
 
 build_centos7_cpu() {
     set -ex
+    build_ccache_wrappers
     cd /work/mxnet
     make \
         DEV=1 \
@@ -201,6 +213,7 @@ build_centos7_cpu() {
 
 build_centos7_mkldnn() {
     set -ex
+    build_ccache_wrappers
     cd /work/mxnet
     make \
         DEV=1 \
@@ -213,6 +226,7 @@ build_centos7_mkldnn() {
 
 build_centos7_gpu() {
     set -ex
+    build_ccache_wrappers
     cd /work/mxnet
     make \
         DEV=1 \
@@ -228,6 +242,7 @@ build_centos7_gpu() {
 
 build_ubuntu_cpu_openblas() {
     set -ex
+    build_ccache_wrappers
     make \
         DEV=1                         \
         USE_CPP_PACKAGE=1             \
@@ -238,54 +253,71 @@ build_ubuntu_cpu_openblas() {
 
 build_ubuntu_cpu_clang39() {
     set -ex
+
+    export CXX=clang++-3.9
+    export CC=clang-3.9
+
+    build_ccache_wrappers
+
     make \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_OPENMP=0                  \
         USE_DIST_KVSTORE=1            \
-        CXX=clang++-3.9               \
-        CC=clang-3.9                  \
         -j$(nproc)
 }
 
 build_ubuntu_cpu_clang50() {
     set -ex
-    make \
+
+    export CXX=clang++-5.0
+    export CC=clang-5.0
+
+    build_ccache_wrappers
+
+    make  \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_OPENMP=1                  \
         USE_DIST_KVSTORE=1            \
-        CXX=clang++-5.0               \
-        CC=clang-5.0                  \
         -j$(nproc)
 }
 
 build_ubuntu_cpu_clang39_mkldnn() {
     set -ex
+
+    export CXX=clang++-3.9
+    export CC=clang-3.9
+
+    build_ccache_wrappers
+
     make \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
         USE_OPENMP=0                  \
-        CXX=clang++-3.9               \
-        CC=clang-3.9                  \
         -j$(nproc)
 }
 
 build_ubuntu_cpu_clang50_mkldnn() {
     set -ex
+
+    export CXX=clang++-5.0
+    export CC=clang-5.0
+
+    build_ccache_wrappers
+
     make \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
         USE_OPENMP=1                  \
-        CXX=clang++-5.0               \
-        CC=clang-5.0                  \
         -j$(nproc)
 }
 
 build_ubuntu_cpu_mkldnn() {
     set -ex
+    build_ccache_wrappers
     make  \
         DEV=1                         \
         USE_CPP_PACKAGE=1             \
@@ -296,6 +328,7 @@ build_ubuntu_cpu_mkldnn() {
 
 build_ubuntu_gpu_mkldnn() {
     set -ex
+    build_ccache_wrappers
     make  \
         DEV=1                         \
         USE_CPP_PACKAGE=1             \
@@ -309,6 +342,7 @@ build_ubuntu_gpu_mkldnn() {
 
 build_ubuntu_gpu_cuda91_cudnn7() {
     set -ex
+    build_ccache_wrappers
     make  \
         DEV=1                         \
         USE_BLAS=openblas             \
@@ -338,6 +372,8 @@ build_ubuntu_gpu_cmake_mkldnn() {
     set -ex
     cd /work/build
     cmake \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DUSE_CUDA=1               \
         -DUSE_CUDNN=1              \
         -DUSE_MKLML_MKL=1          \
@@ -356,6 +392,8 @@ build_ubuntu_gpu_cmake() {
     set -ex
     cd /work/build
     cmake \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
         -DUSE_CUDA=1               \
         -DUSE_CUDNN=1              \
         -DUSE_MKLML_MKL=0          \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -38,7 +38,9 @@ clean_repo() {
 build_jetson() {
     set -ex
     pushd .
-    mv make/crosscompile.jetson.mk make/config.mk
+
+    cp -f make/crosscompile.jetson.mk ./config.mk
+
     make -j$(nproc)
 
     export MXNET_LIBRARY_PATH=`pwd`/libmxnet.so
@@ -73,6 +75,7 @@ build_armv6() {
 
     cmake \
         -DCMAKE_TOOLCHAIN_FILE=$CROSS_ROOT/Toolchain.cmake \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DUSE_CUDA=OFF \
         -DUSE_OPENCV=OFF \
         -DUSE_OPENMP=OFF \

--- a/make/config.mk
+++ b/make/config.mk
@@ -37,9 +37,15 @@
 # choice of compiler
 #--------------------
 
+ifndef CC
 export CC = gcc
+endif
+ifndef CXX
 export CXX = g++
+endif
+ifndef NVCC
 export NVCC = nvcc
+endif
 
 # whether compile with options for MXNet developer
 DEV = 0

--- a/make/crosscompile.jetson.mk
+++ b/make/crosscompile.jetson.mk
@@ -57,10 +57,10 @@ DEBUG = 0
 USE_SIGNAL_HANDLER = 1
 
 # the additional link flags you want to add
-ADD_LDFLAGS =
+ADD_LDFLAGS = -L${CROSS_ROOT}/lib
 
 # the additional compile flags you want to add
-ADD_CFLAGS =
+ADD_CFLAGS = -I${CROSS_ROOT}/include
 
 #---------------------------------------------
 # matrix computation libraries for CPU/GPU
@@ -96,7 +96,7 @@ USE_LIBJPEG_TURBO = 0
 USE_LIBJPEG_TURBO_PATH = NONE
 
 # use openmp for parallelization
-USE_OPENMP = 1
+USE_OPENMP = 0
 
 # whether use MKL-DNN library
 USE_MKLDNN = 0


### PR DESCRIPTION
## Description ##

This is a work on top of [Perdo's PR](https://github.com/apache/incubator-mxnet/pull/11036), but has a few improvements.

## Checklist ##
### Essentials ###
- [x] The PR title starts with [MXNET-472](https://issues.apache.org/jira/projects/MXNET/issues/MXNET-472)
- [x] Changes are complete

### Changes ###
- [x] CCache latest version and build for all different docker builds
- [x] CPU and GPU builds are supported

## Comments ##

The ccache dir is meant to be shared via EFS on instances with the same label on CI builds.