### PR TITLE
[MXNET-599] Partial shape infer for Slice

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -686,7 +686,7 @@ inline void SetSliceOpOutputDimSize(const index_t i, const int b,
                      << e << ", and step[" << i << "]=" << s << " is invalid";
       (*oshape)[i] = (b - e - 1) / (-s) + 1;
     }
-  } // else leave oshape[i] as 0 for partial infer
+  }  // else leave oshape[i] as 0 for partial infer
 }
 
 inline bool SliceOpShape(const nnvm::NodeAttrs& attrs,

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -676,15 +676,17 @@ inline void GetIndexRange(const TShape& dshape,
 inline void SetSliceOpOutputDimSize(const index_t i, const int b,
                                     const int e, const int s,
                                     TShape* oshape) {
-  if (s > 0) {
-    CHECK_LE(b, e) << "slicing with begin=[" << i << "]=" << b << ", end[" << i << "]="
-                   << e << ", and step[" << i << "]=" << s << " is invalid";
-    (*oshape)[i] = (e - b - 1) / s + 1;
-  } else {
-    CHECK_LE(e, b) << "slicing with begin=[" << i << "]=" << b << ", end[" << i << "]="
-                   << e << ", and step[" << i << "]=" << s << " is invalid";
-    (*oshape)[i] = (b - e - 1) / (-s) + 1;
-  }
+  if (e != b) {
+    if (s > 0) {
+      CHECK_LT(b, e) << "slicing with begin=[" << i << "]=" << b << ", end[" << i << "]="
+                     << e << ", and step[" << i << "]=" << s << " is invalid";
+      (*oshape)[i] = (e - b - 1) / s + 1;
+    } else {
+      CHECK_LT(e, b) << "slicing with begin=[" << i << "]=" << b << ", end[" << i << "]="
+                     << e << ", and step[" << i << "]=" << s << " is invalid";
+      (*oshape)[i] = (b - e - 1) / (-s) + 1;
+    }
+  } // else leave oshape[i] as 0 for partial infer
 }
 
 inline bool SliceOpShape(const nnvm::NodeAttrs& attrs,

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -701,8 +701,10 @@ inline bool SliceOpShape(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(in_attrs->size(), 1U);
   CHECK_EQ(out_attrs->size(), 1U);
   const TShape& dshape = (*in_attrs)[0];
+  if (dshape.ndim() == 0) return false;
   const SliceParam& param = nnvm::get<SliceParam>(attrs.parsed);
   TShape oshape = dshape;
+
   MXNET_NDIM_SWITCH(dshape.ndim(), ndim, {
     common::StaticArray<int, ndim> begin, end, step;
     GetIndexRange(dshape, param.begin, param.end, param.step, &begin, &end, &step);

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -663,7 +663,6 @@ inline void GetIndexRange(const TShape& dshape,
     (*begin)[i] = b;
     (*end)[i] = e;
     (*step)[i] = s;
-
   }
   for (index_t i = param_begin.ndim(); i < dshape.ndim(); ++i) {
     (*begin)[i] = 0;

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -606,7 +606,6 @@ inline void GetIndexRange(const TShape& dshape,
                           common::StaticArray<int, ndim>* end,
                           common::StaticArray<int, ndim>* step) {
   CHECK_NE(dshape.ndim(), 0U);
-//  CHECK_NE(dshape.Size(), 0U);
   CHECK_LE(param_begin.ndim(), dshape.ndim())
     << "Slicing axis exceeds data dimensions";
   CHECK_LE(param_end.ndim(), dshape.ndim())
@@ -643,8 +642,11 @@ inline void GetIndexRange(const TShape& dshape,
     } else if (s < 0) {
       b = len - 1;
     }
-    CHECK_LE(b, len) << "slicing with begin[" << i << "]="
-                     << b << " exceends limit of " << len;
+
+    if (len != 0) {
+      CHECK_LT(b, len) << "slicing with begin[" << i << "]="
+                       << b << " exceends limit of " << len;
+    }
 
     if (param_end[i].has_value()) {
       e = param_end[i].value();

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5743,26 +5743,26 @@ def test_slice():
 def test_slice_partial_infer():
     var1 = mx.sym.var(name="data", shape=(0,20))
     var2 = mx.sym.slice(var1,begin=(None, None), end=(None,10))
-    assert (var2.infer_shape_partial()[1][0] == (0L, 10L)), var2.infer_shape_partial()[1]
+    assert (var2.infer_shape_partial()[1][0] == (0, 10)), var2.infer_shape_partial()[1]
 
     var2 = mx.sym.slice(var1,begin=(None, 3), end=(None,10))
-    assert (var2.infer_shape_partial()[1][0] == (0L, 7L)), var2.infer_shape_partial()[1]
+    assert (var2.infer_shape_partial()[1][0] == (0, 7)), var2.infer_shape_partial()[1]
 
     var2 = mx.sym.slice(var1,begin=(None, 3), end=(5,10))
-    assert (var2.infer_shape_partial()[1][0] == (0L, 7L)), var2.infer_shape_partial()[1]
+    assert (var2.infer_shape_partial()[1][0] == (0, 7)), var2.infer_shape_partial()[1]
 
     var2 = mx.sym.slice(var1,begin=(2, 3), end=(None,10))
-    assert (var2.infer_shape_partial()[1][0] == (0L, 7L)), var2.infer_shape_partial()[1]
+    assert (var2.infer_shape_partial()[1][0] == (0, 7)), var2.infer_shape_partial()[1]
 
     var1 = mx.sym.var(name="data", shape=(10, 0))
     var2 = mx.sym.slice(var1,begin=(1, None), end=(3,None))
-    assert (var2.infer_shape_partial()[1][0] == (2L, 0L)), var2.infer_shape_partial()[1]
+    assert (var2.infer_shape_partial()[1][0] == (2, 0)), var2.infer_shape_partial()[1]
 
     var2 = mx.symbol.slice_axis(data=var1, axis=0, begin=0, end=5)
-    assert (var2.infer_shape_partial()[1][0] == (5L, 0L)), var2.infer_shape_partial()[1]
+    assert (var2.infer_shape_partial()[1][0] == (5, 0)), var2.infer_shape_partial()[1]
 
     var2 = mx.symbol.slice_axis(data=var1, axis=1, begin=0, end=5)
-    assert (var2.infer_shape_partial()[1][0] == (10L, 0L)), var2.infer_shape_partial()[1]
+    assert (var2.infer_shape_partial()[1][0] == (10, 0)), var2.infer_shape_partial()[1]
 
 
 @with_seed()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5748,12 +5748,21 @@ def test_slice_partial_infer():
     var2 = mx.sym.slice(var1,begin=(None, 3), end=(None,10))
     assert (var2.infer_shape_partial()[1][0] == (0L, 7L)), var2.infer_shape_partial()[1]
 
-    var1 = mx.sym.var(name="data", shape=(10,0))
+    var2 = mx.sym.slice(var1,begin=(None, 3), end=(5,10))
+    assert (var2.infer_shape_partial()[1][0] == (0L, 7L)), var2.infer_shape_partial()[1]
+
+    var2 = mx.sym.slice(var1,begin=(2, 3), end=(None,10))
+    assert (var2.infer_shape_partial()[1][0] == (0L, 7L)), var2.infer_shape_partial()[1]
+
+    var1 = mx.sym.var(name="data", shape=(10, 0))
     var2 = mx.sym.slice(var1,begin=(1, None), end=(3,None))
     assert (var2.infer_shape_partial()[1][0] == (2L, 0L)), var2.infer_shape_partial()[1]
 
     var2 = mx.symbol.slice_axis(data=var1, axis=0, begin=0, end=5)
     assert (var2.infer_shape_partial()[1][0] == (5L, 0L)), var2.infer_shape_partial()[1]
+
+    var2 = mx.symbol.slice_axis(data=var1, axis=1, begin=0, end=5)
+    assert (var2.infer_shape_partial()[1][0] == (10L, 0L)), var2.infer_shape_partial()[1]
 
 
 @with_seed()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5741,29 +5741,26 @@ def test_slice():
     check_numeric_gradient(slice_sym, [in_data])
 
 def test_slice_partial_infer():
-    var1 = mx.sym.var(name="data", shape=(0,20))
-    var2 = mx.sym.slice(var1,begin=(None, None), end=(None,10))
-    assert (var2.infer_shape_partial()[1][0] == (0, 10)), var2.infer_shape_partial()[1]
+    def check_slice_partial_infer(data, begin, end, step, expected_out_shape):
+        out = mx.sym.slice(data, begin=begin, end=end, step=step)
+        assert (out.infer_shape_partial()[1][0] == expected_out_shape), out.infer_shape_partial()[1]
 
-    var2 = mx.sym.slice(var1,begin=(None, 3), end=(None,10))
-    assert (var2.infer_shape_partial()[1][0] == (0, 7)), var2.infer_shape_partial()[1]
+    def check_slice_axis_partial_infer(data, axis, begin, end, expected_out_shape):
+        out = mx.sym.slice_axis(data, axis=axis, begin=begin, end=end)
+        assert (out.infer_shape_partial()[1][0] == expected_out_shape), out.infer_shape_partial()[1]
 
-    var2 = mx.sym.slice(var1,begin=(None, 3), end=(5,10))
-    assert (var2.infer_shape_partial()[1][0] == (0, 7)), var2.infer_shape_partial()[1]
-
-    var2 = mx.sym.slice(var1,begin=(2, 3), end=(None,10))
-    assert (var2.infer_shape_partial()[1][0] == (0, 7)), var2.infer_shape_partial()[1]
+    var1 = mx.sym.var(name="data", shape=(0, 20))
+    check_slice_partial_infer(var1, (None, None), (None, 10), [], (0, 10))
+    check_slice_partial_infer(var1, (None, None), (None, 10), (None, 2), (0, 5))
+    check_slice_partial_infer(var1, (None, 3), (None, 10), [], (0, 7))
+    check_slice_partial_infer(var1, (None, 3), (5, 10), [], (0, 7))
+    check_slice_partial_infer(var1, (2, 3), (None, 10), [], (0, 7))
+    check_slice_partial_infer(var1, (2, 3), (None, 10), (None, 1), (0, 7))
+    check_slice_partial_infer(var1, (2, 3), (None, 10), (3, 3), (0, 3))
 
     var1 = mx.sym.var(name="data", shape=(10, 0))
-    var2 = mx.sym.slice(var1,begin=(1, None), end=(3,None))
-    assert (var2.infer_shape_partial()[1][0] == (2, 0)), var2.infer_shape_partial()[1]
-
-    var2 = mx.symbol.slice_axis(data=var1, axis=0, begin=0, end=5)
-    assert (var2.infer_shape_partial()[1][0] == (5, 0)), var2.infer_shape_partial()[1]
-
-    var2 = mx.symbol.slice_axis(data=var1, axis=1, begin=0, end=5)
-    assert (var2.infer_shape_partial()[1][0] == (10, 0)), var2.infer_shape_partial()[1]
-
+    check_slice_axis_partial_infer(var1, 0, 0, 5, (5, 0))
+    check_slice_axis_partial_infer(var1, 1, 0, 5, (10, 0))
 
 @with_seed()
 def test_float16_min_max():

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5740,6 +5740,17 @@ def test_slice():
     slice_sym = mx.sym.slice(data, begin=[0, None], end=[1, None], step=[2, -1])
     check_numeric_gradient(slice_sym, [in_data])
 
+def test_slice_partial_infer():
+    var1 = mx.sym.var(name="data", shape=(0,20))
+    var2 = mx.sym.slice(var1,begin=(None, None), end=(None,10))
+    assert (var2.infer_shape_partial()[1][0] == (0L, 10L)), var2.infer_shape_partial()[1]
+
+    var2 = mx.sym.slice(var1,begin=(None, 3), end=(None,10))
+    assert (var2.infer_shape_partial()[1][0] == (0L, 7L)), var2.infer_shape_partial()[1]
+
+    var1 = mx.sym.var(name="data", shape=(10,0))
+    var2 = mx.sym.slice(var1,begin=(1, None), end=(3,None))
+    assert (var2.infer_shape_partial()[1][0] == (2L, 0L)), var2.infer_shape_partial()[1]
 
 @with_seed()
 def test_float16_min_max():

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5752,6 +5752,10 @@ def test_slice_partial_infer():
     var2 = mx.sym.slice(var1,begin=(1, None), end=(3,None))
     assert (var2.infer_shape_partial()[1][0] == (2L, 0L)), var2.infer_shape_partial()[1]
 
+    var2 = mx.symbol.slice_axis(data=var1, axis=0, begin=0, end=5)
+    assert (var2.infer_shape_partial()[1][0] == (5L, 0L)), var2.infer_shape_partial()[1]
+
+
 @with_seed()
 def test_float16_min_max():
     """Test for issue: https://github.com/apache/incubator-mxnet/issues/9007"""


### PR DESCRIPTION
## Description ##
Fix for https://github.com/apache/incubator-mxnet/issues/11349
Allow partial shape inference of slice operator

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Compute shape based on known info


@sandeep-krishnamurthy @reminisce Please review, thanks!