### PR TITLE
Make check_isfinite, check_scale optional in clip_global_norm

### DIFF
--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -115,7 +115,7 @@ def split_and_load(data, ctx_list, batch_axis=0, even_split=True):
     return [i.as_in_context(ctx) for i, ctx in zip(slices, ctx_list)]
 
 
-def clip_global_norm(arrays, max_norm, check_isfinite=True, check_scale=True):
+def clip_global_norm(arrays, max_norm, check_isfinite=True):
     """Rescales NDArrays so that the sum of their 2-norm is smaller than `max_norm`.
 
     Parameters
@@ -125,11 +125,6 @@ def clip_global_norm(arrays, max_norm, check_isfinite=True, check_scale=True):
     check_isfinite : bool, default True
          If True, check that the total_norm is finite (not nan or inf). This
          requires a blocking .asscalar() call.
-    check_scale : bool, default True
-         If True, skip array rescaling if max_norm / total_norm >= 1. This
-         requires a blocking call. If False, rescale arrays with min(1,
-         max_norm / total_norm).
-
     """
     def _norm(array):
         if array.stype == 'default':
@@ -146,14 +141,9 @@ def clip_global_norm(arrays, max_norm, check_isfinite=True, check_scale=True):
                 UserWarning('nan or inf is detected. '
                             'Clipping results will be undefined.'), stacklevel=2)
     scale = max_norm / (total_norm + 1e-8)
-    if check_scale:
-        if scale < 1.0:
-            for arr in arrays:
-                arr *= scale.as_in_context(arr.context)
-    else:
-        scale = ndarray.min(ndarray.concat(scale, ndarray.ones(1, ctx=ctx), dim=0))
-        for arr in arrays:
-            arr *= scale.as_in_context(arr.context)
+    scale = ndarray.min(ndarray.concat(scale, ndarray.ones(1, ctx=ctx), dim=0))
+    for arr in arrays:
+        arr *= scale.as_in_context(arr.context)
     return total_norm
 
 

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -125,6 +125,13 @@ def clip_global_norm(arrays, max_norm, check_isfinite=True):
     check_isfinite : bool, default True
          If True, check that the total_norm is finite (not nan or inf). This
          requires a blocking .asscalar() call.
+
+    Returns
+    -------
+    NDArray or float
+      Total norm. Return type is NDArray of shape (1,) if check_isfinite is
+      False. Otherwise a float is returned.
+
     """
     def _norm(array):
         if array.stype == 'default':
@@ -144,7 +151,10 @@ def clip_global_norm(arrays, max_norm, check_isfinite=True):
     scale = ndarray.min(ndarray.concat(scale, ndarray.ones(1, ctx=ctx), dim=0))
     for arr in arrays:
         arr *= scale.as_in_context(arr.context)
-    return total_norm
+    if check_isfinite:
+        return total_norm.asscalar()
+    else:
+        return total_norm
 
 
 def _indent(s_, numSpaces):

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -115,8 +115,21 @@ def split_and_load(data, ctx_list, batch_axis=0, even_split=True):
     return [i.as_in_context(ctx) for i, ctx in zip(slices, ctx_list)]
 
 
-def clip_global_norm(arrays, max_norm):
+def clip_global_norm(arrays, max_norm, check_isfinite=True, check_scale=True):
     """Rescales NDArrays so that the sum of their 2-norm is smaller than `max_norm`.
