### PR TITLE
[MXNET-392] Support for a bunch of unary functions for csr matrices

### DIFF
--- a/docs/api/python/ndarray/sparse.md
+++ b/docs/api/python/ndarray/sparse.md
@@ -160,12 +160,63 @@ We summarize the interface for each class in the following sections.
     CSRNDArray.norm
 ```
 
+### Array rounding
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    CSRNDArray.round
+    CSRNDArray.rint
+    CSRNDArray.fix
+    CSRNDArray.floor
+    CSRNDArray.ceil
+    CSRNDArray.trunc
+```
+
+### Trigonometric functions
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    CSRNDArray.sin
+    CSRNDArray.tan
+    CSRNDArray.arcsin
+    CSRNDArray.arctan
+    CSRNDArray.degrees
+    CSRNDArray.radians
+```
+
+### Hyperbolic functions
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    CSRNDArray.sinh
+    CSRNDArray.tanh
+    CSRNDArray.arcsinh
+    CSRNDArray.arctanh
+```
+
+### Exponents and logarithms
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    CSRNDArray.expm1
+    CSRNDArray.log1p
+```
+
 ### Powers
 
 ```eval_rst
 .. autosummary::
     :nosignatures:
 
+    CSRNDArray.sqrt
     CSRNDArray.square
 ```
 
@@ -187,6 +238,16 @@ We summarize the interface for each class in the following sections.
     CSRNDArray.__getitem__
     CSRNDArray.__setitem__
     CSRNDArray.slice
+```
+
+### Miscellaneous
+
+```eval_rst
+.. autosummary::
+    :nosignatures:
+
+    CSRNDArray.clip
+    CSRNDArray.sign
 ```
 
 ### Lazy evaluation
@@ -520,7 +581,7 @@ We summarize the interface for each class in the following sections.
 ```eval_rst
 
 .. autoclass:: mxnet.ndarray.sparse.CSRNDArray
-    :members: shape, context, dtype, stype, data, indices, indptr, copy, copyto, as_in_context, asscipy, asnumpy, asscalar, astype, tostype, slice, wait_to_read, zeros_like, __neg__, sum, mean, norm, square, __getitem__, __setitem__, check_format
+    :members: shape, context, dtype, stype, data, indices, indptr, copy, copyto, as_in_context, asscipy, asnumpy, asscalar, astype, tostype, slice, wait_to_read, zeros_like, round, rint, fix, floor, ceil, trunc, sin, tan, arcsin, arctan, degrees, radians, sinh, tanh, arcsinh, arctanh, expm1, log1p, sqrt, square, __neg__, sum, mean, norm, square, __getitem__, __setitem__, check_format, clip, sign
 
 .. autoclass:: mxnet.ndarray.sparse.RowSparseNDArray
     :members: shape, context, dtype, stype, data, indices, copy, copyto, as_in_context, asnumpy, asscalar, astype, tostype, wait_to_read, zeros_like, round, rint, fix, floor, ceil, trunc, sin, tan, arcsin, arctan, degrees, radians, sinh, tanh, arcsinh, arctanh, expm1, log1p, sqrt, square, __negative__, norm, __getitem__, __setitem__, check_format, retain, clip, sign

--- a/docs/api/python/ndarray/sparse.md
+++ b/docs/api/python/ndarray/sparse.md
@@ -246,6 +246,7 @@ We summarize the interface for each class in the following sections.
 .. autosummary::
     :nosignatures:
 
+    CSRNDArray.abs
     CSRNDArray.clip
     CSRNDArray.sign
 ```
@@ -403,6 +404,7 @@ We summarize the interface for each class in the following sections.
 .. autosummary::
     :nosignatures:
 
+    RowSparseNDArray.abs
     RowSparseNDArray.clip
     RowSparseNDArray.sign
 ```
@@ -581,10 +583,10 @@ We summarize the interface for each class in the following sections.
 ```eval_rst
 
 .. autoclass:: mxnet.ndarray.sparse.CSRNDArray
-    :members: shape, context, dtype, stype, data, indices, indptr, copy, copyto, as_in_context, asscipy, asnumpy, asscalar, astype, tostype, slice, wait_to_read, zeros_like, round, rint, fix, floor, ceil, trunc, sin, tan, arcsin, arctan, degrees, radians, sinh, tanh, arcsinh, arctanh, expm1, log1p, sqrt, square, __neg__, sum, mean, norm, square, __getitem__, __setitem__, check_format, clip, sign
+    :members: shape, context, dtype, stype, data, indices, indptr, copy, copyto, as_in_context, asscipy, asnumpy, asscalar, astype, tostype, slice, wait_to_read, zeros_like, round, rint, fix, floor, ceil, trunc, sin, tan, arcsin, arctan, degrees, radians, sinh, tanh, arcsinh, arctanh, expm1, log1p, sqrt, square, __neg__, sum, mean, norm, square, __getitem__, __setitem__, check_format, abs, clip, sign
 
 .. autoclass:: mxnet.ndarray.sparse.RowSparseNDArray
-    :members: shape, context, dtype, stype, data, indices, copy, copyto, as_in_context, asnumpy, asscalar, astype, tostype, wait_to_read, zeros_like, round, rint, fix, floor, ceil, trunc, sin, tan, arcsin, arctan, degrees, radians, sinh, tanh, arcsinh, arctanh, expm1, log1p, sqrt, square, __negative__, norm, __getitem__, __setitem__, check_format, retain, clip, sign
+    :members: shape, context, dtype, stype, data, indices, copy, copyto, as_in_context, asnumpy, asscalar, astype, tostype, wait_to_read, zeros_like, round, rint, fix, floor, ceil, trunc, sin, tan, arcsin, arctan, degrees, radians, sinh, tanh, arcsinh, arctanh, expm1, log1p, sqrt, square, __negative__, norm, __getitem__, __setitem__, check_format, retain, abs, clip, sign
 
 .. automodule:: mxnet.ndarray.sparse
     :members:

