### PR TITLE
use ResourceScope in Model/Trainer/FeedForward.scala

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/FeedForward.scala
@@ -17,9 +17,10 @@
 
 package org.apache.mxnet
 
+import org.apache.mxnet.Base.CPtrAddress
 import org.apache.mxnet.io.NDArrayIter
 import org.apache.mxnet.optimizer.SGD
-import org.slf4j.{LoggerFactory, Logger}
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.mutable.ListBuffer
 
@@ -55,7 +56,7 @@ class FeedForward private(
     argParams: Map[String, NDArray],
     auxParams: Map[String, NDArray],
     private val allowExtraParams: Boolean,
-    val beginEpoch: Int) {
+    val beginEpoch: Int) extends NativeResource {
 
   val logger: Logger = LoggerFactory.getLogger(classOf[FeedForward])
   private var argumentChecked = false
@@ -126,6 +127,8 @@ class FeedForward private(
   }
 
   // Initialize weight parameters and auxiliary states
+  // The NDArrays associated with the _argParms and _auxParams are not disposed instead
+  // they are passed a outer scope if available.
   private def initParams(inputShapes: Map[String, Shape], overwrite: Boolean = false)
   : (IndexedSeq[String], IndexedSeq[String], IndexedSeq[String]) = {
     val (argShapes, _, auxShapes) = symbol.inferShape(inputShapes)
@@ -137,16 +140,26 @@ class FeedForward private(
     val paramNameShapes = (argNames zip argShapes).filter { case (name, _) =>
       paramNames.contains(name)
     }
-    val argParams = paramNameShapes.map { case (name, shape) =>
-      (name, NDArray.zeros(shape))
+    val argParams = paramNameShapes.map { case (name, shape) => {
+        val param = NDArray.zeros(shape)
+        val curScope = ResourceScope.getCurrentScope()
+        if (curScope.isDefined) curScope.get.moveToOuterScope(param)
+        (name, param)
+      }
     }.toMap
-    val auxParams = (auxNames zip auxShapes).map { case (name, shape) =>
-      (name, NDArray.zeros(shape))
+
+    val auxParams = (auxNames zip auxShapes).map { case (name, shape) => {
+        val param = NDArray.zeros(shape)
+        val curScope = ResourceScope.getCurrentScope()
+        if (curScope.isDefined) curScope.get.moveToOuterScope(param)
+        (name, param)
+      }
     }.toMap
 
     for ((k, v) <- argParams) {
       if (_argParams != null && _argParams.contains(k) && (!overwrite)) {
         argParams(k).set(_argParams(k))
+
       } else {
         initializer(k, v)
       }
@@ -356,7 +369,11 @@ class FeedForward private(
                   batchEndCallback: BatchEndCallback = null, logger: Logger = FeedForward.logger,
                   workLoadList: Seq[Float] = null): Unit = {
     require(evalMetric != null, "evalMetric cannot be null")
-    ResourceScope.using() {
+    // TODO: https://issues.apache.org/jira/browse/MXNET-1171
+    // this leaks memory, initSymbolParams->initParams is already called which allocates
+    // NDArray in argParams, auxParams and here we are overwriting it by calling again.
+    // PhantomRef should take care of releasing this when GC is called, however we have to
+    // wait for the GC call to happen.
       val (argNames, paramNames, auxNames) = initSymbolParams(trainData)
 
       // init optimizer
@@ -395,7 +412,6 @@ class FeedForward private(
         workLoadList = workLoadList,
         monitor = monitor,
         symGen = symGen)
-    }
   }
 
   /**
@@ -422,9 +438,29 @@ class FeedForward private(
   def serialize(): Array[Byte] = {
     Model.serialize(this.symbol, getArgParams, getAuxParams)
   }
+
+  // hack to make the FeedForward.scala work with ResourceScope and
+  // automatically release _argParms and _auxParms
+  override def nativeAddress: CPtrAddress = hashCode()
+
+  override def nativeDeAllocator: CPtrAddress => Int = FeedForward.doNothingDeAllocator
+
+  override val ref: NativeResourceRef = super.register()
+
+  override val bytesAllocated: Long = 0L
+
+  override def dispose(): Unit = {
+    if (!super.isDisposed) {
+      _argParams.foreach { case (_, param) => param.dispose() }
+      _auxParams.foreach { case (_, param) => param.dispose() }
+    }
+  }
 }
 
 object FeedForward {
+
+  private def doNothingDeAllocator(dummy: CPtrAddress): Int = 0
+
   private val logger: Logger = LoggerFactory.getLogger(classOf[FeedForward])
   // Check if name is a data argument.
   private def isDataArg(name: String): Boolean = {

--- a/scala-package/core/src/main/scala/org/apache/mxnet/NativeResource.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NativeResource.scala
@@ -46,7 +46,8 @@ private[mxnet] trait NativeResource
     */
   def nativeDeAllocator: (CPtrAddress => Int)
 
-  /** Call NativeResource.register to get the reference
+  /**
+    * Call NativeResource.register to get the reference
     */
   val ref: NativeResourceRef
 
@@ -56,6 +57,7 @@ private[mxnet] trait NativeResource
   // intentionally making it a val, so it gets evaluated when defined
   val bytesAllocated: Long
 
+  // this is set and unset by [[ResourceScope.add]] and [[ResourceScope.remove]]
   private[mxnet] var scope: Option[ResourceScope] = None
 
   @volatile private var disposed = false
@@ -69,11 +71,11 @@ private[mxnet] trait NativeResource
     *         using PhantomReference
     */
   def register(): NativeResourceRef = {
-    scope = ResourceScope.getCurrentScope()
+    val scope = ResourceScope.getCurrentScope()
     if (scope.isDefined) scope.get.add(this)
 
     NativeResource.totalBytesAllocated.getAndAdd(bytesAllocated)
-    // register with PhantomRef tracking to release incase the objects go
+    // register with PhantomRef tracking to release in case the objects go
     // out of reference within scope but are held for long time
     NativeResourceRef.register(this, nativeDeAllocator)
  }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
@@ -58,6 +58,7 @@ class ResourceScope extends AutoCloseable {
     */
   def add(resource: NativeResource): Unit = {
     resourceQ.+=(resource)
+    resource.scope = Some(this)
   }
 
   /**
@@ -67,7 +68,21 @@ class ResourceScope extends AutoCloseable {
     */
   def remove(resource: NativeResource): Unit = {
     resourceQ.-=(resource)
+    resource.scope = None
   }
+
+  /**
+    * Removes from current Scope and moves to outer scope if it exists
+    * @param resource Resource to be moved to an outer scope
+    */
+  def moveToOuterScope(resource: NativeResource): Unit = {
+    val prevScope: Option[ResourceScope] = ResourceScope.getPrevScope()
+    if (prevScope.isDefined) {
+      this.remove(resource)
+      prevScope.get.add(resource)
+    } else this.remove(resource)
+  }
+
 }
 
 object ResourceScope {
@@ -92,30 +107,20 @@ object ResourceScope {
 
     val curScope = if (scope != null) scope else new ResourceScope()
 
-    val prevScope: Option[ResourceScope] = ResourceScope.getPrevScope()
-
     @inline def resourceInGeneric(g: scala.collection.Iterable[_]) = {
       g.foreach( n =>
         n match {
           case nRes: NativeResource => {
-            removeAndAddToPrevScope(nRes)
+            curScope.moveToOuterScope(nRes)
           }
           case kv: scala.Tuple2[_, _] => {
-            if (kv._1.isInstanceOf[NativeResource]) removeAndAddToPrevScope(
+            if (kv._1.isInstanceOf[NativeResource]) curScope.moveToOuterScope(
               kv._1.asInstanceOf[NativeResource])
-            if (kv._2.isInstanceOf[NativeResource]) removeAndAddToPrevScope(
+            if (kv._2.isInstanceOf[NativeResource]) curScope.moveToOuterScope(
               kv._2.asInstanceOf[NativeResource])
           }
         }
       )
-    }
-
-    @inline def removeAndAddToPrevScope(r: NativeResource) = {
-      curScope.remove(r)
-      if (prevScope.isDefined)  {
-        prevScope.get.add(r)
-        r.scope = prevScope
-      }
     }
 
     @inline def safeAddSuppressed(t: Throwable, suppressed: Throwable): Unit = {
@@ -129,8 +134,8 @@ object ResourceScope {
        ret match {
           // don't de-allocate if returning any collection that contains NativeResource.
         case resInGeneric: scala.collection.Iterable[_] => resourceInGeneric(resInGeneric)
-        case nRes: NativeResource => removeAndAddToPrevScope(nRes)
-        case ndRet: NDArrayFuncReturn => ndRet.arr.foreach( nd => removeAndAddToPrevScope(nd) )
+        case nRes: NativeResource => curScope.moveToOuterScope(nRes)
+        case ndRet: NDArrayFuncReturn => ndRet.arr.foreach( nd => curScope.moveToOuterScope(nd) )
         case _ => // do nothing
       }
       ret

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/imclassification/util/Trainer.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/imclassification/util/Trainer.scala
@@ -50,83 +50,84 @@ object Trainer {
           lr: Float = 0.1f, lrFactor: Float = 1f, lrFactorEpoch: Float = 1f,
           clipGradient: Float = 0f, monitorSize: Int = -1): Accuracy = {
     // kvstore
-    var kv = KVStore.create(kvStore)
+    ResourceScope.using()  {
+      var kv = KVStore.create(kvStore)
 
-    // load model
-    val modelPrefixWithRank =
-      if (modelPrefix == null) null
-      else modelPrefix + s"-${kv.rank}"
+      // load model
+      val modelPrefixWithRank =
+        if (modelPrefix == null) null
+        else modelPrefix + s"-${kv.rank}"
 
-    val (argParams, auxParams, beginEpoch) =
-      if (loadEpoch >= 0) {
-        require(modelPrefixWithRank != null)
-        val tmp = FeedForward.load(modelPrefix, loadEpoch)
-        (tmp.getArgParams, tmp.getAuxParams, loadEpoch)
-      } else {
-        (null, null, 0)
-      }
-
-    // save model
-    val checkpoint: EpochEndCallback =
-      if (modelPrefix == null) null
-      else new EpochEndCallback {
-        override def invoke(epoch: Int, symbol: Symbol,
-                            argParams: Map[String, NDArray],
-                            auxStates: Map[String, NDArray]): Unit = {
-          Model.saveCheckpoint(modelPrefix, epoch + 1, symbol, argParams, auxParams)
+      val (argParams, auxParams, beginEpoch) =
+        if (loadEpoch >= 0) {
+          require(modelPrefixWithRank != null)
+          val tmp = FeedForward.load(modelPrefix, loadEpoch)
+          (tmp.getArgParams, tmp.getAuxParams, loadEpoch)
+        } else {
+          (null, null, 0)
         }
+
+      // save model
+      val checkpoint: EpochEndCallback =
+        if (modelPrefix == null) null
+        else new EpochEndCallback {
+          override def invoke(epoch: Int, symbol: Symbol,
+                              argParams: Map[String, NDArray],
+                              auxStates: Map[String, NDArray]): Unit = {
+            Model.saveCheckpoint(modelPrefix, epoch + 1, symbol, argParams, auxParams)
+          }
+        }
+
+      // data
+      val (train, validation) = dataLoader(batchSize, kv)
+
+      // train
+      val epochSize =
+        if (kvStore == "dist_sync") numExamples / batchSize / kv.numWorkers
+        else numExamples / batchSize
+
+      val lrScheduler =
+        if (lrFactor < 1f) {
+          new FactorScheduler(step = Math.max((epochSize * lrFactorEpoch).toInt, 1),
+                              factor = lrFactor)
+        } else {
+          null
+        }
+      val optimizer: Optimizer = new SGD(learningRate = lr,
+        lrScheduler = lrScheduler, clipGradient = clipGradient,
+        momentum = 0.9f, wd = 0.00001f)
+
+      // disable kvstore for single device
+      if (kv.`type`.contains("local") && (devs.length == 1 || devs(0).deviceType != "gpu")) {
+        kv.dispose()
+        kv = null
       }
 
-    // data
-    val (train, validation) = dataLoader(batchSize, kv)
-
-    // train
-    val epochSize =
-      if (kvStore == "dist_sync") numExamples / batchSize / kv.numWorkers
-      else numExamples / batchSize
-
-    val lrScheduler =
-      if (lrFactor < 1f) {
-        new FactorScheduler(step = Math.max((epochSize * lrFactorEpoch).toInt, 1),
-                            factor = lrFactor)
-      } else {
-        null
+      val model = new FeedForward(ctx = devs,
+                                  symbol = network,
+                                  numEpoch = numEpochs,
+                                  optimizer = optimizer,
+                                  initializer = new Xavier(factorType = "in", magnitude = 2.34f),
+                                  argParams = argParams,
+                                  auxParams = auxParams,
+                                  beginEpoch = beginEpoch,
+                                  epochSize = epochSize)
+      if (monitorSize > 0) {
+        model.setMonitor(new Monitor(monitorSize))
       }
-    val optimizer: Optimizer = new SGD(learningRate = lr,
-      lrScheduler = lrScheduler, clipGradient = clipGradient,
-      momentum = 0.9f, wd = 0.00001f)
-
-    // disable kvstore for single device
-    if (kv.`type`.contains("local") && (devs.length == 1 || devs(0).deviceType != "gpu")) {
-      kv.dispose()
-      kv = null
+      val acc = new Accuracy()
+      model.fit(trainData = train,
+                evalData = validation,
+                evalMetric = acc,
+                kvStore = kv,
+                batchEndCallback = new Speedometer(batchSize, 50),
+                epochEndCallback = checkpoint)
+      if (kv != null) {
+        kv.dispose()
+      }
+      acc
     }
-
-    val model = new FeedForward(ctx = devs,
-                                symbol = network,
-                                numEpoch = numEpochs,
-                                optimizer = optimizer,
-                                initializer = new Xavier(factorType = "in", magnitude = 2.34f),
-                                argParams = argParams,
-                                auxParams = auxParams,
-                                beginEpoch = beginEpoch,
-                                epochSize = epochSize)
-    if (monitorSize > 0) {
-      model.setMonitor(new Monitor(monitorSize))
-    }
-    val acc = new Accuracy()
-    model.fit(trainData = train,
-              evalData = validation,
-              evalMetric = acc,
-              kvStore = kv,
-              batchEndCallback = new Speedometer(batchSize, 50),
-              epochEndCallback = checkpoint)
-    if (kv != null) {
-      kv.dispose()
-    }
-    acc
   }
-
   // scalastyle:on parameterNum
 }
 


### PR DESCRIPTION
## Description ##
Use ResourceScope to remove Leaks in FeedForward and Model.scala 

* Before Changes
```
NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadLabelMulti(ExecutorManager.scala:261)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:511)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,894 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadDataMulti(ExecutorManager.scala:251)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:510)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,894 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getLabel(MXDataIter.scala:142)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,894 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getData(MXDataIter.scala:132)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,894 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.NDArray.slice(NDArray.scala:652)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
	scala.collection.AbstractTraversable.map(Traversable.scala:104)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:526)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	org.apache.mxnet.DataParallelExecutorGroup.updateMetric(ExecutorManager.scala:526)
	org.apache.mxnet.DataParallelExecutorManager.updateMetric(ExecutorManager.scala:168)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:313)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,894 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadLabelMulti(ExecutorManager.scala:261)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:511)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,894 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadDataMulti(ExecutorManager.scala:251)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:510)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,894 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getLabel(MXDataIter.scala:142)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,894 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getData(MXDataIter.scala:132)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,894 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.NDArray.slice(NDArray.scala:652)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
	scala.collection.AbstractTraversable.map(Traversable.scala:104)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:526)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	org.apache.mxnet.DataParallelExecutorGroup.updateMetric(ExecutorManager.scala:526)
	org.apache.mxnet.DataParallelExecutorManager.updateMetric(ExecutorManager.scala:168)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:313)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,894 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadLabelMulti(ExecutorManager.scala:261)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:511)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,894 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadDataMulti(ExecutorManager.scala:251)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:510)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getLabel(MXDataIter.scala:142)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getData(MXDataIter.scala:132)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.NDArray.slice(NDArray.scala:652)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
	scala.collection.AbstractTraversable.map(Traversable.scala:104)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:526)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	org.apache.mxnet.DataParallelExecutorGroup.updateMetric(ExecutorManager.scala:526)
	org.apache.mxnet.DataParallelExecutorManager.updateMetric(ExecutorManager.scala:168)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:313)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadLabelMulti(ExecutorManager.scala:261)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:511)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadDataMulti(ExecutorManager.scala:251)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:510)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getLabel(MXDataIter.scala:142)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getData(MXDataIter.scala:132)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.NDArray.slice(NDArray.scala:652)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
	scala.collection.AbstractTraversable.map(Traversable.scala:104)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:526)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	org.apache.mxnet.DataParallelExecutorGroup.updateMetric(ExecutorManager.scala:526)
	org.apache.mxnet.DataParallelExecutorManager.updateMetric(ExecutorManager.scala:168)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:313)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadLabelMulti(ExecutorManager.scala:261)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:511)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadDataMulti(ExecutorManager.scala:251)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:510)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getLabel(MXDataIter.scala:142)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getData(MXDataIter.scala:132)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.NDArray.slice(NDArray.scala:652)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
	scala.collection.AbstractTraversable.map(Traversable.scala:104)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:526)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	org.apache.mxnet.DataParallelExecutorGroup.updateMetric(ExecutorManager.scala:526)
	org.apache.mxnet.DataParallelExecutorManager.updateMetric(ExecutorManager.scala:168)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:313)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadLabelMulti(ExecutorManager.scala:261)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:511)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadDataMulti(ExecutorManager.scala:251)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:510)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getLabel(MXDataIter.scala:142)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getData(MXDataIter.scala:132)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.NDArray.slice(NDArray.scala:652)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
	scala.collection.AbstractTraversable.map(Traversable.scala:104)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:526)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	org.apache.mxnet.DataParallelExecutorGroup.updateMetric(ExecutorManager.scala:526)
	org.apache.mxnet.DataParallelExecutorManager.updateMetric(ExecutorManager.scala:168)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:313)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadLabelMulti(ExecutorManager.scala:261)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:511)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,895 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadDataMulti(ExecutorManager.scala:251)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:510)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,896 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getLabel(MXDataIter.scala:142)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,896 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.io.MXDataIter.getData(MXDataIter.scala:132)
	org.apache.mxnet.io.MXDataIter.iterNext(MXDataIter.scala:116)
	org.apache.mxnet.io.MXDataIter.hasNext(MXDataIter.scala:185)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:294)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,896 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.NDArray.slice(NDArray.scala:652)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1$$anonfun$25.apply(ExecutorManager.scala:527)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
	scala.collection.AbstractTraversable.map(Traversable.scala:104)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:527)
	org.apache.mxnet.DataParallelExecutorGroup$$anonfun$updateMetric$1.apply(ExecutorManager.scala:526)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	org.apache.mxnet.DataParallelExecutorGroup.updateMetric(ExecutorManager.scala:526)
	org.apache.mxnet.DataParallelExecutorManager.updateMetric(ExecutorManager.scala:168)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:313)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
	org.apache.mxnetexamples.imclassification.ModelTrain$.fit(ModelTrain.scala:100)
	org.apache.mxnetexamples.imclassification.TrainMnist$.main(TrainMnist.scala:147)
	org.apache.mxnetexamples.imclassification.TrainMnist.main(TrainMnist.scala)
2018-10-19 16:15:00,896 [Finalizer] [org.apache.mxnet.WarnIfNotDisposed] [WARN] - LEAK: An instance of class org.apache.mxnet.NDArray was not disposed. Creation point of this resource was:
	java.lang.Thread.getStackTrace(Thread.java:1559)
	org.apache.mxnet.WarnIfNotDisposed$class.$init$(WarnIfNotDisposed.scala:52)
	org.apache.mxnet.NDArray.<init>(NDArray.scala:561)
	org.apache.mxnet.NDArray.slice(NDArray.scala:648)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:240)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2$$anonfun$apply$3.apply(ExecutorManager.scala:239)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
	scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:186)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:239)
	org.apache.mxnet.ExecutorManager$$anonfun$loadGeneralMulti$2.apply(ExecutorManager.scala:238)
	scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:733)
	scala.collection.Iterator$class.foreach(Iterator.scala:893)
	scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
	scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
	scala.collection.AbstractIterable.foreach(Iterable.scala:54)
	scala.collection.TraversableLike$WithFilter.foreach(TraversableLike.scala:732)
	org.apache.mxnet.ExecutorManager$.loadGeneralMulti(ExecutorManager.scala:238)
	org.apache.mxnet.ExecutorManager$.loadLabelMulti(ExecutorManager.scala:261)
	org.apache.mxnet.DataParallelExecutorGroup.loadDataBatch(ExecutorManager.scala:511)
	org.apache.mxnet.DataParallelExecutorManager.loadDataBatch(ExecutorManager.scala:153)
	org.apache.mxnet.Model$$anonfun$trainMultiDevice$1.apply$mcVI$sp(Model.scala:296)
	scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
	org.apache.mxnet.Model$.trainMultiDevice(Model.scala:284)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:377)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:316)
	org.apache.mxnet.FeedForward.fit(FeedForward.scala:324)
```
** Many Many Many more **

* After Changes
```
16:07:05] src/io/iter_mnist.cc:110: MNISTIter: load 60000 images, shuffle=1, shape=(128,784)
[16:07:06] src/io/iter_mnist.cc:110: MNISTIter: load 10000 images, shuffle=1, shape=(128,784)
2018-10-19 16:07:06,545 [main] [org.apache.mxnet.FeedForward] [DEBUG] - Start training on multi-device
2018-10-19 16:07:06,548 [main] [org.apache.mxnet.DataParallelExecutorManager] [INFO] - Start training with [cpu(0)]
2018-10-19 16:07:07,114 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [50]	Speed: 14512.47 samples/sec	Train-accuracy=0.676094
2018-10-19 16:07:07,441 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [100]	Speed: 19692.31 samples/sec	Train-accuracy=0.778437
2018-10-19 16:07:07,687 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [150]	Speed: 26122.45 samples/sec	Train-accuracy=0.824115
2018-10-19 16:07:07,946 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [200]	Speed: 24710.42 samples/sec	Train-accuracy=0.852734
2018-10-19 16:07:08,308 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [250]	Speed: 17679.56 samples/sec	Train-accuracy=0.870094
2018-10-19 16:07:08,614 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [300]	Speed: 20915.03 samples/sec	Train-accuracy=0.882500
2018-10-19 16:07:08,822 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [350]	Speed: 30917.87 samples/sec	Train-accuracy=0.892254
2018-10-19 16:07:09,117 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [400]	Speed: 21694.92 samples/sec	Train-accuracy=0.899863
2018-10-19 16:07:09,347 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[0] Batch [450]	Speed: 27947.60 samples/sec	Train-accuracy=0.905330
2018-10-19 16:07:09,416 [main] [org.apache.mxnet.Model] [INFO] - Epoch[0] Train-accuracy=0.9072349
2018-10-19 16:07:09,416 [main] [org.apache.mxnet.Model] [INFO] - Epoch[0] Time cost=2805
2018-10-19 16:07:09,587 [main] [org.apache.mxnet.Model] [INFO] - Epoch[0] Validation-accuracy=0.9566306
2018-10-19 16:07:09,869 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [50]	Speed: 27705.63 samples/sec	Train-accuracy=0.956406
2018-10-19 16:07:10,061 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [100]	Speed: 33333.33 samples/sec	Train-accuracy=0.959766
2018-10-19 16:07:10,231 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [150]	Speed: 37647.06 samples/sec	Train-accuracy=0.961927
2018-10-19 16:07:10,405 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [200]	Speed: 36781.61 samples/sec	Train-accuracy=0.963164
2018-10-19 16:07:10,595 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [250]	Speed: 33684.21 samples/sec	Train-accuracy=0.963625
2018-10-19 16:07:10,855 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [300]	Speed: 24615.38 samples/sec	Train-accuracy=0.963750
2018-10-19 16:07:11,169 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [350]	Speed: 20447.28 samples/sec	Train-accuracy=0.964286
2018-10-19 16:07:11,380 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [400]	Speed: 30476.19 samples/sec	Train-accuracy=0.964648
2018-10-19 16:07:11,631 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[1] Batch [450]	Speed: 25600.00 samples/sec	Train-accuracy=0.964774
2018-10-19 16:07:11,726 [main] [org.apache.mxnet.Model] [INFO] - Epoch[1] Train-accuracy=0.9649105
2018-10-19 16:07:11,726 [main] [org.apache.mxnet.Model] [INFO] - Epoch[1] Time cost=2096
2018-10-19 16:07:11,906 [main] [org.apache.mxnet.Model] [INFO] - Epoch[1] Validation-accuracy=0.9675481
2018-10-19 16:07:12,156 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[2] Batch [50]	Speed: 26229.51 samples/sec	Train-accuracy=0.969688
2018-10-19 16:07:12,398 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[2] Batch [100]	Speed: 26446.28 samples/sec	Train-accuracy=0.972734
2018-10-19 16:07:12,630 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[2] Batch [150]	Speed: 27586.21 samples/sec	Train-accuracy=0.974375
2018-10-19 16:07:12,926 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[2] Batch [200]	Speed: 21621.62 samples/sec	Train-accuracy=0.974336
2018-10-19 16:07:13,232 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[2] Batch [250]	Speed: 21052.63 samples/sec	Train-accuracy=0.974406
2018-10-19 16:07:13,519 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[2] Batch [300]	Speed: 22377.62 samples/sec	Train-accuracy=0.974740
2018-10-19 16:07:13,786 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[2] Batch [350]	Speed: 23970.04 samples/sec	Train-accuracy=0.975357
2018-10-19 16:07:14,214 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[2] Batch [400]	Speed: 15023.47 samples/sec	Train-accuracy=0.975488
2018-10-19 16:07:14,428 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[2] Batch [450]	Speed: 29906.54 samples/sec	Train-accuracy=0.975625
2018-10-19 16:07:14,503 [main] [org.apache.mxnet.Model] [INFO] - Epoch[2] Train-accuracy=0.97574455
2018-10-19 16:07:14,503 [main] [org.apache.mxnet.Model] [INFO] - Epoch[2] Time cost=2596
2018-10-19 16:07:14,602 [main] [org.apache.mxnet.Model] [INFO] - Epoch[2] Validation-accuracy=0.9707532
2018-10-19 16:07:14,818 [main] [org.apache.mxnet.Callback$Speedometer] [INFO] - Epoch[3] Batch [50]	Speed: 30622.01 samples/sec	Train-accuracy=0.976094
```