### PR TITLE
add/update infer_range docs

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -2547,6 +2547,9 @@ def arange(start, stop=None, step=1.0, repeat=1, infer_range=False, ctx=None, dt
         Spacing between values. The default step size is 1.
     repeat : int, optional
         Number of times to repeat each element. The default repeat count is 1.
+    infer_range : boolean, optional
+        When set to True, infer the stop position from the start, step,
+        repeat, and output tensor size.
     ctx : Context, optional
         Device context. Default context is the current default context.
     dtype : str or numpy.dtype, optional

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -2926,6 +2926,9 @@ def arange(start, stop=None, step=1.0, repeat=1, infer_range=False, name=None, d
     repeat : int, optional
         "The repeating time of all elements.
         E.g repeat=3, the element a will be repeated three times --> a, a, a.
+    infer_range : boolean, optional
+        When set to True, infer the stop position from the start, step,
+        repeat, and output tensor size.
     dtype : str or numpy.dtype, optional
         The value type of the inner value, default to ``np.float32``.
 

--- a/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
@@ -403,6 +403,9 @@ object NDArray extends NDArrayBase {
    * @param stop End of interval.
    * @param step Spacing between values. The default step size is 1.
    * @param repeat Number of times to repeat each element. The default repeat count is 1.
+   * @param infer_range
+   *          When set to True, infer the stop position from the start, step,
+   *          repeat, and output tensor size.
    * @param ctx Device context. Default context is the current default context.
    * @param dType The data type of the `NDArray`. The default datatype is `DType.Float32`.
    * @return NDArray of evenly spaced values in the specified range.

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
@@ -979,7 +979,9 @@ object Symbol extends SymbolBase {
    * @param stop End of interval.
    * @param step Spacing between values. The default step size is 1.
    * @param repeat Number of times to repeat each element. The default repeat count is 1.
-   * @param infer_range Infer the stop value from output shape
+   * @param infer_range
+   *          When set to True, infer the stop position from the start, step,
+   *          repeat, and output tensor size.
    * @param ctx Device context. Default context is the current default context.
    * @param dType The data type of the `NDArray`. The default datatype is `DType.Float32`.
    * @return NDArray of evenly spaced values in the specified range.

--- a/src/operator/tensor/init_op.h
+++ b/src/operator/tensor/init_op.h
@@ -161,8 +161,8 @@ struct RangeParam : public dmlc::Parameter<RangeParam> {
               " E.g repeat=3, the element a will be repeated three times --> a, a, a.");
     DMLC_DECLARE_FIELD(infer_range)
     .set_default(false)
-    .describe("Whether to infer the stop position from the start, step, repeat, and output tensor"
-              "size.");
+    .describe("When set to True, infer the stop position from the start, step, "
+              "repeat, and output tensor size.");
     DMLC_DECLARE_FIELD(ctx)
     .set_default("")
     .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."


### PR DESCRIPTION
## Description ##
This PR adds or updates the docs for the `infer_range` feature.
* Clarifies the param in the C op docs
* Clarifies the param in the the Scala symbol docs
* Adds the param for the the Scala ndarray docs
* Adds the param for the Python symbol docs
* Adds the param for the Python ndarray docs

Fixes #12874 