### PR TITLE
Apache RAT check readme updated

### DIFF
--- a/tests/nightly/apache_rat_license_check/README.md
+++ b/tests/nightly/apache_rat_license_check/README.md
@@ -14,7 +14,7 @@ The following commands can be used to run a Apache RAT check locally -
 
 Docker based 1-click-method:
 ```
-ci/build.py --platform ubuntu_rat /work/runtime_functions.sh nightly_test_rat_check
+ci/build.py -p ubuntu_rat nightly_test_rat_check
 ```
 
 Manual method:
@@ -25,8 +25,8 @@ sudo apt-get install maven -y #>/dev/null
 #install svn
 sudo apt-get install subversion -y #>/dev/null
 
-#download RAT
-svn co http://svn.apache.org/repos/asf/creadur/rat/trunk/ #>/dev/null
+#download RAT 0.12 version
+svn co http://svn.apache.org/repos/asf/creadur/rat/tags/apache-rat-project-0.12-RC3/ #>/dev/null
 
 #cd into correct directory
 cd trunk
@@ -38,5 +38,5 @@ mvn install #>/dev/null
 cd apache-rat/target
 
 #run Apache RAT check on the src
-java -jar apache-rat-0.13-SNAPSHOT.jar -E <path-to-.rat-excludes-file> -d <path-to-mxnet-source>
+java -jar apache-rat-0.12.jar -E <path-to-.rat-excludes-file> -d <path-to-mxnet-source>
 ```


### PR DESCRIPTION
## Description ##
The readme was outdated and had references to RAT 0.13 version which is currently broken. 
https://github.com/apache/incubator-mxnet/pull/12148

@larroy @marcoabreu @sandeep-krishnamurthy 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change