### PR TITLE
fix test_activation by lowering threshold + validate eps for check_numeric_gradient

### DIFF
--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -828,7 +828,8 @@ def check_numeric_gradient(sym, location, aux_states=None, numeric_eps=1e-3, rto
     ..[1] https://github.com/Theano/Theano/blob/master/theano/gradient.py
     """
     assert dtype in (np.float16, np.float32, np.float64)
-    assert numeric_eps >= 1e-5
+    # cannot use finite differences with small eps without high precision
+    if dtype in (np.float32, np.float16): assert numeric_eps >= 1e-5
     if ctx is None:
         ctx = default_context()
 

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -828,6 +828,7 @@ def check_numeric_gradient(sym, location, aux_states=None, numeric_eps=1e-3, rto
     ..[1] https://github.com/Theano/Theano/blob/master/theano/gradient.py
     """
     assert dtype in (np.float16, np.float32, np.float64)
+    assert numeric_eps >= 1e-5
     if ctx is None:
         ctx = default_context()
 

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -829,7 +829,8 @@ def check_numeric_gradient(sym, location, aux_states=None, numeric_eps=1e-3, rto
     """
     assert dtype in (np.float16, np.float32, np.float64)
     # cannot use finite differences with small eps without high precision
-    if dtype in (np.float32, np.float16): assert numeric_eps >= 1e-5
+    if dtype in (np.float32, np.float16):
+        assert numeric_eps >= 1e-5
     if ctx is None:
         ctx = default_context()
 

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -778,7 +778,7 @@ def numeric_grad(executor, location, aux_states=None, eps=1e-4,
             executor.forward(is_train=use_forward_train)
             f_neps = executor.outputs[0].asnumpy()
 
-            approx_grad = (f_peps - f_neps).mean() / eps
+            approx_grad = (f_peps - f_neps).sum() / eps
             approx_grads[k].ravel()[i] = approx_grad
             v.ravel()[i] = old_value.ravel()[i]
         # copy back the original value

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -778,7 +778,7 @@ def numeric_grad(executor, location, aux_states=None, eps=1e-4,
             executor.forward(is_train=use_forward_train)
             f_neps = executor.outputs[0].asnumpy()
 
-            approx_grad = (f_peps - f_neps).sum() / eps
+            approx_grad = (f_peps - f_neps).mean() / eps
             approx_grads[k].ravel()[i] = approx_grad
             v.ravel()[i] = old_value.ravel()[i]
         # copy back the original value

--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -281,7 +281,6 @@ def test_pooling():
         check_pooling_training(stype)
 
 
-@unittest.skip("Flaky test: https://github.com/apache/incubator-mxnet/issues/12377")
 @with_seed()
 def test_activation():
     def check_activation_training(stype):

--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -291,7 +291,7 @@ def test_activation():
             in_location = [mx.nd.array(data_tmp).tostype(stype)]
 
             test = mx.symbol.Activation(data, act_type="relu")
-            check_numeric_gradient(test, in_location, numeric_eps=1e-6, rtol=0.16, atol=1e-4)
+            check_numeric_gradient(test, in_location, numeric_eps=1e-5, rtol=0.16, atol=1e-4)
 
     stypes = ['row_sparse', 'default']
     for stype in stypes:

--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -291,7 +291,7 @@ def test_activation():
             in_location = [mx.nd.array(data_tmp).tostype(stype)]
 
             test = mx.symbol.Activation(data, act_type="relu")
-            check_numeric_gradient(test, in_location, numeric_eps=1e-2, rtol=0.16, atol=1e-4)
+            check_numeric_gradient(test, in_location, numeric_eps=1e-6, rtol=0.16, atol=1e-4)
 
     stypes = ['row_sparse', 'default']
     for stype in stypes:


### PR DESCRIPTION
## Description ##
Address problem with https://github.com/apache/incubator-mxnet/issues/12377 by setting threshold my appropriately. Ran test with 10000 random seeds and did not produce error.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] set activation to 1e-5

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
