### PR TITLE
enable CPU kernel for all RNN layer forward

### DIFF
--- a/python/mxnet/gluon/rnn/rnn_layer.py
+++ b/python/mxnet/gluon/rnn/rnn_layer.py
@@ -189,11 +189,7 @@ class _RNNLayer(Block):
             for i in range(self._dir):
                 self.i2h_weight[i].shape = (self._gates*self._hidden_size, inputs.shape[2])
                 self.i2h_weight[i]._finish_deferred_init()
-        if inputs.context.device_type == 'gpu' or \
-           self._mode in ['lstm', 'gru'] and not self._dropout:
-            out = self._forward_kernel(inputs, states)
-        else:
-            out = self._forward(inputs, states)
+        out = self._forward_kernel(inputs, states)
 
         # out is (output, state)
         return out[0] if skip_states else out


### PR DESCRIPTION
## Description ##
After #10104, #10311, and #11399 are merged, rnn operator's CPU implementation is compatible with GPU implementation.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests already cover it.
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] always use CPU kernel for RNN layer forward.

## Comments ##
- Changing RNN layer to hybrid block is out of scope for this PR and will happen in #11482 instead.