### PR TITLE
GPU Memory Query to C API

### DIFF
--- a/include/mxnet/base.h
+++ b/include/mxnet/base.h
@@ -334,10 +334,10 @@ inline int32_t Context::GetGPUCount() {
 #endif
 }
 
+inline void Context::GetGPUMemoryInformation(int dev, int *free_mem,
+                                             int *total_mem) {
+#if MXNET_USE_CUDA
 
-inline void Context::GetGPUMemoryInformation(int dev, int *free_mem, int *total_mem) {
-  #if MXNET_USE_CUDA
-  
   size_t memF, memT;
   cudaError_t e;
 

--- a/include/mxnet/base.h
+++ b/include/mxnet/base.h
@@ -223,6 +223,14 @@ struct Context {
    */
   inline static int32_t GetGPUCount();
   /*!
+   * \brief get the free and total available memory on a GPU
+   * \param dev the GPU number to query
+   * \param free_mem pointer to the integer holding free GPU memory
+   * \param total_mem pointer to the integer holding total GPU memory
+   * \return No return value
+   */
+  inline static void GetGPUMemoryInformation(int dev, int *free, int *total);
+  /*!
    * Create a pinned CPU context.
    * \param dev_id the device id for corresponding GPU.
    * \return Pinned CPU context. -1 for current GPU.
@@ -323,6 +331,35 @@ inline int32_t Context::GetGPUCount() {
   return count;
 #else
   return 0;
+#endif
+}
+
+
+inline void Context::GetGPUMemoryInformation(int dev, int *free_mem, int *total_mem) {
+  #if MXNET_USE_CUDA
+  
+  size_t memF, memT;
+  cudaError_t e;
+
+  int curDevice;
+  e = cudaGetDevice(&curDevice);
+  CHECK_EQ(e, cudaSuccess) << " CUDA: " << cudaGetErrorString(e);
+
+  e = cudaSetDevice(dev);
+  CHECK_EQ(e, cudaSuccess) << " CUDA: " << cudaGetErrorString(e);
+
+  e = cudaMemGetInfo(&memF, &memT);
+  CHECK_EQ(e, cudaSuccess) << " CUDA: " << cudaGetErrorString(e);
+
+  e = cudaSetDevice(curDevice);
+  CHECK_EQ(e, cudaSuccess) << " CUDA: " << cudaGetErrorString(e);
+
+  *free_mem = static_cast<int>(memF);
+  *total_mem = static_cast<int>(memT);
+
+#else
+  LOG(FATAL)
+      << "This call is only supported for MXNet built with CUDA support.";
 #endif
 }
 

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -391,6 +391,15 @@ MXNET_DLL int MXEngineSetBulkSize(int bulk_size, int* prev_bulk_size);
 MXNET_DLL int MXGetGPUCount(int* out);
 
 /*!
+ * \brief get the free and total available memory on a GPU
+ * \param dev the GPU number to query
+ * \param free_mem pointer to the integer holding free GPU memory
+ * \param total_mem pointer to the integer holding total GPU memory
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXGetGPUMemoryInformation(int dev, int* free_mem, int* total_mem);
+
+/*!
  * \brief get the MXNet library version as an integer
  * \param pointer to the integer holding the version number
  * \return 0 when success, -1 when failure happens

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -397,7 +397,7 @@ MXNET_DLL int MXGetGPUCount(int* out);
  * \param total_mem pointer to the integer holding total GPU memory
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXGetGPUMemoryInformation(int dev, int* free_mem, int* total_mem);
+MXNET_DLL int MXGetGPUMemoryInformation(int dev, int *free_mem, int *total_mem);
 
 /*!
  * \brief get the MXNet library version as an integer

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -122,6 +122,12 @@ int MXGetGPUCount(int* out) {
   API_END();
 }
 
+int MXGetGPUMemoryInformation(int dev, int *free_mem, int *total_mem) {
+  API_BEGIN();
+  Context::GetGPUMemoryInformation(dev, free_mem, total_mem);
+  API_END();
+}
+
 int MXGetVersion(int *out) {
   API_BEGIN();
   *out = static_cast<int>(MXNET_VERSION);


### PR DESCRIPTION
This PR adds a function `MXNET_DLL int MXGetGPUMemoryInformation(int dev, int* free_mem, int* total_mem);` to the C API to allow any language binding to easily query for the total and available memory available on a particular GPU. 

Its useful as `nvidia-smi` is not available on certain platforms (like OSX). Having a platform-independent way of querying this (eg to automatically figure out appropriate batch sizes) is very useful for higher-level frameworks built on top of MXNet.

This is similar to the cuTorch function [getMemoryUsage](https://github.com/torch/cutorch/blob/7126f4bc02757838dd597d94e5d8ee67b45e0388/init.c#L710), with the same implementation. 