### PR TITLE
[Nightly Tests] Fix regex which processes Apache RAT check output

### DIFF
--- a/tests/nightly/apache_rat_license_check/license_check.sh
+++ b/tests/nightly/apache_rat_license_check/license_check.sh
@@ -43,7 +43,7 @@ SOURCE="^0 Unknown Licenses"
 
 echo "-------Process The Output-------"
 
-if [[ "$OUTPUT" =~ "$SOURCE" ]]; then
+if [[ "$OUTPUT" =~ $SOURCE ]]; then
       echo "SUCCESS: There are no files with an Unknown License.";
 else
       echo "ERROR: RAT Check detected files with unknown licenses. Please fix and run test again!";


### PR DESCRIPTION
## Description ##
@marcoabreu 
I had recently updated the `license_check.sh` script to process the output correctly for an edge case (`20 Unknown Licenses` was being successfully parsed as `0 Unknown Licenses`)

However, this was not working as expected due to unnecessary quotes. This PR fixes this. 