### PR TITLE
Fix error in try/finally block for blc

### DIFF
--- a/tests/nightly/broken_link_checker_test/JenkinsfileForBLC
+++ b/tests/nightly/broken_link_checker_test/JenkinsfileForBLC
@@ -32,10 +32,8 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/brokenLinkChecker') {
           timeout(time: 60, unit: 'MINUTES') {
-            try {
               utils.init_git()
               utils.docker_run('ubuntu_blc', 'broken_link_checker', false)
-            }
           }
         }
       }

--- a/tests/nightly/broken_link_checker_test/JenkinsfileForBLC
+++ b/tests/nightly/broken_link_checker_test/JenkinsfileForBLC
@@ -32,8 +32,12 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/brokenLinkChecker') {
           timeout(time: 60, unit: 'MINUTES') {
+            try {
               utils.init_git()
               utils.docker_run('ubuntu_blc', 'broken_link_checker', false)
+            } catch(Exception ex) {
+              sh "echo Broken Link Checker failed with exception - " + ex.toString()
+            }
           }
         }
       }


### PR DESCRIPTION
## Description ##
This fixes an issue introduced in this PR - https://github.com/apache/incubator-mxnet/pull/12507 for broken link checker.
"finally" block was removed because regression checks were removed. but, I had missed to remove "try" block.
Fails with this error - http://jenkins.mxnet-ci.amazon-ml.com/job/Broken_Link_Checker_Pipeline/310/console

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] Code is well-documented: 

@lebeg 