### PR TITLE
[MXNET-687] Fix spatial transformer op

### DIFF
--- a/tests/python/unittest/common.py
+++ b/tests/python/unittest/common.py
@@ -95,7 +95,7 @@ def random_seed(seed=None):
         random.seed(next_seed)
 
 
-def assert_raises_cudnn_disabled(assertion_error=False):
+def assert_raises_cudnn_disabled():
     def test_helper(orig_test):
         @make_decorator(orig_test)
         def test_new(*args, **kwargs):
@@ -103,10 +103,7 @@ def assert_raises_cudnn_disabled(assertion_error=False):
             if not cudnn_disabled or mx.context.current_context().device_type == 'cpu':
                 orig_test(*args, **kwargs)
             else:
-                if assertion_error:
-                    errors = (MXNetError, RuntimeError, AssertionError)
-                else:
-                    errors = (MXNetError, RuntimeError)
+                errors = (MXNetError, RuntimeError)
                 assert_raises(errors, orig_test, *args, **kwargs)
         return test_new
     return test_helper

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2407,9 +2407,6 @@ def test_flip():
 
 
 @with_seed()
-# The test is disabled with USE_CUDA=ON and USE_CUDNN=OFF because of failures with the SpatialTransformer op.
-# Tracked at https://github.com/apache/incubator-mxnet/issues/11568
-@assert_raises_cudnn_disabled(assertion_error=True)
 def test_stn():
     np.set_printoptions(threshold=np.nan)
     num_filter = 2  # conv of loc net


### PR DESCRIPTION
## Description ##
Spatial transformer op produced incorrect results with `USE_CUDA=ON` `USE_CUDNN=OFF` till now. This was due to separate threads writing to the same global memory locations causing undefined behavior.
Replaced all such writes with `atomicAdd`. I have also reenabled the disabled test: `test_stn`.
Removed assertion_error param for `assert_raises_cudnn_disabled`.

This fixes #11568

@tornadomeet @marcoabreu 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
