### PR TITLE
[MXNET-855] Update clang to version 6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,12 +173,12 @@ core_logic: {
         }
       }
     },
-    'CPU: Clang 5': {
+    'CPU: Clang 6': {
       node(NODE_LINUX_CPU) {
-        ws('workspace/build-cpu-clang50') {
+        ws('workspace/build-cpu-clang60') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
-            utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_clang50', false)
+            utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_clang60', false)
           }
         }
       }
@@ -194,13 +194,13 @@ core_logic: {
         }
       }
     },
-    'CPU: Clang 5 MKLDNN': {
+    'CPU: Clang 6 MKLDNN': {
       node(NODE_LINUX_CPU) {
-        ws('workspace/build-cpu-mkldnn-clang50') {
+        ws('workspace/build-cpu-mkldnn-clang60') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
-            utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_clang50_mkldnn', false)
-            utils.pack_lib('mkldnn_cpu_clang5', mx_mkldnn_lib)
+            utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_clang60_mkldnn', false)
+            utils.pack_lib('mkldnn_cpu_clang6', mx_mkldnn_lib)
           }
         }
       }

--- a/ci/docker/install/ubuntu_clang.sh
+++ b/ci/docker/install/ubuntu_clang.sh
@@ -21,11 +21,11 @@
 # the whole docker cache for the image
 
 set -ex
-# Install clang 3.9 (the same version as in XCode 8.*) and 5.0 (latest major release)
+# Install clang 3.9 (the same version as in XCode 8.*) and 6.0 (latest major release)
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" && \
-    apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" && \
+    apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main" && \
     apt-get update && \
-    apt-get install -y clang-3.9 clang-5.0 && \
+    apt-get install -y clang-3.9 clang-6.0 && \
     clang-3.9 --version && \
-    clang-5.0 --version
+    clang-6.0 --version

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -349,11 +349,11 @@ build_ubuntu_cpu_clang39() {
         -j$(nproc)
 }
 
-build_ubuntu_cpu_clang50() {
+build_ubuntu_cpu_clang60() {
     set -ex
 
-    export CXX=clang++-5.0
-    export CC=clang-5.0
+    export CXX=clang++-6.0
+    export CC=clang-6.0
 
     build_ccache_wrappers
 
@@ -381,11 +381,11 @@ build_ubuntu_cpu_clang39_mkldnn() {
         -j$(nproc)
 }
 
-build_ubuntu_cpu_clang50_mkldnn() {
+build_ubuntu_cpu_clang60_mkldnn() {
     set -ex
 
-    export CXX=clang++-5.0
-    export CC=clang-5.0
+    export CXX=clang++-6.0
+    export CC=clang-6.0
 
     build_ccache_wrappers
 


### PR DESCRIPTION
## Description ##
Clang 6 has now been officially released (as of July 5th, 2018).  It will be a very popular compiler in the future, and we should adopt it in CI to try and guarantee the maximum amount of forwards compatibility possible for releases.

http://releases.llvm.org/6.0.1/tools/clang/docs/ReleaseNotes.html

Clang 6 contains better tooling, more openmp support and improved sanitizers which may be interesting for the MXNet project.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change