### PR TITLE
NPE in BucketingModule when providedLabel of DataBatch is not set

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/IO.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/IO.scala
@@ -356,6 +356,10 @@ object DataDesc {
   }
 
   implicit def ListMap2Descs(shapes: ListMap[String, Shape]): IndexedSeq[DataDesc] = {
-    shapes.map { case (k, s) => new DataDesc(k, s) }.toIndexedSeq
+    if (shapes != null) {
+      shapes.map { case (k, s) => new DataDesc(k, s) }.toIndexedSeq
+    } else {
+      null
+    }
   }
 }


### PR DESCRIPTION
## Description ##
Using BucketingModule together with a DataBatch in which the `provideLabel` field is not set triggers a NullPointerException in `BucketingModule.forward(...)`. This happens because the implicit method `ListMap2Descs` tries to convert `ListMap[String, Shape]` into `IndexedSeq[DataDesc]` but fails because the former is null by default. A simple fix is to do a null check in the implicit method.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
