### PR TITLE
[MXNET-696] Delete comment line that contains a Unicode character

### DIFF
--- a/tests/nightly/model_backwards_compatibility_check/common.py
+++ b/tests/nightly/model_backwards_compatibility_check/common.py
@@ -32,7 +32,6 @@ from mxnet.test_utils import assert_almost_equal
 try:
     cmp             # Python 2
 except NameError:
-    # See: https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
     def cmp(x, y):  # Python 3
         return (x > y) - (x < y)
 


### PR DESCRIPTION
Python 2 has low tolerance for Unicode characters in source files without proper encoding specified.  This PR removes the comment line that contains the Unicode character

Fix suggested by the discussion at https://github.com/apache/incubator-mxnet/pull/12231#issuecomment-413999694

Probably a better way to proceed than #12231

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
