### PR TITLE
[MXNET-950] Enable parallel R dep builds in CI

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -741,7 +741,7 @@ unittest_ubuntu_cpu_R() {
     mkdir -p /tmp/r-site-library
     # build R packages in parallel
     mkdir -p ~/.R/
-    echo  "MAKEFLAGS = -j72" > ~/.R/Makevars
+    echo  "MAKEFLAGS = -j"$(nproc) > ~/.R/Makevars
     # make -j not supported
     make rpkg USE_BLAS=openblas R_LIBS=/tmp/r-site-library
     R CMD INSTALL --library=/tmp/r-site-library R-package
@@ -753,7 +753,7 @@ unittest_ubuntu_gpu_R() {
     mkdir -p /tmp/r-site-library
     # build R packages in parallel
     mkdir -p ~/.R/
-    echo  "MAKEFLAGS = -j72" > ~/.R/Makevars
+    echo  "MAKEFLAGS = -j"$(nproc) > ~/.R/Makevars
     # make -j not supported
     make rpkg USE_BLAS=openblas R_LIBS=/tmp/r-site-library
     R CMD INSTALL --library=/tmp/r-site-library R-package

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -739,6 +739,9 @@ unittest_ubuntu_gpu_cpp() {
 unittest_ubuntu_cpu_R() {
     set -ex
     mkdir -p /tmp/r-site-library
+    # build R packages in parallel
+    mkdir -p ~/.R/
+    echo  "MAKEFLAGS = -j72" > ~/.R/Makevars
     # make -j not supported
     make rpkg USE_BLAS=openblas R_LIBS=/tmp/r-site-library
     R CMD INSTALL --library=/tmp/r-site-library R-package
@@ -748,6 +751,9 @@ unittest_ubuntu_cpu_R() {
 unittest_ubuntu_gpu_R() {
     set -ex
     mkdir -p /tmp/r-site-library
+    # build R packages in parallel
+    mkdir -p ~/.R/
+    echo  "MAKEFLAGS = -j72" > ~/.R/Makevars
     # make -j not supported
     make rpkg USE_BLAS=openblas R_LIBS=/tmp/r-site-library
     R CMD INSTALL --library=/tmp/r-site-library R-package


### PR DESCRIPTION
## Description ##
This PR should speedup R builds in CI by enabling parallel compilation of dependencies.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
