### PR TITLE
[MXNET-319] Reduce Scala Warning messages

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
@@ -89,7 +89,10 @@ object NDArray extends NDArrayBase {
         output match {
           case nd: NDArray => (Array(nd), Array(nd.handle))
           case ndFuncRet: NDArrayFuncReturn => (ndFuncRet.arr, ndFuncRet.arr.map(_.handle))
-          case ndArr: Seq[NDArray] => (ndArr.toArray, ndArr.toArray.map(_.handle))
+          case ndArr: Seq[NDArray @unchecked] =>
+            if (ndArr.head.isInstanceOf[NDArray]) (ndArr.toArray, ndArr.toArray.map(_.handle))
+            else throw new IllegalArgumentException(
+              "Unsupported out var type, should be NDArray or subclass of Seq[NDArray]")
           case _ => throw new IllegalArgumentException(
             "Unsupported out var type, should be NDArray or subclass of Seq[NDArray]")
         }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
@@ -89,6 +89,7 @@ object NDArray extends NDArrayBase {
         output match {
           case nd: NDArray => (Array(nd), Array(nd.handle))
           case ndFuncRet: NDArrayFuncReturn => (ndFuncRet.arr, ndFuncRet.arr.map(_.handle))
+         // Seq[NDArray] erasure problem explained here https://stackoverflow.com/questions/1094173/
           case ndArr: Seq[NDArray @unchecked] =>
             if (ndArr.head.isInstanceOf[NDArray]) (ndArr.toArray, ndArr.toArray.map(_.handle))
             else throw new IllegalArgumentException(

--- a/scala-package/core/src/main/scala/org/apache/mxnet/RecordIO.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/RecordIO.scala
@@ -98,7 +98,7 @@ object MXRecordIO {
 
   /**
    * pack an string into MXImageRecord.
-   * @param
+   * @param header
    *  header of the image record.
    *  header.label an array.
    * @param s string to pack

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/APIDocGenerator.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/APIDocGenerator.scala
@@ -22,8 +22,7 @@ import org.apache.mxnet.utils.CToScalaUtils
 import java.io._
 import java.security.MessageDigest
 
-import scala.collection.mutable.ListBuffer
-import scala.io.Source
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
 
 /**
   * This object will generate the Scala documentation of the new Scala API
@@ -104,9 +103,12 @@ private[mxnet] object APIDocGenerator{
 
   // Generate ScalaDoc type
   def generateAPIDocFromBackend(func : absClassFunction, withParam : Boolean = true) : String = {
-    val desc = func.desc.split("\n").map({ currStr =>
-      s"  * $currStr<br>"
+    val desc = ArrayBuffer[String]()
+    desc += "  * <pre>"
+      func.desc.split("\n").foreach({ currStr =>
+      desc += s"  * $currStr"
     })
+    desc += "  * </pre>"
     val params = func.listOfArgs.map({ absClassArg =>
       val currArgName = absClassArg.argName match {
                 case "var" => "vari"

--- a/scala-package/spark/src/main/scala/org/apache/mxnet/spark/MXNDArray.scala
+++ b/scala-package/spark/src/main/scala/org/apache/mxnet/spark/MXNDArray.scala
@@ -20,7 +20,7 @@ package org.apache.mxnet.spark
 import org.apache.mxnet.NDArray
 
 /**
- * A wrapper for serialize & deserialize [[org.apache.mxnet.NDArray]] in spark job
+ * A wrapper for serialize & deserialize <pre>[[org.apache.mxnet.NDArray]]</pre> in spark job
  * @author Yizhi Liu
  */
 class MXNDArray(@transient private var ndArray: NDArray) extends Serializable {

--- a/scala-package/spark/src/main/scala/org/apache/mxnet/spark/MXNetModel.scala
+++ b/scala-package/spark/src/main/scala/org/apache/mxnet/spark/MXNetModel.scala
@@ -23,7 +23,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.mllib.linalg.Vector
 
 /**
- * Wrapper for [[org.apache.mxnet.Model]] which used in Spark application
+ * Wrapper for <pre>[[org.apache.mxnet.Model]]</pre> which used in Spark application
  * @author Yizhi Liu
  */
 class MXNetModel private[mxnet](
@@ -38,7 +38,7 @@ class MXNetModel private[mxnet](
   val serializedModel = model.serialize()
 
   /**
-   * Get inner model [[FeedForward]]
+   * Get inner model <pre>[[FeedForward]]</pre>
    * @return the underlying model used to train & predict
    */
   def innerModel: FeedForward = {


### PR DESCRIPTION
## Description ##
The previous JavaDoc generation is causing too much warning messages. This PR is intend to reduce the numbers of issues we have as indicated in https://github.com/apache/incubator-mxnet/issues/11603.

There are three fixs:
-  Seq[NDArray] erasure problem, same explained in [here](https://stackoverflow.com/questions/1094173/how-do-i-get-around-type-erasure-on-scala-or-why-cant-i-get-the-type-paramete)
- Add `<pre>` tag on `JavaDoc` to reduce warnings
- Minor fixing on the other files

@nswamy @yzhliu @andrewfayres 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
