### PR TITLE
Improve data transform for gluon data loader

### DIFF
--- a/python/mxnet/gluon/data/vision/transforms.py
+++ b/python/mxnet/gluon/data/vision/transforms.py
@@ -196,7 +196,7 @@ class RandomResizedCrop(Block):
         - **out**: output tensor with (H x W x C) shape.
     """
     def __init__(self, size, scale=(0.08, 1.0), ratio=(3.0/4.0, 4.0/3.0),
-                 interpolation=2):
+                 interpolation=1):
         super(RandomResizedCrop, self).__init__()
         if isinstance(size, numeric_types):
             size = (size, size)
@@ -233,7 +233,7 @@ class CenterCrop(Block):
     >>> transformer(image)
     <NDArray 500x1000x3 @cpu(0)>
     """
-    def __init__(self, size, interpolation=2):
+    def __init__(self, size, interpolation=1):
         super(CenterCrop, self).__init__()
         if isinstance(size, numeric_types):
             size = (size, size)
@@ -250,6 +250,9 @@ class Resize(Block):
     ----------
     size : int or tuple of (W, H)
         Size of output image.
+    keep_aspect_ratio : bool
+        Whether to resize the short edge or both edges to `size`,
+        if size is give as an integer.
     interpolation : int
         Interpolation method for resizing. By default uses bilinear
         interpolation. See OpenCV's resize function for available choices.
@@ -268,14 +271,29 @@ class Resize(Block):
     >>> transformer(image)
     <NDArray 500x1000x3 @cpu(0)>
     """
-    def __init__(self, size, interpolation=2):
+    def __init__(self, size, keep_aspect_ratio=True, interpolation=1):
         super(Resize, self).__init__()
-        if isinstance(size, numeric_types):
-            size = (size, size)
-        self._args = tuple(size) + (interpolation,)
+        self._keep = keep_aspect_ratio
+        self._size = size
+        self._interpolation = interpolation
 
     def forward(self, x):
-        return image.imresize(x, *self._args)
+        if isinstance(self._size, numeric_types):
+            if not self._keep:
+                wsize = size
+                hsize = size
+            else:
+                h, w, _ = x.shape
+                if h > w:
+                    wsize = self._size
+                    hsize = int(h * wsize / w)
+                else:
+                    hsize = self._size
+                    wsize = int(w * hsize / h)
+        else:
+            wsize, hsize = self._size
+        _args = tuple((wsize, hsize)) + (self._interpolation,)
+        return image.imresize(x, *_args)
 
 
 class RandomFlipLeftRight(HybridBlock):

--- a/python/mxnet/gluon/data/vision/transforms.py
+++ b/python/mxnet/gluon/data/vision/transforms.py
@@ -250,7 +250,7 @@ class Resize(Block):
     ----------
     size : int or tuple of (W, H)
         Size of output image.
-    keep_aspect_ratio : bool
+    keep_ratio : bool
         Whether to resize the short edge or both edges to `size`,
         if size is give as an integer.
     interpolation : int
@@ -271,9 +271,9 @@ class Resize(Block):
     >>> transformer(image)
     <NDArray 500x1000x3 @cpu(0)>
     """
-    def __init__(self, size, keep_aspect_ratio=True, interpolation=1):
+    def __init__(self, size, keep_ratio=True, interpolation=1):
         super(Resize, self).__init__()
-        self._keep = keep_aspect_ratio
+        self._keep = keep_ratio
         self._size = size
         self._interpolation = interpolation
 
@@ -292,8 +292,7 @@ class Resize(Block):
                     wsize = int(w * hsize / h)
         else:
             wsize, hsize = self._size
-        _args = tuple((wsize, hsize)) + (self._interpolation,)
-        return image.imresize(x, *_args)
+        return image.imresize(x, wsize, hsize, self._interpolation)
 
 
 class RandomFlipLeftRight(HybridBlock):

