### PR TITLE
[MXNET-875] pass global step and names of params to callback function stat_func i…

### DIFF
--- a/python/mxnet/monitor.py
+++ b/python/mxnet/monitor.py
@@ -67,7 +67,7 @@ class Monitor(object):
             array = NDArray(array, writable=False)
             if not self.activated or not self.re_prog.match(py_str(name)):
                 return
-            self.queue.append((self.step, py_str(name), self.stat_func(array)))
+            self.queue.append((self.step, py_str(name), self.stat_func(py_str(name), self.step, array)))
         self.stat_helper = stat_helper
 
     def install(self, exe):
@@ -113,10 +113,10 @@ class Monitor(object):
         for exe in self.exes:
             for name, array in zip(exe._symbol.list_arguments(), exe.arg_arrays):
                 if self.re_prog.match(name):
-                    self.queue.append((self.step, name, self.stat_func(array)))
+                    self.queue.append((self.step, name, self.stat_func(name, self.step, array)))
             for name, array in zip(exe._symbol.list_auxiliary_states(), exe.aux_arrays):
                 if self.re_prog.match(name):
-                    self.queue.append((self.step, name, self.stat_func(array)))
+                    self.queue.append((self.step, name, self.stat_func(name, self.step, array)))
         self.activated = False
         res = []
         if self.sort:


### PR DESCRIPTION
…n class Monitor

## Description ##
(Brief description on what this PR is about)
pass global step and parameters' names to Monitor's callback function stat_func, so that mxboard can be easily integrated into fit() interface for visualization.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
