### PR TITLE
fixed docs/website build checkout bug

### DIFF
--- a/docs/build_version_doc/build_all_version.sh
+++ b/docs/build_version_doc/build_all_version.sh
@@ -114,7 +114,7 @@ function checkout () {
   # Overriding configs later will cause a conflict here, so stashing...
   git stash
   # Fails to checkout if not available locally, so try upstream
-  git checkout "$repo_folder" || git branch $repo_folder "upstream/$repo_folder"
+  git checkout "$repo_folder" || git branch $repo_folder "upstream/$repo_folder" && git checkout "$repo_folder" || exit 1
   if [ $tag == 'master' ]; then
     git pull
   fi
@@ -174,4 +174,4 @@ done
 
 echo "Now you may want to run update_all_version.sh to create the production layout with the versions dropdown and other per-version corrections."
 echo "The following pattern is recommended (tags, default tag, url base):"
-echo "./update_all_version.sh "$tags_to_display " master http://mxnet.incubator.apache.org/"
+echo "./update_all_version.sh \"$2\" master http://mxnet.incubator.apache.org/"

--- a/docs/settings.ini
+++ b/docs/settings.ini
@@ -14,7 +14,7 @@ r_docs = 0
 scala_docs = 1
 
 [document_sets_v1.2.0]
-clojure_docs = 1
+clojure_docs = 0
 doxygen_docs = 1
 r_docs = 0
 scala_docs = 1


### PR DESCRIPTION
## Description ##
Fixes a bug in the docs build pipeline where a failover case didn't checkout a different branch as expected. This caused master API docs to appear in older versions in CI. Local builds would run fine.

Added a hard error stop on the checkout step to prevent any issue like this popping up silently in CI.
Also fixed the echo statement to print exactly what should be run next.
Also removed Clojure from the v1.2.0 settings for docs generation. These should only generate in master or in 1.3.0+. 

For example, in the CI logs:
```
+ git checkout v1.0.0
error: pathspec 'v1.0.0' did not match any file(s) known to git.
+ git branch v1.0.0 upstream/v1.0.0
Branch v1.0.0 set up to track remote branch v1.0.0 from upstream.
```
It checks if the branch is there already, if not it grabs it from upstream. What is missing here is that it also needed to checkout the newly created branch. If all fails then the process aborts on this step, rather than continue with master.

## Comments
The consistent theme is patched in a separate PR: #12426.
