### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/benchmark/python/control_flow/rnn.py
+++ b/benchmark/python/control_flow/rnn.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/benchmark/python/quantization/benchmark_op.py
+++ b/benchmark/python/quantization/benchmark_op.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/benchmark/python/sparse/cast_storage.py
+++ b/benchmark/python/sparse/cast_storage.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/benchmark/python/sparse/dot.py
+++ b/benchmark/python/sparse/dot.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -224,7 +225,7 @@ def test_dot_real(data_dict):
     assert default_batch_size_index < len(batch_size_list)
     assert default_output_index < len(m)
     if ARGS.verbose:
-        print("Running Benchmarking on %r data") % data_dict['data_mini']
+        print(("Running Benchmarking on %r data") % data_dict['data_mini'])
     print('{:>15} {:>10} {:>10} {:>10} {:>20} {:>15} {:>15} {:>10} {:>10}'.format('density(%)',
                                                                                  'n',
                                                                                  'm',
@@ -324,8 +325,8 @@ def test_dot_synthetic(data_dict):
     def print_benchmark_info(lhs, rhs, lhs_trans, fw):
         trans_str = "^T" if lhs_trans else ""
         print("========================================================")
-        print("  %s sparse dot benchmark: dot(%s, %s) = %s  ") % (fw, lhs, rhs, rhs)
-        print("  (matrix multiplication: (m x k)%s * (k x n) = m x n)  ") % (trans_str)
+        print(("  %s sparse dot benchmark: dot(%s, %s) = %s  ") % (fw, lhs, rhs, rhs))
+        print(("  (matrix multiplication: (m x k)%s * (k x n) = m x n)  ") % (trans_str))
         print("========================================================")
         headline_pattern = '{:>15} {:>15} {:>10} {:>8} {:>8} {:>8} {:>13} {:>13} {:>8}'
         headline = headline_pattern.format('lhs_density(%)',
@@ -463,4 +464,4 @@ if __name__ == "__main__":
     test_dot_synthetic(SYNTHETIC1)
     test_dot_synthetic(SYNTHETIC2)
     total_time = time.time() - begin_time
-    print("total time is %f") % total_time
+    print(("total time is %f") % total_time)

--- a/benchmark/python/sparse/sparse_op.py
+++ b/benchmark/python/sparse/sparse_op.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -96,9 +97,9 @@ def test_dot_real(data_dict):
         os.system("head -n 2000 %r > %r" % (path, mini_path))
         assert os.path.exists(mini_path)
 
-    print "Running Benchmarking on %r data" % data_dict['data_mini']
+    print("Running Benchmarking on %r data" % data_dict['data_mini'])
     for batch_size in data_dict['batch_size']:  # iterator through different batch size of choice
-        print "batch_size is %d" % batch_size
+        print("batch_size is %d" % batch_size)
         # model
         data_shape = (k, )
         train_iter = get_iter(mini_path, data_shape, batch_size)

--- a/benchmark/python/sparse/updater.py
+++ b/benchmark/python/sparse/updater.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/ci/build.py
+++ b/ci/build.py
@@ -21,6 +21,8 @@
 """Multi arch dockerized build tool.
 
 """
+from __future__ import print_function
+from __future__ import absolute_import
 
 __author__ = 'Marco de Abreu, Kellen Sunderland, Anton Chernov, Pedro Larroy'
 __version__ = '0.1'
@@ -197,7 +199,7 @@ def list_platforms() -> str:
 def load_docker_cache(tag, docker_registry) -> None:
     if docker_registry:
         try:
-            import docker_cache
+            from . import docker_cache
             logging.info('Docker cache download is enabled from registry %s', docker_registry)
             docker_cache.load_docker_cache(registry=docker_registry, docker_tag=tag)
         except Exception:

--- a/ci/build.py
+++ b/ci/build.py
@@ -199,7 +199,7 @@ def list_platforms() -> str:
 def load_docker_cache(tag, docker_registry) -> None:
     if docker_registry:
         try:
-            from . import docker_cache
+            import docker_cache
             logging.info('Docker cache download is enabled from registry %s', docker_registry)
             docker_cache.load_docker_cache(registry=docker_registry, docker_tag=tag)
         except Exception:

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -31,7 +31,7 @@ import argparse
 import sys
 import subprocess
 import json
-from . import build as build_util
+import build as build_util
 from joblib import Parallel, delayed
 
 

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -23,6 +23,7 @@ Utility to handle distributed docker cache. This is done by keeping the entire i
 on an S3 bucket. This utility allows cache creation and download. After execution, the cache will be in an identical
 state as if the container would have been built locally already.
 """
+from __future__ import absolute_import
 
 import os
 import logging
@@ -30,7 +31,7 @@ import argparse
 import sys
 import subprocess
 import json
-import build as build_util
+from . import build as build_util
 from joblib import Parallel, delayed
 
 

--- a/ci/test_docker_cache.py
+++ b/ci/test_docker_cache.py
@@ -21,6 +21,7 @@
 """
 Distributed Docker cache tests
 """
+from __future__ import absolute_import
 
 import unittest.mock
 import tempfile
@@ -31,8 +32,8 @@ import sys
 from unittest.mock import MagicMock
 
 sys.path.append(os.path.dirname(__file__))
-import docker_cache
-import build as build_util
+from . import docker_cache
+from . import build as build_util
 
 DOCKERFILE_DIR = 'docker'
 DOCKER_REGISTRY_NAME = 'test_registry'

--- a/cpp-package/scripts/OpWrapperGenerator.py
+++ b/cpp-package/scripts/OpWrapperGenerator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/cpp-package/scripts/lint.py
+++ b/cpp-package/scripts/lint.py
@@ -21,6 +21,7 @@
 """Lint helper to generate lint summary of source.
 Copyright by Contributors
 """
+from __future__ import print_function
 import codecs
 import sys
 import re
@@ -91,7 +92,7 @@ class LintHelper(object):
         (pylint_stdout, pylint_stderr) = epylint.py_run(
             ' '.join([str(path)] + self.pylint_opts), return_std=True)
         emap = {}
-        print pylint_stderr.read()
+        print(pylint_stderr.read())
         for line in pylint_stdout:
             sys.stderr.write(line)
             key = line.split(':')[-1].split('(')[0].strip()

--- a/docs/build_version_doc/AddVersion.py
+++ b/docs/build_version_doc/AddVersion.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -16,6 +16,7 @@
 # under the License.
 
 """A sphnix-doc plugin to build mxnet docs"""
+from __future__ import print_function
 import subprocess
 import re
 import os

--- a/example/autoencoder/solver.py
+++ b/example/autoencoder/solver.py
@@ -122,10 +122,10 @@ class Solver(object):
                 if self.iter_start_callback(i):
                     return
             try:
-                batch = data_iter.next()
+                batch = next(data_iter)
             except StopIteration:
                 data_iter.reset()
-                batch = data_iter.next()
+                batch = next(data_iter)
             for data, buff in zip(batch.data+batch.label, input_buffs):
                 data.copyto(buff)
             exe.forward(is_train=True)

--- a/example/bi-lstm-sort/infer_sort.py
+++ b/example/bi-lstm-sort/infer_sort.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/capsnet/capsulenet.py
+++ b/example/capsnet/capsulenet.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/cnn_text_classification/text_cnn.py
+++ b/example/cnn_text_classification/text_cnn.py
@@ -19,6 +19,7 @@
 
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import sys
 import os
 import mxnet as mx
@@ -85,11 +86,11 @@ def data_iter(batch_size, num_embed, pre_trained_word2vec=False):
     x_train, x_dev = x_shuffled[:-1000], x_shuffled[-1000:]
     y_train, y_dev = y_shuffled[:-1000], y_shuffled[-1000:]
     print('Train/Valid split: %d/%d' % (len(y_train), len(y_dev)))
-    print('train shape:', x_train.shape)
-    print('valid shape:', x_dev.shape)
-    print('sentence max words', sentence_size)
-    print('embedding size', embed_size)
-    print('vocab size', vocab_size)
+    print(('train shape:', x_train.shape))
+    print(('valid shape:', x_dev.shape))
+    print(('sentence max words', sentence_size))
+    print(('embedding size', embed_size))
+    print(('vocab size', vocab_size))
 
     train = mx.io.NDArrayIter(
         x_train, y_train, batch_size, shuffle=True)

--- a/example/cnn_visualization/gradcam_demo.py
+++ b/example/cnn_visualization/gradcam_demo.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/deep-embedded-clustering/solver.py
+++ b/example/deep-embedded-clustering/solver.py
@@ -122,10 +122,10 @@ class Solver(object):
                 if self.iter_start_callback(i):
                     return
             try:
-                batch = data_iter.next()
+                batch = next(data_iter)
             except StopIteration:
                 data_iter.reset()
-                batch = data_iter.next()
+                batch = next(data_iter)
             for data, buff in zip(batch.data+batch.label, input_buffs):
                 data.copyto(buff)
             exe.forward(is_train=True)

--- a/example/gluon/data.py
+++ b/example/gluon/data.py
@@ -17,6 +17,7 @@
 
 # pylint: skip-file
 """ data iterator for mnist """
+from __future__ import print_function
 import os
 import random
 import logging

--- a/example/gluon/dcgan.py
+++ b/example/gluon/dcgan.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/gluon/embedding_learning/train.py
+++ b/example/gluon/embedding_learning/train.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from __future__ import division
+from __future__ import print_function
 
 import argparse
 import logging
@@ -204,7 +205,7 @@ def train(epochs, ctx):
 
         # Inner training loop.
         for i in range(200):
-            batch = train_data.next()
+            batch = next(train_data)
             data = gluon.utils.split_and_load(batch.data[0], ctx_list=ctx, batch_axis=0)
             label = gluon.utils.split_and_load(batch.label[0], ctx_list=ctx, batch_axis=0)
 

--- a/example/gluon/image_classification.py
+++ b/example/gluon/image_classification.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from __future__ import division
+from __future__ import print_function
 
 import argparse, time, os
 import logging

--- a/example/gluon/kaggle_k_fold_cross_validation.py
+++ b/example/gluon/kaggle_k_fold_cross_validation.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/gluon/lstm_crf.py
+++ b/example/gluon/lstm_crf.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/gluon/style_transfer/data.py
+++ b/example/gluon/style_transfer/data.py
@@ -93,8 +93,7 @@ class ImageFolder(data.Dataset):
         classes, class_to_idx = find_classes(root)
         imgs = make_dataset(root, class_to_idx)
         if len(imgs) == 0:
-            raise(RuntimeError("Found 0 images in subfolders of: " + root + "\n"
-                               "Supported image extensions are: " + ",".join(IMG_EXTENSIONS)))
+            raise RuntimeError
 
         self.root = root
         self.imgs = imgs

--- a/example/gluon/style_transfer/main.py
+++ b/example/gluon/style_transfer/main.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -47,7 +48,7 @@ def train(args):
     train_loader = gluon.data.DataLoader(train_dataset, batch_size=args.batch_size,
                                          last_batch='discard')
     style_loader = utils.StyleLoader(args.style_folder, args.style_size, ctx=ctx)
-    print('len(style_loader):',style_loader.size())
+    print(('len(style_loader):',style_loader.size()))
     # models
     vgg = net.Vgg16()
     utils.init_vgg_params(vgg, 'models', ctx=ctx)
@@ -56,7 +57,7 @@ def train(args):
     if args.resume is not None:
         print('Resuming, initializing using weight from {}.'.format(args.resume))
         style_model.load_parameters(args.resume, ctx=ctx)
-    print('style_model:',style_model)
+    print(('style_model:',style_model))
     # optimizer and loss
     trainer = gluon.Trainer(style_model.collect_params(), 'adam',
                             {'learning_rate': args.lr})
@@ -122,14 +123,14 @@ def train(args):
                     args.content_weight) + "_" + str(args.style_weight) + ".params"
                 save_model_path = os.path.join(args.save_model_dir, save_model_filename)
                 style_model.save_parameters(save_model_path)
-                print("\nCheckpoint, trained model saved at", save_model_path)
+                print(("\nCheckpoint, trained model saved at", save_model_path))
 
     # save model
     save_model_filename = "Final_epoch_" + str(args.epochs) + "_" + str(time.ctime()).replace(' ', '_') + "_" + str(
         args.content_weight) + "_" + str(args.style_weight) + ".params"
     save_model_path = os.path.join(args.save_model_dir, save_model_filename)
     style_model.save_parameters(save_model_path)
-    print("\nDone, trained model saved at", save_model_path)
+    print(("\nDone, trained model saved at", save_model_path))
 
 
 def evaluate(args):

--- a/example/gluon/tree_lstm/main.py
+++ b/example/gluon/tree_lstm/main.py
@@ -122,7 +122,7 @@ def test(ctx, data_iter, best, mode='validation', num_iter=-1):
     preds = []
     labels = [mx.nd.array(data_iter.labels, ctx=ctx[0]).reshape((-1,1))]
     for _ in tqdm(range(batches), desc='Testing in {} mode'.format(mode)):
-        l_tree, l_sent, r_tree, r_sent, label = data_iter.next()
+        l_tree, l_sent, r_tree, r_sent, label = next(data_iter)
         z = net(mx.nd, l_sent, r_sent, l_tree, r_tree)
         preds.append(z)
 
@@ -166,7 +166,7 @@ def train(epoch, ctx, train_data, dev_data):
         labels = [mx.nd.array(train_data.labels, ctx=ctx[0]).reshape((-1,1))]
         for j in tqdm(range(num_batches), desc='Training epoch {}'.format(i)):
             # get next batch
-            l_tree, l_sent, r_tree, r_sent, label = train_data.next()
+            l_tree, l_sent, r_tree, r_sent, label = next(train_data)
             # use autograd to record the forward calculation
             with ag.record():
                 # forward calculation. the output is log probability

--- a/example/gluon/tree_lstm/scripts/preprocess-sick.py
+++ b/example/gluon/tree_lstm/scripts/preprocess-sick.py
@@ -19,6 +19,7 @@
 Preprocessing script for SICK data.
 
 """
+from __future__ import print_function
 
 import os
 import glob

--- a/example/gluon/word_language_model/train.py
+++ b/example/gluon/word_language_model/train.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/image-classification/benchmark_score.py
+++ b/example/image-classification/benchmark_score.py
@@ -18,8 +18,9 @@
 """
 Benchmark the scoring performance on various CNNs
 """
-from common import find_mxnet
-from common.util import get_gpus
+from __future__ import absolute_import
+from .common import find_mxnet
+from .common.util import get_gpus
 import mxnet as mx
 from importlib import import_module
 import logging

--- a/example/image-classification/common/data.py
+++ b/example/image-classification/common/data.py
@@ -121,7 +121,7 @@ class SyntheticDataIter(DataIter):
         else:
             raise StopIteration
     def __next__(self):
-        return self.next()
+        return next(self)
     def reset(self):
         self.cur_iter = 0
 

--- a/example/image-classification/fine-tune.py
+++ b/example/image-classification/fine-tune.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -19,8 +20,8 @@ import os
 import argparse
 import logging
 logging.basicConfig(level=logging.DEBUG)
-from common import find_mxnet
-from common import data, fit, modelzoo
+from .common import find_mxnet
+from .common import data, fit, modelzoo
 import mxnet as mx
 import numpy as np
 

--- a/example/image-classification/score.py
+++ b/example/image-classification/score.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,7 +17,7 @@
 # under the License.
 
 import argparse
-from common import modelzoo, find_mxnet
+from .common import modelzoo, find_mxnet
 import mxnet as mx
 import time
 import os

--- a/example/image-classification/test_score.py
+++ b/example/image-classification/test_score.py
@@ -19,9 +19,10 @@
 test pretrained models
 """
 from __future__ import print_function
+from __future__ import absolute_import
 import mxnet as mx
-from common import find_mxnet, modelzoo
-from score import score
+from .common import find_mxnet, modelzoo
+from .score import score
 
 VAL_DATA='data/val-5k-256.rec'
 def download_data():

--- a/example/image-classification/train_cifar10.py
+++ b/example/image-classification/train_cifar10.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -19,8 +20,8 @@ import os
 import argparse
 import logging
 logging.basicConfig(level=logging.DEBUG)
-from common import find_mxnet, data, fit
-from common.util import download_file
+from .common import find_mxnet, data, fit
+from .common.util import download_file
 import mxnet as mx
 
 def download_cifar10():

--- a/example/image-classification/train_imagenet.py
+++ b/example/image-classification/train_imagenet.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -19,8 +20,8 @@ import os
 import argparse
 import logging
 logging.basicConfig(level=logging.DEBUG)
-from common import find_mxnet, data, fit
-from common.util import download_file
+from .common import find_mxnet, data, fit
+from .common.util import download_file
 import mxnet as mx
 
 if __name__ == '__main__':

--- a/example/image-classification/train_mnist.py
+++ b/example/image-classification/train_mnist.py
@@ -18,12 +18,13 @@
 """
 Train mnist, see more explanation at http://mxnet.io/tutorials/python/mnist.html
 """
+from __future__ import absolute_import
 import os
 import argparse
 import logging
 logging.basicConfig(level=logging.DEBUG)
-from common import find_mxnet, fit
-from common.util import download_file
+from .common import find_mxnet, fit
+from .common.util import download_file
 import mxnet as mx
 import numpy as np
 import gzip, struct

--- a/example/kaggle-ndsb1/train_dsb.py
+++ b/example/kaggle-ndsb1/train_dsb.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -98,4 +99,4 @@ def get_iterator(args, kv):
 # train
 tic=time.time()
 train_model.fit(args, net, get_iterator)
-print "time elapsed to train model", time.time()-tic
+print("time elapsed to train model", time.time()-tic)

--- a/example/kaggle-ndsb2/Preprocessing.py
+++ b/example/kaggle-ndsb2/Preprocessing.py
@@ -19,6 +19,7 @@
 
 This script walks over the directories and dump the frames into a csv file
 """
+from __future__ import print_function
 import os
 import csv
 import sys

--- a/example/kaggle-ndsb2/Train.py
+++ b/example/kaggle-ndsb2/Train.py
@@ -17,6 +17,7 @@
 
 """Training script, this is converted from a ipython notebook
 """
+from __future__ import print_function
 
 import os
 import csv

--- a/example/memcost/inception_memcost.py
+++ b/example/memcost/inception_memcost.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/model-parallel/matrix_factorization/get_data.py
+++ b/example/model-parallel/matrix_factorization/get_data.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/module/mnist_mlp.py
+++ b/example/module/mnist_mlp.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/multi-task/example_multi_task.py
+++ b/example/multi-task/example_multi_task.py
@@ -64,7 +64,7 @@ class Multi_mnist_iterator(mx.io.DataIter):
         self.data_iter.reset()
 
     def next(self):
-        batch = self.data_iter.next()
+        batch = next(self.data_iter)
         label = batch.label[0]
 
         return mx.io.DataBatch(data=batch.data, label=[label, label], \

--- a/example/multivariate_time_series/src/lstnet.py
+++ b/example/multivariate_time_series/src/lstnet.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # !/usr/bin/env python
 
 # Licensed to the Apache Software Foundation (ASF) under one

--- a/example/mxnet_adversarial_vae/vaegan_mxnet.py
+++ b/example/mxnet_adversarial_vae/vaegan_mxnet.py
@@ -437,7 +437,7 @@ def train(dataset, nef, ndf, ngf, nc, batch_size, Z, lr, beta1, epsilon, ctx, ch
         train_iter.reset()
         for t, batch in enumerate(train_iter):
 
-            rbatch = rand_iter.next()
+            rbatch = next(rand_iter)
 
             if mon is not None:
                 mon.tic()

--- a/example/named_entity_recognition/src/iterators.py
+++ b/example/named_entity_recognition/src/iterators.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # !/usr/bin/env python
 
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -42,7 +43,7 @@ class BucketNerIter(DataIter):
             seq_counts = np.bincount([len(s) for s in sentences])
             buckets = [i for i, j in enumerate(seq_counts) if j >= batch_size]
         buckets.sort()
-        print("\nBuckets  created: ", buckets)
+        print(("\nBuckets  created: ", buckets))
         assert(len(buckets) > 0), "Not enough utterances to create any buckets."
 
         ###########
@@ -64,7 +65,7 @@ class BucketNerIter(DataIter):
             buff[:len(sent)] = sent # Fill with actual values
             self.sentences[buck_idx].append(buff) # Append array to index = bucket index
         self.sentences = [np.asarray(i, dtype=dtype) for i in self.sentences] # Convert to list of array
-        print("Warning, {0} sentences sliced to largest bucket size.".format(nslice)) if nslice > 0 else None
+        print(("Warning, {0} sentences sliced to largest bucket size.".format(nslice)) if nslice > 0 else None)
 
         ############
         # Characters

--- a/example/neural-style/end_to_end/basic.py
+++ b/example/neural-style/end_to_end/basic.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -160,7 +161,7 @@ if __name__ == "__main__":
         data_grad = mod.get_input_grads()[0]
         gnorm = mx.nd.norm(data_grad).asscalar()
         if gnorm > clip_norm:
-            print("Data Grad: ", gnorm / clip_norm)
+            print(("Data Grad: ", gnorm / clip_norm))
             data_grad[:] *= clip_norm / gnorm
 
         optimizer.update(0, img, data_grad, optim_state)

--- a/example/neural-style/end_to_end/model_vgg19.py
+++ b/example/neural-style/end_to_end/model_vgg19.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/neural-style/model_vgg19.py
+++ b/example/neural-style/model_vgg19.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/neural-style/nstyle.py
+++ b/example/neural-style/nstyle.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/numpy-ops/custom_sparse_sqr.py
+++ b/example/numpy-ops/custom_sparse_sqr.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/numpy-ops/weighted_logistic_regression.py
+++ b/example/numpy-ops/weighted_logistic_regression.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/profiler/profiler_executor.py
+++ b/example/profiler/profiler_executor.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/profiler/profiler_imageiter.py
+++ b/example/profiler/profiler_imageiter.py
@@ -34,7 +34,7 @@ def run_imageiter(path_rec, n, batch_size=32):
     data.reset()
     tic = time.time()
     for i in range(n):
-        data.next()
+        next(data)
     mx.nd.waitall()
     print(batch_size*n/(time.time() - tic))
 

--- a/example/python-howto/data_iter.py
+++ b/example/python-howto/data_iter.py
@@ -21,6 +21,7 @@ This example shows how to create a iterator reading from recordio,
 introducing image augmentations and using a backend thread to hide IO cost.
 All you need to do is to set some parameters.
 """
+from __future__ import print_function
 import mxnet as mx
 
 dataiter = mx.io.ImageRecordIter(
@@ -71,6 +72,6 @@ for dbatch in dataiter:
     label = dbatch.label[0]
     pad = dbatch.pad
     index = dbatch.index
-    print("Batch", batchidx)
+    print(("Batch", batchidx))
     print(label.asnumpy().flatten())
     batchidx += 1

--- a/example/python-howto/debug_conv.py
+++ b/example/python-howto/debug_conv.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/python-howto/multiple_outputs.py
+++ b/example/python-howto/multiple_outputs.py
@@ -19,6 +19,7 @@
 
 This example shows how to create a multiple output configuration.
 """
+from __future__ import print_function
 import mxnet as mx
 
 net = mx.symbol.Variable('data')
@@ -28,7 +29,7 @@ net = mx.symbol.FullyConnected(data=net, name='fc2', num_hidden=64)
 out = mx.symbol.SoftmaxOutput(data=net, name='softmax')
 # group fc1 and out together
 group = mx.symbol.Group([fc1, out])
-print group.list_outputs()
+print(group.list_outputs())
 
 # You can go ahead and bind on the group
 # executor = group.simple_bind(data=data_shape)

--- a/example/quantization/imagenet_inference.py
+++ b/example/quantization/imagenet_inference.py
@@ -59,7 +59,7 @@ def advance_data_iter(data_iter, n):
     has_next_batch = True
     while has_next_batch:
         try:
-            data_iter.next()
+            next(data_iter)
             n -= 1
             if n == 0:
                 return data_iter

--- a/example/rcnn/rcnn/cython/setup.py
+++ b/example/rcnn/rcnn/cython/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # --------------------------------------------------------
 # Fast R-CNN
 # Copyright (c) 2015 Microsoft

--- a/example/rcnn/rcnn/dataset/imdb.py
+++ b/example/rcnn/rcnn/dataset/imdb.py
@@ -25,6 +25,7 @@ basic format [image_index]
 ['image', 'height', 'width', 'flipped',
 'boxes', 'gt_classes', 'gt_overlaps', 'max_classes', 'max_overlaps', 'bbox_targets']
 """
+from __future__ import print_function
 
 from ..logger import logger
 import os

--- a/example/rcnn/rcnn/pycocotools/coco.py
+++ b/example/rcnn/rcnn/pycocotools/coco.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/rcnn/rcnn/pycocotools/cocoeval.py
+++ b/example/rcnn/rcnn/pycocotools/cocoeval.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/rcnn/rcnn/utils/combine_model.py
+++ b/example/rcnn/rcnn/utils/combine_model.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,8 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from load_model import load_checkpoint
-from save_model import save_checkpoint
+from .load_model import load_checkpoint
+from .save_model import save_checkpoint
 
 
 def combine_model(prefix1, epoch1, prefix2, epoch2, prefix_out, epoch_out):

--- a/example/recommenders/crossentropy.py
+++ b/example/recommenders/crossentropy.py
@@ -19,6 +19,7 @@
 
 """Cross-entropy loss layer for MXNet.
 """
+from __future__ import print_function
 import os
 import time
 

--- a/example/recommenders/movielens_data.py
+++ b/example/recommenders/movielens_data.py
@@ -17,6 +17,7 @@
 
 """MovieLens data handling: download, parse, and expose as DataIter
 """
+from __future__ import print_function
 
 import os
 import mxnet as mx

--- a/example/recommenders/negativesample.py
+++ b/example/recommenders/negativesample.py
@@ -17,6 +17,7 @@
 
 """DataIter for negative sampling.
 """
+from __future__ import print_function
 import mxnet as mx
 import numpy as np
 
@@ -157,13 +158,13 @@ if __name__ == "__main__":
     R = np.random.randint(1,5,size=(100,))
     batch_size=3
     oridi = mx.io.NDArrayIter(data={'a':A,'b':B},label=R, batch_size=batch_size)
-    oribatch = oridi.next()
+    oribatch = next(oridi)
     oridi.reset()
     for ratio in range(0,5):
         nsdi = NegativeSamplingDataIter(oridi, sample_ratio=ratio)
 
         # Check sizes of output
-        bat = nsdi.next()
+        bat = next(nsdi)
         for i in range(len(bat.data)):
             assert bat.data[i].shape[0] == batch_size
             assert bat.data[i].shape[1] == oribatch.data[i].shape[1]

--- a/example/recommenders/randomproj.py
+++ b/example/recommenders/randomproj.py
@@ -18,6 +18,7 @@
 """Random projection layers in MXNet as custom python ops.
 Currently slow and memory-inefficient, but functional.
 """
+from __future__ import print_function
 import os
 import numpy as np
 import mxnet as mx

--- a/example/reinforcement-learning/a3c/a3c.py
+++ b/example/reinforcement-learning/a3c/a3c.py
@@ -223,7 +223,7 @@ def test():
     score = np.zeros((args.batch_size,))
     for t in range(N):
         dataiter.clear_history()
-        data = dataiter.next()
+        data = next(dataiter)
         module.forward(data, is_train=False)
         act = module.get_outputs()[0].asnumpy()
         act = [np.random.choice(dataiter.act_dim, p=act[i]) for i in range(act.shape[0])]

--- a/example/reinforcement-learning/a3c/rl_data.py
+++ b/example/reinforcement-learning/a3c/rl_data.py
@@ -172,6 +172,6 @@ if __name__ == '__main__':
         for _ in range(100):
             dataiter.act([env.action_space.sample() for env in dataiter.env])
             dataiter.clear_history()
-            dataiter.next()
+            next(dataiter)
         print(batch_size*100/(time.time() - tic))
         tic = time.time()

--- a/example/reinforcement-learning/ddpg/strategies.py
+++ b/example/reinforcement-learning/ddpg/strategies.py
@@ -61,7 +61,7 @@ class OUStrategy(BaseStrategy):
     def get_action(self, obs, policy):
 
         # get_action accepts a 2D tensor with one row
-    	obs = obs.reshape((1, -1))
+        obs = obs.reshape((1, -1))
         action = policy.get_action(obs)
         increment = self.evolve_state()
 
@@ -94,5 +94,3 @@ if __name__ == "__main__":
 
     plt.plot(states)
     plt.show()
-
-

--- a/example/reinforcement-learning/dqn/dqn_run_test.py
+++ b/example/reinforcement-learning/dqn/dqn_run_test.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import print_function
 import mxnet as mx
 import mxnet.ndarray as nd
 import numpy

--- a/example/reinforcement-learning/parallel_actor_critic/train.py
+++ b/example/reinforcement-learning/parallel_actor_critic/train.py
@@ -16,6 +16,7 @@
 # under the License.
 
 """Trains an `Agent` using trajectories from multiple environments."""
+from __future__ import print_function
 
 import argparse
 from itertools import chain

--- a/example/rnn/bucketing/cudnn_rnn_bucketing.py
+++ b/example/rnn/bucketing/cudnn_rnn_bucketing.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/rnn/large_word_lm/data.py
+++ b/example/rnn/large_word_lm/data.py
@@ -174,7 +174,7 @@ class MultiSentenceIter(mx.io.DataIter):
         self._iter = self._dataset.iterate_once(batch_size, bptt)
 
     def iter_next(self):
-        data = self._iter.next()
+        data = next(self._iter)
         if data is None:
             return False
         self._next_data = mx.nd.array(data[0], dtype=np.int32)

--- a/example/rnn/large_word_lm/train.py
+++ b/example/rnn/large_word_lm/train.py
@@ -85,7 +85,7 @@ if __name__ == '__main__':
         # reset initial LSTMP states
         module.set_states(value=0)
         state_cache = module.get_states(merge_multi_context=False)[:-num_sample_names]
-        next_batch = train_data.next()
+        next_batch = next(train_data)
         next_sampled_values = generate_samples(next_batch.label[0], ngpus, sampler)
         stop_iter = False
         while not stop_iter:
@@ -104,7 +104,7 @@ if __name__ == '__main__':
             module.forward(batch)
             try:
                 # prefetch the next batch of data and samples
-                next_batch = train_data.next()
+                next_batch = next(train_data)
                 next_sampled_values = generate_samples(next_batch.label[0], ngpus, sampler)
             except StopIteration:
                 stop_iter = True

--- a/example/sparse/linear_classification/data.py
+++ b/example/sparse/linear_classification/data.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/sparse/wide_deep/data.py
+++ b/example/sparse/wide_deep/data.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/example/speech_recognition/singleton.py
+++ b/example/speech_recognition/singleton.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -30,7 +31,7 @@ class Singleton:
             return self._instance
 
     def __new__(class_, *args, **kwargs):
-        print "__new__"
+        print("__new__")
         class_.instances[class_] = super(Singleton, class_).__new__(class_, *args, **kwargs)
         return class_.instances[class_]
 

--- a/example/speech_recognition/stt_io_iter.py
+++ b/example/speech_recognition/stt_io_iter.py
@@ -103,11 +103,11 @@ class STTIter(mx.io.DataIter):
             texts = []
             for i in range(self.batch_size):
                 try:
-                    duration, audio_path, text = self.trainDataIter.next()
+                    duration, audio_path, text = next(self.trainDataIter)
                 except:
                     random.shuffle(self.trainDataList)
                     self.trainDataIter = iter(self.trainDataList)
-                    duration, audio_path, text = self.trainDataIter.next()
+                    duration, audio_path, text = next(self.trainDataIter)
                 audio_paths.append(audio_path)
                 texts.append(text)
             if self.is_first_epoch:

--- a/example/ssd/benchmark_score.py
+++ b/example/ssd/benchmark_score.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from __future__ import print_function
+from __future__ import absolute_import
 import os
 import sys
 import argparse
@@ -24,9 +25,9 @@ import mxnet as mx
 import time
 import logging
 
-from symbol.symbol_factory import get_symbol
-from symbol.symbol_factory import get_symbol_train
-from symbol import symbol_builder
+from .symbol.symbol_factory import get_symbol
+from .symbol.symbol_factory import get_symbol_train
+from .symbol import symbol_builder
 
 
 parser = argparse.ArgumentParser(description='MxNet SSD benchmark')

--- a/example/ssd/config/config.py
+++ b/example/ssd/config/config.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,7 +17,7 @@
 # under the License.
 
 import os
-from config.utils import DotDict, namedtuple_with_defaults, zip_namedtuple, config_as_dict
+from .config.utils import DotDict, namedtuple_with_defaults, zip_namedtuple, config_as_dict
 
 RandCropper = namedtuple_with_defaults('RandCropper',
     'min_crop_scales, max_crop_scales, \

--- a/example/ssd/dataset/iterator.py
+++ b/example/ssd/dataset/iterator.py
@@ -99,7 +99,7 @@ class DetRecordIter(mx.io.DataIter):
             raise StopIteration
 
     def _get_batch(self):
-        self._batch = self.rec.next()
+        self._batch = next(self.rec)
         if not self._batch:
             return False
 

--- a/example/ssd/dataset/pycocotools/coco.py
+++ b/example/ssd/dataset/pycocotools/coco.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 __author__ = 'tylin'
 __version__ = '2.0'
 # Interface for accessing the Microsoft COCO dataset.

--- a/example/ssd/dataset/yolo_format.py
+++ b/example/ssd/dataset/yolo_format.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -17,7 +18,7 @@
 
 import os
 import numpy as np
-from imdb import Imdb
+from .imdb import Imdb
 
 
 class YoloFormat(Imdb):

--- a/example/ssd/demo.py
+++ b/example/ssd/demo.py
@@ -18,14 +18,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import absolute_import
 import argparse
-import tools.find_mxnet
 import mxnet as mx
 import os
 import sys
-from detect.detector import Detector
-from symbol.symbol_factory import get_symbol
-from dataset.cv2Iterator import CameraIterator
+from mxnet.tools import find_mxnet
+from .detect.detector import Detector
+from .symbol.symbol_factory import get_symbol
+from .dataset.cv2Iterator import CameraIterator
 import logging
 import cv2
 
@@ -238,4 +239,3 @@ def main():
 
 if __name__ == '__main__':
     sys.exit(main())
-

--- a/example/ssd/deploy.py
+++ b/example/ssd/deploy.py
@@ -16,13 +16,14 @@
 # under the License.
 
 from __future__ import print_function
+from __future__ import absolute_import
 import argparse
-import tools.find_mxnet
 import mxnet as mx
+from mxnet.tools import find_mxnet
 import os
 import importlib
 import sys
-from symbol.symbol_factory import get_symbol
+from .symbol.symbol_factory import get_symbol
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Convert a trained model to deploy model')

--- a/example/ssd/evaluate.py
+++ b/example/ssd/evaluate.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,11 +17,11 @@
 # under the License.
 
 import argparse
-import tools.find_mxnet
 import mxnet as mx
+from mxnet.tools import find_mxnet
 import os
 import sys
-from evaluate.evaluate_net import evaluate_net
+from .evaluate.evaluate_net import evaluate_net
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Evaluate a network')

--- a/example/ssd/symbol/legacy_vgg16_ssd_300.py
+++ b/example/ssd/symbol/legacy_vgg16_ssd_300.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,8 +17,8 @@
 # under the License.
 
 import mxnet as mx
-from common import legacy_conv_act_layer
-from common import multibox_layer
+from .common import legacy_conv_act_layer
+from .common import multibox_layer
 
 def get_symbol_train(num_classes=20, nms_thresh=0.5, force_suppress=False,
                      nms_topk=400, **kwargs):

--- a/example/ssd/symbol/legacy_vgg16_ssd_512.py
+++ b/example/ssd/symbol/legacy_vgg16_ssd_512.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,8 +17,8 @@
 # under the License.
 
 import mxnet as mx
-from common import legacy_conv_act_layer
-from common import multibox_layer
+from .common import legacy_conv_act_layer
+from .common import multibox_layer
 
 def get_symbol_train(num_classes=20, nms_thresh=0.5, force_suppress=False, nms_topk=400):
     """

--- a/example/ssd/tools/visualize_net.py
+++ b/example/ssd/tools/visualize_net.py
@@ -16,7 +16,8 @@
 # under the License.
 
 from __future__ import print_function
-import find_mxnet
+from __future__ import absolute_import
+from . import find_mxnet
 import mxnet as mx
 import argparse
 import sys, os

--- a/example/ssd/train.py
+++ b/example/ssd/train.py
@@ -18,10 +18,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import absolute_import
 import argparse
 import mxnet as mx
 import os
-from train.train_net import train_net
+from .train.train_net import train_net
 
 
 def parse_args():

--- a/python/mxnet/autograd.py
+++ b/python/mxnet/autograd.py
@@ -19,6 +19,7 @@
 """Autograd for NDArray."""
 from __future__ import absolute_import
 from __future__ import division
+from __future__ import print_function
 
 from array import array
 from threading import Lock

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -18,6 +18,7 @@
 # coding: utf-8
 # pylint: disable= arguments-differ, too-many-lines
 """Base container class for all neural network models."""
+from __future__ import print_function
 __all__ = ['Block', 'HybridBlock', 'SymbolBlock']
 
 import threading

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -18,6 +18,7 @@
 # coding: utf-8
 # pylint: disable=
 """Parallelization utility optimizer."""
+from __future__ import print_function
 __all__ = ['split_data', 'split_and_load', 'clip_global_norm',
            'check_sha1', 'download']
 

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -229,7 +229,7 @@ class DataIter(object):
             raise StopIteration
 
     def __next__(self):
-        return self.next()
+        return next(self)
 
     def iter_next(self):
         """Move to the next batch.
@@ -326,10 +326,10 @@ class ResizeIter(DataIter):
         if self.cur == self.size:
             return False
         try:
-            self.current_batch = self.data_iter.next()
+            self.current_batch = next(self.data_iter)
         except StopIteration:
             self.data_iter.reset()
-            self.current_batch = self.data_iter.next()
+            self.current_batch = next(self.data_iter)
 
         self.cur += 1
         return True
@@ -398,7 +398,7 @@ class PrefetchingIter(DataIter):
                 if not self.started:
                     break
                 try:
-                    self.next_batch[i] = self.iters[i].next()
+                    self.next_batch[i] = next(self.iters[i])
                 except StopIteration:
                     self.next_batch[i] = None
                 self.data_taken[i].clear()
@@ -797,7 +797,7 @@ class MXDataIter(DataIter):
 
         # load the first batch to get shape information
         self.first_batch = None
-        self.first_batch = self.next()
+        self.first_batch = next(self)
         data = self.first_batch.data[0]
         label = self.first_batch.label[0]
 

--- a/python/mxnet/kvstore_server.py
+++ b/python/mxnet/kvstore_server.py
@@ -18,6 +18,7 @@
 # coding: utf-8
 """A server node for the key value store."""
 from __future__ import absolute_import
+from __future__ import print_function
 import ctypes
 import sys
 import pickle

--- a/python/mxnet/operator.py
+++ b/python/mxnet/operator.py
@@ -19,6 +19,7 @@
 # pylint: disable=invalid-name, protected-access, too-many-arguments, no-self-use, too-many-locals, broad-except, too-many-lines
 """numpy interface for operators."""
 from __future__ import absolute_import
+from __future__ import print_function
 
 import traceback
 import warnings

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -20,6 +20,7 @@
 # pylint: disable=import-error, no-name-in-module
 """Symbolic configuration API of MXNet."""
 from __future__ import absolute_import as _abs
+from __future__ import print_function
 try:
     from __builtin__ import slice as py_slice
 except ImportError:

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -22,6 +22,7 @@
 # pylint: disable=dangerous-default-value
 """Visualization module"""
 from __future__ import absolute_import
+from __future__ import print_function
 
 import re
 import copy

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,6 +18,7 @@
 # pylint: disable=invalid-name, exec-used
 """Setup mxnet package."""
 from __future__ import absolute_import
+from __future__ import print_function
 import os
 import sys
 # need to use distutils.core for correct placement of cython dll

--- a/tests/nightly/TestDoc/doc_spell_checker.py
+++ b/tests/nightly/TestDoc/doc_spell_checker.py
@@ -21,6 +21,7 @@
     An exclude list is provided to avoid checking specific word,
     such as NDArray.
 """
+from __future__ import print_function
 
 import os
 import sys
@@ -171,8 +172,8 @@ if __name__ == "__main__":
             spell_check_res = DOC_PARSER.get_res()[0]
             grammar_check_res = DOC_PARSER.get_res()[1]
             if len(spell_check_res) > 0:
-                print "%s has typo:" % os.path.join(root, read_file)
-                print "%s\n" % spell_check_res
+                print("%s has typo:" % os.path.join(root, read_file))
+                print("%s\n" % spell_check_res)
                 ALL_CLEAR = False
     if ALL_CLEAR:
-        print "No typo is found."
+        print("No typo is found.")

--- a/tests/nightly/broken_link_checker_test/test_broken_links.py
+++ b/tests/nightly/broken_link_checker_test/test_broken_links.py
@@ -18,6 +18,7 @@
 # under the License.
 
 
+from __future__ import print_function
 import sys
 from subprocess import check_output, STDOUT, CalledProcessError
 

--- a/tests/nightly/compilation_warnings/process_output.py
+++ b/tests/nightly/compilation_warnings/process_output.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -40,17 +41,17 @@ def generate_stats(warnings):
 
 def print_summary(time, warnings):
     sorted_warnings, total_count = generate_stats(warnings)
-    print "START - Compilation warnings count"
-    print total_count, 'warnings'
-    print "END - Compilation warnings count"
-    print 'START - Compilation warnings summary'
-    print 'Time taken to compile:', time, 's'
-    print 'Total number of warnings:', total_count, '\n'
+    print("START - Compilation warnings count")
+    print(total_count, 'warnings')
+    print("END - Compilation warnings count")
+    print('START - Compilation warnings summary')
+    print('Time taken to compile:', time, 's')
+    print('Total number of warnings:', total_count, '\n')
     if total_count>0:
-        print 'Below is the list of unique warnings and the number of occurrences of that warning'
+        print('Below is the list of unique warnings and the number of occurrences of that warning')
         for warning, count in sorted_warnings:
-            print count, ': ', warning
-    print 'END - Compilation warnings summary'
+            print(count, ': ', warning)
+    print('END - Compilation warnings summary')
 
 c_output = open(sys.argv[1],'r')
 time, warnings = process_output(c_output.read())

--- a/tests/nightly/dist_device_sync_kvstore.py
+++ b/tests/nightly/dist_device_sync_kvstore.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import print_function
 import sys
 sys.path.insert(0, "../../python/")
 import mxnet as mx

--- a/tests/nightly/dist_sync_kvstore.py
+++ b/tests/nightly/dist_sync_kvstore.py
@@ -18,6 +18,7 @@
 # under the License.
 
 # pylint: skip-file
+from __future__ import print_function
 import sys
 sys.path.insert(0, "../../python/")
 import argparse

--- a/tests/nightly/multi_lenet.py
+++ b/tests/nightly/multi_lenet.py
@@ -29,6 +29,7 @@
 # are performed, which can be controlled by either increasing the batch size or
 # decreasing the number of epochs
 
+from __future__ import print_function
 import os, sys
 curr_path = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.join(curr_path, "../../example/image-classification"))
@@ -89,7 +90,7 @@ def get_XY(data_iter):
 def test_data(data_iter):
     # test whether we will get the identical data each time
     X, Y = get_XY(data_iter)
-    print X.shape, Y.shape
+    print(X.shape, Y.shape)
     for i in range(4):
         A, B = get_XY(data_iter)
         assert(A.shape == X.shape)

--- a/tests/nightly/test_kvstore.py
+++ b/tests/nightly/test_kvstore.py
@@ -17,6 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from __future__ import print_function
 import sys
 sys.path.insert(0, "../../python/")
 import mxnet as mx

--- a/tests/python/gpu/test_gluon_model_zoo_gpu.py
+++ b/tests/python/gpu/test_gluon_model_zoo_gpu.py
@@ -57,7 +57,7 @@ def test_inference():
             label_name         = 'softmax_label',
             rand_crop          = False,
             rand_mirror        = False)
-        data_batch = dataIter.next()
+        data_batch = next(dataIter)
         data = data_batch.data[0]
         label = data_batch.label[0]
         gpu_data = data.as_in_context(mx.gpu())
@@ -120,7 +120,7 @@ def test_training():
         label_name         = 'softmax_label',
         rand_crop          = False,
         rand_mirror        = False)
-    data_batch = dataIter.next()
+    data_batch = next(dataIter)
     data = data_batch.data[0]
     label = data_batch.label[0]
     gpu_data = data.as_in_context(mx.gpu())

--- a/tests/python/gpu/test_nccl.py
+++ b/tests/python/gpu/test_nccl.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/python/predict/mxnet_predict_example.py
+++ b/tests/python/predict/mxnet_predict_example.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -38,7 +39,7 @@ synset = [l.strip() for l in open('resnet/synset.txt').readlines()]
 def PreprocessImage(path, show_img=False):
     # load image
     img = io.imread(path)
-    print("Original Image Shape: ", img.shape)
+    print(("Original Image Shape: ", img.shape))
     # we crop image from center
     short_egde = min(img.shape[:2])
     yy = int((img.shape[0] - short_egde) / 2)
@@ -64,8 +65,8 @@ prob = predictor.get_output(0)[0]
 pred = np.argsort(prob)[::-1]
 # Get top1 label
 top1 = synset[pred[0]]
-print("Top1: ", top1)
+print(("Top1: ", top1))
 # Get top5 label
 top5 = [synset[pred[i]] for i in range(5)]
-print("Top5: ", top5)
+print(("Top5: ", top5))
 

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -18,6 +18,7 @@
 """Some of the tests using CUDNN require a special GPU instruction called dp4a.
 Ref: http://images.nvidia.com/content/pdf/tesla/184457-Tesla-P4-Datasheet-NV-Final-Letter-Web.pdf
 """
+from __future__ import print_function
 import os
 import mxnet as mx
 import numpy as np

--- a/tests/python/train/test_dtype.py
+++ b/tests/python/train/test_dtype.py
@@ -152,7 +152,7 @@ class CustomDataIter(mx.io.DataIter):
         self.data.reset()
 
     def next(self):
-        return self.data.next()
+        return next(self.data)
 
     def iter_next(self):
         return self.data.iter_next()

--- a/tests/python/train/test_resnet_aug.py
+++ b/tests/python/train/test_resnet_aug.py
@@ -136,7 +136,7 @@ class CustomDataIter(mx.io.DataIter):
         self.data.reset()
 
     def next(self):
-        return self.data.next()
+        return next(self.data)
 
     def iter_next(self):
         return self.data.iter_next()

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/python/unittest/test_gluon_rnn.py
+++ b/tests/python/unittest/test_gluon_rnn.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -359,7 +359,7 @@ def test_ImageRecordIter_seed_augmentation():
         random_h=10,
         max_shear_ratio=2,
         seed_aug=seed_aug)
-    batch = dataiter.next()
+    batch = next(dataiter)
     data = batch.data[0].asnumpy().astype(np.uint8)
 
     dataiter = mx.io.ImageRecordIter(
@@ -378,7 +378,7 @@ def test_ImageRecordIter_seed_augmentation():
         random_h=10,
         max_shear_ratio=2,
         seed_aug=seed_aug)
-    batch = dataiter.next()
+    batch = next(dataiter)
     data2 = batch.data[0].asnumpy().astype(np.uint8)
     assert(np.array_equal(data,data2))
 
@@ -399,7 +399,7 @@ def test_ImageRecordIter_seed_augmentation():
         random_h=10,
         max_shear_ratio=2,
         seed_aug=seed_aug+1)
