### PR TITLE
[MXNET-313] Undefined names: C --> ctypes

### DIFF
--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -732,13 +732,13 @@ def _generate_op_module_signature(root_namespace, module_name, op_code_gen_func)
 
 def cint(init_val=0):
     """create a C int with an optional initial value"""
-    return C.c_int(init_val)
+    return ctypes.c_int(init_val)
 
 def int_addr(x):
     """given a c_int, return it's address as an int ptr"""
-    x_addr = C.addressof(x)
-    int_p = C.POINTER(C.c_int)
-    x_int_addr = C.cast(x_addr, int_p)
+    x_addr = ctypes.addressof(x)
+    int_p = ctypes.POINTER(ctypes.c_int)
+    x_int_addr = ctypes.cast(x_addr, int_p)
     return x_int_addr
 
 def checked_call(f, *args):


### PR DESCRIPTION
Discovered via https://github.com/apache/incubator-mxnet/issues/8270#issuecomment-412399056

This could be a copy and paste error where the source file had __import ctypes as C__ whereas this file just has __import ctypes__

@vandanavk @mkolod @KellenSunderland

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] __C__ --> __ctypes__ five times

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
