### PR TITLE
[MXNET-1001] Add new cuddn flag in Gluon Conv blocks to control - cudnn_tune, cudnn_off params

### DIFF
--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -38,7 +38,21 @@ def _infer_weight_shape(op_name, data_shape, kwargs):
     return sym.infer_shape_partial()[0]
 
 def _get_cuddn_controls(cudnn_flag):
-    assert cudnn in ('off', 'default', 'fastest', 'limited_workspace', 'global'),
+    """Prepare cudnn_tune, cudnn_off flags for sym and ndarray conv APIs
+    from given cudnn flags in Gluon Conv blocks.
+
+    Example: if cudnn_flag=limited_workspace, then returns,
+    cudnn_off=False, cudnn_tune='limited_workspace'
+
+    Parameters:
+    -----------
+    cudnn_flag : str
+        Supported flags - {'off', 'default', 'fastest', 'limited_workspace', 'global'}
+
+    Outputs:
+        - cudnn_off, cudnn_tune
+    """
+    assert cudnn in ('off', 'default', 'fastest', 'limited_workspace', 'global'), \
         "Invalid cudnn flag - '{0}' provided. \
         Supported options - ‘off’, 'default', ‘fastest’, ‘limited_workspace’, ‘global’".format(cudnn_flag)
     

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -52,7 +52,7 @@ def _get_cuddn_controls(cudnn_flag):
     Outputs:
         - cudnn_off, cudnn_tune
     """
-    assert cudnn_flag in ('off', 'default', 'fastest', 'limited_workspace', 'global'), \
+    assert cudnn_flag in ('off', 'default', 'fastest', 'limited_workspace', 'global', None), \
         "Invalid cudnn flag - '{0}' provided. \
         Supported options - 'off', 'default', \
         'fastest','limited_workspace', 'global'".format(cudnn_flag)
@@ -292,11 +292,10 @@ class Conv1D(_Conv):
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)
         assert len(kernel_size) == 1, "kernel_size must be a number or a list of 1 ints"
-        cudnn_off, cudnn_tune = _get_cuddn_controls(cudnn)
         super(Conv1D, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer, bias_initializer,
-            cudnn_tune, cudnn_off, **kwargs)
+            cudnn, **kwargs)
 
 
 class Conv2D(_Conv):
@@ -385,11 +384,10 @@ class Conv2D(_Conv):
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
         assert len(kernel_size) == 2, "kernel_size must be a number or a list of 2 ints"
-        cudnn_off, cudnn_tune = _get_cuddn_controls(cudnn)
         super(Conv2D, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer, bias_initializer,
-            cudnn_tune, cudnn_off, **kwargs)
+            cudnn, **kwargs)
 
 
 class Conv3D(_Conv):
@@ -477,11 +475,10 @@ class Conv3D(_Conv):
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3
         assert len(kernel_size) == 3, "kernel_size must be a number or a list of 3 ints"
-        cudnn_off, cudnn_tune = _get_cuddn_controls(cudnn)
         super(Conv3D, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer, bias_initializer,
-            cudnn_tune, cudnn_off, **kwargs)
+            cudnn, **kwargs)
 
 
 class Conv1DTranspose(_Conv):
@@ -573,11 +570,10 @@ class Conv1DTranspose(_Conv):
             output_padding = (output_padding,)
         assert len(kernel_size) == 1, "kernel_size must be a number or a list of 1 ints"
         assert len(output_padding) == 1, "output_padding must be a number or a list of 1 ints"
-        cudnn_off, cudnn_tune = _get_cuddn_controls(cudnn)
         super(Conv1DTranspose, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer,
-            bias_initializer, cudnn_tune, cudnn_off,
+            bias_initializer, cudnn,
             op_name='Deconvolution', adj=output_padding, **kwargs)
         self.outpad = output_padding
 
@@ -676,11 +672,10 @@ class Conv2DTranspose(_Conv):
             output_padding = (output_padding,)*2
         assert len(kernel_size) == 2, "kernel_size must be a number or a list of 2 ints"
         assert len(output_padding) == 2, "output_padding must be a number or a list of 2 ints"
-        cudnn_off, cudnn_tune = _get_cuddn_controls(cudnn)
         super(Conv2DTranspose, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer,
-            bias_initializer, cudnn_tune, cudnn_off,
+            bias_initializer, cudnn,
             op_name='Deconvolution', adj=output_padding, **kwargs)
         self.outpad = output_padding
 
@@ -781,11 +776,10 @@ class Conv3DTranspose(_Conv):
             output_padding = (output_padding,)*3
         assert len(kernel_size) == 3, "kernel_size must be a number or a list of 3 ints"
         assert len(output_padding) == 3, "output_padding must be a number or a list of 3 ints"
-        cudnn_off, cudnn_tune = _get_cuddn_controls(cudnn)
         super(Conv3DTranspose, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer, bias_initializer,
-            cudnn_tune, cudnn_off, op_name='Deconvolution',
+            cudnn, op_name='Deconvolution',
             adj=output_padding, **kwargs)
         self.outpad = output_padding
 

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -55,7 +55,7 @@ def _get_cuddn_controls(cudnn_flag):
     assert cudnn_flag in ('off', 'no_autotune', 'fastest', 'limited_workspace', 'default', None), \
         "Invalid cudnn flag - '{0}' provided. \
         Supported options - 'off', 'no_autotune', \
-        'fastest','limited_workspace', 'default'".format(cudnn_flag)
+        'fastest', 'limited_workspace', 'default'".format(cudnn_flag)
 
     # Default cudnn controls - Use cudnn and use limited_workspace tuning.
     cudnn_off = False

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -54,7 +54,8 @@ def _get_cuddn_controls(cudnn_flag):
     """
     assert cudnn_flag in ('off', 'default', 'fastest', 'limited_workspace', 'global'), \
         "Invalid cudnn flag - '{0}' provided. \
-        Supported options - ‘off’, 'default', ‘fastest’, ‘limited_workspace’, ‘global’".format(cudnn_flag)
+        Supported options - 'off', 'default', \
+        'fastest','limited_workspace', 'global'".format(cudnn_flag)
 
     # Default cudnn controls - Use cudnn and use limited_workspace tuning.
     cudnn_off = False
