### PR TITLE
[MXAPPS-581] Disable an additional long test in the SD nightly.

### DIFF
--- a/tests/nightly/straight_dope/test_notebooks_single_gpu.py
+++ b/tests/nightly/straight_dope/test_notebooks_single_gpu.py
@@ -41,6 +41,7 @@ NOTEBOOKS_WHITELIST = [
     'chapter07_distributed-learning/multiple-gpus-scratch',
     'chapter07_distributed-learning/multiple-gpus-gluon',
     'chapter07_distributed-learning/training-with-multiple-machines',
+    'chapter08_computer-vision/visual-question-answer', # > 10 mins.
     'chapter11_recommender-systems/intro-recommender-systems',  # Early draft, non-working.
     'chapter12_time-series/intro-forecasting-gluon',
     'chapter12_time-series/intro-forecasting-2-gluon',
@@ -225,9 +226,6 @@ class StraightDopeSingleGpuTests(unittest.TestCase):
 
     def test_fine_tuning(self):
         assert _test_notebook('chapter08_computer-vision/fine-tuning')
-
-    def test_visual_question_answer(self):
-        assert _test_notebook('chapter08_computer-vision/visual-question-answer')
 
     # Chapter 9
 


### PR DESCRIPTION
* Disable an additional test in the SD nightly that also takes over the
  timeout.

This is an additional test that should have bene disabled in to https://github.com/apache/incubator-mxnet/pull/12326

Confusingly this test is failing just for Python 2. I will revisit and adjust the timeouts.

Here is the log message:

[StraightDope: Python2 Single-GPU] .INFO:root:Running notebook 'chapter08_computer-vision/visual-question-answer'
[StraightDope: Python2 Single-GPU] INFO:traitlets:Executing notebook with kernel: python2
[StraightDope: Python3 Single-GPU] ERROR:traitlets:Timeout waiting for execute reply (600s).




## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [* ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ *] Changes are complete (i.e. I finished coding on this PR)
- [ *] Code is well-documented: 
- [* ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
