### PR TITLE
[MXNET-1026] [Perl] Sync with recent changes in Python's API

### DIFF
--- a/docs/install/validate_mxnet.md
+++ b/docs/install/validate_mxnet.md
@@ -137,8 +137,25 @@ Please contribute an example!
 
 ### Perl
 
-Please contribute an example!
+Start the pdl2 terminal.
 
+```bash
+$ pdl2
+```
+
+Run a short *MXNet* python program to create a 2X3 matrix of ones, multiply each element in the matrix by 2 followed by adding 1. We expect the output to be a 2X3 matrix with all elements being 3.
+
+```perl
+pdl> use AI::MXNet qw(mx)
+pdl> $a = mx->nd->ones([2, 3])
+pdl> $b = $a * 2 + 1
+pdl> print $b->aspdl
+
+[
+ [3 3 3]
+ [3 3 3]
+]
+```
 
 ### R
 

--- a/docs/install/validate_mxnet.md
+++ b/docs/install/validate_mxnet.md
@@ -143,7 +143,7 @@ Start the pdl2 terminal.
 $ pdl2
 ```
 
-Run a short *MXNet* python program to create a 2X3 matrix of ones, multiply each element in the matrix by 2 followed by adding 1. We expect the output to be a 2X3 matrix with all elements being 3.
+Run a short *MXNet* Perl program to create a 2X3 matrix of ones, multiply each element in the matrix by 2 followed by adding 1. We expect the output to be a 2X3 matrix with all elements being 3.
 
 ```perl
 pdl> use AI::MXNet qw(mx)

--- a/perl-package/AI-MXNet-Gluon-Contrib/Changes
+++ b/perl-package/AI-MXNet-Gluon-Contrib/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension AI::MXNet::Gluon::Contrib
 
+1.33    Thu Oct  4 13:25:56 PDT 2018
+        - Fixed kwalitee issues.
+
 1.32    Sun Jul 15 12:12:15 PDT 2018
         - Missing POD fixes.
 

--- a/perl-package/AI-MXNet-Gluon-Contrib/META.json
+++ b/perl-package/AI-MXNet-Gluon-Contrib/META.json
@@ -30,7 +30,7 @@
       },
       "runtime" : {
          "requires" : {
-            "AI::MXNet" : "1.31",
+            "AI::MXNet" : "1.33"
          }
       },
       "test" : {
@@ -38,5 +38,5 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.32"
+   "version" : "1.33"
 }

--- a/perl-package/AI-MXNet-Gluon-Contrib/META.yml
+++ b/perl-package/AI-MXNet-Gluon-Contrib/META.yml
@@ -18,4 +18,4 @@ no_index:
     - inc
 requires:
   AI::MXNet: '1.31'
-version: '1.32'
+version: '1.33'

--- a/perl-package/AI-MXNet-Gluon-Contrib/Makefile.PL
+++ b/perl-package/AI-MXNet-Gluon-Contrib/Makefile.PL
@@ -39,7 +39,7 @@ my %WriteMakefileArgs = (
     "AI::MXNet" => "1.31",
   },
   "TEST_REQUIRES" => {},
-  "VERSION" => "1.32",
+  "VERSION" => "1.33",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/perl-package/AI-MXNet-Gluon-Contrib/README
+++ b/perl-package/AI-MXNet-Gluon-Contrib/README
@@ -1,5 +1,5 @@
 This archive contains the distribution AI-MXNet-Gluon-Contrib,
-version 1.32:
+version 1.33:
 
   Perl interface to MXNet Gluon Contib modules, a collection of supplemental Gluon blocks.
 

--- a/perl-package/AI-MXNet-Gluon-Contrib/lib/AI/MXNet/Gluon/Contrib.pm
+++ b/perl-package/AI-MXNet-Gluon-Contrib/lib/AI/MXNet/Gluon/Contrib.pm
@@ -20,10 +20,20 @@ use strict;
 use warnings;
 use AI::MXNet;
 use AI::MXNet::Gluon::Contrib::NN::BasicLayers;
