### PR TITLE
fix a minor bug in while_loop

### DIFF
--- a/python/mxnet/symbol/contrib.py
+++ b/python/mxnet/symbol/contrib.py
@@ -539,9 +539,6 @@ def while_loop(cond, func, loop_vars, max_iterations=None, name="while_loop"):
     # find symbols used in either cond_g or func_g
     input_syms, ((cond_input_locs, _), (func_input_locs, func_var_locs)) = \
         _union_inputs(cond_g, func_g)
-    for i_th, loc in enumerate(func_var_locs, 1):
-        if loc == -1:
-            raise ValueError("The %d-th loop_var doesn't involve into the computation" % i_th)
     result = symbol._internal._while_loop(
         # [cond, func_g, *input_syms]
         cond_g,

--- a/tests/python/unittest/test_contrib_control_flow.py
+++ b/tests/python/unittest/test_contrib_control_flow.py
@@ -139,6 +139,28 @@ def test_while_loop_simple_forward():
         assert result_s.asscalar() == 0
 
 
+def test_while_loop2():
+    class TestBlock(gluon.HybridBlock):
+        def __init__(self, prefix=None, params=None):
+            super(TestBlock, self).__init__(prefix=prefix, params=params)
+
+        def hybrid_forward(self, F, data):
+            def cond_func(state1, state2):
+                return state1 > 0
+            def body_func(state1, state2):
+                return (state2, [state2 + 1, state2 + 2])
+            return F.contrib.while_loop(
+                    cond=cond_func,
+                    func=body_func,
+                    loop_vars=[data, data + 1],
+                    max_iterations=10)
+
+    block = TestBlock()
+    block.initialize(ctx=default_context())
+    block.hybridize()
+    block(mx.nd.ones((1)))
+
+
 def _verify_while_loop(cond, func, loop_var_shapes, free_var_shapes, is_train, max_iterations, is_for, n_steps):
 
     def _create_vars(num, prefix):

--- a/tests/python/unittest/test_contrib_control_flow.py
+++ b/tests/python/unittest/test_contrib_control_flow.py
@@ -144,6 +144,8 @@ def test_while_loop2():
         def __init__(self, prefix=None, params=None):
             super(TestBlock, self).__init__(prefix=prefix, params=params)
 
+        # In this test, body_func only accesses one of the states,
+        # so not all loop variables are used.
         def hybrid_forward(self, F, data):
             def cond_func(state1, state2):
                 return state1 > 0


### PR DESCRIPTION
## Description ##
We don't need to make sure all loop variables are used in the loop body. Sometimes, some of the loop variables used in the condition, but not used in the body.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
