### PR TITLE
[MXNET-730][WIP] Scala test in nightly

### DIFF
--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/cnntextclassification/CNNTextClassification.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/cnntextclassification/CNNTextClassification.scala
@@ -103,9 +103,8 @@ object CNNTextClassification {
   def trainCNN(model: CNNModel, trainBatches: Array[Array[Array[Float]]],
                trainLabels: Array[Float], devBatches: Array[Array[Array[Float]]],
                devLabels: Array[Float], batchSize: Int, saveModelPath: String,
-               learningRate: Float = 0.001f): Float = {
+               learningRate: Float = 0.001f, epoch : Int = 10): Float = {
     val maxGradNorm = 0.5f
-    val epoch = 10
     val initializer = new Uniform(0.1f)
     val opt = new RMSProp(learningRate)
     val updater = Optimizer.getUpdater(opt)
@@ -236,7 +235,7 @@ object CNNTextClassification {
   }
 
   def test(w2vFilePath : String, mrDatasetPath: String,
-           ctx : Context, saveModelPath: String) : Float = {
+           ctx : Context, saveModelPath: String, epoch : Int) : Float = {
     val (numEmbed, word2vec) = DataHelper.loadGoogleModel(w2vFilePath)
     val (datas, labels) = DataHelper.loadMSDataWithWord2vec(
       mrDatasetPath, numEmbed, word2vec)
@@ -259,7 +258,7 @@ object CNNTextClassification {
     val lr = 0.001f
     val cnnModel = setupCnnModel(ctx, batchSize, sentenceSize, numEmbed)
     val result = trainCNN(cnnModel, trainDats, trainLabels, devDatas, devLabels, batchSize,
-      saveModelPath, learningRate = lr)
+      saveModelPath, learningRate = lr, epoch)
     result
   }
 

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostTrain.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostTrain.scala
@@ -55,7 +55,8 @@ object BoostTrain {
   }
 
   def runTraining(dataPath : String, vggModelPath: String, ctx : Context,
-                  styleImage : String, saveModelPath : String) : Unit = {
+                  styleImage : String, saveModelPath : String,
+                  startEpoch : Int = 0, endEpoch : Int = 3) : Unit = {
     // params
     val vggParams = NDArray.load2Map(vggModelPath)
     val styleWeight = 1.2f
@@ -105,9 +106,6 @@ object BoostTrain {
     logger.info(s"Dataset size: $numImage")
 
     val tvWeight = 1e-2f
-
-    val startEpoch = 0
-    val endEpoch = 3
 
     for (k <- 0 until gens.length) {
       val path = new File(s"${saveModelPath}/$k")

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/cnntextclassification/CNNClassifierExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/cnntextclassification/CNNClassifierExampleSuite.scala
@@ -58,7 +58,7 @@ class CNNClassifierExampleSuite extends FunSuite with BeforeAndAfterAll {
       val modelDirPath = tempDirPath + File.separator + "CNN"
 
       val output = CNNTextClassification.test(modelDirPath + File.separator + w2vModelName,
-        modelDirPath, context, modelDirPath)
+        modelDirPath, context, modelDirPath, 10)
 
       Process("rm -rf " + modelDirPath) !
 

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyleSuite.scala
@@ -70,7 +70,7 @@ class NeuralStyleSuite extends FunSuite with BeforeAndAfterAll {
       System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
       val ctx = Context.gpu()
       BoostTrain.runTraining(tempDirPath + "/NS/images", tempDirPath + "/NS/vgg19.params", ctx,
-        tempDirPath + "/NS/starry_night.jpg", tempDirPath + "/NS")
+        tempDirPath + "/NS/starry_night.jpg", tempDirPath + "/NS", 0, 3)
     } else {
       logger.info("GPU test only, skip CPU...")
     }


### PR DESCRIPTION
## Description ##
This is the PR for migrating Scala test to nightly build. The action I applied here is to provide a new function in `Util` that can check which test to run and how many epochs needed to run. All Integration test will run 1 epoch in default and nightly will run more for performance and accuracy checking.

@nswamy @yzhliu @andrewfayres @marcoabreu 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
