### PR TITLE
Fix TabError for Python 3

### DIFF
--- a/example/reinforcement-learning/ddpg/strategies.py
+++ b/example/reinforcement-learning/ddpg/strategies.py
@@ -61,7 +61,7 @@ class OUStrategy(BaseStrategy):
     def get_action(self, obs, policy):
 
         # get_action accepts a 2D tensor with one row
-    	obs = obs.reshape((1, -1))
+        obs = obs.reshape((1, -1))
         action = policy.get_action(obs)
         increment = self.evolve_state()
 
@@ -94,5 +94,3 @@ if __name__ == "__main__":
 
     plt.plot(states)
     plt.show()
-
-


### PR DESCRIPTION
TabError: inconsistent use of tabs and spaces in indentation is treated as a syntax error in Python 3.
```
./example/reinforcement-learning/ddpg/strategies.py:65:39: E999 TabError: inconsistent use of tabs and spaces in indentation
        action = policy.get_action(obs)
                                      ^
```