### PR TITLE
updating installation info to have latest packages and more clarity

### DIFF
--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -76,10 +76,11 @@ Alternatively, you can use the table below to select the package that suits your
 
 
 #### pip Package Availability
+
 The following table presents the pip packages that are recommended for each version of MXNet.
 
-| | 1.2.1 | 1.1.0 | 1.0.0 | 0.12.1 | 0.11.0 |
-|-|-|-|-|-|
+| Package / MXNet Version | 1.2.1 | 1.1.0 | 1.0.0 | 0.12.1 | 0.11.0 |
+|-|-|-|-|-|-|
 | mxnet-cu92mkl | :white_check_mark: | :x: | :x: | :x: | :x: |
 | mxnet-cu92 | :white_check_mark: | :x: | :x: | :x: | :x: |
 | mxnet-cu90mkl | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |

--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -1,38 +1,189 @@
 # Installing MXNet on Ubuntu
 
-**NOTE:** For MXNet with Python installation, please refer to the [new install guide](http://mxnet.io/install/index.html).
+The following installation instructions are for installing MXNet on computers running **Ubuntu 12 to Ubuntu 16.04**. Support for later versions of Ubuntu is [not yet available](#contributions).
+<hr>
 
-MXNet currently supports Python, R, Julia, Scala, and Perl. For users of R on Ubuntu operating systems, MXNet provides a set of Git Bash scripts that installs all of the required MXNet dependencies and the MXNet library.
+## Contents
 
-The simple installation scripts set up MXNet for Python and R on computers running Ubuntu 12 or later. The scripts install MXNet in your home folder ```~/mxnet```.
+* [CUDA Dependencies](#cuda-dependencies)
+* [Quick Installation](#quick-installation)
+    * [Python](#install-mxnet-for-python)
+    * [pip Packages](#pip-package-availability)
+* [Standard Installation](#standard-installation)
+* [Installing Language Packages](#installing-language-packages-for-mxnet)
+    * [R](#install-the-mxnet-package-for-r)
+    * [Julia](#install-the-mxnet-package-for-julia)
+    * [Scala](#install-the-mxnet-package-for-scala)
+    * [Perl](#install-the-mxnet-package-for-perl)
+  * [Contributions](#contributions)
+  * [Next Steps](#next-steps)
 
-## Prepare environment for GPU Installation
+<hr>
 
-If you plan to build with GPU, you need to set up the environment for CUDA and CUDNN.
+## CUDA Dependencies
 
-First, download and install [CUDA 8 toolkit](https://developer.nvidia.com/cuda-toolkit).
+If you plan to build with GPU, you need to set up the environment for CUDA and cuDNN.
 
-Then download [cudnn 6](https://developer.nvidia.com/cudnn).
+First, download and install [CUDA toolkit](https://developer.nvidia.com/cuda-toolkit). CUDA 9.2 is recommended.
 
-Unzip the file and change to the cudnn root directory. Move the header and libraries to your local CUDA Toolkit folder:
+Then download [cuDNN 7.1.4](https://developer.nvidia.com/cudnn).
+
+Unzip the file and change to the cuDNN root directory. Move the header and libraries to your local CUDA Toolkit folder:
 
 ```bash
-    tar xvzf cudnn-8.0-linux-x64-v6.0.tgz
+    tar xvzf cudnn-9.2-linux-x64-v7.1
     sudo cp -P cuda/include/cudnn.h /usr/local/cuda/include
     sudo cp -P cuda/lib64/libcudnn* /usr/local/cuda/lib64
     sudo chmod a+r /usr/local/cuda/include/cudnn.h /usr/local/cuda/lib64/libcudnn*
     sudo ldconfig
 ```
 
-Finally, add configurations to config.mk file:
+<hr>
 
-```bash
-    cp make/config.mk .
-```
 
 ## Quick Installation
 
-### Install MXNet for R
+### Install MXNet for Python
+
+#### Dependencies
+
+The following scripts will install Ubuntu 16.04 dependencies for MXNet Python development.
+
+```bash
+wget https://raw.githubusercontent.com/apache/incubator-mxnet/master/ci/docker/install/ubuntu_core.sh
+wget https://raw.githubusercontent.com/apache/incubator-mxnet/master/ci/docker/install/ubuntu_python.sh
+sudo ./ubuntu_core.sh
+sudo ./ubuntu_python.sh
+```
+
+Using the latest MXNet with CUDA 9.2 package is recommended for the fastest training speeds with MXNet.
+
+**Recommended for training:**
+```bash
+pip install mxnet-cu92
+```
+
+**Recommended for inference:**
+```bash
+pip install mxnet-cu92mkl
+```
+
+Alternatively, you can use the table below to select the package that suits your purpose.
+
+| MXNet Version | Basic | CUDA | MKL | CUDA/MKL |
+|-|-|-|-|-|
+| Latest | mxnet | mxnet-cu92 | mxnet-mkl | mxnet-cu92mkl |
+
+
+#### pip Package Availability
+The following table presents the pip packages that are recommended for each version of MXNet.
+
+| | 1.2.1 | 1.1.0 | 1.0.0 | 0.12.1 | 0.11.0 |
+|-|-|-|-|-|
+| mxnet-cu92mkl | :white_check_mark: | :x: | :x: | :x: | :x: |
+| mxnet-cu92 | :white_check_mark: | :x: | :x: | :x: | :x: |
+| mxnet-cu90mkl | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
+| mxnet-cu90 | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
+| mxnet-cu80mkl | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| mxnet-cu80 | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| mxnet-mkl | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| mxnet | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+To install an older version of MXNet with one of the packages in the previous table add `==` with the version you require. For example for version 1.1.0 of MXNet with CUDA 8, you would use `pip install mxnet-cu80==1.1.0`.
+
+<hr>
+
+
+## Standard installation
+
+Installing MXNet is a two-step process:
+
+1. Build the shared library from the MXNet C++ source code.
+2. Install the supported language-specific packages for MXNet.
+
+**Note:** To change the compilation options for your build, edit the ```make/config.mk``` file prior to building MXNet. More information on this is mentioned in the different language package instructions.
+
+### Build the Shared Library
+
+On Ubuntu versions 13.10 or later, you need the following dependencies:
+
+**Step 1:** Install build tools and git.
+```bash
+    sudo apt-get update
+    sudo apt-get install -y build-essential git
+```
+
+**Step 2:** Install OpenBLAS.
+
+*MXNet* uses [BLAS](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms) library for accelerated numerical computations on CPU machine. There are several flavors of BLAS libraries - [OpenBLAS](http://www.openblas.net/), [ATLAS](http://math-atlas.sourceforge.net/) and [MKL](https://software.intel.com/en-us/intel-mkl). In this step we install OpenBLAS. You can choose to install ATLAS or MKL.
+
+```bash
+    sudo apt-get install -y libopenblas-dev
+```
+
+**Step 3:** Install OpenCV.
+
+*MXNet* uses [OpenCV](http://opencv.org/) for efficient image loading and augmentation operations.
+
+```bash
+    sudo apt-get install -y libopencv-dev
+```
+
+**Step 4:** Download MXNet sources and build MXNet core shared library.
+
+If building on CPU:
+
+```bash
+    git clone --recursive https://github.com/apache/incubator-mxnet.git
+    cd mxnet
+    make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas
+```
+
+If building on GPU:
+
+```bash
+    git clone --recursive https://github.com/apache/incubator-mxnet.git
+    cd mxnet
+    make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1
+```
+
+*Note* - USE_OPENCV and USE_BLAS are make file flags to set compilation options to use OpenCV and BLAS library. You can explore and use more compilation options in `make/config.mk`.
+
+Executing these commands creates a library called ```libmxnet.so```.
+
+Next, you may optionally install ```graphviz``` library that is used for visualizing network graphs you build on MXNet. You may also install [Jupyter Notebook](http://jupyter.readthedocs.io/) which is used for running MXNet tutorials and examples.
+
+```bash
+    sudo apt-get install -y python-pip
+    sudo pip install graphviz
+    sudo pip install jupyter
+```
+<hr>
+
+
+## Installing Language Packages for MXNet
+
+After you have installed the MXNet core library. You may install MXNet interface packages for the programming language of your choice:
+- [Scala](#install-the-mxnet-package-for-scala)
+- [R](#install-the-mxnet-package-for-r)
+- [Julia](#install-the-mxnet-package-for-julia)
+- [Perl](#install-the-mxnet-package-for-perl)
+
+
+### Install the MXNet Package for Scala
+
+To use the MXNet-Scala package, you can acquire the Maven package as a dependency.
+
+Further information is in the [MXNet-Scala Setup Instructions](./scala_setup.md).
+
+If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial](../tutorials/scala/mxnet_scala_on_intellij.md) instead.
+<hr>
+
+### Install the MXNet Package for R
+
+#### MXNet-R Dependencies
+
+For users of R on Ubuntu operating systems, MXNet provides a set of Git Bash scripts that installs all of the required MXNet dependencies and the MXNet library. The scripts install MXNet in your home folder ```~/mxnet```.
 
 MXNet requires R-version to be 3.2.0 and above. If you are running an earlier version of R, run below commands to update your R version, before running the installation script.
 
@@ -63,81 +214,6 @@ To install MXNet for R:
 ```
 The installation script to install MXNet for R can be found [here](https://raw.githubusercontent.com/dmlc/mxnet/master/setup-utils/install-mxnet-ubuntu-r.sh).
 
-## Standard installation
-
-Installing MXNet is a two-step process:
-
-1. Build the shared library from the MXNet C++ source code.
-2. Install the supported language-specific packages for MXNet.
-
-**Note:** To change the compilation options for your build, edit the ```make/config.mk``` file and submit a build request with the ```make``` command.
-
-### Build the Shared Library
-
-On Ubuntu versions 13.10 or later, you need the following dependencies:
-
-**Step 1** Install build tools and git.
-```bash
-    sudo apt-get update
-    sudo apt-get install -y build-essential git
-```
-
-**Step 2** Install OpenBLAS.
-
-*MXNet* uses [BLAS](https://en.wikipedia.org/wiki/Basic_Linear_Algebra_Subprograms) library for accelerated numerical computations on CPU machine. There are several flavors of BLAS libraries - [OpenBLAS](http://www.openblas.net/), [ATLAS](http://math-atlas.sourceforge.net/) and [MKL](https://software.intel.com/en-us/intel-mkl). In this step we install OpenBLAS. You can choose to install ATLAS or MKL.
-
-```bash
-    sudo apt-get install -y libopenblas-dev
-```
-
-**Step 3** Install OpenCV.
-
-*MXNet* uses [OpenCV](http://opencv.org/) for efficient image loading and augmentation operations.
-
-```bash
-    sudo apt-get install -y libopencv-dev
-```
-
-**Step 4** Download MXNet sources and build MXNet core shared library.
-
-If building on CPU:
-
-```bash
-    git clone --recursive https://github.com/dmlc/mxnet
-    cd mxnet
-    make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas
-```
-
-If building on GPU:
-
-```bash
-    git clone --recursive https://github.com/dmlc/mxnet
-    cd mxnet
-    make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1
-```
-
-*Note* - USE_OPENCV and USE_BLAS are make file flags to set compilation options to use OpenCV and BLAS library. You can explore and use more compilation options in `make/config.mk`.
-
-Executing these commands creates a library called ```libmxnet.so```.
-
-Next, we install ```graphviz``` library that we use for visualizing network graphs you build on MXNet. We will also install [Jupyter Notebook](http://jupyter.readthedocs.io/) used for running MXNet tutorials and examples.
-
-```bash
-    sudo apt-get install -y python-pip
-    sudo pip install graphviz
-    sudo pip install Jupyter
-```
-
-&nbsp;
-
-We have installed MXNet core library. Next, we will install MXNet interface package for programming language of your choice:
-- [R](#install-the-mxnet-package-for-r)
-- [Julia](#install-the-mxnet-package-for-julia)
-- [Scala](#install-the-mxnet-package-for-scala)
-- [Perl](#install-the-mxnet-package-for-perl)
-
-### Install the MXNet Package for R
-
 Run the following commands to install the MXNet dependencies and build the MXNet R package.
 
 ```r
@@ -157,6 +233,8 @@ These commands create the MXNet R package as a tar.gz file that you can install 
 ```bash
     R CMD INSTALL mxnet_current_r.tar.gz
 ```
+<hr>
+
 
 ### Install the MXNet Package for Julia
 
@@ -179,59 +257,9 @@ You might want to add this command to your ```~/.bashrc``` file. If you do, you 
 ```
 
 For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](http://dmlc.ml/MXNet.jl/latest/user-guide/install/).
+<hr>
 
-### Install the MXNet Package for Scala
-There are two ways to install the MXNet package for Scala:
 
-* Use the prebuilt binary package
-
-* Build the library from source code
-
-#### Use the Prebuilt Binary Package
-For Linux users, MXNet provides prebuilt binary packages that support computers with either GPU or CPU processors. To download and build these packages using ```Maven```, change the ```artifactId``` in the following Maven dependency to match your architecture:
-
-```HTML
-<dependency>
-  <groupId>ml.dmlc.mxnet</groupId>
-  <artifactId>mxnet-full_<system architecture></artifactId>
-  <version>0.1.1</version>
-</dependency>
-```
-
-For example, to download and build the 64-bit CPU-only version for Linux, use:
-
-```HTML
-<dependency>
-  <groupId>ml.dmlc.mxnet</groupId>
-  <artifactId>mxnet-full_2.10-linux-x86_64-cpu</artifactId>
-  <version>0.1.1</version>
-</dependency>
-```
-
-If your native environment differs slightly from the assembly package, for example, if you use the openblas package instead of the atlas package, it's better to use the mxnet-core package and put the compiled Java native library in your load path:
-
-```HTML
-<dependency>
-  <groupId>ml.dmlc.mxnet</groupId>
-  <artifactId>mxnet-core_2.10</artifactId>
-  <version>0.1.1</version>
-</dependency>
-```
-
-#### Build the Library from Source Code
-Before you build MXNet for Scala from source code, you must complete [building the shared library](#build-the-shared-library). After you build the shared library, run the following command from the MXNet source root directory to build the MXNet Scala package:
-
-```bash
-    make scalapkg
-```
-
-This command creates the JAR files for the assembly, core, and example modules. It also creates the native library in the ```native/{your-architecture}/target directory```, which you can use to cooperate with the core module.
-
-To install the MXNet Scala package into your local Maven repository, run the following command from the MXNet source root directory:
-
-```bash
-    make scalainstall
-```
 ### Install the MXNet Package for Perl
 
 Before you build MXNet for Perl from source code, you must complete [building the shared library](#build-the-shared-library). After you build the shared library, run the following command from the MXNet source root directory to build the MXNet Perl package:
@@ -256,11 +284,14 @@ Before you build MXNet for Perl from source code, you must complete [building th
     perl Makefile.PL INSTALL_BASE=${HOME}/perl5
     make install
 ```
+<hr>
 
-**Note - ** You are more than welcome to contribute easy installation scripts for other operating systems and programming languages, see [community page](http://mxnet.io/community/index.html) for contributors guidelines.
+## Contributions
+
+You are more than welcome to contribute easy installation scripts for other operating systems and programming languages. See the [community contributions page](../community/contribute.html) for further information.
 
 ## Next Steps
 
-* [Tutorials](http://mxnet.io/tutorials/index.html)
-* [How To](http://mxnet.io/faq/index.html)
-* [Architecture](http://mxnet.io/architecture/index.html)
+* [Tutorials](../tutorials/index.html)
+* [How To](../faq/index.html)
+* [Architecture](../architecture/index.html)

--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -1,6 +1,6 @@
 # Installing MXNet on Ubuntu
 
-The following installation instructions are for installing MXNet on computers running **Ubuntu 12 to Ubuntu 16.04**. Support for later versions of Ubuntu is [not yet available](#contributions).
+The following installation instructions are for installing MXNet on computers running **Ubuntu 16.04**. Support for later versions of Ubuntu is [not yet available](#contributions).
 <hr>
 
 ## Contents

--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -79,16 +79,20 @@ Alternatively, you can use the table below to select the package that suits your
 
 The following table presents the pip packages that are recommended for each version of MXNet.
 
+<!-- Must find sol'n for both github and website; image in the meantime
 | Package / MXNet Version | 1.2.1 | 1.1.0 | 1.0.0 | 0.12.1 | 0.11.0 |
 |-|-|-|-|-|-|
-| mxnet-cu92mkl | :white_check_mark: | :x: | :x: | :x: | :x: |
-| mxnet-cu92 | :white_check_mark: | :x: | :x: | :x: | :x: |
+| mxnet-cu92mkl | :white_check_mark:<i class="fas fa-check"></i> | :x: | :x: | :x: | :x: |
+| mxnet-cu92 | :white_check_mark:<i class="fas fa-check"></i> | :x: | :x: | :x: | :x: |
 | mxnet-cu90mkl | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
 | mxnet-cu90 | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: |
 | mxnet-cu80mkl | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | mxnet-cu80 | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | mxnet-mkl | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | mxnet | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+-->
+
+![pip package table](https://user-images.githubusercontent.com/5974205/42119928-362ad5ba-7bc7-11e8-97de-dba8fd099c90.png)
 
 To install an older version of MXNet with one of the packages in the previous table add `==` with the version you require. For example for version 1.1.0 of MXNet with CUDA 8, you would use `pip install mxnet-cu80==1.1.0`.
 
@@ -296,3 +300,6 @@ You are more than welcome to contribute easy installation scripts for other oper
 * [Tutorials](../tutorials/index.html)
 * [How To](../faq/index.html)
 * [Architecture](../architecture/index.html)
+
+
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">


### PR DESCRIPTION
## Description ##

There hasn't been an update on installation instructions for Ubuntu in a while. Many new packages are out and not referenced, so I'm trying to fix that.

- Fixed a lot of old info in the Ubuntu instructions.
- Added a table of different pip packages and what versions they support.
- Added recommended installations.
- Added scripts for quick installation.
- Reorganized sections for clarity.
- Untangled some R instructions - these were sort of inter-mingled with the standard instructions.

## Comments ##
- I didn't mark mkl as experimental. LMK if I should change that.
- I made an assumption that I don't want to show CUDA 9.1 packages... since NVIDIA isn't even offering it...
- I assume that CUDA 9.2 and cuDNN 7.1.4 is what is desired.
- I assume that `pip install mxnet-cu92mkl` is recommended for inference.
- I assume that `pip install mxnet-cu92` is recommended for training.
- Once any comments settle down on this PR, I can apply these kind of changes on macOS.
- I didn't try to vet the standard install instructions; this section might need updating, and I would like to see it simplified.