### PR TITLE
[MXNET-766] add unroll RNN for HybridBlock

### DIFF
--- a/python/mxnet/gluon/contrib/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/contrib/rnn/rnn_cell.py
@@ -22,7 +22,6 @@ __all__ = ['VariationalDropoutCell', 'LSTMPCell']
 from ...rnn import BidirectionalCell, SequentialRNNCell, ModifierCell, HybridRecurrentCell
 from ...rnn.rnn_cell import _format_sequence, _get_begin_state, _mask_sequence_variable_length
 from ... import tensor_types
-from .... import symbol, ndarray
 from ....base import _as_list
 
 class VariationalDropoutCell(ModifierCell):

--- a/python/mxnet/gluon/contrib/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/contrib/rnn/rnn_cell.py
@@ -399,7 +399,7 @@ def unroll(cell, inputs, begin_state, drop_inputs=0, drop_outputs=0,
         zeros = []
         for s in states:
             zeros.append(F.zeros_like(s))
-        states = _as_list(states)
+        states = list(_as_list(states))
         states.append(F.zeros((1)))
         def loop_body(inputs, states):
             cell_states = states[:-1]

--- a/python/mxnet/gluon/contrib/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/contrib/rnn/rnn_cell.py
@@ -369,7 +369,7 @@ def unroll(cell, inputs, begin_state, drop_inputs=0, drop_outputs=0,
             out, new_states = cell(inputs, cell_states)
             for i in range(len(new_states)):
                 new_states[i] = F.where(F.broadcast_greater(valid_length, iter_no),
-                                        new_states[i], zeros[i])
+                                        new_states[i], cell_states[i])
             new_states.append(iter_no + 1)
             return out, new_states
 

--- a/python/mxnet/gluon/contrib/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/contrib/rnn/rnn_cell.py
@@ -323,8 +323,8 @@ class LSTMPCell(HybridRecurrentCell):
     # pylint: enable= arguments-differ
 
 
-def unroll(cell, inputs, begin_state, drop_inputs=0, drop_outputs=0,
-           layout='TNC', valid_length=None):
+def dynamic_unroll(cell, inputs, begin_state, drop_inputs=0, drop_outputs=0,
+                   layout='TNC', valid_length=None):
     """Unrolls an RNN cell across time steps.
 
     Currently, 'TNC' is a preferred layout. unroll on the input of this layout
@@ -376,9 +376,9 @@ def unroll(cell, inputs, begin_state, drop_inputs=0, drop_outputs=0,
     >>> state_shape = (batch_size, input_size)
     >>> states = [mx.nd.normal(loc=0, scale=1, shape=state_shape) for i in range(2)]
     >>> valid_length = mx.nd.array([2, 3])
-    >>> output, states = mx.gluon.contrib.rnn.rnn_cell.unroll(cell, rnn_data, states,
-                                                              valid_length=valid_length,
-                                                              layout='TNC')
+    >>> output, states = mx.gluon.contrib.rnn.rnn_cell.dynamic_unroll(cell, rnn_data, states,
+                                                                      valid_length=valid_length,
+                                                                      layout='TNC')
     >>> print(output)
     [[[ 0.00767238  0.00023103  0.03973929 -0.00925503 -0.05660512]
       [ 0.00881535  0.05428379 -0.02493718 -0.01834097  0.02189514]]

--- a/python/mxnet/gluon/contrib/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/contrib/rnn/rnn_cell.py
@@ -324,28 +324,6 @@ class LSTMPCell(HybridRecurrentCell):
     # pylint: enable= arguments-differ
 
 
-def _contrib_format_sequence(inputs, layout, in_layout=None):
-    assert inputs is not None, \
-        "unroll(inputs=None) has been deprecated. " \
-        "Please create input variables outside unroll."
-
-    axis = layout.find('T')
-    batch_axis = layout.find('N')
-    batch_size = 0
-    in_axis = in_layout.find('T') if in_layout is not None else axis
-    assert isinstance(inputs, tensor_types)
-    if isinstance(inputs, symbol.Symbol):
-        F = symbol
-    else:
-        F = ndarray
-        batch_size = inputs.shape[batch_axis]
-
-    if axis != in_axis:
-        inputs = F.swapaxes(inputs, dim1=axis, dim2=in_axis)
-
-    return inputs, axis, F, batch_size
-
-
 def unroll(cell, inputs, begin_state, drop_inputs=0, drop_outputs=0,
            layout='TNC', valid_length=None):
     """Unrolls an RNN cell across time steps.
@@ -412,7 +390,8 @@ def unroll(cell, inputs, begin_state, drop_inputs=0, drop_outputs=0,
      <NDArray 3x2x5 @cpu(0)>
     """
 
-    inputs, axis, F, _ = _contrib_format_sequence(inputs, layout)
+    # Merge is always True, so we don't need length.
+    inputs, axis, F, _ = _format_sequence(0, inputs, layout, True)
     if axis != 0:
         axes = list(range(len(layout)))
         tmp = axes[0]

--- a/python/mxnet/gluon/contrib/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/contrib/rnn/rnn_cell.py
@@ -350,6 +350,9 @@ def unroll(cell, inputs, begin_state, drop_inputs=0, drop_outputs=0,
            layout='NTC', valid_length=None):
     """Unrolls an RNN cell across time steps.
 
+    Currently, 'TNC' is a preferred layout. unroll on the input of this layout
+    runs much faster.
+
     Parameters
     ----------
     cell : an object whose base class is RNNCell.
@@ -384,6 +387,29 @@ def unroll(cell, inputs, begin_state, drop_inputs=0, drop_outputs=0,
     states : list of Symbol
         The new state of this RNN after this unrolling.
         The type of this symbol is same as the output of `begin_state`.
+
+    Examples
+    --------
+    >>> seq_len = 3
+    >>> batch_size = 2
+    >>> input_size = 5
+    >>> cell = mx.gluon.rnn.LSTMCell(input_size, prefix='rnn_')
+    >>> cell.initialize(ctx=mx.cpu())
+    >>> rnn_data = mx.nd.normal(loc=0, scale=1, shape=(seq_len, batch_size, input_size))
+    >>> state_shape = (batch_size, input_size)
+    >>> states = [mx.nd.normal(loc=0, scale=1, shape=state_shape) for i in range(2)]
+    >>> valid_length = mx.nd.array([2, 3])
+    >>> output, states = mx.gluon.contrib.rnn.rnn_cell.unroll(cell, rnn_data, states,
+                                                              valid_length=valid_length,
+                                                              layout='TNC')
+    >>> print(output)
+    [[[ 0.00767238  0.00023103  0.03973929 -0.00925503 -0.05660512]
+      [ 0.00881535  0.05428379 -0.02493718 -0.01834097  0.02189514]]
+     [[-0.00676967  0.01447039  0.01287002 -0.00574152 -0.05734247]
+      [ 0.01568508  0.02650866 -0.04270559 -0.04328435  0.00904011]]
+     [[ 0.          0.          0.          0.          0.        ]
+      [ 0.01055336  0.02734251 -0.03153727 -0.03742751 -0.01378113]]]
+     <NDArray 3x2x5 @cpu(0)>
     """
 
     inputs, axis, F, _ = _contrib_format_sequence(inputs, layout)

--- a/python/mxnet/gluon/contrib/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/contrib/rnn/rnn_cell.py
@@ -347,7 +347,7 @@ def _contrib_format_sequence(inputs, layout, in_layout=None):
 
 
 def unroll(cell, inputs, begin_state, drop_inputs=0, drop_outputs=0,
-           layout='NTC', valid_length=None):
+           layout='TNC', valid_length=None):
     """Unrolls an RNN cell across time steps.
 
     Currently, 'TNC' is a preferred layout. unroll on the input of this layout

--- a/tests/python/unittest/test_gluon_contrib.py
+++ b/tests/python/unittest/test_gluon_contrib.py
@@ -324,8 +324,9 @@ class TestRNNLayer(gluon.HybridBlock):
     def hybrid_forward(self, F, inputs, states, valid_length):
         if isinstance(valid_length, list) and len(valid_length) == 0:
             valid_length = None
-        return contrib.rnn.rnn_cell.unroll(self.cell, inputs, states,
-                                           valid_length=valid_length, layout=self.layout)
+        return contrib.rnn.rnn_cell.dynamic_unroll(self.cell, inputs, states,
+                                                   valid_length=valid_length,
+                                                   layout=self.layout)
 
 def check_unroll(cell_type, num_states, layout):
     batch_size = 20

--- a/tests/python/unittest/test_gluon_contrib.py
+++ b/tests/python/unittest/test_gluon_contrib.py
@@ -372,9 +372,9 @@ def check_unroll(cell_type, num_states):
             res2, states2 = layer(rnn_data, states, valid_length)
         assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=0.001, atol=0.0001)
         assert len(states1) == len(states2)
-        #for i in range(len(states1)):
-        #    assert_almost_equal(states1[i].asnumpy(), states2[i].asnumpy(),
-        #                        rtol=0.001, atol=0.0001)
+        for i in range(len(states1)):
+            assert_almost_equal(states1[i].asnumpy(), states2[i].asnumpy(),
+                                rtol=0.001, atol=0.0001)
         res2.backward()
         trainer.step(batch_size)
 

--- a/tests/python/unittest/test_gluon_contrib.py
+++ b/tests/python/unittest/test_gluon_contrib.py
@@ -17,12 +17,14 @@
 
 from __future__ import print_function
 import mxnet as mx
+import copy
+from mxnet import gluon
 from mxnet.gluon import contrib
 from mxnet.gluon import nn
 from mxnet.gluon.contrib.nn import (
     Concurrent, HybridConcurrent, Identity, SparseEmbedding, PixelShuffle1D,
     PixelShuffle2D, PixelShuffle3D)
-from mxnet.test_utils import almost_equal
+from mxnet.test_utils import almost_equal, default_context, assert_almost_equal
 from common import setup_module, with_seed, teardown
 import numpy as np
 from numpy.testing import assert_allclose
@@ -311,6 +313,84 @@ def test_sampler():
     assert sorted(list(interval_sampler)) == list(range(10))
     interval_sampler = contrib.data.IntervalSampler(10, 3, rollover=False)
     assert list(interval_sampler) == [0, 3, 6, 9]
+
+
+class TestRNNLayer(gluon.HybridBlock):
+    def __init__(self, cell_type, hidden_size, prefix=None, params=None):
+        super(TestRNNLayer, self).__init__(prefix=prefix, params=params)
+        self.cell = cell_type(hidden_size, prefix='rnn_')
+
+    def hybrid_forward(self, F, inputs, states, valid_length):
+        if isinstance(valid_length, list) and len(valid_length) == 0:
+            valid_length = None
+        return contrib.rnn.rnn_cell.unroll(self.cell, inputs, states,
+                                           valid_length=valid_length, layout='TNC')
+
+def check_unroll(cell_type, num_states):
+    batch_size = 1
+    input_size = 5
+    hidden_size = 3
+    seq_len = 1
+    rnn_data = mx.nd.normal(loc=0, scale=1, shape=(seq_len, batch_size, input_size))
+    valid_length = mx.nd.round(mx.nd.random.uniform(low=1, high=10, shape=(batch_size)))
+    state_shape = (batch_size, hidden_size)
+    states = [mx.nd.normal(loc=0, scale=1, shape=state_shape) for i in range(num_states)]
+
+    cell = cell_type(hidden_size, prefix='rnn_')
+    cell.initialize(ctx=default_context())
+    cell(rnn_data[0], states)
+    params1 = cell.collect_params()
+    orig_params1 = copy.deepcopy(params1)
+
+    trainer = gluon.Trainer(params1, 'sgd', {'learning_rate' : 0.03})
+    with mx.autograd.record():
+        res1, states1 = cell.unroll(seq_len, rnn_data, states, valid_length=valid_length,
+                                    layout='TNC', merge_outputs=True)
+    res1.backward()
+    trainer.step(batch_size)
+
+    configs = [
+            #{},
+            {'static_alloc': True},
+            #{'static_alloc': True, 'static_shape': True}
+            ]
+    # We can't pass None to a hybrid block, but it accepts an empty list.
+    # so we use an empty list to represent valid_length if it's None.
+    if valid_length is None:
+        valid_length = []
+    for config in configs:
+        layer = TestRNNLayer(cell_type, hidden_size)
+        layer.initialize(ctx=default_context())
+        layer.hybridize(**config)
+        res2, states2 = layer(rnn_data, states, valid_length)
+        params2 = layer.collect_params()
+        for key, val in orig_params1.items():
+            params2[key].set_data(copy.deepcopy(val.data()))
+
+        trainer = gluon.Trainer(params2, 'sgd', {'learning_rate' : 0.03})
+        with mx.autograd.record():
+            res2, states2 = layer(rnn_data, states, valid_length)
+        assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=0.001, atol=0.0001)
+        assert len(states1) == len(states2)
+        for i in range(len(states1)):
+            assert_almost_equal(states1[i].asnumpy(), states2[i].asnumpy(),
+                                rtol=0.001, atol=0.0001)
+        res2.backward()
+        trainer.step(batch_size)
+
+        for key, val in params1.items():
+            weight1 = val.data()
+            weight2 = params2[key].data()
+            assert_almost_equal(weight1.asnumpy(), weight2.asnumpy(),
+                    rtol=0.001, atol=0.0001)
+
+
+@with_seed()
+def test_contrib_unroll():
+    cell_types = [(gluon.rnn.RNNCell, 1), (gluon.rnn.LSTMCell, 2),
+            (gluon.rnn.GRUCell, 1)]
+    for cell_type, num_states in cell_types:
+        check_unroll(cell_type, num_states)
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_gluon_contrib.py
+++ b/tests/python/unittest/test_gluon_contrib.py
@@ -327,10 +327,10 @@ class TestRNNLayer(gluon.HybridBlock):
                                            valid_length=valid_length, layout='TNC')
 
 def check_unroll(cell_type, num_states):
