### PR TITLE
[MXNET-696] Define cmp() in Python 3 for line 222

### DIFF
--- a/tests/nightly/model_backwards_compatibility_check/common.py
+++ b/tests/nightly/model_backwards_compatibility_check/common.py
@@ -32,6 +32,7 @@ from mxnet.test_utils import assert_almost_equal
 try:
     cmp             # Python 2
 except NameError:
+    # See: https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
     def cmp(x, y):  # Python 3
         return (x > y) - (x < y)
 

--- a/tests/nightly/model_backwards_compatibility_check/common.py
+++ b/tests/nightly/model_backwards_compatibility_check/common.py
@@ -30,7 +30,7 @@ import re
 from mxnet.test_utils import assert_almost_equal
 
 try:
-    cmp             # Python 2 
+    cmp             # Python 2
 except NameError:
     # See: https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
     def cmp(x, y):  # Python 3

--- a/tests/nightly/model_backwards_compatibility_check/common.py
+++ b/tests/nightly/model_backwards_compatibility_check/common.py
@@ -30,7 +30,7 @@ import re
 from mxnet.test_utils import assert_almost_equal
 
 try:
-    cmp             # Python 2
+    cmp             # Python 2 
 except NameError:
     # See: https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
     def cmp(x, y):  # Python 3

--- a/tests/nightly/model_backwards_compatibility_check/common.py
+++ b/tests/nightly/model_backwards_compatibility_check/common.py
@@ -29,6 +29,12 @@ from mxnet.gluon import nn
 import re
 from mxnet.test_utils import assert_almost_equal
 
+try:
+    cmp             # Python 2
+except NameError:
+    def cmp(x, y):  # Python 3
+        return (x > y) - (x < y)
+
 # Set fixed random seeds.
 mx.random.seed(7)
 np.random.seed(7)


### PR DESCRIPTION
[__cmp()__ was removed in Python 3](https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons) so this PR recreates it if required leveraging the formula at http://python-future.org/compatible_idioms.html#cmp

## Description ##
Define cmp() in Python 3

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Define cmp() in Python 3

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
