### PR TITLE
Fix __all__ in optimizer/optimizer.py

### DIFF
--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -33,8 +33,8 @@ from ..random import normal
 
 __all__ = [
     'AdaDelta', 'AdaGrad', 'Adam', 'Adamax', 'DCASGD', 'FTML', 'Ftrl', 'LBSGD',
-    'NAG', 'NDArray', 'NDabs', 'Nadam', 'Optimizer', 'RMSProp', 'SGD', 'SGLD',
-    'Signum', 'Test', 'Updater', 'ccSGD', 'create', 'get_updater', 'register'
+    'NAG', 'NDabs', 'Nadam', 'Optimizer', 'RMSProp', 'SGD', 'SGLD', 'Signum',
+    'Test', 'Updater', 'ccSGD', 'create', 'get_updater', 'register'
 ]
 
 


### PR DESCRIPTION
## Description ##
There was a typo in https://github.com/apache/incubator-mxnet/pull/12365/files#diff-0c893416e9e93fbd94dfaa9fa6c13d67R34 and `NDArray` was wrongly included in  `__all__` in optimizer/optimizer.py. This may have confused Sphinx: https://github.com/apache/incubator-mxnet/issues/12829

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Fix `__all__` in optimizer/optimizer.py
