### PR TITLE
fix BucketSentenceIter bug related to #11430

### DIFF
--- a/python/mxnet/rnn/io.py
+++ b/python/mxnet/rnn/io.py
@@ -117,15 +117,20 @@ class BucketSentenceIter(DataIter):
 
         ndiscard = 0
         self.data = [[] for _ in buckets]
+        valid_buckets = {}
+        for item in range(len(buckets)):
+            valid_buckets[item] = 0
+
         for i, sent in enumerate(sentences):
             buck = bisect.bisect_left(buckets, len(sent))
+            valid_buckets[buck] = 1
             if buck == len(buckets):
                 ndiscard += 1
                 continue
             buff = np.full((buckets[buck],), invalid_label, dtype=dtype)
             buff[:len(sent)] = sent
             self.data[buck].append(buff)
-
+        buckets = [j for i, j in enumerate(buckets) if valid_buckets[i] == 1]
         self.data = [np.asarray(i, dtype=dtype) for i in self.data if i]
 
         print("WARNING: discarded %d sentences longer than the largest bucket."%ndiscard)

--- a/tests/python/train/test_bucketing.py
+++ b/tests/python/train/test_bucketing.py
@@ -36,7 +36,7 @@ def test_bucket_module():
     num_embed = 25
     num_layers = 2
     len_vocab = 50
-    buckets = [10, 20, 30, 40]
+    buckets = [5, 10, 20, 30, 40]
 
     invalid_label = -1
     num_sentence = 1000
@@ -45,7 +45,7 @@ def test_bucket_module():
     val_sent = []
 
     for _ in range(num_sentence):
-        len_sentence = randint(1, max(buckets)-1) # leave out the two last buckets empty
+        len_sentence = randint(6, max(buckets)-1) # leave out the two last buckets empty
         train_sentence = []
         val_sentence = []
         for _ in range(len_sentence):


### PR DESCRIPTION
## Description ##
BucketSentenceIter has bug  
when there are buckets with no item.  
It keeps invalid buckets as self.buckets  
but self.data contains only valid buckets and  
it leads to the mismatch with sentence length of symbol and actual data shape.  
I fixed the problem by checking valid buckets and handed it to self.buckets.
This fixes issue  #11430.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
