### PR TITLE
[MXNET-1159]Added unit tests for making Resource Scope work in Java

### DIFF
--- a/scala-package/core/src/test/java/org/apache/mxnet/javaapi/ResourceScopeTestSuite.java
+++ b/scala-package/core/src/test/java/org/apache/mxnet/javaapi/ResourceScopeTestSuite.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.mxnet.javaapi;
+
+import org.apache.mxnet.NativeResourceRef;
+import org.apache.mxnet.ResourceScope;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.concurrent.Callable;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ResourceScopeTestSuite {
+
+    /**
+     * This is a placeholder class to test out whether NDArray References get collected or not when using
+     * try-with-resources in Java.
+     *
+     */
+    class TestNDArray  {
+        NDArray selfArray;
+
+        public TestNDArray(Context context, int[] shape) {
+            this.selfArray = NDArray.ones(context, shape);
+        }
+
+        public boolean verifyIsDisposed() {
+            return this.selfArray.nd().isDisposed();
+        }
+
+        public NativeResourceRef getNDArrayReference() {
+            return this.selfArray.nd().ref();
+        }
+    }
+
+    @Test
+    public void testNDArrayAutoRelease() {
+        TestNDArray test = null;
+
+        try (ResourceScope scope = new ResourceScope()) {
+            test = new TestNDArray(Context.cpu(), new int[]{100, 100});
+        }
+
+        assertTrue(test.verifyIsDisposed());
+    }
+
+    @Test
+    public void testObjectReleaseFromList() {
+        List<TestNDArray> list = new ArrayList<>();
+
+        try (ResourceScope scope = new ResourceScope()) {
+            for (int i = 0;i < 10; i++) {
+                list.add(new TestNDArray(Context.cpu(), new int[] {100, 100}));
+            }
+        }
+
+        assertEquals(list.size() , 10);
+        list.forEach(n -> assertTrue(n.verifyIsDisposed()));
+    }
+
+    @Test
+    public void testObjectReleaseFromMap() {
+        Map<String, TestNDArray> stringToNDArrayMap = new HashMap<>();
+
+        try (ResourceScope scope = new ResourceScope()) {
+            for (int i = 0;i < 10; i++) {
+                stringToNDArrayMap.put(String.valueOf(i),new TestNDArray(Context.cpu(), new int[] {i, i}));
+            }
+        }
+
+        assertEquals(stringToNDArrayMap.size(), 10);
+        stringToNDArrayMap.forEach((key, value) ->  assertTrue(value.verifyIsDisposed()));
+
+        Map<TestNDArray, String> ndArrayToStringMap = new HashMap<>();
+
+        try (ResourceScope scope = new ResourceScope()) {
+            for (int i = 0;i < 10; i++) {
+                ndArrayToStringMap.put(new TestNDArray(Context.cpu(), new int[] {i, i}), String.valueOf(i));
+            }
+        }
+
+        assertEquals(ndArrayToStringMap.size(), 10);
+        ndArrayToStringMap.forEach((key, value) ->  assertTrue(key.verifyIsDisposed()));
+
+    }
+}

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -190,8 +190,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description ##
Add unit tests to ensure ResourceScope works in Java and to also demonstrate an example use-case.

It works by using try-with-resources technique in Java.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Made Maven compiler plugin to use 1.8 in order to use Java Lambda expressions for try-with-resources in Java.

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
