### PR TITLE
Fix flaky tests for test_hinge_loss

### DIFF
--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -292,7 +292,7 @@ def test_huber_loss():
     assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.05
 
 
-@with_seed(1234)
+@with_seed()
 def test_hinge_loss():
     N = 20
     data = mx.random.uniform(-1, 1, shape=(N, 10))
@@ -307,7 +307,7 @@ def test_hinge_loss():
     mod.fit(data_iter, num_epoch=200, optimizer_params={'learning_rate': 0.01},
             initializer=mx.init.Xavier(magnitude=2), eval_metric=mx.metric.Loss(),
             optimizer='adam')
-    assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.05
+    assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.06
 
 
 @with_seed(1234)


### PR DESCRIPTION
## Description ##
Fix for issue [#11695](https://github.com/apache/incubator-mxnet/issues/11695) -- Removing fixed seed as the flakiness is not producible with increased tolerance

The test only failed at one instance with the original tolerance, however I did not record the seed that caused the failure.  After ~40k additional iterations, I have been unable to reproduce another failure with the original tolerance.  However, the increased tolerance would have accepted that failure, so I updated it.

Ran `tests/python/unittest/test_loss.py:test_hinge_loss` and `tests/python/gpu/test_operator_gpu.py:test_hinge_loss` 10k times each without producing the error at an increased tolerance

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x ] Changes are complete (i.e. I finished coding on this PR)
- [ x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x ] Remove fixed seed for test_loss.py:test_squared_hinge_loss

## Comments ##
CPU Run with increased tolerance:
```
ubuntu@ip-172-31-27-232:~/incubator-mxnet$ MXNET_TEST_COUNT=10000 nosetests --logging-level=DEBUG --verbose -s tests/python/unittest/test_loss.py:test_hinge_loss

Produces:

[DEBUG] 9999 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=2140149943 to reproduce.
0.0
[DEBUG] 10000 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=552569265 to reproduce.
0.0
ok

----------------------------------------------------------------------
Ran 1 test in 7793.215s

OK
```

GPU Run with increased tolerance:
```
ubuntu@ip-172-31-27-232:~/incubator-mxnet$ MXNET_TEST_COUNT=10000 nosetests --logging-level=DEBUG --verbose -s tests/python/gpu/test_operator_gpu.py:test_hinge_loss

Produces:

[DEBUG] 9999 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=175424733 to reproduce.
0.0
[DEBUG] 10000 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=745050216 to reproduce.
0.0
ok

----------------------------------------------------------------------
Ran 1 test in 8036.187s

OK
```