### PR TITLE
[MXNET-1164] Generate the document for cpp-package using Doxygen

### DIFF
--- a/cpp-package/scripts/OpWrapperGenerator.py
+++ b/cpp-package/scripts/OpWrapperGenerator.py
@@ -221,14 +221,14 @@ class Op:
             if arg.isEnum and use_name:
                 # comments
                 ret = ret + self.GenDescription(arg.description, \
-                                        '/*! \\breif ', \
+                                        '/*! \\brief ', \
                                         ' *        ')
                 ret = ret + " */\n"
                 # definition
                 ret = ret + arg.enum.GetDefinitionString(indent) + '\n'
         # create function comments
         ret = ret + self.GenDescription(self.description, \
-                                        '/*!\n * \\breif ', \
+                                        '/*!\n * \\brief ', \
                                         ' *        ')
         for arg in self.args:
             if arg.name != 'symbol_name' or use_name:

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -805,7 +805,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                =
+EXCLUDE                = 3rdparty
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -770,7 +770,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = include src/common
+INPUT                  = include src/common cpp-package/include/mxnet-cpp
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/api/c++/index.md
+++ b/docs/api/c++/index.md
@@ -50,6 +50,6 @@ For namespaces, classes, and code files for the MXNet C++ package, see the  foll
 The classes and functions in MXNet C++ API are available under **mxnet::cpp** namespace. The links to the documenation are as follows:
 
 1. [Namespaces](http://mxnet.io/doxygen/namespaces.html)
-2. [Classes](http://mxnet.io/doxygen/annotated.html)
+2. [Classes in mxnet::cpp namespace](http://mxnet.io/doxygen/namespacemxnet_1_1cpp.html)
 3. [Code Files](http://mxnet.io/doxygen/files.html)
 4. [MXNet CPP Package](https://github.com/dmlc/mxnet/tree/master/cpp-package)

--- a/docs/api/c++/index.md
+++ b/docs/api/c++/index.md
@@ -49,7 +49,7 @@ For namespaces, classes, and code files for the MXNet C++ package, see the  foll
 
 The classes and functions in MXNet C++ API are available under **mxnet::cpp** namespace. The links to the documenation are as follows:
 
-1. [Namespaces](http://mxnet.io/doxygen/namespaces.html)
-2. [Classes in mxnet::cpp namespace](http://mxnet.io/doxygen/namespacemxnet_1_1cpp.html)
-3. [Code Files](http://mxnet.io/doxygen/files.html)
+1. [Namespaces](../../doxygen/namespaces.html)
+2. [Classes in mxnet::cpp namespace](../..//doxygen/namespacemxnet_1_1cpp.html)
+3. [Code Files](../..//doxygen/files.html)
 4. [MXNet CPP Package](https://github.com/dmlc/mxnet/tree/master/cpp-package)

--- a/docs/api/c++/index.md
+++ b/docs/api/c++/index.md
@@ -1,8 +1,55 @@
 # MXNet - C++ API
 
+The MXNet C++ Package provides C++ API bindings to the users of MXNet.  Currently, these bindings are not available as standalone package.
+The users of these bindings are required to build this package as mentioned below.
+
+## Building C++ Package
+
+The cpp-package directory contains the implementation of C++ API. As mentioned above, users are required to build this directory or package before using it.
+**The cpp-package is built while building the MXNet shared library, *libmxnet.so*.**
+
+### Steps to build the C++ package:
+1.  Building the MXNet C++ package requires building MXNet from source.
+2.  Clone the MXNet GitHub repository **recursively** to ensure the code in submodules is available for building MXNet.
+	```
+	git clone --recursive https://github.com/apache/incubator-mxnet mxnet
+	```
+
+3.  Install the [prerequisites](<https://mxnet.incubator.apache.org/install/build_from_source#prerequisites>), desired [BLAS libraries](<https://mxnet.incubator.apache.org/install/build_from_source#blas-library>) and optional [OpenCV, CUDA, and cuDNN](<https://mxnet.incubator.apache.org/install/build_from_source#optional>) for building MXNet from source.
+4.  There is a configuration file for make, [make/config.mk](<https://github.com/apache/incubator-mxnet/blob/master/make/config.mk>) that contains all the compilation options. You can edit this file and set the appropriate options prior to running the **make** command.
+5.  Please refer to  [platform specific build instructions](<https://mxnet.incubator.apache.org/install/build_from_source#build-instructions-by-operating-system>) and available [build configurations](https://mxnet.incubator.apache.org/install/build_from_source#build-configurations) for more details.
+5.  For enabling the build of C++ Package, set the **USE\_CPP\_PACKAGE = 1** in [make/config.mk](<https://github.com/apache/incubator-mxnet/blob/master/make/config.mk>). Optionally, the compilation flag can also be specified on **make** command line as follows.
+	```
+	make -j USE_CPP_PACKAGE=1
+	```
+
+## Usage
+
+In order to consume the C++ API please follow the steps below.
+
+1. Ensure that the MXNet shared library is built from source with the **USE\_CPP\_PACKAGE = 1**.
+2. Include the [MxNetCpp.h](<https://github.com/apache/incubator-mxnet/blob/master/cpp-package/include/mxnet-cpp/MxNetCpp.h>) in the program that is going to consume MXNet C++ API.
+	```
+	#include <mxnet-cpp/MxNetCpp.h>
+	```
+3. While building the program, ensure that the correct paths to the directories containing header files and MXNet shared library.
+4. The program links the MXNet shared library dynamically. Hence the library needs to be accessible to the program during runtime. This can be achieved by including the path to the shared library in the environment variable  **LD\_LIBRARY\_PATH** for Linux, Mac. and Ubuntu OS and **PATH** for Windows OS.
+
+
+## Tutorial
+
+A basic tutorial can be found at <https://mxnet.incubator.apache.org/tutorials/c++/basics.html>.
+
+## Examples
+
+The example directory contains examples for you to get started.
 For namespaces, classes, and code files for the MXNet C++ package, see the  following:
 
-* [Namespaces](http://mxnet.io/doxygen/namespaces.html)
-* [Classes](http://mxnet.io/doxygen/annotated.html)
-* [Code Files](http://mxnet.io/doxygen/files.html)
-* [MXNet CPP Package](https://github.com/dmlc/mxnet/tree/master/cpp-package)
+## Links to the documentation
+
+The classes and functions in MXNet C++ API are available under **mxnet::cpp** namespace. The links to the documenation are as follows:
+
+1. [Namespaces](http://mxnet.io/doxygen/namespaces.html)
+2. [Classes](http://mxnet.io/doxygen/annotated.html)
+3. [Code Files](http://mxnet.io/doxygen/files.html)
+4. [MXNet CPP Package](https://github.com/dmlc/mxnet/tree/master/cpp-package)

--- a/docs/api/c++/index.md
+++ b/docs/api/c++/index.md
@@ -50,6 +50,6 @@ For namespaces, classes, and code files for the MXNet C++ package, see the  foll
 The classes and functions in MXNet C++ API are available under **mxnet::cpp** namespace. The links to the documenation are as follows:
 
 1. [Namespaces](../../doxygen/namespaces.html)
-2. [Classes in mxnet::cpp namespace](../..//doxygen/namespacemxnet_1_1cpp.html)
-3. [Code Files](../..//doxygen/files.html)
+2. [Classes in mxnet::cpp namespace](../../doxygen/namespacemxnet_1_1cpp.html)
+3. [Code Files](../../doxygen/files.html)
 4. [MXNet CPP Package](https://github.com/dmlc/mxnet/tree/master/cpp-package)


### PR DESCRIPTION
## Description ##
The PR includes changes to Doxyfile for generating documents for cpp-package.  Also modified the index.md file in api/c++ directory to include brief build instructions and links to the correct classes in mxnet::cpp namespace

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [y] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [y] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
Verified that the doxygen generates the docs for cpp-package. 

## Comments ##
