### PR TITLE
 [MXNET-696][PYTHON][UNDEFINED NAME] import logging in ci/util.py

### DIFF
--- a/ci/util.py
+++ b/ci/util.py
@@ -17,6 +17,7 @@
 
 import os
 import contextlib
+import logging
 import requests
 
 def get_mxnet_root() -> str:


### PR DESCRIPTION
## Description ##
Fixes #12406 @larroy @marcoabreu @szha 

[flake8](http://flake8.pycqa.org) testing of https://github.com/apache/incubator-mxnet on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./ci/util.py:73:21: F821 undefined name 'logging'
                    logging.warning("Exception: %s, Retrying in %d seconds...", str(e), mdelay)
                    ^
1     F821 undefined name 'logging'
1
```
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] __import logging__ in ci/util.py to fix __undefined name__

## Comments ##