-our $VERSION = '1.32';
+our $VERSION = '1.33';
 =head1 NAME 
 
     AI::MXNet::Gluon::Contrib - A collection of supplemental Gluon blocks.
 =cut
 
 1;
+
+=head1 AUTHOR
+
+    Sergey Kolychev, <sergeykolychev.github@gmail.com>
+
+=head1 COPYRIGHT & LICENSE
+
+    This library is licensed under Apache 2.0 license L<https://www.apache.org/licenses/LICENSE-2.0>
+
+=cut

--- a/perl-package/AI-MXNet-Gluon-ModelZoo/Changes
+++ b/perl-package/AI-MXNet-Gluon-ModelZoo/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension AI::MXNet::Gluon::ModelZoo
 
+1.33    Thu Oct  4 13:25:56 PDT 2018
+        - Fixed kwalitee issues.
+
 1.32    Sun Aug  5 14:25:31 PDT 2018
         - Updated vgg16/19 models
 

--- a/perl-package/AI-MXNet-Gluon-ModelZoo/META.json
+++ b/perl-package/AI-MXNet-Gluon-ModelZoo/META.json
@@ -31,7 +31,8 @@
       "runtime" : {
          "requires" : {
             "AI::MXNet" : "1.31",
-            "AI::MXNet::Gluon::Contrib" : "1.3"
+            "AI::MXNet::Gluon::Contrib" : "1.3",
+            "IO::Uncompress::Unzip" : "0"
          }
       },
       "test" : {
@@ -39,5 +40,5 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.32"
+   "version" : "1.33"
 }

--- a/perl-package/AI-MXNet-Gluon-ModelZoo/META.yml
+++ b/perl-package/AI-MXNet-Gluon-ModelZoo/META.yml
@@ -19,4 +19,5 @@ no_index:
 requires:
   AI::MXNet: '1.31'
   AI::MXNet::Gluon::Contrib: '1.3'
-version: '1.32'
+  IO::Uncompress::Unzip: '0'
+version: '1.33'