-    batch = dataiter.next()
+    batch = next(dataiter)
     data2 = batch.data[0].asnumpy().astype(np.uint8)
     assert(not np.array_equal(data,data2))
 
@@ -411,7 +411,7 @@ def test_ImageRecordIter_seed_augmentation():
         data_shape=(3, 28, 28),
         batch_size=3,
         seed_aug=seed_aug)
-    batch = dataiter.next()
+    batch = next(dataiter)
     data = batch.data[0].asnumpy().astype(np.uint8)
 
     dataiter = mx.io.ImageRecordIter(
@@ -421,7 +421,7 @@ def test_ImageRecordIter_seed_augmentation():
         data_shape=(3, 28, 28),
         batch_size=3,
         seed_aug=seed_aug)
-    batch = dataiter.next()
+    batch = next(dataiter)
     data2 = batch.data[0].asnumpy().astype(np.uint8)
     assert(np.array_equal(data,data2))
 

--- a/tests/python/unittest/test_model_parallel.py
+++ b/tests/python/unittest/test_model_parallel.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/python/unittest/test_rnn.py
+++ b/tests/python/unittest/test_rnn.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -305,7 +306,7 @@ def test_encode_sentences():
     dict = {'a':1, 'b':2, 'c':3}
     result, vocab = mx.rnn.io.encode_sentences(sentences, vocab=dict, invalid_label=-1, invalid_key='\n',
                          start_label=0, unknown_token='UNK')
