### PR TITLE
allow int shape in parameter

### DIFF
--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -68,7 +68,7 @@ class Parameter(object):
           iteration when using this option.
         - 'null' means gradient is not requested for this parameter. gradient arrays
           will not be allocated.
-    shape : tuple of int, default None
+    shape : int or tuple of int, default None
         Shape of this parameter. By default shape is not specified. Parameter with
         unknown shape can be used for :py:class:`Symbol` API, but ``init`` will throw an error
         when using :py:class:`NDArray` API.
@@ -112,6 +112,8 @@ class Parameter(object):
         self._differentiable = differentiable
         self._allow_deferred_init = allow_deferred_init
         self._grad_req = None
+        if isinstance(shape, int):
+            shape = (shape,)
         self._shape = shape
         self.name = name
         self.dtype = dtype

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -349,7 +349,7 @@ def test_sparse_symbol_block():
 def test_sparse_hybrid_block():
     params = gluon.ParameterDict('net_')
     params.get('weight', shape=(5,5), stype='row_sparse', dtype='float32')
-    params.get('bias', shape=(5,), dtype='float32')
+    params.get('bias', shape=(5), dtype='float32')
     net = gluon.nn.Dense(5, params=params)
     net.initialize()
     x = mx.nd.ones((2,5))


### PR DESCRIPTION
## Description ##
allow int shape in Gluon parameter. fixes #9838 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated.
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] allow int shape in parameter