### PR TITLE
[MXNET-498] Test MKLDNN backward operators 

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_act.cc
+++ b/src/operator/nn/mkldnn/mkldnn_act.cc
@@ -184,14 +184,22 @@ void MKLDNNActivationBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx
     return;
   }
 
+  NDArray out_buffer = out_grad;
+  if (out_grad.IsView() && out_grad.IsMKLDNNData())
+    out_buffer = out_grad.Reorder2Default();
+
+  NDArray in_buffer = in_data;
+  if (in_data.IsView() && in_data.IsMKLDNNData())
+    in_buffer = in_data.Reorder2Default();
+
   const ActivationParam& param = nnvm::get<ActivationParam>(attrs.parsed);
   TmpMemMgr::Get()->Init(ctx.requested[activation::kTempSpace]);
-  auto diff_dst_memory = out_grad.GetMKLDNNData();
-  auto input_mem = in_data.GetMKLDNNData();
+  auto diff_dst_memory = out_buffer.GetMKLDNNData();
+  auto input_mem = in_buffer.GetMKLDNNData();
   // We need to make sure the two inputs to eltwise_backward has the same memory
   // descriptor. Otherwise, the perf will suffer.
   if (input_mem->get_primitive_desc() != diff_dst_memory->get_primitive_desc())
-    input_mem = in_data.GetMKLDNNDataReorder(diff_dst_memory->get_primitive_desc());
+    input_mem = in_buffer.GetMKLDNNDataReorder(diff_dst_memory->get_primitive_desc());
   mkldnn::memory::primitive_desc data_mpd = input_mem->get_primitive_desc();
   mkldnn::memory::desc data_md = data_mpd.desc();
   mkldnn::memory::desc diff_md = diff_dst_memory->get_primitive_desc().desc();
@@ -201,7 +209,7 @@ void MKLDNNActivationBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx
   auto alg = GetMKLDNNActAlgo(param);
   mkldnn_output_t diff_src_memory;
 
-  MSHADOW_REAL_TYPE_SWITCH(in_data.dtype(), DType, {
+  MSHADOW_REAL_TYPE_SWITCH(in_buffer.dtype(), DType, {
     DType alpha = 0;
     mkldnn::eltwise_forward::desc fw_desc(mkldnn::prop_kind::forward_training,
                                           alg, data_md, alpha);

--- a/src/operator/tensor/elemwise_binary_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_op_basic.cc
@@ -112,7 +112,9 @@ static void _backward_ElemwiseAddEx(const nnvm::NodeAttrs& attrs,
     MKLDNNCopy(attrs, ctx, inputs[0], req[1], outputs[1]);
     return;
   } else if (common::ContainsOnlyStorage(inputs, kDefaultStorage)) {
-    FallBackCompute(ElemwiseBinaryOp::BackwardUseNone<cpu, mshadow_op::identity, mshadow_op::identity>, attrs, ctx, inputs, req, outputs);
+    FallBackCompute(
+        ElemwiseBinaryOp::BackwardUseNone<cpu, mshadow_op::identity, mshadow_op::identity>,
+            attrs, ctx, inputs, req, outputs);
     return;
   }
 #endif

--- a/src/operator/tensor/elemwise_binary_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_op_basic.cc
@@ -111,6 +111,9 @@ static void _backward_ElemwiseAddEx(const nnvm::NodeAttrs& attrs,
     MKLDNNCopy(attrs, ctx, inputs[0], req[0], outputs[0]);
     MKLDNNCopy(attrs, ctx, inputs[0], req[1], outputs[1]);
     return;
+  } else if (common::ContainsOnlyStorage(inputs, kDefaultStorage)) {
+    FallBackCompute(ElemwiseBinaryOp::BackwardUseNone<cpu, mshadow_op::identity, mshadow_op::identity>, attrs, ctx, inputs, req, outputs);
+    return;
   }
 #endif
   ElemwiseBinaryOp::BackwardUseNoneEx<cpu, mshadow_op::identity, mshadow_op::identity>(

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -785,8 +785,8 @@ void TestUnaryOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
 }
 
 void TestUnaryBackwardsOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
-  std::vector<NDArray*> inputs(attrs.num_inputs || 2);
-  std::vector<NDArray*> outputs(attrs.num_outputs || 1);
+  std::vector<NDArray*> inputs(attrs.num_inputs != 0 ? attrs.num_inputs : 2);
+  std::vector<NDArray*> outputs(attrs.num_outputs != 0 ? attrs.num_outputs : 1);
   std::vector<OpReqType> req(1);
   std::vector<DispatchMode> dispatches = attrs.dispatches;
 
@@ -882,8 +882,8 @@ void TestBinaryOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
 }
 
 void TestBinaryBackwardsOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
-  std::vector<NDArray*> inputs(attrs.num_inputs || 3);
-  std::vector<NDArray*> outputs(attrs.num_inputs || 2);
+  std::vector<NDArray*> inputs(attrs.num_inputs != 0 ? attrs.num_inputs : 3);
+  std::vector<NDArray*> outputs(attrs.num_outputs != 0 ? attrs.num_outputs : 2);
   std::vector<OpReqType> req(1);
   std::vector<DispatchMode> dispatches = attrs.dispatches;
 

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -366,6 +366,9 @@ struct NDArrayAttrs {
 struct OpAttrs {
   nnvm::NodeAttrs attrs;
   std::vector<DispatchMode> dispatches;
+  // for backward operators
+  int num_inputs;
+  int num_outputs;
 };
 
 OpAttrs GetCopyOp() {
@@ -380,6 +383,7 @@ OpAttrs GetCopyOp() {
 OpAttrs GetCopyBackwardsOp() {
   OpAttrs attrs;
   attrs.attrs.op = Op::Get("_backward_copy");
+  attrs.num_inputs = 1;
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
   attrs.dispatches[1] = DispatchMode::kFComputeEx;
@@ -777,8 +781,8 @@ void TestUnaryOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
 }
 
 void TestUnaryBackwardsOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
-  std::vector<NDArray*> inputs(2);
-  std::vector<NDArray*> outputs(1);
+  std::vector<NDArray*> inputs(attrs.num_inputs || 2);
+  std::vector<NDArray*> outputs(attrs.num_outputs || 1);
   std::vector<OpReqType> req(1);
   std::vector<DispatchMode> dispatches = attrs.dispatches;
 
@@ -874,8 +878,8 @@ void TestBinaryOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
 }
 
 void TestBinaryBackwardsOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
-  std::vector<NDArray*> inputs(3);
-  std::vector<NDArray*> outputs(2);
+  std::vector<NDArray*> inputs(attrs.num_inputs || 3);
+  std::vector<NDArray*> outputs(attrs.num_inputs || 2);
   std::vector<OpReqType> req(1);
   std::vector<DispatchMode> dispatches = attrs.dispatches;
 

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -702,7 +702,7 @@ void TestUnaryOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
         PrintVerifyMsg(in_arr, out_arr);
         Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
                                     outputs, req, dispatch, mxnet::OpStatePtr());
-        out_arr.arr.WaitToRead();
+        outputs[0]->WaitToRead();
         verify_fn(inputs, outputs);
       }
     }

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -884,7 +884,7 @@ void TestBinaryOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
 void TestBinaryBackwardsOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
   std::vector<NDArray*> inputs(attrs.num_inputs != 0 ? attrs.num_inputs : 3);
   std::vector<NDArray*> outputs(attrs.num_outputs != 0 ? attrs.num_outputs : 2);
-  std::vector<OpReqType> req(1);
+  std::vector<OpReqType> req(2);
   std::vector<DispatchMode> dispatches = attrs.dispatches;
 
   TestArrayShapes tas = GetTestArrayShapes();
@@ -897,6 +897,7 @@ void TestBinaryBackwardsOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
                                                                InitDefaultArray);
       for (auto out_arr : out_arrs) {
         req[0] = kWriteTo;
+        req[1] = kWriteTo;
         inputs[0] = &in_arr1.arr;
         inputs[1] = &in_arr1.arr;
         inputs[2] = &in_arr1.arr;

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -755,25 +755,25 @@ void TestUnaryBackwardsOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc ver
       }
     }
   }
