### PR TITLE
fix shared_storage free

### DIFF
--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -57,6 +57,8 @@ else:
 
     def reduce_ndarray(data):
         """Reduce ndarray to shared memory handle"""
+        # keep a local ref before duplicating fd
+        data = data.as_in_context(context.Context('cpu_shared', 0))
         pid, fd, shape, dtype = data._to_shared_mem()
         if sys.version_info[0] == 2:
             fd = multiprocessing.reduction.reduce_handle(fd)

--- a/src/storage/cpu_shared_storage_manager.h
+++ b/src/storage/cpu_shared_storage_manager.h
@@ -174,8 +174,12 @@ void CPUSharedStorageManager::Alloc(Storage::Handle* handle) {
   }
 
   if (fid == -1) {
-    LOG(FATAL) << "Failed to open shared memory. shm_open failed with error "
-               << strerror(errno);
+    if (is_new) {
+      LOG(FATAL) << "Failed to open shared memory. shm_open failed with error "
+                 << strerror(errno);
+    } else {
+      LOG(FATAL) << "Invalid file descriptor from shared array.";
+    }
   }
 
   if (is_new) CHECK_EQ(ftruncate(fid, size), 0);

--- a/src/storage/cpu_shared_storage_manager.h
+++ b/src/storage/cpu_shared_storage_manager.h
@@ -216,11 +216,11 @@ void CPUSharedStorageManager::FreeImpl(const Storage::Handle& handle) {
       << strerror(errno);
 
 #ifdef __linux__
-    if (handle.shared_id != -1) {
-    CHECK_EQ(close(handle.shared_id), 0)
-        << "Failed to close shared memory. close failed with error "
-        << strerror(errno);
-    }
+  if (handle.shared_id != -1) {
+  CHECK_EQ(close(handle.shared_id), 0)
+      << "Failed to close shared memory. close failed with error "
+      << strerror(errno);
+  }
 #else
   if (count == 0) {
     auto filename = SharedHandleToString(handle.shared_pid, handle.shared_id);

--- a/src/storage/cpu_shared_storage_manager.h
+++ b/src/storage/cpu_shared_storage_manager.h
@@ -215,18 +215,20 @@ void CPUSharedStorageManager::FreeImpl(const Storage::Handle& handle) {
       << "Failed to unmap shared memory. munmap failed with error "
       << strerror(errno);
 
-  if (count == 0) {
 #ifdef __linux__
+    if (handle.shared_id != -1) {
     CHECK_EQ(close(handle.shared_id), 0)
         << "Failed to close shared memory. close failed with error "
         << strerror(errno);
+    }
 #else
+  if (count == 0) {
     auto filename = SharedHandleToString(handle.shared_pid, handle.shared_id);
     CHECK_EQ(shm_unlink(filename.c_str()), 0)
         << "Failed to unlink shared memory. shm_unlink failed with error "
         << strerror(errno);
-#endif  // __linux__
   }
+#endif  // __linux__
 #endif  // _WIN32
 }
 

--- a/src/storage/cpu_shared_storage_manager.h
+++ b/src/storage/cpu_shared_storage_manager.h
@@ -225,8 +225,8 @@ void CPUSharedStorageManager::FreeImpl(const Storage::Handle& handle) {
     CHECK_EQ(shm_unlink(filename.c_str()), 0)
         << "Failed to unlink shared memory. shm_unlink failed with error "
         << strerror(errno);
-  }
 #endif  // __linux__
+  }
 #endif  // _WIN32
 }
 

--- a/src/storage/cpu_shared_storage_manager.h
+++ b/src/storage/cpu_shared_storage_manager.h
@@ -215,12 +215,12 @@ void CPUSharedStorageManager::FreeImpl(const Storage::Handle& handle) {
       << "Failed to unmap shared memory. munmap failed with error "
       << strerror(errno);
 
-#ifdef __linux__
-  CHECK_EQ(close(handle.shared_id), 0)
-      << "Failed to close shared memory. close failed with error "
-      << strerror(errno);
-#else
   if (count == 0) {
+#ifdef __linux__
+    CHECK_EQ(close(handle.shared_id), 0)
+        << "Failed to close shared memory. close failed with error "
+        << strerror(errno);
+#else
     auto filename = SharedHandleToString(handle.shared_pid, handle.shared_id);
     CHECK_EQ(shm_unlink(filename.c_str()), 0)
         << "Failed to unlink shared memory. shm_unlink failed with error "

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -140,6 +140,16 @@ def test_multi_worker_forked_data_loader():
         def __len__(self):
             return 50
 
+        def batchify_list(self, data):
+            """
+            return list of ndarray without stack/concat/pad
+            """
+            if isinstance(data, (tuple, list)):
+                return list(data)
+            if isinstance(data, mx.nd.NDArray):
+                return [data]
+            return data
+
         def batchify(self, data):
             """
             Collate data into batch. Use shared memory for stacking.
@@ -188,6 +198,13 @@ def test_multi_worker_forked_data_loader():
     if platform.system() != 'Windows':
         data = Dummy(True)
         loader = DataLoader(data, batch_size=40, batchify_fn=data.batchify, num_workers=2)
+        for epoch in range(1):
+            for i, data in enumerate(loader):
+                if i % 100 == 0:
+                    print(data)
+                    print('{}:{}'.format(epoch, i))
+
+        loader = DataLoader(data, batch_size=40, batchify_fn=data.batchify_list, num_workers=2)
         for epoch in range(1):
             for i, data in enumerate(loader):
                 if i % 100 == 0:

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -204,6 +204,7 @@ def test_multi_worker_forked_data_loader():
                     print(data)
                     print('{}:{}'.format(epoch, i))
 
+        data = Dummy(True)
         loader = DataLoader(data, batch_size=40, batchify_fn=data.batchify_list, num_workers=2)
         for epoch in range(1):
             for i, data in enumerate(loader):

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1304,14 +1304,6 @@ def test_norm(ctx=default_context()):
             assert arr1.shape == arr2.shape
             mx.test_utils.assert_almost_equal(arr1, arr2.asnumpy())
 
-@with_seed()
-def test_cpu_shared_storage():
-    data = mx.nd.array([1, 2, 3], ctx=mx.cpu(0))
-    pid, fd, shape, dtype = data._to_shared_mem()
-    new_data = mx.nd.NDArray(mx.nd.ndarray._new_from_shared_mem(pid, fd, shape, dtype))
-    b = mx.nd.array([1, 2, 3], ctx=mx.Context('cpu_shared', 0))
-    assert(new_data.context == b.context)
-
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1304,6 +1304,13 @@ def test_norm(ctx=default_context()):
             assert arr1.shape == arr2.shape
             mx.test_utils.assert_almost_equal(arr1, arr2.asnumpy())
 
+@with_seed()
+def test_cpu_shared_storage():
+    data = mx.nd.array([1, 2, 3], ctx=mx.cpu(0))
+    pid, fd, shape, dtype = data._to_shared_mem()
+    new_data = mx.nd.NDArray(mx.nd.ndarray._new_from_shared_mem(pid, fd, shape, dtype))
+    b = mx.nd.array([1, 2, 3], ctx=mx.Context('cpu_shared', 0))
+    assert(new_data.context == b.context)
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
Fix ndarray free on cpu_shared.

Original problem:

Using gluon.data.DataLoader with num_workers > 0 if ndarray was not originally on cpu_shared will cause 

```
IOError: [Errno 9] Bad file descriptor
```
because file is already closed.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here