### PR TITLE
Fail the broken link job when broken links are found

### DIFF
--- a/tests/nightly/broken_link_checker_test/test_broken_links.py
+++ b/tests/nightly/broken_link_checker_test/test_broken_links.py
@@ -101,4 +101,5 @@ if broken_links_count == 0:
 else:
     print(broken_links_summary)
     print("END - Broken links summary")
-
+    # Fail the job as we found the broken links
+    sys.exit(-1)


### PR DESCRIPTION
## Description ##
This change fails the broken link nightly test when there are broken links. Without this change, currently, jobs are silently succeeding.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] Code is well-documented: 
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Fail the blc check if broken links are found

@aaronmarkham @lebeg 
