### PR TITLE
Correct PR branch detection in code coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,7 +103,6 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/sanity-lint') {
           utils.init_git()
-          utils.publish_test_coverage()
           utils.docker_run('ubuntu_cpu', 'sanity_check', false)
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -103,6 +103,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/sanity-lint') {
           utils.init_git()
+          utils.publish_test_coverage()
           utils.docker_run('ubuntu_cpu', 'sanity_check', false)
         }
       }

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -78,7 +78,7 @@ echo ${libs} | sed -e 's/,/ /g' | xargs md5sum
 def publish_test_coverage() {
     // CodeCovs auto detection has trouble with our CIs PR validation due the merging strategy
     def codecovArgs = ""
-    if (env.CHANGE_ID != '') {
+    if (env.CHANGE_ID) {
       // PR execution
       // Take the previous commit because of our PR merge strategy that adds a temporary commit for CI
       GIT_COMMIT_HASH = sh (script: "git rev-parse @~", returnStdout: true)

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -78,6 +78,10 @@ echo ${libs} | sed -e 's/,/ /g' | xargs md5sum
 def publish_test_coverage() {
     // CodeCovs auto detection has trouble with our CIs PR validation due the merging strategy
     lastCommitMessage = sh (script: "git log -1 --pretty=%B", returnStdout: true)
+    lastCommitMessage = lastCommitMessage.trim()
+    echo lastCommitMessage
+    echo lastCommitMessage.startsWith("Merge commit '").toString()
+    echo lastCommitMessage.endsWith("' into HEAD").toString()
     if (lastCommitMessage.startsWith("Merge commit '") && lastCommitMessage.endsWith("' into HEAD")) {
         // Merge commit applied by Jenkins, skip that commit
         GIT_COMMIT_HASH = sh (script: "git rev-parse @~", returnStdout: true)

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -77,8 +77,15 @@ echo ${libs} | sed -e 's/,/ /g' | xargs md5sum
 
 def publish_test_coverage() {
     // CodeCovs auto detection has trouble with our CIs PR validation due the merging strategy
+    lastCommitMessage = sh (script: "git log -1 --pretty=%B", returnStdout: true)
+    if (lastCommitMessage.startsWith("Merge commit '") && lastCommitMessage.endsWith("' into HEAD")) {
+        // Merge commit applied by Jenkins, skip that commit
+        GIT_COMMIT_HASH = sh (script: "git rev-parse @~", returnStdout: true)
+    } else {
+        GIT_COMMIT_HASH = sh (script: "git rev-parse @", returnStdout: true)
+    }
+   
     def codecovArgs = ""
-    GIT_COMMIT_HASH = sh (script: "git rev-parse @", returnStdout: true)
     if (env.CHANGE_ID) {
       // PR execution
       codecovArgs += "-B ${env.CHANGE_TARGET} " +

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -79,9 +79,6 @@ def publish_test_coverage() {
     // CodeCovs auto detection has trouble with our CIs PR validation due the merging strategy
     lastCommitMessage = sh (script: "git log -1 --pretty=%B", returnStdout: true)
     lastCommitMessage = lastCommitMessage.trim()
-    echo lastCommitMessage
-    echo lastCommitMessage.startsWith("Merge commit '").toString()
-    echo lastCommitMessage.endsWith("' into HEAD").toString()
     if (lastCommitMessage.startsWith("Merge commit '") && lastCommitMessage.endsWith("' into HEAD")) {
         // Merge commit applied by Jenkins, skip that commit
         GIT_COMMIT_HASH = sh (script: "git rev-parse @~", returnStdout: true)

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -78,16 +78,14 @@ echo ${libs} | sed -e 's/,/ /g' | xargs md5sum
 def publish_test_coverage() {
     // CodeCovs auto detection has trouble with our CIs PR validation due the merging strategy
     def codecovArgs = ""
+    GIT_COMMIT_HASH = sh (script: "git rev-parse @", returnStdout: true)
     if (env.CHANGE_ID) {
       // PR execution
-      // Take the previous commit because of our PR merge strategy that adds a temporary commit for CI
-      GIT_COMMIT_HASH = sh (script: "git rev-parse @~", returnStdout: true)
       codecovArgs += "-B ${env.CHANGE_TARGET} " +
         "-C ${GIT_COMMIT_HASH} " +
         "-P ${env.CHANGE_ID} "
     } else {
       // Branch execution
-      GIT_COMMIT_HASH = sh (script: "git rev-parse @", returnStdout: true)
       codecovArgs += "-B ${env.BRANCH_NAME} " +
         "-C ${GIT_COMMIT_HASH} "
     }


### PR DESCRIPTION
The branch detection in the code coverage script was broken because a non-existing environment variable in groovy is considered null opposed to other documentation I've found that states it as being an empty string.

A CI run to test the branch detection in a non-PR job is available below (that's why I created the branch in the main repository instead of my own fork). 

A CI run to test the branch detection in a PR job is the regular PR validation.

Accept criteria is both reports referencing the same commit hash.


Background for the change was that during my testing I used ```git log``` while I switched to ```rev-parse``` during last minute. Since CI automatically moves the currently checked out commit to the right one, ```rev-parse``` is actually working for PR-merge as well as for Branch validation.