### PR TITLE
Add Java API docs generation

### DIFF
--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -417,7 +417,6 @@ def add_buttons(app, docname, source):
         # source[i] = '\n'.join(lines)
 
 def setup(app):
-
     # If MXNET_DOCS_BUILD_MXNET is set something different than 1
     # Skip the build step
     if os.getenv('MXNET_DOCS_BUILD_MXNET', '1') == '1' or _MXNET_DOCS_BUILD_MXNET:

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -140,7 +140,7 @@ def build_clojure_docs(app):
     _run_cmd('rm -rf ' + dest_path)
     _run_cmd('mkdir -p ' + dest_path)
     clojure_doc_path = app.builder.srcdir + '/../contrib/clojure-package/target/doc'
-    _run_cmd('cd ' + clojure_doc_path + ' && cp -r *  ' + dest_path; exit 0)
+    _run_cmd('cd ' + clojure_doc_path + ' && cp -r *  ' + dest_path + '; exit 0')
 
 def _convert_md_table_to_rst(table):
     """Convert a markdown table to rst format"""

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -59,7 +59,8 @@ _CODE_MARK = re.compile('^([ ]*)```([\w]*)')
 # language names and the according file extensions and comment symbol
 _LANGS = {'python' : ('py', '#'),
           'r' : ('R','#'),
-          'scala' : ('scala', '#'),
+          'scala' : ('scala', '//'),
+          'java' : ('java', '//'),
           'julia' : ('jl', '#'),
           'perl' : ('pl', '#'),
           'cpp' : ('cc', '//'),
@@ -102,7 +103,7 @@ def build_r_docs(app):
     _run_cmd('mkdir -p ' + dest_path + '; mv ' + pdf_path + ' ' + dest_path)
 
 def build_scala(app):
-    """build scala for scala docs and clojure docs to use"""
+    """build scala for scala docs, java docs, and clojure docs to use"""
     _run_cmd("cd %s/.. && make scalapkg" % app.builder.srcdir)
     _run_cmd("cd %s/.. && make scalainstall" % app.builder.srcdir)
 
@@ -114,9 +115,10 @@ def build_scala_docs(app):
     dest_path = app.builder.outdir + '/api/scala/docs'
     _run_cmd('rm -rf ' + dest_path)
     _run_cmd('mkdir -p ' + dest_path)
-    scaladocs = ['index.html', 'org', 'lib', 'index.js']
+    # 'index' and 'package.html' do not exist in later versions of scala; delete these after upgrading scala>2.12.x
+    scaladocs = ['index', 'index.html', 'org', 'lib', 'index.js', 'package.html']
     for doc_file in scaladocs:
-        _run_cmd('cd ' + scala_path + ' && mv -f ' + doc_file + ' ' + dest_path)
+        _run_cmd('cd ' + scala_path + ' && mv -f ' + doc_file + ' ' + dest_path + '; exit 0')
 
 def build_java_docs(app):
     """build java docs and then move the outdir"""
@@ -126,9 +128,9 @@ def build_java_docs(app):
     dest_path = app.builder.outdir + '/api/java/docs'
     _run_cmd('rm -rf ' + dest_path)
     _run_cmd('mkdir -p ' + dest_path)
-    javadocs = ['index.html', 'org', 'lib', 'index.js']
+    javadocs = ['index', 'index.html', 'org', 'lib', 'index.js', 'package.html']
     for doc_file in javadocs:
-        _run_cmd('cd ' + java_path + ' && mv -f ' + doc_file + ' ' + dest_path)
+        _run_cmd('cd ' + java_path + ' && mv -f ' + doc_file + ' ' + dest_path + '; exit 0')
 
 def build_clojure_docs(app):
     """build clojure doc and then move the outdir"""
@@ -138,7 +140,7 @@ def build_clojure_docs(app):
     _run_cmd('rm -rf ' + dest_path)
     _run_cmd('mkdir -p ' + dest_path)
     clojure_doc_path = app.builder.srcdir + '/../contrib/clojure-package/target/doc'
-    _run_cmd('cd ' + clojure_doc_path + ' && cp -r *  ' + dest_path)
+    _run_cmd('cd ' + clojure_doc_path + ' && cp -r *  ' + dest_path; exit 0)
 
 def _convert_md_table_to_rst(table):
     """Convert a markdown table to rst format"""

--- a/docs/settings.ini
+++ b/docs/settings.ini
@@ -4,65 +4,76 @@ build_mxnet = 0
 [document_sets_default]
 clojure_docs = 1
 doxygen_docs = 1
+java_docs = 1
 r_docs = 0
 scala_docs = 1
 
 [document_sets_1.2.0]
 clojure_docs = 0
 doxygen_docs = 1
+java_docs = 0
 r_docs = 0
 scala_docs = 1
 
 [document_sets_v1.2.0]
 clojure_docs = 0
 doxygen_docs = 1
+java_docs = 0
 r_docs = 0
 scala_docs = 1
 
 [document_sets_1.1.0]
 clojure_docs = 0
 doxygen_docs = 1
+java_docs = 0
 r_docs = 0
 scala_docs = 0
 
 [document_sets_v1.1.0]
 clojure_docs = 0
 doxygen_docs = 1
+java_docs = 0
 r_docs = 0
 scala_docs = 0
 
 [document_sets_1.0.0]
 clojure_docs = 0
 doxygen_docs = 1
+java_docs = 0
 r_docs = 0
 scala_docs = 0
 
 [document_sets_v1.0.0]
 clojure_docs = 0
 doxygen_docs = 1
+java_docs = 0
 r_docs = 0
 scala_docs = 0
 
 [document_sets_0.12.0]
 clojure_docs = 0
 doxygen_docs = 1
+java_docs = 0
 r_docs = 0
 scala_docs = 0
 
 [document_sets_v0.12.0]
 clojure_docs = 0
 doxygen_docs = 1
+java_docs = 0
 r_docs = 0
 scala_docs = 0
 
 [document_sets_0.11.0]
 clojure_docs = 0
 doxygen_docs = 1
+java_docs = 0
 r_docs = 0
 scala_docs = 0
 
 [document_sets_v0.11.0]
 clojure_docs = 0
 doxygen_docs = 1
+java_docs = 0
 r_docs = 0
 scala_docs = 0


### PR DESCRIPTION
## Description ##
This PR splits out the Java API from the Scala API docs.

## Preview

From CI:
Java API docs: http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-13071/8/api/java/docs/index.html#org.apache.mxnet.javaapi.package

Scala API docs: http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-13071/8/api/scala/docs/index.html#org.apache.mxnet.package

If we upgraded Scala they'd look like this:
Java API docs: http://34.201.8.176/versions/javadocs/api/java/docs/org/apache/mxnet/javaapi/index.html
Scala API docs: http://34.201.8.176/versions/javadocs/api/scala/docs/org/apache/mxnet/index.html

Note that they look better because I upgraded Scala on my dev server. AFAIK we're not doing that for production... yet. I added an 'exit 0' to the copy command to avoid failing with newer versions of scala. This fixes https://github.com/apache/incubator-mxnet/issues/10858 as a workaround.

