### PR TITLE
Fix flaky test test_deconvolution

### DIFF
--- a/src/operator/linalg_impl.h
+++ b/src/operator/linalg_impl.h
@@ -169,23 +169,50 @@ void linalg_gemm<cpu, mshadow::half::half_t>(const Tensor<cpu, 2, mshadow::half:
 
 // cublas col-major processing accounted for by switching first two operands
 
-#define LINALG_GPU_GEMM(fname, DType) \
-template<> inline \
-void linalg_gemm<gpu, DType>(const Tensor<gpu, 2, DType>& A, const Tensor<gpu, 2, DType>& B, \
-                             const Tensor<gpu, 2, DType>& C, DType alpha, DType beta, \
-                             bool tA, bool tB, Stream<gpu> *s) { \
-  using namespace mxnet; \
-  using mshadow::gpu; \
-  CHECK_NOTNULL(s); \
-  check_gemm(A, B, C, alpha, beta, tA, tB); \
-  CUBLAS_CALL(cublas##fname(Stream<gpu>::GetBlasHandle(s), \
-                            (tB ? CUBLAS_OP_T : CUBLAS_OP_N), \
-                            (tA ? CUBLAS_OP_T : CUBLAS_OP_N), \
-                            C.size(1), C.size(0), (tB ? B.size(1) : B.size(0)), \
-                            &alpha, B.dptr_, B.stride_, A.dptr_, A.stride_, \
-                            &beta, C.dptr_, C.stride_)) \
+#define LINALG_GPU_GEMM(fname, DType)                                      \
+  template <>                                                              \
+  inline void linalg_gemm<gpu, DType>(                                     \
+      const Tensor<gpu, 2, DType>& A, const Tensor<gpu, 2, DType>& B,      \
+      const Tensor<gpu, 2, DType>& C, DType alpha, DType beta, bool tA,    \
+      bool tB, Stream<gpu>* s) {                                           \
+    using namespace mxnet;                                                 \
+    using mshadow::gpu;                                                    \
+    CHECK_NOTNULL(s);                                                      \
+    check_gemm(A, B, C, alpha, beta, tA, tB);                              \
+    CUBLAS_CALL(cublas##fname(                                             \
+        Stream<gpu>::GetBlasHandle(s), (tB ? CUBLAS_OP_T : CUBLAS_OP_N),   \
+        (tA ? CUBLAS_OP_T : CUBLAS_OP_N), C.size(1), C.size(0),            \
+        (tB ? B.size(1) : B.size(0)), &alpha, B.dptr_, B.stride_, A.dptr_, \
+        A.stride_, &beta, C.dptr_, C.stride_))                             \
+  }
+
+#if CUDA_VERSION >= 7050
+template <>
+inline void linalg_gemm<gpu, float>(const Tensor<gpu, 2, float>& A,
+                                    const Tensor<gpu, 2, float>& B,
+                                    const Tensor<gpu, 2, float>& C, float alpha,
+                                    float beta, bool tA, bool tB,
+                                    Stream<gpu>* s) {
+  using namespace mxnet;
+  using mshadow::gpu;
+  CHECK_NOTNULL(s);
+  check_gemm(A, B, C, alpha, beta, tA, tB);
+#if CUDA_VERSION >= 8000
+  cudaDataType_t full_datatype = CUDA_R_32F;
+#else
+  cublasDataType_t full_datatype = CUBLAS_DATA_FULL;
+#endif
+  CUBLAS_CALL(cublasSgemmEx(
+      Stream<gpu>::GetBlasHandle(s), (tB ? CUBLAS_OP_T : CUBLAS_OP_N),
+      (tA ? CUBLAS_OP_T : CUBLAS_OP_N), C.size(1), C.size(0),
+      (tB ? B.size(1) : B.size(0)), &alpha, B.dptr_, full_datatype, B.stride_,
+      A.dptr_, full_datatype, A.stride_, &beta, C.dptr_, full_datatype,
+      C.stride_))
 }
+
+#else
 LINALG_GPU_GEMM(Sgemm, float)
+#endif
 LINALG_GPU_GEMM(Dgemm, double)
 
 // Version where matrix rows are given by first axis.

--- a/src/operator/linalg_impl.h
+++ b/src/operator/linalg_impl.h
@@ -186,6 +186,8 @@ void linalg_gemm<cpu, mshadow::half::half_t>(const Tensor<cpu, 2, mshadow::half:
         A.stride_, &beta, C.dptr_, C.stride_))                             \
   }
 
+// Use cublasSgemmEx when it is available (CUDA >= 7.5). Resolves precision issues with
+// cublasSgemm. Please see https://github.com/apache/incubator-mxnet/pull/11630
 #if CUDA_VERSION >= 7050
 template <>
 inline void linalg_gemm<gpu, float>(const Tensor<gpu, 2, float>& A,


### PR DESCRIPTION
## Description ##
This is to fix the flaky test: https://github.com/apache/incubator-mxnet/issues/10973. Prereq PR: https://github.com/apache/incubator-mxnet/pull/11470.
`cublasSgemm` and `cublasDgemm` are currently used for linear algebra operations when cudnn is disabled for the Convolution and Deconvolution operators. The test_deconvolution test on gpu fails on the input gradients comparison for conv and deconv operators. When looking at the failures, the difference in the gradients are as big as 0.1. Replacing `cublasSgemm` with `cublasSgemmex` while keeping all other code the same, causes the failure to go away. Also, the failure doesnt happen on CPU with openblas or MKLDNN or on gpu with cudnn enabled. If both APIs work as documented, both cases should have seen the failure. My guess is that `cublasSgemm` is doing the conversion of float32 to float16 before doing the conversion, causing the precision issues. Digging through the cublas documentation, I couldn't find enough information on the computation for `cublasSgemm`.
Please see: http://lutgw1.lunet.edu/cuda/pdf/CUBLAS_Library.pdf  2.8.11 (cublassgemmex) and 2.7.1 (cublassgemm).
 
@DickJC123 @ptrendx any inputs on if there should be any difference in behavior of two apis when all tensors have float32 dtype.

The important changes are in the file: `src/operator/linalg_impl.h`
