### PR TITLE
fix mac r install and windows python build from source docs

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -597,7 +597,19 @@ MXNet developers should refer to the MXNet wiki's <a href="https://cwiki.apache.
 <div class="r">
 <div class="cpu">
 </br>
-Install OpenCV and OpenBLAS.
+
+
+Install the latest version (3.5.1+) of R from [CRAN](https://cran.r-project.org/bin/macosx/).
+You can [build MXNet-R from source](osx_setup.html#install-the-mxnet-package-for-r), or you can use a pre-built binary:
+
+```r
+cran <- getOption("repos")
+cran["dmlc"] <- "https://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/R/CRAN/"
+options(repos = cran)
+install.packages("mxnet")
+```
+
+To run MXNet you also should have OpenCV and OpenBLAS installed. You may install them with `brew` as follows:
 
 ```bash
 brew install opencv
@@ -608,16 +620,6 @@ Add a soft link to the OpenBLAS installation. This example links the 0.3.1 versi
 
 ```bash
 ln -sf /usr/local/opt/openblas/lib/libopenblasp-r0.3.* /usr/local/opt/openblas/lib/libopenblasp-r0.3.1.dylib
-```
-
-Install the latest version (3.5.1+) of R from [CRAN](https://cran.r-project.org/bin/macosx/).
-You can [build MXNet-R from source](osx_setup.html#install-the-mxnet-package-for-r), or you can use a pre-built binary:
-
-```r
-cran <- getOption("repos")
-cran["dmlc"] <- "https://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/R/CRAN/"
-options(repos = cran)
-install.packages("mxnet")
 ```
 
 </div> <!-- END of CPU -->
@@ -757,7 +759,7 @@ All MKL pip packages are experimental prior to version 1.3.0.
 </div> <!-- End of pip -->
 
 
-<div class="docker build-from-source">
+<div class="docker">
 <br/>
 
 Docker images with *MXNet* are available at [Docker Hub](https://hub.docker.com/r/mxnet/).
@@ -800,7 +802,13 @@ mxnet/python        1.3.0_cpu_mkl       deaf9bf61d29        4 days ago          
 **Step 4** <a href="validate_mxnet.html">Validate the installation</a>.
 
 
-</div> <!-- End of docker build-from-source -->
+</div> <!-- End of docker -->
+
+<div class="build-from-source">
+<br/>
+Refer to the <a href="windows_setup.html">MXNet Windows installation guide</a>
+
+</div> <!-- End of Build from source -->
 </div> <!-- End of CPU -->
 
 
@@ -886,7 +894,7 @@ Refer to [#8671](https://github.com/apache/incubator-mxnet/issues/8671) for stat
 
 You can either upgrade your CUDA install or install the MXNet package that supports your CUDA version.
 
-</div>
+</div> <!-- End of pip -->
 
 <div class="build-from-source">
 <br/>
@@ -894,7 +902,7 @@ You can either upgrade your CUDA install or install the MXNet package that suppo
 To build from source, refer to the <a href="windows_setup.html">MXNet Windows installation guide</a>.
 
 
-</div> <!-- End of pip -->
+</div> <!-- End of build from source -->
 </div> <!-- End of GPU -->
 </div> <!-- End of Python -->
 
@@ -914,6 +922,8 @@ cran["dmlc"] <- "https://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/R/CR
 options(repos = cran)
 install.packages("mxnet")
 ```
+
+To run MXNet you also should have OpenCV and OpenBLAS installed.
 
 </div> <!-- END - Windows R CPU -->
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -598,17 +598,6 @@ MXNet developers should refer to the MXNet wiki's <a href="https://cwiki.apache.
 <div class="cpu">
 </br>
 
-
-Install the latest version (3.5.1+) of R from [CRAN](https://cran.r-project.org/bin/macosx/).
-You can [build MXNet-R from source](osx_setup.html#install-the-mxnet-package-for-r), or you can use a pre-built binary:
-
-```r
-cran <- getOption("repos")
-cran["dmlc"] <- "https://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/R/CRAN/"
-options(repos = cran)
-install.packages("mxnet")
-```
-
 To run MXNet you also should have OpenCV and OpenBLAS installed. You may install them with `brew` as follows:
 
 ```bash
@@ -620,6 +609,16 @@ Add a soft link to the OpenBLAS installation. This example links the 0.3.1 versi
 
 ```bash
 ln -sf /usr/local/opt/openblas/lib/libopenblasp-r0.3.* /usr/local/opt/openblas/lib/libopenblasp-r0.3.1.dylib
+```
+
+Install the latest version (3.5.1+) of R from [CRAN](https://cran.r-project.org/bin/macosx/).
+You can [build MXNet-R from source](osx_setup.html#install-the-mxnet-package-for-r), or you can use a pre-built binary:
+
+```r
+cran <- getOption("repos")
+cran["dmlc"] <- "https://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/R/CRAN/"
+options(repos = cran)
+install.packages("mxnet")
 ```
 
 </div> <!-- END of CPU -->


### PR DESCRIPTION
## Description ##
Fixes https://github.com/apache/incubator-mxnet/issues/12892

* macOS R install section was not rendering properly. The rendering of this page is really brittle. I'm not sure why moving the dependencies down a few lines mattered, but that was the fix.
* I also noticed that the build from source for Python / Windows was missing/replaced by Docker, so I fixed that too.

## Preview
http://34.201.8.176/versions/install_macos_r_fix/install/index.html?platform=MacOS&language=R&processor=CPU

http://34.201.8.176/versions/install_macos_r_fix/install/index.html?platform=Windows&language=Python&processor=CPU - then select build from source