### PR TITLE
Fix https://github.com/apache/incubator-mxnet/issues/12672

### DIFF
--- a/amalgamation/python/mxnet_predict.py
+++ b/amalgamation/python/mxnet_predict.py
@@ -163,7 +163,7 @@ class Predictor(object):
         for k, v in kwargs.items():
             if not isinstance(v, np.ndarray):
                 raise ValueError("Expect numpy ndarray as input")
-            v = np.ascontiguousarray(v, dtype=np.float32)
+            v = np.asarray(v, dtype=np.float32, order='C')
             _check_call(_LIB.MXPredSetInput(
                 self.handle, c_str(k),
                 v.ctypes.data_as(mx_float_p),

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -866,7 +866,7 @@ fixed-size items.
             except:
                 raise TypeError('array must consist of array-like data,' +
                                 'type %s is not supported' % str(type(array)))
-        source_array = np.ascontiguousarray(source_array, dtype=self.dtype)
+        source_array = np.asarray(source_array, dtype=self.dtype, order='C')
         if source_array.shape != self.shape:
             raise ValueError('Shape inconsistent: expected %s vs got %s'%(
                 str(self.shape), str(source_array.shape)))

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -753,7 +753,7 @@ def numeric_grad(executor, location, aux_states=None, eps=1e-4,
         if stype == 'default':
             executor.arg_dict[k][:] = as_stype(v, stype, dtype=dtype)
     for k in location:
-        location[k] = np.ascontiguousarray(location[k])
+        location[k] = np.asarray(location[k], order='C')
     for k, v in location.items():
         if v.dtype.kind != 'f':
             continue

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -118,6 +118,14 @@ def test_ndarray_setitem():
     x_np[:, -3:-1, -2:-1] = 1
     assert same(x.asnumpy(), x_np)
 
+    # numpy assignment for empty axis
+    for trivial_shape in [(), (1), (1, 1), (1, 1, 1)]:
+        x = mx.nd.zeros(trivial_shape)
+        x[:] = np.ones(trivial_shape)
+        x_np = np.ones(trivial_shape, dtype=x.dtype)
+        assert x.shape == trivial_shape
+        assert same(x.asnumpy(), x_np)
+
 
 @with_seed()
 def test_ndarray_elementwise():
@@ -215,6 +223,13 @@ def test_ndarray_onehot():
         npy[np.arange(shape[0]), indices] = 1.0
         mx.nd.onehot_encode(mx.nd.array(indices), out=arr)
         assert same(npy, arr.asnumpy())
+
+
+def test_init_from_scalar():
+    npy = np.ones([])
+    arr = mx.nd.array(npy)
+    assert arr.shape == ()
+    assert same(npy, arr.asnumpy())
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##

Problem that caused #12672 is in using np.ascontiguousarray,
which is buggy for zero-dimensional arrays
(see https://github.com/numpy/numpy/issues/5300 for details and discussion).

Here I use the solution proposed by numpy team:
switch to `np.asarray` with `order='C'`.


### Essentials ###

- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

- use `np.asarray` instead of `np.ascontiguousarray`, tests added for indexing and for init.
