### PR TITLE
[MXNET-749] Correct usages of `CutSubgraph` in 3 control flow operators

### DIFF
--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -372,13 +372,13 @@ int MXSymbolCutSubgraph(SymbolHandle sym, SymbolHandle **input_symbols,
   // a subgraph.
   API_BEGIN();
   nnvm::Symbol *s = static_cast<nnvm::Symbol*>(sym);
-  std::string subg_attr = "__subgraph_name__";
+  const std::string subg_attr = "__subgraph_name__";
   auto out_node = s->outputs[0].node;
   auto it = out_node->attrs.dict.find(subg_attr);
   if (it != out_node->attrs.dict.end()) {
-    std::string subg_name = it->second;
+    const std::string &subg_name = it->second;
     std::vector<nnvm::NodeEntry *> input_entries;
-    DFSVisit(s->outputs, [subg_attr, subg_name, &input_entries]
+    DFSVisit(s->outputs, [&subg_attr, &subg_name, &input_entries]
              (nnvm::NodePtr n) {
       // If the node itself isn't in the subgraph, we ignore it.
       auto it = n->attrs.dict.find(subg_attr);

--- a/src/operator/control_flow.cc
+++ b/src/operator/control_flow.cc
@@ -1226,7 +1226,7 @@ static bool BackwardCondStorageType(const nnvm::NodeAttrs& attrs,
     return ret;
   };
   for (const dim_t &cond_in : params.cond_input_locs) {
-    (*out_attrs)[cond_in] = 0;
+    (*out_attrs)[cond_in] = kDefaultStorage;
   }
   bool succ_0 = sub_pass(attrs.subgraphs[1], params.then_input_locs);
   bool succ_1 = sub_pass(attrs.subgraphs[2], params.else_input_locs);

--- a/src/operator/control_flow.cc
+++ b/src/operator/control_flow.cc
@@ -1225,6 +1225,9 @@ static bool BackwardCondStorageType(const nnvm::NodeAttrs& attrs,
     CHECK(sync_in_in(input_locs, out_attrs, &subg_out_attrs, is_udf));
     return ret;
   };
+  for (const dim_t &cond_in : params.cond_input_locs) {
+    (*out_attrs)[cond_in] = 0;
+  }
   bool succ_0 = sub_pass(attrs.subgraphs[1], params.then_input_locs);
   bool succ_1 = sub_pass(attrs.subgraphs[2], params.else_input_locs);
   return succ_0 && succ_1;


### PR DESCRIPTION
## Description ##
This PR corrects the usage of `CutSubgraph`.

`CutSubgraph` consumes a Symbol `s`, and
1) Assumes the attribute `__subgraph_name__` of `s->outputs[0].node` is the name of the subgraph
2) Assumes the boundary of this subgraph be nodes who has at least one immediate predecessor whose attribute `__subgraph_name__` is not the name of the subgraph
3) Duplicates and puts these immediate predecessors into this subgraph

Calling `CutSubgraph` without very special care will cause disastrous consequences, often when `s->outputa[0].node` has an improper name. For example, in control flow operators, if we write a function `lambda: x` which captures an outside symbol `x` (so the attribute of `x` is not desirable), and an operator passes `x` into `CutGraph` as the first output of subgraph, the entire procedure breaks. Without copying and manually correcting such symbols, this will happen anywhere and be very hard to debug. An example that causes this bug could be https://github.com/dmlc/gluon-nlp/pull/233 in which the `pred` I pass to `cond` is calculated outside the subgraph.

This bug affects all three control flow operators, `foreach`, `while_loop` and `cond`.

CC: @zheng-da 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] 3 control flow operators.
- [x] BTW, remove some unnecessary copies of std::string in the implementation of CutSubgraph.

## Comments ##
- Just looked into the code, seems that another thing we haven't ensure is that each subgraph should have its distinct name, otherwise the CutSubgraph may not work properly. Fixed in #12106.