### PR TITLE
[MXNET-522] Add Media query support for Multi-size logos

### DIFF
--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -63,7 +63,6 @@
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     <script type="text/javascript"> jQuery(function() { Search.loadIndex("{{ pathto('/searchindex.js', 1) }}"); Search.init();}); </script>
-
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new

--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -103,6 +103,7 @@
     {{ metatags }}
     {%- block htmltitle %}
     {%- if pagename != 'index' and 'no title' not in title%}
+    <rex>{{ title }}</rex>
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
     {%- else %}
     <title>MXNet: A Scalable Deep Learning Framework</title>

--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -102,8 +102,8 @@
        must come *after* these tags. #}
     {{ metatags }}
     {%- block htmltitle %}
-    {%- if pagename != 'index' and 'no title' not in title%}
-    <rex>{{ title }}</rex>
+    {%- if pagename != 'index' %}
+
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
     {%- else %}
     <title>MXNet: A Scalable Deep Learning Framework</title>

--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -104,8 +104,10 @@
     {%- block htmltitle %}
     {%- if pagename != 'index' and 'no title' not in title%}
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
-    {%- else %}
+    {%- elif pagename == 'index' %}
     <title>MXNet: A Scalable Deep Learning Framework</title>
+    {%- else %}
+    <title>{{ pagename.split('/')[0]|capitalize }}{{ titlesuffix }}</title>
     {%- endif %}
     {%- endblock %}
     {{ css() }}

--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -102,8 +102,8 @@
        must come *after* these tags. #}
     {{ metatags }}
     {%- block htmltitle %}
-    {%- if pagename != 'index' %}
-
+    {%- if pagename != 'index' and 'no title' not in title%}
+    <rex>{{ title }}</rex>
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
     {%- else %}
     <title>MXNet: A Scalable Deep Learning Framework</title>

--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -104,10 +104,8 @@
     {%- block htmltitle %}
     {%- if pagename != 'index' and 'no title' not in title%}
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
-    {%- elif pagename == 'index' %}
-    <title>MXNet: A Scalable Deep Learning Framework</title>
     {%- else %}
-    <title>{{ pagename.split('/')[0]|capitalize }}{{ titlesuffix }}</title>
+    <title>MXNet: A Scalable Deep Learning Framework</title>
     {%- endif %}
     {%- endblock %}
     {{ css() }}

--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -103,7 +103,6 @@
     {{ metatags }}
     {%- block htmltitle %}
     {%- if pagename != 'index' and 'no title' not in title%}
-    <rex>{{ title }}</rex>
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
     {%- else %}
     <title>MXNet: A Scalable Deep Learning Framework</title>

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -2,7 +2,7 @@
   <div class="container" id="navContainer">
     <div id="header-inner" class="innder">
       <h1 id="logo-wrap">
-        <a href="{{ url_root }}" id="logo"><img class="logo-small" src="/_images/600-logo.png"><img class="logo-medium" src="/_images/955-logo.png"><img class="logo-reco" src="/_images/1200-logo.png"></a>
+        <a href="{{ url_root }}" id="logo"><img class="logo-small" src="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/600-logo.png"><img class="logo-medium" src="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/955-logo.png"><img class="logo-reco" src="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/1200-logo.png"></a>
       </h1>
       <nav id="main-nav" class='nav-bar'>
         <a class="main-nav-link" href="{{url_root}}install/index.html">Install</a>

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -2,7 +2,7 @@
   <div class="container" id="navContainer">
     <div id="header-inner" class="innder">
       <h1 id="logo-wrap">
-        <a href="{{ url_root }}" id="logo"><img src="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/mxnet_logo.png"></a>
+        <a href="{{ url_root }}" id="logo"><img class="logo-small" src="/_images/600-logo.png"><img class="logo-medium" src="/_images/955-logo.png"><img class="logo-reco" src="/_images/1200-logo.png"></a>
       </h1>
       <nav id="main-nav" class='nav-bar'>
         <a class="main-nav-link" href="{{url_root}}install/index.html">Install</a>

--- a/docs/_static/mxnet.css
+++ b/docs/_static/mxnet.css
@@ -188,9 +188,47 @@ img {
     text-decoration: none;
 }
 
+
 #logo > img {
-  display: block;
+/*  display: block; */
   width: 110px;
+}
+
+
+@media (max-width: 1040px) {
+    #logo > img.logo-small {
+        display: block;
+    }
+    #logo > img.logo-medium {
+        display: none;
+    }
+    #logo > img.logo-reco {
+        display: none;
+    }
+}
+
+@media (min-width: 1040px) and (max-width: 2200px) {
+    #logo > img.logo-small {
+        display: none;
+    }
+    #logo > img.logo-medium {
+        display: block;
+    }
+    #logo > img.logo-reco {
+        display: none;
+    }
+}
+
+@media (min-width: 2200px) {
+   #logo > img.logo-reco {
+        display: block;
+   }
+   #logo > img.logo-medium {
+        display: none;
+   }
+   #logo > img.logo-small {
+        display: none;
+   }
 }
 
 .nav-bar {


### PR DESCRIPTION
## Description ##
Add three different size logo images in the Navbar. Use CSS media queries to display only one of them based on the current width.

## Checklist ##
### Changes ###
- [ x ] Add three different-sized CSS media query images
- [ x ] Add media queries to select images based on width
