### PR TITLE
[MXNET-696] 'make pylint' should run a current version of PyLint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -534,9 +534,9 @@ cpplint:
 	--exclude_path src/operator/contrib/ctc_include
 
 pylint:
-	python3 --version
+	python3 --version  # Python 3.5.2
 	python3 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
-	python2 --version
+	python2 --version  # Python 2.7.12
 	python2 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 
 doc: docs

--- a/Makefile
+++ b/Makefile
@@ -534,11 +534,11 @@ cpplint:
 	--exclude_path src/operator/contrib/ctc_include
 
 pylint:
-	python3 -m pip install --upgrade pylint
+	python3 -m pip install --upgrade --user pylint
 	python3 -m pylint --version  # Python 3.5.2
 	python3 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 
-	python2 -m pip install --upgrade pylint
+	python2 -m pip install --upgrade --user pylint
 	python2 -m pylint --version  # Python 2.7.12
 	python2 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 

--- a/Makefile
+++ b/Makefile
@@ -534,9 +534,9 @@ cpplint:
 	--exclude_path src/operator/contrib/ctc_include
 
 pylint:
-	python3 --version  # Python 3.5.2
+	python3 -m pylint --version  # Python 3.5.2
 	python3 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
-	python2 --version  # Python 2.7.12
+	python2 -m pylint --version  # Python 2.7.12
 	python2 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 
 doc: docs

--- a/Makefile
+++ b/Makefile
@@ -534,10 +534,10 @@ cpplint:
 	--exclude_path src/operator/contrib/ctc_include
 
 pylint:
-	python2 --version
-	python2 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 	python3 --version
 	python3 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
+	python2 --version
+	python2 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 
 doc: docs
 

--- a/Makefile
+++ b/Makefile
@@ -534,10 +534,7 @@ cpplint:
 	--exclude_path src/operator/contrib/ctc_include
 
 pylint:
-	python2 -m pylint --version  # on Python 2.7.12
-	python2 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
-	python3 -m pylint --version  # on Python 3.5.2
-	python3 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
+	pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 
 doc: docs
 

--- a/Makefile
+++ b/Makefile
@@ -534,7 +534,10 @@ cpplint:
 	--exclude_path src/operator/contrib/ctc_include
 
 pylint:
-	pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
+	python2 --version
+	python2 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
+	python3 --version
+	python3 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 
 doc: docs
 

--- a/Makefile
+++ b/Makefile
@@ -534,12 +534,12 @@ cpplint:
 	--exclude_path src/operator/contrib/ctc_include
 
 pylint:
-	python3 -m pip install --upgrade --user pylint
-	python3 -m pylint --version  # Python 3.5.2
+	python3 -m pip install --upgrade --user pylint  # v1.8.3 --> v2.1.1
+	python3 -m pylint --version                     # on Python 3.5.2
 	python3 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 
-	python2 -m pip install --upgrade --user pylint
-	python2 -m pylint --version  # Python 2.7.12
+	python2 -m pip install --upgrade --user pylint  # v1.8.3 --> v2.1.1
+	python2 -m pylint --version                     # on Python 2.7.12
 	python2 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 
 doc: docs

--- a/Makefile
+++ b/Makefile
@@ -534,11 +534,11 @@ cpplint:
 	--exclude_path src/operator/contrib/ctc_include
 
 pylint:
-        python3 -m pip install --upgrade pylint
+	python3 -m pip install --upgrade pylint
 	python3 -m pylint --version  # Python 3.5.2
 	python3 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 
-        python2 -m pip install --upgrade pylint
+	python2 -m pip install --upgrade pylint
 	python2 -m pylint --version  # Python 2.7.12
 	python2 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 

--- a/Makefile
+++ b/Makefile
@@ -534,8 +534,11 @@ cpplint:
 	--exclude_path src/operator/contrib/ctc_include
 
 pylint:
+        python3 -m pip install --upgrade pylint
 	python3 -m pylint --version  # Python 3.5.2
 	python3 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
+
+        python2 -m pip install --upgrade pylint
 	python2 -m pylint --version  # Python 2.7.12
 	python2 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 

--- a/Makefile
+++ b/Makefile
@@ -534,13 +534,10 @@ cpplint:
 	--exclude_path src/operator/contrib/ctc_include
 
 pylint:
-	python3 -m pip install --upgrade --user pylint  # v1.8.3 --> v2.1.1
-	python3 -m pylint --version                     # on Python 3.5.2
-	python3 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
-
-	python2 -m pip install --upgrade --user pylint  # v1.8.3 --> v2.1.1
-	python2 -m pylint --version                     # on Python 2.7.12
+	python2 -m pylint --version  # on Python 2.7.12
 	python2 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
