### PR TITLE
Fix flaky test test_gluon.test_hybrid_static_memory_switching

### DIFF
--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -516,9 +516,6 @@ class NDArray {
     ret.shape_ = shape;
     ret.dtype_ = dtype;
     ret.reuse_ = true;
-#if MXNET_USE_MKLDNN == 1
-    ret.InvalidateMKLDNNData();
-#endif
     return ret;
   }
 

--- a/src/operator/nn/fully_connected.cc
+++ b/src/operator/nn/fully_connected.cc
@@ -118,7 +118,6 @@ void FullyConnectedComputeExCPU(const nnvm::NodeAttrs& attrs,
       }
     }
     // output
-    if (req[0] == kWriteTo) const_cast<NDArray &>(outputs[0]).InvalidateMKLDNNData();
     FullyConnectedCompute<cpu>(attrs, ctx, in_blobs, req, {outputs[0].data()});
   } else {
     LogUnimplementedOp(attrs, ctx, inputs, req, outputs);

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1174,7 +1174,7 @@ def check_hybrid_static_memory(**kwargs):
     for key in grads1:
         assert_almost_equal(grads1[key].asnumpy(), grads2[key].asnumpy(), rtol=1e-3, atol=1e-5)
 
-@unittest.skip("Flaky test: https://github.com/apache/incubator-mxnet/issues/11171")
+@with_seed()
 def test_hybrid_static_memory():
     check_hybrid_static_memory()
     check_hybrid_static_memory(static_alloc=True)
@@ -1197,7 +1197,7 @@ def check_hybrid_static_memory_switching(**kwargs):
         y.backward()
     mx.nd.waitall()
 
-@unittest.skip("Flaky test: https://github.com/apache/incubator-mxnet/issues/11171")
+@with_seed()
 def test_hybrid_static_memory_switching():
     check_hybrid_static_memory_switching()
     check_hybrid_static_memory_switching(static_alloc=True)

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1187,11 +1187,13 @@ def check_hybrid_static_memory_switching(**kwargs):
 
     x = mx.nd.random.uniform(shape=(4, 3, 32, 32))
     net(x)
+    x.attach_grad()
     with mx.autograd.record():
         y = net(x)
         y.backward()
     x = mx.nd.random.uniform(shape=(2, 3, 32, 32))
     net(x)
+    x.attach_grad()
     with mx.autograd.record():
         y = net(x)
         y.backward()

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1187,13 +1187,11 @@ def check_hybrid_static_memory_switching(**kwargs):
 
     x = mx.nd.random.uniform(shape=(4, 3, 32, 32))
     net(x)
-    x.attach_grad()
     with mx.autograd.record():
         y = net(x)
         y.backward()
     x = mx.nd.random.uniform(shape=(2, 3, 32, 32))
     net(x)
-    x.attach_grad()
     with mx.autograd.record():
         y = net(x)
         y.backward()


### PR DESCRIPTION
## Description ##
This is to fix the flaky test https://github.com/apache/incubator-mxnet/issues/11171
There was a race condition when we invalidate MKLDNN memory in NDArray. The original code invalidates MKLDNN memory in the memory planning phase (AsArray) as well, which is called outside the threaded engine. The static memory allocation mode of CachedOp shares the same NDArrays in different model executions. Therefore, the NDArrays may still be used in the threaded engine from the previous model execution, while the same CachedOp is executed for the next execution and the same NDArrays are used in memory planning. With MKLDNN enabled, NDArrays were modified in the memory planning phase, which leads to race condition.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
