### PR TITLE
Fix MXPredReshape in the c_predict_api

### DIFF
--- a/amalgamation/python/mxnet_predict.py
+++ b/amalgamation/python/mxnet_predict.py
@@ -51,17 +51,17 @@ def c_array(ctype, values):
 def _find_lib_path():
     """Find mxnet library."""
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    api_path = os.path.join(curr_path, '..', '..', 'lib')
-    dll_path = [curr_path, api_path]
-    dll_path = [os.path.join(p, 'libmxnet.so') for p in dll_path] + \
-        [os.path.join(p, 'libmxnet_predict.so') for p in dll_path] + \
-        [os.path.join(p, 'libmxnet.dll') for p in dll_path] + \
-        [os.path.join(p, 'libmxnet_predict.dll') for p in dll_path]
-    lib_path = [p for p in dll_path if os.path.exists(p) and os.path.isfile(p)]
-    if len(lib_path) == 0:
-        raise RuntimeError('Cannot find the files.\n' +
-                           'List of candidates:\n' + str('\n'.join(dll_path)))
-    return lib_path
+    amalgamation_lib_path = os.path.join(curr_path, '../../lib/libmxnet_predict.so')
+    if os.path.exists(amalgamation_lib_path) and os.path.isfile(amalgamation_lib_path):
+        lib_path = [amalgamation_lib_path]
+        return lib_path
+    else:
+        # from python/setup.py
+        libinfo_py = os.path.join(curr_path, '../../python/mxnet/libinfo.py')
+        libinfo = {'__file__': libinfo_py}
+        exec(compile(open(libinfo_py, "rb").read(), libinfo_py, 'exec'), libinfo, libinfo)
+        lib_path = libinfo['find_lib_path']()
+        return lib_path
 
 
 def _load_lib():

--- a/amalgamation/python/mxnet_predict.py
+++ b/amalgamation/python/mxnet_predict.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import
 import os
 import sys
 import ctypes
+import logging
 import numpy as np
 
 __all__ = ["Predictor", "load_ndarray_file"]
@@ -56,6 +57,7 @@ def _find_lib_path():
         lib_path = [amalgamation_lib_path]
         return lib_path
     else:
+        logging.info('Cannot find libmxnet_predict.so. Will search for MXNet library using libinfo.py then.')
         try:
             from mxnet.libinfo import find_lib_path
             lib_path = find_lib_path()
@@ -68,7 +70,7 @@ def _find_lib_path():
                 lib_path = libinfo['find_lib_path']()
                 return lib_path
             else:
-                raise RuntimeError('Cannot find libinfo.py at %s.\n' % libinfo_path)
+                raise RuntimeError('Cannot find libinfo.py at %s.' % libinfo_path)
 
 
 def _load_lib():

--- a/amalgamation/python/mxnet_predict.py
+++ b/amalgamation/python/mxnet_predict.py
@@ -159,6 +159,39 @@ class Predictor(object):
                 mx_uint(v.size)))
         _check_call(_LIB.MXPredForward(self.handle))
 
