### PR TITLE
[MXNET-849] - Enable armv7 with pinned docker images.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -363,16 +363,16 @@ core_logic: {
         }
       }
     },
-    // 'ARMv7':{
-    //   node(NODE_LINUX_CPU) {
-    //     ws('workspace/build-ARMv7') {
-    //       timeout(time: max_time, unit: 'MINUTES') {
-    //         utils.init_git()
-    //         utils.docker_run('armv7', 'build_armv7', false)
-    //       }
-    //     }
-    //   }
-    // },
+    'ARMv7':{
+      node(NODE_LINUX_CPU) {
+        ws('workspace/build-ARMv7') {
+          timeout(time: max_time, unit: 'MINUTES') {
+            utils.init_git()
+            utils.docker_run('armv7', 'build_armv7', false)
+          }
+        }
+      }
+    },
     'ARMv6':{
       node(NODE_LINUX_CPU) {
         ws('workspace/build-ARMv6') {

--- a/ci/docker/Dockerfile.build.armv7
+++ b/ci/docker/Dockerfile.build.armv7
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for Android ARMv7
 
-FROM dockcross/linux-armv7
+FROM mxnetci/dockcross-linux-armv7:08212018
 
 ENV ARCH armv7l
 ENV HOSTCC gcc


### PR DESCRIPTION
## Description ##
Re-enable ARMv7 builds using pinned dockcross images.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change