### PR TITLE
[MXNET-563] Refactor R optimizers to fix memory leak

### DIFF
--- a/R-package/R/model.R
+++ b/R-package/R/model.R
@@ -147,7 +147,7 @@ mx.model.train <- function(symbol, ctx, input.shape, output.shape,
     kvstore$set.optimizer(optimizer)
   } else {
     updaters <- lapply(seq_len(ndevice), function(i) {
-      mx.opt.get.updater(optimizer, train.execs[[i]]$ref.arg.arrays)
+      mx.opt.get.updater(optimizer, train.execs[[i]]$ref.arg.arrays, ctx = ctx[[i]])
     })
   }
   if (!is.null(kvstore)) {

--- a/R-package/R/model.rnn.R
+++ b/R-package/R/model.rnn.R
@@ -1,36 +1,36 @@
 # Internal function to do multiple device training on RNN
-mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data, 
-                                   dlist, arg.params, aux.params, 
-                                   grad.req, arg.update.idx, 
+mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
+                                   dlist, arg.params, aux.params,
+                                   grad.req, arg.update.idx,
                                    begin.round, end.round, optimizer, metric, metric_cpu,
                                    epoch.end.callback, batch.end.callback, kvstore, verbose) {
-  
+
   ndevice <- length(ctx)
-  if (verbose) 
+  if (verbose)
     message("Start training with ", ndevice, " devices")
-  
+
   input.names <- names(dlist)
   arg.params.names <- names(arg.params)
-  
+
   if (is.list(symbol)) sym_ini <- symbol[[names(train.data$bucketID)]] else sym_ini <- symbol
-  
+
   slices <- lapply(seq_len(ndevice), function(i) {
     sapply(names(dlist), function(n) mx.nd.split(data=dlist[[n]], num_outputs = ndevice, axis = 0, squeeze_axis = FALSE))
   })
-  
+
   train.execs <- lapply(seq_len(ndevice), function(i) {
     s <- slices[[i]]
-    mx.symbol.bind(symbol = sym_ini, arg.arrays = c(s, arg.params)[arg.update.idx], 
+    mx.symbol.bind(symbol = sym_ini, arg.arrays = c(s, arg.params)[arg.update.idx],
                    aux.arrays = aux.params, ctx = ctx[[i]], grad.req = grad.req)
   })
-  
+
   # KVStore related stuffs
   params.index <- as.integer(
     mx.util.filter.null(
       lapply(seq_along(train.execs[[1]]$ref.grad.arrays), function(k) {
         if (!is.null(train.execs[[1]]$ref.grad.arrays[[k]])) k else NULL}
       )))
-  
+
   update.on.kvstore <- FALSE
   if (!is.null(kvstore) && kvstore$update.on.kvstore) {
     update.on.kvstore <- TRUE
@@ -40,11 +40,11 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
       mx.opt.get.updater(optimizer, train.execs[[i]]$ref.arg.arrays, ctx = ctx[[i]])
     })
   }
-  
+
   if (!is.null(kvstore)) {
     kvstore$init(params.index, train.execs[[1]]$ref.arg.arrays[params.index])
   }
-  
+
   # train over specified number of epochs
   for (iteration in begin.round:end.round) {
     nbatch <- 0
@@ -54,20 +54,20 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
     }
     train.data$reset()
     while (train.data$iter.next()) {
-      
+
       # Get iterator data
       dlist <- train.data$value()[input.names]
-      
+
       # Slice inputs for multi-devices
       slices <- lapply(seq_len(ndevice), function(i) {
         sapply(names(dlist), function(n) mx.nd.split(data=dlist[[n]], num_outputs = ndevice, axis = 0, squeeze_axis = F))
       })
-      
+
       # Assign input to each executor - bug on inference if using BatchNorm
       if (is.list(symbol)) {
         train.execs <- lapply(seq_len(ndevice), function(i) {
           s <- slices[[i]]
-          mx.symbol.bind(symbol = symbol[[names(train.data$bucketID)]], 
+          mx.symbol.bind(symbol = symbol[[names(train.data$bucketID)]],
                          arg.arrays = c(s, train.execs[[i]]$arg.arrays[arg.params.names])[arg.update.idx],
                          aux.arrays = train.execs[[i]]$aux.arrays, ctx = ctx[[i]], grad.req = grad.req)
         })
@@ -77,12 +77,12 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
           mx.exec.update.arg.arrays(train.execs[[i]], s, match.name=TRUE)
         }
       }
-      
+
       # forward pass
       for (texec in train.execs) {
         mx.exec.forward(texec, is.train = TRUE)
       }
-      
+
       # copy of preds and labels for metric
       if (!is.null(metric)) {
         preds <- lapply(train.execs, function(texec) {texec$ref.outputs[[1]]})
@@ -92,12 +92,12 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
           labels <- lapply(seq_along(train.execs), function(i) {mx.nd.copyto(labels[[i]], mx.cpu())})
         }
       }
-      
+
       # backward pass
       for (texec in train.execs) {
         mx.exec.backward(texec)
       }
-      
+
       if (!is.null(kvstore)) {
         # push the gradient
         kvstore$push(params.index, lapply(train.execs, function(texec) {
@@ -123,7 +123,7 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
           mx.exec.update.arg.arrays(train.execs[[i]], arg.blocks[[i]], skip.null = TRUE)
         }
       }
-      
+
       # Update the evaluation metrics
       if (!is.null(metric)) {
         for (i in seq_len(ndevice)) {
@@ -132,40 +132,40 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
                                         state = train.metric)
         }
       }
-      
+
       nbatch <- nbatch + 1
-      
+
       if (!is.null(batch.end.callback)) {
         batch.end.callback(iteration, nbatch, environment())
       }
     }
-    
+
     if (!is.null(metric)) {
       result <- metric$get(train.metric)
-      if (verbose) 
+      if (verbose)
         message("[", iteration, "] Train-", result$name, "=", result$value)
     }
