### PR TITLE
Enable C++ coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,6 +21,10 @@ parsers:
       method: no
       macro: no
 
+ignore:
+ - "cpp-package/example/**/*"
+ - "tests/**/*"
+
 # Disable comments for now to gather data in the background
 comment: false
 #  layout: "header, diff"

--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,10 @@ tests/mxnet_unit_tests
 # generated wrappers for ccache
 cc
 cxx
+
+# Code coverage related
+.coverage
+*.gcov
+*.gcno
+coverage.xml
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ mxnet_option(INSTALL_EXAMPLES     "Install the example source files." OFF)
 mxnet_option(USE_SIGNAL_HANDLER   "Print stack traces on segfaults." OFF)
 mxnet_option(USE_TENSORRT         "Enable infeference optimization with TensorRT." OFF)
 mxnet_option(USE_ASAN             "Enable Clang/GCC ASAN sanitizers." OFF)
+mxnet_option(ENABLE_TESTCOVERAGE  "Enable compilation with test coverage metric output" OFF)
 
 message(STATUS "CMAKE_SYSTEM_NAME ${CMAKE_SYSTEM_NAME}")
 if(USE_CUDA AND NOT USE_OLDCMAKECUDA)
@@ -216,6 +217,20 @@ if(USE_TENSORRT)
 
   list(APPEND mxnet_LINKER_LIBS libnvinfer.so ${ONNX_TRT_PARSER_LIBRARY} ${ONNX_TRT_RUNTIME_LIBRARY}
           ${ONNX_PROTO_LIBRARY} ${ONNX_LIBRARY} ${PROTOBUF_LIBRARY})
+endif()
+
+if(ENABLE_TESTCOVERAGE)
+  message(STATUS "Compiling with test coverage support enabled. This will result in additional files being written to your source directory!")
+  find_program( GCOV_PATH gcov )
+  if(NOT GCOV_PATH)
+    message(FATAL_ERROR "gcov not found! Aborting...")
+  endif() # NOT GCOV_PATH
+  
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+  set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} --coverage")
+  set(GTEST_LIBRARIES "${GTEST_LIBRARIES} --coverage")
+  link_libraries(gcov)
 endif()
 
 if(USE_MKLDNN)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('centos7_cpu', 'build_centos7_cpu', false)
-            utils.pack_lib('centos7_cpu', mx_lib)
+            utils.pack_lib('centos7_cpu', mx_lib, true)
           }
         }
       }
@@ -135,7 +135,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('centos7_cpu', 'build_centos7_mkldnn', false)
-            utils.pack_lib('centos7_mkldnn', mx_lib)
+            utils.pack_lib('centos7_mkldnn', mx_lib, true)
           }
         }
       }
@@ -146,7 +146,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('centos7_gpu', 'build_centos7_gpu', false)
-            utils.pack_lib('centos7_gpu', mx_lib)
+            utils.pack_lib('centos7_gpu', mx_lib, true)
           }
         }
       }
@@ -157,7 +157,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_openblas', false)
-            utils.pack_lib('cpu', mx_dist_lib)
+            utils.pack_lib('cpu', mx_dist_lib, true)
           }
         }
       }
@@ -179,7 +179,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_cmake_debug', false)
-            utils.pack_lib('cpu_debug', mx_cmake_lib_debug)
+            utils.pack_lib('cpu_debug', mx_cmake_lib_debug, true)
           }
         }
       }
@@ -220,7 +220,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_clang39_mkldnn', false)
-            utils.pack_lib('mkldnn_cpu_clang3', mx_mkldnn_lib)
+            utils.pack_lib('mkldnn_cpu_clang3', mx_mkldnn_lib, true)
           }
         }
       }
@@ -231,7 +231,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_clang60_mkldnn', false)
-            utils.pack_lib('mkldnn_cpu_clang6', mx_mkldnn_lib)
+            utils.pack_lib('mkldnn_cpu_clang6', mx_mkldnn_lib, true)
           }
         }
       }
