### PR TITLE
Fix incorrect variable name in tutorial code

### DIFF
--- a/docs/tutorials/scala/char_lstm.md
+++ b/docs/tutorials/scala/char_lstm.md
@@ -129,7 +129,7 @@ To prepare the data:
     ```scala
         scala> // Build  a vocabulary of what char we have in the content
         scala> def buildVocab(path: String): Map[String, Int] = {
-                val content = readContent(dataPath).split("\n")
+                val content = readContent(path).split("\n")
                 var idx = 1 // 0 is left for zero padding
                 var theVocab = Map[String, Int]()
                 for (line <- content) {


### PR DESCRIPTION
## Description ##
Fix the incorrect variable name raised in issue #13051

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)

### Changes ###
- [x] variable name in code snippet corrected

## Comments ##
- N/A