@@ -121,12 +122,12 @@ class _Conv(HybridBlock):
     bias_initializer: str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
+        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
-                           that doesn’t exceed workspace limit.
+                           that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
         global: Use cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
@@ -262,12 +263,12 @@ class Conv1D(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
+        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
-                           that doesn’t exceed workspace limit.
+                           that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
         global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
@@ -351,12 +352,12 @@ class Conv2D(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
+        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
-                           that doesn’t exceed workspace limit.
+                           that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
         global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
@@ -444,12 +445,12 @@ class Conv3D(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
+        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
-                           that doesn’t exceed workspace limit.
+                           that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
         global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
@@ -540,12 +541,12 @@ class Conv1DTranspose(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
+        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
-                           that doesn’t exceed workspace limit.
+                           that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
         global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
@@ -640,12 +641,12 @@ class Conv2DTranspose(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
+        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
-                           that doesn’t exceed workspace limit.
+                           that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
         global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
@@ -743,12 +744,12 @@ class Conv3DTranspose(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
+        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
-                           that doesn’t exceed workspace limit.
+                           that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
         global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -86,10 +86,15 @@ class _Conv(HybridBlock):
         Initializer for the `weight` weights matrix.
     bias_initializer: str or `Initializer`
         Initializer for the bias vector.
+    cudnn_tune: {None, 'fastest', 'limited_workspace', 'off'}, Optional, default='None'
+        Whether to pick convolution algo by running performance test.
+    cudnn_off: boolean, optional, default=False
+        Turn off cudnn for this layer.
     """
     def __init__(self, channels, kernel_size, strides, padding, dilation,
                  groups, layout, in_channels=0, activation=None, use_bias=True,
                  weight_initializer=None, bias_initializer='zeros',
+                 cudnn_tune=None, cudnn_off=False,
                  op_name='Convolution', adj=None, prefix=None, params=None):
         super(_Conv, self).__init__(prefix=prefix, params=params)
         with self.name_scope():
@@ -105,7 +110,8 @@ class _Conv(HybridBlock):
             self._kwargs = {
                 'kernel': kernel_size, 'stride': strides, 'dilate': dilation,
                 'pad': padding, 'num_filter': channels, 'num_group': groups,
-                'no_bias': not use_bias, 'layout': layout}
+                'no_bias': not use_bias, 'layout': layout,
+                'cudnn_tune': cudnn_tune, 'cudnn_off': cudnn_off}
             if adj is not None:
                 self._kwargs['adj'] = adj
 
@@ -215,6 +221,10 @@ class Conv1D(_Conv):
         Initializer for the `weight` weights matrix.
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
+    cudnn_tune: {None, 'fastest', 'limited_workspace', 'off'}, Optional, default='None'
+        Whether to pick convolution algo by running performance test.
+    cudnn_off: boolean, optional, default=False
+        Turn off cudnn for this layer.
 
 
     Inputs:
@@ -230,14 +240,15 @@ class Conv1D(_Conv):
     def __init__(self, channels, kernel_size, strides=1, padding=0, dilation=1,
                  groups=1, layout='NCW', activation=None, use_bias=True,
                  weight_initializer=None, bias_initializer='zeros',
-                 in_channels=0, **kwargs):
+                 in_channels=0, cudnn_tune=None, cudnn_off=False, **kwargs):
         assert layout == 'NCW', "Only supports 'NCW' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)
         assert len(kernel_size) == 1, "kernel_size must be a number or a list of 1 ints"
         super(Conv1D, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
-            in_channels, activation, use_bias, weight_initializer, bias_initializer, **kwargs)
+            in_channels, activation, use_bias, weight_initializer, bias_initializer,
+            cudnn_tune, cudnn_off, **kwargs)
 
 
 class Conv2D(_Conv):
@@ -292,6 +303,10 @@ class Conv2D(_Conv):
         Initializer for the `weight` weights matrix.
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
+    cudnn_tune: {None, 'fastest', 'limited_workspace', 'off'}, Optional, default='None'
+        Whether to pick convolution algo by running performance test.
+    cudnn_off: boolean, optional, default=False
+        Turn off cudnn for this layer.
 
 
     Inputs:
@@ -310,14 +325,16 @@ class Conv2D(_Conv):
     def __init__(self, channels, kernel_size, strides=(1, 1), padding=(0, 0),
                  dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
-                 bias_initializer='zeros', in_channels=0, **kwargs):
+                 bias_initializer='zeros', in_channels=0,
+                 cudnn_tune=None, cudnn_off=False, **kwargs):
         assert layout in ('NCHW', 'NHWC'), "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
         assert len(kernel_size) == 2, "kernel_size must be a number or a list of 2 ints"
         super(Conv2D, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
-            in_channels, activation, use_bias, weight_initializer, bias_initializer, **kwargs)
+            in_channels, activation, use_bias, weight_initializer, bias_initializer,
+            cudnn_tune, cudnn_off, **kwargs)
 
 
 class Conv3D(_Conv):
@@ -372,7 +389,10 @@ class Conv3D(_Conv):
         Initializer for the `weight` weights matrix.
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
-
+    cudnn_tune: {None, 'fastest', 'limited_workspace', 'off'}, Optional, default='None'
+        Whether to pick convolution algo by running the performance test.
+    cudnn_off: boolean, optional, default=False
+        Turn off cudnn for this layer.
 
     Inputs:
         - **data**: 5D input tensor with shape
@@ -391,14 +411,15 @@ class Conv3D(_Conv):
     def __init__(self, channels, kernel_size, strides=(1, 1, 1), padding=(0, 0, 0),
                  dilation=(1, 1, 1), groups=1, layout='NCDHW', activation=None,
                  use_bias=True, weight_initializer=None, bias_initializer='zeros',
-                 in_channels=0, **kwargs):
+                 in_channels=0, cudnn_tune=None, cudnn_off=False, **kwargs):
         assert layout in ('NCDHW', 'NDHWC'), "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3
         assert len(kernel_size) == 3, "kernel_size must be a number or a list of 3 ints"
         super(Conv3D, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
-            in_channels, activation, use_bias, weight_initializer, bias_initializer, **kwargs)
+            in_channels, activation, use_bias, weight_initializer, bias_initializer,
+            cudnn_tune, cudnn_off, **kwargs)
 
 
 class Conv1DTranspose(_Conv):
@@ -457,6 +478,10 @@ class Conv1DTranspose(_Conv):
         Initializer for the `weight` weights matrix.
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
+    cudnn_tune: {None, 'fastest', 'limited_workspace', 'off'}, Optional, default='None'
+        Whether to pick convolution algo by running performance test.
+    cudnn_off: boolean, optional, default=False
+        Turn off cudnn for this layer.
 
 
     Inputs:
@@ -472,7 +497,7 @@ class Conv1DTranspose(_Conv):
     def __init__(self, channels, kernel_size, strides=1, padding=0, output_padding=0,
                  dilation=1, groups=1, layout='NCW', activation=None, use_bias=True,
                  weight_initializer=None, bias_initializer='zeros',
-                 in_channels=0, **kwargs):
+                 in_channels=0, cudnn_tune=None, cudnn_off=False, **kwargs):
         assert layout == 'NCW', "Only supports 'NCW' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)
@@ -483,7 +508,8 @@ class Conv1DTranspose(_Conv):
         super(Conv1DTranspose, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer,
-            bias_initializer, op_name='Deconvolution', adj=output_padding, **kwargs)
+            bias_initializer, cudnn_tune, cudnn_off,
+            op_name='Deconvolution', adj=output_padding, **kwargs)
         self.outpad = output_padding
 
 
@@ -545,7 +571,10 @@ class Conv2DTranspose(_Conv):
         Initializer for the `weight` weights matrix.
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
-
+    cudnn_tune: {None, 'fastest', 'limited_workspace', 'off'}, Optional, default='None'
+        Whether to pick convolution algo by running performance test.
+    cudnn_off: boolean, optional, default=False
+        Turn off cudnn for this layer.
 
     Inputs:
         - **data**: 4D input tensor with shape
@@ -563,7 +592,8 @@ class Conv2DTranspose(_Conv):
     def __init__(self, channels, kernel_size, strides=(1, 1), padding=(0, 0),
                  output_padding=(0, 0), dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
-                 bias_initializer='zeros', in_channels=0, **kwargs):
+                 bias_initializer='zeros', in_channels=0,
+                 cudnn_tune=None, cudnn_off=False, **kwargs):
         assert layout in ('NCHW', 'NHWC'), "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
@@ -574,7 +604,8 @@ class Conv2DTranspose(_Conv):
         super(Conv2DTranspose, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer,
-            bias_initializer, op_name='Deconvolution', adj=output_padding, **kwargs)
+            bias_initializer, cudnn_true, cudnn_off,
+            op_name='Deconvolution', adj=output_padding, **kwargs)
         self.outpad = output_padding
 
 
@@ -636,6 +667,10 @@ class Conv3DTranspose(_Conv):
         Initializer for the `weight` weights matrix.
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
+    cudnn_tune: {None, 'fastest', 'limited_workspace', 'off'}, Optional, default='None'
+        Whether to pick convolution algo by running performance test.
+    cudnn_off: boolean, optional, default=False
+        Turn off cudnn for this layer.
 
 
     Inputs:
@@ -655,7 +690,8 @@ class Conv3DTranspose(_Conv):
     def __init__(self, channels, kernel_size, strides=(1, 1, 1), padding=(0, 0, 0),
                  output_padding=(0, 0, 0), dilation=(1, 1, 1), groups=1, layout='NCDHW',
                  activation=None, use_bias=True, weight_initializer=None,
-                 bias_initializer='zeros', in_channels=0, **kwargs):
+                 bias_initializer='zeros', in_channels=0,
+                 cudnn_tune=None, cudnn_off=False, **kwargs):
         assert layout in ('NCDHW', 'NDHWC'), "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3
@@ -666,7 +702,8 @@ class Conv3DTranspose(_Conv):
         super(Conv3DTranspose, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer, bias_initializer,
-            op_name='Deconvolution', adj=output_padding, **kwargs)
+            cudnn_tune, cudnn_off, op_name='Deconvolution',
+            adj=output_padding, **kwargs)
         self.outpad = output_padding
 
 

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -58,17 +58,16 @@ def _get_cuddn_controls(cudnn_flag):
     
     # Default cudnn controls - Use cudnn and use limited_workspace tuning.
     cudnn_off = False
-    cudnn_tune = 'limited_workspace'
+    cudnn_tune = None
 
     if cuddn_flag == 'off':
         cudnn_off = True
-        cudnn_tune = None
+    elif cudnn_flag == 'default':
+        cudnn_tune = 'off'
     elif cudnn_flag == 'fastest':
         cudnn_tune = 'fastest'
     elif cudnn_flag == 'limited_workspace':
         cudnn_tune = 'limited_workspace'
-    elif cudnn_flag == 'global':
-        cudnn_tune = None
 
     return cudnn_off, cudnn_tune
 
@@ -123,18 +122,18 @@ class _Conv(HybridBlock):
         Initializer for the bias vector.
     cudnn : str,
         Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
-        Optional, If you do not specificy anything, defaults to 'limited_workspace'.
+        Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
                            that doesn’t exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable 
+        global: Use cuddn. Use global cudnn behavior determined by the environment variable 
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
     """
     def __init__(self, channels, kernel_size, strides, padding, dilation,
                  groups, layout, in_channels=0, activation=None, use_bias=True,
-                 weight_initializer=None, bias_initializer='zeros', cudnn='limited_workspace',
+                 weight_initializer=None, bias_initializer='zeros', cudnn='global',
                  op_name='Convolution', adj=None, prefix=None, params=None):
         super(_Conv, self).__init__(prefix=prefix, params=params)
         with self.name_scope():
@@ -264,7 +263,7 @@ class Conv1D(_Conv):
         Initializer for the bias vector.
     cudnn : str,
         Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
-        Optional, If you do not specificy anything, defaults to 'limited_workspace'.
+        Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
@@ -287,7 +286,7 @@ class Conv1D(_Conv):
     def __init__(self, channels, kernel_size, strides=1, padding=0, dilation=1,
                  groups=1, layout='NCW', activation=None, use_bias=True,
                  weight_initializer=None, bias_initializer='zeros',
-                 in_channels=0, cudnn='limited_workspace', **kwargs):
+                 in_channels=0, cudnn='global', **kwargs):
         assert layout == 'NCW', "Only supports 'NCW' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)
@@ -353,7 +352,7 @@ class Conv2D(_Conv):
         Initializer for the bias vector.
     cudnn : str,
         Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
-        Optional, If you do not specificy anything, defaults to 'limited_workspace'.
+        Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
@@ -380,7 +379,7 @@ class Conv2D(_Conv):
                  dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0,
-                 cudnn='limited_workspace', **kwargs):
+                 cudnn='global', **kwargs):
         assert layout in ('NCHW', 'NHWC'), "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
@@ -446,7 +445,7 @@ class Conv3D(_Conv):
         Initializer for the bias vector.
     cudnn : str,
         Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
-        Optional, If you do not specificy anything, defaults to 'limited_workspace'.
+        Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
@@ -472,7 +471,7 @@ class Conv3D(_Conv):
     def __init__(self, channels, kernel_size, strides=(1, 1, 1), padding=(0, 0, 0),
                  dilation=(1, 1, 1), groups=1, layout='NCDHW', activation=None,
                  use_bias=True, weight_initializer=None, bias_initializer='zeros',
-                 in_channels=0, cudnn='limited_workspace', **kwargs):
+                 in_channels=0, cudnn='global', **kwargs):
         assert layout in ('NCDHW', 'NDHWC'), "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3
@@ -542,7 +541,7 @@ class Conv1DTranspose(_Conv):
         Initializer for the bias vector.
     cudnn : str,
         Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
-        Optional, If you do not specificy anything, defaults to 'limited_workspace'.
+        Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
@@ -565,7 +564,7 @@ class Conv1DTranspose(_Conv):
     def __init__(self, channels, kernel_size, strides=1, padding=0, output_padding=0,
                  dilation=1, groups=1, layout='NCW', activation=None, use_bias=True,
                  weight_initializer=None, bias_initializer='zeros',
-                 in_channels=0, cudnn='limited_workspace', **kwargs):
+                 in_channels=0, cudnn='global', **kwargs):
         assert layout == 'NCW', "Only supports 'NCW' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)
@@ -642,7 +641,7 @@ class Conv2DTranspose(_Conv):
         Initializer for the bias vector.
     cudnn : str,
         Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
-        Optional, If you do not specificy anything, defaults to 'limited_workspace'.
+        Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
@@ -668,7 +667,7 @@ class Conv2DTranspose(_Conv):
                  output_padding=(0, 0), dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0,
-                 cudnn='limited_workspace', **kwargs):
+                 cudnn='global', **kwargs):
         assert layout in ('NCHW', 'NHWC'), "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
