### PR TITLE
MXNET-336 [Perl] Major Gluon update for Perl API.

### DIFF
--- a/perl-package/AI-MXNet/Changes
+++ b/perl-package/AI-MXNet/Changes
@@ -1,5 +1,13 @@
 Revision history for Perl extension AI::MXNet
 
+1.3     Tue Jun 26 20:57:40 PDT 2018
+        - Miscellaneous bugfixes and improvements.
+        - Major Gluon update towards parity with Python's API.
+        - Miscellaneous bugfixes and improvements.
+        - New Engine API.
+        - Module::reshape moved to C++ backend.
+        - Examples were updated to work on multi-gpu boxes
+
 1.23    Thu Apr 19 15:38:10 PDT 2018
         - Support for image operations on symbols and ndarrays.
 

--- a/perl-package/AI-MXNet/MANIFEST
+++ b/perl-package/AI-MXNet/MANIFEST
@@ -25,6 +25,7 @@ lib/AI/MXNet/Contrib.pm
 lib/AI/MXNet/Contrib/NDArray.pm
 lib/AI/MXNet/Contrib/Symbol.pm
 lib/AI/MXNet/CudaModule.pm
+lib/AI/MXNet/Engine.pm
 lib/AI/MXNet/Executor.pm
 lib/AI/MXNet/Executor/Group.pm
 lib/AI/MXNet/Function/Parameters.pm
@@ -38,6 +39,7 @@ lib/AI/MXNet/Gluon/Data/Vision.pm
 lib/AI/MXNet/Gluon/Loss.pm
 lib/AI/MXNet/Gluon/Mouse.pm
 lib/AI/MXNet/Gluon/NN.pm
+lib/AI/MXNet/Gluon/NN/Activation.pm
 lib/AI/MXNet/Gluon/NN/BasicLayers.pm
 lib/AI/MXNet/Gluon/NN/ConvLayers.pm
 lib/AI/MXNet/Gluon/Parameter.pm
@@ -97,10 +99,12 @@ t/test_autograd.t
 t/test_base.t
 t/test_conv.t
 t/test_cuda_module.t
+t/test_engine.t
 t/test_executor.t
 t/test_gluon.t
 t/test_gluon_data.t
 t/test_gluon_rnn.t
+t/test_gluon_trainer.t
 t/test_infer_shape.t
 t/test_init.t
 t/test_io.t

--- a/perl-package/AI-MXNet/META.json
+++ b/perl-package/AI-MXNet/META.json
@@ -30,8 +30,8 @@
       },
       "runtime" : {
          "requires" : {
-            "AI::MXNetCAPI" : "1.2",
-            "AI::NNVMCAPI" : "1.2",
+            "AI::MXNetCAPI" : "1.3",
+            "AI::NNVMCAPI" : "1.3",
             "Function::Parameters" : "1.0705",
             "Hash::Ordered" : "0.012",
             "GraphViz" : "2.14",
@@ -45,5 +45,5 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.23"
+   "version" : "1.3"
 }

--- a/perl-package/AI-MXNet/META.yml
+++ b/perl-package/AI-MXNet/META.yml
@@ -17,12 +17,12 @@ no_index:
     - t
     - inc
 requires:
-  AI::MXNetCAPI: '1.2'
-  AI::NNVMCAPI: '1.2'
+  AI::MXNetCAPI: '1.3'
+  AI::NNVMCAPI: '1.3'
   Function::Parameters: '1.0705'
   Hash::Ordered: '0.012'
   GraphViz: '2.14'
   Mouse: v2.1.0
   PDL: '2.007'
   PDL::CCS: '1.23.4'
-version: '1.23'
+version: '1.3'

--- a/perl-package/AI-MXNet/README
+++ b/perl-package/AI-MXNet/README
@@ -1,5 +1,5 @@
 This archive contains the distribution AI-MXNet,
-version 1.23:
+version 1.3:
 
   Perl interface to MXNet machine learning library
 

--- a/perl-package/AI-MXNet/examples/char_lstm.pl
+++ b/perl-package/AI-MXNet/examples/char_lstm.pl
@@ -233,22 +233,23 @@ $model->fit(
     initializer         => mx->init->Xavier(factor_type => "in", magnitude => 2.34),
     num_epoch           => $num_epoch,
     batch_end_callback  => mx->callback->Speedometer($batch_size, $disp_batches),
-    ($chkp_epoch ? (epoch_end_callback  => [mx->rnn->do_rnn_checkpoint($stack, $chkp_prefix, $chkp_epoch), \&sample]) : ())
+    ($chkp_epoch ? (epoch_end_callback  => [mx->callback->module_checkpoint($model, $chkp_prefix, $chkp_epoch), \&sample]) : ())
 );
 
+my $chkp = 1;
 sub sample {
     return if not $sample_size;
-    $model->reshape(data_shapes=>[['data',[1, $seq_size]]], label_shapes=>[['softmax_label',[1, $seq_size]]]);
+    my $inference_model = mx->mod->Module->load($chkp_prefix, $chkp++);
+    $inference_model->bind(data_shapes=>[['data',[1, $seq_size]]], label_shapes=>[['softmax_label',[1, $seq_size]]]);
     my $input = mx->nd->array($fdata->slice([0, $seq_size-1]))->reshape([1, $seq_size]);
     $| = 1;
     for (0..$sample_size-1)
     {
-        $model->forward(mx->io->DataBatch(data=>[$input]), is_train => 0);
-        my $prob = $model->get_outputs(0)->[0][0]->at($seq_size-1)->aspdl;
+        $inference_model->forward(mx->io->DataBatch(data=>[$input]), is_train => 0);
+        my $prob = $inference_model->get_outputs(0)->[0][0]->at($seq_size-1)->aspdl;
         my $next_char = Math::Random::Discrete->new($prob->reshape(-1)->unpdl, [0..scalar(keys %vocabulary)-1])->rand;
         print "$reverse_vocab{$next_char}";
         $input->at(0)->slice([0, $seq_size-2]) .= $input->at(0)->slice([1, $seq_size-1])->copy;
         $input->at(0)->at($seq_size-1) .= $next_char;
     }
-    $model->reshape(data_shapes=>[['data',[$batch_size, $seq_size]]], label_shapes=>[['softmax_label',[$batch_size, $seq_size]]]);
 }

--- a/perl-package/AI-MXNet/examples/gluon/mnist.pl
+++ b/perl-package/AI-MXNet/examples/gluon/mnist.pl
@@ -48,7 +48,7 @@ $net->name_scope(sub {
     $net->add(nn->Dense(10));
 });
 $net->hybridize() if $hybridize;
-$net->load_params('mnist.params') if $load_params;
+$net->load_parameters('mnist.params') if $load_params;
 # data
 
 sub transformer
@@ -130,7 +130,7 @@ sub train
         my ($val_name, $val_acc) = test($ctx);
         print "[Epoch $epoch] Validation: $val_name=$val_acc\n"
     }
-    $net->save_params('mnist.params');
+    $net->save_parameters('mnist.params');
 }
 
 train($epochs, $cuda ? mx->gpu(0) : mx->cpu);

--- a/perl-package/AI-MXNet/lib/AI/MXNet.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet.pm
@@ -50,7 +50,8 @@ use AI::MXNet::AutoGrad;
 use AI::MXNet::Gluon;
 use AI::MXNet::NDArray::Sparse;
 use AI::MXNet::Symbol::Sparse;
