### PR TITLE
R install instructions update for macOS

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -142,7 +142,7 @@ $ pip install mxnet --pre
 </div> <!-- End of master-->
 <hr> <!-- pip footer -->
 MXNet offers MKL pip packages that will be much faster when running on Intel hardware.
-Check the chart below for other options, refer to <a href="https://pypi.org/project/mxnet/">PyPI for other MXNet pip packages</a>, or <a href="validate_mxnet.html">validate your MXNet installation</a>. 
+Check the chart below for other options, refer to <a href="https://pypi.org/project/mxnet/">PyPI for other MXNet pip packages</a>, or <a href="validate_mxnet.html">validate your MXNet installation</a>.
 
 <img src="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/install/pip-packages-1.3.0.png" alt="pip packages"/>
 
@@ -597,6 +597,18 @@ MXNet developers should refer to the MXNet wiki's <a href="https://cwiki.apache.
 <div class="r">
 <div class="cpu">
 </br>
+Install OpenCV and OpenBLAS.
+
+```bash
+brew install opencv
+brew install openblas
+```
+
+Add a soft link the OpenBLAS installation. This example links the 0.3.1 version:
+
+```bash
+ln -sf /usr/local/opt/openblas/lib/libopenblasp-r0.3.* /usr/local/opt/openblas/lib/libopenblasp-r0.3.1.dylib
+```
 
 Install the latest version (3.5.1+) of R from [CRAN](https://cran.r-project.org/bin/macosx/).
 You can [build MXNet-R from source](osx_setup.html#install-the-mxnet-package-for-r), or you can use a pre-built binary:

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -601,10 +601,10 @@ Install OpenCV and OpenBLAS.
 
 ```bash
 brew install opencv
-brew install openblas
+brew install openblas@0.3.1
 ```
 
-Add a soft link the OpenBLAS installation. This example links the 0.3.1 version:
+Add a soft link to the OpenBLAS installation. This example links the 0.3.1 version:
 
 ```bash
 ln -sf /usr/local/opt/openblas/lib/libopenblasp-r0.3.* /usr/local/opt/openblas/lib/libopenblasp-r0.3.1.dylib

--- a/docs/install/osx_setup.md
+++ b/docs/install/osx_setup.md
@@ -128,10 +128,10 @@ Install OpenCV and OpenBLAS.
 
 ```bash
 brew install opencv
-brew install openblas
+brew install openblas@0.3.1
 ```
 
-Add a soft link the OpenBLAS installation. This example links the 0.3.1 version:
+Add a soft link to the OpenBLAS installation. This example links the 0.3.1 version:
 
 ```bash
 ln -sf /usr/local/opt/openblas/lib/libopenblasp-r0.3.* /usr/local/opt/openblas/lib/libopenblasp-r0.3.1.dylib

--- a/docs/install/osx_setup.md
+++ b/docs/install/osx_setup.md
@@ -124,6 +124,18 @@ You have 2 options:
 2. Building MXNet from Source Code
 
 ### Building MXNet with the Prebuilt Binary Package
+Install OpenCV and OpenBLAS.
+
+```bash
+brew install opencv
+brew install openblas
+```
+
+Add a soft link the OpenBLAS installation. This example links the 0.3.1 version:
+
+```bash
+ln -sf /usr/local/opt/openblas/lib/libopenblasp-r0.3.* /usr/local/opt/openblas/lib/libopenblasp-r0.3.1.dylib
+```
 
 Install the latest version (3.5.1+) of R from [CRAN](https://cran.r-project.org/bin/macosx/).
 For OS X (Mac) users, MXNet provides a prebuilt binary package for CPUs. The prebuilt package is updated weekly. You can install the package directly in the R console using the following commands:


### PR DESCRIPTION
## Description ##
This PR updates installation instructions for R on Mac by adding OpenCV and OpenBLAS prerequisites.

## Comments
OpenBLAS is pinned to v0.3.1. We're not doing this for other bindings, so it would be nice if this kind of thing is made consistent.
