### PR TITLE
Some Python 3 fixes in ./tools

### DIFF
--- a/tools/accnn/rank_selection.py
+++ b/tools/accnn/rank_selection.py
@@ -16,11 +16,12 @@
 # under the License.
 
 import numpy as np
-import mxnet as mx
 import json
 import utils
 import math
 import sys
+from six.moves import xrange
+
 
 def calc_complexity(ishape, node):
   y, x = map(int, eval(node['param']['kernel']))

--- a/tools/accnn/rank_selection.py
+++ b/tools/accnn/rank_selection.py
@@ -20,7 +20,11 @@ import json
 import utils
 import math
 import sys
-from six.moves import xrange
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 
 def calc_complexity(ishape, node):

--- a/tools/accnn/rank_selection.py
+++ b/tools/accnn/rank_selection.py
@@ -21,10 +21,7 @@ import utils
 import math
 import sys
 
-try:
-    xrange          # Python 2
-except NameError:
-    xrange = range  # Python 3
+from mxnet.base import xrange
 
 
 def calc_complexity(ishape, node):

--- a/tools/accnn/utils.py
+++ b/tools/accnn/utils.py
@@ -20,6 +20,7 @@ import mxnet as mx
 import copy
 import json
 import ast
+from six.moves import xrange
 
 
 def load_model(args):

--- a/tools/accnn/utils.py
+++ b/tools/accnn/utils.py
@@ -21,10 +21,7 @@ import copy
 import json
 import ast
 
-try:
-    xrange          # Python 2
-except NameError:
-    xrange = range  # Python 3
+from mxnet.base import xrange
 
 
 def load_model(args):

--- a/tools/accnn/utils.py
+++ b/tools/accnn/utils.py
@@ -20,7 +20,11 @@ import mxnet as mx
 import copy
 import json
 import ast
-from six.moves import xrange
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 
 def load_model(args):

--- a/tools/caffe_converter/convert_symbol.py
+++ b/tools/caffe_converter/convert_symbol.py
@@ -20,7 +20,9 @@
 from __future__ import print_function
 import argparse
 import re
+import mxnet as mx
 import caffe_parser
+
 
 def _get_input(proto):
     """Get input size

--- a/tools/coreml/test/test_mxnet_image.py
+++ b/tools/coreml/test/test_mxnet_image.py
@@ -21,7 +21,6 @@ import numpy as np
 import unittest
 import sys
 import os
-from six.moves import xrange
 
 current_working_directory = os.getcwd()
 sys.path.append(current_working_directory + "/..")
@@ -29,6 +28,10 @@ sys.path.append(current_working_directory + "/../converter/")
 import _mxnet_converter as mxnet_converter
 from converter.utils import load_model
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 VAL_DATA = 'data/val-5k-256.rec'
 URL = 'http://data.mxnet.io/data/val-5k-256.rec'

--- a/tools/coreml/test/test_mxnet_image.py
+++ b/tools/coreml/test/test_mxnet_image.py
@@ -22,16 +22,13 @@ import unittest
 import sys
 import os
 
+from mxnet.base import xrange
+
 current_working_directory = os.getcwd()
 sys.path.append(current_working_directory + "/..")
 sys.path.append(current_working_directory + "/../converter/")
 import _mxnet_converter as mxnet_converter
 from converter.utils import load_model
-
-try:
-    xrange          # Python 2
-except NameError:
-    xrange = range  # Python 3
 
 VAL_DATA = 'data/val-5k-256.rec'
 URL = 'http://data.mxnet.io/data/val-5k-256.rec'

--- a/tools/coreml/test/test_mxnet_image.py
+++ b/tools/coreml/test/test_mxnet_image.py
@@ -21,6 +21,8 @@ import numpy as np
 import unittest
 import sys
 import os
+from six.moves import xrange
+
 current_working_directory = os.getcwd()
 sys.path.append(current_working_directory + "/..")
 sys.path.append(current_working_directory + "/../converter/")

--- a/tools/coreml/test/test_mxnet_models.py
+++ b/tools/coreml/test/test_mxnet_models.py
@@ -22,12 +22,16 @@ import numpy as np
 import sys
 import os
 from collections import namedtuple
-from six.moves import xrange
 
 current_working_directory = os.getcwd()
 sys.path.append(current_working_directory + "/..")
 sys.path.append(current_working_directory + "/../converter/")
 import _mxnet_converter as mxnet_converter
+
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
 
 
 def _mxnet_remove_batch(input_data):

--- a/tools/coreml/test/test_mxnet_models.py
+++ b/tools/coreml/test/test_mxnet_models.py
@@ -23,15 +23,12 @@ import sys
 import os
 from collections import namedtuple
 
+from mxnet.base import xrange
+
 current_working_directory = os.getcwd()
 sys.path.append(current_working_directory + "/..")
 sys.path.append(current_working_directory + "/../converter/")
 import _mxnet_converter as mxnet_converter
-
-try:
-    xrange          # Python 2
-except NameError:
-    xrange = range  # Python 3
 
 
 def _mxnet_remove_batch(input_data):

--- a/tools/coreml/test/test_mxnet_models.py
+++ b/tools/coreml/test/test_mxnet_models.py
@@ -21,11 +21,13 @@ import mxnet as mx
 import numpy as np
 import sys
 import os
+from collections import namedtuple
+from six.moves import xrange
+
 current_working_directory = os.getcwd()
 sys.path.append(current_working_directory + "/..")
 sys.path.append(current_working_directory + "/../converter/")
 import _mxnet_converter as mxnet_converter
-from collections import namedtuple
 
 
 def _mxnet_remove_batch(input_data):


### PR DESCRIPTION
## Description ##
Fix undefined names found be flake8 F821 that are mostly (but not exclusively) related to Python 3.  Each undefined name has the potential to raise NameError at runtime.  Used the __six__ module as discussed at https://github.com/apache/incubator-mxnet/pull/10833#issuecomment-404568638  Also see #11669

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
