### PR TITLE
Fixed regex for matching platform type in Scala Benchmark scripts

### DIFF
--- a/scala-package/examples/scripts/benchmark/run_image_inference_bm.sh
+++ b/scala-package/examples/scripts/benchmark/run_image_inference_bm.sh
@@ -22,14 +22,14 @@ set -e
 echo $OSTYPE
 
 hw_type=cpu
-if [ "$1" = "gpu" ]
+if [[ $1 = gpu ]]
 then
     hw_type=gpu
 fi
 
 platform=linux-x86_64
 
-if [ "$OSTYPE" == "darwin"* ]
+if [[ $OSTYPE = [darwin]* ]]
 then
     platform=osx-x86_64
 fi

--- a/scala-package/examples/scripts/benchmark/run_text_charrnn_bm.sh
+++ b/scala-package/examples/scripts/benchmark/run_text_charrnn_bm.sh
@@ -19,18 +19,21 @@
 
 set -e
 
+echo $OSTYPE
+
 hw_type=cpu
-if [ "$1" = "gpu" ]
+if [[ $1 = gpu ]]
 then
     hw_type=gpu
 fi
 
 platform=linux-x86_64
 
-if [ "$OSTYPE" == "darwin"* ]
+if [[ $OSTYPE = [darwin]* ]]
 then
     platform=osx-x86_64
 fi
+
 
 MXNET_ROOT=$(cd "$(dirname $0)/../../../.."; pwd)
 CLASS_PATH=$MXNET_ROOT/scala-package/assembly/$platform-$hw_type/target/*:$MXNET_ROOT/scala-package/examples/target/*:$MXNET_ROOT/scala-package/examples/target/classes/lib/*:$MXNET_ROOT/scala-package/infer/target/*


### PR DESCRIPTION
## Description ##
The regex in determining the OS Type in the script to run scala benchmarks was incorrect. Fixed the regular expression. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change