### PR TITLE
Support for data iterators returning lists of batches

### DIFF
--- a/example/image-classification/common/fit.py
+++ b/example/image-classification/common/fit.py
@@ -159,8 +159,13 @@ def fit(args, network, data_loader, **kwargs):
     if args.test_io:
         tic = time.time()
         for i, batch in enumerate(train):
-            for j in batch.data:
-                j.wait_to_read()
+            if isinstance(batch, list):
+                for b in batch:
+                    for j in b.data:
+                        j.wait_to_read()
+            else:
+                for j in batch.data:
+                    j.wait_to_read()
             if (i + 1) % args.disp_batches == 0:
                 logging.info('Batch [%d]\tSpeed: %.2f samples/sec', i,
                              args.disp_batches * args.batch_size / (time.time() - tic))

--- a/python/mxnet/executor_manager.py
+++ b/python/mxnet/executor_manager.py
@@ -286,10 +286,13 @@ class DataParallelExecutorGroup(object):
         for texec in self.train_execs:
             texec.backward()
 
-    def update_metric(self, metric, labels):
+    def update_metric(self, metric, labels, pre_sliced=False):
         """Update evaluation metric with label and current outputs."""
-        for texec, islice in zip(self.train_execs, self.slices):
-            labels_slice = [label[islice] for label in labels]
+        for current_exec, (texec, islice) in enumerate(zip(self.train_execs, self.slices)):
+            if not pre_sliced:
+                labels_slice = [label[islice] for label in labels]
+            else:
+                labels_slice = labels[current_exec]
             metric.update(labels_slice, texec.outputs)
 
 class DataParallelExecutorManager(object):
@@ -436,6 +439,6 @@ class DataParallelExecutorManager(object):
         """Run backward on the current executor."""
         self.curr_execgrp.backward()
 
-    def update_metric(self, metric, labels):
+    def update_metric(self, metric, labels, pre_sliced=False):
         """Update metric with the current executor."""
-        self.curr_execgrp.update_metric(metric, labels)
+        self.curr_execgrp.update_metric(metric, labels, pre_sliced)

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -146,7 +146,8 @@ class BaseModule(object):
         - `get_outputs()`: get outputs of the previous forward operation.
         - `get_input_grads()`: get the gradients with respect to the inputs computed
           in the previous backward operation.
-        - `update_metric(metric, labels, pre_sliced=False)`: update performance metric for the previous forward
+        - `update_metric(metric, labels, pre_sliced=False)`: update performance metric
+          for the previous forward
           computed results.
 
     - other properties (mostly for backward compatibility)
@@ -521,7 +522,9 @@ class BaseModule(object):
                     end_of_batch = True
 
                 if isinstance(data_batch, list):
-                    self.update_metric(eval_metric, [db.label for db in data_batch], pre_sliced=True)
+                    self.update_metric(eval_metric,
+                                       [db.label for db in data_batch],
+                                       pre_sliced=True)
                 else:
                     self.update_metric(eval_metric, data_batch.label)
 
@@ -957,8 +960,8 @@ class BaseModule(object):
         ----------
         eval_metric : EvalMetric
             Evaluation metric to use.
-        labels : list of NDArray if `pre_sliced` parameter is set to `False`, list of lists of NDArray otherwise
-            Typically `data_batch.label`.
+        labels : list of NDArray if `pre_sliced` parameter is set to `False`,
+            list of lists of NDArray otherwise. Typically `data_batch.label`.
         pre_sliced: bool
             Whether the labels are already sliced per device (default: False).
 

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -249,7 +249,7 @@ class BaseModule(object):
                 break
             self.prepare(eval_batch, sparse_row_id_fn=sparse_row_id_fn)
             self.forward(eval_batch, is_train=False)
-            if isinstance(data_batch, list):
+            if isinstance(eval_batch, list):
                 self.update_metric(eval_metric, [eb.label for eb in eval_batch], pre_sliced=True)
             else:
                 self.update_metric(eval_metric, eval_batch.label)

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -146,7 +146,7 @@ class BaseModule(object):
         - `get_outputs()`: get outputs of the previous forward operation.
         - `get_input_grads()`: get the gradients with respect to the inputs computed
           in the previous backward operation.
