### PR TITLE
update docs to list cmake required for build from source page

### DIFF
--- a/docs/install/build_from_source.md
+++ b/docs/install/build_from_source.md
@@ -16,6 +16,8 @@ This document explains how to build MXNet from source code. Building MXNet from 
 
 You need C++ build tools and a BLAS library to build the MXNet shared library. If you want to run MXNet with GPUs, you will need to install [NVDIA CUDA and cuDNN](https://developer.nvidia.com/cuda-downloads) first.
 
+You may use [GNU Make](https://www.gnu.org/software/make/) to build the library but [cmake](https://cmake.org/) is required
+
 
 ### C++ build tools
 
@@ -25,7 +27,7 @@ You need C++ build tools and a BLAS library to build the MXNet shared library. I
 
 2. [Git](https://git-scm.com/downloads) for downloading the sources from Github repository.
 
-3. [cmake](https://cmake.org/) is recommended. You may also use [GNU Make](https://www.gnu.org/software/make/) to build the library.
+
 
 
 ### BLAS library


### PR DESCRIPTION
## Description ##
https://mxnet.incubator.apache.org/install/build_from_source.html

currently our docs state that cmake is recommended but not required. in the process to migrate fully to cmake (and because it is required by some of our builds already) we will state that cmake is a prerequisite for building from source.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] move cmake to required section in build from source page.


## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
