### PR TITLE
Don't override global warnings filter

### DIFF
--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -24,14 +24,11 @@ import atexit
 import ctypes
 import os
 import sys
-import warnings
 import inspect
 import platform
 import numpy as np
 
 from . import libinfo
-
-warnings.filterwarnings('default', category=DeprecationWarning)
 
 __all__ = ['MXNetError']
 #----------------------------


### PR DESCRIPTION
## Description ##
Currently import mxnet causes warnings.filterwarnings('default', category=DeprecationWarning) to be executed.
This is very bad, as there are valid use cases where our users may have decided to filter out DeprecationWarning and we should not overwrite their configuration.

It is also not always possible for users to change the warnings filter after mxnet has changed it. Consider a package that relies on mxnet (such as https://github.com/dmlc/gluon-nlp ) but also imports third-party packages that may raise warnings. If now gluon-nlp is imported, mxnet will overwrite the warnings filter and the user has no option to change it back to whatever settings he needs before gluon-nlp goes on to import other packages that may raise warnings.

### Changes ###
- [X] Don't overwride global warnings.filterwarnings filter

### Comments ###
@szha This breaks our notebooks for KDD18
@Roshrini  Can we get this into mxnet 1.3 please? 