### PR TITLE
[MXNET-860] Reduce redundant copies, check for regressions with clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,7 +54,7 @@ Checks: >
 
 # In order to trigger an error, you must have a rule defined both in checks and in this section.
 WarningsAsErrors: >
-    cppcoreguidelines-no-malloc
+    cppcoreguidelines-no-malloc, performance-unnecessary-copy-initialization
 
 # Todo: define a better regex match that includes most project headers, but excludes third party
 # code.

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -1031,7 +1031,7 @@ inline void CopyFromToRspImpl(const NDArray& from, const NDArray& to, RunContext
     op::FillZerosRspImpl(s, to);
     return;
   }
-  auto aux_shape = from.aux_shape(rowsparse::kIdx);
+  const auto& aux_shape = from.aux_shape(rowsparse::kIdx);
   to.CheckAndAlloc({aux_shape});
   TBlob val = to.data();
   TBlob idx = to.aux_data(rowsparse::kIdx);
@@ -1122,7 +1122,7 @@ void CopyFromToImpl(const NDArray& from, const NDArray& to,
     if (from_stype == to_stype) {
       casted_nd = from;  // same stype, no need to cast from
     } else {  // different stypes on different ctx needs an temporary casted_nd
-      TShape shape = from.shape();
+      const TShape& shape = from.shape();
       if (to_stype == kDefaultStorage) {
         casted_nd = NDArray(shape, from_ctx);
       } else {

--- a/src/operator/contrib/roi_align.cc
+++ b/src/operator/contrib/roi_align.cc
@@ -422,7 +422,7 @@ void ROIAlignForwardCompute(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(out_data.size(), expected_out);
   CHECK_EQ(out_data[roialign::kOut].shape_[0], in_data[roialign::kBox].shape_[0]);
 
-  const ROIAlignParam param = nnvm::get<ROIAlignParam>(attrs.parsed);
+  const ROIAlignParam& param = nnvm::get<ROIAlignParam>(attrs.parsed);
 
   const int count = out_data[roialign::kOut].Size();
   // const int num_rois = in_data[roialign::kBox].size(0);
@@ -466,7 +466,7 @@ void ROIAlignBackwardCompute(const nnvm::NodeAttrs& attrs,
   CHECK_NE(req[1], kWriteInplace) <<
     "ROIAlign: Backward doesn't support kWriteInplace.";
 
-  const ROIAlignParam param = nnvm::get<ROIAlignParam>(attrs.parsed);
+  const ROIAlignParam& param = nnvm::get<ROIAlignParam>(attrs.parsed);
 
   const int count = out_grad[0].Size();
   const int num_rois = in_data[0].size(0);
@@ -534,7 +534,7 @@ He, Kaiming, et al. "Mask R-CNN." ICCV, 2017
 .set_attr<nnvm::FInferShape>("FInferShape", [](const nnvm::NodeAttrs& attrs,
       std::vector<TShape> *in_shape, std::vector<TShape> *out_shape){
   using namespace mshadow;
-  const ROIAlignParam param = nnvm::get<ROIAlignParam>(attrs.parsed);
+  const ROIAlignParam& param = nnvm::get<ROIAlignParam>(attrs.parsed);
   CHECK_EQ(in_shape->size(), 2) << "Input:[data, rois]";
   // data: [batch_size, c, h, w]
   TShape dshape = in_shape->at(roialign::kData);


### PR DESCRIPTION
## Description ##
Reduce redundant copies and add a check to clang-tidy to prevent future redundant copies.  This change is a failure straightforward optimization that should not impact the correctness of the library.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

Note: should only be applied after https://github.com/apache/incubator-mxnet/pull/12282