### PR TITLE
Fix test failure due to hybridize call in test_gluon_rnn.test_layer_fill_shape

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -190,6 +190,7 @@ List of Contributors
 * [Denisa Roberts](https://github.com/D-Roberts)
 * [Dick Carter](https://github.com/DickJC123)
 * [Rahul Padmanabhan](https://github.com/rahul3)
+* [Yuxi Hu](https://github.com/yuxihu)
 
 Label Bot
 ---------

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -855,10 +855,15 @@ OpStatePtr CachedOp::Forward(
   int prev_bulk_size = Engine::Get()->set_bulk_size(config_.forward_bulk_size);
 
   OpStatePtr op_state;
-  if (config_.static_alloc) {
-    op_state = StaticForward(default_ctx, inputs, outputs);
-  } else {
-    op_state = DynamicForward(default_ctx, inputs, outputs);
+  try {
+    if (config_.static_alloc) {
+      op_state = StaticForward(default_ctx, inputs, outputs);
+    } else {
+      op_state = DynamicForward(default_ctx, inputs, outputs);
+    }
+  } catch (const dmlc::Error& e) {
+    Engine::Get()->set_bulk_size(prev_bulk_size);
+    throw e;
   }
 
   Engine::Get()->set_bulk_size(prev_bulk_size);

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -1063,10 +1063,15 @@ void CachedOp::Backward(
 
   int prev_bulk_size = Engine::Get()->set_bulk_size(config_.backward_bulk_size);
 
-  if (config_.static_alloc) {
-    StaticBackward(retain_graph, state, inputs, reqs, outputs);
-  } else {
-    DynamicBackward(retain_graph, state, inputs, reqs, outputs);
+  try {
+    if (config_.static_alloc) {
+      StaticBackward(retain_graph, state, inputs, reqs, outputs);
+    } else {
+      DynamicBackward(retain_graph, state, inputs, reqs, outputs);
+    }
+  } catch (const dmlc::Error& e) {
+    Engine::Get()->set_bulk_size(prev_bulk_size);
+    throw e;
   }
 
   Engine::Get()->set_bulk_size(prev_bulk_size);

--- a/src/imperative/imperative.cc
+++ b/src/imperative/imperative.cc
@@ -500,6 +500,8 @@ std::vector<NDArray*> Imperative::Backward(
             is_recording());
   } catch (const dmlc::Error& e) {
     Engine::Get()->set_bulk_size(prev_bulk_size);
+    set_is_recording(prev_recording);
+    set_is_training(prev_training);
     throw e;
   }
 

--- a/src/imperative/imperative.cc
+++ b/src/imperative/imperative.cc
@@ -494,9 +494,14 @@ std::vector<NDArray*> Imperative::Backward(
   bool prev_training = set_is_training(is_train);
   int prev_bulk_size = Engine::Get()->set_bulk_size(backward_bulk_size_);
 
-  RunGraph(retain_graph, idx, arrays, num_forward_nodes, idx.num_nodes(),
-           std::move(array_reqs), std::move(ref_count), &states, dispatch_modes,
-           is_recording());
+  try {
+    RunGraph(retain_graph, idx, arrays, num_forward_nodes, idx.num_nodes(),
+            std::move(array_reqs), std::move(ref_count), &states, dispatch_modes,
+            is_recording());
+  } catch (const dmlc::Error& e) {
+    Engine::Get()->set_bulk_size(prev_bulk_size);
+    throw e;
+  }
 
   Engine::Get()->set_bulk_size(prev_bulk_size);
   set_is_recording(prev_recording);

--- a/tests/python/unittest/test_gluon_rnn.py
+++ b/tests/python/unittest/test_gluon_rnn.py
@@ -594,6 +594,7 @@ def test_cell_fill_shape():
 @assert_raises_cudnn_not_satisfied(min_version='5.1.10')
 def test_layer_fill_shape():
     layer = gluon.rnn.LSTM(10)
+    layer.hybridize()
     check_rnn_layer_forward(layer, mx.nd.ones((3, 2, 7)))
     print(layer)
     assert layer.l0_i2h_weight.shape[1] == 7, layer.l0_i2h_weight.shape[1]


### PR DESCRIPTION
## Description ##
Previously, the value of bulk_size in struct BulkStatus of ThreadedEngine was not reset to its original one if there is exception thrown when executing StaticForward/DynamicForward for CachedOp. This causes another test (test_operator_gpu.test_incorrect_gpu) to fail if we add hybridize call in test_gluon_rnn.test_layer_fill_shape. We fix this by adding a try-catch block and reset the bulk_size in case of exception when executing CachedOp::StaticForward/DynamicForward. We also add the try-catch block in other similar places to prevent potential bugs.




