### PR TITLE
[MXNET-770] Remove fixed seed in flaky test

### DIFF
--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -381,7 +381,7 @@ def test_module_set_params():
                  aux_params={}, allow_missing=True, allow_extra=False)
 
 
-@with_seed(11)
+@with_seed()
 def test_monitor():
     # data iter
     data = mx.nd.array([[0.05, .10]]);


### PR DESCRIPTION
## Description ##
Getting rid of the fixed seed for test_module.test_monitor as the flakiness cannot be reproduced.
Issue reported: https://github.com/apache/incubator-mxnet/issues/11706
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Get rid of the fixed seed for test_module.test_monitor

## Comments ##
Can pass more than 10k times on CPU and GPU:
CPU on m4.4xlarge
```
test_module.test_monitor ... [DEBUG] 1 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=341502476 to reproduce.
[DEBUG] 2 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1911419844 to reproduce.
[DEBUG] 3 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=2081311389 to reproduce.
[DEBUG] 4 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1300376807 to reproduce.
[DEBUG] 5 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=747761998 to reproduce.
...
[DEBUG] 9993 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1960288796 to reproduce.
[DEBUG] 9994 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=126697537 to reproduce.
[DEBUG] 9995 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=508893563 to reproduce.
[DEBUG] 9996 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=800422860 to reproduce.
[DEBUG] 9997 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1152882755 to reproduce.
[DEBUG] 9998 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=2102456845 to reproduce.
[DEBUG] 9999 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=343132162 to reproduce.
[DEBUG] 10000 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1430358686 to reproduce.
ok

----------------------------------------------------------------------
Ran 1 test in 84.045s
```

GPU on p2.8xlarge
```
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=25908830 to reproduce.
test_module.test_monitor ... [DEBUG] 1 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=956191307 to reproduce.
[DEBUG] 2 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=213068082 to reproduce.
[DEBUG] 3 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1699665312 to reproduce.
[DEBUG] 4 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=393344086 to reproduce.
[DEBUG] 5 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=254104386 to reproduce.
...
[DEBUG] 9992 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=38503839 to reproduce.
[DEBUG] 9993 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1410251565 to reproduce.
[DEBUG] 9994 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1003687319 to reproduce.
[DEBUG] 9995 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=10094790 to reproduce.
[DEBUG] 9996 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1177029780 to reproduce.
[DEBUG] 9997 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1426750291 to reproduce.
[DEBUG] 9998 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1707703760 to reproduce.
[DEBUG] 9999 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1759791823 to reproduce.
[DEBUG] 10000 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1920483801 to reproduce.
ok

----------------------------------------------------------------------
Ran 1 test in 81.948s
```