### PR TITLE
[MXNET-1173] Debug operators - isfinite and isinf

### DIFF
--- a/python/mxnet/ndarray/contrib.py
+++ b/python/mxnet/ndarray/contrib.py
@@ -19,6 +19,7 @@
 # pylint: disable=wildcard-import, unused-wildcard-import,redefined-outer-name
 """Contrib NDArray API of MXNet."""
 import math
+import numpy as np
 from ..context import current_context
 from ..random import uniform
 from ..base import _as_list
@@ -28,7 +29,7 @@ try:
 except ImportError:
     pass
 
-__all__ = ["rand_zipfian", "foreach", "while_loop", "cond"]
+__all__ = ["rand_zipfian", "foreach", "while_loop", "cond", "isinf", "isfinite"]
 
 # pylint: disable=line-too-long
 def rand_zipfian(true_classes, num_sampled, range_max, ctx=None):
@@ -460,3 +461,65 @@ def cond(pred, then_func, else_func):
         return then_func()
     else:
         return else_func()
+
+def isinf(data, ctx=None):
+    """Checks whether a given NDArray has infinity or not
+
+
+    Parameters
+    ----------
+    input : NDArray
+        An N-D NDArray.
+    ctx : Context
+        Device context of output. Default is current context.
+
+    Returns
+    -------
+    output: NDArray
+        The output NDarray with 1 and 0 indicating whether infinite or not.
+
+    Examples
+    --------
+    >>> data = mx.nd.array([np.inf, -np.inf, np.NINF, -1])
+    >>> output = mx.nd.contrib.isinf(data)
+    >>> output
+    [1. 1. 1. 0.]
+    <NDArray 4 @cpu(0)>
+    """
+    if ctx is None:
+        ctx = current_context()
+    # any(x in data for x in [np.inf, -np.inf])
+    # abs(data) == np.inf > TypeError: bad operand type for abs(): 'NDArray'
+    # [abs(x) == np.inf for x in data] > TypeError: bad operand type for abs(): 'NDArray'
+    return ndarray.NDArray.abs(data) == np.inf
+
+def isfinite(data, ctx=None):
+    """Checks whether a given NDArray has finit value or not
+
+
+    Parameters
+    ----------
+    input : NDArray
+        An N-D NDArray.
+    ctx : Context
+        Device context of output. Default is current context.
+
+    Returns
+    -------
+    output: NDArray
+        The output NDarray with 1 and 0 indicating whether finite or not.
+
+    Examples
+    --------
+    >>> data = mx.nd.array([np.inf, -np.inf, np.NINF, -1])
+    >>> output = mx.nd.contrib.isfinite(data)
+    >>> output
+    [0. 0. 0. 1.]
+    <NDArray 4 @cpu(0)>
+    """
+    if ctx is None:
+        ctx = current_context()
+    # any(x in data for x in [np.inf, -np.inf])
+    # abs(data) == np.inf > TypeError: bad operand type for abs(): 'NDArray'
+    # [abs(x) == np.inf for x in data] > TypeError: bad operand type for abs(): 'NDArray'
+    return ndarray.NDArray.abs(data) != np.inf

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1495,6 +1495,12 @@ def test_dlpack():
             mx.test_utils.assert_almost_equal(a_np, d_np)
             mx.test_utils.assert_almost_equal(a_np, e_np)
 
+@with_seed()
+def test_ndarray_is_inf():
+    shape = (3, 4, 2)
+    x = mx.nd.zeros(shape)
+    assert_almost_equal(mx.nd.contrib.isinf(x),False)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
First two Debug operators. isinf was discussed in #12623 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Added unit tests
- [ ] Added functions in python front-end api

## Comments ##
- just the 2 of the total 6-7 operators that can be clubbed under "debug operators" 
