### PR TITLE
[MXNET-652] Allow for multi-context input to load gluon models from onnx

### DIFF
--- a/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
@@ -157,15 +157,15 @@ class GraphProto(object): # pylint: disable=too-few-public-methods
                    }
         return metadata
 
-    def graph_to_gluon(self, graph, context):
+    def graph_to_gluon(self, graph, ctx):
         """Construct SymbolBlock from onnx graph.
 
         Parameters
         ----------
         graph : onnx protobuf object
             The loaded onnx graph
-        context : str
-            context for mxnet module object. Should be 'CPU' or 'GPU'
+        ctx : Context or list of Context
+            Loads the model into one or many context(s).
 
         Returns
         -------
@@ -177,7 +177,6 @@ class GraphProto(object): # pylint: disable=too-few-public-methods
         data_names = [input_tensor[0] for input_tensor in metadata['input_tensor_data']]
         data_inputs = [symbol.var(data_name) for data_name in data_names]
 
-        ctx = gpu() if context == 'GPU' else cpu()
         from ....gluon import SymbolBlock
         net = SymbolBlock(outputs=sym, inputs=data_inputs)
         net_params = net.collect_params()

--- a/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
@@ -20,7 +20,6 @@
 """ Support import export formats."""
 from __future__ import absolute_import as _abs
 from .... import symbol
-from .... import cpu, gpu
 from .... import ndarray as nd
 from ....base import string_types
 from ._import_helper import _convert_map as convert_map

--- a/python/mxnet/contrib/onnx/onnx2mx/import_to_gluon.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/import_to_gluon.py
@@ -21,7 +21,7 @@
 
 from .import_onnx import GraphProto
 
-def import_to_gluon(model_file, context):
+def import_to_gluon(model_file, ctx):
     """
     Imports the ONNX model files, passed as a parameter, into Gluon SymbolBlock object.
 
@@ -29,8 +29,8 @@ def import_to_gluon(model_file, context):
     ----------
     model_file : str
         ONNX model file name
-    context : str
-        context. Should be 'CPU' or 'GPU'
+    ctx : Context or list of Context
+        Loads the model into one or many context(s).
 
     Returns
     -------
@@ -44,5 +44,5 @@ def import_to_gluon(model_file, context):
         raise ImportError("Onnx and protobuf need to be installed. Instructions to"
                           + " install - https://github.com/onnx/onnx#installation")
     model_proto = onnx.load(model_file)
-    net = graph.graph_to_gluon(model_proto.graph, context)
+    net = graph.graph_to_gluon(model_proto.graph, ctx)
     return net

--- a/tests/python-pytest/onnx/import/gluon_backend.py
+++ b/tests/python-pytest/onnx/import/gluon_backend.py
@@ -18,6 +18,7 @@
 # coding: utf-8
 """Gluon backend wrapper for onnx test infrastructure"""
 from mxnet.contrib.onnx.onnx2mx.import_onnx import GraphProto
+import mxnet as mx
 
 try:
     from onnx import helper, TensorProto
@@ -55,13 +56,19 @@ class GluonBackend(Backend):
             used to run inference on the input model and return the result for comparison.
         """
         graph = GraphProto()
-        net = graph.graph_to_gluon(model.graph, device)
+        if device == 'CPU':
+            ctx = mx.cpu()
+        else:
+            raise NotImplementedError("ONNX tests are run only for CPU context.")
+
+        net = graph.graph_to_gluon(model.graph, ctx)
         return GluonBackendRep(net, device)
 
     @classmethod
     def supports_device(cls, device):
         """Supports only CPU for testing"""
         return device == 'CPU'
+
 
 prepare = GluonBackend.prepare
 

--- a/tests/python-pytest/onnx/import/gluon_backend_rep.py
+++ b/tests/python-pytest/onnx/import/gluon_backend_rep.py
@@ -34,6 +34,7 @@ from mxnet import nd
 # Implemented by following onnx docs guide:
 # https://github.com/onnx/onnx/blob/master/docs/ImplementingAnOnnxBackend.md
 
+
 class GluonBackendRep(BackendRep):
     """Running model inference on gluon backend and return the result
      to onnx test infrastructure for comparison."""


### PR DESCRIPTION
## Description ##
Currently, Airbnb is developing applications that use mxnet(particularly `gluon`). We use the `mxnet.contrib.onnx` package, which supports importing to gluon from ONNX format. As this is an extremely important part of our pipeline, we want to add support to multi-gpu imports, which is currently not supported.

This is actually a very simple change, because `_load_init()` already supports, directly, a `Context` object or an iterable of them. However, the current implementation for `import_to_gluon` suggests a `str` of `'CPU'` or `'GPU'`. This is not only different from other parts of the mxnet codebase, but also does not allow us to specify which gpu's we want to load the model into. I am aware that this is to comply with ONNX, but the abstraction should be handled at the abstraction layer, not the core utility for importing ONNX to gluon.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-652], where 652 refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Modified gluon model loading from ONNX to allow multi-context argument.

## Comments ##
- Currently, mxnet uses `ctx` as an arg for a large portion of the core library. There doesn't seem to be any significant reason for why the `contrib.onnx` code uses `str` instead, rather than it being a minor oversight that passed PR's.
