### PR TITLE
Scala Docs - Replace old Symbol api usages

### DIFF
--- a/docs/api/scala/model.md
+++ b/docs/api/scala/model.md
@@ -21,10 +21,10 @@ The following example creates a two-layer neural network.
 ```scala
     // configure a two layer neuralnetwork
     val data = Symbol.Variable("data")
-    val fc1 = Symbol.FullyConnected(name = "fc1")()(Map("data" -> data, "num_hidden" -> 128))
-    val act1 = Symbol.Activation(name = "relu1")()(Map("data" -> fc1, "act_type" -> "relu"))
-    val fc2 = Symbol.FullyConnected(name = "fc2")()(Map("data" -> act1, "num_hidden" -> 64))
-    val softmax = Symbol.SoftmaxOutput(name = "sm")()(Map("data" -> fc2))
+    val fc1 = Symbol.api.FullyConnected(data, num_hidden = 128, name = "fc1")
+    val act1 = Symbol.api.Activation(Some(fc1), "relu", "relu1")
+    val fc2 = Symbol.api.FullyConnected(Some(act1), num_hidden = 64, name = "fc2")
+    val softmax = Symbol.api.SoftmaxOutput(Some(fc2), name = "sm")
 
     // Construct the FeedForward model and fit on the input training data
     val model = FeedForward.newBuilder(softmax)

--- a/docs/api/scala/module.md
+++ b/docs/api/scala/module.md
@@ -12,12 +12,12 @@ To construct a module, refer to the constructors for the module class. For examp
 
     // construct a simple MLP
     val data = Symbol.Variable("data")
-    val fc1 = Symbol.FullyConnected(name = "fc1")(data)(Map("num_hidden" -> 128))
-    val act1 = Symbol.Activation(name = "relu1")(fc1)(Map("act_type" -> "relu"))
-    val fc2 = Symbol.FullyConnected(name = "fc2")(act1)(Map("num_hidden" -> 64))
-    val act2 = Symbol.Activation(name = "relu2")(fc2)(Map("act_type" -> "relu"))
-    val fc3 = Symbol.FullyConnected(name = "fc3")(act2)(Map("num_hidden" -> 10))
-    val out = Symbol.SoftmaxOutput(name = "softmax")(fc3)()
+    val fc1 = Symbol.api.FullyConnected(Some(data), num_hidden = 128, name = "fc1")
+    val act1 = Symbol.api.Activation(Some(fc1), "relu", "relu1")
+    val fc2 = Symbol.api.FullyConnected(Some(act1), num_hidden = 64, name = "fc2")
+    val act2 = Symbol.api.Activation(Some(fc2), "relu", "relu2")
+    val fc3 = Symbol.api.FullyConnected(Some(act2), num_hidden = 10, name = "fc3")
+    val out = Symbol.api.SoftmaxOutput(fc3, name = "softmax")
 
     // construct the module
     val mod = new Module(out)

--- a/docs/api/scala/symbol.md
+++ b/docs/api/scala/symbol.md
@@ -22,10 +22,10 @@ The following example configures a two-layer neural network.
 ```scala
     scala> import org.apache.mxnet._
     scala> val data = Symbol.Variable("data")
-    scala> val fc1 = Symbol.FullyConnected(name = "fc1")()(Map("data" -> data, "num_hidden" -> 128))
-    scala> val act1 = Symbol.Activation(name = "relu1")()(Map("data" -> fc1, "act_type" -> "relu"))
-    scala> val fc2 = Symbol.FullyConnected(name = "fc2")()(Map("data" -> act1, "num_hidden" -> 64))
-    scala> val net = Symbol.SoftmaxOutput(name = "out")()(Map("data" -> fc2))
+    scala> val fc1 = Symbol.api.FullyConnected(Some(data), num_hidden = 128, name = "fc1")
+    scala> val act1 = Symbol.api.Activation(Some(fc1), "relu", "relu1")
+    scala> val fc2 = Symbol.api.FullyConnected(some(act1), num_hidden = 64, name = "fc2")
+    scala> val net = Symbol.api.SoftmaxOutput(Some(fc2), name = "out")
     scala> :type net
     org.apache.mxnet.Symbol
 ```
@@ -48,8 +48,7 @@ You can add an attribute to a symbol by providing an attribute dictionary when y
 
 ```scala
     val data = Symbol.Variable("data", Map("mood"-> "angry"))
