### PR TITLE
[MXNET-839] Fix the broken link in the Scala package

### DIFF
--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
@@ -31,9 +31,9 @@ import scala.collection.mutable.ListBuffer
 /**
   * <p>
   * Example inference showing usage of the Infer package on a resnet-152 model.
-  * @see <pre><a href="https://github.com/apache/incubator-mxnet/tree/master/s
-    cala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/im
-    ageclassifier" target="_blank">Instructions to run this example</a></pre>
+  * @see <a href="https://github.com/apache/incubator-mxnet/tree/master/sca\
+  *      la-package/examples/src/main/scala/org/apache/mxnetexamples/infer/im\
+  *      ageclassifier" target="_blank">Instructions to run this example</a>
   */
 object ImageClassifierExample {
 

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
@@ -32,8 +32,8 @@ import scala.collection.mutable.ListBuffer
   * <p>
   * Example inference showing usage of the Infer package on a resnet-152 model.
   * @see <a href="https://github.com/apache/incubator-mxnet/tree/master/sca\
-  *      la-package/examples/src/main/scala/org/apache/mxnetexamples/infer/im\
-  *      ageclassifier" target="_blank">Instructions to run this example</a>
+  * la-package/examples/src/main/scala/org/apache/mxnetexamples/infer/im\
+  * ageclassifier" target="_blank">Instructions to run this example</a>
   */
 object ImageClassifierExample {
 

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
@@ -28,13 +28,13 @@ import java.io.File
 
 import scala.collection.mutable.ListBuffer
 
+// scalastyle:off
 /**
   * <p>
   * Example inference showing usage of the Infer package on a resnet-152 model.
-  * @see <a href="https://github.com/apache/incubator-mxnet/tree/master/sca\
-  * la-package/examples/src/main/scala/org/apache/mxnetexamples/infer/im\
-  * ageclassifier" target="_blank">Instructions to run this example</a>
+  * @see <a href="https://github.com/apache/incubator-mxnet/tree/master/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier" target="_blank">Instructions to run this example</a>
   */
+// scalastyle:on
 object ImageClassifierExample {
 
   private val logger = LoggerFactory.getLogger(classOf[ImageClassifierExample])

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
@@ -34,8 +34,8 @@ import scala.collection.mutable.ListBuffer
   * Example single shot detector (SSD) using the Infer package
   * on a ssd_resnet50_512 model.
   * @see <a href="https://github.com/apache/incubator-mxnet/tree/master/s\
-  *      cala-package/examples/src/main/scala/org/apache/mxnetexamples/in\
-  *      fer/objectdetector" target="_blank">Instructions to run this example</a>
+  * cala-package/examples/src/main/scala/org/apache/mxnetexamples/in\
+  * fer/objectdetector" target="_blank">Instructions to run this example</a>
   */
 class SSDClassifierExample {
   @Option(name = "--model-path-prefix", usage = "the input model directory and prefix of the model")

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
@@ -29,14 +29,14 @@ import java.nio.file.{Files, Paths}
 
 import scala.collection.mutable.ListBuffer
 
+// scalastyle:off
 /**
   * <p>
   * Example single shot detector (SSD) using the Infer package
   * on a ssd_resnet50_512 model.
-  * @see <a href="https://github.com/apache/incubator-mxnet/tree/master/s\
-  * cala-package/examples/src/main/scala/org/apache/mxnetexamples/in\
-  * fer/objectdetector" target="_blank">Instructions to run this example</a>
+  * @see <a href="https://github.com/apache/incubator-mxnet/tree/master/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector" target="_blank">Instructions to run this example</a>
   */
+// scalastyle:on
 class SSDClassifierExample {
   @Option(name = "--model-path-prefix", usage = "the input model directory and prefix of the model")
   private val modelPathPrefix: String = "/model/ssd_resnet50_512"

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
@@ -33,9 +33,9 @@ import scala.collection.mutable.ListBuffer
   * <p>
   * Example single shot detector (SSD) using the Infer package
   * on a ssd_resnet50_512 model.
-  * @see <pre><a href="https://github.com/apache/incubator-mxnet/tree/master/s
-    cala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/object
-    detector" target="_blank">Instructions to run this example</a></pre>
+  * @see <a href="https://github.com/apache/incubator-mxnet/tree/master/s\
+  *      cala-package/examples/src/main/scala/org/apache/mxnetexamples/in\
+  *      fer/objectdetector" target="_blank">Instructions to run this example</a>
   */
 class SSDClassifierExample {
   @Option(name = "--model-path-prefix", usage = "the input model directory and prefix of the model")


### PR DESCRIPTION
## Description ##
This would revert what has been changed in here:
https://github.com/apache/incubator-mxnet/pull/11465, because the broken link were generated:

http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/Broken_Link_Checker_Pipeline/detail/Broken_Link_Checker_Pipeline/233/pipeline

@aaronmarkham @nswamy @marcoabreu 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
