### PR TITLE
Fix indpt[0] and dtype switch for take(csr)

### DIFF
--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -137,7 +137,10 @@ struct CsrTakeRowCountKernel {
   MSHADOW_XINLINE static void Map(int tid, RType* out_indptr,
                                   const RType* src_indptr, const IType* idx_ptr,
                                   const nnvm::dim_t num_rows) {
-    if (tid == 0) out_indptr[0] = 0;
+    if (tid == 0) {
+      out_indptr[0] = 0;
+      return;
+    }
     nnvm::dim_t idx = static_cast<nnvm::dim_t>(idx_ptr[tid - 1]);
     // clip mode
     if (clip) {
@@ -181,7 +184,7 @@ void TakeOpForwardCsrImpl<cpu>(const TakeParam& params,
   out.CheckAndAllocAuxData(kIndPtr, {Shape1(num_rows + 1)});
 
   MSHADOW_TYPE_SWITCH(idx.type_flag_, IType, {
-    MSHADOW_SGL_DBL_TYPE_SWITCH(arr.dtype(), DType, {
+    MSHADOW_TYPE_SWITCH(arr.dtype(), DType, {
       MSHADOW_IDX_TYPE_SWITCH(out.aux_type(kIdx), RType, {
         RType* out_indptr = out.aux_data(kIndPtr).dptr<RType>();
         const RType* src_indptr = arr.aux_data(kIndPtr).dptr<RType>();

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -1018,13 +1018,14 @@ def test_sparse_take():
     def check_sparse_take(density, mode):
         data_shape = rand_shape_2d()
         idx_shape = (np.random.randint(low=1, high=10),)
-        data = rand_ndarray(data_shape, 'csr', density=density)
+        data = rand_ndarray(data_shape, 'csr', density=density).astype('int32')
         idx = mx.nd.array(np.random.randint(low=-5, high=15, size=idx_shape))
-        result = mx.nd.take(data, idx, mode=mode)
         data_np = data.asnumpy()
         idx_np = idx.asnumpy().astype('int32')
         expected_result = np.take(data_np, idx_np, mode=mode, axis=0)
+        result = mx.nd.take(data, idx, mode=mode)
         assert_almost_equal(result.asnumpy(), expected_result)
+        assert result.indptr[0].asscalar() == 0
     densities = [0, 0.5, 1]
     modes = ['clip', 'wrap']
     for d in densities:


### PR DESCRIPTION
## Description ##
As title

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
