### PR TITLE
Revert "fixed flaky test issue for test_operator_gpu.test_depthwise_c…

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1616,6 +1616,7 @@ def test_convolution_grouping():
             np.testing.assert_allclose(arr1.asnumpy(), arr2.asnumpy(), rtol=1e-3, atol=1e-3)
 
 
+@unittest.skip("Flaky test https://github.com/apache/incubator-mxnet/issues/12203")
 @with_seed()
 def test_depthwise_convolution():
     for dim in [1,2]:
@@ -1649,7 +1650,7 @@ def test_depthwise_convolution():
                             exe2 = y2.simple_bind(mx.cpu(), x=shape, w=(num_filter, shape[1]//num_group)+kernel,
                                     b=(num_filter,))
                             for arr1, arr2 in zip(exe1.arg_arrays, exe2.arg_arrays):
-                                arr1[:] = np.float32(np.random.normal(size=arr1.shape))
+                                arr1[:] = np.random.normal(size=arr1.shape)
                                 arr2[:] = arr1
                             exe1.forward(is_train=True)
                             exe1.backward(exe1.outputs[0])
@@ -1657,7 +1658,7 @@ def test_depthwise_convolution():
                             exe2.backward(exe2.outputs[0])
 
                             for arr1, arr2 in zip(exe1.outputs + exe1.grad_arrays, exe2.outputs + exe2.grad_arrays):
-                                np.testing.assert_allclose(arr1.asnumpy(), arr2.asnumpy(), rtol=1e-2, atol=1e-3)
+                                np.testing.assert_allclose(arr1.asnumpy(), arr2.asnumpy(), rtol=1e-3, atol=1e-3)
 
 def gen_broadcast_data(idx):
     # Manually set test cases


### PR DESCRIPTION
…onvolution (#12402)"

This reverts commit 58560f6d2e96da605c658742ebb0e26a7d0cbcd3.

## Description ##

Test if failing again: 
* http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/PR-12429/1/pipeline/
* http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/master/1550/pipeline/

```
======================================================================
FAIL: test_operator_gpu.test_depthwise_convolution
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/usr/local/lib/python2.7/dist-packages/nose/util.py", line 620, in newfunc
    return func(*arg, **kw)
  File "/work/mxnet/tests/python/gpu/../unittest/common.py", line 172, in test_new
    orig_test(*args, **kwargs)
  File "/work/mxnet/tests/python/gpu/../unittest/test_operator.py", line 1660, in test_depthwise_convolution
    np.testing.assert_allclose(arr1.asnumpy(), arr2.asnumpy(), rtol=1e-2, atol=1e-3)
  File "/usr/local/lib/python2.7/dist-packages/numpy/testing/nose_tools/utils.py", line 1396, in assert_allclose
    verbose=verbose, header=header, equal_nan=equal_nan)
  File "/usr/local/lib/python2.7/dist-packages/numpy/testing/nose_tools/utils.py", line 779, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Not equal to tolerance rtol=0.01, atol=0.001
(mismatch 4.0%)
 x: array([[[[ 26.400417, -36.113285, -64.04252 ,  -8.254103,  17.523859],
         [ 45.250435,  76.37607 ,  24.216667,  23.500875, -87.81845 ],
         [ 32.61415 ,   0.185663,  77.17114 ,  56.433533, -63.38382 ],...
 y: array([[[[ 26.399519, -36.111725, -64.04085 ,  -8.25362 ,  17.523405],
         [ 45.24878 ,  76.3775  ,  24.218298,  23.501816, -87.819145],
         [ 32.61278 ,   0.188967,  77.171234,  56.432304, -63.3824  ],...
-------------------- >> begin captured logging << --------------------
common: INFO: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=589329529 to reproduce.
--------------------- >> end captured logging << ---------------------
```
