### PR TITLE
[MXNET-612] Optimize RAT setup and move it into PR stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,11 +163,21 @@ def python3_gpu_ut(docker_container_name) {
 }
 
 try {
-  stage("Sanity Check") {
-    node('mxnetlinux-cpu') {
-      ws('workspace/sanity') {
-        init_git()
-        docker_run('ubuntu_cpu', 'sanity_check', false)
+  stage('Sanity Check') {
+    parallel 'Lint': {
+      node('mxnetlinux-cpu') {
+        ws('workspace/sanity-lint') {
+          init_git()
+          docker_run('ubuntu_cpu', 'sanity_check', false)
+        }
+      }
+    },
+    'RAT License': {
+      node('mxnetlinux-cpu') {
+        ws('workspace/sanity-rat') {
+          init_git()
+          docker_run('ubuntu_rat', 'nightly_test_rat_check', false)
+        }
       }
     }
   }

--- a/ci/docker/Dockerfile.build.ubuntu_rat
+++ b/ci/docker/Dockerfile.build.ubuntu_rat
@@ -1,0 +1,35 @@
+# -*- mode: dockerfile -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Dockerfile to run the Apache RAT license check
+
+FROM ubuntu:16.04
+
+WORKDIR /work/deps
+
+COPY install/ubuntu_rat.sh /work/
+RUN /work/ubuntu_rat.sh
+
+ARG USER_ID=0
+COPY install/ubuntu_adduser.sh /work/
+RUN /work/ubuntu_adduser.sh
+
+COPY runtime_functions.sh /work/
+
+WORKDIR /work/mxnet
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib

--- a/ci/docker/install/ubuntu_rat.sh
+++ b/ci/docker/install/ubuntu_rat.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,8 +17,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+set -ex
 
-#mvn and svn are installed in the docker container via the nghtly test script
+echo "Install dependencies"
+apt-get update
+apt-get install -y subversion maven openjdk-8-jdk openjdk-8-jre
 
 echo "download RAT"
 svn co http://svn.apache.org/repos/asf/creadur/rat/trunk/ #>/dev/null
@@ -31,21 +34,3 @@ mvn -Dmaven.test.skip=true install #>/dev/null
 
 echo "build success, cd into target"
 cd apache-rat/target
-
-
-echo "-------Run Apache RAT check on MXNet-------"
-
-#Command has been run twice, once for the logs and once to store in the variable to parse.
-java -jar apache-rat-0.13-SNAPSHOT.jar -E /work/mxnet/tests/nightly/apache_rat_license_check/rat-excludes -d /work/mxnet
-OUTPUT="$(java -jar apache-rat-0.13-SNAPSHOT.jar -E /work/mxnet/tests/nightly/apache_rat_license_check/rat-excludes -d /work/mxnet)"
-SOURCE="^0 Unknown Licenses"
-
-
-echo "-------Process The Output-------"
-
-if [[ "$OUTPUT" =~ $SOURCE ]]; then
-      echo "SUCCESS: There are no files with an Unknown License.";
-else
-      echo "ERROR: RAT Check detected files with unknown licenses. Please fix and run test again!";
-      exit 1
-fi

--- a/ci/docker/install/ubuntu_rat.sh
+++ b/ci/docker/install/ubuntu_rat.sh
@@ -24,13 +24,10 @@ apt-get update
 apt-get install -y subversion maven openjdk-8-jdk openjdk-8-jre
 
 echo "download RAT"
-svn co http://svn.apache.org/repos/asf/creadur/rat/trunk/ #>/dev/null
+svn co http://svn.apache.org/repos/asf/creadur/rat/trunk/
 
 echo "cd into directory"
 cd trunk
 
 echo "mvn install"
-mvn -Dmaven.test.skip=true install #>/dev/null
-
-echo "build success, cd into target"
-cd apache-rat/target
+mvn -Dmaven.test.skip=true install

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -784,7 +784,25 @@ build_docs() {
 #Runs Apache RAT Check on MXNet Source for License Headers
 nightly_test_rat_check() {
     set -ex
-    ./tests/nightly/apache_rat_license_check/license_check.sh
+    pushd .
+    
+    cd /work/deps/trunk/apache-rat/target
+
+    #Command has been run twice, once for the logs and once to store in the variable to parse.
+    java -jar apache-rat-0.13-SNAPSHOT.jar -E /work/mxnet/tests/nightly/apache_rat_license_check/rat-excludes -d /work/mxnet
+    OUTPUT="$(java -jar apache-rat-0.13-SNAPSHOT.jar -E /work/mxnet/tests/nightly/apache_rat_license_check/rat-excludes -d /work/mxnet)"
+    SOURCE="^0 Unknown Licenses"
+
+
+    echo "-------Process The Output-------"
+
+    if [[ "$OUTPUT" =~ $SOURCE ]]; then
+        echo "SUCCESS: There are no files with an Unknown License.";
+    else
+        echo "ERROR: RAT Check detected files with unknown licenses. Please fix and run test again!";
+        exit 1
+    fi
+    popd
 }
 
 #Checks MXNet for Compilation Warnings

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -783,7 +783,7 @@ build_docs() {
 
 #Runs Apache RAT Check on MXNet Source for License Headers
 nightly_test_rat_check() {
-    set -ex
+    set -e
     pushd .
     
     cd /work/deps/trunk/apache-rat/target
@@ -791,16 +791,16 @@ nightly_test_rat_check() {
     # Use shell number 5 to duplicate the log output. It get sprinted and stored in $OUTPUT at the same time https://stackoverflow.com/a/12451419
     exec 5>&1
     OUTPUT=$(java -jar apache-rat-0.13-SNAPSHOT.jar -E /work/mxnet/tests/nightly/apache_rat_license_check/rat-excludes -d /work/mxnet|tee >(cat - >&5))
-    SOURCE="^0 Unknown Licenses"
+    ERROR_MESSAGE="Printing headers for text files without a valid license header"
 
 
     echo "-------Process The Output-------"
 
-    if [[ "$OUTPUT" =~ $SOURCE ]]; then
-        echo "SUCCESS: There are no files with an Unknown License.";
-    else
+    if [[ $OUTPUT =~ $ERROR_MESSAGE ]]; then
         echo "ERROR: RAT Check detected files with unknown licenses. Please fix and run test again!";
         exit 1
+    else
+        echo "SUCCESS: There are no files with an Unknown License.";
     fi
     popd
 }

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -788,9 +788,9 @@ nightly_test_rat_check() {
     
     cd /work/deps/trunk/apache-rat/target
 
-    #Command has been run twice, once for the logs and once to store in the variable to parse.
-    java -jar apache-rat-0.13-SNAPSHOT.jar -E /work/mxnet/tests/nightly/apache_rat_license_check/rat-excludes -d /work/mxnet
-    OUTPUT="$(java -jar apache-rat-0.13-SNAPSHOT.jar -E /work/mxnet/tests/nightly/apache_rat_license_check/rat-excludes -d /work/mxnet)"
+    # Use shell number 5 to duplicate the log output. It get sprinted and stored in $OUTPUT at the same time https://stackoverflow.com/a/12451419
+    exec 5>&1
+    OUTPUT=$(java -jar apache-rat-0.13-SNAPSHOT.jar -E /work/mxnet/tests/nightly/apache_rat_license_check/rat-excludes -d /work/mxnet|tee >(cat - >&5))
     SOURCE="^0 Unknown Licenses"
 
 

--- a/tests/nightly/Jenkinsfile
+++ b/tests/nightly/Jenkinsfile
@@ -73,7 +73,7 @@ try {
       node('mxnetlinux-cpu') {
         ws('workspace/nt-RATTest') {
           init_git()
-          docker_run('ubuntu_nightly_cpu', 'nightly_test_rat_check', false)
+          docker_run('ubuntu_rat', 'nightly_test_rat_check', false)
         }
       }
     },

--- a/tests/nightly/Jenkinsfile
+++ b/tests/nightly/Jenkinsfile
@@ -69,15 +69,7 @@ def docker_run(platform, function_name, use_nvidia, shared_mem = '500m') {
 
 try {
   stage('NightlyTests'){
-    parallel 'RATCheck: CPU': {
-      node('mxnetlinux-cpu') {
-        ws('workspace/nt-RATTest') {
-          init_git()
-          docker_run('ubuntu_rat', 'nightly_test_rat_check', false)
-        }
-      }
-    },
-    'CompilationWarnings: CPU': {
+    parallel 'CompilationWarnings: CPU': {
       node('mxnetlinux-cpu') {
         ws('workspace/nt-compilationTest') {
           init_git()

--- a/tests/nightly/apache_rat_license_check/README.md
+++ b/tests/nightly/apache_rat_license_check/README.md
@@ -12,6 +12,12 @@ The license check script called by the Jenkinsfile
 ### How to run the RAT check locally
 The following commands can be used to run a Apache RAT check locally - 
 
+Docker based 1-click-method:
+```
+ci/build.py --platform ubuntu_rat /work/runtime_functions.sh nightly_test_rat_check
+```
+
+Manual method:
 ```
 #install maven
 sudo apt-get install maven -y #>/dev/null


### PR DESCRIPTION
## Description ##
At the moment, Apache RAT is being installed during runtime. This is not time-efficient and will cause future problems if we move the RAT check into the sanity check.

Now, it will be part of a Dockerfile and thus cached. Execution time is about 20 seconds.

Also, we're moving the Apache RAT check to the PR pipeline instead of running it nightly.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Moved Apache RAT installation into Dockerfile
- Apache RAT check is now part of PR pipeline

## Comments ##