+    def reshape(self, input_shapes):
+        """Change the input shape of the predictor.
+
+        Parameters
+        ----------
+        input_shapes : dict of str to tuple
+            The new shape of input data.
+
+        Examples
+        --------
+        >>> predictor.reshape({'data':data_shape_tuple})
+        """
+        indptr = [0]
+        sdata = []
+        keys = []
+        for k, v  in input_shapes.items():
+            if not isinstance(v, tuple):
+                raise ValueError("Expect input_shapes to be dict str->tuple")
+            keys.append(c_str(k))
+            sdata.extend(v)
+            indptr.append(len(sdata))
+
+        new_handle = PredictorHandle()
+        _check_call(_LIB.MXPredReshape(
+            mx_uint(len(indptr) - 1),
+            c_array(ctypes.c_char_p, keys),
+            c_array(mx_uint, indptr),
+            c_array(mx_uint, sdata),
+            self.handle,
+            ctypes.byref(new_handle)))
+        _check_call(_LIB.MXPredFree(self.handle))
+        self.handle = new_handle
+
     def get_output(self, index):
         """Get the index-th output.
 

--- a/amalgamation/python/mxnet_predict.py
+++ b/amalgamation/python/mxnet_predict.py
@@ -51,10 +51,12 @@ def c_array(ctype, values):
 def _find_lib_path():
     """Find mxnet library."""
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    api_path = os.path.join(curr_path, '../../lib/')
+    api_path = os.path.join(curr_path, '..', '..', 'lib')
     dll_path = [curr_path, api_path]
     dll_path = [os.path.join(p, 'libmxnet.so') for p in dll_path] + \
-        [os.path.join(p, 'libmxnet_predict.so') for p in dll_path]
+        [os.path.join(p, 'libmxnet_predict.so') for p in dll_path] + \
+        [os.path.join(p, 'libmxnet.dll') for p in dll_path] + \
+        [os.path.join(p, 'libmxnet_predict.dll') for p in dll_path]
     lib_path = [p for p in dll_path if os.path.exists(p) and os.path.isfile(p)]
     if len(lib_path) == 0:
         raise RuntimeError('Cannot find the files.\n' +

--- a/amalgamation/python/mxnet_predict.py
+++ b/amalgamation/python/mxnet_predict.py
@@ -56,8 +56,13 @@ def _find_lib_path():
         lib_path = [amalgamation_lib_path]
         return lib_path
     else:
-        # from python/setup.py
-        libinfo_py = os.path.join(curr_path, '../../python/mxnet/libinfo.py')
+        libinfo_search_pathes = sys.path + [os.path.join(curr_path, '../../python/')]
+        libinfo_search_pathes = [os.path.join(p, 'mxnet/libinfo.py') for p in libinfo_search_pathes]
+        libinfo_pathes = [p for p in libinfo_search_pathes if os.path.exists(p) and os.path.isfile(p)]
+        if len(libinfo_pathes) == 0:
+            raise RuntimeError('Cannot find libinfo.py.\n' +
+                               'List of candidates:\n' + str('\n'.join(libinfo_search_pathes)))
+        libinfo_py = libinfo_pathes[0]
         libinfo = {'__file__': libinfo_py}
         exec(compile(open(libinfo_py, "rb").read(), libinfo_py, 'exec'), libinfo, libinfo)
         lib_path = libinfo['find_lib_path']()

--- a/amalgamation/python/mxnet_predict.py
+++ b/amalgamation/python/mxnet_predict.py
@@ -56,17 +56,19 @@ def _find_lib_path():
         lib_path = [amalgamation_lib_path]
         return lib_path
     else:
-        libinfo_search_pathes = sys.path + [os.path.join(curr_path, '../../python/')]
-        libinfo_search_pathes = [os.path.join(p, 'mxnet/libinfo.py') for p in libinfo_search_pathes]
-        libinfo_pathes = [p for p in libinfo_search_pathes if os.path.exists(p) and os.path.isfile(p)]
-        if len(libinfo_pathes) == 0:
-            raise RuntimeError('Cannot find libinfo.py.\n' +
-                               'List of candidates:\n' + str('\n'.join(libinfo_search_pathes)))
-        libinfo_py = libinfo_pathes[0]
-        libinfo = {'__file__': libinfo_py}
-        exec(compile(open(libinfo_py, "rb").read(), libinfo_py, 'exec'), libinfo, libinfo)
-        lib_path = libinfo['find_lib_path']()
-        return lib_path
+        try:
+            from mxnet.libinfo import find_lib_path
+            lib_path = find_lib_path()
+            return lib_path
+        except ImportError:
+            libinfo_path = os.path.join(curr_path, '../../python/mxnet/libinfo.py')
+            if os.path.exists(libinfo_path) and os.path.isfile(libinfo_path):
+                libinfo = {'__file__': libinfo_py}
+                exec(compile(open(libinfo_py, "rb").read(), libinfo_py, 'exec'), libinfo, libinfo)
+                lib_path = libinfo['find_lib_path']()
+                return lib_path
+            else:
+                raise RuntimeError('Cannot find libinfo.py at %s.\n' % libinfo_path)
 
 
 def _load_lib():

--- a/src/c_api/c_predict_api.cc
+++ b/src/c_api/c_predict_api.cc
@@ -140,6 +140,7 @@ int MXPredCreatePartialOut(const char* symbol_json_str,
     }
     sym = nnvm::Symbol::CreateGroup(out_syms);
   }
+  ret->sym = sym;
 
   // load the parameters
   std::unordered_map<std::string, NDArray> arg_params, aux_params;
@@ -214,6 +215,7 @@ int MXPredCreatePartialOut(const char* symbol_json_str,
   }
 
   Context ctx = Context::Create(static_cast<Context::DeviceType>(dev_type), dev_id);
+  ret->ctx = ctx;
 
   std::vector<NDArray> arg_arrays, aux_arrays;
   for (size_t i = 0; i < arg_shapes.size(); ++i) {
@@ -231,6 +233,7 @@ int MXPredCreatePartialOut(const char* symbol_json_str,
     aux_arrays.push_back(nd);
   }
   ret->arg_arrays = arg_arrays;
+  ret->aux_arrays = aux_arrays;
   // bind
   {
     std::map<std::string, Context> ctx_map;
@@ -309,7 +312,6 @@ int MXPredReshape(mx_uint num_input_nodes,
         << " shape has been changed, only allow to change the shape of input data.";
     }
   }
-  p->arg_arrays.clear();
 
   for (size_t i=0; i < aux_names.size(); ++i) {
     TShape newShape = aux_shapes[i];
@@ -319,7 +321,6 @@ int MXPredReshape(mx_uint num_input_nodes,
       << " shape has been changed, only allow to change the shape of input data.";
   }
   ret->aux_arrays = p->aux_arrays;
-  p->aux_arrays.clear();
 
   // bind
   {

--- a/tests/python/unittest/test_predictor.py
+++ b/tests/python/unittest/test_predictor.py
@@ -1,0 +1,88 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from __future__ import print_function
+import numpy as np
+import mxnet as mx
+import mxnet.ndarray as nd
+from mxnet import gluon
+from mxnet.test_utils import assert_almost_equal
+from common import setup_module, with_seed, teardown
+
+import sys, os
+curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+sys.path.append("../../../amalgamation/python/")
+from mxnet_predict import Predictor, load_ndarray_file
+
+@with_seed()
+def test_predictor():
+    prefix = 'test_predictor_simple_dense'
+    symbol_file = "%s-symbol.json" % prefix
+    param_file = "%s-0000.params" % prefix
+
+    # two inputs with different batch sizes
+    input1 = np.random.uniform(size=(1,3))
+    input2 = np.random.uniform(size=(3,3))
+
+    # define a simple model
+    block = gluon.nn.HybridSequential()
+    block.add(gluon.nn.Dense(7))
+    block.add(gluon.nn.Dense(3))
+    block.hybridize()
+    block.initialize()
+    out1 = block.forward(nd.array(input1))
+    out2 = block.forward(nd.array(input2))
+    block.export(prefix)
+
+    # create a predictor
+    predictor = Predictor(open(symbol_file, "r").read(),
+                      open(param_file, "rb").read(),
+                      {'data':input1.shape})
+
+    # forward and get output
+    predictor.forward(data=input1)
+    predictor_out1 = predictor.get_output(0)
+    assert_almost_equal(out1.asnumpy(), predictor_out1)
+
+    # reshape
+    predictor.reshape({'data':input2.shape})
+    predictor.forward(data=input2)
+    predictor_out2 = predictor.get_output(0)
+    assert_almost_equal(out2.asnumpy(), predictor_out2)
+
+    # destroy the predictor
+    del predictor
+
+@with_seed()
+def test_load_ndarray():
+
+    nd_file = 'test_predictor_load_ndarray.params'
+    a = nd.random.uniform(shape=(7, 3))
+    b = nd.random.uniform(shape=(7,))
+    nd_data = {'a':a, 'b':b}
+    nd.save(nd_file, nd_data)
+
+    # test load_ndarray_file
+    nd_load = load_ndarray_file(open(nd_file, "rb").read())
+    assert(set(nd_data.keys()) == set(nd_load.keys()))
+    for k in nd_data.keys():
+        assert_almost_equal(nd_data[k].asnumpy(), nd_load[k])
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule()

--- a/tests/python/unittest/test_predictor.py
+++ b/tests/python/unittest/test_predictor.py
@@ -69,7 +69,6 @@ def test_predictor():
 
 @with_seed()
 def test_load_ndarray():
-
     nd_file = 'test_predictor_load_ndarray.params'
     a = nd.random.uniform(shape=(7, 3))
     b = nd.random.uniform(shape=(7,))

--- a/tests/python/unittest/test_predictor.py
+++ b/tests/python/unittest/test_predictor.py
@@ -62,7 +62,7 @@ def test_predictor():
     predictor.reshape({'data':input2.shape})
     predictor.forward(data=input2)
     predictor_out2 = predictor.get_output(0)
-    assert_almost_equal(out2.asnumpy(), predictor_out2)
+    assert_almost_equal(out2.asnumpy(), predictor_out2, rtol=1e-5, atol=1e-6)
 
     # destroy the predictor
     del predictor
@@ -79,7 +79,7 @@ def test_load_ndarray():
     nd_load = load_ndarray_file(open(nd_file, "rb").read())
     assert(set(nd_data.keys()) == set(nd_load.keys()))
     for k in nd_data.keys():
-        assert_almost_equal(nd_data[k].asnumpy(), nd_load[k])
+        assert_almost_equal(nd_data[k].asnumpy(), nd_load[k], rtol=1e-5, atol=1e-6)
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_predictor.py
+++ b/tests/python/unittest/test_predictor.py
@@ -25,7 +25,8 @@ from common import setup_module, with_seed, teardown
 
 import sys, os
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-sys.path.append("../../../amalgamation/python/")
+amalgamation_path = os.path.join(curr_path, '..', '..', '..', 'amalgamation', 'python')
+sys.path.append(amalgamation_path)
 from mxnet_predict import Predictor, load_ndarray_file
 
 @with_seed()

--- a/tests/python/unittest/test_predictor.py
+++ b/tests/python/unittest/test_predictor.py
@@ -16,17 +16,17 @@
 # under the License.
 
 from __future__ import print_function
+import sys, os
+curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+sys.path.append(os.path.join(curr_path, "../../../amalgamation/python/"))
+from mxnet_predict import Predictor, load_ndarray_file
+
 import numpy as np
 import mxnet as mx
 import mxnet.ndarray as nd
 from mxnet import gluon
 from mxnet.test_utils import assert_almost_equal
 from common import setup_module, with_seed, teardown
-
-import sys, os
-curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-sys.path.append(os.path.join(curr_path, "../../../amalgamation/python/"))
-from mxnet_predict import Predictor, load_ndarray_file
 
 @with_seed()
 def test_predictor():

--- a/tests/python/unittest/test_predictor.py
+++ b/tests/python/unittest/test_predictor.py
@@ -56,7 +56,7 @@ def test_predictor():
     # forward and get output
     predictor.forward(data=input1)
     predictor_out1 = predictor.get_output(0)
-    assert_almost_equal(out1.asnumpy(), predictor_out1)
+    assert_almost_equal(out1.asnumpy(), predictor_out1, rtol=1e-5, atol=1e-6)
 
     # reshape
     predictor.reshape({'data':input2.shape})

--- a/tests/python/unittest/test_predictor.py
+++ b/tests/python/unittest/test_predictor.py
@@ -25,8 +25,7 @@ from common import setup_module, with_seed, teardown
 
 import sys, os
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-amalgamation_path = os.path.join(curr_path, '..', '..', '..', 'amalgamation', 'python')
-sys.path.append(amalgamation_path)
+sys.path.append(os.path.join(curr_path, "../../../amalgamation/python/"))
 from mxnet_predict import Predictor, load_ndarray_file
 
 @with_seed()


### PR DESCRIPTION
## Description ##

This PR fixes the `MXPredReshape` implementation in the c_predict_api. 
In https://github.com/apache/incubator-mxnet/pull/9984, `aux_arrays`, `sym`, and `ctx` members were introduced in `struct MXAPIPredictor` but not assigned in `MXPredCreatePartialOut`, 
thus the `PredictorHandle` created by `MXPredCreatePartialOut` cannot be reshaped in `MXPredReshape`.
This was pointed out in https://github.com/apache/incubator-mxnet/issues/10502, and likely also related to https://github.com/apache/incubator-mxnet/issues/11413, https://github.com/apache/incubator-mxnet/issues/10937.

Also removed the clean-up of the original handle,
```
  p->arg_arrays.clear();
  ...
  p->aux_arrays.clear();
```
in `MXPredReshape`, as it makes the original handle invalid. I think it would be better to leave the freedom to the user that whether they want to free the old handle after reshaping, or to free the reshaped new handle after use and revive the old one.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
