### PR TITLE
[MXNET-548] fixed path for auto_module_index.js

### DIFF
--- a/docs/api/python/autograd/autograd.md
+++ b/docs/api/python/autograd/autograd.md
@@ -63,7 +63,7 @@ Detailed tutorials are available in Part 1 of
 
 
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ## Autograd
 
@@ -86,7 +86,7 @@ Detailed tutorials are available in Part 1 of
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.autograd

--- a/docs/api/python/autograd/autograd.md
+++ b/docs/api/python/autograd/autograd.md
@@ -13,7 +13,7 @@ In machine learning applications,
 of loss functions with respect to parameters.
 
 
-### Record vs Pause
+## Record vs Pause
 
 `autograd` records computation history on the fly to calculate gradients later.
 This is only enabled inside a `with autograd.record():` block.

--- a/docs/api/python/callback/callback.md
+++ b/docs/api/python/callback/callback.md
@@ -17,7 +17,7 @@ This document lists the routines of the callback package
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.callback

--- a/docs/api/python/contrib/onnx.md
+++ b/docs/api/python/contrib/onnx.md
@@ -40,7 +40,7 @@ This document describes all the ONNX-MXNet APIs.
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 

--- a/docs/api/python/contrib/text.md
+++ b/docs/api/python/contrib/text.md
@@ -375,7 +375,7 @@ The following functions provide utilities for text data processing.
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 

--- a/docs/api/python/executor/executor.md
+++ b/docs/api/python/executor/executor.md
@@ -30,7 +30,7 @@ graph execution. This document is only intended for reference for advanced users
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.executor

--- a/docs/api/python/gluon/gluon.md
+++ b/docs/api/python/gluon/gluon.md
@@ -5,7 +5,7 @@
 .. currentmodule:: mxnet.gluon
 ```
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ## Overview
 
@@ -152,7 +152,7 @@ net.hybridize()
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.gluon

--- a/docs/api/python/gluon/loss.md
+++ b/docs/api/python/gluon/loss.md
@@ -30,7 +30,7 @@ This package includes several commonly used loss functions in neural networks.
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.gluon.loss

--- a/docs/api/python/gluon/nn.md
+++ b/docs/api/python/gluon/nn.md
@@ -85,7 +85,7 @@ This document lists the neural network blocks in Gluon:
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.gluon.nn

--- a/docs/api/python/gluon/rnn.md
+++ b/docs/api/python/gluon/rnn.md
@@ -71,7 +71,7 @@ for i in range(5):
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.gluon.rnn

--- a/docs/api/python/image/image.md
+++ b/docs/api/python/image/image.md
@@ -156,7 +156,7 @@ and a list of augmenters specific for `Object detection` is provided
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.image

--- a/docs/api/python/io/io.md
+++ b/docs/api/python/io/io.md
@@ -149,7 +149,7 @@ The backend engine will recognize the index of `N` in the `layout` as the axis f
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.io

--- a/docs/api/python/kvstore/kvstore.md
+++ b/docs/api/python/kvstore/kvstore.md
@@ -119,7 +119,7 @@ update on key: 9
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.kvstore

--- a/docs/api/python/metric/metric.md
+++ b/docs/api/python/metric/metric.md
@@ -18,7 +18,7 @@ the performance of a learned model.
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.metric

--- a/docs/api/python/model.md
+++ b/docs/api/python/model.md
@@ -99,7 +99,7 @@ Training occurs in parallel on the GPUs that you specify.
 ```eval_rst
     .. raw:: html
 
-        <script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+        <script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 ```
 
 

--- a/docs/api/python/module/module.md
+++ b/docs/api/python/module/module.md
@@ -190,7 +190,7 @@ additional functionality. We summarize them in this section.
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. autoclass:: mxnet.module.BaseModule

--- a/docs/api/python/optimization/optimization.md
+++ b/docs/api/python/optimization/optimization.md
@@ -149,7 +149,7 @@ for examples.
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.optimizer

--- a/docs/api/python/profiler/profiler.md
+++ b/docs/api/python/profiler/profiler.md
@@ -73,7 +73,7 @@ These profiling objects can be created and accessed from python in order to reso
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.profiler

--- a/docs/api/python/rtc/rtc.md
+++ b/docs/api/python/rtc/rtc.md
@@ -19,7 +19,7 @@ frontend. The compiled kernels can be used stand-alone or combined with
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. automodule:: mxnet.rtc

--- a/docs/api/python/symbol/rnn.md
+++ b/docs/api/python/symbol/rnn.md
@@ -317,7 +317,7 @@ conversion transparently based on the provided cells.
 
 ## API Reference
 
-<script type="text/javascript" src='../../_static/js/auto_module_index.js'></script>
+<script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
 ```eval_rst
 .. autoclass:: mxnet.rnn.BaseRNNCell


### PR DESCRIPTION
## Description ##

Fixes #11238 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

Updated the path for a js file that was triggering 404s.

The following error is what you [see on production](https://mxnet.incubator.apache.org/api/python/metric/metric.html) today:
![2018-06-28_18-00-18](https://user-images.githubusercontent.com/5974205/42067823-3be87ef0-7afd-11e8-8c01-72d5aca0ab0c.png)

I cherry-picked this commit and added here:
http://35.170.70.99/api/python/metric/metric.html
And if you inspect the console the error is gone now that it can find this file.

I used the same pattern on the rest of the file updates.
