### PR TITLE
redirecting navigation items to latest info

### DIFF
--- a/docs/build_version_doc/artifacts/.htaccess
+++ b/docs/build_version_doc/artifacts/.htaccess
@@ -4,3 +4,12 @@ RewriteRule ^get_started.*$ /install/ [R=301,L]
 RewriteRule ^how_to.*$ /faq/ [R=301,L]
 RewriteRule ^api/python/symbol.html$ /api/python/symbol/symbol.html [R=301,L]
 RewriteRule ^community/index.html$ /community/contribute.html [R=301,L]
+
+# Navigation bar redirects to latest info
+RewriteRule ^versions/[^\/]+/architecture/.*$ /architecture/ [R=301,L]
+RewriteRule ^versions/[^\/]+/community/.*$ /community/ [R=301,L]
+RewriteRule ^versions/[^\/]+/faq/.*$ /faq/ [R=301,L]
+RewriteRule ^versions/[^\/]+/gluon/.*$ /gluon/ [R=301,L]
+RewriteRule ^versions/[^\/]+/install/.*$ /install/ [R=301,L]
+RewriteRule ^versions/[^\/]+/tutorials/.*$ /tutorials/ [R=301,L]
+RewriteRule ^versions/[^\/]+/api/python/contrib/onnx.html /api/python/contrib/onnx.html [R=301,L]


### PR DESCRIPTION
## Description ##
The website's different versions show people old and sometimes inaccurate info. This PR redirects traffic to old version content to the latest info.
API docs traffic is unaffected. Although I redirect ONNX to the latest.

It should combine nicely with the other htaccess redirects for Clojure and error documents that I have in #12426.