### PR TITLE
[MXNET-696] Fix undefined variable errors

### DIFF
--- a/example/fcn-xs/image_segmentaion.py
+++ b/example/fcn-xs/image_segmentaion.py
@@ -93,8 +93,8 @@ def main():
     model_prefix = "FCN8s_VGG16"
     epoch = 19
 
-    # By default, MXNet will run on the CPU. Uncomment the line below to execute on the GPU
-    # ctx = mx.gpu()
+    # By default, MXNet will run on the CPU. Change to ctx = mx.gpu() to run on GPU.
+    ctx = mx.cpu()
 
     fcnxs, fcnxs_args, fcnxs_auxs = mx.model.load_checkpoint(model_prefix, epoch)
     fcnxs_args["data"] = mx.nd.array(get_data(args.input), ctx)

--- a/example/ssd/dataset/pycocotools/coco.py
+++ b/example/ssd/dataset/pycocotools/coco.py
@@ -255,22 +255,7 @@ class COCO:
                             color.append(c)
                     else:
                         # mask
-                        t = self.imgs[ann['image_id']]
-                        if type(ann['segmentation']['counts']) == list:
-                            # rle = maskUtils.frPyObjects([ann['segmentation']], t['height'], t['width'])
-                            raise NotImplementedError("maskUtils disabled!")
-                        else:
-                            rle = [ann['segmentation']]
-                        # m = maskUtils.decode(rle)
                         raise NotImplementedError("maskUtils disabled!")
-                        img = np.ones( (m.shape[0], m.shape[1], 3) )
-                        if ann['iscrowd'] == 1:
-                            color_mask = np.array([2.0,166.0,101.0])/255
-                        if ann['iscrowd'] == 0:
-                            color_mask = np.random.random((1, 3)).tolist()[0]
-                        for i in range(3):
-                            img[:,:,i] = color_mask[i]
-                        ax.imshow(np.dstack( (img, m*0.5) ))
                 if 'keypoints' in ann and type(ann['keypoints']) == list:
                     # turn skeleton into zero-based index
                     sks = np.array(self.loadCats(ann['category_id'])[0]['skeleton'])-1
@@ -430,6 +415,4 @@ class COCO:
         :return: binary mask (numpy 2D array)
         """
         rle = self.annToRLE(ann)
-        # m = maskUtils.decode(rle)
         raise NotImplementedError("maskUtils disabled!")
-        return m

--- a/example/ssd/symbol/common.py
+++ b/example/ssd/symbol/common.py
@@ -206,6 +206,9 @@ def multibox_layer(from_layers, num_classes, sizes=[.2, .95],
          assert sizes[0] > 0 and sizes[0] < 1
          assert sizes[1] > 0 and sizes[1] < 1 and sizes[1] > sizes[0]
          tmp = np.linspace(sizes[0], sizes[1], num=(len(from_layers)-1))
+         # Ref for start_offset value:
+         # https://arxiv.org/abs/1512.02325
+         start_offset = 0.1
          min_sizes = [start_offset] + tmp.tolist()
          max_sizes = tmp.tolist() + [tmp[-1]+start_offset]
          sizes = zip(min_sizes, max_sizes)


### PR DESCRIPTION
## Description ##
Pylint throws an error for variables that are used but not defined previously. Since these variables are found in paths that are not executed, they don't show up as errors at runtime. But if executed, they could throw a Python NameError.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- image_segmentation.py - Defining ctx to be cpu by default.
- coco.py - maskUtils is disabled as of now. Commenting out the code that references this until it is implemented.
- common.py - start_offset was uninitialized. Setting this variable to a default of 0.1 based on information from the author of the example and the reference paper.

## Comments ##
- Related issues https://github.com/apache/incubator-mxnet/issues/8270, https://github.com/apache/incubator-mxnet/issues/11904

@cclauss @zhreshold 