### PR TITLE
[MXNET-696] Simplify the logic behind the reload(mxnet) test

### DIFF
--- a/tests/python/unittest/test_engine_import.py
+++ b/tests/python/unittest/test_engine_import.py
@@ -33,7 +33,7 @@ def test_engine_import():
             os.environ['MXNET_ENGINE_TYPE'] = type
         else:
             os.environ.pop('MXNET_ENGINE_TYPE', None)
-        reload(mxnet) 
+        reload(mxnet)
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_engine_import.py
+++ b/tests/python/unittest/test_engine_import.py
@@ -16,29 +16,24 @@
 # under the License.
 
 import os
-import sys
+
+try:
+    reload         # Python 2
+except NameError:  # Python 3
+    from importlib import reload
 
 
 def test_engine_import():
     import mxnet
-    def test_import():
-        version = sys.version_info
-        if version >= (3, 4):
-            import importlib
-            importlib.reload(mxnet)
-        elif version >= (3, ):
-            import imp
-            imp.reload(mxnet)
-        else:
-            reload(mxnet)
+        
     engine_types = ['', 'NaiveEngine', 'ThreadedEngine', 'ThreadedEnginePerDevice']
 
     for type in engine_types:
-        if not type:
-            os.environ.pop('MXNET_ENGINE_TYPE', None)
-        else:
+        if type:
             os.environ['MXNET_ENGINE_TYPE'] = type
-        test_import()
+        else:
+            os.environ.pop('MXNET_ENGINE_TYPE', None)
+        reload(mxnet)
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_engine_import.py
+++ b/tests/python/unittest/test_engine_import.py
@@ -33,7 +33,7 @@ def test_engine_import():
             os.environ['MXNET_ENGINE_TYPE'] = type
         else:
             os.environ.pop('MXNET_ENGINE_TYPE', None)
-        reload(mxnet)
+        reload(mxnet) 
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
Simplify the logic behind the reload(mxnet) test

Implements Python porting best practice [__use feature detection instead of version detection__](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).

[flake8](http://flake8.pycqa.org) testing of https://github.com/apache/incubator-mxnet on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./tests/python/unittest/test_engine_import.py:33:13: F821 undefined name 'reload'
            reload(mxnet)
            ^
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Simplify the logic behind the reload(mxnet) test

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
