### PR TITLE
[MXNET-751] fix ce_loss flaky

### DIFF
--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -64,7 +64,6 @@ def get_net(num_hidden, flatten=True):
     fc3 = mx.symbol.FullyConnected(act2, name='fc3', num_hidden=num_hidden, flatten=flatten)
     return fc3
 
-# @lanking520: adding Xavier initializer and problem solved
 # tracked at: https://github.com/apache/incubator-mxnet/issues/11692
 @with_seed()
 def test_ce_loss():

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -64,7 +64,9 @@ def get_net(num_hidden, flatten=True):
     fc3 = mx.symbol.FullyConnected(act2, name='fc3', num_hidden=num_hidden, flatten=flatten)
     return fc3
 
-@with_seed(1234)
+# @lanking520: adding Xavier initializer and problem solved
+# tracked at: https://github.com/apache/incubator-mxnet/issues/11692
+@with_seed()
 def test_ce_loss():
     nclass = 10
     N = 20
@@ -78,7 +80,8 @@ def test_ce_loss():
     loss = mx.sym.make_loss(loss)
     mod = mx.mod.Module(loss, data_names=('data',), label_names=('label',))
     mod.fit(data_iter, num_epoch=200, optimizer_params={'learning_rate': 0.01},
-            eval_metric=mx.metric.Loss(), optimizer='adam')
+            eval_metric=mx.metric.Loss(), optimizer='adam',
+            initializer=mx.init.Xavier(magnitude=2))
     assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.05
 
 


### PR DESCRIPTION
## Description ##
Remove random seed, add Xavier initializer. test 10000 time passed!
@haojin2 @eric-haibin-lin
#11692
```
python tools/flakiness_checker.py -n 10000 test_operator_gpu.test_ce_loss
INFO:root:Testing: /home/ubuntu/incubator-mxnet/tests/python/gpu/test_operator_gpu.py:test_ce_loss
INFO:root:No test seed provided, using random seed
/usr/local/lib/python3.5/dist-packages/nose/util.py:453: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
  inspect.getargspec(func)
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=449509033 to reproduce.
test_operator_gpu.test_ce_loss ... ok

----------------------------------------------------------------------
Ran 1 test in 9277.876s

OK
INFO:root:Nosetests terminated with exit code 0
```


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
