### PR TITLE
[MXNET-606] Fix R installation in CI

### DIFF
--- a/ci/docker/install/ubuntu_r.sh
+++ b/ci/docker/install/ubuntu_r.sh
@@ -29,16 +29,10 @@ cd "$(dirname "$0")"
 # install libraries for mxnet's r package on ubuntu
 echo "deb http://cran.rstudio.com/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list
 
-key=E084DAB9
-
-gpg --keyserver keyserver.ubuntu.com --recv-key $key || \
-    gpg --keyserver keyserver.pgp.com --recv-keys $key || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys $key ;
+apt-key add r.gpg
 
 # Installing the latest version (3.3+) that is compatible with MXNet
 add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu xenial/'
-
-gpg -a --export $key | apt-key add -
 
 apt-get update
 apt-get install -y --allow-unauthenticated \


### PR DESCRIPTION
## Description ##
This patch fixes a regression in the R installation in CI.  

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

Relates to: #11601 #11602

## Comments ##
Without manually adding the key we're getting occasional gpg server errors (happens approx 1/10 requests).  My understanding is this change was made to align with documentation.  Would like to chat about the tradeoffs with @aaronmarkham  and @anirudh2290, but it's important that we keep the CI stable for other MXNet developers.  Is the main concern with adding the key manually that it doesn't align with documentation?  Would you be alright with me updating the doc instructions (I can include updated instructions in this PR).

