### PR TITLE
parallelize NDArray::Copy<cpu, cpu> when data size is large

### DIFF
--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -206,7 +206,7 @@ When USE_PROFILER is enabled in Makefile or CMake, the following environments ca
   - Values: Int ```(default=200000)```
   - The minimum size to call parallel copy by openMP in CPU2CPU mode.
   - When the array size is bigger than this threshold, NDArray::Copy(from, to) is implemented by OpenMP with the Recommended OMP Thread Count.
-  - When the array size is less than this threshold, NDArray::Copy(from , to)) is implemented by mshadow::Copy(to, from) in single thread.
+  - When the array size is less than this threshold, NDArray::Copy(from , to)) is implemented by memcpy in single thread.
 
 Settings for Minimum Memory Usage
 ---------------------------------

--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -202,6 +202,12 @@ When USE_PROFILER is enabled in Makefile or CMake, the following environments ca
   If no such algorithm exists given other constraints, MXNet will error out. This variable affects the choice
   of CUDNN convolution algorithms. Please see [CUDNN developer guide](https://docs.nvidia.com/deeplearning/sdk/cudnn-developer-guide/index.html) for more details.
 
+* MXNET_CPU_PARALLEL_COPY_SIZE
+  - Values: Int ```(default=200000)```
+  - The minimum size to call parallel copy by openMP in CPU2CPU mode.
+  - When the array size is bigger than this threshold, NDArray::Copy(from, to) is implemented by OpenMP with the Recommended OMP Thread Count.
+  - When the array size is less than this threshold, NDArray::Copy(from , to)) is implemented by mshadow::Copy(to, from) in single thread.
+
 Settings for Minimum Memory Usage
 ---------------------------------
 - Make sure ```min(MXNET_EXEC_NUM_TEMP, MXNET_GPU_WORKER_NTHREADS) = 1```

--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -204,8 +204,8 @@ When USE_PROFILER is enabled in Makefile or CMake, the following environments ca
 
 * MXNET_CPU_PARALLEL_COPY_SIZE
   - Values: Int ```(default=200000)```
-  - The minimum size to call parallel copy by openMP in CPU2CPU mode.
-  - When the array size is bigger than this threshold, NDArray::Copy(from, to) is implemented by OpenMP with the Recommended OMP Thread Count.
+  - The minimum size to call parallel copy by OpenMP in CPU2CPU mode.
+  - When the array size is bigger than or equal to  this threshold, NDArray::Copy(from, to) is implemented by OpenMP with the Recommended OMP Thread Count.
   - When the array size is less than this threshold, NDArray::Copy(from , to)) is implemented by memcpy in single thread.
 
 Settings for Minimum Memory Usage

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -713,6 +713,20 @@ inline void EmplaceBackZeros(const NDArrayStorageType stype, const TShape &shape
   }
 }
 
+
+/*!
+ * \brief parallelize copy by OpenMP.
+ */
+template<typename DType>
+void OMPCopy(const TBlob &from, TBlob *to, const index_t size) {
+  DType* dst_dptr = to->dptr<DType>();
+  const DType* src_dptr = from.dptr<DType>();
+  #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+  for (index_t i = 0; i < size; ++i) {
+    dst_dptr[i] = src_dptr[i];
+  }
+}
+
 }  // namespace common
 }  // namespace mxnet
 #endif  // MXNET_COMMON_UTILS_H_

