### PR TITLE
Add index_copy() tensor operator

### DIFF
--- a/src/operator/contrib/index_copy-inl.h
+++ b/src/operator/contrib/index_copy-inl.h
@@ -1,0 +1,60 @@
+ /*
+  * Licensed to the Apache Software Foundation (ASF) under one
+  * or more contributor license agreements.  See the NOTICE file
+  * distributed with this work for additional information
+  * regarding copyright ownership.  The ASF licenses this file
+  * to you under the Apache License, Version 2.0 (the
+  * "License"); you may not use this file except in compliance
+  * with the License.  You may obtain a copy of the License at
+  *
+  *   http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing,
+  * software distributed under the License is distributed on an
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  * KIND, either express or implied.  See the License for the
+  * specific language governing permissions and limitations
+  * under the License.
+  */
+ 
+  /*!
+   * \file index_copy-inl.h
+   * \brief implementation of index_copy operation
+   */
+
+#ifndef MXNET_OPERATOR_CONTRIB_INDEX_COPY_INL_H_
+#define MXNET_OPERATOR_CONTRIB_INDEX_COPY_INL_H_
+
+#include <mxnet/operator_util.h>
+#include <vector>
+#include <limits>
+#include "../elemwise_op_common.h"
+#include "../mshadow_op.h"
+#include "../mxnet_op.h"
+
+struct index_copy {
+
+};
+
+template<typename xpu>
+void IndexCopyCompute(const nnvm::NodeAttrs& attrs,
+                      const OpContext& ctx,
+                      const std::vector<TBlob>& inputs,
+                      const std::vector<OpReqType>& req,
+                      const std::vector<TBlob>& outputs) {
+
+}
+
+inline bool IndexCopyShape(const nnvm::NodeAttrs& attrs,
+                           std::vector<TShape> *in_attrs,
+                           std::vector<TShape> *out_attrs) {
+
+}
+
+inline bool IndexCopyType(const nnvm::NodeAttrs& attrs,
+                          std::vector<int> *in_attrs,
+                          std::vector<int> *out_attrs) {
+  
+}
+
+#endif  // MXNET_OPERATOR_CONTRIB_INDEX_COPY_INL_H_

--- a/src/operator/contrib/index_copy-inl.h
+++ b/src/operator/contrib/index_copy-inl.h
@@ -16,7 +16,7 @@
   * specific language governing permissions and limitations
   * under the License.
   */
- 
+
   /*!
    * \file index_copy-inl.h
    * \brief implementation of index_copy tensor operation
@@ -46,10 +46,10 @@ struct copy_all {
 
 struct index_copy {
   template<typename DType, typename IType>
-  MSHADOW_XINLINE static void Map(int i, 
+  MSHADOW_XINLINE static void Map(int i,
                                   int dim,
-                                  IType* index, 
-                                  DType* new_tensor, 
+                                  IType* index,
+                                  DType* new_tensor,
                                   DType* out_tensor) {
     DType* out_ptr = out_tensor + static_cast<int>(index[i]) * dim;
     DType* new_ptr = new_tensor + i * dim;

--- a/src/operator/contrib/index_copy.cc
+++ b/src/operator/contrib/index_copy.cc
@@ -1,0 +1,24 @@
+ /*
+  * Licensed to the Apache Software Foundation (ASF) under one
+  * or more contributor license agreements.  See the NOTICE file
+  * distributed with this work for additional information
+  * regarding copyright ownership.  The ASF licenses this file
+  * to you under the Apache License, Version 2.0 (the
+  * "License"); you may not use this file except in compliance
+  * with the License.  You may obtain a copy of the License at
+  *
+  *   http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing,
+  * software distributed under the License is distributed on an
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  * KIND, either express or implied.  See the License for the
+  * specific language governing permissions and limitations
+  * under the License.
+  */
+ 
+ /*!
+  * \file index_copy.cc
+  * \brief
+  */
+ #include "./index_copy-inl.h"

