### PR TITLE
Disabled: test_gluon_gpu.test_slice_batchnorm_reshape_batchnorm

### DIFF
--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -2007,6 +2007,7 @@ def test_reshape_batchnorm_reshape_batchnorm():
 
 
 @with_seed()
+@unittest.skip('Flaky test: https://github.com/apache/incubator-mxnet/issues/12767')
 def test_slice_batchnorm_reshape_batchnorm():
     class Net(gluon.HybridBlock):
         def __init__(self, shape, slice, **kwargs):


### PR DESCRIPTION
## Description ##

Disabled flaky test: test_gluon_gpu.test_slice_batchnorm_reshape_batchnorm. Tracked in https://github.com/apache/incubator-mxnet/issues/12767