### PR TITLE
[Nightly Tests] Fix the rat-excludes for license checks post 1.2.1 release

### DIFF
--- a/tests/nightly/apache_rat_license_check/rat-excludes
+++ b/tests/nightly/apache_rat_license_check/rat-excludes
@@ -50,8 +50,10 @@ im2col.h
 pool.h
 README.rst
 dataset.cPickle
-
 rcnn/*
 image-classification/*
 rat-excludes
 apache-rat-tasks/*
+moderngpu/*
+deformable_im2col.cuh
+deformable_im2col.h


### PR DESCRIPTION
## Description ##
Apache RAT check license test is failing on nightly for 19 files. This PR modifies the rat-excludes file to include these 19 files. 
More details here: Issue #11453