### PR TITLE
[WIP] Add broadcast_like backend tensor operator

### DIFF
--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -346,7 +346,7 @@ inline bool BroadcastLikeShape(const nnvm::NodeAttrs& attrs,
   for (index_t i = 0; i < ishape.ndim(); ++i) {
     if (oshape[i] != 0) {
       CHECK(ishape[i] == oshape[i] || ishape[i] == 1)
-        << "Array cannot be broadcasted from " << ishape << " to " << oshape; 
+        << "Array cannot be broadcasted from " << ishape << " to " << oshape;
     } else {
       oshape[i] = ishape[i];
     }
@@ -354,7 +354,6 @@ inline bool BroadcastLikeShape(const nnvm::NodeAttrs& attrs,
   SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);
   return true;
 }
-
 
 inline void BroadcastReduceShapeCompact(const TShape& big, const TShape& small,
                                         TShape *new_big, TShape *new_small) {
@@ -1247,18 +1246,6 @@ void PickOpBackward(const nnvm::NodeAttrs& attrs,
     })                                                          \
   .add_argument("data", "NDArray-or-Symbol", "The input")
 
-#define MXNET_OPERATOR_REGISTER_BROADCAST_LIKE(name)                 \
-  NNVM_REGISTER_OP(name)                                        \
-  .set_num_inputs(2)                                            \
-  .set_num_outputs(1)                                           \
-  .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>) \
-  .set_attr<nnvm::FGradient>("FGradient",                       \
-    [](const nnvm::NodePtr& n,                                  \
-       const std::vector<nnvm::NodeEntry>& ograds) {            \
-      return MakeNonlossGradNode("_broadcast_backward", n, ograds, {},    \
-                                 {{"keepdims", "true"}});              \
-    })                                                          \
-  .add_argument("data", "NDArray-or-Symbol", "The input")
 }  // namespace op
 }  // namespace mxnet
 #endif  // MXNET_OPERATOR_TENSOR_BROADCAST_REDUCE_OP_H_

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -771,7 +771,7 @@ void ReduceAxesBackwardUseInOutImpl(const OpContext& ctx,
       Tensor<xpu, 2, DType> out =
         inputs[2].get_with_shape<xpu, 2, DType>(dst_shape.get<2>(), s);
       ASSIGN_DISPATCH(igrad, req[0],
-          broadcast_to(ograd, src_shape*F<OP>(data, broadcast_to(out, src_shape)));
+          broadcast_to(ograd, src_shape)*F<OP>(data, broadcast_to(out, src_shape)));
       if (normalize) igrad /= scalar<DType>(src_shape.Size()/dst_shape.Size());
     } else {
       const int ndim = MXNET_SPECIAL_MAX_NDIM;

--- a/src/operator/tensor/broadcast_reduce_op_value.cc
+++ b/src/operator/tensor/broadcast_reduce_op_value.cc
@@ -264,7 +264,7 @@ So with `shape=(2,0)`, we will obtain the same result as in the above example.
 .set_attr<nnvm::FInferShape>("FInferShape", BroadcastToShape)
 .set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>);
 
-MXNET_OPERATOR_REGISTER_BROADCAST_LIKE(broadcast_like)
+NNVM_REGISTER_OP(broadcast_like)
 .describe(R"code(Broadcasts the input array to be like a target array
 
 Broadcasting is allowed on axes with size 1, such as from `(2,1,3,1)` to
@@ -275,8 +275,19 @@ For example::
    broadcast_like([[1,2,3]], target=[[0, 0, 0], [0, 0, 0]]) = [[ 1.,  2.,  3.],
                                                                [ 1.,  2.,  3.]]
 )code" ADD_FILELINE)
+.set_num_inputs(2)
+.set_num_outputs(1)
 .set_attr<nnvm::FInferShape>("FInferShape", BroadcastLikeShape)
-.set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>);
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)
+.set_attr<nnvm::FGradient>("FGradient",
+    [](const nnvm::NodePtr& n,
+       const std::vector<nnvm::NodeEntry>& ograds) {
+      return MakeNonlossGradNode("_broadcast_backward", n, ograds, {},
+                                 {{"keepdims", "true"}});
+    })
+.set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>)
+.add_argument("data", "NDArray-or-Symbol", "The input")
+.add_argument("target", "NDArray-or-Symbol", "The target array")
 
 // backward op for broadcast.
 NNVM_REGISTER_OP(_broadcast_backward)

--- a/src/operator/tensor/broadcast_reduce_op_value.cc
+++ b/src/operator/tensor/broadcast_reduce_op_value.cc
@@ -287,7 +287,7 @@ For example::
     })
 .set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>)
 .add_argument("data", "NDArray-or-Symbol", "The input")
-.add_argument("target", "NDArray-or-Symbol", "The target array")
+.add_argument("target", "NDArray-or-Symbol", "The target array");
 
 // backward op for broadcast.
 NNVM_REGISTER_OP(_broadcast_backward)

--- a/src/operator/tensor/broadcast_reduce_op_value.cc
+++ b/src/operator/tensor/broadcast_reduce_op_value.cc
@@ -264,7 +264,7 @@ So with `shape=(2,0)`, we will obtain the same result as in the above example.
 .set_attr<nnvm::FInferShape>("FInferShape", BroadcastToShape)
 .set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>);
 