-    
+
     if (!is.null(eval.data)) {
       if (!is.null(metric)) {
         eval.metric <- metric$init()
       }
       eval.data$reset()
       while (eval.data$iter.next()) {
-        
+
         # Get iterator data
         dlist <- eval.data$value()[input.names]
-        
+
         # Slice input to multiple devices
         slices <- lapply(seq_len(ndevice), function(i) {
           sapply(names(dlist), function(n) mx.nd.split(data=dlist[[n]], num_outputs = ndevice, axis = 0, squeeze_axis = FALSE))
         })
-        
+
         # Assign input to each executor - bug on inference if using BatchNorm
         if (is.list(symbol)) {
           train.execs <- lapply(seq_len(ndevice), function(i) {
             s <- slices[[i]]
-            mx.symbol.bind(symbol = symbol[[names(eval.data$bucketID)]], 
+            mx.symbol.bind(symbol = symbol[[names(eval.data$bucketID)]],
                            arg.arrays = c(s, train.execs[[i]]$arg.arrays[arg.params.names])[arg.update.idx],
                            aux.arrays = train.execs[[i]]$aux.arrays, ctx = ctx[[i]], grad.req = grad.req)
           })
@@ -175,12 +175,12 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
             mx.exec.update.arg.arrays(train.execs[[i]], s, match.name=TRUE)
           }
         }
-        
+
         # forward pass
         for (texec in train.execs) {
           mx.exec.forward(texec, is.train = FALSE)
         }
-        
+
         # copy of preds and labels for metric and update metric
         if (!is.null(metric)) {
           preds <- lapply(train.execs, function(texec) {texec$ref.outputs[[1]]})
@@ -190,17 +190,17 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
             labels <- lapply(seq_along(train.execs), function(i) {mx.nd.copyto(labels[[i]], mx.cpu())})
           }
           for (i in seq_len(ndevice)) {
-            eval.metric <- metric$update(label = labels[[i]], 
-                                         pred = preds[[i]], 
+            eval.metric <- metric$update(label = labels[[i]],
+                                         pred = preds[[i]],
                                          state = eval.metric)
           }
         }
       }
-      
+
       if (!is.null(metric)) {
         result <- metric$get(eval.metric)
         if (verbose) {
-          message("[", iteration, "] Validation-", result$name, "=", 
+          message("[", iteration, "] Validation-", result$name, "=",
                   result$value)
         }
       }
@@ -209,12 +209,12 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
     }
     # get the model out
     model <- mx.model.extract.model(sym_ini, train.execs)
-    
+
     epoch_continue <- TRUE
     if (!is.null(epoch.end.callback)) {
       epoch_continue <- epoch.end.callback(iteration, 0, environment(), verbose = verbose)
     }
-    
+
     if (!epoch_continue) {
       break
     }
@@ -223,7 +223,7 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
 }
 
 
-# 
+#
 #' Train RNN with bucket support
 #'
 #' @param symbol Symbol or list of Symbols representing the model
@@ -241,33 +241,33 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
 #' @param verbose
 #'
 #' @export