--- a/src/ndarray/ndarray_function.cc
+++ b/src/ndarray/ndarray_function.cc
@@ -38,14 +38,9 @@ void Copy<cpu, cpu>(const TBlob &from, TBlob *to,
                     RunContext ctx) {
   MSHADOW_TYPE_SWITCH(to->type_flag_, DType, {
     if (to->type_flag_ == from.type_flag_) {
-      static index_t copy_block_size = dmlc::GetEnv("MXNET_CPU_PARALLEL_COPY_SIZE", 200000);
       const index_t size = from.Size();
       CHECK_EQ(size, to->Size());
-      if (size >= copy_block_size) {
-        common::OMPCopy<DType>(from, to, size);
-      } else {
-        mshadow::Copy(to->FlatTo1D<cpu, DType>(), from.FlatTo1D<cpu, DType>());
-      }
+      common::ParallelCopy(to->dptr<DType>(), from.dptr<DType>(), size);
     } else {
       MSHADOW_TYPE_SWITCH(from.type_flag_, SrcDType, {
           to->FlatTo1D<cpu, DType>() =

--- a/src/ndarray/ndarray_function.cc
+++ b/src/ndarray/ndarray_function.cc
@@ -39,7 +39,8 @@ void Copy<cpu, cpu>(const TBlob &from, TBlob *to,
   MSHADOW_TYPE_SWITCH(to->type_flag_, DType, {
     if (to->type_flag_ == from.type_flag_) {
       const index_t size = from.Size();
-      CHECK_EQ(size, to->Size());
+      CHECK_EQ(size, to->Size()) << "copying size mismatch, from: " << size * sizeof(DType)
+               << " bytes, to: " << to->Size() * sizeof(DType) << " bytes.";
       common::ParallelCopy(to->dptr<DType>(), from.dptr<DType>(), size);
     } else {
       MSHADOW_TYPE_SWITCH(from.type_flag_, SrcDType, {

--- a/src/ndarray/ndarray_function.cc
+++ b/src/ndarray/ndarray_function.cc
@@ -32,19 +32,34 @@
 
 namespace mxnet {
 namespace ndarray {
+template<typename DType>
+void OMPCopy(const TBlob &from, TBlob *to, const index_t size) {
+  DType* dst_dptr = to->dptr<DType>();
+  DType* src_dptr = from.dptr<DType>();
+  #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+  for (index_t i = 0; i < size; ++i) {
+    dst_dptr[i] = src_dptr[i];
+  }
+}
+
 template<>
 void Copy<cpu, cpu>(const TBlob &from, TBlob *to,
                     Context from_ctx, Context to_ctx,
                     RunContext ctx) {
   MSHADOW_TYPE_SWITCH(to->type_flag_, DType, {
     if (to->type_flag_ == from.type_flag_) {
-        mshadow::Copy(to->FlatTo1D<cpu, DType>(),
-                      from.FlatTo1D<cpu, DType>());
+      index_t copy_block_size = dmlc::GetEnv("MXNET_CPU_PARALLEL_COPY_SIZE", 200000);
+      const index_t size = from.Size();
+      if (size >= copy_block_size) {
+        OMPCopy<DType>(from, to, size);
+      } else {
+        mshadow::Copy(to->FlatTo1D<cpu, DType>(), from.FlatTo1D<cpu, DType>());
+      }
     } else {
-        MSHADOW_TYPE_SWITCH(from.type_flag_, SrcDType, {
-            to->FlatTo1D<cpu, DType>() =
-                mshadow::expr::tcast<DType>(from.FlatTo1D<cpu, SrcDType>());
-        })
+      MSHADOW_TYPE_SWITCH(from.type_flag_, SrcDType, {
+          to->FlatTo1D<cpu, DType>() =
+              mshadow::expr::tcast<DType>(from.FlatTo1D<cpu, SrcDType>());
+      })
     }
   })
 }


### PR DESCRIPTION
## Description ##
1. Parallelize NDArray::Copy<cpu, cpu> OP by OpenMP when data size bigger than MXNET_CPU_PARALLEL_COPY_SIZE.
2. introduce the environment variable named: MXNET_CPU_PARALLEL_COPY_SIZE (default 200,000) . When data size is bigger than this threshold, NDArray::Copy is implemented by OpenMP with the Recommended OMP Thread Count, otherwise implemented by default.

## Comments ##
We are optimizing [Sockeye](https://github.com/awslabs/sockeye)'s performance on CPU and found that the CopyCPU2CPU operation take too much time, probably accounting for 14% of the overall time (detail data as below). So we parallelized NDArray::Copy<cpu, cpu> operator. 

As far as i know, NDArray::Copy<cpu, cpu> is called in the front-end by those functions: **nd.copy(), nd.copyto(), nd.asnumpy(), nd.array(),nd.ones(), nd.zeros()** . **Those functions can gain 2-14 times speedup when data size is range from 20000 to 2e8.  And Sockeye's perf increased from 17.10 sent/sec to 19.19 sent/sec on CPU inference, CopyCPU2CPU time overhead dropped from 14.68% to 2.3%.**  the detail data as below.

the logs and scripts are here: [logs and scripts](https://github.com/XiaotaoChen/incubator-mxnet/tree/cxt-test/tests/cxt-test/parallel-copy)
@pengzhao-intel
### detail data

**hardware: skx-8180 single socket(28 cores)**

| functions\size | 20,000(shape:[20000,1]) |              |             | 200,000(shape:[20000,10]) |              |             | 2000,000(shape:[20000,100]) |              |           | 20,000,000(shape:[20000,1000]) |              |            | 200,000,000(shape:[20000,10000]) |              |            |
| -------------- | ----------------------- | ------------ | ----------- | ------------------------- | ------------ | ----------- | --------------------------- | ------------ | --------- | ------------------------------ | ------------ | ---------- | -------------------------------- | ------------ | ---------- |
| APIs           | default(us)             | parallel(us) | speedup     | default(us)               | parallel(us) | speedup     | default(us)                 | parallel(us) | speedup   | default(us)                    | parallel(us) | speedup    | default(us)                      | parallel(us) | speedup    |
| nd.copy        | 44.98164                | 45.434634    | 0.990029743 | 208.68778                 | 79.902013    | 2.611796301 | 1651.295                    | 190.01166    | 8.6904931 | 26326.93                       | 3634.23824   | 7.24413888 | 291151.8                         | 30640.8008   | 9.5020948  |
| nd.copyto      | 37.51119                | 37.384033    | 1.003401372 | 192.45942                 | 61.178207    | 3.145882062 | 1566.815                    | 157.308578   | 9.9601395 | 15042.04                       | 2261.47175   | 6.6514396  | 148679.5                         | 23665.7222   | 6.28248457 |
| nd.asnumpy     | 15.06805                | 15.155474    | 0.994231787 | 146.02343                 | 25.184949    | 5.798043585 | 1210.038                    | 85.465113    | 14.158267 | 26839.42                       | 3322.951     | 8.07698195 | 288313.9                         | 30143.3802   | 9.56474928 |
| nd.array       | 56.04426                | 55.130323    | 1.016577773 | 651.10525                 | 485.841433   | 1.34015998  | 4410.593                    | 2852.86109   | 1.5460244 | 60601.87                       | 35724.5922   | 1.69636283 | 596539.3                         | 339708.265   | 1.75603397 |
| nd.ones        | 37.59066                | 31.590462    | 1.189937108 | 42.200089                 | 41.898092    | 1.007207894 | 49.11423                    | 49.090385    | 1.0004857 | 1991.232                       | 1997.4788    | 0.99687277 | 22429.08                         | 22386.3522   | 1.00190887 |
| nd.zeros       | 32.32956                | 31.971931    | 1.011185687 | 43.678284                 | 43.423971    | 1.005856512 | 55.90121                    | 56.385994    | 0.9914024 | 2319.415                       | 2365.28715   | 0.98060627 | 22368.08                         | 22318.8877   | 1.00220413 |

  **hardware: bdw-2699(44 cores)**

| functions\size | 20,000(shape:[20000,1]) |              |             | 200,000(shape:[20000,10]) |              |             | 2000,000(shape:[20000,100]) |              |           | 20,000,000(shape:[20000,1000]) |              |            | 200,000,000(shape:[20000,10000]) |              |            |
| -------------- | ----------------------- | ------------ | ----------- | ------------------------- | ------------ | ----------- | --------------------------- | ------------ | --------- | ------------------------------ | ------------ | ---------- | -------------------------------- | ------------ | ---------- |
| APIs           | default(us)             | parallel(us) | speedup     | default(us)               | parallel(us) | speedup     | default(us)                 | parallel(us) | speedup   | default(us)                    | parallel(us) | speedup    | default(us)                      | parallel(us) | speedup    |
| nd.copy        | 141.3822                | 139.125188   | 1.016223008 | 283.70222                 | 143.504143   | 1.976961843 | 1530.663                    | 267.05265    | 5.7316906 | 42425.86                       | 3845.33405   | 11.033076  | 424523.7                         | 29502.2726   | 14.3895266 |
| nd.copyto      | 135.1595                | 136.534373   | 0.989930147 | 274.32442                 | 93.11835     | 2.945975922 | 1973.446                    | 294.510523   | 6.7007664 | 20426.01                       | 3140.17932   | 6.50472761 | 153221.1                         | 30291.3427   | 5.05824612 |
| nd.asnumpy     | 40.90468                | 41.572253    | 0.983941885 | 124.11277                 | 41.222572    | 3.010796245 | 1521.81                     | 81.857045    | 18.591068 | 32866.75                       | 3491.84672   | 9.4124258  | 370223.1                         | 27558.4698   | 13.4340953 |
| nd.array       | 227.8487                | 190.917651   | 1.193439621 | 1233.6016                 | 648.3078     | 1.902802295 | 4065.005                    | 2900.36202   | 1.4015509 | 83189.32                       | 49047.1363   | 1.69610964 | 819595.4                         | 489327.01    | 1.67494413 |
| nd.ones        | 107.8765                | 100.541115   | 1.07295866  | 133.58593                 | 126.187007   | 1.058634587 | 117.8583                    | 114.28992    | 1.0312217 | 1897.2                         | 1758.56749   | 1.07883261 | 18391.24                         | 18327.9673   | 1.00345244 |
| nd.zeros       | 97.52909                | 94.858805    | 1.028150133 | 123.48493                 | 116.785367   | 1.057366451 | 114.3217                    | 115.57738    | 0.9891357 | 1996.326                       | 1979.92325   | 1.00828477 | 18440.56                         | 18458.9148   | 0.99900545 |

**sockeye profile on skx-8180 single socket**

- offical master

```shell
Time of each OP:
FullyConnected        47694.792 ms      0.78006594485     ms/call       61142  calls    28.58 %
ImperativeBulk        29801.262 ms      1.89865328746     ms/call       15696  calls    17.86 %
CopyCPU2CPU           24502.718 ms      0.668176979084    ms/call       36671  calls    14.68 %
take                  17288.25  ms      0.507969971205    ms/call       34034  calls    10.36 %
log                   12085.495 ms      6.92975630734     ms/call       1744   calls    7.24 %
SliceChannel          10051.787 ms      0.350407411281    ms/call       28686  calls    6.02 %
softmax               4577.321  ms      1.31230533257     ms/call       3488   calls    2.74 %
_mul_scalar           4498.783  ms      2.57957740826     ms/call       1744   calls    2.70 %
Activation            4148.085  ms      0.028656693218    ms/call       144751 calls    2.49 %
elemwise_add          3534.039  ms      0.0621074654669   ms/call       56902  calls    2.12 %
batch_dot             2317.371  ms      0.664383887615    ms/call       3488   calls    1.39 %
DeleteVariable        2129.944  ms      0.0337539856106   ms/call       63102  calls    1.28 %
elemwise_mul          1196.172  ms      0.0140144107413   ms/call       85353  calls    0.72 %
Concat                887.246   ms      0.0558578443717   ms/call       15884  calls    0.53 %
LayerNorm             828.937   ms      0.332106169872    ms/call       2496   calls    0.50 %
repeat                463.889   ms      0.469998986829    ms/call       987    calls    0.28 %
_slice_assign         396.031   ms      0.131659242021    ms/call       3008   calls    0.24 %
Embedding             101.812   ms      0.0568464544947   ms/call       1791   calls    0.06 %
SetupExec             65.807    ms      0.000731863829977 ms/call       89917  calls    0.04 %
Dropout               59.13     ms      0.0167270155587   ms/call       3535   calls    0.04 %
_full                 58.297    ms      0.0317176278564   ms/call       1838   calls    0.03 %
stack                 40.659    ms      0.288361702128    ms/call       141    calls    0.02 %
SequenceMask          36.445    ms      0.0208973623853   ms/call       1744   calls    0.02 %
sum                   27.585    ms      0.0154020100503   ms/call       1791   calls    0.02 %
argsort               21.859    ms      0.465085106383    ms/call       47     calls    0.01 %
WaitForVar            19.604    ms      0.00400653995504  ms/call       4893   calls    0.01 %
expand_dims           18.804    ms      0.00283876811594  ms/call       6624   calls    0.01 %
SwapAxis              12.079    ms      0.1285            ms/call       94     calls    0.01 %
_zeros                10.918    ms      0.0100999074931   ms/call       1081   calls    0.01 %
Reshape               9.636     ms      0.00272588401697  ms/call       3535   calls    0.01 %
SequenceReverse       7.18      ms      0.0763829787234   ms/call       94     calls    0.00 %
tile                  1.412     ms      0.0300425531915   ms/call       47     calls    0.00 %
SequenceLast          0.833     ms      0.0177234042553   ms/call       47     calls    0.00 %
broadcast_to          0.627     ms      0.0133404255319   ms/call       47     calls    0.00 %
broadcast_not_equal   0.55      ms      0.0117021276596   ms/call       47     calls    0.00 %
_slice_assign_scalar  0.473     ms      0.0100638297872   ms/call       47     calls    0.00 %
broadcast_add         0.447     ms      0.00951063829787  ms/call       47     calls    0.00 %
_ones                 0.418     ms      0.00889361702128  ms/call       47     calls    0.00 %
_unravel_index        0.347     ms      0.0073829787234   ms/call       47     calls    0.00 %
Cast                  0.28      ms      0.00595744680851  ms/call       47     calls    0.00 %
zeros_like            0.244     ms      0.00259574468085  ms/call       94     calls    0.00 %

Total OP Time: 166897.56800000 ms
```

- parallelized copy

```shell
Time of each OP:
FullyConnected        48756.792 ms      0.797435347224    ms/call       61142  calls    33.61 %
ImperativeBulk        29133.28  ms      1.85609582059     ms/call       15696  calls    20.08 %
take                  16485.268 ms      0.484376447082    ms/call       34034  calls    11.36 %
log                   11493.641 ms      6.59039048165     ms/call       1744   calls    7.92 %
SliceChannel          10047.895 ms      0.350271735341    ms/call       28686  calls    6.93 %
softmax               4443.701  ms      1.27399684633     ms/call       3488   calls    3.06 %
Activation            4366.243  ms      0.0301638192482   ms/call       144751 calls    3.01 %
_mul_scalar           4272.24   ms      2.44967889908     ms/call       1744   calls    2.95 %
elemwise_add          3784.498  ms      0.0665090506485   ms/call       56902  calls    2.61 %
CopyCPU2CPU           3337.278  ms      0.0910059174825   ms/call       36671  calls    2.30 %
batch_dot             2183.933  ms      0.626127580275    ms/call       3488   calls    1.51 %
DeleteVariable        1929.185  ms      0.0305724858166   ms/call       63102  calls    1.33 %
elemwise_mul          1111.778  ms      0.013025646433    ms/call       85353  calls    0.77 %
Concat                919.976   ms      0.0579184084613   ms/call       15884  calls    0.63 %
_slice_assign         808.582   ms      0.268810505319    ms/call       3008   calls    0.56 %
LayerNorm             804.849   ms      0.322455528846    ms/call       2496   calls    0.55 %
repeat                643.624   ms      0.652101317123    ms/call       987    calls    0.44 %
Embedding             98.968    ms      0.0552585147962   ms/call       1791   calls    0.07 %
_full                 96.208    ms      0.0523438520131   ms/call       1838   calls    0.07 %
Dropout               60.788    ms      0.017196039604    ms/call       3535   calls    0.04 %
SetupExec             59.639    ms      0.000663267235339 ms/call       89917  calls    0.04 %
stack                 35.195    ms      0.249609929078    ms/call       141    calls    0.02 %
SequenceMask          34.082    ms      0.0195424311927   ms/call       1744   calls    0.02 %
sum                   32.254    ms      0.0180089335567   ms/call       1791   calls    0.02 %
argsort               21.612    ms      0.459829787234    ms/call       47     calls    0.01 %
WaitForVar            19.927    ms      0.0040725526262   ms/call       4893   calls    0.01 %
expand_dims           17.696    ms      0.00267149758454  ms/call       6624   calls    0.01 %
SwapAxis              15.528    ms      0.165191489362    ms/call       94     calls    0.01 %
SequenceReverse       11.077    ms      0.117840425532    ms/call       94     calls    0.01 %
_zeros                10.9      ms      0.0100832562442   ms/call       1081   calls    0.01 %
Reshape               9.855     ms      0.00278783592645  ms/call       3535   calls    0.01 %
_slice_assign_scalar  1.715     ms      0.0364893617021   ms/call       47     calls    0.00 %
tile                  1.378     ms      0.0293191489362   ms/call       47     calls    0.00 %
broadcast_to          1.365     ms      0.0290425531915   ms/call       47     calls    0.00 %
broadcast_not_equal   0.836     ms      0.0177872340426   ms/call       47     calls    0.00 %
SequenceLast          0.835     ms      0.0177659574468   ms/call       47     calls    0.00 %
broadcast_add         0.452     ms      0.0096170212766   ms/call       47     calls    0.00 %
_unravel_index        0.338     ms      0.0071914893617   ms/call       47     calls    0.00 %
Cast                  0.305     ms      0.00648936170213  ms/call       47     calls    0.00 %
_ones                 0.282     ms      0.006             ms/call       47     calls    0.00 %
zeros_like            0.256     ms      0.00272340425532  ms/call       94     calls    0.00 %

Total OP Time: 145054.25400000 ms
```

