### PR TITLE
Remove fixed seed for test_sparse_ndarray/test_operator_gpu.test_sparse_nd_pickle

### DIFF
--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -514,24 +514,22 @@ def test_sparse_nd_astype_copy():
         assert (id(x) == id(y))
 
 
-@with_seed(0)
+@with_seed()
 def test_sparse_nd_pickle():
-    repeat = 1
     dim0 = 40
     dim1 = 40
     stypes = ['row_sparse', 'csr']
     densities = [0, 0.5]
     stype_dict = {'row_sparse': RowSparseNDArray, 'csr': CSRNDArray}
-    for _ in range(repeat):
-        shape = rand_shape_2d(dim0, dim1)
-        for stype in stypes:
-            for density in densities:
-                a, _ = rand_sparse_ndarray(shape, stype, density)
-                assert isinstance(a, stype_dict[stype])
-                data = pkl.dumps(a)
-                b = pkl.loads(data)
-                assert isinstance(b, stype_dict[stype])
-                assert same(a.asnumpy(), b.asnumpy())
+    shape = rand_shape_2d(dim0, dim1)
+    for stype in stypes:
+        for density in densities:
+            a, _ = rand_sparse_ndarray(shape, stype, density)
+            assert isinstance(a, stype_dict[stype])
+            data = pkl.dumps(a)
+            b = pkl.loads(data)
+            assert isinstance(b, stype_dict[stype])
+            assert same(a.asnumpy(), b.asnumpy())
 
 
 # @kalyc: Getting rid of fixed seed as flakiness could not be reproduced


### PR DESCRIPTION
## Description ##
Fix for #11740. Remove fixed seed.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Remove fixed seed for test_sparse_ndarray/test_operator_gpu.test_sparse_nd_pickle

## Comments ##
Passed 10000 times on both CPU & GPU:
```
python tools/flakiness_checker.py test_sparse_ndarray.test_sparse_nd_pickle -n 10000
INFO:root:Testing: /home/ubuntu/incubator-mxnet/tests/python/unittest/test_sparse_ndarray.py:test_sparse_nd_pickle
INFO:root:No test seed provided, using random seed
/home/ubuntu/anaconda3/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py:46: DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead
  import OpenSSL.SSL
/home/ubuntu/anaconda3/lib/python3.6/site-packages/nose/util.py:453: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
  inspect.getargspec(func)
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=1776342650 to reproduce.
test_sparse_ndarray.test_sparse_nd_pickle ... ok

----------------------------------------------------------------------
Ran 1 test in 53.822s

OK
```
```
python tools/flakiness_checker.py test_operator_gpu.test_sparse_nd_pickle -n 10000
INFO:root:Testing: /home/ubuntu/incubator-mxnet/tests/python/gpu/test_operator_gpu.py:test_sparse_nd_pickle
INFO:root:No test seed provided, using random seed
/home/ubuntu/anaconda3/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py:46: DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead
  import OpenSSL.SSL
/home/ubuntu/anaconda3/lib/python3.6/site-packages/nose/util.py:453: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
  inspect.getargspec(func)
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=250441551 to reproduce.
test_operator_gpu.test_sparse_nd_pickle ... ok

----------------------------------------------------------------------
Ran 1 test in 76.829s

OK
```