### PR TITLE
[MXNET-501] Navbar community fix

### DIFF
--- a/docs/_static/js/navbar.js
+++ b/docs/_static/js/navbar.js
@@ -1,10 +1,11 @@
 var searchBox = $("#search-input-wrap");
 var TITLE = ['/install/', '/gluon/', '/api/', '/docs/', '/community/' ];
 var DOC_TITLE = ['/faq/', '/tutorials/', '/architecture/', '/model_zoo/'];
-var APISubmenu, versionSubmenu, docSubmenu;
+var APISubmenu, versionSubmenu, docSubmenu, communitySubmenu;
 $("#burgerMenu").children().each(function () {
     if($(this).children().first().html() == 'API') APISubmenu = $(this).clone();
     if($(this).children().first().html().startsWith('Versions')) versionSubmenu = $(this).clone();
+    if($(this).children().first().html().startsWith('Community')) communitySubmenu = $(this).clone();
     if($(this).children().first().html() == 'Docs') docSubmenu= $(this).clone();
 });
 
@@ -49,6 +50,9 @@ function navbar() {
         }
         else if(plusMenuList[i].attr('id') == 'dropdown-menu-position-anchor-docs') {
             $("#plusMenu").append(docSubmenu);
+        }
+        else if(plusMenuList[i].attr('id') == 'dropdown-menu-position-anchor-community') {
+            $("#plusMenu").append(communitySubmenu);
         }
         else {
             $("#plusMenu").append("<li></li>");

--- a/docs/_static/js/navbar.js
+++ b/docs/_static/js/navbar.js
@@ -9,6 +9,9 @@ $("#burgerMenu").children().each(function () {
     if($(this).children().first().html() == 'Docs') docSubmenu= $(this).clone();
 });
 
+$('.burger-link').on('click', function(e) { e.stopPropagation() });
+$('.burger-link').on('touchstart', function(e) { e.stopPropagation() });
+
 function navbar() {
     var leftOffset = 40;
     var plusMenuList = [];

--- a/docs/_static/js/options.js
+++ b/docs/_static/js/options.js
@@ -1,3 +1,5 @@
+$('.burger-link').on('click', function(e) { e.stopPropagation() });
+
 $(document).ready(function () {
     function label(lbl) {
         return lbl.replace(/[ .]/g, '-').toLowerCase();

--- a/docs/_static/js/options.js
+++ b/docs/_static/js/options.js
@@ -1,4 +1,5 @@
-$('.burger-link').on('click', function(e) { e.stopPropagation() });
+//$('.burger-link').on('click', function(e) { e.stopPropagation() });
+//$('.burger-link').on('touchstart', function(e) { e.stopPropagation() });
 
 $(document).ready(function () {
     function label(lbl) {

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -55,8 +55,8 @@
           <ul id="burgerMenu" class="dropdown-menu">
               <li><a href="{{url_root}}install/index.html">Install</a></li>
               <li><a class="main-nav-link" href="{{url_root}}tutorials/index.html">Tutorials</a></li>
-              <li class="dropdown-submenu">
-                <a href="#" tabindex="-1">Community</a>
+              <li class="dropdown-submenu dropdown axel">
+                <a href="#" tabindex="-1" aria-haspopup="true" role="button" class="dropdown-toggle axel" data-toggle="dropdown">Community</a>
                 <ul class="dropdown-menu">
                   <li><a tabindex="-1"  href="http://discuss.mxnet.io">Forum</a></li>
                   <li><a tabindex="-1"  href="https://github.com/apache/incubator-mxnet">Github</a></li>
@@ -66,7 +66,7 @@
               </li>
               {% for name in ['API'] %}
               <li class="dropdown-submenu">
-                <a href="#" tabindex="-1">{{name}}</a>
+                <a href="#" tabindex="-1" role="button" aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown">{{name}}</a>
                 <ul class="dropdown-menu">
                   {% for lang in ['Python', 'Scala', 'R', 'Julia', 'C++', 'Perl'] %}
                     <li><a tabindex="-1" href="{{url_root}}{{name.lower()|replace(" ", "_")}}/{{lang.lower()}}/index.html">{{lang}}</a>
@@ -76,7 +76,7 @@
               </li>
               {% endfor %}
               <li class="dropdown-submenu">
-                <a href="#" tabindex="-1">Docs</a>
+                <a href="#" tabindex="-1" aria-haspopup="true" aria-expanded="true" class="dropdown-toggle" data-toggle="dropdown">Docs</a>
                 <ul class="dropdown-menu">
                   <li><a tabindex="-1"  href="{{url_root}}tutorials/index.html">Tutorials</a></li>
                   <li><a tabindex="-1"  href="{{url_root}}faq/index.html">FAQ</a></li>

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -55,8 +55,8 @@
           <ul id="burgerMenu" class="dropdown-menu">
               <li><a href="{{url_root}}install/index.html">Install</a></li>
               <li><a class="main-nav-link" href="{{url_root}}tutorials/index.html">Tutorials</a></li>
-              <li class="dropdown-submenu dropdown axel">
-                <a href="#" tabindex="-1" aria-haspopup="true" role="button" class="dropdown-toggle axel" data-toggle="dropdown">Community</a>
+              <li class="dropdown-submenu dropdown">
+                <a href="#" tabindex="-1" aria-haspopup="true" role="button" class="dropdown-toggle burger-link" data-toggle="dropdown">Community</a>
                 <ul class="dropdown-menu">
                   <li><a tabindex="-1"  href="http://discuss.mxnet.io">Forum</a></li>
                   <li><a tabindex="-1"  href="https://github.com/apache/incubator-mxnet">Github</a></li>
@@ -66,7 +66,7 @@
               </li>
               {% for name in ['API'] %}
               <li class="dropdown-submenu">
-                <a href="#" tabindex="-1" role="button" aria-haspopup="true" class="dropdown-toggle" data-toggle="dropdown">{{name}}</a>
+                <a href="#" tabindex="-1" role="button" aria-haspopup="true" class="dropdown-toggle burger-link" data-toggle="dropdown">{{name}}</a>
                 <ul class="dropdown-menu">
                   {% for lang in ['Python', 'Scala', 'R', 'Julia', 'C++', 'Perl'] %}
                     <li><a tabindex="-1" href="{{url_root}}{{name.lower()|replace(" ", "_")}}/{{lang.lower()}}/index.html">{{lang}}</a>
@@ -76,7 +76,7 @@
               </li>
               {% endfor %}
               <li class="dropdown-submenu">
-                <a href="#" tabindex="-1" aria-haspopup="true" aria-expanded="true" class="dropdown-toggle" data-toggle="dropdown">Docs</a>
+                <a href="#" tabindex="-1" aria-haspopup="true" aria-expanded="true" class="dropdown-toggle burger-link" data-toggle="dropdown">Docs</a>
                 <ul class="dropdown-menu">
                   <li><a tabindex="-1"  href="{{url_root}}tutorials/index.html">Tutorials</a></li>
                   <li><a tabindex="-1"  href="{{url_root}}faq/index.html">FAQ</a></li>

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -58,7 +58,8 @@
               <li class="dropdown-submenu">
                 <a href="#" tabindex="-1">Community</a>
                 <ul class="dropdown-menu">
-                  <li><a tabindex="-1"  href="{{url_root}}community/index.html">Community</a></li>
+                  <li><a tabindex="-1"  href="http://discuss.mxnet.io">Forum</a></li>
+                  <li><a tabindex="-1"  href="https://github.com/apache/incubator-mxnet">Github</a></li>
                   <li><a tabindex="-1"  href="{{url_root}}community/contribute.html">Contribute</a></li>
                   <li><a tabindex="-1"  href="{{url_root}}community/powered_by.html">Powered By</a></li>
                 </ul>


### PR DESCRIPTION
## Description ##
The community drop-down doesn't work properly when the screen width is drastically reduced. This is because it's sub-menu was never added to the display logic. The clicking of the sub-menu closes out the menu. This PR fixes these issues

## Checklist ##
### Changes ###
- [ x ] Community drop-down now works when the screen-width is reduced and it's added to the Plus icon
- [ x ] The sub-menu under the burger icon won't disappear on click when the screen is width is reduced
