### PR TITLE
[MXNET-850] Fix incorrect abs function call

### DIFF
--- a/src/operator/correlation.cc
+++ b/src/operator/correlation.cc
@@ -73,8 +73,8 @@ inline void CorrelationForward(const Tensor<cpu, 4, Dtype> &out,
                         out[nbatch][top_channel][i][j] += \
                         tmp1[nbatch][y1+h][x1+w][channel]*tmp2[nbatch][y2+h][x2+w][channel];
                     else
-                        out[nbatch][top_channel][i][j] += \
-                        fabsf(tmp1[nbatch][y1+h][x1+w][channel]-tmp2[nbatch][y2+h][x2+w][channel]);
+                        out[nbatch][top_channel][i][j] += std::abs(\
+                        tmp1[nbatch][y1+h][x1+w][channel]-tmp2[nbatch][y2+h][x2+w][channel]);
                   }
               out[nbatch][top_channel][i][j] /= sumelems;
             }


### PR DESCRIPTION
## Description ##
Addresses associated clang build warning.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

