### PR TITLE
Module predict API can accept NDArray as input

### DIFF
--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -334,7 +334,7 @@ class BaseModule(object):
 
         Parameters
         ----------
-        eval_data : DataIter or NDArray or ndarray
+        eval_data : DataIter or NDArray or numpy array
             Evaluation data to run prediction on.
         num_batch : int
             Defaults to ``None``, indicates running all the batches in the data iterator.

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -371,8 +371,7 @@ class BaseModule(object):
             return self.get_outputs()[0]
 
         if not isinstance(eval_data, DataIter):
-            raise ValueError('eval_data must be of type ndarray, np.array or DataIter')
-
+            raise ValueError('eval_data must be of type NDArray or DataIter')
 
         if reset:
             eval_data.reset()

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -364,8 +364,11 @@ class BaseModule(object):
         """
         assert self.binded and self.params_initialized
 
-        if isinstance(eval_data, (ndarray.NDArray,np.ndarray)):
+        if isinstance(eval_data, ndarray.NDArray):
             return self.forward(DataBatch([eval_data]))
+
+        if isinstance(eval_data, np.ndarray):
+            return self.forward(DataBatch([ndarray.array(eval_data)]))
 
         if not isinstance(eval_data, DataIter):
             raise ValueError('eval_data must be of type ndarray, np.array or DataIter')

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -22,6 +22,7 @@
 import time
 import logging
 import warnings
+import numpy as np
 
 from .. import metric
 from .. import ndarray
@@ -29,7 +30,7 @@ from .. import ndarray
 from ..context import cpu
 from ..model import BatchEndParam
 from ..initializer import Uniform
-from ..io import DataDesc
+from ..io import DataDesc, DataIter, DataBatch
 from ..base import _as_list
 
 
@@ -362,6 +363,13 @@ class BaseModule(object):
         >>> mod.predict(eval_data=val_dataiter, num_batch=10)
         """
         assert self.binded and self.params_initialized
+
+        if isinstance(eval_data, (ndarray.NDArray,np.ndarray)):
+            return self.forward(DataBatch([eval_data]))
+
+        if not isinstance(eval_data, DataIter):
+            raise ValueError('eval_data must be of type ndarray, np.array or DataIter')
+
 
         if reset:
             eval_data.reset()

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -364,11 +364,11 @@ class BaseModule(object):
         """
         assert self.binded and self.params_initialized
 
-        if isinstance(eval_data, ndarray.NDArray):
-            return self.forward(DataBatch([eval_data]))
-
-        if isinstance(eval_data, np.ndarray):
-            return self.forward(DataBatch([ndarray.array(eval_data)]))
+        if isinstance(eval_data, (ndarray.NDArray, np.ndarray)):
+            if isinstance(eval_data, np.ndarray):
+                eval_data = ndarray.array(eval_data)
+            self.forward(DataBatch([eval_data]))
+            return self.get_outputs()[0]
 
         if not isinstance(eval_data, DataIter):
             raise ValueError('eval_data must be of type ndarray, np.array or DataIter')

--- a/python/mxnet/module/base_module.py
+++ b/python/mxnet/module/base_module.py
@@ -334,7 +334,7 @@ class BaseModule(object):
 
         Parameters
         ----------
-        eval_data : DataIter
+        eval_data : DataIter or NDArray or ndarray
             Evaluation data to run prediction on.
         num_batch : int
             Defaults to ``None``, indicates running all the batches in the data iterator.

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -584,7 +584,7 @@ class Module(BaseModule):
 
         Parameters
         ----------
-        data_batch : DataBatch
+        data_batch : DataBatch or NDArray or ndarray
             Could be anything with similar API implemented.
         is_train : bool
             Default is ``None``, which means ``is_train`` takes the value of ``self.for_training``.

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -591,12 +591,6 @@ class Module(BaseModule):
         """
         assert self.binded and self.params_initialized
 
-        if isinstance(data_batch, nd.NDArray):
-            data_batch = DataBatch([data_batch])
-
-        if isinstance(data_batch, np.ndarray):
-            data_batch = DataBatch([nd.array(data_batch)])
-
         curr_data_shapes = tuple(i.shape for i in self._data_shapes)
         if isinstance(data_batch, list):
             assert data_batch is not None, "Encountered empty data batch"

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -591,8 +591,11 @@ class Module(BaseModule):
         """
         assert self.binded and self.params_initialized
 
-        if isinstance(data_batch, (nd.NDArray, np.ndarray)):
+        if isinstance(data_batch, nd.NDArray):
             data_batch = DataBatch([data_batch])
+
+        if isinstance(data_batch, np.ndarray):
+            data_batch = DataBatch([nd.array(data_batch)])
 
         curr_data_shapes = tuple(i.shape for i in self._data_shapes)
         if isinstance(data_batch, list):

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -23,6 +23,7 @@ more `Executor` for data parallelization.
 
 import logging
 import warnings
+import numpy as np
 
 from .. import context as ctx
 from .. import optimizer as opt
@@ -32,7 +33,7 @@ from .executor_group import DataParallelExecutorGroup
 from ..model import _create_kvstore, _initialize_kvstore, _update_params, _update_params_on_kvstore
 from ..model import load_checkpoint
 from ..initializer import Uniform, InitDesc
-from ..io import DataDesc
+from ..io import DataDesc, DataBatch
 from ..ndarray import zeros
 
 from .base_module import BaseModule, _check_input_names, _parse_data_desc
@@ -589,6 +590,9 @@ class Module(BaseModule):
             Default is ``None``, which means ``is_train`` takes the value of ``self.for_training``.
         """
         assert self.binded and self.params_initialized
