### PR TITLE
WIP: Enable clang tidy on CUDA code

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,12 +228,12 @@ core_logic: {
         }
       }
     },
-    'CPU: Clang Tidy': {
+    'GPU: Clang Tidy': {
       node(NODE_LINUX_CPU) {
-        ws('workspace/build-cpu-clang60_tidy') {
+        ws('workspace/build-gpu-clang60_tidy') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
-            utils.docker_run('ubuntu_cpu', 'build_ubuntu_cpu_clang_tidy', false)
+            utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_clang_tidy', false)
           }
         }
       }

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -405,24 +405,29 @@ build_ubuntu_cpu_clang60() {
         -j$(nproc)
 }
 
-build_ubuntu_cpu_clang_tidy() {
+build_ubuntu_gpu_clang_tidy() {
     set -ex
 
-    export CXX=clang++-6.0
-    export CC=clang-6.0
+    export CC="gcc"
+    export CXX="g++"
     export CLANG_TIDY=/usr/lib/llvm-6.0/share/clang/run-clang-tidy.py
 
     pushd .
     cd /work/build
     cmake \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-        -DUSE_CUDA=OFF \
-        -DUSE_MKL_IF_AVAILABLE=OFF \
-        -DUSE_OPENCV=ON \
-        -DCMAKE_BUILD_TYPE=Debug \
-        -G Ninja \
-        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache    \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache      \
+        -DUSE_CUDA=ON                           \
+        -DUSE_CUDNN=ON                          \
+        -DCUDA_HOST_COMPILER=/usr/bin/gcc       \
+        -DCUDA_ARCH_NAME=Manual                 \
+        -DCUDA_ARCH_BIN=$CI_CMAKE_CUDA_ARCH_BIN \
+        -DUSE_OPENMP=OFF                        \
+        -DUSE_MKL_IF_AVAILABLE=OFF              \
+        -DUSE_OPENCV=ON                         \
+        -DCMAKE_BUILD_TYPE=Debug                \
+        -G Ninja                                \
+        -DCMAKE_EXPORT_COMPILE_COMMANDS=ON      \
         /work/mxnet
 
     ninja -v


### PR DESCRIPTION
## Description ##
Enable clang tidy on CUDA code

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
