### PR TITLE
[MXNET-711] Website build and version dropdown update

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -814,7 +814,11 @@ build_docs() {
     set -ex
     pushd .
     cd /work/mxnet/docs/build_version_doc
-    ./build_all_version.sh $1
+    # Parameters are set in the Jenkins pipeline: restricted-website-build
+    # $1 is the list of branches to build; $2 is the list of tags to display
+    # So you can build from the 1.2.0 branch, but display 1.2.1 on the site
+    ./build_all_version.sh $1 $2
+    # $3 is the default version tag for the website; $4 is the base URL
     ./update_all_version.sh $2 $3 $4
     cd VersionedWeb
     tar -zcvf ../artifacts.tgz .

--- a/docs/Jenkinsfile
+++ b/docs/Jenkinsfile
@@ -47,13 +47,13 @@ def init_git() {
 
 try {
   stage('Build Docs') {
-    node('mxnetlinux-cpu') {
+    node('restricted-mxnetlinux-cpu') {
       ws('workspace/docs') {
         init_git()
         timeout(time: max_time, unit: 'MINUTES') {
             sh "ci/build.py -p ubuntu_cpu --docker-registry ${env.DOCKER_CACHE_REGISTRY} --docker-build-retries 3 /work/runtime_functions.sh build_docs ${params.tags_to_build} ${params.tag_list} ${params.tag_default} ${params.domain}"
             archiveArtifacts 'docs/build_version_doc/artifacts.tgz'
-            build 'test-website-publish'
+            build 'restricted-website-publish'
         }
       }
     }
@@ -62,13 +62,13 @@ try {
   // set build status to success at the end
   currentBuild.result = "SUCCESS"
 } catch (caughtError) {
-  node("mxnetlinux-cpu") {
+  node("restricted-mxnetlinux-cpu") {
     sh "echo caught ${caughtError}"
     err = caughtError
     currentBuild.result = "FAILURE"
   }
 } finally {
-  node("mxnetlinux-cpu") {
+  node("restricted-mxnetlinux-cpu") {
     // Only send email if master failed
     if (currentBuild.result == "FAILURE") {
       emailext body: 'Generating the website has failed. Please view the build at ${BUILD_URL}', replyTo: '${EMAIL}', subject: '[WEBSITE FAILED] Build ${BUILD_NUMBER}', to: '${EMAIL}'

--- a/docs/Jenkinsfile
+++ b/docs/Jenkinsfile
@@ -47,13 +47,13 @@ def init_git() {
 
 try {
   stage('Build Docs') {
-    node('restricted-mxnetlinux-cpu') {
+    node('mxnetlinux-cpu') {
       ws('workspace/docs') {
         init_git()
         timeout(time: max_time, unit: 'MINUTES') {
             sh "ci/build.py -p ubuntu_cpu --docker-registry ${env.DOCKER_CACHE_REGISTRY} --docker-build-retries 3 /work/runtime_functions.sh build_docs ${params.tags_to_build} ${params.tag_list} ${params.tag_default} ${params.domain}"
             archiveArtifacts 'docs/build_version_doc/artifacts.tgz'
-            build 'restricted-website-publish'
+            build 'test-website-publish'
         }
       }
     }
@@ -62,13 +62,13 @@ try {
   // set build status to success at the end
   currentBuild.result = "SUCCESS"
 } catch (caughtError) {
-  node("restricted-mxnetlinux-cpu") {
+  node("mxnetlinux-cpu") {
     sh "echo caught ${caughtError}"
     err = caughtError
     currentBuild.result = "FAILURE"
   }
 } finally {
-  node("restricted-mxnetlinux-cpu") {
+  node("mxnetlinux-cpu") {
     // Only send email if master failed
     if (currentBuild.result == "FAILURE") {
       emailext body: 'Generating the website has failed. Please view the build at ${BUILD_URL}', replyTo: '${EMAIL}', subject: '[WEBSITE FAILED] Build ${BUILD_NUMBER}', to: '${EMAIL}'

--- a/docs/build_version_doc/update_all_version.sh
+++ b/docs/build_version_doc/update_all_version.sh
@@ -23,12 +23,12 @@
 # the tags you want to update.
 
 # Takes three arguments:
-# * tag list - space delimited list of Github tags; Example: "1.1.0 1.0.0 master"
+# * tag list - semicolon delimited list of tags to display on site; Example: "1.1.0;1.0.0;master"
 # * default tag - which version should the site default to; Example: 1.0.0
 # * root URL - for the versions dropdown to change to production or dev server; Example: http://mxnet.incubator.apache.org/
 
 # Example Usage:
-# ./update_all_version.sh "1.1.0 1.0.0 master" 1.0.0 http://mxnet.incubator.apache.org/
+# ./update_all_version.sh "1.1.0;1.0.0;master" 1.0.0 http://mxnet.incubator.apache.org/
 
 set -e
 set -x
@@ -36,7 +36,6 @@ set -x
 MASTER_SOURCE_DIR="../../docs"
 STATIC_FILES_DIR="_static"
 MXNET_THEME_DIR="_static/mxnet-theme"
-BUILD_HTML_DIR="_build/html"
 
 if [ -z "$1" ]
   then
@@ -132,4 +131,3 @@ for tag in $tag_list; do
 done
 
 echo "The output of this process can be found in the VersionedWeb folder."
-


### PR DESCRIPTION
## Description ##

The website was displaying the versions based on the build of the branch names and not any minor version updates. For example, even though we're on v1.2.1 code, we're displaying v1.2.0 in the dropdown.

![2018-07-25_15-11-11](https://user-images.githubusercontent.com/5974205/43230466-2ed95e2a-901d-11e8-9fbf-bce5aecef006.png)

I implemented new Jenkins and website build logic that allows you to control the display from Jenkins. You can now map code from a branch or a tag to whatever display name you want. Here I've updated 1.2.0 to say 1.2.1.
 
![2018-07-25_15-10-41](https://user-images.githubusercontent.com/5974205/43230470-34f9d906-901d-11e8-9a15-539da05ef244.png)

A preview is here: http://34.201.8.176/versions/1.2.1/index.html
A smaller, limited versions test Jenkins run is here: http://jenkins.mxnet-ci.amazon-ml.com/job/test-website-build/5/console
After I run a complete, all versions test run this PR should be ready to roll.

## Checklist ##
### Essentials ###
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Code is well-documented: 
- [x] Code changes are complete - several Jenkins-related updates are needed once this PR is about to be merged:
    - [x] docs/Jenkinsfile: I removed "reserved-$node", so I could test. "reserved" needs to be added back before merge. **UPDATE: added this back and see post-merge notes below**

![2018-07-25_15-40-35](https://user-images.githubusercontent.com/5974205/43231421-25c09548-9021-11e8-80dc-7249fe4634f6.png)


### Changes ###
1. CI will call an updated Jenkinsfile in /docs that will run the test jobs on unrestricted nodes. (This file should be reverted once the PR is approved.)
1. CI's runtime_functions will now send the tag_list param (what to display) to the build script (build_all_version.sh) that builds each branch as a new version of the site.
1. build_all_version.sh will build each version and put the artifacts into the folders that were defined in the new display param.
1. update_all_version.sh picks up like before and injects the versions dropdown, but now will have new versions display (1.2.1 instead of 1.2.0).

### Important for Post-Merge

- [x] Jenkins job - restricted-website-build - this production job should be updated to use the new tag capability where you can choose tags or branches for tags to build. This requires the "v" to be appended to each. Then for the `tag_list` param, you use the display you want. So for branch`v1.2.0` you use `1.2.1` and for `v0.12.0` you use `0.12.1`. **Just copy the `tags_list` and `tags_to_build` settings in the test-website-build pipeline.**