### PR TITLE
fix website search result 404s

### DIFF
--- a/docs/_static/searchtools_custom.js
+++ b/docs/_static/searchtools_custom.js
@@ -8,14 +8,14 @@
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
  * met:
- * 
+ *
  * * Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
- * 
+ *
  * * Redistributions in binary form must reproduce the above copyright
  *   notice, this list of conditions and the following disclaimer in the
  *   documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -523,7 +523,7 @@ var Search = {
             displayNextItem();
           });
         } else if (DOCUMENTATION_OPTIONS.HAS_SOURCE) {
-          $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + '_sources/' + item[0] + '.txt',
+          $.ajax({url: DOCUMENTATION_OPTIONS.URL_ROOT + '_sources/' + item[0] + '.md.txt',
                   dataType: "text",
                   complete: function(jqxhr, textstatus) {
                     var data = jqxhr.responseText;


### PR DESCRIPTION
## Description ##
Currently the site will return a few results then the rest will have previews that show 404 messaging. The _sources directory has just .md.txt files in it but the customsearch.js was looking for .txt files. 
This patch fixes the js to look for what's actually there. The previews aren't the best because sometimes there's rst at the top, but this is much better than showing a 404 message.

![2018-08-30_11-11-40](https://user-images.githubusercontent.com/5974205/44870790-edf86500-ac45-11e8-873b-f1146f401849.png)

Now you get:
![2018-08-30_11-11-54](https://user-images.githubusercontent.com/5974205/44870796-f486dc80-ac45-11e8-9590-a7c776150c3b.png)
