### PR TITLE
Add randn to random module

### DIFF
--- a/python/mxnet/ndarray/random.py
+++ b/python/mxnet/ndarray/random.py
@@ -152,7 +152,7 @@ def normal(loc=0, scale=1, shape=_Null, dtype=_Null, ctx=None, out=None, **kwarg
                           [loc, scale], shape, dtype, ctx, out, kwargs)
 
 
-def randn(*args, loc=0, scale=1, dtype=_Null, ctx=None, out=None, **kwargs):
+def randn(*shape, **kwargs):
     """Draw random samples from a normal (Gaussian) distribution.
 
     Samples are distributed according to a normal distribution parametrized
@@ -196,9 +196,10 @@ def randn(*args, loc=0, scale=1, dtype=_Null, ctx=None, out=None, **kwargs):
      [ 2.79666662  5.44254589]]
     <NDArray 3x2 @cpu(0)>
     """
-    shape = args
     return _random_helper(_internal._random_normal, _internal._sample_normal,
-                          [loc, scale], shape, dtype, ctx, out, kwargs)
+                          [kwargs.get('loc', 0), kwargs.get('scale', 1)], shape,
+                          kwargs.get('dtype', _Null), kwargs.get('ctx', None),
+                          kwargs.get('out', None), kwargs)
 
 
 def poisson(lam=1, shape=_Null, dtype=_Null, ctx=None, out=None, **kwargs):

--- a/python/mxnet/ndarray/random.py
+++ b/python/mxnet/ndarray/random.py
@@ -152,7 +152,7 @@ def normal(loc=0, scale=1, shape=_Null, dtype=_Null, ctx=None, out=None, **kwarg
                           [loc, scale], shape, dtype, ctx, out, kwargs)
 
 
-def randn(*shape, loc=0, scale=1, dtype=_Null, ctx=None, out=None, **kwargs):
+def randn(*shape, **kwargs):
     """Draw random samples from a normal (Gaussian) distribution.
 
     Samples are distributed according to a normal distribution parametrized
@@ -193,6 +193,11 @@ def randn(*shape, loc=0, scale=1, dtype=_Null, ctx=None, out=None, **kwargs):
     [5.357444  5.7793283 3.9896927]]
     <NDArray 2x3 @cpu(0)>
     """
