### PR TITLE
fix potential floating number overflow, enable float16

### DIFF
--- a/src/operator/contrib/bounding_box-inl.cuh
+++ b/src/operator/contrib/bounding_box-inl.cuh
@@ -45,9 +45,9 @@ struct valid_score {
 
 template<typename DType>
 int FilterScores(mshadow::Tensor<gpu, 1, DType> out_scores,
-                 mshadow::Tensor<gpu, 1, double> out_sorted_index,
+                 mshadow::Tensor<gpu, 1, int32_t> out_sorted_index,
                  mshadow::Tensor<gpu, 1, DType> scores,
-                 mshadow::Tensor<gpu, 1, double> sorted_index,
+                 mshadow::Tensor<gpu, 1, int32_t> sorted_index,
                  float valid_thresh) {
   valid_score<DType> pred(static_cast<DType>(valid_thresh));
   DType * end_scores = thrust::copy_if(thrust::device, scores.dptr_, scores.dptr_ + scores.MSize(),

--- a/src/operator/contrib/bounding_box-inl.cuh
+++ b/src/operator/contrib/bounding_box-inl.cuh
@@ -45,9 +45,9 @@ struct valid_score {
 
 template<typename DType>
 int FilterScores(mshadow::Tensor<gpu, 1, DType> out_scores,
-                 mshadow::Tensor<gpu, 1, DType> out_sorted_index,
+                 mshadow::Tensor<gpu, 1, double> out_sorted_index,
                  mshadow::Tensor<gpu, 1, DType> scores,
-                 mshadow::Tensor<gpu, 1, DType> sorted_index,
+                 mshadow::Tensor<gpu, 1, double> sorted_index,
                  float valid_thresh) {
   valid_score<DType> pred(static_cast<DType>(valid_thresh));
   DType * end_scores = thrust::copy_if(thrust::device, scores.dptr_, scores.dptr_ + scores.MSize(),

--- a/src/operator/contrib/bounding_box-inl.h
+++ b/src/operator/contrib/bounding_box-inl.h
@@ -414,11 +414,14 @@ void BoxNMSForward(const nnvm::NodeAttrs& attrs,
     // prepare workspace
     Shape<1> sort_index_shape = Shape1(num_batch * num_elem);
     Shape<3> buffer_shape = Shape3(num_batch, num_elem, width_elem);
-    index_t workspace_size = sort_index_shape.Size() * sizeof(int32_t) / sizeof(DType);  // index
+    // ceil up when sizeof(DType) is larger than sizeof(DType)
+    // index
+    index_t workspace_size = ((sort_index_shape.Size() * sizeof(int32_t) - 1) / sizeof(DType)) + 1;
     workspace_size += workspace_size * 2;  // all_sorted_index, batch_id
     workspace_size += 2 * sort_index_shape.Size();  // scores, batch_id, areas
     Shape<1> batch_start_shape = Shape1(num_batch + 1);
-    workspace_size += batch_start_shape.Size() * sizeof(int32_t) / sizeof(DType);  // batch_start
+    // batch_start
+    workspace_size += ((batch_start_shape.Size() * sizeof(int32_t) - 1) / sizeof(DType)) + 1;
     if (req[0] == kWriteInplace) {
       workspace_size += buffer_shape.Size();
     }
@@ -782,7 +785,7 @@ void BipartiteMatchingForward(const nnvm::NodeAttrs& attrs,
      .get_with_shape<xpu, 2, DType>(Shape2(batch_size, col), s);
     Shape<1> sort_index_shape = Shape1(dshape.Size());
     index_t workspace_size = sort_index_shape.Size();
-    workspace_size += sort_index_shape.Size() * sizeof(int32_t) / sizeof(DType) * 2;
+    workspace_size += ((sort_index_shape.Size() * sizeof(int32_t) - 1) / sizeof(DType)) * 2;
     Tensor<xpu, 1, DType> workspace = ctx.requested[0]
       .get_space_typed<xpu, 1, DType>(Shape1(workspace_size), s);
     Tensor<xpu, 1, DType> scores_copy(workspace.dptr_,

--- a/src/operator/contrib/bounding_box-inl.h
+++ b/src/operator/contrib/bounding_box-inl.h
@@ -414,17 +414,24 @@ void BoxNMSForward(const nnvm::NodeAttrs& attrs,
     // prepare workspace
     Shape<1> sort_index_shape = Shape1(num_batch * num_elem);
     Shape<3> buffer_shape = Shape3(num_batch, num_elem, width_elem);
-    // ceil up when sizeof(DType) is larger than sizeof(DType)
-    // index
-    index_t workspace_size = ((sort_index_shape.Size() * sizeof(int32_t) - 1) / sizeof(DType)) + 1;
-    workspace_size += workspace_size * 2;  // all_sorted_index, batch_id
-    workspace_size += 2 * sort_index_shape.Size();  // scores, batch_id, areas
     Shape<1> batch_start_shape = Shape1(num_batch + 1);
-    // batch_start
-    workspace_size += ((batch_start_shape.Size() * sizeof(int32_t) - 1) / sizeof(DType)) + 1;
+
+    // index
+    index_t int32_size = sort_index_shape.Size() * 3 + batch_start_shape.Size();
+    index_t dtype_size = sort_index_shape.Size() * 2;
     if (req[0] == kWriteInplace) {
-      workspace_size += buffer_shape.Size();
+      dtype_size += buffer_shape.Size();
     }
+    // ceil up when sizeof(DType) is larger than sizeof(DType)
+    index_t workspace_size = (int32_size * sizeof(int32_t) - 1) / sizeof(DType) + 1 + dtype_size;
+    // workspace_size += workspace_size * 2;  // all_sorted_index, batch_id
+    // workspace_size += 2 * sort_index_shape.Size();  // scores, batch_id, areas
+    //
+    // // batch_start
+    // workspace_size += ((batch_start_shape.Size() * sizeof(int32_t) - 1) / sizeof(DType)) + 1;
+    // if (req[0] == kWriteInplace) {
+    //   workspace_size += buffer_shape.Size();
+    // }
     Tensor<xpu, 1, DType> workspace = ctx.requested[box_nms_enum::kTempSpace]
       .get_space_typed<xpu, 1, DType>(Shape1(workspace_size), s);
     Tensor<xpu, 1, int32_t> sorted_index(

--- a/src/operator/tensor/sort_op-inl.cuh
+++ b/src/operator/tensor/sort_op-inl.cuh
@@ -113,14 +113,15 @@ SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
     // No workspace, sort using thrust
     thrust::device_ptr<KDType> key_iter = thrust::device_pointer_cast(keys.dptr_);
     thrust::device_ptr<VDType> value_iter = thrust::device_pointer_cast(values.dptr_);
+    auto key_iter_end = key_iter + keys.size(0);
     if (is_ascend) {
       thrust::stable_sort_by_key(
         thrust::cuda::par.on(stream),
-        key_iter, (key_iter + keys.size(0)), value_iter, thrust::less<KDType>());
+        key_iter, key_iter_end, value_iter, thrust::less<KDType>());
     } else {
       thrust::stable_sort_by_key(
         thrust::cuda::par.on(stream),
-        key_iter, (key_iter + keys.size(0)), value_iter, thrust::greater<KDType>());
+        key_iter, key_iter_end, value_iter, thrust::greater<KDType>());
     }
 #ifndef SORT_WITH_THRUST
   }
@@ -146,14 +147,15 @@ SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
   // No workspace, sort using thrust
   thrust::device_ptr<KDType> key_iter = thrust::device_pointer_cast(keys.dptr_);
   thrust::device_ptr<VDType> value_iter = thrust::device_pointer_cast(values.dptr_);
+  auto key_iter_end = key_iter + keys.size(0);
   if (is_ascend) {
     thrust::stable_sort_by_key(
       thrust::cuda::par.on(stream),
-      key_iter, (key_iter + keys.size(0)), value_iter, thrust::less<KDType>());
+      key_iter, key_iter_end, value_iter, thrust::less<KDType>());
   } else {
     thrust::stable_sort_by_key(
       thrust::cuda::par.on(stream),
-      key_iter, (key_iter + keys.size(0)), value_iter, thrust::greater<KDType>());
+      key_iter, key_iter_end, value_iter, thrust::greater<KDType>());
   }
   MSHADOW_CUDA_POST_KERNEL_CHECK(SortByKey);
 #else

--- a/src/operator/tensor/sort_op-inl.cuh
+++ b/src/operator/tensor/sort_op-inl.cuh
@@ -25,6 +25,7 @@
 #ifndef MXNET_OPERATOR_TENSOR_SORT_OP_INL_CUH_
 #define MXNET_OPERATOR_TENSOR_SORT_OP_INL_CUH_
 #include <type_traits>
+#include <iterator>
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>
 #if defined(_MSC_VER) && __CUDACC_VER_MAJOR__ == 8 && __CUDACC_VER_BUILD__ != 44
@@ -113,15 +114,14 @@ SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
     // No workspace, sort using thrust
     thrust::device_ptr<KDType> key_iter = thrust::device_pointer_cast(keys.dptr_);
     thrust::device_ptr<VDType> value_iter = thrust::device_pointer_cast(values.dptr_);
-    auto key_iter_end = key_iter + keys.size(0);
     if (is_ascend) {
       thrust::stable_sort_by_key(
         thrust::cuda::par.on(stream),
-        key_iter, key_iter_end, value_iter, thrust::less<KDType>());
+        key_iter, std::advance(key_iter, keys.size(0)), value_iter, thrust::less<KDType>());
     } else {
       thrust::stable_sort_by_key(
         thrust::cuda::par.on(stream),
-        key_iter, key_iter_end, value_iter, thrust::greater<KDType>());
+        key_iter, std::advance(key_iter, keys.size(0)), value_iter, thrust::greater<KDType>());
     }
 #ifndef SORT_WITH_THRUST
   }
@@ -147,15 +147,14 @@ SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
   // No workspace, sort using thrust
   thrust::device_ptr<KDType> key_iter = thrust::device_pointer_cast(keys.dptr_);
   thrust::device_ptr<VDType> value_iter = thrust::device_pointer_cast(values.dptr_);
-  auto key_iter_end = key_iter + keys.size(0);
   if (is_ascend) {
     thrust::stable_sort_by_key(
       thrust::cuda::par.on(stream),
-      key_iter, key_iter_end, value_iter, thrust::less<KDType>());
+      key_iter, std::advance(key_iter, keys.size(0)), value_iter, thrust::less<KDType>());
   } else {
     thrust::stable_sort_by_key(
       thrust::cuda::par.on(stream),
-      key_iter, key_iter_end, value_iter, thrust::greater<KDType>());
+      key_iter, std::advance(key_iter, keys.size(0)), value_iter, thrust::greater<KDType>());
   }
   MSHADOW_CUDA_POST_KERNEL_CHECK(SortByKey);
 #else

--- a/src/operator/tensor/sort_op-inl.cuh
+++ b/src/operator/tensor/sort_op-inl.cuh
@@ -25,6 +25,7 @@
 #ifndef MXNET_OPERATOR_TENSOR_SORT_OP_INL_CUH_
 #define MXNET_OPERATOR_TENSOR_SORT_OP_INL_CUH_
 #include <type_traits>
+#include <iterator>
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>
 #if defined(_MSC_VER) && __CUDACC_VER_MAJOR__ == 8 && __CUDACC_VER_BUILD__ != 44
@@ -113,14 +114,16 @@ SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
     // No workspace, sort using thrust
     thrust::device_ptr<KDType> key_iter = thrust::device_pointer_cast(keys.dptr_);
     thrust::device_ptr<VDType> value_iter = thrust::device_pointer_cast(values.dptr_);
+    auto key_iter_end = key_iter;
+    std::advance(key_iter_end, keys.size(0));
     if (is_ascend) {
       thrust::stable_sort_by_key(
-        thrust::cuda::par.on(stream), key_iter,
-        key_iter + static_cast<size_t>(keys.size(0)), value_iter, thrust::less<KDType>());
+        thrust::cuda::par.on(stream),
+        key_iter, key_iter_end, value_iter, thrust::less<KDType>());
     } else {
       thrust::stable_sort_by_key(
-        thrust::cuda::par.on(stream), key_iter,
-        key_iter + static_cast<size_t>(keys.size(0)), value_iter, thrust::greater<KDType>());
+        thrust::cuda::par.on(stream),
+        key_iter, key_iter_end, value_iter, thrust::greater<KDType>());
     }
 #ifndef SORT_WITH_THRUST
   }
