### PR TITLE
Gluon DataLoader: avoid recursionlimit error

### DIFF
--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -175,7 +175,9 @@ def _recursive_fork_recordio(obj, depth, max_depth=1000):
 def worker_loop(dataset, key_queue, data_queue, batchify_fn):
     """Worker loop for multiprocessing DataLoader."""
     # re-fork a new recordio handler in new process if applicable
-    _recursive_fork_recordio(dataset, 0, 1000)
+    if sys.getrecursionlimit() < 1000:
+        sys.setrecursionlimit(1000)
+    _recursive_fork_recordio(dataset, 0, 1000 - 5)  # reserve 5 stack in ops
 
     while True:
         idx, samples = key_queue.get()

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -175,7 +175,12 @@ def _recursive_fork_recordio(obj, depth, max_depth=1000):
 def worker_loop(dataset, key_queue, data_queue, batchify_fn):
     """Worker loop for multiprocessing DataLoader."""
     # re-fork a new recordio handler in new process if applicable
-    _recursive_fork_recordio(dataset, 0, sys.getrecursionlimit() - 5)
+    # for a dataset with transform function, the depth of MXRecordIO is 1
+    # for a lazy transformer, the depth is 2
+    # for a user defined transformer, the depth is unknown, try a reasonable depth
+    limit = sys.getrecursionlimit()
+    max_recursion_depth = min(limit - 5, max(10, limit // 2))
+    _recursive_fork_recordio(dataset, 0, max_recursion_depth)
 
     while True:
         idx, samples = key_queue.get()

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -175,9 +175,7 @@ def _recursive_fork_recordio(obj, depth, max_depth=1000):
 def worker_loop(dataset, key_queue, data_queue, batchify_fn):
     """Worker loop for multiprocessing DataLoader."""
     # re-fork a new recordio handler in new process if applicable
-    if sys.getrecursionlimit() < 1000:
-        sys.setrecursionlimit(1000)
-    _recursive_fork_recordio(dataset, 0, 1000 - 5)  # reserve 5 stack in ops
+    _recursive_fork_recordio(dataset, 0, sys.getrecursionlimit() - 5)
 
     while True:
         idx, samples = key_queue.get()

--- a/python/mxnet/recordio.py
+++ b/python/mxnet/recordio.py
@@ -83,6 +83,17 @@ class MXRecordIO(object):
     def __del__(self):
         self.close()
 
+    def __getstate__(self):
+        # pickling pointer is not allowed
+        d = dict(self.__dict__)
+        d['is_open'] = False
+        del d['handle']
+        return d
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+        self.handle = RecordIOHandle()
+
     def close(self):
         """Closes the record file."""
         if not self.is_open:

--- a/python/mxnet/recordio.py
+++ b/python/mxnet/recordio.py
@@ -84,15 +84,30 @@ class MXRecordIO(object):
         self.close()
 
     def __getstate__(self):
+        """Override pickling behavior."""
         # pickling pointer is not allowed
+        is_open = self.is_open
+        self.close()
         d = dict(self.__dict__)
-        d['is_open'] = False
+        d['is_open'] = is_open
+        uri = self.uri.value
+        try:
+            uri = uri.decode('utf-8')
+        except AttributeError:
+            pass
         del d['handle']
+        d['uri'] = uri
         return d
 
     def __setstate__(self, d):
+        """Restore from pickled."""
         self.__dict__ = d
+        is_open = d['is_open']
+        self.is_open = False
         self.handle = RecordIOHandle()
+        self.uri = c_str(self.uri)
+        if is_open:
+            self.open()
 
     def close(self):
         """Closes the record file."""
@@ -227,6 +242,12 @@ class MXIndexedRecordIO(MXRecordIO):
             return
         super(MXIndexedRecordIO, self).close()
         self.fidx.close()
+
+    def __getstate__(self):
+        """Override pickling behavior."""
+        d = super(MXIndexedRecordIO, self).__getstate__()
+        d['fidx'] = None
+        return d
 
     def seek(self, idx):
         """Sets the current read pointer position.

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -75,24 +75,35 @@ def test_recordimage_dataset():
 
 @with_seed()
 def test_recordimage_dataset_with_data_loader_multiworker():
-    # This test is pointless on Windows because Windows doesn't fork
-    if platform.system() != 'Windows':
-        recfile = prepare_record()
-        dataset = gluon.data.vision.ImageRecordDataset(recfile)
-        loader = gluon.data.DataLoader(dataset, 1, num_workers=5)
+    recfile = prepare_record()
+    dataset = gluon.data.vision.ImageRecordDataset(recfile)
+    loader = gluon.data.DataLoader(dataset, 1, num_workers=5)
 
-        for i, (x, y) in enumerate(loader):
-            assert x.shape[0] == 1 and x.shape[3] == 3
-            assert y.asscalar() == i
+    for i, (x, y) in enumerate(loader):
+        assert x.shape[0] == 1 and x.shape[3] == 3
+        assert y.asscalar() == i
 
-        # with transform
-        fn = lambda x, y : (x, y)
-        dataset = gluon.data.vision.ImageRecordDataset(recfile).transform(fn)
-        loader = gluon.data.DataLoader(dataset, 1, num_workers=5)
+    # with transform
+    fn = lambda x, y : (x, y)
+    dataset = gluon.data.vision.ImageRecordDataset(recfile).transform(fn)
+    loader = gluon.data.DataLoader(dataset, 1, num_workers=5)
 
-        for i, (x, y) in enumerate(loader):
-            assert x.shape[0] == 1 and x.shape[3] == 3
-            assert y.asscalar() == i
+    for i, (x, y) in enumerate(loader):
+        assert x.shape[0] == 1 and x.shape[3] == 3
+        assert y.asscalar() == i
+
+    # try limit recursion depth
+    import sys
+    old_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(10)  # this should be smaller than any default value used in python
+    fn = lambda x, y : (x, y)
+    dataset = gluon.data.vision.ImageRecordDataset(recfile).transform(fn)
+    loader = gluon.data.DataLoader(dataset, 1, num_workers=5)
+
+    for i, (x, y) in enumerate(loader):
+        assert x.shape[0] == 1 and x.shape[3] == 3
+        assert y.asscalar() == i
+    sys.setrecursionlimit(old_limit)
 
 @with_seed()
 def test_sampler():

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -95,7 +95,7 @@ def test_recordimage_dataset_with_data_loader_multiworker():
     # try limit recursion depth
     import sys
     old_limit = sys.getrecursionlimit()
-    sys.setrecursionlimit(10)  # this should be smaller than any default value used in python
+    sys.setrecursionlimit(100)  # this should be smaller than any default value used in python
     fn = lambda x, y : (x, y)
     dataset = gluon.data.vision.ImageRecordDataset(recfile).transform(fn)
     loader = gluon.data.DataLoader(dataset, 1, num_workers=5)

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -73,6 +73,10 @@ def test_recordimage_dataset():
         assert x.shape[0] == 1 and x.shape[3] == 3
         assert y.asscalar() == i
 
+def _dataset_transform_fn(x, y):
+    """Named transform function since lambda function cannot be pickled."""
+    return x, y
+
 @with_seed()
 def test_recordimage_dataset_with_data_loader_multiworker():
     recfile = prepare_record()
@@ -84,8 +88,7 @@ def test_recordimage_dataset_with_data_loader_multiworker():
         assert y.asscalar() == i
 
     # with transform
-    fn = lambda x, y : (x, y)
-    dataset = gluon.data.vision.ImageRecordDataset(recfile).transform(fn)
+    dataset = gluon.data.vision.ImageRecordDataset(recfile).transform(_dataset_transform_fn)
     loader = gluon.data.DataLoader(dataset, 1, num_workers=5)
 
     for i, (x, y) in enumerate(loader):
@@ -95,9 +98,8 @@ def test_recordimage_dataset_with_data_loader_multiworker():
     # try limit recursion depth
     import sys
     old_limit = sys.getrecursionlimit()
-    sys.setrecursionlimit(100)  # this should be smaller than any default value used in python
-    fn = lambda x, y : (x, y)
-    dataset = gluon.data.vision.ImageRecordDataset(recfile).transform(fn)
+    sys.setrecursionlimit(500)  # this should be smaller than any default value used in python
+    dataset = gluon.data.vision.ImageRecordDataset(recfile).transform(_dataset_transform_fn)
     loader = gluon.data.DataLoader(dataset, 1, num_workers=5)
 
     for i, (x, y) in enumerate(loader):


### PR DESCRIPTION
## Description ##
- Avoid RecursionError: maximum recursion depth exceeded in comparison if in some hardware the default value is smaller than or close to 1000.
- Fixed multi_worker dataloader on windows since spawn instead of fork is used in windows by default.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here