### PR TITLE
set bind flag after bind completes

### DIFF
--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -398,7 +398,6 @@ class Module(BaseModule):
 
         self.for_training = for_training
         self.inputs_need_grad = inputs_need_grad
-        self.binded = True
         self._grad_req = grad_req
 
         if not for_training:
@@ -453,6 +452,8 @@ class Module(BaseModule):
 
         if shared_module is not None and shared_module.optimizer_initialized:
             self.borrow_optimizer(shared_module)
+
+        self.binded = True
 
     def reshape(self, data_shapes, label_shapes=None):
         """Reshapes the module for new input shapes.


### PR DESCRIPTION
## Description ##
Currently the bind flag under the module API is set in the beginning of the function. However, if any of the downstream functions error out then the module will not work properly and the bound flag will still be set. If the user acknowledges the issue and attempts to rebind they are unable to. 

```
In [19]: mod.bind(data_shapes=[('data_shapes', (10))])
WARNING:root:Already bound, ignoring bind()
```

We currently have a `force_rebind` flag, however users may not realize that they need to as the above warning message indicates that the mod is already bound.

A host of problems then occurs if the user attempts to use the incorrectly bound module such as when they init_params:

```
In [20]: mod.init_params()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-20-b2c7a95a0724> in <module>()
----> 1 mod.init_params()

~/anaconda3/lib/python3.6/site-packages/mxnet/module/module.py in init_params(self, initializer, arg_params, aux_params, allow_missing, force_init, allow_extra)
    305
    306         attrs = self._symbol.attr_dict()
--> 307         for name, arr in sorted(self._arg_params.items()):
    308             desc = InitDesc(name, attrs.get(name, None))
    309             _impl(desc, arr, arg_params)

AttributeError: 'NoneType' object has no attribute 'items'
```

I moved the `bind` flag to the end so that they user will get the usual 'call bind before initializing the parameters' if the module is incorrectly bound.

Below is simple example that would bind the module incorrectly:
```
import mxnet as mx

# from docs https://mxnet.apache.org/api/python/module/module.html
data = mx.sym.Variable('data')
fc1  = mx.sym.FullyConnected(data, name='fc1', num_hidden=128)
act1 = mx.sym.Activation(fc1, name='relu1', act_type="relu")
fc2  = mx.sym.FullyConnected(act1, name='fc2', num_hidden=10)
out  = mx.sym.SoftmaxOutput(fc2, name = 'softmax')
mod = mx.mod.Module(out)

mod.bind(data_shapes=[('data', mx.nd.array([10,10]))]) # this errors
```


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] set bind flag to end of bind method


## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
