### PR TITLE
Fix InferStorage for sparse fallback in FullyConnected

### DIFF
--- a/src/operator/nn/fully_connected-inl.h
+++ b/src/operator/nn/fully_connected-inl.h
@@ -35,6 +35,7 @@
 #include "../operator_common.h"
 #include "../elemwise_op_common.h"
 #include "../linalg.h"
+#include "../../common/utils.h"
 
 namespace mxnet {
 namespace op {

--- a/src/operator/nn/fully_connected.cc
+++ b/src/operator/nn/fully_connected.cc
@@ -210,17 +210,21 @@ inline static bool BackwardFCStorageType(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(in_attrs->size(), 3U);
   CHECK_EQ(out_attrs->size(), out_expected);
 
-  DispatchMode wanted_mode;
-#if 0
+  bool dispatched = false;
   // TODO(zhengda) let's disable MKLDNN for FullyConnected for now.
   // It seems there is a bug.
-  if (dev_mask == mshadow::cpu::kDevMask)
-    *dispatch_mode = DispatchMode::kFComputeEx;
-  else
-#endif
-    wanted_mode = DispatchMode::kFCompute;
-  return storage_type_assign(out_attrs, mxnet::kDefaultStorage,
-                             dispatch_mode, wanted_mode);
+  if (!dispatched && common::ContainsOnlyStorage(*in_attrs, mxnet::kDefaultStorage)) {
+    storage_type_assign(out_attrs, mxnet::kDefaultStorage,
+                        dispatch_mode, DispatchMode::kFCompute);
+  }
+  if (!dispatched && common::ContainsStorageType(*in_attrs, mxnet::kRowSparseStorage)) {
+    dispatched = dispatch_fallback(out_attrs, dispatch_mode);
+  }
+  if (!dispatched) {
+    dispatched = storage_type_assign(out_attrs, mxnet::kDefaultStorage,
+                                     dispatch_mode, DispatchMode::kFCompute);
+  }
+  return dispatched;
 }
 
 DMLC_REGISTER_PARAMETER(FullyConnectedParam);

--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -22,7 +22,7 @@ import sys
 import os
 import numpy as np
 import mxnet as mx
-from mxnet.test_utils import assert_almost_equal
+from mxnet.test_utils import rand_ndarray, assert_almost_equal
 from mxnet import gluon
 from mxnet.gluon import nn
 from mxnet.test_utils import *
@@ -239,6 +239,26 @@ def test_batchnorm():
     stypes = ['row_sparse', 'default']
     for stype in stypes:
         check_batchnorm_training(stype)
+
+
+@with_seed()
+def test_fullyconnected():
+    def check_fullyconnected_training(stype):
+        data_shape = rand_shape_nd(2)
+        weight_shape = rand_shape_nd(2)
+        weight_shape = (weight_shape[0], data_shape[1])
+        for density in [1.0, 0.5, 0.0]:
+            x = rand_ndarray(shape=data_shape, stype=stype, density=density)
+            w = rand_ndarray(shape=weight_shape, stype=stype, density=density)
+            x_sym = mx.sym.Variable("data")
+            w_sym = mx.sym.Variable("weight")
+            sym = mx.sym.FullyConnected(data=x_sym, weight=w_sym, num_hidden=weight_shape[0], no_bias=True)
+            in_location = [x, w]
+            check_numeric_gradient(sym, in_location, numeric_eps=1e-3, rtol=1e-3, atol=5e-3)
+    stypes = ['row_sparse', 'default']
+    for stype in stypes:
+        check_fullyconnected_training(stype)
+
 
 if __name__ == '__main__':
     test_mkldnn_install()


### PR DESCRIPTION
## Description ##
#11448

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fix storage fallback in backward

## Comments ##
