### PR TITLE
[MXNET-968] Fix MacOS python tests

### DIFF
--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -60,7 +60,7 @@ class LibraryInitializer {
         // Make children single threaded since they are typically workers
         dmlc::SetEnv("MXNET_CPU_WORKER_NTHREADS", 1);
         dmlc::SetEnv("OMP_NUM_THREADS", 1);
-#if MXNET_USE_OPENCV
+#if MXNET_USE_OPENCV && !__APPLE__
         cv::setNumThreads(0);  // disable opencv threading
 #endif  // MXNET_USE_OPENCV
         engine::OpenMP::Get()->set_enabled(false);


### PR DESCRIPTION
## Description ##

Fixes: https://github.com/apache/incubator-mxnet/issues/12089
MacOS python tests are failing.  This seems to be because OpenCV on brew is missing some threading symbols that we're calling.  As a work around I'm reverting to a previously working behaviour (not setting threading limits explicitly on MacOS builds).

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Testing Done ##

Tested locally and with TravisCI on a prior commit.  Tests pass correctly.
