### PR TITLE
Make sure input symbol names are unique in control flow operators.

### DIFF
--- a/python/mxnet/symbol/contrib.py
+++ b/python/mxnet/symbol/contrib.py
@@ -195,7 +195,7 @@ def _construct_subgraph(sym_out, sym_states, name):
 
     for s in sym_states:
         if s.name in all_input_names or s.name in output_names or \
-                s.list_attr().get("__subgraph_name__", "") != name:
+           s.list_attr().get("__subgraph_name__", "") != name:
             flat_out.append(symbol.op.identity(s))
         else:
             flat_out.append(s)

--- a/python/mxnet/symbol/contrib.py
+++ b/python/mxnet/symbol/contrib.py
@@ -135,6 +135,9 @@ def _regroup(args, fmt):
     return ret, args
 
 
+# We want to generate a unique name for input symbols to a control flow
+# operator. The names are generated on purpose differently from the symbols
+# cut from the graph.
 def _get_sym_uniq_name(sym):
     return sym.name + "-" + sym.attr("_value_index")
 
@@ -319,6 +322,8 @@ def foreach(body, data, init_states, name="foreach"):
     cut_var_names = cut_var_map.keys()
 
     subg_input_names = g.list_inputs()
+    assert len(set(subg_input_names)) == len(subg_input_names), \
+            "The inputs of the subgraph don't have unique names: " + str(subg_input_names)
     # ordered_ins contains input symbols in the following order:
     # data_syms, state_syms, followed by cut_vars and vars in the closure.
     ordered_ins = [x for x in flatten_data]
@@ -530,7 +535,10 @@ def while_loop(cond, func, loop_vars, max_iterations=None, name="while_loop"):
             # collect arguments for each subgraph
             input_locs = []                         # results from the second step
             var_locs = [-1] * len(flatten_loop_vars)        # results from the third step
-            for name in graph.list_inputs():
+            subg_input_names = graph.list_inputs()
+            assert len(set(subg_input_names)) == len(subg_input_names), \
+                    "The inputs of the subgraph don't have unique names: " + str(subg_input_names)
+            for name in subg_input_names:
                 assert name in name_to_input_syms   # it should obviously hold
                 # name -> sym
                 if name in name_to_loop_vars:

--- a/python/mxnet/symbol/contrib.py
+++ b/python/mxnet/symbol/contrib.py
@@ -139,7 +139,7 @@ def _regroup(args, fmt):
 # operator. The names are generated on purpose differently from the symbols
 # cut from the graph.
 def _get_sym_uniq_name(sym):
-    return sym.name + "-" + sym.attr("_value_index")
+    return '{}-{}'.format(sym.name, sym.attr('_value_index'))
 
 def _get_graph_inputs(subg):
     num_handles = ctypes.c_int(0)

--- a/python/mxnet/symbol/contrib.py
+++ b/python/mxnet/symbol/contrib.py
@@ -30,7 +30,7 @@ except ImportError:
     pass
 
 from . import symbol
-from ..base import _LIB, check_call, py_str
+from ..base import _LIB, check_call
 from ..base import SymbolHandle, _as_list
 from ..attribute import AttrScope
 

--- a/python/mxnet/symbol/contrib.py
+++ b/python/mxnet/symbol/contrib.py
@@ -486,7 +486,7 @@ def while_loop(cond, func, loop_vars, max_iterations=None, name="while_loop"):
             # create new variables with the same name,
             # them feed them to the given func
             graph_vars, var_fmt = _flatten(graph_vars, "while loop_vars")
-            new_graph_vars = [symbol.var(sym.name) for sym in graph_vars]
+            new_graph_vars = [symbol.var(_get_sym_uniq_name(sym)) for sym in graph_vars]
             new_graph_vars, _ = _regroup(new_graph_vars, var_fmt)
             outputs, final_state, out_fmt, var_fmt = graph_func(new_graph_vars)
             # first `num_out_data` elements belong to `outputs`
@@ -520,13 +520,13 @@ def while_loop(cond, func, loop_vars, max_iterations=None, name="while_loop"):
                                 # to a `loc`, where inputs[loc] = sym
         for graph in graphs:
             # some loop_vars are inputs to `graph`, some are not
