### PR TITLE
onnx split op import

### DIFF
--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -417,6 +417,8 @@ def split(attrs, inputs, proto_obj):
         num_outputs = len(proto_obj.model_metadata.get('output_tensor_data'))
     else:
         raise NotImplementedError("Operator {} in MXNet does not support variable splits."
+                                  "Tracking the issue to support variable split here: "
+                                  "https://github.com/apache/incubator-mxnet/issues/11594"
                                   .format('split'))
 
     new_attrs['num_outputs'] = num_outputs

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -407,8 +407,19 @@ def cast(attrs, inputs, proto_obj):
 
 def split(attrs, inputs, proto_obj):
     """Splits an array along a particular axis into multiple sub-arrays."""
+    split_list = attrs.get('split') if 'split' in attrs else []
     new_attrs = translation_utils._fix_attribute_names(attrs,
                                                        {'split' : 'num_outputs'})
+    if 'axis' not in attrs:
+        new_attrs = translation_utils._add_extra_attributes(new_attrs, {'axis': 0})
+
+    if not split_list:
+        num_outputs = len(proto_obj.model_metadata.get('output_tensor_data'))
+    else:
+        raise NotImplementedError("Operator {} in MXNet does not support variable splits.".format('split'))
+
+    new_attrs['num_outputs'] = num_outputs
+
     return 'split', new_attrs, inputs
 
 def _slice(attrs, inputs, proto_obj):

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -416,7 +416,8 @@ def split(attrs, inputs, proto_obj):
     if not split_list:
         num_outputs = len(proto_obj.model_metadata.get('output_tensor_data'))
     else:
-        raise NotImplementedError("Operator {} in MXNet does not support variable splits.".format('split'))
+        raise NotImplementedError("Operator {} in MXNet does not support variable splits."
+                                  .format('split'))
 
     new_attrs['num_outputs'] = num_outputs
 

--- a/tests/python-pytest/onnx/import/mxnet_backend_rep.py
+++ b/tests/python-pytest/onnx/import/mxnet_backend_rep.py
@@ -82,4 +82,7 @@ class MXNetBackendRep(BackendRep):
         # run inference
         mod.forward(mx.io.DataBatch(data_forward))
         result = mod.get_outputs()[0].asnumpy()
+        # split operator inference returns 1 less dimension
+        if self.symbol.name.startswith('split'):
+            return [i.asnumpy() for i in mod.get_outputs()]
         return [result]

--- a/tests/python-pytest/onnx/import/test_cases.py
+++ b/tests/python-pytest/onnx/import/test_cases.py
@@ -18,6 +18,7 @@
 """Test Cases to be run for the import module"""
 
 IMPLEMENTED_OPERATORS_TEST = [
+    'test_split_equal'
     'test_random_uniform',
     'test_random_normal',
     'test_add',


### PR DESCRIPTION
## Description ##
ONNX split operator supports equal and variable splits and MXNet supports only equal splits of a tensor. 
Modified operator to support only "equal" splits and enabled test cases.
#11555  

@sandeep-krishnamurthy @anirudh2290 

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
