### PR TITLE
[MXNET-625] Handle ARM repo size errors gracefully.

### DIFF
--- a/ci/docker/install/ubuntu_arm.sh
+++ b/ci/docker/install/ubuntu_arm.sh
@@ -19,6 +19,6 @@
 
 set -ex
 
-apt update
+apt update || true
 apt install -y \
     unzip


### PR DESCRIPTION
## Description ##
Some ARM repos are reporting incorrect file sizes.  This PR handles these filesize warnings gracefully, and does not fail the build.

Should address issue https://github.com/apache/incubator-mxnet/issues/11567.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change