### PR TITLE
Fix ONNX export of keepdims param

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -955,7 +955,7 @@ def convert_argmax(node, **kwargs):
     name, input_nodes, attrs = get_inputs(node, kwargs)
 
     axis = int(attrs.get("axis"))
-    keepdims = int(attrs.get("keepdims")) if "keepdims" in attrs  else 1
+    keepdims = get_boolean_attribute_value(attrs, "keepdims")
 
     node = onnx.helper.make_node(
         'ArgMax',
@@ -975,7 +975,7 @@ def convert_argmin(node, **kwargs):
     name, input_nodes, attrs = get_inputs(node, kwargs)
 
     axis = int(attrs.get("axis"))
-    keepdims = int(attrs.get("keepdims")) if "keepdims" in attrs  else 1
+    keepdims = get_boolean_attribute_value(attrs, "keepdims")
 
     node = onnx.helper.make_node(
         'ArgMin',
@@ -1012,7 +1012,7 @@ def convert_min(node, **kwargs):
     mx_axis = attrs.get("axis", None)
     axes = convert_string_to_list(str(mx_axis)) if mx_axis is not None else None
 
-    keepdims = int(attrs.get("keepdims", 0))
+    keepdims = get_boolean_attribute_value(attrs, "keepdims")
 
     if axes is not None:
         node = onnx.helper.make_node(
@@ -1047,7 +1047,7 @@ def convert_max(node, **kwargs):
     mx_axis = attrs.get("axis", None)
     axes = convert_string_to_list(str(mx_axis)) if mx_axis is not None else None
 
-    keepdims = int(attrs.get("keepdims", 0))
+    keepdims = get_boolean_attribute_value(attrs, "keepdims")
 
     if axes is not None:
         node = onnx.helper.make_node(
@@ -1082,7 +1082,7 @@ def convert_mean(node, **kwargs):
     mx_axis = attrs.get("axis", None)
     axes = convert_string_to_list(str(mx_axis)) if mx_axis is not None else None
 
-    keepdims = int(attrs.get("keepdims", 0))
+    keepdims = get_boolean_attribute_value(attrs, "keepdims")
 
     if axes is not None:
         node = onnx.helper.make_node(
@@ -1117,7 +1117,7 @@ def convert_prod(node, **kwargs):
     mx_axis = attrs.get("axis", None)
     axes = convert_string_to_list(str(mx_axis)) if mx_axis is not None else None
 
-    keepdims = int(attrs.get("keepdims", 0))
+    keepdims = get_boolean_attribute_value(attrs, "keepdims")
 
     if axes is not None:
         node = onnx.helper.make_node(


### PR DESCRIPTION
## Description ##
Fix of failure to export a model containing a mean operator to ONNX:
```
...
  File "/usr/lib64/python3.6/site-packages/mxnet-1.3.1-py3.6.egg/mxnet/contrib/onnx/mx2onnx/export_model.py", line 82, in export_model
    verbose=verbose)
  File "/usr/lib64/python3.6/site-packages/mxnet-1.3.1-py3.6.egg/mxnet/contrib/onnx/mx2onnx/export_onnx.py", line 281, in create_onnx_graph_proto
    idx=idx
  File "/usr/lib64/python3.6/site-packages/mxnet-1.3.1-py3.6.egg/mxnet/contrib/onnx/mx2onnx/export_onnx.py", line 92, in convert_layer
    return convert_func(node, **kwargs)
  File "/usr/lib64/python3.6/site-packages/mxnet-1.3.1-py3.6.egg/mxnet/contrib/onnx/mx2onnx/_op_translations.py", line 1439, in convert_mean
    keepdims = int(node.get("attrs", {}).get("keepdims", 0))
ValueError: invalid literal for int() with base 10: 'True'
```
