### PR TITLE
[MXNet-970] improve tutorial redirection

### DIFF
--- a/docs/build_version_doc/artifacts/.htaccess
+++ b/docs/build_version_doc/artifacts/.htaccess
@@ -11,7 +11,7 @@ RewriteRule ^versions/[^\/]+/community/.*$ /community/ [R=301,L]
 RewriteRule ^versions/[^\/]+/faq/.*$ /faq/ [R=301,L]
 RewriteRule ^versions/[^\/]+/gluon/.*$ /gluon/ [R=301,L]
 RewriteRule ^versions/[^\/]+/install/.*$ /install/ [R=301,L]
-RewriteRule ^versions/[^\/]+/tutorials/.*$ /tutorials/ [R=301,L]
+RewriteRule ^versions/[^\/]+/tutorials/(.*)$ /tutorials/$1 [R=301,L]
 
 # Redirect navbar APIs that did not exist
 RewriteRule ^versions/0.11.0/api/python/contrib/onnx.html /error/api.html [R=301,L]


### PR DESCRIPTION
## Description ##
This PR improves the tutorial redirects. It takes the request for an old version tutorial and maps the request back to the default version of the website with the document request intact.
Prior to my #12540 update, users would land on untested, broken tutorials. However, I found it less than ideal that a request to an old tutorial wouldn't just take you to the latest one. This PR does just that.

Say a user googles image prediction with mxnet and gets this result:
http://34.201.8.176/versions/0.11.0/tutorials/python/predict_image.html
Before, they'd get to it and if they were on Windows, it wouldn't work. This was [fixed a couple of months ago](https://github.com/apache/incubator-mxnet/commit/fa935a833f6ebc6581cb399e2ea0a73dd6939520).

With my recent update, they redirect to the tutorials index which was better than going to a broken tutorial, but with this update they just redirect the latest version of the tutorial:
http://34.201.8.176/tutorials/python/predict_image.html

Say a user finds an old google result or link to this old LSTM tutorial that's been deleted: http://34.201.8.176/versions/0.11.0/tutorials/speech_recognition/speech_lstm.html
We'll give them a 404.

Thanks goes to @ddavydenko for guiding me on the frustrating journey of regexes. 
:sparkles: https://regex101.com/ FTW! :sparkles: