### PR TITLE
fix bug when prefetch_buffer=1

### DIFF
--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -514,12 +514,6 @@ class BaseModule(object):
                     monitor.tic()
                 self.forward_backward(data_batch)
                 self.update()
-                try:
-                    # pre fetch next batch
-                    next_data_batch = next(data_iter)
-                    self.prepare(next_data_batch, sparse_row_id_fn=sparse_row_id_fn)
-                except StopIteration:
-                    end_of_batch = True
 
                 if isinstance(data_batch, list):
                     self.update_metric(eval_metric,
@@ -528,6 +522,13 @@ class BaseModule(object):
                 else:
                     self.update_metric(eval_metric, data_batch.label)
 
+                try:
+                    # pre fetch next batch
+                    next_data_batch = next(data_iter)
+                    self.prepare(next_data_batch, sparse_row_id_fn=sparse_row_id_fn)
+                except StopIteration:
+                    end_of_batch = True
+                    
                 if monitor is not None:
                     monitor.toc_print()
 

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -528,7 +528,7 @@ class BaseModule(object):
                     self.prepare(next_data_batch, sparse_row_id_fn=sparse_row_id_fn)
                 except StopIteration:
                     end_of_batch = True
-                    
+
                 if monitor is not None:
                     monitor.toc_print()
 


### PR DESCRIPTION
When  prefetch_buffer=1 in mx.io.ImageRecordIter, read next batch before use data_batch.label can make the label change to next batch. It will lead the accuracy drop.
So we move read data program after update metric, this can solve this problem.
#7448