### PR TITLE
do not regularize beta and bias

### DIFF
--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -208,7 +208,7 @@ class Dense(HybridBlock):
             if use_bias:
                 self.bias = self.params.get('bias', shape=(units,),
                                             init=bias_initializer, dtype=dtype,
-                                            allow_deferred_init=True)
+                                            wd_mult=0.0, allow_deferred_init=True)
             else:
                 self.bias = None
             if activation is not None:
@@ -334,7 +334,7 @@ class BatchNorm(HybridBlock):
                                      differentiable=scale)
         self.beta = self.params.get('beta', grad_req='write' if center else 'null',
                                     shape=(in_channels,), init=beta_initializer,
-                                    allow_deferred_init=True,
+                                    wd_mult=0.0, allow_deferred_init=True,
                                     differentiable=center)
         self.running_mean = self.params.get('running_mean', grad_req='null',
                                             shape=(in_channels,),
@@ -509,7 +509,7 @@ class InstanceNorm(HybridBlock):
                                      allow_deferred_init=True)
         self.beta = self.params.get('beta', grad_req='write' if center else 'null',
                                     shape=(in_channels,), init=beta_initializer,
-                                    allow_deferred_init=True)
+                                    wd_mult=0.0, allow_deferred_init=True)
 
     def hybrid_forward(self, F, x, gamma, beta):
         if self._axis == 1:
@@ -597,7 +597,7 @@ class LayerNorm(HybridBlock):
                                      allow_deferred_init=True)
         self.beta = self.params.get('beta', grad_req='write' if center else 'null',
                                     shape=(in_channels,), init=beta_initializer,
-                                    allow_deferred_init=True)
+                                    wd_mult=0.0, allow_deferred_init=True)
 
     def hybrid_forward(self, F, data, gamma, beta):
         norm_data = F.LayerNorm(data, gamma=gamma, beta=beta, axis=self._axis, eps=self._epsilon)

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -118,7 +118,7 @@ class _Conv(HybridBlock):
                                           allow_deferred_init=True)
             if use_bias:
                 self.bias = self.params.get('bias', shape=wshapes[2],
-                                            init=bias_initializer,
+                                            init=bias_initializer, wd_mult=0.0,
                                             allow_deferred_init=True)
             else:
                 self.bias = None

--- a/python/mxnet/gluon/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/rnn/rnn_cell.py
@@ -369,10 +369,10 @@ class RNNCell(HybridRecurrentCell):
                                           allow_deferred_init=True)
         self.i2h_bias = self.params.get('i2h_bias', shape=(hidden_size,),
                                         init=i2h_bias_initializer,
-                                        allow_deferred_init=True)
+                                        wd_mult=0.0, allow_deferred_init=True)
         self.h2h_bias = self.params.get('h2h_bias', shape=(hidden_size,),
                                         init=h2h_bias_initializer,
-                                        allow_deferred_init=True)
+                                        wd_mult=0.0, allow_deferred_init=True)
 
     def state_info(self, batch_size=0):
         return [{'shape': (batch_size, self._hidden_size), '__layout__': 'NC'}]
@@ -482,10 +482,10 @@ class LSTMCell(HybridRecurrentCell):
                                           allow_deferred_init=True)
         self.i2h_bias = self.params.get('i2h_bias', shape=(4*hidden_size,),
                                         init=i2h_bias_initializer,
-                                        allow_deferred_init=True)
+                                        wd_mult=0.0, allow_deferred_init=True)
         self.h2h_bias = self.params.get('h2h_bias', shape=(4*hidden_size,),
                                         init=h2h_bias_initializer,
-                                        allow_deferred_init=True)
+                                        wd_mult=0.0, allow_deferred_init=True)
         self._activation = activation
         self._recurrent_activation = recurrent_activation
 
@@ -597,10 +597,10 @@ class GRUCell(HybridRecurrentCell):
                                           allow_deferred_init=True)
         self.i2h_bias = self.params.get('i2h_bias', shape=(3*hidden_size,),
                                         init=i2h_bias_initializer,
-                                        allow_deferred_init=True)
+                                        wd_mult=0.0, allow_deferred_init=True)
         self.h2h_bias = self.params.get('h2h_bias', shape=(3*hidden_size,),
                                         init=h2h_bias_initializer,
-                                        allow_deferred_init=True)
+                                        wd_mult=0.0, allow_deferred_init=True)
 
     def state_info(self, batch_size=0):
         return [{'shape': (batch_size, self._hidden_size), '__layout__': 'NC'}]

--- a/python/mxnet/gluon/rnn/rnn_layer.py
+++ b/python/mxnet/gluon/rnn/rnn_layer.py
@@ -71,11 +71,11 @@ class _RNNLayer(Block):
                 self.i2h_bias.append(
                     self.params.get('%s%d_i2h_bias'%(j, i), shape=(ng*nh,),
                                     init=i2h_bias_initializer,
-                                    allow_deferred_init=True))
+                                    wd_mult=0.0, allow_deferred_init=True))
                 self.h2h_bias.append(
                     self.params.get('%s%d_h2h_bias'%(j, i), shape=(ng*nh,),
                                     init=h2h_bias_initializer,
-                                    allow_deferred_init=True))
+                                    wd_mult=0.0, allow_deferred_init=True))
             ni = nh * self._dir
 
         self._unfused = self._unfuse()


### PR DESCRIPTION
In Module we only put weight decay on variables ending in "_weight" or "_gamma" while in gluon we are regularizing everything.

This PR removes regularization on bias and beta. Further issues to discuss:
1. should we regularize Embedding layer's weight? (this is currently regularized in module)
2. should we regularize alpha in PReLU?

For some context:
1. Pytorch by default regularizes everything. Users need to manually specify params_groups to filter out regularization for some weights.
2. Keras by default doesn't regularize anything. Users need to manually attach regularization for each weight.