### PR TITLE
Fix example for mxnet.nd.contrib.cond and fix typo in src/engine

### DIFF
--- a/python/mxnet/ndarray/contrib.py
+++ b/python/mxnet/ndarray/contrib.py
@@ -436,8 +436,8 @@ def cond(pred, then_func, else_func):
     --------
     >>> a, b = mx.nd.array([1]), mx.nd.array([2])
     >>> pred = a * b < 5
-    >>> then_func = lambda a, b: (a + 5) * (b + 5)
-    >>> else_func = lambda a, b: (a - 5) * (b - 5)
+    >>> then_func = lambda: (a + 5) * (b + 5)
+    >>> else_func = lambda: (a - 5) * (b - 5)
     >>> outputs = mx.nd.contrib.cond(pred, then_func, else_func)
     >>> outputs[0]
     [42.]

--- a/src/engine/engine.cc
+++ b/src/engine/engine.cc
@@ -48,7 +48,7 @@ inline Engine* CreateEngine() {
   ret = CreateNaiveEngine();
   #endif
 
-  if (ret ==nullptr) {
+  if (ret == nullptr) {
     LOG(FATAL) << "Cannot find Engine " << type;
   }
   if (!default_engine) {

--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -182,7 +182,7 @@ class ThreadedVar final
  private:
   // TODO(hotpxl) change this to spinlock for faster runtime
   // TODO(hotpxl) consider rename head
-  /*! \brief inetrnal mutex of the ThreadedVar */
+  /*! \brief internal mutex of the ThreadedVar */
   std::mutex mutex_;
   /*!
    * \brief number of pending reads operation in the variable.


### PR DESCRIPTION
## Description ##
Fix the issue #12825 

In the file [python/mxnet/ndarray/contrib.py](https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/ndarray/contrib.py#L460), the two functions `then_func` and `else_func` don't accept any parameter.

The following example works.
```python
import mxnet as mx
a, b = mx.nd.array([1]), mx.nd.array([2])
pred = a * b < 5
then_func = lambda: (a + 5) * (b + 5)
else_func = lambda: (a - 5) * (b - 5)
outputs = mx.nd.contrib.cond(pred, then_func, else_func)
print (outputs[0])
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Tiny Changes. The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fix example for mxnet.nd.contrib.cond
- [x] Fix typo in src/engine/{engine.cc, threaded_engine.h}

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