-        - `update_metric(metric, labels)`: update performance metric for the previous forward
+        - `update_metric(metric, labels, pre_sliced=False)`: update performance metric for the previous forward
           computed results.
 
     - other properties (mostly for backward compatibility)
@@ -249,7 +249,10 @@ class BaseModule(object):
                 break
             self.prepare(eval_batch, sparse_row_id_fn=sparse_row_id_fn)
             self.forward(eval_batch, is_train=False)
-            self.update_metric(eval_metric, eval_batch.label)
+            if isinstance(data_batch, list):
+                self.update_metric(eval_metric, [eb.label for eb in eval_batch], pre_sliced=True)
+            else:
+                self.update_metric(eval_metric, eval_batch.label)
 
             if batch_end_callback is not None:
                 batch_end_params = BatchEndParam(epoch=epoch,
@@ -517,7 +520,10 @@ class BaseModule(object):
                 except StopIteration:
                     end_of_batch = True
 
-                self.update_metric(eval_metric, data_batch.label)
+                if isinstance(data_batch, list):
+                    self.update_metric(eval_metric, [db.label for db in data_batch], pre_sliced=True)
+                else:
+                    self.update_metric(eval_metric, data_batch.label)
 
                 if monitor is not None:
                     monitor.toc_print()
@@ -943,7 +949,7 @@ class BaseModule(object):
         """
         raise NotImplementedError()
 
-    def update_metric(self, eval_metric, labels):
+    def update_metric(self, eval_metric, labels, pre_sliced=False):
         """Evaluates and accumulates evaluation metric on outputs of the last forward
         computation.
 
@@ -951,8 +957,10 @@ class BaseModule(object):
         ----------
         eval_metric : EvalMetric
             Evaluation metric to use.
-        labels : list of NDArray
+        labels : list of NDArray if `pre_sliced` parameter is set to `False`, list of lists of NDArray otherwise
             Typically `data_batch.label`.
+        pre_sliced: bool
+            Whether the labels are already sliced per device (default: False).
 
         Examples
         --------

--- a/python/mxnet/module/bucketing_module.py
+++ b/python/mxnet/module/bucketing_module.py
@@ -517,7 +517,7 @@ class BucketingModule(BaseModule):
         assert self.binded and self.params_initialized and self.inputs_need_grad
         return self._curr_module.get_input_grads(merge_multi_context=merge_multi_context)
 
-    def update_metric(self, eval_metric, labels):
+    def update_metric(self, eval_metric, labels, pre_sliced=False):
         """Evaluates and accumulates evaluation metric on outputs of the last forward computation.
 
         Parameters
@@ -527,7 +527,7 @@ class BucketingModule(BaseModule):
             Typically ``data_batch.label``.
         """
         assert self.binded and self.params_initialized
-        self._curr_module.update_metric(eval_metric, labels)
+        self._curr_module.update_metric(eval_metric, labels, pre_sliced)
 
     @property
     def symbol(self):

--- a/python/mxnet/module/executor_group.py
+++ b/python/mxnet/module/executor_group.py
@@ -64,12 +64,26 @@ def _load_general(data, targets, major_axis):
 
 def _load_data(batch, targets, major_axis):
     """Load data into sliced arrays."""
-    _load_general(batch.data, targets, major_axis)
+    if isinstance(batch, list):
+        new_batch = []
+        for i in range(len(targets)):
+            new_batch.append([b.data[i] for b in batch])
+        new_targets = [[dst for _, dst in d_target] for d_target in targets]
+        _load_general(new_batch, new_targets, major_axis)
+    else:
+        _load_general(batch.data, targets, major_axis)
 
 
 def _load_label(batch, targets, major_axis):
     """Load label into sliced arrays."""
-    _load_general(batch.label, targets, major_axis)
+    if isinstance(batch, list):
+        new_batch = []
+        for i in range(len(targets)):
+            new_batch.append([b.label[i] for b in batch])
+        new_targets = [[dst for _, dst in d_target] for d_target in targets]
+        _load_general(new_batch, new_targets, major_axis)
+    else:
+        _load_general(batch.label, targets, major_axis)
 
 
 def _merge_multi_context(outputs, major_axis):
@@ -437,8 +451,12 @@ class DataParallelExecutorGroup(object):
         if is_train is None:
             is_train = self.for_training
 
-        if self.label_arrays is not None and data_batch.label:
-            _load_label(data_batch, self.label_arrays, self.label_layouts)
+        if isinstance(data_batch, list):
+            if self.label_arrays is not None and data_batch is not None and data_batch[0].label:
+                _load_label(data_batch, self.label_arrays, self.label_layouts)
+        else:
+            if self.label_arrays is not None and data_batch.label:
+                _load_label(data_batch, self.label_arrays, self.label_layouts)
 
         for exec_ in self.execs:
             exec_.forward(is_train=is_train)
@@ -580,7 +598,7 @@ class DataParallelExecutorGroup(object):
                     out_grads_slice.append(grad.copyto(self.contexts[i]))
             exec_.backward(out_grads=out_grads_slice)
 
-    def update_metric(self, eval_metric, labels):
+    def update_metric(self, eval_metric, labels, pre_sliced):
         """Accumulate the performance according to `eval_metric` on all devices
         by comparing outputs from [begin, end) to labels. By default use all
         outputs.
@@ -591,25 +609,30 @@ class DataParallelExecutorGroup(object):
             The metric used for evaluation.
         labels : list of NDArray
             Typically comes from `label` of a `DataBatch`.
+        pre_sliced : bool
+            Whether labels are already sliced.
         begin : int
             Starting index of used outputs.
         end : int or None
             Ending index of used outputs.
         """
-        for texec, islice in zip(self.execs, self.slices):
-            labels_slice = []
-            for label, axis in zip(labels, self.label_layouts):
-                if axis == 0:
-                    # slicing NDArray along axis 0 can avoid copying
-                    labels_slice.append(label[islice])
-                elif axis > 0:
-                    # pylint: disable=no-member
-                    label_my_slice = nd.slice_axis(label, axis=axis, begin=islice.start,
-                                                   end=islice.stop).as_in_context(label.context)
-                    # pylint: enable=no-member
-                    labels_slice.append(label_my_slice)
-                else:
-                    labels_slice.append(label)
+        for current_exec, (texec, islice) in enumerate(zip(self.execs, self.slices)):
+            if not pre_sliced:
+                labels_slice = []
+                for label, axis in zip(labels, self.label_layouts):
+                    if axis == 0:
+                        # slicing NDArray along axis 0 can avoid copying
+                        labels_slice.append(label[islice])
+                    elif axis > 0:
+                        # pylint: disable=no-member
+                        label_my_slice = nd.slice_axis(label, axis=axis, begin=islice.start,
+                                                       end=islice.stop).as_in_context(label.context)
+                        # pylint: enable=no-member
+                        labels_slice.append(label_my_slice)
+                    else:
+                        labels_slice.append(label)
+            else:
+                labels_slice = labels[current_exec]
 
             labels_ = OrderedDict(zip(self.label_names, labels_slice))
             preds = OrderedDict(zip(self.output_names, texec.outputs))

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -764,8 +764,8 @@ class Module(BaseModule):
         ----------
         eval_metric : EvalMetric
             Evaluation metric to use.
-        labels : list of NDArray if `pre_sliced` parameter is set to `False`, list of lists of NDArray otherwise
-            Typically `data_batch.label`.
+        labels : list of NDArray if `pre_sliced` parameter is set to `False`,
+            list of lists of NDArray otherwise. Typically `data_batch.label`.
         pre_sliced: bool
             Whether the labels are already sliced per device (default: False).
         """

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -590,7 +590,19 @@ class Module(BaseModule):
         assert self.binded and self.params_initialized
 
         curr_data_shapes = tuple(i.shape for i in self._data_shapes)
-        new_data_shapes = tuple(i.shape for i in data_batch.data)
+        if isinstance(data_batch, list):
+            assert data_batch is not None, "Encountered empty data batch"
+            new_data_shapes = []
+            for i in range(len(data_batch[0].data)):
+                shape = data_batch[0].data[i].shape
+                for db in data_batch:
+                    assert shape == db.data[i].shape, \
+                        "All data batches in a list need to have the same shape"
+                new_batch_size = len(data_batch) * shape[0]
+                new_data_shapes.append((new_batch_size,) + shape[1:])
+            new_data_shapes = tuple(new_data_shapes)
+        else:
+            new_data_shapes = tuple(i.shape for i in data_batch.data)
 
         if curr_data_shapes != new_data_shapes:
             if hasattr(data_batch, "provide_data") and data_batch.provide_data:
@@ -741,7 +753,7 @@ class Module(BaseModule):
         assert self.binded and self.params_initialized
         self._exec_group.set_states(states, value)
 
-    def update_metric(self, eval_metric, labels):
+    def update_metric(self, eval_metric, labels, pre_sliced=False):
         """Evaluates and accumulates evaluation metric on outputs of the last forward computation.
 
         See Also
@@ -751,10 +763,13 @@ class Module(BaseModule):
         Parameters
         ----------
         eval_metric : EvalMetric
-        labels : list of NDArray
-            Typically ``data_batch.label``.
+            Evaluation metric to use.
+        labels : list of NDArray if `pre_sliced` parameter is set to `False`, list of lists of NDArray otherwise
+            Typically `data_batch.label`.
+        pre_sliced: bool
+            Whether the labels are already sliced per device (default: False).
         """
-        self._exec_group.update_metric(eval_metric, labels)
+        self._exec_group.update_metric(eval_metric, labels, pre_sliced)
 
     def _sync_params_from_devices(self):
         """Synchronizes parameters from devices to CPU. This function should be called after

--- a/python/mxnet/module/python_module.py
+++ b/python/mxnet/module/python_module.py
@@ -138,7 +138,7 @@ class PythonModule(BaseModule):
         """
         pass
 
-    def update_metric(self, eval_metric, labels):
+    def update_metric(self, eval_metric, labels, pre_sliced=False):
         """Evaluates and accumulates evaluation metric on outputs of the last forward computation.
         Subclass should override this method if needed.
 
@@ -152,6 +152,9 @@ class PythonModule(BaseModule):
             # since we do not need labels, we are probably not a module with a loss
             # function or predictions, so just ignore this call
             return
+
+        if pre_sliced:
+            raise RuntimeError("PythonModule does not support presliced labels")
 
         # by default we expect our outputs are some scores that could be evaluated
         eval_metric.update(labels, self.get_outputs())

--- a/python/mxnet/module/sequential_module.py
+++ b/python/mxnet/module/sequential_module.py
@@ -416,7 +416,7 @@ class SequentialModule(BaseModule):
         assert self.binded and self.params_initialized and self.inputs_need_grad
         return self._modules[0].get_input_grads(merge_multi_context=merge_multi_context)
 
-    def update_metric(self, eval_metric, labels):
+    def update_metric(self, eval_metric, labels, pre_sliced=False):
         """Evaluates and accumulates evaluation metric on outputs of the last forward computation.
 
         Parameters
@@ -430,7 +430,7 @@ class SequentialModule(BaseModule):
         for meta, module in zip(self._metas, self._modules):
             if SequentialModule.META_TAKE_LABELS in meta and \
                     meta[SequentialModule.META_TAKE_LABELS]:
-                module.update_metric(eval_metric, labels)
+                module.update_metric(eval_metric, labels, pre_sliced)
 
     def install_monitor(self, mon):
         """Installs monitor on all executors."""


### PR DESCRIPTION
## Description ##
This PR enables module.fit to accept data iterators that return already sliced lists of batches, 1 batch per device.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- This PR does not change any behavior when used with current iterators producing a single batch for all devices but is necessary to handle iterators producing presliced data
- Gluon (due to being more explicit) can handle such iterators without any changes, this change enables those iterators only for module.fit API
