### PR TITLE
Adding models to example list and ONNX API page

### DIFF
--- a/docs/api/python/contrib/onnx.md
+++ b/docs/api/python/contrib/onnx.md
@@ -40,7 +40,8 @@ This document describes all the ONNX-MXNet APIs.
 
 ## ONNX Examples
 
-* [Face Recognition with ArcFace](https://github.com/onnx/models/tree/master/models/face_recognition/ArcFace)
+* Face Recognition with [ArcFace](https://github.com/onnx/models/tree/master/models/face_recognition/ArcFace)
+* Image Classification with [MobileNet](https://github.com/onnx/models/tree/master/models/image_classification/mobilenet), [ResNet](https://github.com/onnx/models/tree/master/models/image_classification/resnet), [SqueezeNet](https://github.com/onnx/models/tree/master/models/image_classification/squeezenet), [VGG](https://github.com/onnx/models/tree/master/models/image_classification/vgg) 
 
 ## API Reference
 

--- a/docs/api/python/contrib/onnx.md
+++ b/docs/api/python/contrib/onnx.md
@@ -38,6 +38,10 @@ This document describes all the ONNX-MXNet APIs.
    /tutorials/onnx/fine_tuning_gluon.md
 ```
 
+## ONNX Examples
+
+* [Face Recognition with ArcFace](https://github.com/onnx/models/tree/master/models/face_recognition/ArcFace)
+
 ## API Reference
 
 <script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>

--- a/example/README.md
+++ b/example/README.md
@@ -5,7 +5,8 @@ This page contains a curated list of awesome MXNet examples, tutorials and blogs
   - [Contributing](#contributing)
   - [List of examples](#list-of-examples)
     - [Languages Binding Examples](#language-binding-examples)
-    - [Deep Learning Examples](#deep-learning-examples)
+    - [Deep Learning Examples in the MXNet Project Repository](#deep-learning-examples-mxnet)
+    - [Other Deep Learning Examples with MXNet](#deep-learning-examples-other)
     - [IPython Notebooks](#ipython-notebooks)
     - [Mobile App Examples](#mobile-apps-examples)
     - [Web Predictive Services](#web-predictive-services)
@@ -76,7 +77,7 @@ If your tutorial depends on specific packages, simply add them to this provision
 * [MXNet Amalgamation](https://github.com/dmlc/mxnet/tree/master/amalgamation) - Amalgamation (entire library in a single file)
 * [MXNet Javascript](https://github.com/dmlc/mxnet.js/) - MXNetJS: Javascript Package for Deep Learning in Browser (without server)
 
-### <a name="deep-learning-examples"></a>Deep Learning Examples in the MXNet Project Repository
+### <a name="deep-learning-examples-mxnet"></a>Deep Learning Examples in the MXNet Project Repository
 --------------
 * [Autoencoder](autoencoder) - unsupervised feature learning
 * [Bayesian Methods](bayesian-methods) - various examples related to Bayesian Methods
@@ -126,8 +127,9 @@ If your tutorial depends on specific packages, simply add them to this provision
 * [Support Vector Machine](svm_mnist) - an SVM example using MNIST
 * [Variational Auto Encoder](vae) - implements the Variational Auto Encoder in MXNet using MNIST
 
-### Other Deep Learning Examples with MXNet
+### <a name="deep-learning-examples-other"></a>Other Deep Learning Examples with MXNet
 
+* [Face Recognition with ArcFace](https://github.com/onnx/models/tree/master/models/face_recognition/ArcFace) - ONNX model for face recognition with notebooks for training, validating and running inference in MXNet by [abhinavs95](https://github.com/abhinavs95)
 * [Chinese plate recognition](https://github.com/imistyrain/mxnet-mr) - Recognize Chinese vehicle plate, by [imistyrain](https://github.com/imistyrain)
 * [Fast R-CNN](https://github.com/precedenceguo/mx-rcnn) by [Jian Guo](https://github.com/precedenceguo)
 * "End2End Captcha Recognition (OCR)" by [xlvector](https://github.com/xlvector) [github link](https://github.com/xlvector/learning-dl/tree/master/mxnet/ocr) [Blog in Chinese](http://blog.xlvector.net/2016-05/mxnet-ocr-cnn/)


### PR DESCRIPTION
## Description ##

Added ArcFace face recognition model to example list 
Added ArcFace, MobileNet, ResNet, Squeezenet, VGG models to ONNX API page

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
* Added ArcFace face recognition model to example list
* Fixed contents in example readme to link to "Other Deep Learning Examples with MXNet" section
* Added ArcFace, MobileNet, ResNet, SqueezeNet, VGG to ONNX API page (created a new section "ONNX examples")

## Comments ##
* All the models and related artifacts are linked from ONNX model zoo 
* For each model, there are pretrained models in ONNX format with notebooks for training, validation and inference, scripts for pre/post processing and dataset prep in MXNet.