### PR TITLE
Documentation fix for Symbol tutorial

### DIFF
--- a/docs/tutorials/basic/symbol.md
+++ b/docs/tutorials/basic/symbol.md
@@ -1,4 +1,4 @@
-# Symbol - Neural network graphs and auto-differentiation
+# Symbol - Neural network graphs
 
 In a [previous tutorial](http://mxnet.io/tutorials/basic/ndarray.html), we introduced `NDArray`,
 the basic data structure for manipulating data in MXNet.


### PR DESCRIPTION
## Description ##
Minor fix in the title of the "Symbol graph" tutorial. The tutorial has nothing to do with Auto-Diff and the title was very misleading. It even showed up on search results when I queried "MXNet AutoDiff"

## Comments ##
- @sandeep-krishnamurthy 