+	python3 -m pylint --version  # on Python 3.5.2
+	python3 -m pylint --rcfile=$(ROOTDIR)/ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet tools/caffe_converter/*.py
 
 doc: docs
 

--- a/ci/docker/install/ubuntu_python.sh
+++ b/ci/docker/install/ubuntu_python.sh
@@ -29,5 +29,5 @@ wget -nv https://bootstrap.pypa.io/get-pip.py
 python3 get-pip.py
 python2 get-pip.py
 
-pip2 install nose cpplint==1.3.0 pylint==1.8.3 'numpy<1.15.0,>=1.8.2' nose-timer 'requests<2.19.0,>=2.18.4' h5py==2.8.0rc1 scipy==1.0.1 boto3
-pip3 install nose cpplint==1.3.0 pylint==1.8.3 'numpy<1.15.0,>=1.8.2' nose-timer 'requests<2.19.0,>=2.18.4' h5py==2.8.0rc1 scipy==1.0.1 boto3
+pip2 install nose cpplint==1.3.0 pylint==1.9.3 'numpy<1.15.0,>=1.8.2' nose-timer 'requests<2.19.0,>=2.18.4' h5py==2.8.0rc1 scipy==1.0.1 boto3
+pip3 install nose cpplint==1.3.0 pylint==2.1.1 'numpy<1.15.0,>=1.8.2' nose-timer 'requests<2.19.0,>=2.18.4' h5py==2.8.0rc1 scipy==1.0.1 boto3

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -114,7 +114,6 @@ disable=
     consider-using-in,
     consider-using-set-comprehension,
     invalid-envvar-default,
-    line-too-long,
     singleton-comparison,
     try-except-raise,
     useless-object-inheritance,
@@ -154,7 +153,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -111,7 +111,6 @@ disable=
     invalid-unary-operand-type,
     chained-comparison,
     consider-using-dict-comprehension,
-    consider-using-in,
     consider-using-set-comprehension,
     invalid-envvar-default,
     singleton-comparison,

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -109,7 +109,17 @@ disable=
     useless-super-delegation,
     len-as-condition,
     invalid-unary-operand-type,
-    useless-object-inheritance
+    chained-comparison,
+    consider-using-dict-comprehension,
+    consider-using-in,
+    consider-using-set-comprehension,
+    invalid-envvar-default,
+    line-too-long,
+    singleton-comparison,
+    try-except-raise,
+    useless-object-inheritance,
+    useless-return
+
 # disable=unicode-builtin,delslice-method,using-cmp-argument,setslice-method,dict-view-method,parameter-unpacking,range-builtin-not-iterating,print-statement,file-builtin,old-raise-syntax,basestring-builtin,execfile-builtin,indexing-exception,import-star-module-level,coerce-method,long-builtin,old-ne-operator,old-division,no-absolute-import,raw_input-builtin,old-octal-literal,oct-method,xrange-builtin,hex-method,unpacking-in-except,nonzero-method,raising-string,intern-builtin,reload-builtin,metaclass-assignment,cmp-method,filter-builtin-not-iterating,apply-builtin,map-builtin-not-iterating,next-method-called,unichr-builtin,buffer-builtin,dict-iter-method,input-builtin,coerce-builtin,getslice-method,useless-suppression,standarderror-builtin,zip-builtin-not-iterating,suppressed-message,cmp-builtin,backtick,long-suffix,reduce-builtin,round-builtin
 
 

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -117,11 +117,7 @@ disable=
     singleton-comparison,
     try-except-raise,
     useless-object-inheritance,
-    useless-return,
-    c-extension-no-member,
-    deprecated-lambda,
-    redefined-builtin,
-    unexpected-keyword-arg
+    useless-return
 
 # disable=unicode-builtin,delslice-method,using-cmp-argument,setslice-method,dict-view-method,parameter-unpacking,range-builtin-not-iterating,print-statement,file-builtin,old-raise-syntax,basestring-builtin,execfile-builtin,indexing-exception,import-star-module-level,coerce-method,long-builtin,old-ne-operator,old-division,no-absolute-import,raw_input-builtin,old-octal-literal,oct-method,xrange-builtin,hex-method,unpacking-in-except,nonzero-method,raising-string,intern-builtin,reload-builtin,metaclass-assignment,cmp-method,filter-builtin-not-iterating,apply-builtin,map-builtin-not-iterating,next-method-called,unichr-builtin,buffer-builtin,dict-iter-method,input-builtin,coerce-builtin,getslice-method,useless-suppression,standarderror-builtin,zip-builtin-not-iterating,suppressed-message,cmp-builtin,backtick,long-suffix,reduce-builtin,round-builtin
 

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -71,7 +71,7 @@ confidence=
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=indexing-exception,old-raise-syntax
+enable=indexing-exception,old-raise-syntax,undefined-variable
 
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -82,7 +82,34 @@ enable=indexing-exception,old-raise-syntax
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=design,similarities,no-self-use,attribute-defined-outside-init,locally-disabled,star-args,pointless-except,bad-option-value,global-statement,fixme,suppressed-message,useless-suppression,locally-enabled,no-member,no-name-in-module,import-error,unsubscriptable-object,unbalanced-tuple-unpacking,undefined-variable,protected-access,superfluous-parens,invalid-name,no-else-return,useless-super-delegation,len-as-condition,invalid-unary-operand-type
+disable=
+    design,
+    similarities,
+    no-self-use,
+    attribute-defined-outside-init,
+    locally-disabled,
+    star-args,
+    pointless-except,
+    bad-option-value,
+    global-statement,
+    fixme,
+    suppressed-message,
+    useless-suppression,
+    locally-enabled,
+    no-member,
+    no-name-in-module,
+    import-error,
+    unsubscriptable-object,
+    unbalanced-tuple-unpacking,
+    undefined-variable,
+    protected-access,
+    superfluous-parens,
+    invalid-name,
+    no-else-return,
+    useless-super-delegation,
+    len-as-condition,
+    invalid-unary-operand-type,
+    useless-object-inheritance
 # disable=unicode-builtin,delslice-method,using-cmp-argument,setslice-method,dict-view-method,parameter-unpacking,range-builtin-not-iterating,print-statement,file-builtin,old-raise-syntax,basestring-builtin,execfile-builtin,indexing-exception,import-star-module-level,coerce-method,long-builtin,old-ne-operator,old-division,no-absolute-import,raw_input-builtin,old-octal-literal,oct-method,xrange-builtin,hex-method,unpacking-in-except,nonzero-method,raising-string,intern-builtin,reload-builtin,metaclass-assignment,cmp-method,filter-builtin-not-iterating,apply-builtin,map-builtin-not-iterating,next-method-called,unichr-builtin,buffer-builtin,dict-iter-method,input-builtin,coerce-builtin,getslice-method,useless-suppression,standarderror-builtin,zip-builtin-not-iterating,suppressed-message,cmp-builtin,backtick,long-suffix,reduce-builtin,round-builtin
 
 

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -117,7 +117,11 @@ disable=
     singleton-comparison,
     try-except-raise,
     useless-object-inheritance,
-    useless-return
+    useless-return,
+    c-extension-no-member,
+    deprecated-lambda,
+    redefined-builtin,
+    unexpected-keyword-arg
 
 # disable=unicode-builtin,delslice-method,using-cmp-argument,setslice-method,dict-view-method,parameter-unpacking,range-builtin-not-iterating,print-statement,file-builtin,old-raise-syntax,basestring-builtin,execfile-builtin,indexing-exception,import-star-module-level,coerce-method,long-builtin,old-ne-operator,old-division,no-absolute-import,raw_input-builtin,old-octal-literal,oct-method,xrange-builtin,hex-method,unpacking-in-except,nonzero-method,raising-string,intern-builtin,reload-builtin,metaclass-assignment,cmp-method,filter-builtin-not-iterating,apply-builtin,map-builtin-not-iterating,next-method-called,unichr-builtin,buffer-builtin,dict-iter-method,input-builtin,coerce-builtin,getslice-method,useless-suppression,standarderror-builtin,zip-builtin-not-iterating,suppressed-message,cmp-builtin,backtick,long-suffix,reduce-builtin,round-builtin
 

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -152,7 +152,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 
 [FORMAT]
 
-# Maximum number of characters on a single line.
+# Maximum number of characters on a single line
 max-line-length=120
 
 # Regexp for a line that is allowed to be longer than the limit.

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -101,7 +101,6 @@ disable=
     import-error,
     unsubscriptable-object,
     unbalanced-tuple-unpacking,
-    undefined-variable,
     protected-access,
     superfluous-parens,
     invalid-name,

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -156,7 +156,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 
 [FORMAT]
 
-# Maximum number of characters on a single line
+# Maximum number of characters on a single line.
 max-line-length=120
 
 # Regexp for a line that is allowed to be longer than the limit.

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -101,6 +101,7 @@ disable=
     import-error,
     unsubscriptable-object,
     unbalanced-tuple-unpacking,
+    undefined-variable,
     protected-access,
     superfluous-parens,
     invalid-name,


### PR DESCRIPTION
@vandanavk

## Description ##
'__make pylint__' should run a current version of PyLint to get the new tests added in PyLint v2.x

1. Upgrade the Docker Ubuntu image with the current version of PyLint v2.1.1 on Python 3
2. Add disable pylintrc directives and increase max-line-length to get all new tests to pass

Once this PR has been merged then contributors can go through pylintrc removing disable directives and shortening max-line-length while fixing the related issues.

Notes:
* Jenkins Pylint version was 1.8.3 while current is 2.1.1.

New tests in PyLint v2.1.1 that fail:
1. chained-comparison
2. consider-using-dict-comprehension
3. consider-using-in
4. consider-using-set-comprehension
5. invalid-envvar-default
6. singleton-comparison
7. try-except-raise
8. useless-object-inheritance
9. useless-return

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] '__make pylint__' should run a current version of PyLint to get the new tests added in PyLint v2.x

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
