### PR TITLE
Fix mistyped variable name in mxnet_predict.py.

### DIFF
--- a/amalgamation/python/mxnet_predict.py
+++ b/amalgamation/python/mxnet_predict.py
@@ -65,8 +65,8 @@ def _find_lib_path():
         except ImportError:
             libinfo_path = os.path.join(curr_path, '../../python/mxnet/libinfo.py')
             if os.path.exists(libinfo_path) and os.path.isfile(libinfo_path):
-                libinfo = {'__file__': libinfo_py}
-                exec(compile(open(libinfo_py, "rb").read(), libinfo_py, 'exec'), libinfo, libinfo)
+                libinfo = {'__file__': libinfo_path}
+                exec(compile(open(libinfo_path, "rb").read(), libinfo_path, 'exec'), libinfo, libinfo)
                 lib_path = libinfo['find_lib_path']()
                 return lib_path
             else:


### PR DESCRIPTION
## Description ##
This is to fix a mistyped variable name in amalgamation/python/mxnet_predict.py introduced by https://github.com/apache/incubator-mxnet/pull/11493.

Related to https://github.com/apache/incubator-mxnet/issues/8270.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
