### PR TITLE
Make MXNetError in Scala Not Private

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/Base.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Base.scala
@@ -152,4 +152,4 @@ private[mxnet] object Base {
   }
 }
 
-private[mxnet] class MXNetError(val err: String) extends Exception(err)
+class MXNetError(val err: String) extends Exception(err)


### PR DESCRIPTION
## Description ##
`MXNetError` is thrown in the event of a CUDA error (e.g., `Check failed: err == cudaSuccess ...`). While ideally we'd never encounter this, it happens sometimes, and we'd like to program our scala code to take the appropriate action (i.e., restart the process).

This PR proposes making the `MXNetError` class public, so that we can `catch` it in our calling code. Without it, we need to put our calling code in the `org.apache.mxnet` package, which we'd rather not do if we can avoid it.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage: (compiling now...)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Make `MXNetError` class public