@@ -745,7 +744,7 @@ class Conv3DTranspose(_Conv):
         Initializer for the bias vector.
     cudnn : str,
         Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
-        Optional, If you do not specificy anything, defaults to 'limited_workspace'.
+        Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
@@ -773,7 +772,7 @@ class Conv3DTranspose(_Conv):
                  output_padding=(0, 0, 0), dilation=(1, 1, 1), groups=1, layout='NCDHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0,
-                 cudnn='limited_workspace', **kwargs):
+                 cudnn='global', **kwargs):
         assert layout in ('NCDHW', 'NDHWC'), "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -47,15 +47,15 @@ def _get_cuddn_controls(cudnn_flag):
     Parameters:
     -----------
     cudnn_flag : str
-        Supported flags - {'off', 'default', 'fastest', 'limited_workspace', 'global'}
+        Supported flags - {'off', 'no_autotune', 'fastest', 'limited_workspace', 'default'}
 
     Outputs:
         - cudnn_off, cudnn_tune
     """
-    assert cudnn_flag in ('off', 'default', 'fastest', 'limited_workspace', 'global', None), \
+    assert cudnn_flag in ('off', 'no_autotune', 'fastest', 'limited_workspace', 'default', None), \
         "Invalid cudnn flag - '{0}' provided. \
-        Supported options - 'off', 'default', \
-        'fastest','limited_workspace', 'global'".format(cudnn_flag)
+        Supported options - 'off', 'no_autotune', \
+        'fastest','limited_workspace', 'default'".format(cudnn_flag)
 
     # Default cudnn controls - Use cudnn and use limited_workspace tuning.
     cudnn_off = False
@@ -63,7 +63,7 @@ def _get_cuddn_controls(cudnn_flag):
 
     if cudnn_flag == 'off':
         cudnn_off = True
-    elif cudnn_flag == 'default':
+    elif cudnn_flag == 'no_autotune':
         cudnn_tune = 'off'
     elif cudnn_flag == 'fastest':
         cudnn_tune = 'fastest'
@@ -122,19 +122,19 @@ class _Conv(HybridBlock):
     bias_initializer: str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
-        Optional, If you do not specificy anything, defaults to 'global'.
+        Supported values - {'off', 'no_autotune', 'fastest', 'limited_workspace', 'default'}.
+        Optional, If you do not specificy anything, defaults to 'default'.
         off: Do not use cudnn for this layer.
-        default: Use cudnn. Do not auto tune to choose the algorithm.
+        no_autotune: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use cuddn. Use global cudnn behavior determined by the environment variable
+        default: Use cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
     """
     def __init__(self, channels, kernel_size, strides, padding, dilation,
                  groups, layout, in_channels=0, activation=None, use_bias=True,
-                 weight_initializer=None, bias_initializer='zeros', cudnn='global',
+                 weight_initializer=None, bias_initializer='zeros', cudnn='default',
                  op_name='Convolution', adj=None, prefix=None, params=None):
         super(_Conv, self).__init__(prefix=prefix, params=params)
         with self.name_scope():
