### PR TITLE
handle the case that inputs and outputs of a graph share NDArrays

### DIFF
--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -720,6 +720,9 @@ OpStatePtr CachedOp::StaticForward(
 
   for (size_t i = 0; i < outputs.size(); ++i) {
     auto eid = idx.entry_id(idx.outputs()[i]);
+    // An input and an output may share the same array.
+    if (!state.arrays[eid]->is_none())
+      *outputs[i] = state.arrays[eid]->Detach();
     state.arrays[eid] = outputs[i];
     if (!outputs[i]->is_none()) continue;
     *outputs[i] = NDArray(static_cast<NDArrayStorageType>(stypes[eid]),
@@ -891,7 +894,11 @@ void CachedOp::DynamicBackward(
   }
   for (size_t i = 0, j = num_forward_outputs; i < reqs.size(); ++i) {
     if (reqs[i] == kNullOp) continue;
-    arrays[idx.entry_id(idx.outputs()[j++])] = outputs[i];
+    auto eid = idx.entry_id(idx.outputs()[j++]);
+    // An input and an output may share the same array.
+    if (!arrays[eid]->is_none())
+      *outputs[i] = arrays[eid]->Detach();
+    arrays[eid] = outputs[i];
   }
 
   // Allocate NDArrays
@@ -952,6 +959,11 @@ void CachedOp::StaticBackward(
     StaticAllocMemory(state_ptr, true, true);
   }
 
+  for (size_t i = 0; i < state.info.bwd_input_eid.size(); ++i) {
+    auto eid = state.info.bwd_input_eid[i];
+    if (state.dynamic_entries[eid]) state.arrays[eid] = inputs[i];
+  }
+
   if (config_.static_shape) {
     for (auto i : config_.param_indices) {
       const auto iter = fwd_input_to_grad_output_.find(i);
@@ -963,6 +975,9 @@ void CachedOp::StaticBackward(
           !(state.array_reqs[eid] == reqs[iter->second])) {
         match = false;
         state.array_reqs[eid] = reqs[iter->second];
+        // An input and an output may share the same array.
+        if (!state.arrays[eid]->is_none())
+          *outputs[iter->second] = state.arrays[eid]->Detach();
         *state.arrays[eid] = *outputs[iter->second];
         state.dynamic_entries[eid] = false;
       }
@@ -974,6 +989,9 @@ void CachedOp::StaticBackward(
       if (!idx.exist(entry.node.get())) continue;
       auto eid = idx.entry_id(entry);
       state.array_reqs[eid] = reqs[iter->second];
+      // An input and an output may share the same array.
+      if (!state.arrays[eid]->is_none())
+        *outputs[iter->second] = state.arrays[eid]->Detach();
       state.arrays[eid] = outputs[iter->second];
     }
   } else {
@@ -982,17 +1000,15 @@ void CachedOp::StaticBackward(
       if (!idx.exist(entry.node.get())) continue;
       auto eid = idx.entry_id(entry);
       state.array_reqs[eid] = reqs[i];
+      // An input and an output may share the same array.
+      if (!state.arrays[eid]->is_none())
+        *outputs[i] = state.arrays[eid]->Detach();
       state.arrays[eid] = outputs[i];
     }
   }
 
   if (!state.bwd_exec_init || !match) {
     StaticInitExec(state_ptr, true, true);
-  }
-
-  for (size_t i = 0; i < state.info.bwd_input_eid.size(); ++i) {
-    auto eid = state.info.bwd_input_eid[i];
-    if (state.dynamic_entries[eid]) state.arrays[eid] = inputs[i];
   }
 
   StaticRunOps(default_ctx, g, state_ptr, num_forward_nodes, idx.num_nodes());

--- a/src/imperative/cached_op.h
+++ b/src/imperative/cached_op.h
@@ -154,6 +154,7 @@ class CachedOp {
       const Context& default_ctx,
       const nnvm::Graph& g,
       const OpStatePtr& state_ptr,
+      const std::vector<NDArray *> &state_arrays,
       size_t start_nid,
       size_t end_nid);
   OpStatePtr StaticForward(

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1361,6 +1361,55 @@ def test_hybrid_static_memory_recording():
     net(x)
 
 
+def test_share_inputs_outputs():
+    class TestIOBackward(gluon.HybridBlock):
+        def __init__(self, prefix=None, params=None):
+            super(TestIOBackward, self).__init__(prefix=prefix, params=params)
+
+        def hybrid_forward(self, F, in1, in2):
+            return in1 + in2
+
+    class TestIOForward(gluon.HybridBlock):
+        def __init__(self, prefix=None, params=None):
+            super(TestIOForward, self).__init__(prefix=prefix, params=params)
+
+        def hybrid_forward(self, F, in1):
+            return in1
+
+    d1 = mx.nd.arange(10)
+    d2 = mx.nd.arange(10)
+
+    params=[{'inline_limit':0},
+            {'inline_limit':0, 'static_alloc':True},
+            {'inline_limit':0, 'static_alloc':True, 'static_shape':True}]
+    # Test the case that inputs and outputs of a forward graph share NDArrays.
+    for param in params:
+        t = TestIOForward()
+        t.hybridize(**param)
+        d1.attach_grad()
+        out_grad = mx.nd.random.uniform(shape=(10))
+        with mx.autograd.record():
+            res = t(d1)
+        assert_almost_equal(res.asnumpy(), d1.asnumpy())
+
+    param = deepcopy(params[2])
+    param['param_indices'] = (1)
+    param['data_indices'] = (0)
+    params.append(param)
+    # Test the case that inputs and outputs of a backward graph share NDArrays.
+    for param in params:
+        t = TestIOBackward()
+        t.hybridize(**param)
+        d1.attach_grad()
+        d2.attach_grad()
+        out_grad = mx.nd.random.uniform(shape=(10))
+        with mx.autograd.record():
+            res = t(d1, d2)
+        res.backward(out_grad=out_grad)
+        assert_almost_equal(out_grad.asnumpy(), d1.grad.asnumpy())
+        assert_almost_equal(out_grad.asnumpy(), d2.grad.asnumpy())
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1386,11 +1386,11 @@ def test_share_inputs_outputs():
     for param in params:
         t = TestIOForward()
         t.hybridize(**param)
-        d1.attach_grad()
-        out_grad = mx.nd.random.uniform(shape=(10))
-        with mx.autograd.record():
+        for i in range(5):
+            d1.attach_grad()
+            out_grad = mx.nd.random.uniform(shape=(10))
             res = t(d1)
-        assert_almost_equal(res.asnumpy(), d1.asnumpy())
+            assert_almost_equal(res.asnumpy(), d1.asnumpy())
 
     param = deepcopy(params[2])
     param['param_indices'] = (1)
@@ -1400,14 +1400,15 @@ def test_share_inputs_outputs():
     for param in params:
         t = TestIOBackward()
         t.hybridize(**param)
-        d1.attach_grad()
-        d2.attach_grad()
-        out_grad = mx.nd.random.uniform(shape=(10))
-        with mx.autograd.record():
-            res = t(d1, d2)
-        res.backward(out_grad=out_grad)
-        assert_almost_equal(out_grad.asnumpy(), d1.grad.asnumpy())
-        assert_almost_equal(out_grad.asnumpy(), d2.grad.asnumpy())
+        for i in range(5):
+            d1.attach_grad()
+            d2.attach_grad()
+            out_grad = mx.nd.random.uniform(shape=(10))
+            with mx.autograd.record():
+                res = t(d1, d2)
+            res.backward(out_grad=out_grad)
+            assert_almost_equal(out_grad.asnumpy(), d1.grad.asnumpy())
+            assert_almost_equal(out_grad.asnumpy(), d2.grad.asnumpy())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
This is to handle the case that inputs and outputs of a graph in CachedOp share NDArrays.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
