### PR TITLE
[MXNET-737][WIP] Add last batch handle for imageiter

### DIFF
--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -225,7 +225,7 @@ class TestImage(unittest.TestCase):
         det_iter = val_iter.sync_label_shape(det_iter)
 
         # test file list
-        fname = './data/test_imageiter.lst'
+        fname = './data/test_imagedetiter.lst'
         im_list = [[k] + _generate_objects() + [x] for k, x in enumerate(TestImage.IMAGES)]
         with open(fname, 'w') as f:
             for line in im_list:


### PR DESCRIPTION
## Description ##

Add `last_batch_handle` parameter to ImageIter based on #11883
* `last_batch_handle` support `pad`(default), `discard`, `roll_over`

Note that reading record files(.rec) without shuffle(i.e. sequential read) didn't support 'discard'
 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
 * Add last_batch_handle feature to ImageIter and adjust test_imageiter to test last_batch_handle parameter
 * Change the shuffle behavior to the same as NDArrayIter where shuffling the data only happen during the iterator initialization

## Comments ##
N/A
@zhreshold 