@@ -146,14 +149,16 @@ SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
   // No workspace, sort using thrust
   thrust::device_ptr<KDType> key_iter = thrust::device_pointer_cast(keys.dptr_);
   thrust::device_ptr<VDType> value_iter = thrust::device_pointer_cast(values.dptr_);
+  auto key_iter_end = key_iter;
+  std::advance(key_iter_end, keys.size(0));
   if (is_ascend) {
     thrust::stable_sort_by_key(
-      thrust::cuda::par.on(stream), key_iter,
-      key_iter + static_cast<size_t>(keys.size(0)), value_iter, thrust::less<KDType>());
+      thrust::cuda::par.on(stream),
+      key_iter, key_iter_end, value_iter, thrust::less<KDType>());
   } else {
     thrust::stable_sort_by_key(
-      thrust::cuda::par.on(stream), key_iter,
-      key_iter + static_cast<size_t>(keys.size(0)), value_iter, thrust::greater<KDType>());
+      thrust::cuda::par.on(stream),
+      key_iter, key_iter_end, value_iter, thrust::greater<KDType>());
   }
   MSHADOW_CUDA_POST_KERNEL_CHECK(SortByKey);
 #else

--- a/src/operator/tensor/sort_op-inl.cuh
+++ b/src/operator/tensor/sort_op-inl.cuh
@@ -116,11 +116,11 @@ SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
     if (is_ascend) {
       thrust::stable_sort_by_key(
         thrust::cuda::par.on(stream),
-        key_iter, key_iter + keys.size(0), value_iter, thrust::less<KDType>());
+        key_iter, (key_iter + keys.size(0)), value_iter, thrust::less<KDType>());
     } else {
       thrust::stable_sort_by_key(
         thrust::cuda::par.on(stream),
-        key_iter, key_iter + keys.size(0), value_iter, thrust::greater<KDType>());
+        key_iter, (key_iter + keys.size(0)), value_iter, thrust::greater<KDType>());
     }
 #ifndef SORT_WITH_THRUST
   }
