### PR TITLE
Avoid Division by Zero

### DIFF
--- a/src/operator/random/sampler.h
+++ b/src/operator/random/sampler.h
@@ -38,7 +38,7 @@ namespace op {
  * \brief Launch a generic kernel with parallel random generator.
  * \tparam gen random generator
  * \tparam N Number of iterations
- * \tparam Args Varargs type to eventually pass to the OP::Map() functoion
+ * \tparam Args Varargs type to eventually pass to the OP::Map() function
  */
 template<typename OP, typename xpu, typename GType, typename ...Args>
 inline static void LaunchRNG(mshadow::Stream<xpu> *s,

--- a/src/operator/random/sampler.h
+++ b/src/operator/random/sampler.h
@@ -44,6 +44,11 @@ template<typename OP, typename xpu, typename GType, typename ...Args>
 inline static void LaunchRNG(mshadow::Stream<xpu> *s,
                              common::random::RandGenerator<xpu, GType> *gen,
                              const int N, Args... args) {
+  // minimal check to avoid division by zero, below.
+  // if `N` is zero the map operation is a no-op in any case.
+  if (N <= 0) {
+    return;
+  }
   const int nloop = (N + RandGenerator<xpu>::kMinNumRandomPerThread - 1) /
                     RandGenerator<xpu>::kMinNumRandomPerThread;
   const int nthread = std::min(nloop, RandGenerator<xpu>::kNumRandomStates);


### PR DESCRIPTION
## Description ##
In Python, expressions like `nd.random_uniform(shape=[5, 5, 0])` cause the runtime to crash. The underlying problem seems to be a division by zero in [`LaunchRNG(...)` at line 50](https://github.com/apache/incubator-mxnet/blob/master/src/operator/random/sampler.h#L50). The divisor `nthread` is zero because `nloop` is zero when `N` is zero due to C++ integer division rules (`N` is zero because the size of the `NDArray` above is zero).

See https://github.com/apache/incubator-mxnet/issues/11398 for the bug report.

## Checklist ##
### Essentials ###
- [x] Changes are complete
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Added a check in `LaunchRNG(...)` to ensure `N` is not zero. Small negative values for `N` would also cause division by zero, but small negative numbers (induced by things like `nd.random_uniform(shape=[5, 5, -1])`) cause allocation failures before this code is even reached, but I check that case to be safe.
- Simply returning if `N <= 0` should be sufficient because the map operation effectively does nothing in this case.