### PR TITLE
[MXNET-681] Add retry mechanism for the docker build stage

### DIFF
--- a/ci/Jenkinsfile_docker_cache
+++ b/ci/Jenkinsfile_docker_cache
@@ -21,7 +21,7 @@
 // See documents at https://jenkins.io/doc/book/pipeline/jenkinsfile/
 
 // timeout in minutes
-total_timeout = 120
+total_timeout = 300
 git_timeout = 15
 // assign any caught errors here
 err = null

--- a/ci/build.py
+++ b/ci/build.py
@@ -67,12 +67,13 @@ def get_docker_binary(use_nvidia_docker: bool) -> str:
     return "nvidia-docker" if use_nvidia_docker else "docker"
 
 
-def build_docker(platform: str, docker_binary: str, registry: str) -> None:
+def build_docker(platform: str, docker_binary: str, registry: str, num_retries: int) -> None:
     """
     Build a container for the given platform
     :param platform: Platform
     :param docker_binary: docker binary to use (docker/nvidia-docker)
     :param registry: Dockerhub registry name
+    :param num_retries: Number of retries to build the docker image
     :return: Id of the top level image
     """
 
@@ -91,10 +92,8 @@ def build_docker(platform: str, docker_binary: str, registry: str) -> None:
     # This doesn't work with multi head docker files.
     # 
 
-    num_retries = int(os.environ['DOCKER_BUILD_NUM_RETRIES']) if 'DOCKER_BUILD_NUM_RETRIES' in os.environ else 1
     for i in range(num_retries):
-        logging.info('%d out of %d tries to build the docker image. You can influence this by setting the '
-                     'environment variable "DOCKER_BUILD_NUM_RETRIES"', i + 1, num_retries)
+        logging.info('%d out of %d tries to build the docker image.', i + 1, num_retries)
 
         cmd = [docker_binary, "build",
                "-f", get_dockerfile(platform),
@@ -294,6 +293,11 @@ def main() -> int:
                         default='mxnetci',
                         type=str)
 
+    parser.add_argument("-r", "--docker-build-retries",
+                        help="Number of times to retry building the docker image. Default is 1",
+                        default=1,
+                        type=int)
+
     parser.add_argument("-c", "--cache", action="store_true",
                         help="Enable docker registry cache")
 
@@ -313,6 +317,7 @@ def main() -> int:
     command = list(chain(*args.command))
     docker_binary = get_docker_binary(args.nvidiadocker)
     shared_memory_size = args.shared_memory_size
+    num_docker_build_retires = args.docker_build_retries
 
     if args.list:
         list_platforms()
@@ -321,7 +326,7 @@ def main() -> int:
         tag = get_docker_tag(platform=platform, registry=args.docker_registry)
         if use_cache():
             load_docker_cache(tag=tag, docker_registry=args.docker_registry)
-        build_docker(platform, docker_binary, registry=args.docker_registry)
+        build_docker(platform, docker_binary, registry=args.docker_registry, num_retries=num_docker_build_retires)
         if args.build_only:
             logging.warning("Container was just built. Exiting due to build-only.")
             return 0
@@ -355,7 +360,7 @@ def main() -> int:
             tag = get_docker_tag(platform=platform, registry=args.docker_registry)
             if use_cache():
                 load_docker_cache(tag=tag, docker_registry=args.docker_registry)
-            build_docker(platform, docker_binary, args.docker_registry)
+            build_docker(platform, docker_binary, args.docker_registry, num_retries=num_docker_build_retires)
             if args.build_only:
                 continue
             build_platform = "build_{}".format(platform)

--- a/ci/build.py
+++ b/ci/build.py
@@ -96,7 +96,6 @@ def build_docker(platform: str, docker_binary: str, registry: str) -> None:
         logging.info('%d out of %d tries to build the docker image. You can influence this by setting the '
                      'environment variable "DOCKER_BUILD_NUM_RETRIES"', i + 1, num_retries)
 