@@ -149,11 +149,11 @@ SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
   if (is_ascend) {
     thrust::stable_sort_by_key(
       thrust::cuda::par.on(stream),
-      key_iter, key_iter + keys.size(0), value_iter, thrust::less<KDType>());
+      key_iter, (key_iter + keys.size(0)), value_iter, thrust::less<KDType>());
   } else {
     thrust::stable_sort_by_key(
       thrust::cuda::par.on(stream),
-      key_iter, key_iter + keys.size(0), value_iter, thrust::greater<KDType>());
+      key_iter, (key_iter + keys.size(0)), value_iter, thrust::greater<KDType>());
   }
   MSHADOW_CUDA_POST_KERNEL_CHECK(SortByKey);
 #else

--- a/src/operator/tensor/sort_op-inl.cuh
+++ b/src/operator/tensor/sort_op-inl.cuh
@@ -58,7 +58,8 @@ SortByKeyWorkspaceSize(const size_t num_keys) {
 }
 
 template<typename KDType, typename VDType>
-inline typename std::enable_if<!std::is_same<KDType,mshadow::half::half_t>::value, void>::type
+inline typename std::enable_if<!(std::is_same<KDType,mshadow::half::half_t>::value ||
+                                 std::is_same<VDType,mshadow::half::half_t>::value), void>::type
 SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
               mshadow::Tensor<gpu, 1, VDType> values, bool is_ascend,
               mshadow::Tensor<gpu, 1, char>* workspace,