-MXNET_OPERATOR_REGISTER_BROADCAST(broadcast_like)
+MXNET_OPERATOR_REGISTER_BROADCAST_LIKE(broadcast_like)
 .describe(R"code(Broadcasts the input array to be like a target array
 
 Broadcasting is allowed on axes with size 1, such as from `(2,1,3,1)` to

--- a/src/operator/tensor/broadcast_reduce_op_value.cc
+++ b/src/operator/tensor/broadcast_reduce_op_value.cc
@@ -264,6 +264,22 @@ So with `shape=(2,0)`, we will obtain the same result as in the above example.
 .set_attr<nnvm::FInferShape>("FInferShape", BroadcastToShape)
 .set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>);
 
+MXNET_OPERATOR_REGISTER_BROADCAST(broadcast_like)
+.describe(R"code(Broadcasts the input array to be like a target array
+
+Broadcasting is allowed on axes with size 1, such as from `(2,1,3,1)` to
+`(2,8,3,9)`. Elements will be duplicated on the broadcasted axes.
+
+For example::
+
+   broadcast_like([[1,2,3]], target=[[0, 0, 0], [0, 0, 0]]) = [[ 1.,  2.,  3.],
+                                                               [ 1.,  2.,  3.]]
+)code" ADD_FILELINE)
+.set_attr_parser(ParamParser<BroadcastLikeParam>)
+.add_arguments(BroadcastLikeParam::__FIELDS__())
+.set_attr<nnvm::FInferShape>("FInferShape", BroadcastLikeShape)
+.set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>);
+
 // backward op for broadcast.
 NNVM_REGISTER_OP(_broadcast_backward)
 .set_attr_parser(ParamParser<ReduceAxesParam>)

--- a/src/operator/tensor/broadcast_reduce_op_value.cc
+++ b/src/operator/tensor/broadcast_reduce_op_value.cc
@@ -275,8 +275,6 @@ For example::
    broadcast_like([[1,2,3]], target=[[0, 0, 0], [0, 0, 0]]) = [[ 1.,  2.,  3.],
                                                                [ 1.,  2.,  3.]]
 )code" ADD_FILELINE)
-.set_attr_parser(ParamParser<BroadcastLikeParam>)
-.add_arguments(BroadcastLikeParam::__FIELDS__())
 .set_attr<nnvm::FInferShape>("FInferShape", BroadcastLikeShape)
 .set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>);
 

--- a/src/operator/tensor/broadcast_reduce_op_value.cu
+++ b/src/operator/tensor/broadcast_reduce_op_value.cu
@@ -97,6 +97,9 @@ NNVM_REGISTER_OP(broadcast_axis)
 NNVM_REGISTER_OP(broadcast_to)
 .set_attr<FCompute>("FCompute<gpu>", BroadcastCompute<gpu>);
 
+NNVM_REGISTER_OP(broadcast_like)
+.set_attr<FCompute>("FCompute<gpu>", BroadcastCompute<gpu>);
+
 NNVM_REGISTER_OP(_broadcast_backward)
 .set_attr<FCompute>("FCompute<gpu>", ReduceAxesCompute<gpu, mshadow::red::sum>);
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2062,7 +2062,7 @@ def test_broadcast():
         axis = tuple(set(np.random.randint(0, ndim, np.random.randint(1, ndim + 1))))
         shape = target_shape.copy()
         size = tuple([shape[ele] for ele in axis])
-        target_array = rand_ndarray(shape=target_shape, style='default')
+        target_array = rand_ndarray(shape=target_shape, stype='default')
         for ele in axis:
             shape[ele] = 1
         a = mx.symbol.Variable('a')

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2062,11 +2062,13 @@ def test_broadcast():
         axis = tuple(set(np.random.randint(0, ndim, np.random.randint(1, ndim + 1))))
         shape = target_shape.copy()
         size = tuple([shape[ele] for ele in axis])
+        target_array = rand_ndarray(shape=target_shape, style='default')
         for ele in axis:
             shape[ele] = 1
         a = mx.symbol.Variable('a')
         sym_bcast_axis = mx.symbol.broadcast_axis(a, axis=axis, size=size)
         sym_bcast_to = mx.symbol.broadcast_to(a, shape=tuple(target_shape))
+        sym_bcast_like = mx.symbol.broadcast_like(a, target=target_array)
         def test_broadcasting_ele(sym_bcast):
             dat_npy = np.random.rand(*shape)
             groundtruth = dat_npy
@@ -2083,6 +2085,7 @@ def test_broadcast():
             assert_almost_equal(grad_nd.asnumpy(), grad_groundtruth, rtol=1e-4)
         test_broadcasting_ele(sym_bcast_axis)
         test_broadcasting_ele(sym_bcast_to)
+        test_broadcasting_ele(sym_bcast_like)
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
This PR adds broadcast_lilke tensor operator which works similar to existing broadcast_to operator.
We followed the basic steps for adding new tensor operator and made necessary definitions on broadcast_reduce_op.h and its corresponding cc/cu files.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
N/A
