### PR TITLE
[WIP] Search update 

### DIFF
--- a/docs/_static/js/docversion.js
+++ b/docs/_static/js/docversion.js
@@ -1,5 +1,5 @@
 function setVersion(){
-        let doc = window.location.pathname.match(/^\/(api\/.*)$/) || window.location.pathname.match(/^\/versions\/[^*]+\/(api\/.*)$/);
+        let doc = window.location.pathname.match(/^\/versions\/[0-9.master]+\/([^*]+.*)$/);
         if (doc) {
             if (document.getElementById('dropdown-menu-position-anchor-version')) {
                     versionNav = $('#dropdown-menu-position-anchor-version a.main-nav-link');
@@ -7,11 +7,11 @@ function setVersion(){
                             currLink = $( el ).attr('href');
                             version = currLink.match(/\/versions\/([0-9.master]+)\//);
                             if (version) {
-                                    versionedDoc = '/versions/' + version[1] + '/' + doc[1] + (window.location.hash || '');
+                                    versionedDoc = '/versions/' + version[1] + '/' + doc[1] + (window.location.hash || '') + (window.location.search || '');
                                     $( el ).attr('href', versionedDoc);
                             }
                     });
-            }        
+            }
         }
 }
 

--- a/docs/_static/searchtools_custom.js
+++ b/docs/_static/searchtools_custom.js
@@ -570,7 +570,7 @@ var Search = {
         }
         Search.title.text(_('Search Results'));
         if (!resultCount)
-          Search.status.text(_('Your search did not match any documents. Please make sure that all words are spelled correctly and that you\'ve selected enough categories.'));
+          Search.status.text(_('Your search did not match any documents in this version of the documentation. You can use the dropdown selector in the navigation bar to try another version. Please make sure that all words are spelled correctly and that you\'ve selected enough categories.'));
         else
             Search.status.text(_('Search finished, found %s page(s) matching the search query.').replace('%s', resultCount));
         Search.status.fadeIn(500);

--- a/docs/build_version_doc/artifacts/.htaccess
+++ b/docs/build_version_doc/artifacts/.htaccess
@@ -1,28 +1,32 @@
 RewriteEngine on
-RewriteRule ^get_started/why_mxnet.html$ /faq/why_mxnet.html [R=301,L]
-RewriteRule ^get_started.*$ /install/ [R=301,L]
-RewriteRule ^how_to.*$ /faq/ [R=301,L]
-RewriteRule ^api/python/symbol.html$ /api/python/symbol/symbol.html [R=301,L]
-RewriteRule ^community/index.html$ /community/contribute.html [R=301,L]
+RewriteRule .* - [E=default_version:/versions/master]
+RewriteRule ^get_started/why_mxnet.html$ %{ENV:default_version}/faq/why_mxnet.html [R=301,L]
+RewriteRule ^get_started.*$ %{ENV:default_version}/install/ [R=301,L]
+#RewriteRule ^get_started.*$ versions/master/install [R=301,L]
+RewriteRule ^how_to.*$ %{ENV:default_version}/faq/ [R=301,L]
+RewriteRule ^api/python/symbol.html$ %{ENV:default_version}/api/python/symbol/symbol.html [R=301,L]
+RewriteRule ^community/index.html$ %{ENV:default_version}/community/contribute.html [R=301,L]
 
 # Navigation bar redirects to latest info
-RewriteRule ^versions/[^\/]+/architecture/.*$ /architecture/ [R=301,L]
-RewriteRule ^versions/[^\/]+/community/.*$ /community/ [R=301,L]
-RewriteRule ^versions/[^\/]+/faq/.*$ /faq/ [R=301,L]
-RewriteRule ^versions/[^\/]+/gluon/.*$ /gluon/ [R=301,L]
-RewriteRule ^versions/[^\/]+/install/.*$ /install/ [R=301,L]
-RewriteRule ^versions/[^\/]+/tutorials/(.*)$ /tutorials/$1 [R=301,L]
+RewriteRule ^versions\/[0-9.]+\/architecture/(.*)$ %{ENV:default_version}/architecture/$1 [R=301,L]
+RewriteRule ^versions\/[0-9.]+\/community/(.*)$ %{ENV:default_version}/community/$1 [R=301,L]
+RewriteRule ^versions\/[0-9.]+\/faq/(.*)$ %{ENV:default_version}/faq/$1 [R=301,L]
+RewriteRule ^versions\/[0-9.]+\/gluon/(.*)$ %{ENV:default_version}/gluon/$1 [R=301,L]
+RewriteRule ^versions\/[0-9.]+\/install/(.*)$ %{ENV:default_version}/install/$1 [R=301,L]
+RewriteRule ^versions\/[0-9.]+\/tutorials/(.*)$ %{ENV:default_version}/tutorials/$1 [R=301,L]
 
 # Redirect navbar APIs that did not exist
