### PR TITLE
[WIP] fix issue of test_gru_bidirectional #11219 and add robust code

### DIFF
--- a/src/operator/rnn_impl.h
+++ b/src/operator/rnn_impl.h
@@ -649,11 +649,11 @@ void GruForwardInferenceSingleLayer(DType* ws,
     //  perform the second direction
     if (D == 2) {
       gemmC1_t = back_gemmC1 + (T - 1 - t) * N * 3 * H;
-      Tensor<cpu, 2, DType> dback_ht_1(back_ht_1, Shape2(N, D * H));
+      Tensor<cpu, 2, DType> dback_ht_1(back_ht_1 - H, Shape2(N, D * H));
       Tensor<cpu, 3, DType> dback_ht_1_tmp = Tensor<cpu, 3, DType>
           (reinterpret_cast<DType*>(tmp_buf), Shape3(D, H, N));
       dback_ht_1_tmp = reshape(dback_ht_1.T(), Shape3(D, H, N));
-      linalg_gemm(dback_ht_1_tmp[0], back_wh, dgemmC2, alpha, beta, true, true);
+      linalg_gemm(dback_ht_1_tmp[1], back_wh, dgemmC2, alpha, beta, true, true);
 
       #pragma omp parallel for num_threads(omp_threads)
       for (int i = 0; i < N; ++i) {
@@ -870,11 +870,11 @@ void GruForwardTrainingSingleLayer(DType* ws,
       zt = back_gateZ + (T - 1 - t) * N * H;
       nt = back_gateN + (T - 1 - t) * N * H;
       gemmC1_t = back_gemmC1 + (T - 1 - t) * N * 3 * H;
-      Tensor<cpu, 2, DType> dback_ht_1(back_ht_1, Shape2(N, D * H));
+      Tensor<cpu, 2, DType> dback_ht_1(back_ht_1 - H, Shape2(N, D * H));
       Tensor<cpu, 3, DType> dback_ht_1_tmp = Tensor<cpu, 3, DType>
           (reinterpret_cast<DType*>(tmp_buf), Shape3(D, H, N));
       dback_ht_1_tmp = reshape(dback_ht_1.T(), Shape3(D, H, N));
-      linalg_gemm(dback_ht_1_tmp[0], back_wh, dgemmC2, alpha, beta, true, true);
+      linalg_gemm(dback_ht_1_tmp[1], back_wh, dgemmC2, alpha, beta, true, true);
 
       DType* back_Mnht = back_Mnh + (T - 1 - t) * N * H;
       #pragma omp parallel for num_threads(omp_threads)

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -132,10 +132,10 @@ def test_gru_bidirectional():
                 mx.rnn.GRUCell(H, prefix='l1_'),
                 mx.rnn.GRUCell(H, prefix='r1_'),
                 output_prefix='bi_gru_1_'))
-    
-    check_rnn_consistency(fused, stack, T, N, I, H, 'write')
-    check_rnn_consistency(fused, stack, T, N, I, H, 'add')
-    check_rnn_consistency(fused, stack, T, N, I, H, 'null')
+    for i in range(100):
+        check_rnn_consistency(fused, stack, T, N, I, H, 'write')
+        check_rnn_consistency(fused, stack, T, N, I, H, 'add')
+        check_rnn_consistency(fused, stack, T, N, I, H, 'null')
 
 
 # Currently, fused LSTM operator doesn't support dropout.

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -115,8 +115,6 @@ def test_gru_sym():
     check_rnn_consistency(fused, stack, T, N, I, H, 'add')
     check_rnn_consistency(fused, stack, T, N, I, H, 'null')
 
-
-@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/11219")
 @with_seed()
 def test_gru_bidirectional():
     T, N, I, H = 5, 20, 800, 800


### PR DESCRIPTION
## Description ##
In this PR, it fixed issue of test_gru_bidirectional #11219 and add robust code. @pengzhao-intel, @TaoLv 

## Feature changes ##
### New features ###
- Fixed issue of test_gru_bidirectional #11219. The reason is when creating temporary tensor for reshape, the code utilize the unallocated memory because of the incorrect start and end point. Because the data in unallocated memory didn't be used in linalg_gemm. Sometimes the code can pass, sometimes it will crash. We added 100 times checking for test_gru_bidirectional in tests/python/unittests/test_operator.py. And will keep 1 time checking after testing is passed
- Add robust code like param initialization. It can also make GRU/LSTM Convergence Curve (example/rnn/bucketing/cudnn_rnn_bucketing.py) be stable. 
- Replace memcpy/memset by using omp for better performance.

### Unit-test changes ###
- Tested 100 times checking for test_gru_bidirectional in tests/python/unittests/test_operator.py. And will keep 1 time checking after testing is passed.

## Checklist ##
 - [X] Passed code style checking (make lint).
 - [X] All changes have test coverage.
 - [ ] Code is well-documented.