### PR TITLE
Add path_suffixes for finding cudnn.lib

### DIFF
--- a/cmake/FirstClassLangCuda.cmake
+++ b/cmake/FirstClassLangCuda.cmake
@@ -38,6 +38,7 @@ function(detect_cuDNN)
 
   find_library(CUDNN_LIBRARY NAMES libcudnn.so cudnn.lib # libcudnn_static.a
                              PATHS ${CUDNN_ROOT} $ENV{CUDNN_ROOT} ${CUDNN_INCLUDE}
+                             PATH_SUFFIXES lib lib/x64
                              DOC "Path to cuDNN library.")
 
   if(CUDNN_INCLUDE AND CUDNN_LIBRARY)


### PR DESCRIPTION
On Windows, the directory structure layout for CUDNN is:

```
/t/incubator-mxnet ❯❯❯ unzip -l /tmp/cudnn-9.0-windows10-x64-v7.1.zip
Archive:  /tmp/cudnn-9.0-windows10-x64-v7.1.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
   122719  04-28-2018 08:01   cuda/include/cudnn.h
    38963  05-01-2018 11:50   cuda/NVIDIA_SLA_cuDNN_Support.txt
    49070  05-05-2018 08:48   cuda/lib/x64/cudnn.lib
331319808  05-05-2018 08:48   cuda/bin/cudnn64_7.dll
---------                     -------
331530560                     4 files
```

When `CUDA_ROOT` is set to `/path/to/extracted/cudnn/cuda`, the `find_library()` call failed, because it couldn't find `cudnn.lib` 

The `find_library()` call tries to find `cudnn.lib` in `%CUDA_ROOT%` and `%CUDA_ROOT%/include` but doesn't look in `%CUDA_ROOT%/lib` or `%CUDA_ROOT%/lib/x64`. This patch fixes the problem by specifying the path suffixes to include `lib` and `lib/x64`.