--- a/src/operator/tensor/elemwise_unary_op.h
+++ b/src/operator/tensor/elemwise_unary_op.h
@@ -492,6 +492,7 @@ void HardSigmoidBackward(const nnvm::NodeAttrs& attrs,
 /*! \brief Unary compute, with FComputeEx for csr and rsp available  */
 #define MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(__name$, __xpu$, __kernel$)                     \
   MXNET_OPERATOR_REGISTER_UNARY(__name$)                                                           \
+  MXNET_ADD_SPARSE_OP_ALIAS(__name$)                                                               \
   .set_attr<FInferStorageType>("FInferStorageType", ElemwiseStorageType<1, 1, false, true, true>)  \
   .set_attr<FCompute>("FCompute<" #__xpu$ ">", UnaryOp::Compute<__xpu$, __kernel$>)                \
   .set_attr<FComputeEx>("FComputeEx<" #__xpu$ ">", UnaryOp::ComputeEx<__xpu$, __kernel$>)
@@ -499,6 +500,7 @@ void HardSigmoidBackward(const nnvm::NodeAttrs& attrs,
 /*! \brief Unary compute, with FComputeEx for rsp available  */
 #define MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(__name$, __xpu$, __kernel$)                         \
   MXNET_OPERATOR_REGISTER_UNARY(__name$)                                                           \
+  MXNET_ADD_SPARSE_OP_ALIAS(__name$)                                                               \
   .set_attr<FInferStorageType>("FInferStorageType", ElemwiseStorageType<1, 1, false, true, false>) \
   .set_attr<FCompute>("FCompute<" #__xpu$ ">", UnaryOp::Compute<__xpu$, __kernel$>)                \
   .set_attr<FComputeEx>("FComputeEx<" #__xpu$ ">", UnaryOp::ComputeEx<__xpu$, __kernel$>)

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -704,7 +704,7 @@ The storage type of ``trunc`` output depends upon the input storage type:
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
 
 // fix
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(fix, cpu, mshadow_op::fix)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(fix, cpu, mshadow_op::fix)
 MXNET_ADD_SPARSE_OP_ALIAS(fix)
 .describe(R"code(Returns element-wise rounded value to the nearest \
 integer towards zero of the input.
@@ -717,6 +717,7 @@ The storage type of ``fix`` output depends upon the input storage type:
 
    - fix(default) = default
    - fix(row_sparse) = row_sparse
+   - fix(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -70,7 +70,7 @@ static bool IdentityAttrLikeRhsStorageType(const nnvm::NodeAttrs& attrs,
 }
 
 // relu
-MXNET_OPERATOR_REGISTER_UNARY(relu)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(relu, cpu, mshadow_op::relu)
 MXNET_ADD_SPARSE_OP_ALIAS(relu)
 .describe(R"code(Computes rectified linear.
 
@@ -81,11 +81,9 @@ The storage type of ``relu`` output depends upon the input storage type:
 
    - relu(default) = default
    - relu(row_sparse) = row_sparse
+   - relu(csr) = csr
 
 )code" ADD_FILELINE)
-.set_attr<FInferStorageType>("FInferStorageType", ElemwiseStorageType<1, 1, false, true, false>)
-.set_attr<FCompute>("FCompute<cpu>", UnaryOp::Compute<cpu, mshadow_op::relu>)
-.set_attr<FComputeEx>("FComputeEx<cpu>", UnaryOp::ComputeEx<cpu, mshadow_op::relu>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseOut{"_backward_relu"});
 
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU(_backward_relu,

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -683,7 +683,7 @@ The storage type of ``floor`` output depends upon the input storage type:
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
 
 // trunc
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(trunc, cpu, mshadow_op::trunc)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(trunc, cpu, mshadow_op::trunc)
 MXNET_ADD_SPARSE_OP_ALIAS(trunc)
 .describe(R"code(Return the element-wise truncated value of the input.
 
@@ -698,6 +698,7 @@ The storage type of ``trunc`` output depends upon the input storage type:
 
    - trunc(default) = default
    - trunc(row_sparse) = row_sparse
+   - trunc(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -917,7 +917,7 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log1p,
                                                   unary_bwd<mshadow_op::log1p_grad>);
 
 // expm1
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(expm1, cpu, mshadow_op::expm1)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(expm1, cpu, mshadow_op::expm1)
 MXNET_ADD_SPARSE_OP_ALIAS(expm1)
 .describe(R"code(Returns ``exp(x) - 1`` computed element-wise on the input.
 
@@ -927,6 +927,7 @@ The storage type of ``expm1`` output depends upon the input storage type:
 
    - expm1(default) = default
    - expm1(row_sparse) = row_sparse
+   - expm1(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_expm1"});

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -583,7 +583,7 @@ The storage type of ``abs`` output depends upon the input storage type:
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU(_backward_abs, unary_bwd<mshadow_op::sign>);
 
 // sign
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(sign, cpu, mshadow_op::sign)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(sign, cpu, mshadow_op::sign)
 MXNET_ADD_SPARSE_OP_ALIAS(sign)
 .describe(R"code(Returns element-wise sign of the input.
 
@@ -595,6 +595,7 @@ The storage type of ``sign`` output depends upon the input storage type:
 
    - sign(default) = default
    - sign(row_sparse) = row_sparse
+   - sign(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_sign"});

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -747,7 +747,7 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU(_backward_square,
                                                unary_bwd<mshadow_op::square_grad>);
 
 // sqrt
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(sqrt, cpu, mshadow_op::square_root)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(sqrt, cpu, mshadow_op::square_root)
 MXNET_ADD_SPARSE_OP_ALIAS(sqrt)
 .describe(R"code(Returns element-wise square-root value of the input.
 
@@ -762,6 +762,7 @@ The storage type of ``sqrt`` output depends upon the input storage type:
 
    - sqrt(default) = default
    - sqrt(row_sparse) = row_sparse
+   - sqrt(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseOut{"_backward_sqrt"});

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -663,7 +663,7 @@ The storage type of ``ceil`` output depends upon the input storage type:
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
 
 // floor
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(floor, cpu, mshadow_op::floor)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(floor, cpu, mshadow_op::floor)
 MXNET_ADD_SPARSE_OP_ALIAS(floor)
 .describe(R"code(Returns element-wise floor of the input.
 
@@ -677,6 +677,7 @@ The storage type of ``floor`` output depends upon the input storage type:
 
    - floor(default) = default
    - floor(row_sparse) = row_sparse
+   - floor(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -897,7 +897,7 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log2,
                                                   unary_bwd<mshadow_op::log2_grad>);
 
 // log1p
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(log1p, cpu, mshadow_op::log1p)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(log1p, cpu, mshadow_op::log1p)
 MXNET_ADD_SPARSE_OP_ALIAS(log1p)
 .describe(R"code(Returns element-wise ``log(1 + x)`` value of the input.
 
@@ -908,6 +908,7 @@ The storage type of ``log1p`` output depends upon the input storage type:
 
    - log1p(default) = default
    - log1p(row_sparse) = row_sparse
+   - log1p(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_log1p"});

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -71,7 +71,6 @@ static bool IdentityAttrLikeRhsStorageType(const nnvm::NodeAttrs& attrs,
 
 // relu
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(relu, cpu, mshadow_op::relu)
-MXNET_ADD_SPARSE_OP_ALIAS(relu)
 .describe(R"code(Computes rectified linear.
 
 .. math::
@@ -533,7 +532,6 @@ NNVM_REGISTER_OP(_backward_cast)
 
 // negative
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(negative, cpu, mshadow_op::negation)
-MXNET_ADD_SPARSE_OP_ALIAS(negative)
 .describe(R"code(Numerical negative of the argument, element-wise.
 
 The storage type of ``negative`` output depends upon the input storage type:
@@ -564,8 +562,7 @@ MXNET_OPERATOR_REGISTER_BINARY(_backward_reciprocal)
   ElemwiseBinaryOp::Compute<cpu, unary_bwd<mshadow_op::reciprocal_grad> >);
 
 // abs
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(abs, cpu, mshadow_op::abs)
-MXNET_ADD_SPARSE_OP_ALIAS(abs)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(abs, cpu, mshadow_op::abs)
 .describe(R"code(Returns element-wise absolute value of the input.
 
 Example::
@@ -576,6 +573,7 @@ The storage type of ``abs`` output depends upon the input storage type:
 
    - abs(default) = default
    - abs(row_sparse) = row_sparse
+   - abs(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_abs"});
@@ -584,7 +582,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU(_backward_abs, unary_bwd<mshadow_
 
 // sign
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(sign, cpu, mshadow_op::sign)
-MXNET_ADD_SPARSE_OP_ALIAS(sign)
 .describe(R"code(Returns element-wise sign of the input.
 
 Example::
@@ -604,7 +601,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU(_backward_sign, unary_bwd<mshadow
 
 // round
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(round, cpu, mshadow_op::round)
-MXNET_ADD_SPARSE_OP_ALIAS(round)
 .describe(R"code(Returns element-wise rounded value to the nearest integer of the input.
 
 Example::
@@ -622,7 +618,6 @@ The storage type of ``round`` output depends upon the input storage type:
 
 // rint
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(rint, cpu, mshadow_op::rint)
-MXNET_ADD_SPARSE_OP_ALIAS(rint)
 .describe(R"code(Returns element-wise rounded value to the nearest integer of the input.
 
 .. note::
@@ -644,7 +639,6 @@ The storage type of ``rint`` output depends upon the input storage type:
 
 // ceil
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(ceil, cpu, mshadow_op::ceil)
-MXNET_ADD_SPARSE_OP_ALIAS(ceil)
 .describe(R"code(Returns element-wise ceiling of the input.
 
 The ceil of the scalar x is the smallest integer i, such that i >= x.
@@ -664,7 +658,6 @@ The storage type of ``ceil`` output depends upon the input storage type:
 
 // floor
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(floor, cpu, mshadow_op::floor)
-MXNET_ADD_SPARSE_OP_ALIAS(floor)
 .describe(R"code(Returns element-wise floor of the input.
 
 The floor of the scalar x is the largest integer i, such that i <= x.
@@ -684,7 +677,6 @@ The storage type of ``floor`` output depends upon the input storage type:
 
 // trunc
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(trunc, cpu, mshadow_op::trunc)
-MXNET_ADD_SPARSE_OP_ALIAS(trunc)
 .describe(R"code(Return the element-wise truncated value of the input.
 
 The truncated value of the scalar x is the nearest integer i which is closer to
@@ -705,7 +697,6 @@ The storage type of ``trunc`` output depends upon the input storage type:
 
 // fix
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(fix, cpu, mshadow_op::fix)
-MXNET_ADD_SPARSE_OP_ALIAS(fix)
 .describe(R"code(Returns element-wise rounded value to the nearest \
 integer towards zero of the input.
 
@@ -724,7 +715,6 @@ The storage type of ``fix`` output depends upon the input storage type:
 
 // square
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(square, cpu, mshadow_op::square)
-MXNET_ADD_SPARSE_OP_ALIAS(square)
 .describe(R"code(Returns element-wise squared value of the input.
 
 .. math::
@@ -748,7 +738,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU(_backward_square,
 
 // sqrt
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(sqrt, cpu, mshadow_op::square_root)
-MXNET_ADD_SPARSE_OP_ALIAS(sqrt)
 .describe(R"code(Returns element-wise square-root value of the input.
 
 .. math::
@@ -792,7 +781,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(
 
 // cbrt
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(cbrt, cpu, mshadow_op::cube_root)
-MXNET_ADD_SPARSE_OP_ALIAS(cbrt)
 .describe(R"code(Returns element-wise cube-root value of the input.
 
 .. math::
@@ -898,7 +886,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log2,
 
 // log1p
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(log1p, cpu, mshadow_op::log1p)
-MXNET_ADD_SPARSE_OP_ALIAS(log1p)
 .describe(R"code(Returns element-wise ``log(1 + x)`` value of the input.
 
 This function is more accurate than ``log(1 + x)``  for small ``x`` so that
@@ -918,7 +905,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log1p,
 
 // expm1
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(expm1, cpu, mshadow_op::expm1)
-MXNET_ADD_SPARSE_OP_ALIAS(expm1)
 .describe(R"code(Returns ``exp(x) - 1`` computed element-wise on the input.
 
 This function provides greater precision than ``exp(x) - 1`` for small values of ``x``.

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -643,7 +643,7 @@ The storage type of ``rint`` output depends upon the input storage type:
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
 
 // ceil
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(ceil, cpu, mshadow_op::ceil)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(ceil, cpu, mshadow_op::ceil)
 MXNET_ADD_SPARSE_OP_ALIAS(ceil)
 .describe(R"code(Returns element-wise ceiling of the input.
 
@@ -657,6 +657,7 @@ The storage type of ``ceil`` output depends upon the input storage type:
 
    - ceil(default) = default
    - ceil(row_sparse) = row_sparse
+   - ceil(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -791,7 +791,8 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(
   _backward_rsqrt, unary_bwd<mshadow_op::reciprocal_square_root_grad>);
 
 // cbrt
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(cbrt, cpu, mshadow_op::cube_root)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(cbrt, cpu, mshadow_op::cube_root)
+MXNET_ADD_SPARSE_OP_ALIAS(cbrt)
 .describe(R"code(Returns element-wise cube-root value of the input.
 
 .. math::
@@ -800,6 +801,12 @@ MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(cbrt, cpu, mshadow_op::cube_root)
 Example::
 
    cbrt([1, 8, -125]) = [1, 2, -5]
+
+The storage type of ``cbrt`` output depends upon the input storage type:
+
+   - cbrt(default) = default
+   - cbrt(row_sparse) = row_sparse
+   - cbrt(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseOut{"_backward_cbrt"});

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -603,7 +603,7 @@ The storage type of ``sign`` output depends upon the input storage type:
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU(_backward_sign, unary_bwd<mshadow_op::sign_grad>);
 
 // round
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(round, cpu, mshadow_op::round)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(round, cpu, mshadow_op::round)
 MXNET_ADD_SPARSE_OP_ALIAS(round)
 .describe(R"code(Returns element-wise rounded value to the nearest integer of the input.
 
@@ -615,12 +615,13 @@ The storage type of ``round`` output depends upon the input storage type:
 
   - round(default) = default
   - round(row_sparse) = row_sparse
+  - round(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
 
 // rint
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(rint, cpu, mshadow_op::rint)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(rint, cpu, mshadow_op::rint)
 MXNET_ADD_SPARSE_OP_ALIAS(rint)
 .describe(R"code(Returns element-wise rounded value to the nearest integer of the input.
 
@@ -636,6 +637,7 @@ The storage type of ``rint`` output depends upon the input storage type:
 
    - rint(default) = default
    - rint(row_sparse) = row_sparse
+   - rint(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);

--- a/src/operator/tensor/elemwise_unary_op_trig.cc
+++ b/src/operator/tensor/elemwise_unary_op_trig.cc
@@ -277,7 +277,7 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_arccosh,
                                                   unary_bwd<mshadow_op::arccosh_grad>);
 
 // arctanh
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(arctanh, cpu, mshadow_op::arctanh)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(arctanh, cpu, mshadow_op::arctanh)
 MXNET_ADD_SPARSE_OP_ALIAS(arctanh)
 .describe(R"code(Returns the element-wise inverse hyperbolic tangent of the input array, \
 computed element-wise.
@@ -286,6 +286,7 @@ The storage type of ``arctanh`` output depends upon the input storage type:
 
    - arctanh(default) = default
    - arctanh(row_sparse) = row_sparse
+   - arctanh(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_arctanh" });

--- a/src/operator/tensor/elemwise_unary_op_trig.cc
+++ b/src/operator/tensor/elemwise_unary_op_trig.cc
@@ -67,7 +67,7 @@ The storage type of ``cos`` output is always dense
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU(_backward_cos, unary_bwd<mshadow_op::cos_grad>);
 
 // tan
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(tan, cpu, mshadow_op::tan)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(tan, cpu, mshadow_op::tan)
 MXNET_ADD_SPARSE_OP_ALIAS(tan)
 .describe(R"code(Computes the element-wise tangent of the input array.
 
@@ -80,6 +80,7 @@ The storage type of ``tan`` output depends upon the input storage type:
 
    - tan(default) = default
    - tan(row_sparse) = row_sparse
+   - tan(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseOut{ "_backward_tan" });

--- a/src/operator/tensor/elemwise_unary_op_trig.cc
+++ b/src/operator/tensor/elemwise_unary_op_trig.cc
@@ -130,7 +130,7 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_arccos,
                                                   unary_bwd<mshadow_op::arccos_grad>);
 
 // arctan
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(arctan, cpu, mshadow_op::arctan)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(arctan, cpu, mshadow_op::arctan)
 MXNET_ADD_SPARSE_OP_ALIAS(arctan)
 .describe(R"code(Returns element-wise inverse tangent of the input array.
 
@@ -143,6 +143,7 @@ The storage type of ``arctan`` output depends upon the input storage type:
 
    - arctan(default) = default
    - arctan(row_sparse) = row_sparse
+   - arctan(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_arctan" });

--- a/src/operator/tensor/elemwise_unary_op_trig.cc
+++ b/src/operator/tensor/elemwise_unary_op_trig.cc
@@ -192,7 +192,7 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_radians,
                                                   unary_bwd<mshadow_op::radians_grad>);
 
 // sinh
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(sinh, cpu, mshadow_op::sinh)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(sinh, cpu, mshadow_op::sinh)
 MXNET_ADD_SPARSE_OP_ALIAS(sinh)
 .describe(R"code(Returns the hyperbolic sine of the input array, computed element-wise.
 
@@ -203,6 +203,7 @@ The storage type of ``sinh`` output depends upon the input storage type:
 
    - sinh(default) = default
    - sinh(row_sparse) = row_sparse
+   - sinh(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_sinh" });

--- a/src/operator/tensor/elemwise_unary_op_trig.cc
+++ b/src/operator/tensor/elemwise_unary_op_trig.cc
@@ -30,7 +30,6 @@ namespace op {
 
 // sin
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(sin, cpu, mshadow_op::sin)
-MXNET_ADD_SPARSE_OP_ALIAS(sin)
 .describe(R"code(Computes the element-wise sine of the input array.
 
 The input should be in radians (:math:`2\pi` rad equals 360 degrees).
@@ -68,7 +67,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU(_backward_cos, unary_bwd<mshadow_
 
 // tan
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(tan, cpu, mshadow_op::tan)
-MXNET_ADD_SPARSE_OP_ALIAS(tan)
 .describe(R"code(Computes the element-wise tangent of the input array.
 
 The input should be in radians (:math:`2\pi` rad equals 360 degrees).
@@ -89,7 +87,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_tan, unary_bwd<mshad
 
 // arcsin
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(arcsin, cpu, mshadow_op::arcsin)
-MXNET_ADD_SPARSE_OP_ALIAS(arcsin)
 .describe(R"code(Returns element-wise inverse sine of the input array.
 
 The input should be in the range `[-1, 1]`.
@@ -131,7 +128,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_arccos,
 
 // arctan
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(arctan, cpu, mshadow_op::arctan)
-MXNET_ADD_SPARSE_OP_ALIAS(arctan)
 .describe(R"code(Returns element-wise inverse tangent of the input array.
 
 The output is in the closed interval :math:`[-\pi/2, \pi/2]`
@@ -153,7 +149,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_arctan,
 
 // degrees
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(degrees, cpu, mshadow_op::degrees)
-MXNET_ADD_SPARSE_OP_ALIAS(degrees)
 .describe(R"code(Converts each element of the input array from radians to degrees.
 
 .. math::
@@ -173,7 +168,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_degrees,
 
 // radians
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(radians, cpu, mshadow_op::radians)
-MXNET_ADD_SPARSE_OP_ALIAS(radians)
 .describe(R"code(Converts each element of the input array from degrees to radians.
 
 .. math::
@@ -193,7 +187,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_radians,
 
 // sinh
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(sinh, cpu, mshadow_op::sinh)
-MXNET_ADD_SPARSE_OP_ALIAS(sinh)
 .describe(R"code(Returns the hyperbolic sine of the input array, computed element-wise.
 
 .. math::
@@ -227,7 +220,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU(_backward_cosh, unary_bwd<mshadow
 
 // tanh
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(tanh, cpu, mshadow_op::tanh)
-MXNET_ADD_SPARSE_OP_ALIAS(tanh)
 .describe(R"code(Returns the hyperbolic tangent of the input array, computed element-wise.
 
 .. math::
@@ -246,7 +238,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_tanh, unary_bwd<msha
 
 // arcsinh
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(arcsinh, cpu, mshadow_op::arcsinh)
-MXNET_ADD_SPARSE_OP_ALIAS(arcsinh)
 .describe(R"code(Returns the element-wise inverse hyperbolic sine of the input array, \
 computed element-wise.
 
@@ -278,7 +269,6 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_arccosh,
 
 // arctanh
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(arctanh, cpu, mshadow_op::arctanh)
-MXNET_ADD_SPARSE_OP_ALIAS(arctanh)
 .describe(R"code(Returns the element-wise inverse hyperbolic tangent of the input array, \
 computed element-wise.
 

--- a/src/operator/tensor/elemwise_unary_op_trig.cc
+++ b/src/operator/tensor/elemwise_unary_op_trig.cc
@@ -172,7 +172,7 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_degrees,
                                                   unary_bwd<mshadow_op::degrees_grad>);
 
 // radians
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(radians, cpu, mshadow_op::radians)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(radians, cpu, mshadow_op::radians)
 MXNET_ADD_SPARSE_OP_ALIAS(radians)
 .describe(R"code(Converts each element of the input array from degrees to radians.
 
@@ -183,6 +183,7 @@ The storage type of ``radians`` output depends upon the input storage type:
 
    - radians(default) = default
    - radians(row_sparse) = row_sparse
+   - radians(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_radians" });

--- a/src/operator/tensor/elemwise_unary_op_trig.cc
+++ b/src/operator/tensor/elemwise_unary_op_trig.cc
@@ -152,7 +152,7 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_arctan,
                                                   unary_bwd<mshadow_op::arctan_grad>);
 
 // degrees
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(degrees, cpu, mshadow_op::degrees)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(degrees, cpu, mshadow_op::degrees)
 MXNET_ADD_SPARSE_OP_ALIAS(degrees)
 .describe(R"code(Converts each element of the input array from radians to degrees.
 
@@ -163,6 +163,7 @@ The storage type of ``degrees`` output depends upon the input storage type:
 
    - degrees(default) = default
    - degrees(row_sparse) = row_sparse
+   - degrees(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_degrees" });

--- a/src/operator/tensor/elemwise_unary_op_trig.cc
+++ b/src/operator/tensor/elemwise_unary_op_trig.cc
@@ -226,7 +226,7 @@ The storage type of ``cosh`` output is always dense
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU(_backward_cosh, unary_bwd<mshadow_op::cosh_grad>);
 
 // tanh
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(tanh, cpu, mshadow_op::tanh)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(tanh, cpu, mshadow_op::tanh)
 MXNET_ADD_SPARSE_OP_ALIAS(tanh)
 .describe(R"code(Returns the hyperbolic tangent of the input array, computed element-wise.
 
@@ -237,6 +237,7 @@ The storage type of ``tanh`` output depends upon the input storage type:
 
    - tanh(default) = default
    - tanh(row_sparse) = row_sparse
+   - tanh(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseOut{ "_backward_tanh" });

--- a/src/operator/tensor/elemwise_unary_op_trig.cc
+++ b/src/operator/tensor/elemwise_unary_op_trig.cc
@@ -245,7 +245,7 @@ The storage type of ``tanh`` output depends upon the input storage type:
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_tanh, unary_bwd<mshadow_op::tanh_grad>);
 
 // arcsinh
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(arcsinh, cpu, mshadow_op::arcsinh)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(arcsinh, cpu, mshadow_op::arcsinh)
 MXNET_ADD_SPARSE_OP_ALIAS(arcsinh)
 .describe(R"code(Returns the element-wise inverse hyperbolic sine of the input array, \
 computed element-wise.
@@ -254,6 +254,7 @@ The storage type of ``arcsinh`` output depends upon the input storage type:
 
    - arcsinh(default) = default
    - arcsinh(row_sparse) = row_sparse
+   - arcsinh(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_arcsinh" });

--- a/src/operator/tensor/elemwise_unary_op_trig.cc
+++ b/src/operator/tensor/elemwise_unary_op_trig.cc
@@ -29,7 +29,7 @@ namespace mxnet {
 namespace op {
 
 // sin
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(sin, cpu, mshadow_op::sin)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(sin, cpu, mshadow_op::sin)
 MXNET_ADD_SPARSE_OP_ALIAS(sin)
 .describe(R"code(Computes the element-wise sine of the input array.
 
@@ -42,6 +42,7 @@ The storage type of ``sin`` output depends upon the input storage type:
 
    - sin(default) = default
    - sin(row_sparse) = row_sparse
+   - sin(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_sin" });

--- a/src/operator/tensor/elemwise_unary_op_trig.cc
+++ b/src/operator/tensor/elemwise_unary_op_trig.cc
@@ -88,7 +88,7 @@ The storage type of ``tan`` output depends upon the input storage type:
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_tan, unary_bwd<mshadow_op::tan_grad>);
 
 // arcsin
-MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP(arcsin, cpu, mshadow_op::arcsin)
+MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(arcsin, cpu, mshadow_op::arcsin)
 MXNET_ADD_SPARSE_OP_ALIAS(arcsin)
 .describe(R"code(Returns element-wise inverse sine of the input array.
 
@@ -102,6 +102,7 @@ The storage type of ``arcsin`` output depends upon the input storage type:
 
    - arcsin(default) = default
    - arcsin(row_sparse) = row_sparse
+   - arcsin(csr) = csr
 
 )code" ADD_FILELINE)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{ "_backward_arcsin" });

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -856,17 +856,16 @@ def test_sparse_nd_fluent():
             else:
                 assert almost_equal(regular.asnumpy(), fluent.asnumpy(), equal_nan=equal_nan)
 
-    common_func = ['zeros_like', 'square']
-    rsp_func = ['round', 'rint', 'fix', 'floor', 'ceil', 'trunc',
-                'abs', 'sign', 'sin', 'degrees', 'radians', 'expm1']
-    for func in common_func:
+    all_funcs = ['zeros_like', 'square', 'round', 'rint', 'fix', 'floor', 'ceil', 'trunc',
+                 'abs', 'sign', 'sin', 'degrees', 'radians', 'expm1']
+    for func in all_funcs:
         check_fluent_regular('csr', func, {})
-    for func in common_func + rsp_func:
         check_fluent_regular('row_sparse', func, {})
 
-    rsp_func = ['arcsin', 'arctan', 'tan', 'sinh', 'tanh',
+    all_funcs = ['arcsin', 'arctan', 'tan', 'sinh', 'tanh',
                 'arcsinh', 'arctanh', 'log1p', 'sqrt', 'relu']
-    for func in rsp_func:
+    for func in all_funcs:
+        check_fluent_regular('csr', func, {}, equal_nan=True)
         check_fluent_regular('row_sparse', func, {}, equal_nan=True)
 
     check_fluent_regular('csr', 'slice', {'begin': (2, 5), 'end': (4, 7)}, shape=(5, 17))

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -901,6 +901,17 @@ def test_sparse_mathematical_core():
                                        force_overlap=force_overlap,
                                        density=density, ograd_density=ograd_density)
 
+        # log1p
+        check_sparse_mathematical_core("log1p", stype,
+                                       lambda x: mx.sym.sparse.log1p(x),
+                                       lambda x: np.log1p(x),
+                                       lambda x: 1. / (1.0 + x),
+                                       data_init=0.5, grad_init=0.5,
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap, density=density,
+                                       ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -1064,17 +1075,6 @@ def test_sparse_mathematical_core():
                                            lambda x: np.arctanh(x),
                                            lambda x: -1./(x**2 - 1.),
                                            data_init=0.5,
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap, density=density,
-                                           ograd_density=ograd_density)
-
-            # log1p
-            check_sparse_mathematical_core("log1p", stype,
-                                           lambda x: mx.sym.sparse.log1p(x),
-                                           lambda x: np.log1p(x),
-                                           lambda x: 1. / (1.0 + x),
-                                           data_init=0.5, grad_init=0.5,
                                            output_grad_stype=output_grad_stype,
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap, density=density,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1008,6 +1008,16 @@ def test_sparse_mathematical_core():
                                        force_overlap=force_overlap, density=density,
                                        ograd_density=ograd_density)
 
+        # arcsinh
+        check_sparse_mathematical_core("arcsinh", stype,
+                                       lambda x: mx.sym.sparse.arcsinh(x),
+                                       lambda x: np.arcsinh(x),
+                                       lambda x: 1./(x**2 + 1.)**(1./2.),
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap, density=density,
+                                       ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -1059,16 +1069,6 @@ def test_sparse_mathematical_core():
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap,
                                            density=density, ograd_density=ograd_density)
-
-            # arcsinh
-            check_sparse_mathematical_core("arcsinh", stype,
-                                           lambda x: mx.sym.sparse.arcsinh(x),
-                                           lambda x: np.arcsinh(x),
-                                           lambda x: 1./(x**2 + 1.)**(1./2.),
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap, density=density,
-                                           ograd_density=ograd_density)
 
             # arccosh
             check_sparse_mathematical_core("arccosh", stype,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1604,6 +1604,12 @@ def test_sparse_unary_with_numerics():
                           None,
                           skip_grad=True)
 
+    check_sparse_function('fix',
+                          lambda x: mx.sym.fix(x),
+                          lambda x: np.fix(x),
+                          None,
+                          skip_grad=True)
+
 
 @with_seed()
 def test_sparse_nd_zeros():

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1029,6 +1029,16 @@ def test_sparse_mathematical_core():
                                        force_overlap=force_overlap, density=density,
                                        ograd_density=ograd_density)
 
+        # abs
+        check_sparse_mathematical_core("abs", stype,
+                                       lambda x: mx.sym.sparse.abs(x),
+                                       lambda x: np.abs(x),
+                                       lambda x: assign_each(x, function=util_sign),
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap,
+                                       density=density, ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -1040,15 +1050,6 @@ def test_sparse_mathematical_core():
                                            force_overlap=force_overlap,
                                            density=density, ograd_density=ograd_density)
 
-            # abs
-            check_sparse_mathematical_core("abs", stype,
-                                           lambda x: mx.sym.sparse.abs(x),
-                                           lambda x: np.abs(x),
-                                           lambda x: assign_each(x, function=util_sign),
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap,
-                                           density=density, ograd_density=ograd_density)
             # cos
             check_sparse_mathematical_core("cos", stype,
                                            lambda x: mx.sym.sparse.cos(x),

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1586,6 +1586,12 @@ def test_sparse_unary_with_numerics():
                           None,
                           skip_grad=True)
 
+    check_sparse_function('ceil',
+                          lambda x: mx.sym.ceil(x),
+                          lambda x: np.ceil(x),
+                          None,
+                          skip_grad=True)
+
 
 @with_seed()
 def test_sparse_nd_zeros():

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -976,6 +976,17 @@ def test_sparse_mathematical_core():
                                        force_overlap=force_overlap,
                                        density=density, ograd_density=ograd_density)
 
+        # radians
+        check_sparse_mathematical_core("radians", stype,
+                                       lambda x: mx.sym.sparse.radians(x),
+                                       lambda x: np.radians(x),
+                                       lambda x: assign_each(x, lambda a: np.pi / 180.),
+                                       data_init=0.6, grad_init=1,
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap,
+                                       density=density, ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -1016,17 +1027,6 @@ def test_sparse_mathematical_core():
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap, density=density,
                                            ograd_density=ograd_density)
-
-            # radians
-            check_sparse_mathematical_core("radians", stype,
-                                           lambda x: mx.sym.sparse.radians(x),
-                                           lambda x: np.radians(x),
-                                           lambda x: assign_each(x, lambda a: np.pi / 180.),
-                                           data_init=0.6, grad_init=1,
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap,
-                                           density=density, ograd_density=ograd_density)
 
             # sinh
             check_sparse_mathematical_core("sinh", stype,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -987,6 +987,16 @@ def test_sparse_mathematical_core():
                                        force_overlap=force_overlap,
                                        density=density, ograd_density=ograd_density)
 
+        # sinh
+        check_sparse_mathematical_core("sinh", stype,
+                                       lambda x: mx.sym.sparse.sinh(x),
+                                       lambda x: np.sinh(x),
+                                       lambda x: np.cosh(x),
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap,
+                                       density=density, ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -1027,16 +1037,6 @@ def test_sparse_mathematical_core():
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap, density=density,
                                            ograd_density=ograd_density)
-
-            # sinh
-            check_sparse_mathematical_core("sinh", stype,
-                                           lambda x: mx.sym.sparse.sinh(x),
-                                           lambda x: np.sinh(x),
-                                           lambda x: np.cosh(x),
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap,
-                                           density=density, ograd_density=ograd_density)
 
             # cosh
             check_sparse_mathematical_core("cosh", stype,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1531,6 +1531,11 @@ def test_sparse_unary_with_numerics():
                                 output_grad_stype=output_grad_stype,
                                 backward_is_use_output=backward_is_use_output)
 
+        for output_grad_stype in [None, "csr", "default"]:
+            check_sparse_simple(name, 'csr', mxnet_func, forward_numpy_call, backward_numpy_call,
+                                output_grad_stype=output_grad_stype,
+                                backward_is_use_output=backward_is_use_output)
+
     check_sparse_function('relu',
                           lambda x: mx.sym.relu(x),
                           lambda x: np.maximum(x, 0.0),

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1547,6 +1547,12 @@ def test_sparse_unary_with_numerics():
                           lambda output, outg: outg * assign_each(output, lambda x: x * (1.0 - x)),
                           backward_is_use_output=True)
 
+    check_sparse_function('sign',
+                          lambda x: mx.sym.sign(x),
+                          lambda x: np.sign(x),
+                          lambda output, outg: outg * assign_each(output, lambda x: 0),
+                          backward_is_use_output=True)
+
 
 @with_seed()
 def test_sparse_nd_zeros():

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1018,6 +1018,17 @@ def test_sparse_mathematical_core():
                                        force_overlap=force_overlap, density=density,
                                        ograd_density=ograd_density)
 
+        # arctanh
+        check_sparse_mathematical_core("arctanh", stype,
+                                       lambda x: mx.sym.sparse.arctanh(x),
+                                       lambda x: np.arctanh(x),
+                                       lambda x: -1./(x**2 - 1.),
+                                       data_init=0.5,
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap, density=density,
+                                       ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -1075,17 +1086,6 @@ def test_sparse_mathematical_core():
                                            lambda x: mx.sym.sparse.arccosh(x),
                                            lambda x: np.arccosh(x),
                                            lambda x: 1./(x**2 - 1.)**(1./2.),
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap, density=density,
-                                           ograd_density=ograd_density)
-
-            # arctanh
-            check_sparse_mathematical_core("arctanh", stype,
-                                           lambda x: mx.sym.sparse.arctanh(x),
-                                           lambda x: np.arctanh(x),
-                                           lambda x: -1./(x**2 - 1.),
-                                           data_init=0.5,
                                            output_grad_stype=output_grad_stype,
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap, density=density,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -954,6 +954,17 @@ def test_sparse_mathematical_core():
                                        force_overlap=force_overlap,
                                        density=density, ograd_density=ograd_density)
 
+        # arctan
+        check_sparse_mathematical_core("arctan", stype,
+                                       lambda x: mx.sym.sparse.arctan(x),
+                                       lambda x: np.arctan(x),
+                                       lambda x: 1. / (x ** 2. + 1.),
+                                       data_init=0.5, grad_init=0.5,
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap,
+                                       density=density, ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -994,17 +1005,6 @@ def test_sparse_mathematical_core():
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap, density=density,
                                            ograd_density=ograd_density)
-
-            # arctan
-            check_sparse_mathematical_core("arctan", stype,
-                                           lambda x: mx.sym.sparse.arctan(x),
-                                           lambda x: np.arctan(x),
-                                           lambda x: 1. / (x ** 2. + 1.),
-                                           data_init=0.5, grad_init=0.5,
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap,
-                                           density=density, ograd_density=ograd_density)
 
             # degrees
             check_sparse_mathematical_core("degrees", stype,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -912,6 +912,17 @@ def test_sparse_mathematical_core():
                                        force_overlap=force_overlap, density=density,
                                        ograd_density=ograd_density)
 
+        # expm1
+        check_sparse_mathematical_core("expm1", stype,
+                                        lambda x: mx.sym.sparse.expm1(x),
+                                        lambda x: np.expm1(x),
+                                        lambda x: np.exp(x),
+                                        data_init=0.5, grad_init=0.5,
+                                        output_grad_stype=output_grad_stype,
+                                        input_grad_stype=input_grad_stype,
+                                        force_overlap=force_overlap, density=density,
+                                        ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -1075,17 +1086,6 @@ def test_sparse_mathematical_core():
                                            lambda x: np.arctanh(x),
                                            lambda x: -1./(x**2 - 1.),
                                            data_init=0.5,
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap, density=density,
-                                           ograd_density=ograd_density)
-
-            # expm1
-            check_sparse_mathematical_core("expm1", stype,
-                                           lambda x: mx.sym.sparse.expm1(x),
-                                           lambda x: np.expm1(x),
-                                           lambda x: np.exp(x),
-                                           data_init=0.5, grad_init=0.5,
                                            output_grad_stype=output_grad_stype,
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap, density=density,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -997,6 +997,17 @@ def test_sparse_mathematical_core():
                                        force_overlap=force_overlap,
                                        density=density, ograd_density=ograd_density)
 
+        # tanh
+        check_sparse_mathematical_core("tanh", stype,
+                                       lambda x: mx.sym.sparse.tanh(x),
+                                       lambda x: np.tanh(x),
+                                       lambda x: 1. - np.tanh(x) ** 2,
+                                       data_init=0.5, grad_init=1,
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap, density=density,
+                                       ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -1048,17 +1059,6 @@ def test_sparse_mathematical_core():
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap,
                                            density=density, ograd_density=ograd_density)
-
-            # tanh
-            check_sparse_mathematical_core("tanh", stype,
-                                           lambda x: mx.sym.sparse.tanh(x),
-                                           lambda x: np.tanh(x),
-                                           lambda x: 1. - np.tanh(x) ** 2,
-                                           data_init=0.5, grad_init=1,
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap, density=density,
-                                           ograd_density=ograd_density)
 
             # arcsinh
             check_sparse_mathematical_core("arcsinh", stype,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1598,6 +1598,12 @@ def test_sparse_unary_with_numerics():
                           None,
                           skip_grad=True)
 
+    check_sparse_function('trunc',
+                          lambda x: mx.sym.trunc(x),
+                          lambda x: np.trunc(x),
+                          None,
+                          skip_grad=True)
+
 
 @with_seed()
 def test_sparse_nd_zeros():

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1551,22 +1551,17 @@ def test_sparse_unary_with_numerics():
         assert inp_grad.stype == expected_grad_result_type
 
     def check_sparse_function(name, mxnet_func, forward_numpy_call, backward_numpy_call,
-                              backward_is_use_output=False, skip_grad=False):
-        if skip_grad:
-            check_sparse_nograd(name, 'default', mxnet_func, forward_numpy_call)
-            check_sparse_nograd(name, 'row_sparse', mxnet_func, forward_numpy_call)
-            check_sparse_nograd(name, 'csr', mxnet_func, forward_numpy_call)
-        else:
-            check_sparse_simple(name, 'default', mxnet_func, forward_numpy_call, backward_numpy_call)
-            for output_grad_stype in [None, "row_sparse", "default"]:
-                check_sparse_simple(name, 'row_sparse', mxnet_func, forward_numpy_call, backward_numpy_call,
-                                    output_grad_stype=output_grad_stype,
-                                    backward_is_use_output=backward_is_use_output)
+                              backward_is_use_output=False):
+        check_sparse_simple(name, 'default', mxnet_func, forward_numpy_call, backward_numpy_call)
+        for output_grad_stype in [None, "row_sparse", "default"]:
+            check_sparse_simple(name, 'row_sparse', mxnet_func, forward_numpy_call, backward_numpy_call,
+                                output_grad_stype=output_grad_stype,
+                                backward_is_use_output=backward_is_use_output)
 
-            for output_grad_stype in [None, "csr", "default"]:
-                check_sparse_simple(name, 'csr', mxnet_func, forward_numpy_call, backward_numpy_call,
-                                    output_grad_stype=output_grad_stype,
-                                    backward_is_use_output=backward_is_use_output)
+        for output_grad_stype in [None, "csr", "default"]:
+            check_sparse_simple(name, 'csr', mxnet_func, forward_numpy_call, backward_numpy_call,
+                                output_grad_stype=output_grad_stype,
+                                backward_is_use_output=backward_is_use_output)
 
     check_sparse_function('relu',
                           lambda x: mx.sym.relu(x),

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1592,6 +1592,12 @@ def test_sparse_unary_with_numerics():
                           None,
                           skip_grad=True)
 
+    check_sparse_function('floor',
+                          lambda x: mx.sym.floor(x),
+                          lambda x: np.floor(x),
+                          None,
+                          skip_grad=True)
+
 
 @with_seed()
 def test_sparse_nd_zeros():

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -943,6 +943,17 @@ def test_sparse_mathematical_core():
                                        density=density,
                                        ograd_density=ograd_density)
 
+        # arcsin
+        check_sparse_mathematical_core("arcsin", stype,
+                                       lambda x: mx.sym.sparse.arcsin(x),
+                                       lambda x: np.arcsin(x),
+                                       lambda x: 1. / (1. - x ** 2) ** (1. / 2.),
+                                       data_init=0.5, grad_init=0.5,
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap,
+                                       density=density, ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -968,17 +979,6 @@ def test_sparse_mathematical_core():
                                            lambda x: mx.sym.sparse.cos(x),
                                            lambda x: np.cos(x),
                                            lambda x: -np.sin(x),
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap,
-                                           density=density, ograd_density=ograd_density)
-
-            # arcsin
-            check_sparse_mathematical_core("arcsin", stype,
-                                           lambda x: mx.sym.sparse.arcsin(x),
-                                           lambda x: np.arcsin(x),
-                                           lambda x: 1. / (1. - x ** 2) ** (1. / 2.),
-                                           data_init=0.5, grad_init=0.5,
                                            output_grad_stype=output_grad_stype,
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -834,6 +834,17 @@ def test_sparse_mathematical_core():
                                        density=density, ograd_density=ograd_density,
                                        verbose=False)
 
+        # cbrt
+        check_sparse_mathematical_core("cbrt", stype,
+                                       lambda x: mx.sym.sparse.cbrt(x),
+                                       lambda x: np.cbrt(x),
+                                       lambda x: 1.0/(3.0 * np.cbrt(x) * np.cbrt(x)),
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap,
+                                       density=density, ograd_density=ograd_density,
+                                       verbose=False)
+
         # rint
         check_sparse_mathematical_core("rint", stype,
                                        lambda x: mx.sym.sparse.rint(x),

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -823,18 +823,74 @@ def test_sparse_mathematical_core():
                                        density=density, ograd_density=ograd_density,
                                        verbose=False)
 
-        if stype != "csr":
-            # sqrt
-            check_sparse_mathematical_core("sqrt", stype,
-                                           lambda x: mx.sym.sparse.sqrt(x),
-                                           lambda x: np.sqrt(x),
-                                           lambda x: 1.0/(2.0 * np.sqrt(x)),
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap,
-                                           density=density, ograd_density=ograd_density,
-                                           verbose=False)
+        # sqrt
+        check_sparse_mathematical_core("sqrt", stype,
+                                       lambda x: mx.sym.sparse.sqrt(x),
+                                       lambda x: np.sqrt(x),
+                                       lambda x: 1.0/(2.0 * np.sqrt(x)),
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap,
+                                       density=density, ograd_density=ograd_density,
+                                       verbose=False)
 
+        # rint
+        check_sparse_mathematical_core("rint", stype,
+                                       lambda x: mx.sym.sparse.rint(x),
+                                       lambda x: np.rint(x),
+                                       force_overlap=force_overlap, density=density,
+                                       input_grad_stype=input_grad_stype,
+                                       ograd_density=ograd_density)
+
+        # fix
+        check_sparse_mathematical_core("fix", stype,
+                                       lambda x: mx.sym.sparse.fix(x),
+                                       lambda x: np.fix(x),
+                                       force_overlap=force_overlap, density=density,
+                                       input_grad_stype=input_grad_stype,
+                                       ograd_density=ograd_density)
+
+        # floor
+        check_sparse_mathematical_core("floor", stype, lambda x: mx.sym.sparse.floor(x),
+                                       lambda x: np.floor(x),
+                                       force_overlap=force_overlap,
+                                       input_grad_stype=input_grad_stype,
+                                       density=density, ograd_density=ograd_density)
+
+        # ceil
+        check_sparse_mathematical_core("ceil", stype,
+                                       lambda x: mx.sym.sparse.ceil(x),
+                                       lambda x: np.ceil(x),
+                                       force_overlap=force_overlap,
+                                       input_grad_stype=input_grad_stype,
+                                       density=density, ograd_density=ograd_density)
+
+        # round
+        check_sparse_mathematical_core("round", stype,
+                                       lambda x: mx.sym.sparse.round(x),
+                                       lambda x: np.round(x),
+                                       force_overlap=force_overlap,
+                                       input_grad_stype=input_grad_stype,
+                                       density=density, ograd_density=ograd_density)
+
+        # trunc
+        check_sparse_mathematical_core("trunc", stype,
+                                       lambda x: mx.sym.sparse.trunc(x),
+                                       lambda x: np.trunc(x),
+                                       force_overlap=force_overlap,
+                                       input_grad_stype=input_grad_stype,
+                                       density=density, ograd_density=ograd_density)
+
+        # sign
+        check_sparse_mathematical_core("sign", stype,
+                                       lambda x: mx.sym.sparse.sign(x),
+                                       lambda x: np.sign(x),
+                                       lambda x: np.zeros(x.shape),
+                                       output_grad_stype=output_grad_stype,
+                                       force_overlap=force_overlap,
+                                       density=density, ograd_density=ograd_density)
+
+        if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
                                            lambda x: mx.sym.sparse.rsqrt(x),
@@ -864,31 +920,6 @@ def test_sparse_mathematical_core():
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap,
                                            density=density, ograd_density=ograd_density)
-
-            # floor
-            check_sparse_mathematical_core("floor", stype, lambda x: mx.sym.sparse.floor(x),
-                                           lambda x: np.floor(x),
-                                           force_overlap=force_overlap,
-                                           input_grad_stype=input_grad_stype,
-                                           density=density, ograd_density=ograd_density)
-
-            # ceil
-            check_sparse_mathematical_core("ceil", stype,
-                                           lambda x: mx.sym.sparse.ceil(x),
-                                           lambda x: np.ceil(x),
-                                           force_overlap=force_overlap,
-                                           input_grad_stype=input_grad_stype,
-                                           density=density, ograd_density=ograd_density)
-
-            # sign
-            check_sparse_mathematical_core("sign", stype,
-                                           lambda x: mx.sym.sparse.sign(x),
-                                           lambda x: np.sign(x),
-                                           lambda x: np.zeros(x.shape),
-                                           output_grad_stype=output_grad_stype,
-                                           force_overlap=force_overlap,
-                                           density=density, ograd_density=ograd_density)
-
             # cos
             check_sparse_mathematical_core("cos", stype,
                                            lambda x: mx.sym.sparse.cos(x),
@@ -1069,21 +1100,6 @@ def test_sparse_mathematical_core():
                                            force_overlap=force_overlap, density=density,
                                            ograd_density=ograd_density)
 
-            # rint
-            check_sparse_mathematical_core("rint", stype,
-                                           lambda x: mx.sym.sparse.rint(x),
-                                           lambda x: np.rint(x),
-                                           force_overlap=force_overlap, density=density,
-                                           input_grad_stype=input_grad_stype,
-                                           ograd_density=ograd_density)
-
-            # fix
-            check_sparse_mathematical_core("fix", stype,
-                                           lambda x: mx.sym.sparse.fix(x),
-                                           lambda x: np.fix(x),
-                                           force_overlap=force_overlap, density=density,
-                                           input_grad_stype=input_grad_stype,
-                                           ograd_density=ograd_density)
 
             try:
                 from scipy import special as scipy_special
@@ -1472,28 +1488,6 @@ def test_sparse_retain():
 
 @with_seed()
 def test_sparse_unary_with_numerics():
-    def check_sparse_nograd(name, stype, mxnet_func, forward_numpy_call):
-        expected_result_type = stype
-        shape = (3, 4)
-        data = mx.symbol.Variable("data")
-
-        y = mxnet_func(data)
-        if stype == 'default':
-            xa = np.random.uniform(low=-1.0, high=1.0, size=shape)
-            xa_np = xa
-        else:
-            xa = create_sparse_array(shape, stype, data_init=None, rsp_indices=[1],
-                                     modifier_func=lambda a: a - 0.5,
-                                     shuffle_csr_indices=True)
-            xa_np = xa.asnumpy()
-
-        output_np = forward_numpy_call(xa_np)
-
-        outputs = check_symbolic_forward(y, [xa], [output_np])
-        output = outputs[0]
-
-        assert output.stype == expected_result_type
-
     def check_sparse_simple(name, stype, mxnet_func, forward_numpy_call,
                             backward_numpy_call, output_grad_stype=None,
                             backward_is_use_output=False):
@@ -1573,42 +1567,6 @@ def test_sparse_unary_with_numerics():
                           lambda x: np.divide(1.0, (1.0 + np.exp(-x))),
                           lambda output, outg: outg * assign_each(output, lambda x: x * (1.0 - x)),
                           backward_is_use_output=True)
-
-    check_sparse_function('sign',
-                          lambda x: mx.sym.sign(x),
-                          lambda x: np.sign(x),
-                          lambda output, outg: outg * assign_each(output, lambda x: 0),
-                          backward_is_use_output=True)
-
-    check_sparse_function('round',
-                          lambda x: mx.sym.round(x),
-                          lambda x: np.round(x),
-                          None,
-                          skip_grad=True)
-
-    check_sparse_function('ceil',
-                          lambda x: mx.sym.ceil(x),
-                          lambda x: np.ceil(x),
-                          None,
-                          skip_grad=True)
-
-    check_sparse_function('floor',
-                          lambda x: mx.sym.floor(x),
-                          lambda x: np.floor(x),
-                          None,
-                          skip_grad=True)
-
-    check_sparse_function('trunc',
-                          lambda x: mx.sym.trunc(x),
-                          lambda x: np.trunc(x),
-                          None,
-                          skip_grad=True)
-
-    check_sparse_function('fix',
-                          lambda x: mx.sym.fix(x),
-                          lambda x: np.fix(x),
-                          None,
-                          skip_grad=True)
 
 
 @with_seed()

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -923,6 +923,16 @@ def test_sparse_mathematical_core():
                                         force_overlap=force_overlap, density=density,
                                         ograd_density=ograd_density)
 
+        # sin
+        check_sparse_mathematical_core("sin", stype,
+                                       lambda x: mx.sym.sparse.sin(x),
+                                       lambda x: np.sin(x),
+                                       lambda x: np.cos(x),
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap,
+                                       density=density, ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -958,16 +968,6 @@ def test_sparse_mathematical_core():
                                            lambda x: mx.sym.sparse.cos(x),
                                            lambda x: np.cos(x),
                                            lambda x: -np.sin(x),
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap,
-                                           density=density, ograd_density=ograd_density)
-
-            # sin
-            check_sparse_mathematical_core("sin", stype,
-                                           lambda x: mx.sym.sparse.sin(x),
-                                           lambda x: np.sin(x),
-                                           lambda x: np.cos(x),
                                            output_grad_stype=output_grad_stype,
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -965,6 +965,17 @@ def test_sparse_mathematical_core():
                                        force_overlap=force_overlap,
                                        density=density, ograd_density=ograd_density)
 
+        # degrees
+        check_sparse_mathematical_core("degrees", stype,
+                                       lambda x: mx.sym.sparse.degrees(x),
+                                       lambda x: np.degrees(x),
+                                       lambda x: assign_each(x, lambda a: 180./np.pi),
+                                       data_init=0.5, grad_init=0.5,
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       force_overlap=force_overlap,
+                                       density=density, ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -1005,17 +1016,6 @@ def test_sparse_mathematical_core():
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap, density=density,
                                            ograd_density=ograd_density)
-
-            # degrees
-            check_sparse_mathematical_core("degrees", stype,
-                                           lambda x: mx.sym.sparse.degrees(x),
-                                           lambda x: np.degrees(x),
-                                           lambda x: assign_each(x, lambda a: 180./np.pi),
-                                           data_init=0.5, grad_init=0.5,
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           force_overlap=force_overlap,
-                                           density=density, ograd_density=ograd_density)
 
             # radians
             check_sparse_mathematical_core("radians", stype,

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -933,6 +933,16 @@ def test_sparse_mathematical_core():
                                        force_overlap=force_overlap,
                                        density=density, ograd_density=ograd_density)
 
+        # tan
+        check_sparse_mathematical_core("tan", stype,
+                                       lambda x: mx.sym.sparse.tan(x),
+                                       lambda x: np.tan(x),
+                                       lambda x: np.tan(x) ** 2 + 1,
+                                       output_grad_stype=output_grad_stype,
+                                       input_grad_stype=input_grad_stype,
+                                       density=density,
+                                       ograd_density=ograd_density)
+
         if stype != "csr":
             # rsqrt
             check_sparse_mathematical_core("rsqrt", stype,
@@ -943,16 +953,6 @@ def test_sparse_mathematical_core():
                                            input_grad_stype=input_grad_stype,
                                            force_overlap=force_overlap,
                                            density=density, ograd_density=ograd_density)
-
-            # tan
-            check_sparse_mathematical_core("tan", stype,
-                                           lambda x: mx.sym.sparse.tan(x),
-                                           lambda x: np.tan(x),
-                                           lambda x: np.tan(x) ** 2 + 1,
-                                           output_grad_stype=output_grad_stype,
-                                           input_grad_stype=input_grad_stype,
-                                           density=density,
-                                           ograd_density=ograd_density)
 
             # abs
             check_sparse_mathematical_core("abs", stype,


### PR DESCRIPTION
## Description ##
As title

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Support for relu, sign, round, ceil, floor, trunc, fix, sqrt, cbrt, log1p, expm1, sin, tan, arcsin, arctan, sinh, arcsinh, tanh, arctanh, degrees, radians
- [x] Corresponding unit tests

## Comments ##

