### PR TITLE
[MXNET-859] Add a clang-tidy stage to CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# The checks defined here will be run and will display by default as warnings.
+Checks: >
+    -*, cppcoreguidelines-c-copy-assignment-signature,
+    cppcoreguidelines-interfaces-global-init, cppcoreguidelines-no-malloc,
+    cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-type-const-cast,
+    cppcoreguidelines-pro-type-cstyle-cast, cppcoreguidelines-pro-type-member-init,
+    cppcoreguidelines-pro-type-static-cast-downcast, cppcoreguidelines-pro-type-union-access,
+    cppcoreguidelines-pro-type-vararg, cppcoreguidelines-slicing,
+    cppcoreguidelines-special-member-functions, clang-analyzer-security.FloatLoopCounter,
+    clang-analyzer-security.insecureAPI.*, clang-analyzer-core.CallAndMessage,
+    clang-analyzer-core.DivideZero, clang-analyzer-core.DynamicTypePropagation,
+    clang-analyzer-core.NonNullParamChecker, clang-analyzer-core.NullDereference,
+    clang-analyzer-core.StackAddressEscape, clang-analyzer-core.UndefinedBinaryOperatorResult,
+    clang-analyzer-core.VLASize, clang-analyzer-core.builtin.BuiltinFunctions,
+    clang-analyzer-core.builtin.NoReturnFunctions, clang-analyzer-core.uninitialized.ArraySubscript,
+    clang-analyzer-core.uninitialized.Assign, clang-analyzer-core.uninitialized.Branch,
+    clang-analyzer-core.uninitialized.CapturedBlockVariable,
+    clang-analyzer-core.uninitialized.UndefReturn, clang-analyzer-cplusplus.NewDelete,
+    clang-analyzer-cplusplus.NewDeleteLeaks, clang-analyzer-cplusplus.SelfAssignment,
+    clang-analyzer-deadcode.DeadStores, modernize-avoid-bind, modernize-deprecated-headers,
+    modernize-loop-convert, modernize-make-shared, modernize-pass-by-value,
+    modernize-raw-string-literal, modernize-redundant-void-arg, modernize-replace-auto-ptr,
+    modernize-replace-random-shuffle, modernize-return-braced-init-list, modernize-shrink-to-fit,
+    modernize-unary-static-assert, modernize-use-bool-literals, modernize-use-default-member-init,
+    modernize-use-emplace, modernize-use-equals-default, modernize-use-equals-delete,
+    modernize-use-noexcept, modernize-use-nullptr, modernize-use-override,
+    modernize-use-transparent-functors, modernize-use-using, performance-*
+
+# cppcoreguidelines checks not enabled:
+# cppcoreguidelines-pro-bounds-pointer-arithmetic
+# cppcoreguidelines-pro-bounds-array-to-pointer-decay
+# cppcoreguidelines-pro-type-reinterpret-cast
+
+# modernize checks not enabled:
+# modernize-use-auto
+# modernize-make-unique (C++14 and newer only)
+
+# In order to trigger an error, you must have a rule defined both in checks and in this section.
+WarningsAsErrors: >
+    cppcoreguidelines-no-malloc
+
+# Todo: define a better regex match that includes most project headers, but excludes third party
+# code.
+HeaderFilterRegex: '^src/.*'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,6 +183,16 @@ core_logic: {
         }
       }
     },
+    'CPU: Clang Tidy': {
+      node(NODE_LINUX_CPU) {
+        ws('workspace/build-cpu-clang60_tidy') {
+          timeout(time: max_time, unit: 'MINUTES') {
+            utils.init_git()
+            utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_clang_tidy', false)
+          }
+        }
+      }
+    },
     'CPU: Clang 3.9 MKLDNN': {
       node(NODE_LINUX_CPU) {
         ws('workspace/build-cpu-mkldnn-clang39') {

--- a/ci/docker/install/ubuntu_clang.sh
+++ b/ci/docker/install/ubuntu_clang.sh
@@ -26,6 +26,11 @@ wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" && \
     apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main" && \
     apt-get update && \
-    apt-get install -y clang-3.9 clang-6.0 && \
+    apt-get install -y clang-3.9 clang-6.0 clang-tidy-6.0 && \
     clang-3.9 --version && \
     clang-6.0 --version
+
+# Use llvm's master version of run-clang-tidy.py.  This version has mostly minor updates, but
+# importantly will properly return a non-zero exit code when an error is reported in clang-tidy.
+# Please remove the below if we install a clang version higher than 6.0.
+wget https://raw.githubusercontent.com/llvm-mirror/clang-tools-extra/7654135f0cbd155c285fd2a37d87e27e4fff3071/clang-tidy/tool/run-clang-tidy.py -O /usr/lib/llvm-6.0/share/clang/run-clang-tidy.py

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -365,6 +365,32 @@ build_ubuntu_cpu_clang60() {
         -j$(nproc)
 }
 
+build_ubuntu_cpu_clang_tidy() {
+    set -ex
+
+    export CXX=clang++-6.0
+    export CC=clang-6.0
+    export CLANG_TIDY=/usr/lib/llvm-6.0/share/clang/run-clang-tidy.py
+
+    pushd .
+    cd /work/build
+    cmake \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DUSE_CUDA=OFF \
+        -DUSE_MKL_IF_AVAILABLE=OFF \
+        -DUSE_OPENCV=ON \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -G Ninja \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        /work/mxnet
+
+    ninja -v
+    cd /work/mxnet
+    $CLANG_TIDY -p /work/build -j $(nproc) -clang-tidy-binary clang-tidy-6.0 /work/mxnet/src
+    popd
+}
+
 build_ubuntu_cpu_clang39_mkldnn() {
     set -ex
 

--- a/src/c_api/.clang-tidy
+++ b/src/c_api/.clang-tidy
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Disable most clang-tidy checks in the c_api folder.
+Checks: -*,readability-non-const-parameter


### PR DESCRIPTION
## Description ##

This integrates clang-tidy into our CI system.  Clang-tidy is a modern c++ linting and static-analysis tool that can find issues in our native codebase.  It can also be used to modernize the codebase, suggesting improvements to adopt features that have been added to the C++11 standard.

This initial integration marks many rules as warnings and only targets cpu builds for our core native codebase.  I'd like to try and introduce this as a minimum useful change.  As we fix warnings we can move rules to errors in the configuration to protect against regressions.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change