### PR TITLE
 Fix flaky test : test_ndarray.test_order

### DIFF
--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -639,7 +639,6 @@ def test_arange():
     assert_almost_equal(pred, gt)
 
 @with_seed()
-@unittest.skip("Flaky test https://github.com/apache/incubator-mxnet/issues/12310")
 def test_order():
     ctx = default_context()
     dat_size = 5
@@ -703,29 +702,33 @@ def test_order():
         return data
 
     large_matrix_npy = get_large_matrix()
-    large_matrix_nd = mx.nd.array(large_matrix_npy, ctx=ctx)
+    large_matrix_nd = mx.nd.array(large_matrix_npy, ctx=ctx, dtype=large_matrix_npy.dtype)
 
     nd_ret_topk = mx.nd.topk(large_matrix_nd, axis=1, ret_typ="indices", k=5, is_ascend=False).asnumpy()
     gt = gt_topk(large_matrix_npy, axis=1, ret_typ="indices", k=5, is_ascend=False)
     assert_almost_equal(nd_ret_topk, gt)
 
-    for dtype in [np.int16, np.int32, np.int64, np.float32, np.float64]:
+    for dtype in [ np.int32, np.int64, np.float32, np.float64]:
         a_npy = get_values(ensure_unique=True, dtype=dtype)
-        a_nd = mx.nd.array(a_npy, ctx=ctx)
+        a_nd = mx.nd.array(a_npy, ctx=ctx, dtype=dtype)
 
         # test for ret_typ=indices
         nd_ret_topk = mx.nd.topk(a_nd, axis=1, ret_typ="indices", k=3, is_ascend=True).asnumpy()
+        assert nd_ret_topk.dtype == np.float32  # Test the default dtype
         gt = gt_topk(a_npy, axis=1, ret_typ="indices", k=3, is_ascend=True)
         assert_almost_equal(nd_ret_topk, gt)
-        nd_ret_topk = mx.nd.topk(a_nd, axis=3, ret_typ="indices", k=2, is_ascend=False).asnumpy()
+        nd_ret_topk = mx.nd.topk(a_nd, axis=3, ret_typ="indices", k=2, is_ascend=False, dtype=np.float64).asnumpy()
+        assert nd_ret_topk.dtype == np.float64
         gt = gt_topk(a_npy, axis=3, ret_typ="indices", k=2, is_ascend=False)
         assert_almost_equal(nd_ret_topk, gt)
-        nd_ret_topk = mx.nd.topk(a_nd, axis=None, ret_typ="indices", k=21, is_ascend=False).asnumpy()
+        nd_ret_topk = mx.nd.topk(a_nd, axis=None, ret_typ="indices", k=21, is_ascend=False, dtype=np.int32).asnumpy()
+        assert nd_ret_topk.dtype == np.int32
         gt = gt_topk(a_npy, axis=None, ret_typ="indices", k=21, is_ascend=False)
         assert_almost_equal(nd_ret_topk, gt)
 
         # test for ret_typ=value
         nd_ret_topk = mx.nd.topk(a_nd, axis=1, ret_typ="value", k=3, is_ascend=True).asnumpy()
+        assert nd_ret_topk.dtype == dtype
         gt = gt_topk(a_npy, axis=1, ret_typ="value", k=3, is_ascend=True)
         assert_almost_equal(nd_ret_topk, gt)
         nd_ret_topk = mx.nd.topk(a_nd, axis=3, ret_typ="value", k=2, is_ascend=False).asnumpy()
@@ -736,7 +739,11 @@ def test_order():
         assert_almost_equal(nd_ret_topk, gt)
 
         # test for ret_typ=mask
