### PR TITLE
[MXNET-753] Fallback when using non-MKLDNN supported operators

### DIFF
--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -159,7 +159,7 @@ class StatefulComputeExExecutor : public OpExecutor {
     op_ctx.run_ctx = rctx;
 #if MXNET_USE_MKLDNN == 1
     InvalidateOutputs(out_array, req);
-    in_array = CreateInputsInputs(in_array);
+    in_array = CreateDefaultInputs(in_array);
     fcompute_(state_, op_ctx, in_array, req, out_array);
     return;
 #endif
@@ -231,7 +231,7 @@ class FComputeExExecutor : public OpExecutor {
     InvalidateOutputs(out_array, req);
     const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
     if (!is_mkldnn.get(attrs_.op, false)) {
-      in_array = CreateInputsInputs(in_array);
+      in_array = CreateDefaultInputs(in_array);
       fcompute_(attrs_, op_ctx, in_array, req, out_array);
       return;
     }

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -159,7 +159,8 @@ class StatefulComputeExExecutor : public OpExecutor {
     op_ctx.run_ctx = rctx;
 #if MXNET_USE_MKLDNN == 1
     InvalidateOutputs(out_array, req);
-    fcompute_(state_, op_ctx, InvalidateInputs(in_array), req, out_array);
+    in_array = CreateInputsInputs(in_array);
+    fcompute_(state_, op_ctx, in_array, req, out_array);
     return;
 #endif
     fcompute_(state_, op_ctx, in_array, req, out_array);
@@ -230,7 +231,8 @@ class FComputeExExecutor : public OpExecutor {
     InvalidateOutputs(out_array, req);
     const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
     if (!is_mkldnn.get(attrs_.op, false)) {
-      fcompute_(attrs_, op_ctx, InvalidateInputs(in_array), req, out_array);
+      in_array = CreateInputsInputs(in_array);
+      fcompute_(attrs_, op_ctx, in_array, req, out_array);
       return;
     }
 #endif

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -159,7 +159,7 @@ class StatefulComputeExExecutor : public OpExecutor {
     op_ctx.run_ctx = rctx;
 #if MXNET_USE_MKLDNN == 1
     InvalidateOutputs(out_array, req);
-    CreateDefaultInputs(in_array, in_array_fallback);
+    CreateDefaultInputs(in_array, &in_array_fallback);
     fcompute_(state_, op_ctx, in_array_fallback, req, out_array);
     return;
 #endif
@@ -232,7 +232,7 @@ class FComputeExExecutor : public OpExecutor {
     // TODO(alex): (MXNET-847) Remove this fallback feature after subgraph implemented
     const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
     if (!is_mkldnn.get(attrs_.op, false)) {
-      CreateDefaultInputs(in_array, in_array_fallback);
+      CreateDefaultInputs(in_array, &in_array_fallback);
       fcompute_(attrs_, op_ctx, in_array_fallback, req, out_array);
       return;
     }

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -159,7 +159,7 @@ class StatefulComputeExExecutor : public OpExecutor {
     op_ctx.run_ctx = rctx;
 #if MXNET_USE_MKLDNN == 1
     InvalidateOutputs(out_array, req);
-    in_array_fallback = CreateDefaultInputs(in_array);
+    CreateDefaultInputs(in_array, in_array_fallback);
     fcompute_(state_, op_ctx, in_array_fallback, req, out_array);
     return;
 #endif
@@ -232,7 +232,7 @@ class FComputeExExecutor : public OpExecutor {
     // TODO(alex): (MXNET-847) Remove this fallback feature after subgraph implemented
     const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
     if (!is_mkldnn.get(attrs_.op, false)) {
-      in_array_fallback = CreateDefaultInputs(in_array);
+      CreateDefaultInputs(in_array, in_array_fallback);
       fcompute_(attrs_, op_ctx, in_array_fallback, req, out_array);
       return;
     }

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -234,6 +234,7 @@ class FComputeExExecutor : public MKLDNNOpExecutor {
     op_ctx.run_ctx = rctx;
 #if MXNET_USE_MKLDNN == 1
     InvalidateOutputs(out_array, req);
+    // TODO (alex): (MXNET-847) Remove this fallback feature after subgraph implemented
     const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
     if (!is_mkldnn.get(attrs_.op, false)) {
       in_array_fallback = CreateDefaultInputs(in_array);

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -159,6 +159,8 @@ class StatefulComputeExExecutor : public OpExecutor {
     op_ctx.run_ctx = rctx;
 #if MXNET_USE_MKLDNN == 1
     InvalidateOutputs(out_array, req);
+    fcompute_(state_, op_ctx, InvalidateInputs(in_array), req, out_array);
+    return;
 #endif
     fcompute_(state_, op_ctx, in_array, req, out_array);
   }
@@ -226,6 +228,11 @@ class FComputeExExecutor : public OpExecutor {
     op_ctx.run_ctx = rctx;
 #if MXNET_USE_MKLDNN == 1
     InvalidateOutputs(out_array, req);
+    const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
+    if (!is_mkldnn.get(attrs_.op, false)) {
+      fcompute_(attrs_, op_ctx, InvalidateInputs(in_array), req, out_array);
+      return;
+    }
 #endif
     fcompute_(attrs_, op_ctx, in_array, req, out_array);
   }

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -234,7 +234,7 @@ class FComputeExExecutor : public MKLDNNOpExecutor {
     op_ctx.run_ctx = rctx;
 #if MXNET_USE_MKLDNN == 1
     InvalidateOutputs(out_array, req);
-    // TODO (alex): (MXNET-847) Remove this fallback feature after subgraph implemented
+    // TODO(alex): (MXNET-847) Remove this fallback feature after subgraph implemented
     const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
     if (!is_mkldnn.get(attrs_.op, false)) {
       in_array_fallback = CreateDefaultInputs(in_array);

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -40,11 +40,6 @@ const OperatorProperty* OpPropGetOpProperty(const NodeAttrs& attrs);
 
 namespace exec {
 
-class FallbackOpExecutor : public OpExecutor {
- protected:
-  std::vector<NDArray> in_array_fallback;
-};
-
 // abstract OpExecutor which provides storage fallback procedure on
 // non-default inputs and outputs
 // FComputeExecutor and FStatefulComputeExecutor inherit from this class
@@ -158,7 +153,7 @@ class StatefulComputeExecutor : public StorageFallbackOpExecutor {
 
 
 // stateful compute_ex executor
-class StatefulComputeExExecutor : public FallbackOpExecutor {
+class StatefulComputeExExecutor : public OpExecutor {
  public:
   void Run(RunContext rctx, bool is_gpu) override {
     op_ctx.run_ctx = rctx;
@@ -228,7 +223,7 @@ class FComputeExecutor : public StorageFallbackOpExecutor {
 };
 
 // fcompute_ex executor
-class FComputeExExecutor : public FallbackOpExecutor {
+class FComputeExExecutor : public OpExecutor {
  public:
   void Run(RunContext rctx, bool is_gpu) override {
     op_ctx.run_ctx = rctx;

--- a/src/executor/attach_op_execs_pass.cc
+++ b/src/executor/attach_op_execs_pass.cc
@@ -40,7 +40,7 @@ const OperatorProperty* OpPropGetOpProperty(const NodeAttrs& attrs);
 
 namespace exec {
 
-class MKLDNNOpExecutor : public OpExecutor {
+class FallbackOpExecutor : public OpExecutor {
  protected:
   std::vector<NDArray> in_array_fallback;
 };
@@ -158,7 +158,7 @@ class StatefulComputeExecutor : public StorageFallbackOpExecutor {
 
 
 // stateful compute_ex executor
-class StatefulComputeExExecutor : public MKLDNNOpExecutor {
+class StatefulComputeExExecutor : public FallbackOpExecutor {
  public:
   void Run(RunContext rctx, bool is_gpu) override {
     op_ctx.run_ctx = rctx;
@@ -228,7 +228,7 @@ class FComputeExecutor : public StorageFallbackOpExecutor {
 };
 
 // fcompute_ex executor
-class FComputeExExecutor : public MKLDNNOpExecutor {
+class FComputeExExecutor : public FallbackOpExecutor {
  public:
   void Run(RunContext rctx, bool is_gpu) override {
     op_ctx.run_ctx = rctx;

--- a/src/executor/exec_pass.h
+++ b/src/executor/exec_pass.h
@@ -86,6 +86,8 @@ class OpExecutor {
   virtual OpStatePtr state() const {
     return OpStatePtr();
   }
+ protected:
+  std::vector<NDArray> in_array_fallback;
 };
 
 /*!

--- a/src/executor/exec_pass.h
+++ b/src/executor/exec_pass.h
@@ -87,6 +87,7 @@ class OpExecutor {
     return OpStatePtr();
   }
 
+  // TODO(alexzai): (MXNET-856) Remove instance member after subgraph feature added
  protected:
   std::vector<NDArray> in_array_fallback;
 };

--- a/src/executor/exec_pass.h
+++ b/src/executor/exec_pass.h
@@ -86,6 +86,7 @@ class OpExecutor {
   virtual OpStatePtr state() const {
     return OpStatePtr();
   }
+
  protected:
   std::vector<NDArray> in_array_fallback;
 };

--- a/src/operator/nn/activation.cc
+++ b/src/operator/nn/activation.cc
@@ -155,6 +155,7 @@ The following activation functions are supported:
 })
 .set_attr<FCompute>("FCompute<cpu>", ActivationCompute<cpu>)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", ActivationComputeExCPU)
 #endif
 .set_attr<nnvm::FGradient>("FGradient", ActivationGrad{"_backward_Activation"})
@@ -184,6 +185,7 @@ NNVM_REGISTER_OP(_backward_Activation)
 #endif
 .set_attr_parser(ParamParser<ActivationParam>)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", ActivationGradComputeExCPU)
 #endif
 .set_attr<FCompute>("FCompute<cpu>", ActivationGradCompute<cpu>);

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -601,6 +601,7 @@ the sparse tensors will fallback.
 #endif
 .set_attr<nnvm::FGradient>("FGradient", BatchNormGrad)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
 })
@@ -633,6 +634,7 @@ NNVM_REGISTER_OP(_backward_BatchNorm)
 #endif
 .set_attr_parser(ParamParser<BatchNormParam>)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", BatchNormGradComputeExCPU)
 #endif
 .set_attr<FCompute>("FCompute<cpu>", BatchNormGradCompute<cpu>);

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -367,6 +367,7 @@ Example::
 .set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
 })
+.set_attr<bool>("TIsMKLDNN", true)
 #endif
 CONCAT_FORWARD_ATTRS
 .set_attr<nnvm::FInferShape>("FInferShape", ConcatShape)
@@ -387,6 +388,7 @@ NNVM_REGISTER_OP(_backward_Concat)
 .set_attr<nnvm::TIsBackward>("TIsBackward", true)
 .set_attr<FInferStorageType>("FInferStorageType", BackwardConcatStorageType)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", ConcatGradComputeExCPU)
 #endif
 .set_attr<FCompute>("FCompute<cpu>", ConcatGradCompute<cpu>);

--- a/src/operator/nn/convolution.cc
+++ b/src/operator/nn/convolution.cc
@@ -484,6 +484,7 @@ There are other options to tune the performance.
 #endif
 .set_attr<FCompute>("FCompute<cpu>", ConvolutionCompute<cpu>)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", ConvolutionComputeExCPU)
 #endif
 .set_attr<nnvm::FGradient>("FGradient", ConvolutionGrad{"_backward_Convolution"})
@@ -509,6 +510,7 @@ NNVM_REGISTER_OP(_backward_Convolution)
 })
 .set_attr_parser(ConvolutionParamParser)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", ConvolutionGradComputeExCPU)
 #endif
 .set_attr<FCompute>("FCompute<cpu>", ConvolutionGradCompute<cpu>);

--- a/src/operator/nn/deconvolution.cc
+++ b/src/operator/nn/deconvolution.cc
@@ -413,6 +413,7 @@ NNVM_REGISTER_OP(Deconvolution)
 })
 .set_attr<FCompute>("FCompute<cpu>", DeconvolutionCompute<cpu>)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", DeconvolutionComputeExCPU)
 #endif
 .set_attr<nnvm::FGradient>("FGradient", DeconvolutionGrad{"_backward_Deconvolution"})
@@ -436,6 +437,7 @@ NNVM_REGISTER_OP(_backward_Deconvolution)
 })
 .set_attr_parser(DeconvolutionParamParser)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", DeconvolutionGradComputeExCPU)
 #endif
 .set_attr<FCompute>("FCompute<cpu>", DeconvolutionGradCompute<cpu>);

--- a/src/operator/nn/fully_connected.cc
+++ b/src/operator/nn/fully_connected.cc
@@ -290,6 +290,7 @@ If ``no_bias`` is set to be true, then the ``bias`` term is ignored.
     return std::vector<std::string>{"output"};
 })
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
 })
@@ -322,6 +323,7 @@ NNVM_REGISTER_OP(_backward_FullyConnected)
 .set_attr<FInferStorageType>("FInferStorageType", BackwardFCStorageType)
 .set_attr_parser(ParamParser<FullyConnectedParam>)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", FullyConnectedGradComputeExCPU)
 #endif
 .set_attr<FCompute>("FCompute<cpu>", FullyConnectedGradCompute<cpu>);

--- a/src/operator/nn/lrn.cc
+++ b/src/operator/nn/lrn.cc
@@ -180,6 +180,7 @@ number of kernels in the layer.
 })
 .set_attr<FCompute>("FCompute<cpu>", LRNCompute<cpu>)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", LRNComputeExCPU)
 #endif
 .set_attr<nnvm::FGradient>("FGradient", LRNGrad{"_backward_LRN"})
@@ -194,6 +195,7 @@ NNVM_REGISTER_OP(_backward_LRN)
 #endif
 .set_attr<nnvm::TIsBackward>("TIsBackward", true)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", LRNGradComputeExCPU)
 // Native compute requires norm while MKLDNN does not so cannot be compared in debug mode
 .set_attr<bool>("TExcludeMKLDNNDebug", true)

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -358,12 +358,12 @@ static inline void InvalidateOutputs(const std::vector<NDArray> &arrs,
 
 // TODO(alexzai): (MXNET-856) Remove helper function after subgraph feature added
 static inline void CreateDefaultInputs(const std::vector<NDArray> &arrs,
-                                       const std::vector<NDArray> &out_arrs) {
+                                       std::vector<NDArray> *out_arrs) {
   for (size_t i = 0; i < arrs.size(); ++i) {
     if (arrs[i].IsMKLDNNData())
-      out_arrs[i] = arrs[i].Reorder2Default();
+      out_arrs->emplace_back(arrs[i].Reorder2Default());
     else
-      out_arrs[i] = arrs[i];
+      out_arrs->emplace_back(arrs[i]);
   }
 }
 

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -359,6 +359,7 @@ static inline void InvalidateOutputs(const std::vector<NDArray> &arrs,
 // TODO(alexzai): (MXNET-856) Remove helper function after subgraph feature added
 static inline void CreateDefaultInputs(const std::vector<NDArray> &arrs,
                                        std::vector<NDArray> *out_arrs) {
+  out_arrs->clear();
   for (size_t i = 0; i < arrs.size(); ++i) {
     if (arrs[i].IsMKLDNNData())
       out_arrs->push_back(arrs[i].Reorder2Default());

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -356,6 +356,7 @@ static inline void InvalidateOutputs(const std::vector<NDArray> &arrs,
   }
 }
 
+// TODO(alexzai): (MXNET-856) Remove helper function after subgraph feature added
 static inline std::vector<NDArray> CreateDefaultInputs(const std::vector<NDArray> &arrs) {
   std::vector<NDArray> buffer(arrs.size());
   for (size_t i = 0; i < arrs.size(); ++i) {

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -358,8 +358,12 @@ static inline void InvalidateOutputs(const std::vector<NDArray> &arrs,
 
 static inline std::vector<NDArray> CreateDefaultInputs(const std::vector<NDArray> &arrs) {
   std::vector<NDArray> buffer(arrs.size());
-  for (size_t i = 0; i < arrs.size(); ++i)
-    buffer[i] = arrs[i].Reorder2Default();
+  for (size_t i = 0; i < arrs.size(); ++i) {
+    if (arrs[i].IsMKLDNNData())
+      buffer[i] = arrs[i].Reorder2Default();
+    else
+      buffer[i] = arrs[i];
+  }
   return buffer;
 }
 

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -357,15 +357,14 @@ static inline void InvalidateOutputs(const std::vector<NDArray> &arrs,
 }
 
 // TODO(alexzai): (MXNET-856) Remove helper function after subgraph feature added
-static inline std::vector<NDArray> CreateDefaultInputs(const std::vector<NDArray> &arrs) {
-  std::vector<NDArray> buffer(arrs.size());
+static inline void CreateDefaultInputs(const std::vector<NDArray> &arrs,
+                                       const std::vector<NDArray> &out_arrs) {
   for (size_t i = 0; i < arrs.size(); ++i) {
     if (arrs[i].IsMKLDNNData())
-      buffer[i] = arrs[i].Reorder2Default();
+      out_arrs[i] = arrs[i].Reorder2Default();
     else
-      buffer[i] = arrs[i];
+      out_arrs[i] = arrs[i];
   }
-  return buffer;
 }
 
 const mkldnn::memory *GetWeights(const NDArray &arr,

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -356,7 +356,7 @@ static inline void InvalidateOutputs(const std::vector<NDArray> &arrs,
   }
 }
 
-static inline std::vector<NDArray> CreateInputsInputs(const std::vector<NDArray> &arrs) {
+static inline std::vector<NDArray> CreateDefaultInputs(const std::vector<NDArray> &arrs) {
   std::vector<NDArray> buffer(arrs.size());
   for (size_t i = 0; i < arrs.size(); ++i)
     buffer[i] = arrs[i].Reorder2Default();

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -356,6 +356,13 @@ static inline void InvalidateOutputs(const std::vector<NDArray> &arrs,
   }
 }
 
+static inline std::vector<NDArray> InvalidateInputs(const std::vector<NDArray> &arrs) {
+  std::vector<NDArray> buffer(arrs.size());
+  for (size_t i = 0; i < arrs.size(); ++i)
+    buffer[i] = arrs[i].Reorder2Default();
+  return buffer;
+}
+
 const mkldnn::memory *GetWeights(const NDArray &arr,
                                  const mkldnn::memory::primitive_desc &target_pd,
                                  int num_groups);

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -361,9 +361,9 @@ static inline void CreateDefaultInputs(const std::vector<NDArray> &arrs,
                                        std::vector<NDArray> *out_arrs) {
   for (size_t i = 0; i < arrs.size(); ++i) {
     if (arrs[i].IsMKLDNNData())
-      out_arrs->emplace_back(arrs[i].Reorder2Default());
+      out_arrs->push_back(arrs[i].Reorder2Default());
     else
-      out_arrs->emplace_back(arrs[i]);
+      out_arrs->push_back(arrs[i]);
   }
 }
 

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -356,7 +356,7 @@ static inline void InvalidateOutputs(const std::vector<NDArray> &arrs,
   }
 }
 
-static inline std::vector<NDArray> InvalidateInputs(const std::vector<NDArray> &arrs) {
+static inline std::vector<NDArray> CreateInputsInputs(const std::vector<NDArray> &arrs) {
   std::vector<NDArray> buffer(arrs.size());
   for (size_t i = 0; i < arrs.size(); ++i)
     buffer[i] = arrs[i].Reorder2Default();

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -395,7 +395,7 @@ For each window ``X``, the mathematical expression for Lp pooling is:
 .set_attr<nnvm::FInferShape>("FInferShape", PoolingShape)
 .set_attr<FCompute>("FCompute<cpu>", PoolingCompute<cpu>)
 #if MXNET_USE_MKLDNN == 1
-    .set_attr<bool>("TIsMKLDNN", true).set_attr<bool>("TIsMKLDNN", true)
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", PoolingComputeExCPU)
 #endif
 .set_attr<nnvm::FGradient>("FGradient",

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -395,6 +395,7 @@ For each window ``X``, the mathematical expression for Lp pooling is:
 .set_attr<nnvm::FInferShape>("FInferShape", PoolingShape)
 .set_attr<FCompute>("FCompute<cpu>", PoolingCompute<cpu>)
 #if MXNET_USE_MKLDNN == 1
+    .set_attr<bool>("TIsMKLDNN", true).set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", PoolingComputeExCPU)
 #endif
 .set_attr<nnvm::FGradient>("FGradient",
@@ -424,6 +425,7 @@ NNVM_REGISTER_OP(_backward_Pooling)
 #endif
 .set_attr_parser(PoolingParamParser)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", PoolingGradComputeExCPU)
 #endif
 .set_attr<FCompute>("FCompute<cpu>", PoolingGradCompute<cpu>);

--- a/src/operator/nn/softmax.cc
+++ b/src/operator/nn/softmax.cc
@@ -98,6 +98,7 @@ Example::
 })
 .set_attr<FCompute>("FCompute<cpu>", SoftmaxCompute<cpu, mxnet_op::softmax_fwd>)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FComputeEx>("FComputeEx<cpu>", SoftmaxComputeExCPU)
 .set_attr<FInferStorageType>("FInferStorageType", SoftmaxStorageType)
 #endif

--- a/src/operator/tensor/elemwise_sum.cc
+++ b/src/operator/tensor/elemwise_sum.cc
@@ -179,6 +179,9 @@ The storage type of ``add_n`` output depends on storage types of inputs
   [](const NodeAttrs& attrs) {
     return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
   })
+#if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
+#endif
 .set_attr<nnvm::FInferShape>("FInferShape", ElementWiseSumShape)
 .set_attr<nnvm::FInferType>("FInferType", ElementWiseSumType)
 .set_attr<FInferStorageType>("FInferStorageType", ElementWiseSumForwardInferStorageType)

--- a/src/operator/tensor/elemwise_unary_op.h
+++ b/src/operator/tensor/elemwise_unary_op.h
@@ -299,8 +299,8 @@ class UnaryOp : public OpBase {
         }
         break;
       case kWriteInplace:
-// cannot check if ptrs are the same for MKLDNN because we may have created copies of input when reordering.
-// WriteInPlace will still write to original array
+// cannot check if ptrs are the same for MKLDNN because we may have
+// created copies of input when reordering. WriteInPlace will still write to original array
 #if MXNET_USE_MKLDNN != 1
         CHECK_EQ(inputs[0].dptr_, outputs[0].dptr_);
 #endif

--- a/src/operator/tensor/elemwise_unary_op.h
+++ b/src/operator/tensor/elemwise_unary_op.h
@@ -299,7 +299,11 @@ class UnaryOp : public OpBase {
         }
         break;
       case kWriteInplace:
+// cannot check if ptrs are the same for MKLDNN because we may have created copies of input when reordering.
+// WriteInPlace will still write to original array
+#if MXNET_USE_MKLDNN != 1
         CHECK_EQ(inputs[0].dptr_, outputs[0].dptr_);
+#endif
         break;
       case kNullOp:
         break;

--- a/src/operator/tensor/elemwise_unary_op.h
+++ b/src/operator/tensor/elemwise_unary_op.h
@@ -301,7 +301,7 @@ class UnaryOp : public OpBase {
       case kWriteInplace:
 // cannot check if ptrs are the same for MKLDNN because we may have
 // created copies of input when reordering. WriteInPlace will still write to original array
-#if MXNET_USE_MKLDNN != 1
+#if MXNET_USE_MKLDNN == 0
         CHECK_EQ(inputs[0].dptr_, outputs[0].dptr_);
 #endif
         break;

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -206,7 +206,7 @@ MXNET_OPERATOR_REGISTER_UNARY(_copy)
 .set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
 })
-    .set_attr<bool>("TIsMKLDNN", true).set_attr<bool>("TIsMKLDNN", true)
+.set_attr<bool>("TIsMKLDNN", true)
 #endif
 .set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
   [](const NodeAttrs& attrs){

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -206,6 +206,7 @@ MXNET_OPERATOR_REGISTER_UNARY(_copy)
 .set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
 })
+    .set_attr<bool>("TIsMKLDNN", true).set_attr<bool>("TIsMKLDNN", true)
 #endif
 .set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
   [](const NodeAttrs& attrs){

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -225,6 +225,7 @@ NNVM_REGISTER_OP(_backward_copy)
 .set_attr<FCompute>("FCompute<cpu>", UnaryOp::IdentityCompute<cpu>)
 .set_attr<FComputeEx>("FComputeEx<cpu>", CopyEx)
 #if MXNET_USE_MKLDNN == 1
+.set_attr<bool>("TIsMKLDNN", true)
 .set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
 })

--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -423,7 +423,7 @@ def test_non_mkldnn_fcomputeex():
     conv = mx.sym.Convolution(data=data, kernel=(5, 5), pad=(1, 1), stride=(1,1), num_filter=8, name="conv", no_bias=True)
     mlp = mx.symbol.Custom(name='custom', data=conv, op_type='custom')
     exec1 = mlp.bind(mx.cpu(), args={'data': mx.nd.ones([10,3,96,96]), 'conv_weight': mx.nd.ones([8,3,5,5])})
-    exec1.forward()
+    exec1.forward()[0].wait_to_read()
 
 
 if __name__ == '__main__':

--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -421,8 +421,8 @@ def test_non_mkldnn_fcomputeex():
 
     data = mx.symbol.Variable('data')
     conv = mx.sym.Convolution(data=data, kernel=(5, 5), pad=(1, 1), stride=(1,1), num_filter=8, name="conv", no_bias=True)
-    mlp = mx.symbol.Custom(name='custom', data=conv, op_type='custom')
-    exec1 = mlp.bind(mx.cpu(), args={'data': mx.nd.ones([10,3,96,96]), 'conv_weight': mx.nd.ones([8,3,5,5])})
+    custom = mx.symbol.Custom(name='custom', data=conv, op_type='custom')
+    exec1 = custom.bind(mx.cpu(), args={'data': mx.nd.ones([10,3,96,96]), 'conv_weight': mx.nd.ones([8,3,5,5])})
     exec1.forward()[0].wait_to_read()
 
 


### PR DESCRIPTION
## Description ##
-convert all mkldnn special format to default in using non-mkldnn operator

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] add attribute to all mkldnn operators to identify mkldnn
- [x] convert inputs to default array if using fcomputeex operator that is not mkldnn

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
