### PR TITLE
[MXNET-502] Fixing broken feature_extract cpp example

### DIFF
--- a/cpp-package/example/feature_extract/Makefile
+++ b/cpp-package/example/feature_extract/Makefile
@@ -21,8 +21,6 @@ CUDA=-DMSHADOW_USE_CUDA=1
 OPENCV_CFLAGS=`pkg-config --cflags opencv`
 OPENCV_LDFLAGS=`pkg-config --libs opencv`
 
-#COMMFLAGS=-static -static-libgcc -static-libstdc++
-
 CFLAGS=$(COMMFLAGS) -I../../../3rdparty/nnvm/include -I../../../3rdparty/dmlc-core/include -I ../../include -I ../../../include -Wall -O3 -msse3 -funroll-loops -Wno-unused-parameter -Wno-unknown-pragmas -fopenmp
 LDFLAGS=$(COMMFLAGS) -L ../../../lib -lmxnet $(BLAS) $(CUDA) -lgomp -pthread
 

--- a/cpp-package/example/feature_extract/Makefile
+++ b/cpp-package/example/feature_extract/Makefile
@@ -16,15 +16,15 @@
 # under the License.
 
 CXX=g++
-BLAS=-L /opt/openblas/lib -lopenblas -DMSHADOW_USE_CBLAS=1 -DMSHADOW_USE_MKL=0 
+BLAS=-L /opt/openblas/lib -lopenblas -DMSHADOW_USE_CBLAS=1 -DMSHADOW_USE_MKL=0
 CUDA=-DMSHADOW_USE_CUDA=1
 OPENCV_CFLAGS=`pkg-config --cflags opencv`
 OPENCV_LDFLAGS=`pkg-config --libs opencv`
 
 #COMMFLAGS=-static -static-libgcc -static-libstdc++
 
-CFLAGS=$(COMMFLAGS) -I ../../include -Wall -O3 -msse3 -funroll-loops -Wno-unused-parameter -Wno-unknown-pragmas -fopenmp 
-LDFLAGS=$(COMMFLAGS) -L ../../lib/linux -lmxnet $(BLAS) $(CUDA) -lgomp -pthread
+CFLAGS=$(COMMFLAGS) -I../../../3rdparty/nnvm/include -I../../../3rdparty/dmlc-core/include -I ../../include -I ../../../include -Wall -O3 -msse3 -funroll-loops -Wno-unused-parameter -Wno-unknown-pragmas -fopenmp
+LDFLAGS=$(COMMFLAGS) -L ../../../lib -lmxnet $(BLAS) $(CUDA) -lgomp -pthread
 
 all: feature_extract prepare_data_with_opencv
 
@@ -34,7 +34,7 @@ feature_extract: ./feature_extract.cpp
 	-rm -f $(basename $@).o
 
 prepare_data_with_opencv: ./prepare_data_with_opencv.cpp
-	$(CXX) -c -std=c++0x $(OPENCV_CFLAGS) $^ 
+	$(CXX) -c -std=c++0x $(OPENCV_CFLAGS) $^
 	$(CXX) $(basename $@).o -o $@ $(OPENCV_LDFLAGS)
 	-rm -f $(basename $@).o
 

--- a/cpp-package/example/feature_extract/README.md
+++ b/cpp-package/example/feature_extract/README.md
@@ -9,4 +9,4 @@ Execute `run.sh` to:
 
 Note:
 1. The filename of network parameters may vary, line 67 in `feature_extract.cpp` should be updated accordingly.
-2. You need to build MXNet from source to get access to the `lib/libmxnet.so`
+2. You need to build MXNet from source to get access to the `lib/libmxnet.so` or point `LD_LIBRARY_PATH` to where it is installed in your system

--- a/cpp-package/example/feature_extract/README.md
+++ b/cpp-package/example/feature_extract/README.md
@@ -6,6 +6,7 @@ Execute `run.sh` to:
 - Compile the files
 - Execute the featurization on `dog.jpg` and `cat.jpg`
 
+
 Note:
 1. The filename of network parameters may vary, line 67 in `feature_extract.cpp` should be updated accordingly.
 2. You need to build MXNet from source to get access to the `lib/libmxnet.so`

--- a/cpp-package/example/feature_extract/README.md
+++ b/cpp-package/example/feature_extract/README.md
@@ -2,9 +2,9 @@ This example shows how to extract features with a pretrained model.
 
 Execute `run.sh` to:
 - Download a pretrained model