+
+        if isinstance(data_batch, (nd.NDArray, np.ndarray)):
+            data_batch = DataBatch([data_batch])
 
         curr_data_shapes = tuple(i.shape for i in self._data_shapes)
         if isinstance(data_batch, list):

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -584,7 +584,7 @@ class Module(BaseModule):
 
         Parameters
         ----------
-        data_batch : DataBatch or NDArray or ndarray
+        data_batch : DataBatch
             Could be anything with similar API implemented.
         is_train : bool
             Default is ``None``, which means ``is_train`` takes the value of ``self.for_training``.

--- a/python/mxnet/module/module.py
+++ b/python/mxnet/module/module.py
@@ -23,7 +23,6 @@ more `Executor` for data parallelization.
 
 import logging
 import warnings
-import numpy as np
 
 from .. import context as ctx
 from .. import optimizer as opt
@@ -33,7 +32,7 @@ from .executor_group import DataParallelExecutorGroup
 from ..model import _create_kvstore, _initialize_kvstore, _update_params, _update_params_on_kvstore
 from ..model import load_checkpoint
 from ..initializer import Uniform, InitDesc
-from ..io import DataDesc, DataBatch
+from ..io import DataDesc
 from ..ndarray import zeros
 
 from .base_module import BaseModule, _check_input_names, _parse_data_desc

--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -772,6 +772,8 @@ def test_forward_reshape():
              for_training=False, force_rebind=True)
     assert mod.predict(pred_dataiter).shape == tuple([10, num_class])
 
+@with_seed()
+def test_forward_types():
     #Test forward with other data batch API
     Batch = namedtuple('Batch', ['data'])
     data = mx.sym.Variable('data')

--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -795,11 +795,9 @@ def test_forward_types():
     mod.bind(data_shapes=[('data', (1, 10))])
     mod.init_params()
     data1 = mx.nd.ones((1, 10))
-    result = mod.forward(data1)
-    assert result.shape == (1, 10)
+    assert mod.predict(data1).shape == (1, 10)
     data2 = np.ones((1, 10))
-    result = mod.forward(data2)
-    assert result.shape == (1, 10)
+    assert mod.predict(data1).shape == (1, 10)
 
 
 

--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -786,6 +786,20 @@ def test_forward_reshape():
     mod.forward(Batch(data2))
     assert mod.get_outputs()[0].shape == (3, 5)
 
+    #Test forward with other NDArray and np.ndarray inputs
+    data = mx.sym.Variable('data')
+    out = data * 2
+    mod = mx.mod.Module(symbol=out, label_names=None)
+    mod.bind(data_shapes=[('data', (1, 10))])
+    mod.init_params()
+    data1 = mx.nd.ones((1, 10))
+    result = mod.forward(data1)
+    assert result.shape == (1, 10)
+    data2 = np.ones((1, 10))
+    result = mod.forward(data2)
+    assert result.shape == (1, 10)
+
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
Currently the module API can only accept DataIter as an input type. However, for developers who wish to quickly try out the module api (build a sym and then bind to a module), the predict API is one of the quickest ways to check if their network produces valid outputs. The developer may not want to learn to use the DataIter API and it is intuitive for the developer to think they can pass an NDArray or np.array as an input the predict  API. 

Additionally, I added an Exception that will warn developers if they use an incorrect input type (currently they run into a runtime exception if the input type does not have a `.data` method.

Currently:
```
In [1]: import mxnet as mx
   ...: import numpy as np
   ...:
   ...: # from docs https://mxnet.apache.org/api/python/module/module.html
   ...: data = mx.sym.Variable('data')
   ...: fc1  = mx.sym.FullyConnected(data, name='fc1', num_hidden=128)
   ...: out  = mx.sym.SoftmaxOutput(fc1, name = 'softmax')
   ...: mod = mx.mod.Module(out)
   ...:
   ...: mod.bind(data_shapes=[('data', [10,10])]) # this errors
   ...: mod.init_params()
   ...:
   ...: data = np.random.rand(10,10)
   ...: mod.predict(data)
   ...:
/Users/alexzai/anaconda3/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters
/Users/alexzai/anaconda3/lib/python3.6/site-packages/mxnet/module/base_module.py:66: UserWarning: Data provided by label_shapes don't match names specified by label_names ([] vs. ['softmax_label'])
  warnings.warn(msg)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-1-3fcda8d7d4fa> in <module>()
     12
     13 data = np.random.rand(10,10)
---> 14 mod.predict(data)

~/anaconda3/lib/python3.6/site-packages/mxnet/module/base_module.py in predict(self, eval_data, num_batch, merge_batches, reset, always_output_list, sparse_row_id_fn)
    361
    362         if reset:
--> 363             eval_data.reset()
    364
    365         output_list = []

AttributeError: 'numpy.ndarray' object has no attribute 'reset'
```

After change:
```
import mxnet as mx
import numpy as np

# from docs https://mxnet.apache.org/api/python/module/module.html
data = mx.sym.Variable('data')
fc1  = mx.sym.FullyConnected(data, name='fc1', num_hidden=128)
out  = mx.sym.SoftmaxOutput(fc1, name = 'softmax')
mod = mx.mod.Module(out)

mod.bind(data_shapes=[('data', [10,10])]) # this errors
mod.init_params()

data = np.random.rand(10,10)
result = mod.predict(data)
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Module.predict API can accept ndarray / np.array as input
- [x] Add exception for invalid input types

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