+
+    Parameters
+    ----------
+    arrays : list of NDArray
+    max_norm : float
+    check_isfinite : bool, default True
+         If True, check that the total_norm is finite (not nan or inf). This
+         requires a blocking .asscalar() call.
+    check_scale : bool, default True
+         If True, skip array rescaling if max_norm / total_norm >= 1. This
+         requires a blocking call. If False, rescale arrays with min(1,
+         max_norm / total_norm).
+
     """
     def _norm(array):
         if array.stype == 'default':
@@ -126,14 +139,21 @@ def clip_global_norm(arrays, max_norm):
     assert len(arrays) > 0
     ctx = arrays[0].context
     total_norm = ndarray.add_n(*[_norm(arr).as_in_context(ctx) for arr in arrays])
-    total_norm = ndarray.sqrt(total_norm).asscalar()
-    if not np.isfinite(total_norm):
-        warnings.warn(UserWarning('nan or inf is detected. Clipping results will be undefined.'),
-                      stacklevel=2)
+    total_norm = ndarray.sqrt(total_norm)
+    if check_isfinite:
+        if not np.isfinite(total_norm.asscalar()):
+            warnings.warn(
+                UserWarning('nan or inf is detected. '
+                            'Clipping results will be undefined.'), stacklevel=2)
     scale = max_norm / (total_norm + 1e-8)
-    if scale < 1.0:
+    if check_scale:
+        if scale < 1.0:
+            for arr in arrays:
+                arr *= scale.as_in_context(arr.context)
+    else:
+        scale = ndarray.min(ndarray.concat(scale, ndarray.ones(1, ctx=ctx), dim=0))
         for arr in arrays:
-            arr *= scale
+            arr *= scale.as_in_context(arr.context)
     return total_norm
 
 

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -111,9 +111,9 @@ def test_gluon_ctc_consistency():
 
 @with_seed()
 def test_global_norm_clip_multi_device():
-    x1 = mx.nd.ones((3,3), ctx=mx.gpu(0))
-    x2 = mx.nd.ones((4,4), ctx=mx.cpu(0))
     for check_isfinite in [True, False]:
+        x1 = mx.nd.ones((3,3), ctx=mx.gpu(0))
+        x2 = mx.nd.ones((4,4), ctx=mx.cpu(0))
         norm = gluon.utils.clip_global_norm([x1, x2], 1.0, check_isfinite=check_isfinite)
         if check_isfinite:
             assert norm == 5.0

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -113,10 +113,13 @@ def test_gluon_ctc_consistency():
 def test_global_norm_clip_multi_device():
     x1 = mx.nd.ones((3,3), ctx=mx.gpu(0))
     x2 = mx.nd.ones((4,4), ctx=mx.cpu(0))
-    norm = gluon.utils.clip_global_norm([x1, x2], 1.0)
-    assert norm == 5.0
-    assert_almost_equal(x1.asnumpy(), np.ones((3,3))/5)
-    assert_almost_equal(x2.asnumpy(), np.ones((4,4))/5)
+    for check_isfinite in [True, False]:
+        for check_scale in [True, False]:
+            norm = gluon.utils.clip_global_norm([x1, x2], 1.0, check_isfinite=check_isfinite,
+                                                check_scale=check_scale)
+            assert norm == 5.0
+            assert_almost_equal(x1.asnumpy(), np.ones((3, 3)) / 5)
+            assert_almost_equal(x2.asnumpy(), np.ones((4, 4)) / 5)
 
 
 def _check_batchnorm_result(input, num_devices=1, cuda=False):

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -114,12 +114,10 @@ def test_global_norm_clip_multi_device():
     x1 = mx.nd.ones((3,3), ctx=mx.gpu(0))
     x2 = mx.nd.ones((4,4), ctx=mx.cpu(0))
     for check_isfinite in [True, False]:
-        for check_scale in [True, False]:
-            norm = gluon.utils.clip_global_norm([x1, x2], 1.0, check_isfinite=check_isfinite,
-                                                check_scale=check_scale)
-            assert norm == 5.0
-            assert_almost_equal(x1.asnumpy(), np.ones((3, 3)) / 5)
-            assert_almost_equal(x2.asnumpy(), np.ones((4, 4)) / 5)
+        norm = gluon.utils.clip_global_norm([x1, x2], 1.0, check_isfinite=check_isfinite)
+        assert norm == 5.0
+        assert_almost_equal(x1.asnumpy(), np.ones((3, 3)) / 5)
+        assert_almost_equal(x2.asnumpy(), np.ones((4, 4)) / 5)
 
 
 def _check_batchnorm_result(input, num_devices=1, cuda=False):

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -115,7 +115,10 @@ def test_global_norm_clip_multi_device():
     x2 = mx.nd.ones((4,4), ctx=mx.cpu(0))
     for check_isfinite in [True, False]:
         norm = gluon.utils.clip_global_norm([x1, x2], 1.0, check_isfinite=check_isfinite)
-        assert norm == 5.0
+        if check_isfinite:
+            assert norm == 5.0
+        else:
+            assert norm.asscalar() == 5.0
         assert_almost_equal(x1.asnumpy(), np.ones((3, 3)) / 5)
         assert_almost_equal(x2.asnumpy(), np.ones((4, 4)) / 5)
 

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -735,10 +735,11 @@ def test_sequential_warning():
 @with_seed()
 def test_global_norm_clip():
     stypes = ['default', 'row_sparse']
-    def check_global_norm_clip(stype):
+    def check_global_norm_clip(stype, check_isfinite, check_scale):
         x1 = mx.nd.ones((3,3)).tostype(stype)
         x2 = mx.nd.ones((4,4)).tostype(stype)
-        norm = gluon.utils.clip_global_norm([x1, x2], 1.0)
+        norm = gluon.utils.clip_global_norm([x1, x2], 1.0, check_isfinite=check_isfinite,
+                                            check_scale=check_scale)
         assert norm == 5.0
         assert_almost_equal(x1.asnumpy(), np.ones((3,3))/5)
         assert_almost_equal(x2.asnumpy(), np.ones((4,4))/5)
@@ -750,7 +751,9 @@ def test_global_norm_clip():
             assert len(w) == 1
 
     for stype in stypes:
-        check_global_norm_clip(stype)
+        for check_isfinite in [True, False]:
+            for check_scale in [True, False]:
+                check_global_norm_clip(stype, check_isfinite, check_scale)
 
 @with_seed()
 def test_embedding():

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -746,8 +746,8 @@ def test_global_norm_clip():
         x3 = mx.nd.array([1.0, 2.0, float('nan')]).tostype(stype)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            gluon.utils.clip_global_norm([x1, x3], 2.0)
-            assert len(w) == 1
+            gluon.utils.clip_global_norm([x1, x3], 2.0, check_isfinite=check_isfinite)
+            assert len(w) == check_isfinite
 
     for stype in stypes:
         for check_isfinite in [True, False]:

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -735,11 +735,10 @@ def test_sequential_warning():
 @with_seed()
 def test_global_norm_clip():
     stypes = ['default', 'row_sparse']
-    def check_global_norm_clip(stype, check_isfinite, check_scale):
+    def check_global_norm_clip(stype, check_isfinite):
         x1 = mx.nd.ones((3,3)).tostype(stype)
         x2 = mx.nd.ones((4,4)).tostype(stype)
-        norm = gluon.utils.clip_global_norm([x1, x2], 1.0, check_isfinite=check_isfinite,
-                                            check_scale=check_scale)
+        norm = gluon.utils.clip_global_norm([x1, x2], 1.0, check_isfinite=check_isfinite)
         assert norm == 5.0
         assert_almost_equal(x1.asnumpy(), np.ones((3,3))/5)
         assert_almost_equal(x2.asnumpy(), np.ones((4,4))/5)
@@ -752,8 +751,7 @@ def test_global_norm_clip():
 
     for stype in stypes:
         for check_isfinite in [True, False]:
-            for check_scale in [True, False]:
-                check_global_norm_clip(stype, check_isfinite, check_scale)
+            check_global_norm_clip(stype, check_isfinite)
 
 @with_seed()
 def test_embedding():


### PR DESCRIPTION
## Description ##
Make check_isfinite, check_scale optional in clip_global_norm. If both are set to false, clip_global_norm does not force any synchronization and throughput can be increased. Note if check_scale=False, this requires multiplying all arrays with 1 in cases where the multiplication could be skipped by doing a blocking check.

While this PR preserves the old default behavior of using blocking calls, we may want to change the default behavior to improve throughput.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Make check_isfinite, check_scale optional in clip_global_norm

## Comments ##
- This improves throughput in https://github.com/dmlc/gluon-nlp/pull/253 by around 10%.
@eric-haibin-lin 