### PR TITLE
[WIP] [MXNET-323] Improve performance of broadcast ops backward pass

### DIFF
--- a/src/operator/tensor/broadcast_reduce-inl.h
+++ b/src/operator/tensor/broadcast_reduce-inl.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <utility>
 #include "../mshadow_op.h"
+#include "../operator_common.h"
 
 namespace mxnet {
 namespace op {
@@ -204,16 +205,46 @@ void seq_reduce_compute(const int N, const int M, const bool addto,
   }
 }
 
-template<typename Reducer, int ndim, typename DType, typename OP>
-void Reduce(Stream<cpu> *s, const TBlob& small, const OpReqType req,
+template <typename Reducer, int ndim, typename DType, typename OP>
+struct seq_reduce_kernel {
+  MSHADOW_XINLINE static void Map(int start, int end, int M, const bool addto,
+                                  const DType* big, DType* small,
+                                  const Shape<ndim> bshape,
+                                  const Shape<ndim> sshape,
+                                  const Shape<ndim> rshape,
+                                  const Shape<ndim> rstride, DType* ws_dptr) {
+    for (int idx = start; idx < end; ++idx) {
+      Shape<ndim> coord = unravel(idx, sshape);
+      int j = ravel(coord, bshape);
+      DType val, residual;
+      Reducer::SetInitValue(val, residual);
+      #pragma unroll
+      for (int k = 0; k < M; k++) {
+        Reducer::Reduce(val, OP::Map(big[j + static_cast<int>(ws_dptr[k])]), residual);
+      }
+      assign(&small[idx], addto, val);
+    }
+  }
+};
+
+template <typename Reducer, int ndim, typename DType, typename OP>
+void Reduce(Stream<cpu>* s, const TBlob& small, const OpReqType req,
             const Tensor<cpu, 1, char>& workspace, const TBlob& big) {
+  using namespace mxnet_op;
   if (req == kNullOp) return;
   Shape<ndim> rshape, rstride;
   diff(small.shape_.get<ndim>(), big.shape_.get<ndim>(), &rshape, &rstride);
+  DType* ws_dptr = reinterpret_cast<DType*>(workspace.dptr_);
   int N = small.shape_.Size(), M = rshape.Size();
-  seq_reduce_compute<Reducer, ndim, DType, OP>(
-    N, M, req == kAddTo, big.dptr<DType>(), small.dptr<DType>(), big.shape_.get<ndim>(),
-    small.shape_.get<ndim>(), rshape, rstride);
+  #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+  for (int k = 0; k < M; k++) {
+    Shape<ndim> coord = unravel(k, rshape);
+    ws_dptr[k] = dot(coord, rstride);
+  }
+
+  mxnet_op::Kernel<seq_reduce_kernel<Reducer, ndim, DType, OP>, cpu>::template LaunchEx(
+    s, N, M, req == kAddTo, big.dptr<DType>(), small.dptr<DType>(), big.shape_.get<ndim>(),
+    small.shape_.get<ndim>(), rshape, rstride, ws_dptr);
 }
 
 template<int ndim, typename DType>

--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -544,13 +544,9 @@ void BinaryBroadcastBackwardUseNone(const nnvm::NodeAttrs& attrs,
       const TBlob out = inputs[0].reshape(new_oshape);
       BROADCAST_NDIM_SWITCH(ndim, NDim, {
         // Request temporary storage
-        size_t workspace_size_l = ReduceWorkspaceSize<NDim, DType>(
-            s, lhs.shape_, req[0], out.shape_);
-        size_t workspace_size_r = ReduceWorkspaceSize<NDim, DType>(
-            s, rhs.shape_, req[1], out.shape_);
-        size_t workspace_size = std::max(workspace_size_l, workspace_size_r);
+        size_t workspace_size = new_oshape.Size();
         Tensor<xpu, 1, char> workspace =
-          ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size), s);
+          ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size * sizeof(DType)), s);
         Reduce<red::sum, NDim, DType, LOP>(s, lhs, req[0], workspace, out);
         Reduce<red::sum, NDim, DType, ROP>(s, rhs, req[1], workspace, out);
       });
@@ -575,13 +571,9 @@ inline void BinaryBroadcastBackwardUseInImpl(const OpContext& ctx,
   const TBlob ograd = inputs[0].reshape(new_oshape);
   const TBlob lhs = inputs[1].reshape(new_lshape);
   const TBlob rhs = inputs[2].reshape(new_rshape);
-  size_t workspace_size_l = ReduceWorkspaceSize<ndim, DType>(
-      s, lgrad.shape_, req[0], ograd.shape_, lhs.shape_, rhs.shape_);
-  size_t workspace_size_r = ReduceWorkspaceSize<ndim, DType>(
-      s, rgrad.shape_, req[1], ograd.shape_, lhs.shape_, rhs.shape_);
-  size_t workspace_size = std::max(workspace_size_l, workspace_size_r);
+  size_t workspace_size = new_oshape.Size();
   Tensor<xpu, 1, char> workspace =
-    ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size), s);
+    ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size * sizeof(DType)), s);
   Reduce<red::sum, ndim, DType, op::mshadow_op::mul, LOP>(s, lgrad, req[0], workspace,
     ograd, lhs, rhs);
   Reduce<red::sum, ndim, DType, op::mshadow_op::mul, ROP>(s, rgrad, req[1], workspace,


### PR DESCRIPTION
## Description ##

This PR tries to improve the performance of broadcast ops backward pass, by caching the intermediate computations and using LaunchEx. The speedup for both forward and backward pass combined for the broadcast_add is around 1.4X. The experiments have been run on p2.8xlarge.

The below numbers are for broadcasting a tensor of shape (1,) to a tensor of shape destination shape as given below.

| Destination tensor shape | Before the Change | After the Change |
| ------------------------- | ------------------- | ----------------- |
| 100, 100 | 0.017 | 0.013 |
| 250, 250 | 0.085 | 0.065 |
| 500, 500 | 0.35 | 0.25 |
| 1000, 1000 | 1.34 | 0.98 |
| 2000, 2000 | 5.6 | 3.9 |
| 12000, 12000 | 188 | 144 |
| 2**17, 10, 10 | 18 | 12 |

```
import numpy as np
import mxnet as mx
import time

a = mx.sym.var('a')
b = mx.sym.var('b')

a_ = mx.nd.ones((2**17, 10, 10))
b_ = mx.nd.ones((1))

func2 = mx.sym.broadcast_add(a, b).bind(mx.cpu(), args={'a': a_, 'b': b_}, args_grad = {'a': mx.nd.ones((2**17, 10, 10)), 'b': mx.nd.ones((1))})

for _ in range(2):
    # boadcast_add(array, array)
    start = time.time()
    for i in range(100):
        out = func2.forward(is_train=True)[0]
        func2.backward(mx.nd.ones((2**17, 10, 10)))
    mx.nd.waitall()
    print("func2: {}".format(time.time() - start))

```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change