### PR TITLE
Bring back MXNET_GPU_COPY_NTHREADS env variable

### DIFF
--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -14,7 +14,7 @@ export MXNET_GPU_WORKER_NTHREADS=3
   - Values: Int ```(default=2)```
   - The maximum number of threads to use on each GPU. This parameter is used to parallelize the computation within a single GPU card.
 * MXNET_GPU_COPY_NTHREADS
-  - Values: Int ```(default=1)```
+  - Values: Int ```(default=2)```
   - The maximum number of concurrent threads that do the memory copy job on each GPU.
 * MXNET_CPU_WORKER_NTHREADS
   - Values: Int ```(default=1)```

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -76,6 +76,7 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
     if (is_worker_) return;
     gpu_worker_nthreads_ = common::GetNumThreadsPerGPU();
     cpu_worker_nthreads_ = dmlc::GetEnv("MXNET_CPU_WORKER_NTHREADS", 1);
+    gpu_copy_nthreads_ = dmlc::GetEnv("MXNET_GPU_COPY_NTHREADS", 2);
     // create CPU task
     int cpu_priority_nthreads = dmlc::GetEnv("MXNET_CPU_PRIORITY_NTHREADS", 4);
     cpu_priority_worker_.reset(new ThreadWorkerBlock<kPriorityQueue>());
@@ -128,8 +129,8 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
         const FnProperty prop = opr_block->opr->prop;
         const bool is_copy = (prop == FnProperty::kCopyFromGPU ||
                               prop == FnProperty::kCopyToGPU);
-        const size_t nthread = gpu_worker_nthreads_;
         if (is_copy) {
+          const size_t nthread = gpu_copy_nthreads_;
           auto ptr = gpu_copy_workers_.Get(ctx.dev_id, [this, ctx, is_copy, nthread]() {
             // Signify to kernel that GPU is being used, so reserve cores as necessary
             OpenMP::Get()->set_reserve_cores(GetReserveCoreCount(true));
@@ -150,6 +151,7 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
             }
           }
         } else {
+          const size_t nthread = gpu_worker_nthreads_;
           auto ptr = gpu_normal_workers_.Get(ctx.dev_id, [this, ctx, is_copy, nthread]() {
             // Signify to kernel that GPU is being used, so reserve cores as necessary
             OpenMP::Get()->set_reserve_cores(GetReserveCoreCount(true));
@@ -194,6 +196,8 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
   size_t cpu_worker_nthreads_;
   /*! \brief number of concurrent thread each gpu worker uses */
   size_t gpu_worker_nthreads_;
+  /*! \brief number of concurrent thread each gpu copy worker uses */
+  int gpu_copy_nthreads_;
   // cpu worker
   common::LazyAllocArray<ThreadWorkerBlock<kWorkerQueue> > cpu_normal_workers_;
   // cpu priority worker

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -197,7 +197,7 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
   /*! \brief number of concurrent thread each gpu worker uses */
   size_t gpu_worker_nthreads_;
   /*! \brief number of concurrent thread each gpu copy worker uses */
-  int gpu_copy_nthreads_;
+  size_t gpu_copy_nthreads_;
   // cpu worker
   common::LazyAllocArray<ThreadWorkerBlock<kWorkerQueue> > cpu_normal_workers_;
   // cpu priority worker


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Restores MXNET_GPU_COPY_NTHREADS environmental variable
- [x] This variable has been set to MXNET_GPU_WORKER_THREADS (default = 2) since MXNet v0.10.0, so env_var doc is changed to reflect that

## Comments ##
- This MXNET_GPU_COPY_NTHREADS environmental variable was (accidentally) removed in commit 3b517f1 with the value taking the value of MXNET_GPU_WORKER_NTHREADS. Then, shortly afterwards the member variable was itself removed in this PR: https://github.com/apache/incubator-mxnet/pull/6773. Since then, it has been set to MXNET_GPU_WORKER_NTHREADS, which is 2.
- Since this variable controls how many CUDA streams are launched in order to do copying from GPU to GPU, it might be good to bring it back so the user has another knob they can use to tune single-machine multi-GPU training.
- Some experimental evidence that 2 may be better than 1. From running `tools/bandwidth/measure.py` on ResNet-50 with 8 GPUs.

```
export MXNET_GPU_COPY_NTHREADS=1
INFO:root:iter 1, 0.033930 sec, 5.261591 GB/sec per gpu, error 0.000000
INFO:root:iter 2, 0.033478 sec, 5.332636 GB/sec per gpu, error 0.000000
INFO:root:iter 3, 0.044507 sec, 4.011239 GB/sec per gpu, error 0.000000
INFO:root:iter 4, 0.034598 sec, 5.159997 GB/sec per gpu, error 0.000000
INFO:root:iter 5, 0.038231 sec, 4.669686 GB/sec per gpu, error 0.000000
export MXNET_GPU_COPY_NTHREADS=2
INFO:root:iter 1, 0.031341 sec, 5.696318 GB/sec per gpu, error 0.000000
INFO:root:iter 2, 0.031575 sec, 5.654080 GB/sec per gpu, error 0.000000
INFO:root:iter 3, 0.035124 sec, 5.082800 GB/sec per gpu, error 0.000000
INFO:root:iter 4, 0.030341 sec, 5.884048 GB/sec per gpu, error 0.000000
INFO:root:iter 5, 0.032198 sec, 5.544681 GB/sec per gpu, error 0.000000
export MXNET_GPU_COPY_NTHREADS=4
INFO:root:iter 1, 0.046252 sec, 3.859864 GB/sec per gpu, error 0.000000
INFO:root:iter 2, 0.034504 sec, 5.174116 GB/sec per gpu, error 0.000000
INFO:root:iter 3, 0.039854 sec, 4.479529 GB/sec per gpu, error 0.000000
INFO:root:iter 4, 0.034815 sec, 5.127841 GB/sec per gpu, error 0.000000
INFO:root:iter 5, 0.034434 sec, 5.184613 GB/sec per gpu, error 0.000000
```