### PR TITLE
[MXNET-11241] Avoid use of troublesome cudnnFind() results when grad_req='add'

### DIFF
--- a/src/operator/nn/cudnn/cudnn_deconvolution-inl.h
+++ b/src/operator/nn/cudnn/cudnn_deconvolution-inl.h
@@ -56,9 +56,11 @@ class CuDNNDeconvolutionOp {
             int backward_compute_type,
             const std::vector<TShape>& in_shape,
             const std::vector<TShape>& out_shape,
-            const RunContext& rctx) {
+            const RunContext& rctx,
+            bool add_to_weight) {
     using namespace mshadow;
     this->param_ = param;
+    this->add_to_weight_ = add_to_weight;
     InitBufferForParam();
     auto cudnn_forward_compute_type = convertToCuDNNDataType(forward_compute_type);
     auto cudnn_backward_compute_type = convertToCuDNNDataType(backward_compute_type);
@@ -257,6 +259,7 @@ class CuDNNDeconvolutionOp {
           filter_desc_,
           gwmat.dptr_ + weight_offset_ * g));
         #elif CUDNN_MAJOR >= 5
+        CHECK_EQ(add_to_weight_, req[deconv::kWeight] == kAddTo);
         CUDNN_CALL(cudnnConvolutionBackwardFilter(
           s->dnn_handle_,
           &alpha,
@@ -543,8 +546,8 @@ class CuDNNDeconvolutionOp {
     if (!CuDNNDeconvAlgoReg::Get()->Find(param_, in_shape, out_shape, dtype_,
                                          cudnn_forward_compute_type,
                                          cudnn_backward_compute_type,
-                                         SMArch(rctx.ctx.dev_id), &forward_algo_,
-                                         &back_algo_, &back_algo_w_)) {
+                                         SMArch(rctx.ctx.dev_id), add_to_weight_,
+                                         &forward_algo_, &back_algo_, &back_algo_w_)) {
       mshadow::Stream <gpu> *s = rctx.get_stream<gpu>();
       CHECK_EQ(s->dnn_handle_ownership_, mshadow::Stream<gpu>::OwnHandle);
       size_t workspace_byte = static_cast<size_t>(param_.workspace * sizeof(DType));
@@ -578,8 +581,10 @@ class CuDNNDeconvolutionOp {
       auto max_bwd_filt_algos = MaxBackwardFilterAlgos(s->dnn_handle_);
       std::vector<cudnnConvolutionBwdFilterAlgoPerf_t> bwd_filt_results(max_bwd_filt_algos);
       int actual_bwd_filter_algos = 0;
-      auto bwd_filter_algo_discoverer =
-        param_.cudnn_tune.value() == conv::kOff ? cudnnGetConvolutionBackwardFilterAlgorithm_v7
+      // In cudnn v7.1.4, find() returned wgrad algos that could fail for large c if we
+      // were summing into the output (i.e. beta != 0).  Get() returned OK algos though.
+      auto bwd_filter_algo_discoverer = (add_to_weight_ ||
+        param_.cudnn_tune.value() == conv::kOff) ? cudnnGetConvolutionBackwardFilterAlgorithm_v7
                                                 : cudnnFindConvolutionBackwardFilterAlgorithm;
       CUDNN_CALL((*bwd_filter_algo_discoverer)(s->dnn_handle_,
                                                out_desc_,
@@ -735,7 +740,8 @@ class CuDNNDeconvolutionOp {
       CuDNNDeconvAlgoReg::Get()->Register(param_, in_shape, out_shape, dtype_,
                                           cudnn_forward_compute_type,
                                           cudnn_backward_compute_type,
-                                          SMArch(rctx.ctx.dev_id), this->forward_algo_,
+                                          SMArch(rctx.ctx.dev_id), this->add_to_weight_,
+                                          this->forward_algo_,
                                           this->back_algo_, this->back_algo_w_);
     }
     // If we're allowing Tensor Core variants of the algos to be considered in
@@ -912,6 +918,8 @@ class CuDNNDeconvolutionOp {
   cudnnTensorFormat_t format_;
   // Allow TensorCore algo policy
   bool cudnn_tensor_core_;
+  // Is req[kWeight] == deconv::kAddTo ?
+  bool add_to_weight_;
   DeconvolutionParam param_;
 };
 #endif  // CUDNN

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -494,7 +494,7 @@ inline void LogUnimplementedOp(const nnvm::NodeAttrs& attrs,
 }
 
 class OpSignature {
-  std::vector<int> eles;
+  std::vector<int64_t> eles;
   uint64_t hash;
 
  public:

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -553,18 +553,13 @@ def test_convolution_large_c():
         check_consistency([sym, sym], ctx_list, tol=tol, grad_req=grad_req)
 
     # Run with different data tensor shapes to run cudnnFind() multiple times.
-    # First, populate algo and op caches with models that use cudnnFind() exclusively.
-    for trial in range(0,6):
-        test_1D_with_width(2**(trial+1), 'write')
-    # Then create symbols that must avoid cached cudnnFind() results in some cases.
-    for trial in range(0,6):
-        test_1D_with_width(2**(trial+1), 'add')
-    #2D
-    for trial in range(0,6):
-        test_2D_with_width(2**(trial+1), 'write')
-    # Then create symbols that must avoid cached cudnnFind() results in some cases.
-    for trial in range(0,6):
-        test_2D_with_width(2**(trial+1), 'add')
+    # First, populate algo and op caches with models that always use cudnnFind() (req == 'write').
+    # Then run models that must avoid cached cudnnFind() results in some cases (req == 'add').
+    widths = [4, 16, 64]
+    for req in ['write', 'add']:
+        for width in widths:
+            test_1D_with_width(width, req)
+            test_2D_with_width(width, req)
 
 
 # This test is designed to expose an issue with cudnn v7.1.4 algo find() when invoked with large c.
@@ -588,18 +583,13 @@ def test_deconvolution_large_c():
         check_consistency([sym, sym], ctx_list, tol=tol, grad_req=grad_req)
 
     # Run with different data tensor shapes to run cudnnFind() multiple times.
-    # First, populate algo and op caches with models that use cudnnFind() exclusively.
-    for trial in range(0,6):
-        test_1D_with_width(2**(trial+1), 'write')
-    # Then create symbols that must avoid cached cudnnFind() results in some cases.
-    for trial in range(0,6):
-        test_1D_with_width(2**(trial+1), 'add')
-    #2D
-    for trial in range(0,6):
-        test_2D_with_width(2**(trial+1), 'write')
-    # Then create symbols that must avoid cached cudnnFind() results in some cases.
-    for trial in range(0,6):
-        test_2D_with_width(2**(trial+1), 'add')
+    # First, populate algo and op caches with models that always use cudnnFind() (req == 'write').
+    # Then run models that must avoid cached cudnnFind() results in some cases (req == 'add').
+    widths = [4, 16, 64]
+    for req in ['write', 'add']:
+        for width in widths:
+            test_1D_with_width(width, req)
+            test_2D_with_width(width, req)
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
The problem of issue #11241 arises because cudnnFind() measures convolution algorithm runtimes with an assumed "output blending parameter" beta of 0.  However, algorithms may have specialized kernels for the beta==0 case, different and faster than the generalized beta kernels.  Should the generalized kernels have issues with the problem size different than the beta==0 kernels, then the algos returned by cudnnFind() might fail when invoked with beta==1 (as it is when the convolution op grad_req='add' argument is present).

The demonstrated problem area involves a large 'c' value of 64K, where for the backprop-to-filter kernel only algo 1 handles the beta==1 case.  CudnnFind() was shown to occasionally return algos 0 or 3 as fastest, and both of these return error 8 "execution failed" when run.

The fix is based on the observation that cudnnGet() returns algo 1 for the backprop-to-filter kernel for the troublesome problem sizes.  Thus,  the fix is to avoid cudnnFind() when grad_req='add' and force use of cudnnGet() instead.  The fix maintains the effectiveness of the caching of algo lookups and convolution op instances, so neither cudnnFind() nor cudnnGet() is called repeatedly.  Deconvolution was similarly updated with this fix.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X ] Changes are complete (i.e. I finished coding on this PR) [1st commit includes test, 2nd the fix]
- [X ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
