### PR TITLE
[MXNET-848] Pin dockcross base images in CI

### DIFF
--- a/ci/docker/Dockerfile.build.android_armv7
+++ b/ci/docker/Dockerfile.build.android_armv7
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for Android ARMv7
 
-FROM dockcross/base:latest
+FROM mxnetci/dockcross-linux-base:08212018
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 
 # The cross-compiling emulator

--- a/ci/docker/Dockerfile.build.android_armv8
+++ b/ci/docker/Dockerfile.build.android_armv8
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for Android ARM64/ARMv8
 
-FROM dockcross/base:latest
+FROM mxnetci/dockcross-linux-base:08212018
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 
 RUN apt-get update && apt-get install -y \

--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for ARMv6
 
-FROM dockcross/linux-armv6
+FROM mxnetci/dockcross-linux-armv6:08212018
 
 ENV ARCH armv6l
 ENV HOSTCC gcc

--- a/ci/docker/Dockerfile.build.armv8
+++ b/ci/docker/Dockerfile.build.armv8
@@ -18,8 +18,6 @@
 #
 # Dockerfile to build MXNet for ARM64/ARMv8
 
-# Temporary fix due to https://github.com/apache/incubator-mxnet/issues/10837
-#FROM dockcross/linux-arm64
 FROM mxnetci/dockcross-linux-arm64:05082018
 
 ENV ARCH aarch64

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -22,9 +22,6 @@
 
 FROM nvidia/cuda:9.0-cudnn7-devel as cudabuilder
 
-
-# Temporary fix due to https://github.com/apache/incubator-mxnet/issues/10837
-# FROM dockcross/linux-arm64
 FROM mxnetci/dockcross-linux-arm64:05082018
 
 ENV ARCH aarch64


### PR DESCRIPTION
## Description ##
This PR will pin our dockcross base images to known working versions.  Pinning these images is necessary as we've had cases where following the 'latest' tag in dockerhub leads us to picking up broken, or incompatible images.  Though the dockcross images are generally high-quality we'd like to avoid these issues from blocking our CI in the future.

The disadvantage here is that we will lose visibility in valid failures for things like new cmake versions that potentially break on ARM builds.  We feel that these test should be done independently of PR validation, and would be best suited for the nightly test runs.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