@@ -242,7 +242,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_mkldnn', false)
-            utils.pack_lib('mkldnn_cpu', mx_mkldnn_lib)
+            utils.pack_lib('mkldnn_cpu', mx_mkldnn_lib, true)
           }
         }
       }
@@ -253,7 +253,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_mkldnn', false)
-            utils.pack_lib('mkldnn_gpu', mx_mkldnn_lib)
+            utils.pack_lib('mkldnn_gpu', mx_mkldnn_lib, true)
           }
         }
       }
@@ -264,7 +264,7 @@ core_logic: {
            timeout(time: max_time, unit: 'MINUTES') {
              utils.init_git()
              utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_mkldnn_nocudnn', false)
-             utils.pack_lib('mkldnn_gpu_nocudnn', mx_mkldnn_lib)
+             utils.pack_lib('mkldnn_gpu_nocudnn', mx_mkldnn_lib, true)
            }
          }
        }
@@ -275,7 +275,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_cuda91_cudnn7', false)
-            utils.pack_lib('gpu', mx_lib_cpp_examples)
+            utils.pack_lib('gpu', mx_lib_cpp_examples, true)
           }
         }
       }
@@ -307,7 +307,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_gpu', 'build_ubuntu_gpu_cmake_mkldnn', false)
-            utils.pack_lib('cmake_mkldnn_gpu', mx_cmake_mkldnn_lib)
+            utils.pack_lib('cmake_mkldnn_gpu', mx_cmake_mkldnn_lib, true)
           }
         }
       }
@@ -318,7 +318,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_gpu', 'build_ubuntu_gpu_cmake', false)
-            utils.pack_lib('cmake_gpu', mx_cmake_lib)
+            utils.pack_lib('cmake_gpu', mx_cmake_lib, true)
           }
         }
       }
@@ -329,7 +329,7 @@ core_logic: {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
             utils.docker_run('ubuntu_gpu_tensorrt', 'build_ubuntu_gpu_tensorrt', false)
-            utils.pack_lib('tensorrt', mx_tensorrt_lib)
+            utils.pack_lib('tensorrt', mx_tensorrt_lib, true)
           }
         }
       }
