### PR TITLE
Remove fixed seed from laop_2 test

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5356,8 +5356,7 @@ def _syevd_combined_symbol(a):
                                    transpose_b=False, name='Ut_L_U')
     return mx.sym.Group([u_ut, ut_lam_u])
 
-# Seed set because the test is not robust enough to operate on random data
-@with_seed(1896893923)
+@with_seed()
 def test_laop_2():
     dtype = np.float64
     rtol_fw = 1e-7


### PR DESCRIPTION
## Description ##
Removing fixed seed from laop_2 test to resolve issue #11719. Tested cpu with 10k runs and gpu with 20k.
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
```
[DEBUG] 9995 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1974728222 to reproduce.
[DEBUG] 9996 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1122107086 to reproduce.
[DEBUG] 9997 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1736967670 to reproduce.
[DEBUG] 9998 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=893789282 to reproduce.
[DEBUG] 9999 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1185803618 to reproduce.
[DEBUG] 10000 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1904581165 to reproduce.
ok

----------------------------------------------------------------------
Ran 1 test in 58495.005s
```
```
[DEBUG] 19994 of 20000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=802362420 to reproduce.
[DEBUG] 19995 of 20000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=573560273 to reproduce.
[DEBUG] 19996 of 20000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=450749924 to reproduce.
[DEBUG] 19997 of 20000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=900864401 to reproduce.
[DEBUG] 19998 of 20000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=417006145 to reproduce.
[DEBUG] 19999 of 20000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=820476791 to reproduce.
[DEBUG] 20000 of 20000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=71120458 to reproduce.
ok

----------------------------------------------------------------------
Ran 1 test in 9491.307s

OK
```
