### PR TITLE
Add extra check for illegal case in reshape

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -452,6 +452,7 @@ MXNET_DLL int MXNDArrayReshape64(NDArrayHandle handle,
   CHECK_GT(arr->shape().Size(), 0) << "Source ndarray's shape is undefined. Input shape: "
     << arr->shape();
   TShape new_shape = mxnet::op::InferReshapeShape(shape, arr->shape(), reverse);
+  mxnet::op::CheckSizeSame(arr->shape(), new_shape);
   *ptr = arr->ReshapeWithRecord(new_shape);
   *out = ptr;
   API_END_HANDLE_ERROR(delete ptr);

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -69,6 +69,13 @@ struct ReshapeParam : public dmlc::Parameter<ReshapeParam> {
   }
 };
 
+inline void CheckSizeSame(const TShape& a, const TShape& b) {
+  CHECK_EQ(a.Size(), b.Size())
+    << "Target shape size is different to source. "
+    << "Target: " << b
+    << "\nSource: " << a;
+}
+
 template<typename IType>
 inline TShape InferReshapeShape(const nnvm::Tuple<IType>& shape,
                                 const TShape& dshape, bool reverse) {
@@ -208,10 +215,7 @@ inline bool ReshapeShape(const nnvm::NodeAttrs& attrs,
     return (*out_attrs)[0].ndim() && ReverseReshapeInferShape(&(*in_attrs)[0], (*out_attrs)[0]);
   }
   ReverseReshapeInferShape(&dshape, oshape);
-  CHECK_EQ(oshape.Size(), dshape.Size())
-    << "Target shape size is different to source. "
-    << "Target: " << oshape
-    << "\nSource: " << dshape;
+  CheckSizeSame(dshape, oshape);
   SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);
   return ReverseReshapeInferShape(&(*in_attrs)[0], (*out_attrs)[0]);
 }

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2109,6 +2109,10 @@ def test_reshape():
                 'Output Shape = %s' %(str(holdout_src_shape), str(shape_args), str(reverse),
                                       str(dst_shape), str(output_shape[0]))
 
+    def test_invalid_reshape():
+        data = mx.nd.arange(16).reshape((4, 4))
+        assert_exception(mx.nd.reshape, MXNetError, data, (1, -2))
+
     # Test new api (Using shape)
     test_cases = [
         [(2, 3, 5, 5),  (0, -1),          False, (2, 75)],
@@ -2156,6 +2160,9 @@ def test_reshape():
     assert_allclose(outputs, data_npy.reshape((5, 4 * 3 * 7)))
     exe.backward(out_grads=[mx.nd.array(out_grad_npy, ctx=default_context())])
     assert_allclose(exe.grad_arrays[0].asnumpy(), out_grad_npy.reshape((5, 4, 3, 7)))
+
+    # Test for invalid cases
+    test_invalid_reshape()
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
Follow-up for #12425, add extra prevention to catch illegal reshape case for convenient method.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Extra check for illegal cases
- [x] Corresponding unit tests

## Comments ##
New test is a pure logic test, no possible flakiness.