@@ -263,14 +263,14 @@ class Conv1D(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
-        Optional, If you do not specificy anything, defaults to 'global'.
+        Supported values - {'off', 'no_autotune', 'fastest', 'limited_workspace', 'default'}.
+        Optional, If you do not specificy anything, defaults to 'default'.
         off: Do not use cudnn for this layer.
-        default: Use cudnn. Do not auto tune to choose the algorithm.
+        no_autotune: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
+        default: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
 
@@ -287,7 +287,7 @@ class Conv1D(_Conv):
     def __init__(self, channels, kernel_size, strides=1, padding=0, dilation=1,
                  groups=1, layout='NCW', activation=None, use_bias=True,
                  weight_initializer=None, bias_initializer='zeros',
-                 in_channels=0, cudnn='global', **kwargs):
+                 in_channels=0, cudnn='default', **kwargs):
         assert layout == 'NCW', "Only supports 'NCW' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)
@@ -351,14 +351,14 @@ class Conv2D(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
-        Optional, If you do not specificy anything, defaults to 'global'.
+        Supported values - {'off', 'no_autotune', 'fastest', 'limited_workspace', 'default'}.
+        Optional, If you do not specificy anything, defaults to 'default'.
         off: Do not use cudnn for this layer.
-        default: Use cudnn. Do not auto tune to choose the algorithm.
+        no_autotune: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
+        default: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
 
@@ -379,7 +379,7 @@ class Conv2D(_Conv):
                  dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0,
-                 cudnn='global', **kwargs):
+                 cudnn='default', **kwargs):
         assert layout in ('NCHW', 'NHWC'), "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