--- a/python/mxnet/gluon/data/vision/transforms.py
+++ b/python/mxnet/gluon/data/vision/transforms.py
@@ -271,7 +271,7 @@ class Resize(Block):
     >>> transformer(image)
     <NDArray 500x1000x3 @cpu(0)>
     """
-    def __init__(self, size, keep_ratio=True, interpolation=1):
+    def __init__(self, size, keep_ratio=False, interpolation=1):
         super(Resize, self).__init__()
         self._keep = keep_ratio
         self._size = size

--- a/python/mxnet/gluon/data/vision/transforms.py
+++ b/python/mxnet/gluon/data/vision/transforms.py
@@ -280,8 +280,8 @@ class Resize(Block):
     def forward(self, x):
         if isinstance(self._size, numeric_types):
             if not self._keep:
-                wsize = size
-                hsize = size
+                wsize = self._size
+                hsize = self._size
             else:
                 h, w, _ = x.shape
                 if h > w:

--- a/tests/python/unittest/test_gluon_data_vision.py
+++ b/tests/python/unittest/test_gluon_data_vision.py
@@ -67,7 +67,7 @@ def test_transformer():
 
     transform = transforms.Compose([
 		transforms.Resize(300),
-		transforms.Resize(300, keep_aspect_ratio=False),
+		transforms.Resize(300, keep_ratio=False),
 		transforms.CenterCrop(256),
 		transforms.RandomResizedCrop(224),
 		transforms.RandomFlipLeftRight(),

--- a/tests/python/unittest/test_gluon_data_vision.py
+++ b/tests/python/unittest/test_gluon_data_vision.py
@@ -66,19 +66,19 @@ def test_transformer():
     from mxnet.gluon.data.vision import transforms
 
     transform = transforms.Compose([
-		transforms.Resize(300),
-		transforms.Resize(300, keep_ratio=False),
-		transforms.CenterCrop(256),
-		transforms.RandomResizedCrop(224),
-		transforms.RandomFlipLeftRight(),
-		transforms.RandomColorJitter(0.1, 0.1, 0.1, 0.1),
-		transforms.RandomBrightness(0.1),
-		transforms.RandomContrast(0.1),
-		transforms.RandomSaturation(0.1),
-		transforms.RandomHue(0.1),
-		transforms.RandomLighting(0.1),
-		transforms.ToTensor(),
-		transforms.Normalize([0, 0, 0], [1, 1, 1])])
+        transforms.Resize(300),
+        transforms.Resize(300, keep_ratio=True),
+        transforms.CenterCrop(256),
+        transforms.RandomResizedCrop(224),
+        transforms.RandomFlipLeftRight(),
+        transforms.RandomColorJitter(0.1, 0.1, 0.1, 0.1),
+        transforms.RandomBrightness(0.1),
+        transforms.RandomContrast(0.1),
+        transforms.RandomSaturation(0.1),
+        transforms.RandomHue(0.1),
+        transforms.RandomLighting(0.1),
+        transforms.ToTensor(),
+        transforms.Normalize([0, 0, 0], [1, 1, 1])])
 
     transform(mx.nd.ones((245, 480, 3), dtype='uint8')).wait_to_read()
 

--- a/tests/python/unittest/test_gluon_data_vision.py
+++ b/tests/python/unittest/test_gluon_data_vision.py
@@ -67,6 +67,7 @@ def test_transformer():
 
     transform = transforms.Compose([
 		transforms.Resize(300),
+		transforms.Resize(300, keep_aspect_ratio=False),
 		transforms.CenterCrop(256),
 		transforms.RandomResizedCrop(224),
 		transforms.RandomFlipLeftRight(),


### PR DESCRIPTION
## Description ##
1. Modify default value of `interpolation` to 1, i.e. bilinear interpolation. The current value is 2 for cubic interpolation, which does not match the document.
2. Add `keep_aspect_ratio` to `transforms.Resize`, so that its default behavior is to resize the short edge to the single input size value.

## Checklist ##
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
