### PR TITLE
MXNET-858 Add Codecov report for Clojure Package

### DIFF
--- a/contrib/clojure-package/ci-test.sh
+++ b/contrib/clojure-package/ci-test.sh
@@ -21,3 +21,4 @@ set -evx
 MXNET_HOME=${PWD}
 cd ${MXNET_HOME}/contrib/clojure-package
 lein test
+lein cloverage --codecov


### PR DESCRIPTION
## Description ##

Add Code coverage report for the Clojure Package 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Modify the ci-test script to add running the clojure coverage tool. This will output a report in the target directory that is picked up by the codecov script. 

Note that the report does not need to be put in the top level project directory. The codecov.io script will recurse and find the report in `/contrib/clojure-package/target/`

Result of running from my local machine `./contrib/clojure-pacakge/ci-test.sh`:

```
Writing HTML report to: /Users/cmeier/workspace/deep-learning/mxnet/contrib/clojure-package/target/coverage/index.html
Writing codecov.io report to: /Users/cmeier/workspace/deep-learning/mxnet/contrib/clojure-package/target/coverage/codecov.json
```

Result of running `curl --retry 10 -s https://codecov.io/bash | bash -s` from the mxnet root directory on my local machine:

```11:29 $ curl --retry 10 -s https://codecov.io/bash | bash -s

  _____          _
 / ____|        | |
| |     ___   __| | ___  ___ _____   __
| |    / _ \ / _` |/ _ \/ __/ _ \ \ / /
| |___| (_) | (_| |  __/ (_| (_) \ V /
 \_____\___/ \__,_|\___|\___\___/ \_/
                              Bash-0b37652


x> No CI provider detected.
    Testing inside Docker? http://docs.codecov.io/docs/testing-with-docker
    Testing with Tox? https://docs.codecov.io/docs/python#section-testing-with-tox
    project root: .
    Yaml found at: .codecov.yml
==> Running gcov in . (disable via -X gcov)
==> Python coveragepy not found
==> Searching for coverage reports in:
    + .
    -> Found 1 reports
==> Detecting git/mercurial file structure
==> Reading reports
    + ./contrib/clojure-package/target/coverage/codecov.json bytes=16866
==> Appending adjustments
    http://docs.codecov.io/docs/fixing-reports
    + Found adjustments
==> Gzipping contents
==> Uploading reports
```