-    batch_size = 1
-    input_size = 5
-    hidden_size = 3
-    seq_len = 1
+    batch_size = 10
+    input_size = 50
+    hidden_size = 30
+    seq_len = 10
     rnn_data = mx.nd.normal(loc=0, scale=1, shape=(seq_len, batch_size, input_size))
     valid_length = mx.nd.round(mx.nd.random.uniform(low=1, high=10, shape=(batch_size)))
     state_shape = (batch_size, hidden_size)
@@ -350,9 +350,9 @@ def check_unroll(cell_type, num_states):
     trainer.step(batch_size)
 
     configs = [
-            #{},
+            {},
             {'static_alloc': True},
-            #{'static_alloc': True, 'static_shape': True}
+            {'static_alloc': True, 'static_shape': True}
             ]
     # We can't pass None to a hybrid block, but it accepts an empty list.
     # so we use an empty list to represent valid_length if it's None.
@@ -372,9 +372,9 @@ def check_unroll(cell_type, num_states):
             res2, states2 = layer(rnn_data, states, valid_length)
         assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=0.001, atol=0.0001)
         assert len(states1) == len(states2)
-        for i in range(len(states1)):
-            assert_almost_equal(states1[i].asnumpy(), states2[i].asnumpy(),
-                                rtol=0.001, atol=0.0001)
+        #for i in range(len(states1)):
+        #    assert_almost_equal(states1[i].asnumpy(), states2[i].asnumpy(),
+        #                        rtol=0.001, atol=0.0001)
         res2.backward()
         trainer.step(batch_size)
 


### PR DESCRIPTION
## Description ##
Currently, Gluon RNNCell unroll can't be used in Gluon HybridBlock. This unroll function works with an RNN cell and can be used in any HybridBlock.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
