### PR TITLE
Enable gluon multi worker data loader test

### DIFF
--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -123,7 +123,7 @@ class Dataset(gluon.data.Dataset):
     def __getitem__(self, key):
         return mx.nd.full((10,), key)
 
-@unittest.skip("Somehow fails with MKL. Cannot reproduce locally")
+@with_seed()
 def test_multi_worker():
     data = Dataset()
     loader = gluon.data.DataLoader(data, batch_size=1, num_workers=5)


### PR DESCRIPTION
## Description ##
Re-enable the skipped test for Gluon DataLoader. Described in this issue - https://github.com/apache/incubator-mxnet/issues/11455

Tests are working fine on latest master.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:

### Changes ###
- Enable - `tests/python/unittest/test_gluon_data.py:test_multi_worker`

## Comments ##

Ran for 10,000 runs on CPU/GPU with/without MKLDNN.
```
~/incubator-mxnet$ MXNET_TEST_COUNT=10000 nosetests -s --verbose tests/python/unittest/test_gluon_data.py:test_multi_worker
/usr/local/lib/python3.5/dist-packages/nose/util.py:453: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead
  inspect.getargspec(func)
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=1359342575 to reproduce.
test_gluon_data.test_multi_worker ... ok

----------------------------------------------------------------------
Ran 1 test in 509.370s

OK
```

@marcoabreu 