### PR TITLE
Add documents for two new environment variables for memory pool.

### DIFF
--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -58,6 +58,15 @@ $env:MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
   - Values: Int ```(default=5)```
   - The percentage of GPU memory to reserve for things other than the GPU array, such as kernel launch or cudnn handle space.
   - If you see a strange out-of-memory error from the kernel launch, after multiple iterations, try setting this to a larger value.  
+* MXNET_GPU_MEM_POOL_TYPE
+  - Values: String ```(default=Naive)```
+  - The type of memory pool.
+  - Choices:
+    - Naive: A simple memory pool that allocates memory for the exact requested size and cache memory buffers. If the buffered memory match the requested size, the memory will be returned from the pool in memory allocation.
+    - Round: A memory pool that always rounds the requested memory size and allocates memory of the rounded size. MXNET_GPU_MEM_POOL_ROUND_LINEAR_CUTOFF defines how to round up a memory size. Caching and allocating buffered memory works in the same way as the naive memory pool.
+* MXNET_GPU_MEM_POOL_ROUND_LINEAR_CUTOFF
+  - Values: Int ```(default=24)```
+  - The threshold that decides the rounding strategy. If the memory size is smaller than the threshold, it rounds to the smallest 2^n; if the memory size is larger than the threshold, it rounds to the next k * 2^CUTOFF.
 
 ## Engine Type
 

--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -66,7 +66,7 @@ $env:MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
     - Round: A memory pool that always rounds the requested memory size and allocates memory of the rounded size. MXNET_GPU_MEM_POOL_ROUND_LINEAR_CUTOFF defines how to round up a memory size. Caching and allocating buffered memory works in the same way as the naive memory pool.
 * MXNET_GPU_MEM_POOL_ROUND_LINEAR_CUTOFF
   - Values: Int ```(default=24)```
-  - The threshold that decides the rounding strategy. If the memory size is smaller than the threshold, it rounds to the smallest 2^n; if the memory size is larger than the threshold, it rounds to the next k * 2^CUTOFF.
+  - The cutoff threshold that decides the rounding strategy. Let's denote the threshold as T. If the memory size is smaller than `2^T`, it rounds to the smallest `2^n` that is larger than the requested memory size; if the memory size is larger than `2^T`, it rounds to the next k * 2^T.
 
 ## Engine Type
 

--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -62,11 +62,11 @@ $env:MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
   - Values: String ```(default=Naive)```
   - The type of memory pool.
   - Choices:
-    - Naive: A simple memory pool that allocates memory for the exact requested size and cache memory buffers. If the buffered memory match the requested size, the memory will be returned from the pool in memory allocation.
+    - Naive: A simple memory pool that allocates memory for the exact requested size and cache memory buffers. If a buffered memory chunk matches the size of a new request, the chunk from the memory pool will be returned and reused.
     - Round: A memory pool that always rounds the requested memory size and allocates memory of the rounded size. MXNET_GPU_MEM_POOL_ROUND_LINEAR_CUTOFF defines how to round up a memory size. Caching and allocating buffered memory works in the same way as the naive memory pool.
 * MXNET_GPU_MEM_POOL_ROUND_LINEAR_CUTOFF
   - Values: Int ```(default=24)```
-  - The cutoff threshold that decides the rounding strategy. Let's denote the threshold as T. If the memory size is smaller than `2^T`, it rounds to the smallest `2^n` that is larger than the requested memory size; if the memory size is larger than `2^T`, it rounds to the next k * 2^T.
+  - The cutoff threshold that decides the rounding strategy. Let's denote the threshold as T. If the memory size is smaller than `2 ** T` (by default, it's 2 ** 24 = 16MB), it rounds to the smallest `2 ** n` that is larger than the requested memory size; if the memory size is larger than `2 ** T`, it rounds to the next k * 2 ** T.
 
 ## Engine Type
 


### PR DESCRIPTION
## Description ##
This documents two new environment variables for memory pool: MXNET_GPU_MEM_POOL_TYPE and MXNET_GPU_MEM_POOL_ROUND_LINEAR_CUTOFF.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