--- a/perl-package/AI-MXNet-Gluon-ModelZoo/Makefile.PL
+++ b/perl-package/AI-MXNet-Gluon-ModelZoo/Makefile.PL
@@ -37,10 +37,11 @@ my %WriteMakefileArgs = (
   "NAME" => "AI::MXNet::Gluon::ModelZoo",
   "PREREQ_PM" => {
     "AI::MXNet" => "1.31",
-    "AI::MXNet::Gluon::Contrib" => "1.3"
+    "AI::MXNet::Gluon::Contrib" => "1.3",
+    "IO::Uncompress::Unzip" => "0"
   },
   "TEST_REQUIRES" => {},
-  "VERSION" => "1.32",
+  "VERSION" => "1.33",
   "test" => {
     "TESTS" => "t/*.t"
   }
@@ -49,7 +50,8 @@ my %WriteMakefileArgs = (
 
 my %FallbackPrereqs = (
   "AI::MXNet" => "1.31",
-  "AI::MXNet::Gluon::Contrib" => "1.3"
+  "AI::MXNet::Gluon::Contrib" => "1.3",
+  "IO::Uncompress::Unzip" => "0"
 );
 
 

--- a/perl-package/AI-MXNet-Gluon-ModelZoo/README
+++ b/perl-package/AI-MXNet-Gluon-ModelZoo/README
@@ -1,5 +1,5 @@
 This archive contains the distribution AI-MXNet-Gluon-ModelZoo,
-version 1.32:
+version 1.33:
 
   Perl interface to MXNet Gluon ModelZoo, a collection of pretrained machine learning models for computer vision.
 

--- a/perl-package/AI-MXNet-Gluon-ModelZoo/lib/AI/MXNet/Gluon/ModelZoo.pm
+++ b/perl-package/AI-MXNet-Gluon-ModelZoo/lib/AI/MXNet/Gluon/ModelZoo.pm
@@ -26,7 +26,7 @@ use AI::MXNet::Gluon::ModelZoo::Vision;
 use Exporter;
 use base qw(Exporter);
 @AI::MXNet::Gluon::ModelZoo::EXPORT_OK = qw(get_model);
-our $VERSION = '1.32';
+our $VERSION = '1.33';
 
 =head1 NAME
 
@@ -130,3 +130,13 @@ sub get_model
 sub vision { 'AI::MXNet::Gluon::ModelZoo::Vision' }
 
 1;
+
+=head1 AUTHOR
+
+    Sergey Kolychev, <sergeykolychev.github@gmail.com>
+
+=head1 COPYRIGHT & LICENSE
+
+    This library is licensed under Apache 2.0 license L<https://www.apache.org/licenses/LICENSE-2.0>
+
+=cut

--- a/perl-package/AI-MXNet/Changes
+++ b/perl-package/AI-MXNet/Changes
@@ -1,5 +1,17 @@
 Revision history for Perl extension AI::MXNet
 
+1.33    Thu Oct  4 13:25:56 PDT 2018
+        - Added randn function.
+        - Internal SELU function on C++ layer.
+        - Predict now accepts ndarray as well.
+        - Gluon: Only warn when the blocks are unregistered.
+        - Gluon: Better sparse support.
+        - Gluon: Improved block summary.
+        - Added validation docs for MXNet installation for Perl.
+        - Flexible perl env for examples.
+        - Gluon: Custom dtypes for the symbol block
+        - Separate eval metric for the epoch level.
+
 1.32    Sun Aug  5 14:25:31 PDT 2018
         - Several new metric classes
         - Expanded documentation

--- a/perl-package/AI-MXNet/META.json
+++ b/perl-package/AI-MXNet/META.json
@@ -30,7 +30,7 @@
       },
       "runtime" : {
          "requires" : {
-            "AI::MXNetCAPI" : "1.32",
+            "AI::MXNetCAPI" : "1.33",
             "AI::NNVMCAPI" : "1.3",
             "Function::Parameters" : "1.0705",
             "Hash::Ordered" : "0.012",
@@ -45,5 +45,5 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.32"
+   "version" : "1.33"
 }

--- a/perl-package/AI-MXNet/META.yml
+++ b/perl-package/AI-MXNet/META.yml
@@ -17,7 +17,7 @@ no_index:
     - t
     - inc
 requires:
-  AI::MXNetCAPI: '1.32'
+  AI::MXNetCAPI: '1.33'
   AI::NNVMCAPI: '1.3'
   Function::Parameters: '1.0705'
   Hash::Ordered: '0.012'
@@ -25,4 +25,4 @@ requires:
   Mouse: v2.1.0
   PDL: '2.007'
   PDL::CCS: '1.23.4'
-version: '1.32'
+version: '1.33'

--- a/perl-package/AI-MXNet/Makefile.PL
+++ b/perl-package/AI-MXNet/Makefile.PL
@@ -36,7 +36,7 @@ my %WriteMakefileArgs = (
   "LICENSE" => "apache_2_0",
   "NAME" => "AI::MXNet",
   "PREREQ_PM" => {
-    "AI::MXNetCAPI" => "1.3",
+    "AI::MXNetCAPI" => "1.33",
     "AI::NNVMCAPI" => "1.3",
     "Function::Parameters" => "1.0705",
     "Hash::Ordered" => "0.012",
@@ -46,7 +46,7 @@ my %WriteMakefileArgs = (
     "GraphViz" => "2.14"
   },
   "TEST_REQUIRES" => {},
-  "VERSION" => "1.32",
+  "VERSION" => "1.33",
   "test" => {
     "TESTS" => "t/*.t"
   }
@@ -54,7 +54,7 @@ my %WriteMakefileArgs = (
 
 
 my %FallbackPrereqs = (
-  "AI::MXNetCAPI" => "1.3",
+  "AI::MXNetCAPI" => "1.33",
   "AI::NNVMCAPI" => "1.3",
   "Function::Parameters" => "1.0705",
   "Hash::Ordered" => "0.012",

--- a/perl-package/AI-MXNet/README
+++ b/perl-package/AI-MXNet/README
@@ -1,5 +1,5 @@
 This archive contains the distribution AI-MXNet,
-version 1.32:
+version 1.33:
 
   Perl interface to MXNet machine learning library
 

--- a/perl-package/AI-MXNet/examples/calculator.pl
+++ b/perl-package/AI-MXNet/examples/calculator.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/perl-package/AI-MXNet/examples/char_lstm.pl
+++ b/perl-package/AI-MXNet/examples/char_lstm.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/perl-package/AI-MXNet/examples/cudnn_lstm_bucketing.pl
+++ b/perl-package/AI-MXNet/examples/cudnn_lstm_bucketing.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/perl-package/AI-MXNet/examples/gluon/dcgan.pl
+++ b/perl-package/AI-MXNet/examples/gluon/dcgan.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/perl-package/AI-MXNet/examples/gluon/mnist.pl
+++ b/perl-package/AI-MXNet/examples/gluon/mnist.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/perl-package/AI-MXNet/examples/lstm_bucketing.pl
+++ b/perl-package/AI-MXNet/examples/lstm_bucketing.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/perl-package/AI-MXNet/examples/mnist.pl
+++ b/perl-package/AI-MXNet/examples/mnist.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/perl-package/AI-MXNet/examples/plot_network.pl
+++ b/perl-package/AI-MXNet/examples/plot_network.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/perl-package/AI-MXNet/lib/AI/MXNet.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet.pm
@@ -51,7 +51,7 @@ use AI::MXNet::Gluon;
 use AI::MXNet::NDArray::Sparse;
 use AI::MXNet::Symbol::Sparse;
 use AI::MXNet::Engine;
-our $VERSION = '1.32';
+our $VERSION = '1.33';
 
 sub import
 {

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon.pm
@@ -82,7 +82,7 @@ sub model_zoo { require AI::MXNet::Gluon::ModelZoo; 'AI::MXNet::Gluon::ModelZoo'
     but rather brings the training algorithm and model closer together to provide flexibility in the development process.
 
     Dynamic Graphs: Gluon enables developers to define neural network models that are dynamic,
-    meaning they can be built on the fly, with any structure, and using any of Perl’s native control flow.
+    meaning they can be built on the fly, with any structure, and using any of Perl's native control flow.
 
     High Performance: Gluon provides all of the above benefits without impacting the training speed that the underlying engine provides.
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/Activation.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/Activation.pm
@@ -201,16 +201,9 @@ package AI::MXNet::Gluon::NN::SELU;
 use AI::MXNet::Gluon::Mouse;
 extends 'AI::MXNet::Gluon::HybridBlock';
 
-sub BUILD
-{
-    my $self = shift;
-    $self->scale(1.0507009873554804934193349852946);
-    $self->alpha(1.6732632423543772848170429916717);
-}
-
 method hybrid_forward(GluonClass $F, GluonInput $x)
 {
-    return $self->scale * $F->where($x > 0, $x, $self->alpha * ($F->exp($x) - 1));
+    $F->LeakyReLU($x, act_type=>'selu', name=>'fwd');
 }
 
 __PACKAGE__->register('AI::MXNet::Gluon::NN');

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Parameter.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Parameter.pm
@@ -421,7 +421,7 @@ method _reduce()
     {
         my $all_row_ids = AI::MXNet::NDArray->arange(stop => $self->shape->[0], dtype=>'int64', ctx=>$ctx);
         $data = AI::MXNet::NDArray->zeros($self->shape, stype=>'row_sparse', ctx=>$ctx);
-        $self->_trainer->_row_sparse_pull($self, $data, $all_row_ids);
+        $self->_trainer->_row_sparse_pull($self, $data, $all_row_ids, 1);
     }
     return $data;
 }
@@ -1046,6 +1046,10 @@ method get(Str $name, %kwargs)
                             $param->_shape(\@inferred_shape);
                             next;
                         }
+                    }
+                    elsif($k eq 'dtype' and ($v//'') eq ($existing//''))
+                    {
+                        next;
                     }
                     assert(
                         (not defined $v or Dumper($v) eq Dumper($param->$k)),

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Initializer.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Initializer.pm
@@ -86,7 +86,7 @@ has '_print_func' => (is => 'rw', isa => 'CodeRef', lazy => 1,
     mx->init->One        Initializes weights to one.
     mx->init->Constant   Initializes the weights to a given value.
     mx->init->Orthogonal Initialize weight as orthogonal matrix.
-    mx->init->Xavier     Returns an initializer performing “Xavier” initialization for weights.
+    mx->init->Xavier     Returns an initializer performing Xavier initialization for weights.
     mx->init->MSRAPrelu  Initialize the weight according to a MSRA paper.
     mx->init->Bilinear   Initialize weight for upsampling layers.
     mx->init->FusedRNN   Initialize parameters for fused rnn layers.

--- a/perl-package/AI-MXNet/lib/AI/MXNet/KVStore.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/KVStore.pm
@@ -215,13 +215,14 @@ method push(
 method pull(
     Str|ArrayRef[Str] $key,
     AI::MXNet::NDArray|ArrayRef[AI::MXNet::NDArray]|ArrayRef[ArrayRef[AI::MXNet::NDArray]] :$out,
-    Int :$priority=0
+    Int :$priority=0,
+    Bool :$ignore_sparse=1
 )
 {
     my ($keys, $vals) = _key_value($key, $out);
     check_call(
-        AI::MXNetCAPI::KVStorePullEx(
-            $self->handle, scalar(@{ $keys }), $keys, $vals, $priority
+        AI::MXNetCAPI::KVStorePullWithSparseEx(
+            $self->handle, scalar(@{ $keys }), $keys, $vals, $priority, $ignore_sparse
         )
     );
 }

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Metric.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Metric.pm
@@ -240,7 +240,7 @@ method get()
 
     The accuracy score is defined as
 
-    accuracy(y, y^) = (1/n) * sum(i=0..n−1) { y^(i)==y(i) }
+    accuracy(y, y^) = (1/n) * sum(i=0..n-1) { y^(i)==y(i) }
 
     Parameters:
     axis (Int, default=1) – The axis that represents classes.

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Module/Base.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Module/Base.pm
@@ -27,6 +27,7 @@ package AI::MXNet::Module::Base;
 use Mouse;
 use AI::MXNet::Base;
 use Time::HiRes qw(time);
+use Storable qw(dclone);
 
 =head1 NAME
 
@@ -350,7 +351,7 @@ method iter_predict(AI::MXNet::DataIter $eval_data, Maybe[Int] :$num_batch=, Boo
 
     Parameters
     ----------
-    $eval_data  : AI::MXNet::DataIter
+    $eval_data  : AI::MXNet::DataIter|AcceptableInput (PDL|NDArray)
     :$num_batch= : Maybe[Int]
         Default is undef, indicating running all the batches in the data iterator.
     :$merge_batches=1 : Bool
@@ -363,6 +364,8 @@ method iter_predict(AI::MXNet::DataIter $eval_data, Maybe[Int] :$num_batch=, Boo
 
     Returns
     -------
+    If the input is AI::MXNet::NDArray|PDL then the return value is AI::MXNet::NDArray.
+
     When $merge_batches is 1 (by default), the return value will be an array ref
     [$out1, $out2, $out3] where each element is concatenation of the outputs for
     all the mini-batches. If $always_output_list` also is 0 (by default),
@@ -378,13 +381,21 @@ method iter_predict(AI::MXNet::DataIter $eval_data, Maybe[Int] :$num_batch=, Boo
 =cut
 
 method predict(
-    AI::MXNet::DataIter $eval_data,
+    AI::MXNet::DataIter|AcceptableInput $eval_data,
     Maybe[Int] :$num_batch=, Bool :$merge_batches=1, Bool :$reset=1, Bool :$always_output_list=0
 )
 {
     assert($self->binded and $self->params_initialized);
+    if(not blessed $eval_data or not $eval_data->isa('AI::MXNet::DataIter'))
+    {
+        if(not blessed $eval_data or not $eval_data->isa('AI::MXNet::NDArray'))
+        {
+            $eval_data = AI::MXNet::NDArray->array($eval_data);
+        }
+        $self->forward(AI::MXNet::DataBatch->new(data => [$eval_data]));
+        return $self->get_outputs->[0];
+    }
     $eval_data->reset() if $reset;
-
     my @output_list;
     my $nbatch = 0;
     while(my $eval_batch = <$eval_data>)
@@ -533,6 +544,7 @@ method fit(
     }
     $eval_metric = AI::MXNet::Metric->create($eval_metric)
         unless blessed $eval_metric;
+    my $epoch_eval_metric = dclone($eval_metric);
 
     ################################################################################
     # training loop
@@ -541,6 +553,7 @@ method fit(
     {
         my $tic = time;
         $eval_metric->reset;
+        $epoch_eval_metric->reset;
         my $nbatch = 0;
         my $end_of_batch = 0;
         my $next_data_batch = <$train_data>;
@@ -559,10 +572,11 @@ method fit(
             {
                 $end_of_batch = 1;
             }
-            $self->update_metric($eval_metric, $data_batch->label);
+            $self->update_metric($epoch_eval_metric, $data_batch->label);
             $monitor->toc_print if $monitor;
             if(defined $batch_end_callback)
             {
+                $self->update_metric($eval_metric, $data_batch->label);
                 my $batch_end_params = AI::MXNet::BatchEndParam->new(
                     epoch       => $epoch,
                     nbatch      => $nbatch,
@@ -576,7 +590,7 @@ method fit(
             $nbatch++;
         }
         # one epoch of training is finished
-        my $name_value = $eval_metric->get_name_value;
+        my $name_value = $epoch_eval_metric->get_name_value;
         while(my ($name, $val) = each %{ $name_value })
         {
             $self->logger->info('Epoch[%d] Train-%s=%f', $epoch, $name, $val);

--- a/perl-package/AI-MXNet/lib/AI/MXNet/NDArray.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/NDArray.pm
@@ -27,14 +27,14 @@ package AI::MXNet::NDArray;
     AI::MXNet::NDArray - Imperative tensor operations on CPU/GPU
     In AI::MXNet, NDArray is the core data structure for all mathematical computations.
     An NDArray represents a multidimensional, fixed-size homogenous array.
-    If you’re familiar with the PDL, you might notice some similarities.
+    If you're familiar with the PDL, you might notice some similarities.
     However, NDArray is row-major, unlike the PDL that is column-major.
     Like the PDL, MXNet’s NDArray enables imperative computation.
 
     Some NDArray advandages compared to PDL:
-    MXNet’s NDArray supports fast execution on a wide range of hardware configurations, including CPU, GPU, and multi-GPU machines.
+    MXNet's NDArray supports fast execution on a wide range of hardware configurations, including CPU, GPU, and multi-GPU machines.
     MXNet also scales to distributed systems in the cloud.
-    MXNet’s NDArray executes code lazily, allowing it to automatically parallelize multiple operations across the available hardware.
+    MXNet's NDArray executes code lazily, allowing it to automatically parallelize multiple operations across the available hardware.
 
     An NDArray is a multidimensional array of numbers with the same type.
     We could represent the coordinates of a point in 3D space, e.g. [2, 1, 6] as a 1D array with shape (3).
@@ -43,9 +43,9 @@ package AI::MXNet::NDArray;
 
     [[0, 1, 2]
      [3, 4, 5]]
-    Note that here the use of “dimension” is overloaded. When we say a 2D array, we mean an array with 2 axes, not an array with two components.
+    Note that here the use of 'dimension' is overloaded. When we say a 2D array, we mean an array with 2 axes, not an array with two components.
 
-    Each NDArray supports some important attributes that you’ll often want to query:
+    Each NDArray supports some important attributes that you'll often want to query:
 
     $ndarray->shape: The dimensions of the array.
     It is an array ref of integers indicating the length of the array along each axis.

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Random.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Random.pm
@@ -90,6 +90,20 @@ sub AUTOLOAD {
     );
     my @args;
     my @tmp = @_;
+    if($sub eq 'randn')
+    {
+        $sub = 'normal';
+        my @shape;
+        while(defined $tmp[0] and $tmp[0] =~ /^\d+$/)
+        {
+            push @shape, shift(@tmp);
+        }
+        if(@shape)
+        {
+            push @tmp, (shape => \@shape);
+        }
+        %defaults = (%defaults, loc => 0, scale => 1);
+    }
     if(ref $tmp[-1] eq 'HASH')
     {
         my @kwargs = %{ pop(@tmp) };

--- a/perl-package/AI-MXNet/t/test_module.t
+++ b/perl-package/AI-MXNet/t/test_module.t
@@ -17,7 +17,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 426;
+use Test::More tests => 428;
 use AI::MXNet qw(mx);
 use AI::MXNet::Base;
 use AI::MXNet::TestUtils qw(almost_equal enumerate same_array dies_like rand_ndarray);
@@ -789,6 +789,17 @@ sub test_forward_reshape
 
 }
 
+sub test_forward_acceptable_input
+{
+    my $data = mx->sym->Variable('data');
+    my $out = $data * 2;
+    my $mod = mx->mod->Module(symbol => $out);
+    $mod->bind(data_shapes => [['data', [1, 10]]]);
+    $mod->init_params();
+    is_deeply($mod->predict(mx->nd->ones([1, 10]))->shape, [1, 10]);
+    is_deeply($mod->predict(mx->nd->ones([1, 10])->aspdl)->shape, [1, 10]);
+}
+
 test_module_input_grads();
 test_module_dtype();
 test_monitor();
@@ -802,3 +813,4 @@ test_module_set_params();
 test_forward_reshape();
 test_module_initializer();
 test_factorization_machine_module();
+test_forward_acceptable_input();

--- a/perl-package/AI-MXNet/t/test_random.t
+++ b/perl-package/AI-MXNet/t/test_random.t
@@ -17,7 +17,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 506;
+use Test::More tests => 515;
 use AI::MXNet qw(mx);
 use AI::MXNet::TestUtils qw(same enumerate);
 
@@ -32,6 +32,15 @@ sub check_with_device
             ndop   => sub { mx->nd->random->normal(@_)  },
             params => { loc => 10.0, scale => 0.5 },
             inputs => [ [loc => [ [ 0.0, 2.5 ], [ -9.75, -7.0 ] ]] , [scale => [ [ 1.0, 3.7 ], [ 4.2, 1.5 ] ]] ],
+            checks => [
+                [mean => sub { my ($x, $params) = @_; $x->astype('float64')->aspdl->avg - $params->{loc} }, $tol],
+                [std  => sub { my ($x, $params) = @_; ($x->astype('float64')->aspdl->stats)[6] - $params->{scale} }, $tol]
+            ]
+        },
+        {
+            name => 'randn',
+            ndop => sub { mx->nd->random->randn(@_) },
+            params => { loc => 10.0, scale => 0.5 },
             checks => [
                 [mean => sub { my ($x, $params) = @_; $x->astype('float64')->aspdl->avg - $params->{loc} }, $tol],
                 [std  => sub { my ($x, $params) = @_; ($x->astype('float64')->aspdl->stats)[6] - $params->{scale} }, $tol]
@@ -126,6 +135,7 @@ sub check_with_device
         }
 
         # check multi-distribution sampling, only supports cpu for now
+        next unless $symbdic->{inputs};
         %params = (shape=>$shape, dtype=>$dtype, ctx=>$device);
         %params = (%params, map { $_->[0] => mx->nd->array($_->[1], ctx=>$device, dtype=>$dtype) } @{ $symbdic->{inputs} });
         mx->random->seed(128);
@@ -149,6 +159,7 @@ sub check_with_device
 
         # check symbolic
         my $symbol = $symbdic->{symbol};
+        next if not $symbol;
         my $X = mx->sym->Variable("X");
         %params = %{ $symbdic->{params} };
         %params = (%params, shape=>$shape, dtype=>$dtype);

--- a/perl-package/AI-MXNetCAPI/Changes
+++ b/perl-package/AI-MXNetCAPI/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension AI::MXNetCAPI
 
+1.33    Thu Oct  4 13:25:56 PDT 2018
+        - Gluon: Better sparse support for KVStore.
+        - Gpu memory info via mxnet api call.
+
 1.32    Sun Aug  5 14:25:31 PDT 2018
         - Bugfixes.
 

--- a/perl-package/AI-MXNetCAPI/META.json
+++ b/perl-package/AI-MXNetCAPI/META.json
@@ -37,5 +37,5 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.32"
+   "version" : "1.33"
 }

--- a/perl-package/AI-MXNetCAPI/META.yml
+++ b/perl-package/AI-MXNetCAPI/META.yml
@@ -19,4 +19,4 @@ no_index:
     - inc
 requires:
   Test::More: '0'
-version: '1.32'
+version: '1.33'

--- a/perl-package/AI-MXNetCAPI/README
+++ b/perl-package/AI-MXNetCAPI/README
@@ -1,4 +1,4 @@
-AI-MXNetCAPI version 1.32
+AI-MXNetCAPI version 1.33
 =====================
 
 Swig interface to MXNet c api.

--- a/perl-package/AI-MXNetCAPI/lib/AI/MXNetCAPI.pm
+++ b/perl-package/AI-MXNetCAPI/lib/AI/MXNetCAPI.pm
@@ -18,7 +18,7 @@
 package AI::MXNetCAPI;
 use base qw(DynaLoader);
 bootstrap AI::MXNetCAPI;
-our $VERSION = '1.32';
+our $VERSION = '1.33';
 1;
 __END__
 

--- a/perl-package/AI-MXNetCAPI/mxnet.i
+++ b/perl-package/AI-MXNetCAPI/mxnet.i
@@ -342,6 +342,15 @@ int MXEngineSetBulkSize(int bulk_size, int* out);
  */
 int MXGetGPUCount(int* out);
 
+/*!
+ * \brief get the free and total available memory on a GPU
+ * \param dev the GPU number to query
+ * \param free_mem pointer to the integer holding free GPU memory
+ * \param total_mem pointer to the integer holding total GPU memory
+ * \return 0 when success, -1 when failure happens
+ */
+int MXGetGPUMemoryInformation(int dev, int *out, int *out);
+
 
 //-------------------------------------
 // Part 1: NDArray creation and deletion
@@ -1816,6 +1825,24 @@ int MXKVStorePullRowSparseEx(KVStoreHandle handle,
                                        NDArrayHandle* in,
                                        NDArrayHandle* in,
                                        int priority);
+
+/*!
+ * \brief pull a list of (key, value) pairs from the kvstore, where each key is a string
+ * \param handle handle to the kvstore
+ * \param num the number of key-value pairs
+ * \param keys the list of keys
+ * \param vals the list of values
+ * \param priority the priority of the action
+ * \param ignore_sparse whether to ignore sparse arrays in the request
+ * \return 0 when success, -1 when failure happens
+ */
+int MXKVStorePullWithSparseEx(KVStoreHandle handle,
+                                        mx_uint num,
+                                        const char** in,
+                                        NDArrayHandle* in,
+                                        int priority,
+                                        bool ignore_sparse);
+
 /*!
  * \brief user-defined updater for the kvstore
  * It's this updater's responsibility to delete \a recv and \a local


### PR DESCRIPTION
## Description ##

* Added randn function.
* Internal SELU function on C++ layer
* Predict now accepts ndarray as well
* Gluon: Only warn when the blocks are unregistered.
* Better sparse support for gluon
* Gpu memory info via mxnet api call.
* Gluon: Improved block summary.
* Added validation docs for MXNet installation for Perl.
* Flexible perl env for examples.
* Gluon: Custom dtypes for the symbol block.
* Separate eval metric for the epoch level.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
