### PR TITLE
Removing the re-size for validation data, which breaking the validation accuracy of CIFAR training

### DIFF
--- a/example/image-classification/common/data.py
+++ b/example/image-classification/common/data.py
@@ -194,7 +194,6 @@ def get_rec_iter(args, kv=None):
         std_r               = rgb_std[0],
         std_g               = rgb_std[1],
         std_b               = rgb_std[2],
-        resize              = 256,
         data_name           = 'data',
         label_name          = 'softmax_label',
         batch_size          = args.batch_size,


### PR DESCRIPTION
## Description ##
The dataloader for example/image-classification resizes the imagesize of validation dataset to 256 by default, and which breaks the validation accuracy of CIFAR10, this PR trying to fix it.
Below firgure is the validation accuracy trends without this fix (model is ResNet-50).
![image](https://user-images.githubusercontent.com/33112206/44627860-f744b180-a967-11e8-8429-95a49c4f94c0.png)

## Checklist ##
### Changes ###
example/image-classification/common/data.py

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
