### PR TITLE
remove ApacheCon promo

### DIFF
--- a/docs/_static/mxnet-theme/index.html
+++ b/docs/_static/mxnet-theme/index.html
@@ -14,8 +14,7 @@
             </div>
           </div>
       </div>
-      <div class="col-lg-6" style="padding-top: 60px;">
-        <a href="https://www.apachecon.com/acna18/" class="section-tout-promo"><img src="https://www.apachecon.com/acna18/banners/acna-sleek-highres.png" width="65%" alt="apachecon"/></a>
+      <div class="col-lg-6" style="padding-top: 60px;"><!--reserved for future promos-->
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description ##
The conference is over. This PR removes the logo from the website, but leaves the `div` there so it is easy to drop another promo in if we want.

## Preview
http://34.201.8.176/versions/remove_apachecon/