### PR TITLE
Drop dmlc-core commits that break MXNet build

### DIFF
--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -309,7 +309,6 @@ def test_DataBatch():
         'DataBatch: data shapes: \[\(2L?, 3L?\), \(7L?, 8L?\)\] label shapes: \[\(4L?, 5L?\)\]', str(batch)))
 
 
-@unittest.skip("Broken test: https://github.com/apache/incubator-mxnet/issues/12139")
 def test_CSVIter():
     def check_CSVIter_synthetic(dtype='float32'):
         cwd = os.getcwd()


### PR DESCRIPTION
## Description ##
Partially reverts apache/incubator-mxnet#12129 by dropping commits dmlc/dmlc-core#409 and dmlc/dmlc-core#399.

These commits by themselves are fine, but they tigger double free memory error inside CSVIter. In #12139, the CSVIter test crashed on CentOS. The memory error has been inside CSVIter but remained undetected until dmlc/dmlc-core#409 and dmlc/dmlc-core#399 were added. See [address_sanitizer_log.txt](https://github.com/apache/incubator-mxnet/files/2291834/address_sanitizer_log.txt) for a detailed log of double-free error.

Note that the dmlc-core submodule will now track the `mxnet-stable` branch of dmlc/dmlc-core.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Revert dmlc-core to last working point
- [x] Selectively add dmlc-core commits so that the double-free memory error in CSVIter is not triggered
- [x] Enabled the disabled test test_CSVIter (disabled in #12139)

## Comments ##
- This is a temporary measure. We'll need to come back to CSVIter and address memory error. Address Sanitizer reveals double free issues in CSVIter.
