### PR TITLE
Update osx.mk - Added "apple" to USE_BLAS comment

### DIFF
--- a/make/osx.mk
+++ b/make/osx.mk
@@ -80,7 +80,7 @@ USE_OPENCV = 1
 USE_OPENMP = 0
 
 # choose the version of blas you want to use
-# can be: mkl, blas, atlas, openblas
+# can be: mkl, blas, atlas, openblas, apple
 USE_BLAS = apple
 
 # whether use lapack during compilation


### PR DESCRIPTION
## Description ##
Added "apple" to USE_BLAS comment because it is one of the values that are possible. 
Currently the comment only has "mkl, blas, atlas, openblas" that can be used

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
