### PR TITLE
[MXNET-886] ONNX export: HardSigmoid, Less, Greater, Equal

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1566,3 +1566,24 @@ def convert_hardsigmoid(node, **kwargs):
         name=name
     )
     return [node]
+
+@mx_op.register("broadcast_lesser")
+def convert_broadcast_lesser(node, **kwargs):
+    """Map MXNet's broadcast_lesser operator attributes to onnx's Less operator
+    and return the created node.
+    """
+    return create_basic_op_node('Less', node, kwargs)
+
+@mx_op.register("broadcast_greater")
+def convert_broadcast_greater(node, **kwargs):
+    """Map MXNet's broadcast_greater operator attributes to onnx's Greater operator
+    and return the created node.
+    """
+    return create_basic_op_node('Greater', node, kwargs)
+
+@mx_op.register("broadcast_equal")
+def convert_broadcast_equal(node, **kwargs):
+    """Map MXNet's broadcast_equal operator attributes to onnx's Equal operator
+    and return the created node.
+    """
+    return create_basic_op_node('Equal', node, kwargs)

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1545,3 +1545,24 @@ def convert_sum(node, **kwargs):
             name=name
         )
     return [node]
+
+@mx_op.register("hard_sigmoid")
+def convert_hardsigmoid(node, **kwargs):
+    """Map MXNet's hard_sigmoid operator attributes to onnx's HardSigmoid operator
+    and return the created node.
+    """
+    name, input_nodes, attrs = get_inputs(node, kwargs)
+
+    # Converting to float32
+    alpha = float(attrs.get("alpha", 0.2))
+    beta = float(attrs.get("beta", 0.5))
+
+    node = onnx.helper.make_node(
+        'HardSigmoid',
+        input_nodes,
+        [name],
+        alpha=alpha,
+        beta=beta,
+        name=name
+    )
+    return [node]

--- a/tests/python-pytest/onnx/export/onnx_backend_test.py
+++ b/tests/python-pytest/onnx/export/onnx_backend_test.py
@@ -94,7 +94,8 @@ IMPLEMENTED_OPERATORS_TEST = [
     'test_operator_permute2',
     'test_clip'
     'test_cast',
-    'test_depthtospace'
+    'test_depthtospace',
+    'test_hardsigmoid'
     ]
 
 BASIC_MODEL_TESTS = [

--- a/tests/python-pytest/onnx/import/test_cases.py
+++ b/tests/python-pytest/onnx/import/test_cases.py
@@ -71,7 +71,7 @@ IMPLEMENTED_OPERATORS_TEST = [
     'test_sin',
     'test_tan',
     'test_shape',
-    'test_hardsigmoid_',
+    'test_hardsigmoid',
     'test_averagepool_1d',
     'test_averagepool_2d_pads_count_include_pad',
     'test_averagepool_2d_precomputed_pads_count_include_pad',


### PR DESCRIPTION
## Description ##
Added support for exporting HardSigmoid, Less, Greater, Equal to ONNX.

v2: Addressed @anirudhacharya's comments on the tests for comparison operators.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Export the 4 operators in _op_translations.py
- Added tests for the 4 operators

## Comments ##

