### PR TITLE
[MXNET-688] Fix quantization divide by zero errors

### DIFF
--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -329,7 +329,7 @@ def _get_optimal_threshold(arr, num_bins=8001, num_quantized_bins=255):
             if norm != 0:
                 q[start:stop] = float(quantized_bins[j]) / float(num_quantized_bins)
         p = _smooth_distribution(p)
-        # There is a chance that q is a completely zero'd probability distribution.
+        # There is a chance that q is an invalid probability distribution.
         try:
             q = _smooth_distribution(q)
         except ValueError:

--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -231,110 +231,7 @@ def _collect_layer_outputs(mod, data, include_layer=None, max_num_examples=None,
     return collector.nd_dict, num_examples
 
 
-def _smooth_distribution(p, eps=0.0001):
-    """Given a discrete distribution (may have not been normalized to 1),
-    smooth it by replacing zeros with eps multiplied by a scaling factor and taking the
-    corresponding amount off the non-zero values.
-    Ref: http://web.engr.illinois.edu/~hanj/cs412/bk3/KL-divergence.pdf
-    """
-    is_zeros = (p == 0).astype(np.float32)
-    is_nonzeros = (p != 0).astype(np.float32)
-    n_zeros = is_zeros.sum()
-    n_nonzeros = p.size - n_zeros
-    eps1 = eps * float(n_zeros) / float(n_nonzeros)
-    assert eps1 < 1.0, 'n_zeros=%d, n_nonzeros=%d, eps1=%f' % (n_zeros, n_nonzeros, eps1)
-    hist = p.astype(np.float32)
-    hist += eps * is_zeros + (-eps1) * is_nonzeros
-    assert (hist <= 0).sum() == 0
-    return hist
 
-
-# pylint: disable=line-too-long
-def _get_optimal_threshold(arr, num_bins=8001, num_quantized_bins=255):
-    """Given a dataset, find the optimal threshold for quantizing it.
-    Ref: http://on-demand.gputechconf.com/gtc/2017/presentation/s7310-8-bit-inference-with-tensorrt.pdf
-    """
-    if isinstance(arr, NDArray):
-        arr = arr.asnumpy()
-    elif isinstance(arr, list):
-        assert len(arr) != 0
-        for i, nd in enumerate(arr):
-            if isinstance(nd, NDArray):
-                arr[i] = nd.asnumpy()
-            elif not isinstance(nd, np.ndarray):
-                raise TypeError('get_optimal_threshold only supports input type of NDArray,'
-                                ' list of np.ndarrays or NDArrays, and np.ndarray,'
-                                ' while received type=%s' % (str(type(nd))))
-        arr = np.concatenate(arr)
-    elif not isinstance(arr, np.ndarray):
-        raise TypeError('get_optimal_threshold only supports input type of NDArray,'
-                        ' list of NDArrays and np.ndarray,'
-                        ' while received type=%s' % (str(type(arr))))
-    min_val = np.min(arr)
-    max_val = np.max(arr)
-    th = max(abs(min_val), abs(max_val))
-
-    hist, hist_edeges = np.histogram(arr, bins=num_bins, range=(-th, th))
-    zero_bin_idx = num_bins // 2
-    num_half_quantized_bins = num_quantized_bins // 2
-    assert np.allclose(hist_edeges[zero_bin_idx] + hist_edeges[zero_bin_idx + 1],
-                       0, rtol=1e-5, atol=1e-7)
-
-    thresholds = np.zeros(num_bins // 2 + 1 - num_quantized_bins // 2)
-    divergence = np.zeros_like(thresholds)
-    quantized_bins = np.zeros(num_quantized_bins, dtype=np.int32)
-    # i means the number of bins on half axis excluding the zero bin
-    for i in range(num_quantized_bins // 2,
-                   num_bins // 2 + 1):
-        p_bin_idx_start = zero_bin_idx - i
-        p_bin_idx_stop = zero_bin_idx + i + 1
-        thresholds[i - num_half_quantized_bins] = hist_edeges[p_bin_idx_stop]
-        # sliced_nd_hist is used to generate candidate distribution q
-        sliced_nd_hist = hist[p_bin_idx_start:p_bin_idx_stop]
-
-        # generate reference distribution p
-        p = sliced_nd_hist.copy()
-        assert p.size % 2 == 1
-        assert p.size >= num_quantized_bins
-        # put left outlier count in p[0]
-        left_outlier_count = np.sum(hist[0:p_bin_idx_start])
-        p[0] += left_outlier_count
-        # put right outlier count in p[-1]
-        right_outlier_count = np.sum(hist[p_bin_idx_stop:])
-        p[-1] += right_outlier_count
-        # is_nonzeros[k] indicates whether hist[k] is nonzero
-        is_nonzeros = (sliced_nd_hist != 0).astype(np.int32)
-
-        # calculate how many bins should be merged to generate quantized distribution q
-        num_merged_bins = p.size // num_quantized_bins
-        # merge hist into num_quantized_bins bins
-        for j in range(num_quantized_bins):
-            start = j * num_merged_bins
-            stop = start + num_merged_bins
-            quantized_bins[j] = sliced_nd_hist[start:stop].sum()
-        quantized_bins[-1] += sliced_nd_hist[num_quantized_bins * num_merged_bins:].sum()
-        # expand quantized_bins into p.size bins
-        q = np.zeros(p.size, dtype=np.float32)
-        for j in range(num_quantized_bins):
-            start = j * num_merged_bins
-            if j == num_quantized_bins - 1:
-                stop = -1
-            else:
-                stop = start + num_merged_bins
-            norm = is_nonzeros[start:stop].sum()
-            if norm != 0:
-                q[start:stop] = float(quantized_bins[j]) / float(norm)
-        q[sliced_nd_hist == 0] = 0
-        p = _smooth_distribution(p)
-        q = _smooth_distribution(q)
-        divergence[i - num_half_quantized_bins] = stats.entropy(p, q)
-        quantized_bins[:] = 0
-
-    min_divergence_idx = np.argmin(divergence)
-    min_divergence = divergence[min_divergence_idx]
-    opt_th = thresholds[min_divergence_idx]
-    return min_val, max_val, min_divergence, opt_th
-# pylint: enable=line-too-long
 
 
 def _get_optimal_thresholds(nd_dict, num_bins=8001, num_quantized_bins=255, logger=None):
@@ -375,6 +272,103 @@ def _load_sym(sym, logger=logging):
     else:
         raise ValueError('_load_sym only accepts Symbol or path to the symbol file,'
                          ' while received type %s' % str(type(sym)))
+
+
+def _smooth_distribution(p, eps=0.0001):
+    """Given a discrete distribution (may have not been normalized to 1),
+    smooth it by replacing zeros with eps multiplied by a scaling factor and taking the
+    corresponding amount off the non-zero values.
+    Ref: http://web.engr.illinois.edu/~hanj/cs412/bk3/KL-divergence.pdf
+    """
+    is_zeros = (p == 0).astype(np.float32)
+    is_nonzeros = (p != 0).astype(np.float32)
+    n_zeros = is_zeros.sum()
+    n_nonzeros = p.size - n_zeros
+    assert n_nonzeros, 'The discrete probability distribution is malformed. All entries are 0.'
+    eps1 = eps * float(n_zeros) / float(n_nonzeros)
+    assert eps1 < 1.0, 'n_zeros=%d, n_nonzeros=%d, eps1=%f' % (n_zeros, n_nonzeros, eps1)
+    hist = p.astype(np.float32)
+    hist += eps * is_zeros + (-eps1) * is_nonzeros
+    assert (hist <= 0).sum() == 0
+    return hist
+
+
+# pylint: disable=line-too-long
+def _get_optimal_threshold(arr, num_bins=8001, num_quantized_bins=255):
+    """Given a dataset, find the optimal threshold for quantizing it.
+    The reference distribution is `hist`, and the candidate distribution is `full_q`.
+    Ref: http://on-demand.gputechconf.com/gtc/2017/presentation/s7310-8-bit-inference-with-tensorrt.pdf
+    """
+    if isinstance(arr, NDArray):
+        arr = arr.asnumpy()
+    elif isinstance(arr, list):
+        assert len(arr) != 0
+        for i, nd in enumerate(arr):
+            if isinstance(nd, NDArray):
+                arr[i] = nd.asnumpy()
+            elif not isinstance(nd, np.ndarray):
+                raise TypeError('get_optimal_threshold only supports input type of NDArray,'
+                                ' list of np.ndarrays or NDArrays, and np.ndarray,'
+                                ' while received type=%s' % (str(type(nd))))
+        arr = np.concatenate(arr)
+    elif not isinstance(arr, np.ndarray):
+        raise TypeError('get_optimal_threshold only supports input type of NDArray,'
+                        ' list of NDArrays and np.ndarray,'
+                        ' while received type=%s' % (str(type(arr))))
+    min_val = np.min(arr)
+    max_val = np.max(arr)
+    th = max(abs(min_val), abs(max_val))
+
+    hist, hist_edeges = np.histogram(arr, bins=num_bins, range=(-th, th))
+    zero_bin_idx = num_bins // 2
+    num_half_quantized_bins = num_quantized_bins // 2
+    assert np.allclose(hist_edeges[zero_bin_idx] + hist_edeges[zero_bin_idx + 1],
+                       0, rtol=1e-5, atol=1e-7)
+
+    thresholds = np.zeros(num_bins // 2 + 1 - num_quantized_bins // 2)
+    divergence = np.zeros_like(thresholds)
+    quantized_bins = np.zeros(num_quantized_bins, dtype=np.int32)
+    # since we're expanding the size of the quantization threshold bound,
+    # we can use a copy of hist and overwrite it with increasing slice size.
+    full_q = hist.copy()
+    # i means the number of bins on half axis excluding the zero bin.
+    for i in range(num_quantized_bins // 2,
+                   num_bins // 2 + 1):
+        p_bin_idx_start = zero_bin_idx - i
+        p_bin_idx_stop = zero_bin_idx + i + 1
+        thresholds[i - num_half_quantized_bins] = hist_edeges[p_bin_idx_stop]
+        sliced_nd_hist = hist[p_bin_idx_start:p_bin_idx_stop]
+
+        # is_nonzeros[k] indicates whether hist[k] is nonzero
+        is_nonzeros = (sliced_nd_hist != 0).astype(np.int32)
+
+        # calculate how many bins should be merged to generate quantized distribution q
+        num_merged_bins = sliced_nd_hist.size // num_quantized_bins
+        # merge hist into num_quantized_bins bins
+        for j in range(num_quantized_bins):
+            start = j * num_merged_bins
+            stop = start + num_merged_bins
+            quantized_bins[j] = sliced_nd_hist[start:stop].sum()
+        quantized_bins[-1] += sliced_nd_hist[num_quantized_bins * num_merged_bins:].sum()
+        # expand quantized_bins into p.size bins
+        q = np.zeros(sliced_nd_hist.size, dtype=np.float32)
+        for j in range(num_quantized_bins):
+            start = j * num_merged_bins
+            if j == num_quantized_bins - 1:
+                stop = len(is_nonzeros)
+            else:
+                stop = start + num_merged_bins
+            norm = is_nonzeros[start:stop].sum()
+            if norm != 0:
+                q[start:stop] = float(quantized_bins[j]) / float(norm)
+        full_q[p_bin_idx_start:p_bin_idx_stop] = q
+        divergence[i - num_half_quantized_bins] = stats.entropy(hist, _smooth_distribution(full_q))
+
+    min_divergence_idx = np.argmin(divergence)
+    min_divergence = divergence[min_divergence_idx]
+    opt_th = thresholds[min_divergence_idx]
+    return min_val, max_val, min_divergence, opt_th
+# pylint: enable=line-too-long
 
 
 def _load_params(params, logger=logging):

--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -231,20 +231,6 @@ def _collect_layer_outputs(mod, data, include_layer=None, max_num_examples=None,
     return collector.nd_dict, num_examples
 
 
-def _load_sym(sym, logger=logging):
-    """Given a str as a path the symbol .json file or a symbol, returns a Symbol object."""
-    if isinstance(sym, str):  # sym is a symbol file path
-        cur_path = os.path.dirname(os.path.realpath(__file__))
-        symbol_file_path = os.path.join(cur_path, sym)
-        logger.info('Loading symbol from file %s' % symbol_file_path)
-        return sym_load(symbol_file_path)
-    elif isinstance(sym, Symbol):
-        return sym
-    else:
-        raise ValueError('_load_sym only accepts Symbol or path to the symbol file,'
-                         ' while received type %s' % str(type(sym)))
-
-
 def _smooth_distribution(p, eps=0.0001):
     """Given a discrete distribution (may have not been normalized to 1),
     smooth it by replacing zeros with eps multiplied by a scaling factor and taking the
@@ -379,6 +365,20 @@ def _get_optimal_thresholds(nd_dict, num_bins=8001, num_quantized_bins=255, logg
             logger.info('layer=%s, min_val=%f, max_val=%f, min_divergence=%f, optimal_threshold=%f'
                         % (name, min_val, max_val, min_divergence, opt_th))
     return th_dict
+
+
+def _load_sym(sym, logger=logging):
+    """Given a str as a path the symbol .json file or a symbol, returns a Symbol object."""
+    if isinstance(sym, str):  # sym is a symbol file path
+        cur_path = os.path.dirname(os.path.realpath(__file__))
+        symbol_file_path = os.path.join(cur_path, sym)
+        logger.info('Loading symbol from file %s' % symbol_file_path)
+        return sym_load(symbol_file_path)
+    elif isinstance(sym, Symbol):
+        return sym
+    else:
+        raise ValueError('_load_sym only accepts Symbol or path to the symbol file,'
+                         ' while received type %s' % str(type(sym)))
 
 
 def _load_params(params, logger=logging):

--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -327,7 +327,8 @@ def _get_optimal_threshold(arr, num_bins=8001, num_quantized_bins=255):
                 stop = start + num_merged_bins
             norm = is_nonzeros[start:stop].sum()
             if norm != 0:
-                q[start:stop] = float(quantized_bins[j]) / float(num_quantized_bins)
+                q[start:stop] = float(quantized_bins[j]) / float(norm)
+        q[p == 0] = 0
         p = _smooth_distribution(p)
         # There is a chance that q is an invalid probability distribution.
         try:

--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -254,7 +254,9 @@ def _smooth_distribution(p, eps=0.0001):
 # pylint: disable=line-too-long
 def _get_optimal_threshold(arr, num_bins=8001, num_quantized_bins=255):
     """Given a dataset, find the optimal threshold for quantizing it.
-    The reference distribution is `hist`, and the candidate distribution is `full_q`.
+    The reference distribution is `q`, and the candidate distribution is `p`.
+    `q` is a truncated version of the original distribution.
+
     Ref: http://on-demand.gputechconf.com/gtc/2017/presentation/s7310-8-bit-inference-with-tensorrt.pdf
     """
     if isinstance(arr, NDArray):

--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -231,9 +231,6 @@ def _collect_layer_outputs(mod, data, include_layer=None, max_num_examples=None,
     return collector.nd_dict, num_examples
 
 
-
-
-
 def _get_optimal_thresholds(nd_dict, num_bins=8001, num_quantized_bins=255, logger=None):
     """Given a ndarray dict, find the optimal threshold for quantizing each value of the key."""
     if stats is None:
@@ -284,7 +281,8 @@ def _smooth_distribution(p, eps=0.0001):
     is_nonzeros = (p != 0).astype(np.float32)
     n_zeros = is_zeros.sum()
     n_nonzeros = p.size - n_zeros
-    assert n_nonzeros, 'The discrete probability distribution is malformed. All entries are 0.'
+    if not n_nonzeros:
+        raise ValueError('The discrete probability distribution is malformed. All entries are 0.')
     eps1 = eps * float(n_zeros) / float(n_nonzeros)
     assert eps1 < 1.0, 'n_zeros=%d, n_nonzeros=%d, eps1=%f' % (n_zeros, n_nonzeros, eps1)
     hist = p.astype(np.float32)
@@ -319,28 +317,35 @@ def _get_optimal_threshold(arr, num_bins=8001, num_quantized_bins=255):
     max_val = np.max(arr)
     th = max(abs(min_val), abs(max_val))
 
-    hist, hist_edeges = np.histogram(arr, bins=num_bins, range=(-th, th))
+    hist, hist_edges = np.histogram(arr, bins=num_bins, range=(-th, th))
     zero_bin_idx = num_bins // 2
     num_half_quantized_bins = num_quantized_bins // 2
-    assert np.allclose(hist_edeges[zero_bin_idx] + hist_edeges[zero_bin_idx + 1],
+    assert np.allclose(hist_edges[zero_bin_idx] + hist_edges[zero_bin_idx + 1],
                        0, rtol=1e-5, atol=1e-7)
 
     thresholds = np.zeros(num_bins // 2 + 1 - num_quantized_bins // 2)
     divergence = np.zeros_like(thresholds)
     quantized_bins = np.zeros(num_quantized_bins, dtype=np.int32)
-    # since we're expanding the size of the quantization threshold bound,
-    # we can use a copy of hist and overwrite it with increasing slice size.
-    full_q = hist.copy()
     # i means the number of bins on half axis excluding the zero bin.
     for i in range(num_quantized_bins // 2,
                    num_bins // 2 + 1):
         p_bin_idx_start = zero_bin_idx - i
         p_bin_idx_stop = zero_bin_idx + i + 1
-        thresholds[i - num_half_quantized_bins] = hist_edeges[p_bin_idx_stop]
+        thresholds[i - num_half_quantized_bins] = hist_edges[p_bin_idx_stop]
         sliced_nd_hist = hist[p_bin_idx_start:p_bin_idx_stop]
 
+        # generate reference distribution p
+        p = sliced_nd_hist.copy()
+        assert p.size % 2 == 1
+        assert p.size >= num_quantized_bins
+        # put left outlier count in p[0]
+        left_outlier_count = np.sum(hist[0:p_bin_idx_start])
+        p[0] += left_outlier_count
+        # put right outlier count in p[-1]
+        right_outlier_count = np.sum(hist[p_bin_idx_stop:])
+        p[-1] += right_outlier_count
         # is_nonzeros[k] indicates whether hist[k] is nonzero
-        is_nonzeros = (sliced_nd_hist != 0).astype(np.int32)
+        is_nonzeros = (p != 0).astype(np.int32)
 
         # calculate how many bins should be merged to generate quantized distribution q
         num_merged_bins = sliced_nd_hist.size // num_quantized_bins
@@ -360,9 +365,14 @@ def _get_optimal_threshold(arr, num_bins=8001, num_quantized_bins=255):
                 stop = start + num_merged_bins
             norm = is_nonzeros[start:stop].sum()
             if norm != 0:
-                q[start:stop] = float(quantized_bins[j]) / float(norm)
-        full_q[p_bin_idx_start:p_bin_idx_stop] = q
-        divergence[i - num_half_quantized_bins] = stats.entropy(hist, _smooth_distribution(full_q))
+                q[start:stop] = float(quantized_bins[j]) / float(num_quantized_bins)
+        p = _smooth_distribution(p)
+        # There is a chance that q is a completely zero'd probability distribution.
+        try:
+            q = _smooth_distribution(q)
+        except ValueError:
+            divergence[i - num_half_quantized_bins] = float("inf")
+        divergence[i - num_half_quantized_bins] = stats.entropy(p, q)
 
     min_divergence_idx = np.argmin(divergence)
     min_divergence = divergence[min_divergence_idx]

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -507,6 +507,7 @@ def test_optimal_threshold_adversarial_case():
     # The threshold should be 2.
     assert res[3] - 2 < 1e-5
 
+
 @with_seed()
 @unittest.skip("Flaky test: https://github.com/apache/incubator-mxnet/issues/11456")
 def test_get_optimal_thresholds():

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -21,7 +21,7 @@ Ref: http://images.nvidia.com/content/pdf/tesla/184457-Tesla-P4-Datasheet-NV-Fin
 import os
 import mxnet as mx
 import numpy as np
-from mxnet.test_utils import assert_almost_equal, rand_ndarray, rand_shape_nd, same, DummyIter
+from mxnet.test_utils import assert_almost_equal, assert_exception, rand_ndarray, rand_shape_nd, same, DummyIter
 from common import with_seed
 from mxnet.module import Module
 from mxnet.io import NDArrayIter
@@ -463,6 +463,7 @@ def test_quantize_model():
     for qdtype in ['int8', 'uint8']:
         check_quantize_model(qdtype)
 
+
 @with_seed()
 def test_quantize_sym_with_calib():
     sym = get_fp32_sym()
@@ -484,6 +485,27 @@ def test_quantize_sym_with_calib():
         rhs = th_dict[op_name_to_th_name[name]][1]
         assert_almost_equal(np.array([lhs]), np.array([rhs]), rtol=1e-3, atol=1e-4)
 
+
+@with_seed()
+def test_smooth_distribution():
+    assert_exception(lambda: mx.contrib.quant._smooth_distribution(np.zeros((2,)), eps=1e-3), ValueError)
+    dirac_delta = np.zeros((5,))
+    dirac_delta[2] = 1
+    smooth_dirac_delta = dirac_delta.copy()
+    smooth_dirac_delta += 1e-3
+    smooth_dirac_delta[2] -= 5e-3
+    assert_almost_equal(mx.contrib.quant._smooth_distribution(dirac_delta, eps=1e-3), smooth_dirac_delta)
+
+
+@with_seed()
+def test_optimal_threshold_adversarial_case():
+    # The worst case for the optimal_threshold function is when the values are concentrated
+    # at one edge: [0, 0, ..., 1000]. (histogram)
+    # We want to make sure that the optimal threshold in this case is the max.
+    arr = np.array([2]*1000)
+    res = mx.contrib.quant._get_optimal_threshold(arr, num_quantized_bins=5)
+    # The threshold should be 2.
+    assert res[3] - 2 < 1e-5
 
 @with_seed()
 @unittest.skip("Flaky test: https://github.com/apache/incubator-mxnet/issues/11456")


### PR DESCRIPTION
## Description ##
The current quantization strategy for `calib_mode='entropy'` is to calculate the KL divergence for different thresholds and choose the best threshold. This assumes that the random variable is nonzero for all reals and is a continuous random variable. Because we are discretizing the distribution, we smooth the distribution over the range `[-threshold, threshold]`. What we are not considering is that the entire sampled distribution may be not in the range `[-threshold, threshold]` and thus we end up with all zeros in the sampled candidate `p` distribution inside of `_get_optimal_threshold`.

I have added a check that the distribution(possibly unnormalized) is proper before attempting to smooth or else we'll run into a divide by 0 error.

In most cases, activation functions and layers for classification type problems output numbers symmetric around 0. This is not the case for a regressor's last layer, and there are various other examples where the activation distribution is not around 0, and this was a major blockage for airbnb's adoption into mxnet's quantization capabilities.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Added tests and extra code inside of quantization.py to set all kl divergence to infinity if the probability distribution formed is all zeros. Also there are some typos and one-off-errors in the original implementation that are now fixed.
