### PR TITLE
fix nd.backward when out_grad is None

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -2080,13 +2080,13 @@ fixed-size items.
             Whether to compute gradient for training or inference.
         """
         if out_grad is None:
-            ograd_handles = [NDArrayHandle(0)]
+            ograd_handles = ctypes.c_void_p(0)
         else:
-            ograd_handles = [out_grad.handle]
+            ograd_handles = c_array(NDArrayHandle, [out_grad.handle])
 
         check_call(_LIB.MXAutogradBackwardEx(
             1, c_handle_array([self]),
-            c_array(NDArrayHandle, ograd_handles),
+            ograd_handles,
             0,
             ctypes.c_void_p(0),
             ctypes.c_int(retain_graph),


### PR DESCRIPTION
## Description ##
Otherwise `ograd_handles` here https://github.com/apache/incubator-mxnet/blob/master/src/c_api/c_api_ndarray.cc#L332, never becomes `nullptr`. And this part is wrong https://github.com/apache/incubator-mxnet/blob/master/src/c_api/c_api_ndarray.cc#L350-L356. 

cc @szha @eric-haibin-lin 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
