### PR TITLE
[MXNET-564] Fix the Flaky test on arange

### DIFF
--- a/scala-package/core/src/test/scala/org/apache/mxnet/CheckUtils.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/CheckUtils.scala
@@ -30,13 +30,4 @@ object CheckUtils {
     val norm: Float = a.reduce(Math.abs(_) + Math.abs(_))
     diff / norm
   }
-
-  def almost_equal(a: Array[Float], b: Array[Float],
-                   rtol : Boolean = false) : (Float, Int) = {
-    val array = (a zip b).map { case (aElem, bElem) =>
-      if (rtol) Math.abs(aElem - bElem) / aElem else Math.abs(aElem - bElem)}
-    def f(x: Float) = -x
-    val argMax = array.indexOf(array.max)
-    (array.max, argMax)
-  }
 }

--- a/scala-package/core/src/test/scala/org/apache/mxnet/CheckUtils.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/CheckUtils.scala
@@ -30,4 +30,13 @@ object CheckUtils {
     val norm: Float = a.reduce(Math.abs(_) + Math.abs(_))
     diff / norm
   }
+
+  def almost_equal(a: Array[Float], b: Array[Float],
+                   rtol : Boolean = false) : (Float, Int) = {
+    val array = (a zip b).map { case (aElem, bElem) =>
+      if (rtol) Math.abs(aElem - bElem) / aElem else Math.abs(aElem - bElem)}
+    def f(x: Float) = -x
+    val argMax = array.indexOf(array.max)
+    (array.max, argMax)
+  }
 }

--- a/scala-package/core/src/test/scala/org/apache/mxnet/OperatorSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/OperatorSuite.scala
@@ -229,7 +229,7 @@ class OperatorSuite extends FunSuite with BeforeAndAfterAll
   }
 
   test("arange") {
-    for (i <- 0 until 100000) {
+    for (i <- 0 until 5) {
       val start = scala.util.Random.nextFloat() * 5
       val stop = start + scala.util.Random.nextFloat() * 100
       val step = scala.util.Random.nextFloat() * 4

--- a/scala-package/core/src/test/scala/org/apache/mxnet/OperatorSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/OperatorSuite.scala
@@ -233,7 +233,7 @@ class OperatorSuite extends FunSuite with BeforeAndAfterAll
       val start = scala.util.Random.nextFloat() * 5
       val stop = start + scala.util.Random.nextFloat() * 100
       val step = scala.util.Random.nextFloat() * 4
-      val repeat = 5
+      val repeat = 1
       var curr = BigDecimal(start)
       val result = ArrayBuffer[Float]()
       while (curr <= BigDecimal(stop)) {

--- a/scala-package/core/src/test/scala/org/apache/mxnet/OperatorSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/OperatorSuite.scala
@@ -234,12 +234,8 @@ class OperatorSuite extends FunSuite with BeforeAndAfterAll
       val stop = start + scala.util.Random.nextFloat() * 100
       val step = scala.util.Random.nextFloat() * 4
       val repeat = 1
-      var curr = BigDecimal(start)
-      val result = ArrayBuffer[Float]()
-      while (curr <= BigDecimal(stop)) {
-        result += curr.toFloat
-        curr += BigDecimal(step)
-      }
+      val result = (start.toDouble until stop.toDouble by step.toDouble)
+        .flatMap(x => Array.fill[Float](repeat)(x.toFloat))
       val x = Symbol.arange(start = start, stop = Some(stop), step = step, repeat = repeat)
       var exe = x.simpleBind(ctx = Context.cpu(), gradReq = "write", shapeDict = Map())
       exe.forward(isTrain = false)

--- a/scala-package/core/src/test/scala/org/apache/mxnet/OperatorSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/OperatorSuite.scala
@@ -252,8 +252,9 @@ class OperatorSuite extends FunSuite with BeforeAndAfterAll
       val scalaOutput = result.toArray
       val backendOutput = exe.outputs.head.toArray
       assert(exe.gradArrays.length == 0)
-      if (!scalaOutput.isEmpty) assert(CheckUtils.reldiff(scalaOutput,
-        backendOutput) <= 1e-3f, s"$start $stop $step $i")
+      val (diff, pos) = almost_equal(scalaOutput, backendOutput, true)
+      assert(diff <= 1e-4f,
+        s"$start $stop $step $pos $i\n${scalaOutput.last}\n${backendOutput.last}")
     }
   }
 


### PR DESCRIPTION
## Description ##
@nswamy @yzhliu @andrewfayres @anirudh2290
Please see the fix for the issue: https://github.com/apache/incubator-mxnet/issues/10387

it may help this as well: https://github.com/apache/incubator-mxnet/issues/8383

After discussion with @andrewfayres , we found the problems was in the Scala section, ~~the last value of the arange is larger than the stop value~~ multiple numbers in the Array are different. We think this should be a bug of Scala as the function is depreciated in the log. As @reminisce recommended, we can increase the minimum value of the step since there is nobody use step in a E-05 level. In summary, there are several ways we can solve this problem:

- [x] ~~Change the precision level of arange into E-03 and remove the last value of the array.~~ Doesn't help, problem persist

- [x] ~~Change the way that Scala works into While loops and set precision level to E-06~~ Doesn't help, problem still there...

- [x] ~~Change the measurement from `reid_diff` into `almost_equal` which mostly used in Python with `rtol = true` and precision level E-04.~~ Doesn't help, problem still there

- [x] Use BigDecimal and while loop to test, Passed!

- [ ] Run multiple times with a fixed number in the start, stop and step since the target in here is to check arange is doing well.

We cannot reproduce the same issue with python after 1M tests done by @haojin2 . Python use numpy which takes `Float` as `Double` in their calculation with high accuracy. This PR represent as the ticked solution shown above. Currently, I keep 100000 runs in the code to make sure CI will pass as well. Will consider remove that when we merge into master.

Generally speaking, this issue is really rare to come out. I tried 100k and the issue is 70% reproducible. With the amended solution, I ran 10 times 100k and all of them passed. Since we already have a concrete Python test for this operator, consider remove this in the nearer future.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
