### PR TITLE
[MXNET-867] Pooling1D with "same" padding

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -180,3 +180,4 @@ List of Contributors
 * [Per Goncalves da Silva](https://github.com/perdasilva)
 * [Zhijingcheng Yu](https://github.com/jasonyu1996)
 * [Cheng-Che Lee](https://github.com/stu1130)
+* [Chaitanya Bapat](https://github.com/ChaiBapchya)

--- a/src/operator/nn/pool.h
+++ b/src/operator/nn/pool.h
@@ -73,7 +73,7 @@ namespace pool_enum {
 enum PoolingOpInputs {kData};
 enum PoolingOpOutputs {kOut, kMask};
 enum PoolingOpType {kMaxPooling, kAvgPooling, kSumPooling, kLpPooling};
-enum PoolingOpPadConventionType {kValid, kFull};
+enum PoolingOpPadConventionType {kValid, kFull, kSame};
 }  // namespace pool_enum
 
 /*!

--- a/src/operator/nn/pooling-inl.h
+++ b/src/operator/nn/pooling-inl.h
@@ -74,6 +74,7 @@ struct PoolingParam : public dmlc::Parameter<PoolingParam> {
     DMLC_DECLARE_FIELD(pooling_convention).set_default(pool_enum::kValid)
     .add_enum("full", pool_enum::kFull)
     .add_enum("valid", pool_enum::kValid)
+    .add_enum("same", pool_enum::kSame)
     .describe("Pooling convention to be applied.");
 
     DMLC_DECLARE_FIELD(stride).set_default(TShape())

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -99,7 +99,7 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
   if (param.pooling_convention == pool_enum::kSame) {
     CHECK_EQ(dshape.ndim(), 3U)
       << "Pooling: Input data should be 3D in (batch, channel, x)"
-      << ", Currently 'same' supports Max Pooling 1-D";
+      << ". Currently 'same' supports Max Pooling 1-D";
   }
   CHECK_GE(dshape.ndim(), 3U)
       << "Pooling: Input data should be  3D in (batch, channel, x)"

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -100,6 +100,8 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
     CHECK_EQ(dshape.ndim(), 3U)
       << "Pooling: Input data should be 3D in (batch, channel, x)"
       << ". Currently 'same' supports Max Pooling 1-D";
+    CHECK(param.pad[0] == 0 and param.pad[1] == 0 and param.pad[2] == 0)
+      << "Same pooling convention disables the use of pad parameter.";
   }
   CHECK_GE(dshape.ndim(), 3U)
       << "Pooling: Input data should be  3D in (batch, channel, x)"
@@ -132,12 +134,12 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
                   (dshape[2] + 2 * param.pad[0] - param.kernel[0]) /
                       param.stride[0];
     } else if (param.pooling_convention == pool_enum::kFull) {
-      oshape[2] = 1 + static_cast<int>(ceil(
+      oshape[2] = 1 + static_cast<int>(std::ceil(
                           static_cast<float>(dshape[2] + 2 * param.pad[0] -
                                              param.kernel[0]) /
                           param.stride[0]));
     } else {
-      oshape[2] = static_cast<int>(ceil(
+      oshape[2] = static_cast<int>(std::ceil(
                           static_cast<float>(dshape[2] + 2 * param.pad[0]) /
                           param.stride[0]));
     }

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -100,7 +100,7 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
     CHECK_EQ(dshape.ndim(), 3U)
       << "Pooling: Input data should be 3D in (batch, channel, x)"
       << ". Currently 'same' supports Max Pooling 1-D";
-    CHECK(param.pad[0] == 0 and param.pad[1] == 0 and param.pad[2] == 0)
+    CHECK(param.pad[0] == 0 && param.pad[1] == 0 && param.pad[2] == 0)
       << "Same pooling convention disables the use of pad parameter.";
   }
   CHECK_GE(dshape.ndim(), 3U)

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -96,6 +96,11 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
     CHECK(param.p_value.has_value());
   }
   const TShape &dshape = (*in_shape)[0];
+  if (param.pooling_convention == pool_enum::kSame) {
+    CHECK_EQ(dshape.ndim(), 3U)
+      << "Pooling: Input data should be 3D in (batch, channel, x)"
+      << ", Currently 'same' supports Max Pooling 1-D";
+  }
   CHECK_GE(dshape.ndim(), 3U)
       << "Pooling: Input data should be  3D in (batch, channel, x)"
       << " Or 4D in (batch, channel, y, x) "
@@ -130,6 +135,10 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
       oshape[2] = 1 + static_cast<int>(ceil(
                           static_cast<float>(dshape[2] + 2 * param.pad[0] -
                                              param.kernel[0]) /
+                          param.stride[0]));
+    } else {
+      oshape[2] = static_cast<int>(ceil(
+                          static_cast<float>(dshape[2] + 2 * param.pad[0]) /
                           param.stride[0]));
     }
     out_shape->clear();

--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -126,7 +126,7 @@ static bool PoolingShape(const nnvm::NodeAttrs &attrs,
       oshape[2] = 1 +
                   (dshape[2] + 2 * param.pad[0] - param.kernel[0]) /
                       param.stride[0];
-    } else {
+    } else if (param.pooling_convention == pool_enum::kFull) {
       oshape[2] = 1 + static_cast<int>(ceil(
                           static_cast<float>(dshape[2] + 2 * param.pad[0] -
                                              param.kernel[0]) /

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6985,6 +6985,7 @@ def test_valid_max_pooling_pad_type_same():
         input_data,
         kernel=kernel,
         stride=stride,
+        pad=(0,0,0),
         pool_type='max',
         name='pooling',
         pooling_convention="same")

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6913,6 +6913,16 @@ def test_spacetodepth():
     test_invalid_block_size()
     test_invalid_depth_dim()
 
+def test_max_pooling_pad_type_same():
+    input_data=mx.nd.array(np.random.rand(1,1,10))
+    output_data=mx.nd.Pooling(
+        input_data, 
+        kernel=(2), 
+        pool_type='max',
+        name='pooling',
+        pooling_convention="same")
+    assert(input_data.shape == output_data.shape)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6913,11 +6913,12 @@ def test_spacetodepth():
     test_invalid_block_size()
     test_invalid_depth_dim()
 
+@with_seed()
 def test_max_pooling_pad_type_same():
     input_data=mx.nd.array(np.random.rand(1,1,10))
     output_data=mx.nd.Pooling(
-        input_data, 
-        kernel=(2), 
+        input_data,
+        kernel=(2),
         pool_type='max',
         name='pooling',
         pooling_convention="same")

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6958,21 +6958,6 @@ def test_spacetodepth():
     test_invalid_depth_dim()
 
 @with_seed()
-def test_max_pooling_pad_type_same():
-    import math
-    input_data = mx.nd.array(np.random.rand(1,1,10))
-    stride = 2
-    kernel = 2
-    output_data=mx.nd.Pooling(
-        input_data,
-        kernel=kernel,
-        stride=stride,
-        pool_type='max',
-        name='pooling',
-        pooling_convention="same")
-    assert(math.ceil(input_data.shape[2]/stride) == output_data.shape[2])
-
-@with_seed()
 def test_invalid_kernel_size():
     invalid_kernel_size = 28
     assert_exception(
@@ -6989,6 +6974,39 @@ def test_valid_kernel_size():
         mx.nd.array(np.random.rand(1, 1, 28, 28)),
         mx.nd.array(np.random.rand(1, 1, 28, 28)),
         kernel_size=valid_kernel_size)
+
+@with_seed()
+def test_valid_max_pooling_pad_type_same():
+    import math
+    input_data = mx.nd.array(np.random.rand(1,1,10))
+    stride = 2
+    kernel = 2
+    output_data=mx.nd.Pooling(
+        input_data,
+        kernel=kernel,
+        stride=stride,
+        pool_type='max',
+        name='pooling',
+        pooling_convention="same")
+    assert(math.ceil(input_data.shape[2]/stride) == output_data.shape[2])
+
+@with_seed()
+def test_invalid_max_pooling_pad_type_same():
+    import math
+    input_data = mx.nd.array(np.random.rand(1,1,10))
+    stride = 2
+    kernel = 2
+    pad = 2
+    assert_exception(
+        mx.nd.Pooling,
+        MXNetError,
+        input_data,
+        stride=stride,
+        kernel=kernel,
+        pad=pad,
+        pool_type='max',
+        name='pooling',
+        pooling_convention="same")
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6958,7 +6958,6 @@ def test_spacetodepth():
     test_invalid_depth_dim()
 
 @with_seed()
-<<<<<<< HEAD
 def test_max_pooling_pad_type_same():
     input_data=mx.nd.array(np.random.rand(1,1,10))
     output_data=mx.nd.Pooling(
@@ -6968,7 +6967,8 @@ def test_max_pooling_pad_type_same():
         name='pooling',
         pooling_convention="same")
     assert(input_data.shape == output_data.shape)
-=======
+
+@with_seed()
 def test_invalid_kernel_size():
     invalid_kernel_size = 28
     assert_exception(
@@ -6985,7 +6985,6 @@ def test_valid_kernel_size():
         mx.nd.array(np.random.rand(1, 1, 28, 28)),
         mx.nd.array(np.random.rand(1, 1, 28, 28)),
         kernel_size=valid_kernel_size)
->>>>>>> upstream/master
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6959,14 +6959,18 @@ def test_spacetodepth():
 
 @with_seed()
 def test_max_pooling_pad_type_same():
-    input_data=mx.nd.array(np.random.rand(1,1,10))
+    import math
+    input_data = mx.nd.array(np.random.rand(1,1,10))
+    stride = 2
+    kernel = 2
     output_data=mx.nd.Pooling(
         input_data,
-        kernel=(2),
+        kernel=kernel,
+        stride=stride,
         pool_type='max',
         name='pooling',
         pooling_convention="same")
-    assert(input_data.shape == output_data.shape)
+    assert(math.ceil(input_data.shape[2]/stride) == output_data.shape[2])
 
 @with_seed()
 def test_invalid_kernel_size():


### PR DESCRIPTION
## Description ##
MaxPooling 1D added another pooling convention (aka padding type) called "same"

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
