### PR TITLE
[Issue #11912] throw mxnet exceptions when decoding invalid images.

### DIFF
--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -140,10 +140,6 @@ def imdecode(buf, *args, **kwargs):
                              'if you would like to input type str, please convert to bytes')
         buf = nd.array(np.frombuffer(buf, dtype=np.uint8), dtype=np.uint8)
 
-    if len(buf) == 0:
-        # empty buf causes OpenCV crash.
-        raise ValueError("input buf cannot be empty.")
-
     return _internal._cvimdecode(buf, *args, **kwargs)
 
 

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -143,11 +143,8 @@ void ImdecodeImpl(int flag, bool to_rgb, void* data, size_t size,
   cv::Mat dst;
   if (out->is_none()) {
     cv::Mat res = cv::imdecode(buf, flag);
-    if (res.empty()) {
-      LOG(INFO) << "Decoding failed. Invalid image file.";
-      *out = NDArray();
-      return;
-    }
+    CHECK(!res.empty()) << "Decoding failed. Invalid image file.";
+
     *out = NDArray(mshadow::Shape3(res.rows, res.cols, flag == 0 ? 1 : 3),
                    Context::CPU(), false, mshadow::kUint8);
     dst = cv::Mat(out->shape()[0], out->shape()[1], flag == 0 ? CV_8U : CV_8UC3,

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -189,6 +189,8 @@ void Imdecode(const nnvm::NodeAttrs& attrs,
 
   uint8_t* str_img = inputs[0].data().dptr<uint8_t>();
   size_t len = inputs[0].shape().Size();
+  CHECK(len > 0) << "Input cannot be an empty buffer";
+
   TShape oshape(3);
   oshape[2] = param.flag == 0 ? 1 : 3;
   if (get_jpeg_size(str_img, len, &oshape[1], &oshape[0])) {

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1931,7 +1931,6 @@ def test_reshape_batchnorm():
 
 
 @with_seed()
-@unittest.skip('Test failing, tracked by https://github.com/apache/incubator-mxnet/issues/12715')
 def test_slice_batchnorm():
     class Net(gluon.HybridBlock):
         def __init__(self, slice, **kwargs):
@@ -2007,7 +2006,6 @@ def test_reshape_batchnorm_reshape_batchnorm():
 
 
 @with_seed()
-@unittest.skip('Flaky test: https://github.com/apache/incubator-mxnet/issues/12767')
 def test_slice_batchnorm_reshape_batchnorm():
     class Net(gluon.HybridBlock):
         def __init__(self, shape, slice, **kwargs):

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -104,7 +104,7 @@ class TestImage(unittest.TestCase):
             cv_image = cv2.imread(img)
             assert_almost_equal(image.asnumpy(), cv_image)
 
-    @raises(ValueError)
+    @raises(mx.base.MXNetError)
     def test_imdecode_empty_buffer(self):
         mx.image.imdecode(b'', to_rgb=0)
 

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -108,6 +108,11 @@ class TestImage(unittest.TestCase):
     def test_imdecode_empty_buffer(self):
         mx.image.imdecode(b'', to_rgb=0)
 
+    @raises(mx.base.MXNetError)
+    def test_imdecode_invalid_image(self):
+        image = mx.image.imdecode(b'clearly not image content')
+        assert_equal(image, None)
+
     def test_scale_down(self):
         assert mx.image.scale_down((640, 480), (720, 120)) == (640, 106)
         assert mx.image.scale_down((360, 1000), (480, 500)) == (360, 375)


### PR DESCRIPTION
## Description ##
Check for invalid images before we pass them to OpenCV and throw a normal exception. Exceptions we can handle, OpenCV assertions not.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X ] Changes are complete (i.e. I finished coding on this PR)
- [ X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Raise an excption when passing an empty buffer to imdecode.
- Raise an exception when passing an invalid data buffer to imdecode. 
