### PR TITLE
Some Python 3 fixes in ./example

### DIFF
--- a/example/gluon/data.py
+++ b/example/gluon/data.py
@@ -19,6 +19,7 @@
 """ data iterator for mnist """
 import os
 import random
+import tarfile
 import logging
 logging.basicConfig(level=logging.INFO)
 
@@ -111,7 +112,7 @@ def get_caltech101_iterator(batch_size, num_workers, dtype):
         # center and crop an area of size (224,224)
         cropped, crop_info = mx.image.center_crop(resized, 224)
         # transpose the channels to be (3,224,224)
-        transposed = nd.transpose(cropped, (2, 0, 1))
+        transposed = mx.nd.transpose(cropped, (2, 0, 1))
         image = mx.nd.cast(image, dtype)
         return image, label
 
@@ -119,8 +120,8 @@ def get_caltech101_iterator(batch_size, num_workers, dtype):
     dataset_train = ImageFolderDataset(root=training_path, transform=transform)
     dataset_test = ImageFolderDataset(root=testing_path, transform=transform)
 
-    train_data = gluon.data.DataLoader(dataset_train, batch_size, shuffle=True, num_workers=num_workers)
-    test_data = gluon.data.DataLoader(dataset_test, batch_size, shuffle=False, num_workers=num_workers)
+    train_data = mx.gluon.data.DataLoader(dataset_train, batch_size, shuffle=True, num_workers=num_workers)
+    test_data = mx.gluon.data.DataLoader(dataset_test, batch_size, shuffle=False, num_workers=num_workers)
     return DataLoaderIter(train_data), DataLoaderIter(test_data)
 
 class DummyIter(mx.io.DataIter):

--- a/example/kaggle-ndsb1/gen_img_list.py
+++ b/example/kaggle-ndsb1/gen_img_list.py
@@ -18,10 +18,10 @@
 from __future__ import print_function
 import csv
 import os
-import sys
 import random
 import numpy as np
 import argparse
+from six.moves import xrange
 
 parser = argparse.ArgumentParser(description='generate train/test image list files form input directory. If training it will also split into tr and va sets.')
 parser.add_argument('--image-folder', type=str, default="data/train/",
@@ -104,5 +104,3 @@ if args.train:
         tr_fo.writerow(item)
     for item in va_lst:
         va_fo.writerow(item)
-
-

--- a/example/kaggle-ndsb1/gen_img_list.py
+++ b/example/kaggle-ndsb1/gen_img_list.py
@@ -21,7 +21,6 @@ import os
 import random
 import numpy as np
 import argparse
-from six.moves import xrange
 
 parser = argparse.ArgumentParser(description='generate train/test image list files form input directory. If training it will also split into tr and va sets.')
 parser.add_argument('--image-folder', type=str, default="data/train/",
@@ -57,7 +56,7 @@ head = "acantharia_protist_big_center,acantharia_protist_halo,acantharia_protist
 img_lst = []
 cnt = 0
 if args.train:
-    for i in xrange(len(head)):
+    for i in range(len(head)):
         path = args.image_folder + head[i]
         lst = os.listdir(args.image_folder + head[i])
         for img in lst:

--- a/example/reinforcement-learning/ddpg/ddpg.py
+++ b/example/reinforcement-learning/ddpg/ddpg.py
@@ -21,7 +21,6 @@ import rllab.misc.logger as logger
 import pyprind
 import mxnet as mx
 import numpy as np
-from mxnet.base import xrange
 
 
 class DDPG(object):
@@ -191,7 +190,7 @@ class DDPG(object):
         end = False
         obs = self.env.reset()
 
-        for epoch in xrange(self.n_epochs):
+        for epoch in range(self.n_epochs):
             logger.push_prefix("epoch #%d | " % epoch)
             logger.log("Training started")
             for epoch_itr in pyprind.prog_bar(range(self.epoch_length)):
@@ -221,7 +220,7 @@ class DDPG(object):
                 obs = nxt
 
                 if memory.size >= self.memory_start_size:
-                    for update_time in xrange(self.n_updates_per_sample):
+                    for update_time in range(self.n_updates_per_sample):
                         batch = memory.get_batch(self.batch_size)
                         self.do_update(itr, batch)
 

--- a/example/reinforcement-learning/ddpg/ddpg.py
+++ b/example/reinforcement-learning/ddpg/ddpg.py
@@ -21,6 +21,7 @@ import rllab.misc.logger as logger
 import pyprind
 import mxnet as mx
 import numpy as np
+from mxnet.base import xrange
 
 
 class DDPG(object):

--- a/example/ssd/dataset/pycocotools/coco.py
+++ b/example/ssd/dataset/pycocotools/coco.py
@@ -55,12 +55,12 @@ import itertools
 # from . import mask as maskUtils
 import os
 from collections import defaultdict
-import sys
-PYTHON_VERSION = sys.version_info[0]
-if PYTHON_VERSION == 2:
-    from urllib import urlretrieve
-elif PYTHON_VERSION == 3:
+from six.moves import string_types
+try:
     from urllib.request import urlretrieve
+except ImportError:
+    from urllib import urlretrieve
+
 
 class COCO:
     def __init__(self, annotation_file=None):
@@ -302,7 +302,7 @@ class COCO:
 
         print('Loading and preparing results...')
         tic = time.time()
-        if type(resFile) == str or type(resFile) == unicode:
+        if type(resFile) in string_types:
             anns = json.load(open(resFile))
         elif type(resFile) == np.ndarray:
             anns = self.loadNumpyAnnotations(resFile)

--- a/example/ssd/dataset/pycocotools/coco.py
+++ b/example/ssd/dataset/pycocotools/coco.py
@@ -55,7 +55,7 @@ import itertools
 # from . import mask as maskUtils
 import os
 from collections import defaultdict
-from six.moves import string_types
+from mxnet.base import string_types
 try:
     from urllib.request import urlretrieve
 except ImportError:


### PR DESCRIPTION
## Description ##
Fix undefined names found be flake8 F821 that are mostly (but not exclusively) related to Python 3.  Each undefined name has the potential to raise NameError at runtime.  Used the __six__ module as discussed at https://github.com/apache/incubator-mxnet/pull/10833#issuecomment-404568638  Also see #11669

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
