### PR TITLE
[MXNET-774] Flaky test in test_executor.py:test_bind

### DIFF
--- a/tests/python/unittest/test_executor.py
+++ b/tests/python/unittest/test_executor.py
@@ -72,7 +72,7 @@ def check_bind_with_uniform(uf, gf, dim, sf=None, lshape=None, rshape=None):
     assert_almost_equal(rhs_grad.asnumpy(), rhs_grad2, rtol=1e-5, atol=1e-5)
 
 
-@with_seed(0)
+@with_seed()
 def test_bind():
     def check_bind(disable_bulk_exec):
         if disable_bulk_exec:
@@ -97,11 +97,11 @@ def test_bind():
                                         dim)
 
                 check_bind_with_uniform(lambda x, y: np.maximum(x, y),
-                                        lambda g, x, y: (g * (x>y), g * (y>x)),
+                                        lambda g, x, y: (g * (x>=y), g * (y>x)),
                                         dim,
                                         sf=mx.symbol.maximum)
                 check_bind_with_uniform(lambda x, y: np.minimum(x, y),
-                                        lambda g, x, y: (g * (x<y), g * (y<x)),
+                                        lambda g, x, y: (g * (x<=y), g * (y<x)),
                                         dim,
                                         sf=mx.symbol.minimum)
         if disable_bulk_exec:

--- a/tests/python/unittest/test_executor.py
+++ b/tests/python/unittest/test_executor.py
@@ -72,8 +72,6 @@ def check_bind_with_uniform(uf, gf, dim, sf=None, lshape=None, rshape=None):
     assert_almost_equal(rhs_grad.asnumpy(), rhs_grad2, rtol=1e-5, atol=1e-5)
 
 
-# @roywei: Removing fixed seed as flakiness in this test is fixed
-# tracked at: https://github.com/apache/incubator-mxnet/issues/11685
 @with_seed()
 def test_bind():
     def check_bind(disable_bulk_exec):

--- a/tests/python/unittest/test_executor.py
+++ b/tests/python/unittest/test_executor.py
@@ -72,6 +72,8 @@ def check_bind_with_uniform(uf, gf, dim, sf=None, lshape=None, rshape=None):
     assert_almost_equal(rhs_grad.asnumpy(), rhs_grad2, rtol=1e-5, atol=1e-5)
 
 
+# @roywei: Removing fixed seed as flakiness in this test is fixed
+# tracked at: https://github.com/apache/incubator-mxnet/issues/11685
 @with_seed()
 def test_bind():
     def check_bind(disable_bulk_exec):


### PR DESCRIPTION
## Description ##
**1. fix flaky test #11685 
2. Pass 10,000 runs.**
**3. Root cause explained:** 

In this unit test, during testing of mx.sym.maximum and minimum. It didn't cover the case when x and y is equal. 
 See [Line 100](https://github.com/apache/incubator-mxnet/blob/master/tests/python/unittest/test_executor.py#L100)
when x = y, the following line 
```
lambda g, x, y: (g * (x>y), g * (y>x)
```
will return `(0, 0)` when the correct value should be `(1, 0)`

In MXNet symbolic implementation, mx.sym.maximum and minimum is using the following logic for element-wise comparison:

maximum is using  (greater or equal, less than) see [here](https://github.com/apache/incubator-mxnet/blob/master/src/operator/tensor/elemwise_binary_broadcast_op_extended.cc#L96)
minimum is using  (less or equal, greater than) see [here](
https://github.com/apache/incubator-mxnet/blob/master/src/operator/tensor/elemwise_binary_broadcast_op_extended.cc#L131)

Modified accordingly and removed fixed seed.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-774](https://issues.apache.org/jira/browse/MXNET-774) 
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
1. fixed gradient condition
2. removed fixed seed

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
