### PR TITLE
Fix the inaccruate instruction on installing nose

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -13,7 +13,7 @@ For running unit tests, you will need the [nose PyPi package](https://pypi.pytho
 pip install --upgrade nose
 ```
 
-Once ```nose``` is installed, run the following from MXNet root directory (please make sure the installation path of ```nosetests``` is included in your ```$PATH``` environment variable or use a ```virtualenv```):
+Once ```nose``` is installed, run the following from MXNet root directory (please make sure the installation path of ```nosetests``` is included in your ```$PATH``` environment variable):
 ```
 nosetests tests/python/unittest
 nosetests tests/python/train

--- a/python/README.md
+++ b/python/README.md
@@ -10,10 +10,10 @@ To install MXNet Python package, visit MXNet [Install Instruction](http://mxnet.
 
 For running unit tests, you will need the [nose PyPi package](https://pypi.python.org/pypi/nose). To install:
 ```bash
-sudo pip install --upgrade nose
+pip install --upgrade nose
 ```
 
-Once ```nose``` is installed, run the following from MXNet root directory:
+Once ```nose``` is installed, run the following from MXNet root directory (please make sure the installation path of ```nosetests``` is included in your ```$PATH``` environment variable or use a ```virtualenv```):
 ```
 nosetests tests/python/unittest
 nosetests tests/python/train

--- a/python/README.md
+++ b/python/README.md
@@ -10,7 +10,7 @@ To install MXNet Python package, visit MXNet [Install Instruction](http://mxnet.
 
 For running unit tests, you will need the [nose PyPi package](https://pypi.python.org/pypi/nose). To install:
 ```bash
-pip install --upgrade nose
+sudo pip install --upgrade nose
 ```
 
 Once ```nose``` is installed, run the following from MXNet root directory:


### PR DESCRIPTION
## Description ##
The instruction for installing nose package should add the 'sudo' in the command. Otherwise, the Mac OS bash would not recognize the nosetests command. This has been discussed in Stackoverflow (https://stackoverflow.com/questions/18796988/installing-nose-using-pip-but-bash-doesnt-recognize-command-on-mac)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
