### PR TITLE
Remove unused header from engine.h

### DIFF
--- a/include/mxnet/engine.h
+++ b/include/mxnet/engine.h
@@ -25,7 +25,6 @@
 #ifndef MXNET_ENGINE_H_
 #define MXNET_ENGINE_H_
 
-#include <dmlc/base.h>
 #if DMLC_USE_CXX11
 #include <algorithm>
 #include <memory>


### PR DESCRIPTION
## Description ##
There are very complicated dependencies in the current mxnet include folder. This is an initial step to reduce unnecessary dependency.