### PR TITLE
Make output of multi input hybrid block unique

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -928,7 +928,8 @@ class HybridBlock(Block):
             # Without this change, prefix will be same for both the inputs
             # passing through this block producing same name output.
             # So, we append name of input to make it unique.
-            self.name_scope()._name_scope._prefix += x.name + "_"
+            if self.name_scope()._name_scope:
+                self.name_scope()._name_scope._prefix += x.name + "_"
             return self.hybrid_forward(symbol, x, *args, **params)
 
     def hybrid_forward(self, F, x, *args, **kwargs):

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -923,6 +923,12 @@ class HybridBlock(Block):
             "Symbol or NDArray, but got %s"%type(x)
         params = {i: j.var() for i, j in self._reg_params.items()}
         with self.name_scope():
+            # This is required to handle case where there are more than one
+            # inputs passing through same block.
+            # Without this change, prefix will be same for both the inputs
+            # passing through this block producing same name output.
+            # So, we append name of input to make it unique.
+            self.name_scope()._name_scope._prefix += x.name + "_"
             return self.hybrid_forward(symbol, x, *args, **params)
 
     def hybrid_forward(self, F, x, *args, **kwargs):


### PR DESCRIPTION
## Description ##
* fixes issue - https://github.com/apache/incubator-mxnet/issues/12795
* Problem: If we have multiple inputs passed to the same block, then output symbol will have same name leading to conflicts. 
* Solution: append input symbol name to the block prefix, making output names to be unique per input symbol.

Example code of having 2 inputs to same block. The same Dense block is applied twice (2 inputs). Without this change, both a and b will have same name.

```python
class MyBlock(mx.gluon.HybridBlock):
    def __init__(self):
        super().__init__()
        with self.name_scope():
            self.model = mx.gluon.nn.Dense(units=5)

    def hybrid_forward(self, F, x, y):
        a = self.model(x)
        b = self.model(y)
        return a + b
```
Before:
```json
{
      "op": "FullyConnected", 
      "name": "myblock0_dense0_fwd", 
      "attrs": {
        "flatten": "True", 
        "no_bias": "False", 
        "num_hidden": "5"
      }, 
      "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
    }, 
    {
      "op": "null", 
      "name": "data1", 
      "inputs": []
    }, 
    {
      "op": "FullyConnected", 
      "name": "myblock0_dense0_fwd", 
      "attrs": {
        "flatten": "True", 
        "no_bias": "False", 
        "num_hidden": "5"
      }, 
      "inputs": [[4, 0, 0], [1, 0, 0], [2, 0, 0]]
    },
```
After
```json
{
      "op": "FullyConnected", 
      "name": "myblock0_dense0_data0_fwd", 
      "attrs": {
        "flatten": "True", 
        "no_bias": "False", 
        "num_hidden": "5"
      }, 
      "inputs": [[0, 0, 0], [1, 0, 0], [2, 0, 0]]
    }, 
    {
      "op": "null", 
      "name": "data1", 
      "inputs": []
    }, 
    {
      "op": "FullyConnected", 
      "name": "myblock0_dense0_data1_fwd", 
      "attrs": {
        "flatten": "True", 
        "no_bias": "False", 
        "num_hidden": "5"
      }, 
      "inputs": [[4, 0, 0], [1, 0, 0], [2, 0, 0]]
    },
```
Created this PR for initial feedback.
@zhreshold @safrooze @szha 