-mx.model.buckets <- function(symbol, train.data, eval.data = NULL, metric = NULL, 
-                             arg.params = NULL, aux.params = NULL, fixed.params = NULL, 
-                             num.round = 1, begin.round = 1, 
-                             initializer = mx.init.uniform(0.01), optimizer = "sgd", ctx = NULL, 
-                             batch.end.callback = NULL, epoch.end.callback = NULL, 
+mx.model.buckets <- function(symbol, train.data, eval.data = NULL, metric = NULL,
+                             arg.params = NULL, aux.params = NULL, fixed.params = NULL,
+                             num.round = 1, begin.round = 1,
+                             initializer = mx.init.uniform(0.01), optimizer = "sgd", ctx = NULL,
+                             batch.end.callback = NULL, epoch.end.callback = NULL,
                              kvstore = "local", verbose = TRUE, metric_cpu = TRUE) {
-  
+
   if (!train.data$iter.next()) {
     train.data$reset()
-    if (!train.data$iter.next()) 
+    if (!train.data$iter.next())
       stop("Empty train.data")
   }
-  
+
   if (!is.null(eval.data)) {
     if (!eval.data$iter.next()) {
       eval.data$reset()
-      if (!eval.data$iter.next()) 
+      if (!eval.data$iter.next())
         stop("Empty eval.data")
     }
   }
-  
-  if (is.null(ctx)) 
+
+  if (is.null(ctx))
     ctx <- mx.ctx.default()
   if (is.mx.context(ctx)) {
     ctx <- list(ctx)
   }
-  if (!is.list(ctx)) 
+  if (!is.list(ctx))
     stop("ctx must be mx.context or list of mx.context")
   if (is.character(optimizer)) {
     if (is.numeric(input.shape)) {
@@ -279,75 +279,75 @@ mx.model.buckets <- function(symbol, train.data, eval.data = NULL, metric = NULL
     }
     optimizer <- mx.opt.create(optimizer, rescale.grad = (1/batchsize), ...)
   }
-  
+
   sym_ini <- if (is.list(symbol)) symbol[[names(train.data$bucketID)]] else symbol
-  
+
   arguments <- sym_ini$arguments
   input.names <- intersect(names(train.data$value()), arguments)
-  
+
   input.shape <- sapply(input.names, function(n) {
     dim(train.data$value()[[n]])
   }, simplify = FALSE)
-  
+
   shapes <- sym_ini$infer.shape(input.shape)
-  
+
   # assign arg.params and aux.params arguments to arg.params.input and aux.params.input
   arg.params.input <- arg.params
   aux.params.input <- aux.params
-  
+
   # initialize all arguments with zeros
   arg.params <- lapply(shapes$arg.shapes, function(shape) {
     mx.nd.zeros(shape = shape, ctx = mx.cpu())
   })
-  
+
   # initialize input parameters
   dlist <- arg.params[input.names]
-  
+
   # initialize parameters - only argument ending with _weight and _bias are initialized
   arg.params.ini <- mx.init.create(initializer = initializer, shape.array = shapes$arg.shapes, ctx = mx.cpu(), skip.unknown = TRUE)
-  
+
   # assign initilized parameters to arg.params
   arg.params[names(arg.params.ini)] <- arg.params.ini
-  
+
   # assign input params to arg.params
   arg.params[names(arg.params.input)] <- arg.params.input
-  
+
   # remove input params from arg.params
   arg.params[input.names] <- NULL
-  
+
   # Grad request
   grad.req <- rep("null", length(arguments))
   grad.req.write <- arguments %in% setdiff(names(arg.params.ini), fixed.params)
   grad.req[grad.req.write] <- "write"
-  
+
   # Arg array order
   update_names <- c(input.names, names(arg.params))
   arg.update.idx <- match(arguments, update_names)
-  
+
   # aux parameters setup
   aux.params <- lapply(shapes$aux.shapes, function(shape) {
     mx.nd.zeros(shape = shape, ctx = mx.cpu())
   })
-  
+
   aux.params.ini <- mx.init.create(initializer, shapes$aux.shapes, ctx = mx.cpu(), skip.unknown = FALSE)
   if (length(aux.params) > 0) {
     aux.params[names(aux.params.ini)] <- aux.params.ini
   } else aux.params <- NULL
-  
+
   aux.params[names(aux.params.input)] <- aux.params.input
-  
+
   # kvstore initialization
-  kvstore <- mx.model.create.kvstore(kvstore, params$arg.params, length(ctx), 
+  kvstore <- mx.model.create.kvstore(kvstore, params$arg.params, length(ctx),
                                      verbose = verbose)
-  
+
   ### Execute training
-  model <- mx.model.train.buckets(symbol = symbol, ctx = ctx,  train.data = train.data, eval.data = eval.data, 
-                                  dlist = dlist,  arg.params = arg.params, aux.params = aux.params, 
-                                  grad.req = grad.req, arg.update.idx = arg.update.idx, 
-                                  optimizer = optimizer, metric = metric, 
-                                  begin.round = begin.round, end.round = num.round, 
-                                  batch.end.callback = batch.end.callback, epoch.end.callback = epoch.end.callback, 
+  model <- mx.model.train.buckets(symbol = symbol, ctx = ctx,  train.data = train.data, eval.data = eval.data,
+                                  dlist = dlist,  arg.params = arg.params, aux.params = aux.params,
+                                  grad.req = grad.req, arg.update.idx = arg.update.idx,
+                                  optimizer = optimizer, metric = metric,
+                                  begin.round = begin.round, end.round = num.round,
+                                  batch.end.callback = batch.end.callback, epoch.end.callback = epoch.end.callback,
                                   kvstore = kvstore, verbose = verbose, metric_cpu = metric_cpu)
-  
+
   return(model)
 }

--- a/R-package/R/model.rnn.R
+++ b/R-package/R/model.rnn.R
@@ -3,8 +3,7 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
                                    dlist, arg.params, aux.params, 
                                    grad.req, arg.update.idx, 
                                    begin.round, end.round, optimizer, metric, metric_cpu,
-                                   epoch.end.callback, batch.end.callback, kvstore, verbose,
-                                   gc_freq) {
+                                   epoch.end.callback, batch.end.callback, kvstore, verbose) {
   
   ndevice <- length(ctx)
   if (verbose) 
@@ -38,7 +37,7 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
     kvstore$set.optimizer(optimizer)
   } else {
     updaters <- lapply(seq_len(ndevice), function(i) {
-      mx.opt.get.updater(optimizer, train.execs[[i]]$ref.arg.arrays)
+      mx.opt.get.updater(optimizer, train.execs[[i]]$ref.arg.arrays, ctx = ctx[[i]])
     })
   }
   
@@ -135,9 +134,6 @@ mx.model.train.buckets <- function(symbol, ctx, train.data, eval.data,
       }
       
       nbatch <- nbatch + 1
-      if (!is.null(gc_freq)) {
-        if (nbatch %% gc_freq == 0) gc()
-      }
       
       if (!is.null(batch.end.callback)) {
         batch.end.callback(iteration, nbatch, environment())
@@ -250,7 +246,7 @@ mx.model.buckets <- function(symbol, train.data, eval.data = NULL, metric = NULL
                              num.round = 1, begin.round = 1, 
                              initializer = mx.init.uniform(0.01), optimizer = "sgd", ctx = NULL, 
                              batch.end.callback = NULL, epoch.end.callback = NULL, 
-                             kvstore = "local", verbose = TRUE, metric_cpu = TRUE, gc_freq = NULL) {
+                             kvstore = "local", verbose = TRUE, metric_cpu = TRUE) {
   
   if (!train.data$iter.next()) {
     train.data$reset()
@@ -351,7 +347,7 @@ mx.model.buckets <- function(symbol, train.data, eval.data = NULL, metric = NULL
                                   optimizer = optimizer, metric = metric, 
                                   begin.round = begin.round, end.round = num.round, 
                                   batch.end.callback = batch.end.callback, epoch.end.callback = epoch.end.callback, 
-                                  kvstore = kvstore, verbose = verbose, metric_cpu = metric_cpu, gc_freq = gc_freq)
+                                  kvstore = kvstore, verbose = verbose, metric_cpu = metric_cpu)
   
   return(model)
 }

--- a/R-package/R/optimizer.R
+++ b/R-package/R/optimizer.R
@@ -17,7 +17,7 @@ mx.opt.sgd <- function(learning.rate = 0.01,
                        momentum = 0,
                        wd = 0,
                        rescale.grad = 1,
-                       clip_gradient = Inf,
+                       clip_gradient = -1,
                        lr_scheduler = NULL) {
 
   lr <- learning.rate

--- a/R-package/R/optimizer.R
+++ b/R-package/R/optimizer.R
@@ -17,7 +17,7 @@ mx.opt.sgd <- function(learning.rate = 0.01,
                        momentum = 0,
                        wd = 0,
                        rescale.grad = 1,
-                       clip_gradient = -1,
+                       clip_gradient = Inf,
                        lr_scheduler = NULL) {
 
   lr <- learning.rate
@@ -94,7 +94,7 @@ mx.opt.sgd <- function(learning.rate = 0.01,
 #'      The initial learning rate.
 #' @param gamma1 float, default=0.95
 #'      decay factor of moving average for gradient, gradient^2.
-#' @param gamm2 float, default=0.9
+#' @param gamma2 float, default=0.9
 #'      "momentum" factor.
 #' @param epsilon float, default=1e-4
 #' @param wd float, default=0.0
@@ -323,7 +323,7 @@ mx.opt.adagrad <- function(learning.rate = 0.05,
 
     grad <- grad * rescale.grad
     if (!is.null(clip_gradient)) {
-      if(clip_gradient >= 0) {
+      if (clip_gradient >= 0) {
         grad <- mx.symbol.clip(data = grad, a.min = -clip_gradient, a.max = clip_gradient)
       }
     }
@@ -398,7 +398,7 @@ mx.opt.adadelta <- function(rho = 0.90,
 
     grad <- grad * rescale.grad
     if (!is.null(clip_gradient)) {
-      if(clip_gradient >= 0) {
+      if (clip_gradient >= 0) {
         grad <- mx.symbol.clip(data = grad, a.min = -clip_gradient, a.max = clip_gradient)
       }
     }

--- a/R-package/R/optimizer.R
+++ b/R-package/R/optimizer.R
@@ -9,7 +9,7 @@
 #'      L2 regularization coefficient add to all the weights.
 #' @param rescale.grad float, default=1.0
 #'      rescaling factor of gradient.
-#' @param clip_gradient float, optional, default=-1
+#' @param clip_gradient float, optional, default=-1 (no clipping if < 0)
 #'      clip gradient in range [-clip_gradient, clip_gradient].
 #' @param lr_scheduler function, optional
 #'      The learning rate scheduler.
@@ -101,7 +101,7 @@ mx.opt.sgd <- function(learning.rate = 0.01,
 #'      L2 regularization coefficient add to all the weights.
 #' @param rescale.grad float, default=1.0
 #'      rescaling factor of gradient.
-#' @param clip_gradient float, optional, default=-1
+#' @param clip_gradient float, optional, default=-1 (no clipping if < 0)
 #'      clip gradient in range [-clip_gradient, clip_gradient].
 #' @param lr_scheduler function, optional
 #'      The learning rate scheduler.
@@ -209,7 +209,7 @@ mx.opt.rmsprop <- function(learning.rate = 0.002,
 #'      L2 regularization coefficient add to all the weights.
 #' @param rescale.grad float, default=1.0
 #'      rescaling factor of gradient.
-#' @param clip_gradient float, optional, default=-1
+#' @param clip_gradient float, optional, default=-1 (no clipping if < 0)
 #'      clip gradient in range [-clip_gradient, clip_gradient].
 #' @param lr_scheduler function, optional
 #'      The learning rate scheduler.
@@ -294,7 +294,7 @@ mx.opt.adam <- function(learning.rate = 1e-3,
 #'      L2 regularization coefficient add to all the weights.
 #' @param rescale.grad float, default=1.0
 #'      rescaling factor of gradient.
-#' @param clip_gradient float, default=-1.0 (ignored)
+#' @param clip_gradient float, default=-1.0 (no clipping if < 0)
 #'      clip gradient in range [-clip_gradient, clip_gradient].
 #' @param lr_scheduler function, optional
 #'      The learning rate scheduler.
@@ -380,7 +380,7 @@ mx.opt.adagrad <- function(learning.rate = 0.05,
 #'      L2 regularization coefficient add to all the weights.
 #' @param rescale.grad float, default=1
 #'      rescaling factor of gradient.
-#' @param clip_gradient float, default=-1 (ignored)
+#' @param clip_gradient float, default=-1 (no clipping if < 0)
 #'      clip gradient in range [-clip_gradient, clip_gradient].
 #'
 mx.opt.adadelta <- function(rho = 0.90,

--- a/R-package/R/optimizer.R
+++ b/R-package/R/optimizer.R
@@ -1,7 +1,7 @@
 #' Create an SGD optimizer with respective parameters.
 #' Perform SGD with momentum update
 #'
-#' @param learning.rate float, default=1e-3
+#' @param learning.rate float, default=0.01
 #'      The initial learning rate.
 #' @param momentum float, default=0
 #'      The momentumvalue
@@ -90,12 +90,13 @@ mx.opt.sgd <- function(learning.rate = 0.01,
 #' Reference: Tieleman T, Hinton G. Lecture 6.5-rmsprop: Divide the gradient by a running average of its recent magnitude[J]. COURSERA: Neural Networks for Machine Learning, 2012, 4(2).
 #' The code follows: http://arxiv.org/pdf/1308.0850v5.pdf Eq(38) - Eq(45) by Alex Graves, 2013.
 #'
-#' @param learning.rate float, default=1e-3
+#' @param learning.rate float, default=0.002
 #'      The initial learning rate.
-#' @param gamma1 float, default=0.9
+#' @param gamma1 float, default=0.95
 #'      decay factor of moving average for gradient, gradient^2.
 #' @param gamm2 float, default=0.9
 #'      "momentum" factor.
+#' @param epsilon float, default=1e-4
 #' @param wd float, default=0.0
 #'      L2 regularization coefficient add to all the weights.
 #' @param rescale.grad float, default=1.0
@@ -105,11 +106,11 @@ mx.opt.sgd <- function(learning.rate = 0.01,
 #' @param lr_scheduler function, optional
 #'      The learning rate scheduler.
 #'
-mx.opt.rmsprop <- function(learning.rate = 1e-3,
+mx.opt.rmsprop <- function(learning.rate = 0.002,
                            centered = TRUE,
-                           gamma1 = 0.9,
+                           gamma1 = 0.95,
                            gamma2 = 0.9,
-                           epsilon = 1e-8,
+                           epsilon = 1e-4,
                            wd = 0,
                            rescale.grad = 1,
                            clip_gradient = -1,
@@ -261,7 +262,7 @@ mx.opt.adam <- function(learning.rate = 1e-3,
       lr <- adam$lr
       ## update count
       indexKey <- paste0('ik', index)
-      if (!exists(envir = adam, x = indexKey, inherits = FALSE)){
+      if (!exists(envir = adam, x = indexKey, inherits = FALSE)) {
         adam[[indexKey]] <- 0
       } else {
         indexValue <- adam[[indexKey]]
@@ -298,8 +299,8 @@ mx.opt.adam <- function(learning.rate = 1e-3,
 #' @param lr_scheduler function, optional
 #'      The learning rate scheduler.
 #'
-mx.opt.adagrad <- function(learning.rate = 0.01,
-                           epsilon = 1e-7,
+mx.opt.adagrad <- function(learning.rate = 0.05,
+                           epsilon = 1e-8,
                            wd = 0,
                            rescale.grad = 1,
                            clip_gradient = -1,
@@ -322,7 +323,7 @@ mx.opt.adagrad <- function(learning.rate = 0.01,
     
     grad <- grad * rescale.grad
     if (!is.null(clip_gradient)) {
-      if(clip_gradient >= 0){
+      if(clip_gradient >= 0) {
         grad <- mx.symbol.clip(data = grad, a.min = -clip_gradient, a.max = clip_gradient)
       }
     }
@@ -344,7 +345,7 @@ mx.opt.adagrad <- function(learning.rate = 0.01,
       lr <- adagrad$lr
       ## update count
       indexKey <- paste0('ik', index)
-      if (!exists(envir = adagrad, x = indexKey, inherits = FALSE)){
+      if (!exists(envir = adagrad, x = indexKey, inherits = FALSE)) {
         adagrad[[indexKey]] <- 0
       } else {
         indexValue <- adagrad[[indexKey]]
@@ -398,7 +399,7 @@ mx.opt.adadelta <- function(rho = 0.90,
     
     grad <- grad * rescale.grad
     if (!is.null(clip_gradient)) {
-      if(clip_gradient >= 0){
+      if(clip_gradient >= 0) {
         grad <- mx.symbol.clip(data = grad, a.min = -clip_gradient, a.max = clip_gradient)
       }
     }
@@ -462,8 +463,11 @@ mx.opt.create <- function(name, ...) {
 mx.opt.get.updater <- function(optimizer, weights, ctx) {
   
   exec_list <- lapply(seq_along(weights), function(i) {
-    if (is.null(weights[[i]])) return(NULL) else
+    if (is.null(weights[[i]])) {
+      return(NULL)
+    } else {
       optimizer$create_exec(index = i, weight_dim = dim(weights[[i]]), ctx = ctx)
+    }
   })
   
   update <- optimizer$update
@@ -471,8 +475,11 @@ mx.opt.get.updater <- function(optimizer, weights, ctx) {
   update.closure <- function(weight, grad) {
     
     weight_list <- lapply(seq_along(weight), function(i) {
-      if (!is.null(grad[[i]])) return(update(i, exec_list[[i]], weight[[i]], grad[[i]])) else
-        return(NULL)
+      if (!is.null(grad[[i]])) {
+        return(update(i, exec_list[[i]], weight[[i]], grad[[i]]))
+      } else {
+        return(NULL) 
+      }
     })
     return(weight_list)
   }

--- a/R-package/R/optimizer.R
+++ b/R-package/R/optimizer.R
@@ -391,12 +391,11 @@ mx.opt.adadelta <- function(rho = 0.90,
   adadelta <- new.env()
   
   create_exec <- function(index, weight_dim, ctx) {
-    
     weight <- mx.symbol.Variable("weight")
     grad <- mx.symbol.Variable("grad")
     acc.g <- mx.symbol.Variable("acc.g")
     acc.delta <- mx.symbol.Variable("acc.delta")
-    
+
     grad <- grad * rescale.grad
     if (!is.null(clip_gradient)) {
       if(clip_gradient >= 0) {

--- a/R-package/R/optimizer.R
+++ b/R-package/R/optimizer.R
@@ -62,7 +62,7 @@ mx.opt.sgd <- function(learning.rate = 0.01,
     exec <- mx.simple.bind(symbol = sym, weight = weight_dim, ctx = ctx, grad.req = "null")
     return(exec)
   }
-  
+
   update <- function(index, exec_w, weight, grad) {
     
     if (!is.null(lr_scheduler)){
@@ -119,7 +119,7 @@ mx.opt.rmsprop <- function(learning.rate = 0.002,
   lr <- learning.rate
   count <- 0
   num_update <- 0
-  
+
   rmsprop <- new.env()
   rmsprop$lr <- lr
   rmsprop$count <- 0
@@ -168,7 +168,7 @@ mx.opt.rmsprop <- function(learning.rate = 0.002,
     exec <- mx.simple.bind(symbol = sym, weight = weight_dim, ctx = ctx, grad.req = "null")
     return(exec)
   }
-  
+
   update <- function(index, exec_w, weight, grad) {
     if (!is.null(lr_scheduler)){
       lr_scheduler(rmsprop) ## changing lr
@@ -226,7 +226,7 @@ mx.opt.adam <- function(learning.rate = 1e-3,
   lr <- learning.rate
   count <- 0
   num_update <- 0
-  
+
   adam <- new.env()
   adam$lr <- lr
   adam$count <- 0
@@ -255,7 +255,7 @@ mx.opt.adam <- function(learning.rate = 1e-3,
     exec <- mx.simple.bind(symbol = sym, weight = weight_dim, ctx = ctx, grad.req = "null")
     return(exec)
   }
-  
+
   update <- function(index, exec_w, weight, grad) {
     if (!is.null(lr_scheduler)){
       lr_scheduler(adam) ## changing lr
@@ -309,7 +309,7 @@ mx.opt.adagrad <- function(learning.rate = 0.05,
   lr <- learning.rate
   count <- 0
   num_update <- 0
-  
+
   adagrad <- new.env()
   adagrad$lr <- lr
   adagrad$count <- 0
@@ -338,7 +338,7 @@ mx.opt.adagrad <- function(learning.rate = 0.05,
     exec <- mx.simple.bind(symbol = sym, weight = weight_dim, ctx = ctx, grad.req = "null")
     return(exec)
   }
-  
+
   update <- function(index, exec_w, weight, grad) {
     if (!is.null(lr_scheduler)) {
       lr_scheduler(adagrad) ## changing lr
@@ -418,7 +418,7 @@ mx.opt.adadelta <- function(rho = 0.90,
     exec <- mx.simple.bind(symbol = sym, weight = weight_dim, ctx = ctx, grad.req = "null")
     return(exec)
   }
-  
+
   update <- function(index, exec_w, weight, grad) {
     
     mx.exec.update.arg.arrays(exec_w, arg.arrays = list(weight = weight,grad = grad), match.name = T)
@@ -469,9 +469,9 @@ mx.opt.get.updater <- function(optimizer, weights, ctx) {
       optimizer$create_exec(index = i, weight_dim = dim(weights[[i]]), ctx = ctx)
     }
   })
-  
+
   update <- optimizer$update
-  
+
   update.closure <- function(weight, grad) {
     
     weight_list <- lapply(seq_along(weight), function(i) {

--- a/R-package/tests/testthat/test_optimizer.R
+++ b/R-package/tests/testthat/test_optimizer.R
@@ -11,55 +11,55 @@ test_that("sgd", {
   x <- mx.nd.array(array(1:6, dim=2:3))
   y <- mx.nd.array(c(5, 11, 16))
   w1 <- mx.nd.array(array(c(1.1, 1.8), dim = c(2,1)))
-  
+
   exec <- mxnet:::mx.symbol.bind(symbol = loss,
                                  ctx = mx.cpu(),
                                  arg.arrays = list(data = x,
                                                    fc1_weight = w1,
                                                    label = y),
-                                 aux.arrays = NULL, 
+                                 aux.arrays = NULL,
                                  grad.reqs = c("null", "write", "null"))
-  
-  optimizer <- mx.opt.create("sgd", 
+
+  optimizer <- mx.opt.create("sgd",
                              learning.rate = 1,
                              momentum = 0,
                              wd = 0,
                              rescale.grad = 1,
                              clip_gradient = -1)
-  
+
   updaters <- mx.opt.get.updater(optimizer, exec$ref.arg.arrays, ctx = mx.cpu())
-  
+
   mx.exec.forward(exec, is.train = T)
   mx.exec.backward(exec)
-  
+
   arg.blocks <- updaters(exec$ref.arg.arrays, exec$ref.grad.arrays)
   mx.exec.update.arg.arrays(exec, arg.blocks, skip.null = TRUE)
-  
+
   expect_equal(as.array(arg.blocks[[2]]), array(c(1.4, 2.6), dim = c(2,1)), tolerance = 1e-1)
-  
+
 })
 
 
 test_that("rmsprop", {
-  
+
   data = mx.symbol.Variable('data')
   label = mx.symbol.Variable('label')
   fc_weight = mx.symbol.Variable('fc_weight')
   fc = mx.symbol.FullyConnected(data = data, weight = fc_weight, no.bias = T, name = 'fc1', num_hidden = 1)
   loss = mx.symbol.LinearRegressionOutput(data = fc, label = label, name = 'loss')
-  
+
   x <- mx.nd.array(array(1:6, dim=2:3))
   y <- mx.nd.array(c(5, 11, 16))
   w1 <- mx.nd.array(array(c(1.1, 1.8), dim = c(2,1)))
-  
+
   exec <- mxnet:::mx.symbol.bind(symbol = loss,
                                  ctx = mx.cpu(),
                                  arg.arrays = list(data = x,
                                                    fc1_weight = w1,
                                                    label = y),
-                                 aux.arrays = NULL, 
+                                 aux.arrays = NULL,
                                  grad.reqs = c("null", "write", "null"))
-  
+
   optimizer <- mx.opt.create("rmsprop", learning.rate = 1,
                              centered = TRUE,
                              gamma1 = 0.95,
@@ -68,138 +68,137 @@ test_that("rmsprop", {
                              wd = 0,
                              rescale.grad = 1,
                              clip_gradient = -1)
-  
+
   updaters <- mx.opt.get.updater(optimizer, exec$ref.arg.arrays, ctx = mx.cpu())
-  
+
   mx.exec.forward(exec, is.train = T)
   mx.exec.backward(exec)
-  
+
   arg.blocks <- updaters(exec$ref.arg.arrays, exec$ref.grad.arrays)
   mx.exec.update.arg.arrays(exec, arg.blocks, skip.null = TRUE)
-  
+
   expect_equal(as.array(arg.blocks[[2]]), array(c(5.64, 6.38), dim = c(2,1)), tolerance = 1e-1)
-  
+
 })
 
 
 test_that("adam", {
-  
+
   data = mx.symbol.Variable('data')
   label = mx.symbol.Variable('label')
   fc_weight = mx.symbol.Variable('fc_weight')
   fc = mx.symbol.FullyConnected(data = data, weight = fc_weight, no.bias = T, name = 'fc1', num_hidden = 1)
   loss = mx.symbol.LinearRegressionOutput(data = fc, label = label, name = 'loss')
-  
+
   x <- mx.nd.array(array(1:6, dim=2:3))
   y <- mx.nd.array(c(5, 11, 16))
   w1 <- mx.nd.array(array(c(1.1, 1.8), dim = c(2,1)))
-  
+
   exec <- mxnet:::mx.symbol.bind(symbol = loss,
                                  ctx = mx.cpu(),
                                  arg.arrays = list(data = x,
                                                    fc1_weight = w1,
                                                    label = y),
-                                 aux.arrays = NULL, 
+                                 aux.arrays = NULL,
                                  grad.reqs = c("null", "write", "null"))
-  
-  optimizer <- mx.opt.create("adam", 
-                             learning.rate = 1, 
+
+  optimizer <- mx.opt.create("adam",
+                             learning.rate = 1,
                              beta1 = 0.9,
                              beta2 = 0.999,
                              epsilon = 1e-8,
                              wd = 0,
                              rescale.grad = 1,
                              clip_gradient = -1)
-  
+
   updaters <- mx.opt.get.updater(optimizer, exec$ref.arg.arrays, ctx = mx.cpu())
-  
+
   mx.exec.forward(exec, is.train = T)
   mx.exec.backward(exec)
-  
+
   arg.blocks <- updaters(exec$ref.arg.arrays, exec$ref.grad.arrays)
   mx.exec.update.arg.arrays(exec, arg.blocks, skip.null = TRUE)
-  
+
   expect_equal(as.array(arg.blocks[[2]]), array(c(4.26, 4.96), dim = c(2,1)), tolerance = 1e-1)
-  
+
 })
 
 
 test_that("adagrad", {
-  
+
   data = mx.symbol.Variable('data')
   label = mx.symbol.Variable('label')
   fc_weight = mx.symbol.Variable('fc_weight')
   fc = mx.symbol.FullyConnected(data = data, weight = fc_weight, no.bias = T, name = 'fc1', num_hidden = 1)
   loss = mx.symbol.LinearRegressionOutput(data = fc, label = label, name = 'loss')
-  
+
   x <- mx.nd.array(array(1:6, dim=2:3))
   y <- mx.nd.array(c(5, 11, 16))
   w1 <- mx.nd.array(array(c(1.1, 1.8), dim = c(2,1)))
-  
+
   exec <- mxnet:::mx.symbol.bind(symbol = loss,
                                  ctx = mx.cpu(),
                                  arg.arrays = list(data = x,
                                                    fc1_weight = w1,
                                                    label = y),
-                                 aux.arrays = NULL, 
+                                 aux.arrays = NULL,
                                  grad.reqs = c("null", "write", "null"))
-  
-  optimizer <- mx.opt.create("adagrad", 
-                             learning.rate = 1, 
+
+  optimizer <- mx.opt.create("adagrad",
+                             learning.rate = 1,
                              epsilon = 1e-8,
                              wd = 0,
                              rescale.grad = 1,
                              clip_gradient = -1)
-  
+
   updaters <- mx.opt.get.updater(optimizer, exec$ref.arg.arrays, ctx = mx.cpu())
-  
+
   mx.exec.forward(exec, is.train = T)
   mx.exec.backward(exec)
-  
+
   arg.blocks <- updaters(exec$ref.arg.arrays, exec$ref.grad.arrays)
   mx.exec.update.arg.arrays(exec, arg.blocks, skip.null = TRUE)
-  
+
   expect_equal(as.array(arg.blocks[[2]]), array(c(2.1, 2.8), dim = c(2,1)), tolerance = 1e-1)
-  
+
 })
 
 
 test_that("adadelta", {
-  
+
   data = mx.symbol.Variable('data')
   label = mx.symbol.Variable('label')
   fc_weight = mx.symbol.Variable('fc_weight')
   fc = mx.symbol.FullyConnected(data = data, weight = fc_weight, no.bias = T, name = 'fc1', num_hidden = 1)
   loss = mx.symbol.LinearRegressionOutput(data = fc, label = label, name = 'loss')
-  
+
   x <- mx.nd.array(array(1:6, dim=2:3))
   y <- mx.nd.array(c(5, 11, 16))
   w1 <- mx.nd.array(array(c(1.1, 1.8), dim = c(2,1)))
-  
+
   exec <- mxnet:::mx.symbol.bind(symbol = loss,
                                  ctx = mx.cpu(),
                                  arg.arrays = list(data = x,
                                                    fc1_weight = w1,
                                                    label = y),
-                                 aux.arrays = NULL, 
+                                 aux.arrays = NULL,
                                  grad.reqs = c("null", "write", "null"))
-  
-  optimizer <- mx.opt.create("adadelta", 
+
+  optimizer <- mx.opt.create("adadelta",
                              rho = 0.90,
                              epsilon = 1e-5,
                              wd = 0,
                              rescale.grad = 1,
                              clip_gradient = -1)
-  
+
   updaters <- mx.opt.get.updater(optimizer, exec$ref.arg.arrays, ctx = mx.cpu())
-  
+
   mx.exec.forward(exec, is.train = T)
   mx.exec.backward(exec)
-  
+
   arg.blocks <- updaters(exec$ref.arg.arrays, exec$ref.grad.arrays)
   mx.exec.update.arg.arrays(exec, arg.blocks, skip.null = TRUE)
-  
-  expect_equal(as.array(arg.blocks[[2]]), array(c(1.11, 1.81), dim = c(2,1)), tolerance = 1e-1)
-  
-})
 
+  expect_equal(as.array(arg.blocks[[2]]), array(c(1.11, 1.81), dim = c(2,1)), tolerance = 1e-1)
+
+})

--- a/R-package/tests/testthat/test_optimizer.R
+++ b/R-package/tests/testthat/test_optimizer.R
@@ -1,0 +1,205 @@
+context("optimizer")
+
+test_that("sgd", {
+
+  data = mx.symbol.Variable('data')
+  label = mx.symbol.Variable('label')
+  fc_weight = mx.symbol.Variable('fc_weight')
+  fc = mx.symbol.FullyConnected(data = data, weight = fc_weight, no.bias = T, name = 'fc1', num_hidden = 1)
+  loss = mx.symbol.LinearRegressionOutput(data = fc, label = label, name = 'loss')
+
+  x <- mx.nd.array(array(1:6, dim=2:3))
+  y <- mx.nd.array(c(5, 11, 16))
+  w1 <- mx.nd.array(array(c(1.1, 1.8), dim = c(2,1)))
+  
+  exec <- mxnet:::mx.symbol.bind(symbol = loss,
+                                 ctx = mx.cpu(),
+                                 arg.arrays = list(data = x,
+                                                   fc1_weight = w1,
+                                                   label = y),
+                                 aux.arrays = NULL, 
+                                 grad.reqs = c("null", "write", "null"))
+  
+  optimizer <- mx.opt.create("sgd", 
+                             learning.rate = 1,
+                             momentum = 0,
+                             wd = 0,
+                             rescale.grad = 1,
+                             clip_gradient = -1)
+  
+  updaters <- mx.opt.get.updater(optimizer, exec$ref.arg.arrays, ctx = mx.cpu())
+  
+  mx.exec.forward(exec, is.train = T)
+  mx.exec.backward(exec)
+  
+  arg.blocks <- updaters(exec$ref.arg.arrays, exec$ref.grad.arrays)
+  mx.exec.update.arg.arrays(exec, arg.blocks, skip.null = TRUE)
+  
+  expect_equal(as.array(arg.blocks[[2]]), array(c(1.4, 2.6), dim = c(2,1)), tolerance = 1e-1)
+  
+})
+
+
+test_that("rmsprop", {
+  
+  data = mx.symbol.Variable('data')
+  label = mx.symbol.Variable('label')
+  fc_weight = mx.symbol.Variable('fc_weight')
+  fc = mx.symbol.FullyConnected(data = data, weight = fc_weight, no.bias = T, name = 'fc1', num_hidden = 1)
+  loss = mx.symbol.LinearRegressionOutput(data = fc, label = label, name = 'loss')
+  
+  x <- mx.nd.array(array(1:6, dim=2:3))
+  y <- mx.nd.array(c(5, 11, 16))
+  w1 <- mx.nd.array(array(c(1.1, 1.8), dim = c(2,1)))
+  
+  exec <- mxnet:::mx.symbol.bind(symbol = loss,
+                                 ctx = mx.cpu(),
+                                 arg.arrays = list(data = x,
+                                                   fc1_weight = w1,
+                                                   label = y),
+                                 aux.arrays = NULL, 
+                                 grad.reqs = c("null", "write", "null"))
+  
+  optimizer <- mx.opt.create("rmsprop", learning.rate = 1,
+                             centered = TRUE,
+                             gamma1 = 0.95,
+                             gamma2 = 0.9,
+                             epsilon = 1e-4,
+                             wd = 0,
+                             rescale.grad = 1,
+                             clip_gradient = -1)
+  
+  updaters <- mx.opt.get.updater(optimizer, exec$ref.arg.arrays, ctx = mx.cpu())
+  
+  mx.exec.forward(exec, is.train = T)
+  mx.exec.backward(exec)
+  
+  arg.blocks <- updaters(exec$ref.arg.arrays, exec$ref.grad.arrays)
+  mx.exec.update.arg.arrays(exec, arg.blocks, skip.null = TRUE)
+  
+  expect_equal(as.array(arg.blocks[[2]]), array(c(5.64, 6.38), dim = c(2,1)), tolerance = 1e-1)
+  
+})
+
+
+test_that("adam", {
+  
+  data = mx.symbol.Variable('data')
+  label = mx.symbol.Variable('label')
+  fc_weight = mx.symbol.Variable('fc_weight')
+  fc = mx.symbol.FullyConnected(data = data, weight = fc_weight, no.bias = T, name = 'fc1', num_hidden = 1)
+  loss = mx.symbol.LinearRegressionOutput(data = fc, label = label, name = 'loss')
+  
+  x <- mx.nd.array(array(1:6, dim=2:3))
+  y <- mx.nd.array(c(5, 11, 16))
+  w1 <- mx.nd.array(array(c(1.1, 1.8), dim = c(2,1)))
+  
+  exec <- mxnet:::mx.symbol.bind(symbol = loss,
+                                 ctx = mx.cpu(),
+                                 arg.arrays = list(data = x,
+                                                   fc1_weight = w1,
+                                                   label = y),
+                                 aux.arrays = NULL, 
+                                 grad.reqs = c("null", "write", "null"))
+  
+  optimizer <- mx.opt.create("adam", 
+                             learning.rate = 1, 
+                             beta1 = 0.9,
+                             beta2 = 0.999,
+                             epsilon = 1e-8,
+                             wd = 0,
+                             rescale.grad = 1,
+                             clip_gradient = -1)
+  
+  updaters <- mx.opt.get.updater(optimizer, exec$ref.arg.arrays, ctx = mx.cpu())
+  
+  mx.exec.forward(exec, is.train = T)
+  mx.exec.backward(exec)
+  
+  arg.blocks <- updaters(exec$ref.arg.arrays, exec$ref.grad.arrays)
+  mx.exec.update.arg.arrays(exec, arg.blocks, skip.null = TRUE)
+  
+  expect_equal(as.array(arg.blocks[[2]]), array(c(4.26, 4.96), dim = c(2,1)), tolerance = 1e-1)
+  
+})
+
+
+test_that("adagrad", {
+  
+  data = mx.symbol.Variable('data')
+  label = mx.symbol.Variable('label')
+  fc_weight = mx.symbol.Variable('fc_weight')
+  fc = mx.symbol.FullyConnected(data = data, weight = fc_weight, no.bias = T, name = 'fc1', num_hidden = 1)
+  loss = mx.symbol.LinearRegressionOutput(data = fc, label = label, name = 'loss')
+  
+  x <- mx.nd.array(array(1:6, dim=2:3))
+  y <- mx.nd.array(c(5, 11, 16))
+  w1 <- mx.nd.array(array(c(1.1, 1.8), dim = c(2,1)))
+  
+  exec <- mxnet:::mx.symbol.bind(symbol = loss,
+                                 ctx = mx.cpu(),
+                                 arg.arrays = list(data = x,
+                                                   fc1_weight = w1,
+                                                   label = y),
+                                 aux.arrays = NULL, 
+                                 grad.reqs = c("null", "write", "null"))
+  
+  optimizer <- mx.opt.create("adagrad", 
+                             learning.rate = 1, 
+                             epsilon = 1e-8,
+                             wd = 0,
+                             rescale.grad = 1,
+                             clip_gradient = -1)
+  
+  updaters <- mx.opt.get.updater(optimizer, exec$ref.arg.arrays, ctx = mx.cpu())
+  
+  mx.exec.forward(exec, is.train = T)
+  mx.exec.backward(exec)
+  
+  arg.blocks <- updaters(exec$ref.arg.arrays, exec$ref.grad.arrays)
+  mx.exec.update.arg.arrays(exec, arg.blocks, skip.null = TRUE)
+  
+  expect_equal(as.array(arg.blocks[[2]]), array(c(2.1, 2.8), dim = c(2,1)), tolerance = 1e-1)
+  
+})
+
+
+test_that("adadelta", {
+  
+  data = mx.symbol.Variable('data')
+  label = mx.symbol.Variable('label')
+  fc_weight = mx.symbol.Variable('fc_weight')
+  fc = mx.symbol.FullyConnected(data = data, weight = fc_weight, no.bias = T, name = 'fc1', num_hidden = 1)
+  loss = mx.symbol.LinearRegressionOutput(data = fc, label = label, name = 'loss')
+  
+  x <- mx.nd.array(array(1:6, dim=2:3))
+  y <- mx.nd.array(c(5, 11, 16))
+  w1 <- mx.nd.array(array(c(1.1, 1.8), dim = c(2,1)))
+  
+  exec <- mxnet:::mx.symbol.bind(symbol = loss,
+                                 ctx = mx.cpu(),
+                                 arg.arrays = list(data = x,
+                                                   fc1_weight = w1,
+                                                   label = y),
+                                 aux.arrays = NULL, 
+                                 grad.reqs = c("null", "write", "null"))
+  
+  optimizer <- mx.opt.create("adadelta", 
+                             rho = 0.90,
+                             epsilon = 1e-5,
+                             wd = 0,
+                             rescale.grad = 1,
+                             clip_gradient = -1)
+  
+  updaters <- mx.opt.get.updater(optimizer, exec$ref.arg.arrays, ctx = mx.cpu())
+  
+  mx.exec.forward(exec, is.train = T)
+  mx.exec.backward(exec)
+  
+  arg.blocks <- updaters(exec$ref.arg.arrays, exec$ref.grad.arrays)
+  mx.exec.update.arg.arrays(exec, arg.blocks, skip.null = TRUE)
+  
+  expect_equal(as.array(arg.blocks[[2]]), array(c(1.11, 1.81), dim = c(2,1)), tolerance = 1e-1)
+  
+})
+


### PR DESCRIPTION
Fix R memory leakage through refactor of the optimizers. 
Given the mutatable NDArray isn't supported in R, optimizers have been ported as symbolic update, an executor being created for each weight. 

! Only optimizers update symbols have been used for now, so only SGD, rmsprop and Adam are now supported. Will need to reimplement the manual update for Adagrad and Adadelta. 

Memory is now kept at low level even for very large networks and embeddings. 
Tested on CPU and single GPU, not multiple GPUs. 