-    val op   = Symbol.Convolution()()(
-      Map("data" -> data, "kernel" -> "(1, 1)", "num_filter" -> 1, "mood"-> "so so"))
+    val op = Symbol.api.Convolution(Some(data), kernel = Shape(1, 1), num_filter = 1, attr = Map("mood" -> "so so"))
 ```
 For proper communication with the C++ backend, both the key and values of the attribute dictionary should be strings. To retrieve the attributes, use `attr(key)`:
 
@@ -114,10 +113,10 @@ To group the symbols together, use the [mxnet.symbol.Group](#mxnet.symbol.Group)
 ```scala
     scala> import org.apache.mxnet._
     scala> val data = Symbol.Variable("data")
-    scala> val fc1 = Symbol.FullyConnected(name = "fc1")()(Map("data" -> data, "num_hidden" -> 128))
-    scala> val act1 = Symbol.Activation(name = "relu1")()(Map("data" -> fc1, "act_type" -> "relu"))
-    scala> val fc2 = Symbol.FullyConnected(name = "fc2")()(Map("data" -> act1, "num_hidden" -> 64))
-    scala> val net = Symbol.SoftmaxOutput(name = "out")()(Map("data" -> fc2))
+    scala> val fc1 = Symbol.api.FullyConnected(Some(data), num_hidden = 128, name = "fc1")
+    scala> val act1 = Symbol.api.Activation(Some(fc1), "relu", "relu1")
+    scala> val fc2 = Symbol.api.FullyConnected(Some(act1), num_hidden = 64, name = "fc2")
+    scala> val net = Symbol.api.SoftmaxOutput(Some(fc2), name = "out")
     scala> val group = Symbol.Group(fc1, net)
     scala> group.listOutputs()
     IndexedSeq[String] = ArrayBuffer(fc1_output, out_output)

--- a/docs/tutorials/scala/mnist.md
+++ b/docs/tutorials/scala/mnist.md
@@ -20,12 +20,12 @@ import org.apache.mxnet.optimizer.SGD
 
 // model definition
 val data = Symbol.Variable("data")
-val fc1 = Symbol.FullyConnected(name = "fc1")()(Map("data" -> data, "num_hidden" -> 128))
-val act1 = Symbol.Activation(name = "relu1")()(Map("data" -> fc1, "act_type" -> "relu"))
-val fc2 = Symbol.FullyConnected(name = "fc2")()(Map("data" -> act1, "num_hidden" -> 64))
-val act2 = Symbol.Activation(name = "relu2")()(Map("data" -> fc2, "act_type" -> "relu"))
-val fc3 = Symbol.FullyConnected(name = "fc3")()(Map("data" -> act2, "num_hidden" -> 10))
-val mlp = Symbol.SoftmaxOutput(name = "sm")()(Map("data" -> fc3))
+val fc1 = Symbol.api.FullyConnected(Some(data), num_hidden = 128, name = "fc1")
+val act1 = Symbol.api.Activation(Some(fc1), "relu", "relu1")
+val fc2 = Symbol.api.FullyConnected(Some(act1), num_hidden = 64, name = "fc2")
+val act2 = Symbol.api.Activation(Some(fc2), "relu", "relu2")
+val fc3 = Symbol.api.FullyConnected(Some(act2), num_hidden = 10, name = "fc3")
+val mlp = Symbol.api.SoftmaxOutput(Some(fc3), name = "sm")
 ```
 
 ## Load the Data


### PR DESCRIPTION
## Description ##
Replace usages of the old Symbol api in the docs with the newer and clearer symbol api

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Update docs