### PR TITLE
[MXNET-892] ONNX export/import: DepthToSpace, SpaceToDepth operators

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2077,3 +2077,28 @@ def convert_sqrt(node, **kwargs):
         name=name,
     )
     return [node]
+
+@mx_op.register("depth_to_space")
+def convert_depthtospace(node, **kwargs):
+    """Map MXNet's depth_to_space operator attributes to onnx's
+    DepthToSpace operator and return the created node.
+    """
+    onnx = import_onnx_modules()
+    name = node["name"]
+    proc_nodes = kwargs["proc_nodes"]
+    inputs = node["inputs"]
+    attrs = node["attrs"]
+
+    input_node_id = kwargs["index_lookup"][inputs[0][0]]
+    input_node = proc_nodes[input_node_id].name
+
+    blksize = int(attrs.get("block_size", 0))
+
+    node = onnx.helper.make_node(
+        "DepthToSpace",
+        [input_node],
+        [name],
+        blocksize=blksize,
+        name=name,
+    )
+    return [node]

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2102,3 +2102,28 @@ def convert_depthtospace(node, **kwargs):
         name=name,
     )
     return [node]
+
+@mx_op.register("space_to_depth")
+def convert_spacetodepth(node, **kwargs):
+    """Map MXNet's space_to_depth operator attributes to onnx's
+    SpaceToDepth operator and return the created node.
+    """
+    onnx = import_onnx_modules()
+    name = node["name"]
+    proc_nodes = kwargs["proc_nodes"]
+    inputs = node["inputs"]
+    attrs = node["attrs"]
+
+    input_node_id = kwargs["index_lookup"][inputs[0][0]]
+    input_node = proc_nodes[input_node_id].name
+
+    blksize = int(attrs.get("block_size", 0))
+
+    node = onnx.helper.make_node(
+        "SpaceToDepth",
+        [input_node],
+        [name],
+        blocksize=blksize,
+        name=name,
+    )
+    return [node]

--- a/python/mxnet/contrib/onnx/onnx2mx/_import_helper.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_import_helper.py
@@ -37,7 +37,7 @@ from ._op_translations import clip, reduce_log_sum, reduce_log_sum_exp
 from ._op_translations import reduce_sum_square, reduce_l1, reduce_l2, max_roi_pooling
 from ._op_translations import log_softmax, softsign, lesser, greater, equal
 from ._op_translations import logical_and, logical_or, logical_xor, logical_not
-from ._op_translations import mean
+from ._op_translations import mean, depthtospace
 
 # convert_map defines maps of ONNX operator names to converter functor(callable)
 # defined in the op_translations module.
@@ -140,5 +140,6 @@ _convert_map = {
     'Shape'             : shape,
     'Gather'            : gather,
     'HardSigmoid'       : hardsigmoid,
-    'LpPool'            : lp_pooling
+    'LpPool'            : lp_pooling,
+    'DepthToSpace'      : depthtospace
 }

--- a/python/mxnet/contrib/onnx/onnx2mx/_import_helper.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_import_helper.py
@@ -37,7 +37,7 @@ from ._op_translations import clip, reduce_log_sum, reduce_log_sum_exp
 from ._op_translations import reduce_sum_square, reduce_l1, reduce_l2, max_roi_pooling
 from ._op_translations import log_softmax, softsign, lesser, greater, equal
 from ._op_translations import logical_and, logical_or, logical_xor, logical_not
-from ._op_translations import mean, depthtospace
+from ._op_translations import mean, depthtospace, spacetodepth
 
 # convert_map defines maps of ONNX operator names to converter functor(callable)
 # defined in the op_translations module.
@@ -141,5 +141,6 @@ _convert_map = {
     'Gather'            : gather,
     'HardSigmoid'       : hardsigmoid,
     'LpPool'            : lp_pooling,
-    'DepthToSpace'      : depthtospace
+    'DepthToSpace'      : depthtospace,
+    'SpaceToDepth'      : spacetodepth
 }

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -694,3 +694,9 @@ def depthtospace(attrs, inputs, proto_obj):
     new_attrs = translation_utils._fix_attribute_names(attrs, {'blocksize':'block_size'})
 
     return "depth_to_space", new_attrs, inputs
+
+def spacetodepth(attrs, inputs, proto_obj):
+    """Rearranges blocks of spatial data into depth."""
+    new_attrs = translation_utils._fix_attribute_names(attrs, {'blocksize':'block_size'})
+
+    return "space_to_depth", new_attrs, inputs

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -688,3 +688,9 @@ def max_roi_pooling(attrs, inputs, proto_obj):
                                                         'spatial_scale': 'spatial_scale'
                                                        })
     return 'ROIPooling', new_attrs, inputs
+
+def depthtospace(attrs, inputs, proto_obj):
+    """Rearranges data from depth into blocks of spatial data."""
+    new_attrs = translation_utils._fix_attribute_names(attrs, {'blocksize':'block_size'})
+
+    return "depth_to_space", new_attrs, inputs

--- a/tests/python-pytest/onnx/export/onnx_backend_test.py
+++ b/tests/python-pytest/onnx/export/onnx_backend_test.py
@@ -91,7 +91,8 @@ IMPLEMENTED_OPERATORS_TEST = [
     'test_operator_params',
     'test_operator_permute2',
     'test_clip'
-    'test_cast'
+    'test_cast',
+    'test_depthtospace'
     ]
 
 BASIC_MODEL_TESTS = [

--- a/tests/python-pytest/onnx/import/test_cases.py
+++ b/tests/python-pytest/onnx/import/test_cases.py
@@ -85,7 +85,8 @@ IMPLEMENTED_OPERATORS_TEST = [
     'test_operator_exp',
     'test_operator_maxpool',
     'test_operator_params',
-    'test_operator_permute2'
+    'test_operator_permute2',
+    'test_depthtospace'
     ]
 
 BASIC_MODEL_TESTS = [


### PR DESCRIPTION
## Description ##
Adding DepthToSpace, SpaceToDepth operators to ONNX import/export

v2: Added tests for SpaceToDepth. 
v3: Updated the test for SpaceToDepth - removed hard coded input/output. Since ONNX export test executed import, export, import, maintaining the custom test only in mxnet_export_test.py.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Added DepthToSpace, SpaceToDepth operator import/export
- Added tests for DepthToSpace

## Comments ##
Temporarily adding tests for SpaceToDepth in mxnet_export_test.py and onnx_import_test.py. 