--- a/src/operator/contrib/index_copy.cc
+++ b/src/operator/contrib/index_copy.cc
@@ -22,3 +22,21 @@
   * \brief
   */
  #include "./index_copy-inl.h"
+
+namespace mxnet {
+namespace op {
+
+NNVM_REGISTER_OP(_contrib_index_copy)
+.describe(R"code(Implementation of index_copy)code" ADD_FILELINE)
+.set_num_inputs(3)
+.set_num_outputs(0)
+.set_attr<nnvm::FInferShape>("FInferShape", IndexCopyShape)
+.set_attr<nnvm::FInferType>("FInferType", IndexCopyType)
+.set_attr<FCompute>("FCompute<cpu>", IndexCopyCompute<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_index_copy"})
+.add_argument("old_tensor", "NDArray-or-Symbol", "Old tensor")
+.add_argument("index_tensor", "NDArray-or-Symbol", "Index vector")
+.add_argument("new_tensor", "NDArray-or-Symbol", "New tensor");
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/contrib/index_copy.cc
+++ b/src/operator/contrib/index_copy.cc
@@ -27,16 +27,40 @@ namespace mxnet {
 namespace op {
 
 NNVM_REGISTER_OP(_contrib_index_copy)
-.describe(R"code(Implementation of index_copy)code" ADD_FILELINE)
+.describe(R"code(Copies the elements of a `new_tensor` into the `old_tensor` by 
+selecting the indices in the order given in `index`. The output will be a new tensor 
+contains the rest elements of old tensor and the copied elements of new tensor. 
+For example, if `index[i] == j`, then the `i`th row of `new_tensor` is copied to the 
+`j`th row of output.
+
+The `index` must be a vector and it must have the same size with the `0`th dimimention of 
+`new_tensor`. Also, the `0`th dimimention of old_tensor must `>=` the `0`th dimimention of 
+`new_tensor`, or an error will be raised.
+
+Examples::
+
+x = mx.nd.zeros((5,3))
+t = mx.nd.array([[1,2,3],[4,5,6],[7,8,9]])
+index = mx.nd.array([0,4,2])
+
+mx.nd.contrib.index_copy(x, index, t)
+
+[[1. 2. 3.]
+ [0. 0. 0.]
+ [7. 8. 9.]
+ [0. 0. 0.]
+ [4. 5. 6.]]
+<NDArray 5x3 @cpu(0)>
+
+)code" ADD_FILELINE)
 .set_num_inputs(3)
-.set_num_outputs(0)
+.set_num_outputs(1)
 .set_attr<nnvm::FInferShape>("FInferShape", IndexCopyShape)
 .set_attr<nnvm::FInferType>("FInferType", IndexCopyType)
 .set_attr<FCompute>("FCompute<cpu>", IndexCopyCompute<cpu>)
-.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_index_copy"})
-.add_argument("old_tensor", "NDArray-or-Symbol", "Old tensor")
-.add_argument("index_tensor", "NDArray-or-Symbol", "Index vector")
-.add_argument("new_tensor", "NDArray-or-Symbol", "New tensor");
+.add_argument("old_tensor", "NDArray", "Old tensor")
+.add_argument("index", "NDArray", "Index vector")
+.add_argument("new_tensor", "NDArray", "New tensor to be copied");
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/contrib/index_copy.cc
+++ b/src/operator/contrib/index_copy.cc
@@ -16,12 +16,12 @@
   * specific language governing permissions and limitations
   * under the License.
   */
- 
+
  /*!
   * \file index_copy.cc
   * \brief
   */
- #include "./index_copy-inl.h"
+#include "./index_copy-inl.h"
 
 namespace mxnet {
 namespace op {

--- a/src/operator/contrib/index_copy.cu
+++ b/src/operator/contrib/index_copy.cu
@@ -22,3 +22,12 @@
   * \brief
   */
  #include "./index_copy-inl.h"
+
+ namespace mxnet {
+ namespace op {
+
+ NNVM_REGISTER_OP(_contrib_index_copy)
+ .set_attr<FCompute>("FCompute<gpu>", IndexCopyCompute<gpu>);
+
+ }
+ }

--- a/src/operator/contrib/index_copy.cu
+++ b/src/operator/contrib/index_copy.cu
@@ -1,0 +1,24 @@
+ /*
+  * Licensed to the Apache Software Foundation (ASF) under one
+  * or more contributor license agreements.  See the NOTICE file
+  * distributed with this work for additional information
+  * regarding copyright ownership.  The ASF licenses this file
+  * to you under the Apache License, Version 2.0 (the
+  * "License"); you may not use this file except in compliance
+  * with the License.  You may obtain a copy of the License at
+  *
+  *   http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing,
+  * software distributed under the License is distributed on an
+  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  * KIND, either express or implied.  See the License for the
+  * specific language governing permissions and limitations
+  * under the License.
+  */
+ 
+ /*!
+  * \file index_copy.cc
+  * \brief
+  */
+ #include "./index_copy-inl.h"

--- a/src/operator/contrib/index_copy.cu
+++ b/src/operator/contrib/index_copy.cu
@@ -16,18 +16,18 @@
   * specific language governing permissions and limitations
   * under the License.
   */
- 
+
  /*!
   * \file index_copy.cc
   * \brief
   */
- #include "./index_copy-inl.h"
+#include "./index_copy-inl.h"
 
- namespace mxnet {
- namespace op {
+namespace mxnet {
+namespace op {
 
- NNVM_REGISTER_OP(_contrib_index_copy)
- .set_attr<FCompute>("FCompute<gpu>", IndexCopyCompute<gpu>);
+NNVM_REGISTER_OP(_contrib_index_copy)
+.set_attr<FCompute>("FCompute<gpu>", IndexCopyCompute<gpu>);
 
- }
- }
+}
+}

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4639,6 +4639,16 @@ def test_quantization_op():
     assert same(qa.asnumpy(), qa_real.asnumpy())
     assert same(a_.asnumpy(),  a_real.asnumpy())
 
+@with_seed()
+def test_index_copy():
+    x = mx.nd.zeros((5,3))
+    t = mx.nd.array([[1,2,3],[4,5,6],[7,8,9]])
+    index = mx.nd.array([0,4,2])
+    out = mx.nd.contrib.index_copy(x, index, t)
+
+    tensor = mx.nd.array([[1,2,3],[0,0,0],[7,8,9],[0,0,0],[4,5,6]])
+
+    assert same(out.asnumpy(), tensor.asnumpy())
 
 @with_seed()
 def test_div_sqrt_dim():


### PR DESCRIPTION
This is a PR to add a index_copy() tensor operator, which will be used in the DGL project.

`output = mx.nd.contrib.index_copy(old_tensor, index, new_tensor)`

This op copies the elements of a `new_tensor` into the `old_tensor` by 
selecting the indices in the order given in `index`. The output will be a new tensor 
contains the rest elements of old tensor and the copied elements of new tensor. 
For example, if `index[i] == j`, then the `i`th row of `new_tensor` is copied to the 
`j`th row of output.

The `index` must be a vector and it must have the same size with the `0`th dimimention of 
`new_tensor`. Also, the `0`th dimimention of old_tensor must `>=` the `0`th dimimention of 
`new_tensor`, or an error will be raised.

Examples::

x = mx.nd.zeros((5,3))
t = mx.nd.array([[1,2,3],[4,5,6],[7,8,9]])
index = mx.nd.array([0,4,2])

mx.nd.contrib.index_copy(x, index, t)

[[1. 2. 3.]
 [0. 0. 0.]
 [7. 8. 9.]
 [0. 0. 0.]
 [4. 5. 6.]]
<NDArray 5x3 @cpu(0)>

Note that, so far we don't need the backward function for this operator.