### PR TITLE
[MXNET-771] Fix Flaky Test test_executor.py:test_dot

### DIFF
--- a/tests/python/unittest/test_executor.py
+++ b/tests/python/unittest/test_executor.py
@@ -18,13 +18,7 @@
 import numpy as np
 import mxnet as mx
 from common import setup_module, with_seed, teardown
-
-
-def reldiff(a, b):
-    diff = np.sum(np.abs(a - b))
-    norm = np.sum(np.abs(a))
-    reldiff = diff  / norm
-    return reldiff
+from mxnet.test_utils import assert_almost_equal
 
 
 def check_bind_with_uniform(uf, gf, dim, sf=None, lshape=None, rshape=None):
@@ -64,9 +58,9 @@ def check_bind_with_uniform(uf, gf, dim, sf=None, lshape=None, rshape=None):
     out1 = uf(lhs_arr.asnumpy(), rhs_arr.asnumpy())
     out3 = exec3.outputs[0].asnumpy()
     out4 = exec4.outputs[0].asnumpy()
-    assert reldiff(out1, out2) < 1e-6
-    assert reldiff(out1, out3) < 1e-6
-    assert reldiff(out1, out4) < 1e-6
+    assert_almost_equal(out1, out2, rtol=1e-5, atol=1e-5)
+    assert_almost_equal(out1, out3, rtol=1e-5, atol=1e-5)
+    assert_almost_equal(out1, out4, rtol=1e-5, atol=1e-5)
     # test gradient
     out_grad = mx.nd.array(np.ones(out2.shape))
     lhs_grad2, rhs_grad2 = gf(out_grad.asnumpy(),
@@ -74,8 +68,8 @@ def check_bind_with_uniform(uf, gf, dim, sf=None, lshape=None, rshape=None):
                               rhs_arr.asnumpy())
     executor.backward([out_grad])
 
-    assert reldiff(lhs_grad.asnumpy(), lhs_grad2) < 1e-6
-    assert reldiff(rhs_grad.asnumpy(), rhs_grad2) < 1e-6
+    assert_almost_equal(lhs_grad.asnumpy(), lhs_grad2, rtol=1e-5, atol=1e-5)
+    assert_almost_equal(rhs_grad.asnumpy(), rhs_grad2, rtol=1e-5, atol=1e-5)
 
 
 @with_seed(0)
@@ -118,12 +112,12 @@ def test_bind():
     check_bind(False)
 
 
-@with_seed(0)
+@with_seed()
 def test_dot():
     nrepeat = 10
     maxdim = 4
     for repeat in range(nrepeat):
-        s =tuple(np.random.randint(1, 500, size=3))
+        s =tuple(np.random.randint(1, 200, size=3))
         check_bind_with_uniform(lambda x, y: np.dot(x, y),
                                 lambda g, x, y: (np.dot(g, y.T), np.dot(x.T, g)),
                                 2,
@@ -131,7 +125,7 @@ def test_dot():
                                 rshape=(s[1], s[2]),
                                 sf = mx.symbol.dot)
     for repeat in range(nrepeat):
-        s =tuple(np.random.randint(1, 500, size=1))
+        s =tuple(np.random.randint(1, 200, size=1))
         check_bind_with_uniform(lambda x, y: np.dot(x, y),
                                 lambda g, x, y: (g * y, g * x),
                                 2,

--- a/tests/python/unittest/test_executor.py
+++ b/tests/python/unittest/test_executor.py
@@ -72,7 +72,7 @@ def check_bind_with_uniform(uf, gf, dim, sf=None, lshape=None, rshape=None):
     assert_almost_equal(rhs_grad.asnumpy(), rhs_grad2, rtol=1e-5, atol=1e-5)
 
 
-@with_seed(0)
+@with_seed()
 def test_bind():
     def check_bind(disable_bulk_exec):
         if disable_bulk_exec:

--- a/tests/python/unittest/test_executor.py
+++ b/tests/python/unittest/test_executor.py
@@ -72,7 +72,7 @@ def check_bind_with_uniform(uf, gf, dim, sf=None, lshape=None, rshape=None):
     assert_almost_equal(rhs_grad.asnumpy(), rhs_grad2, rtol=1e-5, atol=1e-5)
 
 
-@with_seed()
+@with_seed(0)
 def test_bind():
     def check_bind(disable_bulk_exec):
         if disable_bulk_exec:

--- a/tests/python/unittest/test_executor.py
+++ b/tests/python/unittest/test_executor.py
@@ -112,6 +112,8 @@ def test_bind():
     check_bind(False)
 
 
+# @roywei: Removing fixed seed as flakiness in this test is fixed
+# tracked at https://github.com/apache/incubator-mxnet/issues/11686
 @with_seed()
 def test_dot():
     nrepeat = 10


### PR DESCRIPTION
## Description ##
Fix #11686, removed fixed seed in test_executor.py:test_dot

1. Verified this test is flaky and the values for comparison are slightly off
2. Flakiness comes from sym.dot of 2 large tensors. The input tensor size was original set to be a random size in range of (1,500). Reduced 500 to 200 to make it more stable.
3.  The test still fails with 1e-6 tolerance, increased it to 1e-5 (reasonable for fp32)
4. removed helper function `reldiff` (calculating relative difference) with `assert_almost_equal` in `mxnet.test_utils`  for value comparison
5. removed fixed seed
6. Passed 10,000 runs


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-771](https://issues.apache.org/jira/browse/MXNET-771) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
See description

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
