### PR TITLE
[MXNET-605] Hotfix for USE_BLAS=mkl compile bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,7 @@ endif
 ifeq ($(USE_MKLDNN), 1)
 	MKLDNNROOT = $(ROOTDIR)/3rdparty/mkldnn/install
 	MKLROOT = $(ROOTDIR)/3rdparty/mkldnn/install
-ifneq ($(USE_BLAS), mkl)
 	export USE_MKLML = 1
-endif
 endif
 
 include $(TPARTYDIR)/mshadow/make/mshadow.mk


### PR DESCRIPTION
## Description ##

This is a hotfix for #11090 which cause bug when building with USE_BLAS=mkl

@pengzhao-intel @szha Please take a review.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
