### PR TITLE
[WIP] Fix race-conditon download function

### DIFF
--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -213,7 +213,7 @@ def download(url, path=None, overwrite=False, sha1_hash=None, retries=5, verify_
         else:
             fname = path
     assert retries >= 0, "Number of retries should be at least 0"
-    
+
     if not verify_ssl:
         warnings.warn(
             'Unverified HTTPS request is being made (verify_ssl=False). '

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -213,6 +213,7 @@ def download(url, path=None, overwrite=False, sha1_hash=None, retries=5, verify_
         else:
             fname = path
     assert retries >= 0, "Number of retries should be at least 0"
+    
     if not verify_ssl:
         warnings.warn(
             'Unverified HTTPS request is being made (verify_ssl=False). '
@@ -234,7 +235,7 @@ def download(url, path=None, overwrite=False, sha1_hash=None, retries=5, verify_
                 random_uuid = str(uuid.uuid4())
                 with open('{}.{}'.format(fname, random_uuid), 'wb') as f:
                     for chunk in r.iter_content(chunk_size=1024):
-                        if chunk:  # filter out keep-alive new chunks
+                        if chunk: # filter out keep-alive new chunks
                             f.write(chunk)
                     # if the target file exists(created by other processes),
                     # delete the temporary file

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -22,11 +22,7 @@ __all__ = ['split_data', 'split_and_load', 'clip_global_norm',
            'check_sha1', 'download']
 
 import os
-import tempfile
-import shutil
-import re
 import uuid
-import glob
 import hashlib
 import warnings
 import collections
@@ -180,39 +176,6 @@ def check_sha1(filename, sha1_hash):
     return sha1.hexdigest() == sha1_hash
 
 
-# def _atomic_cp(temp_file, fname):
-#     """ Implement lock-free whack-a-mole algorithm to achieve atmoic cp 
-#         Reference https://stackoverflow.com/questions/11614815/a-safe-atomic-file-copy-operation
-#     """
-#     if os.path.exists(fname):
-#         return
-#     random_uuid = str(uuid.uuid4())
-#     print('generatate UUID {}'.format(random_uuid))
-#     shutil.copy(temp_file, '{}.{}.tmp'.format(fname, random_uuid))
-#     os.rename('{}.{}.tmp'.format(fname, random_uuid),
-#               '{}-{}.mole.tmp'.format(fname, random_uuid))
-#     other_mole_files = glob.glob('{}-*.mole.tmp'.format(fname))
-#     for other_mole_file in other_mole_files:
-#         file_uuid = re.search(r'{}-(.+?).mole.tmp'.format(fname), other_mole_file).group(1)
-#         print('~~~~~~~~~~~~~~~~~~~~~~~')
-#         print(other_mole_file)
-#         print(file_uuid)
-#         assert file_uuid is not None, 'mole.tmp filename is missing'
-#         if uuid.UUID(file_uuid) > uuid.UUID(random_uuid):
-#             print('remove other {}'.format(other_mole_file))
-#             os.remove(other_mole_file)
-#         if uuid.UUID(file_uuid) < uuid.UUID(random_uuid):
-#             print('remove my own {}-{}.mole.tmp'.format(fname, random_uuid))
-#             os.remove('{}-{}.mole.tmp'.format(fname, random_uuid))
-#             random_uuid = file_uuid
-#     if os.path.exists(fname):
-#         print('remove {}'.format(random_uuid))
-#         os.remove('{}-{}.mole.tmp'.format(fname, random_uuid))
-#     else:
-#         print('rename {}'.format())
-#         os.rename('{}-{}.mole.tmp'.format(fname, random_uuid), fname)
-
-
 def download(url, path=None, overwrite=False, sha1_hash=None, retries=5, verify_ssl=True):
     """Download an given URL
 
@@ -267,23 +230,25 @@ def download(url, path=None, overwrite=False, sha1_hash=None, retries=5, verify_
                 r = requests.get(url, stream=True, verify=verify_ssl)
                 if r.status_code != 200:
                     raise RuntimeError("Failed downloading url %s"%url)
-                # create uuid
+                # create uuid for temporary files
                 random_uuid = str(uuid.uuid4())
                 with open('{}.{}'.format(fname, random_uuid), 'wb') as f:
                     for chunk in r.iter_content(chunk_size=1024):
                         if chunk:  # filter out keep-alive new chunks
                             f.write(chunk)
-                    # if the target file exists(created by other process), delete the tmp file
+                    # if the target file exists(created by other processes),
+                    # delete the temporary file
                     if os.path.exists(fname):
                         os.remove('{}.{}'.format(fname, random_uuid))
                     else:
                         # atmoic operation in the same file system
                         os.replace('{}.{}'.format(fname, random_uuid), fname)
                     if sha1_hash and not check_sha1(fname, sha1_hash):
-                        raise UserWarning('File {} is downloaded but the content hash does not match.'
-                                        ' The repo may be outdated or download may be incomplete. '
-                                        'If the "repo_url" is overridden, consider switching to '
-                                        'the default repo.'.format(fname))
+                        raise UserWarning(
+                            'File {} is downloaded but the content hash does not match.'
+                            ' The repo may be outdated or download may be incomplete. '
+                            'If the "repo_url" is overridden, consider switching to '
+                            'the default repo.'.format(fname))
                 break
             except Exception as e:
                 retries -= 1

--- a/tests/python/unittest/test_gluon_utils.py
+++ b/tests/python/unittest/test_gluon_utils.py
@@ -26,10 +26,9 @@ try:
     from unittest import mock
 except ImportError:
     import mock
-import mxnet as mx
 import requests
 from nose.tools import raises
-
+import mxnet as mx
 
 class MockResponse(requests.Response):
     def __init__(self, status_code, content):
@@ -50,41 +49,43 @@ def test_download_retries():
     'requests.get',
     mock.Mock(side_effect=lambda *args, **kwargs: MockResponse(200, 'MOCK CONTENT' * 100)))
 def _download_successful(tmp):
+    """ internal use for testing download successfully """
     mx.gluon.utils.download(
         "https://raw.githubusercontent.com/apache/incubator-mxnet/master/README.md",
         path=tmp)
 
 
 def test_download_successful():
+    """ test download with one process """
     tmp = tempfile.mkdtemp()
     tmpfile = os.path.join(tmp, 'README.md')
     _download_successful(tmpfile)
     assert os.path.getsize(tmpfile) > 100, os.path.getsize(tmpfile)
-    # assert there is no mole.tmp
     pattern = os.path.join(tmp, 'README.md*')
+    # check only one file we want left
     assert len(glob.glob(pattern)) == 1, glob.glob(pattern)
     # delete temp dir
     shutil.rmtree(tmp)
 
 
-
-def test_multithreading_download_successful():
-    for _ in range(1000000):
-        tmp = tempfile.mkdtemp()
-        tmpfile = os.path.join(tmp, 'README.md')
-        process_list = []
-        for i in range(1000):
-            process_list.append(mp.Process(
-                target=_download_successful, args=(tmpfile,)))
-            process_list[i].start()
-        for i in range(1000):
-            process_list[i].join()
-        assert os.path.getsize(tmpfile) > 100, os.path.getsize(tmpfile)
-        # assert there is no mole.tmp
-        pattern = os.path.join(tmp, 'README.md*')
-        assert len(glob.glob(pattern)) == 1, glob.glob(pattern)
-        # delete temp dir
-        shutil.rmtree(tmp)
+def test_multiprocessing_download_successful():
+    """ test download with multiprocessing """
+    tmp = tempfile.mkdtemp()
+    tmpfile = os.path.join(tmp, 'README.md')
+    process_list = []
+    # test it with 10 processes
+    for i in range(10):
+        process_list.append(mp.Process(
+            target=_download_successful, args=(tmpfile,)))
+        process_list[i].start()
+    for i in range(10):
+        process_list[i].join()
+    assert os.path.getsize(tmpfile) > 100, os.path.getsize(tmpfile)
+    # check only one file we want left
+    pattern = os.path.join(tmp, 'README.md*')
+    assert len(glob.glob(pattern)) == 1, glob.glob(pattern)
+    # delete temp dir
+    shutil.rmtree(tmp)
 
 
 @mock.patch(
@@ -92,6 +93,7 @@ def test_multithreading_download_successful():
     mock.Mock(
         side_effect=lambda *args, **kwargs: MockResponse(200, 'MOCK CONTENT')))
 def test_download_ssl_verify():
+    """ test download verify_ssl parameter """
     with warnings.catch_warnings(record=True) as warnings_:
         mx.gluon.utils.download(
             "https://mxnet.incubator.apache.org/index.html", verify_ssl=False)


### PR DESCRIPTION
## Description ##
Originally download function within gluon/utils.py would cause race-condition(#11646).
The PR tackle the problem by giving the downloaded file a tempory name and renaming back to target filename.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Assign a uuid for the downloaded file and rename back to the target filename
- Add corresponding unittests to check the correctness within multiprocesses

## Comments ##
N/A