-
         cmd = [docker_binary, "build",
                "-f", get_dockerfile(platform),
                "--build-arg", "USER_ID={}".format(os.getuid()),
@@ -110,11 +109,13 @@ def build_docker(platform: str, docker_binary: str, registry: str) -> None:
             # Docker build was successful. Call break to break out of the retry mechanism
             break
         except subprocess.CalledProcessError as e:
-            logging.exception('Error during building docker image', e)
+            saved_exception = e
+            logging.error('Failed to build docker image')
             # Building the docker image failed. Call continue to trigger the retry mechanism
             continue
     else:
         # Num retries exceeded
+        logging.exception('Exception during build of docker image', saved_exception)
         logging.fatal('Failed to build the docker image, aborting...')
         sys.exit(1)
 

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -76,6 +76,9 @@ def _build_save_container(platform, registry, load_cache) -> str:
     # Start building
     logging.debug('Building %s as %s', platform, docker_tag)
     try:
+        # Increase the number of retries for building the cache.
+        os.environ['DOCKER_BUILD_NUM_RETRIES'] = \
+            max(10, os.environ['DOCKER_BUILD_NUM_RETRIES'] if 'DOCKER_BUILD_NUM_RETRIES' in os.environ else 1)
         image_id = build_util.build_docker(docker_binary='docker', platform=platform, registry=registry)
         logging.info('Built %s as %s', docker_tag, image_id)
 

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -77,9 +77,7 @@ def _build_save_container(platform, registry, load_cache) -> str:
     logging.debug('Building %s as %s', platform, docker_tag)
     try:
         # Increase the number of retries for building the cache.
-        os.environ['DOCKER_BUILD_NUM_RETRIES'] = \
-            max(10, os.environ['DOCKER_BUILD_NUM_RETRIES'] if 'DOCKER_BUILD_NUM_RETRIES' in os.environ else 1)
-        image_id = build_util.build_docker(docker_binary='docker', platform=platform, registry=registry)
+        image_id = build_util.build_docker(docker_binary='docker', platform=platform, registry=registry, num_retries=10)
         logging.info('Built %s as %s', docker_tag, image_id)
 
         # Push cache to registry

--- a/docs/Jenkinsfile
+++ b/docs/Jenkinsfile
@@ -51,7 +51,7 @@ try {
       ws('workspace/docs') {
         init_git()
         timeout(time: max_time, unit: 'MINUTES') {
-            sh "ci/build.py -p ubuntu_cpu /work/runtime_functions.sh build_docs ${params.tags_to_build} ${params.tag_list} ${params.tag_default} ${params.domain}"
+            sh "ci/build.py -p ubuntu_cpu --docker-registry ${env.DOCKER_CACHE_REGISTRY} %USE_NVIDIA% --docker-build-retries 3 /work/runtime_functions.sh build_docs ${params.tags_to_build} ${params.tag_list} ${params.tag_default} ${params.domain}"
             archiveArtifacts 'docs/build_version_doc/artifacts.tgz'
             build 'restricted-website-publish'
         }

--- a/tests/nightly/Jenkinsfile
+++ b/tests/nightly/Jenkinsfile
@@ -58,7 +58,7 @@ def init_git() {
 }
 
 def docker_run(platform, function_name, use_nvidia, shared_mem = '500m') {
-  def command = "ci/build.py --docker-registry ${env.DOCKER_CACHE_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
+  def command = "ci/build.py --docker-registry ${env.DOCKER_CACHE_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --docker-build-retries 3 --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
   command = command.replaceAll('%USE_NVIDIA%', use_nvidia ? '--nvidiadocker' : '')
   command = command.replaceAll('%PLATFORM%', platform)
   command = command.replaceAll('%FUNCTION_NAME%', function_name)

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -57,7 +57,7 @@ def init_git() {
 }
 
 def docker_run(platform, function_name, use_nvidia, shared_mem = '500m') {
-  def command = "ci/build.py --docker-registry ${env.DOCKER_CACHE_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
+  def command = "ci/build.py --docker-registry ${env.DOCKER_CACHE_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --docker-build-retries 3 --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
   command = command.replaceAll('%USE_NVIDIA%', use_nvidia ? '--nvidiadocker' : '')
   command = command.replaceAll('%PLATFORM%', platform)
   command = command.replaceAll('%FUNCTION_NAME%', function_name)

--- a/tests/nightly/broken_link_checker_test/JenkinsfileForBLC
+++ b/tests/nightly/broken_link_checker_test/JenkinsfileForBLC
@@ -39,7 +39,7 @@ def init_git() {
 }
 
 def docker_run(platform, function_name, use_nvidia, shared_mem = '500m') {
-  def command = "ci/build.py --docker-registry ${env.DOCKER_CACHE_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
+  def command = "ci/build.py --docker-registry ${env.DOCKER_CACHE_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --docker-build-retries 3 --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
   command = command.replaceAll('%USE_NVIDIA%', use_nvidia ? '--nvidiadocker' : '')
   command = command.replaceAll('%PLATFORM%', platform)
   command = command.replaceAll('%FUNCTION_NAME%', function_name)


### PR DESCRIPTION
## Description ##
This PR adds retry mechanisms to the docker build stage. The setting is controlled as an environment variable in Jenkins to ensure that user systems are not getting this retry mechanism applied.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Add retry mechanism
- Set high number of retries for Docker cache generation job

## Comments ##

