### PR TITLE
[MXNET-506] Fix missing titles in certain pages

### DIFF
--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -104,8 +104,10 @@
     {%- block htmltitle %}
     {%- if pagename != 'index' and 'no title' not in title%}
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
-    {%- else %}
+    {%- elif pagename == 'index' %}
     <title>MXNet: A Scalable Deep Learning Framework</title>
+    {%- else %}
+    <title>{{ pagename.split('/')[0]|capitalize }}{{ titlesuffix }}</title>
     {%- endif %}
     {%- endblock %}
     {{ css() }}

--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -102,8 +102,8 @@
        must come *after* these tags. #}
     {{ metatags }}
     {%- block htmltitle %}
-    {%- if pagename != 'index' %}
-
+    {%- if pagename != 'index' and 'no title' not in title%}
+    <rex>{{ title }}</rex>
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
     {%- else %}
     <title>MXNet: A Scalable Deep Learning Framework</title>

--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -103,7 +103,6 @@
     {{ metatags }}
     {%- block htmltitle %}
     {%- if pagename != 'index' and 'no title' not in title%}
-    <rex>{{ title }}</rex>
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
     {%- else %}
     <title>MXNet: A Scalable Deep Learning Framework</title>


### PR DESCRIPTION
## Description ##
The title variable in jinja2 for certain pages like gluon/index.html are missing and hence is rendering as <no title>.

## Checklist ##
### Changes ###
- [ x ] Check if title variable is set
- [ x ] If so, generate a quasi-title from the pagename
