### PR TITLE
fix broken Python IO API docs

### DIFF
--- a/docs/api/python/io/io.md
+++ b/docs/api/python/io/io.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This document summarizes supported data formats and iterator APIs to read the
-data including
+data including:
 
 ```eval_rst
 .. autosummary::
@@ -68,8 +68,7 @@ A detailed tutorial is available at
 
 ## Helper classes and functions
 
-
-Data structures and other iterators provided in the ``mxnet.io`` packages.
+### Data structures and other iterators
 
 ```eval_rst
 .. autosummary::
@@ -83,7 +82,7 @@ Data structures and other iterators provided in the ``mxnet.io`` packages.
     io.MXDataIter
 ```
 
-Functions to read and write RecordIO files.
+### Functions to read and write RecordIO files
 
 ```eval_rst
 .. autosummary::
@@ -95,7 +94,7 @@ Functions to read and write RecordIO files.
     recordio.pack_img
 ```
 
-## Develop a new iterator
+## How to develop a new iterator
 
 Writing a new data iterator in Python is straightforward. Most MXNet
 training/inference programs accept an iterable object with ``provide_data``
@@ -133,7 +132,7 @@ Parsing and performing another pre-processing such as augmentation may be expens
 If performance is critical, we can implement a data iterator in C++. Refer to
 [src/io](https://github.com/dmlc/mxnet/tree/master/src/io) for examples.
 
-### Change batch layout
+### How to change the batch layout
 
 By default, the backend engine treats the first dimension of each data and label variable in data
 iterators as the batch size (i.e. `NCHW` or `NT` layout). In order to override the axis for batch size,
@@ -151,10 +150,35 @@ The backend engine will recognize the index of `N` in the `layout` as the axis f
 
 <script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
+### mxnet.io - Data Iterators
+
 ```eval_rst
 .. automodule:: mxnet.io
-    :members:
+    :members: NDArrayIter, CSVIter, LibSVMIter, ImageRecordIter, ImageRecordUInt8Iter, MNISTIter
+```
+
+### mxnet.io - Helper Classes & Functions
+
+```eval_rst
+.. automodule:: mxnet.io
+   :members: DataBatch, DataDesc, DataIter, MXDataIter, PrefetchingIter, ResizeIter
+
+```
+
+### mxnet.recordio
+
+```eval_rst
+.. currentmodule:: mxnet.recordio
+
 .. automodule:: mxnet.recordio
     :members:
+
 ```
+
+```eval_rst
+.. _name: mxnet.symbol.Symbol.name
+.. _shape: mxnet.ndarray.NDArray.shape
+
+```
+
 <script>auto_index("api-reference");</script>

--- a/python/mxnet/io/io.py
+++ b/python/mxnet/io/io.py
@@ -102,8 +102,8 @@ class DataDesc(namedtuple('DataDesc', ['name', 'shape'])):
 
         Parameters
         ----------
-        shapes : a tuple of (name, shape)
-        types : a tuple of  (name, type)
+        shapes : a tuple of (name_, shape_)
+        types : a tuple of  (name_, np.dtype)
         """
         if types is not None:
             type_dict = dict(types)


### PR DESCRIPTION
## Description ##
Fixes #12854 
* This PR manually specifies members of the IO module so that the docs will render as expected. This is workaround in the docs to deal with a bug introduced in the Python code/structure since v1.3.0. See the comments for more info.

* This PR also fixes another issue that may or may not be related. Cross references to same-named entities like `name`, `shape`, or `type` are confusing Sphinx and it seems to just link to whatever it last dealt with that has the same name, and not the current module. To fix this you have to be very specific. Don't use `type`, use `np.type` if that's what you want. Otherwise you might end up with `mxnet.kvstore.KVStore.type`.

I mapped these to aliases, so the docs still have a shorthand reference. 
```
.. _name: mxnet.symbol.Symbol.name
.. _shape: mxnet.ndarray.NDArray.shape
```
So you will see me use `name_` in the docstring, and that will link up to the `_name` alias for `mxnet.symbol.Symbol.name` that is defined at the end of the documentation page's rst code.

**This is important for any future modules** - that they recognize this issue and make efforts to map the params and other elements.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Preview
**To see the APIs populated:**
Go to the 1.3.0 docs: http://mxnet.incubator.apache.org/versions/1.3.0/api/python/io/io.html#data-iterators
Then switch to master. See how links are not there, and down in the API Reference none of those things are present.
Now go to my preview: http://34.201.8.176/versions/1.3.1/api/python/io/io.html

**To see the parameter mapping:**
It's broken on master and not even visible, but you can look at 1.3.0.
http://mxnet.incubator.apache.org/versions/1.3.0/api/python/io/io.html#mxnet.io.DataDesc.get_list
Note that the mappings pretty much work, but type seems messed up because I doubt it is intended to be from `kvstore`. Now look at my preview:
http://34.201.8.176/versions/1.3.1/api/python/io/io.html#mxnet.io.DataDesc.get_list


## Comments ##
Changes that have come in since v1.3.0 have caused some havoc with Sphinx. This could be a bug in the Python code or maybe Sphinx needs things to be a certain way to function properly.
* It can't distinguish between methods of the same name
* It can't use automodule to fetch all members automatically 
**This means a lot of the docs are currently broken!** I ask that some more people take a look because it could be a minor change in the Python versus having to go through and update every single bit of docs and doc strings in each module.

You can see in this PR what had to be done just for one module. Note the `recordio` hasn't been touched and Sphinx renders the docs just fine.
http://mxnet.incubator.apache.org/versions/1.3.0/api/python/io/io.html#data-iterators

