### PR TITLE
Disable installation nightly test

### DIFF
--- a/docs/build_version_doc/AddVersion.py
+++ b/docs/build_version_doc/AddVersion.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
                          'style="position: relative">' \
                          '<a href="#" tabindex="-1">Versions(%s)</a><ul class="dropdown-menu">' % (args.current_version)
     for i, tag in enumerate(tag_list):
-        url = root_url if tag == args.tag_default else root_url + 'versions/%s/index.html' % (tag)
+        url = root_url + 'versions/%s/api/python/index.html' % (tag)
         version_str += '<li><a class="main-nav-link" href=%s>%s</a></li>' % (url, tag)
         version_str_mobile += '<li><a tabindex="-1" href=%s>%s</a></li>' % (url, tag)
     version_str += '</ul></span>'

--- a/docs/build_version_doc/AddVersion.py
+++ b/docs/build_version_doc/AddVersion.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
                          'style="position: relative">' \
                          '<a href="#" tabindex="-1">Versions(%s)</a><ul class="dropdown-menu">' % (args.current_version)
     for i, tag in enumerate(tag_list):
-        url = root_url + 'versions/%s/api/python/index.html' % (tag)
+        url = root_url if tag == args.tag_default else root_url + 'versions/%s/index.html' % (tag)
         version_str += '<li><a class="main-nav-link" href=%s>%s</a></li>' % (url, tag)
         version_str_mobile += '<li><a tabindex="-1" href=%s>%s</a></li>' % (url, tag)
     version_str += '</ul></span>'

--- a/tests/nightly/Jenkinsfile
+++ b/tests/nightly/Jenkinsfile
@@ -45,7 +45,7 @@ core_logic: {
           //Some install guide tests are currently diabled and tracked here:
           //1. https://github.com/apache/incubator-mxnet/issues/11369
           //2. https://github.com/apache/incubator-mxnet/issues/11288
-          utils.docker_run('ubuntu_base_cpu', 'nightly_test_installation ubuntu_python_cpu_virtualenv', false)
+          //utils.docker_run('ubuntu_base_cpu', 'nightly_test_installation ubuntu_python_cpu_virtualenv', false)
           //docker_run('ubuntu_base_cpu', 'nightly_test_installation ubuntu_python_cpu_pip', false)
           //docker_run('ubuntu_base_cpu', 'nightly_test_installation ubuntu_python_cpu_docker', false)
           //docker_run('ubuntu_base_cpu', 'nightly_test_installation ubuntu_python_cpu_source', false)
@@ -59,7 +59,7 @@ core_logic: {
           //Some install guide tests are currently diabled and tracked here:
           //1. https://github.com/apache/incubator-mxnet/issues/11369
           //2. https://github.com/apache/incubator-mxnet/issues/11288
-          utils.docker_run('ubuntu_base_gpu', 'nightly_test_installation ubuntu_python_gpu_virtualenv', true)
+          //utils.docker_run('ubuntu_base_gpu', 'nightly_test_installation ubuntu_python_gpu_virtualenv', true)
           //docker_run('ubuntu_base_gpu', 'nightly_test_installation ubuntu_python_gpu_pip', true)
           //docker_run('ubuntu_base_gpu', 'nightly_test_installation ubuntu_python_gpu_docker', true)
           utils.docker_run('ubuntu_base_gpu', 'nightly_test_installation ubuntu_python_gpu_source', true)
@@ -131,4 +131,3 @@ failure_handler: {
   }
 }
 )
-


### PR DESCRIPTION
## Description ##
The nightly installation tests have been mostly disabled. The virtualenv one is breaking because that section was removed from the installation page.

This is a quick fix (like the others) that disables the tests.

## Comments
I recommend that this test concept be reimagined and reimplemented so it has actual coverage. It looks like only one out of seven would be running now.
