### PR TITLE
Add bytearray support back to imdecode (#12855, #12868)

### DIFF
--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -93,7 +93,7 @@ def imdecode(buf, *args, **kwargs):
 
     Parameters
     ----------
-    buf : str/bytes or numpy.ndarray
+    buf : str/bytes/bytearray or numpy.ndarray
         Binary image data as string or numpy ndarray.
     flag : int, optional, default=1
         1 for three channel color output. 0 for grayscale output.
@@ -135,10 +135,15 @@ def imdecode(buf, *args, **kwargs):
     <NDArray 224x224x3 @cpu(0)>
     """
     if not isinstance(buf, nd.NDArray):
-        if sys.version_info[0] == 3 and not isinstance(buf, (bytes, np.ndarray)):
-            raise ValueError('buf must be of type bytes or numpy.ndarray,'
+        if sys.version_info[0] == 3 and not isinstance(buf, (bytes, bytearray, np.ndarray)):
+            raise ValueError('buf must be of type bytes, bytearray or numpy.ndarray,'
                              'if you would like to input type str, please convert to bytes')
         buf = nd.array(np.frombuffer(buf, dtype=np.uint8), dtype=np.uint8)
+
+    if len(buf) == 0:
+        # empty buf causes OpenCV crash.
+        raise ValueError("input buf cannot be empty.")
+
     return _internal._cvimdecode(buf, *args, **kwargs)
 
 

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -92,6 +92,22 @@ class TestImage(unittest.TestCase):
             cv_image = cv2.imread(img)
             assert_almost_equal(image.asnumpy(), cv_image)
 
+    def test_imdecode_bytearray(self):
+        try:
+            import cv2
+        except ImportError:
+            return
+        for img in TestImage.IMAGES:
+            with open(img, 'rb') as fp:
+                str_image = bytearray(fp.read())
+                image = mx.image.imdecode(str_image, to_rgb=0)
+            cv_image = cv2.imread(img)
+            assert_almost_equal(image.asnumpy(), cv_image)
+
+    @raises(ValueError)
+    def test_imdecode_empty_buffer(self):
+        mx.image.imdecode(b'', to_rgb=0)
+
     def test_scale_down(self):
         assert mx.image.scale_down((640, 480), (720, 120)) == (640, 106)
         assert mx.image.scale_down((360, 1000), (480, 500)) == (360, 375)


### PR DESCRIPTION
## Description ##
1. image.imdecode used to support bytearray, There is a regression introduced in: d4991a0e324b53d8d6e84decbd237ff6a5a3ab08. This commit trying to address the regression.

2. When input buffer is empty, OpenCV crash and Python process is killed. Add empty check to workaround this issue in OpenCV.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Fixed backward compatibility issue regarding bytearray support.
- [X] Avoid OpenCV crash for empty input.

## Comments ##
