### PR TITLE
[MXNET-860] Remove std::moves that have no affect

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -54,7 +54,8 @@ Checks: >
 
 # In order to trigger an error, you must have a rule defined both in checks and in this section.
 WarningsAsErrors: >
-    cppcoreguidelines-no-malloc, modernize-use-nullptr, performance-unnecessary-copy-initialization
+    cppcoreguidelines-no-malloc, modernize-use-nullptr, performance-unnecessary-copy-initialization,
+    performance-move-const-arg
 
 # Todo: define a better regex match that includes most project headers, but excludes third party
 # code.

--- a/src/executor/infer_graph_attr_pass.cc
+++ b/src/executor/infer_graph_attr_pass.cc
@@ -330,7 +330,7 @@ nnvm::Graph InferShape(nnvm::Graph&& graph,
     graph.attrs["shape_inputs"] = std::make_shared<any>(std::move(shape_inputs));
   }
   if (shape_attr_key.length() != 0) {
-    graph.attrs["shape_attr_key"] = std::make_shared<any>(std::move(shape_attr_key));
+    graph.attrs["shape_attr_key"] = std::make_shared<any>(shape_attr_key);
   }
   return InferAttr<nnvm::TShape, nnvm::FInferShape>(
       std::move(graph), nnvm::TShape(),
@@ -348,7 +348,7 @@ nnvm::Graph InferType(nnvm::Graph&& graph,
     graph.attrs["dtype_inputs"] = std::make_shared<any>(std::move(dtype_inputs));
   }
   if (dtype_attr_key.length() != 0) {
-    graph.attrs["dtype_attr_key"] = std::make_shared<any>(std::move(dtype_attr_key));
+    graph.attrs["dtype_attr_key"] = std::make_shared<any>(dtype_attr_key);
   }
   return InferAttr<int, nnvm::FInferType>(
       std::move(graph), -1,
@@ -366,7 +366,7 @@ nnvm::Graph InferStorageType(nnvm::Graph&& graph,
     graph.attrs["storage_type_inputs"] = std::make_shared<any>(std::move(storage_type_inputs));
   }
   if (storage_type_attr_key.length() != 0) {
-    graph.attrs["storage_type_attr_key"] = std::make_shared<any>(std::move(storage_type_attr_key));
+    graph.attrs["storage_type_attr_key"] = std::make_shared<any>(storage_type_attr_key);
   }
   // initialize unknown values for dispatch modes
   if (graph.attrs.count("dispatch_mode") == 0) {

--- a/src/operator/tensor/elemwise_unary_op.h
+++ b/src/operator/tensor/elemwise_unary_op.h
@@ -126,10 +126,10 @@ class OpBase {
     in_blobs.reserve(inputs.size());
     out_blobs.reserve(outputs.size());
     for (size_t i = 0, n = inputs.size(); i < n; ++i) {
-      in_blobs.emplace_back(std::move(inputs[i].data()));
+      in_blobs.emplace_back(inputs[i].data());
     }
     for (size_t i = 0, n = outputs.size(); i < n; ++i) {
-      out_blobs.emplace_back(std::move(outputs[i].data()));
+      out_blobs.emplace_back(outputs[i].data());
     }
     computer(attrs, ctx, in_blobs, req, out_blobs);
   }


### PR DESCRIPTION
## Description ##
Remove std::moves that have no affect, enable checks as errors in clang tidy.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change