### PR TITLE
[MXNET-729] Scala Examples memory leak fix

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/IO.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/IO.scala
@@ -408,10 +408,7 @@ object DataDesc {
   @deprecated
   implicit def ListMap2Descs(shapes: ListMap[String, Shape]): IndexedSeq[DataDesc] = {
     if (shapes != null) {
-      if (shapes.toIndexedSeq(0)._2.length == 2) {
-        shapes.map { case (k, s) => new DataDesc(k, s, layout = "NT") }.toIndexedSeq
-      }
-      else shapes.map { case (k, s) => new DataDesc(k, s) }.toIndexedSeq
+      shapes.map { case (k, s) => new DataDesc(k, s) }.toIndexedSeq
     } else {
       null
     }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/IO.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/IO.scala
@@ -408,7 +408,10 @@ object DataDesc {
   @deprecated
   implicit def ListMap2Descs(shapes: ListMap[String, Shape]): IndexedSeq[DataDesc] = {
     if (shapes != null) {
-      shapes.map { case (k, s) => new DataDesc(k, s) }.toIndexedSeq
+      if (shapes.toIndexedSeq(0)._2.length == 2) {
+        shapes.map { case (k, s) => new DataDesc(k, s, layout = "NT") }.toIndexedSeq
+      }
+      else shapes.map { case (k, s) => new DataDesc(k, s) }.toIndexedSeq
     } else {
       null
     }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/NDArrayCollector.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NDArrayCollector.scala
@@ -18,6 +18,7 @@
 package org.apache.mxnet
 
 import org.apache.mxnet.Base.CPtrAddress
+import org.apache.mxnet.annotation.Experimental
 import org.slf4j.LoggerFactory
 
 import scala.annotation.varargs
@@ -80,6 +81,7 @@ object NDArrayCollector {
    * Create a collector allows users to later dispose the collected NDArray manually.
    * @return a manually-disposable collector.
    */
+  @Experimental
   def manual(): NDArrayCollector = new NDArrayCollector(false)
 
   /**
@@ -135,6 +137,7 @@ class NDArrayCollector private(private val autoDispose: Boolean = true,
    * @tparam T return type of the function <em>codeBlock</em>.
    * @return The result of function <em>codeBlock</em>.
    */
+  @Experimental
   def withScope[T](codeBlock: => T): T = {
     val old = NDArrayCollector.currCollector.get()
     NDArrayCollector.currCollector.set(this)

--- a/scala-package/core/src/main/scala/org/apache/mxnet/annotation/Experimental.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/annotation/Experimental.scala
@@ -19,6 +19,10 @@ package org.apache.mxnet.annotation
 
 import java.lang.annotation.{ElementType, Retention, Target, _}
 
+/**
+  * Experimental: there is a comparably high chance that
+  * the API will undergo some kind of changes
+  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(Array(ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER,
   ElementType.CONSTRUCTOR, ElementType.LOCAL_VARIABLE, ElementType.PACKAGE))

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/gan/GanMnist.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/gan/GanMnist.scala
@@ -104,77 +104,80 @@ object GanMnist {
 
   def runTraining(dataPath : String, context : Context,
                   outputPath : String, numEpoch : Int): Float = {
-    val lr = 0.0005f
-    val beta1 = 0.5f
-    val batchSize = 100
-    val randShape = Shape(batchSize, 100)
-    val dataShape = Shape(batchSize, 1, 28, 28)
+    val output = NDArrayCollector.auto().withScope {
+      val lr = 0.0005f
+      val beta1 = 0.5f
+      val batchSize = 100
+      val randShape = Shape(batchSize, 100)
+      val dataShape = Shape(batchSize, 1, 28, 28)
 
-    val (symGen, symDec) =
-      makeDcganSym(oShape = dataShape, ngf = 32, finalAct = "sigmoid")
+      val (symGen, symDec) =
+        makeDcganSym(oShape = dataShape, ngf = 32, finalAct = "sigmoid")
 
-    val gMod = new GANModule(
-      symGen,
-      symDec,
-      context = context,
-      dataShape = dataShape,
-      codeShape = randShape)
+      val gMod = new GANModule(
+        symGen,
+        symDec,
+        context = context,
+        dataShape = dataShape,
+        codeShape = randShape)
 
-    gMod.initGParams(new Xavier(factorType = "in", magnitude = 2.34f))
-    gMod.initDParams(new Xavier(factorType = "in", magnitude = 2.34f))
+      gMod.initGParams(new Xavier(factorType = "in", magnitude = 2.34f))
+      gMod.initDParams(new Xavier(factorType = "in", magnitude = 2.34f))
 
-    gMod.initOptimizer(new Adam(learningRate = lr, wd = 0f, beta1 = beta1))
+      gMod.initOptimizer(new Adam(learningRate = lr, wd = 0f, beta1 = beta1))
 
-    val params = Map(
-      "image" -> s"$dataPath/train-images-idx3-ubyte",
-      "label" -> s"$dataPath/train-labels-idx1-ubyte",
-      "input_shape" -> s"(1, 28, 28)",
-      "batch_size" -> s"$batchSize",
-      "shuffle" -> "True"
-    )
+      val params = Map(
+        "image" -> s"$dataPath/train-images-idx3-ubyte",
+        "label" -> s"$dataPath/train-labels-idx1-ubyte",
+        "input_shape" -> s"(1, 28, 28)",
+        "batch_size" -> s"$batchSize",
+        "shuffle" -> "True"
+      )
 
-    val mnistIter = IO.MNISTIter(params)
+      val mnistIter = IO.MNISTIter(params)
 
-    val metricAcc = new CustomMetric(ferr, "ferr")
+      val metricAcc = new CustomMetric(ferr, "ferr")
 
-    var t = 0
-    var dataBatch: DataBatch = null
-    var acc = 0.0f
-    for (epoch <- 0 until numEpoch) {
-      mnistIter.reset()
-      metricAcc.reset()
-      t = 0
-      while (mnistIter.hasNext) {
-        dataBatch = mnistIter.next()
-        NDArrayCollector.auto().withScope {
-          gMod.update(dataBatch)
-          gMod.dLabel.set(0f)
-          metricAcc.update(Array(gMod.dLabel), gMod.outputsFake)
-          gMod.dLabel.set(1f)
-          metricAcc.update(Array(gMod.dLabel), gMod.outputsReal)
+      var t = 0
+      var dataBatch: DataBatch = null
+      var acc = 0.0f
+      for (epoch <- 0 until numEpoch) {
+        mnistIter.reset()
+        metricAcc.reset()
+        t = 0
+        while (mnistIter.hasNext) {
+          dataBatch = mnistIter.next()
+          NDArrayCollector.auto().withScope {
+            gMod.update(dataBatch)
+            gMod.dLabel.set(0f)
+            metricAcc.update(Array(gMod.dLabel), gMod.outputsFake)
+            gMod.dLabel.set(1f)
+            metricAcc.update(Array(gMod.dLabel), gMod.outputsReal)
 
-          if (t % 50 == 0) {
-            val (name, value) = metricAcc.get
-            acc = value(0)
-            logger.info(s"epoch: $epoch, iter $t, metric=${value.mkString(" ")}")
-            Viz.imSave("gout", outputPath, gMod.tempOutG(0), flip = true)
-            val diff = gMod.tempDiffD
-            val arr = diff.toArray
-            val mean = arr.sum / arr.length
-            val std = {
-              val tmpA = arr.map(a => (a - mean) * (a - mean))
-              Math.sqrt(tmpA.sum / tmpA.length).toFloat
+            if (t % 50 == 0) {
+              val (name, value) = metricAcc.get
+              acc = value(0)
+              logger.info(s"epoch: $epoch, iter $t, metric=${value.mkString(" ")}")
+              Viz.imSave("gout", outputPath, gMod.tempOutG(0), flip = true)
+              val diff = gMod.tempDiffD
+              val arr = diff.toArray
+              val mean = arr.sum / arr.length
+              val std = {
+                val tmpA = arr.map(a => (a - mean) * (a - mean))
+                Math.sqrt(tmpA.sum / tmpA.length).toFloat
+              }
+              diff.set((diff - mean) / std + 0.5f)
+              Viz.imSave("diff", outputPath, diff, flip = true)
+              Viz.imSave("data", outputPath, dataBatch.data(0), flip = true)
             }
-            diff.set((diff - mean) / std + 0.5f)
-            Viz.imSave("diff", outputPath, diff, flip = true)
-            Viz.imSave("data", outputPath, dataBatch.data(0), flip = true)
           }
+          dataBatch.dispose()
+          t += 1
         }
-        dataBatch.dispose()
-        t += 1
       }
+      acc
     }
-    acc
+    output
   }
 
   def main(args: Array[String]): Unit = {

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/imclassification/TrainMnist.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/imclassification/TrainMnist.scala
@@ -93,16 +93,18 @@ object TrainMnist {
   }
 
   def test(dataPath : String) : Float = {
-    val (dataShape, net) = (Shape(784), getMlp)
-    val devs = Array(Context.cpu(0))
-    val envs: mutable.Map[String, String] = mutable.HashMap.empty[String, String]
-    val Acc = ModelTrain.fit(dataDir = dataPath,
-      batchSize = 128, numExamples = 60000, devs = devs,
-      network = net, dataLoader = getIterator(dataShape),
-      kvStore = "local", numEpochs = 10)
-    logger.info("Finish test fit ...")
-    val (_, num) = Acc.get
-    num(0)
+    NDArrayCollector.auto().withScope {
+      val (dataShape, net) = (Shape(784), getMlp)
+      val devs = Array(Context.cpu(0))
+      val envs: mutable.Map[String, String] = mutable.HashMap.empty[String, String]
+      val Acc = ModelTrain.fit(dataDir = dataPath,
+        batchSize = 128, numExamples = 60000, devs = devs,
+        network = net, dataLoader = getIterator(dataShape),
+        kvStore = "local", numEpochs = 10)
+      logger.info("Finish test fit ...")
+      val (_, num) = Acc.get
+      num(0)
+    }
   }
 
 

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
@@ -17,10 +17,9 @@
 
 package org.apache.mxnetexamples.infer.imageclassifier
 
-import org.apache.mxnet.Shape
+import org.apache.mxnet._
 import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.LoggerFactory
-import org.apache.mxnet.{DType, DataDesc, Context}
 import org.apache.mxnet.infer.ImageClassifier
 
 import scala.collection.JavaConverters._
@@ -43,47 +42,50 @@ object ImageClassifierExample {
   def runInferenceOnSingleImage(modelPathPrefix: String, inputImagePath: String,
                                 context: Array[Context]):
   IndexedSeq[IndexedSeq[(String, Float)]] = {
-    val dType = DType.Float32
-    val inputShape = Shape(1, 3, 224, 224)
+    NDArrayCollector.auto().withScope {
+      val dType = DType.Float32
+      val inputShape = Shape(1, 3, 224, 224)
 
-    val inputDescriptor = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
+      val inputDescriptor = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
 
-    // Create object of ImageClassifier class
-    val imgClassifier: ImageClassifier = new
-        ImageClassifier(modelPathPrefix, inputDescriptor, context)
+      // Create object of ImageClassifier class
+      val imgClassifier: ImageClassifier = new
+          ImageClassifier(modelPathPrefix, inputDescriptor, context)
 
-    // Loading single image from file and getting BufferedImage
-    val img = ImageClassifier.loadImageFromFile(inputImagePath)
+      // Loading single image from file and getting BufferedImage
+      val img = ImageClassifier.loadImageFromFile(inputImagePath)
 
-    // Running inference on single image
-    val output = imgClassifier.classifyImage(img, Some(5))
-
-    output
+      // Running inference on single image
+      val output = imgClassifier.classifyImage(img, Some(5))
+      output
+    }
   }
 
   def runInferenceOnBatchOfImage(modelPathPrefix: String, inputImageDir: String,
                                  context: Array[Context]):
   IndexedSeq[IndexedSeq[(String, Float)]] = {
-    val dType = DType.Float32
-    val inputShape = Shape(1, 3, 224, 224)
+    NDArrayCollector.auto().withScope {
+      val dType = DType.Float32
+      val inputShape = Shape(1, 3, 224, 224)
 
-    val inputDescriptor = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
+      val inputDescriptor = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
 
-    // Create object of ImageClassifier class
-    val imgClassifier: ImageClassifier = new
-        ImageClassifier(modelPathPrefix, inputDescriptor, context)
+      // Create object of ImageClassifier class
+      val imgClassifier: ImageClassifier = new
+          ImageClassifier(modelPathPrefix, inputDescriptor, context)
 
-    // Loading batch of images from the directory path
-    val batchFiles = generateBatches(inputImageDir, 20)
-    var outputList = IndexedSeq[IndexedSeq[(String, Float)]]()
+      // Loading batch of images from the directory path
+      val batchFiles = generateBatches(inputImageDir, 20)
+      var outputList = IndexedSeq[IndexedSeq[(String, Float)]]()
 
-    for (batchFile <- batchFiles) {
-      val imgList = ImageClassifier.loadInputBatch(batchFile)
-      // Running inference on batch of images loaded in previous step
-      outputList ++= imgClassifier.classifyImageBatch(imgList, Some(5))
+      for (batchFile <- batchFiles) {
+        val imgList = ImageClassifier.loadInputBatch(batchFile)
+        // Running inference on batch of images loaded in previous step
+        outputList ++= imgClassifier.classifyImageBatch(imgList, Some(5))
+      }
+
+      outputList
     }
-
-    outputList
   }
 
   def generateBatches(inputImageDirPath: String, batchSize: Int = 100): List[List[String]] = {

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
@@ -19,7 +19,7 @@ package org.apache.mxnetexamples.infer.objectdetector
 
 import java.io.File
 
-import org.apache.mxnet.{Context, DType, DataDesc, Shape}
+import org.apache.mxnet._
 import org.apache.mxnet.infer._
 import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.LoggerFactory
@@ -54,37 +54,41 @@ object SSDClassifierExample {
   def runObjectDetectionSingle(modelPathPrefix: String, inputImagePath: String,
                                context: Array[Context]):
   IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
-    val dType = DType.Float32
-    val inputShape = Shape(1, 3, 512, 512)
-    // ssd detections, numpy.array([[id, score, x1, y1, x2, y2]...])
-    val outputShape = Shape(1, 6132, 6)
-    val inputDescriptors = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
-    val img = ImageClassifier.loadImageFromFile(inputImagePath)
-    val objDetector = new ObjectDetector(modelPathPrefix, inputDescriptors, context)
-    val output = objDetector.imageObjectDetect(img, Some(3))
+    NDArrayCollector.auto().withScope {
+      val dType = DType.Float32
+      val inputShape = Shape(1, 3, 512, 512)
+      // ssd detections, numpy.array([[id, score, x1, y1, x2, y2]...])
+      val outputShape = Shape(1, 6132, 6)
+      val inputDescriptors = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
+      val img = ImageClassifier.loadImageFromFile(inputImagePath)
+      val objDetector = new ObjectDetector(modelPathPrefix, inputDescriptors, context)
+      val output = objDetector.imageObjectDetect(img, Some(3))
 
-    output
+      output
+    }
   }
 
   def runObjectDetectionBatch(modelPathPrefix: String, inputImageDir: String,
                               context: Array[Context]):
   IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
-    val dType = DType.Float32
-    val inputShape = Shape(1, 3, 512, 512)
-    // ssd detections, numpy.array([[id, score, x1, y1, x2, y2]...])
-    val outputShape = Shape(1, 6132, 6)
-    val inputDescriptors = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
-    val objDetector = new ObjectDetector(modelPathPrefix, inputDescriptors, context)
-    // Loading batch of images from the directory path
-    val batchFiles = generateBatches(inputImageDir, 20)
-    var outputList = IndexedSeq[IndexedSeq[(String, Array[Float])]]()
+    NDArrayCollector.auto().withScope {
+      val dType = DType.Float32
+      val inputShape = Shape(1, 3, 512, 512)
+      // ssd detections, numpy.array([[id, score, x1, y1, x2, y2]...])
+      val outputShape = Shape(1, 6132, 6)
+      val inputDescriptors = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
+      val objDetector = new ObjectDetector(modelPathPrefix, inputDescriptors, context)
+      // Loading batch of images from the directory path
+      val batchFiles = generateBatches(inputImageDir, 20)
+      var outputList = IndexedSeq[IndexedSeq[(String, Array[Float])]]()
 
-    for (batchFile <- batchFiles) {
-      val imgList = ImageClassifier.loadInputBatch(batchFile)
-      // Running inference on batch of images loaded in previous step
-      outputList ++= objDetector.imageBatchObjectDetect(imgList, Some(5))
+      for (batchFile <- batchFiles) {
+        val imgList = ImageClassifier.loadInputBatch(batchFile)
+        // Running inference on batch of images loaded in previous step
+        outputList ++= objDetector.imageBatchObjectDetect(imgList, Some(5))
+      }
+      outputList
     }
-    outputList
   }
 
   def generateBatches(inputImageDirPath: String, batchSize: Int = 100): List[List[String]] = {

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/multitask/ExampleMultiTask.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/multitask/ExampleMultiTask.scala
@@ -231,7 +231,8 @@ object ExampleMultiTask {
 
       val datasAndLabels = trainMultiIt.provideData ++ trainMultiIt.provideLabel
 
-      val (argShapes, outputShapes, auxShapes) = network.inferShape(trainMultiIt.provideData("data"))
+      val (argShapes, outputShapes, auxShapes)
+      = network.inferShape(trainMultiIt.provideData("data"))
       val initializer = new Xavier(factorType = "in", magnitude = 2.34f)
 
       val argNames = network.listArguments

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/multitask/ExampleMultiTask.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/multitask/ExampleMultiTask.scala
@@ -25,11 +25,9 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import org.apache.commons.io.FileUtils
-
-import org.apache.mxnet.{Context, DataBatch, DataDesc, DataIter, EvalMetric, NDArray, Shape, Symbol, Xavier}
+import org.apache.mxnet.{Context, DataBatch, DataDesc, DataIter, EvalMetric, Executor, NDArray, NDArrayCollector, Shape, Symbol, Xavier}
 import org.apache.mxnet.DType.DType
 import org.apache.mxnet.optimizer.RMSProp
-import org.apache.mxnet.Executor
 import org.apache.mxnetexamples.Util
 
 import scala.collection.immutable.ListMap
@@ -223,120 +221,122 @@ object ExampleMultiTask {
 
   def train(batchSize: Int, numEpoch: Int, ctx: Context, modelDirPath: String):
   (Executor, MultiAccuracy) = {
-    val lr = 0.001f
-    val network = ExampleMultiTask.buildNetwork()
-    val (trainIter, valIter) =
-      Data.mnistIterator(modelDirPath, batchSize = batchSize, inputShape = Shape(784))
-    val trainMultiIt = new MultiMnistIterator(trainIter)
-    val valMultiIter = new MultiMnistIterator(valIter)
+    NDArrayCollector.auto().withScope {
+      val lr = 0.001f
+      val network = ExampleMultiTask.buildNetwork()
+      val (trainIter, valIter) =
+        Data.mnistIterator(modelDirPath, batchSize = batchSize, inputShape = Shape(784))
+      val trainMultiIt = new MultiMnistIterator(trainIter)
+      val valMultiIter = new MultiMnistIterator(valIter)
 
-    val datasAndLabels = trainMultiIt.provideData ++ trainMultiIt.provideLabel
+      val datasAndLabels = trainMultiIt.provideData ++ trainMultiIt.provideLabel
 
-    val (argShapes, outputShapes, auxShapes) = network.inferShape(trainMultiIt.provideData("data"))
-    val initializer = new Xavier(factorType = "in", magnitude = 2.34f)
+      val (argShapes, outputShapes, auxShapes) = network.inferShape(trainMultiIt.provideData("data"))
+      val initializer = new Xavier(factorType = "in", magnitude = 2.34f)
 
-    val argNames = network.listArguments
-    val argDict = argNames.zip(argShapes.map(NDArray.empty(_, ctx))).toMap
+      val argNames = network.listArguments
+      val argDict = argNames.zip(argShapes.map(NDArray.empty(_, ctx))).toMap
 
-    val gradDict = argNames.zip(argShapes).filter { case (name, shape) =>
-      !datasAndLabels.contains(name)
-    }.map(x => x._1 -> NDArray.empty(x._2, ctx)).toMap
+      val gradDict = argNames.zip(argShapes).filter { case (name, shape) =>
+        !datasAndLabels.contains(name)
+      }.map(x => x._1 -> NDArray.empty(x._2, ctx)).toMap
 
-    argDict.foreach { case (name, ndArray) =>
-      if (!datasAndLabels.contains(name)) {
-        initializer.initWeight(name, ndArray)
+      argDict.foreach { case (name, ndArray) =>
+        if (!datasAndLabels.contains(name)) {
+          initializer.initWeight(name, ndArray)
+        }
       }
-    }
 
-    val data = argDict("data")
-    val label1 = argDict("softmaxoutput0_label")
-    val label2 = argDict("softmaxoutput1_label")
-    val maxGradNorm = 0.5f
-    val executor = network.bind(ctx, argDict, gradDict)
+      val data = argDict("data")
+      val label1 = argDict("softmaxoutput0_label")
+      val label2 = argDict("softmaxoutput1_label")
+      val maxGradNorm = 0.5f
+      val executor = network.bind(ctx, argDict, gradDict)
 
-    val opt = new RMSProp(learningRate = lr, wd = 0.00001f)
+      val opt = new RMSProp(learningRate = lr, wd = 0.00001f)
 
-    val paramsGrads = gradDict.toList.zipWithIndex.map { case ((name, grad), idx) =>
-      (idx, name, grad, opt.createState(idx, argDict(name)))
-    }
+      val paramsGrads = gradDict.toList.zipWithIndex.map { case ((name, grad), idx) =>
+        (idx, name, grad, opt.createState(idx, argDict(name)))
+      }
 
-    val evalMetric = new ExampleMultiTask.MultiAccuracy(num = 2, name = "multi_accuracy")
-    val batchEndCallback = new ExampleMultiTask.Speedometer(batchSize, 50)
+      val evalMetric = new ExampleMultiTask.MultiAccuracy(num = 2, name = "multi_accuracy")
+      val batchEndCallback = new ExampleMultiTask.Speedometer(batchSize, 50)
 
-    for (epoch <- 0 until numEpoch) {
-      // Training phase
-      val tic = System.currentTimeMillis
-      evalMetric.reset()
-      var nBatch = 0
-      var epochDone = false
-      // Iterate over training data.
-      trainMultiIt.reset()
+      for (epoch <- 0 until numEpoch) {
+        // Training phase
+        val tic = System.currentTimeMillis
+        evalMetric.reset()
+        var nBatch = 0
+        var epochDone = false
+        // Iterate over training data.
+        trainMultiIt.reset()
 
-      while (!epochDone) {
-        var doReset = true
-        while (doReset && trainMultiIt.hasNext) {
-          val dataBatch = trainMultiIt.next()
+        while (!epochDone) {
+          var doReset = true
+          while (doReset && trainMultiIt.hasNext) {
+            val dataBatch = trainMultiIt.next()
 
-          data.set(dataBatch.data(0))
-          label1.set(dataBatch.label(0))
-          label2.set(dataBatch.label(1))
+            data.set(dataBatch.data(0))
+            label1.set(dataBatch.label(0))
+            label2.set(dataBatch.label(1))
+
+            executor.forward(isTrain = true)
+            executor.backward()
+
+            val norm = Math.sqrt(paramsGrads.map { case (idx, name, grad, optimState) =>
+              val l2Norm = NDArray.api.norm(data = (grad / batchSize)).toScalar
+              l2Norm * l2Norm
+            }.sum).toFloat
+
+            paramsGrads.foreach { case (idx, name, grad, optimState) =>
+              if (norm > maxGradNorm) {
+                grad.set(grad.toArray.map(_ * (maxGradNorm / norm)))
+                opt.update(idx, argDict(name), grad, optimState)
+              } else opt.update(idx, argDict(name), grad, optimState)
+            }
+
+            // evaluate at end, so out_cpu_array can lazy copy
+            evalMetric.update(dataBatch.label, executor.outputs)
+
+            nBatch += 1
+            batchEndCallback.invoke(epoch, nBatch, evalMetric)
+          }
+          if (doReset) {
+            trainMultiIt.reset()
+          }
+          // this epoch is done
+          epochDone = true
+        }
+        var nameVals = evalMetric.get
+        nameVals.foreach { case (name, value) =>
+          logger.info(s"Epoch[$epoch] Train-$name=$value")
+        }
+        val toc = System.currentTimeMillis
+        logger.info(s"Epoch[$epoch] Time cost=${toc - tic}")
+
+        evalMetric.reset()
+        valMultiIter.reset()
+        while (valMultiIter.hasNext) {
+          val evalBatch = valMultiIter.next()
+
+          data.set(evalBatch.data(0))
+          label1.set(evalBatch.label(0))
+          label2.set(evalBatch.label(1))
 
           executor.forward(isTrain = true)
-          executor.backward()
 
-          val norm = Math.sqrt(paramsGrads.map { case (idx, name, grad, optimState) =>
-            val l2Norm = NDArray.api.norm(data = (grad / batchSize)).toScalar
-            l2Norm * l2Norm
-          }.sum).toFloat
-
-          paramsGrads.foreach { case (idx, name, grad, optimState) =>
-            if (norm > maxGradNorm) {
-              grad.set(grad.toArray.map(_ * (maxGradNorm / norm)))
-              opt.update(idx, argDict(name), grad, optimState)
-            } else opt.update(idx, argDict(name), grad, optimState)
-          }
-
-          // evaluate at end, so out_cpu_array can lazy copy
-          evalMetric.update(dataBatch.label, executor.outputs)
-
-          nBatch += 1
-          batchEndCallback.invoke(epoch, nBatch, evalMetric)
+          evalMetric.update(evalBatch.label, executor.outputs)
+          evalBatch.dispose()
         }
-        if (doReset) {
-          trainMultiIt.reset()
+
+        nameVals = evalMetric.get
+        nameVals.foreach { case (name, value) =>
+          logger.info(s"Epoch[$epoch] Validation-$name=$value")
         }
-        // this epoch is done
-        epochDone = true
-      }
-      var nameVals = evalMetric.get
-      nameVals.foreach { case (name, value) =>
-        logger.info(s"Epoch[$epoch] Train-$name=$value")
-      }
-      val toc = System.currentTimeMillis
-      logger.info(s"Epoch[$epoch] Time cost=${toc - tic}")
-
-      evalMetric.reset()
-      valMultiIter.reset()
-      while (valMultiIter.hasNext) {
-        val evalBatch = valMultiIter.next()
-
-        data.set(evalBatch.data(0))
-        label1.set(evalBatch.label(0))
-        label2.set(evalBatch.label(1))
-
-        executor.forward(isTrain = true)
-
-        evalMetric.update(evalBatch.label, executor.outputs)
-        evalBatch.dispose()
       }
 
-      nameVals = evalMetric.get
-      nameVals.foreach { case (name, value) =>
-        logger.info(s"Epoch[$epoch] Validation-$name=$value")
-      }
+      (executor, evalMetric)
     }
-
-    (executor, evalMetric)
   }
 
   def main(args: Array[String]): Unit = {

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostInference.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostInference.scala
@@ -17,7 +17,7 @@
 
 package org.apache.mxnetexamples.neuralstyle.end2end
 
-import org.apache.mxnet.{Context, Shape}
+import org.apache.mxnet.{Context, NDArrayCollector, Shape}
 import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.LoggerFactory
 
@@ -46,11 +46,13 @@ object BoostInference {
       DataProcessing.preprocessContentImage(s"$inputImage", dShape, ctx)
     var data = Array(contentNp)
     for (i <- 0 until gens.length) {
-      gens(i).forward(data.takeRight(1))
-      val newImg = gens(i).getOutputs()(0)
-      data :+= newImg
-      DataProcessing.saveImage(newImg, s"$outputPath/out_$i.jpg", guassianRadius)
-      logger.info(s"Converted image: $outputPath/out_$i.jpg")
+      NDArrayCollector.auto().withScope {
+        gens(i).forward(data.takeRight(1))
+        val newImg = gens(i).getOutputs()(0)
+        data :+= newImg
+        DataProcessing.saveImage(newImg, s"$outputPath/out_$i.jpg", guassianRadius)
+        logger.info(s"Converted image: $outputPath/out_$i.jpg")
+      }
     }
   }
 

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostInference.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostInference.scala
@@ -29,29 +29,31 @@ object BoostInference {
 
   def runInference(modelPath: String, outputPath: String, guassianRadius : Int,
                    inputImage : String, ctx : Context): Unit = {
-    val dShape = Shape(1, 3, 480, 640)
-    val clipNorm = 1.0f * dShape.product
-    // generator
-    val gens = Array(
-      GenV4.getModule("g0", dShape, ctx, isTrain = false),
-      GenV3.getModule("g1", dShape, ctx, isTrain = false),
-      GenV3.getModule("g2", dShape, ctx, isTrain = false),
-      GenV4.getModule("g3", dShape, ctx, isTrain = false)
-    )
-    gens.zipWithIndex.foreach { case (gen, i) =>
-      gen.loadParams(s"$modelPath/$i/v3_0002-0026000.params")
-    }
+    NDArrayCollector.auto().withScope {
+      val dShape = Shape(1, 3, 480, 640)
+      val clipNorm = 1.0f * dShape.product
+      // generator
+      val gens = Array(
+        GenV4.getModule("g0", dShape, ctx, isTrain = false),
+        GenV3.getModule("g1", dShape, ctx, isTrain = false),
+        GenV3.getModule("g2", dShape, ctx, isTrain = false),
+        GenV4.getModule("g3", dShape, ctx, isTrain = false)
+      )
+      gens.zipWithIndex.foreach { case (gen, i) =>
+        gen.loadParams(s"$modelPath/$i/v3_0002-0026000.params")
+      }
 
-    val contentNp =
-      DataProcessing.preprocessContentImage(s"$inputImage", dShape, ctx)
-    var data = Array(contentNp)
-    for (i <- 0 until gens.length) {
-      NDArrayCollector.auto().withScope {
-        gens(i).forward(data.takeRight(1))
-        val newImg = gens(i).getOutputs()(0)
-        data :+= newImg
-        DataProcessing.saveImage(newImg, s"$outputPath/out_$i.jpg", guassianRadius)
-        logger.info(s"Converted image: $outputPath/out_$i.jpg")
+      val contentNp =
+        DataProcessing.preprocessContentImage(s"$inputImage", dShape, ctx)
+      var data = Array(contentNp)
+      for (i <- 0 until gens.length) {
+        NDArrayCollector.auto().withScope {
+          gens(i).forward(data.takeRight(1))
+          val newImg = gens(i).getOutputs()(0)
+          data :+= newImg
+          DataProcessing.saveImage(newImg, s"$outputPath/out_$i.jpg", guassianRadius)
+          logger.info(s"Converted image: $outputPath/out_$i.jpg")
+        }
       }
     }
   }

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostTrain.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostTrain.scala
@@ -56,118 +56,120 @@ object BoostTrain {
 
   def runTraining(dataPath : String, vggModelPath: String, ctx : Context,
                   styleImage : String, saveModelPath : String) : Unit = {
-    // params
-    val vggParams = NDArray.load2Map(vggModelPath)
-    val styleWeight = 1.2f
-    val contentWeight = 10f
-    val dShape = Shape(1, 3, 384, 384)
-    val clipNorm = 0.05f * dShape.product
-    val modelPrefix = "v3"
-    // init style
-    val styleNp = DataProcessing.preprocessStyleImage(styleImage, dShape, ctx)
-    var styleMod = Basic.getStyleModule("style", dShape, ctx, vggParams)
-    styleMod.forward(Array(styleNp))
-    val styleArray = styleMod.getOutputs().map(_.copyTo(Context.cpu()))
-    styleMod.dispose()
-    styleMod = null
+    NDArrayCollector.auto().withScope {
+      // params
+      val vggParams = NDArray.load2Map(vggModelPath)
+      val styleWeight = 1.2f
+      val contentWeight = 10f
+      val dShape = Shape(1, 3, 384, 384)
+      val clipNorm = 0.05f * dShape.product
+      val modelPrefix = "v3"
+      // init style
+      val styleNp = DataProcessing.preprocessStyleImage(styleImage, dShape, ctx)
+      var styleMod = Basic.getStyleModule("style", dShape, ctx, vggParams)
+      styleMod.forward(Array(styleNp))
+      val styleArray = styleMod.getOutputs().map(_.copyTo(Context.cpu()))
+      styleMod.dispose()
+      styleMod = null
 
-    // content
-    val contentMod = Basic.getContentModule("content", dShape, ctx, vggParams)
+      // content
+      val contentMod = Basic.getContentModule("content", dShape, ctx, vggParams)
 
-    // loss
-    val (loss, gScale) = Basic.getLossModule("loss", dShape, ctx, vggParams)
-    val extraArgs = (0 until styleArray.length)
-      .map( i => s"target_gram_$i" -> styleArray(i)).toMap
-    loss.setParams(extraArgs)
-    var gradArray = Array[NDArray]()
-    for (i <- 0 until styleArray.length) {
-      gradArray = gradArray :+ (NDArray.ones(Shape(1), ctx) * (styleWeight / gScale(i)))
-    }
-    gradArray = gradArray :+ (NDArray.ones(Shape(1), ctx) * contentWeight)
+      // loss
+      val (loss, gScale) = Basic.getLossModule("loss", dShape, ctx, vggParams)
+      val extraArgs = (0 until styleArray.length)
+        .map(i => s"target_gram_$i" -> styleArray(i)).toMap
+      loss.setParams(extraArgs)
+      var gradArray = Array[NDArray]()
+      for (i <- 0 until styleArray.length) {
+        gradArray = gradArray :+ (NDArray.ones(Shape(1), ctx) * (styleWeight / gScale(i)))
+      }
+      gradArray = gradArray :+ (NDArray.ones(Shape(1), ctx) * contentWeight)
 
-    // generator
-    val gens = Array(
-      GenV4.getModule("g0", dShape, ctx),
-      GenV3.getModule("g1", dShape, ctx),
-      GenV3.getModule("g2", dShape, ctx),
-      GenV4.getModule("g3", dShape, ctx)
-    )
-    gens.foreach { gen =>
-      val opt = new SGD(learningRate = 1e-4f,
-        momentum = 0.9f,
-        wd = 5e-3f,
-        clipGradient = 5f)
-      gen.initOptimizer(opt)
-    }
+      // generator
+      val gens = Array(
+        GenV4.getModule("g0", dShape, ctx),
+        GenV3.getModule("g1", dShape, ctx),
+        GenV3.getModule("g2", dShape, ctx),
+        GenV4.getModule("g3", dShape, ctx)
+      )
+      gens.foreach { gen =>
+        val opt = new SGD(learningRate = 1e-4f,
+          momentum = 0.9f,
+          wd = 5e-3f,
+          clipGradient = 5f)
+        gen.initOptimizer(opt)
+      }
 
-    var filelist = new File(dataPath).list().toList
-    val numImage = filelist.length
-    logger.info(s"Dataset size: $numImage")
+      var filelist = new File(dataPath).list().toList
+      val numImage = filelist.length
+      logger.info(s"Dataset size: $numImage")
 
-    val tvWeight = 1e-2f
+      val tvWeight = 1e-2f
 
-    val startEpoch = 0
-    val endEpoch = 3
+      val startEpoch = 0
+      val endEpoch = 3
 
-    for (k <- 0 until gens.length) {
-      val path = new File(s"${saveModelPath}/$k")
-      if (!path.exists()) path.mkdir()
-    }
+      for (k <- 0 until gens.length) {
+        val path = new File(s"${saveModelPath}/$k")
+        if (!path.exists()) path.mkdir()
+      }
 
-    // train
-    for (i <- startEpoch until endEpoch) {
-      NDArrayCollector.auto().withScope {
-        filelist = Random.shuffle(filelist)
-        for (idx <- filelist.indices) {
-          var dataArray = Array[NDArray]()
-          var lossGradArray = Array[NDArray]()
-          val data =
-            DataProcessing.preprocessContentImage(s"${dataPath}/${filelist(idx)}", dShape, ctx)
-          dataArray = dataArray :+ data
-          // get content
-          contentMod.forward(Array(data))
-          // set target content
-          loss.setParams(Map("target_content" -> contentMod.getOutputs()(0)))
-          // gen_forward
-          for (k <- 0 until gens.length) {
-            gens(k).forward(dataArray.takeRight(1))
-            dataArray = dataArray :+ gens(k).getOutputs()(0)
-            // loss forward
-            loss.forward(dataArray.takeRight(1))
-            loss.backward(gradArray)
-            lossGradArray = lossGradArray :+ loss.getInputGrads()(0)
-          }
-          val grad = NDArray.zeros(data.shape, ctx)
-          for (k <- gens.length - 1 to 0 by -1) {
-            val tvGradExecutor = getTvGradExecutor(gens(k).getOutputs()(0), ctx, tvWeight)
-            tvGradExecutor.forward()
-            grad += lossGradArray(k) + tvGradExecutor.outputs(0)
-            val gNorm = NDArray.norm(grad)
-            if (gNorm.toScalar > clipNorm) {
-              grad *= clipNorm / gNorm.toScalar
-            }
-            gens(k).backward(Array(grad))
-            gens(k).update()
-            gNorm.dispose()
-            tvGradExecutor.dispose()
-          }
-          grad.dispose()
-          if (idx % 20 == 0) {
-            logger.info(s"Epoch $i: Image $idx")
+      // train
+      for (i <- startEpoch until endEpoch) {
+        NDArrayCollector.auto().withScope {
+          filelist = Random.shuffle(filelist)
+          for (idx <- filelist.indices) {
+            var dataArray = Array[NDArray]()
+            var lossGradArray = Array[NDArray]()
+            val data =
+              DataProcessing.preprocessContentImage(s"${dataPath}/${filelist(idx)}", dShape, ctx)
+            dataArray = dataArray :+ data
+            // get content
+            contentMod.forward(Array(data))
+            // set target content
+            loss.setParams(Map("target_content" -> contentMod.getOutputs()(0)))
+            // gen_forward
             for (k <- 0 until gens.length) {
-              val n = NDArray.norm(gens(k).getInputGrads()(0))
-              logger.info(s"Data Norm : ${n.toScalar / dShape.product}")
-              n.dispose()
+              gens(k).forward(dataArray.takeRight(1))
+              dataArray = dataArray :+ gens(k).getOutputs()(0)
+              // loss forward
+              loss.forward(dataArray.takeRight(1))
+              loss.backward(gradArray)
+              lossGradArray = lossGradArray :+ loss.getInputGrads()(0)
             }
-          }
-          if (idx % 1000 == 0) {
-            for (k <- 0 until gens.length) {
-              gens(k).saveParams(
-                s"${saveModelPath}/$k/${modelPrefix}_" +
-                  s"${"%04d".format(i)}-${"%07d".format(idx)}.params")
+            val grad = NDArray.zeros(data.shape, ctx)
+            for (k <- gens.length - 1 to 0 by -1) {
+              val tvGradExecutor = getTvGradExecutor(gens(k).getOutputs()(0), ctx, tvWeight)
+              tvGradExecutor.forward()
+              grad += lossGradArray(k) + tvGradExecutor.outputs(0)
+              val gNorm = NDArray.norm(grad)
+              if (gNorm.toScalar > clipNorm) {
+                grad *= clipNorm / gNorm.toScalar
+              }
+              gens(k).backward(Array(grad))
+              gens(k).update()
+              gNorm.dispose()
+              tvGradExecutor.dispose()
             }
+            grad.dispose()
+            if (idx % 20 == 0) {
+              logger.info(s"Epoch $i: Image $idx")
+              for (k <- 0 until gens.length) {
+                val n = NDArray.norm(gens(k).getInputGrads()(0))
+                logger.info(s"Data Norm : ${n.toScalar / dShape.product}")
+                n.dispose()
+              }
+            }
+            if (idx % 1000 == 0) {
+              for (k <- 0 until gens.length) {
+                gens(k).saveParams(
+                  s"${saveModelPath}/$k/${modelPrefix}_" +
+                    s"${"%04d".format(i)}-${"%07d".format(idx)}.params")
+              }
+            }
+            data.dispose()
           }
-          data.dispose()
         }
       }
     }

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/LstmBucketing.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/LstmBucketing.scala
@@ -20,13 +20,14 @@ package org.apache.mxnetexamples.rnn
 
 import org.apache.mxnet.Callback.Speedometer
 import org.apache.mxnet._
-import org.apache.mxnet.module.{BucketingModule, FitParams}
+import BucketIo.BucketSentenceIter
 import org.apache.mxnet.optimizer.SGD
 import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.{Logger, LoggerFactory}
-import BucketIo.BucketSentenceIter
 
 import scala.collection.JavaConverters._
+import org.apache.mxnet.module.BucketingModule
+import org.apache.mxnet.module.FitParams
 
 /**
   * Bucketing LSTM examples
@@ -53,11 +54,9 @@ object LstmBucketing {
     pred.waitToRead()
     val labelArr = label.T.toArray.map(_.toInt)
     var loss = .0
-    (0 until pred.shape(0)).foreach(i => {
-      val temp = pred.slice(i)
-      loss -= Math.log(Math.max(1e-10f, temp.toArray(labelArr(i))))
-      temp.dispose()
-    })
+    (0 until pred.shape(0)).foreach(i =>
+      loss -= Math.log(Math.max(1e-10f, pred.slice(i).toArray(labelArr(i))))
+    )
     Math.exp(loss / labelArr.length).toFloat
   }
 

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/LstmBucketing.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/LstmBucketing.scala
@@ -20,14 +20,13 @@ package org.apache.mxnetexamples.rnn
 
 import org.apache.mxnet.Callback.Speedometer
 import org.apache.mxnet._
-import BucketIo.BucketSentenceIter
+import org.apache.mxnet.module.{BucketingModule, FitParams}
 import org.apache.mxnet.optimizer.SGD
 import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.{Logger, LoggerFactory}
+import BucketIo.BucketSentenceIter
 
 import scala.collection.JavaConverters._
-import org.apache.mxnet.module.BucketingModule
-import org.apache.mxnet.module.FitParams
 
 /**
   * Bucketing LSTM examples
@@ -54,9 +53,11 @@ object LstmBucketing {
     pred.waitToRead()
     val labelArr = label.T.toArray.map(_.toInt)
     var loss = .0
-    (0 until pred.shape(0)).foreach(i =>
-      loss -= Math.log(Math.max(1e-10f, pred.slice(i).toArray(labelArr(i))))
-    )
+    (0 until pred.shape(0)).foreach(i => {
+      val temp = pred.slice(i)
+      loss -= Math.log(Math.max(1e-10f, temp.toArray(labelArr(i))))
+      temp.dispose()
+    })
     Math.exp(loss / labelArr.length).toFloat
   }
 

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TestCharRnn.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TestCharRnn.scala
@@ -30,7 +30,7 @@ object TestCharRnn {
 
   private val logger = LoggerFactory.getLogger(classOf[TrainCharRnn])
 
-  def runTestCharRNN(dataPath: String, modelPrefix: String, starterSentence : String): Unit = {
+  def runInferenceCharRNN(dataPath: String, modelPrefix: String, starterSentence : String): Unit = {
     // The batch size for training
     val batchSize = 32
     // We can support various length input
@@ -86,7 +86,7 @@ object TestCharRnn {
     try {
       parser.parseArgument(args.toList.asJava)
       assert(stcr.dataPath != null && stcr.modelPrefix != null && stcr.starterSentence != null)
-      runTestCharRNN(stcr.dataPath, stcr.modelPrefix, stcr.starterSentence)
+      runInferenceCharRNN(stcr.dataPath, stcr.modelPrefix, stcr.starterSentence)
     } catch {
       case ex: Exception => {
         logger.error(ex.getMessage, ex)

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TestCharRnn.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TestCharRnn.scala
@@ -31,53 +31,55 @@ object TestCharRnn {
   private val logger = LoggerFactory.getLogger(classOf[TrainCharRnn])
 
   def runInferenceCharRNN(dataPath: String, modelPrefix: String, starterSentence : String): Unit = {
-    // The batch size for training
-    val batchSize = 32
-    // We can support various length input
-    // For this problem, we cut each input sentence to length of 129
-    // So we only need fix length bucket
-    val buckets = List(129)
-    // hidden unit in LSTM cell
-    val numHidden = 512
-    // embedding dimension, which is, map a char to a 256 dim vector
-    val numEmbed = 256
-    // number of lstm layer
-    val numLstmLayer = 3
+    NDArrayCollector.auto().withScope {
+      // The batch size for training
+      val batchSize = 32
+      // We can support various length input
+      // For this problem, we cut each input sentence to length of 129
+      // So we only need fix length bucket
+      val buckets = List(129)
+      // hidden unit in LSTM cell
+      val numHidden = 512
+      // embedding dimension, which is, map a char to a 256 dim vector
+      val numEmbed = 256
+      // number of lstm layer
+      val numLstmLayer = 3
 
-    // build char vocabluary from input
-    val vocab = Utils.buildVocab(dataPath)
+      // build char vocabluary from input
+      val vocab = Utils.buildVocab(dataPath)
 
-    // load from check-point
-    val (_, argParams, _) = Model.loadCheckpoint(modelPrefix, 75)
+      // load from check-point
+      val (_, argParams, _) = Model.loadCheckpoint(modelPrefix, 75)
 
-    // build an inference model
-    val model = new RnnModel.LSTMInferenceModel(numLstmLayer, vocab.size + 1,
-      numHidden = numHidden, numEmbed = numEmbed,
-      numLabel = vocab.size + 1, argParams = argParams, dropout = 0.2f)
+      // build an inference model
+      val model = new RnnModel.LSTMInferenceModel(numLstmLayer, vocab.size + 1,
+        numHidden = numHidden, numEmbed = numEmbed,
+        numLabel = vocab.size + 1, argParams = argParams, dropout = 0.2f)
 
-    // generate a sequence of 1200 chars
-    val seqLength = 1200
-    val inputNdarray = NDArray.zeros(1)
-    val revertVocab = Utils.makeRevertVocab(vocab)
+      // generate a sequence of 1200 chars
+      val seqLength = 1200
+      val inputNdarray = NDArray.zeros(1)
+      val revertVocab = Utils.makeRevertVocab(vocab)
 
-    // Feel free to change the starter sentence
-    var output = starterSentence
-    val randomSample = true
-    var newSentence = true
-    val ignoreLength = output.length()
+      // Feel free to change the starter sentence
+      var output = starterSentence
+      val randomSample = true
+      var newSentence = true
+      val ignoreLength = output.length()
 
-    for (i <- 0 until seqLength) {
-      if (i <= ignoreLength - 1) Utils.makeInput(output(i), vocab, inputNdarray)
-      else Utils.makeInput(output.takeRight(1)(0), vocab, inputNdarray)
-      val prob = model.forward(inputNdarray, newSentence)
-      newSentence = false
-      val nextChar = Utils.makeOutput(prob, revertVocab, randomSample)
-      if (nextChar == "") newSentence = true
-      if (i >= ignoreLength) output = output ++ nextChar
+      for (i <- 0 until seqLength) {
+        if (i <= ignoreLength - 1) Utils.makeInput(output(i), vocab, inputNdarray)
+        else Utils.makeInput(output.takeRight(1)(0), vocab, inputNdarray)
+        val prob = model.forward(inputNdarray, newSentence)
+        newSentence = false
+        val nextChar = Utils.makeOutput(prob, revertVocab, randomSample)
+        if (nextChar == "") newSentence = true
+        if (i >= ignoreLength) output = output ++ nextChar
+      }
+
+      // Let's see what we can learned from char in Obama's speech.
+      logger.info(output)
     }
-
-    // Let's see what we can learned from char in Obama's speech.
-    logger.info(output)
   }
 
   def main(args: Array[String]): Unit = {

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TrainCharRnn.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TrainCharRnn.scala
@@ -33,125 +33,127 @@ object TrainCharRnn {
 
   def runTrainCharRnn(dataPath: String, saveModelPath: String,
                       ctx : Context, numEpoch : Int): Unit = {
-    // The batch size for training
-    val batchSize = 32
-    // We can support various length input
-    // For this problem, we cut each input sentence to length of 129
-    // So we only need fix length bucket
-    val buckets = Array(129)
-    // hidden unit in LSTM cell
-    val numHidden = 512
-    // embedding dimension, which is, map a char to a 256 dim vector
-    val numEmbed = 256
-    // number of lstm layer
-    val numLstmLayer = 3
-    // we will show a quick demo in 2 epoch
-    // learning rate
-    val learningRate = 0.001f
-    // we will use pure sgd without momentum
-    val momentum = 0.0f
+    NDArrayCollector.auto().withScope {
+      // The batch size for training
+      val batchSize = 32
+      // We can support various length input
+      // For this problem, we cut each input sentence to length of 129
+      // So we only need fix length bucket
+      val buckets = Array(129)
+      // hidden unit in LSTM cell
+      val numHidden = 512
+      // embedding dimension, which is, map a char to a 256 dim vector
+      val numEmbed = 256
+      // number of lstm layer
+      val numLstmLayer = 3
+      // we will show a quick demo in 2 epoch
+      // learning rate
+      val learningRate = 0.001f
+      // we will use pure sgd without momentum
+      val momentum = 0.0f
 
-    val vocab = Utils.buildVocab(dataPath)
+      val vocab = Utils.buildVocab(dataPath)
 
-    // generate symbol for a length
-    def symGen(seqLen: Int): Symbol = {
-      Lstm.lstmUnroll(numLstmLayer, seqLen, vocab.size + 1,
-        numHidden = numHidden, numEmbed = numEmbed,
-        numLabel = vocab.size + 1, dropout = 0.2f)
-    }
-
-    // initalize states for LSTM
-    val initC = for (l <- 0 until numLstmLayer)
-      yield (s"l${l}_init_c_beta", (batchSize, numHidden))
-    val initH = for (l <- 0 until numLstmLayer)
-      yield (s"l${l}_init_h_beta", (batchSize, numHidden))
-    val initStates = initC ++ initH
-
-    val dataTrain = new BucketIo.BucketSentenceIter(dataPath, vocab, buckets,
-      batchSize, initStates, seperateChar = "\n",
-      text2Id = Utils.text2Id, readContent = Utils.readContent)
-
-    // the network symbol
-    val symbol = symGen(buckets(0))
-
-    val datasAndLabels = dataTrain.provideData ++ dataTrain.provideLabel
-    val (argShapes, outputShapes, auxShapes) = symbol.inferShape(datasAndLabels)
-
-    val initializer = new Xavier(factorType = "in", magnitude = 2.34f)
-
-    val argNames = symbol.listArguments()
-    val argDict = argNames.zip(argShapes.map(NDArray.zeros(_, ctx))).toMap
-    val auxNames = symbol.listAuxiliaryStates()
-    val auxDict = auxNames.zip(auxShapes.map(NDArray.zeros(_, ctx))).toMap
-
-    val gradDict = argNames.zip(argShapes).filter { case (name, shape) =>
-      !datasAndLabels.contains(name)
-    }.map(x => x._1 -> NDArray.empty(x._2, ctx) ).toMap
-
-    argDict.foreach { case (name, ndArray) =>
-      if (!datasAndLabels.contains(name)) {
-        initializer.initWeight(name, ndArray)
+      // generate symbol for a length
+      def symGen(seqLen: Int): Symbol = {
+        Lstm.lstmUnroll(numLstmLayer, seqLen, vocab.size + 1,
+          numHidden = numHidden, numEmbed = numEmbed,
+          numLabel = vocab.size + 1, dropout = 0.2f)
       }
-    }
 
-    val data = argDict("data")
-    val label = argDict("softmax_label")
+      // initalize states for LSTM
+      val initC = for (l <- 0 until numLstmLayer)
+        yield (s"l${l}_init_c_beta", (batchSize, numHidden))
+      val initH = for (l <- 0 until numLstmLayer)
+        yield (s"l${l}_init_h_beta", (batchSize, numHidden))
+      val initStates = initC ++ initH
 
-    val executor = symbol.bind(ctx, argDict, gradDict)
+      val dataTrain = new BucketIo.BucketSentenceIter(dataPath, vocab, buckets,
+        batchSize, initStates, seperateChar = "\n",
+        text2Id = Utils.text2Id, readContent = Utils.readContent)
 
-    val opt = new Adam(learningRate = learningRate, wd = 0.0001f)
+      // the network symbol
+      val symbol = symGen(buckets(0))
 
-    val paramsGrads = gradDict.toList.zipWithIndex.map { case ((name, grad), idx) =>
-      (idx, name, grad, opt.createState(idx, argDict(name)))
-    }
+      val datasAndLabels = dataTrain.provideData ++ dataTrain.provideLabel
+      val (argShapes, outputShapes, auxShapes) = symbol.inferShape(datasAndLabels)
 
-    val evalMetric = new CustomMetric(Utils.perplexity, "perplexity")
-    val batchEndCallback = new Callback.Speedometer(batchSize, 50)
-    val epochEndCallback = Utils.doCheckpoint(s"${saveModelPath}/obama")
+      val initializer = new Xavier(factorType = "in", magnitude = 2.34f)
 
-    for (epoch <- 0 until numEpoch) {
-      // Training phase
-      val tic = System.currentTimeMillis
-      evalMetric.reset()
-      var nBatch = 0
-      var epochDone = false
-      // Iterate over training data.
-      dataTrain.reset()
-      while (!epochDone) {
-        var doReset = true
-        while (doReset && dataTrain.hasNext) {
-          val dataBatch = dataTrain.next()
+      val argNames = symbol.listArguments()
+      val argDict = argNames.zip(argShapes.map(NDArray.zeros(_, ctx))).toMap
+      val auxNames = symbol.listAuxiliaryStates()
+      val auxDict = auxNames.zip(auxShapes.map(NDArray.zeros(_, ctx))).toMap
 
-          data.set(dataBatch.data(0))
-          label.set(dataBatch.label(0))
-          executor.forward(isTrain = true)
-          executor.backward()
-          paramsGrads.foreach { case (idx, name, grad, optimState) =>
-            opt.update(idx, argDict(name), grad, optimState)
+      val gradDict = argNames.zip(argShapes).filter { case (name, shape) =>
+        !datasAndLabels.contains(name)
+      }.map(x => x._1 -> NDArray.empty(x._2, ctx)).toMap
+
+      argDict.foreach { case (name, ndArray) =>
+        if (!datasAndLabels.contains(name)) {
+          initializer.initWeight(name, ndArray)
+        }
+      }
+
+      val data = argDict("data")
+      val label = argDict("softmax_label")
+
+      val executor = symbol.bind(ctx, argDict, gradDict)
+
+      val opt = new Adam(learningRate = learningRate, wd = 0.0001f)
+
+      val paramsGrads = gradDict.toList.zipWithIndex.map { case ((name, grad), idx) =>
+        (idx, name, grad, opt.createState(idx, argDict(name)))
+      }
+
+      val evalMetric = new CustomMetric(Utils.perplexity, "perplexity")
+      val batchEndCallback = new Callback.Speedometer(batchSize, 50)
+      val epochEndCallback = Utils.doCheckpoint(s"${saveModelPath}/obama")
+
+      for (epoch <- 0 until numEpoch) {
+        // Training phase
+        val tic = System.currentTimeMillis
+        evalMetric.reset()
+        var nBatch = 0
+        var epochDone = false
+        // Iterate over training data.
+        dataTrain.reset()
+        while (!epochDone) {
+          var doReset = true
+          while (doReset && dataTrain.hasNext) {
+            val dataBatch = dataTrain.next()
+
+            data.set(dataBatch.data(0))
+            label.set(dataBatch.label(0))
+            executor.forward(isTrain = true)
+            executor.backward()
+            paramsGrads.foreach { case (idx, name, grad, optimState) =>
+              opt.update(idx, argDict(name), grad, optimState)
+            }
+
+            // evaluate at end, so out_cpu_array can lazy copy
+            evalMetric.update(dataBatch.label, executor.outputs)
+
+            nBatch += 1
+            batchEndCallback.invoke(epoch, nBatch, evalMetric)
           }
-
-          // evaluate at end, so out_cpu_array can lazy copy
-          evalMetric.update(dataBatch.label, executor.outputs)
-
-          nBatch += 1
-          batchEndCallback.invoke(epoch, nBatch, evalMetric)
+          if (doReset) {
+            dataTrain.reset()
+          }
+          // this epoch is done
+          epochDone = true
         }
-        if (doReset) {
-          dataTrain.reset()
+        val (name, value) = evalMetric.get
+        name.zip(value).foreach { case (n, v) =>
+          logger.info(s"Epoch[$epoch] Train-$n=$v")
         }
-        // this epoch is done
-        epochDone = true
-      }
-      val (name, value) = evalMetric.get
-      name.zip(value).foreach { case (n, v) =>
-        logger.info(s"Epoch[$epoch] Train-$n=$v")
-      }
-      val toc = System.currentTimeMillis
-      logger.info(s"Epoch[$epoch] Time cost=${toc - tic}")
+        val toc = System.currentTimeMillis
+        logger.info(s"Epoch[$epoch] Time cost=${toc - tic}")
 
-      epochEndCallback.invoke(epoch, symbol, argDict, auxDict)
+        epochEndCallback.invoke(epoch, symbol, argDict, auxDict)
+      }
+      executor.dispose()
     }
-    executor.dispose()
   }
 
   def main(args: Array[String]): Unit = {

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/cnntextclassification/CNNClassifierExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/cnntextclassification/CNNClassifierExampleSuite.scala
@@ -57,10 +57,8 @@ class CNNClassifierExampleSuite extends FunSuite with BeforeAndAfterAll {
 
       val modelDirPath = tempDirPath + File.separator + "CNN"
 
-      val output = NDArrayCollector.auto().withScope {
-          CNNTextClassification.test(modelDirPath + File.separator + w2vModelName,
-            modelDirPath, context, modelDirPath)
-        }
+      val output = CNNTextClassification.test(modelDirPath + File.separator + w2vModelName,
+        modelDirPath, context, modelDirPath)
 
       Process("rm -rf " + modelDirPath) !
 

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/cnntextclassification/CNNClassifierExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/cnntextclassification/CNNClassifierExampleSuite.scala
@@ -21,7 +21,7 @@ import java.io.File
 import java.net.URL
 
 import org.apache.commons.io.FileUtils
-import org.apache.mxnet.Context
+import org.apache.mxnet.{Context, NDArrayCollector}
 import org.apache.mxnetexamples.Util
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.slf4j.LoggerFactory
@@ -57,8 +57,10 @@ class CNNClassifierExampleSuite extends FunSuite with BeforeAndAfterAll {
 
       val modelDirPath = tempDirPath + File.separator + "CNN"
 
-      val output = CNNTextClassification.test(modelDirPath + File.separator + w2vModelName,
-        modelDirPath, context, modelDirPath)
+      val output = NDArrayCollector.auto().withScope {
+          CNNTextClassification.test(modelDirPath + File.separator + w2vModelName,
+            modelDirPath, context, modelDirPath)
+        }
 
       Process("rm -rf " + modelDirPath) !
 

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/gan/GanExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/gan/GanExampleSuite.scala
@@ -44,9 +44,8 @@ class GanExampleSuite extends FunSuite with BeforeAndAfterAll{
 
         val context = Context.gpu()
 
-        val output = NDArrayCollector.auto().withScope {
-          GanMnist.runTraining(modelDirPath, context, modelDirPath, 3)
-        }
+        val output = GanMnist.runTraining(modelDirPath, context, modelDirPath, 3)
+
         Process("rm -rf " + modelDirPath) !
 
         assert(output >= 0.0f)

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/gan/GanExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/gan/GanExampleSuite.scala
@@ -18,14 +18,14 @@
 package org.apache.mxnetexamples.gan
 
 import java.io.File
-import org.apache.mxnet.Context
+
+import org.apache.mxnet.{Context, NDArrayCollector}
 import org.apache.mxnetexamples.Util
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Ignore}
 import org.slf4j.LoggerFactory
 
 import scala.sys.process.Process
 
-@Ignore
 class GanExampleSuite extends FunSuite with BeforeAndAfterAll{
   private val logger = LoggerFactory.getLogger(classOf[GanExampleSuite])
 
@@ -44,7 +44,9 @@ class GanExampleSuite extends FunSuite with BeforeAndAfterAll{
 
         val context = Context.gpu()
 
-        val output = GanMnist.runTraining(modelDirPath, context, modelDirPath, 5)
+        val output = NDArrayCollector.auto().withScope {
+          GanMnist.runTraining(modelDirPath, context, modelDirPath, 3)
+        }
         Process("rm -rf " + modelDirPath) !
 
         assert(output >= 0.0f)

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExampleSuite.scala
@@ -23,7 +23,7 @@ import java.io.File
 import java.net.URL
 
 import org.apache.commons.io.FileUtils
-import org.apache.mxnet.Context
+import org.apache.mxnet.{Context, NDArrayCollector}
 import org.apache.mxnetexamples.Util
 
 import sys.process.Process
@@ -63,11 +63,15 @@ class ImageClassifierExampleSuite extends FunSuite with BeforeAndAfterAll {
       context = Context.gpu()
     }
 
-    val output = ImageClassifierExample.runInferenceOnSingleImage(modelDirPath + "resnet-18",
-      inputImagePath, context)
+    val output = NDArrayCollector.auto().withScope {
+      ImageClassifierExample.runInferenceOnSingleImage(modelDirPath + "resnet-18",
+        inputImagePath, context)
+    }
 
-    val outputList = ImageClassifierExample.runInferenceOnBatchOfImage(modelDirPath + "resnet-18",
-      inputImageDir, context)
+    val outputList = NDArrayCollector.auto().withScope {
+      ImageClassifierExample.runInferenceOnBatchOfImage(modelDirPath + "resnet-18",
+        inputImageDir, context)
+    }
 
     Process("rm -rf " + modelDirPath + " " + inputImageDir) !
 

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExampleSuite.scala
@@ -63,15 +63,11 @@ class ImageClassifierExampleSuite extends FunSuite with BeforeAndAfterAll {
       context = Context.gpu()
     }
 
-    val output = NDArrayCollector.auto().withScope {
-      ImageClassifierExample.runInferenceOnSingleImage(modelDirPath + "resnet-18",
+    val output = ImageClassifierExample.runInferenceOnSingleImage(modelDirPath + "resnet-18",
         inputImagePath, context)
-    }
 
-    val outputList = NDArrayCollector.auto().withScope {
-      ImageClassifierExample.runInferenceOnBatchOfImage(modelDirPath + "resnet-18",
+    val outputList = ImageClassifierExample.runInferenceOnBatchOfImage(modelDirPath + "resnet-18",
         inputImageDir, context)
-    }
 
     Process("rm -rf " + modelDirPath + " " + inputImageDir) !
 

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/infer/objectdetector/ObjectDetectorExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/infer/objectdetector/ObjectDetectorExampleSuite.scala
@@ -21,7 +21,7 @@ import java.io.File
 import java.net.URL
 
 import org.apache.commons.io.FileUtils
-import org.apache.mxnet.Context
+import org.apache.mxnet.{Context, NDArrayCollector}
 import org.apache.mxnetexamples.Util
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.slf4j.LoggerFactory
@@ -60,12 +60,16 @@ class ObjectDetectorExampleSuite extends FunSuite with BeforeAndAfterAll {
       context = Context.gpu()
     }
 
-    val output = SSDClassifierExample.runObjectDetectionSingle(modelDirPath + "resnet50_ssd_model",
-      inputImagePath, context)
+    val output = NDArrayCollector.auto().withScope {
+      SSDClassifierExample.runObjectDetectionSingle(modelDirPath + "resnet50_ssd_model",
+        inputImagePath, context)
+    }
 
-    val outputList = SSDClassifierExample.runObjectDetectionBatch(
-      modelDirPath + "resnet50_ssd_model",
-      inputImageDir, context)
+    val outputList = NDArrayCollector.auto().withScope {
+      SSDClassifierExample.runObjectDetectionBatch(
+        modelDirPath + "resnet50_ssd_model",
+        inputImageDir, context)
+    }
 
     Process("rm -rf " + modelDirPath + " " + inputImageDir) !
 

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/infer/objectdetector/ObjectDetectorExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/infer/objectdetector/ObjectDetectorExampleSuite.scala
@@ -60,16 +60,12 @@ class ObjectDetectorExampleSuite extends FunSuite with BeforeAndAfterAll {
       context = Context.gpu()
     }
 
-    val output = NDArrayCollector.auto().withScope {
-      SSDClassifierExample.runObjectDetectionSingle(modelDirPath + "resnet50_ssd_model",
+    val output = SSDClassifierExample.runObjectDetectionSingle(modelDirPath + "resnet50_ssd_model",
         inputImagePath, context)
-    }
 
-    val outputList = NDArrayCollector.auto().withScope {
-      SSDClassifierExample.runObjectDetectionBatch(
+    val outputList = SSDClassifierExample.runObjectDetectionBatch(
         modelDirPath + "resnet50_ssd_model",
         inputImageDir, context)
-    }
 
     Process("rm -rf " + modelDirPath + " " + inputImageDir) !
 

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/multitask/MultiTaskSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/multitask/MultiTaskSuite.scala
@@ -40,9 +40,7 @@ class MultiTaskSuite extends FunSuite {
       val ctx = Context.gpu()
 
       val modelPath = ExampleMultiTask.getTrainingData
-      val (executor, evalMetric) = NDArrayCollector.auto().withScope {
-        ExampleMultiTask.train(batchSize, numEpoch, ctx, modelPath)
-      }
+      val (executor, evalMetric) = ExampleMultiTask.train(batchSize, numEpoch, ctx, modelPath)
       evalMetric.get.foreach { case (name, value) =>
         assert(value >= 0.95f)
       }

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/multitask/MultiTaskSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/multitask/MultiTaskSuite.scala
@@ -17,26 +17,11 @@
 
 package org.apache.mxnetexamples.multitask
 
-import org.apache.commons.io.FileUtils
-import org.apache.mxnet.Context
-import org.scalatest.FunSuite
+import org.apache.mxnet._
 import org.slf4j.LoggerFactory
-import org.apache.mxnet.Symbol
-import org.apache.mxnet.DataIter
-import org.apache.mxnet.DataBatch
-import org.apache.mxnet.NDArray
-import org.apache.mxnet.Shape
-import org.apache.mxnet.EvalMetric
 import org.apache.mxnet.Context
-import org.apache.mxnet.Xavier
-import org.apache.mxnet.optimizer.RMSProp
-import java.io.File
-import java.net.URL
 
-import scala.sys.process.Process
-import scala.collection.immutable.ListMap
-import scala.collection.immutable.IndexedSeq
-import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+import org.scalatest.FunSuite
 
 
 /**
@@ -55,7 +40,9 @@ class MultiTaskSuite extends FunSuite {
       val ctx = Context.gpu()
 
       val modelPath = ExampleMultiTask.getTrainingData
-      val (executor, evalMetric) = ExampleMultiTask.train(batchSize, numEpoch, ctx, modelPath)
+      val (executor, evalMetric) = NDArrayCollector.auto().withScope {
+        ExampleMultiTask.train(batchSize, numEpoch, ctx, modelPath)
+      }
       evalMetric.get.foreach { case (name, value) =>
         assert(value >= 0.95f)
       }

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyleSuite.scala
@@ -60,10 +60,8 @@ class NeuralStyleSuite extends FunSuite with BeforeAndAfterAll {
       System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
       ctx = Context.gpu()
     }
-    NDArrayCollector.auto().withScope {
-      BoostInference.runInference(tempDirPath + "/NS/model", tempDirPath + "/NS", 2,
-        tempDirPath + "/NS/IMG_4343.jpg", ctx)
-    }
+    BoostInference.runInference(tempDirPath + "/NS/model", tempDirPath + "/NS", 2,
+      tempDirPath + "/NS/IMG_4343.jpg", ctx)
   }
 
   test("Example CI: Test Boost Training") {
@@ -71,10 +69,8 @@ class NeuralStyleSuite extends FunSuite with BeforeAndAfterAll {
     if (System.getenv().containsKey("SCALA_TEST_ON_GPU") &&
       System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
       val ctx = Context.gpu()
-      NDArrayCollector.auto().withScope {
-        BoostTrain.runTraining(tempDirPath + "/NS/images", tempDirPath + "/NS/vgg19.params", ctx,
-          tempDirPath + "/NS/starry_night.jpg", tempDirPath + "/NS")
-      }
+      BoostTrain.runTraining(tempDirPath + "/NS/images", tempDirPath + "/NS/vgg19.params", ctx,
+        tempDirPath + "/NS/starry_night.jpg", tempDirPath + "/NS")
     } else {
       logger.info("GPU test only, skip CPU...")
     }
@@ -85,12 +81,10 @@ class NeuralStyleSuite extends FunSuite with BeforeAndAfterAll {
     if (System.getenv().containsKey("SCALA_TEST_ON_GPU") &&
       System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
       val ctx = Context.gpu()
-      NDArrayCollector.auto().withScope {
-        NeuralStyle.runTraining("vgg19", tempDirPath + "/NS/IMG_4343.jpg",
-          tempDirPath + "/NS/starry_night.jpg",
-          ctx, tempDirPath + "/NS/vgg19.params", tempDirPath + "/NS",
-          1f, 20f, 0.01f, 1, 10f, 60, 600, 50, 0.0005f)
-      }
+      NeuralStyle.runTraining("vgg19", tempDirPath + "/NS/IMG_4343.jpg",
+        tempDirPath + "/NS/starry_night.jpg",
+        ctx, tempDirPath + "/NS/vgg19.params", tempDirPath + "/NS",
+        1f, 20f, 0.01f, 1, 10f, 60, 600, 50, 0.0005f)
     } else {
       logger.info("GPU test only, skip CPU")
     }

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyleSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.mxnetexamples.neuralstyle
 
-import org.apache.mxnet.Context
+import org.apache.mxnet.{Context, NDArrayCollector}
 import org.apache.mxnetexamples.Util
 import org.apache.mxnetexamples.neuralstyle.end2end.{BoostInference, BoostTrain}
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
@@ -60,8 +60,10 @@ class NeuralStyleSuite extends FunSuite with BeforeAndAfterAll {
       System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
       ctx = Context.gpu()
     }
-    BoostInference.runInference(tempDirPath + "/NS/model", tempDirPath + "/NS", 2,
-      tempDirPath + "/NS/IMG_4343.jpg", ctx)
+    NDArrayCollector.auto().withScope {
+      BoostInference.runInference(tempDirPath + "/NS/model", tempDirPath + "/NS", 2,
+        tempDirPath + "/NS/IMG_4343.jpg", ctx)
+    }
   }
 
   test("Example CI: Test Boost Training") {
@@ -69,8 +71,10 @@ class NeuralStyleSuite extends FunSuite with BeforeAndAfterAll {
     if (System.getenv().containsKey("SCALA_TEST_ON_GPU") &&
       System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
       val ctx = Context.gpu()
-      BoostTrain.runTraining(tempDirPath + "/NS/images", tempDirPath + "/NS/vgg19.params", ctx,
-        tempDirPath + "/NS/starry_night.jpg", tempDirPath + "/NS")
+      NDArrayCollector.auto().withScope {
+        BoostTrain.runTraining(tempDirPath + "/NS/images", tempDirPath + "/NS/vgg19.params", ctx,
+          tempDirPath + "/NS/starry_night.jpg", tempDirPath + "/NS")
+      }
     } else {
       logger.info("GPU test only, skip CPU...")
     }
@@ -81,10 +85,12 @@ class NeuralStyleSuite extends FunSuite with BeforeAndAfterAll {
     if (System.getenv().containsKey("SCALA_TEST_ON_GPU") &&
       System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
       val ctx = Context.gpu()
-      NeuralStyle.runTraining("vgg19", tempDirPath + "/NS/IMG_4343.jpg",
-        tempDirPath + "/NS/starry_night.jpg",
-        ctx, tempDirPath + "/NS/vgg19.params", tempDirPath + "/NS",
-        1f, 20f, 0.01f, 1, 10f, 60, 600, 50, 0.0005f)
+      NDArrayCollector.auto().withScope {
+        NeuralStyle.runTraining("vgg19", tempDirPath + "/NS/IMG_4343.jpg",
+          tempDirPath + "/NS/starry_night.jpg",
+          ctx, tempDirPath + "/NS/vgg19.params", tempDirPath + "/NS",
+          1f, 20f, 0.01f, 1, 10f, 60, 600, 50, 0.0005f)
+      }
     } else {
       logger.info("GPU test only, skip CPU")
     }

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
@@ -69,11 +69,11 @@ class ExampleRNNSuite extends FunSuite with BeforeAndAfterAll {
     }
   }
 
-  test("Example CI: Test TestCharRNN") {
+  test("Example CI: Test Inference on CharRNN") {
     val tempDirPath = System.getProperty("java.io.tmpdir")
     val ctx = Context.gpu()
     NDArrayCollector.auto().withScope {
-      TestCharRnn.runTestCharRNN(tempDirPath + "/RNN/obama.txt",
+      TestCharRnn.runInferenceCharRNN(tempDirPath + "/RNN/obama.txt",
         tempDirPath + "/RNN/obama", "The joke")
     }
   }

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
@@ -49,10 +49,8 @@ class ExampleRNNSuite extends FunSuite with BeforeAndAfterAll {
       System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
       ctx = Context.gpu()
     }
-    NDArrayCollector.auto().withScope {
-      LstmBucketing.runTraining(tempDirPath + "/RNN/sherlockholmes.train.txt",
-        tempDirPath + "/RNN/sherlockholmes.valid.txt", Array(ctx), 1)
-    }
+    LstmBucketing.runTraining(tempDirPath + "/RNN/sherlockholmes.train.txt",
+      tempDirPath + "/RNN/sherlockholmes.valid.txt", Array(ctx), 1)
   }
 
   test("Example CI: Test TrainCharRNN") {
@@ -60,10 +58,8 @@ class ExampleRNNSuite extends FunSuite with BeforeAndAfterAll {
     if (System.getenv().containsKey("SCALA_TEST_ON_GPU") &&
       System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
       val ctx = Context.gpu()
-      NDArrayCollector.auto().withScope {
-        TrainCharRnn.runTrainCharRnn(tempDirPath + "/RNN/obama.txt",
-          tempDirPath, ctx, 1)
-      }
+      TrainCharRnn.runTrainCharRnn(tempDirPath + "/RNN/obama.txt",
+        tempDirPath, ctx, 1)
     } else {
       logger.info("CPU not supported for this test, skipped...")
     }
@@ -72,9 +68,7 @@ class ExampleRNNSuite extends FunSuite with BeforeAndAfterAll {
   test("Example CI: Test Inference on CharRNN") {
     val tempDirPath = System.getProperty("java.io.tmpdir")
     val ctx = Context.gpu()
-    NDArrayCollector.auto().withScope {
-      TestCharRnn.runInferenceCharRNN(tempDirPath + "/RNN/obama.txt",
-        tempDirPath + "/RNN/obama", "The joke")
-    }
+    TestCharRnn.runInferenceCharRNN(tempDirPath + "/RNN/obama.txt",
+      tempDirPath + "/RNN/obama", "The joke")
   }
 }

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory
 
 import scala.sys.process.Process
 
-@Ignore
 class ExampleRNNSuite extends FunSuite with BeforeAndAfterAll {
   private val logger = LoggerFactory.getLogger(classOf[ExampleRNNSuite])
 
@@ -50,8 +49,10 @@ class ExampleRNNSuite extends FunSuite with BeforeAndAfterAll {
       System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
       ctx = Context.gpu()
     }
-    LstmBucketing.runTraining(tempDirPath + "/RNN/sherlockholmes.train.txt",
+    NDArrayCollector.auto().withScope {
+      LstmBucketing.runTraining(tempDirPath + "/RNN/sherlockholmes.train.txt",
         tempDirPath + "/RNN/sherlockholmes.valid.txt", Array(ctx), 1)
+    }
   }
 
   test("Example CI: Test TrainCharRNN") {
@@ -59,8 +60,10 @@ class ExampleRNNSuite extends FunSuite with BeforeAndAfterAll {
     if (System.getenv().containsKey("SCALA_TEST_ON_GPU") &&
       System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
       val ctx = Context.gpu()
-      TrainCharRnn.runTrainCharRnn(tempDirPath + "/RNN/obama.txt",
+      NDArrayCollector.auto().withScope {
+        TrainCharRnn.runTrainCharRnn(tempDirPath + "/RNN/obama.txt",
           tempDirPath, ctx, 1)
+      }
     } else {
       logger.info("CPU not supported for this test, skipped...")
     }
@@ -69,7 +72,9 @@ class ExampleRNNSuite extends FunSuite with BeforeAndAfterAll {
   test("Example CI: Test TestCharRNN") {
     val tempDirPath = System.getProperty("java.io.tmpdir")
     val ctx = Context.gpu()
-    TestCharRnn.runTestCharRNN(tempDirPath + "/RNN/obama.txt",
+    NDArrayCollector.auto().withScope {
+      TestCharRnn.runTestCharRNN(tempDirPath + "/RNN/obama.txt",
         tempDirPath + "/RNN/obama", "The joke")
+    }
   }
 }

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory
 
 import scala.sys.process.Process
 
-@Ignore
 class ExampleRNNSuite extends FunSuite with BeforeAndAfterAll {
   private val logger = LoggerFactory.getLogger(classOf[ExampleRNNSuite])
 

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory
 
 import scala.sys.process.Process
 
+@Ignore
 class ExampleRNNSuite extends FunSuite with BeforeAndAfterAll {
   private val logger = LoggerFactory.getLogger(classOf[ExampleRNNSuite])
 


### PR DESCRIPTION
## Description ##
Currently the Scala integration test running are strong influenced by CUDA memory not enough. In order to address that issue, this PR gives a test run on the `NDArrayCollector` created by @yzhliu.
@andrewfayres @nswamy 

related CI failure:
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/PR-11753/9/pipeline

http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/PR-11753/10/pipeline

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
