### PR TITLE
Removed fixed seed from , test_loss:test_ctc_loss_train

### DIFF
--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -207,7 +207,7 @@ def test_ctc_loss():
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
 
-@with_seed(1234)
+@with_seed()
 def test_ctc_loss_train():
     N = 20
     data = mx.random.uniform(-1, 1, shape=(N, 20, 10))


### PR DESCRIPTION
## Description ##
Getting rid of fixed seed in, test_loss:test_ctc_loss_train. 
Related issue #11694 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Get red of fixed seed in test_loss:test_ctc_loss_train

## Comments ##
```bash
[DEBUG] 21727 of 100000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=579214465 to reproduce.
[DEBUG] 21728 of 100000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=911031498 to reproduce.
[DEBUG] 21729 of 100000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1126810714 to reproduce.
[DEBUG] 21730 of 100000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=933239347 to reproduce.
[DEBUG] 21731 of 100000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1718160090 to reproduce.
[DEBUG] 21732 of 100000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1745376750 to reproduce.
[DEBUG] 21733 of 100000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=316797658 to reproduce.
[DEBUG] 21734 of 100000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1350417275 to reproduce.
[DEBUG] 21735 of 100000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=181038807 to reproduce
# passed over 21735 runs with no issues
```
