### PR TITLE
[MXNET-860] - Avoid implicit double conversions in math operations.

### DIFF
--- a/src/io/image_det_aug_default.cc
+++ b/src/io/image_det_aug_default.cc
@@ -560,7 +560,7 @@ class DefaultImageDetAugmenter : public ImageAugmenter {
         }
         cv::cvtColor(res, res, CV_HLS2BGR);
       }
-      if (fabs(c) > 1e-3) {
+      if (std::fabs(c) > 1e-3) {
         cv::Mat tmp = res;
         tmp.convertTo(res, -1, c + 1.f, 0);
       }

--- a/src/operator/contrib/adaptive_avg_pooling.cc
+++ b/src/operator/contrib/adaptive_avg_pooling.cc
@@ -26,8 +26,8 @@
 // #include "elemwise_op_common.h"
 #include "../elemwise_op_common.h"
 
-#define START_IND(a, b, c) static_cast<int>(floor(static_cast<float>(a * c) / b))
-#define END_IND(a, b, c) static_cast<int>(ceil(static_cast<float>((a + 1) * c) / b))
+#define START_IND(a, b, c) static_cast<int>(std::floor(static_cast<float>(a * c) / b))
+#define END_IND(a, b, c) static_cast<int>(std::ceil(static_cast<float>((a + 1) * c) / b))
 
 namespace mxnet {
 namespace op {

--- a/src/operator/contrib/multi_proposal.cc
+++ b/src/operator/contrib/multi_proposal.cc
@@ -67,8 +67,8 @@ inline void BBoxTransformInv(const mshadow::Tensor<cpu, 2>& boxes,
 
     float pred_ctr_x = dx * width + ctr_x;
     float pred_ctr_y = dy * height + ctr_y;
-    float pred_w = exp(dw) * width;
-    float pred_h = exp(dh) * height;
+    float pred_w = std::exp(dw) * width;
+    float pred_h = std::exp(dh) * height;
 
     float pred_x1 = pred_ctr_x - 0.5 * (pred_w - 1.0);
     float pred_y1 = pred_ctr_y - 0.5 * (pred_h - 1.0);

--- a/src/operator/contrib/multibox_detection.cc
+++ b/src/operator/contrib/multibox_detection.cc
@@ -62,8 +62,8 @@ inline void TransformLocations(DType *out, const DType *anchors,
   DType ph = loc_pred[3];
   DType ox = px * vx * aw + ax;
   DType oy = py * vy * ah + ay;
-  DType ow = exp(pw * vw) * aw / 2;
-  DType oh = exp(ph * vh) * ah / 2;
+  DType ow = std::exp(pw * vw) * aw / 2;
+  DType oh = std::exp(ph * vh) * ah / 2;
   out[0] = clip ? std::max(DType(0), std::min(DType(1), ox - ow)) : (ox - ow);
   out[1] = clip ? std::max(DType(0), std::min(DType(1), oy - oh)) : (oy - oh);
   out[2] = clip ? std::max(DType(0), std::min(DType(1), ox + ow)) : (ox + ow);

--- a/src/operator/contrib/proposal.cc
+++ b/src/operator/contrib/proposal.cc
@@ -63,8 +63,8 @@ inline void BBoxTransformInv(const mshadow::Tensor<cpu, 2>& boxes,
 
         float pred_ctr_x = dx * width + ctr_x;
         float pred_ctr_y = dy * height + ctr_y;
-        float pred_w = exp(dw) * width;
-        float pred_h = exp(dh) * height;
+        float pred_w = std::exp(dw) * width;
+        float pred_h = std::exp(dh) * height;
 
         float pred_x1 = pred_ctr_x - 0.5 * (pred_w - 1.0);
         float pred_y1 = pred_ctr_y - 0.5 * (pred_h - 1.0);

--- a/src/operator/contrib/roi_align.cc
+++ b/src/operator/contrib/roi_align.cc
@@ -182,9 +182,9 @@ void ROIAlignForward(
     // We use roi_bin_grid to sample the grid and mimic integral
     int roi_bin_grid_h = (sampling_ratio > 0)
         ? sampling_ratio
-        : ceil(roi_height / pooled_height);  // e.g., = 2
+        : std::ceil(roi_height / pooled_height);  // e.g., = 2
     int roi_bin_grid_w =
-        (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
+        (sampling_ratio > 0) ? sampling_ratio : std::ceil(roi_width / pooled_width);
 
     // We do average (integral) pooling inside a bin
     const T count = roi_bin_grid_h * roi_bin_grid_w;  // e.g. = 4
@@ -357,9 +357,9 @@ void ROIAlignBackward(
     // We use roi_bin_grid to sample the grid and mimic integral
     int roi_bin_grid_h = (sampling_ratio > 0)
         ? sampling_ratio
-        : ceil(roi_height / pooled_height);  // e.g., = 2
+        : std::ceil(roi_height / pooled_height);  // e.g., = 2
     int roi_bin_grid_w =
-        (sampling_ratio > 0) ? sampling_ratio : ceil(roi_width / pooled_width);
+        (sampling_ratio > 0) ? sampling_ratio : std::ceil(roi_width / pooled_width);
 
     // We do average (integral) pooling inside a bin
     const T count = roi_bin_grid_h * roi_bin_grid_w;  // e.g. = 4

--- a/src/operator/correlation-inl.h
+++ b/src/operator/correlation-inl.h
@@ -98,9 +98,9 @@ class CorrelationOp : public Operator {
     border_size_ = param_.max_displacement + kernel_radius_;
     stride1 = param_.stride1;
     stride2 = param_.stride2;
-    top_width_ = ceil(static_cast<float>(paddedbottomwidth - border_size_ * 2)\
+    top_width_ = std::ceil(static_cast<float>(paddedbottomwidth - border_size_ * 2)\
      / static_cast<float>(stride1));
-    top_height_ = ceil(static_cast<float>(paddedbottomheight - border_size_ * 2)\
+    top_height_ = std::ceil(static_cast<float>(paddedbottomheight - border_size_ * 2)\
      / static_cast<float>(stride1));
     neighborhood_grid_radius_ = param_.max_displacement / stride2;
     neighborhood_grid_width_ = neighborhood_grid_radius_ * 2 + 1;
@@ -211,9 +211,9 @@ void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) overr
     border_size_ = param_.max_displacement + kernel_radius_;
     stride1 = param_.stride1;
     stride2 = param_.stride2;
-    top_width_ = ceil(static_cast<float>(paddedbottomwidth - border_size_ * 2)\
+    top_width_ = std::ceil(static_cast<float>(paddedbottomwidth - border_size_ * 2)\
      / static_cast<float>(stride1));
-    top_height_ = ceil(static_cast<float>(paddedbottomheight - border_size_ * 2)\
+    top_height_ = std::ceil(static_cast<float>(paddedbottomheight - border_size_ * 2)\
      / static_cast<float>(stride1));
     neighborhood_grid_radius_ = param_.max_displacement / stride2;
     neighborhood_grid_width_ = neighborhood_grid_radius_ * 2 + 1;

--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -418,10 +418,10 @@ void RGB2HLSConvert(const float& src_r,
   float diff;
 
   vmax = vmin = r;
-  vmax = fmax(vmax, g);
-  vmax = fmax(vmax, b);
-  vmin = fmin(vmin, g);
-  vmin = fmin(vmin, b);
+  vmax = std::fmax(vmax, g);
+  vmax = std::fmax(vmax, b);
+  vmin = std::fmin(vmin, g);
+  vmin = std::fmin(vmin, b);
 
   diff = vmax - vmin;
   l = (vmax + vmin) * 0.5f;

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -33,7 +33,7 @@
 #endif
 
 /*! \brief inverse standard deviation <-> variance */
-#define VARIANCE_TO_INVSTD(__var$,    __eps$)   (1.0/sqrt((__var$) + DType(__eps$)))
+#define VARIANCE_TO_INVSTD(__var$,    __eps$)   (1.0/std::sqrt((__var$) + DType(__eps$)))
 #define INVSTD_TO_VARIANCE(__invstd$, __eps$)   ((1.0 / ((__invstd$) * (__invstd$))) - (__eps$))
 
 namespace mxnet {

--- a/src/operator/nn/lrn-inl.h
+++ b/src/operator/nn/lrn-inl.h
@@ -61,9 +61,9 @@ struct LRNParam : public dmlc::Parameter<LRNParam> {
 
   bool operator==(const LRNParam& other) const {
     return (this->nsize == other.nsize &&
-            fabs(this->alpha - other.alpha) < 1e-6 &&
-            fabs(this->beta  - other.beta)  < 1e-6 &&
-            fabs(this->knorm - other.knorm) < 1e-6);
+            std::fabs(this->alpha - other.alpha) < 1e-6 &&
+            std::fabs(this->beta  - other.beta)  < 1e-6 &&
+            std::fabs(this->knorm - other.knorm) < 1e-6);
   }
 };  // struct LRNParam
 

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -34,7 +34,7 @@
 #include "./mkldnn_ops-inl.h"
 #include "./mkldnn_base-inl.h"
 
-#define VARIANCE_TO_INVSTD(__var$,    __eps$)   (1.0/sqrt((__var$) + DType(__eps$)))
+#define VARIANCE_TO_INVSTD(__var$,    __eps$)   (1.0/std::sqrt((__var$) + DType(__eps$)))
 #define INVSTD_TO_VARIANCE(__invstd$, __eps$)   ((1.0 / ((__invstd$) * (__invstd$))) - (__eps$))
 namespace mxnet {
 namespace op {

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -127,7 +127,7 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
                   (dshape[2] + 2 * param.pad[0] - param.kernel[0]) /
                       param.stride[0];
     } else {
-      oshape[2] = 1 + static_cast<int>(ceil(
+      oshape[2] = 1 + static_cast<int>(std::ceil(
                           static_cast<float>(dshape[2] + 2 * param.pad[0] -
                                              param.kernel[0]) /
                           param.stride[0]));
@@ -157,11 +157,11 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
                   (dshape[3] + 2 * param.pad[1] - param.kernel[1]) /
                       param.stride[1];
     } else {
-      oshape[2] = 1 + static_cast<int>(ceil(
+      oshape[2] = 1 + static_cast<int>(std::ceil(
                           static_cast<float>(dshape[2] + 2 * param.pad[0] -
                                              param.kernel[0]) /
                           param.stride[0]));
-      oshape[3] = 1 + static_cast<int>(ceil(
+      oshape[3] = 1 + static_cast<int>(std::ceil(
                           static_cast<float>(dshape[3] + 2 * param.pad[1] -
                                              param.kernel[1]) /
                           param.stride[1]));
@@ -192,15 +192,15 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
                   (dshape[4] + 2 * param.pad[2] - param.kernel[2]) /
                       param.stride[2];
     } else {
-      oshape[2] = 1 + static_cast<int>(ceil(
+      oshape[2] = 1 + static_cast<int>(std::ceil(
                           static_cast<float>(dshape[2] + 2 * param.pad[0] -
                                              param.kernel[0]) /
                           param.stride[0]));
-      oshape[3] = 1 + static_cast<int>(ceil(
+      oshape[3] = 1 + static_cast<int>(std::ceil(
                           static_cast<float>(dshape[3] + 2 * param.pad[1] -
                                              param.kernel[1]) /
                           param.stride[1]));
-      oshape[4] = 1 + static_cast<int>(ceil(
+      oshape[4] = 1 + static_cast<int>(std::ceil(
                           static_cast<float>(dshape[4] + 2 * param.pad[2] -
                                              param.kernel[2]) /
                           param.stride[2]));

--- a/src/operator/pooling_v1-inl.h
+++ b/src/operator/pooling_v1-inl.h
@@ -273,10 +273,10 @@ class PoolingV1Prop : public OperatorProperty {
           oshape[3] = 1 + (dshape[3] + 2 * param_.pad[1] - param_.kernel[1]) /
                               param_.stride[1];
       } else {
-          oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(
+          oshape[2] = 1 + static_cast<int>(std::ceil(static_cast<float>(
                               dshape[2] + 2 * param_.pad[0] -
                               param_.kernel[0]) / param_.stride[0]));
-          oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(
+          oshape[3] = 1 + static_cast<int>(std::ceil(static_cast<float>(
                               dshape[3] + 2 * param_.pad[1] -
                               param_.kernel[1]) / param_.stride[1]));
       }
@@ -296,13 +296,13 @@ class PoolingV1Prop : public OperatorProperty {
           oshape[4] = 1 + (dshape[4] + 2 * param_.pad[2] - param_.kernel[2]) /
                               param_.stride[2];
       } else {
-          oshape[2] = 1 + static_cast<int>(ceil(static_cast<float>(
+          oshape[2] = 1 + static_cast<int>(std::ceil(static_cast<float>(
                               dshape[2] + 2 * param_.pad[0] -
                               param_.kernel[0]) / param_.stride[0]));
-          oshape[3] = 1 + static_cast<int>(ceil(static_cast<float>(
+          oshape[3] = 1 + static_cast<int>(std::ceil(static_cast<float>(
                               dshape[3] + 2 * param_.pad[1] -
                               param_.kernel[1]) / param_.stride[1]));
-          oshape[4] = 1 + static_cast<int>(ceil(static_cast<float>(
+          oshape[4] = 1 + static_cast<int>(std::ceil(static_cast<float>(
                               dshape[4] + 2 * param_.pad[2] -
                               param_.kernel[2]) / param_.stride[2]));
       }

--- a/src/operator/roi_pooling.cc
+++ b/src/operator/roi_pooling.cc
@@ -66,10 +66,10 @@ inline void ROIPoolForward(const Tensor<cpu, 4, Dtype> &out,
     Dtype *top_data_n = top_data + n * out_size;
     Dtype *argmax_data_n = argmax_data + n * max_idx_size;
     int roi_batch_ind = bottom_rois_n[0];
-    int roi_start_w = round(bottom_rois_n[1] * spatial_scale_);
-    int roi_start_h = round(bottom_rois_n[2] * spatial_scale_);
-    int roi_end_w = round(bottom_rois_n[3] * spatial_scale_);
-    int roi_end_h = round(bottom_rois_n[4] * spatial_scale_);
+    int roi_start_w = std::round(bottom_rois_n[1] * spatial_scale_);
+    int roi_start_h = std::round(bottom_rois_n[2] * spatial_scale_);
+    int roi_end_w = std::round(bottom_rois_n[3] * spatial_scale_);
+    int roi_end_h = std::round(bottom_rois_n[4] * spatial_scale_);
     assert(roi_batch_ind >= 0);
     assert(static_cast<index_t>(roi_batch_ind) < data.size(0) /* batch size */);
 
@@ -171,10 +171,10 @@ inline void ROIPoolBackwardAcc(const Tensor<cpu, 4, Dtype> &in_grad,
               continue;
             }
 
-            int roi_start_w = round(offset_bottom_rois[1] * spatial_scale_);
-            int roi_start_h = round(offset_bottom_rois[2] * spatial_scale_);
-            int roi_end_w = round(offset_bottom_rois[3] * spatial_scale_);
-            int roi_end_h = round(offset_bottom_rois[4] * spatial_scale_);
+            int roi_start_w = std::round(offset_bottom_rois[1] * spatial_scale_);
+            int roi_start_h = std::round(offset_bottom_rois[2] * spatial_scale_);
+            int roi_end_w = std::round(offset_bottom_rois[3] * spatial_scale_);
+            int roi_end_h = std::round(offset_bottom_rois[4] * spatial_scale_);
 
             bool in_roi = (w >= roi_start_w && w <= roi_end_w &&
                            h >= roi_start_h && h <= roi_end_h);

--- a/src/operator/spatial_transformer.cc
+++ b/src/operator/spatial_transformer.cc
@@ -51,8 +51,8 @@ inline void BilinearSamplingForward(const Tensor<cpu, 4, DType> &output,
           const index_t grid_index = n * o_h * o_w * 2 + h * o_w + w;
           const DType y_real = (*(grid + grid_index + o_h * o_w) + 1) * (i_h - 1) / 2;
           const DType x_real = (*(grid + grid_index) + 1) * (i_w - 1) / 2;
-          const auto top_left_y = static_cast<int>(floor(y_real));
-          const auto top_left_x = static_cast<int>(floor(x_real));
+          const auto top_left_y = static_cast<int>(std::floor(y_real));
+          const auto top_left_x = static_cast<int>(std::floor(x_real));
           const DType top_left_y_w = 1.0 - (y_real - top_left_y);
           const DType top_left_x_w = 1.0 - (x_real - top_left_x);
           const int data_index = n * i_c * i_h * i_w + c * i_h * i_w +
@@ -99,8 +99,8 @@ inline void BilinearSamplingBackward(const Tensor<cpu, 4, DType> &input_grad,
           const index_t grid_src_index = n * o_h * o_w * 2 + h * o_w + w;
           const DType y_real = (*(grid_src + grid_src_index + o_h * o_w) + 1) * (i_h - 1) / 2;
           const DType x_real = (*(grid_src + grid_src_index) + 1) * (i_w - 1) / 2;
-          const auto top_left_y = static_cast<int>(floor(y_real));
-          const auto top_left_x = static_cast<int>(floor(x_real));
+          const auto top_left_y = static_cast<int>(std::floor(y_real));
+          const auto top_left_x = static_cast<int>(std::floor(x_real));
           const DType top_left_y_w = 1.0 - (y_real - top_left_y);
           const DType top_left_x_w = 1.0 - (x_real - top_left_x);
           for (index_t c = 0; c < static_cast<index_t>(o_c); ++c) {

--- a/src/operator/tensor/elemwise_binary_op-inl.h
+++ b/src/operator/tensor/elemwise_binary_op-inl.h
@@ -68,13 +68,13 @@ void ElemwiseBinaryOp::RspRspOp(mshadow::Stream<cpu> *s,
       if (rhs_is_dense) {
         // For right-side dense, in order to have sparse output, lhs input zero should
         // always output zero
-        CHECK(fabs(static_cast<float>(OP::Map(DType(0), DType(99)))) < 1e-4f);
+        CHECK(std::fabs(static_cast<float>(OP::Map(DType(0), DType(99)))) < 1e-4f);
         CHECK(!is_dense_result);  // Currently not handled
       }
       if (lhs_is_dense) {
         // For left-side dense, in order to have sparse output, lhs input zero should
         // always output zero
-        CHECK(fabs(static_cast<float>(OP::Map(DType(99), DType(0)))) < 1e-4f);
+        CHECK(std::fabs(static_cast<float>(OP::Map(DType(99), DType(0)))) < 1e-4f);
         CHECK(!is_dense_result);  // Currently not handled
       }
 
@@ -102,10 +102,10 @@ void ElemwiseBinaryOp::RspRspOp(mshadow::Stream<cpu> *s,
             CHECK_EQ(is_dense_result, false);
             if (lhs_in_place) {
               // For in-place, zero L-value must always be zero output
-              DCHECK(fabs(static_cast<float>(OP::Map(DType(0), DType(99)))) < DType(1e-3));
+              DCHECK(std::fabs(static_cast<float>(OP::Map(DType(0), DType(99)))) < DType(1e-3));
             } else {
               // For in-place, zero R-value must always be zero output
-              DCHECK(fabs(static_cast<float>(OP::Map(DType(99), DType(0)))) < DType(1e-3));
+              DCHECK(std::fabs(static_cast<float>(OP::Map(DType(99), DType(0)))) < DType(1e-3));
             }
           }
         }

--- a/src/operator/tensor/elemwise_binary_op.h
+++ b/src/operator/tensor/elemwise_binary_op.h
@@ -646,7 +646,7 @@ class ElemwiseBinaryOp : public OpBase {
       if (in_stype == lhs_stype && (in_stype == kRowSparseStorage || in_stype == kCSRStorage)) {
         CHECK_EQ(outputs[0].storage_type(), in_stype);
         // rsp -> rsp, _. op requires 0-input returns 0-output
-        DCHECK_LT(fabs(static_cast<float>(LOP::Map(0))), 1e-5f);
+        DCHECK_LT(std::fabs(static_cast<float>(LOP::Map(0))), 1e-5f);
         UnaryOp::ComputeEx<xpu, LOP>(attrs, ctx, inputs, req, {outputs[0]});
       } else {
         LogUnimplementedOp(attrs, ctx, inputs, req, outputs);
@@ -657,7 +657,7 @@ class ElemwiseBinaryOp : public OpBase {
       if (in_stype == rhs_stype && (in_stype == kRowSparseStorage || in_stype == kCSRStorage)) {
         CHECK_EQ(outputs[0].storage_type(), in_stype);
         // rsp -> _, rsp. op requires 0-input returns 0-output
-        DCHECK_LT(fabs(static_cast<float>(ROP::Map(0))), 1e-5f);
+        DCHECK_LT(std::fabs(static_cast<float>(ROP::Map(0))), 1e-5f);
         UnaryOp::ComputeEx<xpu, ROP>(attrs, ctx, inputs, req, {outputs[1]});
       } else {
         LogUnimplementedOp(attrs, ctx, inputs, req, outputs);


### PR DESCRIPTION
## Description ##
Avoid implicit double conversions in legacy math operations.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

Note:  After investigating this warning I'm not sure it's always applicable, however using std::math_func does catch some cases where double promotions happen.  It will also make sure we have uniform implementations across compilers that support the C++11 standard.

```cpp
#include <cmath>

int main() {
    float input = 0.5f;
    return static_cast<int>(std::ceil(input));
}
```

```cpp
main:
    push   rbp
    mov    rbp,rsp
    sub    rsp,0x20
    movss  xmm0,DWORD PTR [rip+0xbe]        # 400624 <_IO_stdin_used+0x4>
    movss  DWORD PTR [rbp-0x4],xmm0
    mov    eax,DWORD PTR [rbp-0x4]
    mov    DWORD PTR [rbp-0x14],eax
    movss  xmm0,DWORD PTR [rbp-0x14]
    call   400581 <std::ceil(float)>
    cvttss2si eax,xmm0
    leave
    ret
```

while
```cpp
#include <stdlib.h>
#include <math.h>

int main() {
    float input = 0.5f;
    return static_cast<int>(ceil(input));
}
```
generates
```cpp
main:
    push   rbp
    mov    rbp,rsp
    sub    rsp,0x10
    movss  xmm0,DWORD PTR [rip+0x9e]        # 400604 <_IO_stdin_used+0x4>
    movss  DWORD PTR [rbp-0x4],xmm0
    cvtss2sd xmm0,DWORD PTR [rbp-0x4]
    call   400440 <ceil@plt>
    cvttsd2si eax,xmm0
    leave
    ret
```
