### PR TITLE
Re-enable randomized test_ndarray_pickle

### DIFF
--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -240,20 +240,18 @@ def test_ndarray_scalar():
     assert(np.sum(d.asnumpy()) < 1e-5)
 
 
-@with_seed(0)
+@with_seed()
 def test_ndarray_pickle():
     maxdim = 5
-    nrepeat = 10
-    for repeat in range(nrepeat):
-        for dim in range(1, maxdim):
-            a = random_ndarray(dim)
-            b = mx.nd.empty(a.shape)
-            a[:] = np.random.uniform(-10, 10, a.shape)
-            b[:] = np.random.uniform(-10, 10, a.shape)
-            a = a + b
-            data = pkl.dumps(a)
-            a2 = pkl.loads(data)
-            assert np.sum(a.asnumpy() != a2.asnumpy()) == 0
+    for dim in range(1, maxdim):
+        a = random_ndarray(dim)
+        b = mx.nd.empty(a.shape)
+        a[:] = np.random.uniform(-10, 10, a.shape)
+        b[:] = np.random.uniform(-10, 10, a.shape)
+        a = a + b
+        data = pkl.dumps(a)
+        a2 = pkl.loads(data)
+        assert np.sum(a.asnumpy() != a2.asnumpy()) == 0
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
Fix #11710.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Get rid of unnecessary repeat in the test
- [x] Get rid of fixed seed to re-enable randomized testing

## Comments ##
Tested on CPU for more than 10000 trials:
```
MXNET_TEST_COUNT=10000 nosetests -s --verbose tests/python/unittest/test_ndarray.py:test_ndarray_pickle
/home/ubuntu/anaconda3/lib/python3.6/site-packages/urllib3/contrib/pyopenssl.py:46: DeprecationWarning: OpenSSL.rand is deprecated - you should use os.urandom instead
  import OpenSSL.SSL
/home/ubuntu/anaconda3/lib/python3.6/site-packages/nose/util.py:453: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
  inspect.getargspec(func)
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=2112071529 to reproduce.
test_ndarray.test_ndarray_pickle ... ok

----------------------------------------------------------------------
Ran 1 test in 36.270s

OK
```