### PR TITLE
[MXNET-549] MKLDNNSum can handle variable number of inputs

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_base.cc
+++ b/src/operator/nn/mkldnn/mkldnn_base.cc
@@ -146,7 +146,8 @@ void CommitOutput(const NDArray &arr, const mkldnn_output_t &res) {
     // We have to allocate new memory for the sum result.
     auto sum_res = TmpMemMgr::Get()->Alloc(
         res.second->get_primitive_desc());
-    op::MKLDNNSum(*res.second, *mem, *sum_res);
+    std::vector<mkldnn::memory> in_mems = {*res.second, *mem};
+    op::MKLDNNSum(in_mems, *sum_res);
     const_cast<NDArray &>(arr).CopyFrom(*sum_res);
   }
 }

--- a/src/operator/nn/mkldnn/mkldnn_copy.cc
+++ b/src/operator/nn/mkldnn/mkldnn_copy.cc
@@ -50,7 +50,8 @@ void MKLDNNCopy(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
     if (out_mem == nullptr)
       out_mem = out_data.GetMKLDNNData();
     auto sum_res = TmpMemMgr::Get()->Alloc(out_mem->get_primitive_desc());
-    MKLDNNSum(*in_mem, *out_mem, *sum_res);
+    std::vector<mkldnn::memory> in_mems = {in_mem, out_mem};
+    MKLDNNSum(in_mems, *sum_res);
     const_cast<NDArray &>(out_data).CopyFrom(*sum_res);
   } else {
     const_cast<NDArray &>(out_data).CopyFrom(*in_mem);

--- a/src/operator/nn/mkldnn/mkldnn_ops-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_ops-inl.h
@@ -104,8 +104,8 @@ void MKLDNNActivationBackward(const nnvm::NodeAttrs& attrs, const OpContext &ctx
                               const NDArray &out_grad, const NDArray &in_data,
                               const OpReqType &req, const NDArray &in_grad);
 
-void MKLDNNSum(const mkldnn::memory &arr1, const mkldnn::memory &arr2,
-         const mkldnn::memory &out);
+void MKLDNNSum(std::vector<mkldnn::memory> &in_mems,
+               const mkldnn::memory &out);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -23,6 +23,7 @@
  * \author Da Zheng
 */
 #include <iostream>
+#include <vector>
 
 #include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
@@ -31,16 +32,15 @@
 namespace mxnet {
 namespace op {
 
-void MKLDNNSum(const mkldnn::memory &arr1, const mkldnn::memory &arr2,
+void MKLDNNSum(std::vector<mkldnn::memory> &in_mems,
          const mkldnn::memory &out) {
-  std::vector<mkldnn::memory::primitive_desc> input_pds(2);
-  std::vector<float> scales(2, 1);
+  std::vector<mkldnn::memory::primitive_desc> input_pds(in_mems.size());
+  std::vector<float> scales(in_mems.size(), 1);
   std::vector<mkldnn::primitive::at> inputs;
-  input_pds[0] = arr1.get_primitive_desc();
-  input_pds[1] = arr2.get_primitive_desc();
-  CHECK(input_pds[0] == input_pds[1]);
-  inputs.push_back(arr1);
-  inputs.push_back(arr2);
+  for (int i = 0; i < in_mems.size(); i++) {
+    input_pds[i] = in_mems[i].get_primitive_desc();
+    inputs.push_back(in_mems[i]);
+  }
   // TODO(zhengda) I need to reorder memory here.
   mkldnn::sum::primitive_desc sum_pd(scales, input_pds);
   MKLDNNStream::Get()->RegisterPrim(mkldnn::sum(sum_pd, inputs, out));

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -74,7 +74,7 @@ void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
   mkldnn::sum::primitive_desc pdesc(scales, in_pds);
   auto mem = CreateMKLDNNMem(out_data, pdesc.dst_primitive_desc(), req, &inputs[0]);
   MKLDNNStream *stream = MKLDNNStream::Get();
-  stream->RegisterPrim(mkldnn::sum(pdesc, in_prims, *mem.second));
+  MKLDNNSum(in_prims, *mem.second);
   CommitOutput(out_data, mem);
   stream->Submit();
 }

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -54,7 +54,7 @@ void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
   }
 
   TmpMemMgr::Get()->Init(ctx.requested[0]);
-  std::vector<mkldnn::primitive::at> in_prims;
+  std::vector<mkldnn::memory> in_prims;
   std::vector<mkldnn::memory::primitive_desc> in_pds(inputs.size());
   std::vector<float> scales(inputs.size(), 1);
   in_prims.reserve(inputs.size());
@@ -70,7 +70,6 @@ void MKLDNNSumForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
     in_prims.push_back(*in_mem);
     in_pds[i] = in_mem->get_primitive_desc();
   }
-
   mkldnn::sum::primitive_desc pdesc(scales, in_pds);
   auto mem = CreateMKLDNNMem(out_data, pdesc.dst_primitive_desc(), req, &inputs[0]);
   MKLDNNStream *stream = MKLDNNStream::Get();

--- a/src/operator/nn/mkldnn/mkldnn_sum.cc
+++ b/src/operator/nn/mkldnn/mkldnn_sum.cc
@@ -40,6 +40,7 @@ void MKLDNNSum(std::vector<mkldnn::memory> &in_mems,
   for (int i = 0; i < in_mems.size(); i++) {
     input_pds[i] = in_mems[i].get_primitive_desc();
     inputs.push_back(in_mems[i]);
+    if (i > 0) CHECK(input_pds[i] == input_pds[i-1]);
   }
   // TODO(zhengda) I need to reorder memory here.
   mkldnn::sum::primitive_desc sum_pd(scales, input_pds);

--- a/tests/cpp/operator/mkldnn.cc
+++ b/tests/cpp/operator/mkldnn.cc
@@ -799,7 +799,8 @@ TEST(MKLDNN_BASE, MKLDNNSum) {
       if (out_mem == nullptr)
         continue;
       PrintVerifyMsg(in_arr, in_arr);
-      op::MKLDNNSum(*in_mem1, *in_mem2, *out_mem);
+      std::vector<mkldnn::memory> in_mems = {*in_mem1, *in_mem2};
+      op::MKLDNNSum(in_mems, *out_mem);
       MKLDNNStream::Get()->Submit();
       VerifySumMemory(*in_mem1, *in_mem2, *out_mem);
     }
@@ -812,7 +813,8 @@ TEST(MKLDNN_BASE, MKLDNNSum) {
     InitMKLDNNArray(&orig_arr.arr, input_mem->get_primitive_desc(), InitDefaultArray);
     orig_arr.arr.CopyFrom(*input_mem);
     auto old_mem = orig_arr.arr.GetMKLDNNData();
-    op::MKLDNNSum(*input_mem, *input_mem2, *input_mem);
+    std::vector<mkldnn::memory> in_mems = {*input_mem, *input_mem2};
+    op::MKLDNNSum(in_mems, *input_mem);
     MKLDNNStream::Get()->Submit();
     VerifySumMemory(*old_mem, *input_mem2, *input_mem);
   }


### PR DESCRIPTION
## Description ##
MKLDNNSum helper function can handle variable number of inputs

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Refactor MKLDNNSum to accept vector in mem

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
