### PR TITLE
Tighten up PyLint directives again

### DIFF
--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -83,24 +83,15 @@ enable=indexing-exception,old-raise-syntax,undefined-variable
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 disable=
-    design,
-    similarities,
     no-self-use,
     attribute-defined-outside-init,
-    locally-disabled,
-    star-args,
-    pointless-except,
     bad-option-value,
     global-statement,
     fixme,
-    suppressed-message,
-    useless-suppression,
-    locally-enabled,
     no-member,
     no-name-in-module,
     import-error,
     unsubscriptable-object,
-    unbalanced-tuple-unpacking,
     protected-access,
     superfluous-parens,
     invalid-name,
@@ -111,15 +102,17 @@ disable=
     chained-comparison,
     consider-using-dict-comprehension,
     consider-using-set-comprehension,
-    invalid-envvar-default,
-    singleton-comparison,
     try-except-raise,
     useless-object-inheritance,
-    useless-return,
     c-extension-no-member,
     deprecated-lambda,
     redefined-builtin,
-    unexpected-keyword-arg
+    too-few-public-methods,
+    too-many-arguments,
+    too-many-branches,
+    too-many-instance-attributes,
+    too-many-public-methods,
+    too-many-statements
 
 # disable=unicode-builtin,delslice-method,using-cmp-argument,setslice-method,dict-view-method,parameter-unpacking,range-builtin-not-iterating,print-statement,file-builtin,old-raise-syntax,basestring-builtin,execfile-builtin,indexing-exception,import-star-module-level,coerce-method,long-builtin,old-ne-operator,old-division,no-absolute-import,raw_input-builtin,old-octal-literal,oct-method,xrange-builtin,hex-method,unpacking-in-except,nonzero-method,raising-string,intern-builtin,reload-builtin,metaclass-assignment,cmp-method,filter-builtin-not-iterating,apply-builtin,map-builtin-not-iterating,next-method-called,unichr-builtin,buffer-builtin,dict-iter-method,input-builtin,coerce-builtin,getslice-method,useless-suppression,standarderror-builtin,zip-builtin-not-iterating,suppressed-message,cmp-builtin,backtick,long-suffix,reduce-builtin,round-builtin
 

--- a/ci/other/pylintrc
+++ b/ci/other/pylintrc
@@ -111,6 +111,7 @@ disable=
     too-many-arguments,
     too-many-branches,
     too-many-instance-attributes,
+    too-many-locals,
     too-many-public-methods,
     too-many-statements
 

--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -574,7 +574,7 @@ def _get_op_name_prefix(op_name):
     return ""
 
 