-RewriteRule ^versions/0.11.0/api/python/contrib/onnx.html /error/api.html [R=301,L]
-RewriteRule ^versions/0.12.1/api/python/contrib/onnx.html /error/api.html [R=301,L]
-RewriteRule ^versions/1.0.0/api/python/contrib/onnx.html /error/api.html [R=301,L]
-RewriteRule ^versions/1.1.0/api/python/contrib/onnx.html /error/api.html [R=301,L]
+RewriteRule ^versions/0.11.0/api/python/contrib/onnx.html %{ENV:default_version}/error/api.html [R=301,L]
+RewriteRule ^versions/0.12.1/api/python/contrib/onnx.html %{ENV:default_version}/error/api.html [R=301,L]
+RewriteRule ^versions/1.0.0/api/python/contrib/onnx.html %{ENV:default_version}/error/api.html [R=301,L]
+RewriteRule ^versions/1.1.0/api/python/contrib/onnx.html %{ENV:default_version}/error/api.html [R=301,L]
 
-RewriteRule ^versions/0.11.0/api/clojure/.*$ /error/api.html [R=301,L]
-RewriteRule ^versions/0.12.1/api/clojure/.*$ /error/api.html [R=301,L]
-RewriteRule ^versions/1.0.0/api/clojure/.*$ /error/api.html [R=301,L]
-RewriteRule ^versions/1.1.0/api/clojure/.*$ /error/api.html [R=301,L]
-RewriteRule ^versions/1.2.1/api/clojure/.*$ /error/api.html [R=301,L]
+RewriteRule ^versions/0.11.0/api/clojure/.*$ %{ENV:default_version}/error/api.html [R=301,L]
+RewriteRule ^versions/0.12.1/api/clojure/.*$ %{ENV:default_version}/error/api.html [R=301,L]
+RewriteRule ^versions/1.0.0/api/clojure/.*$ %{ENV:default_version}/error/api.html [R=301,L]
+RewriteRule ^versions/1.1.0/api/clojure/.*$ %{ENV:default_version}/error/api.html [R=301,L]
+RewriteRule ^versions/1.2.1/api/clojure/.*$ %{ENV:default_version}/error/api.html [R=301,L]
 
+# Redirect any root requests to the default version
+RewriteRule ^(?!versions\/[0-9.master]+\/)(.*)$ %{ENV:default_version}/$1 [R=301,NC,L]
 ErrorDocument 404 https://mxnet.incubator.apache.org/error/404.html


### PR DESCRIPTION
## Description ##
This PR improves version switching on the website. The new feature helps with searching for APIs mostly, but can also work for pages you're searching for that exist in different versions.

The current version selector will kick you to the home page from the search page. I fixed this behavior for the API section of the docs last week, but thought fixing search would be a big UX improvement too.

It's generalized now too. 
* It should work for any section of the site. 
* It should retain both bookmarks `#` and query strings `?`.
* It is overridden by the .htaccess file, so sections like tutorials will still always go to the latest.

**UPDATE**: To deal with requests to the root of the website, I updated the redirects to point to the default version. Right now this means any request to / will go to /versions/master. Or requests to /tutorials/xyz go to /versions/master/tutorials/xyz.

## Usage
As this is a javascript update, please be sure to clear your cache.
Let's say you're looking for `allreduce`, but for whatever reason you're on the v1.0.0 of the site (like coming in from Google):
http://34.201.8.176/versions/1.0.0/search.html?q=allreduce&check_keywords=yes&area=default#
You get no results, but you're prompted to use the versions dropdown.
So you choose 1.3.0:
http://34.201.8.176/versions/1.3.0/search.html?q=allreduce&check_keywords=yes&area=default
You get a result.

## Preview
![2018-09-27_16-15-22](https://user-images.githubusercontent.com/5974205/46179744-8ac41780-c271-11e8-8e3e-c6fe9702659d.gif)

## Comment
It would be awesome if the search fails we have it return other versions as suggestions, but I'm not that familiar yet with how Sphinx does its search magic... so that can be another day!

## Test Plan
@safrooze found a hole in the regex coverage, so I think it is worth identifying the various angles of entry and usage.
* Home page redirects to default version (master): http://34.201.8.176/
* Old deep links to resources are redirected to default version: http://34.201.8.176/tutorials
* Deep links to resources on specific versions are accepted: http://34.201.8.176/versions/1.2.1/tutorials/index.html (this is broken unfortunately, so back to the regexes)
