### PR TITLE
fix quantize_graph pass error when there're multiple outputs from a single node

### DIFF
--- a/python/mxnet/contrib/quantization.py
+++ b/python/mxnet/contrib/quantization.py
@@ -71,11 +71,11 @@ def _quantize_params(qsym, params, th_dict):
         elif name in params:
             quantized_params[name] = params[name]
         elif name.endswith(('_min')):
-            output = name[: - len('_min')] + "_output"
+            output = name[: - len('_min')]
             if output in th_dict:
                 quantized_params[name] = ndarray.array([th_dict[output][0]])
         elif name.endswith(('_max')):
-            output = name[: - len('_min')] + "_output"
+            output = name[: - len('_min')]
             if output in th_dict:
                 quantized_params[name] = ndarray.array([th_dict[output][1]])
     return quantized_params
@@ -513,8 +513,6 @@ def quantize_model(sym, arg_params, aux_params,
         if not isinstance(calib_data, DataIter):
             raise ValueError('calib_data must be of DataIter type when calib_mode=%s,'
                              ' while received type %s' % (calib_mode, str(type(calib_data))))
-        if calib_layer is None:
-            calib_layer = lambda name: name.endswith('_output')
 
         mod = Module(symbol=sym, data_names=data_names, label_names=label_names, context=ctx)
         if len(calib_data.provide_label) > 0:

--- a/src/operator/quantization/quantize_graph_pass.cc
+++ b/src/operator/quantization/quantize_graph_pass.cc
@@ -194,7 +194,8 @@ Graph QuantizeGraph(Graph &&src) {
             max_node->op()->attr_parser(&(max_node->attrs));
           }
           // Only update the mapping when there's only 1 output from e.node.
-          // Need to insert "_contrib_quantize"/"min"/"max" for each entry when there's more than one.
+          // Need to insert "_contrib_quantize"/"min"/"max" for each entry when there's
+          // more than one.
           if (e.node->num_outputs() == 1) {
             mirror_map[e.node.get()] = std::move(quantize_node);
           } else {

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -419,6 +419,7 @@ def get_fp32_residual():
 def get_fp32_sym_with_multiple_outputs(length=1):
     data = mx.sym.Variable('data')
     inputs = list(mx.sym.split(data, axis=0, num_outputs=length, squeeze_axis=1, name='split'))
+
     _conv_outs = []
     for i in range(length):
         _conv_outs.append(mx.sym.Convolution(data=inputs[i], kernel=(1, 1), num_filter=16, name='conv_{0}'.format(i)))


### PR DESCRIPTION
## Description ##
The PR is to fix an error of quantize_graph pass which can't handle multiple outputs (like split op followd by convolution or fullyconnected) correctly. The current implementation is only quantizing for the first outputs but not the rest ones. In fact, for the case with multiple outputs from a single node, it requires to quantize separately for each output but not only the first one.

Check the attachment for the symbols before and after the fix.
* symbols from current implementation: [original_split_quantize.pdf](https://github.com/apache/incubator-mxnet/files/2524495/original_split_quantize.pdf)
* symbols from fixed version: [fixed_split_quantize.pdf](https://github.com/apache/incubator-mxnet/files/2524494/fixed_split_quantize.pdf)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

@pengzhao-intel @ZhennanQin 