### PR TITLE
Fix typo in clojure project dependencies.

### DIFF
--- a/contrib/clojure-package/project.clj
+++ b/contrib/clojure-package/project.clj
@@ -22,7 +22,7 @@
 
                  ;; Jars from Nexus
                  ;[org.apache.mxnet/mxnet-full_2.11-osx-x86_64-cpu "1.2.1"]
-                 ;[org.apache.mxnet/mxnet-full_2.11-linux-x86_64-gpu "1.2.1"]
+                 ;[org.apache.mxnet/mxnet-full_2.11-linux-x86_64-cpu "1.2.1"]
                  ;[org.apache.mxnet/mxnet-full_2.11-linux-x86_64-gpu "1.2.1"]
 
                  ;;; CI


### PR DESCRIPTION
## Description ##
A minor typo fix for the Clojure contrib project.

I assume the duplicate dependency is a typo. When I checked out and setup the project, it worked when I used the corrected dependency.