+    loc=kwargs.pop('loc', 0)
+    scale=kwargs.pop('scale', 1)
+    dtype=kwargs.pop('dtype', _Null)
+    ctx=kwargs.pop('ctx', None)
+    out=kwargs.pop('out', None)
     assert isinstance(loc, (int, float))
     assert isinstance(scale, (int, float))
     return _random_helper(_internal._random_normal, _internal._sample_normal,

--- a/python/mxnet/ndarray/random.py
+++ b/python/mxnet/ndarray/random.py
@@ -188,14 +188,13 @@ def randn(*shape, loc=0, scale=1, dtype=_Null, ctx=None, out=None, **kwargs):
     [[-1.856082   -1.9768796 ]
     [-0.20801921  0.2444218 ]]
     <NDArray 2x2 @cpu(0)>
-    >>> loc = mx.nd.array([1,2,3])
-    >>> scale = mx.nd.array([2,3,4])
-    >>> mx.nd.random.normal(loc, scale, shape=2)
-    [[ 0.55912292  3.19566321]
-     [ 1.91728961  2.47706747]
-     [ 2.79666662  5.44254589]]
-    <NDArray 3x2 @cpu(0)>
+    >>> mx.nd.random.randn(2, 3, loc=5, scale=1)
+    [[4.19962   4.8311777 5.936328 ]
+    [5.357444  5.7793283 3.9896927]]
+    <NDArray 2x3 @cpu(0)>
     """
+    assert isinstance(loc, (int, float))
+    assert isinstance(scale, (int, float))
     return _random_helper(_internal._random_normal, _internal._sample_normal,
                           [loc, scale], shape, dtype, ctx, out, kwargs)
 

--- a/python/mxnet/ndarray/random.py
+++ b/python/mxnet/ndarray/random.py
@@ -152,7 +152,7 @@ def normal(loc=0, scale=1, shape=_Null, dtype=_Null, ctx=None, out=None, **kwarg
                           [loc, scale], shape, dtype, ctx, out, kwargs)
 
 
-def randn(*shape, **kwargs):
+def randn(*shape, loc=0, scale=1, shape=_Null, dtype=_Null, ctx=None, out=None, **kwargs):
     """Draw random samples from a normal (Gaussian) distribution.
 
     Samples are distributed according to a normal distribution parametrized
@@ -197,9 +197,7 @@ def randn(*shape, **kwargs):
     <NDArray 3x2 @cpu(0)>
     """
     return _random_helper(_internal._random_normal, _internal._sample_normal,
-                          [kwargs.get('loc', 0), kwargs.get('scale', 1)], shape,
-                          kwargs.get('dtype', _Null), kwargs.get('ctx', None),
-                          kwargs.get('out', None), kwargs)
+                          [loc, scale], shape, dtype, ctx, out, kwargs)
 
 
 def poisson(lam=1, shape=_Null, dtype=_Null, ctx=None, out=None, **kwargs):

--- a/python/mxnet/ndarray/random.py
+++ b/python/mxnet/ndarray/random.py
@@ -151,7 +151,7 @@ def normal(loc=0, scale=1, shape=_Null, dtype=_Null, ctx=None, out=None, **kwarg
                           [loc, scale], shape, dtype, ctx, out, kwargs)
 
 
-def randn(loc=0, scale=1, dtype=_Null, ctx=None, out=None, *args, **kwargs):
+def randn(*args, loc=0, scale=1, dtype=_Null, ctx=None, out=None, **kwargs):
     """Draw random samples from a normal (Gaussian) distribution.
 
     Samples are distributed according to a normal distribution parametrized

--- a/python/mxnet/ndarray/random.py
+++ b/python/mxnet/ndarray/random.py
@@ -23,8 +23,9 @@ from . import _internal
 from .ndarray import NDArray
 
 
-__all__ = ['uniform', 'normal', 'poisson', 'exponential', 'gamma', 'multinomial',
-           'negative_binomial', 'generalized_negative_binomial', 'shuffle']
+__all__ = ['uniform', 'normal', 'randn', 'poisson', 'exponential', 'gamma',
+           'multinomial', 'negative_binomial', 'generalized_negative_binomial',
+           'shuffle']
 
 
 def _random_helper(random, sampler, params, shape, dtype, ctx, out, kwargs):
@@ -184,11 +185,9 @@ def randn(*args, loc=0, scale=1, dtype=_Null, ctx=None, out=None, **kwargs):
     2.21220636
     <NDArray 1 @cpu(0)>
     >>> mx.nd.random.randn(2, 2)
-    [ 0.29253659]
-    <NDArray 1 @gpu(0)>
-    >>> mx.nd.random.randn(-1, 1, shape=(2,))
-    [-0.2259962  -0.51619542]
-    <NDArray 2 @cpu(0)>
+    [[-1.856082   -1.9768796 ]
+    [-0.20801921  0.2444218 ]]
+    <NDArray 2x2 @cpu(0)>
     >>> loc = mx.nd.array([1,2,3])
     >>> scale = mx.nd.array([2,3,4])
     >>> mx.nd.random.normal(loc, scale, shape=2)

--- a/python/mxnet/ndarray/random.py
+++ b/python/mxnet/ndarray/random.py
@@ -193,11 +193,11 @@ def randn(*shape, **kwargs):
     [5.357444  5.7793283 3.9896927]]
     <NDArray 2x3 @cpu(0)>
     """
-    loc=kwargs.pop('loc', 0)
-    scale=kwargs.pop('scale', 1)
-    dtype=kwargs.pop('dtype', _Null)
-    ctx=kwargs.pop('ctx', None)
-    out=kwargs.pop('out', None)
+    loc = kwargs.pop('loc', 0)
+    scale = kwargs.pop('scale', 1)
+    dtype = kwargs.pop('dtype', _Null)
+    ctx = kwargs.pop('ctx', None)
+    out = kwargs.pop('out', None)
     assert isinstance(loc, (int, float))
     assert isinstance(scale, (int, float))
     return _random_helper(_internal._random_normal, _internal._sample_normal,

--- a/python/mxnet/ndarray/random.py
+++ b/python/mxnet/ndarray/random.py
@@ -152,7 +152,7 @@ def normal(loc=0, scale=1, shape=_Null, dtype=_Null, ctx=None, out=None, **kwarg
                           [loc, scale], shape, dtype, ctx, out, kwargs)
 
 
-def randn(*shape, loc=0, scale=1, shape=_Null, dtype=_Null, ctx=None, out=None, **kwargs):
+def randn(*shape, loc=0, scale=1, dtype=_Null, ctx=None, out=None, **kwargs):
     """Draw random samples from a normal (Gaussian) distribution.
 
     Samples are distributed according to a normal distribution parametrized

--- a/python/mxnet/ndarray/random.py
+++ b/python/mxnet/ndarray/random.py
@@ -151,6 +151,57 @@ def normal(loc=0, scale=1, shape=_Null, dtype=_Null, ctx=None, out=None, **kwarg
                           [loc, scale], shape, dtype, ctx, out, kwargs)
 
 
