### PR TITLE
[WIP][MXNET-918] Random api

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
@@ -40,6 +40,8 @@ object NDArray extends NDArrayBase {
 
   val api = NDArrayAPI
 
+  val random = NDArrayRandomAPI
+
   private def addDependency(froms: Array[NDArray], tos: Array[NDArray]): Unit = {
     froms.foreach { from =>
       val weakRef = new WeakReference(from)

--- a/scala-package/core/src/main/scala/org/apache/mxnet/NDArrayAPI.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NDArrayAPI.scala
@@ -23,3 +23,13 @@ package org.apache.mxnet
 object NDArrayAPI extends NDArrayAPIBase {
   // TODO: Implement CustomOp for NDArray
 }
+
+@AddNDArrayRandomAPIs(false)
+/**
+  * typesafe NDArray random module: NDArray.random._
+  * Main code will be generated during compile time through Macros
+  */
+object NDArrayRandomAPI extends NDArrayRandomAPIBase {
+
+}
+

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
@@ -840,6 +840,8 @@ object Symbol extends SymbolBase {
   private val functions: Map[String, SymbolFunction] = initSymbolModule()
   private val bindReqMap = Map("null" -> 0, "write" -> 1, "add" -> 3)
 
+  type SymbolOrFloat = Any
+
   val api = SymbolAPI
 
   val random = SymbolRandomAPI

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
@@ -842,6 +842,8 @@ object Symbol extends SymbolBase {
 
   val api = SymbolAPI
 
+  val random = SymbolRandomAPI
+
   def pow(sym1: Symbol, sym2: Symbol): Symbol = {
     Symbol.createFromListedSymbols("_Power")(Array(sym1, sym2))
   }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/SymbolAPI.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/SymbolAPI.scala
@@ -35,7 +35,7 @@ object SymbolAPI extends SymbolAPIBase {
 
 @AddSymbolRandomAPIs(false)
 /**
-  * typesafe Symbol API: Symbol.random._
+  * typesafe Symbol random module: Symbol.random._
   * Main code will be generated during compile time through Macros
   */
 object SymbolRandomAPI extends SymbolRandomAPIBase {

--- a/scala-package/core/src/main/scala/org/apache/mxnet/SymbolAPI.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/SymbolAPI.scala
@@ -32,3 +32,13 @@ object SymbolAPI extends SymbolAPIBase {
     Symbol.createSymbolGeneral("Custom", name, attr, Seq(), map.toMap)
   }
 }
+
+@AddSymbolRandomAPIs(false)
+/**
+  * typesafe Symbol API: Symbol.random._
+  * Main code will be generated during compile time through Macros
+  */
+object SymbolRandomAPI extends SymbolRandomAPIBase {
+
+}
+

--- a/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
@@ -580,8 +580,8 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
   test("random module is present") {
     val loc = NDArray.ones(1, 2)
     val scale = NDArray.ones(1, 2) * 2
-    val rnd = NDArray.random.sample_normal(mu = loc, sigma = scale, shape = Some(Shape(3, 4)))
-    val rnd2 = NDArray.random.random_normal(loc = Some(1f), scale = Some(2f),
+    val rnd = NDArray.random._sample_normal(mu = loc, sigma = scale, shape = Some(Shape(3, 4)))
+    val rnd2 = NDArray.random._random_normal(loc = Some(1f), scale = Some(2f),
       shape = Some(Shape(3, 4)))
     assert(rnd.shape === Shape(1, 2, 3, 4))
     assert(rnd2.shape === Shape(3, 4))

--- a/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
@@ -577,11 +577,19 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
     assert(arr.internal.toByteArray === Array(2.toByte, 2.toByte))
   }
 
-  test("random module is present") {
-    val loc = NDArray.ones(1, 2)
-    val scale = NDArray.ones(1, 2) * 2
-    val rnd = NDArray.random.sample_normal(mu = loc, sigma = scale, shape = Some(Shape(3, 4)))
-    val rnd2 = NDArray.random.random_normal(loc = Some(1f), scale = Some(2f),
+  test("random module is generated properly") {
+    val lam = NDArray.ones(1, 2)
+    val rnd = NDArray.random.poisson(lam = Some(lam), shape = Some(Shape(3, 4)))
+    val rnd2 = NDArray.random.poisson(lam = Some(1f), shape = Some(Shape(3, 4)))
+    assert(rnd.shape === Shape(1, 2, 3, 4))
+    assert(rnd2.shape === Shape(3, 4))
+  }
+
+  test("random module is generated properly - special case of 'normal'") {
+    val mu = NDArray.ones(1, 2)
+    val sigma = NDArray.ones(1, 2) * 2
+    val rnd = NDArray.random.normal(mu = Some(mu), sigma = Some(sigma), shape = Some(Shape(3, 4)))
+    val rnd2 = NDArray.random.normal(mu = Some(1f), sigma = Some(2f),
       shape = Some(Shape(3, 4)))
     assert(rnd.shape === Shape(1, 2, 3, 4))
     assert(rnd2.shape === Shape(3, 4))

--- a/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
@@ -576,4 +576,14 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
     assert(arr.internal.toDoubleArray === Array(2d, 2d))
     assert(arr.internal.toByteArray === Array(2.toByte, 2.toByte))
   }
+
+  test("random module is present") {
+    val loc = NDArray.ones(1, 2)
+    val scale = NDArray.ones(1, 2) * 2
+    val rnd = NDArray.random.sample_normal(mu = loc, sigma = scale, shape = Some(Shape(3, 4)))
+    val rnd2 = NDArray.random.random_normal(loc = Some(1f), scale = Some(2f),
+      shape = Some(Shape(3, 4)))
+    assert(rnd.shape === Shape(1, 2, 3, 4))
+    assert(rnd2.shape === Shape(3, 4))
+  }
 }

--- a/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
@@ -580,8 +580,8 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
   test("random module is present") {
     val loc = NDArray.ones(1, 2)
     val scale = NDArray.ones(1, 2) * 2
-    val rnd = NDArray.random._sample_normal(mu = loc, sigma = scale, shape = Some(Shape(3, 4)))
-    val rnd2 = NDArray.random._random_normal(loc = Some(1f), scale = Some(2f),
+    val rnd = NDArray.random.sample_normal(mu = loc, sigma = scale, shape = Some(Shape(3, 4)))
+    val rnd2 = NDArray.random.random_normal(loc = Some(1f), scale = Some(2f),
       shape = Some(Shape(3, 4)))
     assert(rnd.shape === Shape(1, 2, 3, 4))
     assert(rnd2.shape === Shape(3, 4))

--- a/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
@@ -76,9 +76,9 @@ class SymbolSuite extends FunSuite with BeforeAndAfterAll {
   test("random module is present") {
     val loc = Symbol.Variable("loc")
     val scale = Symbol.Variable("scale")
-    val rnd = Symbol.random._sample_normal(mu = Some(loc), sigma = Some(scale),
+    val rnd = Symbol.random.sample_normal(mu = Some(loc), sigma = Some(scale),
       shape = Some(Shape(2, 2)))
-    val rnd2 = Symbol.random._random_normal(loc = Some(1f), scale = Some(2f),
+    val rnd2 = Symbol.random.random_normal(loc = Some(1f), scale = Some(2f),
       shape = Some(Shape(2, 2)))
     // scalastyle:off println
     println(s"Symbol.random.sample_normal debug info: ${rnd.debugStr}")

--- a/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
@@ -19,6 +19,7 @@ package org.apache.mxnet
 
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
+
 class SymbolSuite extends FunSuite with BeforeAndAfterAll {
 
   test("symbol compose") {

--- a/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
@@ -74,12 +74,22 @@ class SymbolSuite extends FunSuite with BeforeAndAfterAll {
     assert(data.toJson === data2.toJson)
   }
 
-  test("random module is present") {
+  test("random module is generated properly") {
+    val lam = Symbol.Variable("lam")
+    val rnd = Symbol.random.poisson(lam = Some(lam), shape = Some(Shape(2, 2)))
+    val rnd2 = Symbol.random.poisson(lam = Some(1f), shape = Some(Shape(2, 2)))
+    // scalastyle:off println
+    println(s"Symbol.random.poisson debug info: ${rnd.debugStr}")
+    println(s"Symbol.random.poisson debug info: ${rnd2.debugStr}")
+    // scalastyle:on println
+  }
+
+  test("random module is generated properly - special case of 'normal'") {
     val loc = Symbol.Variable("loc")
     val scale = Symbol.Variable("scale")
-    val rnd = Symbol.random.sample_normal(mu = Some(loc), sigma = Some(scale),
+    val rnd = Symbol.random.normal(mu = Some(loc), sigma = Some(scale),
       shape = Some(Shape(2, 2)))
-    val rnd2 = Symbol.random.random_normal(loc = Some(1f), scale = Some(2f),
+    val rnd2 = Symbol.random.normal(mu = Some(1f), sigma = Some(2f),
       shape = Some(Shape(2, 2)))
     // scalastyle:off println
     println(s"Symbol.random.sample_normal debug info: ${rnd.debugStr}")

--- a/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
@@ -20,6 +20,20 @@ package org.apache.mxnet
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 class SymbolSuite extends FunSuite with BeforeAndAfterAll {
+
+  test("random module - normal") {
+    val loc = Symbol.Variable("loc")
+    val scale = Symbol.Variable("scale")
+    val rnd = Symbol.random.sample_normal(mu = Some(loc), sigma = Some(scale),
+      shape = Some(Shape(2, 2)))
+    val rnd2 = Symbol.random.random_normal(loc = Some(1f), scale = Some(2f),
+      shape = Some(Shape(2, 2)))
+    // scalastyle:off println
+    println(s"Symbol.random.normal Symbol args debug info: ${rnd.debugStr}")
+    println(s"Symbol.random.normal Symbol args debug info: ${rnd2.debugStr}")
+    // scalastyle:on println
+  }
+
   test("symbol compose") {
     val data = Symbol.Variable("data")
 

--- a/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
@@ -21,19 +21,6 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 class SymbolSuite extends FunSuite with BeforeAndAfterAll {
 
-  test("random module - normal") {
-    val loc = Symbol.Variable("loc")
-    val scale = Symbol.Variable("scale")
-    val rnd = Symbol.random.sample_normal(mu = Some(loc), sigma = Some(scale),
-      shape = Some(Shape(2, 2)))
-    val rnd2 = Symbol.random.random_normal(loc = Some(1f), scale = Some(2f),
-      shape = Some(Shape(2, 2)))
-    // scalastyle:off println
-    println(s"Symbol.random.normal Symbol args debug info: ${rnd.debugStr}")
-    println(s"Symbol.random.normal Symbol args debug info: ${rnd2.debugStr}")
-    // scalastyle:on println
-  }
-
   test("symbol compose") {
     val data = Symbol.Variable("data")
 
@@ -84,5 +71,18 @@ class SymbolSuite extends FunSuite with BeforeAndAfterAll {
     val data = Symbol.Variable("data")
     val data2 = data.clone()
     assert(data.toJson === data2.toJson)
+  }
+
+  test("random module is present") {
+    val loc = Symbol.Variable("loc")
+    val scale = Symbol.Variable("scale")
+    val rnd = Symbol.random.sample_normal(mu = Some(loc), sigma = Some(scale),
+      shape = Some(Shape(2, 2)))
+    val rnd2 = Symbol.random.random_normal(loc = Some(1f), scale = Some(2f),
+      shape = Some(Shape(2, 2)))
+    // scalastyle:off println
+    println(s"Symbol.random.sample_normal debug info: ${rnd.debugStr}")
+    println(s"Symbol.random.random_normal debug info: ${rnd2.debugStr}")
+    // scalastyle:on println
   }
 }

--- a/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/SymbolSuite.scala
@@ -76,9 +76,9 @@ class SymbolSuite extends FunSuite with BeforeAndAfterAll {
   test("random module is present") {
     val loc = Symbol.Variable("loc")
     val scale = Symbol.Variable("scale")
-    val rnd = Symbol.random.sample_normal(mu = Some(loc), sigma = Some(scale),
+    val rnd = Symbol.random._sample_normal(mu = Some(loc), sigma = Some(scale),
       shape = Some(Shape(2, 2)))
-    val rnd2 = Symbol.random.random_normal(loc = Some(1f), scale = Some(2f),
+    val rnd2 = Symbol.random._random_normal(loc = Some(1f), scale = Some(2f),
       shape = Some(Shape(2, 2)))
     // scalastyle:off println
     println(s"Symbol.random.sample_normal debug info: ${rnd.debugStr}")

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/APIDocGenerator.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/APIDocGenerator.scala
@@ -57,7 +57,8 @@ private[mxnet] object APIDocGenerator{
   def absRndClassGen(FILE_PATH : String, isSymbol : Boolean) : String = {
     typeSafeClassGen(
       getSymbolNDArrayMethods(isSymbol)
-        .filter(f => f.name.startsWith("_random") || f.name.startsWith("_sample")),
+        .filter(f => f.name.startsWith("_random") || f.name.startsWith("_sample"))
+        .map(f => f.copy(name = f.name.stripPrefix("_"))),
       FILE_PATH,
       if (isSymbol) "SymbolRandomAPIBase" else "NDArrayRandomAPIBase",
       isSymbol
@@ -224,8 +225,8 @@ private[mxnet] object APIDocGenerator{
       handle, name, desc, numArgs, argNames, argTypes, argDescs, keyVarNumArgs)
     val argList = argNames zip argTypes zip argDescs map { case ((argName, argType), argDesc) =>
       val typeAndOption = CToScalaUtils.argumentCleaner(argName, argType, returnType)
-      new absClassArg(argName, typeAndOption._1, argDesc, typeAndOption._2)
+      absClassArg(argName, typeAndOption._1, argDesc, typeAndOption._2)
     }
-    new absClassFunction(aliasName, desc.value, argList.toList, returnType)
+    absClassFunction(aliasName, desc.value, argList.toList, returnType)
   }
 }

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/APIDocGenerator.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/APIDocGenerator.scala
@@ -41,7 +41,7 @@ private[mxnet] object APIDocGenerator{
     hashCollector += absClassGen(FILE_PATH, true)
     hashCollector += absClassGen(FILE_PATH, false)
     hashCollector += absRndClassGen(FILE_PATH, true)
-//    hashCollector += absClassGen(FILE_PATH, false) // TODO random NDArray
+    hashCollector += absRndClassGen(FILE_PATH, false)
     hashCollector += nonTypeSafeClassGen(FILE_PATH, true)
     hashCollector += nonTypeSafeClassGen(FILE_PATH, false)
     val finalHash = hashCollector.mkString("\n")
@@ -58,7 +58,8 @@ private[mxnet] object APIDocGenerator{
     // scalastyle:off
     val absClassFunctions = getSymbolNDArrayMethods(isSymbol)
     // TODO: Add Filter to the same location in case of refactor
-    val absFuncs = absClassFunctions.filter(f => f.name.startsWith("sample") || f.name.startsWith("random"))
+
+    val absFuncs = absClassFunctions.filter(f => f.name.startsWith("sample_") || f.name.startsWith("random_"))
       .map(absClassFunction => {
         val scalaDoc = generateAPIDocFromBackend(absClassFunction)
         val defBody = generateAPISignature(absClassFunction, isSymbol)
@@ -85,8 +86,8 @@ private[mxnet] object APIDocGenerator{
     // TODO: Add Filter to the same location in case of refactor
     val absFuncs = absClassFunctions
       .filterNot(_.name.startsWith("_"))
-      .filterNot(_.name.startsWith("sample"))
-      .filterNot(_.name.startsWith("random"))
+      .filterNot(_.name.startsWith("random_"))
+      .filterNot(_.name.startsWith("sample_"))
       .filterNot(ele => notGenerated.contains(ele.name))
       .map(absClassFunction => {
       val scalaDoc = generateAPIDocFromBackend(absClassFunction)

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/APIDocGenerator.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/APIDocGenerator.scala
@@ -51,12 +51,11 @@ private[mxnet] object APIDocGenerator extends GeneratorBase {
   }
 
   def absRndClassGen(FILE_PATH: String, isSymbol: Boolean): String = {
-    val funcs = getSymbolNDArrayMethods(isSymbol)
-      .filter(f => f.name.startsWith("_sample_") || f.name.startsWith("_random_"))
-      .map(f => f.copy(name = f.name.stripPrefix("_")))
+    val funcs = buildRandomFunctionList(isSymbol)
+
     val body = funcs.map(func => {
       val scalaDoc = generateAPIDocFromBackend(func)
-      val decl = generateRandomAPISignature(func, isSymbol)
+      val decl = generateAPISignature(func, isSymbol)
       s"$scalaDoc\n$decl"
     })
     writeFile(
@@ -67,7 +66,7 @@ private[mxnet] object APIDocGenerator extends GeneratorBase {
 
   def absClassGen(FILE_PATH: String, isSymbol: Boolean): String = {
     val notGenerated = Set("Custom")
-    val funcs = getSymbolNDArrayMethods(isSymbol)
+    val funcs = buildFunctionList(isSymbol)
       .filterNot(_.name.startsWith("_"))
       .filterNot(ele => notGenerated.contains(ele.name))
     val body = funcs.map(func => {
@@ -82,7 +81,7 @@ private[mxnet] object APIDocGenerator extends GeneratorBase {
   }
 
   def nonTypeSafeClassGen(FILE_PATH: String, isSymbol: Boolean): String = {
-    val absClassFunctions = getSymbolNDArrayMethods(isSymbol)
+    val absClassFunctions = buildFunctionList(isSymbol)
     val absFuncs = absClassFunctions
       .filterNot(_.name.startsWith("_"))
       .map(absClassFunction => {
@@ -162,10 +161,6 @@ private[mxnet] object APIDocGenerator extends GeneratorBase {
     }
   }
 
-  def generateRandomAPISignature(func: absClassFunction, isSymbol: Boolean): String = {
-    generateAPISignature(func, isSymbol)
-  }
-
   def generateAPISignature(func: absClassFunction, isSymbol: Boolean): String = {
     val argDef = ListBuffer[String]()
 
@@ -184,9 +179,5 @@ private[mxnet] object APIDocGenerator extends GeneratorBase {
     s"$experimentalTag\ndef ${func.name} (${argDef.mkString(", ")}) : $returnType"
   }
 
-  // List and add all the atomic symbol functions to current module.
-  private def getSymbolNDArrayMethods(isSymbol: Boolean): List[absClassFunction] = {
-    buildFunctionList(isSymbol)
-  }
 
 }

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/GeneratorBase.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/GeneratorBase.scala
@@ -1,0 +1,116 @@
+package org.apache.mxnet
+
+import org.apache.mxnet.init.Base.{RefInt, RefLong, RefString, _LIB}
+import org.apache.mxnet.utils.{CToScalaUtils, OperatorBuildUtils}
+
+import scala.collection.mutable.ListBuffer
+import scala.reflect.macros.blackbox
+
+abstract class GeneratorBase {
+  type Handle = Long
+
+  case class Arg(argName: String, argType: String, argDesc: String, isOptional: Boolean) {
+    def safeArgName: String = argName match {
+      case "var" => "vari"
+      case "type" => "typeOf"
+      case _ => argName
+    }
+  }
+
+  case class Func(name: String, desc: String, listOfArgs: List[Arg], returnType: String)
+
+  protected def buildFunctionList(isSymbol: Boolean): List[Func] = {
+    val opNames = ListBuffer.empty[String]
+    _LIB.mxListAllOpNames(opNames)
+    opNames.map(opName => {
+      val opHandle = new RefLong
+      _LIB.nnGetOpHandle(opName, opHandle)
+      makeAtomicFunction(opHandle.value, opName, isSymbol)
+    }).toList
+  }
+
+  protected def makeAtomicFunction(handle: Handle, aliasName: String, isSymbol: Boolean): Func = {
+    val name = new RefString
+    val desc = new RefString
+    val keyVarNumArgs = new RefString
+    val numArgs = new RefInt
+    val argNames = ListBuffer.empty[String]
+    val argTypes = ListBuffer.empty[String]
+    val argDescs = ListBuffer.empty[String]
+
+    _LIB.mxSymbolGetAtomicSymbolInfo(
+      handle, name, desc, numArgs, argNames, argTypes, argDescs, keyVarNumArgs)
+    val paramStr = OperatorBuildUtils.ctypes2docstring(argNames, argTypes, argDescs)
+    val extraDoc: String = if (keyVarNumArgs.value != null && keyVarNumArgs.value.length > 0) {
+      s"This function support variable length of positional input (${keyVarNumArgs.value})."
+    } else {
+      ""
+    }
+    val realName = if (aliasName == name.value) "" else s"(a.k.a., ${name.value})"
+    val docStr = s"$aliasName $realName\n${desc.value}\n\n$paramStr\n$extraDoc\n"
+    // scalastyle:off println
+    if (System.getenv("MXNET4J_PRINT_OP_DEF") != null
+      && System.getenv("MXNET4J_PRINT_OP_DEF").toLowerCase == "true") {
+      println("Function definition:\n" + docStr)
+    }
+    // scalastyle:on println
+    val argList = argNames zip argTypes zip argDescs map { case ((argName, argType), argDesc) =>
+      val family = if(isSymbol) "org.apache.mxnet.Symbol" else "org.apache.mxnet.NDArray"
+      val typeAndOption =
+        CToScalaUtils.argumentCleaner(argName, argType, family)
+      Arg(argName, typeAndOption._1, argDesc, typeAndOption._2)
+    }
+    val returnType = if(isSymbol) "org.apache.mxnet.Symbol" else "org.apache.mxnet.NDArrayFuncReturn"
+    Func(aliasName, desc.value, argList.toList, returnType)
+  }
+
+  /**
+    * Generate class structure for all function APIs
+    *
+    * @param c
+    * @param funcDef DefDef type of function definitions
+    * @param annottees
+    * @return
+    */
+  protected def structGeneration(c: blackbox.Context)
+                                (funcDef: List[c.universe.DefDef], annottees: c.Expr[Any]*)
+  : c.Expr[Any] = {
+    import c.universe._
+    val inputs = annottees.map(_.tree).toList
+    // pattern match on the inputs
+    val modDefs = inputs map {
+      case ClassDef(mods, name, something, template) =>
+        val q = template match {
+          case Template(superMaybe, emptyValDef, defs) =>
+            Template(superMaybe, emptyValDef, defs ++ funcDef)
+          case ex =>
+            throw new IllegalArgumentException(s"Invalid template: $ex")
+        }
+        ClassDef(mods, name, something, q)
+      case ModuleDef(mods, name, template) =>
+        val q = template match {
+          case Template(superMaybe, emptyValDef, defs) =>
+            Template(superMaybe, emptyValDef, defs ++ funcDef)
+          case ex =>
+            throw new IllegalArgumentException(s"Invalid template: $ex")
+        }
+        ModuleDef(mods, name, q)
+      case ex =>
+        throw new IllegalArgumentException(s"Invalid macro input: $ex")
+    }
+    // wrap the result up in an Expr, and return it
+    val result = c.Expr(Block(modDefs, Literal(Constant())))
+    result
+  }
+
+  protected def buildArgDefs(func: Func): List[String] = {
+    func.listOfArgs.map(arg =>
+      if (arg.isOptional)
+        s"${arg.safeArgName} : Option[${arg.argType}] = None"
+      else
+        s"${arg.safeArgName} : ${arg.argType}"
+    )
+  }
+
+
+}

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/GeneratorBase.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/GeneratorBase.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.mxnet
 
 import org.apache.mxnet.init.Base.{RefInt, RefLong, RefString, _LIB}

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/NDArrayMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/NDArrayMacro.scala
@@ -193,7 +193,8 @@ private[mxnet] object NDArrayMacro extends GeneratorBase {
     if(arg.isOptional) {
       impl +=
         s"""val target = ${arg.safeArgName} match {
-           |   case _:Option[$arrayType] => "sample_${function.name}"
+           |   case Some(a:$arrayType) => "sample_${function.name}"
+           |   case None => "sample_${function.name}"
            |   case _ => "random_${function.name}"
            |}
       """.stripMargin

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/NDArrayMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/NDArrayMacro.scala
@@ -92,8 +92,9 @@ private[mxnet] object NDArrayMacro {
   private def typeSafeRandomAPIImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
     import c.universe._
 
-    val rndFunctions =
-      ndarrayFunctions.filter(f => f.name.startsWith("_sample_") || f.name.startsWith("_random_"))
+    val rndFunctions = ndarrayFunctions
+      .filter(f => f.name.startsWith("_sample_") || f.name.startsWith("_random_"))
+      .map(f => f.copy(name = f.name.stripPrefix("_")))
 
     val functionDefs = rndFunctions.map(f => buildTypeSafeFunction(c)(f))
     structGeneration(c)(functionDefs, annottees: _*)
@@ -256,8 +257,8 @@ private[mxnet] object NDArrayMacro {
     val argList = argNames zip argTypes map { case (argName, argType) =>
       val typeAndOption =
         CToScalaUtils.argumentCleaner(argName, argType, "org.apache.mxnet.NDArray")
-      new NDArrayArg(argName, typeAndOption._1, typeAndOption._2)
+      NDArrayArg(argName, typeAndOption._1, typeAndOption._2)
     }
-    new NDArrayFunction(aliasName, argList.toList)
+    NDArrayFunction(aliasName, argList.toList)
   }
 }

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/NDArrayMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/NDArrayMacro.scala
@@ -93,7 +93,7 @@ private[mxnet] object NDArrayMacro {
     import c.universe._
 
     val rndFunctions =
-      ndarrayFunctions.filter(f => f.name.startsWith("sample_") || f.name.startsWith("random_"))
+      ndarrayFunctions.filter(f => f.name.startsWith("_sample_") || f.name.startsWith("_random_"))
 
     val functionDefs = rndFunctions.map(f => buildTypeSafeFunction(c)(f))
     structGeneration(c)(functionDefs, annottees: _*)
@@ -114,8 +114,7 @@ private[mxnet] object NDArrayMacro {
     val newNDArrayFunctions = {
       if (isContrib) ndarrayFunctions.filter(
         func => func.name.startsWith("_contrib_") || !func.name.startsWith("_"))
-      else ndarrayFunctions.filterNot(f => f.name.startsWith("_") &&
-        !f.name.startsWith("sample_") && !f.name.startsWith("random_"))
+      else ndarrayFunctions.filterNot(f => f.name.startsWith("_"))
     }.filterNot(ele => notGenerated.contains(ele.name))
 
     val functionDefs = newNDArrayFunctions.map(f => buildTypeSafeFunction(c)(f))

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
@@ -188,7 +188,8 @@ private[mxnet] object SymbolImplMacros extends GeneratorBase {
     if(arg.isOptional) {
       impl +=
         s"""val target = ${arg.safeArgName} match {
-           |   case _:Option[$symbolType] => "sample_${function.name}"
+           |   case Some(s:$symbolType) => "sample_${function.name}"
+           |   case None => "sample_${function.name}"
            |   case _ => "random_${function.name}"
            |}
       """.stripMargin

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
@@ -93,7 +93,7 @@ private[mxnet] object SymbolImplMacros {
     import c.universe._
 
     val rndFunctions =
-      symbolFunctions.filter(f => f.name.startsWith("sample") || f.name.startsWith("random"))
+      symbolFunctions.filter(f => f.name.startsWith("sample_") || f.name.startsWith("random_"))
 
     val functionDefs = rndFunctions.map(f => buildTypedFunction(c)(f))
     structGeneration(c)(functionDefs, annottees: _*)
@@ -118,7 +118,7 @@ private[mxnet] object SymbolImplMacros {
       if (isContrib) symbolFunctions.filter(
         func => func.name.startsWith("_contrib_") || !func.name.startsWith("_"))
       else symbolFunctions.filter(f => !f.name.startsWith("_") &&
-        !f.name.startsWith("sample") && !f.name.startsWith("random"))
+        !f.name.startsWith("sample_") && !f.name.startsWith("random_"))
     }.filterNot(ele => notGenerated.contains(ele.name))
 
     val functionDefs = newSymbolFunctions.map(f => buildTypedFunction(c)(f))

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
@@ -93,7 +93,7 @@ private[mxnet] object SymbolImplMacros {
     import c.universe._
 
     val rndFunctions =
-      symbolFunctions.filter(f => f.name.startsWith("sample_") || f.name.startsWith("random_"))
+      symbolFunctions.filter(f => f.name.startsWith("_sample_") || f.name.startsWith("_random_"))
 
     val functionDefs = rndFunctions.map(f => buildTypedFunction(c)(f))
     structGeneration(c)(functionDefs, annottees: _*)
@@ -117,8 +117,7 @@ private[mxnet] object SymbolImplMacros {
     val newSymbolFunctions = {
       if (isContrib) symbolFunctions.filter(
         func => func.name.startsWith("_contrib_") || !func.name.startsWith("_"))
-      else symbolFunctions.filter(f => !f.name.startsWith("_") &&
-        !f.name.startsWith("sample_") && !f.name.startsWith("random_"))
+      else symbolFunctions.filter(f => !f.name.startsWith("_"))
     }.filterNot(ele => notGenerated.contains(ele.name))
 
     val functionDefs = newSymbolFunctions.map(f => buildTypedFunction(c)(f))

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/SymbolMacro.scala
@@ -21,26 +21,21 @@ import scala.annotation.StaticAnnotation
 import scala.collection.mutable.ListBuffer
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
-import org.apache.mxnet.init.Base._
-import org.apache.mxnet.utils.{CToScalaUtils, OperatorBuildUtils}
 
 private[mxnet] class AddSymbolFunctions(isContrib: Boolean) extends StaticAnnotation {
   private[mxnet] def macroTransform(annottees: Any*) = macro SymbolImplMacros.addDefs
 }
-
 private[mxnet] class AddSymbolAPIs(isContrib: Boolean) extends StaticAnnotation {
   private[mxnet] def macroTransform(annottees: Any*) = macro SymbolImplMacros.typeSafeAPIDefs
 }
-
 private[mxnet] class AddSymbolRandomAPIs(isContrib: Boolean) extends StaticAnnotation {
   private[mxnet] def macroTransform(annottees: Any*) = macro SymbolImplMacros.typedRandomAPIDefs
 }
 
-
-private[mxnet] object SymbolImplMacros {
-  case class SymbolArg(argName: String, argType: String, isOptional : Boolean)
-  case class SymbolFunction(name: String, listOfArgs: List[SymbolArg])
-
+private[mxnet] object SymbolImplMacros extends GeneratorBase {
+  type SymbolArg = Arg
+  type SymbolFunction = Func
+  
   // scalastyle:off havetype
   def addDefs(c: blackbox.Context)(annottees: c.Expr[Any]*) = {
     impl(c)(annottees: _*)
@@ -53,7 +48,7 @@ private[mxnet] object SymbolImplMacros {
   }
   // scalastyle:on havetype
 
-  private val symbolFunctions: List[SymbolFunction] = initSymbolModule()
+  private val symbolFunctions: List[SymbolFunction] = buildFunctionList(true)
 
   /**
     * Implementation for fixed input API structure
@@ -72,31 +67,17 @@ private[mxnet] object SymbolImplMacros {
     }
 
     val functionDefs = newSymbolFunctions map { symbolfunction =>
-        val funcName = symbolfunction.name
-        val tName = TermName(funcName)
-        q"""
+      val funcName = symbolfunction.name
+      val tName = TermName(funcName)
+      q"""
             def $tName(name : String = null, attr : Map[String, String] = null)
             (args : org.apache.mxnet.Symbol*)(kwargs : Map[String, Any] = null)
              : org.apache.mxnet.Symbol = {
               createSymbolGeneral($funcName,name,attr,args,kwargs)
               }
          """.asInstanceOf[DefDef]
-      }
+    }
 
-    structGeneration(c)(functionDefs, annottees : _*)
-  }
-
-  /**
-    * Implementation for Dynamic typed API Symbol.random.<functioname>
-    */
-  private def typedRandomAPIImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
-    import c.universe._
-
-    val rndFunctions = symbolFunctions
-      .filter(f => f.name.startsWith("_sample_") || f.name.startsWith("_random_"))
-      .map(f => f.copy(name = f.name.stripPrefix("_")))
-
-    val functionDefs = rndFunctions.map(f => buildTypedFunction(c)(f))
     structGeneration(c)(functionDefs, annottees: _*)
   }
 
@@ -122,146 +103,67 @@ private[mxnet] object SymbolImplMacros {
     }.filterNot(ele => notGenerated.contains(ele.name))
 
     val functionDefs = newSymbolFunctions.map(f => buildTypedFunction(c)(f))
-    structGeneration(c)(functionDefs, annottees : _*)
+    structGeneration(c)(functionDefs, annottees: _*)
+  }
+
+  private def typedRandomAPIImpl(c: blackbox.Context)(annottees: c.Expr[Any]*): c.Expr[Any] = {
+    val rndFunctions = symbolFunctions
+      .filter(f => f.name.startsWith("_sample_") || f.name.startsWith("_random_"))
+      .map(f => f.copy(name = f.name.stripPrefix("_")))
+
+    val functionDefs = rndFunctions.map(f => buildTypedFunction(c)(f))
+    structGeneration(c)(functionDefs, annottees: _*)
   }
 
   private def buildTypedFunction(c: blackbox.Context)
                                 (symbolfunction: SymbolFunction): c.universe.DefDef = {
     import c.universe._
 
+    val returnType = "org.apache.mxnet.Symbol"
+
     // Construct argument field
-    var argDef = ListBuffer[String]()
+    val argDef = ListBuffer[String]()
+
+    argDef ++= buildArgDefs(symbolfunction)
+    argDef += "name : String = null"
+    argDef += "attr : Map[String, String] = null"
+
     // Construct Implementation field
     var impl = ListBuffer[String]()
     impl += "val map = scala.collection.mutable.Map[String, Any]()"
     impl += "var args = Seq[org.apache.mxnet.Symbol]()"
+
     symbolfunction.listOfArgs.foreach({ symbolarg =>
-      // var is a special word used to define variable in Scala,
-      // need to changed to something else in order to make it work
-      val currArgName = symbolarg.argName match {
-        case "var" => "vari"
-        case "type" => "typeOf"
-        case default => symbolarg.argName
-      }
-      if (symbolarg.isOptional) {
-        argDef += s"${currArgName} : Option[${symbolarg.argType}] = None"
-      }
-      else {
-        argDef += s"${currArgName} : ${symbolarg.argType}"
-      }
       // Symbol arg implementation
-      val returnType = "org.apache.mxnet.Symbol"
+      val symbolType = "org.apache.mxnet.Symbol"
+
       val base =
-        if (symbolarg.argType.equals(s"Array[$returnType]")) {
-          if (symbolarg.isOptional) s"if (!$currArgName.isEmpty) args = $currArgName.get.toSeq"
-          else s"args = $currArgName.toSeq"
+        if (symbolarg.argType.equals(s"Array[$symbolType]")) {
+          if (symbolarg.isOptional)
+            s"if (!${symbolarg.safeArgName}.isEmpty) args = ${symbolarg.safeArgName}.get.toSeq"
+          else
+            s"args = ${symbolarg.safeArgName}.toSeq"
         } else {
           if (symbolarg.isOptional) {
             // scalastyle:off
-            s"if (!$currArgName.isEmpty) map(" + "\"" + symbolarg.argName + "\"" + s") = $currArgName.get"
+            s"if (!${symbolarg.safeArgName}.isEmpty) map(" + "\"" + symbolarg.argName + "\"" + s") = ${symbolarg.safeArgName}.get"
             // scalastyle:on
           }
-          else "map(\"" + symbolarg.argName + "\"" + s") = $currArgName"
+          else "map(\"" + symbolarg.argName + "\"" + s") = ${symbolarg.safeArgName}"
         }
 
       impl += base
     })
-    argDef += "name : String = null"
-    argDef += "attr : Map[String, String] = null"
+
     // scalastyle:off
-    // TODO: Seq() here allows user to place Symbols rather than normal arguments to run, need to fix if old API deprecated
     impl += "org.apache.mxnet.Symbol.createSymbolGeneral(\"" + symbolfunction.name + "\", name, attr, args, map.toMap)"
     // scalastyle:on
+
     // Combine and build the function string
-    val returnType = "org.apache.mxnet.Symbol"
     var finalStr = s"def ${symbolfunction.name}"
     finalStr += s" (${argDef.mkString(",")}) : $returnType"
     finalStr += s" = {${impl.mkString("\n")}}"
     c.parse(finalStr).asInstanceOf[DefDef]
   }
 
-  /**
-    * Generate class structure for all function APIs
-    * @param c
-    * @param funcDef DefDef type of function definitions
-    * @param annottees
-    * @return
-    */
-  private def structGeneration(c: blackbox.Context)
-                              (funcDef : List[c.universe.DefDef], annottees: c.Expr[Any]*)
-  : c.Expr[Any] = {
-    import c.universe._
-    val inputs = annottees.map(_.tree).toList
-    // pattern match on the inputs
-    val modDefs = inputs map {
-      case ClassDef(mods, name, something, template) =>
-        val q = template match {
-          case Template(superMaybe, emptyValDef, defs) =>
-            Template(superMaybe, emptyValDef, defs ++ funcDef)
-          case ex =>
-            throw new IllegalArgumentException(s"Invalid template: $ex")
-        }
-        ClassDef(mods, name, something, q)
-      case ModuleDef(mods, name, template) =>
-        val q = template match {
-          case Template(superMaybe, emptyValDef, defs) =>
-            Template(superMaybe, emptyValDef, defs ++ funcDef)
-          case ex =>
-            throw new IllegalArgumentException(s"Invalid template: $ex")
-        }
-        ModuleDef(mods, name, q)
-      case ex =>
-        throw new IllegalArgumentException(s"Invalid macro input: $ex")
-    }
-    // wrap the result up in an Expr, and return it
-    val result = c.Expr(Block(modDefs, Literal(Constant())))
-    result
-  }
-
-  // List and add all the atomic symbol functions to current module.
-  private def initSymbolModule(): List[SymbolFunction] = {
-    val opNames = ListBuffer.empty[String]
-    _LIB.mxListAllOpNames(opNames)
-    // TODO: Add '_linalg_', '_sparse_', '_image_' support
-    opNames.map(opName => {
-      val opHandle = new RefLong
-      _LIB.nnGetOpHandle(opName, opHandle)
-      makeAtomicSymbolFunction(opHandle.value, opName)
-    }).toList
-  }
-
-  // Create an atomic symbol function by handle and function name.
-  private def makeAtomicSymbolFunction(handle: SymbolHandle, aliasName: String)
-      : SymbolFunction = {
-    val name = new RefString
-    val desc = new RefString
-    val keyVarNumArgs = new RefString
-    val numArgs = new RefInt
-    val argNames = ListBuffer.empty[String]
-    val argTypes = ListBuffer.empty[String]
-    val argDescs = ListBuffer.empty[String]
-
-    _LIB.mxSymbolGetAtomicSymbolInfo(
-      handle, name, desc, numArgs, argNames, argTypes, argDescs, keyVarNumArgs)
-    val paramStr = OperatorBuildUtils.ctypes2docstring(argNames, argTypes, argDescs)
-    val extraDoc: String = if (keyVarNumArgs.value != null && keyVarNumArgs.value.length > 0) {
-        s"This function support variable length of positional input (${keyVarNumArgs.value})."
-      } else {
-        ""
-      }
-    val realName = if (aliasName == name.value) "" else s"(a.k.a., ${name.value})"
-    val docStr = s"$aliasName $realName\n${desc.value}\n\n$paramStr\n$extraDoc\n"
-    // scalastyle:off println
-    if (System.getenv("MXNET4J_PRINT_OP_DEF") != null
-          && System.getenv("MXNET4J_PRINT_OP_DEF").toLowerCase == "true") {
-      println("Symbol function definition:\n" + docStr)
-    }
-    // scalastyle:on println
-    val argList = argNames zip argTypes map { case (argName, argType) =>
-        val typeAndOption =
-          CToScalaUtils.argumentCleaner(argName, argType, "org.apache.mxnet.Symbol")
-      SymbolArg(argName, typeAndOption._1, typeAndOption._2)
-    }
-    SymbolFunction(aliasName, argList.toList)
-  }
 }

--- a/scala-package/macros/src/main/scala/org/apache/mxnet/utils/CToScalaUtils.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/utils/CToScalaUtils.scala
@@ -22,12 +22,12 @@ private[mxnet] object CToScalaUtils {
 
   // Convert C++ Types to Scala Types
   def typeConversion(in : String, argType : String = "",
-                     argName : String, returnType : String) : String = {
+                     argName : String, familyType : String) : String = {
     in match {
       case "Shape(tuple)" | "ShapeorNone" => "org.apache.mxnet.Shape"
-      case "Symbol" | "NDArray" | "NDArray-or-Symbol" => returnType
+      case "Symbol" | "NDArray" | "NDArray-or-Symbol" => familyType
       case "Symbol[]" | "NDArray[]" | "NDArray-or-Symbol[]" | "SymbolorSymbol[]"
-      => s"Array[$returnType]"
+      => s"Array[$familyType]"
       case "float" | "real_t" | "floatorNone" => "org.apache.mxnet.Base.MXFloat"
       case "int" | "intorNone" | "int(non-negative)" => "Int"
       case "long" | "long(non-negative)" => "Long"
@@ -53,7 +53,7 @@ private[mxnet] object CToScalaUtils {
     * @return (Scala_Type, isOptional)
     */
   def argumentCleaner(argName: String,
-                      argType : String, returnType : String) : (String, Boolean) = {
+                      argType : String, familyType : String) : (String, Boolean) = {
     val spaceRemoved = argType.replaceAll("\\s+", "")
     var commaRemoved : Array[String] = new Array[String](0)
     // Deal with the case e.g: stype : {'csr', 'default', 'row_sparse'}
@@ -71,9 +71,9 @@ private[mxnet] object CToScalaUtils {
         s"""expected "optional" got ${commaRemoved(1)}""")
       require(commaRemoved(2).startsWith("default="),
         s"""expected "default=..." got ${commaRemoved(2)}""")
-      (typeConversion(commaRemoved(0), argType, argName, returnType), true)
+      (typeConversion(commaRemoved(0), argType, argName, familyType), true)
     } else if (commaRemoved.length == 2 || commaRemoved.length == 1) {
-      val tempType = typeConversion(commaRemoved(0), argType, argName, returnType)
+      val tempType = typeConversion(commaRemoved(0), argType, argName, familyType)
       val tempOptional = tempType.equals("org.apache.mxnet.Symbol")
       (tempType, tempOptional)
     } else {


### PR DESCRIPTION
## Description ##
Introduce Symbol.random and NDArray.random modules in scala API

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Symbol.random api generated by macros
- NDArray.random api generated by macros

## Comments ##
- ~~Is there any JIRA mentioning this feature ?~~ 
- ~~Only implemented for Symbol. Adding the same for NDArray seems quite straightforward. Tell me if I should to it in the same PR or in a separate~~
- ~~I *moved* functions from Symbol.api to Symbol.random. Is it OK ?~~
- The produced API is not strictly similar to the one in python: 
   * in python, each function, eg random.normal, has 2 overrides, one scalar, one symbolic.
   * the generated scala api has different namings: Symbol.random.sample_normal for symbol inputs, and Symbol.random.random_normal for scalars. The arguments naming is also not fully consistent (mu & sigma, vs loc & scale). 
   => What are your recommendations on this ?
- The unit-test is poor. What should be tested for generated code like this ?
   
