### PR TITLE
Remove pip overwrites

### DIFF
--- a/docs/build_version_doc/AddVersion.py
+++ b/docs/build_version_doc/AddVersion.py
@@ -87,10 +87,5 @@ if __name__ == '__main__':
                 outstr = outstr.replace('http://mxnet.io', 'https://mxnet.incubator.apache.org/'
                                                                'versions/%s' % (args.current_version))
 
-            # Add tag for example link
-            outstr = outstr.replace('https://github.com/apache/incubator-mxnet/tree/master/example',
-                                    'https://github.com/apache/incubator-mxnet/tree/%s/example' %
-                                    (args.current_version))
-
             with open(os.path.join(path, name), "w") as outf:
                 outf.write(outstr)

--- a/docs/build_version_doc/AddVersion.py
+++ b/docs/build_version_doc/AddVersion.py
@@ -87,26 +87,6 @@ if __name__ == '__main__':
                 outstr = outstr.replace('http://mxnet.io', 'https://mxnet.incubator.apache.org/'
                                                                'versions/%s' % (args.current_version))
 
-            # Fix git clone and pip installation to specific tag
-            pip_pattern = ['', '-cu80', '-cu75', '-cu80mkl', '-cu75mkl', '-mkl']
-            if args.current_version == 'master':
-                outstr = outstr.replace('git clone --recursive https://github.com/dmlc/mxnet',
-                                        'git clone --recursive https://github.com/apache/incubator-mxnet.git mxnet')
-                for trail in pip_pattern:
-                    outstr = outstr.replace('pip install mxnet%s<' % (trail),
-                                            'pip install mxnet%s --pre<' % (trail))
-                    outstr = outstr.replace('pip install mxnet%s\n<' % (trail),
-                                            'pip install mxnet%s --pre\n<' % (trail))
-            else:
-                outstr = outstr.replace('git clone --recursive https://github.com/dmlc/mxnet',
-                                        'git clone --recursive https://github.com/apache/incubator-mxnet.git mxnet '
-                                        '--branch %s' % (args.current_version))
-                for trail in pip_pattern:
-                    outstr = outstr.replace('pip install mxnet%s<' % (trail),
-                                            'pip install mxnet%s==%s<' % (trail, args.current_version))
-                    outstr = outstr.replace('pip install mxnet%s\n<' % (trail),
-                                            'pip install mxnet%s==%s\n<' % (trail, args.current_version))
-
             # Add tag for example link
             outstr = outstr.replace('https://github.com/apache/incubator-mxnet/tree/master/example',
                                     'https://github.com/apache/incubator-mxnet/tree/%s/example' %


### PR DESCRIPTION
## Description ##
This PR removes the overwriting of pip install instructions on the website. When we make updates to source to have the correct info, this script will overwrite it based on some dated logic. Now that we have consolidated install info, it doesn't make sense to have this injection happen. Also, the injection was a nuisance anyway since it would be so hard to track down. No one ever sees it happen in local dev builds of the docs.

This also resolves point 1.3 in the recent feedback thread about MXNet.
https://lists.apache.org/thread.html/fe2e883b2daf06e03283e4f3fcb3312c811a6e4cef8dbf1768ec29eb@%3Cdev.mxnet.apache.org%3E

This script was taking instructions that were correct in the source of the page and making them incorrect when the site was being published. (by add --pre)

The script also swaps out links to the examples based on your current version... which doesn't make a lot of sense because the example may not have existed for the version of the site that you're on. I guess it made sense if you were time-traveling through the site versions... maybe. Anyway, that's deleted by this PR too.

## Comments
Generally, I would say that these kind of magical injections that happen at web publishing time are a bad idea because it makes the developer go crazy. They put in a link in their source, and then it gets magically butchered by an invisible script well after their code was merged. I hope to eventually get rid of this entire script once the versions dropdown is better integrated with the API docs.