+def randn(loc=0, scale=1, dtype=_Null, ctx=None, out=None, *args, **kwargs):
+    """Draw random samples from a normal (Gaussian) distribution.
+
+    Samples are distributed according to a normal distribution parametrized
+    by *loc* (mean) and *scale* (standard deviation).
+
+
+    Parameters
+    ----------
+    loc : float or NDArray
+        Mean (centre) of the distribution.
+    scale : float or NDArray
+        Standard deviation (spread or width) of the distribution.
+    shape : int or tuple of ints
+        The number of samples to draw. If shape is, e.g., `(m, n)` and `loc` and
+        `scale` are scalars, output shape will be `(m, n)`. If `loc` and `scale`
+        are NDArrays with shape, e.g., `(x, y)`, then output will have shape
+        `(x, y, m, n)`, where `m*n` samples are drawn for each `[loc, scale)` pair.
+    dtype : {'float16','float32', 'float64'}
+        Data type of output samples. Default is 'float32'
+    ctx : Context
+        Device context of output. Default is current context. Overridden by
+        `loc.context` when `loc` is an NDArray.
+    out : NDArray
+        Store output to an existing NDArray.
+
+
+    Examples
+    --------
+    >>> mx.nd.random.randn()
+    2.21220636
+    <NDArray 1 @cpu(0)>
+    >>> mx.nd.random.randn(2, 2)
+    [ 0.29253659]
+    <NDArray 1 @gpu(0)>
+    >>> mx.nd.random.randn(-1, 1, shape=(2,))
+    [-0.2259962  -0.51619542]
+    <NDArray 2 @cpu(0)>
+    >>> loc = mx.nd.array([1,2,3])
+    >>> scale = mx.nd.array([2,3,4])
+    >>> mx.nd.random.normal(loc, scale, shape=2)
+    [[ 0.55912292  3.19566321]
+     [ 1.91728961  2.47706747]
+     [ 2.79666662  5.44254589]]
+    <NDArray 3x2 @cpu(0)>
+    """
+    shape = args
+    return _random_helper(_internal._random_normal, _internal._sample_normal,
+                          [loc, scale], shape, dtype, ctx, out, kwargs)
+
+
 def poisson(lam=1, shape=_Null, dtype=_Null, ctx=None, out=None, **kwargs):
     """Draw random samples from a Poisson distribution.
 

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -47,7 +47,7 @@ def check_with_device(device, dtype):
         },
         {
             'name': 'randn',
-            'symbol': mx.sym.random.randn,
+            'symbol': mx.sym.random.normal,
             'ndop': mx.nd.random.randn,
             'params': { 'loc': 10.0, 'scale': 0.5 },
             'inputs': [ ('loc', 10) , ('scale', 5) ],

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -46,7 +46,7 @@ def check_with_device(device, dtype):
             ]
         },
         {
-            'name': 'normal',
+            'name': 'randn',
             'symbol': mx.sym.random.randn,
             'ndop': mx.nd.random.randn,
             'params': { 'loc': 10.0, 'scale': 0.5 },

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -50,7 +50,7 @@ def check_with_device(device, dtype):
             'symbol': mx.sym.random.randn,
             'ndop': mx.nd.random.randn,
             'params': { 'loc': 10.0, 'scale': 0.5 },
-            'inputs': [ ('loc',[ [ 0.0, 2.5 ], [ -9.75, -7.0 ] ]) , ('scale',[ [ 1.0, 3.7 ], [ 4.2, 1.5 ] ]) ],
+            'inputs': [ ('loc', 10) , ('scale', 5) ],
             'checks': [
                 ('mean', lambda x, params: np.mean(x.astype(np.float64) - params['loc']),  tol),
                 ('std',  lambda x, params: np.std(x.astype(np.float64)) - params['scale'], tol)

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -46,6 +46,17 @@ def check_with_device(device, dtype):
             ]
         },
         {
+            'name': 'normal',
+            'symbol': mx.sym.random.randn,
+            'ndop': mx.nd.random.randn,
+            'params': { 'loc': 10.0, 'scale': 0.5 },
+            'inputs': [ ('loc',[ [ 0.0, 2.5 ], [ -9.75, -7.0 ] ]) , ('scale',[ [ 1.0, 3.7 ], [ 4.2, 1.5 ] ]) ],
+            'checks': [
+                ('mean', lambda x, params: np.mean(x.astype(np.float64) - params['loc']),  tol),
+                ('std',  lambda x, params: np.std(x.astype(np.float64)) - params['scale'], tol)
+            ]
+        },
+        {
             'name': 'uniform',
             'symbol': mx.sym.random.uniform,
             'ndop': mx.nd.random.uniform,


### PR DESCRIPTION
## Description ##
Added a randn method to random module. numpy currently has support for a random tensor generator that accepts a shape and outputs with normal distribution (https://docs.scipy.org/doc/numpy/reference/generated/numpy.random.randn.html). This behavior can currently be emulated with mx.nd.random.normal(shape=(3,3)), but adding this method to mxnet will make it easier for developers who are familiar with numpy API:

```
mx.nd.random.rand(3,3)
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add `randn` method to random module

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