-- Download sample pictures (`1.jpg` and `2.jpg`)
+- Download sample pictures (`dog.jpg` and `cat.jpg`)
 - Compile the files
-- Execute the featurization on `1.jpg` and `2.jpg`
+- Execute the featurization on `dog.jpg` and `cat.jpg`
 
 Note:
 1. The filename of network parameters may vary, line 67 in `feature_extract.cpp` should be updated accordingly.

--- a/cpp-package/example/feature_extract/README.md
+++ b/cpp-package/example/feature_extract/README.md
@@ -1,8 +1,11 @@
 This example shows how to extract features with a pretrained model.
 
-You can first get a pretrained model from <https://github.com/dmlc/mxnet-model-gallery/blob/master/imagenet-1k-inception-bn.md>,
-then prepare 2 pictures 1.jpg and 2.jpg to extract by executing `run.sh`.
+Execute `run.sh` to:
+- Download a pretrained model
+- Download sample pictures (`1.jpg` and `2.jpg`)
+- Compile the files
+- Execute the featurization on `1.jpg` and `2.jpg`
 
 Note:
 1. The filename of network parameters may vary, line 67 in `feature_extract.cpp` should be updated accordingly.
-2. As the build system has changed a lot, to build this example, you need to put the compiled library `libmxnet.so` in `../lib/linux`.
+2. You need to build MXNet from source to get access to the `lib/libmxnet.so`

