### PR TITLE
Moves f16c autodetection to its own cmake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,26 +110,16 @@ else(MSVC)
   endif()
   # For cross complication, turn off flag if target device does not support it
   if(USE_F16C)
-    check_cxx_compiler_flag("-mf16c"     COMPILER_SUPPORT_MF16C)
-    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-      execute_process(COMMAND cat /proc/cpuinfo
-              COMMAND grep flags
-              COMMAND grep f16c
-              OUTPUT_VARIABLE CPU_SUPPORT_F16C)
-    elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-      execute_process(COMMAND sysctl -a
-              COMMAND grep machdep.cpu.features
-              COMMAND grep F16C
-              OUTPUT_VARIABLE CPU_SUPPORT_F16C)
-    endif()
-    if(NOT CPU_SUPPORT_F16C)
-      message("CPU does not support F16C instructions")
-    endif()
-    if(CPU_SUPPORT_F16C AND COMPILER_SUPPORT_MF16C)
-      set(SUPPORT_F16C TRUE)
-    endif()
+    # Determine if hardware supports F16C instruction set
+    message(STATUS "Determining F16C support")
+    include(cmake/AutoDetectF16C.cmake)
   else()
     set(SUPPORT_F16C FALSE)
+  endif()
+  if(SUPPORT_F16C)
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -mf16c")
+  else()
+    add_definitions(-DMSHADOW_USE_F16C=0)
   endif()
   set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   set(CMAKE_C_FLAGS "-Wall -Wno-unknown-pragmas -Wno-sign-compare")

--- a/cmake/AutoDetectF16C.cmake
+++ b/cmake/AutoDetectF16C.cmake
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Determines whether hardware and compiler support F16C 
+# instruction set
+#
+# The following are set after configuration is done:
+#  SUPPORT_F16C
+
+if(AUTO_DETECT_F16_CMAKE_INCLUDED)
+  return()
+endif()
+set(AUTO_DETECT_F16_CMAKE_INCLUDED True)
+
+set(SUPPORT_F16C False)
+if(MSVC)
+    message("F16C instruction set is not yet supported for MSVC")
+    return()
+endif()
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-mf16c" COMPILER_SUPPORT_MF16C)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    execute_process(COMMAND cat /proc/cpuinfo
+            COMMAND grep flags
+            COMMAND grep f16c
+            OUTPUT_VARIABLE CPU_SUPPORT_F16C)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    execute_process(COMMAND sysctl -a
+            COMMAND grep machdep.cpu.features
+            COMMAND grep F16C
+            OUTPUT_VARIABLE CPU_SUPPORT_F16C)
+endif()
+if(NOT CPU_SUPPORT_F16C)
+    message("CPU does not support F16C instructions")
+    return()
+endif()
+if(CPU_SUPPORT_F16C AND COMPILER_SUPPORT_MF16C)	
+    set(SUPPORT_F16C TRUE)
+endif()


### PR DESCRIPTION
## Description ##
Move F16C support detection to its own module. The support detection module is taken from the mshadow project's cmake.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Small refactor moving F16C support detection to its own cmake module

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
