### PR TITLE
Manually check node existence in CachedOp

### DIFF
--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -330,8 +330,7 @@ void SetBackwardInputEid(const std::vector<uint32_t>& bwd_in_dep,
     auto ograd = ograd_entries[i];
     if (idx.exist(ograd.node.get())) {
       bwd_input_eid->push_back(idx.entry_id(ograd));
-    }
-    else {
+    } else {
       bwd_input_eid->push_back(std::numeric_limits<uint32_t>::max());
     }
   }

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -327,8 +327,13 @@ void SetBackwardInputEid(const std::vector<uint32_t>& bwd_in_dep,
                          const nnvm::IndexedGraph& idx,
                          std::vector<uint32_t> *bwd_input_eid) {
   for (const auto& i : bwd_ograd_dep) {
-    auto eid = idx.entry_id(ograd_entries[i]);
-    bwd_input_eid->push_back(eid);
+    auto ograd = ograd_entries[i];
+    if (idx.exist(ograd.node.get())) {
+      bwd_input_eid->push_back(idx.entry_id(ograd));
+    }
+    else {
+      bwd_input_eid->push_back(std::numeric_limits<uint32_t>::max());
+    }
   }
   for (const auto& i : bwd_in_dep) {
     auto eid = idx.entry_id(idx.input_nodes()[i], 0);
@@ -381,7 +386,11 @@ bool CachedOp::SetBackwardGraph(
     for (size_t i = num_forward_nodes; i < idx.num_nodes(); ++i) {
       for (const auto& j : idx[i].inputs) ++ref_count[idx.entry_id(j)];
     }
-    for (size_t i = 0; i < inputs.size(); ++i) ++ref_count[info->bwd_input_eid[i]];
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      if (info->bwd_input_eid[i] != std::numeric_limits<uint32_t>::max()) {
+        ++ref_count[info->bwd_input_eid[i]];
+      }
+    }
     for (const auto& i : idx.outputs()) ++ref_count[idx.entry_id(i)];
     g.attrs["backward_ref_count"] = std::make_shared<dmlc::any>(std::move(ref_count));
   }
@@ -394,6 +403,9 @@ bool CachedOp::SetBackwardGraph(
   stypes.resize(idx.num_node_entries(), -1);
 
   for (size_t i = 0; i < inputs.size(); ++i) {
+    if (info->bwd_input_eid[i] == std::numeric_limits<uint32_t>::max()) {
+      continue;
+    }
     shapes[info->bwd_input_eid[i]] = inputs[i]->shape();
     dtypes[info->bwd_input_eid[i]] = inputs[i]->dtype();
     stypes[info->bwd_input_eid[i]] = inputs[i]->storage_type();
@@ -896,6 +908,9 @@ void CachedOp::DynamicBackward(
   arrays.reserve(buff.size());
   for (size_t i = 0; i < buff.size(); ++i) arrays.push_back(&buff[i]);
   for (size_t i = 0; i < inputs.size(); ++i) {
+    if (runtime.info.bwd_input_eid[i] == std::numeric_limits<uint32_t>::max()) {
+      continue;
+    }
     arrays[runtime.info.bwd_input_eid[i]] = inputs[i];
   }
   for (size_t i = 0, j = num_forward_outputs; i < reqs.size(); ++i) {
@@ -971,6 +986,9 @@ void CachedOp::StaticBackward(
   auto arrays = state.arrays;
   for (size_t i = 0; i < state.info.bwd_input_eid.size(); ++i) {
     auto eid = state.info.bwd_input_eid[i];
+    if (eid == std::numeric_limits<uint32_t>::max()) {
+      continue;
+    }
     if (state.dynamic_entries[eid]) arrays[eid] = inputs[i];
   }
 
@@ -1104,6 +1122,9 @@ bool CachedOp::BackwardStorageType(const nnvm::NodeAttrs& attrs,
   // Prepare these to before invoking infer storage on the subgraph
   for (size_t i = 0; i < out_attrs->size(); i++) {
     const auto eid = idx.entry_id(outputs[i + num_forward_outputs]);
+    if (bwd_input_eid[i] == std::numeric_limits<uint32_t>::max()) {
+      continue;
+    }
     stypes[eid] = out_attrs->at(i);
   }
   exec::DevMaskVector dev_masks(idx.num_nodes(), dev_mask);

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1414,6 +1414,22 @@ def test_share_inputs_outputs():
             assert_almost_equal(out_grad.asnumpy(), d2.grad.asnumpy())
 
 
+def test_grad_graph_change():
+    class Model(mx.gluon.HybridBlock):
+        def hybrid_forward(self, F, array, index):
+            row = array.take(index)
+            return row, index
+    array = mx.nd.arange(3)
+    index = mx.nd.array([2])
+    array.attach_grad()
+    # index.attach_grad()
+    model = Model()
+    model.hybridize(inline_limit=0)
+    with mx.autograd.record(train_mode=True):
+        row, _ = model(array, index)
+    row.backward()
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1422,7 +1422,6 @@ def test_grad_graph_change():
     array = mx.nd.arange(3)
     index = mx.nd.array([2])
     array.attach_grad()
-    # index.attach_grad()
     model = Model()
     model.hybridize(inline_limit=0)
     with mx.autograd.record(train_mode=True):


### PR DESCRIPTION
## Description ##
Constructing a weird `CachedOp` directly in C++, in rare cases might lead to rebuilding `full_graph` in `CachedOp` without updating `bwd_ograd_dep_`. This potentially causes crash when `OpReqType` of one of `outputs` of `grad_graph_` is `OpReqType::kNullOp`. This PR enhances the capability of `CachedOp` to handle this case.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Manually check node existence in CachedOp

## Comments ##
- This change is fully backward compatible.