+        # test needs to be re-enabled once flaky topk gets fixed
+        # tracked in https://github.com/apache/incubator-mxnet/pull/12446
+        '''
         nd_ret_topk = mx.nd.topk(a_nd, axis=1, ret_typ="mask", k=3, is_ascend=True).asnumpy()
+        assert nd_ret_topk.dtype == dtype
         gt = gt_topk(a_npy, axis=1, ret_typ="mask", k=3, is_ascend=True)
         assert_almost_equal(nd_ret_topk, gt)
         nd_ret_topk = mx.nd.topk(a_nd, axis=1, ret_typ="mask", k=2, is_ascend=False).asnumpy()
@@ -745,17 +752,20 @@ def test_order():
         nd_ret_topk = mx.nd.topk(a_nd, axis=None, ret_typ="mask", k=21, is_ascend=False).asnumpy()
         gt = gt_topk(a_npy, axis=None, ret_typ="mask", k=21, is_ascend=False)
         assert_almost_equal(nd_ret_topk, gt)
-
+        '''
         # test for ret_typ=both
         nd_ret_topk_val, nd_ret_topk_ind = mx.nd.topk(a_nd, axis=1, ret_typ="both", k=3, is_ascend=True)
         nd_ret_topk_val = nd_ret_topk_val.asnumpy()
         nd_ret_topk_ind = nd_ret_topk_ind.asnumpy()
+        assert nd_ret_topk_val.dtype == dtype
+        assert nd_ret_topk_ind.dtype == np.float32
         gt_val = gt_topk(a_npy, axis=1, ret_typ="value", k=3, is_ascend=True)
         gt_ind = gt_topk(a_npy, axis=1, ret_typ="indices", k=3, is_ascend=True)
         assert_almost_equal(nd_ret_topk_val, gt_val)
         assert_almost_equal(nd_ret_topk_ind, gt_ind)
         # test for kNullOp
-        _, nd_ret_topk_ind = mx.nd.topk(a_nd, axis=1, ret_typ="both", k=3, is_ascend=True)
+        _, nd_ret_topk_ind = mx.nd.topk(a_nd, axis=1, ret_typ="both", k=3, is_ascend=True, dtype=np.float64)
+        assert nd_ret_topk_ind.dtype == np.float64
         nd_ret_topk_ind = nd_ret_topk_ind.asnumpy()
         assert_almost_equal(nd_ret_topk_ind, gt_ind)
         # test for kNullOp
@@ -778,6 +788,7 @@ def test_order():
             gt = gt_topk(a_npy, axis=3, ret_typ="indices", k=dat_size, is_ascend=True)
             assert_almost_equal(nd_ret_argsort, gt)
             nd_ret_argsort = mx.nd.argsort(a_nd, axis=None, is_ascend=False, dtype=idtype).asnumpy()
+            assert nd_ret_argsort.dtype == idtype
             gt = gt_topk(a_npy, axis=None, ret_typ="indices",
                          k=dat_size*dat_size*dat_size*dat_size, is_ascend=False)
             assert_almost_equal(nd_ret_argsort, gt)
@@ -786,7 +797,7 @@ def test_order():
         # duplicated input data values (over many repeated runs with different random seeds,
         # this will be tested).
         a_npy = get_values(ensure_unique=False, dtype=dtype)
-        a_nd = mx.nd.array(a_npy, ctx=ctx)
+        a_nd = mx.nd.array(a_npy, ctx=ctx, dtype=dtype)
 
         # test for ret_typ=value
         nd_ret_topk = mx.nd.topk(a_nd, axis=1, ret_typ="value", k=3, is_ascend=True).asnumpy()
@@ -837,9 +848,9 @@ def test_order():
     # Repeat those tests that don't involve indices.  These should pass even with
     # duplicated input data values (over many repeated runs with different random seeds,
     # this will be tested).
-    for dtype in [np.int16, np.int32, np.int64, np.float32, np.float64]:
+    for dtype in [ np.int32, np.int64, np.float32, np.float64]:
         a_npy = get_values(ensure_unique=False, dtype=dtype)
-        a_nd = mx.nd.array(a_npy, ctx=ctx)
+        a_nd = mx.nd.array(a_npy, ctx=ctx, dtype=dtype)
 
         # test for ret_typ=value
         nd_ret_topk = mx.nd.topk(a_nd, axis=1, ret_typ="value", k=3, is_ascend=True).asnumpy()


### PR DESCRIPTION
## Description ##
 Fix flaky test: test_ndarray.test_order. Tracked in #12310

The test uses np.int16 which is not a supported dtype for ndarray.
Also, conversion of np array to ndarray defaults to float32 in destination ndarray even though the dtype of source could be anything leading to failure of unites due to loss of precision in some cases.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

--> Removed tests for np.int16
--> Instead of using default dtype for converting arrays , used the type from source array to convert to target array.

Ran the test with changes for 5000 runs for different seeds and verified it.

