### PR TITLE
[MXNET-953] Fix oob memory read

### DIFF
--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -492,7 +492,8 @@ void ShapeComputeCPU(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(req.size(), 1U);
   const TBlob& in_data = inputs[0];
   const TBlob& out_data = outputs[0];
-  memcpy(out_data.dptr_, in_data.shape_.data(), in_data.ndim() * sizeof(int64_t));
+  size_t type_size = mshadow::mshadow_sizeof(out_data.type_flag_);
+  memcpy(out_data.dptr_, in_data.shape_.data(), in_data.ndim() * type_size);
 }
 
 NNVM_REGISTER_OP(shape_array)
@@ -542,8 +543,9 @@ void SizeComputeCPU(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(req.size(), 1U);
   const TBlob& in_data = inputs[0];
   const TBlob& out_data = outputs[0];
+  size_t type_size = mshadow::mshadow_sizeof(out_data.type_flag_);
   const index_t size_var = in_data.Size();
-  memcpy(out_data.dptr_, &size_var, 1U * sizeof(int64_t));
+  memcpy(out_data.dptr_, &size_var, type_size);
 }
 
 NNVM_REGISTER_OP(size_array)


### PR DESCRIPTION
## Description ##
Simple bugfix addressing an out-of-bounds memory read.  

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- This fixes the problem but I'm open to suggestions on what the correct way to properly assign the memory to avoid similar errors.  Should we be using memcpy in cases like this?

## Testing Done ##
Ran nosetests-3.4 --verbose tests/python/unittest/test_operator.py:test_size_array with an ASAN build (described in more detail here: https://cwiki.apache.org/confluence/display/MXNET/Detecting+Memory+Leaks+and+Buffer+Overflows+in+MXNet ).

ASAN initially reported:
```
SUMMARY: AddressSanitizer: stack-buffer-overflow /work/mxnet/src/operator/tensor/elemwise_unary_op_basic.cc:546 in mxnet::op::SizeComputeCPU(nnvm::NodeAttrs const&, mxnet::OpContext const&, std::vector<mxnet::TBlob, std::allocator<mxnet::TBlob> > const&, std::vector<mxnet::OpReqType, std::allocator<mxnet::OpReqType> > const&, std::vector<mxnet::TBlob, std::allocator<mxnet::TBlob> > const&)
Shadow bytes around the buggy address:
  0x1000162b7420: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000162b7430: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000162b7440: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000162b7450: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000162b7460: f1 f1 f1 f1 f8 f2 f2 f2 f2 f2 f2 f2 f8 f2 f2 f2
=>0x1000162b7470: f2 f2 f2 f2 f8 f2 f2 f2 f2 f2 f2 f2[04]f2 f2 f2
  0x1000162b7480: f2 f2 f2 f2 f8 f2 f2 f2 f2 f2 f2 f2 f8 f2 f2 f2
  0x1000162b7490: f2 f2 f2 f2 f8 f2 f2 f2 f2 f2 f2 f2 f8 f2 f2 f2
  0x1000162b74a0: f2 f2 f2 f2 f8 f2 f2 f2 f2 f2 f2 f2 f8 f2 f2 f2
  0x1000162b74b0: f2 f2 f2 f2 00 00 00 00 00 00 00 00 00 00 00 00
  0x1000162b74c0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```
After patch test passes as expected.
```
root@bf8e737c8b91:/work/mxnet#  nosetests-3.4 --verbose tests/python/unittest/test_operator.py:test_size_array
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=1029956617 to reproduce.
test_operator.test_size_array ... ok

----------------------------------------------------------------------
Ran 1 test in 0.049s

OK
```