### PR TITLE
Throw exception if MXSymbolInferShape fails.

### DIFF
--- a/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
@@ -1581,6 +1581,18 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxSymbolInferShape
   env->ReleaseIntArrayElements(jargShapeData, argShapeData, 0);
   env->ReleaseIntArrayElements(jargIndPtr, argIndPtr, 0);
 
+  if (ret != 0) {
+    if (jkeys != NULL) {
+      for (int i = 0; i < jnumArgs; i++ ) {
+        jstring jkey = reinterpret_cast<jstring>(env->GetObjectArrayElement(jkeys, i));
+        env->ReleaseStringUTFChars(jkey, keys[i]);
+        env->DeleteLocalRef(jkey);
+      }
+    }
+    jclass illArgClass = env->FindClass("java/lang/IllegalArgumentException");
+    return env->ThrowNew(illArgClass, MXGetLastError());
+  }
+
   jclass listClass = env->FindClass("scala/collection/mutable/ListBuffer");
   jmethodID listAppend = env->GetMethodID(listClass,
     "$plus$eq", "(Ljava/lang/Object;)Lscala/collection/mutable/ListBuffer;");

--- a/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
@@ -1586,7 +1586,8 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxSymbolInferShape
     jmethodID listAppend = env->GetMethodID(listClass,
       "$plus$eq", "(Ljava/lang/Object;)Lscala/collection/mutable/ListBuffer;");
 
-    if (FillSymbolInferShape(env, listAppend, jinShapeData, inShapeSize, inShapeNdim, inShapeData)) {
+    if (FillSymbolInferShape(
+          env, listAppend, jinShapeData, inShapeSize, inShapeNdim, inShapeData)) {
       // TODO(Yizhi): out of memory error thrown, return a specific error code ?
       return -1;
     }

--- a/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
@@ -1583,7 +1583,7 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxSymbolInferShape
 
   if (ret != 0) {
     if (jkeys != NULL) {
-      for (int i = 0; i < jnumArgs; i++ ) {
+      for (int i = 0; i < jnumArgs; i++) {
         jstring jkey = reinterpret_cast<jstring>(env->GetObjectArrayElement(jkeys, i));
         env->ReleaseStringUTFChars(jkey, keys[i]);
         env->DeleteLocalRef(jkey);

--- a/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
@@ -1589,8 +1589,7 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxSymbolInferShape
         env->DeleteLocalRef(jkey);
       }
     }
-    jclass illArgClass = env->FindClass("java/lang/IllegalArgumentException");
-    return env->ThrowNew(illArgClass, MXGetLastError());
+    return ret;
   }
 
   jclass listClass = env->FindClass("scala/collection/mutable/ListBuffer");


### PR DESCRIPTION
* scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc:
  (Java_org_apache_mxnet_LibInfo_mxSymbolInferShape): throw
  IllegalArgumentException with the content of MXGetError if call to
  MXSymbolInferShape fails.

## Description ##
Properly handle any errors returned from `MXSymbolInferShape`, by throwing an exception to the caller. Otherwise, an error in that function call would mean subsequent calls (e.g. FillSymbolInferShape) would be operating on invalid, uninitialized data.