### PR TITLE
[MXNET-543][WIP]Scala Spark test

### DIFF
--- a/scala-package/spark/pom.xml
+++ b/scala-package/spark/pom.xml
@@ -36,6 +36,24 @@
       </properties>
     </profile>
   </profiles>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <configuration>
+          <argLine>
+            -Djava.library.path=${project.parent.basedir}/native/${platform}/target \
+            -Dlog4j.configuration=file://${project.basedir}/src/test/resources/log4j.properties
+          </argLine>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.scalastyle</groupId>
+        <artifactId>scalastyle-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
   <dependencies>
     <dependency>
       <groupId>org.apache.mxnet</groupId>

--- a/scala-package/spark/src/test/resources/log4j.properties
+++ b/scala-package/spark/src/test/resources/log4j.properties
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# for development debugging
+log4j.rootLogger = info, stdout
+
+log4j.appender.stdout = org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target = System.out
+log4j.appender.stdout.layout = org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} [%t] [%c] [%p] - %m%n

--- a/scala-package/spark/src/test/scala/org/apache/mxnet/spark/MXNetGeneralSuite.scala
+++ b/scala-package/spark/src/test/scala/org/apache/mxnet/spark/MXNetGeneralSuite.scala
@@ -21,13 +21,15 @@ import java.io.{BufferedReader, File, InputStreamReader}
 import java.nio.file.Files
 
 import scala.sys.process.Process
-
 import org.apache.spark.SparkContext
 import org.apache.spark.mllib.linalg.Vectors
 import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.rdd.RDD
+import org.slf4j.LoggerFactory
 
 class MXNetGeneralSuite extends SharedSparkContext {
+
+  private val logger = LoggerFactory.getLogger(classOf[MXNetGeneralSuite])
 
   private var testDataDir: String = _
 
@@ -42,6 +44,7 @@ class MXNetGeneralSuite extends SharedSparkContext {
   }
 
   private def downloadTestData(): Unit = {
+    logger.info("Downloading the training data...")
     Process("wget http://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/gluon" +
       "/dataset/mxnet-spark-test/train.txt" + " -P " + testDataDir + " -q") !
   }
@@ -55,14 +58,24 @@ class MXNetGeneralSuite extends SharedSparkContext {
   }
 
   test("run spark with MLP") {
-    val trainData = parseRawData(sc, s"$testDataDir/train.txt")
-    val model = buildMlp().fit(trainData)
-    assert(model != null)
+    if (System.getenv().containsKey("SCALA_TEST_ON_GPU") &&
+      System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
+      val trainData = parseRawData(sc, s"$testDataDir/train.txt")
+      val model = buildMlp().fit(trainData)
+      assert(model != null)
+    } else {
+      logger.info("Currently not supporting CPU, skipped for now")
+    }
   }
 
   test("run spark with LeNet") {
-    val trainData = parseRawData(sc, s"$testDataDir/train.txt")
-    val model = buildLeNet().fit(trainData)
-    assert(model != null)
+    if (System.getenv().containsKey("SCALA_TEST_ON_GPU") &&
+      System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
+      val trainData = parseRawData(sc, s"$testDataDir/train.txt")
+      val model = buildLeNet().fit(trainData)
+      assert(model != null)
+    } else {
+      logger.info("Currently not supporting CPU, skipped for now")
+    }
   }
 }

--- a/scala-package/spark/src/test/scala/org/apache/mxnet/spark/MXNetGeneralSuite.scala
+++ b/scala-package/spark/src/test/scala/org/apache/mxnet/spark/MXNetGeneralSuite.scala
@@ -46,26 +46,23 @@ class MXNetGeneralSuite extends SharedSparkContext {
       "/dataset/mxnet-spark-test/train.txt" + " -P " + testDataDir + " -q") !
   }
 
-//  override def beforeAll(): Unit = {
-//  val tempDirFile = Files.createTempDirectory(s"mxnet-spark-test-${System.currentTimeMillis()}").
-//      toFile
-//    testDataDir = tempDirFile.getPath
-//    tempDirFile.deleteOnExit()
-//    downloadTestData()
-//  }
-
-  test("Dummy test on Spark") {
-
+  override def beforeAll(): Unit = {
+  val tempDirFile = Files.createTempDirectory(s"mxnet-spark-test-${System.currentTimeMillis()}").
+      toFile
+    testDataDir = tempDirFile.getPath
+    tempDirFile.deleteOnExit()
+    downloadTestData()
   }
-//  test("run spark with MLP") {
-//    val trainData = parseRawData(sc, s"$testDataDir/train.txt")
-//    val model = buildMlp().fit(trainData)
-//    assert(model != null)
-//  }
-//
-//  test("run spark with LeNet") {
-//    val trainData = parseRawData(sc, s"$testDataDir/train.txt")
-//    val model = buildLeNet().fit(trainData)
-//    assert(model != null)
-//  }
+
+  test("run spark with MLP") {
+    val trainData = parseRawData(sc, s"$testDataDir/train.txt")
+    val model = buildMlp().fit(trainData)
+    assert(model != null)
+  }
+
+  test("run spark with LeNet") {
+    val trainData = parseRawData(sc, s"$testDataDir/train.txt")
+    val model = buildLeNet().fit(trainData)
+    assert(model != null)
+  }
 }


### PR DESCRIPTION
## Description ##
This PR is a bug fixes on the Spark Example for Scala. We need to ensure there are enough amount of tests. Here is the plan for the release:

- Fix the [Ubuntu GPU problem](https://github.com/apache/incubator-mxnet/issues/11263)
- Fix the [Ubuntu CPU problem](https://github.com/apache/incubator-mxnet/issues/11249)
- Fix the Mac problem (USE_DIST_KVSTORE=1)

@nswamy @yzhliu @CodingCat @marcoabreu @andrewfayres 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

