### PR TITLE
Update packages and tests in the straight dope nightly

### DIFF
--- a/ci/docker/install/ubuntu_nightly_tests.sh
+++ b/ci/docker/install/ubuntu_nightly_tests.sh
@@ -32,5 +32,5 @@ apt-get -y install time
 apt-get install -y subversion maven -y #>/dev/null
 
 # Packages needed for the Straight Dope Nightly tests.
-pip2 install pandas scikit-image
-pip3 install pandas scikit-image
+pip2 install pandas scikit-image prompt_toolkit
+pip3 install pandas scikit-image prompt_toolkit

--- a/tests/nightly/straight_dope/test_notebooks_single_gpu.py
+++ b/tests/nightly/straight_dope/test_notebooks_single_gpu.py
@@ -35,13 +35,11 @@ NOTEBOOKS_WHITELIST = [
     'chapter02_supervised-learning/environment',
     'chapter03_deep-neural-networks/kaggle-gluon-kfold',
     'chapter04_convolutional-neural-networks/deep-cnns-alexnet',  # > 10 mins.
-    'chapter05_recurrent-neural-networks/rnns-gluon', # > 10 mins.
     'chapter06_optimization/gd-sgd-scratch',  # Overflow warning is intended.
     'chapter06_optimization/gd-sgd-gluon',  # Overflow warning is intended.
     'chapter07_distributed-learning/multiple-gpus-scratch',
     'chapter07_distributed-learning/multiple-gpus-gluon',
     'chapter07_distributed-learning/training-with-multiple-machines',
-    'chapter08_computer-vision/visual-question-answer', # > 10 mins.
     'chapter11_recommender-systems/intro-recommender-systems',  # Early draft, non-working.
     'chapter12_time-series/intro-forecasting-gluon',
     'chapter12_time-series/intro-forecasting-2-gluon',
@@ -178,6 +176,9 @@ class StraightDopeSingleGpuTests(unittest.TestCase):
     def test_gru_scratch(self):
         assert _test_notebook('chapter05_recurrent-neural-networks/gru-scratch')
 
+    def test_rnn_gluon(self):
+        assert _test_notebook('chapter05_recurrent-neural-networks/rnns-gluon')
+ 
     # Chapter 6
 
     def test_optimization_intro(self):
@@ -226,6 +227,10 @@ class StraightDopeSingleGpuTests(unittest.TestCase):
 
     def test_fine_tuning(self):
         assert _test_notebook('chapter08_computer-vision/fine-tuning')
+
+    def test_visual_qa(self):
+        assert _test_notebook('chapter08_computer-vision/visual-question-answer')
+
 
     # Chapter 9
 

--- a/tests/utils/notebook_test/__init__.py
+++ b/tests/utils/notebook_test/__init__.py
@@ -80,11 +80,13 @@ def run_notebook(notebook, notebook_dir, kernel=None, no_cache=False, temp_dir='
         else:
             eprocessor = ExecutePreprocessor(timeout=TIME_OUT)
 
+        success = False
         # There is a low (< 1%) chance that starting a notebook executor will fail due to the kernel
         # taking to long to start, or a port collision, etc.
         for i in range(RETRIES):
             try:
                 nb, _ = eprocessor.preprocess(notebook, {'metadata': {'path': working_dir}})
+                success = True
             except RuntimeError as rte:
                 # We check if the exception has to do with the Jupyter kernel failing to start. If
                 # not, we rethrow to prevent the notebook from erring RETRIES times. It is not ideal
@@ -97,6 +99,8 @@ def run_notebook(notebook, notebook_dir, kernel=None, no_cache=False, temp_dir='
                 time.sleep(1)
                 continue
             break
+        if not success:
+            errors.append('Error: Notebook failed to run.')
     except Exception as err:
         err_msg = str(err)
         errors.append(err_msg)

--- a/tests/utils/notebook_test/__init__.py
+++ b/tests/utils/notebook_test/__init__.py
@@ -32,7 +32,7 @@ import nbformat
 
 IPYTHON_VERSION = 4  # Pin to ipython version 4.
 TIME_OUT = 10*60  # Maximum 10 mins/test. Reaching timeout causes test failure.
-RETRIES = 8
+ATTEMPTS = 8
 KERNEL_ERROR_MSG = 'Kernel died before replying to kernel_info'
 
 
@@ -83,24 +83,25 @@ def run_notebook(notebook, notebook_dir, kernel=None, no_cache=False, temp_dir='
         success = False
         # There is a low (< 1%) chance that starting a notebook executor will fail due to the kernel
         # taking to long to start, or a port collision, etc.
-        for i in range(RETRIES):
+        for i in range(ATTEMPTS):
             try:
                 nb, _ = eprocessor.preprocess(notebook, {'metadata': {'path': working_dir}})
                 success = True
             except RuntimeError as rte:
                 # We check if the exception has to do with the Jupyter kernel failing to start. If
-                # not, we rethrow to prevent the notebook from erring RETRIES times. It is not ideal
-                # to inspect the exception message, but necessary for retry logic, as Jupyter client
-                # throws the generic RuntimeError that can be confused with other Runtime errors.
+                # not, we rethrow to prevent the notebook from erring ATTEMPTS times. It is not
+                # ideal to inspect the exception message, but necessary for retry logic, as Jupyter
+                # client throws the generic RuntimeError that can be confused with other Runtime
+                # errors.
                 if str(rte) != KERNEL_ERROR_MSG:
                     raise rte
 
-                logging.info("Error starting preprocessor: {}. Attempt {}/{}".format(str(rte), i+1, RETRIES))
+                logging.info("Error starting preprocessor: {}. Attempt {}/{}".format(str(rte), i+1, ATTEMPTS))
                 time.sleep(1)
                 continue
             break
         if not success:
-            errors.append('Error: Notebook failed to run.')
+            errors.append("Error: Notebook failed to run after {} attempts.".format(ATTEMPTS))
     except Exception as err:
         err_msg = str(err)
         errors.append(err_msg)


### PR DESCRIPTION
## Description ##
This PR enables two tutorial tests that were previously running too long. Both of those notebooks have since been updated in the Straight Dope repository to run faster. This addresses https://github.com/apache/incubator-mxnet/issues/12345.
This PR also updates a missing python dependency in the tutorial runner and adds a check so that future breakages will trigger an error: Addresses  https://github.com/apache/incubator-mxnet/issues/12743)

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