-//  for (auto dispatch : dispatches) {
-//    in_arrs = GetTestInputArrays(init_fn);
-//    for (auto arr : in_arrs) {
-//      // If the array is a view, we shouldn't write data to it.
-//      if (arr.arr.IsView())
-//        continue;
-//
-//      NDArrayAttrs orig(arr.arr.Copy(arr.arr.ctx()), "InPlace Copy");
-//      req[0] = kWriteInplace;
-//      inputs[0] = &arr.arr;
-//      outputs[0] = &arr.arr;
-//      PrintVerifyMsg(orig, arr);
-//      Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req,
-//                                  dispatch, mxnet::OpStatePtr());
-//      arr.arr.WaitToRead();
-//      inputs[0] = &orig.arr;
-//      verify_fn(inputs, *outputs[0]);
-//    }
-//  }
+  for (auto dispatch : dispatches) {
+    in_arrs = GetTestInputArrays(init_fn);
+    for (auto arr : in_arrs) {
+      // If the array is a view, we shouldn't write data to it.
+      if (arr.arr.IsView())
+        continue;
+
+      NDArrayAttrs orig(arr.arr.Copy(arr.arr.ctx()), "InPlace Copy");
+      req[0] = kWriteInplace;
+      inputs[0] = &arr.arr;
+      inputs[1] = &arr.arr;
+      outputs[0] = &arr.arr;
+      PrintVerifyMsg(orig, arr);
+      Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req,
+                                  dispatch, mxnet::OpStatePtr());
+      arr.arr.WaitToRead();
+      verify_fn({&orig.arr, &orig.arr}, *outputs[0]);
+    }
+  }
 }
 
 void TestBinaryOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
@@ -830,6 +830,11 @@ TEST(IMPERATIVE, UnaryOp) {
   OpAttrs attrs = GetCopyOp();
   TestUnaryOp(attrs, InitDefaultArray, VerifyCopyResult);
 }
