### PR TITLE
Revert "[MXNET-696] Define cmp() in Python 3 for line 222"

### DIFF
--- a/tests/nightly/model_backwards_compatibility_check/common.py
+++ b/tests/nightly/model_backwards_compatibility_check/common.py
@@ -29,13 +29,6 @@ from mxnet.gluon import nn
 import re
 from mxnet.test_utils import assert_almost_equal
 
-try:
-    cmp             # Python 2
-except NameError:
-    # See: https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
-    def cmp(x, y):  # Python 3
-        return (x > y) - (x < y)
-
 # Set fixed random seeds.
 mx.random.seed(7)
 np.random.seed(7)


### PR DESCRIPTION
Reverts apache/incubator-mxnet#12191

We reverted the underlying change and thus this PR is not necessary (and is no longer compatible)