### PR TITLE
Improve dot(csr, rsp) on CPU by 10x 

### DIFF
--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -521,14 +521,14 @@ struct DotCsrRspDnsByRowBlocks {
       const RType* row_idx_ptr = first;
       // end of binary search
       if (row_idx_ptr == row_idx_r+nnr_r || *row_idx_ptr > col_idx_l[indptr_l[j+1]-1]) continue;
-      const auto end = row_idx_r + nnr_r;
-      auto start = row_idx_ptr;
+      const RType* end = row_idx_r + nnr_r;
+      const RType* start = row_idx_ptr;
       for (IType k = indptr_l[j]; k < indptr_l[j+1] && start < end; ++k) {
-        const auto v = col_idx_l[k];
+        const CType v = col_idx_l[k];
         if (v < *start) {
           continue;
         }
-        const auto p = std::lower_bound(start, end, v);
+        const RType* p = std::lower_bound(start, end, v);
         start = p;
         if (p >= end || v < *p) {
           continue;


### PR DESCRIPTION
## Description ##

The row sparse matrix, which usually represents weights in LR, may get denser and denser in the training. The current implementation sequentially search the matched indices. This change fully utilize the sorted indices by binary search the index. 

Here is a simple script to test the perf change. The script intentionally makes the row sparse matrix quite dense to simulate the effects of half-dense matrix in the training.  Change `b` to larger number (e.g. 28) and the speedup is even larger (50x - 70x)

``` python
import argparse
import mxnet as mx
import numpy as np
import time


parser = argparse.ArgumentParser()
parser.add_argument('rsp_density', type=float)
parser.add_argument('hash_bit', type=int)
parser.add_argument('csr_density', type=float)
parser.add_argument('batch_size', type=int)
args = parser.parse_args()

b = args.hash_bit
batch_size = args.batch_size
hash_dim = 2 ** b
nnz = int(hash_dim * args.csr_density)
nnw = int(hash_dim * args.rsp_density)

print('rsp density = {}'.format(args.rsp_density))

def create_linear_csr():
    indices = np.array([], dtype=np.int)
    indptr = [0]

    for i in range(batch_size):
        l = np.unique(np.random.randint(0, hash_dim, nnz))
        n = len(l)
        indices = np.append(indices, l)
        indptr.append(indptr[-1] + n)
    data = [1.] * indptr[-1]
    print('csr density = {:03f}'.format(float(indptr[-1]) / batch_size / hash_dim))
    return mx.nd.sparse.csr_matrix((data, indices, indptr),
                                   (batch_size, hash_dim))


def create_linear_weight():
    shape = (hash_dim, 2)
    indices_list = np.unique(np.random.randint(0, hash_dim, nnw))
    data = np.random.rand(len(indices_list), 2).astype(np.float32)
    return mx.nd.sparse.row_sparse_array((data, indices_list), shape=shape)


csr = create_linear_csr()
rsp = create_linear_weight()
mx.nd.waitall()
print("start dot")
t0 = time.time()
for i in range(10):
    res = mx.nd.sparse.dot(csr, rsp)
mx.nd.waitall()
print(time.time() - t0)
```


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
