### PR TITLE
Add tqdm to support The Straight Dope CI

### DIFF
--- a/ci/docker/install/ubuntu_tutorials.sh
+++ b/ci/docker/install/ubuntu_tutorials.sh
@@ -22,5 +22,5 @@
 
 set -ex
 apt-get install graphviz python-opencv
-pip2 install jupyter matplotlib Pillow opencv-python scikit-learn graphviz
-pip3 install jupyter matplotlib Pillow opencv-python scikit-learn graphviz
+pip2 install jupyter matplotlib Pillow opencv-python scikit-learn graphviz tqdm
+pip3 install jupyter matplotlib Pillow opencv-python scikit-learn graphviz tqdm


### PR DESCRIPTION
## Description ##
Some tutorials of The Straight Dope relies on tqdm to show progress. Add it to Docker, so it wouldn't fail the execution 

### Changes ###
- [ ] tqdm is added to tutorial related Docker
