### PR TITLE
Adding missing optimizers that use momentum.

### DIFF
--- a/example/image-classification/common/fit.py
+++ b/example/image-classification/common/fit.py
@@ -216,7 +216,7 @@ def fit(args, network, data_loader, **kwargs):
         'multi_precision': True}
 
     # Only a limited number of optimizers have 'momentum' property
-    has_momentum = {'sgd', 'dcasgd', 'nag'}
+    has_momentum = {'sgd', 'dcasgd', 'nag', 'signum', 'lbsgd'}
     if args.optimizer in has_momentum:
         optimizer_params['momentum'] = args.mom
 


### PR DESCRIPTION
## Description ##
This addresses an omission in the image classification examples where signum and lbsgd are not listed as optimizers having momentum. Resolves issue [11620](https://github.com/apache/incubator-mxnet/issues/11620).
