### PR TITLE
Fix file name creation for Windows

### DIFF
--- a/docs/tutorials/python/predict_image.md
+++ b/docs/tutorials/python/predict_image.md
@@ -57,8 +57,8 @@ from collections import namedtuple
 Batch = namedtuple('Batch', ['data'])
 
 def get_image(url, show=False):
-    # download and show the image
-    fname = mx.test_utils.download(url)
+    # download and show the image. Remove query string from the file name.
+    fname = mx.test_utils.download(url, fname=url.split('/')[-1].split('?')[0])
     img = mx.image.imread(fname)
     if img is None:
         return None


### PR DESCRIPTION
## Description ##
By default filename is generated by just taking last part of the url. If it contains query string, which is separated with "?" symbol, file cannot be created on windows machine.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Small file name generation fix for one particular tutorial