### PR TITLE
Fix Batch input issue with Scala Benchmark

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/Shape.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Shape.scala
@@ -34,7 +34,6 @@ class Shape(dims: Traversable[Int]) extends Serializable {
   def size: Int = shape.size
   def length: Int = shape.length
   def drop(dim: Int): Shape = new Shape(shape.drop(dim))
-  def dropBack(dim : Int) : Shape = new Shape(shape.dropRight(dim))
   def slice(from: Int, end: Int): Shape = new Shape(shape.slice(from, end))
   def product: Int = shape.product
   def head: Int = shape.head

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Shape.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Shape.scala
@@ -34,6 +34,7 @@ class Shape(dims: Traversable[Int]) extends Serializable {
   def size: Int = shape.size
   def length: Int = shape.length
   def drop(dim: Int): Shape = new Shape(shape.drop(dim))
+  def dropBack(dim : Int) : Shape = new Shape(shape.dropRight(dim))
   def slice(from: Int, end: Int): Shape = new Shape(shape.slice(from, end))
   def product: Int = shape.product
   def head: Int = shape.head

--- a/scala-package/core/src/test/scala/org/apache/mxnet/ShapeSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/ShapeSuite.scala
@@ -29,4 +29,22 @@ class ShapeSuite extends FunSuite with BeforeAndAfterAll {
     assert(Shape(1, 2, 3) === Shape(1, 2, 3))
     assert(Shape(1, 2) != Shape(1, 2, 3))
   }
+
+  test("drop") {
+    val s = Shape(1, 2, 3)
+    val s2 = s.drop(1)
+    assert(s == Shape(1, 2, 3))
+    assert(s2 == Shape(2, 3))
+    val s3 = s.dropBack(1)
+    assert(s == Shape(1, 2, 3))
+    assert(s3 == Shape(1, 2))
+    val s4 = s.drop(2)
+    assert(s4 == Shape(3))
+  }
+
+  test("slice") {
+    val s = Shape(1, 2, 3)
+    val s2 = s.slice(0, 1)
+    assert(s2 == Shape(1))
+  }
 }

--- a/scala-package/core/src/test/scala/org/apache/mxnet/ShapeSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/ShapeSuite.scala
@@ -35,11 +35,8 @@ class ShapeSuite extends FunSuite with BeforeAndAfterAll {
     val s2 = s.drop(1)
     assert(s == Shape(1, 2, 3))
     assert(s2 == Shape(2, 3))
-    val s3 = s.dropBack(1)
-    assert(s == Shape(1, 2, 3))
-    assert(s3 == Shape(1, 2))
-    val s4 = s.drop(2)
-    assert(s4 == Shape(3))
+    val s3 = s.drop(2)
+    assert(s3 == Shape(3))
   }
 
   test("slice") {

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/InferBase.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/InferBase.scala
@@ -21,7 +21,7 @@ import org.apache.mxnet._
 
 trait InferBase {
 
-  def loadModel(context: Array[Context]): Any
+  def loadModel(context: Array[Context], batchInference : Boolean): Any
   def loadSingleData(): Any
   def loadBatchFileList(batchSize: Int): List[Any]
   def loadInputBatch(source: Any): Any

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/benchmark/ScalaInferenceBenchmark.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/benchmark/ScalaInferenceBenchmark.scala
@@ -31,9 +31,9 @@ object ScalaInferenceBenchmark {
 
   private val logger = LoggerFactory.getLogger(classOf[CLIParserBase])
 
-  def loadModel(objectToRun: InferBase, context: Array[Context]):
+  def loadModel(objectToRun: InferBase, context: Array[Context], batchInference : Boolean):
   Any = {
-    objectToRun.loadModel(context)
+    objectToRun.loadModel(context, batchInference)
   }
 
   def loadDataSet(objectToRun: InferBase):
@@ -134,7 +134,7 @@ object ScalaInferenceBenchmark {
       logger.info("Running single inference call")
       // Benchmarking single inference call
       NDArrayCollector.auto().withScope {
-        val loadedModel = loadModel(exampleToBenchmark, context)
+        val loadedModel = loadModel(exampleToBenchmark, context, false)
         val dataSet = loadDataSet(exampleToBenchmark)
         val inferenceTimes = runInference(exampleToBenchmark, loadedModel, dataSet, baseCLI.count)
         printStatistics(inferenceTimes, "single_inference")
@@ -144,7 +144,7 @@ object ScalaInferenceBenchmark {
         logger.info("Running for batch inference call")
         // Benchmarking batch inference call
         NDArrayCollector.auto().withScope {
-          val loadedModel = loadModel(exampleToBenchmark, context)
+          val loadedModel = loadModel(exampleToBenchmark, context, true)
           val batchDataSet = loadBatchDataSet(exampleToBenchmark, baseCLI.batchSize)
           val inferenceTimes = runBatchInference(exampleToBenchmark, loadedModel, batchDataSet)
           printStatistics(inferenceTimes, "batch_inference")

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
@@ -175,9 +175,11 @@ class CLIParser extends CLIParserBase{
 
 class ImageClassifierExample(CLIParser: CLIParser) extends InferBase{
 
-  override def loadModel(context: Array[Context]): Classifier = {
+  override def loadModel(context: Array[Context],
+                         batchInference : Boolean = false): Classifier = {
     val dType = DType.Float32
-    val inputShape = Shape(1, 3, 224, 224)
+    val batchSize = if (batchInference) CLIParser.batchSize else 1
+    val inputShape = Shape(batchSize, 3, 224, 224)
 
     val inputDescriptor = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
 

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
@@ -203,9 +203,10 @@ class CLIParser extends CLIParserBase {
 
 class SSDClassifierExample(CLIParser: CLIParser)
   extends InferBase {
-  override def loadModel(context: Array[Context]): Any = {
+  override def loadModel(context: Array[Context], batchInference: Boolean = false): Any = {
     val dType = DType.Float32
-    val inputShape = Shape(1, 3, 512, 512)
+    val batchSize = if (batchInference) CLIParser.batchSize else 1
+    val inputShape = Shape(batchSize, 3, 512, 512)
     val inputDescriptors = IndexedSeq(DataDesc("data", inputShape, dType, "NCHW"))
     new ObjectDetector(CLIParser.modelPathPrefix, inputDescriptors, context)
   }

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TestCharRnn.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TestCharRnn.scala
@@ -115,7 +115,7 @@ class TestCharRnn(CLIParser: CLIParser) extends InferBase {
 
   private var vocab : Map[String, Int] = null
 
-  override def loadModel(context: Array[Context]): Any = {
+  override def loadModel(context: Array[Context], batchInference : Boolean = false): Any = {
     val batchSize = 32
     val buckets = List(129)
     val numHidden = 512

--- a/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ImageClassifier.scala
+++ b/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ImageClassifier.scala
@@ -76,7 +76,7 @@ class ImageClassifier(modelPathPrefix: String,
                     topK: Option[Int] = None): IndexedSeq[IndexedSeq[(String, Float)]] = {
 
     val scaledImage = ImageClassifier.reshapeImage(inputImage, width, height)
-    val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape)
+    val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(0))
     inputImage.flush()
     scaledImage.flush()
 
@@ -100,7 +100,7 @@ class ImageClassifier(modelPathPrefix: String,
     val imageBatch = ListBuffer[NDArray]()
     for (image <- inputBatch) {
       val scaledImage = ImageClassifier.reshapeImage(image, width, height)
-      val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape)
+      val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(0))
       imageBatch += pixelsNDArray
     }
     val op = NDArray.concatenate(imageBatch)
@@ -147,7 +147,7 @@ object ImageClassifier {
     * returned by this method after the use.
     * </p>
     * @param resizedImage     BufferedImage to get pixels from
-    * @param inputImageShape  Input shape; for example for resnet it is (1,3,224,224).
+    * @param inputImageShape  Input shape; for example for resnet it is (3,224,224).
                               Should be same as inputDescriptor shape.
     * @return                 NDArray pixels array
     */

--- a/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ImageClassifier.scala
+++ b/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ImageClassifier.scala
@@ -154,7 +154,7 @@ object ImageClassifier {
     * @param resizedImage     BufferedImage to get pixels from
     * @param inputImageShape  Input shape; for example for resnet it is (3,224,224).
                               Should be same as inputDescriptor shape.
-    * @return                 NDArray pixels array with shape (1, 3, 224, 224) in NCHW format
+    * @return                 NDArray pixels array with shape (3, 224, 224) in CHW format
     */
   def bufferedImageToPixels(resizedImage: BufferedImage, inputImageShape: Shape): NDArray = {
     // Get height and width of the image

--- a/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ImageClassifier.scala
+++ b/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ImageClassifier.scala
@@ -182,7 +182,7 @@ object ImageClassifier {
     resizedImage.flush()
 
     // creating NDArray according to the input shape
-    val pixelsArray = NDArray.array(result, shape = inputImageShape)
+    val pixelsArray = NDArray.array(result, shape = new Shape(1 +: inputImageShape.toVector))
     pixelsArray
   }
 

--- a/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ImageClassifier.scala
+++ b/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ImageClassifier.scala
@@ -76,7 +76,7 @@ class ImageClassifier(modelPathPrefix: String,
                     topK: Option[Int] = None): IndexedSeq[IndexedSeq[(String, Float)]] = {
 
     val scaledImage = ImageClassifier.reshapeImage(inputImage, width, height)
-    val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(0))
+    val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(1))
     inputImage.flush()
     scaledImage.flush()
 
@@ -100,7 +100,7 @@ class ImageClassifier(modelPathPrefix: String,
     val imageBatch = ListBuffer[NDArray]()
     for (image <- inputBatch) {
       val scaledImage = ImageClassifier.reshapeImage(image, width, height)
-      val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(0))
+      val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(1))
       imageBatch += pixelsNDArray
     }
     val op = NDArray.concatenate(imageBatch)
@@ -149,7 +149,7 @@ object ImageClassifier {
     * @param resizedImage     BufferedImage to get pixels from
     * @param inputImageShape  Input shape; for example for resnet it is (3,224,224).
                               Should be same as inputDescriptor shape.
-    * @return                 NDArray pixels array
+    * @return                 NDArray pixels array with shape (1, 3, 224, 224) in NCHW format
     */
   def bufferedImageToPixels(resizedImage: BufferedImage, inputImageShape: Shape): NDArray = {
     // Get height and width of the image

--- a/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ImageClassifier.scala
+++ b/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ImageClassifier.scala
@@ -76,7 +76,8 @@ class ImageClassifier(modelPathPrefix: String,
                     topK: Option[Int] = None): IndexedSeq[IndexedSeq[(String, Float)]] = {
 
     val scaledImage = ImageClassifier.reshapeImage(inputImage, width, height)
-    val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(1))
+    val imageShape = inputShape.drop(1)
+    val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, imageShape)
     inputImage.flush()
     scaledImage.flush()
 
@@ -100,7 +101,8 @@ class ImageClassifier(modelPathPrefix: String,
     val inputBatchSeq = inputBatch.toIndexedSeq
     val imageBatch = inputBatchSeq.indices.par.map(idx => {
       val scaledImage = ImageClassifier.reshapeImage(inputBatchSeq(idx), width, height)
-      ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(1))
+      val imageShape = inputShape.drop(1)
+      ImageClassifier.bufferedImageToPixels(scaledImage, imageShape)
     }).toList
     val op = NDArray.concatenate(imageBatch)
     val result = super.classifyWithNDArray(IndexedSeq(op), topK)

--- a/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ObjectDetector.scala
+++ b/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ObjectDetector.scala
@@ -72,7 +72,7 @@ class ObjectDetector(modelPathPrefix: String,
   : IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
 
     val scaledImage = ImageClassifier.reshapeImage(inputImage, width, height)
-    val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(0))
+    val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(1))
     val output = objectDetectWithNDArray(IndexedSeq(pixelsNDArray), topK)
     handler.execute(pixelsNDArray.dispose())
     output
@@ -150,7 +150,7 @@ class ObjectDetector(modelPathPrefix: String,
     val imageBatch = ListBuffer[NDArray]()
     for (image <- inputBatch) {
       val scaledImage = ImageClassifier.reshapeImage(image, width, height)
-      val pixelsNdarray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(0))
+      val pixelsNdarray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(1))
       imageBatch += pixelsNdarray
     }
     val op = NDArray.concatenate(imageBatch)

--- a/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ObjectDetector.scala
+++ b/scala-package/infer/src/main/scala/org/apache/mxnet/infer/ObjectDetector.scala
@@ -72,7 +72,7 @@ class ObjectDetector(modelPathPrefix: String,
   : IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
 
     val scaledImage = ImageClassifier.reshapeImage(inputImage, width, height)
-    val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape)
+    val pixelsNDArray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(0))
     val output = objectDetectWithNDArray(IndexedSeq(pixelsNDArray), topK)
     handler.execute(pixelsNDArray.dispose())
     output
@@ -150,7 +150,7 @@ class ObjectDetector(modelPathPrefix: String,
     val imageBatch = ListBuffer[NDArray]()
     for (image <- inputBatch) {
       val scaledImage = ImageClassifier.reshapeImage(image, width, height)
-      val pixelsNdarray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape)
+      val pixelsNdarray = ImageClassifier.bufferedImageToPixels(scaledImage, inputShape.drop(0))
       imageBatch += pixelsNdarray
     }
     val op = NDArray.concatenate(imageBatch)

--- a/scala-package/infer/src/main/scala/org/apache/mxnet/infer/Predictor.scala
+++ b/scala-package/infer/src/main/scala/org/apache/mxnet/infer/Predictor.scala
@@ -181,7 +181,7 @@ class Predictor(modelPathPrefix: String,
 
     // rebind with the new batchSize
     if (batchSize != inputBatchSize) {
-      logger.warn(s"Latency increased due to batchSize mismatch $batchSize vs $inputBatchSize")
+      logger.info(s"Latency increased due to batchSize mismatch $batchSize vs $inputBatchSize")
       val desc = iDescriptors.map((f : DataDesc) => new DataDesc(f.name,
         Shape(f.shape.toVector.patch(batchIndex, Vector(inputBatchSize), 1)), f.dtype, f.layout) )
       mxNetHandler.execute(mod.bind(desc, forceRebind = true,

--- a/scala-package/infer/src/main/scala/org/apache/mxnet/infer/Predictor.scala
+++ b/scala-package/infer/src/main/scala/org/apache/mxnet/infer/Predictor.scala
@@ -181,6 +181,7 @@ class Predictor(modelPathPrefix: String,
 
     // rebind with the new batchSize
     if (batchSize != inputBatchSize) {
+      logger.warn(s"Latency increased due to batchSize mismatch $batchSize vs $inputBatchSize")
       val desc = iDescriptors.map((f : DataDesc) => new DataDesc(f.name,
         Shape(f.shape.toVector.patch(batchIndex, Vector(inputBatchSize), 1)), f.dtype, f.layout) )
       mxNetHandler.execute(mod.bind(desc, forceRebind = true,

--- a/scala-package/infer/src/test/scala/org/apache/mxnet/infer/ImageClassifierSuite.scala
+++ b/scala-package/infer/src/test/scala/org/apache/mxnet/infer/ImageClassifierSuite.scala
@@ -67,7 +67,7 @@ class ImageClassifierSuite extends ClassifierSuite with BeforeAndAfterAll {
 
     val result = ImageClassifier.bufferedImageToPixels(image2, Shape(3, 2, 2))
 
-    assert(result.shape == inputDescriptor(0).shape.drop(0))
+    assert(result.shape == inputDescriptor(0).shape)
   }
 
   test("ImageClassifierSuite-testWithInputImage") {

--- a/scala-package/infer/src/test/scala/org/apache/mxnet/infer/ImageClassifierSuite.scala
+++ b/scala-package/infer/src/test/scala/org/apache/mxnet/infer/ImageClassifierSuite.scala
@@ -65,9 +65,9 @@ class ImageClassifierSuite extends ClassifierSuite with BeforeAndAfterAll {
     val image1 = new BufferedImage(100, 200, BufferedImage.TYPE_BYTE_GRAY)
     val image2 = ImageClassifier.reshapeImage(image1, 2, 2)
 
-    val result = ImageClassifier.bufferedImageToPixels(image2, Shape(1, 3, 2, 2))
+    val result = ImageClassifier.bufferedImageToPixels(image2, Shape(3, 2, 2))
 
-    assert(result.shape == inputDescriptor(0).shape)
+    assert(result.shape == inputDescriptor(0).shape.drop(0))
   }
 
   test("ImageClassifierSuite-testWithInputImage") {

--- a/scala-package/infer/src/test/scala/org/apache/mxnet/infer/ImageClassifierSuite.scala
+++ b/scala-package/infer/src/test/scala/org/apache/mxnet/infer/ImageClassifierSuite.scala
@@ -67,7 +67,7 @@ class ImageClassifierSuite extends ClassifierSuite with BeforeAndAfterAll {
 
     val result = ImageClassifier.bufferedImageToPixels(image2, Shape(3, 2, 2))
 
-    assert(result.shape == inputDescriptor(0).shape)
+    assert(result.shape == inputDescriptor(0).shape.drop(1))
   }
 
   test("ImageClassifierSuite-testWithInputImage") {


### PR DESCRIPTION
## Description ##
This PR is intended to solve the issue explained here:
https://github.com/apache/incubator-mxnet/issues/12836
Modification applied on Benchmark script as well as basic image classifier section.
@nswamy @piyushghai @yzhliu 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
