### PR TITLE
[MXNET-772] Re-enable test_module.py:test_module_set_params

### DIFF
--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -317,8 +317,9 @@ def test_module_switch_bucket():
     assert total_bytes_after == total_bytes_before
 
 
-
-@with_seed(11)
+# roywei: Getting rid of fixed seed as flakiness could not be reproduced,
+# tracked at: https://github.com/apache/incubator-mxnet/issues/11705
+@with_seed()
 def test_module_set_params():
     # data iter
     data = mx.nd.array([[0.05, .10]]);


### PR DESCRIPTION
## Description ##
fix #11705  as not able to reproduce.
Removed fixed seed.
Test passed 50,000 runs 

```
[DEBUG] 49998 of 50000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1348753378 to reproduce.
[DEBUG] 49999 of 50000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1239829816 to reproduce.
[DEBUG] 50000 of 50000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=765197359 to reproduce.
ok

----------------------------------------------------------------------
Ran 1 test in 301.038s

OK
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-772](https://issues.apache.org/jira/browse/MXNET-772
)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
removed fixed seed

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
