### PR TITLE
Fix flaky tests in control flow

### DIFF
--- a/tests/python/unittest/test_contrib_control_flow.py
+++ b/tests/python/unittest/test_contrib_control_flow.py
@@ -237,11 +237,11 @@ def _verify_while_loop(cond, func, loop_var_shapes, free_var_shapes, is_train, m
     for imp_out, sym_out in zip(imp_outs, sym_outs):
         if imp_out is None or sym_out is None:
             continue
-        assert_almost_equal(imp_out, sym_out, rtol=1e-4, atol=1e-4)
+        assert_almost_equal(imp_out, sym_out, rtol=1e-3, atol=1e-3)
     for imp_grad, sym_grad in zip(imp_grads, sym_grads):
         if imp_grad is None or sym_grad is None:
             continue
-        assert_almost_equal(imp_grad, sym_grad, rtol=1e-4, atol=1e-4)
+        assert_almost_equal(imp_grad, sym_grad, rtol=1e-3, atol=1e-3)
 
 
 @with_seed()
@@ -888,9 +888,9 @@ def test_while_loop_nested():
         assert len(imp_out) == len(sym_out)
         assert len(imp_grad) == len(sym_grad)
         for x, y in zip(imp_out, sym_out):
-            assert_almost_equal(x, y, rtol=1e-4, atol=1e-4)
+            assert_almost_equal(x, y, rtol=1e-3, atol=1e-3)
         for x, y in zip(imp_grad, sym_grad):
-            assert_almost_equal(x, y, rtol=1e-4, atol=1e-4)
+            assert_almost_equal(x, y, rtol=1e-3, atol=1e-3)
 
 
 @with_seed()
@@ -966,14 +966,14 @@ def test_while_loop_rnn():
             for x, y in zip(e_1.outputs, e_2.outputs):
                 x = x.asnumpy()
                 y = y.asnumpy()
-                assert_almost_equal(x, y, rtol=1e-4, atol=1e-4)
+                assert_almost_equal(x, y, rtol=1e-3, atol=1e-3)
             grad_keys = list(e_2.grad_dict.keys())
             e_1_grad = [e_1.grad_dict[x] for x in grad_keys]
             e_2_grad = [e_2.grad_dict[x] for x in grad_keys]
             for x, y in zip(e_1_grad, e_2_grad):
                 x = x.asnumpy()
                 y = y.asnumpy()
-                assert_almost_equal(x, y, rtol=1e-4, atol=1e-4)
+                assert_almost_equal(x, y, rtol=1e-3, atol=1e-3)
 
 def _verify_cond(cond_func, then_func, else_func, input_var_shapes, free_var_shapes, is_train):
 
@@ -1053,11 +1053,11 @@ def _verify_cond(cond_func, then_func, else_func, input_var_shapes, free_var_sha
     for imp_out, sym_out in zip(imp_outs, sym_outs):
         if imp_out is None or sym_out is None:
             continue
-        assert_almost_equal(imp_out, sym_out, rtol=1e-5, atol=1e-5)
+        assert_almost_equal(imp_out, sym_out, rtol=1e-3, atol=1e-3)
     for imp_grad, sym_grad in zip(imp_grads, sym_grads):
         if imp_grad is None or sym_grad is None:
             continue
-        assert_almost_equal(imp_grad, sym_grad, rtol=1e-5, atol=1e-5)
+        assert_almost_equal(imp_grad, sym_grad, rtol=1e-3, atol=1e-3)
 
 
 @with_seed()
@@ -1174,7 +1174,7 @@ def check_contrib_rnn(cell_type, num_states):
         trainer = gluon.Trainer(params2, 'sgd', {'learning_rate' : 0.03})
         with mx.autograd.record():
             res2 = layer(rnn_data, states)
-        assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=0.001, atol=0.0001)
+        assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=1e-3, atol=1e-3)
         res2.backward()
         trainer.step(batch_size)
 