--- a/cpp-package/example/feature_extract/feature_extract.cpp
+++ b/cpp-package/example/feature_extract/feature_extract.cpp
@@ -99,7 +99,7 @@ class FeatureExtractor {
     data.Slice(0, 1) -= mean_img;
     data.Slice(1, 2) -= mean_img;
     args_map["data"] = data;
-    /*bind the excutor*/
+    /*bind the executor*/
     executor = net.SimpleBind(global_ctx, args_map, map<string, NDArray>(),
                               map<string, OpReqType>(), aux_map);
     executor->Forward(false);

--- a/cpp-package/example/feature_extract/feature_extract.cpp
+++ b/cpp-package/example/feature_extract/feature_extract.cpp
@@ -58,13 +58,13 @@ class FeatureExtractor {
       LG<<layer_name;
     }
     */
-    net = Symbol::Load("./model/Inception_BN-symbol.json")
+    net = Symbol::Load("./model/Inception-BN-symbol.json")
               .GetInternals()["global_pool_output"];
   }
   /*Fill the trained paramters into the model, a.k.a. net, executor*/
   void LoadParameters() {
     map<string, NDArray> paramters;
-    NDArray::Load("./model/Inception_BN-0039.params", 0, &paramters);
+    NDArray::Load("./model/Inception-BN-0126.params", 0, &paramters);
     for (const auto &k : paramters) {
       if (k.first.substr(0, 4) == "aux:") {
         auto name = k.first.substr(4, k.first.size() - 4);
@@ -117,7 +117,7 @@ NDArray Data2NDArray() {
   NDArray ret(Shape(2, 3, 224, 224), global_ctx, false);
   ifstream inf("./img.dat", ios::binary);
   vector<float> data(2 * 3 * 224 * 224);
-  inf.read(reinterpret_cast<char *>data.data(), 2 * 3 * 224 * 224 * sizeof(float));
+  inf.read(reinterpret_cast<char *>(data.data()), 2 * 3 * 224 * 224 * sizeof(float));
   inf.close();
   ret.SyncCopyFromCPU(data.data(), 2 * 3 * 224 * 224);
   NDArray::WaitAll();

--- a/cpp-package/example/feature_extract/prepare_data_with_opencv.cpp
+++ b/cpp-package/example/feature_extract/prepare_data_with_opencv.cpp
@@ -45,7 +45,7 @@ void Mat2Array() {
     }
   }
   ofstream outf("./img.dat", ios::binary);
-  outf.write(reinterpret_cast<char *>array.data(), array.size() * sizeof(float));
+  outf.write(reinterpret_cast<char *>(array.data()), array.size() * sizeof(float));
   outf.close();
 }
 

--- a/cpp-package/example/feature_extract/prepare_data_with_opencv.cpp
+++ b/cpp-package/example/feature_extract/prepare_data_with_opencv.cpp
@@ -29,7 +29,7 @@ using namespace std;
 
 /*read images and store them the NDArray format that MXNet.cpp can handle*/
 void Mat2Array() {
-  string file_name_list[] = {"./1.jpg", "./2.jpg"};
+  string file_name_list[] = {"./dog.jpg", "./cat.jpg"};
 
   std::vector<float> array;
   for (auto &t : file_name_list) {

--- a/cpp-package/example/feature_extract/run.sh
+++ b/cpp-package/example/feature_extract/run.sh
@@ -24,6 +24,19 @@
 ### 2.
 ### Then Prepare 2 pictures, 1.jpg 2.jpg to extract
 
+# Getting the data
+mkdir -p model
+wget -nc http://data.dmlc.ml/mxnet/models/imagenet/inception-bn.tar.gz
+wget -nc -O 1.jpg https://github.com/dmlc/web-data/blob/master/mxnet/doc/tutorials/python/predict_image/cat.jpg?raw=true 
+wget -nc -O 2.jpg https://github.com/dmlc/web-data/blob/master/mxnet/doc/tutorials/python/predict_image/dog.jpg?raw=true 
+wget -nc -O model/mean_224.nd https://github.com/h2oai/deepwater/raw/master/mxnet/src/main/resources/deepwater/backends/mxnet/models/Inception/mean_224.nd
+tar -xvzf inception-bn.tar.gz -C model --skip-old-files
+
+# Building
 make
+
+# Preparing the data
 ./prepare_data_with_opencv
-LD_LIBRARY_PATH=../../lib/linux ./feature_extract
+
+# Running the featurization
+LD_LIBRARY_PATH=../../../lib/linux ./feature_extract

--- a/cpp-package/example/feature_extract/run.sh
+++ b/cpp-package/example/feature_extract/run.sh
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Getting the data
+# Downloading the data and model
 mkdir -p model
 wget -nc http://data.dmlc.ml/mxnet/models/imagenet/inception-bn.tar.gz
 wget -nc -O cat.jpg https://github.com/dmlc/web-data/blob/master/mxnet/doc/tutorials/python/predict_image/cat.jpg?raw=true

--- a/cpp-package/example/feature_extract/run.sh
+++ b/cpp-package/example/feature_extract/run.sh
@@ -15,15 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-### To run the this example,
-###
-### 1.
-### Get Inseption-BN model first, from here
-###     https://github.com/dmlc/mxnet-model-gallery
-###
-### 2.
-### Then Prepare 2 pictures, 1.jpg 2.jpg to extract
-
 # Getting the data
 mkdir -p model
 wget -nc http://data.dmlc.ml/mxnet/models/imagenet/inception-bn.tar.gz

--- a/cpp-package/example/feature_extract/run.sh
+++ b/cpp-package/example/feature_extract/run.sh
@@ -39,4 +39,4 @@ make
 ./prepare_data_with_opencv
 
 # Running the featurization
-LD_LIBRARY_PATH=../../../lib/linux ./feature_extract
+LD_LIBRARY_PATH=../../../lib ./feature_extract

--- a/cpp-package/example/feature_extract/run.sh
+++ b/cpp-package/example/feature_extract/run.sh
@@ -27,9 +27,9 @@
 # Getting the data
 mkdir -p model
 wget -nc http://data.dmlc.ml/mxnet/models/imagenet/inception-bn.tar.gz
-wget -nc -O 1.jpg https://github.com/dmlc/web-data/blob/master/mxnet/doc/tutorials/python/predict_image/cat.jpg?raw=true 
-wget -nc -O 2.jpg https://github.com/dmlc/web-data/blob/master/mxnet/doc/tutorials/python/predict_image/dog.jpg?raw=true 
-wget -nc -O model/mean_224.nd https://github.com/h2oai/deepwater/raw/master/mxnet/src/main/resources/deepwater/backends/mxnet/models/Inception/mean_224.nd
+wget -nc -O cat.jpg https://github.com/dmlc/web-data/blob/master/mxnet/doc/tutorials/python/predict_image/cat.jpg?raw=true
+wget -nc -O dog.jpg https://github.com/dmlc/web-data/blob/master/mxnet/doc/tutorials/python/predict_image/dog.jpg?raw=true
+wget -nc -O model/mean_224.nd https://github.com/dmlc/web-data/raw/master/mxnet/example/feature_extract/mean_224.nd
 tar -xvzf inception-bn.tar.gz -C model --skip-old-files
 
 # Building


### PR DESCRIPTION
## Description ##
- Makefile was broken [fixed]
- Pictures were missing -> automatic download
- Manual download of model -> automatic download
- .cpp files didn't compile [fixed]

[MXNET-502](https://issues.apache.org/jira/browse/MXNET-502)