### PR TITLE
Update CPP Lenet Example to remove additional 3 layers

### DIFF
--- a/cpp-package/example/lenet.cpp
+++ b/cpp-package/example/lenet.cpp
@@ -24,7 +24,6 @@
 #include <string>
 #include <vector>
 #include <cstdlib>
-#include <ctime>
 #include <chrono>
 #include "mxnet-cpp/MxNetCpp.h"
 

--- a/cpp-package/example/lenet.cpp
+++ b/cpp-package/example/lenet.cpp
@@ -24,6 +24,8 @@
 #include <string>
 #include <vector>
 #include <cstdlib>
+#include <ctime>
+#include <chrono>
 #include "mxnet-cpp/MxNetCpp.h"
 
 using namespace mxnet::cpp;
@@ -67,13 +69,7 @@ class Lenet {
     Symbol pool2 = Pooling("pool2", tanh2, Shape(2, 2), PoolingPoolType::kMax,
       false, false, PoolingPoolingConvention::kValid, Shape(2, 2));
 
-    Symbol conv3 = Convolution("conv3", pool2, conv3_w, conv3_b,
-      Shape(2, 2), 500);
-    Symbol tanh3 = Activation("tanh3", conv3, ActivationActType::kTanh);
-    Symbol pool3 = Pooling("pool3", tanh3, Shape(2, 2), PoolingPoolType::kMax,
-      false, false, PoolingPoolingConvention::kValid, Shape(1, 1));
-
-    Symbol flatten = Flatten("flatten", pool3);
+    Symbol flatten = Flatten("flatten", pool2);
     Symbol fc1 = FullyConnected("fc1", flatten, fc1_w, fc1_b, 500);
     Symbol tanh4 = Activation("tanh4", fc1, ActivationActType::kTanh);
     Symbol fc2 = FullyConnected("fc2", tanh4, fc2_w, fc2_b, 10);
@@ -88,9 +84,8 @@ class Lenet {
     int val_fold = 1;
     int W = 28;
     int H = 28;
-    int batch_size = 42;
-    float learning_rate = 1e-4;
-    float weight_decay = 1e-4;
+    int batch_size = 64;
+    float learning_rate = 0.05;
 
     /*prepare the data*/
     std::vector<float> data_vec, label_vec;
@@ -135,18 +130,16 @@ class Lenet {
     // args_map["fc1_b"] = 0;
 
     lenet.InferArgsMap(ctx_dev, &args_map, args_map);
-    Optimizer* opt = OptimizerRegistry::Find("ccsgd");
-    opt->SetParam("momentum", 0.9)
-       ->SetParam("rescale_grad", 1.0)
-       ->SetParam("clip_gradient", 10)
-       ->SetParam("lr", learning_rate)
-       ->SetParam("wd", weight_decay);
+    Optimizer* opt = OptimizerRegistry::Find("sgd");
+    opt->SetParam("lr", learning_rate);
 
     Executor *exe = lenet.SimpleBind(ctx_dev, args_map);
     auto arg_names = lenet.ListArguments();
 
     for (int ITER = 0; ITER < max_epoch; ++ITER) {
       size_t start_index = 0;
+      auto e_start = std::chrono::high_resolution_clock::now();
+
       while (start_index < train_num) {
         if (start_index + batch_size > train_num) {
           start_index = train_num - batch_size;
@@ -169,7 +162,9 @@ class Lenet {
         }
       }
 
-      LG << "Iter " << ITER
+      auto e_end = std::chrono::high_resolution_clock::now();
+      auto time_taken = std::chrono::duration<double, std::milli> (e_end - e_start).count()/1000L;
+      LG << "Epoch [" << ITER << "] Time cost :" << time_taken
          << ", accuracy: " << ValAccuracy(batch_size * 10, lenet);
     }
     delete exe;


### PR DESCRIPTION
## Description ##
This is a small PR to remove the additional 3 layers in the network to keep it similar to the lenet-5 architecture and python lenet Example. 
With the additional 3 layers, users running this examples would see the time to process each epoch to be twice than the python version of the example and raises concern that it might an issue with the APIs. 
I have also changed the Opitmizer to `sgd` similar to Python.
The accuracy of this model is still pretty bad and needs fixing, this is in my todo unless someone wants to pick up #11901 

Time taken after removing 3 layers(conv,pool,activation)
```
[21:16:06] lenet.cpp:173: Epoch [0] Time cost :2.16074, accuracy: 0.0992187
[21:16:08] lenet.cpp:173: Epoch [1] Time cost :1.80743, accuracy: 0.0976562
[21:16:10] lenet.cpp:173: Epoch [2] Time cost :1.78453, accuracy: 0.095625
[21:16:12] lenet.cpp:173: Epoch [3] Time cost :1.74847, accuracy: 0.0989062
[21:16:13] lenet.cpp:173: Epoch [4] Time cost :1.72876, accuracy: 0.0989062
[21:16:15] lenet.cpp:173: Epoch [5] Time cost :1.73068, accuracy: 0.095625
[21:16:17] lenet.cpp:173: Epoch [6] Time cost :1.75381, accuracy: 0.0989062
[21:16:19] lenet.cpp:173: Epoch [7] Time cost :1.73349, accuracy: 0.0917187
[21:16:21] lenet.cpp:173: Epoch [8] Time cost :1.72195, accuracy: 0.0976562
[21:16:23] lenet.cpp:173: Epoch [9] Time cost :1.72871, accuracy: 0.0992187
[21:16:24] lenet.cpp:173: Epoch [10] Time cost :1.73538, accuracy: 0.103594
[21:16:26] lenet.cpp:173: Epoch [11] Time cost :1.72449, accuracy: 0.105
[21:16:28] lenet.cpp:173: Epoch [12] Time cost :1.73199, accuracy: 0.0992187
[21:16:30] lenet.cpp:173: Epoch [13] Time cost :1.72219, accuracy: 0.111562
[21:16:32] lenet.cpp:173: Epoch [14] Time cost :1.73825, accuracy: 0.111562
[21:16:33] lenet.cpp:173: Epoch [15] Time cost :1.70859, accuracy: 0.105
[21:16:35] lenet.cpp:173: Epoch [16] Time cost :1.71811, accuracy: 0.0992187
[21:16:37] lenet.cpp:173: Epoch [17] Time cost :1.71841, accuracy: 0.0976562
[21:16:39] lenet.cpp:173: Epoch [18] Time cost :1.73148, accuracy: 0.095625
[21:16:41] lenet.cpp:173: Epoch [19] Time cost :1.7357, accuracy: 0.0989062
[21:16:42] lenet.cpp:173: Epoch [20] Time cost :1.71531, accuracy: 0.0989062
[21:16:44] lenet.cpp:173: Epoch [21] Time cost :1.72765, accuracy: 0.095625
[21:16:46] lenet.cpp:173: Epoch [22] Time cost :1.71419, accuracy: 0.0989062
```
**Time taken with additional 3 layers**
```
[08:03:11] lenet.cpp:191: Epoch [251] Time cost :2.82437, accuracy: 0.0917187
[08:03:14] lenet.cpp:191: Epoch [252] Time cost :2.80197, accuracy: 0.105
[08:03:17] lenet.cpp:191: Epoch [253] Time cost :2.84335, accuracy: 0.0992187
[08:03:20] lenet.cpp:191: Epoch [254] Time cost :2.84199, accuracy: 0.105
[08:03:23] lenet.cpp:191: Epoch [255] Time cost :2.82093, accuracy: 0.103594
[08:03:26] lenet.cpp:191: Epoch [256] Time cost :2.82659, accuracy: 0.105
[08:03:29] lenet.cpp:191: Epoch [257] Time cost :2.83494, accuracy: 0.0976562
[08:03:32] lenet.cpp:191: Epoch [258] Time cost :2.81344, accuracy: 0.105
[08:03:35] lenet.cpp:191: Epoch [259] Time cost :2.82905, accuracy: 0.0992187
[08:03:38] lenet.cpp:191: Epoch [260] Time cost :2.84072, accuracy: 0.105
[08:03:41] lenet.cpp:191: Epoch [261] Time cost :2.80219, accuracy: 0.111562
[08:03:44] lenet.cpp:191: Epoch [262] Time cost :2.81896, accuracy: 0.095625
[08:03:46] lenet.cpp:191: Epoch [263] Time cost :2.80515, accuracy: 0.0976562
[08:03:49] lenet.cpp:191: Epoch [264] Time cost :2.81536, accuracy: 0.105
[08:03:52] lenet.cpp:191: Epoch [265] Time cost :2.80752, accuracy: 0.100781
[08:03:55] lenet.cpp:191: Epoch [266] Time cost :2.85179, accuracy: 0.0976562
[08:03:58] lenet.cpp:191: Epoch [267] Time cost :2.82427, accuracy: 0.0917187
[08:04:01] lenet.cpp:191: Epoch [268] Time cost :2.85179, accuracy: 0.105
[08:04:04] lenet.cpp:191: Epoch [269] Time cost :2.82831, accuracy: 0.0992187
[08:04:07] lenet.cpp:191: Epoch [270] Time cost :2.84071, accuracy: 0.105
[08:04:10] lenet.cpp:191: Epoch [271] Time cost :2.82893, accuracy: 0.103594
[08:04:13] lenet.cpp:191: Epoch [272] Time cost :2.83461, accuracy: 0.105
[08:04:16] lenet.cpp:191: Epoch [273] Time cost :2.80872, accuracy: 0.0976562
[08:04:19] lenet.cpp:191: Epoch [274] Time cost :2.82435, accuracy: 0.105
[08:04:22] lenet.cpp:191: Epoch [275] Time cost :2.83497, accuracy: 0.0992187
[08:04:24] lenet.cpp:191: Epoch [276] Time cost :2.82968, accuracy: 0.105
```