### PR TITLE
MXPredReshape bug: need to reshape softmax_label

### DIFF
--- a/src/c_api/c_predict_api.cc
+++ b/src/c_api/c_predict_api.cc
@@ -304,7 +304,8 @@ int MXPredReshape(mx_uint num_input_nodes,
   for (size_t i=0; i < arg_names.size(); ++i) {
     TShape newShape = arg_shapes[i];
     NDArray &arr = p->arg_arrays[i];
-    if (new_shape.count(arg_names[i]) != 0) {
+    if (new_shape.count(arg_names[i]) != 0 ||
+        strcmp("softmax_label", arg_names[i].c_str()) == 0) {
       ret->arg_arrays[i].ReshapeAndAlloc(newShape);
     } else {
        CHECK_EQ(newShape.Size(), arr.shape().Size())


### PR DESCRIPTION
## Description ##

The fix in #11493 allows reshape only for networks that don't use SoftmaxOutput, so none of the pretrained image classification networks, e.g. inception, can be reshaped. The current test did not catch this because it only used gluon blocks. The reason SoftmaxOutput is weird is because it requires the label "softmax_label" to be reshaped even though "softmax_label" is only used as an input for training and should not even be looked at for prediction, [which has been mentioned in other context before](https://stackoverflow.com/questions/44947104/mxnet-label-shapes-dont-match-names-specified-by-label-names). I don't know what's the best way to deal with SoftmaxOutput's label reshape requirement because I can't find a way to get the label names. I am sending this pull request with an edit that allows resnet and inception to be reshaped, along with a test that covers this edge case, but I hope someone can comment on a more robust solution.

I found this issue when I made the following edits to [image-classification-predict.cc:223](https://github.com/apache/incubator-mxnet/blob/master/example/image-classification/predict-cpp/image-classification-predict.cc#L223). Before this change, the following would print out -1 and I traced it to `c_predict_api.cc:304` where `newShape.Size() != arr.shape().Size()` for when `arg_names[I]` is `softmax_label`: 
```c++
  // Create Predictor
  PredictorHandle old_hnd = nullptr;
  const mx_uint old_input_shape_data[4] = { 2,
                                        static_cast<mx_uint>(channels),
                                        static_cast<mx_uint>(height),
                                        static_cast<mx_uint>(width) };
  MXPredCreate(static_cast<const char*>(json_data.GetBuffer()),
               static_cast<const char*>(param_data.GetBuffer()),
               static_cast<int>(param_data.GetLength()),
               dev_type,
               dev_id,
               num_input_nodes,
               input_keys,
               input_shape_indptr,
               old_input_shape_data,
               &old_hnd);
  assert(old_hnd);

  int e = MXPredReshape(num_input_nodes,
                        input_keys,
                        input_shape_indptr,
                        input_shape_data,
                        old_hnd,
                        &pred_hnd);
  printf("%d\n", e);
```


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change