### PR TITLE
Optimization for embedding OP for CPU

### DIFF
--- a/src/operator/mxnet_op.h
+++ b/src/operator/mxnet_op.h
@@ -506,7 +506,7 @@ struct Kernel<OP, cpu> {
   inline static bool Launch(mshadow::Stream<cpu> *, const int N, Args... args) {
 #ifdef _OPENMP
     const int omp_threads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
-    if (omp_threads < 2) {
+    if (omp_threads < 2 || N < 2) {
       for (int i = 0; i < N; ++i) {
         OP::Map(i, args...);
       }

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -63,8 +63,9 @@ bool CheckIndexOutOfBound(const DType* data_ptr, size_t data_size,
   bool is_valid = true;
   // to avoid Jenkins omp check error
   int64_t size = data_size;
+  int64_t check_block_size = dmlc::GetEnv("MXNET_CPU_PARALLEL_CHECK_SIZE", 14000);
   int omp_threads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
-  #pragma omp parallel for num_threads(omp_threads) if (data_size > 2000)
+  #pragma omp parallel for num_threads(omp_threads) if (data_size > check_block_size)
   for (int64_t i = 0; i < size; i++) {
     if (data_ptr[i] > max || data_ptr[i] < min) {
       is_valid = false;

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -61,11 +61,8 @@ template<typename DType>
 bool CheckIndexOutOfBound(const DType* data_ptr, size_t data_size,
                           const DType min, const DType max) {
   bool is_valid = true;
-  // to avoid Jenkins omp check error
-  int64_t size = data_size;
-  int64_t check_block_size = dmlc::GetEnv("MXNET_CPU_PARALLEL_CHECK_SIZE", 14000);
   int omp_threads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
-  #pragma omp parallel for num_threads(omp_threads) if (size > check_block_size)
+  #pragma omp parallel for num_threads(omp_threads) if (data_size > 2000)
   for (size_t i = 0; i < data_size; i++) {
     if (data_ptr[i] > max || data_ptr[i] < min) {
       is_valid = false;

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -65,7 +65,7 @@ bool CheckIndexOutOfBound(const DType* data_ptr, size_t data_size,
   int64_t size = data_size;
   int64_t check_block_size = dmlc::GetEnv("MXNET_CPU_PARALLEL_CHECK_SIZE", 14000);
   int omp_threads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
-  #pragma omp parallel for num_threads(omp_threads) if (data_size > check_block_size)
+  #pragma omp parallel for num_threads(omp_threads) if (size > check_block_size)
   for (int64_t i = 0; i < size; i++) {
     if (data_ptr[i] > max || data_ptr[i] < min) {
       is_valid = false;

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -63,7 +63,7 @@ bool CheckIndexOutOfBound(const DType* data_ptr, size_t data_size,
   bool is_valid = true;
   int omp_threads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
   #pragma omp parallel for num_threads(omp_threads) if (data_size > 2000)
-  for (size_t i = 0; i < data_size; i++) {
+  for (int i = 0; i < data_size; i++) {
     if (data_ptr[i] > max || data_ptr[i] < min) {
       is_valid = false;
     }

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -61,9 +61,11 @@ template<typename DType>
 bool CheckIndexOutOfBound(const DType* data_ptr, size_t data_size,
                           const DType min, const DType max) {
   bool is_valid = true;
+  //to avoid Jenkins omp check error
+  int64_t size = data_size;
   int omp_threads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
   #pragma omp parallel for num_threads(omp_threads) if (data_size > 2000)
-  for (int i = 0; i < data_size; i++) {
+  for (int64_t i = 0; i < size; i++) {
     if (data_ptr[i] > max || data_ptr[i] < min) {
       is_valid = false;
     }

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -61,10 +61,14 @@ template<typename DType>
 bool CheckIndexOutOfBound(const DType* data_ptr, size_t data_size,
                           const DType min, const DType max) {
   bool is_valid = true;
+  // to avoid Jenkins omp check error
+  int64_t size = data_size;
+  int64_t check_block_size = dmlc::GetEnv("MXNET_CPU_PARALLEL_CHECK_SIZE", 14000);
+  int omp_threads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
+  #pragma omp parallel for num_threads(omp_threads) if (size > check_block_size)
   for (size_t i = 0; i < data_size; i++) {
     if (data_ptr[i] > max || data_ptr[i] < min) {
       is_valid = false;
-      break;
     }
   }
   return is_valid;

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -61,7 +61,7 @@ template<typename DType>
 bool CheckIndexOutOfBound(const DType* data_ptr, size_t data_size,
                           const DType min, const DType max) {
   bool is_valid = true;
-  //to avoid Jenkins omp check error
+  // to avoid Jenkins omp check error
   int64_t size = data_size;
   int omp_threads = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
   #pragma omp parallel for num_threads(omp_threads) if (data_size > 2000)

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -338,6 +338,7 @@ struct Take {
     in_src_index += (axis == 0) ? 0 : in_head_index * in_stride[axis - 1];
     out_data[i] = in_data[in_src_index];
   }
+
 };
 
 // Embedding forward implementation with dense weight

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -338,7 +338,6 @@ struct Take {
     in_src_index += (axis == 0) ? 0 : in_head_index * in_stride[axis - 1];
     out_data[i] = in_data[in_src_index];
   }
-
 };
 
 // Embedding forward implementation with dense weight


### PR DESCRIPTION
## Description ##
Optimization for embedding OP for CPU platform. By overload OP Take map function, it has a more than 3 times speedup.
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ done] Changes are complete (i.e. I finished coding on this PR)
- [done ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
pass tests/python/unittest/test_operator.py:test_embedding

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

@pengzhao-intel