### PR TITLE
[MXNET-564] Fix the Flaky test on arange for NDArray

### DIFF
--- a/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
@@ -166,8 +166,9 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
       val start = scala.util.Random.nextFloat() * 5
       val stop = start + scala.util.Random.nextFloat() * 100
       val step = scala.util.Random.nextFloat() * 4
-      val repeat = (scala.util.Random.nextFloat() * 5).toInt + 1
-      val result = (start until stop by step).flatMap(x => Array.fill[Float](repeat)(x))
+      val repeat = 1
+      val result = (start.toDouble until stop.toDouble by step.toDouble)
+              .flatMap(x => Array.fill[Float](repeat)(x.toFloat))
       val range = NDArray.arange(start = start, stop = Some(stop), step = step,
         repeat = repeat, ctx = Context.cpu(), dType = DType.Float32)
       assert(CheckUtils.reldiff(result.toArray, range.toArray) <= 1e-4f)


### PR DESCRIPTION
## Description ##
This is a follow up of #11377. I see my CI crash on the NDArray test.
@nswamy @yzhliu @andrewfayres 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change