### PR TITLE
Temporarily disable flaky tests for test_contrib_svrg_module

### DIFF
--- a/tests/python/unittest/test_contrib_svrg_module.py
+++ b/tests/python/unittest/test_contrib_svrg_module.py
@@ -20,7 +20,7 @@ import numpy as np
 from common import with_seed, assertRaises
 from mxnet.contrib.svrg_optimization.svrg_module import SVRGModule
 from mxnet.test_utils import *
-
+import unittest
 
 def setup():
     train_data = np.random.randint(1, 5, [1000, 2])
@@ -94,6 +94,7 @@ def test_module_bind():
     assert mod._mod_aux.binded == True
 
 
+@unittest.skip("Flaky test https://gitsvrhub.com/apache/incubator-mxnet/issues/12510")
 @with_seed()
 def test_module_save_load():
     import tempfile
@@ -134,6 +135,7 @@ def test_module_save_load():
     assert mod3._symbol.tojson() == mod4._symbol.tojson()
 
 
+@unittest.skip("Flaky test https://github.com/apache/incubator-mxnet/issues/12510")
 @with_seed()
 def test_svrgmodule_reshape():
     data = mx.sym.Variable("data")
@@ -161,6 +163,7 @@ def test_svrgmodule_reshape():
     assert mod.get_outputs()[0].shape == dshape
 
 
+@unittest.skip("Flaky test https://github.com/apache/incubator-mxnet/issues/12510")
 @with_seed()
 def test_update_full_grad():
     def create_network():
@@ -203,6 +206,7 @@ def test_update_full_grad():
     assert same(full_grads_weights, svrg_mod._param_dict[0]['fc1_weight'])
 
 
+@unittest.skip("Flaky test https://github.com/apache/incubator-mxnet/issues/12510")
 @with_seed()
 def test_svrg_with_sgd():
     def create_module_with_sgd():
@@ -266,6 +270,7 @@ def test_svrg_with_sgd():
     assert svrg_mse < sgd_mse
 
 
+@unittest.skip("Flaky test https://github.com/apache/incubator-mxnet/issues/12510")
 @with_seed()
 def test_accumulate_kvstore():
     # Test KVStore behavior when push a list of values
@@ -289,6 +294,7 @@ def test_accumulate_kvstore():
     assert same(svrg_mod._param_dict[0]["fc1_weight"], b[0])
 
 
+@unittest.skip("Flaky test https://github.com/apache/incubator-mxnet/issues/12510")
 @with_seed()
 def test_fit():
     di, mod = setup()


### PR DESCRIPTION
Temporarily disable unit tests in test_contrib_svrg_module that involves floating point calculations. 
Track in issue #12510 

