### PR TITLE
Fix scala maven repos

### DIFF
--- a/docs/install/scala_setup.md
+++ b/docs/install/scala_setup.md
@@ -53,19 +53,19 @@ https://mvnrepository.com/artifact/org.apache.mxnet
 
 **Linux GPU**
 ```html
-<!-- https://mvnrepository.com/artifact/org.apache.mxnet/mxnet-full_2.11-osx-x86_64-cpu -->
+<!-- https://mvnrepository.com/artifact/org.apache.mxnet/mxnet-full_2.11-linux-x86_64-gpu -->
 <dependency>
     <groupId>org.apache.mxnet</groupId>
-    <artifactId>mxnet-full_2.11-osx-x86_64-cpu</artifactId>
+    <artifactId>mxnet-full_2.11-linux-x86_64-gpu</artifactId>
 </dependency>
 ```
 
 **macOS CPU**
 ```html
-<!-- https://mvnrepository.com/artifact/org.apache.mxnet/mxnet-full_2.11-linux-x86_64-gpu -->
+<!-- https://mvnrepository.com/artifact/org.apache.mxnet/mxnet-full_2.11-osx-x86_64-cpu -->
 <dependency>
     <groupId>org.apache.mxnet</groupId>
-    <artifactId>mxnet-full_2.11-linux-x86_64-gpu</artifactId>
+    <artifactId>mxnet-full_2.11-osx-x86_64-cpu</artifactId>
 </dependency>
 ```
 


### PR DESCRIPTION
## Description ##
The Maven Repo of Linux GPU and MacOS CPU were interchanged in the Scala package installation page. So made the necessary changes.