### PR TITLE
Add Clojure to website nav

### DIFF
--- a/docs/_static/js/sidebar.js
+++ b/docs/_static/js/sidebar.js
@@ -1,5 +1,5 @@
 /*Preprocess*/
-var LANG = ['python', 'scala', 'r', 'julia', 'c++', 'perl'];
+var LANG = ['python', 'scala', 'clojure', 'r', 'julia', 'c++', 'perl'];
 var TITLE_WITH_LANG = ['/get_started/', '/tutorials/', '/faq/', '/architecture/', '/community/'];
 for(var i = 0; i < LANG.length; ++i) {
     TITLE_WITH_LANG.push('/api/' + LANG[i] + '/');

--- a/docs/_static/js/sidebar.js
+++ b/docs/_static/js/sidebar.js
@@ -1,5 +1,5 @@
 /*Preprocess*/
-var LANG = ['python', 'scala', 'clojure', 'r', 'julia', 'c++', 'perl'];
+var LANG = ['python', 'c++', 'clojure', 'julia', 'perl', 'r', 'scala'];
 var TITLE_WITH_LANG = ['/get_started/', '/tutorials/', '/faq/', '/architecture/', '/community/'];
 for(var i = 0; i < LANG.length; ++i) {
     TITLE_WITH_LANG.push('/api/' + LANG[i] + '/');

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -50,7 +50,7 @@
           </ul>
         </span>
       </nav>
-      
+
       <script> function getRootPath(){ return "{{url_root}}" } </script>
       <div class="burgerIcon dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button">☰</a>
@@ -71,7 +71,7 @@
               <li class="dropdown-submenu">
                 <a href="#" tabindex="-1" role="button" aria-haspopup="true" class="dropdown-toggle burger-link" data-toggle="dropdown">{{name}}</a>
                 <ul class="dropdown-menu">
-                  {% for lang in ['Python', 'Scala', 'R', 'Julia', 'C++', 'Perl'] %}
+                  {% for lang in ['C++', 'Clojure', 'Julia',  'Perl', 'Python', 'R', 'Scala'] %}
                     <li><a tabindex="-1" href="{{url_root}}{{name.lower()|replace(" ", "_")}}/{{lang.lower()}}/index.html">{{lang}}</a>
                     </li>
                   {% endfor %}

--- a/docs/_static/mxnet-theme/navbar.html
+++ b/docs/_static/mxnet-theme/navbar.html
@@ -20,10 +20,11 @@
           <ul id="package-dropdown-menu" class="dropdown-menu navbar-menu">
             <li><a class="main-nav-link" href="{{url_root}}api/python/index.html">Python</a></li>
             <li><a class="main-nav-link" href="{{url_root}}api/c++/index.html">C++</a></li>
-            <li><a class="main-nav-link" href="{{url_root}}api/scala/index.html">Scala</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/clojure/index.html">Clojure</a></li>
             <li><a class="main-nav-link" href="{{url_root}}api/julia/index.html">Julia</a></li>
             <li><a class="main-nav-link" href="{{url_root}}api/perl/index.html">Perl</a></li>
             <li><a class="main-nav-link" href="{{url_root}}api/r/index.html">R</a></li>
+            <li><a class="main-nav-link" href="{{url_root}}api/scala/index.html">Scala</a></li>
           </ul>
         </span>
 
@@ -71,7 +72,7 @@
               <li class="dropdown-submenu">
                 <a href="#" tabindex="-1" role="button" aria-haspopup="true" class="dropdown-toggle burger-link" data-toggle="dropdown">{{name}}</a>
                 <ul class="dropdown-menu">
-                  {% for lang in ['C++', 'Clojure', 'Julia',  'Perl', 'Python', 'R', 'Scala'] %}
+                  {% for lang in ['Python', 'C++', 'Clojure', 'Julia',  'Perl', 'R', 'Scala'] %}
                     <li><a tabindex="-1" href="{{url_root}}{{name.lower()|replace(" ", "_")}}/{{lang.lower()}}/index.html">{{lang}}</a>
                     </li>
                   {% endfor %}


### PR DESCRIPTION
## Description ##
This adds Clojure to the navigation. I also alphabetized the list since it is getting pretty long and there didn't seem to be any logical order.

This also is taking over the Clojure aspect from #11921 - since I think that PR is going to be blocked forever and will need to be parsed out and closed.
