### PR TITLE
add ignore_reinit to initialize to skip warnings

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -478,7 +478,7 @@ class Block(object):
         return self
 
     def initialize(self, init=initializer.Uniform(), ctx=None, verbose=False,
-                   force_reinit=False):
+                   force_reinit=False, ignore_reinit=False):
         """Initializes :py:class:`Parameter` s of this :py:class:`Block` and its children.
         Equivalent to ``block.collect_params().initialize(...)``
 
@@ -493,8 +493,10 @@ class Block(object):
             Whether to verbosely print out details on initialization.
         force_reinit : bool, default False
             Whether to force re-initialization if parameter is already initialized.
+        ignore_reinit : bool, default False
+            Whether to ignore re-initialization warning if `force_reinit` is not True.
         """
-        self.collect_params().initialize(init, ctx, verbose, force_reinit)
+        self.collect_params().initialize(init, ctx, verbose, force_reinit, ignore_reinit)
 
     def hybridize(self, active=True, **kwargs):
         """Activates or deactivates :py:class:`HybridBlock` s recursively. Has no effect on

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -323,7 +323,7 @@ class Parameter(object):
         return data
 
     def initialize(self, init=None, ctx=None, default_init=initializer.Uniform(),
-                   force_reinit=False):
+                   force_reinit=False, ignore_reinit=False):
         """Initializes parameter and gradient arrays. Only used for :py:class:`NDArray` API.
 
         Parameters
@@ -344,6 +344,8 @@ class Parameter(object):
             and :py:meth:`Parameter.init` are ``None``.
         force_reinit : bool, default False
             Whether to force re-initialization if parameter is already initialized.
+        ignore_reinit : bool, default False
+            Whether to ignore re-initialization warning if `force_reinit` is not True.
 
         Examples
         --------
@@ -368,9 +370,10 @@ class Parameter(object):
         <NDArray 2x2 @gpu(1)>
         """
         if self._data is not None and not force_reinit:
-            warnings.warn("Parameter '%s' is already initialized, ignoring. " \
-                          "Set force_reinit=True to re-initialize."%self.name,
-                          stacklevel=2)
+            if not ignore_reinit:
+                warnings.warn("Parameter '%s' is already initialized, ignoring. " \
+                              "Set force_reinit=True to re-initialize."%self.name,
+                              stacklevel=2)
             return
         self._data = self._grad = None
 
@@ -789,7 +792,7 @@ class ParameterDict(object):
             self._params[k] = v
 
     def initialize(self, init=initializer.Uniform(), ctx=None, verbose=False,
-                   force_reinit=False):
+                   force_reinit=False, ignore_reinit=False):
         """Initializes all Parameters managed by this dictionary to be used for :py:class:`NDArray`
         API. It has no effect when using :py:class:`Symbol` API.
 
@@ -804,11 +807,13 @@ class ParameterDict(object):
             Whether to verbosely print out details on initialization.
         force_reinit : bool, default False
             Whether to force re-initialization if parameter is already initialized.
+        ignore_reinit : bool, default False
+            Whether to ignore re-initialization warning if `force_reinit` is not True.
         """
         if verbose:
             init.set_verbosity(verbose=verbose)
         for _, v in self.items():
-            v.initialize(None, ctx, init, force_reinit=force_reinit)
+            v.initialize(None, ctx, init, force_reinit=force_reinit, ignore_reinit=ignore_reinit)
 
     def zero_grad(self):
         """Sets all Parameters' gradient buffer to 0."""

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1360,6 +1360,29 @@ def test_hybrid_static_memory_recording():
         net(x)
     net(x)
 
+@with_seed()
+def test_ignore_force_reinit():
+    net = nn.HybridSequential()
+    net.add(nn.Dense(4))
+    net.add(nn.Dense(2))
+    net.add(nn.Dense(1))
+    net.collect_params().initialize()
+    net(mx.nd.zeros((4,)))
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        net.initialize(force_reinit=True)
+        assert len(w) == 0
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        net.initialize(force_reinit=False, ignore_reinit=False)
+        assert len(w) == (3 * 2)  # weight and bias, 3 layers
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        net.initialize(force_reinit=False, ignore_reinit=True)
+        assert len(w) == 0
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
When net is partially initialized(which is very common), this PR allow 
```
net.collect_params().initialize(ignore_reinit=True) 
```
without throwing warnings for each initialized parameter.
Otherwise user have to use warnings.catch_warnings if they already understand the situation.

This PR has no effect on any functionality, simply don't generate warnings if set to True.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here