-            name_to_loop_vars = {sym.name: sym for sym in flatten_loop_vars}
+            name_to_loop_vars = {_get_sym_uniq_name(sym): sym for sym in flatten_loop_vars}
             # other inputs to `graph` created by cut_graph
             name_to_cut_g_syms = {sym.list_outputs()[0]: sym for sym in _cut_subgraph(graph)}
             # input_syms: all inputs to the `graph`
             name_to_input_syms = {sym.name: sym for sym in _get_graph_inputs(graph)}
             # also we collect the mapping from var's name to var's loc in loop_vars
-            name_to_var_locs = {sym.name: i for i, sym in enumerate(flatten_loop_vars)}
+            name_to_var_locs = {_get_sym_uniq_name(sym): i for i, sym in enumerate(flatten_loop_vars)}
             # collect arguments for each subgraph
             input_locs = []                         # results from the second step
             var_locs = [-1] * len(flatten_loop_vars)        # results from the third step

--- a/tests/python/unittest/test_contrib_control_flow.py
+++ b/tests/python/unittest/test_contrib_control_flow.py
@@ -1730,7 +1730,7 @@ def test_uniq_name():
                 return data + 1, states
             out1, states1 = F.contrib.foreach(step1, inputs, states)
             def step2(data, states):
-                return data, states[0] + states1[0] + F.squeeze(out1.slice_axis(axis=0, begin=0, end=1))
+                return data, [states[0] + states1[0] + F.squeeze(out1.slice_axis(axis=0, begin=0, end=1))]
             # The input variables have the same symbol names.
             # The free variables have the same symbol names as the input variables.
             out, states = F.contrib.foreach(step2, out1, states1)
@@ -1750,7 +1750,7 @@ def test_uniq_name():
             out1, states1 = F.contrib.while_loop(cond, step, states, max_iterations=5)
             # The input variables have the same symbol name.
             out, states = F.contrib.while_loop(cond, step, states1, max_iterations=5)
-            return out[0]
+            return out
 
     class WhileLayer2(gluon.HybridBlock):
         def __init__(self, prefix=None, params=None):
@@ -1768,7 +1768,7 @@ def test_uniq_name():
                 return state1 + 1, [state1 + states1[0], state2 + states1[1]]
             # The input variables have the same symbol name.
             out, states = F.contrib.while_loop(cond, step2, states1, max_iterations=5)
-            return out[0]
+            return out
 
     TestLayers = [ForeachLayer1, ForeachLayer2,
             WhileLayer1, WhileLayer2]
@@ -1776,7 +1776,6 @@ def test_uniq_name():
     data = mx.nd.normal(loc=0, scale=1, shape=(2, 5))
     states = mx.nd.normal(loc=0, scale=1, shape=(5))
     for TestLayer in TestLayers:
-        print(TestLayer)
         layer = TestLayer()
         layer.initialize(ctx=default_context())
         res1 = layer(data, [states])

--- a/tests/python/unittest/test_contrib_control_flow.py
+++ b/tests/python/unittest/test_contrib_control_flow.py
@@ -1742,7 +1742,8 @@ def test_uniq_name():
 
         def hybrid_forward(self, F, inputs, states):
             def cond(state1, state2):
-                return F.squeeze(state1.slice_axis(axis=0, begin=0, end=1)) != 0
+                s = F.squeeze(state1.slice_axis(axis=0, begin=0, end=1))
+                return s == s
             def step(state1, state2):
                 return state1 + 1, [state1, state2]
             states = [states[0], states[0] + 1]
@@ -1757,7 +1758,8 @@ def test_uniq_name():
 
         def hybrid_forward(self, F, inputs, states):
             def cond(state1, state2):
-                return F.squeeze(state1.slice_axis(axis=0, begin=0, end=1)) != 0
+                s = F.squeeze(state1.slice_axis(axis=0, begin=0, end=1))
+                return s == s
             def step1(state1, state2):
                 return state1 + 1, [state1, state2]
             states = [states[0], states[0] + 1]


### PR DESCRIPTION
## Description ##
This is to fix the issue described in
https://github.com/apache/incubator-mxnet/issues/12163

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