+
+//TEST(IMPERATIVE, CopyBackwardsOp) {
+//  OpAttrs attrs = GetCopyBackwardsOp();
+//  TestUnaryBackwardsOp(attrs, InitDefaultArray, VerifyCopyBackwardsResult);
+//}
 
 TEST(IMPERATIVE, ActOp) {
   OpAttrs attrs = GetReluOp();

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -659,16 +659,6 @@ void VerifySumResult(const std::vector<NDArray *> &in_arrs,
     ASSERT_EQ(d1[i] + d2[i], o[i]);
 }
 
-void VerifyCopyBackwardsResult(const std::vector<NDArray *> &in_arrs,
-                               const std::vector<NDArray *> &out_arrs) {
-  NDArray output_grads = in_arrs[0]->Reorder2Default();
-  NDArray input_grads = out_arrs[0]->Reorder2Default();
-  mshadow::default_real_t *og = output_grads.data().dptr<mshadow::default_real_t>();
-  mshadow::default_real_t *ig = input_grads.data().dptr<mshadow::default_real_t>();
-  for (size_t i = 0; i < output_grads.shape().Size(); i++)
-    ASSERT_EQ(og[i], ig[i]);
-}
-
 void VerifyActBackwardsResult(const std::vector<NDArray *> &in_arrs,
                               const std::vector<NDArray *> &out_arrs) {
   NDArray tmp1 = in_arrs[0]->Reorder2Default();  // out grads
@@ -797,7 +787,7 @@ TEST(IMPERATIVE, UnaryOp) {
 
 TEST(IMPERATIVE, CopyBackwardsOp) {
   OpAttrs attrs = GetCopyBackwardsOp();
-  TestOp(attrs, InitDefaultArray, VerifyCopyBackwardsResult);
+  TestOp(attrs, InitDefaultArray, VerifyCopyResult);
 }
 
 TEST(IMPERATIVE, ActOp) {

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -123,8 +123,9 @@ static void VerifyDefMem(const mkldnn::memory &mem) {
       = static_cast<mshadow::default_real_t *>(mem.get_data_handle());
   size_t size = pd.get_size() / sizeof(mshadow::default_real_t);
   size_t num_same = 0;
-  for (size_t i = 0; i < size; i++)
-    num_same += data[i] == static_cast<mshadow::default_real_t>(i);
+  int shift = size >> 1;
+  for (int i = 0; i < size; i++)
+    num_same += data[i] == static_cast<mshadow::default_real_t>(i - shift);
   EXPECT_EQ(num_same, size);
 }
 
@@ -803,7 +804,7 @@ void TestOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
   }
 }
 
-TEST(IMPERATIVE, UnaryOp) {
+TEST(IMPERATIVE, CopyOp) {
   OpAttrs attrs = GetCopyOp();
   TestOp(attrs, VerifyCopyResult);
 }
@@ -823,12 +824,12 @@ TEST(IMPERATIVE, ActBackwardsOp) {
   TestOp(attrs, VerifyActBackwardsResult);
 }
 
-TEST(IMPERATIVE, BinaryOp) {
+TEST(IMPERATIVE, SumOp) {
   OpAttrs attrs = GetSumOp();
   TestOp(attrs, VerifySumResult);
 }
 
-TEST(IMPERATIVE, BinaryBackwardsOp) {
+TEST(IMPERATIVE, SumBackwardsOp) {
   OpAttrs attrs = GetSumBackwardsOp();
   TestOp(attrs, VerifySumBackwardsResult);
 }

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -730,7 +730,7 @@ void TestUnaryOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
 }
 
 void TestUnaryBackwardsOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
-  std::vector<NDArray*> inputs(1);
+  std::vector<NDArray*> inputs(2);
   std::vector<NDArray*> outputs(1);
   std::vector<OpReqType> req(1);
   std::vector<DispatchMode> dispatches = attrs.dispatches;
@@ -744,9 +744,9 @@ void TestUnaryBackwardsOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc ver
       std::vector<NDArrayAttrs> out_arrs = GetTestOutputArrays(in_arr.arr.shape(), pds, init_fn);
       for (auto out_arr : out_arrs) {
         req[0] = kWriteTo;
-        inputs[0] = &in_arr.arr; // output grads
-        inputs[0] = &in_arr.arr; // input
-        outputs[0] = &out_arr.arr;
+        inputs[0] = &out_arr.arr; // output grads
+        inputs[1] = &out_arr.arr; // input
+        outputs[0] = &in_arr.arr;
         PrintVerifyMsg(in_arr, out_arr);
         Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
                                     outputs, req, dispatch, mxnet::OpStatePtr());

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -850,6 +850,7 @@ void TestBinaryOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
         inputs[0] = &in_arr1.arr;
         inputs[1] = &in_arr1.arr;
         outputs[0] = &out_arr.arr;
+        PrintVerifyMsg(in_arr1, out_arr);
         Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
                                     outputs, req, dispatch, mxnet::OpStatePtr());
         out_arr.arr.WaitToRead();
@@ -865,17 +866,18 @@ void TestBinaryOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
       if (arr.arr.IsView())
         continue;
 
-      NDArray orig = arr.arr.Copy(arr.arr.ctx());
+      NDArrayAttrs orig(arr.arr.Copy(arr.arr.ctx()), "InPlace Copy");
       req[0] = kWriteInplace;
       inputs[0] = &arr.arr;
       inputs[1] = &arr.arr;
       outputs[0] = &arr.arr;
+      PrintVerifyMsg(orig, arr);
       Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req,
                                   dispatch, mxnet::OpStatePtr());
       arr.arr.WaitToRead();
       std::vector<NDArray*> orig_inputs(2);
-      orig_inputs[0] = &orig;
-      orig_inputs[1] = &orig;
+      orig_inputs[0] = &orig.arr;
+      orig_inputs[1] = &orig.arr;
       verify_fn(orig_inputs, outputs);
     }
   }
@@ -905,6 +907,7 @@ void TestBinaryBackwardsOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
         NDArray tmp2 = out_arr.arr.Copy(in_arr1.arr.ctx());
         outputs[0] = &tmp1;
         outputs[1] = &tmp2;
+        PrintVerifyMsg(in_arr1, out_arr);
         Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
                                     outputs, req, dispatch, mxnet::OpStatePtr());
         outputs[0]->WaitToRead();
@@ -914,27 +917,25 @@ void TestBinaryBackwardsOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
     }
   }
 
