### PR TITLE
Update ONNX API docs references

### DIFF
--- a/docs/api/python/contrib/onnx.md
+++ b/docs/api/python/contrib/onnx.md
@@ -22,10 +22,9 @@ This document describes all the ONNX-MXNet APIs.
 .. autosummary::
     :nosignatures:
 
-    mxnet.contrib.onnx.import_model
-    mxnet.contrib.onnx.get_model_metadata
-    mxnet.contrib.onnx.import_to_gluon
-    mxnet.contrib.onnx.export_model
+    mxnet.contrib.onnx.onnx2mx.import_model
+    mxnet.contrib.onnx.onnx2mx.import_to_gluon
+    mxnet.contrib.onnx.mx2onnx.export_model
 ```
 
 ## ONNX Tutorials
@@ -33,7 +32,7 @@ This document describes all the ONNX-MXNet APIs.
 ```eval_rst
 .. toctree::
    :maxdepth: 1
-   
+
    /tutorials/onnx/super_resolution.md
    /tutorials/onnx/inference_on_onnx_model.md
    /tutorials/onnx/fine_tuning_gluon.md
@@ -42,7 +41,7 @@ This document describes all the ONNX-MXNet APIs.
 ## ONNX Examples
 
 * Face Recognition with [ArcFace](https://github.com/onnx/models/tree/master/models/face_recognition/ArcFace)
-* Image Classification with [MobileNet](https://github.com/onnx/models/tree/master/models/image_classification/mobilenet), [ResNet](https://github.com/onnx/models/tree/master/models/image_classification/resnet), [SqueezeNet](https://github.com/onnx/models/tree/master/models/image_classification/squeezenet), [VGG](https://github.com/onnx/models/tree/master/models/image_classification/vgg) 
+* Image Classification with [MobileNet](https://github.com/onnx/models/tree/master/models/image_classification/mobilenet), [ResNet](https://github.com/onnx/models/tree/master/models/image_classification/resnet), [SqueezeNet](https://github.com/onnx/models/tree/master/models/image_classification/squeezenet), [VGG](https://github.com/onnx/models/tree/master/models/image_classification/vgg)
 
 ## API Reference
 
@@ -50,11 +49,12 @@ This document describes all the ONNX-MXNet APIs.
 
 ```eval_rst
 
-.. automodule:: mxnet.contrib.onnx.import_model
-.. automodule:: mxnet.contrib.onnx.get_model_metadata
-.. automodule:: mxnet.contrib.onnx.import_to_gluon
-.. automodule:: mxnet.contrib.onnx.export_model
-
+.. automodule:: mxnet.contrib.onnx.onnx2mx.import_model
+    :members: import_model, get_model_metadata
+.. automodule:: mxnet.contrib.onnx.onnx2mx.import_to_gluon
+    :members: import_to_gluon
+.. automodule:: mxnet.contrib.onnx.mx2onnx.export_model
+    :members: export_model
 ```
 
 <script>auto_index("api-reference");</script>

--- a/python/mxnet/contrib/onnx/mx2onnx/export_model.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_model.py
@@ -18,7 +18,7 @@
 # coding: utf-8
 #pylint: disable-msg=too-many-arguments
 
-"""export function"""
+"""Exports an MXNet model to the ONNX model format"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/python/mxnet/contrib/onnx/onnx2mx/import_model.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/import_model.py
@@ -16,7 +16,7 @@
 # under the License.
 
 # coding: utf-8
-"""import function"""
+"""Functions for importing ONNX models to MXNet and for checking metadata"""
 # pylint: disable=no-member
 
 from .import_onnx import GraphProto
@@ -72,6 +72,7 @@ def get_model_metadata(model_file):
             'output_tensor_data' : <list of tuples representing the shape of the output
                                     of the model>
         }
+
     """
     graph = GraphProto()
     try:


### PR DESCRIPTION
## Description ##
The ONNX page is currently broken due to some name changes. The API Reference is blank:
https://mxnet.incubator.apache.org/api/python/contrib/onnx.html#api-reference

I fixed the overview table to link to things and now have the API reference appearing. I also updated the description text.

## Comments ##

Sphinx won't render any shortcut references to the functions, so I'm calling them out the long way. When the Python config for these ONNX modules are updated we can try out the shorthand references and see if Sphinx likes it or not.
![2018-08-23_15-08-55](https://user-images.githubusercontent.com/5974205/44554604-775be480-a6e6-11e8-8747-194f6b4f0a69.png)

There are lint issues showing up in the docs build logs from these ONNX files as well as many other files. 

I'll create a separate issues for these comments.