### PR TITLE
Updating readme to fix broken docs status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<div align="center">
+  <a href="https://mxnet.incubator.apache.org/"><img src="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/mxnet_logo_2.png"></a><br>
+</div>
+
 Apache MXNet (incubating) for Deep Learning
 =====
 | Master         | Docs          | License  |

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 Apache MXNet (incubating) for Deep Learning
 =====
-
-[![Build Status](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/badge/icon)](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/)
-[![Documentation Status](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet-build-site/badge/icon)](https://mxnet.incubator.apache.org/)
-[![GitHub license](http://dmlc.github.io/img/apache2.svg)](./LICENSE)
+| Master         | Docs          | License  |
+| :-------------:|:-------------:|:--------:|
+| [![Build Status](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/badge/icon)](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/)  | [![Documentation Status](http://jenkins.mxnet-ci.amazon-ml.com/job/website%20build%20pipeline/badge/icon)](https://mxnet.incubator.apache.org/) | [![GitHub license](http://dmlc.github.io/img/apache2.svg)](./LICENSE) |
 
 ![banner](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/banner.png)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Apache MXNet (incubating) for Deep Learning
 =====
 | Master         | Docs          | License  |
 | :-------------:|:-------------:|:--------:|
-| [![Build Status](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/badge/icon)](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/)  | [![Documentation Status](http://jenkins.mxnet-ci.amazon-ml.com/job/website%20build%20pipeline/badge/icon)](https://mxnet.incubator.apache.org/) | [![GitHub license](http://dmlc.github.io/img/apache2.svg)](./LICENSE) |
+| [![Build Status](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/badge/icon)](http://jenkins.mxnet-ci.amazon-ml.com/job/incubator-mxnet/job/master/)  | [![Documentation Status](http://jenkins.mxnet-ci.amazon-ml.com/job/restricted-website-build/badge/icon)](https://mxnet.incubator.apache.org/) | [![GitHub license](http://dmlc.github.io/img/apache2.svg)](./LICENSE) |
 
 ![banner](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/banner.png)
 


### PR DESCRIPTION
Current readme shows a broken docs build icon because the job has been removed, fixing and adding a table to know what build is what.

**previous**
![screen shot 2018-05-30 at 2 57 07 pm](https://user-images.githubusercontent.com/3716307/40750041-cedc7b0c-641a-11e8-851a-b74950ac22b7.png)

**new**

![screen shot 2018-05-30 at 2 57 16 pm](https://user-images.githubusercontent.com/3716307/40750058-da68d1aa-641a-11e8-9097-32797b79372c.png)
