### PR TITLE
Fixed __setattr__ method of _MXClassPropertyMetaClass

### DIFF
--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -165,10 +165,9 @@ class _MXClassPropertyDescriptor(object):
 
 class _MXClassPropertyMetaClass(type):
     def __setattr__(cls, key, value):
-        if key in cls.__dict__:
-            obj = cls.__dict__.get(key)
-            if obj and isinstance(obj, _MXClassPropertyDescriptor):
-                return obj.__set__(cls, value)
+        obj = cls.__dict__.get(key)
+        if obj and isinstance(obj, _MXClassPropertyDescriptor):
+            return obj.__set__(cls, value)
 
         return super(_MXClassPropertyMetaClass, cls).__setattr__(key, value)
 

--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -167,8 +167,8 @@ class _MXClassPropertyMetaClass(type):
     def __setattr__(cls, key, value):
         if key in cls.__dict__:
             obj = cls.__dict__.get(key)
-        if obj and isinstance(obj, _MXClassPropertyDescriptor):
-            return obj.__set__(cls, value)
+            if obj and isinstance(obj, _MXClassPropertyDescriptor):
+                return obj.__set__(cls, value)
 
         return super(_MXClassPropertyMetaClass, cls).__setattr__(key, value)
 


### PR DESCRIPTION
## Description ##
There is probably a bad indentation in `_MXClassPropertyMetaClass.__setattr__`

### Changes ###
- [x] Fixed `__setattr__` method

### MWE ###

```
import mxnet as mx
mx.Context.a = 1
```

```
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
<ipython-input-2-b03cab36b304> in <module>()
----> 1 mx.Context.a = 1

[...]/lib/python3.6/site-packages/mxnet/base.py in __setattr__(cls, key, value)
    168         if key in cls.__dict__:
    169             obj = cls.__dict__.get(key)
--> 170         if obj and isinstance(obj, _MXClassPropertyDescriptor):
    171             return obj.__set__(cls, value)
    172

UnboundLocalError: local variable 'obj' referenced before assignment
```
