### PR TITLE
[MXNET-678] Fix nightly R installation

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu_nightly_cpu
+++ b/ci/docker/Dockerfile.build.ubuntu_nightly_cpu
@@ -36,9 +36,9 @@ COPY install/sbt.gpg /work/
 RUN /work/ubuntu_scala.sh
 
 COPY install/ubuntu_r.sh /work/
+COPY install/r.gpg /work/
 RUN /work/ubuntu_r.sh
 
-COPY install/r.gpg /work/
 COPY install/ubuntu_perl.sh /work/
 RUN /work/ubuntu_perl.sh
 


### PR DESCRIPTION
## Description ##
Fixes an out-of-order installation issue during the creation of our nightly Docker images.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- Example failure: http://jenkins.mxnet-ci.amazon-ml.com/blue/rest/organizations/jenkins/pipelines/restricted-docker-cache-refresh/branches/master/runs/325/nodes/4/log/?start=0

Example failed output:
```
Step 12/38 : COPY install/ubuntu_r.sh /work/
Step 13/38 : RUN /work/ubuntu_r.sh
[91m+ apt-key add r.gpg
[0m[91mgpg: can't open `r.gpg': No such file or directory
```
