### PR TITLE
[MXNET-558] Fix 'AttributeError: '_thread._local' object has no attribute 'value'' on distributed processing applications

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -50,8 +50,9 @@ class _BlockScope(object):
         current = getattr(_BlockScope._current, "value", None)
         if current is None:
             if prefix is None:
-                with _name.NameManager():
-                    prefix = _name.NameManager._current.value.get(None, hint) + '_'
+                if not hasattr(_name.NameManager._current, "value"):
+                    _name.NameManager._current.value = _name.NameManager()
+                prefix = _name.NameManager._current.value.get(None, hint) + '_'
             if params is None:
                 params = ParameterDict(prefix)
             else:

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -50,7 +50,8 @@ class _BlockScope(object):
         current = getattr(_BlockScope._current, "value", None)
         if current is None:
             if prefix is None:
-                prefix = _name.NameManager._current.value.get(None, hint) + '_'
+                with _name.NameManager():
+                    prefix = _name.NameManager._current.value.get(None, hint) + '_'
             if params is None:
                 params = ParameterDict(prefix)
             else:

--- a/python/mxnet/symbol/register.py
+++ b/python/mxnet/symbol/register.py
@@ -113,8 +113,12 @@ def %s(*%s, **kwargs):"""%(func_name, arr_name))
             dtype_name, dtype_name, dtype_name))
             code.append("""
     attr = kwargs.pop('attr', None)
+    if not hasattr(AttrScope._current, "value"):
+        AttrScope._current.value = AttrScope()
     kwargs.update(AttrScope._current.value.get(attr))
     name = kwargs.pop('name', None)
+    if not hasattr(NameManager._current, "value"):
+        NameManager._current.value = NameManager()
     name = NameManager._current.value.get(name, '%s')
     _ = kwargs.pop('out', None)
     keys = []
@@ -141,6 +145,8 @@ def %s(*%s, **kwargs):"""%(func_name, arr_name))
 def %s(%s):"""%(func_name, ', '.join(signature)))
         if not signature_only:
             code.append("""
+    if not hasattr(AttrScope._current, "value"):
+        AttrScope._current.value = AttrScope()
     kwargs.update(AttrScope._current.value.get(attr))
     sym_kwargs = dict()
     _keys = []
@@ -172,6 +178,8 @@ def %s(%s):"""%(func_name, ', '.join(signature)))
         _vals.append(np.dtype(%s).name)"""%(dtype_name, dtype_name, dtype_name))
 
             code.append("""
+    if not hasattr(NameManager._current, "value"):
+        NameManager._current.value = NameManager()
     name = NameManager._current.value.get(name, '%s')
     return _symbol_creator(%d, None, sym_kwargs, _keys, _vals, name)"""%(
         func_name.lower(), handle.value))

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -2451,8 +2451,9 @@ def var(name, attr=None, shape=None, lr_mult=None, wd_mult=None, dtype=None,
     handle = SymbolHandle()
     check_call(_LIB.MXSymbolCreateVariable(c_str(name), ctypes.byref(handle)))
     ret = Symbol(handle)
-    with AttrScope():
-        attr = AttrScope._current.value.get(attr)
+    if not hasattr(AttrScope._current, "value"):
+        AttrScope._current.value = AttrScope()
+    attr = AttrScope._current.value.get(attr)
     attr = {} if attr is None else attr
     if shape is not None:
         attr['__shape__'] = str(shape)

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -2451,7 +2451,8 @@ def var(name, attr=None, shape=None, lr_mult=None, wd_mult=None, dtype=None,
     handle = SymbolHandle()
     check_call(_LIB.MXSymbolCreateVariable(c_str(name), ctypes.byref(handle)))
     ret = Symbol(handle)
-    attr = AttrScope._current.value.get(attr)
+    with AttrScope():
+        attr = AttrScope._current.value.get(attr)
     attr = {} if attr is None else attr
     if shape is not None:
         attr['__shape__'] = str(shape)

--- a/tests/python/unittest/test_thread_local.py
+++ b/tests/python/unittest/test_thread_local.py
@@ -133,19 +133,35 @@ def test_blockscope():
     thread.join()
     event.clear()
     assert status[0], "Spawned thread isn't using the correct blockscope namemanager"
-    
+
 def test_createblock():
     status = [False]
     def f():
         net = mx.gluon.nn.Dense(2)
         net.initialize()
-        net(mx.nd.array([1, 2, 3]))
+        x = net(mx.nd.array([1, 2, 3]))
+        x.wait_to_read()
         status[0] = True
 
     thread = threading.Thread(target=f)
     thread.start()
     thread.join()
     assert status[0], "Failed to create a layer within a thread"
+
+def test_symbol():
+    status = [False]
+    def f():
+        a = mx.sym.var("a")
+        b = mx.sym.var("b")
+        a_ = mx.nd.ones((2, 2))
+        c_ = a_.copy()
+        func1 = (a + b).bind(mx.cpu(), args={'a': a_, 'b': c_})
+        func1.forward()[0].wait_to_read()
+        status[0] = True
+    thread = threading.Thread(target=f)
+    thread.start()
+    thread.join()
+    assert status[0], "Failed to execute a symbolic graph within a thread"
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_thread_local.py
+++ b/tests/python/unittest/test_thread_local.py
@@ -141,7 +141,6 @@ def test_createblock():
         net.initialize()
         net(mx.nd.array([1, 2, 3]))
         status[0] = True
-
     thread = threading.Thread(target=f)
     thread.start()
     thread.join()

--- a/tests/python/unittest/test_thread_local.py
+++ b/tests/python/unittest/test_thread_local.py
@@ -141,6 +141,7 @@ def test_createblock():
         net.initialize()
         net(mx.nd.array([1, 2, 3]))
         status[0] = True
+
     thread = threading.Thread(target=f)
     thread.start()
     thread.join()

--- a/tests/python/unittest/test_thread_local.py
+++ b/tests/python/unittest/test_thread_local.py
@@ -133,6 +133,19 @@ def test_blockscope():
     thread.join()
     event.clear()
     assert status[0], "Spawned thread isn't using the correct blockscope namemanager"
+    
+def test_createblock():
+    status = [False]
+    def f():
+        net = mx.gluon.nn.Dense(2)
+        net.initialize()
+        net(mx.nd.array([1, 2, 3]))
+        status[0] = True
+
+    thread = threading.Thread(target=f)
+    thread.start()
+    thread.join()
+    assert status[0], "Failed to create a layer within a thread"
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
Using distributed processing frameworks, django or ray, users encountered errors when trying to run mxnet in separate threads.

https://github.com/apache/incubator-mxnet/issues/11331 and https://github.com/dmlc/gluon-cv/issues/156

Calling the `_current.value.get` within the context of the respective object solved the issue.

Does anybody have a suggestion as to how to test this without introducing a dependency on ray?

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
