### PR TITLE
[WIP] support dynamic shape in the imperative mode.

### DIFF
--- a/src/imperative/imperative.cc
+++ b/src/imperative/imperative.cc
@@ -107,7 +107,15 @@ OpStatePtr Imperative::Invoke(
   std::vector<OpReqType> req;
   SetWriteInplaceReq(inputs, outputs, &req);
 
-  return InvokeOp(ctx, attrs, inputs, outputs, req, dispatch_mode);
+  auto ret = InvokeOp(ctx, attrs, inputs, outputs, req, dispatch_mode);
+  for (size_t i = 0; i < outputs.size(); i++) {
+    if (outputs[i]->shape().ndim() == 0) {
+      outputs[i]->WaitToRead();
+      outputs[i]->SetShapeFromChunk();
+    }
+    CHECK(outputs[i]->shape().ndim());
+  }
+  return ret;
 }
 
 void Imperative::MarkVariables(

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -117,10 +117,15 @@ inline void SetShapeType(const Context& ctx,
   for (auto& i : outputs) {
     out_shapes.push_back(i->shape());
   }
-  CHECK(infershape.count(attrs.op))
-    << "Operator " << attrs.op->name << " is missing FInferShape attribute";
-  CHECK(infershape[attrs.op](attrs, &in_shapes, &out_shapes));
-  CHECK_EQ(out_shapes.size(), outputs.size());
+
+  bool dynamic_shape;
+  if (infershape.count(attrs.op)) {
+    CHECK(infershape[attrs.op](attrs, &in_shapes, &out_shapes));
+    CHECK_EQ(out_shapes.size(), outputs.size());
+    dynamic_shape = false;
+  } else {
+    dynamic_shape = true;
+  }
 
   // infer type
   std::vector<int>& in_types = ret->arg_types;
@@ -178,7 +183,9 @@ inline void SetShapeType(const Context& ctx,
   for (size_t i = 0; i < outputs.size(); ++i) {
     NDArrayStorageType storage_type = static_cast<NDArrayStorageType>(out_storage_types[i]);
     if (outputs[i]->is_none()) {
-      if (storage_type == kDefaultStorage) {
+      if (dynamic_shape) {
+        *outputs[i] = NDArray(ctx, out_types[i]);
+      } else if (storage_type == kDefaultStorage) {
         *outputs[i] = NDArray(out_shapes[i], ctx, true, out_types[i]);
       } else {
         *outputs[i] = NDArray(storage_type, out_shapes[i], ctx, true, out_types[i]);

--- a/src/operator/contrib/boolean_mask-inl.h
+++ b/src/operator/contrib/boolean_mask-inl.h
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file boolean_mask-inl.h
+*/
+
+#ifndef MXNET_OPERATOR_CONTRIB_BOOLEAN_MASK_INL_H_
+#define MXNET_OPERATOR_CONTRIB_BOOLEAN_MASK_INL_H_
+
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <mxnet/ndarray.h>
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+#include "../operator_common.h"
+#include "../mxnet_op.h"
+#include "../mshadow_op.h"
+
+namespace mxnet {
+namespace op {
+
+struct BooleanMaskParam : public dmlc::Parameter<BooleanMaskParam> {
+  int axis;
+  DMLC_DECLARE_PARAMETER(BooleanMaskParam) {
+    DMLC_DECLARE_FIELD(axis).set_default(0)
+    .describe("An integer that represents the axis in NDArray to mask from.");
+  }
+};
+
+template <typename xpu>
+inline void BooleanMaskForward(const nnvm::NodeAttrs& attrs,
+                               const OpContext &ctx,
+                               const std::vector<NDArray> &inputs,
+                               const std::vector<OpReqType> &req,
+                               const std::vector<NDArray> &outputs) {
+  CHECK_EQ(inputs.size(), 2U);
+  CHECK_EQ(outputs.size(), 1U);
+  const BooleanMaskParam& param = nnvm::get<BooleanMaskParam>(attrs.parsed);
+  CHECK_EQ(param.axis, 0);
+  CHECK_EQ(inputs[0].shape()[param.axis], inputs[1].shape()[0]);
+  CHECK_EQ(inputs[1].shape().ndim(), 1U);
+  size_t valid_num = 0;
+  const TBlob &idx = inputs[1].data();
+  MSHADOW_TYPE_SWITCH(inputs[1].dtype(), DType, {
+    for (int i = 0; i < inputs[1].shape()[0]; i++) {
+      if (idx.dptr<DType>()[i])
+        valid_num++;
+    }
+  });
+  TShape s = inputs[0].shape();
+  s[0] = valid_num;
+  const_cast<NDArray &>(outputs[0]).Init(s);
+  size_t j = 0;
+  size_t ele_size = mshadow::mshadow_sizeof(inputs[0].dtype());
+  MSHADOW_TYPE_SWITCH(inputs[1].dtype(), DType, {
+  for (int i = 0; i < inputs[1].shape()[0]; i++) {
+    if (idx.dptr<DType>()[i]) {
+      NDArray src = inputs[0].At(i);
+      NDArray dst = outputs[0].At(j);
+      CHECK(src.shape() == dst.shape());
+      memcpy(dst.data().dptr_, src.data().dptr_, src.shape().Size() * ele_size);
+      j++;
+    }
+  }
+  });
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_CONTRIB_BOOLEAN_MASK_INL_H_

--- a/src/operator/contrib/boolean_mask.cc
+++ b/src/operator/contrib/boolean_mask.cc
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file boolean_mask.cc
+*/
+
+#include "./boolean_mask-inl.h"
+
+namespace mxnet {
+namespace op {
+
+DMLC_REGISTER_PARAMETER(BooleanMaskParam);
+
+bool BooleanMaskStorageType(const nnvm::NodeAttrs& attrs,
+                            const int dev_mask,
+                            DispatchMode* dispatch_mode,
+                            std::vector<int> *in_attrs,
+                            std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 2);
+  CHECK_EQ(out_attrs->size(), 1);
+  for (size_t i = 0; i < out_attrs->size(); i++)
+    out_attrs->at(i) = kDefaultStorage;
+  *dispatch_mode = DispatchMode::kFComputeEx;
+  return true;
+}
+
+NNVM_REGISTER_OP(_contrib_BooleanMask)
+.describe(R"code(
+)code" ADD_FILELINE)
+.set_attr_parser(ParamParser<BooleanMaskParam>)
+.set_num_inputs(2)
+.set_num_outputs(1)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskForward<cpu>)
+.set_attr<FInferStorageType>("FInferStorageType", BooleanMaskStorageType)
+//.set_attr<nnvm::FGradient>("FGradient",
+//  ElemwiseGradUseNone{"_backward_contrib_BooleanMask"})
+.add_argument("data", "NDArray-or-Symbol", "Data")
+.add_argument("index", "NDArray-or-Symbol", "Mask")
+.add_arguments(BooleanMaskParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet


### PR DESCRIPTION
## Description ##
This is the first step of supporting dynamic shape in mxnet. As the first step, the PR only supports dynamic shape in the imperative mode. It creates a boolean_mask operator to test dynamic shape.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
