### PR TITLE
fix flasky unittest for deformable psroi pooling

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5071,7 +5071,7 @@ def test_deformable_psroipooling():
                     # By now we only have gpu implementation
                     if default_context().device_type == 'gpu':
                         check_numeric_gradient(op, [im_data, rois_data, offset_data], rtol=rtol, atol=atol,
-                                               grad_nodes=grad_nodes, ctx=mx.gpu(1))
+                                               grad_nodes=grad_nodes, ctx=mx.gpu(0))
 
 
 # Helper functions for test_laop


### PR DESCRIPTION
## Description ##
This PR aims to fix the problem raised by issue #11713. 

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
The deformable ps roi pooling operator includes several corner cases which the function is not differentiable. Therefore during the unittest, we need to add some check to ensure the input values are within the smooth regions.

## Comments ##
The issue and solution are discussed with @ankkhedia, @sandeep-krishnamurthy, @YuwenXiong and the fix is ran by @ankkhedia for about 2500 times on his local machine.

@ankkhedia could you help review it?