### PR TITLE
[MXNET -1004] Poisson NegativeLog Likelihood loss

### DIFF
--- a/docs/api/python/gluon/loss.md
+++ b/docs/api/python/gluon/loss.md
@@ -25,6 +25,7 @@ This package includes several commonly used loss functions in neural networks.
     LogisticLoss
     TripletLoss
     CTCLoss
+    PoissonNLLLoss
 ```
 
 

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -762,6 +762,7 @@ class PoissonNLLLoss(Loss):
         else:
             loss = pred - target * F.log(pred + epsilon)
         if self._compute_full:
+            # Using numpy's pi value
             stirling_factor = target * F.log(target)- target + 0.5 * F.log(2 * target * np.pi)
             target_gt_1 = target > 1
             stirling_factor *= target_gt_1

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -23,7 +23,7 @@ __all__ = ['Loss', 'L2Loss', 'L1Loss',
            'SigmoidBinaryCrossEntropyLoss', 'SigmoidBCELoss',
            'SoftmaxCrossEntropyLoss', 'SoftmaxCELoss',
            'KLDivLoss', 'CTCLoss', 'HuberLoss', 'HingeLoss',
-           'SquaredHingeLoss', 'LogisticLoss', 'TripletLoss']
+           'SquaredHingeLoss', 'LogisticLoss', 'TripletLoss','PoissonNLLLoss']
 
 from .. import ndarray
 from ..base import numeric_types
@@ -706,3 +706,63 @@ class TripletLoss(Loss):
                      axis=self._batch_axis, exclude=True)
         loss = F.relu(loss + self._margin)
         return _apply_weighting(F, loss, self._weight, None)
+
+
+class PoissonNLLLoss(Loss):
+    r"""For a target (Random Variable) in a Poisson distribution, the function calculates the Negative Log likelihood loss.
+    PoissonNLLLoss measures the loss accrued from a poisson regression prediction made by the model.
+
+    .. math::
+        L = \text{pred} - \text{target} * \log(\text{pred}) +\log(\text{target!})
+
+    `pred`, `target` can have arbitrary shape as long as they have the same number of elements.
+
+    Parameters
+    ----------
+    from_logits : boolean, default True
+        indicating whether log(predicted) value has already been computed. If True, the loss is computed as :
+        :math:`\exp(\text{pred}) - \text{target} * \text{pred}`, and if False, then loss is computed as :
+        :math:`\text{pred} - \text{target} * \log(\text{pred}+\text{epsislon})`.The default value 
+    weight : float or None
+        Global scalar weight for loss.
+    batch_axis : int, default 0
+        The axis that represents mini-batch.
+    compute_full: boolean, default False
+        Indicates whether to add an approximation(Stirling factor) for the Factorial term in the formula for the loss.
+        The Stirling factor is:
+            \text{target} * \log(\text{target}) - \text{target} + 0.5 * \log(2 * \PI * \text{target})
+    epsilon: float, default 1e-08
+        This is to avoid calculating log(0) which is not defined.
+
+
+    Inputs:
+    ------
+        - **pred**:   prediction tensor with arbitrary shape
+        - **target**: Random variable(count or number) which belongs to a Poisson distribution.
+        - **sample_weight**: element-wise weighting tensor. Must be broadcastable
+          to the same shape as pred. For example, if pred has shape (64, 10)
+          and you want to weigh each sample in the batch separately,
+          sample_weight should have shape (64, 1).
+        
+
+    Outputs:
+    --------
+        - **loss**: Average loss (shape=(1,1)) of the loss tensor with shape (batch_size,).
+    """
+    def __init__(self, margin=1, weight=None, from_logits=True, batch_axis=0, **kwargs):
+        super(PoissonNLLLoss, self).__init__(weight, batch_axis, **kwargs)
+        self._from_logits = from_logits
+
+    def hybrid_forward(self, F, pred, target, sample_weight = None, compute_full = False, epsilon = 1e-08):
+        target = _reshape_like(F, target, pred)
+        if self._from_logits:
+            loss = F.exp(pred) - target * pred
+        else:
+            if compute_full: 
+                stirling_factor = target * F.log(target)- target + 0.5 * F.log(2 * target * np.pi)
+                stirling_factor = stirling_factor[target>1]
+            else:
+                stirling_factor = 0.0
+            loss = pred - target * F.log( pred + epsilon ) + stirling_factor
+        loss = _apply_weighting(F, loss, self._weight, sample_weight)
+        return F.mean(loss)

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -24,6 +24,7 @@ __all__ = ['Loss', 'L2Loss', 'L1Loss',
            'SoftmaxCrossEntropyLoss', 'SoftmaxCELoss',
            'KLDivLoss', 'CTCLoss', 'HuberLoss', 'HingeLoss',
            'SquaredHingeLoss', 'LogisticLoss', 'TripletLoss', 'PoissonNLLLoss']
+
 import numpy as np
 from .. import ndarray
 from ..base import numeric_types

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -29,7 +29,6 @@ from .. import ndarray
 from ..base import numeric_types
 from .block import HybridBlock
 
-
 def _apply_weighting(F, loss, weight=None, sample_weight=None):
     """Apply weighting to loss.
 

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -732,13 +732,12 @@ class PoissonNLLLoss(Loss):
     compute_full: boolean, default False
         Indicates whether to add an approximation(Stirling factor) for the Factorial term in the formula for the loss.
         The Stirling factor is:
-            \text{target} * \log(\text{target}) - \text{target} + 0.5 * \log(2 * \PI * \text{target})
+        :math:`\text{target} * \log(\text{target}) - \text{target} + 0.5 * \log(2 * \PI * \text{target})`
     epsilon: float, default 1e-08
         This is to avoid calculating log(0) which is not defined.
 
 
     Inputs:
-    ------
         - **pred**:   prediction tensor with arbitrary shape
         - **target**: Random variable(count or number) which belongs to a Poisson distribution.
         - **sample_weight**: element-wise weighting tensor. Must be broadcastable
@@ -747,7 +746,6 @@ class PoissonNLLLoss(Loss):
           sample_weight should have shape (64, 1).
 
     Outputs:
-    --------
         - **loss**: Average loss (shape=(1,1)) of the loss tensor with shape (batch_size,).
     """
     def __init__(self, weight=None, from_logits=True, batch_axis=0, compute_full=False, **kwargs):

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -723,7 +723,7 @@ class PoissonNLLLoss(Loss):
     from_logits : boolean, default True
         indicating whether log(predicted) value has already been computed. If True, the loss is computed as
         :math:`\exp(\text{pred}) - \text{target} * \text{pred}`, and if False, then loss is computed as
-        :math:`\text{pred} - \text{target} * \log(\text{pred}+\text{epsislon})`.The default value
+        :math:`\text{pred} - \text{target} * \log(\text{pred}+\text{epsilon})`.The default value
     weight : float or None
         Global scalar weight for loss.
     batch_axis : int, default 0

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -738,7 +738,7 @@ class PoissonNLLLoss(Loss):
 
 
     Inputs:
-        - **pred**:   prediction tensor with arbitrary shape
+        - **pred**:   Predicted value
         - **target**: Random variable(count or number) which belongs to a Poisson distribution.
         - **sample_weight**: element-wise weighting tensor. Must be broadcastable
           to the same shape as pred. For example, if pred has shape (64, 10)

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -731,7 +731,7 @@ class PoissonNLLLoss(Loss):
     compute_full: boolean, default False
         Indicates whether to add an approximation(Stirling factor) for the Factorial term in the formula for the loss.
         The Stirling factor is:
-        :math:`\text{target} * \log(\text{target}) - \text{target} + 0.5 * \log(2 * \PI * \text{target})`
+        :math:`\text{target} * \log(\text{target}) - \text{target} + 0.5 * \log(2 * \pi * \text{target})`
     epsilon: float, default 1e-08
         This is to avoid calculating log(0) which is not defined.
 

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -14,13 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-import numpy as np
+
 import mxnet as mx
+import numpy as np
 from mxnet import gluon
 from mxnet.test_utils import assert_almost_equal, default_context
-from common import with_seed
-# from common import setup_module, teardown
-#import unittest
+from common import setup_module, with_seed, teardown
+import unittest
 
 
 @with_seed()
@@ -49,17 +49,17 @@ def test_loss_ndarray():
 
     loss = gluon.loss.SoftmaxCrossEntropyLoss()
     L = loss(output, label).asnumpy()
-    mx.test_utils.assert_almost_equal(L, np.array([2.12692809, 0.04858733]))
+    mx.test_utils.assert_almost_equal(L, np.array([ 2.12692809,  0.04858733]))
 
     L = loss(output, label, weighting).asnumpy()
-    mx.test_utils.assert_almost_equal(L, np.array([1.06346405, 0.04858733]))
+    mx.test_utils.assert_almost_equal(L, np.array([ 1.06346405,  0.04858733]))
 
 
 def get_net(num_hidden, flatten=True):
     data = mx.symbol.Variable('data')
     fc1 = mx.symbol.FullyConnected(data, name='fc1', num_hidden=128, flatten=flatten)
     act1 = mx.symbol.Activation(fc1, name='relu1', act_type="relu")
-    fc2 = mx.symbol.FullyConnected(act1, name='fc2', num_hidden=64, flatten=flatten)
+    fc2 = mx.symbol.FullyConnected(act1, name = 'fc2', num_hidden = 64, flatten=flatten)
     act2 = mx.symbol.Activation(fc2, name='relu2', act_type="relu")
     fc3 = mx.symbol.FullyConnected(act2, name='fc3', num_hidden=num_hidden, flatten=flatten)
     return fc3
@@ -185,28 +185,27 @@ def test_l1_loss():
 @with_seed(1234)
 def test_ctc_loss():
     loss = gluon.loss.CTCLoss()
-    l = loss(mx.nd.ones((2, 20, 4)), mx.nd.array([[1, 0, -1, -1], [2, 1, 1, -1]]))
+    l = loss(mx.nd.ones((2, 20,4)), mx.nd.array([[1,0,-1,-1],[2,1,1,-1]]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss(layout='TNC')
-    l = loss(mx.nd.ones((20, 2, 4)), mx.nd.array([[1, 0, -1, -1], [2, 1, 1, -1]]))
+    l = loss(mx.nd.ones((20,2,4)), mx.nd.array([[1,0,-1,-1],[2,1,1,-1]]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss(layout='TNC', label_layout='TN')
-    l = loss(mx.nd.ones((20, 2, 4)), mx.nd.array([[1, 0, -1, -1], [2, 1, 1, -1]]).T)
+    l = loss(mx.nd.ones((20,2,4)), mx.nd.array([[1,0,-1,-1],[2,1,1,-1]]).T)
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss()
-    l = loss(mx.nd.ones((2, 20, 4)), mx.nd.array([[2, 1, 2, 2], [3, 2, 2, 2]]), None, mx.nd.array([2, 3]))
+    l = loss(mx.nd.ones((2,20,4)), mx.nd.array([[2,1,2,2],[3,2,2,2]]), None, mx.nd.array([2,3]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss()
-    l = loss(mx.nd.ones((2, 25, 4)), mx.nd.array([[2, 1, -1, -1], [3, 2, 2, -1]]), mx.nd.array([20, 20]))
+    l = loss(mx.nd.ones((2,25,4)), mx.nd.array([[2,1,-1,-1],[3,2,2,-1]]), mx.nd.array([20,20]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss()
-    l = loss(mx.nd.ones((2, 25, 4)), mx.nd.array([[2, 1, 3, 3], [3, 2, 2, 3]]),
-             mx.nd.array([20, 20]), mx.nd.array([2, 3]))
+    l = loss(mx.nd.ones((2,25,4)), mx.nd.array([[2,1,3,3],[3,2,2,3]]), mx.nd.array([20,20]), mx.nd.array([2,3]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
 
@@ -246,10 +245,10 @@ def test_sample_weight_loss():
     mod.fit(data_iter, num_epoch=200, optimizer_params={'learning_rate': 0.01},
             eval_metric=mx.metric.Loss(), optimizer='adam')
     data_iter = mx.io.NDArrayIter(data[10:], {'label': label, 'w': weight}, batch_size=10)
-    score = mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1]
+    score =  mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1]
     assert score > 1
     data_iter = mx.io.NDArrayIter(data[:10], {'label': label, 'w': weight}, batch_size=10)
-    score = mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1]
+    score =  mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1]
     assert score < 0.05
 
 
@@ -343,7 +342,7 @@ def test_triplet_loss():
     Loss = gluon.loss.TripletLoss()
     loss = Loss(output, pos, neg)
     loss = mx.sym.make_loss(loss)
-    mod = mx.mod.Module(loss, data_names=('data',), label_names=('pos', 'neg'))
+    mod = mx.mod.Module(loss, data_names=('data',), label_names=('pos','neg'))
     mod.fit(data_iter, num_epoch=200, optimizer_params={'learning_rate': 0.01},
             initializer=mx.init.Xavier(magnitude=2), eval_metric=mx.metric.Loss(),
             optimizer='adam')
@@ -361,20 +360,25 @@ def test_poisson_nllloss():
     #This is necessary to ensure only positive random values are generated for prediction,
     # to avoid ivalid log calculation
     target[:] += mx.nd.abs(min_target)
+
     Loss = gluon.loss.PoissonNLLLoss(from_logits=True)
     Loss_no_logits = gluon.loss.PoissonNLLLoss(from_logits=False)
     #Calculating by brute formula for default value of from_logits = True
+
+    # 1) Testing for flag logits = True
     brute_loss = np.mean(np.exp(pred.asnumpy()) - target.asnumpy() * pred.asnumpy())
     loss_withlogits = Loss(pred, target)
     assert_almost_equal(brute_loss, loss_withlogits.asscalar())
-    #Now testing for the option from_Logits = False
+
+    #2) Testing for flag logits = False
     loss_no_logits = Loss_no_logits(pred, target)
     np_loss_no_logits = np.mean(pred.asnumpy() - target.asnumpy() * np.log(pred.asnumpy() + 1e-08))
     if np.isnan(loss_no_logits.asscalar()):
         assert_almost_equal(np.isnan(np_loss_no_logits), np.isnan(loss_no_logits.asscalar()))
     else:
         assert_almost_equal(np_loss_no_logits, loss_no_logits.asscalar())
-    # Adding test case for compute full use case for the stirling factor calculation
+
+    #3) Testing for Sterling approximation
     np_pred = np.random.uniform(1, 5, (2, 3))
     np_target = np.random.uniform(1, 5, (2, 3))
     np_compute_full = np.mean((np_pred - np_target * np.log(np_pred + 1e-08)) + ((np_target * np.log(np_target)-\

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -185,7 +185,7 @@ def test_l1_loss():
 @with_seed(1234)
 def test_ctc_loss():
     loss = gluon.loss.CTCLoss()
-    l = loss(mx.nd.ones((2, 20,4)), mx.nd.array([[1,0,-1,-1],[2,1,1,-1]]))
+    l = loss(mx.nd.ones((2,20,4)), mx.nd.array([[1,0,-1,-1],[2,1,1,-1]]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss(layout='TNC')

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -14,13 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-import mxnet as mx
 import numpy as np
+import mxnet as mx
 from mxnet import gluon
 from mxnet.test_utils import assert_almost_equal, default_context
-from common import setup_module, with_seed, teardown
-import unittest
+from common import with_seed
+# from common import setup_module, teardown
+#import unittest
 
 
 @with_seed()
@@ -49,17 +49,17 @@ def test_loss_ndarray():
 
     loss = gluon.loss.SoftmaxCrossEntropyLoss()
     L = loss(output, label).asnumpy()
-    mx.test_utils.assert_almost_equal(L, np.array([ 2.12692809,  0.04858733]))
+    mx.test_utils.assert_almost_equal(L, np.array([2.12692809, 0.04858733]))
 
     L = loss(output, label, weighting).asnumpy()
-    mx.test_utils.assert_almost_equal(L, np.array([ 1.06346405,  0.04858733]))
+    mx.test_utils.assert_almost_equal(L, np.array([1.06346405, 0.04858733]))
 
 
 def get_net(num_hidden, flatten=True):
     data = mx.symbol.Variable('data')
     fc1 = mx.symbol.FullyConnected(data, name='fc1', num_hidden=128, flatten=flatten)
     act1 = mx.symbol.Activation(fc1, name='relu1', act_type="relu")
-    fc2 = mx.symbol.FullyConnected(act1, name = 'fc2', num_hidden = 64, flatten=flatten)
+    fc2 = mx.symbol.FullyConnected(act1, name='fc2', num_hidden=64, flatten=flatten)
     act2 = mx.symbol.Activation(fc2, name='relu2', act_type="relu")
     fc3 = mx.symbol.FullyConnected(act2, name='fc3', num_hidden=num_hidden, flatten=flatten)
     return fc3
@@ -82,7 +82,6 @@ def test_ce_loss():
             eval_metric=mx.metric.Loss(), optimizer='adam',
             initializer=mx.init.Xavier(magnitude=2))
     assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.05
-    
 
 # tracked at: https://github.com/apache/incubator-mxnet/issues/11691
 @with_seed()
@@ -186,27 +185,28 @@ def test_l1_loss():
 @with_seed(1234)
 def test_ctc_loss():
     loss = gluon.loss.CTCLoss()
-    l = loss(mx.nd.ones((2,20,4)), mx.nd.array([[1,0,-1,-1],[2,1,1,-1]]))
+    l = loss(mx.nd.ones((2, 20, 4)), mx.nd.array([[1, 0, -1, -1], [2, 1, 1, -1]]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss(layout='TNC')
-    l = loss(mx.nd.ones((20,2,4)), mx.nd.array([[1,0,-1,-1],[2,1,1,-1]]))
+    l = loss(mx.nd.ones((20, 2, 4)), mx.nd.array([[1, 0, -1, -1], [2, 1, 1, -1]]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss(layout='TNC', label_layout='TN')
-    l = loss(mx.nd.ones((20,2,4)), mx.nd.array([[1,0,-1,-1],[2,1,1,-1]]).T)
+    l = loss(mx.nd.ones((20, 2, 4)), mx.nd.array([[1, 0, -1, -1], [2, 1, 1, -1]]).T)
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss()
-    l = loss(mx.nd.ones((2,20,4)), mx.nd.array([[2,1,2,2],[3,2,2,2]]), None, mx.nd.array([2,3]))
+    l = loss(mx.nd.ones((2, 20, 4)), mx.nd.array([[2, 1, 2, 2], [3, 2, 2, 2]]), None, mx.nd.array([2, 3]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss()
-    l = loss(mx.nd.ones((2,25,4)), mx.nd.array([[2,1,-1,-1],[3,2,2,-1]]), mx.nd.array([20,20]))
+    l = loss(mx.nd.ones((2, 25, 4)), mx.nd.array([[2, 1, -1, -1], [3, 2, 2, -1]]), mx.nd.array([20, 20]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss()
-    l = loss(mx.nd.ones((2,25,4)), mx.nd.array([[2,1,3,3],[3,2,2,3]]), mx.nd.array([20,20]), mx.nd.array([2,3]))
+    l = loss(mx.nd.ones((2, 25, 4)), mx.nd.array([[2, 1, 3, 3], [3, 2, 2, 3]]), 
+             mx.nd.array([20, 20]), mx.nd.array([2, 3]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
 
@@ -246,10 +246,10 @@ def test_sample_weight_loss():
     mod.fit(data_iter, num_epoch=200, optimizer_params={'learning_rate': 0.01},
             eval_metric=mx.metric.Loss(), optimizer='adam')
     data_iter = mx.io.NDArrayIter(data[10:], {'label': label, 'w': weight}, batch_size=10)
-    score =  mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1]
+    score = mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1]
     assert score > 1
     data_iter = mx.io.NDArrayIter(data[:10], {'label': label, 'w': weight}, batch_size=10)
-    score =  mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1]
+    score = mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1]
     assert score < 0.05
 
 
@@ -343,43 +343,37 @@ def test_triplet_loss():
     Loss = gluon.loss.TripletLoss()
     loss = Loss(output, pos, neg)
     loss = mx.sym.make_loss(loss)
-    mod = mx.mod.Module(loss, data_names=('data',), label_names=('pos','neg'))
+    mod = mx.mod.Module(loss, data_names=('data',), label_names=('pos', 'neg'))
     mod.fit(data_iter, num_epoch=200, optimizer_params={'learning_rate': 0.01},
             initializer=mx.init.Xavier(magnitude=2), eval_metric=mx.metric.Loss(),
             optimizer='adam')
     assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.05
 
-
-
 @with_seed()
 def test_poisson_nllloss():
-    pred = mx.nd.random.normal(shape = (3, 4))
+    pred = mx.nd.random.normal(shape=(3, 4))
     min_pred = mx.nd.min(pred)
     #This is necessary to ensure only positive random values are generated for prediction,
     # to avoid ivalid log calculation
     pred[:] = pred + mx.nd.abs(min_pred)
-    target = mx.nd.random.normal(shape = (3, 4))
+    target = mx.nd.random.normal(shape=(3, 4))
     min_target = mx.nd.min(target)
     #This is necessary to ensure only positive random values are generated for prediction,
     # to avoid ivalid log calculation
     target[:] += mx.nd.abs(min_target)
-    Loss                = gluon.loss.PoissonNLLLoss(from_logits=True)
-    Loss_no_logits      = gluon.loss.PoissonNLLLoss(from_logits=False)
-
+    Loss = gluon.loss.PoissonNLLLoss(from_logits=True)
+    Loss_no_logits = gluon.loss.PoissonNLLLoss(from_logits=False)
     #Calculating by brute formula for default value of from_logits = True
-    brute_loss          = np.mean(np.exp(pred.asnumpy()) - target.asnumpy() * pred.asnumpy())
-    loss_withlogits     = Loss(pred, target)
+    brute_loss = np.mean(np.exp(pred.asnumpy()) - target.asnumpy() * pred.asnumpy())
+    loss_withlogits = Loss(pred, target)
     assert_almost_equal(brute_loss, loss_withlogits.asscalar())
-
     #Now testing for the option from_Logits = False
-    loss_no_logits      =  Loss_no_logits(pred, target)
-    np_loss_no_logits   =  np.mean(pred.asnumpy() - target.asnumpy() * np.log( pred.asnumpy() + 1e-08 ))
+    loss_no_logits = Loss_no_logits(pred, target)
+    np_loss_no_logits = np.mean(pred.asnumpy() - target.asnumpy() * np.log(pred.asnumpy() + 1e-08))
     if np.isnan(loss_no_logits.asscalar()):
         assert_almost_equal(np.isnan(np_loss_no_logits), np.isnan(loss_no_logits.asscalar()))
-    else:    
+    else: 
         assert_almost_equal(np_loss_no_logits, loss_no_logits.asscalar())
-
-
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -205,7 +205,7 @@ def test_ctc_loss():
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
     loss = gluon.loss.CTCLoss()
-    l = loss(mx.nd.ones((2, 25, 4)), mx.nd.array([[2, 1, 3, 3], [3, 2, 2, 3]]), 
+    l = loss(mx.nd.ones((2, 25, 4)), mx.nd.array([[2, 1, 3, 3], [3, 2, 2, 3]]),
              mx.nd.array([20, 20]), mx.nd.array([2, 3]))
     mx.test_utils.assert_almost_equal(l.asnumpy(), np.array([18.82820702, 16.50581741]))
 
@@ -372,8 +372,17 @@ def test_poisson_nllloss():
     np_loss_no_logits = np.mean(pred.asnumpy() - target.asnumpy() * np.log(pred.asnumpy() + 1e-08))
     if np.isnan(loss_no_logits.asscalar()):
         assert_almost_equal(np.isnan(np_loss_no_logits), np.isnan(loss_no_logits.asscalar()))
-    else: 
+    else:
         assert_almost_equal(np_loss_no_logits, loss_no_logits.asscalar())
+    # Adding test case for compute full use case for the stirling factor calculation
+    np_pred = np.random.uniform(1, 5, (2, 3))
+    np_target = np.random.uniform(1, 5, (2, 3))
+    np_compute_full = np.mean((np_pred - np_target * np.log(np_pred + 1e-08)) + ((np_target * np.log(np_target)-\
+     np_target + 0.5 * np.log(2 * np_target * np.pi))*(np_target > 1)))
+    Loss_compute_full = gluon.loss.PoissonNLLLoss(from_logits=False, compute_full=True)
+    loss_compute_full = Loss_compute_full(mx.nd.array(np_pred), mx.nd.array(np_target))
+    assert_almost_equal(np_compute_full, loss_compute_full.asscalar())
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -354,40 +354,26 @@ def test_triplet_loss():
 @with_seed()
 def test_poisson_nllloss():
     pred = mx.nd.random.normal(shape = (3, 4))
-    print (" Prediction before the adjustment done: ",pred)
     min_pred = mx.nd.min(pred)
-    print("Found the minimum as: ",min_pred)
     #This is necessary to ensure only positive random values are generated for prediction,
     # to avoid ivalid log calculation
     pred[:] = pred + mx.nd.abs(min_pred)
-    print (" Prediction after the adjustment done: ",pred)
-
     target = mx.nd.random.normal(shape = (3, 4))
     min_target = mx.nd.min(target)
     #This is necessary to ensure only positive random values are generated for prediction,
     # to avoid ivalid log calculation
     target[:] += mx.nd.abs(min_target)
-    print(" Pred = ", pred)
-    print("Target: ", target)
     Loss                = gluon.loss.PoissonNLLLoss(from_logits=True)
     Loss_no_logits      = gluon.loss.PoissonNLLLoss(from_logits=False)
 
     #Calculating by brute formula for default value of from_logits = True
     brute_loss          = np.mean(np.exp(pred.asnumpy()) - target.asnumpy() * pred.asnumpy())
     loss_withlogits     = Loss(pred, target)
-
-    print(loss_withlogits, " is from the loss function!")
-    print (brute_loss," is the numpy calculated loss!")
-
     assert_almost_equal(brute_loss, loss_withlogits.asscalar())
 
     #Now testing for the option from_Logits = False
     loss_no_logits      =  Loss_no_logits(pred, target)
     np_loss_no_logits   =  np.mean(pred.asnumpy() - target.asnumpy() * np.log( pred.asnumpy() + 1e-08 ))
-
-    print("The so called invalid value = ",(pred.asnumpy() + 1e-08))
-    print("No logits - ",loss_no_logits, " is from the loss function!")
-    print ("No logits - ",np_loss_no_logits," is the numpy calculated loss!")
     if np.isnan(loss_no_logits.asscalar()):
         assert_almost_equal(np.isnan(np_loss_no_logits), np.isnan(loss_no_logits.asscalar()))
     else:    

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -389,20 +389,21 @@ def test_poisson_nllloss():
 
 @with_seed()
 def test_poisson_nllloss_mod():
-    N = 30
-    data = mx.random.uniform(shape=(N, 10))
-    label = mx.random.poisson(shape=(N, 1))
-    data_iter = mx.io.NDArrayIter(data, label, batch_size=10, label_name='label', shuffle=True)
+    N = 1000
+    data = mx.random.poisson(shape=(N, 2))
+    label = mx.random.poisson(lam=4, shape=(N, 1))
+    data_iter = mx.io.NDArrayIter(data, label, batch_size=20, label_name='label', shuffle=True)
     output = mx.sym.exp(get_net(1))
     l = mx.symbol.Variable('label')
     Loss = gluon.loss.PoissonNLLLoss(from_logits=False)
     loss = Loss(output, l)
     loss = mx.sym.make_loss(loss)
     mod = mx.mod.Module(loss, data_names=('data',), label_names=('label',))
-    mod.fit(data_iter, num_epoch=200, optimizer_params={'learning_rate': 0.01},
-            initializer=mx.init.Xavier(magnitude=2), eval_metric=mx.metric.Loss(),
+    mod.fit(data_iter, num_epoch=20, optimizer_params={'learning_rate': 0.01},
+            initializer=mx.init.Normal(sigma=0.1), eval_metric=mx.metric.Loss(),
             optimizer='adam')
-    assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 1
+    assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.05
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -390,7 +390,7 @@ def test_poisson_nllloss():
 @with_seed()
 def test_poisson_loss_mod():
     N = 100
-    data = mx.random.uniform( shape=(N, 10))
+    data = mx.random.uniform(shape=(N, 10))
     label = mx.random.poisson(shape=(N, 1))
     data_iter = mx.io.NDArrayIter(data, label, batch_size=10, label_name='label', shuffle=True)
     output = mx.sym.exp(get_net(1))
@@ -399,7 +399,7 @@ def test_poisson_loss_mod():
     loss = Loss(output, l)
     loss = mx.sym.make_loss(loss)
     mod = mx.mod.Module(loss, data_names=('data',), label_names=('label',))
-    mod.fit(data_iter, num_epoch=300, optimizer_params={'learning_rate': 0.01},
+    mod.fit(data_iter, num_epoch=100, optimizer_params={'learning_rate': 0.01},
             initializer=mx.init.Normal(sigma=0.1), eval_metric=mx.metric.Loss(),
             optimizer='adam')
     assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.5

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -388,7 +388,7 @@ def test_poisson_nllloss():
     assert_almost_equal(np_compute_full, loss_compute_full.asscalar())
 
 @with_seed()
-def test_poisson_loss_mod():
+def test_poisson_nllloss_mod():
     N = 100
     data = mx.random.uniform(shape=(N, 10))
     label = mx.random.poisson(shape=(N, 1))
@@ -399,7 +399,7 @@ def test_poisson_loss_mod():
     loss = Loss(output, l)
     loss = mx.sym.make_loss(loss)
     mod = mx.mod.Module(loss, data_names=('data',), label_names=('label',))
-    mod.fit(data_iter, num_epoch=100, optimizer_params={'learning_rate': 0.01},
+    mod.fit(data_iter, num_epoch=300, optimizer_params={'learning_rate': 0.01},
             initializer=mx.init.Normal(sigma=0.1), eval_metric=mx.metric.Loss(),
             optimizer='adam')
     assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.5

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -389,7 +389,7 @@ def test_poisson_nllloss():
 
 @with_seed()
 def test_poisson_nllloss_mod():
-    N = 100
+    N = 30
     data = mx.random.uniform(shape=(N, 10))
     label = mx.random.poisson(shape=(N, 1))
     data_iter = mx.io.NDArrayIter(data, label, batch_size=10, label_name='label', shuffle=True)
@@ -399,10 +399,10 @@ def test_poisson_nllloss_mod():
     loss = Loss(output, l)
     loss = mx.sym.make_loss(loss)
     mod = mx.mod.Module(loss, data_names=('data',), label_names=('label',))
-    mod.fit(data_iter, num_epoch=300, optimizer_params={'learning_rate': 0.01},
-            initializer=mx.init.Normal(sigma=0.1), eval_metric=mx.metric.Loss(),
+    mod.fit(data_iter, num_epoch=200, optimizer_params={'learning_rate': 0.01},
+            initializer=mx.init.Xavier(magnitude=2), eval_metric=mx.metric.Loss(),
             optimizer='adam')
-    assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.5
+    assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 1
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -387,6 +387,22 @@ def test_poisson_nllloss():
     loss_compute_full = Loss_compute_full(mx.nd.array(np_pred), mx.nd.array(np_target))
     assert_almost_equal(np_compute_full, loss_compute_full.asscalar())
 
+@with_seed()
+def test_poisson_loss_mod():
+    N = 100
+    data = mx.random.uniform( shape=(N, 10))
+    label = mx.random.poisson(shape=(N, 1))
+    data_iter = mx.io.NDArrayIter(data, label, batch_size=10, label_name='label', shuffle=True)
+    output = mx.sym.exp(get_net(1))
+    l = mx.symbol.Variable('label')
+    Loss = gluon.loss.PoissonNLLLoss(from_logits=False)
+    loss = Loss(output, l)
+    loss = mx.sym.make_loss(loss)
+    mod = mx.mod.Module(loss, data_names=('data',), label_names=('label',))
+    mod.fit(data_iter, num_epoch=300, optimizer_params={'learning_rate': 0.01},
+            initializer=mx.init.Normal(sigma=0.1), eval_metric=mx.metric.Loss(),
+            optimizer='adam')
+    assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.5
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
The function computes the poisson's negative log likelihood loss that serves as measurement of the loss accrued from a Poisson regression prediction made by the model.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)

- [x] Code is well-documented: 

- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] PoissonNLLLoss computation function tests, (and when applicable, API doc)


## Comments ##
- If this change is a backward incompatible change, why must this change be made.

 - Below is the link for pytorch's current implementation:
    [PyTorch Implementation] . 
    (https://github.com/pytorch/pytorch/blob/master/torch/nn/functional.py)