@@ -443,14 +443,14 @@ class Conv3D(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
-        Optional, If you do not specificy anything, defaults to 'global'.
+        Supported values - {'off', 'no_autotune', 'fastest', 'limited_workspace', 'default'}.
+        Optional, If you do not specificy anything, defaults to 'default'.
         off: Do not use cudnn for this layer.
-        default: Use cudnn. Do not auto tune to choose the algorithm.
+        no_autotune: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
+        default: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
     Inputs:
@@ -470,7 +470,7 @@ class Conv3D(_Conv):
     def __init__(self, channels, kernel_size, strides=(1, 1, 1), padding=(0, 0, 0),
                  dilation=(1, 1, 1), groups=1, layout='NCDHW', activation=None,
                  use_bias=True, weight_initializer=None, bias_initializer='zeros',
-                 in_channels=0, cudnn='global', **kwargs):
+                 in_channels=0, cudnn='default', **kwargs):
         assert layout in ('NCDHW', 'NDHWC'), "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3
@@ -538,14 +538,14 @@ class Conv1DTranspose(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
-        Optional, If you do not specificy anything, defaults to 'global'.
+        Supported values - {'off', 'no_autotune', 'fastest', 'limited_workspace', 'default'}.
+        Optional, If you do not specificy anything, defaults to 'default'.
         off: Do not use cudnn for this layer.
-        default: Use cudnn. Do not auto tune to choose the algorithm.
+        no_autotune: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
+        default: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
 
@@ -562,7 +562,7 @@ class Conv1DTranspose(_Conv):
     def __init__(self, channels, kernel_size, strides=1, padding=0, output_padding=0,
                  dilation=1, groups=1, layout='NCW', activation=None, use_bias=True,
                  weight_initializer=None, bias_initializer='zeros',
-                 in_channels=0, cudnn='global', **kwargs):
+                 in_channels=0, cudnn='default', **kwargs):
         assert layout == 'NCW', "Only supports 'NCW' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)
