### PR TITLE
[MXNET-615] Fix for flaky test_svmoutput_with_type

### DIFF
--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1288,7 +1288,7 @@ def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
         if n not in aux_params:
             aux_params[n] = 0
     for exe in exe_list:
-            for name, arr in exe.arg_dict.items():
+        for name, arr in exe.arg_dict.items():
             arr[:] = arg_params[name]
         for name, arr in exe.aux_dict.items():
             arr[:] = aux_params[name]

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1206,7 +1206,7 @@ def check_speed(sym, location=None, ctx=None, N=20, grad_req=None, typ="whole",
 
 def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
                       arg_params=None, aux_params=None, tol=None,
-                      raise_on_err=True, ground_truth=None, equal_nan=False):
+                      raise_on_err=True, ground_truth=None, equal_nan=False, use_uniform=False):
     """Check symbol gives the same output for different running context
 
     Parameters
@@ -1219,7 +1219,10 @@ def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
         Standard deviation of the inner normal distribution. Used in initialization.
     grad_req : str or list of str or dict of str to str
         Gradient requirement.
-
+    use_unifrom: bool 
+        Optional, When flag set to true, 
+        random input data generated follows uniform distribution,
+        not normal distribution 
     Examples
     --------
     >>> # create the symbol
@@ -1277,7 +1280,10 @@ def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
     aux_params = {} if aux_params is None else aux_params
     for n, arr in exe_list[0].arg_dict.items():
         if n not in arg_params:
-            arg_params[n] = np.random.normal(size=arr.shape, scale=scale)
+            if use_uniform:
+                arg_params[n] = np.random.uniform(low=-0.92, high=0.92, size=arr.shape)
+            else:
+	        arg_params[n] = np.random.normal(size=arr.shape, scale=scale)
     for n, arr in exe_list[0].aux_dict.items():
         if n not in aux_params:
             aux_params[n] = 0

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1219,10 +1219,10 @@ def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
         Standard deviation of the inner normal distribution. Used in initialization.
     grad_req : str or list of str or dict of str to str
         Gradient requirement.
-    use_unifrom: bool 
-        Optional, When flag set to true, 
+    use_unifrom: bool
+        Optional, When flag set to true,
         random input data generated follows uniform distribution,
-        not normal distribution 
+        not normal distribution
     Examples
     --------
     >>> # create the symbol
@@ -1283,7 +1283,7 @@ def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
             if use_uniform:
                 arg_params[n] = np.random.uniform(low=-0.92, high=0.92, size=arr.shape)
             else:
-	        arg_params[n] = np.random.normal(size=arr.shape, scale=scale)
+	            arg_params[n] = np.random.normal(size=arr.shape, scale=scale)
     for n, arr in exe_list[0].aux_dict.items():
         if n not in aux_params:
             aux_params[n] = 0

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1283,12 +1283,12 @@ def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
             if use_uniform:
                 arg_params[n] = np.random.uniform(low=-0.92, high=0.92, size=arr.shape)
             else:
-	            arg_params[n] = np.random.normal(size=arr.shape, scale=scale)
+                arg_params[n] = np.random.normal(size=arr.shape, scale=scale)
     for n, arr in exe_list[0].aux_dict.items():
         if n not in aux_params:
             aux_params[n] = 0
     for exe in exe_list:
-        for name, arr in exe.arg_dict.items():
+            for name, arr in exe.arg_dict.items():
             arr[:] = arg_params[name]
         for name, arr in exe.aux_dict.items():
             arr[:] = aux_params[name]

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1242,7 +1242,7 @@ def test_svmoutput_with_type():
                 {'ctx': mx.cpu(0), 'svmoutput_data': (20, 10), 'type_dict': {'svmoutput_data': np.float64}},
                 {'ctx': mx.cpu(0), 'svmoutput_data': (20, 10), 'type_dict': {'svmoutput_data': np.float32}},
                 {'ctx': mx.cpu(0), 'svmoutput_data': (20, 10), 'type_dict': {'svmoutput_data': np.float16}}]
-    check_consistency(sym, ctx_list, use_uniform=True )
+    check_consistency(sym, ctx_list, use_uniform=True)
 
 
 @with_seed()

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1233,7 +1233,6 @@ def test_embedding_with_type():
     test_embedding_helper(data_types, weight_types, 0, 5)
 
 
-@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/8288")
 @with_seed()
 def test_svmoutput_with_type():
     sym = mx.sym.SVMOutput(name='svmoutput', use_linear=True)
@@ -1243,7 +1242,7 @@ def test_svmoutput_with_type():
                 {'ctx': mx.cpu(0), 'svmoutput_data': (20, 10), 'type_dict': {'svmoutput_data': np.float64}},
                 {'ctx': mx.cpu(0), 'svmoutput_data': (20, 10), 'type_dict': {'svmoutput_data': np.float32}},
                 {'ctx': mx.cpu(0), 'svmoutput_data': (20, 10), 'type_dict': {'svmoutput_data': np.float16}}]
-    check_consistency(sym, ctx_list)
+    check_consistency(sym, ctx_list, use_uniform=True )
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
Fixes flaky test #8288 
@eric-haibin-lin  
passing uniform distributed input rather than normal distributed inputs
@nswamy  

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
