### PR TITLE
Removed fixed seed for test_nadam.

### DIFF
--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -943,7 +943,7 @@ def test_ftrl():
         compare_optimizer(opt1(lazy_update=True, **kwarg), opt2(**kwarg), shape,
                           np.float32, w_stype='row_sparse', g_stype='row_sparse')
 
-@with_seed(1234)
+@with_seed()
 def test_nadam():
 
     def get_net(num_hidden, flatten=True):
@@ -965,10 +965,10 @@ def test_nadam():
     loss = Loss(output, l)
     loss = mx.sym.make_loss(loss)
     mod = mx.mod.Module(loss, data_names=('data',), label_names=('label',))
-    mod.fit(data_iter, num_epoch=60, optimizer_params={'learning_rate': 0.0005, 'wd': 0.0005},
+    mod.fit(data_iter, num_epoch=60, optimizer_params={'learning_rate': 0.001, 'wd': 0.0005},
             initializer=mx.init.Xavier(magnitude=2), eval_metric=mx.metric.Loss(),
             optimizer='nadam')
-    assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.1
+    assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.11
 
 # AdaGrad
 class PyAdaGrad(mx.optimizer.Optimizer):


### PR DESCRIPTION
## Description ##
Fix for Issue [#11736](https://github.com/apache/incubator-mxnet/issues/11736)
Removed fixed seed and increased learning rate and tolerance for test_nadam. 
by keeping tolerance rate fixed(10%) and increasing the learning rate(0.0005->0.001) the test failed once after 5500 run but ran successfully the next time for all 10k runs. Increasing the no. of epochs will increase the total time for the test hence avoided increasing the no. of epochs and increased the tolerance by 1%.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Removed Fixed seed. Doubled learning rate and increased tolerance limit for nadam test

## Comments ##
Ran Test for both CPU and GPU 10000 times.

CPU:
MXNET_TEST_COUNT=10000 nosetests --logging-level=DEBUG --verbose -s /home/ubuntu/mxnet/tests/python/unittest/test_optimizer.py:test_nadam

[DEBUG] 10000 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1479356436 to reproduce.
ok

----------------------------------------------------------------------
Ran 1 test in 16983.485s


GPU:
MXNET_TEST_COUNT=10000 nosetests --logging-level=DEBUG --verbose -s /home/ubuntu/mxnet/tests/python/gpu/test_operator_gpu.py:test_nadam

[DEBUG] 10000 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=789728632 to reproduce.
ok

----------------------------------------------------------------------
Ran 1 test in 20428.980s
