### PR TITLE
[MXNET-562] Broken link fixes IV

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,6 @@ These are used to generate the indexes for search functionality.
 - [Scala Documents](api/scala/index.md)
 - [Perl Documents](api/perl/index.md)
 - [HowTo Documents](faq/index.md)
-- [Get Started Documents](get_started/index.md)
 - [System Documents](architecture/index.md)
 - [Tutorials](tutorials/index.md)
-- [Community](community/index.md)
+- [Community](community/contribute.md)


### PR DESCRIPTION
## Description ##
Invalid community/index links being generated in the toc tree

## Checklist ##
### Changes ###
- [ x ] Removing the old invalid links from the docs/index.md