-# pylint: enable=too-many-locals, invalid-name
+# pylint: enable=invalid-name
 def _init_op_module(root_namespace, module_name, make_op_func):
     """
     Registers op functions created by `make_op_func` under

--- a/python/mxnet/executor_manager.py
+++ b/python/mxnet/executor_manager.py
@@ -127,7 +127,7 @@ def _bind_exec(sym, ctx, input_shapes, param_names, need_grad=False,
     assert(arg_types is not None)
 
     arg_arrays = []
-    grad_arrays = {} if need_grad != False else None
+    grad_arrays = {} if need_grad is not False else None
 
     arg_names = sym.list_arguments()
 

--- a/python/mxnet/gluon/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/rnn/rnn_cell.py
@@ -252,14 +252,12 @@ class RecurrentCell(Block):
     #pylint: disable=no-self-use
     def _get_activation(self, F, inputs, activation, **kwargs):
         """Get activation function. Convert if is string"""
-        if activation == 'tanh':
-            return F.tanh(inputs, **kwargs)
-        elif activation == 'sigmoid':
-            return F.sigmoid(inputs, **kwargs)
-        elif activation == 'relu':
-            return F.relu(inputs, **kwargs)
-        elif activation == 'softsign':
-            return F.softsign(inputs, **kwargs)
+        func = {'tanh': F.tanh,
+                'relu': F.relu,
+                'sigmoid': F.sigmoid,
+                'softsign': F.softsign}.get(activation)
+        if func:
+            return func(inputs, **kwargs)
         elif isinstance(activation, string_types):
             return F.Activation(inputs, act_type=activation, **kwargs)
         elif isinstance(activation, LeakyReLU):

--- a/python/mxnet/image/detection.py
+++ b/python/mxnet/image/detection.py
@@ -308,8 +308,7 @@ class DetRandomCropAug(DetAugmenter):
                 h -= 1
                 w = int(round(h * ratio))
                 area = w * h
-            if (area < min_area or area > max_area or w > width or h > height \
-                or w <= 0 or h <= 0):
+            if not (min_area <= area <= max_area and 0 <= w <= width and 0 <= h <= height):
                 continue
 
             y = random.randint(0, max(0, height - h))

--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -132,7 +132,7 @@ def _update_params_on_kvstore_nccl(param_arrays, grad_arrays, kvstore, param_nam
     size = len(valid_grad_arrays)
     start = 0
     # Use aggregation by default only with NCCL
-    default_batch = 16
+    default_batch = '16'
     batch = int(os.getenv('MXNET_UPDATE_AGGREGATION_SIZE', default_batch))
     while start < size:
         end = start + batch if start + batch < size else size
@@ -378,7 +378,6 @@ def _train_multi_device(symbol, ctx, arg_names, param_names, aux_names,
                 _multiple_callbacks(eval_end_callback, eval_end_params)
             eval_data.reset()
     # end of all epochs
-    return
 
 
 def save_checkpoint(prefix, epoch, symbol, arg_params, aux_params):

--- a/python/mxnet/ndarray/register.py
+++ b/python/mxnet/ndarray/register.py
@@ -26,6 +26,7 @@ from ..ndarray_doc import _build_doc
 from ..base import mx_uint, check_call, _LIB, py_str, _init_op_module, _Null # pylint: disable=unused-import
 
 
+# pylint: disable=too-many-locals
 def _generate_ndarray_function_code(handle, name, func_name, signature_only=False):
     """Generate function for ndarray op by handle and function name."""
     real_name = ctypes.c_char_p()

--- a/python/mxnet/ndarray/register.py
+++ b/python/mxnet/ndarray/register.py
@@ -26,7 +26,6 @@ from ..ndarray_doc import _build_doc
 from ..base import mx_uint, check_call, _LIB, py_str, _init_op_module, _Null # pylint: disable=unused-import
 
 
-# pylint: disable=too-many-locals
 def _generate_ndarray_function_code(handle, name, func_name, signature_only=False):
     """Generate function for ndarray op by handle and function name."""
     real_name = ctypes.c_char_p()

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1285,6 +1285,7 @@ class Symbol(SymbolBase):
             raise TypeError('Only accept list of NDArrays or dict of str to NDArray')
         return c_array(NDArrayHandle, arg_handles), arg_arrays
 
+    # pylint: disable=too-many-locals
     def simple_bind(self, ctx, grad_req='write', type_dict=None, stype_dict=None,
                     group2ctx=None, shared_arg_names=None, shared_exec=None,
                     shared_buffer=None, **kwargs):

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1285,7 +1285,6 @@ class Symbol(SymbolBase):
             raise TypeError('Only accept list of NDArrays or dict of str to NDArray')
         return c_array(NDArrayHandle, arg_handles), arg_arrays
 
-    # pylint: disable=too-many-locals
     def simple_bind(self, ctx, grad_req='write', type_dict=None, stype_dict=None,
                     group2ctx=None, shared_arg_names=None, shared_exec=None,
                     shared_buffer=None, **kwargs):

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -27,4 +27,4 @@ def makedirs(d):
         from distutils.dir_util import mkpath
         mkpath(d)
     else:
-        os.makedirs(d, exist_ok=True)
+        os.makedirs(d, exist_ok=True)  # pylint: disable=unexpected-keyword-arg

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,6 +20,8 @@
 from __future__ import absolute_import
 import os
 import sys
+
+from setuptools import find_packages
 # need to use distutils.core for correct placement of cython dll
 kwargs = {}
 if "--inplace" in sys.argv:
@@ -29,7 +31,6 @@ else:
     from setuptools import setup
     from setuptools.extension import Extension
     kwargs = {'install_requires': ['numpy<=1.15.0,>=1.8.2', 'requests<2.19.0,>=2.18.4', 'graphviz<0.9.0,>=0.8.1'], 'zip_safe': False}
-from setuptools import find_packages
 
 with_cython = False
 if '--with-cython' in sys.argv:


### PR DESCRIPTION
## Description ##
#12278 became disconnected from my fork so its branch is now __unknown repository__.  This prevents me from resolving the conflict or making other requested changes.  This PR attempts to be and exact copy of #12278  @ vandanavk and @marcoabreu, please rereview this PR.

Remove PyLint disable directives that the codebase is not violating.  This tightens up the linting of future proposed changes.  Also looked through PyLint issues that were only being flagged once in the code base to see if small changes code make the code compliant.  __Fixed__ via code changes:
```
************* Module setup
python/setup.py:32:0: C0413: Import "from setuptools import find_packages" should be placed at the top of the module (wrong-import-position)
************* Module mxnet.executor_manager
python/mxnet/executor_manager.py:130:24: C0121: Comparison to False should be 'expr' or 'expr is not False' (singleton-comparison)
************* Module mxnet.model
python/mxnet/model.py:136:16: W1508: os.getenv default type is builtins.int. Expected str or None. (invalid-envvar-default)
python/mxnet/model.py:192:0: R1711: Useless return at end of function or method (useless-return)
************* Module mxnet.gluon.rnn.rnn_cell
python/mxnet/gluon/rnn/rnn_cell.py:253:4: R0911: Too many return statements (7/6) (too-many-return-statements)
************* Module mxnet.image.detection
python/mxnet/image/detection.py:311:16: R0916: Too many boolean expressions in if statement (6/5) (too-many-boolean-expressions)
```

@vandanavk 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
