### PR TITLE
MXNET-884 - Clojure with-resources macro for Improved Memory Handling

### DIFF
--- a/contrib/clojure-package/src/org/apache/clojure_mxnet/util.clj
+++ b/contrib/clojure-package/src/org/apache/clojure_mxnet/util.clj
@@ -208,7 +208,10 @@
   "bindings => [name init ...]
   Similar to with-open. Evaluates body in a try expression with names bound to the values
   of the inits, and a finally clause that calls (.dispose name) on each
-  name in reverse order. Use for NDArrays, Symbols, Iterators, Executors and others that need to be disposed"
+  name in reverse order. Use for NDArrays, Symbols, Iterators, Executors and others that   need to be disposed. The resources in the binding vector will be auto-disposed.
+  Example: (util/with-resources [a (ndarray/ones [3])
+                                 b (ndarray/ones [3])]
+             (ndarray/+ a b))"
   [bindings & body]
   (cond
     (= (count bindings) 0) `(do ~@body)
@@ -218,4 +221,4 @@
                                 (finally
                                   (. ~(bindings 0) dispose))))
     :else (throw (IllegalArgumentException.
-                  "with-open only allows Symbols in bindings"))))
+                  "with-resources only allows Symbols in bindings"))))

--- a/contrib/clojure-package/test/org/apache/clojure_mxnet/util_test.clj
+++ b/contrib/clojure-package/test/org/apache/clojure_mxnet/util_test.clj
@@ -196,27 +196,27 @@
 
 (deftest test-with-resources
   (testing "with ndarrays"
-   (let [a (ndarray/array [-1 0 1 2 3 4] [2 3])
-         result-map (util/with-resources
-                      [b (ndarray/relu a)
-                       c (ndarray/+ a b)]
-                      {:result (ndarray/slice c 0 1)
-                       :b b
-                       :c c})]
-     (is (= [-1.0 0.0 2.0] (ndarray/->vec (:result result-map))))
-     (is (true? (.isDisposed (:b result-map))))
-     (is (true? (.isDisposed (:c result-map))))
-     (is (false? (.isDisposed a)))
-     (is (false? (.isDisposed (:result result-map))))))
+    (let [a (ndarray/array [-1 0 1 2 3 4] [2 3])
+          result-map (util/with-resources
+                       [b (ndarray/relu a)
+                        c (ndarray/+ a b)]
+                       {:result (ndarray/slice c 0 1)
+                        :b b
+                        :c c})]
+      (is (= [-1.0 0.0 2.0] (ndarray/->vec (:result result-map))))
+      (is (true? (.isDisposed (:b result-map))))
+      (is (true? (.isDisposed (:c result-map))))
+      (is (false? (.isDisposed a)))
+      (is (false? (.isDisposed (:result result-map))))))
 
   (testing "with nested ndarrays"
-      (let [result-map2 (util/with-resources [a (ndarray/ones [3 3])]
-                          (let [result-map1 (util/with-resources
-                                              [b (ndarray/zeros [1 1])]
-                                              {:b b})]
-                            (is (true? (.isDisposed (:b result-map1)))))
-                          {:a a})]
-        (is (true? (.isDisposed (:a result-map2))))))
+    (let [result-map2 (util/with-resources [a (ndarray/ones [3 3])]
+                        (let [result-map1 (util/with-resources
+                                            [b (ndarray/zeros [1 1])]
+                                            {:b b})]
+                          (is (true? (.isDisposed (:b result-map1)))))
+                        {:a a})]
+      (is (true? (.isDisposed (:a result-map2))))))
 
   (testing "with symbols and executor"
     (let [result-map

--- a/contrib/clojure-package/test/org/apache/clojure_mxnet/util_test.clj
+++ b/contrib/clojure-package/test/org/apache/clojure_mxnet/util_test.clj
@@ -204,20 +204,14 @@
      (is (= [-1.0 0.0 2.0] (ndarray/->vec (:result result-map))))
      (is (true? (.isDisposed (:b result-map))))
      (is (true? (.isDisposed (:c result-map))))
-     (is (false? (.isDisposed a)))))
+     (is (false? (.isDisposed a)))
+     (is (false? (.isDisposed (:result result-map))))))
 
     (testing "with nested ndarrays"
-      (let [result-map1 (util/with-resources
-                          [a (ndarray/array [-1 0 1 2 3 4] [2 3])]
-                          (let [result-map2 (util/with-resources
-                                             [b (ndarray/relu a)
-                                              c (ndarray/+ a b)]
-                                             {:result (ndarray/slice c 0 1)
-                                              :b b
-                                              :c c})]
-                            (is (= [-1.0 0.0 2.0] (ndarray/->vec (:result result-map2))))
-                            (is (true? (.isDisposed (:b result-map2))))
-                            (is (true? (.isDisposed (:c result-map2))))
-                            (is (false? (.isDisposed a))))
+      (let [result-map2 (util/with-resources [a (ndarray/ones [3 3])]
+                          (let [result-map1 (util/with-resources
+                                              [b (ndarray/zeros [1 1])]
+                                              {:b b})]
+                            (is (true? (.isDisposed (:b result-map1)))))
                           {:a a})]
-        (is (true? (.isDisposed (:a result-map1)))))))
+        (is (true? (.isDisposed (:a result-map2)))))))


### PR DESCRIPTION
## Description ##

This adds a `with-resources` macro to the Clojure package to provide an idiomatic way, (similar to `with-open`), to explicitly dispose of resources with a `.dispose` call.

It works with any Scala object that has a `.dispose` method -  NDArray, Symbol, Executor, Iterators, etc..

Usage is:

```clojure 
(util/with-resources [a (ndarray/ones [3])
                      b (ndarray/ones [3])]
    (ndarray/+ a b))
```
Any resources in the binding vector will be disposed. Result resources will not.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- The Scala package uses scopes with an NDArrayCollector. However, scopes do not mesh well with the Clojure language and the macro pattern for `with-open` for resources is well established and idiomatic in Clojure.
- This will allow users to better control the resources and memory management, however it is not a full solution. There is still investigation into other avenues ongoing with the Scala package.
- Applications of with-resources to the examples will happen in a separate PR
