### PR TITLE
Add ignore beta option for mkldnn batchnorm ignore

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -224,6 +224,7 @@ void MKLDNNBatchNormForward(const OpContext &ctx, const BatchNormParam &param,
 
   // mxnet will always use scale shift.
   // But if fix_gamma is true, then all scale elements will be set to 1.0f
+  // If fix_beta is true, then all center elements will be set to 0.0f
   if (flags & use_scale_shift) {
     const NDArray &gamma    = in_data[batchnorm::kGamma];
     const NDArray &beta     = in_data[batchnorm::kBeta];
@@ -237,19 +238,32 @@ void MKLDNNBatchNormForward(const OpContext &ctx, const BatchNormParam &param,
     CHECK(weight_mem.get_primitive_desc().get_size() == channels_ * sizeof(DType) * 2);
     DType* weight_ptr = gamma.data().dptr<DType>();
     DType* bias_ptr = beta.data().dptr<DType>();
+
+    // Use or ignore gamma
     if (!param.fix_gamma) {
       memcpy(weight_buf, weight_ptr, sizeof(weight_buf[0]) * channels_);
-      memcpy(&weight_buf[channels_], bias_ptr, sizeof(weight_buf[0]) * channels_);
     } else if (IsBNWriting(req[batchnorm::kGamma])) {
       for (int i = 0; i < channels_; i++) {
         weight_buf[i] = (DType)1.0f;
         weight_ptr[i] = (DType)1.0f;
-        weight_buf[channels_ + i] = bias_ptr[i];  // bias
       }
     } else {
       for (int i = 0; i < channels_; i++) {
         weight_buf[i] = (DType)1.0f;
-        weight_buf[channels_ + i] = bias_ptr[i];  // bias
+      }
+    }
+
+    // Use or ignore beta
+    if (!param.fix_beta) {
+      memcpy(&weight_buf[channels_], bias_ptr, sizeof(weight_buf[0]) * channels_);
+    } else if (IsBNWriting(req[batchnorm::kBeta])) {
+      for (int i = 0; i < channels_; i++) {
+        weight_buf[channels_ + i] = (DType)0.0f;
+        bias_ptr[i] = (DType)0.0f;
+      }
+    } else {
+      for (int i = 0; i < channels_; i++) {
+        weight_buf[channels_ + i] = (DType)0.0f;
       }
     }
 
@@ -420,7 +434,10 @@ void MKLDNNBatchNormBackward(const OpContext &ctx, const BatchNormParam &param,
     }
 
     for (int i = 0; i < channels_; i++) {
-      weight_buf[channels_ + i] = (beta.data().dptr<DType>())[i];  // bias
+      if (~param.fix_beta)
+        weight_buf[channels_ + i] = (beta.data().dptr<DType>())[i];  // bias
+      else
+        weight_buf[channels_ + i] = (DType)0.0f;
     }
 
     // training but no input mean and variance
@@ -461,7 +478,10 @@ void MKLDNNBatchNormBackward(const OpContext &ctx, const BatchNormParam &param,
     }
 
     for (int i = 0; i < channels_; i++) {
-      (in_grad[2].data().dptr<DType>())[i] = gw_buf[i + channels_];
+      if (!param.fix_beta)
+        (in_grad[2].data().dptr<DType>())[i] = gw_buf[i + channels_];
+      else
+        (in_grad[2].data().dptr<DType>())[i] = 0.0f;
     }
   } else {
     LOG(FATAL) << "MKLDNN batch normalization backward: should not reach here ...";

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -434,7 +434,7 @@ void MKLDNNBatchNormBackward(const OpContext &ctx, const BatchNormParam &param,
     }
 
     for (int i = 0; i < channels_; i++) {
-      if (~param.fix_beta)
+      if (!param.fix_beta)
         weight_buf[channels_ + i] = (beta.data().dptr<DType>())[i];  // bias
       else
         weight_buf[channels_ + i] = (DType)0.0f;


### PR DESCRIPTION
## Description ##
PR https://github.com/apache/incubator-mxnet/pull/12625 making beta optional for batchnorm layer missed mkldnn batchnorm implementation. Currently master build is broken due to this.

In this PR, I address this functionality in mkldnn batchnorm layer. This is an important fix to make master build green again.
@zheng-da - Can you please take a look?

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.

- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


## Comments ##
- If I can get this PR asap, I will revert my other batchnorm PR https://github.com/apache/incubator-mxnet/pull/12625
Here is the reverting PR - https://github.com/apache/incubator-mxnet/pull/12789 in case this PR is unable to merge soon - 