### PR TITLE
[MXAPPS-581] Disable a long test in the SD nightly.

### DIFF
--- a/tests/nightly/straight_dope/test_notebooks_single_gpu.py
+++ b/tests/nightly/straight_dope/test_notebooks_single_gpu.py
@@ -35,6 +35,7 @@ NOTEBOOKS_WHITELIST = [
     'chapter02_supervised-learning/environment',
     'chapter03_deep-neural-networks/kaggle-gluon-kfold',
     'chapter04_convolutional-neural-networks/deep-cnns-alexnet',  # > 10 mins.
+    'chapter05_recurrent-neural-networks/rnns-gluon', # > 10 mins.
     'chapter06_optimization/gd-sgd-scratch',  # Overflow warning is intended.
     'chapter06_optimization/gd-sgd-gluon',  # Overflow warning is intended.
     'chapter07_distributed-learning/multiple-gpus-scratch',
@@ -175,9 +176,6 @@ class StraightDopeSingleGpuTests(unittest.TestCase):
 
     def test_gru_scratch(self):
         assert _test_notebook('chapter05_recurrent-neural-networks/gru-scratch')
-
-    def test_rnns_gluon(self):
-        assert _test_notebook('chapter05_recurrent-neural-networks/rnns-gluon')
 
     # Chapter 6
 


### PR DESCRIPTION
## Description ##
Disable a test that's taking longer than 10 minutes with the Python 2 interpreter in the Straight Dope Nightly.

This was missed previously as the hardware I'm running my tests on was a little faster than the hardware the test runner is using.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [*] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [*] Changes are complete (i.e. I finished coding on this PR)
- [* ] Code is well-documented: 
- [ *] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