-our $VERSION = '1.22';
+use AI::MXNet::Engine;
+our $VERSION = '1.3';
 
 sub import
 {
@@ -76,6 +77,7 @@ sub import
             sub Context { shift; AI::MXNet::Context->new(\@_) }
             sub context { 'AI::MXNet::Context' }
             sub cpu { AI::MXNet::Context->cpu(\$_[1]//0) }
+            sub cpu_pinned { AI::MXNet::Context->cpu_pinned(\$_[1]//0) }
             sub gpu { AI::MXNet::Context->gpu(\$_[1]//0) }
             sub kv { 'AI::MXNet::KVStore' }
             sub recordio { 'AI::MXNet::RecordIO' }
@@ -92,8 +94,10 @@ sub import
             sub contrib { 'AI::MXNet::Contrib' }
             sub linalg { 'AI::MXNet::LinAlg' }
             sub autograd { 'AI::MXNet::AutoGrad' }
+            sub engine { 'AI::MXNet::Engine' }
             sub name { '$short_name' }
             sub rtc { '$short_name' }
+            sub gluon { 'AI::MXNet::Gluon' }
             sub CudaModule { shift; AI::MXNet::CudaModule->new(\@_) }
             sub AttrScope { shift; AI::MXNet::Symbol::AttrScope->new(\@_) }
             *AI::MXNet::Symbol::AttrScope::current = sub { \$${short_name}::AttrScope; };
@@ -106,6 +110,8 @@ sub import
             *AI::MXNet::Context::current_context = sub { \$${short_name}::Context; };
             *AI::MXNet::Context::set_current = sub { \$${short_name}::Context = \$_[1]; };
             \$${short_name}::Context = AI::MXNet::Context->new(device_type => 'cpu', device_id => 0);
+            package nd;
+            \@nd::ISA = ('AI::MXNet::NDArray');
             1;
 EOP
             eval $short_name_package;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/AutoLoad.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/AutoLoad.pm
@@ -27,7 +27,7 @@ sub AUTOLOAD
     my $sub = "_${prefix}_$name";
     {
         no strict 'refs';
-        *{"$class::$name"} = sub { shift; $real_class->$sub(@_); };
+        *{"${class}::$name"} = sub { shift; $real_class->$sub(@_); };
     }
     goto $class->can($name);
 }

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Base.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Base.pm
@@ -21,8 +21,8 @@ use warnings;
 use PDL;
 use PDL::Types ();
 use PDL::CCS::Nd;
-use AI::MXNetCAPI 1.2;
-use AI::NNVMCAPI 1.2;
+use AI::MXNetCAPI 1.3;
+use AI::NNVMCAPI 1.3;
 use AI::MXNet::Types;
 use Time::HiRes;
 use Scalar::Util qw(blessed);
@@ -169,9 +169,16 @@ sub zip
 
 sub enumerate
 {
-    my ($sub, @arrays) = @_;
-    my $len = @{ $arrays[0] };
-    zip($sub, [0..$len-1], @arrays);
+    if('CODE' eq ref $_[0])
+    {
+        # continue supporting the callback style
+        my $code = shift;
+        my $len = @{ $_[0] };
+        $code->(@$_) for AI::MXNetCAPI::py_zip([0..$len-1], map { \@$_ } @_);
+        return;
+    }
+    my $len = @{ $_[0] };
+    return AI::MXNetCAPI::py_zip([0..$len-1], map { \@$_ } @_);
 }
 
 =head2 product

--- a/perl-package/AI-MXNet/lib/AI/MXNet/CachedOp.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/CachedOp.pm
@@ -32,10 +32,17 @@ has 'handle'   => (is => 'ro', isa => 'CachedOpHandle', required => 1);
 around BUILDARGS => sub {
     my $orig  = shift;
     my $class = shift;
-    my ($sym) = @_;
+    my ($sym, $flags) = @_;
+    for my $key (keys %$flags)
+    {
+        $flags->{ $key } = "(" .join(", ", map { defined($_) ? $_ : 'None' } @{ $flags->{ $key } }) .")"
+                if ref $flags->{ $key } eq 'ARRAY';
+    }
     my $handle = check_call(
-        AI::MXNetCAPI::CreateCachedOp(
-            $sym->handle
+        AI::MXNetCAPI::CreateCachedOpEx(
+            $sym->handle,
+            scalar(keys %{ $flags//{} }),
+            $flags//{},
         )
     );
     return $class->$orig(handle => $handle);
@@ -84,8 +91,8 @@ sub call
     {
         $out = [];
     }
-    my $output = check_call(
-        AI::MXNetCAPI::InvokeCachedOp(
+    my ($output, $stypes) = check_call(
+        AI::MXNetCAPI::InvokeCachedOpEx(
             $self->handle,
             scalar(@args),
             [map { $_->handle } @args],
@@ -95,11 +102,12 @@ sub call
     return $original_output if defined $original_output;
     if(@$output == 1)
     {
-        return AI::MXNet::NDArray->_ndarray_cls($output->[0]);
+        return AI::MXNet::NDArray->_ndarray_cls($output->[0], 1, $stypes->[0]);
     }
     else
     {
-        return [map { AI::MXNet::NDArray->_ndarray_cls($_) } @$output];
+        my $i = 0;
+        return [map { AI::MXNet::NDArray->_ndarray_cls($_, 1, $stypes->[$i++]) } @$output];
     }
 }
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Context.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Context.pm
@@ -19,6 +19,7 @@ package AI::MXNet::Context;
 use strict;
 use warnings;
 use Mouse;
+use AI::MXNet::Base;
 use AI::MXNet::Types;
 use AI::MXNet::Function::Parameters;
 use constant devtype2str => { 1 => 'cpu', 2 => 'gpu', 3 => 'cpu_pinned' };
@@ -111,6 +112,28 @@ method cpu(Int $device_id=0)
     return $self->new(device_type => 'cpu', device_id => $device_id);
 }
 
+=head2 cpu_pinned
+
+    Returns a CPU pinned memory context. Copying from CPU pinned memory to GPU
+    is faster than from normal CPU memory.
+
+    Parameters
+    ----------
+    device_id : int, optional
+        The device id of the device. `device_id` is not needed for CPU.
+        This is included to make interface compatible with GPU.
+
+    Returns
+    -------
+    context : Context
+        The corresponding CPU pinned memory context.
+=cut
+
+method cpu_pinned(Int $device_id=0)
+{
+    return $self->new(device_type => 'cpu_pinned', device_id => $device_id);
+}
+
 =head2 gpu
 
     Returns a GPU context.
@@ -138,6 +161,27 @@ method gpu(Int $device_id=0)
     -------
     $default_ctx : AI::MXNet::Context
 =cut
+
+
+=head2 num_gpus
+
+    Query CUDA for the number of GPUs present.
+
+    Raises
+    ------
+    Will raise an exception on any CUDA error.
+
+    Returns
+    -------
+    count : int
+        The number of GPUs.
+
+=cut
+
+method num_gpus()
+{
+    return scalar(check_call(AI::MXNetCAPI::GetGPUCount()));
+}
 
 method current_ctx()
 {

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Engine.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Engine.pm
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+package AI::MXNet::Engine;
+use strict;
+use warnings;
+use AI::MXNet::Function::Parameters;
+use AI::MXNet::Base;
+=head1 NAME
+
+    AI::MXNet::Engine - Engine properties management.
+=cut
+
+=head2 set_bulk_size
+
+    Set size limit on bulk execution.
+
+    Bulk execution bundles many operators to run together.
+    This can improve performance when running a lot of small
+    operators sequentially.
+
+    Parameters
+    ----------
+    $size : int
+        Maximum number of operators that can be bundled in a bulk.
+
+    Returns
+    -------
+    int
+        Previous bulk size.
+=cut
+
+method set_bulk_size(Int $size)
+{
+    return scalar(check_call(AI::MXNetCAPI::EngineSetBulkSize($size)));
+}
+
+
+=head2 bulk
+
+    Bulk execution bundles many operators to run together.
+    This can improve performance when running a lot of small
+    operators sequentially.
+
+    Parameters
+    ----------
+    $size : int
+        Maximum number of operators that can be bundled in a bulk.
+    $sub: CodeRef to execute
+
+    my $x;
+    mx->engine->bulk(10, sub {
+        $x = mx->nd->zeros([1]);
+        for my $i (1..100)
+        {
+            $x += 1;
+        }
+    });
+=cut
+
+method bulk(Int $size, CodeRef $sub)
+{
+    my $prev = __PACKAGE__->set_bulk_size($size);
+    eval { $sub->() };
+    my $err = $@;
+    __PACKAGE__->set_bulk_size($prev) unless $prev == $size;
+    Carp::confess($err) if $err;
+}
+
+1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Executor.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Executor.pm
@@ -429,120 +429,70 @@ method copy_params_from(
 
 method reshape(HashRef[Shape] $kwargs, Int :$partial_shaping=0, Int :$allow_up_sizing=0)
 {
-    my ($arg_shapes, undef, $aux_shapes) = $self->_symbol->infer_shape(%{ $kwargs });
-    confess("Insufficient argument shapes provided.")
-        unless defined $arg_shapes;
-    my %new_arg_dict;
-    my %new_grad_dict;
-    my $i = 0;
-    for my $name (@{ $self->_symbol->list_arguments() })
+    my @provided_arg_shape_data;
+    # argument shape index in sdata,
+    # e.g. [sdata[indptr[0]], sdata[indptr[1]]) is the shape of the first arg
+    my @provided_arg_shape_idx = (0);
+    my @provided_arg_shape_names = ();  # provided argument names
+    while(my ($k, $v) = each %{ $kwargs })
     {
-        my $new_shape = $arg_shapes->[$i];
-        my $arr       = $self->arg_arrays->[$i];
-        my $darr;
-        if(@{ $self->grad_arrays })
+        if(ref $v eq 'ARRAY')
         {
-            $darr = $self->grad_arrays->[$i];
+            push @provided_arg_shape_names, $k;
+            push @provided_arg_shape_data, @{ $v };
+            push @provided_arg_shape_idx, scalar(@provided_arg_shape_data);
         }
-        if(
-            $partial_shaping
-                or
-            exists $kwargs->{ $name }
-                or
-            join(',', @{ $new_shape }) eq join(',', @{ $arr->shape })
+    }
+
+    my @ctx_map_keys;
+    my @ctx_map_dev_types;
+    my @ctx_map_dev_ids;
+
+    if(ref $self->_group2ctx eq 'HASH')
+    {
+        while(my ($k, $v) = each %{ $self->_group2ctx })
+        {
+            push @ctx_map_keys, $k;
+            push @ctx_map_dev_types, $v->device_type_id;
+            push @ctx_map_dev_ids, $v->device_id;
+        }
+    }
+
+    my $shared_handle = $self->handle;
+
+    my ($in_args_and_grad_handles, $aux_state_handles, $handle) = check_call(
+        AI::MXNetCAPI::ExecutorReshape(
+            $partial_shaping,
+            $allow_up_sizing,
+            $self->_ctx->device_type_id,
+            $self->_ctx->device_id,
+            scalar(@ctx_map_keys),
+            \@ctx_map_keys,
+            \@ctx_map_dev_types,
+            \@ctx_map_dev_ids,
+            scalar(@provided_arg_shape_names),
+            \@provided_arg_shape_names,
+            \@provided_arg_shape_data,
+            \@provided_arg_shape_idx,
+            $shared_handle
         )
-        {
-            if(AI::MXNet::NDArray->size($new_shape) > $arr->size)
-            {
-                confess(
-                    "New shape of arg:$name larger than original. "
-                    ."First making a big executor and then down sizing it "
-                    ."is more efficient than the reverse."
-                    ."If you really want to up size, set \$allow_up_sizing=1 "
-                    ."to enable allocation of new arrays."
-                ) unless $allow_up_sizing;
-                $new_arg_dict{ $name }  = AI::MXNet::NDArray->empty(
-                    $new_shape,
-                    ctx => $arr->context,
-                    dtype => $arr->dtype
-                );
-                if(defined $darr)
-                {
-                    $new_grad_dict{ $name } = AI::MXNet::NDArray->empty(
-                        $new_shape,
-                        ctx => $darr->context,
-                        dtype => $arr->dtype
-                    );
-                }
-            }
-            else
-            {
-                $new_arg_dict{ $name } = $arr->reshape($new_shape);
-                if(defined $darr)
-                {
-                    $new_grad_dict{ $name } = $darr->reshape($new_shape);
-                }
-            }
-        }
-        else
-        {
-            confess(
-                    "Shape of unspecified array arg:$name changed. "
-                    ."This can cause the new executor to not share parameters "
-                    ."with the old one. Please check for error in network."
-                    ."If this is intended, set partial_shaping=True to suppress this warning."
-            );
-        }
-        $i++;
-    }
-    my %new_aux_dict;
-    $i = 0;
-    for my $name (@{ $self->_symbol->list_auxiliary_states() })
-    {
-        my $new_shape = $aux_shapes->[$i];
-        my $arr = $self->aux_arrays->[$i];
-        if($partial_shaping or join(',', @{ $new_shape }) eq join (',', @{ $arr->shape }))
-        {
-            if(AI::MXNet::NDArray->size($new_shape) > $arr->size)
-            {
-                confess(
-                    "New shape of arg:$name larger than original. "
-                    ."First making a big executor and then down sizing it "
-                    ."is more efficient than the reverse."
-                    ."If you really want to up size, set \$allow_up_sizing=1 "
-                    ."to enable allocation of new arrays."
-                ) unless $allow_up_sizing;
-                $new_aux_dict{ $name }  = AI::MXNet::NDArray->empty(
-                    $new_shape,
-                    ctx => $arr->context,
-                    dtype => $arr->dtype
-                );
-            }
-            else
-            {
-                $new_aux_dict{ $name } = $arr->reshape($new_shape);
-            }
-        }
-        else
-        {
-            confess(
-                "Shape of unspecified array aux:$name changed. "
-                ."This can cause the new executor to not share parameters "
-                ."with the old one. Please check for error in network."
-                ."If this is intended, set partial_shaping=True to suppress this warning."
-            );
-        }
-        $i++;
-    }
-    return $self->_symbol->bind(
-                ctx         => $self->_ctx,
-                args        => \%new_arg_dict,
-                args_grad   => \%new_grad_dict,
-                grad_req    => $self->_grad_req,
-                aux_states  => \%new_aux_dict,
-                group2ctx   => $self->_group2ctx,
-                shared_exec => $self
     );
+    my ($in_args_handles, $arg_grad_handles) = @{ $in_args_and_grad_handles };
+    my @arg_arrays  = map { AI::MXNet::NDArray->_ndarray_cls($_) } @{ $in_args_handles };
+    my @grad_arrays = map { defined($_) ? AI::MXNet::NDArray->_ndarray_cls($_) : undef } @{ $arg_grad_handles };
+    my @aux_arrays  = map { AI::MXNet::NDArray->_ndarray_cls($_) } @{ $aux_state_handles };
+
+    my $executor = __PACKAGE__->new(
+        handle     => $handle,
+        symbol    => $self->_symbol,
+        ctx       => $self->_ctx,
+        grad_req  => $self->_grad_req,
+        group2ctx => $self->_group2ctx
+    );
+    $executor->arg_arrays(\@arg_arrays);
+    $executor->grad_arrays(\@grad_arrays);
+    $executor->aux_arrays(\@aux_arrays);
+    return $executor;
 }
 
 =head2 debug_str

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Executor/Group.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Executor/Group.pm
@@ -47,7 +47,7 @@ func _split_input_slice($batch_size, $work_load_list)
         $end = int(min($begin + $batch_num, $batch_size));
         if($begin >= $end)
         {
-            confess('Too many slices such that some splits are empty');
+            Carp::confess('Too many slices such that some splits are empty');
         }
         push @slices, [$begin, $end];
     }

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/Activation.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/Activation.pm
@@ -1,0 +1,249 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+package AI::MXNet::Gluon::NN::Activation;
+use strict;
+use warnings;
+use AI::MXNet::Function::Parameters;
+
+=head1
+
+    AI::MXNet::Gluon::NN::Activation
+=cut
+
+=head1 DESCRIPTION
+
+    Applies an activation function to input.
+
+    Parameters
+    ----------
+    activation : str
+        Name of activation function to use.
+        See mxnet.ndarray.Activation for available choices.
+
+    Input shape:
+        Arbitrary.
+
+    Output shape:
+        Same shape as input.
+=cut
+
+use AI::MXNet::Gluon::Mouse;
+extends 'AI::MXNet::Gluon::HybridBlock';
+has 'activation' => (is => 'ro', isa => 'Str', required => 1);
+
+method python_constructor_arguments()
+{
+    ['activation'];
+}
+
+method _alias()
+{
+    return $self->activation;
+}
+
+method hybrid_forward(GluonClass $F, GluonInput $x)
+{
+    return $F->Activation($x, act_type => $self->activation, name=>'fwd');
+}
+
+use overload '""' => sub { my $self = shift; "${\ $self->_class_name }(${\ $self->activation })"; };
+
+__PACKAGE__->register('AI::MXNet::Gluon::NN');
+
+package AI::MXNet::Gluon::NN::LeakyReLU;
+=head1
+
+    AI::MXNet::Gluon::NN::LeakyReLU - Leaky version of a Rectified Linear Unit.
+=cut
+
+=head1 DESCRIPTION
+
+    Leaky version of a Rectified Linear Unit.
+
+    It allows a small gradient when the unit is not active
+
+    Parameters
+    ----------
+    alpha : float
+        slope coefficient for the negative half axis. Must be >= 0.
+=cut
+
+use AI::MXNet::Gluon::Mouse;
+extends 'AI::MXNet::Gluon::HybridBlock';
+has 'alpha' => (is => 'ro', isa => 'Num', required => 1);
+
+method python_constructor_arguments()
+{
+    ['alpha'];
+}
+
+sub BUILD
+{
+    confess('Slope coefficient for LeakyReLU must be no less than 0')
+        unless shift->alpha > 0;
+}
+
+method hybrid_forward(GluonClass $F, GluonInput $x)
+{
+    return $F->LeakyReLU($x, act_type => 'leaky', slope => $self->alpha, name=>'fwd');
+}
+
+use overload '""' => sub { my $self = shift; "${\ $self->_class_name }(${\ $self->alpha })"; };
+
+__PACKAGE__->register('AI::MXNet::Gluon::NN');
+
+package AI::MXNet::Gluon::NN::PReLU;
+=head1
+
+    AI::MXNet::Gluon::NN::PReLU - Parametric leaky version of a Rectified Linear Unit.
+=cut
+
+=head1 DESCRIPTION
+
+    Parametric leaky version of a Rectified Linear Unit.
+    https://arxiv.org/abs/1502.01852
+
+    It learns a gradient when the unit is not active
+
+    Parameters
+    ----------
+    alpha_initializer : Initializer
+        Initializer for the embeddings matrix.
+=cut
+
+use AI::MXNet::Gluon::Mouse;
+extends 'AI::MXNet::Gluon::HybridBlock';
+has 'alpha_initializer' => (is => 'ro', isa => 'Initializer', default => sub { AI::MXNet::Constant->new(0.25) });
+
+method python_constructor_arguments()
+{
+    ['alpha_initializer'];
+}
+
+sub BUILD
+{
+    my $self = shift;
+    $self->name_scope(sub {
+        $self->alpha($self->params->get('alpha', shape=>[1], init=>$self->alpha_initializer));
+    });
+}
+
+method hybrid_forward(GluonClass $F, GluonInput $x, GluonInput :$alpha)
+{
+    return $F->LeakyReLU($x, gamma => $alpha, act_type => 'prelu',  name=>'fwd');
+}
+
+__PACKAGE__->register('AI::MXNet::Gluon::NN');
+
+package AI::MXNet::Gluon::NN::ELU;
+=head1
+
+    AI::MXNet::Gluon::NN::ELU - Exponential Linear Unit (ELU)
+=cut
+
+=head1 DESCRIPTION
+
+    Exponential Linear Unit (ELU)
+        "Fast and Accurate Deep Network Learning by Exponential Linear Units", Clevert et al, 2016
+        https://arxiv.org/abs/1511.07289
+        Published as a conference paper at ICLR 2016
+
+    Parameters
+    ----------
+    alpha : float
+        The alpha parameter as described by Clevert et al, 2016
+=cut
+
+use AI::MXNet::Gluon::Mouse;
+extends 'AI::MXNet::Gluon::HybridBlock';
+has 'alpha' => (is => 'ro', isa => 'Num', default => 1);
+
+method python_constructor_arguments()
+{
+    ['alpha'];
+}
+
+method hybrid_forward(GluonClass $F, GluonInput $x)
+{
+    return $F->where($x > 0, $x, $self->alpha * ($F->exp($x) - 1));
+}
+
+__PACKAGE__->register('AI::MXNet::Gluon::NN');
+
+package AI::MXNet::Gluon::NN::SELU;
+=head1
+
+    AI::MXNet::Gluon::NN::SELU - Scaled Exponential Linear Unit (SELU)
+=cut
+
+=head1 DESCRIPTION
+
+    Scaled Exponential Linear Unit (SELU)
+    "Self-Normalizing Neural Networks", Klambauer et al, 2017
+    https://arxiv.org/abs/1706.02515
+=cut
+
+use AI::MXNet::Gluon::Mouse;
+extends 'AI::MXNet::Gluon::HybridBlock';
+
+sub BUILD
+{
+    my $self = shift;
+    $self->scale(1.0507009873554804934193349852946);
+    $self->alpha(1.6732632423543772848170429916717);
+}
+
+method hybrid_forward(GluonClass $F, GluonInput $x)
+{
+    return $self->scale * $F->where($x > 0, $x, $self->alpha * ($F->exp($x) - 1));
+}
+
+__PACKAGE__->register('AI::MXNet::Gluon::NN');
+
+package AI::MXNet::Gluon::NN::Swish;
+=head1
+
+    AI::MXNet::Gluon::NN::Swish - Swish Activation function
+=cut
+
+=head1 DESCRIPTION
+
+    Swish Activation function
+        https://arxiv.org/pdf/1710.05941.pdf
+
+    Parameters
+    ----------
+    beta : float
+        swish(x) = x * sigmoid(beta*x)
+=cut
+
+use AI::MXNet::Gluon::Mouse;
+extends 'AI::MXNet::Gluon::HybridBlock';
+has 'beta' => (is => 'ro', isa => 'Num', default => 1);
+
+method python_constructor_arguments()
+{
+    ['beta'];
+}
+
+method hybrid_forward(GluonClass $F, GluonInput $x)
+{
+    return return $x * $F->sigmoid($self->beta * $x, name=>'fwd');
+}
+
+__PACKAGE__->register('AI::MXNet::Gluon::NN');

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Parameter.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Parameter.pm
@@ -53,7 +53,7 @@ use AI::MXNet::Function::Parameters;
           iteration when using this option.
         - 'null' means gradient is not requested for this parameter. gradient arrays
           will not be allocated.
-    shape : array ref of int, default None
+    shape : array ref of int or int, default undef
         Shape of this parameter. By default shape is not specified. Parameter with
         unknown shape can be used for `Symbol` API, but `init` will throw an error
         when using `NDArray` API.
@@ -66,6 +66,11 @@ use AI::MXNet::Function::Parameters;
         Weight decay multiplier (L2 regularizer coefficient). Works similar to lr_mult.
     init : Initializer, default None
         Initializer of this parameter. Will use the global initializer by default.
+    stype: {'default', 'row_sparse', 'csr'}, defaults to 'default'.
+        The storage type of the parameter.
+    grad_stype: {'default', 'row_sparse', 'csr'}, defaults to 'default'.
+        The storage type of the parameter's gradient.
+
 
     Attributes
     ----------
@@ -80,8 +85,9 @@ use AI::MXNet::Base;
 use overload '""' => sub {
         my $self = shift;
         "Parameter " . $self->name.
-        " (shape=(" . join(',', @{ $self->shape//[] }) .")".
-        ", dtype=" . $self->dtype.")"
+        " (shape=(" . join(', ', @{ $self->shape//[] }) .")".
+        ", dtype=" . $self->dtype.
+        ", stype=" . $self->stype.")"
     },
     fallback => 1;
 
@@ -103,19 +109,22 @@ sub BUILD
 {
     my $self = shift;
     $self->grad_req($self->_grad_req);
+    $self->_shape([$self->_shape]) if defined $self->_shape and not ref $self->_shape;
     $self->_deferred_init([]);
 }
 
 has 'name'                => (is => 'ro', isa => 'Str', required => 1);
 has '_grad_req'           => (is => 'rw', isa => 'GradReq', init_arg => 'grad_req', default => 'write');
-has 'shape'               => (is => 'rw', isa => 'Shape');
+has '_shape'              => (is => 'rw', isa => 'Maybe[Shape|Int]', init_arg => 'shape');
 has 'dtype'               => (is => 'rw', isa => 'Dtype', default => 'float32');
+has ['stype',
+     'grad_stype']        => (is => 'rw', isa => 'Stype', default => 'default');
 has [qw/lr_mult wd_mult/] => (is => 'rw', isa => 'Num', default => 1);
 has 'init'                => (is => 'rw', isa => 'Maybe[Initializer]');
 has 'allow_deferred_init' => (is => 'rw', isa => 'Bool', default => 0);
 has 'differentiable'      => (is => 'rw', isa => 'Bool', default => 1);
 has [qw/_var _data _grad
-    _deferred_init
+    _deferred_init _trainer
     _ctx_list _ctx_map/]  => (is => 'rw', init_arg => undef);
 
 method grad_req(Maybe[GradReq] $req=)
@@ -138,6 +147,64 @@ method grad_req(Maybe[GradReq] $req=)
     }
 }
 
+method shape(@args)
+{
+    return $self->_shape unless @args;
+    if(not defined $args[0])
+    {
+        $self->_shape(undef);
+        return undef;
+    }
+    if(not defined $self->_shape and defined $args[0])
+    {
+        $self->_shape(ref $args[0] ? $args[0] : [$args[0]]);
+        return $self->_shape;
+    }
+    my $new_shape = ref $args[0] ? $args[0] : [$args[0]];
+    my $shape_validated = 0;
+    if(@{ $self->_shape } == @{ $new_shape })
+    {
+        $shape_validated = 1;
+        zip(sub {
+            my ($i, $j) = @_;
+            return unless $i;
+            return if $i == $j;
+            $shape_validated = 0;
+        }, $self->_shape, $new_shape);
+    }
+    assert($shape_validated, 'Expected shape is incompatible with given shape');
+    $self->_shape($new_shape);
+    return $self->_shape;
+}
+
+method _set_trainer($trainer)
+{
+    if($self->stype ne 'default' and $self->_trainer and $trainer and Scalar::Util::refaddr($self->_trainer) ne Scalar::Util::refaddr($trainer))
+    {
+        confess(
+            "Failed to set the trainer for Parameter '${\ $self->name }' because it was already set. ".
+            "More than one trainers for a ${\ $self->stype } Parameter is not supported."
+        );
+    }
+    $self->_trainer($trainer);
+}
+
+method _get_row_sparse($arr_list, $ctx, AI::MXNet::NDArray $row_id)
+{
+    if(not $self->_trainer)
+    {
+        confess(
+            "Cannot get row_sparse data for Parameter '${\ $self->name }' when no ".
+            "Trainer is created with it."
+        );
+    }
+    my $results = $self->_check_and_get($arr_list, $ctx);
+
+    # fetch row sparse params from the trainer
+    $self->_trainer->_row_sparse_pull($self, $results, $row_id);
+    return $results;
+}
+
 method _check_and_get($arr_list, $ctx)
 {
     if(defined $arr_list)
@@ -157,31 +224,31 @@ method _check_and_get($arr_list, $ctx)
                 $ctx = AI::MXNet::Context->current_ctx;
             }
         }
-        my $idx;
-        if(ref $self->_ctx_map->[$ctx->device_type_id])
+        my $ctx_list = $self->_ctx_map->[$ctx->device_type_id&1];
+        if($ctx->device_id < @{ $ctx_list })
         {
-            $idx = $self->_ctx_map->[$ctx->device_type_id][$ctx->device_id];
-        }
-        if(defined $idx)
-        {
-            return $arr_list->[$idx];
+            my $idx = $ctx_list->[$ctx->device_id];
+            if(defined $idx)
+            {
+                return $arr_list->[$idx];
+            }
         }
         confess(
-            "Parameter ${\ $self->name } was not initialized on context $ctx. ".
+            "Parameter '${\ $self->name }' was not initialized on context $ctx. ".
             "It was only initialized on @{ $self->_ctx_list }."
         );
     }
     if(@{ $self->_deferred_init })
     {
         confess("DeferredInitializationError: ".
-            "Parameter ${\ $self->name } has not been initialized yet because initialization was ".
+            "Parameter '${\ $self->name }' has not been initialized yet because initialization was ".
             "deferred. Actual initialization happens during the first forward pass. ".
             "Please pass one batch of data through the network before accessing Parameters. ".
             "You can also avoid deferred initialization by specifying in_units, ".
             "num_features, etc., for network layers.");
     }
     confess(
-        "Parameter ${\ $self->name } has not been initialized. Note that ".
+        "Parameter '${\ $self->name }' has not been initialized. Note that ".
         "you should initialize parameters and create Trainer ".
         "with Block.collect_params() instead of Block.params ".
         "because the later does not include Parameters of ".
@@ -189,34 +256,41 @@ method _check_and_get($arr_list, $ctx)
     );
 }
 
-# (Re)initializes by loading from data.
+
+# (Re)initializes by loading from data. 
 method _load_init($data, $ctx)
 {
     if($self->shape)
     {
         for(zip($self->shape, $data->shape)) {
-            my ($i, $j) = @$_;
+            my ($self_dim, $data_dim) = @$_;
             assert(
-                ($i == 0 or $i == $j),
+                ($self_dim == 0 or $self_dim == $data_dim),
                 sprintf(
-                    "Failed loading Parameter %s from saved params: ".
-                    "shape incompatible expacted (%s) vs saved (%s)",
+                    "Failed loading Parameter '%s' from saved params: ".
+                    "shape incompatible expected (%s) vs saved (%s)",
                     $self->name, "@{$self->shape}", "@{$data->shape}"
                 )
             );
         }
+        $self->shape([map { $_->[0] ? $_->[0] : $_->[1] } zip($self->shape, $data->shape)]);
     }
     if($self->dtype)
     {
         assert(
             ($self->dtype eq $data->dtype),
             sprintf(
-                "Failed loading Parameter %s from saved params: ".
-                "dtype incompatible expacted %s vs saved %s",
+                "Failed loading Parameter '%s' from saved params: ".
+                "dtype incompatible expected %s vs saved %s",
                 $self->name, $self->dtype, $data->dtype
             )
         );
     }
+    if($self->stype ne $data->stype)
+    {
+        $data = $data->tostype($self->stype);
+    }
+
     if(blessed ($ctx) and $ctx->isa('AI::MXNet::Context'))
     {
         $ctx = [$ctx];
@@ -226,23 +300,28 @@ method _load_init($data, $ctx)
         if(@{ $self->_deferred_init })
         {
             assert(
-                ($ctx eq $self->_deferred_init->[1]),
+                (not defined $ctx or join('', @{ $ctx }) eq join('', @{ $self->_deferred_init->[1] })),
                 sprintf(
-                    "Failed to load Parameter %s on %s because it was ".
-                    "previous initialized on %s.",
+                    "Failed to load Parameter '%s' on %s because it was ".
+                    "previously initialized on %s.",
                     $self->name, $ctx, $self->list_ctx
                 )
             );
+            $ctx = $self->_deferred_init->[1];
+        }
+        elsif(not defined $ctx)
+        {
+            $ctx = [AI::MXNet::Context->cpu];
         }
         $self->_init_impl($data, $ctx);
     }
     else
     {
         assert(
-            (join('', @{ $ctx }) eq join('', @{ $self->list_ctx })),
+            (not defined $ctx or join('', @{ $ctx }) eq join('', @{ $self->list_ctx })),
             sprintf(
-                "Failed to load Parameter %s on %s because it was ".
-                "previous initialized on %s.",
+                "Failed to load Parameter '%s' on %s because it was ".
+                "previously initialized on %s.",
                 $self->name, "@$ctx", "@{$self->list_ctx}"
             )
         );
@@ -255,28 +334,34 @@ method _load_init($data, $ctx)
 method _finish_deferred_init()
 {
     return unless @{ $self->_deferred_init };
-    my ($init, $ctx, $default_init) = @{ $self->_deferred_init };
+    my ($init, $ctx, $default_init, $data) = @{ $self->_deferred_init };
     $self->_deferred_init([]);
     assert(
         (defined($self->shape) and product(@{ $self->shape }) > 0),
         sprintf(
-            "Cannot initialize Parameter %s because it has ".
+            "Cannot initialize Parameter '%s' because it has ".
             "invalid shape: %s. Please specify in_units, ".
             "in_channels, etc for `Block`s.",
             $self->name, $self->shape
         )
     );
     AI::MXNet::AutoGrad->pause(sub {
-        my $data = AI::MXNet::NDArray->zeros(
-            $self->shape, dtype => $self->dtype, ctx => AI::MXNet::Context->cpu
-        );
-        AI::MXNet::Initializer->new->(
-            AI::MXNet::InitDesc->new(
-                name => $self->name,
-                attrs => { __init__ => defined $init ? "$init" : "$default_init" }
-            ),
-            $data
-        );
+        if(not defined $data)
+        {
+            $data = AI::MXNet::NDArray->zeros(
+                $self->shape,
+                dtype => $self->dtype,
+                ctx => AI::MXNet::Context->cpu,
+                stype => $self->stype
+            );
+            AI::MXNet::Initializer->new->(
+                AI::MXNet::InitDesc->new(
+                    name => $self->name,
+                    attrs => { __init__ => defined $init ? "$init" : "$default_init" }
+                ),
+                $data
+            );
+        }
         $self->_init_impl($data, $ctx);
     });
 }
@@ -285,14 +370,10 @@ method _finish_deferred_init()
 method _init_impl($data, $ctx_list)
 {
     $self->_ctx_list([@{ $ctx_list }]);
-    $self->_ctx_map([]);
+    $self->_ctx_map([[], []]);
     enumerate(sub {
         my ($i, $ctx) = @_;
-        while(@{ $self->_ctx_map } <= $ctx->device_type_id)
-        {
-            push @{ $self->_ctx_map }, [];
-        }
-        my $dev_list = $self->_ctx_map->[$ctx->device_type_id];
+        my $dev_list = $self->_ctx_map->[$ctx->device_type_id&1];
         while(@{ $dev_list } <= $ctx->device_id)
         {
             push @{ $dev_list }, undef;
@@ -311,19 +392,39 @@ method _init_grad()
         $self->_grad(undef);
         return;
     }
-    $self->_grad([map { AI::MXNet::NDArray->zeros_like($_) } @{ $self->_data }]);
-    AI::MXNet::AutoGrad->mark_variables($self->list_data, $self->list_grad, grad_reqs => $self->grad_req);
+    $self->_grad([
+        map {
+            AI::MXNet::NDArray->zeros(
+                $_->shape, dtype => $_->dtype,
+                ctx => $_->context, stype => $self->grad_stype
+            )
+        } @{ $self->_data }
+    ]);
+    AI::MXNet::AutoGrad->mark_variables(
+        $self->_check_and_get($self->_data, []),
+        $self->_grad,
+        grad_reqs => $self->grad_req
+    );
 }
 
-# Reduce data from multiple context.
-
+# Reduce data from multiple contexts to cpu.
 method _reduce()
 {
-    my $block = $self->list_data;
-    my $data = AI::MXNet::NDArray->add_n(map { $_->copyto(AI::MXNet::Context->cpu) } @{ $block }) / @{ $block };
+    my $data;
+    my $ctx = AI::MXNet::Context->cpu;
+    if($self->stype eq 'default')
+    {
+        my $block = $self->list_data;
+        $data = AI::MXNet::NDArray->add_n(map { $_->copyto($ctx) } @{ $block }) / @{ $block };
+    }
+    else
+    {
+        my $all_row_ids = AI::MXNet::NDArray->arange(stop => $self->shape->[0], dtype=>'int64', ctx=>$ctx);
+        $data = AI::MXNet::NDArray->zeros($self->shape, stype=>'row_sparse', ctx=>$ctx);
+        $self->_trainer->_row_sparse_pull($self, $data, $all_row_ids);
+    }
     return $data;
 }
-
 
 =head2 initialize
 
@@ -377,7 +478,7 @@ method initialize(
     if(defined $self->_data and not $force_reinit)
     {
         AI::MXNet::Logging->warning(
-            "Parameter %s is already initialized, ignoring. ".
+            "Parameter '%s' is already initialized, ignoring. ".
             "Set force_reinit=True to re-initialize.", $self->name
         );
         return;
@@ -403,13 +504,13 @@ method initialize(
     {
         if($self->allow_deferred_init)
         {
-            $self->_deferred_init([$init, $ctx, $default_init]);
+            $self->_deferred_init([$init, $ctx, $default_init, undef]);
             return;
         }
-        confess("Cannot initialize Parameter ${\ $self->name } because it has ".
+        confess("Cannot initialize Parameter '${\ $self->name }' because it has ".
                 "invalid shape: @{$self->shape//[]}.");
     }
-    $self->_deferred_init([$init, $ctx, $default_init]);
+    $self->_deferred_init([$init, $ctx, $default_init, undef]);
     $self->_finish_deferred_init;
 }
 
@@ -437,12 +538,12 @@ method reset_ctx(Maybe[AI::MXNet::Context|ArrayRef[AI::MXNet::Context]] :$ctx=AI
     }
     elsif(@{ $self->_deferred_init })
     {
-        my ($init, undef, $default_init) = @{ $self->_deferred_init };
-        $self->_deferred_init([$init, $ctx, $default_init]);
+        my ($init, undef, $default_init, $data) = @{ $self->_deferred_init };
+        $self->_deferred_init([$init, $ctx, $default_init, $data]);
     }
     else
     {
-        confess("Cannot reset context for Parameter ${ \ $self->name } because it ".
+        confess("Cannot reset context for Parameter '${ \ $self->name }' because it ".
                 "has not been initialized.");
     }
 }
@@ -454,20 +555,93 @@ method reset_ctx(Maybe[AI::MXNet::Context|ArrayRef[AI::MXNet::Context]] :$ctx=AI
 
 method set_data($data)
 {
-    assert(
-        (defined $self->_data),
-        "Parameter ${\ $self->name } has not been initialized"
-    );
-    for my $arr (@{ $self->list_data })
+    $self->shape($data->shape);
+    if(not defined $self->_data)
+    {
+        assert(
+            (@{ $self->_deferred_init }),
+            "Parameter '${\ $self->name }' has not been initialized"
+        );
+        $self->_deferred_init->[3] = $data;
+        return;
+    }
+
+    # if update_on_kvstore, we need to make sure the copy stored in kvstore is in sync
+    if($self->_trainer and $self->_trainer->_kv_initialized and $self->_trainer->update_on_kvstore)
+    {
+        if(!grep { Scalar::Util::refaddr($self) == Scalar::Util::refaddr($_) } @{ $self->_trainer->_params_to_init })
+        {
+            $self->_trainer->_reset_kvstore();
+        }
+    }
+    for my $arr (@{ $self->_check_and_get($self->_data, []) })
     {
         $arr .= $data;
     }
 }
 
+=head2 row_sparse_data 
+
+        Returns a copy of the 'row_sparse' parameter on the same context as row_id's.
+        The copy only retains rows whose ids occur in provided row ids.
+        The parameter must have been initialized on this context before.
+
+        Parameters
+        ----------
+        $row_id: AI::MXNet::NDArray
+            Row ids to retain for the 'row_sparse' parameter.
+
+        Returns
+        -------
+        AI::MXNet::NDArray on row_id's context
+=cut
+
+method row_sparse_data(AI::MXNet::NDArray $row_id)
+{
+    if($self->stype ne 'row_sparse')
+    {
+        confess(
+            "Cannot return a copy of Parameter ${\ $self->name } via row_sparse_data() ".
+            "because its storage type is ${\ $self->stype }. Please use data() instead."
+        );
+    }
+    return $self->_get_row_sparse($self->_data, $row_id->context, $row_id);
+}
+
+=head2 list_row_sparse_data
+
+        Returns copies of the 'row_sparse' parameter on all contexts, in the same order
+        as creation. The copy only retains rows whose ids occur in provided row ids.
+        The parameter must have been initialized before.
+
+        Parameters
+        ----------
+        $row_id: AI::MXNet::NDArray
+            Row ids to retain for the 'row_sparse' parameter.
+
+        Returns
+        -------
+        array ref of AI::MXNet::NDArrays
+=cut
+
+method list_row_sparse_data(AI::MXNet::NDArray $row_id)
+{
+    if($self->stype ne 'row_sparse')
+    {
+        confess(
+            "Cannot return copies of Parameter '${\ $self->name }' on all contexts via ".
+            "list_row_sparse_data() because its storage type is ${\ $self->stype }. Please ".
+            "use data() instead."
+        );
+    }
+    return $self->_get_row_sparse($self->_data, [], $row_id);
+}
+
 =head2 data
 
         Returns a copy of this parameter on one context. Must have been
-        initialized on this context before.
+        initialized on this context before. For sparse parameters, use
+        row_sparse_data instead.
 
         Parameters
         ----------
@@ -481,17 +655,35 @@ method set_data($data)
 
 method data(Maybe[AI::MXNet::Context] $ctx=)
 {
+    if($self->stype ne 'default')
+    {
+        $ctx //= AI::MXNet::Context->current_ctx;
+        confess(
+            "Cannot return a copy of Parameter '${\ $self->name }' on ctx $ctx via data() ".
+            "because its storage type is ${\ $self->stype }. Please use row_sparse_data() ".
+            "instead."
+        );
+    }
     return $self->_check_and_get($self->_data, $ctx);
 }
 
 =head2 list_data
 
         Returns copies of this parameter on all contexts, in the same order
-        as creation.
+        as creation. For sparse parameters, use list_row_sparse_data
+        instead.
 =cut
 
 method list_data()
 {
+    if($self->stype ne 'default')
+    {
+        confess(
+            "Cannot return a copies of Parameter '${\ $self->data }' on all contexts via list_data() ".
+            "because its storage type is ${\ $self->stype }. Please use row_sparse_data() ".
+            "instead."
+        );
+    }
     return $self->_check_and_get($self->_data, [])
 }
 
@@ -562,7 +754,7 @@ method list_ctx()
 method zero_grad()
 {
     return unless defined $self->_grad;
-    map { $_ .= 0 } @{ $self->_grad };
+    AI::MXNet::NDArray->zeros_like($_, { out => $_ }) for @{ $self->_grad };
 }
 
 =head2 var
@@ -578,13 +770,129 @@ method var()
             AI::MXNet::Symbol->var(
                 $self->name, shape => $self->shape, dtype => $self->dtype,
                 lr_mult => $self->lr_mult, wd_mult => $self->wd_mult,
-                init => $self->init
+                init => $self->init, stype => $self->stype
             )
         );
     }
     return $self->_var;
 }
 
+=head2 cast
+
+    Cast data and gradient of this Parameter to a new data type.
+
+    Parameters
+     ----------
+    $dtype : Dtype
+    The new data type.
+=cut
+
+method cast(Dtype $dtype)
+{
+    $self->dtype($dtype);
+    return unless defined $self->_data;
+    AI::MXNet::AutoGrad->pause(sub {
+        $self->_data([map { $_->astype($dtype) } @{ $self->_data }]);
+        return unless defined $self->_grad;
+        $self->_grad([map { $_->astype($dtype) } @{ $self->_grad }]);
+        AI::MXNet::AutoGrad->mark_variables($self->_data, $self->_grad, grad_reqs => $self->grad_req);
+    });
+}
+
+package AI::MXNet::Gluon::Constant;
+use strict;
+use warnings;
+use Mouse;
+extends 'AI::MXNet::Gluon::Parameter';
+
+=head1 NAME 
+
+    AI::MXNet::Gluon::Constant - A constant parameter for holding immutable tensors.
+=cut
+
+=head1 DESCRIPTION
+
+    A constant parameter for holding immutable tensors.
+    Constants are ignored by autograd and Trainer, thus their values
+    will not change during training. But you can still update their values
+    manually with the set_data method.
+
+    Constants can be created with either
+
+        $const = mx->gluon->Constant('const', [[1,2],[3,4]]);
+
+    or
+
+        package Block;
+        use AI::MXNet::Gluon::Mouse;
+        extends 'AI::MXNet::Gluon::Block';
+        sub BUILD
+        {
+            $self->const($self->params->get_constant('const', [[1,2],[3,4]]));
+        }
+
+    Constructor Attributes
+    ----------
+    name : str
+        Name of the parameter.
+    value : AcceptableInput (perl array, pdl, ndarray, etc)
+        Initial value for the constant.
+=cut
+
+use Mouse;
+use AI::MXNet::Base;
+use Scalar::Util qw(refaddr);
+around BUILDARGS => \&AI::MXNet::Base::process_arguments;
+method python_constructor_arguments() { ['name', 'value'] }
+has 'value'     => (is => 'rw', isa => 'AcceptableInput');
+has '+_grad_req' => (is => 'rw', default => 'null');
+use overload '""' => sub {
+        my $self = shift;
+        "Constant " . $self->name.
+        " (shape=(" . join(', ', @{ $self->shape//[] }) .")".
+        ", dtype=" . $self->dtype.
+        ", stype=" . $self->stype.")"
+    },
+    fallback => 1;
+
+
+sub BUILD
+{
+    my $self = shift;
+    if(not (blessed $self->value and $self->value->isa('AI::MXNet::NDArray')))
+    {
+        $self->value(AI::MXNet::NDArray->array($self->value, dtype => $self->dtype));
+    }
+    $self->shape($self->value->shape);
+    my $init = "AI::MXNet::Gluon::Constant::Init_${\ $self->name }_${\ refaddr($self) }";
+    my $tmp =<<"EOP";
+    package $init;
+    use Mouse;
+    extends 'AI::MXNet::Initializer';
+    sub _init_weight
+    {
+        \$self->value->copyto(\$_[2]);
+    }
+    $init->register;
+    1;
+EOP
+    eval $tmp;
+    $self->init($init->new);
+}
+
+method grad_req($req=)
+{
+    if(defined $req and $req ne 'null')
+    {
+        AI::MXNet::Logging->warning(
+            'Constant parameter "%s" does not support '.
+            'grad_req other than "null", and new value "%s" '.
+            'is ignored.',
+            $self->name, $req
+        );
+    }
+    return 'null';
+}
 
 package AI::MXNet::Gluon::ParameterDict;
 use AI::MXNet::Base;
@@ -650,6 +958,10 @@ method prefix()
     $self->_prefix;
 }
 
+method params()
+{
+    $self->_params;
+}
 
 method _get_impl($name)
 {
@@ -702,12 +1014,51 @@ method get(Str $name, %kwargs)
         {
             if($param->can($k))
             {
-                assert(
-                    (not defined $v or Dumper($v) eq Dumper($param->$k)),
-                    "Cannot retrieve Parameter $name because desired attribute ".
-                    "does not match with stored for attribute $k: ".
-                    "desired ".Dumper($v)." vs stored ". Dumper($param->$k)
-                );
+                if(defined $param->$k)
+                {
+                    my $existing = $param->$k;
+                    if($k eq 'shape' and @{$v} == @{$existing})
+                    {
+                        my @inferred_shape;
+                        my $matched = 1;
+                        for(zip($v, $existing))
+                        {
+                            my ($dim1, $dim2) = @$_;
+                            if($dim1 != $dim2 and $dim1 * $dim2 != 0)
+                            {
+                                $matched = 0;
+                                 last;
+                            }
+                            elsif($dim1 == $dim2)
+                            {
+                                push @inferred_shape, $dim1;
+                            }
+                            elsif($dim1 == 0)
+                            {
+                                push @inferred_shape, $dim2;
+                            }
+                            else
+                            {
+                                push @inferred_shape, $dim1;
+                            }
+                        }
+                        if($matched)
+                        {
+                            $param->_shape(\@inferred_shape);
+                            next;
+                        }
+                    }
+                    assert(
+                        (not defined $v or Dumper($v) eq Dumper($param->$k)),
+                        "Cannot retrieve Parameter $name because desired attribute ".
+                        "does not match with stored for attribute $k: ".
+                        "desired ".Dumper($v)." vs stored ". Dumper($param->$k)
+                    );
+                }
+                else
+                {
+                    $param->$k($v);
+                }
             }
             else
             {
@@ -723,10 +1074,10 @@ method get(Str $name, %kwargs)
     Copies all Parameters in $other to self.
 =cut
 
-method update($other)
+method update($other, Maybe[Str] $select=)
 {
     my @keys = $other->keys;
-    for my $k (@keys)
+    for my $k (grep { not defined $select or /$select/ } @keys)
     {
         if($self->_params->exists($k))
         {
@@ -743,6 +1094,50 @@ method update($other)
     }
 }
 
+=head2 get_constant
+
+        Retrieves AI::MXNet::Gluon::Constant with name $self->prefix.$name. If not found,
+        'get' will first try to retrieve it from "shared" dictionary. If still not
+        found, 'get' will create a new Constant with key-word
+        arguments and insert it to self.
+
+        Parameters
+        ----------
+        name : str
+            Name of the desired Constant. It will be prepended with this dictionary's
+            prefix.
+        value : array-like
+            Initial value of constant.
+
+        Returns
+        -------
+        Constant
+            The created or retrieved Constant.
+=cut
+
+method get_constant(Str $name, Maybe[AcceptableInput] $value=)
+{
+    $name = $self->prefix . $name;
+    my $param = $self->_get_impl($name);
+    if(not defined $param)
+    {
+        if(not defined $value)
+        {
+            confess(
+                "No constant named '$name'. Please specify value ".
+                "if you want to create a new constant."
+            );
+        }
+        $param = AI::MXNet::Gluon::Constant->new($name, $value);
+        $self->_params->set($name, $param);
+    }
+    elsif(defined $value)
+    {
+        confess("reinit of Constant $name is not allowed");
+    }
+    return $param;
+}
+
 =head2 initialize
 
         Initializes all Parameters managed by this dictionary to be used for 'NDArray'
@@ -757,8 +1152,9 @@ method update($other)
             Keeps a copy of Parameters on one or many context(s).
         :$force_reinit : bool, default False
             Whether to force re-initialization if parameter is already initialized.
+        :$verbose : bool, default False
+            Whether to force re-initialization if parameter is already initialized.
 =cut
-
 
 method initialize(
     Initializer                                            :$init=AI::MXNet::Initializer->Uniform(),
@@ -873,6 +1269,7 @@ method save(Str $filename, Str $strip_prefix='')
         :$restore_prefix : str, default ''
             prepend prefix to names of stored parameters before loading.
 =cut
+
 method load(
     Str                                              $filename,
     AI::MXNet::Context|ArrayRef[AI::MXNet::Context] :$ctx=AI::MXNet::Context->current_ctx,
@@ -894,7 +1291,7 @@ method load(
     }
     my $lprefix  = length $restore_prefix;
     my %orig_load = %{ AI::MXNet::NDArray->load($filename) };
-    my %arg_dict  = map { ($restore_prefix.$_, $orig_load{$_}) } keys %orig_load;
+    my %arg_dict  = map { my $k = $_; s/^(?:arg|aux)://; ($restore_prefix.$_, $orig_load{$k}) } keys %orig_load;
     if(not $allow_missing)
     {
         for my $name ($self->keys())
@@ -919,7 +1316,7 @@ method load(
             );
             next;
         }
-        @{$self}{$name}->_load_init($arg_dict{$name}, $ctx);
+        $self->{ $name }->_load_init($arg_dict{$name}, $ctx);
     }
 }
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/RNN.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/RNN.pm
@@ -31,7 +31,7 @@ sub import
         {
             my $short_name_package =<<"EOP";
             package $short_name;
-            \@${short_name}::ISA = ('AI::MXNet::Gluon::RNN_');;
+            \@${short_name}::ISA = ('AI::MXNet::Gluon::RNN_');
             1;
 EOP
             eval $short_name_package;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Trainer.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Trainer.pm
@@ -23,6 +23,7 @@ use AI::MXNet::Function::Parameters;
 use IO::File;
 use Mouse;
 
+
 =head1 NAME
 
     AI::MXNet::Gluon::Trainer
@@ -35,53 +36,78 @@ use Mouse;
 
     Parameters
     ----------
-    params : ParameterDict
+    params : AI::MXNet::Gluon::ParameterDict
         The set of parameters to optimize.
     optimizer : str or Optimizer
         The optimizer to use. See
         `help <http://mxnet.io/api/python/optimization/optimization.html#the-mxnet-optimizer-package>`_
         on Optimizer for a list of available optimizers.
-    optimizer_params : dict
+    optimizer_params : hash ref
         Key-word arguments to be passed to optimizer constructor. For example,
-        `{'learning_rate': 0.1}`. All optimizers accept learning_rate, wd (weight decay),
+        {learning_rate => 0.1}. All optimizers accept learning_rate, wd (weight decay),
         clip_gradient, and lr_scheduler. See each optimizer's
         constructor for a list of additional supported arguments.
     kvstore : str or KVStore
         kvstore type for multi-gpu and distributed training. See help on
-        :any:`mxnet.kvstore.create` for more information.
+        mx->kvstore->create for more information.
+    compression_params : hash ref
+        Specifies type of gradient compression and additional arguments depending
+        on the type of compression being used. For example, 2bit compression requires a threshold.
+        Arguments would then be {type => '2bit', threshold => 0.5}
+        See AI::MXNet::KVStore->set_gradient_compression method for more details on gradient compression.
+    update_on_kvstore : Bool, default undef
+        Whether to perform parameter updates on kvstore. If undef, then trainer will choose the more
+        suitable option depending on the type of kvstore.
+
+    Properties
+    ----------
+    learning_rate : float
+        The current learning rate of the optimizer. Given an Optimizer object
+        optimizer, its learning rate can be accessed as optimizer->learning_rate.
 =cut
 
-has '_params'          => (is => 'rw', init_arg => 'params', isa => 'HashRef|ArrayRef|AI::MXNet::Gluon::ParameterDict');
-has 'optimizer'        => (is => 'ro', isa => 'Optimizer');
-has 'optimizer_params' => (is => 'ro', isa => 'Maybe[HashRef]');
-has '_kv_store'        => (is => 'rw', init_arg => 'kvstore', isa => 'Maybe[KVStore]', default => 'device');
+has 'params'             => (is => 'rw', isa => 'HashRef|ArrayRef|AI::MXNet::Gluon::ParameterDict');
+has 'optimizer'          => (is => 'ro', isa => 'Optimizer');
+has 'optimizer_params'   => (is => 'ro', isa => 'Maybe[HashRef]');
+has 'compression_params' => (is => 'ro', isa => 'Maybe[HashRef]');
+has 'kvstore'            => (is => 'rw', isa => 'Maybe[KVStore]', default => 'device');
+has 'update_on_kvstore'  => (is => 'rw', isa => 'Maybe[Bool]');
 has [qw/_scale _contexts
     _kv_initialized
-    _update_on_kvstore
+    _param2idx
+    _kvstore_params
+    _contains_sparse
+    _params_to_init
     _updaters
     _optimizer/]       => (is => 'rw', init_arg => undef);
 around BUILDARGS => \&AI::MXNet::Base::process_arguments;
-method python_constructor_arguments() { ['params', 'optimizer', 'optimizer_params'] }
+method python_constructor_arguments()
+{
+    [qw/params optimizer optimizer_params kvstore compression_params update_on_kvstore/]
+}
 
 sub BUILD
 {
     my $self = shift;
     my @params;
-    if(blessed $self->_params)
+    if(blessed $self->params)
     {
-        @params = $self->_params->values;
+        @params = $self->params->values;
     }
-    elsif(ref $self->_params eq 'HASH')
+    elsif(ref $self->params eq 'HASH')
     {
-        @params = values %{ $self->_params };
+        @params = values %{ $self->params };
     }
     else
     {
-        @params = @{ $self->_params };
+        @params = @{ $self->params };
     }
-    $self->_params([]);
-    for my $param (@params)
+    $self->params([]);
+    $self->_contains_sparse(0);
+    $self->_param2idx({});
+    for(enumerate(\@params))
     {
+        my ($i, $param) = @$_;
         if(not(blessed $param and $param->isa('AI::MXNet::Gluon::Parameter')))
         {
             confess(
@@ -89,19 +115,33 @@ sub BUILD
                 "got list of [$param]."
             );
         }
-        push @{ $self->_params }, $param;
+        $self->_param2idx->{ $param->name } = $i;
+        push @{ $self->params }, $param;
+        $param->_set_trainer($self);
+        if($param->stype ne 'default')
+        {
+            $self->_contains_sparse(1);
+        }
     }
     my $optimizer_params = $self->optimizer_params//{};
     $self->_scale(delete $optimizer_params->{rescale_grad}//1);
     $self->_contexts($self->_check_contexts);
     $self->_init_optimizer($self->optimizer, $optimizer_params);
+    $self->_kvstore_params({
+        kvstore => $self->kvstore,
+        update_on_kvstore => $self->update_on_kvstore
+    });
     $self->_kv_initialized(0);
+    $self->kvstore(undef);
+    $self->update_on_kvstore(undef);
+    $self->_params_to_init([]);
+    $self->_reset_kvstore();
 }
 
 method _check_contexts()
 {
     my $contexts;
-    for my $param (@{ $self->_params })
+    for my $param (@{ $self->params })
     {
         my $ctx = $param->list_ctx;
         assert(
@@ -117,7 +157,7 @@ method _check_contexts()
 
 method _init_optimizer($optimizer, $optimizer_params)
 {
-    my %param_dict = map { $_ => $self->_params->[$_] } 0 .. @{ $self->_params } - 1;
+    my %param_dict = map { $_ => $self->params->[$_] } 0 .. @{ $self->params } - 1;
     if(blessed $optimizer and $optimizer->isa('AI::MXNet::Optimizer'))
     {
         assert(
@@ -142,104 +182,187 @@ method _init_optimizer($optimizer, $optimizer_params)
     ]);
 }
 
+method _init_params()
+{
+    assert(
+        $self->_kv_initialized,
+        "Cannot initialize parameters in KVStore ".
+        "when KVStore is not initialized."
+    );
+    my @params_to_init;
+    if($self->kvstore)
+    {
+        for my $param (@{ $self->_params_to_init })
+        {
+            if(@{ $param->_deferred_init })
+            {
+                push @params_to_init, $param;
+            }
+            else
+            {
+                my $param_arrays = $param->_check_and_get($param->_data, []);
+                my $idx = $self->_param2idx->{ $param->name };
+                $self->kvstore->init($idx, $param_arrays->[0]);
+                if($param->stype eq 'default')
+                {
+                    $self->kvstore->pull($idx, out => $param_arrays, priority=>-$idx);
+                }
+            }
+        }
+    }
+    $self->_params_to_init(\@params_to_init);
+}
+
+method _reset_kvstore()
+{
+    if($self->kvstore and $self->kvstore->type =~ /dist/)
+    {
+        confess("Cannot reset distributed KVStore.");
+    }
+    $self->_kv_initialized(0);
+    $self->kvstore(undef);
+    $self->update_on_kvstore(undef);
+    $self->_params_to_init([@{ $self->params }]);
+}
+
 method _init_kvstore()
 {
-    my %arg_arrays = map { $_->name => $_->data($self->_contexts->[0]) } @{ $self->_params };
-    my ($kvstore, $update_on_kvstore) = AI::MXNet::Module::_create_kvstore(
-        $self->_kv_store, scalar(@{$self->_contexts }), \%arg_arrays
-    );
-    if($kvstore)
+    my $config = $self->_kvstore_params;
+    my ($kvstore, $update_on_kvstore);
+    if($self->_contains_sparse)
     {
-        if($kvstore->type =~ /dist/)
+        ($kvstore, $update_on_kvstore) = AI::MXNet::Module::_create_sparse_kvstore($config->{kvstore});
+        # update_on_kvstore is set to False by the user
+        if(defined $config->{update_on_kvstore} and not $config->{update_on_kvstore})
         {
-            $update_on_kvstore = 0;
+            confess(
+                "Cannot set update_on_kvstore to False when sparse ".
+                "gradients and/or sparse weights are present."
+            )
         }
-        enumerate(sub {
-            my ($i, $param) = @_;
-            my $param_arrays = $param->list_data;
-            $kvstore->init($i, $param_arrays->[0]);
-            $kvstore->pull($i, out => $param_arrays, priority => -$i);
-        }, $self->_params);
-        if($update_on_kvstore)
-        {
-            $kvstore->set_optimizer($self->_optimizer);
-        }
-        $self->_kv_store($kvstore);
-        $self->_update_on_kvstore($update_on_kvstore);
     }
     else
     {
-        $self->_kv_store(undef);
-        $self->_update_on_kvstore(undef)
+        my %arg_arrays = map { $_->name => $_->data($self->_contexts->[0]) } @{ $self->params };
+        ($kvstore, $update_on_kvstore) = AI::MXNet::Module::_create_kvstore(
+            $config->{kvstore}, scalar(@{$self->_contexts }), \%arg_arrays
+        );
+        if(defined $config->{update_on_kvstore})
+        {
+            $update_on_kvstore = $config->{update_on_kvstore};
+        }
+    }
+    if($kvstore)
+    {
+        if($self->compression_params)
+        {
+            $kvstore->set_gradient_compression($self->compression_params);
+        }
+        # kv->pull(row_sparse_grad) is not supported
+        if($kvstore->type =~ /dist/ and not $self->_contains_sparse)
+        {
+            $update_on_kvstore = 0;
+        }
+        if($update_on_kvstore)
+        {
+            # optimizer preferably needs to be set before init for multiprecision
+            $kvstore->set_optimizer($self->_optimizer);
+        }
+        $self->kvstore($kvstore);
+        $self->update_on_kvstore($update_on_kvstore);
+    }
+    else
+    {
+        $self->kvstore(undef);
+        $self->update_on_kvstore(undef);
     }
     $self->_kv_initialized(1);
+}
+
+method _row_sparse_pull($parameter, $out, $row_id)
+{
+    # initialize kv and params if not already
+    $self->_init_kvstore() unless $self->_kv_initialized;
+    $self->_init_params() if scalar(@{ $self->_params_to_init });
+    $self->kvstore->row_sparse_pull(
+        $self->_param2idx->{ $parameter->name },
+        out => $out,
+        row_ids => $row_id
+    );
 }
 
 =head2 step
 
         Makes one step of parameter update. Should be called after
-        `autograd.compute_gradient` and outside of `record()` scope.
+        `autograd->backward()` and outside of `record()` scope.
+
+        For normal parameter updates, `step()` should be used, which internally calls
+        `allreduce_grads()` and then `update()`. However, if you need to get the reduced
+        gradients to perform certain transformation, such as in gradient clipping, then
+        you may want to manually call `allreduce_grads()` and `update()` separately.
 
         Parameters
         ----------
-        batch_size : int
+        $batch_size : Int
             Batch size of data processed. Gradient will be normalized by `1/batch_size`.
             Set this to 1 if you normalized loss manually with `loss = mean(loss)`.
-        ignore_stale_grad : bool, optional, default=False
+        $ignore_stale_grad : Bool, optional, default=False
             If true, ignores Parameters with stale gradient (gradient that has not
             been updated by `backward` after last step) and skip update.
 =cut
 
 method step(Int $batch_size, Bool $ignore_stale_grad=0)
 {
-    if(not $self->_kv_initialized)
-    {
-        $self->_init_kvstore;
-    }
+    $self->_init_kvstore() unless $self->_kv_initialized;
+    $self->_init_params() if scalar(@{ $self->_params_to_init });
     $self->_optimizer->rescale_grad($self->_scale/$batch_size);
-    enumerate(sub {
-        my ($i, $param) = @_;
-        return if $param->grad_req eq 'null';
-        if(not $ignore_stale_grad)
+    $self->_allreduce_grads();
+    $self->_update($ignore_stale_grad);
+}
+
+=head2 allreduce_grads
+
+        For each parameter, reduce the gradients from different contexts.
+
+        Should be called after `autograd.backward()`, outside of `record()` scope,
+        and before `trainer.update()`.
+
+        For normal parameter updates, `step()` should be used, which internally calls
+        `allreduce_grads()` and then `update()`. However, if you need to get the reduced
+        gradients to perform certain transformation, such as in gradient clipping, then
+        you may want to manually call `allreduce_grads()` and `update()` separately.
+=cut
+
+method allreduce_grads()
+{
+    $self->_init_kvstore() unless $self->_kv_initialized;
+    $self->_init_params() if scalar(@{ $self->_params_to_init });
+    assert(
+        (not ($self->kvstore and $self->update_on_kvstore)),
+        'allreduce_grads() when parameters are updated on kvstore '.
+        'is not supported. Try setting `update_on_kvstore` '.
+        'to False when creating trainer.'
+    );
+    $self->_allreduce_grads();
+}
+
+method _allreduce_grads()
+{
+    if($self->kvstore)
+    {
+        for(enumerate($self->params))
         {
-            for my $data (@{ $param->list_data })
+            my ($i, $param) = @$_;
+            if($param->grad_req ne 'null')
             {
-                if(not $data->_fresh_grad)
+                $self->kvstore->push($i, $param->list_grad(), priority=>-$i);
+                if(not $self->update_on_kvstore)
                 {
-                    AI::MXNet::Logging->warning(
-                        "Gradient of Parameter `%s` on context %s has not been updated ".
-                        "by backward since last `step`. This could mean a bug in your ".
-                        "model that maked it only use a subset of the Parameters (Blocks) ".
-                        "for this iteration. If you are intentionally only using a subset, ".
-                        "call step with ignore_stale_grad=True to suppress this ".
-                        "warning and skip updating of Parameters with stale gradient",
-                        $param->name, $data->context
-                    );
+                    $self->kvstore->pull($i, out => $param->list_grad(), priority=>-$i);
                 }
             }
         }
-        if($self->_kv_store)
-        {
-            $self->_kv_store->push($i, $param->list_grad, priority => -$i);
-            if($self->_update_on_kvstore)
-            {
-                $self->_kv_store->pull($i, out => $param->list_data, priority => -$i);
-                return;
-            }
-            else
-            {
-                $self->_kv_store->pull($i, out => $param->list_grad, priority => -$i);
-            }
-        }
-        for(zip($self->_updaters, $param->list_data, $param->list_grad)) {
-            my ($upd, $arr, $grad) = @$_;
-            if(not $ignore_stale_grad or $arr->_fresh_grad)
-            {
-                $upd->($i, $grad, $arr);
-                $arr->_fresh_grad(0);
-            }
-        }
-    }, $self->_params);
+    }
 }
 
 method learning_rate(Maybe [Num] $lr)
@@ -277,6 +400,91 @@ method set_learning_rate(Num $lr)
     $self->learning_rate($lr);
 }
 
+=head2 update
+
+        Makes one step of parameter update.
+
+        Should be called after autograd->backward() and outside of record() scope,
+        and after trainer->update`.
+
+
+        For normal parameter updates, step() should be used, which internally calls
+        allreduce_grads() and then update(). However, if you need to get the reduced
+        gradients to perform certain transformation, such as in gradient clipping, then
+        you may want to manually call allreduce_grads() and update() separately.
+
+        Parameters
+        ----------
+        $batch_size : Int
+            Batch size of data processed. Gradient will be normalized by `1/$batch_size`.
+            Set this to 1 if you normalized loss manually with $loss = mean($loss).
+        $ignore_stale_grad : Bool, optional, default=False
+            If true, ignores Parameters with stale gradient (gradient that has not
+            been updated by backward() after last step) and skip update.
+=cut
+
+method update(Int $batch_size, Bool $ignore_stale_grad=0)
+{
+    $self->_init_kvstore() unless $self->_kv_initialized;
+    $self->_init_params() if scalar(@{ $self->_params_to_init });
+    assert(
+        (not ($self->kvstore and $self->update_on_kvstore)),
+        'update() when parameters are updated on kvstore '.
+        'is not supported. Try setting `update_on_kvstore` '.
+        'to False when creating trainer.'
+    );
+    $self->_optimizer->rescale_grad($self->_scale/$batch_size);
+    $self->_update($ignore_stale_grad);
+}
+
+method _update(Bool $ignore_stale_grad=0):
+{
+    for(enumerate($self->params))
+    {
+        my ($i, $param) = @$_;
+        next if($param->grad_req eq 'null');
+
+        if(not $ignore_stale_grad)
+        {
+            for my $data (@{ $param->_check_and_get($param->_data, []) })
+            {
+                if(not $data->_fresh_grad)
+                {
+                    AI::MXNet::Logging->warning(
+                        "Gradient of Parameter '%s' on context %s has not been updated ".
+                        "by backward since last `step`. This could mean a bug in your ".
+                        "model that made it only use a subset of the Parameters (Blocks) ".
+                        "for this iteration. If you are intentionally only using a subset, ".
+                        "call step with ignore_stale_grad=True to suppress this ".
+                        "warning and skip updating of Parameters with stale gradient",
+                        $param->name, $data->context
+                    );
+                }
+            }
+        }
+        if($self->kvstore and $self->update_on_kvstore)
+        {
+            if($param->stype eq 'default')
+            {
+                # 'row_sparse' parameters are not pulled immediately - they're pulled
+                # in `SparseBlock.sparse_forward`
+                $self->kvstore->pull($i, out => $param->list_data(), priority=>-$i);
+            }
+            next;
+        }
+
+        for(zip($self->_updaters, $param->list_data(), $param->list_grad()))
+        {
+            my ($upd, $arr, $grad) = @$_;
+            if(not $ignore_stale_grad or $arr->_fresh_grad)
+            {
+                $upd->($i, $grad, $arr);
+                $arr->_fresh_grad(0);
+            }
+        }
+    }
+}
+
 =head2 save_states
 
         Saves trainer states (e.g. optimizer, momentum) to a file.
@@ -290,14 +498,17 @@ method set_learning_rate(Num $lr)
 method save_states(Str $fname)
 {
     assert(defined $self->_optimizer);
-    if($self->_update_on_kvstore)
+    $self->_init_kvstore() unless $self->_kv_initialized;
+    $self->_init_params() if scalar(@{ $self->_params_to_init });
+
+    if($self->update_on_kvstore)
     {
-        $self->_kv_store->save_optimizer_states($fname, dump_optimizer=>1);
+        $self->kvstore->save_optimizer_states($fname, dump_optimizer=>1);
     }
     else
     {
         open(F, ">$fname") or Carp::confess("can not open $fname: $1");
-        print F $self->_updaters->[0]->get_states(dump_optimizer=>1);
+        print F $self->_updaters->[0]->get_states(dump_optimizer => 1);
         close(F);
     }
 }
@@ -314,10 +525,14 @@ method save_states(Str $fname)
 
 method load_states(Str $fname)
 {
-    if($self->_update_on_kvstore)
+    $self->_init_kvstore() unless $self->_kv_initialized;
+    $self->_init_params() if scalar(@{ $self->_params_to_init });
+
+    if($self->update_on_kvstore)
     {
-        $self->_kv_store->load_optimizer_states($fname);
-        $self->_optimizer($self->_kv_store->_updater->optimizer);
+        $self->kvstore->load_optimizer_states($fname);
+        $self->_optimizer($self->kvstore->_updater->optimizer);
+        $self->_optimizer->param_dict({ map { $_->[0] => $_->[1] } enumerate($self->params) });
     }
     else
     {

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Utils.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Utils.pm
@@ -161,7 +161,7 @@ method split_and_load(
     {
         return [$data->as_in_context($ctx_list->[0])];
     }
-    my $slices = __PACKAGE__->split_data($data, scalar(@$ctx_list), $batch_axis, $even_split);
+    my $slices = __PACKAGE__->split_data($data, scalar(@$ctx_list), $batch_axis, even_split => $even_split);
     my @ret;
     for(zip($slices, $ctx_list)) {
         my ($i, $ctx) = @$_;
@@ -177,20 +177,31 @@ method split_and_load(
 
 method clip_global_norm(ArrayRef[AI::MXNet::NDArray] $arrays, Num $max_norm)
 {
+    my $_norm = sub { my ($array) = @_;
+        if($array->stype eq 'default')
+        {
+            my $x = $array->reshape([-1]);
+            return AI::MXNet::NDArray->dot($x, $x);
+        }
+        return $array->norm->square;
+    };
     assert(@$arrays > 0);
-    my $total_norm = 0;
-    for my $arr (@$arrays)
+    my $ctx = $arrays->[0]->context;
+    my $total_norm = AI::MXNet::NDArray->add_n(map { $_norm->($_)->as_in_context($ctx) } @$arrays);
+    $total_norm = $total_norm->sqrt->asscalar;
+    if(lc($total_norm) eq 'nan' or $total_norm =~ /inf/i)
     {
-        $arr = $arr->reshape([-1]);
-        $total_norm += AI::MXNet::NDArray->dot($arr, $arr);
+        AI::MXNet::Logging->warning('nan or inf is detected. Clipping results will be undefined.');
     }
-    $total_norm = sqrt($total_norm->asscalar);
     my $scale = $max_norm / ($total_norm + 1e-8);
-    if($scale < 1)
+    if($scale < 1.0)
     {
-        $_ *= $scale for @{ $arrays };
+        for my $arr (@$arrays)
+        {
+            $arr *= $scale;
+        }
     }
-    return $total_norm
+    return $total_norm;
 }
 
 =head2 check_sha1
@@ -275,6 +286,30 @@ func download(Str $url, Maybe[Str] :$path=, Bool :$overwrite=0, Maybe[Str] :$sha
         close(F);
     }
     return $fname
+}
+
+package AI::MXNet::Gluon::Utils::HookHandle;
+use Mouse;
+use AI::MXNet::Base;
+use Scalar::Util qw(refaddr);
+has [qw/_hooks_dict_ref/] => (is => 'rw', init_arg => undef, weak_ref => 1);
+has [qw/_id/]             => (is => 'rw', init_arg => undef);
+
+method attach(Hash::Ordered $hooks_dict, $hook)
+{
+    assert((not $self->_hooks_dict_ref), 'The same handle cannot be attached twice.');
+    $self->_id(refaddr($hook));
+    $hooks_dict->set($self->_id, $hook);
+    $self->_hooks_dict_ref($hooks_dict);
+}
+
+method detach()
+{
+    my $hooks_dict = $self->_hooks_dict_ref;
+    if($hooks_dict and $hooks_dict->exists($self->_id))
+    {
+        $hooks_dict->delete($self->_id);
+    }
 }
 
 1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Module.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Module.pm
@@ -38,6 +38,22 @@ use List::Util qw(max);
 use Data::Dumper ();
 use Mouse;
 
+func _create_sparse_kvstore(Maybe[Str|AI::MXNet::KVStore] $kvstore)
+{
+    # always update on kvstore
+    my $update_on_kvstore = 1;
+    my $kv;
+    if(blessed $kvstore)
+    {
+        $kv = $kvstore;
+    }
+    else
+    {
+        $kv = AI::MXNet::KVStore->create($kvstore);
+    }
+    return ($kv, $update_on_kvstore);
+}
+
 func _create_kvstore(
     Maybe[Str|AI::MXNet::KVStore] $kvstore,
     Int                           $num_device,

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Optimizer.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Optimizer.pm
@@ -1314,7 +1314,7 @@ method update(
     my $lr = $self->_get_lr($index);
     my $wd = $self->_get_wd($index);
     $self->_update_count($index);
-    my $is_sparse = ($weight->stype eq 'row_sparse' and $grad->stype eq 'row_sparse') ? 1 : 0;
+    my $is_sparse = $grad->stype eq 'row_sparse' ? 1 : 0;
     my $history = $state;
     if($is_sparse)
     {
@@ -1950,7 +1950,15 @@ method set_states($states)
 
 method get_states(Bool $dump_optimizer=0)
 {
-    return freeze($dump_optimizer ? [$self->states, $self->optimizer] : $self->states);
+    if($dump_optimizer)
+    {
+        my $param_dict = $self->optimizer->param_dict;
+        $self->optimizer->param_dict({});
+        my $freezed = freeze([$self->states, $self->optimizer]);
+        $self->optimizer->param_dict($param_dict);
+        return $freezed;
+    }
+    return freeze($self->states);
 }
 
 package AI::MXNet::Optimizer;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Symbol.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Symbol.pm
@@ -229,6 +229,16 @@ method hypot(AI::MXNet::Symbol|Num $other)
     );
 }
 
+method reshape(@args)
+{
+    if(@args%2)
+    {
+        unshift @args, 'shape';
+    }
+    return $self->SUPER::reshape(@args);
+}
+
+
 method deepcopy()
 {
     my $handle = check_call(AI::MXNetCAPI::SymbolCopy($self->handle));
@@ -1494,6 +1504,8 @@ sub  _ufunc_helper
         return __PACKAGE__->can($fn_symbol)->(__PACKAGE__, $lhs, $rhs);
     }
 }
+
+method histogram(@args) { __PACKAGE__->_histogram(@args%2 ? ('data', @args) : @args) }
 
 sub contrib { 'AI::MXNet::Contrib::Symbol' }
 sub random  { 'AI::MXNet::Symbol::Random' }

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Visualization.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Visualization.pm
@@ -340,6 +340,18 @@ method plot_network(
         {
             $attr{fillcolor} = $cm[3];
         }
+        elsif($op eq 'Flatten')
+        {
+            $label = $op;
+        }
+        elsif($op eq 'Dropout')
+        {
+            $label = "$op ($node->{attrs}{p})";
+        }
+        elsif($op eq 'Reshape')
+        {
+            $label = "$op $node->{attrs}{shape}";
+        }
         elsif($op eq 'Activation' or $op eq 'LeakyReLU')
         {
             $label = "$op\n$node->{attrs}{act_type}";

--- a/perl-package/AI-MXNet/t/test_conv.t
+++ b/perl-package/AI-MXNet/t/test_conv.t
@@ -22,7 +22,7 @@ use AI::MXNet::TestUtils qw(GetMNIST_ubyte);
 use Test::More tests => 1;
 
 ## speed up the tests when gpu present
-my $gpu_present = (`perl -e 'use AI::MXNet qw(mx); print mx->nd->ones([1], ctx => mx->gpu(0))->asscalar' 2>/dev/null` eq '1');
+my $gpu_present = mx->context->num_gpus;
 
 # symbol net
 my $batch_size = 100;

--- a/perl-package/AI-MXNet/t/test_cuda_module.t
+++ b/perl-package/AI-MXNet/t/test_cuda_module.t
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 use AI::MXNet qw(mx);
 use Test::More tests => 3;
-my $gpu_present = (`perl -e 'use AI::MXNet qw(mx); print mx->nd->ones([1], ctx => mx->gpu(0))->asscalar' 2>/dev/null` eq '1');
+my $gpu_present = mx->context->num_gpus;
 
 sub test_cuda_rtc
 {

--- a/perl-package/AI-MXNet/t/test_engine.t
+++ b/perl-package/AI-MXNet/t/test_engine.t
@@ -15,30 +15,27 @@
 # specific language governing permissions and limitations
 # under the License.
 
-package AI::MXNet::Gluon::NN;
 use strict;
 use warnings;
-use AI::MXNet::Gluon::Block;
-use AI::MXNet::Gluon::NN::Activation;
-use AI::MXNet::Gluon::NN::BasicLayers;
-use AI::MXNet::Gluon::NN::ConvLayers;
+use AI::MXNet qw(mx);
+use Test::More tests => 2;
 
-sub import
+sub test_bulk
 {
-    my ($class, $short_name) = @_;
-    if($short_name)
-    {
-        $short_name =~ s/[^\w:]//g;
-        if(length $short_name)
+    my $x;
+    mx->engine->bulk(10, sub {
+        $x = mx->nd->ones([10]);
+        $x *= 2;
+        $x += 1;
+        $x->wait_to_read();
+        $x += 1;
+        ok(($x->aspdl == 4)->all);
+        for my $i (1..100)
         {
-            my $short_name_package =<<"EOP";
-            package $short_name;
-            \@${short_name}::ISA = ('AI::MXNet::Gluon::NN_');
-            1;
-EOP
-            eval $short_name_package;
+            $x += 1;
         }
-    }
+    });
+    ok(($x->aspdl == 104)->all);
 }
 
-1;
+test_bulk();

--- a/perl-package/AI-MXNet/t/test_executor.t
+++ b/perl-package/AI-MXNet/t/test_executor.t
@@ -17,7 +17,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 2283;
+use Test::More tests => 2285;
 use AI::MXNet qw(mx);
 use AI::MXNet::TestUtils qw(reldiff pdl_maximum pdl_minimum);
 use PDL;
@@ -181,6 +181,12 @@ sub test_reshape
     # test base exec forward
     $exe->forward(0);
     ok(($new_exe->outputs->[0]->aspdl == 4)->all);
+    $new_exe = $exe->reshape({ x=>[6,4] }, allow_up_sizing=>1);
+    # data ndarray is not shared between exe and new_exe
+    $new_exe->arg_arrays->[0] .= 0;
+    ok(($exe->arg_arrays->[0]->aspdl == 1)->all);
+    # weight ndarray is shared between exe and new_exe
+    ok(($new_exe->arg_arrays->[1]->aspdl == 1)->all);
 }
 
 test_bind(0);

--- a/perl-package/AI-MXNet/t/test_gluon.t
+++ b/perl-package/AI-MXNet/t/test_gluon.t
@@ -17,11 +17,11 @@
 
 use strict;
 use warnings;
-use Test::More tests => 119;
+use Test::More tests => 232;
 use AI::MXNet qw(mx);
 use AI::MXNet::Gluon qw(gluon);
 use AI::MXNet::Gluon::NN qw(nn);
-use AI::MXNet::TestUtils qw(almost_equal);
+use AI::MXNet::TestUtils qw(almost_equal dies_ok);
 use Scalar::Util qw(refaddr);
 use AI::MXNet::Base;
 
@@ -34,6 +34,8 @@ sub test_parameter
     ok($p->data(mx->cpu(1))->context eq mx->cpu(1));
     is_deeply($p->data(mx->cpu(0))->shape, [10, 10]);
     ok($p->var->name eq  'weight');
+    ok($p->grad(mx->cpu(0))->stype eq 'default');
+    ok($p->data(mx->cpu(0))->stype eq 'default');
 
     $p->reset_ctx(ctx=>[mx->cpu(1), mx->cpu(2)]);
     is_deeply($p->list_ctx, [mx->cpu(1), mx->cpu(2)]);
@@ -41,29 +43,187 @@ sub test_parameter
 
 test_parameter();
 
+sub test_invalid_parameter_stype
+{
+    dies_ok(sub { gluon->Parameter('weight', shape=>[10, 10], stype=>'invalid') });
+}
+
+test_invalid_parameter_stype();
+
+sub test_invalid_parameter_grad_stype
+{
+    dies_ok(sub { gluon->Parameter('weight', shape=>[10, 10], grad_stype=>'invalid') });
+}
+
+test_invalid_parameter_grad_stype();
+
+sub test_sparse_parameter
+{
+    my $p = gluon->Parameter('weight', shape=>[10, 10], stype=>'row_sparse', grad_stype=>'row_sparse');
+    $p->initialize(init=>'xavier', ctx=>[mx->cpu(0), mx->cpu(1)]);
+    my $row_id = mx->nd->arange(start => 0, stop => 10, ctx=>mx->cpu(1));
+    ok(@{ $p->list_grad } == 2);
+    # getting row_sparse data without trainer throws an exception
+    dies_ok(sub { $p->list_row_sparse_data($row_id) });
+    my $trainer = gluon->Trainer([$p], 'sgd');
+    ok(@{ $p->list_row_sparse_data($row_id) } == 2);
+    my $weight = $p->row_sparse_data($row_id);
+    ok($weight->context eq mx->cpu(1));
+    is_deeply($weight->shape, [10, 10]);
+    ok($weight->stype eq 'row_sparse');
+    ok($p->var->name eq 'weight');
+    ok($p->var->attr('__storage_type__') eq STORAGE_TYPE_STR_TO_ID->{row_sparse});
+    ok($p->grad(mx->cpu(0))->stype eq 'row_sparse');
+
+    $p->reset_ctx(ctx=>[mx->cpu(1), mx->cpu(2)]);
+    is_deeply($p->list_ctx, [mx->cpu(1), mx->cpu(2)]);
+}
+
+test_sparse_parameter();
+
+sub test_parameter_invalid_access
+{
+    # cannot call data on row_sparse parameters
+    my $p0 = gluon->Parameter('weight', shape=>[10, 10], stype=>'row_sparse', grad_stype=>'row_sparse');
+    $p0->initialize(init=>'xavier', ctx=>[mx->cpu(0), mx->cpu(1)]);
+    dies_ok(sub { $p0->data });
+    dies_ok(sub { $p0->list_data });
+    my $row_id = mx->nd->arange(start => 0, stop => 10);
+    # cannot call row_sparse_data on dense parameters
+    my $p1 = gluon->Parameter('weight', shape=>[10, 10]);
+    $p1->initialize(init=>'xavier', ctx=>[mx->cpu(0), mx->cpu(1)]);
+    dies_ok(sub { $p1->row_sparse_data($row_id->copyto(mx->cpu(0))) });
+    dies_ok(sub { $p1->list_row_sparse_data($row_id) });
+}
+
+test_parameter_invalid_access();
+
 sub test_paramdict
 {
-    my $params = gluon->ParameterDict('net_');
-    $params->get('weight', shape=>[10, 10]);
-    is_deeply([$params->keys], ['net_weight']);
-    $params->initialize(ctx=>mx->cpu());
-    $params->save('test.params');
-    $params->load('test.params', ctx => mx->cpu());
+    my $ctx = mx->cpu(1);
+    my $params0 = gluon->ParameterDict('net_');
+    $params0->get('w0', shape=>[10, 10]);
+    $params0->get('w1', shape=>[10, 10], stype=>'row_sparse');
+    my $all_row_ids = mx->nd->arange(start => 0, stop => 10, ctx=>$ctx);
+    # check param names
+    is_deeply([$params0->keys()], ['net_w0', 'net_w1']);
+    $params0->initialize(ctx=>$ctx);
+    my $trainer0 = gluon->Trainer($params0, 'sgd');
+    my $prev_w0 = $params0->get('w0')->data($ctx);
+    my $prev_w1 = $params0->get('w1')->row_sparse_data($all_row_ids);
+    # save params
+    $params0->save('test_paramdict.params');
+
+    # load params
+    my $params1 = gluon->ParameterDict('net_');
+    $params1->get('w0', shape=>[10, 10]);
+    $params1->get('w1', shape=>[10, 10], stype=>'row_sparse');
+    $params1->load('test_paramdict.params', ctx=>$ctx);
+    my $trainer1 = gluon->Trainer($params1, 'sgd');
+
+    # compare the values before and after save/load
+    my $cur_w0 = $params1->get('w0')->data($ctx);
+    my $cur_w1 = $params1->get('w1')->row_sparse_data($all_row_ids);
+    ok(almost_equal($prev_w0->aspdl, $cur_w0->aspdl));
+    ok(almost_equal($prev_w1->aspdl, $cur_w1->aspdl));
+
+    # create a new param dict with dense params, and load from the checkpoint
+    # of sparse & dense params
+    my $params2 = gluon->ParameterDict('net_');
+    $params2->get('w0', shape=>[10, 10]);
+    $params2->get('w1', shape=>[10, 10]);
+    $params2->load('test_paramdict.params', ctx=>$ctx);
+
+    # compare the values before and after save/load
+    $cur_w0 = $params2->get('w0')->data($ctx);
+    $cur_w1 = $params2->get('w1')->data($ctx);
+    ok(almost_equal($prev_w0->aspdl, $cur_w0->aspdl));
+    ok(almost_equal($prev_w1->aspdl, $cur_w1->aspdl));
 }
 
 test_paramdict();
+
+sub test_parameter_row_sparse_data
+{
+    my $ctx0 = mx->cpu(1);
+    my $ctx1 = mx->cpu(2);
+    my $dim0 = 4;
+    my $x = gluon->Parameter('x', shape=>[$dim0, 2], stype=>'row_sparse');
+    $x->initialize(init=>'xavier', ctx=>[$ctx0, $ctx1]);
+    my $trainer = gluon->Trainer([$x], 'sgd');
+    my $x_param = $x->_data->[0]->copy();
+    is($x_param->stype, 'row_sparse');
+    my $row_id_0 = mx->nd->array([0,1], ctx=>$ctx0);
+    my $retained_0 = $x->row_sparse_data($row_id_0);
+    my $retained_target_0 = mx->nd->sparse->retain($x_param, $row_id_0->as_in_context($ctx0));
+    ok(almost_equal($retained_0->aspdl, $retained_target_0->aspdl));
+    is($retained_0->context, $ctx0);
+    my $row_id_1 = mx->nd->arange(start => 0, stop => $dim0, ctx=>$ctx1);
+    my $retained_1 = $x->row_sparse_data($row_id_1);
+    my $retained_target_1 = $x_param;
+    ok(almost_equal($retained_1->aspdl, $retained_target_1->aspdl));
+    is($retained_1->context, $ctx1);
+    my $row_id_2 = mx->nd->array([0,1,2]);
+    my $retained_2 = $x->list_row_sparse_data($row_id_2);
+    my $retained_target_2 = mx->nd->sparse->retain($x_param, $row_id_2->as_in_context($ctx0));
+    ok(almost_equal($retained_2->[0]->aspdl, $retained_target_2->aspdl));
+}
+
+test_parameter_row_sparse_data();
+
+sub test_constant
+{
+    package Test {
+        use AI::MXNet::Gluon::Mouse;
+        extends 'AI::MXNet::Gluon::HybridBlock';
+        sub BUILD
+        {
+            my $self = shift;
+            $self->value(mx->nd->array([[1,2], [3,4]])->aspdl);
+            $self->const($self->params->get_constant('const', $self->value));
+        }
+        sub hybrid_forward
+        {
+            my ($self, $F, $x, $name, $const) = @_;
+            return $x + $const;
+        }
+    };
+
+    my $test = Test->new();
+    $test->initialize();
+    my $trainer = gluon->Trainer(
+        $test->collect_params(), 'sgd',
+        {learning_rate => 1.0, momentum => 0.5}
+    );
+
+    my ($x, $y);
+    mx->autograd->record(sub {
+        $x = mx->nd->ones([2,2]);
+        $x->attach_grad();
+        $y = $test->($x);
+        $y->backward();
+    });
+
+    $trainer->step(1);
+
+    ok(($test->const->data->aspdl == $test->value)->all);
+    ok(($x->grad->aspdl == 1)->all);
+}
+
+test_constant();
 
 package Net;
 use AI::MXNet::Gluon::Mouse;
 use AI::MXNet::Function::Parameters;
 extends 'AI::MXNet::Gluon::Block';
+has 'in_units' => (is => 'rw', default => 0);
 
 sub BUILD
 {
     my $self = shift;
     $self->name_scope(sub {
-        $self->dense0(nn->Dense(5, in_units=>5));
-        $self->dense1(nn->Dense(5, in_units=>5));
+        $self->dense0(nn->Dense(5, in_units=>$self->in_units));
+        $self->dense1(nn->Dense(5, in_units=>$self->in_units));
     });
 }
 
@@ -76,16 +236,70 @@ package main;
 
 sub test_parameter_sharing
 {
-    my $net1 = Net->new(prefix=>'net1_');
+    my $net1 = Net->new(prefix=>'net1_', in_units => 5);
     my $net2 = Net->new(prefix=>'net2_', params=>$net1->collect_params());
     $net1->collect_params()->initialize();
     $net2->(mx->nd->zeros([3, 5]));
-    $net1->save_params('net1.params');
+    $net1->save_parameters('net1.params');
     my $net3 = Net->new(prefix=>'net3_');
-    $net3->load_params('net1.params', ctx => mx->cpu());
+    $net3->load_parameters('net1.params', ctx => mx->cpu());
+    my $net4 = Net->new(prefix=>'net4_');
+    my $net5 = Net->new(prefix=>'net5_', in_units=>5, params=>$net4->collect_params());
+    $net4->collect_params()->initialize();
+    $net5->(mx->nd->zeros([3, 5]));
+    $net4->save_parameters('net4.params');
+    my $net6 = Net->new(prefix=>'net6_');
+    $net6->load_parameters('net4.params', ctx => mx->cpu());
 }
 
 test_parameter_sharing();
+
+sub test_parameter_str
+{
+    package Net1 {
+        use AI::MXNet::Gluon::Mouse;
+        extends 'AI::MXNet::Gluon::Block';
+        sub BUILD
+        {
+            my $self = shift;
+            $self->name_scope(sub {
+                $self->dense0(nn->Dense(10, in_units=>5, use_bias=>0));
+            });
+        }
+    };
+    my $net = Net1->new(prefix=>'net1_');
+    my @lines = split(/\n/, $net->collect_params());
+    ok($lines[0] eq 'net1_ (');
+    ok($lines[1] =~ /net1_dense0_weight/);
+    ok($lines[1] =~ /\(10, 5\)/);
+    ok($lines[1] =~ /float32/);
+    ok($lines[2] eq ')');
+}
+
+test_parameter_str();
+
+sub test_collect_parameters
+{
+    my $net = nn->HybridSequential(prefix=>"test_");
+    $net->name_scope(sub {
+        $net->add(nn->Conv2D(10, 3));
+        $net->add(nn->Dense(10, activation=>'relu'));
+    });
+    is_deeply(
+        [$net->collect_params->keys],
+        ['test_conv0_weight', 'test_conv0_bias','test_dense0_weight','test_dense0_bias']
+    );
+    is_deeply(
+        [$net->collect_params('.*weight')->keys],
+        ['test_conv0_weight', 'test_dense0_weight']
+    );
+    is_deeply(
+        [$net->collect_params('test_conv0_bias|test_dense0_bias')->keys],
+        ['test_conv0_bias', 'test_dense0_bias']
+    )
+};
+
+test_collect_parameters();
 
 sub test_basic
 {
@@ -165,7 +379,7 @@ sub test_symbol_block
     my $outputs = $model->($inputs)->get_internals();
     my $smodel = gluon->SymbolBlock($outputs, $inputs, params=>$model->collect_params);
 
-    ok(@{ $smodel->(mx->nd->zeros([16, 10])) } == 14);
+    ok($smodel->(mx->nd->zeros([16, 10])) == 14);
     my $out = $smodel->(mx->sym->var('in'));
     ok(@{ $out } == @{ $outputs->list_outputs() });
 
@@ -182,6 +396,32 @@ sub test_symbol_block
 }
 
 test_symbol_block();
+
+sub test_sparse_symbol_block
+{
+    my $data = mx->sym->var('data');
+    my $weight = mx->sym->var('weight', stype=>'row_sparse');
+    my $bias = mx->sym->var('bias');
+    my $out = mx->sym->broadcast_add(mx->sym->dot($data, $weight), $bias);
+    # an exception is expected when creating a SparseBlock w/ sparse param
+    dies_ok(sub { gluon->SymbolBlock($out, $data) });
+}
+
+test_sparse_symbol_block();
+
+sub test_sparse_hybrid_block0
+{
+    my $params = gluon->ParameterDict('net_');
+    $params->get('weight', shape=>[5,5], stype=>'row_sparse', dtype=>'float32', allow_deferred_init => 1);
+    $params->get('bias', shape=>[5], dtype=>'float32', allow_deferred_init => 1);
+    my $net = nn->Dense(5, params=>$params);
+    $net->initialize();
+    my $x = mx->nd->ones([2,5]);
+    # an exception is expected when forwarding a HybridBlock w/ sparse param
+    dies_ok(sub { $net->($x) });
+}
+
+test_sparse_hybrid_block0();
 
 sub check_layer_forward
 {
@@ -314,6 +554,7 @@ sub test_pool
         nn->MaxPool1D(3),
         nn->MaxPool1D(3, 2),
         nn->AvgPool1D(),
+        nn->AvgPool1D(count_include_pad=>0),
         nn->GlobalAvgPool1D(),
     );
     for my $layer (@layers1d)
@@ -326,6 +567,7 @@ sub test_pool
         nn->MaxPool2D([3, 3]),
         nn->MaxPool2D(3, 2),
         nn->AvgPool2D(),
+        nn->AvgPool2D(count_include_pad=>0),
         nn->GlobalAvgPool2D(),
     );
     for my $layer (@layers2d)
@@ -338,6 +580,7 @@ sub test_pool
         nn->MaxPool3D([3, 3, 3]),
         nn->MaxPool3D(3, 2),
         nn->AvgPool3D(),
+        nn->AvgPool3D(count_include_pad=>0),
         nn->GlobalAvgPool3D(),
     );
     for my $layer (@layers3d)
@@ -366,6 +609,30 @@ sub test_batchnorm
 }
 
 test_batchnorm();
+
+sub test_instancenorm
+{
+    my $layer = nn->InstanceNorm(in_channels=>10);
+    check_layer_forward($layer, [2, 10, 10, 10]);
+}
+
+test_instancenorm();
+
+sub test_layernorm
+{
+    my $layer = nn->LayerNorm(in_channels=>10);
+    check_layer_forward($layer, [2, 10, 10, 10]);
+}
+
+test_layernorm();
+
+sub test_reflectionpad
+{
+    my $layer = nn->ReflectionPad2D(3);
+    check_layer_forward($layer, [2, 3, 24, 24]);
+}
+
+test_reflectionpad();
 
 sub test_reshape
 {
@@ -460,71 +727,6 @@ sub test_flatten
 
 test_flatten();
 
-sub test_trainer
-{
-    my $dict_equ = sub { my ($a, $b) = @_;
-        is_deeply({ map { $_ => 1 } keys %$a }, { map { $_ => 1 } keys %$b });
-        for my $k (keys %$a)
-        {
-            ok(($a->{$k}->aspdl == $b->{$k}->aspdl)->all);
-        }
-    };
-    my $x = gluon->Parameter('x', shape=>[10]);
-    $x->initialize(ctx=>[mx->cpu(0), mx->cpu(1)], init=>'zeros');
-    my $trainer = gluon->Trainer([$x], 'sgd', {'learning_rate'=> 1.0, 'momentum'=> 0.5});
-    my $y;
-    mx->autograd->record(sub {
-        for my $w (@{ $x->list_data() })
-        {
-            $y = $w + 1;
-            $y->backward();
-        }
-    });
-    $trainer->step(1);
-
-    ok(($x->data(mx->cpu(1))->aspdl == -2)->all);
-
-    $x->lr_mult(0.5);
-
-    mx->autograd->record(sub {
-        for my $w (@{ $x->list_data() })
-        {
-            $y = $w + 1;
-            $y->backward();
-        }
-    });
-    $trainer->step(1);
-
-    ok(($x->data(mx->cpu(1))->aspdl == -4)->all);
-
-    $trainer->save_states('test.states');
-    my $states;
-    if($trainer->_update_on_kvstore)
-    {
-        $states = { %{ $trainer->_kv_store->_updater->states } };
-    }
-    else
-    {
-        $states = { %{ $trainer->_updaters->[0]->states } };
-    }
-    $trainer->load_states('test.states');
-    if($trainer->_update_on_kvstore)
-    {
-        $dict_equ->($trainer->_kv_store->_updater->states, $states);
-        ok($trainer->_optimizer eq $trainer->_kv_store->_updater->optimizer);
-    }
-    else
-    {
-        for my $updater (@{ $trainer->_updaters })
-        {
-            $dict_equ->($updater->states, $states);
-        }
-        ok($trainer->_optimizer eq $trainer->_updaters->[0]->optimizer);
-    }
-}
-
-test_trainer();
-
 sub test_block_attr_hidden
 {
     my $b = gluon->Block();
@@ -565,23 +767,554 @@ sub test_block_attr_regular
     $b->c(gluon->Block());
     my $c2 = gluon->Block();
     $b->c($c2);
-    ok(refaddr($b->c) == refaddr($c2) and refaddr($b->_children->[0]) == refaddr($c2));
+    ok(refaddr($b->c) == refaddr($c2) and refaddr(($b->_children->values)[0]) == refaddr($c2));
 }
 
 test_block_attr_regular();
 
+sub test_block_attr_list_of_block
+{
+    package Model1 {
+        use AI::MXNet::Gluon::Mouse;
+        extends 'AI::MXNet::Gluon::Block';
+        sub BUILD
+        {
+            my $self = shift;
+            $self->name_scope(sub {
+                $self->layers([map { nn->Dense($_ * 10) } 0..5]);
+            });
+        }
+    };
+    package Model2 {
+        use AI::MXNet::Gluon::Mouse;
+        extends 'AI::MXNet::Gluon::Block';
+        sub BUILD
+        {
+            my $self = shift;
+            $self->name_scope(sub {
+                $self->layers({});
+                $self->layers->{a} = [map { nn->Dense($_ * 10) } 0..5];
+            });
+        }
+    };
+    package Model3 {
+        use AI::MXNet::Gluon::Mouse;
+        extends 'AI::MXNet::Gluon::Block';
+        sub BUILD
+        {
+            my $self = shift;
+            $self->name_scope(sub {
+                $self->layers(nn->Sequential());
+                $self->layers->add(map { nn->Dense($_ * 10) } 0..5);
+            });
+        }
+    };
+    package Model4 {
+        use AI::MXNet::Gluon::Mouse;
+        extends 'AI::MXNet::Gluon::Block';
+        sub BUILD
+        {
+            my $self = shift;
+            $self->name_scope(sub {
+                $self->data({a => '4', b => 123});
+            });
+        }
+    };
+    my $w = 0;
+    local($SIG{__WARN__}) = sub {
+        $w++;
+    };
+    Model1->new->collect_params;
+    ok($w > 0); $w = 0;
+    Model2->new->collect_params;
+    ok($w > 0); $w = 0;
+    Model3->new->collect_params;
+    ok($w == 0); $w = 0;
+    Model4->new->collect_params;
+    ok($w == 0);
+}
+
+test_block_attr_list_of_block();
+
+sub check_sequential
+{
+    my ($net) = @_;
+    my $dense1 = nn->Dense(10);
+    $net->add($dense1);
+    my $dense2 = nn->Dense(10);
+    $net->add($dense2);
+    my $dense3 = nn->Dense(10);
+    $net->add($dense3);
+
+    ok(refaddr($net->[1]) == refaddr($dense2));
+    ok(refaddr($net->[-1]) == refaddr($dense3));
+    my $slc = $net->slice([1,2]);
+    ok(@$slc == 2 and refaddr($slc->[0]) == refaddr($dense2) and refaddr($slc->[1]) == refaddr($dense3));
+    ok(ref $slc eq ref $net);
+}
+
+sub test_sequential
+{
+    check_sequential(nn->Sequential());
+    check_sequential(nn->HybridSequential());
+}
+
+test_sequential();
+
+sub test_global_norm_clip
+{
+    my @stypes = ('default', 'row_sparse');
+    my $check_global_norm_clip = sub { my ($stype) = @_;
+        my $x1 = mx->nd->ones([3,3])->tostype($stype);
+        my $x2 = mx->nd->ones([4,4])->tostype($stype);
+        my $norm = gluon->utils->clip_global_norm([$x1, $x2], 1.0);
+        ok($norm == 5);
+        ok(almost_equal($x1->aspdl, mx->nd->ones([3,3])->aspdl/5));
+        ok(almost_equal($x2->aspdl, mx->nd->ones([4,4])->aspdl/5));
+
+        my $x3 = mx->nd->array([1.0, 2.0, 'nan'])->tostype($stype);
+        my $w = 0;
+        local($SIG{__WARN__}) = sub {
+            $w++;
+        };
+        gluon->utils->clip_global_norm([$x1, $x3], 2.0);
+        ok($w == 1);
+    };
+    for my $stype (@stypes)
+    {
+        $check_global_norm_clip->($stype);
+    }
+}
+
+test_global_norm_clip();
+
 sub test_embedding
 {
-    my $layer = gluon->nn->Embedding(10, 100);
-    $layer->initialize();
-    my $x = mx->nd->array([3,4,2,0,1]);
-    my $y;
-    mx->autograd->record(sub {
-        $y = $layer->($x);
-        $y->backward();
-    });
-    ok(($layer->weight->grad->slice([0,4]) == 1)->aspdl->all);
-    ok(($layer->weight->grad->slice([5, -1]) == 0)->aspdl->all);
+    local($ENV{MXNET_STORAGE_FALLBACK_LOG_VERBOSE}) = 0;
+    my $check_embedding = sub { my ($sparse_grad) = @_;
+        my $layer = nn->Embedding(10, 100, sparse_grad=>$sparse_grad);
+        $layer->initialize();
+        my $x = mx->nd->array([3,4,2,0,1]); my $y;
+        mx->autograd->record(sub {
+            $y = $layer->($x);
+            $y->backward();
+        });
+        ok(($layer->weight->grad->aspdl->slice('X', [0, 4]) == 1)->all);
+        ok(($layer->weight->grad->aspdl->slice('X', [5, -1]) == 0)->all);
+    };
+    my $check_embedding_large_input = sub { my ($sparse_grad) = @_;
+        my $embedding = nn->Embedding(10, 1, sparse_grad=>$sparse_grad);
+        $embedding->initialize();
+        $embedding->hybridize();
+        my $shape = [20481];
+        my ($emb_in, $loss);
+        mx->autograd->record(sub {
+            $emb_in = $embedding->(mx->nd->ones($shape));
+            $loss = $emb_in->sum;
+        });
+        $loss->backward;
+        ok($embedding->weight->grad->sum->asscalar == 20481);
+    };
+    $check_embedding->(1);
+    $check_embedding->(0);
+    $check_embedding_large_input->(1);
+    $check_embedding_large_input->(0);
 }
 
 test_embedding();
+
+sub test_hybrid_stale_cache
+{
+    my $net = nn->HybridSequential();
+    $net->name_scope(sub {
+        $net->add(nn->Dense(10, weight_initializer=>'zeros', bias_initializer=>'ones', flatten=>0));
+    });
+
+    $net->hybridize();
+    $net->initialize();
+    $net->(mx->nd->ones([2,3,5]));
+
+    $net->add(nn->Flatten());
+    is_deeply($net->(mx->nd->ones([2,3,5]))->shape, [2, 30]);
+
+    $net = nn->HybridSequential();
+    $net->name_scope(sub {
+        $net->fc1(nn->Dense(10, weight_initializer=>'zeros',
+                                    bias_initializer=>'ones', flatten=>0));
+        $net->fc2(nn->Dense(10, weight_initializer=>'zeros',
+                                    bias_initializer=>'ones', flatten=>0));
+    });
+    $net->hybridize();
+    $net->initialize();
+    $net->(mx->nd->ones([2,3,5]));
+
+    $net->fc2(nn->Dense(10, weight_initializer=>'zeros',
+                                bias_initializer=>'ones', flatten=>1));
+    $net->initialize();
+    is_deeply($net->(mx->nd->ones([2,3,5]))->shape, [2, 10]);
+}
+
+test_hybrid_stale_cache();
+
+sub test_lambda
+{
+    my $net1 = nn->HybridSequential();
+    $net1->add(nn->Activation('tanh'),
+             nn->LeakyReLU(0.1));
+
+    my $net2 = nn->HybridSequential();
+    my $op3 = sub { my ($F, $x, @args) = @_; $F->LeakyReLU($x, @args, slope=>0.1); };
+    $net2->add(nn->HybridLambda('tanh'),
+             nn->HybridLambda($op3));
+
+    my $op4 = sub { mx->nd->LeakyReLU($_[0], slope=>0.1); };
+    my $net3 = nn->Sequential();
+    $net3->add(nn->Lambda('tanh'),
+             nn->Lambda($op4));
+
+    my $input_data = mx->nd->random->uniform(shape=>[2, 3, 5, 7]);
+    my ($out1, $out2, $out3) = ($net1->($input_data), $net2->($input_data), $net3->($input_data));
+    ok(almost_equal($out1->aspdl, $out2->aspdl, 1e-3));
+    ok(almost_equal($out1->aspdl, $out3->aspdl, 1e-3));
+}
+
+test_lambda();
+
+sub test_fill_shape_deferred
+{
+    my $net = nn->HybridSequential();
+    $net->name_scope(sub {
+        $net->add(nn->Conv2D(64, kernel_size=>2, padding=>1),
+                nn->BatchNorm(),
+                nn->Dense(10));
+    });
+    $net->hybridize();
+    $net->initialize();
+    $net->(mx->nd->ones([2,3,5,7]));
+    ok($net->[0]->weight->shape->[1] == 3);
+    ok($net->[1]->gamma->shape->[0] == 64);
+    ok($net->[2]->weight->shape->[1] == 3072);
+}
+
+test_fill_shape_deferred();
+
+sub test_fill_shape_load
+{
+    my $ctx = mx->context->current_context();
+    my $net1 = nn->HybridSequential();
+    $net1->name_scope(sub {
+        $net1->add(nn->Conv2D(64, kernel_size=>2, padding=>1),
+                 nn->BatchNorm(),
+                 nn->Dense(10))
+    });
+    $net1->hybridize();
+    $net1->initialize(mx->init->Uniform, ctx => $ctx);
+    $net1->(mx->nd->ones([2,3,5,7], ctx => $ctx));
+    $net1->save_parameters('net_fill.params');
+
+    my $net2 = nn->HybridSequential();
+    $net2->name_scope(sub {
+        $net2->add(nn->Conv2D(64, kernel_size=>2, padding=>1),
+                 nn->BatchNorm(),
+                 nn->Dense(10))
+    });
+    $net2->hybridize();
+    $net2->initialize();
+    $net2->load_parameters('net_fill.params', ctx=>$ctx);
+    ok($net2->[0]->weight->shape->[1] == 3);
+    ok($net2->[1]->gamma->shape->[0] == 64);
+    ok($net2->[2]->weight->shape->[1] == 3072);
+}
+
+test_fill_shape_load();
+
+use JSON::PP qw(decode_json);
+
+sub test_inline
+{
+    my $y;
+
+    my $net = nn->HybridSequential();
+    $net->name_scope(sub {
+        $net->add(nn->Dense(10));
+        $net->add(nn->Dense(10));
+        $net->add(nn->Dense(10));
+    });
+    $net->initialize();
+
+    $net->hybridize(inline_limit=>3);
+    mx->autograd->record(sub {
+        $y = $net->(mx->nd->zeros([1,10]));
+    });
+    my $len_1 = @{ decode_json(mx->autograd->get_symbol($y)->tojson())->{nodes} };
+    $y->backward();
+
+    $net->hybridize(inline_limit=>0);
+    mx->autograd->record(sub {
+        $y = $net->(mx->nd->zeros([1,10]));
+    });
+    my $len_2 = @{ decode_json(mx->autograd->get_symbol($y)->tojson())->{nodes} };
+    $y->backward();
+
+    is($len_1, $len_2 + 2);
+}
+
+test_inline();
+
+sub test_activations
+{
+    my $point_to_validate = mx->nd->array([(-0.1, 0.1) x 3]);
+
+    my $swish = nn->Swish();
+    my $swish_test = sub { my ($x) = @_;
+        return $x * mx->nd->sigmoid($x)
+    };
+
+    for(zip($swish_test->($point_to_validate), $swish->($point_to_validate)))
+    {
+        my ($test_point, $ref_point) = @$_;
+        ok($test_point == $ref_point);
+    }
+
+    my $elu = nn->ELU();
+    my $elu_test = sub { my ($x) = @_;
+        my $elu = sub { my ($x) = @_;
+            return $x < 0 ? 1.0 * (mx->nd->exp($x) - 1) : $x;
+        };
+        return [map { $elu->($_) } @{ $x }];
+    };
+
+    for(zip($elu_test->($point_to_validate), $elu->($point_to_validate)))
+    {
+        my ($test_point, $ref_point) = @$_;
+        ok($test_point == $ref_point);
+    }
+
+    my $selu = nn->SELU();
+    my $selu_test = sub { my ($x) = @_;
+        my $selu = sub { my ($x) = @_;
+            my ($scale, $alpha) = (1.0507009873554804934193349852946, 1.6732632423543772848170429916717);
+            return $x => 0 ? $scale * $x : $alpha * mx->nd->exp($x) - $alpha;
+        };
+        return [map { $selu->($_) } @{ $x }];
+    };
+
+    for(zip($selu_test->($point_to_validate), $selu->($point_to_validate)))
+    {
+        my ($test_point, $ref_point) = @$_;
+        ok($test_point == $ref_point);
+    }
+
+    my $prelu = nn->PReLU();
+    $prelu->initialize();
+    my $x = $point_to_validate->reshape([1, 3, 2]);
+    ok(almost_equal($prelu->($x)->aspdl, mx->nd->where($x >= 0, $x, 0.25 * $x)->aspdl));
+}
+
+test_activations();
+
+sub test_req
+{
+    my $data = mx->nd->random->uniform(shape=>[1,3,224,224]);
+    my $label = mx->nd->array([1]);
+    my $loss = gluon->loss->SoftmaxCrossEntropyLoss();
+
+    my $net = nn->HybridSequential();
+    my $net1 = nn->HybridSequential();
+    $net1->add(nn->Dense(4));
+    my $net2 = nn->HybridSequential();
+    $net2->add(nn->Dense(3));
+    $net2->add(nn->Dense(2));
+    $net->add($net1);
+    $net->add($net2);
+    $net->initialize();
+
+    $net->hybridize();
+
+    for my $v ($net->collect_params->values)
+    {
+        $v->grad_req('add');
+    }
+
+    $net->collect_params->zero_grad();
+    my $grad;
+    mx->autograd->record(sub {
+        my $pred = $net->($data);
+        my $l = $loss->($pred, $label);
+        $l->backward();
+        $grad = $net->[0][0]->weight->grad->mean->aspdl;
+        # run twice to check req = add
+        $pred = $net->($data);
+        $l = $loss->($pred, $label);
+        $l->backward;
+    });
+
+    my $grad_double = $net->[0][0]->weight->grad->mean->aspdl;
+    ok(almost_equal($grad * 2, $grad_double));
+}
+
+test_req();
+
+sub test_zero_grad
+{
+    my $data = mx->nd->random->uniform(shape=>[3,3]);
+    my $net = nn->Embedding(3, 4, sparse_grad=>1, prefix=>'test_zero_grad_');
+    $net->initialize();
+    mx->autograd->record(sub {
+        $net->($data)->backward;
+    });
+    $net->collect_params->zero_grad;
+    my $grad = $net->collect_params->{test_zero_grad_weight}->grad;
+    ok(almost_equal($grad->aspdl, $grad->aspdl * 0));
+}
+
+test_zero_grad();
+
+sub test_hook
+{
+    my $hook_call_count = 0;
+    my $pre_hook_call_count = 0;
+
+    my $call_hook = sub { my ($block, $x, $y) = @_;
+        $hook_call_count += 1;
+    };
+
+    my $call_pre_hook = sub { my ($block, $x) = @_;
+        $pre_hook_call_count += 1;
+    };
+
+    my $block = nn->Dense(10);
+    $block->initialize();
+    my $handle = $block->register_forward_hook($call_hook);
+    my $pre_handle = $block->register_forward_pre_hook($call_pre_hook);
+    $block->(mx->nd->ones([3, 5]));
+
+    ok($hook_call_count == 1);
+    ok($pre_hook_call_count == 1);
+
+    $handle->detach();
+    $block->(mx->nd->ones([3, 5]));
+
+    ok($hook_call_count == 1);
+    ok($pre_hook_call_count == 2);
+
+    $pre_handle->detach();
+    $block->(mx->nd->ones([3, 5]));
+
+    ok($hook_call_count == 1);
+    ok($pre_hook_call_count == 2);
+}
+
+test_hook();
+
+sub test_apply
+{
+    my @called_blocks;
+
+    my $record_name = sub { my ($block) = @_;
+        push @called_blocks, $block->name;
+    };
+    my $block = nn->HybridSequential(prefix=>'test_');
+    $block->name_scope(sub {
+        $block->add(nn->Dense(10));
+        $block->add(nn->Dropout(0.5));
+    });
+    $block->apply($record_name);
+
+    is_deeply(\@called_blocks, ['test_dense0', 'test_dropout0', 'test']);
+}
+
+test_apply();
+
+sub test_sparse_hybrid_block_grad
+{
+    package Embedding {
+        use AI::MXNet::Gluon::Mouse;
+        use AI::MXNet::Function::Parameters;
+        extends 'AI::MXNet::Gluon::HybridBlock';
+        has ['num_tokens', 'embedding_size'] => (is => 'rw');
+        method python_constructor_arguments() { ['num_tokens', 'embedding_size'] }
+        sub BUILD {
+            my $self = shift;
+            $self->name_scope(sub {
+                $self->embedding(nn->Embedding(
+                    $self->num_tokens, $self->embedding_size, sparse_grad=>1
+                ));
+            });
+        }
+
+        method hybrid_forward($F, $words)
+        {
+            my $emb = $self->embedding->($words);
+            return $emb + $F->ones_like($emb);
+        }
+    };
+    my $embedding = Embedding->new(20, 3);
+    $embedding->initialize();
+    $embedding->hybridize();
+
+    my $loss;
+    mx->autograd->record(sub {
+        my $emb0 = $embedding->(mx->nd->arange(stop => 10))->sum;
+        my $emb1 = $embedding->(mx->nd->arange(stop => 10))->sum;
+        $loss = $emb0 + $emb1;
+    });
+    $loss->backward();
+    my $grad = $embedding->embedding->weight->grad->aspdl;
+    ok(($grad->slice('X', ':9') == 2)->all);
+    ok(($grad->slice('X', '10:') == 0)->all);
+}
+
+test_sparse_hybrid_block_grad();
+
+sub test_sparse_hybrid_block
+{
+    package Linear {
+        use AI::MXNet::Gluon::Mouse;
+        use AI::MXNet::Function::Parameters;
+        extends 'AI::MXNet::Gluon::HybridBlock';
+        has ['units'] => (is => 'rw');
+        method python_constructor_arguments() { ['units'] }
+        sub BUILD {
+            my $self = shift;
+            $self->name_scope(sub {
+                $self->w($self->params->get(
+                    'w', shape => [$self->units, $self->units]
+                ));
+            });
+        }
+        method hybrid_forward($F, $x, :$w)
+        {
+            return $F->dot($x, $w);
+        }
+    };
+    package SparseBlock {
+        use AI::MXNet::Gluon::Mouse;
+        use AI::MXNet::Function::Parameters;
+        extends 'AI::MXNet::Gluon::HybridBlock';
+        has ['units'] => (is => 'rw');
+        method python_constructor_arguments() { ['units'] }
+        sub BUILD {
+            my $self = shift;
+            $self->name_scope(sub {
+                $self->net(Linear->new($self->units));
+            });
+        }
+        method hybrid_forward($F, $x)
+        {
+            return $self->net->($x) * $x;
+        }
+    };
+    my $block = SparseBlock->new(2);
+    $block->initialize();
+    $block->hybridize();
+    my $x = mx->nd->ones([2,2])->tostype('csr');
+    my $z;
+    mx->autograd->record(sub {
+        $z = $block->($x) + $block->($x);
+    });
+    $z->backward;
+    ok(($block->net->w->grad->aspdl == 4)->all);
+}
+
+test_sparse_hybrid_block();

--- a/perl-package/AI-MXNet/t/test_gluon_trainer.t
+++ b/perl-package/AI-MXNet/t/test_gluon_trainer.t
@@ -1,0 +1,253 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+use strict;
+use warnings;
+use Test::More tests => 30;
+use AI::MXNet qw(mx);
+use AI::MXNet::Gluon qw(gluon);
+use AI::MXNet::Gluon::NN qw(nn);
+use AI::MXNet::TestUtils qw(almost_equal dies_ok);
+use Scalar::Util qw(refaddr);
+use AI::MXNet::Base;
+
+sub test_multi_trainer
+{
+    my $x = gluon->Parameter('x', shape=>[10], stype=>'row_sparse');
+    $x->initialize();
+    # test set trainer
+    my $trainer0 = gluon->Trainer([$x], 'sgd');
+    ok(refaddr($x->_trainer) == refaddr($trainer0));
+    # test unset trainer
+    $x->_set_trainer(undef);
+    ok(not defined $x->_trainer);
+    $x->_set_trainer($trainer0);
+    # multiple trainers for a sparse Parameter are not allowed
+    dies_ok(sub { gluon->Trainer([$x], 'sgd') });
+}
+
+sub test_trainer
+{
+    my $dict_equ = sub { my ($a, $b) = @_;
+        is_deeply({ map { $_ => 1 } keys %$a }, { map { $_ => 1 } keys %$b });
+        for my $k (keys %$a)
+        {
+            ok(($a->{$k}->aspdl == $b->{$k}->aspdl)->all);
+        }
+    };
+    my $x = gluon->Parameter('x', shape=>[10]);
+    $x->initialize(ctx=>[mx->cpu(0), mx->cpu(1)], init=>'zeros');
+    my $trainer = gluon->Trainer([$x], 'sgd', {'learning_rate'=> 1.0, 'momentum'=> 0.5});
+    my $y;
+    mx->autograd->record(sub {
+        for my $w (@{ $x->list_data() })
+        {
+            $y = $w + 1;
+            $y->backward();
+        }
+    });
+    $trainer->step(1);
+
+    ok(($x->data(mx->cpu(1))->aspdl == -2)->all);
+
+    $x->lr_mult(0.5);
+
+    mx->autograd->record(sub {
+        for my $w (@{ $x->list_data() })
+        {
+            $y = $w + 1;
+            $y->backward();
+        }
+    });
+    $trainer->step(1);
+
+    ok(($x->data(mx->cpu(1))->aspdl == -4)->all);
+
+    $trainer->save_states('test_trainer.states');
+    my $states;
+    if($trainer->update_on_kvstore)
+    {
+        $states = { %{ $trainer->kvstore->_updater->states } };
+    }
+    else
+    {
+        $states = { %{ $trainer->_updaters->[0]->states } };
+    }
+    $trainer->load_states('test_trainer.states');
+    if($trainer->update_on_kvstore)
+    {
+        $dict_equ->($trainer->kvstore->_updater->states, $states);
+        ok($trainer->_optimizer eq $trainer->kvstore->_updater->optimizer);
+    }
+    else
+    {
+        for my $updater (@{ $trainer->_updaters })
+        {
+            $dict_equ->($updater->states, $states);
+        }
+        ok($trainer->_optimizer eq $trainer->_updaters->[0]->optimizer);
+    }
+
+    dies_ok(sub { $trainer->update(1 ) });
+    dies_ok(sub { $trainer->allreduce_grads() });
+
+    $x = gluon->Parameter('x', shape=>[10]);
+    $x->initialize(ctx=>[mx->cpu(0), mx->cpu(1)], init=>'zeros');
+    my $trainer2 = gluon->Trainer([$x], 'sgd', {learning_rate => 1.0, momentum => 0.5},
+                             update_on_kvstore=>0);
+    mx->autograd->record(sub {
+        for(enumerate($x->list_data))
+        {
+            my ($i, $w) = @$_;
+            my $y = $i*$w;
+            $y->backward;
+        }
+    });
+    ok(($x->grad(mx->cpu(0))->aspdl != $x->grad(mx->cpu(1))->aspdl)->all);
+    $trainer2->allreduce_grads;
+    ok(($x->grad(mx->cpu(0))->aspdl == $x->grad(mx->cpu(1))->aspdl)->all);
+    $trainer2->update(1);
+    ok(($x->data(mx->cpu(1))->aspdl == -1)->all);
+
+}
+
+test_trainer();
+
+sub test_trainer_save_load
+{
+    my $x = gluon->Parameter('x', shape=>[10], lr_mult=>1.0);
+    $x->initialize(ctx=>[mx->cpu(0), mx->cpu(1)], init=>'zeros');
+    my $trainer = gluon->Trainer([$x], 'sgd', {learning_rate => 0.1});
+    mx->autograd->record(sub {
+        for my $w (@{ $x->list_data })
+        {
+            my $y = $w + 1;
+            $y->backward();
+        }
+    });
+    $trainer->step(1);
+    ok($trainer->kvstore->_updater->optimizer->_get_lr(0) == 0.1);
+    $trainer->save_states('test_trainer_save_load.states');
+    $trainer->load_states('test_trainer_save_load.states');
+    $x->lr_mult(2.0);
+    # check if parameter dict is correctly associated with optimizer after load_state
+    ok($trainer->kvstore->_updater->optimizer->_get_lr(0) == 0.2);
+}
+
+test_trainer_save_load();
+
+sub test_trainer_multi_layer_init
+{
+    local($ENV{MXNET_STORAGE_FALLBACK_LOG_VERBOSE}) = 0;
+    package Net {
+        use AI::MXNet::Gluon::Mouse;
+        extends 'AI::MXNet::Gluon::Block';
+        use AI::MXNet::Function::Parameters;
+        sub BUILD {
+            my $self = shift;
+            $self->name_scope(sub {
+                # sparse param
+                $self->embed_weight($self->params->get('embed_weight', stype=>'row_sparse',
+                                                    shape=>[4,3], grad_stype=>'row_sparse'));
+                # dense param from a hybrid block
+                $self->dense0(nn->Dense(2));
+            });
+        }
+        method forward($x)
+        {
+            my $embed_weight = $self->embed_weight->row_sparse_data($x);
+            my $embed = mx->nd->Embedding(data=>$x, weight=>$embed_weight,
+                                    input_dim=>4, output_dim=>3, sparse_grad=>1);
+            return $self->dense0->($embed);
+        }
+    };
+    my $check_init = sub { my ($ctxes) = @_;
+        my $net = Net->new(prefix=>'net_');
+        $net->initialize(mx->init->One(), ctx=>$ctxes);
+        my $trainer = gluon->Trainer($net->collect_params(), 'sgd', {learning_rate => 1});
+        my $data = mx->nd->array([[0,2], [1,2]]);
+        my $xs = gluon->utils->split_and_load($data, ctx_list => $ctxes);
+        my @ys;
+        mx->autograd->record(sub {
+            for my $x (@{ $xs })
+            {
+                my $y = $net->($x);
+                push @ys, $y;
+            }
+        });
+        for my $y (@ys)
+        {
+            $y->backward;
+        }
+        $trainer->step(1);
+        # all parameters should be initialized
+        ok(not @{ $trainer->_params_to_init });
+        my $all_rows = mx->nd->arange(start => 0, stop => 4, ctx=>mx->cpu(1));
+        # check the updated weights
+        my $weight = $net->embed_weight->row_sparse_data($all_rows)->aspdl;
+        ok(($weight->at(0) == -1)->all);
+        ok(($weight->at(1) == -1)->all);
+        ok(($weight->at(2) == -3)->all);
+        ok(($weight->at(3) ==  1)->all);
+    };
+    $check_init->([mx->cpu(1), mx->cpu(2)]);
+    $check_init->([mx->cpu(1)]);
+}
+
+test_trainer_multi_layer_init();
+
+sub test_trainer_reset_kv
+{
+    my $check_trainer_reset_kv = sub { my ($kv) = @_;
+        my $params = gluon->ParameterDict();
+        my $x = $params->get('x', shape=>[10], lr_mult=>1.0);
+        $params->initialize(ctx=>[mx->cpu(0), mx->cpu(1)], init=>'zeros');
+        my $trainer = gluon->Trainer($params, 'sgd', {learning_rate => 0.1}, kvstore=>$kv);
+        $params->save('test_trainer_reset_kv.params');
+        mx->autograd->record(sub {
+            for my $w (@{ $x->list_data })
+            {
+                my $y = $w + 1;
+                $y->backward;
+            }
+        });
+        $trainer->step(1);
+        is($trainer->kvstore->type, $kv);
+        # load would reset kvstore
+        $params->load('test_trainer_reset_kv.params', ctx => [mx->cpu(0), mx->cpu(1)]);
+        ok(not defined $trainer->kvstore);
+        ok (defined $trainer->_kv_initialized and not $trainer->_kv_initialized);
+        mx->autograd->record(sub {
+            for my $w (@{ $x->list_data })
+            {
+                my $y = $w + 1;
+                $y->backward;
+            }
+        });
+        $trainer->step(1);
+        # the updated parameter should be based on the loaded checkpoint
+        ok(($x->data(mx->cpu()) == -0.2)->aspdl->all);
+    };
+    my @kvs = ('local', 'device');
+    for my $kv (@kvs)
+    {
+        $check_trainer_reset_kv->($kv);
+    }
+}
+
+test_trainer_reset_kv();
+

--- a/perl-package/AI-MXNet/t/test_ndarray.t
+++ b/perl-package/AI-MXNet/t/test_ndarray.t
@@ -18,26 +18,29 @@
 use strict;
 use warnings;
 use AI::MXNet qw(mx);
-use AI::MXNet::TestUtils qw(almost_equal same);
-use Test::More tests => 20;
+use AI::MXNet::TestUtils qw(almost_equal same rand_ndarray randint zip);
+use Test::More tests => 251;
 use PDL;
+use File::Temp qw(tempdir);
+use IO::File;
 
 sub test_ndarray_reshape
 {
-    my $tensor = mx->nd->array([[[1, 2], [3, 4]],
-                                [[5, 6], [7, 8]]]);
-    my $true_res = mx->nd->arange(stop => 8) + 1;
-    is_deeply($tensor->reshape([-1])->aspdl->unpdl, $true_res->aspdl->unpdl);
-    $true_res  = mx->nd->array([[1, 2, 3, 4],
-                                [5, 6, 7, 8]]);
-    is_deeply($tensor->reshape([2, -1])->aspdl->unpdl, $true_res->aspdl->unpdl);
-    $true_res  = mx->nd->array([[1, 2],
-                                [3, 4],
-                                [5, 6],
-                                [7, 8]]);
-    is_deeply($tensor->reshape([-1, 2])->aspdl->unpdl, $true_res->aspdl->unpdl);
+    my $tensor = (mx->nd->arange(stop => 30) + 1)->reshape([2, 3, 5]);
+    my $true_res = mx->nd->arange(stop => 30) + 1;
+    ok(same($tensor->reshape([-1])->aspdl, $true_res->aspdl));
+    ok(same($tensor->reshape([2, -1])->aspdl, $true_res->reshape([2, 15])->aspdl));
+    ok(same($tensor->reshape([0, -1])->aspdl, $true_res->reshape([2, 15])->aspdl));
+    ok(same($tensor->reshape([-1, 2])->aspdl, $true_res->reshape([15, 2])->aspdl));
+    ok(same($tensor->reshape([6, 5])->aspdl, $true_res->reshape([6, 5])->aspdl));
+    ok(same($tensor->reshape([30])->aspdl, $true_res->aspdl));
+    ok(same($tensor->reshape([-1, 6])->aspdl, $true_res->reshape([5, 6])->aspdl));
+    ok(same($tensor->reshape([-2])->aspdl, $true_res->reshape([2, 3, 5])->aspdl));
+    ok(same($tensor->reshape([-3, -1])->aspdl, $true_res->reshape([6, 5])->aspdl));
+    ok(same($tensor->reshape([-1, 15])->reshape([0, -4, 3, -1])->aspdl, $true_res->reshape([2, 3, 5])->aspdl));
+    ok(same($tensor->reshape([-1, 0])->aspdl, $true_res->reshape([10, 3])->aspdl));
+    ok(same($tensor->reshape([-1, 0], reverse=>1)->aspdl, $true_res->reshape([6, 5])->aspdl));
 }
-
 
 sub test_moveaxis
 {
@@ -169,6 +172,51 @@ sub test_image_to_tensor
     );
 }
 
+sub test_buffer_load
+{
+    my $nrepeat = 10;
+    my $tmpdir = tempdir(CLEANUP => 1);
+    for my $repeat (1..$nrepeat)
+    {
+        # test load_buffer as list
+        my @data;
+        for(1..10)
+        {
+            push @data, rand_ndarray([randint(1, 5)], 'default');
+        }
+        my $fname = "$tmpdir/list_$repeat.param";
+        mx->nd->save($fname, \@data);
+        my $buf_data = join('',IO::File->new($fname)->getlines);
+        my $data2 = mx->nd->load_frombuffer($buf_data);
+        ok(@data == @$data2);
+        zip(sub {
+            my ($x, $y) = @_;
+            ok(same($x->aspdl, $y->aspdl));
+        }, \@data, $data2);
+        # test load_buffer as hash
+        my $i = 0;
+        my %hash = map { 'ndarray xx '.$i++ => $_ } @data;
+        $fname = "$tmpdir/hash_$repeat.param";
+        mx->nd->save($fname, \%hash);
+        $buf_data = join('',IO::File->new($fname)->getlines);
+        my $hash2 = mx->nd->load_frombuffer($buf_data);
+        ok(%hash == %$hash2);
+        while(my ($k, $v) = each %hash)
+        {
+            ok(same($v->aspdl, $hash2->{$k}->aspdl));
+        }
+    }
+}
+
+sub test_histogram
+{
+    my $z = mx->nd->array([0..99]);
+    my $b = mx->nd->array([10, 20, 30, 60]);
+    my ($hist, $bins) = @{ mx->nd->histogram($z, bins => $b) };
+    ok(same($hist->aspdl, pdl([10, 10, 31])));
+    ok(same($bins->aspdl, pdl([10, 20, 30, 60])));
+}
+
 test_ndarray_slice();
 test_ndarray_reshape();
 test_moveaxis();
@@ -176,4 +224,5 @@ test_output();
 test_cached();
 test_linalg_gemm2();
 test_image_to_tensor();
-
+test_buffer_load();
+test_histogram();

--- a/perl-package/AI-MXNet/t/test_optimizers.t
+++ b/perl-package/AI-MXNet/t/test_optimizers.t
@@ -638,7 +638,7 @@ method update($index, $weight, $grad, $state)
 
 package main;
 use Carp;
-use Test::More tests => 7884;
+use Test::More tests => 7992;
 use AI::MXNet::Base;
 use PDL::NiceSlice;
 use AI::MXNet::TestUtils qw(same reldiff almost_equal rand_ndarray);
@@ -1075,6 +1075,7 @@ sub test_adagrad
                         if(($wd_option->{wd}//0) == 0)
                         {
                             compare_optimizer($opt1->new(%kwarg), $opt2->new(%kwarg), $shape, $dtype, 'row_sparse', 'row_sparse');
+                            compare_optimizer($opt1->new(%kwarg), $opt2->new(%kwarg), $shape, $dtype, 'default', 'row_sparse');
                         }
                     }
                 }

--- a/perl-package/AI-MXNet/t/test_random.t
+++ b/perl-package/AI-MXNet/t/test_random.t
@@ -17,7 +17,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 505;
+use Test::More tests => 506;
 use AI::MXNet qw(mx);
 use AI::MXNet::TestUtils qw(same enumerate);
 
@@ -225,3 +225,13 @@ sub test_sample_multinomial
 
 test_sample_multinomial();
 
+sub test_seed_context
+{
+    ## only checking perl/swig interaction
+    ## c++ implementation is tested on python's side thoroughly already
+    mx->random->seed(1234);
+    mx->random->seed(1234, ctx => mx->cpu(0));
+    ok(1);
+}
+
+test_seed_context();

--- a/perl-package/AI-MXNet/t/test_symbol.t
+++ b/perl-package/AI-MXNet/t/test_symbol.t
@@ -17,7 +17,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 101;
+use Test::More tests => 103;
 use AI::MXNet qw(mx);
 use AI::MXNet::TestUtils qw(mlp2 conv check_consistency zip assert enumerate almost_equal same);
 use Storable qw(freeze thaw);
@@ -278,6 +278,17 @@ sub test_image_to_tensor
 }
 
 test_image_to_tensor();
+
+sub test_histogram
+{
+    my $z = mx->nd->array([0..99]);
+    my $b = mx->nd->array([10, 20, 30, 60]);
+    my ($hist, $bins) = @{ mx->sym->histogram(mx->sym->var("z"), bins => mx->sym->var("bins"))->eval(args => { z => $z, bins => $b }) };
+    ok(same($hist->aspdl, pdl([10, 10, 31])));
+    ok(same($bins->aspdl, pdl([10, 20, 30, 60])));
+}
+
+test_histogram();
 
 __DATA__
 {

--- a/perl-package/AI-MXNetCAPI/Changes
+++ b/perl-package/AI-MXNetCAPI/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension AI::MXNetCAPI
 
+1.3     Tue Jun 26 20:57:40 PDT 2018
+        - Major update, Gluon interface updated to parity with Python's API
+
 1.2     Sun Mar  4 16:29:19 PST 2018
         - Support for sparse tensors
 

--- a/perl-package/AI-MXNetCAPI/META.json
+++ b/perl-package/AI-MXNetCAPI/META.json
@@ -37,5 +37,5 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.2"
+   "version" : "1.3"
 }

--- a/perl-package/AI-MXNetCAPI/META.yml
+++ b/perl-package/AI-MXNetCAPI/META.yml
@@ -19,4 +19,4 @@ no_index:
     - inc
 requires:
   Test::More: '0'
-version: '1.2'
+version: '1.3'

--- a/perl-package/AI-MXNetCAPI/README
+++ b/perl-package/AI-MXNetCAPI/README
@@ -1,4 +1,4 @@
-AI-MXNetCAPI version 1.2
+AI-MXNetCAPI version 1.3
 =====================
 
 Swig interface to MXNet c api.

--- a/perl-package/AI-MXNetCAPI/lib/AI/MXNetCAPI.pm
+++ b/perl-package/AI-MXNetCAPI/lib/AI/MXNetCAPI.pm
@@ -18,7 +18,7 @@
 package AI::MXNetCAPI;
 use base qw(DynaLoader);
 bootstrap AI::MXNetCAPI;
-our $VERSION = '1.2';
+our $VERSION = '1.3';
 1;
 __END__
 

--- a/perl-package/AI-MXNetCAPI/mxnet_typemaps.i
+++ b/perl-package/AI-MXNetCAPI/mxnet_typemaps.i
@@ -161,6 +161,7 @@
                          (mx_uint *out_size, const char ***out_array) (mx_uint temp_size, char** temp)
 {
     $1 = &temp_size;
+    *$1 = 0;
     $2 = &temp;
 }
 
@@ -188,6 +189,7 @@
 %typemap(in,numinputs=0) (mx_uint *out_size, const char ***out_array2) (mx_uint temp_size, char** temp)
 {
     $1 = &temp_size;
+    *$1 = 0;
     $2 = &temp;
 }
 
@@ -297,6 +299,37 @@
 }
 
 %typemap(freearg) (const int *in), (int *in) {
+    Safefree($1);
+}
+
+%typemap(in) (dim_t *in)
+{
+    AV *tempav;
+    int i;
+    SV  **tv;
+    int av_len; 
+    if (!SvROK($input))
+        croak("Argument $argnum is not a reference.");
+        if (SvTYPE(SvRV($input)) != SVt_PVAV)
+        croak("Argument $argnum is not an array.");
+        tempav = (AV*)SvRV($input);
+    av_len = av_len(tempav) + 1;
+    if(av_len)
+    {
+        $1 = (dim_t *)safemalloc(av_len*sizeof(dim_t));
+        for (i = 0; i < av_len; i++) {
+            tv = av_fetch(tempav, i, 0);
+            $1[i] = (dim_t)SvIV(*tv);
+        }
+    }
+    else
+    {
+       $1 = NULL;
+    }
+
+}
+
+%typemap(freearg) (dim_t *in) {
     Safefree($1);
 }
 
@@ -449,6 +482,7 @@
 %typemap(in,numinputs=0) (char const **out_array, size_t *out_size) (char * temp, size_t temp_size)
 {
     $2 = &temp_size;
+    *$2 = 0;
     $1 = &temp;
 }
 
@@ -465,6 +499,7 @@
 %typemap(in,numinputs=0) (size_t *out_size, char const **out_array) (size_t temp_size, char *temp)
 {
     $1 = &temp_size;
+    *$1 = 0;
     $2 = &temp;
 }
 
@@ -508,6 +543,7 @@
 {
     $1 = &temp1;
     $2 = &temp2;
+    *$2 = 0;
 }
 
 %typemap(argout) (uint64_t **out_index, uint64_t *out_size)
@@ -536,6 +572,7 @@
                          (mx_uint *out_size, NDArrayHandle** out_array) (mx_uint temp_size, NDArrayHandle* temp)
 {
     $1 = &temp_size;
+    *$1 = 0;
     $2 = &temp;
 }
 
@@ -616,6 +653,36 @@
     }
 }
 
+%typemap(in,numinputs=0) (mx_uint* couple_out_size, NDArrayHandle** out_first_array, NDArrayHandle** out_second_array)
+                         (mx_uint t, NDArrayHandle* t1, NDArrayHandle* t2)
+{
+    $1 = &t;
+    *$1 = 0;
+    $2 = &t1;
+    $3 = &t2;
+}
+
+%typemap(argout) (mx_uint* couple_out_size, NDArrayHandle** out_first_array, NDArrayHandle** out_second_array)
+{
+    if(!result)
+    {
+        AV *container, *in_args, *arg_grads;
+        int i;
+        container = newAV();
+        in_args = newAV();
+        arg_grads = newAV();
+        for (i = 0; i < *$1 ; i++) {
+            av_push(in_args, SvREFCNT_inc(SWIG_NewPointerObj(SWIG_as_voidptr((*$2)[i]), SWIGTYPE_p_MXNDArray, 0)));
+            av_push(arg_grads, SvREFCNT_inc(SWIG_NewPointerObj(SWIG_as_voidptr((*$3)[i]), SWIGTYPE_p_MXNDArray, 0)));
+        }
+        av_push(container, newRV_noinc((SV*)in_args));
+        av_push(container, newRV_noinc((SV*)arg_grads));
+        $result = newRV_noinc((SV*)container);
+        sv_2mortal($result);
+        argvi++;
+    }
+}
+
 %typemap(in,numinputs=0) (NDArrayHandle **out_grad) (NDArrayHandle* temp)
 {
     int vars = SvIV(ST(3));
@@ -628,6 +695,7 @@
         $1 = NULL;
     }
 }
+
 
 %typemap(argout) (NDArrayHandle** out_grad)
 {
@@ -756,6 +824,7 @@
     $1 = &name_temp;
     $2 = &desc_temp;
     $3 = &num_args_temp;
+    *$3 = 0;
     $4 = &names_temp;
     $5 = &types_temp;
     $6 = &descs_temp;
@@ -815,7 +884,8 @@
 {
     $1 = &name_temp; 
     $2 = &desc_temp;
-    $3 = &num_args_temp; 
+    $3 = &num_args_temp;
+    *$3 = 0;
     $4 = &names_temp;
     $5 = &types_temp;
     $6 = &descs_temp;
@@ -861,7 +931,8 @@
 
 %typemap(in,numinputs=0) (mx_uint *out) (mx_uint temp), (size_t *out) (size_t temp)
 {
-    $1 = &temp; 
+    $1 = &temp;
+    *$1 = 0;
 }
 
 %typemap(argout) (mx_uint *out), (size_t *out)

--- a/perl-package/AI-NNVMCAPI/Changes
+++ b/perl-package/AI-NNVMCAPI/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension AI::NNVMCAPI.
 
+1.3     Tue Jun 26 20:57:40 PDT 2018
+        - Major update, Gluon interface updated to parity with Python's API
+
 1.2     Sun Mar  4 16:29:19 PST 2018
         - Support for sparse tensors
 

--- a/perl-package/AI-NNVMCAPI/META.json
+++ b/perl-package/AI-NNVMCAPI/META.json
@@ -37,5 +37,5 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.2"
+   "version" : "1.3"
 }

--- a/perl-package/AI-NNVMCAPI/META.yml
+++ b/perl-package/AI-NNVMCAPI/META.yml
@@ -19,4 +19,4 @@ no_index:
     - inc
 requires:
   Test::More: '0'
-version: '1.2'
+version: '1.3'

--- a/perl-package/AI-NNVMCAPI/README
+++ b/perl-package/AI-NNVMCAPI/README
@@ -1,4 +1,4 @@
-AI-NNVMCAPI version 1.2
+AI-NNVMCAPI version 1.3
 =====================
 
 Swig interface to MXNet c api.

--- a/perl-package/AI-NNVMCAPI/lib/AI/NNVMCAPI.pm
+++ b/perl-package/AI-NNVMCAPI/lib/AI/NNVMCAPI.pm
@@ -18,7 +18,7 @@
 package AI::NNVMCAPI;
 use base qw(DynaLoader);
 bootstrap AI::NNVMCAPI;
-our $VERSION = '1.2';
+our $VERSION = '1.3';
 1;
 __END__
 

--- a/perl-package/AI-NNVMCAPI/nnvm_typemaps.i
+++ b/perl-package/AI-NNVMCAPI/nnvm_typemaps.i
@@ -96,6 +96,7 @@
 %typemap(in,numinputs=0) (int *out) (int temp)
 {
     $1 = &temp;
+    *$1 = 0;
 }
 
 %typemap(argout) (int *out)
@@ -112,6 +113,7 @@
                          (mx_uint *out_size, const char ***out_array) (mx_uint temp_size, char** temp)
 {
     $1 = &temp_size;
+    *$1 = 0;
     $2 = &temp;
 }
 
@@ -139,6 +141,7 @@
 %typemap(in,numinputs=0) (nn_uint *half_of_out_size, const char ***out_array) (nn_uint temp_size, char **temp)
 {
     $1 = &temp_size;
+    *$1 = 0;
     $2 = &temp;
 }
 %typemap(argout) (nn_uint *half_of_out_size, const char ***out_array)
@@ -279,6 +282,7 @@
 %typemap(in,numinputs=0) (nn_uint *out_size, OpHandle** out_array) (nn_uint temp_num, OpHandle* temp)
 {
     $1 = &temp_num;
+    *$1 = 0;
     $2 = &temp;
 }
 %typemap(argout) (nn_uint *out_size, OpHandle** out_array)
@@ -303,6 +307,7 @@
 %typemap(in,numinputs=0) (nn_uint *out_size, SymbolHandle** out_array) (nn_uint temp_num, SymbolHandle* temp)
 {
     $1 = &temp_num;
+    *$1 = 0;
     $2 = &temp;
 }
 %typemap(argout) (nn_uint *out_size, SymbolHandle** out_array)


### PR DESCRIPTION
## Description ##

Major Gluon update towards parity with Python's API.
Miscellaneous bugfixes and improvements.
New Engine API.
Module::reshape moved to C++ backend.
Examples were updated to work on multi-gpu boxes.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

Major Gluon update towards parity with Python's API.
Miscellaneous bugfixes and improvements.
New Engine API.
Module::reshape moved to C++ backend.
Examples were updated to work on multi-gpu boxes.

## Comments ##

