### PR TITLE
Remove fixed seed for test_l1_loss and test_l2_loss

### DIFF
--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -144,7 +144,7 @@ def test_kl_loss():
     assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.05
 
 
-@with_seed(1234)
+@with_seed()
 def test_l2_loss():
     N = 20
     data = mx.random.uniform(-1, 1, shape=(N, 10))
@@ -162,7 +162,7 @@ def test_l2_loss():
     assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.05
 
 
-@with_seed(1234)
+@with_seed()
 def test_l1_loss():
     N = 20
     data = mx.random.uniform(-1, 1, shape=(N, 10))


### PR DESCRIPTION
## Description ##
```
ubuntu@ip-172-31-20-16:~/mxnet/tests/python/unittest$ MXNET_TEST_COUNT=10000  nosetests test_loss.py:test_l1_loss; MXNET_TEST_COUNT=10000  nosetests ../gpu/test_operator_gpu.py:test
_l1_loss;
/usr/local/lib/python3.5/dist-packages/nose/util.py:453: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
  inspect.getargspec(func)
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=27178258 to reproduce.
^C[INFO] 2454 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1464611288 to reproduce.

----------------------------------------------------------------------
Ran 1 test in 2414.984s

OK
/usr/local/lib/python3.5/dist-packages/nose/util.py:453: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
  inspect.getargspec(func)
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=376845522 to reproduce.
[INFO] 9113 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1915136543 to reproduce.

----------------------------------------------------------------------
Ran 1 test in 8659.136s

OK

ubuntu@ip-172-31-20-16:~/mxnet/tests/python/unittest$ MXNET_TEST_COUNT=10000  nosetests test_loss.py:test_l2_loss
/usr/local/lib/python3.5/dist-packages/nose/util.py:453: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
  inspect.getargspec(func)
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=1323890397 to reproduce.
[INFO] 2890 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=227084913 to reproduce.

----------------------------------------------------------------------
Ran 1 test in 4019.911s
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
