### PR TITLE
Adding support for dict in  infer_shape

### DIFF
--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1068,7 +1068,7 @@ class Symbol(SymbolBase):
 
     def _infer_shape_impl(self, partial, *args, **kwargs):
         """The actual implementation for calling shape inference API."""
-        # pylint: disable=too-many-locals
+        # pylint: disable=too-many-locals, too-many-nested-blocks
         if len(args) != 0 and len(kwargs) != 0:
             raise ValueError('Can only specify known argument \
                     shapes either by positional or kwargs way.')

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1089,12 +1089,14 @@ class Symbol(SymbolBase):
                                                 % (type(k)))
                             str_keys.append(k)
                             sdata.extend(v)
+                            indptr.append(len(sdata))
                         keys = c_str_array(str_keys)
                     else:
                         if not isinstance(s, tuple):
                             raise TypeError("Arguments need to be shapes (tuple), "
                                             "but argument %d is %s." % (i, type(s)))
                         sdata.extend(s)
+                        indptr.append(len(sdata))
         else:
             str_keys = []
             for k, v in kwargs.items():
@@ -1103,8 +1105,9 @@ class Symbol(SymbolBase):
                                     "but '%s' is %s." % (k, type(v)))
                 str_keys.append(k)
                 sdata.extend(v)
+                indptr.append(len(sdata))
             keys = c_str_array(str_keys)
-        indptr.append(len(sdata))
+
         arg_shape_size = mx_uint()
         arg_shape_ndim = ctypes.POINTER(mx_uint)()
         arg_shape_data = ctypes.POINTER(ctypes.POINTER(mx_uint))()

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1078,11 +1078,22 @@ class Symbol(SymbolBase):
             keys = c_array(ctypes.c_char_p, [])
             for i, s in enumerate(args):
                 if s is not None:
-                    if not isinstance(s, tuple):
-                        raise TypeError("Arguments need to be shapes (tuple), "
-                                        "but argument %d is %s." % (i, type(s)))
-                    sdata.extend(s)
-                indptr.append(len(sdata))
+                    if isinstance(s, dict):
+                        str_keys = []
+                        for k, v in s.items():
+                            if not isinstance(v, tuple):
+                                raise TypeError("Arguments need to be shapes (tuple), "
+                                                "but '%s' is %s." % (k, type(v)))
+                            str_keys.append(k)
+                            sdata.extend(v)
+                            indptr.append(len(sdata))
+                        keys = c_str_array(str_keys)
+                    else:
+                        if not isinstance(s, tuple):
+                            raise TypeError("Arguments need to be shapes (tuple), "
+                                            "but argument %d is %s." % (i, type(s)))
+                        sdata.extend(s)
+                        indptr.append(len(sdata))
         else:
             str_keys = []
             for k, v in kwargs.items():

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1084,16 +1084,17 @@ class Symbol(SymbolBase):
                             if not isinstance(v, tuple):
                                 raise TypeError("Arguments need to be shapes (tuple), "
                                                 "but '%s' is %s." % (k, type(v)))
+                            if not isinstance(k, string_types):
+                                raise TypeError("Key should be of string type but is %s"
+                                                % (type(k)))
                             str_keys.append(k)
                             sdata.extend(v)
-                            indptr.append(len(sdata))
                         keys = c_str_array(str_keys)
                     else:
                         if not isinstance(s, tuple):
                             raise TypeError("Arguments need to be shapes (tuple), "
                                             "but argument %d is %s." % (i, type(s)))
                         sdata.extend(s)
-                        indptr.append(len(sdata))
         else:
             str_keys = []
             for k, v in kwargs.items():
@@ -1102,8 +1103,8 @@ class Symbol(SymbolBase):
                                     "but '%s' is %s." % (k, type(v)))
                 str_keys.append(k)
                 sdata.extend(v)
-                indptr.append(len(sdata))
             keys = c_str_array(str_keys)
+        indptr.append(len(sdata))
         arg_shape_size = mx_uint()
         arg_shape_ndim = ctypes.POINTER(mx_uint)()
         arg_shape_data = ctypes.POINTER(ctypes.POINTER(mx_uint))()


### PR DESCRIPTION
Currently in MXNET if I have below code, infer shape fails:

```
data = mx.sym.Variable('data-gpu0')
prev = mx.sym.Variable('prev')
fc1  = mx.sym.FullyConnected(data=data, name='fc1', num_hidden=128)
fc2  = mx.sym.FullyConnected(data=prev, name='fc2', num_hidden=128)
out  = mx.sym.Activation(data=mx.sym.elemwise_add(fc1, fc2), act_type='relu')
out.infer_shape(data-gpu0=(10,64), prev=(10,128))

  File "<ipython-input-6-3834d8e9b880>", line 2
    out.infer_shape(data-gpu0=(10,64), 'prev'=(10,128))
SyntaxError: keyword can't be an expression
```
Also one cannot infer_shape using variable  as name  i.e
```
data = mx.sym.Variable('data')
prev = mx.sym.Variable('prev')
fc1  = mx.sym.FullyConnected(data=data, name='fc1', num_hidden=128)
fc2  = mx.sym.FullyConnected(data=prev, name='fc2', num_hidden=128)
out  = mx.sym.Activation(data=mx.sym.elemwise_add(fc1, fc2), act_type='relu')
name="data"
out.infer_shape(name=(10,64), prev=(10,128))

MXNetError: [10:24:51] src/c_api/c_api_symbolic.cc:422: InferShapeKeyword argument name name not found.
Candidate arguments:
	[0]data
	[1]fc1_weight
	[2]fc1_bias
	[3]prev
	[4]fc2_weight
	[5]fc2_bias
```

To solve this issue I propose solution in this PR to add support for infer_shape to accept dict, so that user can provide data_names and shapes freely.(This will also be similar to mx.viz.plot_network that takes inputs as dict)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add infer_shape to accept "dict" of input names and shapes as key value pair.


## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

@sandeep-krishnamurthy  @lupesko  @nswamy 