### PR TITLE
Speed up CI windows builds

### DIFF
--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -149,7 +149,9 @@ def windows_build(args):
         check_call("cmake -G \"Visual Studio 14 2015 Win64\" {} {}".format(CMAKE_FLAGS[args.flavour], mxnet_root), shell=True)
         logging.info("Building with visual studio")
         t0 = int(time.time())
-        check_call(["msbuild", "mxnet.sln","/p:configuration=release;platform=x64", "/maxcpucount","/v:minimal"])
+        check_call(
+            ["msbuild", "mxnet.sln", "/p:configuration=release;platform=x64;BuildInParallel=true", "/maxcpucount",
+             "/v:minimal"])
         logging.info("Build flavour: %s complete in directory: \"%s\"", args.flavour, os.path.abspath(path))
         logging.info("Build took %s" , datetime.timedelta(seconds=int(time.time()-t0)))
     windows_package(args)


### PR DESCRIPTION
## Description ##

MSBuild was missing a flag for parallel builds.