-    print(result, vocab)
+    print((result, vocab))
     assert vocab == {'a': 1, 'b': 2, 'c': 3, 'UNK': 0}
     assert result == [[1,2,3],[2,3,0]]
     

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -251,10 +252,10 @@ def test_elemwise_binary_ops():
         assert outputs[0].stype == expected_result_storage_type
 
         if verbose is True:
-            print ("mx forward output: ", outputs[0].asnumpy())
-            print ("lhs_nd: ", lhs_nd.stype)
-            print ("rhs_nd: ", rhs_nd.stype)
-            print ("forward output: ", outputs[0].stype)
+            print(("mx forward output: ", outputs[0].asnumpy()))
+            print(("lhs_nd: ", lhs_nd.stype))
+            print(("rhs_nd: ", rhs_nd.stype))
+            print(("forward output: ", outputs[0].stype))
 
         if outputs[0].stype != 'default':
             out_grad = create_sparse_array_zd(
@@ -277,14 +278,14 @@ def test_elemwise_binary_ops():
         out_grad_np = out_grad.asnumpy()
 
         if verbose is True:
-            print("out_grad_np", out_grad_np)
+            print(("out_grad_np", out_grad_np))
 
         ingrad_lhs_np, ingrad_rhs_np = backward_numpy_call(out_grad_np, lhs_np, rhs_np)
 
         if verbose is True:
-            print("out_grad", out_grad.asnumpy())
-            print("ingrad_lhs_np", ingrad_lhs_np)
-            print("ingrad_rhs_np", ingrad_rhs_np)
+            print(("out_grad", out_grad.asnumpy()))
+            print(("ingrad_lhs_np", ingrad_lhs_np))
+            print(("ingrad_rhs_np", ingrad_rhs_np))
 
         igrads_result = check_symbolic_backward(test, location, [out_grad],
                                                 [ingrad_lhs_np, ingrad_rhs_np],
@@ -292,8 +293,8 @@ def test_elemwise_binary_ops():
                                                 equal_nan=True)
 
         if verbose is True:
-            print("ingrad_lhs", igrads_result['lhs'].asnumpy())
-            print("ingrad_rhs", igrads_result['rhs'].asnumpy())
+            print(("ingrad_lhs", igrads_result['lhs'].asnumpy()))
+            print(("ingrad_rhs", igrads_result['rhs'].asnumpy()))
 
         assert len(igrads_result) == 2
 
@@ -623,7 +624,7 @@ def check_sparse_mathematical_core(name, stype,
     shape = rand_shape_2d()
 
     if verbose is True:
-        print("Shape: ", shape, "density: ", density, "force_overlap", force_overlap)
+        print(("Shape: ", shape, "density: ", density, "force_overlap", force_overlap))
 
     if stype == 'default':
         data_tmp = np.zeros(shape)
@@ -643,10 +644,10 @@ def check_sparse_mathematical_core(name, stype,
         )
         data_tmp = arr_data.asnumpy()
         if verbose is True:
-            print("arr_data indices", arr_data.indices.asnumpy())
+            print(("arr_data indices", arr_data.indices.asnumpy()))
 
     if verbose is True:
-        print("input", data_tmp)
+        print(("input", data_tmp))
 
     if backward_numpy_call is None:
         arr_grad = None
@@ -692,8 +693,8 @@ def check_sparse_mathematical_core(name, stype,
         npout = forward_numpy_call(data_tmp)
 
     if verbose is True:
-        print("out", out)
-        print("npout", npout)
+        print(("out", out))
+        print(("npout", npout))
 
     assert_almost_equal(out, npout, equal_nan=True)
 
@@ -715,7 +716,7 @@ def check_sparse_mathematical_core(name, stype,
         npout_grad = out_grad.asnumpy()
 
         if verbose is True:
-            print("npout_grad", npout_grad)
+            print(("npout_grad", npout_grad))
 
         if rhs_arg is not None:
             temp = backward_numpy_call(data_tmp, rhs_arg)
@@ -735,8 +736,8 @@ def check_sparse_mathematical_core(name, stype,
 
         if verbose is True:
             print(name)
-            print("arr_grad", arr_grad)
-            print("input_grad", input_grad)
+            print(("arr_grad", arr_grad))
+            print(("input_grad", input_grad))
 
         assert_almost_equal(arr_grad, input_grad, equal_nan=True)
 
@@ -1143,7 +1144,7 @@ def test_sparse_mathematical_core():
                 print("Could not import scipy. Skipping unit tests for special functions")
 
     for i in range(1):
-        print("pass", i)
+        print(("pass", i))
         for density in [0.0, random.uniform(0, 1), 1.0]:
             for ograd_density in [0.0, random.uniform(0, 1), 1.0]:
                 for force_overlap in [False, True]:

--- a/tests/tutorials/test_sanity_tutorials.py
+++ b/tests/tutorials/test_sanity_tutorials.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -60,7 +61,7 @@ def test_tutorial_downloadable():
         downloadable = download_button_string in last or download_button_string in second_last
         friendly_name = '/'.join(tutorial.split('/')[-2:])
         if not downloadable and friendly_name  not in whitelist_set:
-            print(last, second_last)
+            print((last, second_last))
             assert False, "{} is missing <!-- INSERT SOURCE DOWNLOAD BUTTONS --> as its last line".format(friendly_name)
 
 def test_tutorial_tested():

--- a/tests/tutorials/test_tutorials.py
+++ b/tests/tutorials/test_tutorials.py
@@ -32,6 +32,7 @@
     NB: in the real CI, the tests will re-download everything since they start from
     a clean workspace.
 """
+from __future__ import print_function
 import os
 import warnings
 import imp

--- a/tools/accnn/utils.py
+++ b/tools/accnn/utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -62,7 +63,7 @@ def sym_factory(node, data):
     for k, v in node['param'].items():
       try:
         params[k] = ast.literal_eval(v)
-      except ValueError, e:
+      except ValueError as e:
         params[k] = v
   return getattr(mx.symbol, node['op'])(data=data, name=name, **params)
 
@@ -83,8 +84,8 @@ def replace_conv_layer(layer_name, old_model, sym_handle, arg_handle):
                                   if not input_node['name'].startswith(node['name'])]
       try:
         data=sym_dict[datas[0]]
-      except Exception, e:
-        print 'can not find symbol %s'%(datas[0])
+      except Exception as e:
+        print('can not find symbol %s'%(datas[0]))
         raise e
       if node['name'] == layer_name:
         sym = sym_handle(data, node)
@@ -101,7 +102,7 @@ def replace_conv_layer(layer_name, old_model, sym_handle, arg_handle):
     arg_shape_dic = dict(zip(arg_names, arg_shapes))
     try:
       arg_handle(arg_shape_dic, arg_params)
-    except Exception, e:
+    except Exception as e:
       raise Exception('Exception in arg_handle')
 
   new_model = mx.model.FeedForward(

--- a/tools/caffe_converter/convert_caffe_modelzoo.py
+++ b/tools/caffe_converter/convert_caffe_modelzoo.py
@@ -17,6 +17,7 @@
 
 """Convert Caffe's modelzoo
 """
+from __future__ import print_function
 import os
 import argparse
 from convert_model import convert_model

--- a/tools/caffe_converter/test_converter.py
+++ b/tools/caffe_converter/test_converter.py
@@ -17,6 +17,7 @@
 
 """Test converted models
 """
+from __future__ import print_function
 import os
 import argparse
 import sys

--- a/tools/coreml/converter/_layers.py
+++ b/tools/coreml/converter/_layers.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import _add_pooling
+from . import _add_pooling
 from ast import literal_eval
 
 def _get_input_output_name(net, node, index=0):

--- a/tools/coreml/converter/_mxnet_converter.py
+++ b/tools/coreml/converter/_mxnet_converter.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+from __future__ import absolute_import
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import _layers
+from . import _layers
 import coremltools as _coremltools
 import coremltools.models.datatypes as _datatypes
 from coremltools.models import neural_network as _neural_network
@@ -68,9 +70,9 @@ def check_error(model, path, shapes, output = 'softmax_output', verbose = True):
     error = _np.linalg.norm(e_out - mx_out)
 
     if verbose:
-        print "First few predictions from CoreML : %s" % e_out[0:10]
-        print "First few predictions from MXNet  : %s" % e_out[0:10]
-        print "L2 Error on random data %s" % error
+        print("First few predictions from CoreML : %s" % e_out[0:10])
+        print("First few predictions from MXNet  : %s" % e_out[0:10])
+        print("L2 Error on random data %s" % error)
     return error
 
 def _set_input_output_layers(builder, input_names, output_names):

--- a/tools/coreml/test/test_mxnet_image.py
+++ b/tools/coreml/test/test_mxnet_image.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -107,27 +108,27 @@ class ImageNetTest(unittest.TestCase):
                 num_batch += 1
             if (num_batch == 5): break # we only use a subset of the batches.
 
-        print "MXNet acc %s" % np.mean(mxnet_acc)
-        print "Coreml acc %s" % np.mean(coreml_acc)
-        print "MXNet top 5 acc %s" % np.mean(mxnet_top_5_acc)
-        print "Coreml top 5 acc %s" % np.mean(coreml_top_5_acc)
+        print("MXNet acc %s" % np.mean(mxnet_acc))
+        print("Coreml acc %s" % np.mean(coreml_acc))
+        print("MXNet top 5 acc %s" % np.mean(mxnet_top_5_acc))
+        print("Coreml top 5 acc %s" % np.mean(coreml_top_5_acc))
         self.assertAlmostEqual(np.mean(mxnet_acc), np.mean(coreml_acc), delta=1e-4)
         self.assertAlmostEqual(np.mean(mxnet_top_5_acc), np.mean(coreml_top_5_acc), delta=1e-4)
 
     def test_squeezenet(self):
-        print "Testing Image Classification with Squeezenet"
+        print("Testing Image Classification with Squeezenet")
         self._test_image_prediction(model_name='squeezenet_v1.1', epoch=0, label_name='prob_label')
 
     def test_inception_with_batch_normalization(self):
-        print "Testing Image Classification with Inception/BatchNorm"
+        print("Testing Image Classification with Inception/BatchNorm")
         self._test_image_prediction(model_name='Inception-BN', epoch=126, label_name='softmax_label')
 
     def test_resnet18(self):
-        print "Testing Image Classification with ResNet18"
+        print("Testing Image Classification with ResNet18")
         self._test_image_prediction(model_name='resnet-18', epoch=0, label_name='softmax_label')
 
     def test_vgg16(self):
-        print "Testing Image Classification with vgg16"
+        print("Testing Image Classification with vgg16")
         self._test_image_prediction(model_name='vgg16', epoch=0, label_name='prob_label')
 
 

--- a/tools/coreml/test/test_mxnet_models.py
+++ b/tools/coreml/test/test_mxnet_models.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -116,7 +117,7 @@ class ModelsTest(unittest.TestCase):
             self.assertEqual(len(mxnet_pred), len(coreml_pred))
             div.append(_kl_divergence(mxnet_pred, coreml_pred))
 
-        print "Average KL divergence is % s" % np.mean(div)
+        print("Average KL divergence is % s" % np.mean(div))
         self.assertTrue(np.mean(div) < 1e-4)
 
     def test_pred_inception_bn(self):

--- a/tools/diagnose.py
+++ b/tools/diagnose.py
@@ -20,6 +20,7 @@
 """Diagnose script for checking OS/hardware/python/pip/mxnet/network.
 The output of this script can be a very good hint to issue/problem.
 """
+from __future__ import print_function
 import platform, subprocess, sys, os
 import socket, time
 try:
@@ -83,17 +84,17 @@ def test_connection(name, url, timeout=10):
 
 def check_python():
     print('----------Python Info----------')
-    print('Version      :', platform.python_version())
-    print('Compiler     :', platform.python_compiler())
-    print('Build        :', platform.python_build())
-    print('Arch         :', platform.architecture())
+    print(('Version      :', platform.python_version()))
+    print(('Compiler     :', platform.python_compiler()))
+    print(('Build        :', platform.python_build()))
+    print(('Arch         :', platform.architecture()))
 
 def check_pip():
     print('------------Pip Info-----------')
     try:
         import pip
-        print('Version      :', pip.__version__)
-        print('Directory    :', os.path.dirname(pip.__file__))
+        print(('Version      :', pip.__version__))
+        print(('Directory    :', os.path.dirname(pip.__file__)))
     except ImportError:
         print('No corresponding pip install for current python.')
 
@@ -101,13 +102,13 @@ def check_mxnet():
     print('----------MXNet Info-----------')
     try:
         import mxnet
-        print('Version      :', mxnet.__version__)
+        print(('Version      :', mxnet.__version__))
         mx_dir = os.path.dirname(mxnet.__file__)
-        print('Directory    :', mx_dir)
+        print(('Directory    :', mx_dir))
         commit_hash = os.path.join(mx_dir, 'COMMIT_HASH')
         with open(commit_hash, 'r') as f:
             ch = f.read().strip()
-            print('Commit Hash   :', ch)
+            print(('Commit Hash   :', ch))
     except ImportError:
         print('No MXNet installed.')
     except IOError:
@@ -121,16 +122,16 @@ def check_mxnet():
 
 def check_os():
     print('----------System Info----------')
-    print('Platform     :', platform.platform())
-    print('system       :', platform.system())
-    print('node         :', platform.node())
-    print('release      :', platform.release())
-    print('version      :', platform.version())
+    print(('Platform     :', platform.platform()))
+    print(('system       :', platform.system()))
+    print(('node         :', platform.node()))
+    print(('release      :', platform.release()))
+    print(('version      :', platform.version()))
 
 def check_hardware():
     print('----------Hardware Info----------')
-    print('machine      :', platform.machine())
-    print('processor    :', platform.processor())
+    print(('machine      :', platform.machine()))
+    print(('processor    :', platform.processor()))
     if sys.platform.startswith('darwin'):
         pipe = subprocess.Popen(('sysctl', '-a'), stdout=subprocess.PIPE)
         output = pipe.communicate()[0]

--- a/tools/ipynb2md.py
+++ b/tools/ipynb2md.py
@@ -24,6 +24,7 @@ removed.
 
 It is heavily adapted from https://gist.github.com/decabyte/0ed87372774cf5d34d7e
 """
+from __future__ import print_function
 
 import sys
 import io
@@ -61,7 +62,7 @@ def main():
     old_ipynb = args.notebook[0]
     new_ipynb = 'tmp.ipynb'
     md_file = args.output
-    print md_file
+    print(md_file)
     if not md_file:
         md_file = os.path.splitext(old_ipynb)[0] + '.md'
 

--- a/tools/kill-mxnet.py
+++ b/tools/kill-mxnet.py
@@ -18,11 +18,12 @@
 # under the License.
 
 
+from __future__ import print_function
 import os, sys
 import subprocess
 
 if len(sys.argv) != 4:
-  print "usage: %s <hostfile> <user> <prog>" % sys.argv[0]
+  print("usage: %s <hostfile> <user> <prog>" % sys.argv[0])
   sys.exit(1)
 
 host_file = sys.argv[1]
@@ -36,19 +37,19 @@ kill_cmd = (
     "awk '{if($1==\"" + user + "\")print $2;}' | "
     "xargs kill -9"
     )
-print kill_cmd
+print(kill_cmd)
 
 # Kill program on remote machines
 with open(host_file, "r") as f:
   for host in f:
     if ':' in host:
       host = host[:host.index(':')]
-    print host
+    print(host)
     subprocess.Popen(["ssh", "-oStrictHostKeyChecking=no", "%s" % host, kill_cmd],
             shell=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
-    print "Done killing"
+    print("Done killing")
 
 # Kill program on local machine
 os.system(kill_cmd)

--- a/tools/launch.py
+++ b/tools/launch.py
@@ -20,6 +20,7 @@
 """
 Launch a distributed job
 """
+from __future__ import print_function
 import argparse
 import os, sys
 import signal

--- a/tools/parse_log.py
+++ b/tools/parse_log.py
@@ -20,6 +20,7 @@
 """
 parse mxnet output log into a markdown table
 """
+from __future__ import print_function
 import argparse
 import sys
 import re


### PR DESCRIPTION
$ __futurize --stage1 -w .__  # http://python-future.org/futurize_cheatsheet.html

Minimal, safe changes required to make this code syntax compatible with both Python 2 and Python 3. More changes will be required to complete the port to Python 3 but this should provide a solid start in that process without breaking backward compatibility with legacy Python.