@@ -442,7 +442,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/ut-python2-cpu') {
           try {
-            utils.unpack_and_init('cpu', mx_lib)
+            utils.unpack_and_init('cpu', mx_lib, true)
             python2_ut('ubuntu_cpu')
             utils.publish_test_coverage()
           } finally {
@@ -457,7 +457,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/ut-python3-cpu') {
           try {
-            utils.unpack_and_init('cpu', mx_lib)
+            utils.unpack_and_init('cpu', mx_lib, true)
             python3_ut('ubuntu_cpu')
             utils.publish_test_coverage()
           } finally {
@@ -479,7 +479,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/ut-python3-cpu-debug') {
           try {
-            utils.unpack_and_init('cpu_debug', mx_cmake_lib_debug)
+            utils.unpack_and_init('cpu_debug', mx_cmake_lib_debug, true)
             python3_ut('ubuntu_cpu')
           } finally {
             utils.collect_test_results_unix('nosetests_unittest.xml', 'nosetests_python3_cpu_debug_unittest.xml')
@@ -492,7 +492,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/ut-python2-gpu') {
           try {
-            utils.unpack_and_init('gpu', mx_lib)
+            utils.unpack_and_init('gpu', mx_lib, true)
             python2_gpu_ut('ubuntu_gpu')
             utils.publish_test_coverage()
           } finally {
@@ -505,7 +505,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/ut-python3-gpu') {
           try {
-            utils.unpack_and_init('gpu', mx_lib)
+            utils.unpack_and_init('gpu', mx_lib, true)
             python3_gpu_ut('ubuntu_gpu')
             utils.publish_test_coverage()
           } finally {
@@ -519,7 +519,7 @@ core_logic: {
         ws('workspace/ut-python2-quantize-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             try {
-              utils.unpack_and_init('gpu', mx_lib)
+              utils.unpack_and_init('gpu', mx_lib, true)
               utils.docker_run('ubuntu_gpu', 'unittest_ubuntu_python2_quantization_gpu', true)
               utils.publish_test_coverage()
             } finally {
@@ -534,7 +534,7 @@ core_logic: {
         ws('workspace/ut-python3-quantize-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             try {
-              utils.unpack_and_init('gpu', mx_lib)
+              utils.unpack_and_init('gpu', mx_lib, true)
               utils.docker_run('ubuntu_gpu', 'unittest_ubuntu_python3_quantization_gpu', true)
               utils.publish_test_coverage()
             } finally {
@@ -548,7 +548,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/ut-python2-mkldnn-cpu') {
           try {
-            utils.unpack_and_init('mkldnn_cpu', mx_mkldnn_lib)
+            utils.unpack_and_init('mkldnn_cpu', mx_mkldnn_lib, true)
             python2_ut('ubuntu_cpu')
             utils.publish_test_coverage()
           } finally {
@@ -563,7 +563,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/ut-python2-mkldnn-gpu') {
           try {
-            utils.unpack_and_init('mkldnn_gpu', mx_mkldnn_lib)
+            utils.unpack_and_init('mkldnn_gpu', mx_mkldnn_lib, true)
             python2_gpu_ut('ubuntu_gpu')
             utils.publish_test_coverage()
           } finally {
@@ -576,7 +576,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/ut-python3-mkldnn-cpu') {
           try {
-            utils.unpack_and_init('mkldnn_cpu', mx_mkldnn_lib)
+            utils.unpack_and_init('mkldnn_cpu', mx_mkldnn_lib, true)
             python3_ut_mkldnn('ubuntu_cpu')
             utils.publish_test_coverage()
           } finally {
@@ -590,7 +590,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/ut-python3-mkldnn-gpu') {
           try {
-            utils.unpack_and_init('mkldnn_gpu', mx_mkldnn_lib)
+            utils.unpack_and_init('mkldnn_gpu', mx_mkldnn_lib, true)
             python3_gpu_ut('ubuntu_gpu')
             utils.publish_test_coverage()
           } finally {
@@ -603,7 +603,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/ut-python3-mkldnn-gpu-nocudnn') {
           try {
-            utils.unpack_and_init('mkldnn_gpu_nocudnn', mx_mkldnn_lib)
+            utils.unpack_and_init('mkldnn_gpu_nocudnn', mx_mkldnn_lib, true)
             python3_gpu_ut_nocudnn('ubuntu_gpu')
             utils.publish_test_coverage()
           } finally {
@@ -617,7 +617,7 @@ core_logic: {
         ws('workspace/build-centos7-cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             try {
-              utils.unpack_and_init('centos7_cpu', mx_lib)
+              utils.unpack_and_init('centos7_cpu', mx_lib, true)
               utils.docker_run('centos7_cpu', 'unittest_centos7_cpu', false)
               utils.publish_test_coverage()
             } finally {
@@ -633,7 +633,7 @@ core_logic: {
         ws('workspace/build-centos7-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             try {
-              utils.unpack_and_init('centos7_gpu', mx_lib)
+              utils.unpack_and_init('centos7_gpu', mx_lib, true)
               utils.docker_run('centos7_gpu', 'unittest_centos7_gpu', true)
               utils.publish_test_coverage()
             } finally {
@@ -648,7 +648,7 @@ core_logic: {
         ws('workspace/build-tensorrt') {
           timeout(time: max_time, unit: 'MINUTES') {
             try {
-              utils.unpack_and_init('tensorrt', mx_tensorrt_lib)
+              utils.unpack_and_init('tensorrt', mx_tensorrt_lib, true)
               utils.docker_run('ubuntu_gpu_tensorrt', 'unittest_ubuntu_tensorrt_gpu', true)
               utils.publish_test_coverage()
             } finally {
@@ -662,7 +662,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/ut-scala-cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('cpu', mx_dist_lib)
+            utils.unpack_and_init('cpu', mx_dist_lib, true)
             utils.docker_run('ubuntu_cpu', 'unittest_ubuntu_cpu_scala', false)
             utils.publish_test_coverage()
           }
@@ -673,7 +673,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/ut-clojure-cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('cpu', mx_dist_lib)
+            utils.unpack_and_init('cpu', mx_dist_lib, true)
             utils.docker_run('ubuntu_cpu', 'unittest_ubuntu_cpu_clojure', false)
             utils.publish_test_coverage()
           }
@@ -684,7 +684,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/ut-perl-cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('cpu', mx_lib)
+            utils.unpack_and_init('cpu', mx_lib, true)
             utils.docker_run('ubuntu_cpu', 'unittest_ubuntu_cpugpu_perl', false)
             utils.publish_test_coverage()
           }
@@ -695,7 +695,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/ut-perl-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('gpu', mx_lib)
+            utils.unpack_and_init('gpu', mx_lib, true)
             utils.docker_run('ubuntu_gpu', 'unittest_ubuntu_cpugpu_perl', true)
             utils.publish_test_coverage()
           }
@@ -706,7 +706,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/ut-cpp-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('cmake_gpu', mx_cmake_lib)
+            utils.unpack_and_init('cmake_gpu', mx_cmake_lib, true)
             utils.docker_run('ubuntu_gpu', 'unittest_ubuntu_gpu_cpp', true)
             utils.publish_test_coverage()
           }
@@ -717,7 +717,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/ut-cpp-mkldnn-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('cmake_mkldnn_gpu', mx_cmake_mkldnn_lib)
+            utils.unpack_and_init('cmake_mkldnn_gpu', mx_cmake_mkldnn_lib, true)
             utils.docker_run('ubuntu_gpu', 'unittest_ubuntu_gpu_cpp', true)
             utils.publish_test_coverage()
           }
@@ -728,7 +728,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/ut-r-cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('cpu', mx_lib)
+            utils.unpack_and_init('cpu', mx_lib, true)
             utils.docker_run('ubuntu_cpu', 'unittest_ubuntu_cpu_R', false)
             utils.publish_test_coverage()
           }
@@ -739,7 +739,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/ut-r-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('gpu', mx_lib)
+            utils.unpack_and_init('gpu', mx_lib, true)
             utils.docker_run('ubuntu_gpu', 'unittest_ubuntu_gpu_R', true)
             utils.publish_test_coverage()
           }
@@ -829,7 +829,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/it-onnx-cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('cpu', mx_lib)
+            utils.unpack_and_init('cpu', mx_lib, true)
             utils.docker_run('ubuntu_cpu', 'integrationtest_ubuntu_cpu_onnx', false)
             utils.publish_test_coverage()
           }
@@ -840,7 +840,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/it-python-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('gpu', mx_lib)
+            utils.unpack_and_init('gpu', mx_lib, true)
             utils.docker_run('ubuntu_gpu', 'integrationtest_ubuntu_gpu_python', true)
             utils.publish_test_coverage()
           }
@@ -851,7 +851,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/it-cpp-package') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('gpu', mx_lib_cpp_examples)
+            utils.unpack_and_init('gpu', mx_lib_cpp_examples, true)
             utils.docker_run('ubuntu_gpu', 'integrationtest_ubuntu_gpu_cpp_package', true)
             utils.publish_test_coverage()
           }
@@ -875,7 +875,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/it-dist-kvstore') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('gpu', mx_lib)
+            utils.unpack_and_init('gpu', mx_lib, true)
             utils.docker_run('ubuntu_gpu', 'integrationtest_ubuntu_gpu_dist_kvstore', true)
             utils.publish_test_coverage()
           }
@@ -890,7 +890,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/it-dist-kvstore') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('cpu', mx_lib)
+            utils.unpack_and_init('cpu', mx_lib, true)
             utils.docker_run('ubuntu_cpu', 'integrationtest_ubuntu_cpu_dist_kvstore', false)
             utils.publish_test_coverage()
           }
@@ -901,7 +901,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/ut-scala-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('gpu', mx_dist_lib)
+            utils.unpack_and_init('gpu', mx_dist_lib, true)
             utils.docker_run('ubuntu_gpu', 'integrationtest_ubuntu_gpu_scala', true)
             utils.publish_test_coverage()
           }

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ LDFLAGS = -pthread $(MSHADOW_LDFLAGS) $(DMLC_LDFLAGS)
 
 ifeq ($(ENABLE_TESTCOVERAGE), 1)
         CFLAGS += --coverage
+        LDFLAGS += --coverage
 endif
 
 ifeq ($(USE_TENSORRT), 1)

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ endif
 CFLAGS += -I$(TPARTYDIR)/mshadow/ -I$(TPARTYDIR)/dmlc-core/include -fPIC -I$(NNVM_PATH)/include -I$(DLPACK_PATH)/include -I$(TPARTYDIR)/tvm/include -Iinclude $(MSHADOW_CFLAGS)
 LDFLAGS = -pthread $(MSHADOW_LDFLAGS) $(DMLC_LDFLAGS)
 
+ifeq ($(ENABLE_TESTCOVERAGE), 1)
+        CFLAGS += --coverage
+endif
 
 ifeq ($(USE_TENSORRT), 1)
 	CFLAGS +=  -I$(ROOTDIR) -I$(TPARTYDIR) -DONNX_NAMESPACE=$(ONNX_NAMESPACE) -DMXNET_USE_TENSORRT=1

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -96,16 +96,12 @@ def publish_test_coverage() {
         GIT_COMMIT_HASH = sh (script: "git rev-parse @", returnStdout: true)
     }
    
-    def codecovArgs = ""
     if (env.CHANGE_ID) {
       // PR execution
-      codecovArgs += "-B ${env.CHANGE_TARGET} " +
-        "-C ${GIT_COMMIT_HASH} " +
-        "-P ${env.CHANGE_ID} "
+      codecovArgs = "-B ${env.CHANGE_TARGET} -C ${GIT_COMMIT_HASH} -P ${env.CHANGE_ID}"
     } else {
       // Branch execution
-      codecovArgs += "-B ${env.BRANCH_NAME} " +
-        "-C ${GIT_COMMIT_HASH} "
+      codecovArgs = "-B ${env.BRANCH_NAME} -C ${GIT_COMMIT_HASH}"
     }
 
     // To make sure we never fail because test coverage reporting is not available

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -57,22 +57,32 @@ def init_git_win() {
 }
 
 // pack libraries for later use
-def pack_lib(name, libs) {
+def pack_lib(name, libs, include_gcov_data = false) {
   sh """
 echo "Packing ${libs} into ${name}"
 echo ${libs} | sed -e 's/,/ /g' | xargs md5sum
 """
   stash includes: libs, name: name
+
+  if (include_gcov_data) {
+    // Store GCNO files that are required for GCOV to operate during runtime
+    sh "find . -name '*.gcno'"
+    stash name: "${name}_gcov_data", includes: "**/*.gcno"
+  }
 }
 
 // unpack libraries saved before
-def unpack_and_init(name, libs) {
+def unpack_and_init(name, libs, include_gcov_data = false) {
   init_git()
   unstash name
   sh """
 echo "Unpacked ${libs} from ${name}"
 echo ${libs} | sed -e 's/,/ /g' | xargs md5sum
 """
+  if (include_gcov_data) {
+    // Restore GCNO files that are required for GCOV to operate during runtime
+    unstash "${name}_gcov_data"
+  }
 }
 
 def publish_test_coverage() {

--- a/ci/build.py
+++ b/ci/build.py
@@ -218,6 +218,8 @@ def container_run(platform: str,
     # Environment setup
     #
     environment = {
+        'GCOV_PREFIX': '/work/mxnet', # GCOV report directory
+        'GCOV_PREFIX_STRIP': '3',
         'CCACHE_MAXSIZE': '500G',
         'CCACHE_TEMPDIR': '/tmp/ccache',  # temp dir should be local and not shared
         'CCACHE_DIR': '/work/ccache',  # this path is inside the container as /work/ccache is

--- a/ci/build.py
+++ b/ci/build.py
@@ -218,8 +218,6 @@ def container_run(platform: str,
     # Environment setup
     #
     environment = {
- #       'GCOV_PREFIX': '/work/mxnet/gcov_coverage', # GCOV report directory
- #       'GCOV_PREFIX_STRIP': '2',
         'CCACHE_MAXSIZE': '500G',
         'CCACHE_TEMPDIR': '/tmp/ccache',  # temp dir should be local and not shared
         'CCACHE_DIR': '/work/ccache',  # this path is inside the container as /work/ccache is

--- a/ci/build.py
+++ b/ci/build.py
@@ -218,8 +218,8 @@ def container_run(platform: str,
     # Environment setup
     #
     environment = {
-        'GCOV_PREFIX': '/work/mxnet', # GCOV report directory
-        'GCOV_PREFIX_STRIP': '3',
+ #       'GCOV_PREFIX': '/work/mxnet/gcov_coverage', # GCOV report directory
+ #       'GCOV_PREFIX_STRIP': '2',
         'CCACHE_MAXSIZE': '500G',
         'CCACHE_TEMPDIR': '/tmp/ccache',  # temp dir should be local and not shared
         'CCACHE_DIR': '/work/ccache',  # this path is inside the container as /work/ccache is

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -767,13 +767,13 @@ unittest_ubuntu_python3_quantization_gpu() {
 unittest_ubuntu_cpu_scala() {
     set -ex
     make scalapkg USE_BLAS=openblas USE_DIST_KVSTORE=1 ENABLE_TESTCOVERAGE=1
-    make scalaunittest USE_BLAS=openblas USE_DIST_KVSTORE=1
+    make scalaunittest USE_BLAS=openblas USE_DIST_KVSTORE=1 ENABLE_TESTCOVERAGE=1
 }
 
 unittest_ubuntu_cpu_clojure() {
     set -ex
     make scalapkg USE_OPENCV=1 USE_BLAS=openblas USE_DIST_KVSTORE=1 ENABLE_TESTCOVERAGE=1
-    make scalainstall USE_OPENCV=1 USE_BLAS=openblas USE_DIST_KVSTORE=1
+    make scalainstall USE_OPENCV=1 USE_BLAS=openblas USE_DIST_KVSTORE=1 ENABLE_TESTCOVERAGE=1
     ./contrib/clojure-package/ci-test.sh
 }
 
@@ -889,7 +889,7 @@ integrationtest_ubuntu_cpu_dist_kvstore() {
 integrationtest_ubuntu_gpu_scala() {
     set -ex
     make scalapkg USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 USE_DIST_KVSTORE=1 SCALA_ON_GPU=1 ENABLE_TESTCOVERAGE=1
-    make scalaintegrationtest USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 SCALA_TEST_ON_GPU=1 USE_DIST_KVSTORE=1
+    make scalaintegrationtest USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 SCALA_TEST_ON_GPU=1 USE_DIST_KVSTORE=1 ENABLE_TESTCOVERAGE=1
 }
 
 integrationtest_ubuntu_gpu_dist_kvstore() {

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -245,6 +245,7 @@ build_centos7_cpu() {
     make \
         DEV=1 \
         USE_LAPACK=1 \
+        ENABLE_TESTCOVERAGE=1 \
         USE_LAPACK_PATH=/usr/lib64/liblapack.so \
         USE_BLAS=openblas \
         USE_DIST_KVSTORE=1 \
@@ -277,6 +278,7 @@ build_centos7_mkldnn() {
 
     make \
         DEV=1 \
+        ENABLE_TESTCOVERAGE=1 \
         USE_LAPACK=1 \
         USE_LAPACK_PATH=/usr/lib64/liblapack.so \
         USE_MKLDNN=1 \
@@ -291,6 +293,7 @@ build_centos7_gpu() {
     # build_ccache_wrappers
     make \
         DEV=1 \
+        ENABLE_TESTCOVERAGE=1 \
         USE_LAPACK=1 \
         USE_LAPACK_PATH=/usr/lib64/liblapack.so \
         USE_BLAS=openblas \
@@ -311,6 +314,7 @@ build_ubuntu_cpu_openblas() {
     export CXX="ccache g++"
     make \
         DEV=1                         \
+        ENABLE_TESTCOVERAGE=1         \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_DIST_KVSTORE=1            \
@@ -371,6 +375,7 @@ build_ubuntu_cpu_clang39() {
     export CC=clang-3.9
      build_ccache_wrappers
      make \
+        ENABLE_TESTCOVERAGE=1         \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_OPENMP=0                  \
@@ -387,6 +392,7 @@ build_ubuntu_cpu_clang60() {
     build_ccache_wrappers
 
     make  \
+        ENABLE_TESTCOVERAGE=1         \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_OPENMP=1                  \
@@ -429,6 +435,7 @@ build_ubuntu_cpu_clang39_mkldnn() {
     build_ccache_wrappers
 
     make \
+        ENABLE_TESTCOVERAGE=1         \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
@@ -445,6 +452,7 @@ build_ubuntu_cpu_clang60_mkldnn() {
     build_ccache_wrappers
 
     make \
+        ENABLE_TESTCOVERAGE=1         \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
@@ -459,6 +467,7 @@ build_ubuntu_cpu_mkldnn() {
 
     make  \
         DEV=1                         \
+        ENABLE_TESTCOVERAGE=1         \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
@@ -510,6 +519,7 @@ build_ubuntu_gpu_tensorrt() {
     rm -rf build
     make \
         DEV=1                                               \
+        ENABLE_TESTCOVERAGE=1                               \
         USE_BLAS=openblas                                   \
         USE_CUDA=1                                          \
         USE_CUDA_PATH=/usr/local/cuda                       \
@@ -531,6 +541,7 @@ build_ubuntu_gpu_mkldnn() {
 
     make  \
         DEV=1                         \
+        ENABLE_TESTCOVERAGE=1         \
         USE_CPP_PACKAGE=1             \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
@@ -547,6 +558,7 @@ build_ubuntu_gpu_mkldnn_nocudnn() {
 
     make  \
         DEV=1                         \
+        ENABLE_TESTCOVERAGE=1         \
         USE_BLAS=openblas             \
         USE_MKLDNN=1                  \
         USE_CUDA=1                    \
@@ -561,6 +573,7 @@ build_ubuntu_gpu_cuda91_cudnn7() {
     # build_ccache_wrappers
     make \
         DEV=1                         \
+        ENABLE_TESTCOVERAGE=1         \
         USE_BLAS=openblas             \
         USE_CUDA=1                    \
         USE_CUDA_PATH=/usr/local/cuda \
@@ -574,14 +587,19 @@ build_ubuntu_amalgamation() {
     set -ex
     # Amalgamation can not be run with -j nproc
     make -C amalgamation/ clean
-    make -C amalgamation/ USE_BLAS=openblas
+    make -C amalgamation/     \
+        USE_BLAS=openblas     \
+        ENABLE_TESTCOVERAGE=1
 }
 
 build_ubuntu_amalgamation_min() {
     set -ex
     # Amalgamation can not be run with -j nproc
     make -C amalgamation/ clean
-    make -C amalgamation/ USE_BLAS=openblas MIN=1
+    make -C amalgamation/     \
+        USE_BLAS=openblas     \
+        MIN=1                 \
+        ENABLE_TESTCOVERAGE=1
 }
 
 build_ubuntu_gpu_cmake_mkldnn() {
@@ -772,7 +790,10 @@ unittest_ubuntu_cpu_R() {
     mkdir -p ~/.R/
     echo  "MAKEFLAGS = -j"$(nproc) > ~/.R/Makevars
     # make -j not supported
-    make rpkg USE_BLAS=openblas R_LIBS=/tmp/r-site-library
+    make rpkg                           \
+        USE_BLAS=openblas               \
+        R_LIBS=/tmp/r-site-library
+
     R CMD INSTALL --library=/tmp/r-site-library R-package
     make rpkgtest R_LIBS=/tmp/r-site-library
 }
@@ -784,7 +805,9 @@ unittest_ubuntu_gpu_R() {
     mkdir -p ~/.R/
     echo  "MAKEFLAGS = -j"$(nproc) > ~/.R/Makevars
     # make -j not supported
-    make rpkg USE_BLAS=openblas R_LIBS=/tmp/r-site-library
+    make rpkg                           \
+        USE_BLAS=openblas               \
+        R_LIBS=/tmp/r-site-library
     R CMD INSTALL --library=/tmp/r-site-library R-package
     make rpkgtest R_LIBS=/tmp/r-site-library R_GPU_ENABLE=1
 }

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -257,6 +257,7 @@ build_amzn_linux_cpu() {
     cmake \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DENABLE_TESTCOVERAGE=ON \
         -DUSE_CUDA=OFF\
         -DUSE_OPENCV=ON\
         -DUSE_OPENMP=ON\
@@ -328,6 +329,7 @@ build_ubuntu_cpu_cmake_debug() {
     cmake \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DENABLE_TESTCOVERAGE=ON \
         -DUSE_CUDA=OFF \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DUSE_OPENMP=OFF \
@@ -608,6 +610,7 @@ build_ubuntu_gpu_cmake_mkldnn() {
     cmake \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DENABLE_TESTCOVERAGE=ON   \
         -DUSE_CUDA=1               \
         -DUSE_CUDNN=1              \
         -DUSE_MKLML_MKL=1          \
@@ -628,6 +631,7 @@ build_ubuntu_gpu_cmake() {
     cmake \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DENABLE_TESTCOVERAGE=ON   \
         -DUSE_CUDA=1               \
         -DUSE_CUDNN=1              \
         -DUSE_MKLML_MKL=0          \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -766,13 +766,13 @@ unittest_ubuntu_python3_quantization_gpu() {
 
 unittest_ubuntu_cpu_scala() {
     set -ex
-    make scalapkg USE_BLAS=openblas USE_DIST_KVSTORE=1
+    make scalapkg USE_BLAS=openblas USE_DIST_KVSTORE=1 ENABLE_TESTCOVERAGE=1
     make scalaunittest USE_BLAS=openblas USE_DIST_KVSTORE=1
 }
 
 unittest_ubuntu_cpu_clojure() {
     set -ex
-    make scalapkg USE_OPENCV=1 USE_BLAS=openblas USE_DIST_KVSTORE=1
+    make scalapkg USE_OPENCV=1 USE_BLAS=openblas USE_DIST_KVSTORE=1 ENABLE_TESTCOVERAGE=1
     make scalainstall USE_OPENCV=1 USE_BLAS=openblas USE_DIST_KVSTORE=1
     ./contrib/clojure-package/ci-test.sh
 }
@@ -888,7 +888,7 @@ integrationtest_ubuntu_cpu_dist_kvstore() {
 
 integrationtest_ubuntu_gpu_scala() {
     set -ex
-    make scalapkg USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 USE_DIST_KVSTORE=1 SCALA_ON_GPU=1
+    make scalapkg USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 USE_DIST_KVSTORE=1 SCALA_ON_GPU=1 ENABLE_TESTCOVERAGE=1
     make scalaintegrationtest USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 SCALA_TEST_ON_GPU=1 USE_DIST_KVSTORE=1
 }
 


### PR DESCRIPTION
This PR adds coverage metrics for the C++ backend. 

Something to verify at a later stage: Compare coverage result of optimized builds with non-optimized: https://github.com/pyarmak/cmake-gtest-coverage-example/blob/master/cmake/modules/CodeCoverage.cmake