### PR TITLE
ONNX export: Fully connected operator w/o bias, ReduceSum, Square

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2086,7 +2086,31 @@ def convert_power(node, **kwargs):
         "Pow",
         [input_node_a, input_node_b],
         [name],
-        name=None
+        name=name
+    )
+    return [node]
+
+@mx_op.register("broadcast_power")
+def convert_broadcast_power(node, **kwargs):
+    """Map MXNet's _power operator attributes to onnx's Pow operator
+    and return the created node.
+    """
+    onnx = import_onnx_modules()
+    name = node["name"]
+    proc_nodes = kwargs["proc_nodes"]
+    inputs = node["inputs"]
+
+    input_node_a_id = kwargs["index_lookup"][inputs[0][0]]
+    input_node_b_id = kwargs["index_lookup"][inputs[1][0]]
+
+    input_node_a = proc_nodes[input_node_a_id].name
+    input_node_b = proc_nodes[input_node_b_id].name
+
+    node = onnx.helper.make_node(
+        "Pow",
+        [input_node_a, input_node_b],
+        [name],
+        name=name
     )
     return [node]
 

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -127,6 +127,14 @@ def convert_string_to_list(string_val):
 
     return result_list
 
+def get_boolean_attribute_value(attrs, attr_name):
+    """ Helper function to convert a string version
+    of Boolean attributes to integer for ONNX.
+    Takes attribute dictionary and attr_name as
+    parameters.
+    """
+    return 1 if attrs.get(attr_name, 0) in ["True", "1"] else 0
+
 @mx_op.register("null")
 def convert_weights_and_inputs(node, **kwargs):
     """Helper function to convert weights and inputs.
@@ -587,10 +595,8 @@ def convert_dot(node, **kwargs):
     trans_a_node = None
     trans_b_node = None
 
-    trans_a = 1 if ("transpose_a" in attrs) and \
-                   attrs.get("transpose_a") in ["True", "1"] else 0
-    trans_b = 1 if ("transpose_b" in attrs) and \
-                   attrs.get("transpose_b") in ["True", "1"] else 0
+    trans_a = get_boolean_attribute_value(attrs, "transpose_a")
+    trans_b = get_boolean_attribute_value(attrs, "transpose_b")
 
     op_name = "transpose" + str(kwargs["idx"])
     create_helper_trans_node(op_name, input_node_a, 'a')
@@ -732,8 +738,8 @@ def convert_pooling(node, **kwargs):
     kernel = eval(attrs["kernel"])
     pool_type = attrs["pool_type"]
     stride = eval(attrs["stride"]) if attrs.get("stride") else None
-    global_pool = True if "global_pool" in attrs and\
-                          attrs.get("global_pool") == "True" else False
+    global_pool = get_boolean_attribute_value(attrs, "global_pool")
+
     node_inputs = node["inputs"]
     input_node_idx = kwargs["index_lookup"][node_inputs[0][0]]
     input_node = proc_nodes[input_node_idx]

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -534,10 +534,15 @@ def squareroot(attrs, inputs, proto_obj):
 def power(attrs, inputs, proto_obj):
     """Returns element-wise result of base element raised to powers from exp element."""
     new_attrs = translation_utils._fix_attribute_names(attrs, {'exponent':'exp'})
-    if 'broadcast' in attrs and attrs['broadcast'] == 1:
+    if 'broadcast' in attrs:
         new_attrs = translation_utils._remove_attributes(new_attrs, ['broadcast'])
-        return 'broadcast_power', new_attrs, inputs
-    return 'pow', new_attrs, inputs
+        if attrs['broadcast'] == 1:
+            return 'broadcast_power', new_attrs, inputs
+        else:
+            mxnet_op = symbol.pow(inputs[0], inputs[1])
+            return mxnet_op, new_attrs, inputs
+    mxnet_op = symbol.broadcast_power(inputs[0], inputs[1])
+    return mxnet_op, new_attrs, inputs
 
 def exponent(attrs, inputs, proto_obj):
     """Elementwise exponent of input array."""

--- a/tests/python-pytest/onnx/export/onnx_backend_test.py
+++ b/tests/python-pytest/onnx/export/onnx_backend_test.py
@@ -64,6 +64,8 @@ IMPLEMENTED_OPERATORS_TEST = [
     'test_reduce_max',
     'test_reduce_mean',
     'test_reduce_prod',
+    'test_reduce_sum_d',
+    'test_reduce_sum_keepdims_random',
     'test_squeeze',
     'test_softmax_example',
     'test_softmax_large_number',


### PR DESCRIPTION
## Description ##
Fully connected operator can be used with no bias. When bias is not specified, making use of bias 0. 
Enabling export of Square operator and Sum operator

v2: Based on @zhreshold's inputs, added a helper function to convert bool (string) attrs to int
v3: Addressed @Roshrini's and @anirudhacharya's review comments
v4: Added Roshani's commit for importing square operator. Added a test for square operator.
v5: Removed import square based on an offline discussion. Instead, based on Roshani's suggestion, modified existing import of Power operator to be compatible with all versions of ONNX's Pow operator.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- create a bias tensor with default value 0 when no_bias=True
- Export mx.sym.Square using Power operator in ONNX
- Export mx.sym.Sum using ReduceSum operator in ONNX
- Added tests for ReduceSum

## Comments ##
- tested with a test model which has both types of nodes - fully connected with bias and fully connected without bias.
- Tested onnx_backend_test.py
