### PR TITLE
[MXNET-995] Constant Initializer for ND Array

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -869,7 +869,7 @@ fixed-size items.
         source_array = np.ascontiguousarray(source_array, dtype=self.dtype)
         if source_array.shape != self.shape:
             raise ValueError('Shape inconsistent: expected %s vs got %s'%(
-                str(self.shape), str(source_array.shape)))
+                str(source_array.shape), str(self.shape)))
         check_call(_LIB.MXNDArraySyncCopyFromCPU(
             self.handle,
             source_array.ctypes.data_as(ctypes.c_void_p),
@@ -2479,6 +2479,8 @@ def array(source_array, ctx=None, dtype=None):
     if isinstance(source_array, NDArray):
         dtype = source_array.dtype if dtype is None else dtype
     else:
+        if isinstance(source_array,(float,int)):
+            source_array=[float(source_array)]
         dtype = mx_real_t if dtype is None else dtype
         if not isinstance(source_array, np.ndarray):
             try:

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -2479,8 +2479,8 @@ def array(source_array, ctx=None, dtype=None):
     if isinstance(source_array, NDArray):
         dtype = source_array.dtype if dtype is None else dtype
     else:
-        if isinstance(source_array,(float,int)):
-            source_array=[float(source_array)]
+        if isinstance(source_array, (float, int)):
+            source_array = [float(source_array)]
         dtype = mx_real_t if dtype is None else dtype
         if not isinstance(source_array, np.ndarray):
             try:

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1471,6 +1471,24 @@ def test_dlpack():
             mx.test_utils.assert_almost_equal(a_np, d_np)
             mx.test_utils.assert_almost_equal(a_np, e_np)
 
+@with_seed()
+def test_ndarray_constant_init():
+    # a=mx.nd.array([1])
+    a=mx.nd.array(9)
+    assert(isinstance(a,mx.nd.NDArray))    
+
+@with_seed()
+def test_symbol_constant_init():
+    # a=mx.nd.array([1])
+    a = mx.sym.Variable('a')
+    b = mx.sym.Variable('b')
+    c = a * b
+    d = c.eval(a=mx.nd.array(2),b=mx.nd.array(3))
+    assert(isinstance(d[0],mx.nd.NDArray))
+    e = c.bind(mx.cpu(),args=[mx.nd.array(2),mx.nd.array(3)])
+    f = e.forward()
+    assert(isinstance(f[0],mx.nd.NDArray))
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1485,7 +1485,7 @@ def test_symbol_constant_init():
     c = a * b
     d = c.eval(a=mx.nd.array(2),b=mx.nd.array(3))
     assert(isinstance(d[0],mx.nd.NDArray))
-    e = c.bind(mx.cpu(),args=[mx.nd.array(2),mx.nd.array(3)])
+    e = c.bind(ctx=mx.cpu(),args=[mx.nd.array(2),mx.nd.array(3)])
     f = e.forward()
     assert(isinstance(f[0],mx.nd.NDArray))
 


### PR DESCRIPTION
## Description ##
Allows 1D (constant) to be used to initialize an NDArray or Symbol
Fixes #12672 and #12676 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Checks if the input is a scalar of the type int/float and converts it into a list for NDArray
- [ ] Unit test for checking initialization with NDArray as well as Symbol API (using bind and eval functions)
- [ ] Mismatch of the Value error shapes changed