### PR TITLE
Scala inference memory leak fix #11204

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
@@ -224,17 +224,25 @@ class FeedForward private(
     var i = 0
     while (data.hasNext && i != numBatch) {
       val batch = data.next()
-      i += 1
-      ExecutorManager.loadData(batch, dataArrays)
-      predExec.forward(isTrain = false)
-      val padded = batch.pad
-      val realSize = batchSize - padded
-      for ((list, nd) <- outputs zip predExec.outputs) {
-        val ndSliced = nd.slice(0, realSize)
-        list += ndSliced.copy()
-        ndSliced.dispose()
+      try {
+        i += 1
+        ExecutorManager.loadData(batch, dataArrays)
+        predExec.forward(isTrain = false)
+        val padded = batch.pad
+        val realSize = batchSize - padded
+        for ((list, nd) <- outputs zip predExec.outputs) {
+          // The slice is being written to a value so that dispose can be called after the copy.
+          // The one liner nd.slice().copy() leads to leaking the memory of the slice.
+          val ndSliced = nd.slice(0, realSize)
+          try {
+            list += ndSliced.copy()
+          } finally {
+            ndSliced.dispose()
+          }
+        }
+      } finally {
+        batch.dispose()
       }
-      batch.dispose()
     }
     // TODO(Yizhi): we can use Symbol.concat to do the same thing. Can it be more efficient?
     val results = outputs.map(NDArray.concatenate(_))

--- a/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
@@ -230,7 +230,9 @@ class FeedForward private(
       val padded = batch.pad
       val realSize = batchSize - padded
       for ((list, nd) <- outputs zip predExec.outputs) {
-        list += nd.slice(0, realSize)
+        val ndSliced = nd.slice(0, realSize)
+        list += ndSliced.copy()
+        ndSliced.dispose()
       }
       batch.dispose()
     }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
@@ -230,8 +230,9 @@ class FeedForward private(
       val padded = batch.pad
       val realSize = batchSize - padded
       for ((list, nd) <- outputs zip predExec.outputs) {
-        list += nd.slice(0, realSize).copy()
+        list += nd.slice(0, realSize)
       }
+      batch.dispose()
     }
     // TODO(Yizhi): we can use Symbol.concat to do the same thing. Can it be more efficient?
     val results = outputs.map(NDArray.concatenate(_))


### PR DESCRIPTION
## Description ##
This fixes a memory leak that results from the FeedForward.predict method not properly disposing of the results from NDArray.slice().

## Testing ##
### Verifying leak exists ###
To verify that there was a leak in the existing code I created and trained a basic model off of MNIST data then called the predict method inside a while(true) loop then monitored the process's memory usage.

### Verifying leak fix ###
After making the code changes, I repeated the process I had used to verify there was a leak. Memory consumption was much improved and looks to be stable.

### More testing ###
In addition to the tests I ran to monitor memory usage, I also ran the existing tests with 'make scalatest'. All tests pass. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
