### PR TITLE
Fix a bug in CachedOP.

### DIFF
--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -824,10 +824,9 @@ OpStatePtr CachedOp::DynamicForward(
   // If CachedOp is running in the inline mode, it uses RunGraph to record
   // computation; otherwise, CachedOp records computation itself.
   // So if it's not the inline mode, we disable recording.
-  if (recording && !inlining_) recording = false;
   RunGraph(false, idx, arrays, 0, idx.num_nodes(), std::move(array_reqs),
            std::move(ref_count), &states, dispatch_modes,
-           recording);
+           recording && inlining_);
 
   return op_state;
 }


### PR DESCRIPTION
## Description ##
As reported in https://github.com/apache/incubator-mxnet/issues/12116, the modification in https://github.com/apache/incubator-mxnet/pull/11951 causes excessive memory consumption. The reason is that https://github.com/apache/incubator-mxnet/pull/11951 actually turns on recording even in the inference mode.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
