### PR TITLE
Added context object to run TestCharRnn example

### DIFF
--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TestCharRnn.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TestCharRnn.scala
@@ -123,9 +123,14 @@ class TestCharRnn(CLIParser: CLIParser) extends InferBase {
     val numLstmLayer = 3
     val (_, argParams, _) = Model.loadCheckpoint(CLIParser.modelPrefix, 75)
     this.vocab = Utils.buildVocab(CLIParser.dataPath)
+    var ctx = Context.cpu()
+    if (System.getenv().containsKey("SCALA_TEST_ON_GPU") &&
+      System.getenv("SCALA_TEST_ON_GPU").toInt == 1) {
+      ctx = Context.gpu()
+    }
     val model = new RnnModel.LSTMInferenceModel(numLstmLayer, vocab.size + 1,
       numHidden = numHidden, numEmbed = numEmbed,
-      numLabel = vocab.size + 1, argParams = argParams, dropout = 0.2f)
+      numLabel = vocab.size + 1, argParams = argParams, dropout = 0.2f, ctx = ctx)
     model
   }
 


### PR DESCRIPTION
## Description ##
The TestCharRnn example was running by default on CPU. Passing in the appropriate context for it to run.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
