### PR TITLE
[MXNET-952] Check for correlation kernel size along with unittest

### DIFF
--- a/src/operator/correlation-inl.h
+++ b/src/operator/correlation-inl.h
@@ -78,6 +78,7 @@ class CorrelationOp : public Operator {
     using namespace mshadow;
     CHECK_EQ(in_data.size(), 2U);
     CHECK_EQ(out_data.size(), 3U);
+    CHECK_NE(param_.kernel_size%2,0) << "kernel size should be odd number";
     Stream<xpu> *s = ctx.get_stream<xpu>();
     Tensor<xpu, 4, DType> data1 = in_data[Correlation::kData1].get<xpu, 4, DType>(s);
     Tensor<xpu, 4, DType> data2 = in_data[Correlation::kData2].get<xpu, 4, DType>(s);

--- a/src/operator/correlation-inl.h
+++ b/src/operator/correlation-inl.h
@@ -78,7 +78,7 @@ class CorrelationOp : public Operator {
     using namespace mshadow;
     CHECK_EQ(in_data.size(), 2U);
     CHECK_EQ(out_data.size(), 3U);
-    CHECK_NE(param_.kernel_size%2, 0) << "kernel size should be odd number";
+    CHECK_NE(param_.kernel_size % 2, 0) << "kernel size should be odd number";
     Stream<xpu> *s = ctx.get_stream<xpu>();
     Tensor<xpu, 4, DType> data1 = in_data[Correlation::kData1].get<xpu, 4, DType>(s);
     Tensor<xpu, 4, DType> data2 = in_data[Correlation::kData2].get<xpu, 4, DType>(s);

--- a/src/operator/correlation-inl.h
+++ b/src/operator/correlation-inl.h
@@ -78,7 +78,7 @@ class CorrelationOp : public Operator {
     using namespace mshadow;
     CHECK_EQ(in_data.size(), 2U);
     CHECK_EQ(out_data.size(), 3U);
-    CHECK_NE(param_.kernel_size%2,0) << "kernel size should be odd number";
+    CHECK_NE(param_.kernel_size%2, 0) << "kernel size should be odd number";
     Stream<xpu> *s = ctx.get_stream<xpu>();
     Tensor<xpu, 4, DType> data1 = in_data[Correlation::kData1].get<xpu, 4, DType>(s);
     Tensor<xpu, 4, DType> data2 = in_data[Correlation::kData2].get<xpu, 4, DType>(s);

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6914,26 +6914,14 @@ def test_spacetodepth():
     test_invalid_depth_dim()
 
 @with_seed()
-def test_correlation_kernel_size():
-    import numpy as np
-    import mxnet as mx
+def test_invalid_kernel_size():
+    invalid_kernel_size = 28
+    assert_exception(mx.nd.Correlation,MXNetError,mx.nd.array(np.random.rand(1, 1, 28, 28)),mx.nd.array(np.random.rand(1, 1, 28, 28)),kernel_size=invalid_kernel_size)
 
-    # Network
-    data1 = mx.symbol.Variable('data1')
-    cor = mx.sym.Correlation(data1=data1, data2=data1, kernel_size=28, stride1=1, stride2=1, pad_size=0, max_displacement=0)
-    loss = mx.sym.MakeLoss(cor, normalization='batch')
-    group = mx.symbol.Group([mx.sym.BlockGrad(cor), loss])
-
-    # Data
-    datashape = (1, 1, 28, 28)  # like mnist
-    data = np.random.rand(1, 1, 28, 28)
-
-    #Bind, execute, get computed correlation
-    executor = group.simple_bind(ctx=mx.cpu(), data1=datashape)
-    outs = executor.forward(is_train=True, data1=data)
-    cor = executor.outputs[0]
-    grad1 = executor.outputs[1]
-    print(cor)
+@with_seed()
+def test_valid_kernel_size():
+    valid_kernel_size = 9
+    mx.nd.Correlation(mx.nd.array(np.random.rand(1, 1, 28, 28)),mx.nd.array(np.random.rand(1, 1, 28, 28)),kernel_size=valid_kernel_size)
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6913,6 +6913,28 @@ def test_spacetodepth():
     test_invalid_block_size()
     test_invalid_depth_dim()
 
+@with_seed()
+def test_correlation_kernel_size():
+    import numpy as np
+    import mxnet as mx
+
+    # Network
+    data1 = mx.symbol.Variable('data1')
+    cor = mx.sym.Correlation(data1=data1, data2=data1, kernel_size=28, stride1=1, stride2=1, pad_size=0, max_displacement=0)
+    loss = mx.sym.MakeLoss(cor, normalization='batch')
+    group = mx.symbol.Group([mx.sym.BlockGrad(cor), loss])
+
+    # Data
+    datashape = (1, 1, 28, 28)  # like mnist
+    data = np.random.rand(1, 1, 28, 28)
+
+    #Bind, execute, get computed correlation
+    executor = group.simple_bind(ctx=mx.cpu(), data1=datashape)
+    outs = executor.forward(is_train=True, data1=data)
+    cor = executor.outputs[0]
+    grad1 = executor.outputs[1]
+    print(cor)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6916,12 +6916,20 @@ def test_spacetodepth():
 @with_seed()
 def test_invalid_kernel_size():
     invalid_kernel_size = 28
-    assert_exception(mx.nd.Correlation,MXNetError,mx.nd.array(np.random.rand(1, 1, 28, 28)),mx.nd.array(np.random.rand(1, 1, 28, 28)),kernel_size=invalid_kernel_size)
+    assert_exception(
+        mx.nd.Correlation,
+        MXNetError,
+        mx.nd.array(np.random.rand(1, 1, 28, 28)),
+        mx.nd.array(np.random.rand(1, 1, 28, 28)),
+        kernel_size=invalid_kernel_size)
 
 @with_seed()
 def test_valid_kernel_size():
     valid_kernel_size = 9
-    mx.nd.Correlation(mx.nd.array(np.random.rand(1, 1, 28, 28)),mx.nd.array(np.random.rand(1, 1, 28, 28)),kernel_size=valid_kernel_size)
+    mx.nd.Correlation(
+        mx.nd.array(np.random.rand(1, 1, 28, 28)),
+        mx.nd.array(np.random.rand(1, 1, 28, 28)),
+        kernel_size=valid_kernel_size)
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
Added a check statement for kernel size whether it's an odd number or not with respect to Correlation operator.
Also added a test case in test_operator python file
This fixes #9034 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
