### PR TITLE
[MXNET-600][WIP] Memory leak fix in the Scala training

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
@@ -147,6 +147,7 @@ class FeedForward private(
     for ((k, v) <- argParams) {
       if (_argParams != null && _argParams.contains(k) && (!overwrite)) {
         v.set(_argParams(k))
+        _argParams(k).dispose()
       } else {
         initializer(k, v)
       }
@@ -155,12 +156,11 @@ class FeedForward private(
     for ((k, v) <- auxParams) {
       if (_auxParams != null && _auxParams.contains(k) && (!overwrite)) {
         v.set(_auxParams(k))
+        _auxParams(k).dispose()
       } else {
         initializer(k, v)
       }
     }
-    _argParams.foreach(ele => ele._2.dispose())
-    _auxParams.foreach(ele => ele._2.dispose())
     _argParams = argParams
     _auxParams = auxParams
     (argNames, paramNames, auxNames)

--- a/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
@@ -146,7 +146,7 @@ class FeedForward private(
 
     for ((k, v) <- argParams) {
       if (_argParams != null && _argParams.contains(k) && (!overwrite)) {
-        argParams(k).set(_argParams(k))
+        v.set(_argParams(k))
       } else {
         initializer(k, v)
       }
@@ -154,12 +154,13 @@ class FeedForward private(
 
     for ((k, v) <- auxParams) {
       if (_auxParams != null && _auxParams.contains(k) && (!overwrite)) {
-        auxParams(k).set(_auxParams(k))
+        v.set(_auxParams(k))
       } else {
         initializer(k, v)
       }
     }
-
+    _argParams.foreach(ele => ele._2.dispose())
+    _auxParams.foreach(ele => ele._2.dispose())
     _argParams = argParams
     _auxParams = auxParams
     (argNames, paramNames, auxNames)

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Model.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Model.scala
@@ -319,6 +319,7 @@ object Model {
           if (epochSize != -1 && nBatch >= epochSize) {
             doReset = false
           }
+          dataBatch.dispose()
         }
         if (doReset) {
           trainData.reset()
@@ -344,6 +345,7 @@ object Model {
           executorManager.loadDataBatch(evalBatch)
           executorManager.forward(isTrain = false)
           executorManager.updateMetric(evalMetric, evalBatch.label)
+          evalBatch.dispose()
         }
 
         val (name, value) = evalMetric.get

--- a/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
@@ -99,10 +99,13 @@ object NDArray {
     val outputs = ArrayBuffer.empty[NDArrayHandle]
     checkCall(_LIB.mxImperativeInvoke(function.handle, ndArgs.map(_.handle).toArray, outputVars,
       outputs, updatedKwargs.size, updatedKwargs.keys.toArray, updatedKwargs.values.toArray))
-    new NDArrayFuncReturn(Option(oriOutputs).getOrElse {
+    new NDArrayFuncReturn(if (oriOutputs == null) {
       val outputArrs = outputs.map(new NDArray(_)).toArray
       addDependency(ndArgs.toArray, outputArrs)
       outputArrs
+    } else {
+      addDependency(ndArgs.toArray, oriOutputs)
+      oriOutputs
     })
   }
 

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Operator.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Operator.scala
@@ -82,6 +82,7 @@ abstract class CustomOp {
       this.forward(isTrain = isTrain, req = reqsArr,
         inData = tensors(0).toArray, outData = tensors(1).toArray,
         aux = tensors(4).toArray)
+      tensors.foreach(arr => arr.foreach(_.dispose()))
     } catch {
       case ex: Throwable => {
         success = false
@@ -112,6 +113,7 @@ abstract class CustomOp {
         inData = tensors(0).toArray, outData = tensors(1).toArray,
         inGrad = tensors(2).toArray, outGrad = tensors(3).toArray,
         aux = tensors(4).toArray)
+      tensors.foreach(arr => arr.foreach(_.dispose()))
     } catch {
       case ex: Throwable => {
         success = false

--- a/scala-package/core/src/main/scala/org/apache/mxnet/io/MXDataIter.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/io/MXDataIter.scala
@@ -101,6 +101,9 @@ private[mxnet] class MXDataIter(private[mxnet] val handle: DataIterHandle,
   private def iterNext(): Boolean = {
     val next = new RefInt
     checkCall(_LIB.mxDataIterNext(handle, next))
+    if (currentBatch != null) {
+      currentBatch.dispose()
+    }
     currentBatch = null
     if (next.value > 0) {
       currentBatch = new DataBatch(data = getData(), label = getLabel(),


### PR DESCRIPTION
## Description ##
This includes an accumulation of memory-leak fixes in Scala package. Will go and test all examples we have in CI to make sure it didn't break.

Warning: We need to treat this PR carefully, it has the potential to cause Scala test flaky

@yzhliu @nswamy @andrewfayres @marcoabreu 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change