### PR TITLE
Fix version dropdown behavior

### DIFF
--- a/docs/_static/js/docversion.js
+++ b/docs/_static/js/docversion.js
@@ -1,0 +1,25 @@
+$(document).ready(function () {
+	function setVersion(){
+  		console.log('Applying current file to links: ', doc[1]);
+  		if (document.getElementById('dropdown-menu-position-anchor-version')) {
+          		console.log('found the versions element');
+          		versionNav = $('#dropdown-menu-position-anchor-version a.main-nav-link');
+          		console.log(versionNav);
+          		$(versionNav).each( function( index, el ) {
+                  		currLink = $( el ).attr('href');
+                  		console.log('current link: ', currLink);
+                  		version = currLink.match(/\/versions\/([0-9.]+)\//);
+                  		if (version) {
+                          		console.log('version: ', version[1]);
+                          		versionedDoc = '/versions/' + version[1] + '/' + doc[1];
+                          		console.log('versionedDoc: ', versionedDoc);
+                          		$( el ).attr('href', versionedDoc);
+                  		}
+          		});
+  		}
+	}
+	let doc = window.location.pathname.match(/^\/versions\/[^*]+\/(api\/.*)$/);
+	if (doc) {
+  		setVersion();
+	};
+});

--- a/docs/_static/js/docversion.js
+++ b/docs/_static/js/docversion.js
@@ -1,11 +1,11 @@
 function setVersion(){
-        let doc = window.location.pathname.match(/^\/versions\/[^*]+\/(api\/.*)$/);
+        let doc = window.location.pathname.match(/^\/(api\/.*)$/) || window.location.pathname.match(/^\/versions\/[^*]+\/(api\/.*)$/);
         if (doc) {
             if (document.getElementById('dropdown-menu-position-anchor-version')) {
                     versionNav = $('#dropdown-menu-position-anchor-version a.main-nav-link');
                     $(versionNav).each( function( index, el ) {
                             currLink = $( el ).attr('href');
-                            version = currLink.match(/\/versions\/([0-9.]+)\//);
+                            version = currLink.match(/\/versions\/([0-9.master]+)\//);
                             if (version) {
                                     versionedDoc = '/versions/' + version[1] + '/' + doc[1] + (window.location.hash || '');
                                     $( el ).attr('href', versionedDoc);

--- a/docs/_static/js/docversion.js
+++ b/docs/_static/js/docversion.js
@@ -1,25 +1,24 @@
+function setVersion(){
+        let doc = window.location.pathname.match(/^\/versions\/[^*]+\/(api\/.*)$/);
+        if (doc) {
+            if (document.getElementById('dropdown-menu-position-anchor-version')) {
+                    versionNav = $('#dropdown-menu-position-anchor-version a.main-nav-link');
+                    $(versionNav).each( function( index, el ) {
+                            currLink = $( el ).attr('href');
+                            version = currLink.match(/\/versions\/([0-9.]+)\//);
+                            if (version) {
+                                    versionedDoc = '/versions/' + version[1] + '/' + doc[1] + (window.location.hash || '');
+                                    $( el ).attr('href', versionedDoc);
+                            }
+                    });
+            }        
+        }
+}
+
 $(document).ready(function () {
-	function setVersion(){
-  		console.log('Applying current file to links: ', doc[1]);
-  		if (document.getElementById('dropdown-menu-position-anchor-version')) {
-          		console.log('found the versions element');
-          		versionNav = $('#dropdown-menu-position-anchor-version a.main-nav-link');
-          		console.log(versionNav);
-          		$(versionNav).each( function( index, el ) {
-                  		currLink = $( el ).attr('href');
-                  		console.log('current link: ', currLink);
-                  		version = currLink.match(/\/versions\/([0-9.]+)\//);
-                  		if (version) {
-                          		console.log('version: ', version[1]);
-                          		versionedDoc = '/versions/' + version[1] + '/' + doc[1];
-                          		console.log('versionedDoc: ', versionedDoc);
-                          		$( el ).attr('href', versionedDoc);
-                  		}
-          		});
-  		}
-	}
-	let doc = window.location.pathname.match(/^\/versions\/[^*]+\/(api\/.*)$/);
-	if (doc) {
-  		setVersion();
-	};
+    setVersion();
+});
+
+$('a.reference.internal').click(function(){
+    setVersion();
 });

--- a/docs/_static/mxnet-theme/layout.html
+++ b/docs/_static/mxnet-theme/layout.html
@@ -191,6 +191,7 @@
     <script type="text/javascript" src="{{ pathto('_static/js/clipboard.min.js', 1) }}"></script>
     <script type="text/javascript" src="{{ pathto('_static/js/copycode.js', 1) }}"></script>
     <script type="text/javascript" src="{{ pathto('_static/js/page.js', 1) }}"></script>
+    <script type="text/javascript" src="{{ pathto('_static/js/docversion.js', 1) }}"></script>
     <script type="text/javascript">
         $('body').ready(function () {
             $('body').css('visibility', 'visible');

--- a/docs/build_version_doc/AddVersion.py
+++ b/docs/build_version_doc/AddVersion.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
                          'style="position: relative">' \
                          '<a href="#" tabindex="-1">Versions(%s)</a><ul class="dropdown-menu">' % (args.current_version)
     for i, tag in enumerate(tag_list):
-        url = root_url if tag == args.tag_default else root_url + 'versions/%s/index.html' % (tag)
+        url = root_url + 'versions/%s/index.html' % (tag)
         version_str += '<li><a class="main-nav-link" href=%s>%s</a></li>' % (url, tag)
         version_str_mobile += '<li><a tabindex="-1" href=%s>%s</a></li>' % (url, tag)
     version_str += '</ul></span>'


### PR DESCRIPTION
## Description ##
This PR fixes the bad behavior of the versions dropdown on the website. It will remember what API document you were viewing when you switch versions. It even remembers which anchor/bookmark you're on.

## Preview
You can play with it here: http://34.201.8.176/

This is how it works on the site now. You're in deep on some doc page, and then think, "I wonder if the params are different in the last release...". You click the versions dropdown, select 1.3.0, and then _bam_, you're taken to the 1.3.0 home page. 
![2018-09-21_11-41-27](https://user-images.githubusercontent.com/5974205/45900325-4d085000-bd94-11e8-96e8-8d9e49b08b79.gif)
This is so annoying. Now you have to go and search for that page again.

With this PR, changing versions does what you'd expect it to do!
![2018-09-21_11-41-27-1](https://user-images.githubusercontent.com/5974205/45900712-5c3bcd80-bd95-11e8-8fb2-f7df35e1e849.gif)

If you pick a doc that didn't exist in a previous version, you get a 404 error.
![2018-09-21_11-41-27-2](https://user-images.githubusercontent.com/5974205/45900827-b9378380-bd95-11e8-91b6-b4b93b3f6fdf.gif)

