### PR TITLE
Fix flaky test: test_mkldnn.test_activation #12377

### DIFF
--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -281,7 +281,6 @@ def test_pooling():
         check_pooling_training(stype)
 
 
-@unittest.skip("Flaky test: https://github.com/apache/incubator-mxnet/issues/12377")
 @with_seed()
 def test_activation():
     def check_activation_training(stype):

--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -292,7 +292,7 @@ def test_activation():
             in_location = [mx.nd.array(data_tmp).tostype(stype)]
 
             test = mx.symbol.Activation(data, act_type="relu")
-            check_numeric_gradient(test, in_location, numeric_eps=1e-2, rtol=0.16, atol=1e-4)
+            check_numeric_gradient(test, in_location, numeric_eps=1e-6, rtol=0.16, atol=1e-4)
 
     stypes = ['row_sparse', 'default']
     for stype in stypes:


### PR DESCRIPTION
## Description ##
Fix the flaky test failure : test_mkldnn.test_activation. #12377
The problem locates in the finite difference method for gradient comparison. In this case, the large eps caused the wrong calculation and this pull request reduces the eps for more accurate calculation.
@pengzhao-intel

