### PR TITLE
[MXNET-908] Speed up travis builds to avoid timeouts 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ sudo: true
 
 language: cpp
 
-cache: ccache
+cache:
+  directories:
+    - $HOME/.ccache
+    - $HOME/.cache/pip
+    - $HOME/.mxnet
+    - $HOME/Library/Caches/Homebrew
 
 os:
   - osx
@@ -17,7 +22,7 @@ before_install:
   - export PYTHONPATH=${PYTHONPATH}:${PWD}/python
 
 install:
-  - brew install ccache
+  - HOMEBREW_NO_AUTO_UPDATE=1 brew install ccache
   - export PATH="/usr/local/opt/ccache/libexec:$PATH"
   - source ci/travis/install.sh
 
@@ -29,4 +34,7 @@ script:
   - export MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
   - mv make/osx.mk config.mk
   - make -j 2
-  - python -m nose --verbose tests/python/unittest/
+  # We ignore several tests to avoid possible timeouts on large PRs.
+  # This lowers our test coverage, but is required for consistent Travis runs.
+  # These tests will be tested in a variety of environments in Jenkins based tests.
+  - python -m nose --with-timer --exclude-test=test_sparse_operator.test_elemwise_binary_ops --exclude-test=test_gluon_model_zoo.test_models --exclude-test=test_random.test_shuffle --exclude-test=test_operator.test_broadcast_binary_op --exclude-test=test_operator.test_pick --exclude-test=test_profiler.test_continuous_profile_and_instant_marker --exclude-test=test_metric_perf.test_metric_performance --exclude-test=test_operator.test_order --verbose tests/python/unittest/

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -17,14 +17,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Disable brew auto-update to avoid long running updates while running tests in CI.
+export HOMEBREW_NO_AUTO_UPDATE=1
+
 if [ ${TRAVIS_OS_NAME} == "osx" ]; then
-    brew update
     brew install opencv
-    brew install python3
-    brew install fftw
-    brew install libpng
-    brew install ImageMagick
-    brew install swig
-    python -m pip install --user nose numpy cython scipy requests mock
-    python3 -m pip install --user nose numpy cython scipy requests mock
+    python -m pip install --user nose numpy cython scipy requests mock nose-timer nose-exclude
 fi


### PR DESCRIPTION
## Description ##
Speed up travis builds to avoid timeouts.  This PR removes some redundant build tasks and removes some slow tests  to try and decrease the number of TravisCI timeouts that would otherwise  occur on large PRs.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change