-//  for (auto dispatch : dispatches) {
-//    in_arrs = GetTestInputArrays(InitDefaultArray);
-//    for (auto arr : in_arrs) {
-//      // If the array is a view, we shouldn't write data to it.
-//      if (arr.arr.IsView())
-//        continue;
-//
-//      NDArray orig = arr.arr.Copy(arr.arr.ctx());
-//      req[0] = kWriteInplace;
-//      inputs[0] = &arr.arr;
-//      inputs[1] = &arr.arr;
-//      outputs[0] = &arr.arr;
-//      Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req,
-//                                  dispatch, mxnet::OpStatePtr());
-//      arr.arr.WaitToRead();
-//      std::vector<NDArray*> orig_inputs(2);
-//      orig_inputs[0] = &orig;
-//      orig_inputs[1] = &orig;
-//      verify_fn({&orig, &orig, &orig}, outputs);
-//    }
-//  }
+  for (auto dispatch : dispatches) {
+    in_arrs = GetTestInputArrays(InitDefaultArray);
+    for (auto arr : in_arrs) {
+      // If the array is a view, we shouldn't write data to it.
+      if (arr.arr.IsView())
+        continue;
+
+      NDArrayAttrs orig(arr.arr.Copy(arr.arr.ctx()), "InPlace Copy");
+      req[0] = kWriteInplace;
+      inputs[0] = &arr.arr;
+      inputs[1] = &arr.arr;
+      outputs[0] = &arr.arr;
+      PrintVerifyMsg(orig, arr);
+      Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req,
+                                  dispatch, mxnet::OpStatePtr());
+      arr.arr.WaitToRead();
+      verify_fn({&orig.arr, &orig.arr}, outputs);
+    }
+  }
 }
 
 TEST(IMPERATIVE, UnaryOp) {

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -771,7 +771,7 @@ void TestUnaryBackwardsOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc ver
       Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req,
                                   dispatch, mxnet::OpStatePtr());
       arr.arr.WaitToRead();
-      verify_fn({&orig.arr, &orig.arr}, *outputs[0]);
+      verify_fn({&orig.arr, &orig.arr}, outputs);
     }
   }
 }

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -366,7 +366,6 @@ struct NDArrayAttrs {
 struct OpAttrs {
   nnvm::NodeAttrs attrs;
   std::vector<DispatchMode> dispatches;
-  // for backward operators
   int num_inputs;
   int num_outputs;
 };

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -376,6 +376,15 @@ OpAttrs GetCopyOp() {
   return attrs;
 }
 
+OpAttrs GetCopyBackwardsOp() {
+  OpAttrs attrs;
+  attrs.attrs.op = Op::Get("_backward_copy");
+  attrs.dispatches.resize(2);
+  attrs.dispatches[0] = DispatchMode::kFCompute;
+  attrs.dispatches[1] = DispatchMode::kFComputeEx;
+  return attrs;
+}
+
 OpAttrs GetReluOp() {
   OpAttrs attrs;
   attrs.attrs.op = Op::Get("Activation");

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -644,7 +644,7 @@ void VerifyActBackwardsResult(const std::vector<NDArray *> &in_arrs, const std::
   mshadow::default_real_t *d3 = static_cast<mshadow::default_real_t*>(blob3.dptr_);
   EXPECT_EQ(tmp1.shape().Size(), tmp2.shape().Size());
   for (size_t i = 0; i < tmp1.shape().Size(); i++) {
-    EXPECT_EQ(int(d2[i] > 0) * d1[i], d3[i]);
+    EXPECT_EQ(d2[i] > 0 ? d1[i] : 0, d3[i]);
   }
 }
 

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -899,6 +899,7 @@ void TestBinaryBackwardsOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
         Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
                                     outputs, req, dispatch, mxnet::OpStatePtr());
         outputs[0]->WaitToRead();
+        outputs[1]->WaitToRead();
         verify_fn(inputs, outputs);
       }
     }

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -845,7 +845,6 @@ TEST(MKLDNN_BASE, MKLDNNSum) {
     PrintVerifyMsg(orig_arr, in_arr);
     InitMKLDNNArray(&orig_arr.arr, input_mem->get_primitive_desc(), InitDefaultArray);
     orig_arr.arr.CopyFrom(*input_mem);
-    auto old_mem = orig_arr.arr.GetMKLDNNData();
     op::MKLDNNSum(*input_mem, *input_mem2, *input_mem);
     MKLDNNStream::Get()->Submit();
     VerifySumResult({&orig_arr.arr, &in_arr2.arr}, {&in_arr.arr});

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -428,7 +428,7 @@ OpAttrs GetSumOp() {
 
 OpAttrs GetSumBackwardsOp() {
   OpAttrs attrs;
-  attrs.attrs.op = Op::Get("_backwards_elemwise_add");
+  attrs.attrs.op = Op::Get("_backward_add");
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
   attrs.dispatches[1] = DispatchMode::kFComputeEx;
@@ -875,7 +875,7 @@ void TestBinaryOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
 
 void TestBinaryBackwardsOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
   std::vector<NDArray*> inputs(3);
-  std::vector<NDArray*> outputs(1);
+  std::vector<NDArray*> outputs(2);
   std::vector<OpReqType> req(1);
   std::vector<DispatchMode> dispatches = attrs.dispatches;
 
@@ -892,7 +892,10 @@ void TestBinaryBackwardsOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
         inputs[0] = &out_arr.arr;
         inputs[1] = &out_arr.arr;
         inputs[2] = &out_arr.arr;
-        outputs[0] = &in_arr1.arr;
+        NDArray tmp1 = in_arr1.arr.Copy(in_arr1.arr.ctx());
+        NDArray tmp2 = in_arr1.arr.Copy(in_arr1.arr.ctx());
+        outputs[0] = &tmp1;
+        outputs[1] = &tmp2;
         Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
                                     outputs, req, dispatch, mxnet::OpStatePtr());
         outputs[0]->WaitToRead();

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -791,9 +791,9 @@ void TestUnaryBackwardsOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc ver
       std::vector<NDArrayAttrs> out_arrs = GetTestOutputArrays(in_arr.arr.shape(), pds, init_fn);
       for (auto out_arr : out_arrs) {
         req[0] = kWriteTo;
-        inputs[0] = &out_arr.arr; // output grads
-        inputs[1] = &out_arr.arr; // input
-        outputs[0] = &in_arr.arr;
+        inputs[0] = &in_arr.arr; // output grads
+        inputs[1] = &in_arr.arr; // input
+        outputs[0] = &out_arr.arr;
         PrintVerifyMsg(in_arr, out_arr);
         Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
                                     outputs, req, dispatch, mxnet::OpStatePtr());
@@ -889,11 +889,11 @@ void TestBinaryBackwardsOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
                                                                InitDefaultArray);
       for (auto out_arr : out_arrs) {
         req[0] = kWriteTo;
-        inputs[0] = &out_arr.arr;
-        inputs[1] = &out_arr.arr;
-        inputs[2] = &out_arr.arr;
-        NDArray tmp1 = in_arr1.arr.Copy(in_arr1.arr.ctx());
-        NDArray tmp2 = in_arr1.arr.Copy(in_arr1.arr.ctx());
+        inputs[0] = &in_arr1.arr;
+        inputs[1] = &in_arr1.arr;
+        inputs[2] = &in_arr1.arr;
+        NDArray tmp1 = out_arr.arr.Copy(in_arr1.arr.ctx());
+        NDArray tmp2 = out_arr.arr.Copy(in_arr1.arr.ctx());
         outputs[0] = &tmp1;
         outputs[1] = &tmp2;
         Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
@@ -904,27 +904,27 @@ void TestBinaryBackwardsOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
     }
   }
 