@@ -131,32 +132,32 @@ SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
 #endif
 }
 
-// half_t is not supported by cub, use thrust instead
-template<typename VDType>
-inline void SortByKeyImpl(mshadow::Tensor<gpu, 1, mshadow::half::half_t> keys,
-                          mshadow::Tensor<gpu, 1, VDType> values, bool is_ascend,
-                          mshadow::Tensor<gpu, 1, char>* workspace,
-                          const int begin_bit, const int end_bit) {
+// use thrust sorting when keys or values are half_t
+template<typename KDType, typename VDType>
+inline typename std::enable_if<(std::is_same<KDType,mshadow::half::half_t>::value ||
+                                std::is_same<VDType,mshadow::half::half_t>::value), void>::type
+SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
+              mshadow::Tensor<gpu, 1, VDType> values, bool is_ascend,
+              mshadow::Tensor<gpu, 1, char>* workspace,
+              const int begin_bit, const int end_bit) {
   CHECK_EQ(keys.CheckContiguous(), true);
   CHECK_EQ(values.CheckContiguous(), true);
 #if CUDA_VERSION >= 7000
-  // use thrust for half_t type keys
   cudaStream_t stream = mshadow::Stream<gpu>::GetStream(keys.stream_);
-  // No workspace, sort using thrust
-  thrust::device_ptr<mshadow::half::half_t> key_iter = thrust::device_pointer_cast(keys.dptr_);
+  thrust::device_ptr<KDType> key_iter = thrust::device_pointer_cast(keys.dptr_);
   thrust::device_ptr<VDType> value_iter = thrust::device_pointer_cast(values.dptr_);
   if (is_ascend) {
     thrust::stable_sort_by_key(
       thrust::cuda::par.on(stream),
-      key_iter, key_iter + keys.size(0), value_iter, thrust::less<mshadow::half::half_t>());
+      key_iter.get(), key_iter.get() + (keys.size(0)), value_iter.get(), thrust::less<KDType>());
   } else {
     thrust::stable_sort_by_key(
       thrust::cuda::par.on(stream),
-      key_iter, key_iter + keys.size(0), value_iter, thrust::greater<mshadow::half::half_t>());
+      key_iter.get(), key_iter.get() + (keys.size(0)), value_iter.get(), thrust::greater<KDType>());
   }
   MSHADOW_CUDA_POST_KERNEL_CHECK(SortByKey);
 #else