@@ -637,14 +637,14 @@ class Conv2DTranspose(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
-        Optional, If you do not specificy anything, defaults to 'global'.
+        Supported values - {'off', 'no_autotune', 'fastest', 'limited_workspace', 'default'}.
+        Optional, If you do not specificy anything, defaults to 'default'.
         off: Do not use cudnn for this layer.
-        default: Use cudnn. Do not auto tune to choose the algorithm.
+        no_autotune: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
+        default: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
     Inputs:
@@ -664,7 +664,7 @@ class Conv2DTranspose(_Conv):
                  output_padding=(0, 0), dilation=(1, 1), groups=1, layout='NCHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0,
-                 cudnn='global', **kwargs):
+                 cudnn='default', **kwargs):
         assert layout in ('NCHW', 'NHWC'), "Only supports 'NCHW' and 'NHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*2
@@ -739,14 +739,14 @@ class Conv3DTranspose(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {'off', 'default', 'fastest', 'limited_workspace', 'global'}.
-        Optional, If you do not specificy anything, defaults to 'global'.
+        Supported values - {'off', 'no_autotune', 'fastest', 'limited_workspace', 'default'}.
+        Optional, If you do not specificy anything, defaults to 'default'.
         off: Do not use cudnn for this layer.
-        default: Use cudnn. Do not auto tune to choose the algorithm.
+        no_autotune: Use cudnn. Do not auto tune to choose the algorithm.
         limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn't exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
+        default: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
 
@@ -768,7 +768,7 @@ class Conv3DTranspose(_Conv):
                  output_padding=(0, 0, 0), dilation=(1, 1, 1), groups=1, layout='NCDHW',
                  activation=None, use_bias=True, weight_initializer=None,
                  bias_initializer='zeros', in_channels=0,
-                 cudnn='global', **kwargs):
+                 cudnn='default', **kwargs):
         assert layout in ('NCDHW', 'NDHWC'), "Only supports 'NCDHW' and 'NDHWC' layout for now"
         if isinstance(kernel_size, numeric_types):
             kernel_size = (kernel_size,)*3

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -52,15 +52,15 @@ def _get_cuddn_controls(cudnn_flag):
     Outputs:
         - cudnn_off, cudnn_tune
     """
-    assert cudnn in ('off', 'default', 'fastest', 'limited_workspace', 'global'), \
+    assert cudnn_flag in ('off', 'default', 'fastest', 'limited_workspace', 'global'), \
         "Invalid cudnn flag - '{0}' provided. \
         Supported options - ‘off’, 'default', ‘fastest’, ‘limited_workspace’, ‘global’".format(cudnn_flag)
-    
+
     # Default cudnn controls - Use cudnn and use limited_workspace tuning.
     cudnn_off = False
     cudnn_tune = None
 
-    if cuddn_flag == 'off':
+    if cudnn_flag == 'off':
         cudnn_off = True
     elif cudnn_flag == 'default':
         cudnn_tune = 'off'
@@ -121,14 +121,14 @@ class _Conv(HybridBlock):
     bias_initializer: str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
+        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
-        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
+        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn’t exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use cuddn. Use global cudnn behavior determined by the environment variable 
+        global: Use cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
     """
     def __init__(self, channels, kernel_size, strides, padding, dilation,
@@ -262,14 +262,14 @@ class Conv1D(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
+        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
-        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
+        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn’t exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable 
+        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
 
@@ -351,14 +351,14 @@ class Conv2D(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
+        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
-        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
+        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn’t exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable 
+        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
 
@@ -444,14 +444,14 @@ class Conv3D(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
+        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
-        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
+        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn’t exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable 
+        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
     Inputs:
@@ -540,14 +540,14 @@ class Conv1DTranspose(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
+        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
-        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
+        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn’t exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable 
+        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
 
@@ -640,14 +640,14 @@ class Conv2DTranspose(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
+        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
-        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
+        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn’t exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable 
+        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
     Inputs:
@@ -743,14 +743,14 @@ class Conv3DTranspose(_Conv):
     bias_initializer : str or `Initializer`
         Initializer for the bias vector.
     cudnn : str,
-        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}. 
+        Supported values - {‘off’, ‘default’, ‘fastest’, ‘limited_workspace’, ‘global’}.
         Optional, If you do not specificy anything, defaults to 'global'.
         off: Do not use cudnn for this layer.
         default: Use cudnn. Do not auto tune to choose the algorithm.
-        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm 
+        limited_workspace: Use cudnn. Run the test and pick the fastest algorithm
                            that doesn’t exceed workspace limit.
         fastest: Use cudnn. Pick the fastest algorithm and ignore workspace limit.
-        global: Use Cuddn. Use global cudnn behavior determined by the environment variable 
+        global: Use Cuddn. Use global cudnn behavior determined by the environment variable
                 MXNET_CUDNN_AUTOTUNE_DEFAULT. 0 for off, 1 for limited workspace (default), 2 for fastest.
 
 

--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -604,7 +604,7 @@ class Conv2DTranspose(_Conv):
         super(Conv2DTranspose, self).__init__(
             channels, kernel_size, strides, padding, dilation, groups, layout,
             in_channels, activation, use_bias, weight_initializer,
-            bias_initializer, cudnn_true, cudnn_off,
+            bias_initializer, cudnn_tune, cudnn_off,
             op_name='Deconvolution', adj=output_padding, **kwargs)
         self.outpad = output_padding
 

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -456,8 +456,8 @@ def test_conv():
     layers1d = [
         nn.Conv1D(16, 3, in_channels=4),
         nn.Conv1D(16, 3, in_channels=4, cudnn='off'),
+        nn.Conv1D(16, 3, in_channels=4, cudnn='no_autotune'),
         nn.Conv1D(16, 3, in_channels=4, cudnn='default'),
-        nn.Conv1D(16, 3, in_channels=4, cudnn='global'),
         nn.Conv1D(16, 3, in_channels=4, cudnn='fastest'),
         nn.Conv1D(16, 3, in_channels=4, cudnn='limited_workspace')
         ]
@@ -467,8 +467,8 @@ def test_conv():
     layers2d = [
         nn.Conv2D(16, (5, 4), in_channels=4),
         nn.Conv2D(16, (3, 4), in_channels=4, cudnn='off'),
-        nn.Conv2D(16, (5, 4), in_channels=4, cudnn='default'),
-        nn.Conv2D(16, (3, 4), in_channels=4, cudnn='global'),
+        nn.Conv2D(16, (5, 4), in_channels=4, cudnn='no_autotune'),
+        nn.Conv2D(16, (3, 4), in_channels=4, cudnn='default'),
         nn.Conv2D(16, (5, 4), in_channels=4, cudnn='fastest'),
         nn.Conv2D(16, (3, 4), in_channels=4, cudnn='limited_workspace'),
         ]
@@ -478,8 +478,8 @@ def test_conv():
     layers3d = [
         nn.Conv3D(16, (5, 4, 3), in_channels=4),
         nn.Conv3D(16, (5, 4, 3), in_channels=4, cudnn='off'),
+        nn.Conv3D(16, (5, 4, 3), in_channels=4, cudnn='no_autotune'),
         nn.Conv3D(16, (5, 4, 3), in_channels=4, cudnn='default'),
-        nn.Conv3D(16, (5, 4, 3), in_channels=4, cudnn='global'),
         nn.Conv3D(16, (5, 4, 3), in_channels=4, cudnn='fastest'),
         nn.Conv3D(16, (5, 4, 3), in_channels=4, cudnn='limited_workspace')
         ]

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -37,7 +37,7 @@ from mxnet.test_utils import rand_ndarray
 
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../unittest'))
-from common import setup_module, with_seed, teardown, assert_raises_cudnn_not_satisfied
+from common import setup_module, with_seed, teardown, assertRaises, assert_raises_cudnn_not_satisfied
 from test_gluon import *
 from test_loss import *
 from test_gluon_rnn import *
@@ -433,23 +433,20 @@ def test_large_models():
 
 @with_seed()
 def test_conv_invalid_cudnn_flag():
-    try:
-        _check_layer_forward(nn.Conv1D(16, 3, in_channels=4, cudnn='fail_me'), (1, 4, 10))
-        assert False, "Gluon Conv1D block did not raise the AssertionError for invalid cudnn flag."
-    except AssertionError:
-        pass
+    # Conv1D should fail for invalid cudnn flag
+    assertRaises(AssertionError,
+                _check_layer_forward,
+                nn.Conv1D(16, 3, in_channels=4, cudnn='fail_me'), (1, 4, 10))
 
-    try:
-        _check_layer_forward(nn.Conv2D(16, (3, 4), in_channels=4, cudnn='fail_me'), (1, 4, 20, 20))
-        assert False, "Gluon Conv2D block did not raise the AssertionError for invalid cudnn flag."
-    except AssertionError:
-        pass
+    # Conv2D should fail for invalid cudnn flag
+    assertRaises(AssertionError,
+                _check_layer_forward,
+                nn.Conv2D(16, (3, 4), in_channels=4, cudnn='fail_me'), (1, 4, 20, 20))
 
-    try:
-        _check_layer_forward(nn.Conv3D(16, (5, 4, 3), in_channels=4, cudnn='fail_me'), (1, 4, 10, 10, 10))
-        assert False, "Gluon Conv3D block did not raise the AssertionError for invalid cudnn flag."
-    except AssertionError:
-        pass
+    # Conv3D should fail for invalid cudnn flag
+    assertRaises(AssertionError,
+                _check_layer_forward,
+                nn.Conv3D(16, (5, 4, 3), in_channels=4, cudnn='fail_me'), (1, 4, 10, 10, 10))
 
 @with_seed()
 def test_conv():

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -454,7 +454,7 @@ def test_conv_invalid_cudnn_flag():
 @with_seed()
 def test_conv():
     layers1d = [
-        nn.Conv1D(16, 3, in_channels=4)
+        nn.Conv1D(16, 3, in_channels=4),
         nn.Conv1D(16, 3, in_channels=4, cudnn='off'),
         nn.Conv1D(16, 3, in_channels=4, cudnn='default'),
         nn.Conv1D(16, 3, in_channels=4, cudnn='global'),

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -435,18 +435,15 @@ def test_large_models():
 def test_conv_invalid_cudnn_flag():
     # Conv1D should fail for invalid cudnn flag
     assertRaises(AssertionError,
-                _check_layer_forward,
-                nn.Conv1D(16, 3, in_channels=4, cudnn='fail_me'), (1, 4, 10))
+                 nn.Conv1D, 16, 3, in_channels=4, cudnn='fail_me')
 
     # Conv2D should fail for invalid cudnn flag
     assertRaises(AssertionError,
-                _check_layer_forward,
-                nn.Conv2D(16, (3, 4), in_channels=4, cudnn='fail_me'), (1, 4, 20, 20))
+                 nn.Conv2D, 16, (3, 4), in_channels=4, cudnn='fail_me')
 
     # Conv3D should fail for invalid cudnn flag
     assertRaises(AssertionError,
-                _check_layer_forward,
-                nn.Conv3D(16, (5, 4, 3), in_channels=4, cudnn='fail_me'), (1, 4, 10, 10, 10))
+                 nn.Conv3D, 16, (5, 4, 3), in_channels=4, cudnn='fail_me')
 
 @with_seed()
 def test_conv():


### PR DESCRIPTION
## Description ##
<s>Add support for two flags - `cudnn_tune` and `cudnn_off` for conv blocks in Gluon.
These options are already supported in symbolic APIs. In this change, we basically take that as param and pass it to underlying ndarray/symbolic APIs. </s>

Add new `cudnn` flag in Gluon Conv blocks to control underlying `cudnn_tune` and `cudnn_off` parameters. Note that, these are supported in sym and ndarray APIs for Conv.

fixes https://github.com/apache/incubator-mxnet/issues/11342

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Support cudnn flag in gluon conv blocks that under the hood controls cudnn_tune and cudnn_off params for sym/ndarray conv APIs.
- [X] Add tests to test cudnn_tune and cudnn_off in gluon conv blocks

### Comments ###
- Verify if API docs are generated correctly as expected.
