### PR TITLE
Do not show "needs to register block" warning for registered blocks.

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -208,26 +208,27 @@ class Block(object):
         super(Block, self).__setattr__(name, value)
 
     def _check_container_with_block(self):
-        def _find_block_in_container(data):
+        children = set(self._children.values())
+        def _find_unregistered_block_in_container(data):
             # Find whether a nested container structure contains Blocks
             if isinstance(data, (list, tuple)):
                 for ele in data:
-                    if _find_block_in_container(ele):
+                    if _find_unregistered_block_in_container(ele):
                         return True
                 return False
             elif isinstance(data, dict):
                 for _, v in data.items():
-                    if _find_block_in_container(v):
+                    if _find_unregistered_block_in_container(v):
                         return True
                 return False
             elif isinstance(data, Block):
-                return True
+                return not data in children
             else:
                 return False
         for k, v in self.__dict__.items():
             if isinstance(v, (list, tuple, dict)) and not (k.startswith('__') or k == '_children'):
-                if _find_block_in_container(v):
-                    warnings.warn('"{name}" is a container with Blocks. '
+                if _find_unregistered_block_in_container(v):
+                    warnings.warn('"{name}" is an unregistered container with Blocks. '
                                   'Note that Blocks inside the list, tuple or dict will not be '
                                   'registered automatically. Make sure to register them using '
                                   'register_child() or switching to '


### PR DESCRIPTION
## Description ##

This slightly modifies the semantics of the `_check_container_with_block` function in `block.py` in order to suppress the `"{name}" is an unregistered container with Blocks.` warning if all blocks nested inside containers are already registered.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
