### PR TITLE
[MXNET-795] Fix a bug that CutSubgraph works only when each subgraph has its distinct name

### DIFF
--- a/python/mxnet/attribute.py
+++ b/python/mxnet/attribute.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 import threading
 import warnings
+from collections import defaultdict
 
 from .base import string_types, classproperty, with_metaclass, _MXClassPropertyMetaClass
 
@@ -34,6 +35,7 @@ class AttrScope(with_metaclass(_MXClassPropertyMetaClass, object)):
         The attributes to set for all symbol creations in the scope.
     """
     _current = threading.local()
+    _subgraph_names = defaultdict(int)
 
     def __init__(self, **kwargs):
         self._old_scope = None

--- a/python/mxnet/symbol/contrib.py
+++ b/python/mxnet/symbol/contrib.py
@@ -128,8 +128,8 @@ def _get_unique_subgraph_name(subgraph_name):
     attrs = AttrScope._current.value._attr
     if attrs.get("__subgraph_name__", "") != "":
         subgraph_name = "".join([attrs["__subgraph_name__"], "$", subgraph_name])
-    subgraph_name = subgraph_name + str(AttrScope._subgraph_names.get(subgraph_name, 0))
     AttrScope._subgraph_names[subgraph_name] += 1
+    subgraph_name = subgraph_name + str(AttrScope._subgraph_names[subgraph_name] - 1)
     return subgraph_name
 
 # This construct a subgraph for given output nodes.

--- a/tests/python/unittest/test_contrib_control_flow.py
+++ b/tests/python/unittest/test_contrib_control_flow.py
@@ -20,8 +20,10 @@ import numpy as np
 import mxnet as mx
 from mxnet import gluon
 from numpy.testing import assert_allclose, assert_array_equal
+from collections import defaultdict
 from mxnet.test_utils import *
 from mxnet.base import _as_list
+from mxnet.attribute import AttrScope
 from common import with_seed
 
 
@@ -1763,6 +1765,45 @@ def test_cut_subgraph_cond():
     with mx.autograd.record():
         res2 = layer(data)
     assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=0.001, atol=0.0001)
+
+
+def test_scope():
+    class TestBlock1(gluon.HybridBlock):
+        def __init__(self, prefix=None, params=None):
+            super(TestBlock1, self).__init__(prefix=prefix, params=params)
+        def hybrid_forward(self, F, data):
+            (new_data, ) = F.contrib.cond(
+                data > 0.5,
+                then_func=lambda: data * 2,
+                else_func=lambda: data * 3,
+                name="my_cond",
+            )
+            return new_data
+    class TestBlock2(gluon.HybridBlock):
+        def __init__(self, prefix=None, params=None):
+            super(TestBlock2, self).__init__(prefix=prefix, params=params)
+        def hybrid_forward(self, F, data):
+            (new_data, ) = F.contrib.cond(
+                data > 0.5,
+                then_func=lambda: data * 2,
+                else_func=lambda: data * 3,
+                name="my_cond",
+            )
+            return new_data
+    AttrScope._subgraph_names = defaultdict(int)
+    data = mx.nd.normal(loc=0, scale=1, shape=(1, ))
+    block1 = TestBlock1()
+    block1.initialize(ctx=default_context())
+    block1.hybridize()
+    _ = block1(data)
+    block2 = TestBlock2()
+    block2.initialize(ctx=default_context())
+    block2.hybridize()
+    _ = block2(data)
+    assert len(AttrScope._subgraph_names) == 3
+    assert AttrScope._subgraph_names['my_cond_else'] == 2
+    assert AttrScope._subgraph_names['my_cond_pred'] == 2
+    assert AttrScope._subgraph_names['my_cond_then'] == 2
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
This PR fixes a bug in assigning names of subgraphs. The `CutSubgraph` works as expected only when each subgraph has its unique name.

This PR ensures it by creating a global dict in `AttrScope`, which is pretty ugly though. I am not aware of any other solutions that could ensure a set of strings to be unique globally. If there is better solution, please let me know. Thanks!

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add `_subgraph_names` into `AttrScope` as static member.

## Comments ##
- See also: https://github.com/apache/incubator-mxnet/pull/12078, which is another bug related to cutting subgraphs.