### PR TITLE
[MXNET-613] Upgrade jetpack to version 3.2.1

### DIFF
--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -50,11 +50,11 @@ COPY --from=cudabuilder /usr/local/cuda /usr/local/cuda
 ENV TARGET_ARCH aarch64
 ENV TARGET_OS linux
 
-# Install ARM depedencies based on Jetpack 3.2
-RUN JETPACK_DOWNLOAD_PREFIX=http://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/3.2GA/m892ki/JetPackL4T_32_b196/ && \
+# Install ARM depedencies based on Jetpack 3.2.1
+RUN JETPACK_DOWNLOAD_PREFIX=https://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/3.2.1/m8u2ki/JetPackL4T_321_b23 && \
     ARM_CUDA_INSTALLER_PACKAGE=cuda-repo-l4t-9-0-local_9.0.252-1_arm64.deb && \
-    ARM_CUDNN_INSTALLER_PACKAGE=libcudnn7_7.0.5.13-1+cuda9.0_arm64.deb && \
-    ARM_CUDNN_DEV_INSTALLER_PACKAGE=libcudnn7-dev_7.0.5.13-1+cuda9.0_arm64.deb && \
+    ARM_CUDNN_INSTALLER_PACKAGE=libcudnn7_7.0.5.15-1+cuda9.0_arm64.deb && \
+    ARM_CUDNN_DEV_INSTALLER_PACKAGE=libcudnn7-dev_7.0.5.15-1+cuda9.0_arm64.deb && \
     wget -nv $JETPACK_DOWNLOAD_PREFIX/$ARM_CUDA_INSTALLER_PACKAGE && \
     wget -nv $JETPACK_DOWNLOAD_PREFIX/$ARM_CUDNN_INSTALLER_PACKAGE && \
     wget -nv $JETPACK_DOWNLOAD_PREFIX/$ARM_CUDNN_DEV_INSTALLER_PACKAGE && \
@@ -62,7 +62,7 @@ RUN JETPACK_DOWNLOAD_PREFIX=http://developer.download.nvidia.com/devzone/devcent
     apt-key add /var/cuda-repo-9-0-local/7fa2af80.pub && \
     dpkg -i $ARM_CUDNN_INSTALLER_PACKAGE && \
     dpkg -i $ARM_CUDNN_DEV_INSTALLER_PACKAGE && \
-    apt update -y && apt install -y unzip cuda-libraries-dev-9-0 libcudnn7-dev
+    apt update -y || true && apt install -y cuda-libraries-dev-9-0 libcudnn7-dev
 
 ENV PATH $PATH:/usr/local/cuda/bin
 ENV NVCCFLAGS "-m64"

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -55,15 +55,15 @@ RUN JETPACK_DOWNLOAD_PREFIX=https://developer.download.nvidia.com/devzone/devcen
     ARM_CUDA_INSTALLER_PACKAGE=cuda-repo-l4t-9-0-local_9.0.252-1_arm64.deb && \
     ARM_CUDNN_INSTALLER_PACKAGE=libcudnn7_7.0.5.15-1+cuda9.0_arm64.deb && \
     ARM_CUDNN_DEV_INSTALLER_PACKAGE=libcudnn7-dev_7.0.5.15-1+cuda9.0_arm64.deb && \
+    dpkg --add-architecture arm64 && \
     wget -nv $JETPACK_DOWNLOAD_PREFIX/$ARM_CUDA_INSTALLER_PACKAGE && \
     wget -nv $JETPACK_DOWNLOAD_PREFIX/$ARM_CUDNN_INSTALLER_PACKAGE && \
     wget -nv $JETPACK_DOWNLOAD_PREFIX/$ARM_CUDNN_DEV_INSTALLER_PACKAGE && \
-    dpkg -i $ARM_CUDA_INSTALLER_PACKAGE && \
+    dpkg -i --force-architecture  $ARM_CUDA_INSTALLER_PACKAGE && \
     apt-key add /var/cuda-repo-9-0-local/7fa2af80.pub && \
-    dpkg -i $ARM_CUDNN_INSTALLER_PACKAGE && \
-    dpkg -i $ARM_CUDNN_DEV_INSTALLER_PACKAGE && \
+    dpkg -i --force-architecture  $ARM_CUDNN_INSTALLER_PACKAGE && \
+    dpkg -i --force-architecture  $ARM_CUDNN_DEV_INSTALLER_PACKAGE && \
     apt update -y || true && apt install -y cuda-libraries-dev-9-0 libcudnn7-dev
-
 ENV PATH $PATH:/usr/local/cuda/bin
 ENV NVCCFLAGS "-m64"
 ENV CUDA_ARCH "-gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62"

--- a/ci/docker/install/deb_ubuntu_ccache.sh
+++ b/ci/docker/install/deb_ubuntu_ccache.sh
@@ -23,7 +23,7 @@ set -ex
 
 pushd .
 
-apt update
+apt update || true
 apt install -y \
     libxslt1-dev \
     docbook-xsl \

--- a/ci/docker/install/ubuntu_arm.sh
+++ b/ci/docker/install/ubuntu_arm.sh
@@ -19,6 +19,6 @@
 
 set -ex
 
-apt update
+apt update || true
 apt install -y \
     unzip


### PR DESCRIPTION
## Description ##
Jetson builds are currently failing to install due to some missing dependencies.  We can fix the dependency issue and upgrade Jetpack to 3.2.1.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
