### PR TITLE
bump timeout on Jenkins for docs/website to 120 min

### DIFF
--- a/docs/Jenkinsfile
+++ b/docs/Jenkinsfile
@@ -21,7 +21,7 @@
 // See documents at https://jenkins.io/doc/book/pipeline/jenkinsfile/
 
 // timeout in minutes
-max_time = 60
+max_time = 120
 
 node('restricted-mxnetlinux-cpu') {
   // Loading the utilities requires a node context unfortunately

--- a/docs/Jenkinsfile-dev
+++ b/docs/Jenkinsfile-dev
@@ -21,7 +21,7 @@
 // See documents at https://jenkins.io/doc/book/pipeline/jenkinsfile/
 
 // timeout in minutes
-max_time = 60
+max_time = 120
 
 node('mxnetlinux-cpu') {
   // Loading the utilities requires a node context unfortunately

--- a/docs/settings.ini
+++ b/docs/settings.ini
@@ -13,7 +13,19 @@ doxygen_docs = 1
 r_docs = 0
 scala_docs = 1
 
+[document_sets_v1.2.0]
+clojure_docs = 1
+doxygen_docs = 1
+r_docs = 0
+scala_docs = 1
+
 [document_sets_1.1.0]
+clojure_docs = 0
+doxygen_docs = 1
+r_docs = 0
+scala_docs = 0
+
+[document_sets_v1.1.0]
 clojure_docs = 0
 doxygen_docs = 1
 r_docs = 0
@@ -25,13 +37,31 @@ doxygen_docs = 1
 r_docs = 0
 scala_docs = 0
 
+[document_sets_v1.0.0]
+clojure_docs = 0
+doxygen_docs = 1
+r_docs = 0
+scala_docs = 0
+
 [document_sets_0.12.0]
 clojure_docs = 0
 doxygen_docs = 1
 r_docs = 0
 scala_docs = 0
 
+[document_sets_v0.12.0]
+clojure_docs = 0
+doxygen_docs = 1
+r_docs = 0
+scala_docs = 0
+
 [document_sets_0.11.0]
+clojure_docs = 0
+doxygen_docs = 1
+r_docs = 0
+scala_docs = 0
+
+[document_sets_v0.11.0]
 clojure_docs = 0
 doxygen_docs = 1
 r_docs = 0


### PR DESCRIPTION
## Description ##
Patch the Jenkins timeout to run for up to 120 minutes. Also add settings for branches to turn on/off doc generation granularly. 

We're getting [timeouts](http://jenkins.mxnet-ci.amazon-ml.com/job/restricted-website-build/) at 60 minutes as the docs jobs are taking longer that. (Odd, since I had them down to 23 minutes for a full site build, but that was on my own instance, and last week prior to a variety of updates.) Maybe once the cache can kick in we'll see better times.

This should be investigated tomorrow, but in the meantime, let's unblock CI. This is a followup on #12195.