-  LOG(FATAL) << "SortByKey is only supported for CUDA version >=7.0!";
+  LOG(FATAL) << "SortByKey with fp16 keys or values is only supported for CUDA version >= 7.0";
 #endif
 }
 

--- a/src/operator/tensor/sort_op-inl.cuh
+++ b/src/operator/tensor/sort_op-inl.cuh
@@ -25,7 +25,6 @@
 #ifndef MXNET_OPERATOR_TENSOR_SORT_OP_INL_CUH_
 #define MXNET_OPERATOR_TENSOR_SORT_OP_INL_CUH_
 #include <type_traits>
-#include <iterator>
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>
 #if defined(_MSC_VER) && __CUDACC_VER_MAJOR__ == 8 && __CUDACC_VER_BUILD__ != 44
@@ -116,12 +115,12 @@ SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
     thrust::device_ptr<VDType> value_iter = thrust::device_pointer_cast(values.dptr_);
     if (is_ascend) {
       thrust::stable_sort_by_key(
-        thrust::cuda::par.on(stream),
-        key_iter, std::advance(key_iter, keys.size(0)), value_iter, thrust::less<KDType>());
+        thrust::cuda::par.on(stream), key_iter,
+        key_iter + static_cast<size_t>(keys.size(0)), value_iter, thrust::less<KDType>());
     } else {
       thrust::stable_sort_by_key(
-        thrust::cuda::par.on(stream),
-        key_iter, std::advance(key_iter, keys.size(0)), value_iter, thrust::greater<KDType>());
+        thrust::cuda::par.on(stream), key_iter,
+        key_iter + static_cast<size_t>(keys.size(0)), value_iter, thrust::greater<KDType>());
     }
 #ifndef SORT_WITH_THRUST
   }
