### PR TITLE
[MXNET-703] Static linking for libprotobuf with TensorRT

### DIFF
--- a/ci/docker/install/tensorrt.sh
+++ b/ci/docker/install/tensorrt.sh
@@ -30,9 +30,12 @@ apt-get install -y automake libtool
 git clone --recursive -b 3.5.1.1 https://github.com/google/protobuf.git
 cd protobuf
 ./autogen.sh
-./configure
+./configure --disable-shared CXXFLAGS=-fPIC
 make -j$(nproc)
 make install
+rm -rf /usr/local/lib/libprotobuf-lite.so*
+rm -rf /usr/local/lib/libprotobuf.so*
+rm -rf /usr/local/lib/libprotoc.so*
 ldconfig
 popd
 


### PR DESCRIPTION
## Description ##
This PR helps make our TensorRT builds more portable by statically linking protobuf.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

Note: stripped filesize after patch is 133M, before patch is 129M.