### PR TITLE
xrange(10) --> range(10) for Python 3

### DIFF
--- a/benchmark/python/sparse/util.py
+++ b/benchmark/python/sparse/util.py
@@ -24,7 +24,7 @@ def estimate_density(DATA_PATH, feature_size):
         raise Exception("Data is not there!")
     density = []
     P = 0.01
-    for _ in xrange(10):
+    for _ in range(10):
         num_non_zero = 0
         num_sample = 0
         with open(DATA_PATH) as f:


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__.  For such a small number as 10 there is no difference between __xrange()__ and __range()__ in Python 2.