-  for (auto dispatch : dispatches) {
-    in_arrs = GetTestInputArrays(InitDefaultArray);
-    for (auto arr : in_arrs) {
-      // If the array is a view, we shouldn't write data to it.
-      if (arr.arr.IsView())
-        continue;
-
-      NDArray orig = arr.arr.Copy(arr.arr.ctx());
-      req[0] = kWriteInplace;
-      inputs[0] = &arr.arr;
-      inputs[1] = &arr.arr;
-      outputs[0] = &arr.arr;
-      Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req,
-                                  dispatch, mxnet::OpStatePtr());
-      arr.arr.WaitToRead();
-      std::vector<NDArray*> orig_inputs(2);
-      orig_inputs[0] = &orig;
-      orig_inputs[1] = &orig;
-      verify_fn({&orig, &orig, &orig}, outputs);
-    }
-  }
+//  for (auto dispatch : dispatches) {
+//    in_arrs = GetTestInputArrays(InitDefaultArray);
+//    for (auto arr : in_arrs) {
+//      // If the array is a view, we shouldn't write data to it.
+//      if (arr.arr.IsView())
+//        continue;
+//
+//      NDArray orig = arr.arr.Copy(arr.arr.ctx());
+//      req[0] = kWriteInplace;
+//      inputs[0] = &arr.arr;
+//      inputs[1] = &arr.arr;
+//      outputs[0] = &arr.arr;
+//      Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req,
+//                                  dispatch, mxnet::OpStatePtr());
+//      arr.arr.WaitToRead();
+//      std::vector<NDArray*> orig_inputs(2);
+//      orig_inputs[0] = &orig;
+//      orig_inputs[1] = &orig;
+//      verify_fn({&orig, &orig, &orig}, outputs);
+//    }
+//  }
 }
 
 TEST(IMPERATIVE, UnaryOp) {

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -121,7 +121,7 @@ static void InitNegPosArray(NDArray *arr, bool is_rand = false) {
 }
 
 using InitFunc = std::function<void (NDArray *arr, bool is_rand)>;
-using VerifyFunc = std::function<void (const std::vector<NDArray *> &in_arrs, const std::vector<NDArray *> &in_arrs)>;
+using VerifyFunc = std::function<void (const std::vector<NDArray *> &in_arrs, const std::vector<NDArray *> &out_arrs)>;
 
 // Init arrays with the specified layout.
 static void InitMKLDNNArray(NDArray *arr, const mkldnn::memory::primitive_desc &pd,

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -121,7 +121,8 @@ static void InitNegPosArray(NDArray *arr, bool is_rand = false) {
 }
 
 using InitFunc = std::function<void (NDArray *arr, bool is_rand)>;
-using VerifyFunc = std::function<void (const std::vector<NDArray *> &in_arrs, const std::vector<NDArray *> &out_arrs)>;
+using VerifyFunc = std::function<void (const std::vector<NDArray *> &in_arrs,
+    const std::vector<NDArray *> &out_arrs)>;
 
 // Init arrays with the specified layout.
 static void InitMKLDNNArray(NDArray *arr, const mkldnn::memory::primitive_desc &pd,
@@ -604,7 +605,8 @@ std::vector<NDArrayAttrs> GetTestOutputArrays(const TShape &shape,
   return in_arrs;
 }
 
-void VerifyCopyResult(const std::vector<NDArray *> &in_arrs, const std::vector<NDArray *> &out_arrs) {
+void VerifyCopyResult(const std::vector<NDArray *> &in_arrs,
+                      const std::vector<NDArray *> &out_arrs) {
   NDArray tmp1 = in_arrs[0]->Reorder2Default();
   NDArray tmp2 = out_arrs[0]->Reorder2Default();
   EXPECT_EQ(tmp1.shape().Size(), tmp2.shape().Size());
@@ -614,7 +616,8 @@ void VerifyCopyResult(const std::vector<NDArray *> &in_arrs, const std::vector<N
                    tmp1.shape().Size() * sizeof(mshadow::default_real_t)), 0);
 }
 
-void VerifyActResult(const std::vector<NDArray *> &in_arrs, const std::vector<NDArray *> &out_arrs) {
+void VerifyActResult(const std::vector<NDArray *> &in_arrs,
+                     const std::vector<NDArray *> &out_arrs) {
   NDArray tmp1 = in_arrs[0]->Reorder2Default();
   NDArray tmp2 = out_arrs[0]->Reorder2Default();
   TBlob blob1 = tmp1.data();
@@ -627,7 +630,8 @@ void VerifyActResult(const std::vector<NDArray *> &in_arrs, const std::vector<ND
   }
 }
 
-void VerifySumResult(const std::vector<NDArray *> &in_arrs, const std::vector<NDArray *> &out_arrs) {
+void VerifySumResult(const std::vector<NDArray *> &in_arrs,
+                     const std::vector<NDArray *> &out_arrs) {
   NDArray in1 = in_arrs[0]->Reorder2Default();
   NDArray in2 = in_arrs[1]->Reorder2Default();
   NDArray out = out_arrs[0]->Reorder2Default();
@@ -641,7 +645,8 @@ void VerifySumResult(const std::vector<NDArray *> &in_arrs, const std::vector<ND
     ASSERT_EQ(d1[i] + d2[i], o[i]);
 }
 
-void VerifyCopyBackwardsResult(const std::vector<NDArray *> &in_arrs, const std::vector<NDArray *> &out_arrs) {
+void VerifyCopyBackwardsResult(const std::vector<NDArray *> &in_arrs,
+                               const std::vector<NDArray *> &out_arrs) {
   NDArray tmp1 = out_arrs[0]->Reorder2Default();
   TBlob blob1 = tmp1.data();
   mshadow::default_real_t *d1 = static_cast<mshadow::default_real_t*>(blob1.dptr_);
@@ -649,10 +654,11 @@ void VerifyCopyBackwardsResult(const std::vector<NDArray *> &in_arrs, const std:
     ASSERT_EQ(1, d1[i]);
 }
 
-void VerifyActBackwardsResult(const std::vector<NDArray *> &in_arrs, const std::vector<NDArray *> &out_arrs) {
-  NDArray tmp1 = in_arrs[0]->Reorder2Default(); // out grads
-  NDArray tmp2 = in_arrs[1]->Reorder2Default(); // input
-  NDArray tmp3 = out_arrs[0]->Reorder2Default(); // input grads
+void VerifyActBackwardsResult(const std::vector<NDArray *> &in_arrs,
+                              const std::vector<NDArray *> &out_arrs) {
+  NDArray tmp1 = in_arrs[0]->Reorder2Default();  // out grads
+  NDArray tmp2 = in_arrs[1]->Reorder2Default();  // input
+  NDArray tmp3 = out_arrs[0]->Reorder2Default();  // input grads
   TBlob blob1 = tmp1.data();
   TBlob blob2 = tmp2.data();
   TBlob blob3 = tmp3.data();

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -751,10 +751,10 @@ void TestOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
       for (auto out_arr : out_arrs) {
         for (int i = 0; i < attrs.num_inputs; i++)
           inputs[i] = &in_arr.arr;
-        for (int i = 0; i < attrs.num_outputs; i++)
+        for (int i = 0; i < attrs.num_outputs; i++) {
           req[i] = kWriteTo;
-
-        outputs[0] = &out_arr.arr;
+          outputs[i] = &out_arr.arr;
+        }
         PrintVerifyMsg(in_arr, out_arr);
         Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
                                     outputs, req, dispatch, mxnet::OpStatePtr());
@@ -773,9 +773,10 @@ void TestOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
       NDArrayAttrs orig(arr.arr.Copy(arr.arr.ctx()), "InPlace Copy");
       for (int i = 0; i < attrs.num_inputs; i++)
         inputs[i] = &arr.arr;
-      for (int i = 0; i < attrs.num_outputs; i++)
+      for (int i = 0; i < attrs.num_outputs; i++) {
         req[i] = kWriteInplace;
-      outputs[0] = &arr.arr;
+        outputs[i] = &arr.arr;
+      }
       PrintVerifyMsg(orig, arr);
       Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req,
                                   dispatch, mxnet::OpStatePtr());

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -98,7 +98,7 @@ static void InitDefaultArray(NDArray *arr, bool is_rand = false) {
   size_t size = blob.Size();
   for (size_t i = 0; i < size; i++) {
     if (is_rand) {
-      data[i] = std::rand();
+      data[i] = std::rand() % 100;
     } else {
       data[i] = i;
     }
@@ -113,7 +113,7 @@ static void InitNegPosArray(NDArray *arr, bool is_rand = false) {
 
   for (int i = 0; i < size; i++)
     if (is_rand) {
-      data[i] = std::rand() - INT_MAX / 2;
+      data[i] = (std::rand() % 100) - 50;
     } else {
       int shift = size >> 1;
       data[i] = i - shift;

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -384,6 +384,7 @@ OpAttrs GetCopyBackwardsOp() {
   OpAttrs attrs;
   attrs.attrs.op = Op::Get("_backward_copy");
   attrs.num_inputs = 1;
+  attrs.num_outputs = 1;
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
   attrs.dispatches[1] = DispatchMode::kFComputeEx;
@@ -406,6 +407,7 @@ OpAttrs GetReluBackwardsOp() {
   attrs.attrs.op = Op::Get("_backward_Activation");
   attrs.attrs.dict.insert({"act_type", "relu"});
   attrs.attrs.op->attr_parser(&attrs.attrs);
+  attrs.num_inputs = 2;
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
   attrs.dispatches[1] = DispatchMode::kFComputeEx;
@@ -433,6 +435,8 @@ OpAttrs GetSumOp() {
 OpAttrs GetSumBackwardsOp() {
   OpAttrs attrs;
   attrs.attrs.op = Op::Get("_backward_add");
+  attrs.num_inputs = 1;
+  attrs.num_outputs = 2;
   attrs.dispatches.resize(2);
   attrs.dispatches[0] = DispatchMode::kFCompute;
   attrs.dispatches[1] = DispatchMode::kFComputeEx;

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -758,7 +758,8 @@ void TestOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
         PrintVerifyMsg(in_arr, out_arr);
         Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs,
                                     outputs, req, dispatch, mxnet::OpStatePtr());
-        outputs[0]->WaitToRead();
+        for (auto output : outputs)
+          output->WaitToRead();
         verify_fn(inputs, outputs);
       }
     }
@@ -780,8 +781,8 @@ void TestOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
       PrintVerifyMsg(orig, arr);
       Imperative::Get()->InvokeOp(Context(), attrs.attrs, inputs, outputs, req,
                                   dispatch, mxnet::OpStatePtr());
-      arr.arr.WaitToRead();
-      inputs[0] = &orig.arr;
+      for (auto output : outputs)
+        output->WaitToRead();
       std::vector<NDArray *> orig_inputs(attrs.num_inputs);
       for (int i = 0; i < attrs.num_inputs; i++)
         orig_inputs[i] = &orig.arr;

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -708,46 +708,6 @@ TEST(MKLDNN_NDArray, CopyFrom) {
   }
 }
 
-TEST(MKLDNN_BASE, MKLDNNSum) {
-  std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays();
-  std::vector<NDArrayAttrs> in_arrs2 = GetTestInputArrays(true);
-  TestArrayShapes tas = GetTestArrayShapes();
-  std::vector<mkldnn::memory::primitive_desc> pds = tas.pds;
-
-  for (int i = 0; i < in_arrs.size(); i++) {
-    auto in_arr = in_arrs[i];
-    auto in_arr2 = in_arrs2[i];
-    std::vector<NDArrayAttrs> out_arrs = GetTestOutputArrays(in_arr.arr.shape(), pds);
-    if (!SupportMKLDNN(in_arr.arr) || !in_arr.arr.IsMKLDNNData() || in_arr.arr.IsView())
-      continue;
-
-    for (auto out_arr : out_arrs) {
-      auto in_mem1 = in_arr.arr.GetMKLDNNData();
-      auto in_mem2 = in_arr2.arr.GetMKLDNNData();
-      auto out_mem = out_arr.arr.GetMKLDNNData(in_mem1->get_primitive_desc());
-
-      // TODO(alexzai) : remove this noop when by reordering in MKLDNNSum
-      if (out_mem == nullptr)
-        continue;
-      PrintVerifyMsg(in_arr, in_arr);
-      op::MKLDNNSum(*in_mem1, *in_mem2, *out_mem);
-      MKLDNNStream::Get()->Submit();
-      VerifySumResult({&in_arr.arr, &in_arr2.arr}, {&out_arr.arr});
-    }
-
-    // in place
-    auto input_mem = in_arr.arr.GetMKLDNNData();
-    auto input_mem2 = in_arr2.arr.GetMKLDNNData();
-    NDArrayAttrs orig_arr(in_arr.arr.Copy(in_arr.arr.ctx()), "In Place Copy");
-    PrintVerifyMsg(orig_arr, in_arr);
-    InitMKLDNNArray(&orig_arr.arr, input_mem->get_primitive_desc());
-    orig_arr.arr.CopyFrom(*input_mem);
-    op::MKLDNNSum(*input_mem, *input_mem2, *input_mem);
-    MKLDNNStream::Get()->Submit();
-    VerifySumResult({&orig_arr.arr, &in_arr2.arr}, {&in_arr.arr});
-  }
-}
-
 void TestOp(const OpAttrs &attrs, VerifyFunc verify_fn) {
   std::vector<NDArray*> inputs(attrs.num_inputs);
   std::vector<NDArray*> outputs(attrs.num_outputs);
@@ -832,6 +792,46 @@ TEST(IMPERATIVE, SumOp) {
 TEST(IMPERATIVE, SumBackwardsOp) {
   OpAttrs attrs = GetSumBackwardsOp();
   TestOp(attrs, VerifySumBackwardsResult);
+}
+
+TEST(MKLDNN_BASE, MKLDNNSum) {
+  std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays();
+  std::vector<NDArrayAttrs> in_arrs2 = GetTestInputArrays(true);
+  TestArrayShapes tas = GetTestArrayShapes();
+  std::vector<mkldnn::memory::primitive_desc> pds = tas.pds;
+
+  for (int i = 0; i < in_arrs.size(); i++) {
+    auto in_arr = in_arrs[i];
+    auto in_arr2 = in_arrs2[i];
+    std::vector<NDArrayAttrs> out_arrs = GetTestOutputArrays(in_arr.arr.shape(), pds);
+    if (!SupportMKLDNN(in_arr.arr) || !in_arr.arr.IsMKLDNNData() || in_arr.arr.IsView())
+      continue;
+
+    for (auto out_arr : out_arrs) {
+      auto in_mem1 = in_arr.arr.GetMKLDNNData();
+      auto in_mem2 = in_arr2.arr.GetMKLDNNData();
+      auto out_mem = out_arr.arr.GetMKLDNNData(in_mem1->get_primitive_desc());
+
+      // TODO(alexzai) : remove this noop when by reordering in MKLDNNSum
+      if (out_mem == nullptr)
+        continue;
+      PrintVerifyMsg(in_arr, in_arr);
+      op::MKLDNNSum(*in_mem1, *in_mem2, *out_mem);
+      MKLDNNStream::Get()->Submit();
+      VerifySumResult({&in_arr.arr, &in_arr2.arr}, {&out_arr.arr});
+    }
+
+    // in place
+    auto input_mem = in_arr.arr.GetMKLDNNData();
+    auto input_mem2 = in_arr2.arr.GetMKLDNNData();
+    NDArrayAttrs orig_arr(in_arr.arr.Copy(in_arr.arr.ctx()), "In Place Copy");
+    PrintVerifyMsg(orig_arr, in_arr);
+    InitMKLDNNArray(&orig_arr.arr, input_mem->get_primitive_desc());
+    orig_arr.arr.CopyFrom(*input_mem);
+    op::MKLDNNSum(*input_mem, *input_mem2, *input_mem);
+    MKLDNNStream::Get()->Submit();
+    VerifySumResult({&orig_arr.arr, &in_arr2.arr}, {&in_arr.arr});
+  }
 }
 
 #endif

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -644,7 +644,7 @@ void VerifyActBackwardsResult(const std::vector<NDArray *> &in_arrs, const std::
   mshadow::default_real_t *d3 = static_cast<mshadow::default_real_t*>(blob3.dptr_);
   EXPECT_EQ(tmp1.shape().Size(), tmp2.shape().Size());
   for (size_t i = 0; i < tmp1.shape().Size(); i++) {
-    EXPECT_EQ(d2[i] > 0 ? d1[i] : 0, d3[i]);
+    ASSERT_EQ(d2[i] > 0 ? d1[i] : 0, d3[i]);
   }
 }
 

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -632,6 +632,14 @@ void VerifySumResult(const std::vector<NDArray *> &in_arrs, const std::vector<ND
     ASSERT_EQ(d1[i] + d2[i], o[i]);
 }
 
+void VerifyCopyBackwardsResult(const std::vector<NDArray *> &in_arrs, const std::vector<NDArray *> &out_arrs) {
+  NDArray tmp1 = out_arrs[0]->Reorder2Default();
+  TBlob blob1 = tmp1.data();
+  mshadow::default_real_t *d1 = static_cast<mshadow::default_real_t*>(blob1.dptr_);
+  for (size_t i = 0; i < tmp1.shape().Size(); i++)
+    ASSERT_EQ(1, d1[i]);
+}
+
 void VerifyActBackwardsResult(const std::vector<NDArray *> &in_arrs, const std::vector<NDArray *> &out_arrs) {
   NDArray tmp1 = in_arrs[0]->Reorder2Default(); // out grads
   NDArray tmp2 = in_arrs[1]->Reorder2Default(); // input
@@ -831,10 +839,10 @@ TEST(IMPERATIVE, UnaryOp) {
   TestUnaryOp(attrs, InitDefaultArray, VerifyCopyResult);
 }
 
-//TEST(IMPERATIVE, CopyBackwardsOp) {
-//  OpAttrs attrs = GetCopyBackwardsOp();
-//  TestUnaryBackwardsOp(attrs, InitDefaultArray, VerifyCopyBackwardsResult);
-//}
+TEST(IMPERATIVE, CopyBackwardsOp) {
+  OpAttrs attrs = GetCopyBackwardsOp();
+  TestUnaryBackwardsOp(attrs, InitDefaultArray, VerifyCopyBackwardsResult);
+}
 
 TEST(IMPERATIVE, ActOp) {
   OpAttrs attrs = GetReluOp();

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -738,7 +738,7 @@ TEST(MKLDNN_NDArray, CopyFrom) {
 void TestOp(const OpAttrs &attrs, InitFunc init_fn, VerifyFunc verify_fn) {
   std::vector<NDArray*> inputs(attrs.num_inputs);
   std::vector<NDArray*> outputs(attrs.num_outputs);
-  std::vector<OpReqType> req(attrs.num_inputs);
+  std::vector<OpReqType> req(attrs.num_outputs);
   std::vector<DispatchMode> dispatches = attrs.dispatches;
 
   TestArrayShapes tas = GetTestArrayShapes();


### PR DESCRIPTION
## Description ##
add backwards C++ unit tests for mkldnn operators

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Backwards activation can handle view/mkldnn input/output
- [x] add unit test for backwards copy
- [x] add unit test for backwards act
- [x] add unit test for backwards sum
- [x] remove initfn interface and merge InitDefaultArray/InitPosNegArray. always init fixture arrays with pos/negative values
- [x] Make TestOp function that can handle variable inputs / backwards

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
