### PR TITLE
[MXNET-622] Add timeout for BLC

### DIFF
--- a/tests/nightly/broken_link_checker_test/JenkinsfileForBLC
+++ b/tests/nightly/broken_link_checker_test/JenkinsfileForBLC
@@ -53,14 +53,16 @@ try {
     parallel 'BrokenLinkChecker: CPU': {
       node('mxnetlinux-cpu') {
         ws('workspace/brokenLinkChecker') {
-		  try {
-          	init_git()
-		  	sh 'aws s3 cp s3://mxnet-ci-prod-slave-data/url_list.txt  ./tests/nightly/broken_link_checker_test/url_list.txt'
-		  	docker_run('ubuntu_blc', 'broken_link_checker', false)
-		  } finally {
-		  	sh "echo Storing the new url_list.txt to S3 bucket" 
-		   	sh 'aws s3 cp ./tests/nightly/broken_link_checker_test/url_list.txt s3://mxnet-ci-prod-slave-data/url_list.txt'
-		  }
+          timeout(time: 60, unit: 'MINUTES') {
+            try {
+              init_git()
+              sh 'aws s3 cp s3://mxnet-ci-prod-slave-data/url_list.txt  ./tests/nightly/broken_link_checker_test/url_list.txt'
+              docker_run('ubuntu_blc', 'broken_link_checker', false)
+            } finally {
+              sh "echo Storing the new url_list.txt to S3 bucket" 
+              sh 'aws s3 cp ./tests/nightly/broken_link_checker_test/url_list.txt s3://mxnet-ci-prod-slave-data/url_list.txt'
+            }
+          }
         }
       }
     }

--- a/tests/nightly/broken_link_checker_test/JenkinsfileForBLC
+++ b/tests/nightly/broken_link_checker_test/JenkinsfileForBLC
@@ -53,7 +53,7 @@ try {
     parallel 'BrokenLinkChecker: CPU': {
       node('mxnetlinux-cpu') {
         ws('workspace/brokenLinkChecker') {
-          timeout(time: 60, unit: 'MINUTES') {
+          timeout(time: 40, unit: 'MINUTES') {
             try {
               init_git()
               sh 'aws s3 cp s3://mxnet-ci-prod-slave-data/url_list.txt  ./tests/nightly/broken_link_checker_test/url_list.txt'


### PR DESCRIPTION
## Description ##
At http://jenkins.mxnet-ci.amazon-ml.com/job/Broken_Link_Checker_Pipeline/51/, the broken link checker gets caught in an infinite loop but does not get terminated. This PR adds a timeout.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Add timeout to BLC

## Comments ##
- This will leave a Docker Zombie behind, but @KellenSunderland is working on a fix for that. In general, I don't expect any bad impact from this process staying alive as a zombie.