### PR TITLE
Fixed NoSuchMethodError for Jenkins Job for MBCC

### DIFF
--- a/tests/nightly/model_backwards_compatibility_check/JenkinsfileForMBCC
+++ b/tests/nightly/model_backwards_compatibility_check/JenkinsfileForMBCC
@@ -54,7 +54,6 @@ core_logic: {
   stage('MBCC Inference'){
     node(NODE_LINUX_CPU) {
       ws('workspace/modelBackwardsCompat') {
-        utils.init_git()
         utils.unpack_and_init('cpu', mx_lib)
         // Perform inference on the latest version of MXNet
         utils.docker_run('ubuntu_nightly_cpu', 'nightly_model_backwards_compat_test', false)

--- a/tests/nightly/model_backwards_compatibility_check/JenkinsfileForMBCC
+++ b/tests/nightly/model_backwards_compatibility_check/JenkinsfileForMBCC
@@ -55,7 +55,7 @@ core_logic: {
     node(NODE_LINUX_CPU) {
       ws('workspace/modelBackwardsCompat') {
         utils.init_git()
-        utils.unpack_lib('cpu', mx_lib)
+        utils.unpack_and_init('cpu', mx_lib)
         // Perform inference on the latest version of MXNet
         utils.docker_run('ubuntu_nightly_cpu', 'nightly_model_backwards_compat_test', false)
       }


### PR DESCRIPTION
## Description ##
A recent change made in PR : #12370 had broken the [Jenkins job for MBCC](http://jenkins.mxnet-ci.amazon-ml.com/job/restricted-backwards-compatibility-checker/72/). 
This PR attempts to fix that.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change.
