### PR TITLE
Manually track num_max_thread

### DIFF
--- a/src/engine/openmp.cc
+++ b/src/engine/openmp.cc
@@ -79,10 +79,24 @@ void OpenMP::set_reserve_cores(int cores) {
 
 int OpenMP::GetRecommendedOMPThreadCount(bool exclude_reserved) const {
 #ifdef _OPENMP
-  if (omp_num_threads_set_in_environment_ || enabled_) {
+  if (omp_num_threads_set_in_environment_) {
     return omp_thread_max_;
   }
-  return 1;
+  if (enabled_) {
+    if (exclude_reserved) {
+      if (reserve_cores_ >= thread_count) {
+        thread_count = 1;
+      } else {
+        thread_count -= reserve_cores_;
+      }
+    }
+    // Check that OMP doesn't suggest more than our 'omp_thread_max_' value
+    if (!omp_thread_max_ || thread_count < omp_thread_max_) {
+      return thread_count;
+    }
+    return omp_thread_max_;
+  }
+
 #else
   return 1;
 #endif

--- a/src/engine/openmp.cc
+++ b/src/engine/openmp.cc
@@ -79,8 +79,9 @@ void OpenMP::set_reserve_cores(int cores) {
 
 int OpenMP::GetRecommendedOMPThreadCount(bool exclude_reserved) const {
 #ifdef _OPENMP
-  if (omp_num_threads_set_in_environment_ || enabled_)
+  if (omp_num_threads_set_in_environment_ || enabled_) {
     return omp_thread_max_;
+  }
   return 1;
 #else
   return 1;

--- a/src/engine/openmp.cc
+++ b/src/engine/openmp.cc
@@ -97,10 +97,8 @@ int OpenMP::GetRecommendedOMPThreadCount(bool exclude_reserved) const {
     }
     return omp_thread_max_;
   }
-
-#else
-  return 1;
 #endif
+  return 1;
 }
 
 OpenMP *__init_omp__ = OpenMP::Get();

--- a/src/engine/openmp.cc
+++ b/src/engine/openmp.cc
@@ -73,11 +73,7 @@ void OpenMP::set_reserve_cores(int cores) {
   CHECK_GE(cores, 0);
   reserve_cores_ = cores;
 #ifdef _OPENMP
-  if (reserve_cores_ >= omp_thread_max_) {
-    omp_thread_max_ = 1;
-  } else {
-    omp_thread_max_ -= reserve_cores_;
-  }
+  omp_thread_max_ = std::max(omp_thread_max_ - reserve_cores_, 1);
 #endif
 }
 

--- a/src/engine/openmp.cc
+++ b/src/engine/openmp.cc
@@ -79,24 +79,8 @@ void OpenMP::set_reserve_cores(int cores) {
 
 int OpenMP::GetRecommendedOMPThreadCount(bool exclude_reserved) const {
 #ifdef _OPENMP
-  if (omp_num_threads_set_in_environment_) {
+  if (omp_num_threads_set_in_environment_ || enabled_)
     return omp_thread_max_;
-  }
-  if (enabled_) {
-    int thread_count = omp_get_max_threads();
-    if (exclude_reserved) {
-      if (reserve_cores_ >= thread_count) {
-        thread_count = 1;
-      } else {
-        thread_count -= reserve_cores_;
-      }
-    }
-    // Check that OMP doesn't suggest more than our 'omp_thread_max_' value
-    if (!omp_thread_max_ || thread_count < omp_thread_max_) {
-      return thread_count;
-    }
-    return omp_thread_max_;
-  }
   return 1;
 #else
   return 1;

--- a/src/engine/openmp.cc
+++ b/src/engine/openmp.cc
@@ -84,7 +84,7 @@ void OpenMP::set_reserve_cores(int cores) {
 int OpenMP::GetRecommendedOMPThreadCount(bool exclude_reserved) const {
 #ifdef _OPENMP
   if (omp_num_threads_set_in_environment_) {
-    return omp_get_max_threads();
+    return omp_thread_max_;
   }
   if (enabled_) {
     int thread_count = omp_get_max_threads();

--- a/src/engine/openmp.cc
+++ b/src/engine/openmp.cc
@@ -74,9 +74,9 @@ void OpenMP::set_reserve_cores(int cores) {
   reserve_cores_ = cores;
 #ifdef _OPENMP
   if (reserve_cores_ >= omp_thread_max_) {
-    omp_set_num_threads(1);
+    omp_thread_max_ = 1;
   } else {
-    omp_set_num_threads(omp_thread_max_ - reserve_cores_);
+    omp_thread_max_ -= reserve_cores_;
   }
 #endif
 }

--- a/src/engine/openmp.cc
+++ b/src/engine/openmp.cc
@@ -83,6 +83,7 @@ int OpenMP::GetRecommendedOMPThreadCount(bool exclude_reserved) const {
     return omp_thread_max_;
   }
   if (enabled_) {
+    int thread_count = omp_get_max_threads();
     if (exclude_reserved) {
       if (reserve_cores_ >= thread_count) {
         thread_count = 1;


### PR DESCRIPTION
## Description ##
Currently we rely on the omp lib (omp_set_max_threads/omp_get_max_threads) to set/fetch the max number threads. However, there is known issue with openmp where the num_thread values do not get updated in a multithreaded environment (https://software.intel.com/en-us/forums/intel-c-compiler/topic/494242). We will keep track of the num_threads manually.

This has caused an issue when the library is called in multi-threaded environment. we will instead only call omp_get_max_threads once and cached the result.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] reserve method modifies num_max_thread directly
- [x] GetRecommendedOMPThreadCount uses cached version  

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