@@ -149,12 +148,12 @@ SortByKeyImpl(mshadow::Tensor<gpu, 1, KDType> keys,
   thrust::device_ptr<VDType> value_iter = thrust::device_pointer_cast(values.dptr_);
   if (is_ascend) {
     thrust::stable_sort_by_key(
-      thrust::cuda::par.on(stream),
-      key_iter, std::advance(key_iter, keys.size(0)), value_iter, thrust::less<KDType>());
+      thrust::cuda::par.on(stream), key_iter,
+      key_iter + static_cast<size_t>(keys.size(0)), value_iter, thrust::less<KDType>());
   } else {
     thrust::stable_sort_by_key(
-      thrust::cuda::par.on(stream),
-      key_iter, std::advance(key_iter, keys.size(0)), value_iter, thrust::greater<KDType>());
+      thrust::cuda::par.on(stream), key_iter,
+      key_iter + static_cast<size_t>(keys.size(0)), value_iter, thrust::greater<KDType>());
   }
   MSHADOW_CUDA_POST_KERNEL_CHECK(SortByKey);
 #else

--- a/tests/python/unittest/test_contrib_operator.py
+++ b/tests/python/unittest/test_contrib_operator.py
@@ -28,11 +28,12 @@ import unittest
 def test_box_nms_op():
     def test_box_nms_forward(data, expected, thresh=0.5, valid=0, topk=-1, coord=2, score=1, cid=0,
                          force=False, in_format='corner', out_format='corner'):
-        data = mx.nd.array(data)
-        out = mx.contrib.nd.box_nms(data, overlap_thresh=thresh, valid_thresh=valid, topk=topk,
-                                coord_start=coord, score_index=score, id_index=cid,
-                                force_suppress=force, in_format=in_format, out_format=out_format)
-        assert_almost_equal(out.asnumpy(), expected)
+        for dtype in ['float16', 'float32', 'float64']:
+            data = mx.nd.array(data, dtype=dtype)
+            out = mx.contrib.nd.box_nms(data, overlap_thresh=thresh, valid_thresh=valid, topk=topk,
+                                    coord_start=coord, score_index=score, id_index=cid,
+                                    force_suppress=force, in_format=in_format, out_format=out_format)
+            assert_almost_equal(out.asnumpy(), expected.astype(dtype), rtol=1e-3, atol=1e-3)
 
     def test_box_nms_backward(data, grad, expected, thresh=0.5, valid=0, topk=-1, coord=2, score=1,
                           cid=0, force=False, in_format='corner', out_format='corner'):
@@ -233,13 +234,13 @@ def test_box_iou_op():
 
 def test_bipartite_matching_op():
     def assert_match(inputs, x, y, threshold, is_ascend=False):
-        inputs = mx.nd.array(inputs)
-        x = np.array(x)
-        y = np.array(y)
-        a, b = mx.nd.contrib.bipartite_matching(inputs, threshold=threshold, is_ascend=is_ascend)
-        print(a, b)
-        assert_array_equal(a.asnumpy().astype('int64'), x.astype('int64'))
-        assert_array_equal(b.asnumpy().astype('int64'), y.astype('int64'))
+        for dtype in ['float16', 'float32', 'float64']:
+            inputs = mx.nd.array(inputs, dtype=dtype)
+            x = np.array(x, dtype=dtype)
+            y = np.array(y, dtype=dtype)
+            a, b = mx.nd.contrib.bipartite_matching(inputs, threshold=threshold, is_ascend=is_ascend)
+            assert_array_equal(a.asnumpy().astype('int64'), x.astype('int64'))
+            assert_array_equal(b.asnumpy().astype('int64'), y.astype('int64'))
     assert_match([[0.5, 0.6], [0.1, 0.2], [0.3, 0.4]], [1, -1, 0], [2, 0], 1e-12, False)
     assert_match([[0.5, 0.6], [0.1, 0.2], [0.3, 0.4]], [-1, 0, 1], [1, 2], 100, True)
 


### PR DESCRIPTION
## Description ##
contrib.box_nms and contrib.bipartite_matchin use floating number array to store indices which can be extremely large. 
To avoid overflow when float32/float16 is casted to integer, this PR force use int32_t in indices arrays. (the new limit is 2^31 - 1 instead of 2^k + 1 where k is the mantissa bits of float type)

- Test updated for various dtypes
- no functionality change
- no API change

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change