### PR TITLE
[MXNET-969] Fix buffer overflow in RNNOp

### DIFF
--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -552,13 +552,6 @@ class RNNOp : public Operator{
     }
 
     DType* reserve_space_ptr = static_cast<DType*>(reserve_space_.dptr);
-
-    int req_statecell = 0;
-    if (param_.mode == rnn_enum::kLstm) {
-      // State cell should be present for LSTMs.
-      req_statecell = req[rnn_enum::kStateCell];
-    }
-
     RNNBackward<DType>(workspace.dptr_,
                        reserve_space_ptr,
                        param_.num_layers,
@@ -583,7 +576,8 @@ class RNNOp : public Operator{
                        req[rnn_enum::kData],
                        req[rnn_enum::kParams],
                        req[rnn_enum::kState],
-                       req_statecell,
+                       // State cell should be present for LSTMs, but is absent for other RNNs.
+                       param_.mode == rnn_enum::kLstm ? req[rnn_enum::kStateCell] : kNullOp,
                        param_.p,
                        param_.mode);
   }

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -552,6 +552,13 @@ class RNNOp : public Operator{
     }
 
     DType* reserve_space_ptr = static_cast<DType*>(reserve_space_.dptr);
+
+    int req_statecell = 0;
+    if (param_.mode == rnn_enum::kLstm) {
+      // State cell should be present for LSTMs.
+      req_statecell = req[rnn_enum::kStateCell];
+    }
+
     RNNBackward<DType>(workspace.dptr_,
                        reserve_space_ptr,
                        param_.num_layers,
@@ -576,7 +583,7 @@ class RNNOp : public Operator{
                        req[rnn_enum::kData],
                        req[rnn_enum::kParams],
                        req[rnn_enum::kState],
-                       req[rnn_enum::kStateCell],
+                       req_statecell,
                        param_.p,
                        param_.mode);
   }


### PR DESCRIPTION
## Description ##
This fixes an buffer overflow detected by ASAN.  Fix is required before we can merge ASAN checks widely into our CI.

Co-authored-by: Sina Md <mdsina@amazon.com>
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## ASAN Summary ##
Buffer overflow in RNNOp<float>::Backward(..) 
SUMMARY: AddressSanitizer: heap-buffer-overflow /work/mxnet/src/operator/./rnn-inl.h:555 in mxnet::op::RNNOp<float>::Backward(mxnet::OpContext const&, std::vector<mxnet::TBlob, std::allocator<mxnet::TBlob> > const&, std::vector<mxnet::TBlob, std::allocator<mxnet::TBlob> > const&, std::vector<mxnet::TBlob, std::allocator<mxnet::TBlob> > const&, std::vector<mxnet::OpReqType, std::allocator<mxnet::OpReqType> > const&, std::vector<mxnet::TBlob, std::allocator<mxnet::TBlob> > const&, std::vector<mxnet::TBlob, std::allocator<mxnet::TBlob> > const&) 
Shadow bytes around the buggy address: 
0x0c048001b850: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa 
0x0c048001b860: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa 
0x0c048001b870: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa 
0x0c048001b880: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa 
0x0c048001b890: fa fa fd fa fa fa fd fa fa fa fd fa fa fa fd fa 
=>0x0c048001b8a0: fa fa fd fa fa fa 00[04]fa fa fa fa fa fa fa fa 
0x0c048001b8b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa 
0x0c048001b8c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa 
0x0c048001b8d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa 
0x0c048001b8e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa 
0x0c048001b8f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa 
Shadow byte legend (one shadow byte represents 8 application bytes): 
Addressable: 00 
Partially addressable: 01 02 03 04 05 06 07 
Heap left redzone: fa 
Freed heap region: fd 
Stack left redzone: f1 
Stack mid redzone: f2 
Stack right redzone: f3 
Stack after return: f5 
Stack use after scope: f8 
Global redzone: f9 
Global init order: f6 
Poisoned by user: f7 
Container overflow: fc 
Array cookie: ac 
Intra object redzone: bb 
ASan internal: fe 
Left alloca redzone: ca 
Right alloca redzone: cb 
==91==ABORTING 
Full output will be attached in work log. 

Testing Done:
Verified locally this fixes the issue.  Will integrate test coverage for this type of error into CI at a future date for all Python tests.