@@ -1182,7 +1182,7 @@ def check_contrib_rnn(cell_type, num_states):
             weight1 = val.data()
             weight2 = params2[key].data()
             assert_almost_equal(weight1.asnumpy(), weight2.asnumpy(),
-                    rtol=0.001, atol=0.0001)
+                    rtol=1e-3, atol=1e-3)
 
 
 @with_seed()
@@ -1294,7 +1294,7 @@ def test_foreach():
         for i in range(len(outs)):
             assert e.outputs[i].shape == outs[i].shape
             assert_almost_equal(e.outputs[i].asnumpy(), outs[i].asnumpy(),
-                    rtol=0.001, atol=0.0001)
+                    rtol=1e-3, atol=1e-3)
         if (is_train):
             all_ins = _as_list(in_arrs)[:]
             all_ins.extend(init_states)
@@ -1303,7 +1303,7 @@ def test_foreach():
             for i in range(size):
                 assert_almost_equal(all_ins[i].grad.asnumpy(),
                         e.grad_arrays[i].asnumpy(),
-                        rtol=0.001, atol=0.0001)
+                        rtol=1e-3, atol=1e-3)
 
     # Test cases:
     # * graph inputs are stored in different orders.
@@ -1559,11 +1559,11 @@ def test_foreach_nested():
         assert isinstance(states, list)
         assert len(states) == 1
         res = mx.nd.broadcast_add(out, states[0])
-    assert_almost_equal(res.asnumpy(), e.outputs[0].asnumpy(), rtol=0.001, atol=0.0001)
+    assert_almost_equal(res.asnumpy(), e.outputs[0].asnumpy(), rtol=1e-3, atol=1e-3)
 
     res.backward(out_grads[0])
-    assert_almost_equal(data.grad.asnumpy(), data_grad.asnumpy())
-    assert_almost_equal(state.grad.asnumpy(), state_grad.asnumpy())
+    assert_almost_equal(data.grad.asnumpy(), data_grad.asnumpy(), rtol=1e-3, atol=1e-3)
+    assert_almost_equal(state.grad.asnumpy(), state_grad.asnumpy(), rtol=1e-3, atol=1e-3)
 
 
 def check_foreach_rnn(cell_type, num_states):
@@ -1649,12 +1649,12 @@ def check_foreach_rnn(cell_type, num_states):
 
         for i in range(len(outputs2)):
             assert_almost_equal(outputs1[i].asnumpy(), outputs2[i].asnumpy(),
-                    rtol=0.001, atol=0.0001)
+                    rtol=1e-3, atol=1e-3)
         input_names = out.list_inputs()
         for i in range(len(e1.grad_arrays)):
             name = input_names[i]
             assert_almost_equal(args_grad1[name].asnumpy(), args_grad2[name].asnumpy(),
-                    rtol=0.001, atol=0.0001)
+                    rtol=1e-3, atol=1e-3)
 
 
 @with_seed()
@@ -1696,7 +1696,7 @@ def test_cut_subgraph_foreach():
 
     with mx.autograd.record():
         res2 = layer(data, [states])
-    assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=0.001, atol=0.0001)
+    assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=1e-3, atol=1e-3)
 
 
 @with_seed()
@@ -1730,7 +1730,7 @@ def test_cut_subgraph_while_loop():
     res2 = layer(data)
     with mx.autograd.record():
         res2 = layer(data)
-    assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=0.001, atol=0.0001)
+    assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=1e-3, atol=1e-3)
 
 
 @with_seed()
@@ -1762,7 +1762,7 @@ def test_cut_subgraph_cond():
     res2 = layer(data)
     with mx.autograd.record():
         res2 = layer(data)
-    assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=0.001, atol=0.0001)
+    assert_almost_equal(res1.asnumpy(), res2.asnumpy(), rtol=1e-3, atol=1e-3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
Fix flaky tests present in #12112 .

(I think it is a very tiny change, so do not have to add a JIRA-ID.)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Increase threshold to 1e-3.

## Comments ##
- At the time of writing control flow operators, `CachedOp` could not behave properly when using `+` a lot, especially at the last step (This weird thing is fixed later). So we decided to use `*` a lot, which could potentially harm numeral stability a lot. So in this PR, I increase the threshold to 1e-3.
