### PR TITLE
Bumping down minimum java support from 8 to 7

### DIFF
--- a/scala-package/core/src/test/java/org/apache/mxnet/javaapi/ResourceScopeTestSuite.java
+++ b/scala-package/core/src/test/java/org/apache/mxnet/javaapi/ResourceScopeTestSuite.java
@@ -73,7 +73,9 @@ public class ResourceScopeTestSuite {
         }
 
         assertEquals(list.size() , 10);
-        list.forEach(n -> assertTrue(n.verifyIsDisposed()));
+        for (TestNDArray item : list) {
+            assertTrue(item.verifyIsDisposed());
+        }
     }
 
     @Test
@@ -87,7 +89,9 @@ public class ResourceScopeTestSuite {
         }
 
         assertEquals(stringToNDArrayMap.size(), 10);
-        stringToNDArrayMap.forEach((key, value) ->  assertTrue(value.verifyIsDisposed()));
+        for (Map.Entry<String, TestNDArray> entry : stringToNDArrayMap.entrySet()) {
+            assertTrue(entry.getValue().verifyIsDisposed());
+        }
 
         Map<TestNDArray, String> ndArrayToStringMap = new HashMap<>();
 
@@ -98,7 +102,9 @@ public class ResourceScopeTestSuite {
         }
 
         assertEquals(ndArrayToStringMap.size(), 10);
-        ndArrayToStringMap.forEach((key, value) ->  assertTrue(key.verifyIsDisposed()));
+        for (Map.Entry<TestNDArray, String> entry : ndArrayToStringMap.entrySet()) {
+            assertTrue(entry.getKey().verifyIsDisposed());
+        }
 
     }
 }

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -190,8 +190,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description ##
As a follow up of #12955 , changing the source and target version of Maven compiler plugin to 1.7

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage: