### PR TITLE
Test/mkldnn batch norm op

### DIFF
--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -380,7 +380,8 @@ static bool BatchNormType(const nnvm::NodeAttrs& attrs,
 }
 
 #if MXNET_USE_MKLDNN == 1
-static inline bool SupportMKLDNNBN(const std::vector<NDArray> &inputs, const BatchNormParam &param) {
+static inline bool SupportMKLDNNBN(const std::vector<NDArray> &inputs,
+    const BatchNormParam &param) {
   TShape shape = inputs[0].shape();
   bool params_valid = shape.ndim() == 4
       && param.axis == mxnet::op::batchnorm::DEFAULT_AXIS

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -392,7 +392,7 @@ static inline bool SupportMKLDNNBN(const std::vector<NDArray> &inputs, const Bat
       inputs_valid = false;
     }
   }
-  return  params_valid && inputs_valid
+  return  params_valid && inputs_valid;
 }
 
 void BatchNormComputeExCPU(const nnvm::NodeAttrs &attrs,

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -99,7 +99,7 @@ void BatchNormForwardImpl(mshadow::Stream<cpu> *,
   batchnorm::BNTensor3<DType> inputData(in_data[batchnorm::kData], param_.axis);
   const TBlob &weights         = in_data[batchnorm::kGamma];
   const TBlob &bias            = in_data[batchnorm::kBeta];
-  
+
   // Aux (Moving)
   const TBlob &runningMean     = aux_states[batchnorm::kMovingMean];
   const TBlob &runningVariance = aux_states[batchnorm::kMovingVar];

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -216,14 +216,24 @@ void MKLDNNBatchNormForward(const OpContext &ctx, const BatchNormParam &param,
   auto &fwd = GetBNForward<DType>(param, ctx, data, flags);
   const NDArray &out  = out_data[batchnorm::kOut];
 
+  auto gamma_buffer = in_data[batchnorm::kGamma];
+  if (gamma_buffer.IsMKLDNNData()) {
+    gamma_buffer = gamma_buffer.Reorder2Default();
+  }
+
+  auto beta_buffer = in_data[batchnorm::kBeta];
+  if (beta_buffer.IsMKLDNNData()) {
+    beta_buffer = beta_buffer.Reorder2Default();
+  }
+
   // for output memory
   auto out_mem = const_cast<NDArray &>(out).CreateMKLDNNData(fwd.GetPd().dst_primitive_desc());
 
   // mxnet will always use scale shift.
   // But if fix_gamma is true, then all scale elements will be set to 1.0f
   if (flags & use_scale_shift) {
-    const NDArray &gamma    = in_data[batchnorm::kGamma];
-    const NDArray &beta     = in_data[batchnorm::kBeta];
+    const NDArray &gamma    = gamma_buffer;
+    const NDArray &beta     = beta_buffer;
     CHECK_EQ(gamma.storage_type(), mxnet::kDefaultStorage);
     CHECK_EQ(beta.storage_type(), mxnet::kDefaultStorage);
 

--- a/tests/cpp/include/test_mkldnn.h
+++ b/tests/cpp/include/test_mkldnn.h
@@ -85,11 +85,11 @@ inline static void InitMKLDNNArray(NDArray *arr, const mkldnn::memory::primitive
   arr->WaitToRead();
 }
 
-inline static NDArray* CopyMKLDNNArray(const NDArray& arr) {
+inline static NDArray CopyMKLDNNArray(const NDArray& arr) {
   auto ret = arr.Copy(Context());
   auto mem = arr.GetMKLDNNData();
   ret.CopyFrom(*mem);
-  return &ret;
+  return ret;
 
 }
 

--- a/tests/cpp/include/test_mkldnn.h
+++ b/tests/cpp/include/test_mkldnn.h
@@ -85,11 +85,11 @@ inline static void InitMKLDNNArray(NDArray *arr, const mkldnn::memory::primitive
   arr->WaitToRead();
 }
 
-inline static NDArray *CopyMKLDNNArray(const NDArray& arr) {
+inline static NDArray CopyMKLDNNArray(const NDArray& arr) {
   auto ret = arr.Copy(Context());
   auto mem = arr.GetMKLDNNData();
   ret.CopyFrom(*mem);
-  return &ret;
+  return ret;
 
 }
 

--- a/tests/cpp/include/test_mkldnn.h
+++ b/tests/cpp/include/test_mkldnn.h
@@ -85,14 +85,6 @@ inline static void InitMKLDNNArray(NDArray *arr, const mkldnn::memory::primitive
   arr->WaitToRead();
 }
 
-inline static NDArray CopyMKLDNNArray(const NDArray& arr) {
-  auto ret = arr.Copy(Context());
-  auto mem = arr.GetMKLDNNData();
-  ret.CopyFrom(*mem);
-  return ret;
-
-}
-
 inline static bool IsSameShape(mkldnn::memory::primitive_desc pd, TShape shape) {
   if (pd.desc().data.ndims != shape.ndim()) return false;
   for (size_t i = 0; i < shape.ndim(); i++)

--- a/tests/cpp/include/test_mkldnn.h
+++ b/tests/cpp/include/test_mkldnn.h
@@ -85,11 +85,11 @@ inline static void InitMKLDNNArray(NDArray *arr, const mkldnn::memory::primitive
   arr->WaitToRead();
 }
 
-inline static NDArray CopyMKLDNNArray(const NDArray& arr) {
+inline static NDArray* CopyMKLDNNArray(const NDArray& arr) {
   auto ret = arr.Copy(Context());
-  auto mem = ret.GetMKLDNNData();
+  auto mem = arr.GetMKLDNNData();
   ret.CopyFrom(*mem);
-  return ret;
+  return &ret;
 
 }
 

--- a/tests/cpp/include/test_mkldnn.h
+++ b/tests/cpp/include/test_mkldnn.h
@@ -85,11 +85,11 @@ inline static void InitMKLDNNArray(NDArray *arr, const mkldnn::memory::primitive
   arr->WaitToRead();
 }
 
-inline static NDArray CopyMKLDNNArray(const NDArray& arr) {
+inline static NDArray *CopyMKLDNNArray(const NDArray& arr) {
   auto ret = arr.Copy(Context());
   auto mem = arr.GetMKLDNNData();
   ret.CopyFrom(*mem);
-  return ret;
+  return &ret;
 
 }
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -352,7 +352,6 @@ OpAttrs GetBNOp() {
   attrs.attrs.op = Op::Get("BatchNorm");
   attrs.num_inputs = 5;
   attrs.num_outputs = 3;
-  attrs.dispatches.resize(2);
   attrs.accept_dims.insert(4);
   attrs.requests.insert(OpReqType::kWriteTo);
   attrs.attrs.op->attr_parser(&attrs.attrs);
@@ -368,7 +367,6 @@ OpAttrs GetBNBackwardOp() {
   attrs.attrs.op = Op::Get("_backward_BatchNorm");
   attrs.num_inputs = 8;
   attrs.num_outputs = 3;
-  attrs.dispatches.resize(2);
   attrs.attrs.op->attr_parser(&attrs.attrs);
   attrs.requests.insert(OpReqType::kWriteTo);
   return attrs;

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -672,7 +672,7 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
       auto tmp_output = in_arr.arr;
       backwards_buffer.emplace_back(tmp_output.Copy(Context()));
       backwards_buffer2.emplace_back(tmp_output.Copy(Context()));
-      if (in_arr.arr.IsMKLDNNData()) {
+      if (in_arr.arr.IsMKLDNNData() && !in_arr.arr.IsView()) {
         backwards_mem.emplace_back(backwards_buffer.back().GetMKLDNNData());
         backwards2_mem.emplace_back(backwards_buffer2.back().GetMKLDNNData());
         backwards_buffer.back().CopyFrom(*backwards_mem.back());
@@ -745,7 +745,7 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
           inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
 
-          if (in_arr.arr.IsMKLDNNData()) {
+          if (in_arr.arr.IsMKLDNNData() && !in_arr.arr.IsView()) {
             inputs_mem.emplace_back(in_arr.arr.GetMKLDNNData());
             inputs2_mem.emplace_back(in_arr.arr.GetMKLDNNData());
             inputs_buffer.back().CopyFrom(*inputs_mem.back());

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -773,8 +773,8 @@ void TestOpExBNBackward(const OpAttrs &forward_attrs,
   std::vector<NDArray> backwards_buffer(backwards_attrs.num_outputs);
   std::vector<NDArray> backwards_buffer2(backwards_attrs.num_outputs);
 
-  std::vector<const mkldnn::memory*> backwards_mem(backwards_attrs.num_outputs);
-  std::vector<const mkldnn::memory*> backwards2_mem(backwards_attrs.num_outputs);
+//  std::vector<const mkldnn::memory*> backwards_mem(backwards_attrs.num_outputs);
+//  std::vector<const mkldnn::memory*> backwards2_mem(backwards_attrs.num_outputs);
 
   std::vector<NDArray*> backwards_outputs(backwards_attrs.num_outputs);
   std::vector<NDArray*> backwards_ex_outputs(backwards_attrs.num_outputs);
@@ -790,8 +790,9 @@ void TestOpExBNBackward(const OpAttrs &forward_attrs,
     backwards_input[6] = inputs[3];  // moving mean
     backwards_input[7] = inputs[4];  // moving var
 
-    auto tmp_output = in_arr.arr;
+
     for (size_t i = 0; i < backwards_attrs.num_outputs; i++) {
+      auto tmp_output = in_arr.arr;
       backwards_buffer.emplace_back(tmp_output.Copy(Context()));
       backwards_buffer2.emplace_back(tmp_output.Copy(Context()));
       backwards_buffer.back().CopyFrom(*tmp_output.GetMKLDNNData());
@@ -824,8 +825,8 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   std::vector<NDArray*> inputs2(forward_attrs.num_inputs);
   std::vector<NDArray> inputs_buffer(forward_attrs.num_inputs);
   std::vector<NDArray> inputs2_buffer(forward_attrs.num_inputs);
-  std::vector<const mkldnn::memory*> inputs_mem(forward_attrs.num_inputs);
-  std::vector<const mkldnn::memory*> inputs2_mem(forward_attrs.num_inputs);
+//  std::vector<const mkldnn::memory*> inputs_mem(forward_attrs.num_inputs);
+//  std::vector<const mkldnn::memory*> inputs2_mem(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
   std::vector<OpReqType> req(forward_attrs.num_outputs);
@@ -863,8 +864,6 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
           inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
           if (in_arr.arr.IsMKLDNNData()) {
-            inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
-            inputs2_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
             inputs_buffer.back().CopyFrom(*inputs_mem.back());
             inputs2_buffer.back().CopyFrom(*inputs2_mem.back());
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -650,9 +650,22 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
 
   if (req == kWriteTo) {
     // backwards test performed same time since output needed
-    backwards_input[0] = outputs[0];  // output grad
-    backwards_input[1] = inputs[0];  // input
-    backwards_input[2] = outputs[1];  // out norm
+
+    if (forward_attrs.attrs.op->name.compare("BatchNorm")) {
+      backwards_input[0] = outputs[0];  // output grad
+      backwards_input[1] = outputs[1]; // mean
+      backwards_input[2] = outputs[2];  // var
+      backwards_input[3] = inputs[0]; // data
+      backwards_input[4] = inputs[1]; // gamma
+      backwards_input[5] = inputs[2]; // beta
+      backwards_input[6] = inputs[3]; // moving mean
+      backwards_input[7] = inputs[4]; // moving var
+    } else {
+      backwards_input[0] = outputs[0];  // output grad
+      backwards_input[1] = inputs[0];  // input
+      backwards_input[2] = outputs[1];  // out norm
+    }
+
 
     auto tmp_output = in_arr.arr;
     backwards_outputs[0] = &tmp_output;

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -717,6 +717,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
           inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
           inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs2_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
+          inputs_buffer.back().WaitToRead();
+          inputs2_buffer.back().WaitToRead();
           inputs[i] = &inputs_buffer[i];
           inputs2[i] = &inputs2_buffer[i];
         }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -362,7 +362,8 @@ OpAttrs GetBNOp() {
       ArrayTypes::MKLDNNReshaped;
   attrs.output_types = ArrayTypes::Normal |
       ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped;
+      ArrayTypes::NormalReshaped |
+      ArrayTypes::MKLDNNReshaped;
   return attrs;
 }
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -745,12 +745,12 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
           inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
 
-          inputs_mem.emplace_back(in_arr.arr.GetMKLDNNData());
-          inputs2_mem.emplace_back(in_arr.arr.GetMKLDNNData());
-
-
-          inputs_buffer.back().CopyFrom(*inputs_mem.back());
-          inputs2_buffer.back().CopyFrom(*inputs2_mem.back());
+          if (in_arr.arr.IsMKLDNNData()) {
+            inputs_mem.emplace_back(in_arr.arr.GetMKLDNNData());
+            inputs2_mem.emplace_back(in_arr.arr.GetMKLDNNData());
+            inputs_buffer.back().CopyFrom(*inputs_mem.back());
+            inputs2_buffer.back().CopyFrom(*inputs2_mem.back());
+          }
           Engine::Get()->WaitForAll();
           inputs[i] = &inputs_buffer.back();
           inputs2[i] = &inputs2_buffer.back();

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -712,9 +712,6 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
 
-        in_arrs = GetTestInputArrays(forward_attrs.input_types, false);
-        in_arrs2 = GetTestInputArrays(forward_attrs.input_types, false);
-
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
           inputs_buffer[i] = CopyMKLDNNArray(in_arr.arr);
           inputs2_buffer[i] = CopyMKLDNNArray(in_arr.arr);

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -696,6 +696,7 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   if (forward_attrs.requests.find(OpReqType::kWriteTo) != forward_attrs.requests.end()) {
     for (int i1 = 0; i1 < in_arrs.size(); i1++) {
       auto in_arr = in_arrs[i1];
+      auto in_arr2 = in_arrs2[i1];
 
       CHECK_NE(forward_attrs.accept_dims.size(), 0);
       if (forward_attrs.accept_dims.find(in_arr.arr.shape().ndim()) ==
@@ -713,8 +714,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
 
         NDArray copy;
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
-          inputs[i] = &in_arr.arr;
-          inputs2[i] = &in_arr2.arr;
+          inputs[i] = CopyMKLDNNArray(in_arr.arr);
+          inputs2[i] = CopyMKLDNNArray(in_arr2.arr);
         }
 
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -713,8 +713,10 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
 
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
-          inputs_buffer[i] = CopyMKLDNNArray(in_arr.arr);
-          inputs2_buffer[i] = CopyMKLDNNArray(in_arr.arr);
+          inputs_buffer[i] = in_arr.arr.Copy(Context());
+          inputs_buffer[i].CopyFrom(*in_arr.arr.GetMKLDNNData());
+          inputs2_buffer[i] = in_arr.arr.Copy(Context());
+          inputs2_buffer[i].CopyFrom(*in_arr.arr.GetMKLDNNData());
           inputs[i] = &inputs_buffer[i];
           inputs2[i] = &inputs2_buffer[i];
         }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -681,6 +681,8 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
 void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   std::vector<NDArray*> inputs(forward_attrs.num_inputs);
   std::vector<NDArray*> inputs2(forward_attrs.num_inputs);
+  std::vector<NDArray> inputs_buffer(forward_attrs.num_inputs);
+  std::vector<NDArray> inputs2_buffer(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
   std::vector<OpReqType> req(forward_attrs.num_outputs);
@@ -689,14 +691,12 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   std::vector<mkldnn::memory::primitive_desc> pds = tas.pds;
 
   std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays(forward_attrs.input_types, false);
-  std::vector<NDArrayAttrs> in_arrs2 = GetTestInputArrays(forward_attrs.input_types, false);
   std::vector<std::vector<NDArrayAttrs>> out_arrs(forward_attrs.num_outputs);
   std::vector<std::vector<NDArrayAttrs>> ex_out_arrs(forward_attrs.num_outputs);
 
   if (forward_attrs.requests.find(OpReqType::kWriteTo) != forward_attrs.requests.end()) {
     for (int i1 = 0; i1 < in_arrs.size(); i1++) {
       auto in_arr = in_arrs[i1];
-      auto in_arr2 = in_arrs2[i1];
 
       CHECK_NE(forward_attrs.accept_dims.size(), 0);
       if (forward_attrs.accept_dims.find(in_arr.arr.shape().ndim()) ==
@@ -715,10 +715,11 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
         in_arrs = GetTestInputArrays(forward_attrs.input_types, false);
         in_arrs2 = GetTestInputArrays(forward_attrs.input_types, false);
 
-        NDArray copy;
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
-          inputs[i] = &in_arrs[i1].arr;
-          inputs2[i] = &in_arrs2[i1].arr;
+          inputs_buffer[i] = CopyMKLDNNArray(in_arr.arr);
+          inputs2_buffer[i] = CopyMKLDNNArray(in_arr.arr);
+          inputs[i] = &inputs_buffer[i];
+          inputs2[i] = &inputs2_buffer[i];
         }
 
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -705,6 +705,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   std::vector<NDArray*> inputs2(forward_attrs.num_inputs);
   std::vector<NDArray> inputs_buffer(forward_attrs.num_inputs);
   std::vector<NDArray> inputs2_buffer(forward_attrs.num_inputs);
+  std::vector<NDArray> inputs_mem(forward_attrs.num_inputs);
+  std::vector<NDArray> inputs2_mem(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
   std::vector<OpReqType> req(forward_attrs.num_outputs);
@@ -736,13 +738,13 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
 
         inputs_buffer.clear();
         inputs2_buffer.clear();
+
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
           inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
           inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs2_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
-          inputs_buffer.back().WaitToRead();
-          inputs2_buffer.back().WaitToRead();
+          Engine::Get()->WaitForAll();
           inputs[i] = &inputs_buffer[i];
           inputs2[i] = &inputs2_buffer[i];
         }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -773,9 +773,6 @@ void TestOpExBNBackward(const OpAttrs &forward_attrs,
   std::vector<NDArray> backwards_buffer(backwards_attrs.num_outputs);
   std::vector<NDArray> backwards_buffer2(backwards_attrs.num_outputs);
 
-//  std::vector<const mkldnn::memory*> backwards_mem(backwards_attrs.num_outputs);
-//  std::vector<const mkldnn::memory*> backwards2_mem(backwards_attrs.num_outputs);
-
   std::vector<NDArray*> backwards_outputs(backwards_attrs.num_outputs);
   std::vector<NDArray*> backwards_ex_outputs(backwards_attrs.num_outputs);
   std::vector<OpReqType> back_req(backwards_attrs.num_outputs);
@@ -825,8 +822,6 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   std::vector<NDArray*> inputs2(forward_attrs.num_inputs);
   std::vector<NDArray> inputs_buffer(forward_attrs.num_inputs);
   std::vector<NDArray> inputs2_buffer(forward_attrs.num_inputs);
-//  std::vector<const mkldnn::memory*> inputs_mem(forward_attrs.num_inputs);
-//  std::vector<const mkldnn::memory*> inputs2_mem(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
   std::vector<OpReqType> req(forward_attrs.num_outputs);
@@ -857,15 +852,13 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
         inputs_buffer.clear();
         inputs2_buffer.clear();
-        inputs_mem.clear();
-        inputs2_mem.clear();
 
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
           inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
           if (in_arr.arr.IsMKLDNNData()) {
-            inputs_buffer.back().CopyFrom(*inputs_mem.back());
-            inputs2_buffer.back().CopyFrom(*inputs2_mem.back());
+            inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
+            inputs2_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
 
           }
           Engine::Get()->WaitForAll();
@@ -892,7 +885,7 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
         AssertEqual(outputs, ex_outputs);
 
         if (!backwards_attrs.requests.empty()) {
-          TestOpExBackward(forward_attrs, backwards_attrs, OpReqType::kWriteTo,
+          TestOpExBNBackward(forward_attrs, backwards_attrs, OpReqType::kWriteTo,
                            inputs, outputs, in_arr, out_arrs[0][output_i]);
         }
       }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -708,12 +708,11 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
             GetTestOutputArrays(in_arr.arr.shape(), pds, {1}, forward_attrs.output_types);
       }
 
-      for (int i = 0; i < forward_attrs.num_inputs; i++) {
-        inputs[i] = CopyMKLDNNArray(in_arr.arr);
-      }
-
-
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
+
+        for (int i = 0; i < forward_attrs.num_inputs; i++)
+          inputs[i] = CopyMKLDNNArray(in_arr.arr);
+
         for (int i = 0; i < forward_attrs.num_outputs; i++) {
           req[i] = kWriteTo;
           outputs[i] = &out_arrs[i][output_i].arr;

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -359,9 +359,7 @@ OpAttrs GetBNOp() {
   attrs.input_types = ArrayTypes::Normal |
       ArrayTypes::MKLDNN;
   attrs.output_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped;
+      ArrayTypes::MKLDNN;
   return attrs;
 }
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -715,8 +715,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
           inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
-          inputs_buffer2.emplace_back(in_arr.arr.Copy(Context()));
-          inputs_buffer2.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
+          inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
+          inputs2_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
           inputs[i] = &inputs_buffer[i];
           inputs2[i] = &inputs2_buffer[i];
         }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -362,9 +362,7 @@ OpAttrs GetBNOp() {
       ArrayTypes::NormalReshaped |
       ArrayTypes::MKLDNNReshaped;
   attrs.output_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped;
+      ArrayTypes::MKLDNN;
   return attrs;
 }
 
@@ -705,9 +703,9 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
 
       for (int i = 0; i < forward_attrs.num_outputs; i++) {
         out_arrs[i] =
-            GetTestOutputArrays(in_arr.arr.shape(), pds, {1}, forward_attrs.output_types);
+            GetTestOutputArrays(in_arr.arr.shape(), pds, {1}, true, forward_attrs.output_types);
         ex_out_arrs[i] =
-            GetTestOutputArrays(in_arr.arr.shape(), pds, {1}, forward_attrs.output_types);
+            GetTestOutputArrays(in_arr.arr.shape(), pds, {1}, true, forward_attrs.output_types);
       }
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -859,15 +859,19 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
         inputs_mem.clear();
         inputs2_mem.clear();
 
-        auto tmp = in_arr.arr;
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
-          inputs_buffer.emplace_back(tmp.Copy(Context()));
-          inputs2_buffer.emplace_back(tmp.Copy(Context()));
-          inputs_buffer.back().CopyFrom(*tmp.GetMKLDNNData());
-          inputs2_buffer.back().CopyFrom(*tmp.GetMKLDNNData());
+          inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
+          inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
+          if (in_arr.arr.IsMKLDNNData()) {
+            inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
+            inputs2_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
+            inputs_buffer.back().CopyFrom(*inputs_mem.back());
+            inputs2_buffer.back().CopyFrom(*inputs2_mem.back());
+
+          }
+          Engine::Get()->WaitForAll();
           inputs[i] = &inputs_buffer.back();
           inputs2[i] = &inputs2_buffer.back();
-          Engine::Get()->WaitForAll();
         }
 
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -710,13 +710,13 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
 
+        inputs_buffer.clear();
+        inputs2_buffer.clear();
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
-          inputs_buffer[i] = in_arr.arr.Copy(Context());
-          inputs_buffer[i].CopyFrom(*in_arr.arr.GetMKLDNNData());
-          inputs2_buffer[i] = in_arr.arr.Copy(Context());
-          inputs2_buffer[i].CopyFrom(*in_arr.arr.GetMKLDNNData());
-          inputs_buffer[i].WaitToRead();
-          inputs2_buffer[i].WaitToRead();
+          inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
+          inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
+          inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
+          inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
           inputs[i] = &inputs_buffer[i];
           inputs2[i] = &inputs2_buffer[i];
         }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -712,10 +712,13 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
 
+        in_arrs = GetTestInputArrays(forward_attrs.input_types, false);
+        in_arrs2 = GetTestInputArrays(forward_attrs.input_types, false);
+
         NDArray copy;
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
-          inputs[i] = &in_arr.arr;
-          inputs2[i] = &in_arr2.arr;
+          inputs[i] = &in_arrs[i1].arr;
+          inputs2[i] = &in_arrs2[i1].arr;
         }
 
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -357,11 +357,7 @@ OpAttrs GetBNOp() {
   attrs.requests.insert(OpReqType::kWriteTo);
   attrs.attrs.op->attr_parser(&attrs.attrs);
   attrs.input_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN |
-      ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped |
-      ArrayTypes::MKLDNNReused |
-      ArrayTypes::NormalReshapedReused;
+      ArrayTypes::MKLDNN;
   attrs.output_types = ArrayTypes::Normal |
       ArrayTypes::MKLDNN |
       ArrayTypes::NormalReshaped |

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -643,6 +643,9 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
   std::vector<NDArray> backwards_buffer(backwards_attrs.num_outputs);
   std::vector<NDArray> backwards_buffer2(backwards_attrs.num_outputs);
 
+  std::vector<const mkldnn::memory*> backwards_mem(backwards_attrs.num_outputs);
+  std::vector<const mkldnn::memory*> backwards2_mem(backwards_attrs.num_outputs);
+
   std::vector<NDArray*> backwards_outputs(backwards_attrs.num_outputs);
   std::vector<NDArray*> backwards_ex_outputs(backwards_attrs.num_outputs);
   std::vector<OpReqType> back_req(backwards_attrs.num_outputs);
@@ -669,8 +672,12 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
       auto tmp_output = in_arr.arr;
       backwards_buffer.emplace_back(tmp_output.Copy(Context()));
       backwards_buffer2.emplace_back(tmp_output.Copy(Context()));
-      backwards_buffer.back().CopyFrom(*tmp_output.GetMKLDNNData());
-      backwards_buffer2.back().CopyFrom(*tmp_output.GetMKLDNNData());
+      if (in_arr.arr.IsMKLDNNData()) {
+        backwards_mem.emplace_back(tmp_output.GetMKLDNNData());
+        backwards2_mem.emplace_back(tmp_output.GetMKLDNNData());
+        backwards_buffer.back().CopyFrom(*backwards_mem.back());
+        backwards_buffer2.back().CopyFrom(*backwards2_mem.back());
+      }
       backwards_outputs[i] = &backwards_buffer.back();
       backwards_ex_outputs[i] = &backwards_buffer.back();
     }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -679,7 +679,7 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
         backwards_buffer2.back().CopyFrom(*backwards2_mem.back());
       }
       backwards_outputs[i] = &backwards_buffer.back();
-      backwards_ex_outputs[i] = &backwards_buffer.back();
+      backwards_ex_outputs[i] = &backwards_buffer2.back();
     }
 
 
@@ -744,14 +744,12 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
           inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
-
           if (in_arr.arr.IsMKLDNNData() && !in_arr.arr.IsView()) {
             inputs_mem.emplace_back(in_arr.arr.GetMKLDNNData());
             inputs2_mem.emplace_back(in_arr.arr.GetMKLDNNData());
             inputs_buffer.back().CopyFrom(*inputs_mem.back());
             inputs2_buffer.back().CopyFrom(*inputs2_mem.back());
           }
-          Engine::Get()->WaitForAll();
           inputs[i] = &inputs_buffer.back();
           inputs2[i] = &inputs2_buffer.back();
         }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -645,7 +645,6 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
 
   if (req == kWriteTo) {
     // backwards test performed same time since output needed
-
     backwards_input[0] = outputs[0];  // output grad
     backwards_input[1] = inputs[0];  // input
     backwards_input[2] = outputs[1];  // out norm
@@ -896,7 +895,7 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
 
       // If the array is a view, we shouldn't write data to it.
       if (in_arr.arr.IsView())
-        continue;
+          continue;
 
       NDArrayAttrs orig(in_arr.arr.Copy(in_arr.arr.ctx()), "InPlace Copy");
       for (int i = 0; i < forward_attrs.num_inputs; i++)
@@ -920,8 +919,6 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
     }
   }
 }
-
-
 
 // Computes second dimension of FC weight matrix based on input shape
 uint32_t GetFCWeightDim2(const nnvm::TShape arr) {

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -359,7 +359,9 @@ OpAttrs GetBNOp() {
   attrs.input_types = ArrayTypes::Normal |
       ArrayTypes::MKLDNN |
       ArrayTypes::NormalReshaped |
-      ArrayTypes::MKLDNNReshaped;
+      ArrayTypes::MKLDNNReshaped |
+      ArrayTypes::MKLDNNReused |
+      ArrayTypes::NormalReshapedReused;
   attrs.output_types = ArrayTypes::Normal |
       ArrayTypes::MKLDNN |
       ArrayTypes::NormalReshaped |

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -688,8 +688,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   TestArrayShapes tas = GetTestArrayShapes();
   std::vector<mkldnn::memory::primitive_desc> pds = tas.pds;
 
-  std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays(forward_attrs.input_types, true);
-  std::vector<NDArrayAttrs> in_arrs2 = GetTestInputArrays(forward_attrs.input_types, true);
+  std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays(forward_attrs.input_types, false);
+  std::vector<NDArrayAttrs> in_arrs2 = GetTestInputArrays(forward_attrs.input_types, false);
   std::vector<std::vector<NDArrayAttrs>> out_arrs(forward_attrs.num_outputs);
   std::vector<std::vector<NDArrayAttrs>> ex_out_arrs(forward_attrs.num_outputs);
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -708,11 +708,10 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
             GetTestOutputArrays(in_arr.arr.shape(), pds, {1}, forward_attrs.output_types);
       }
 
-      NDArray copy;
       for (int i = 0; i < forward_attrs.num_inputs; i++) {
-        copy = CopyMKLDNNArray(in_arr.arr);
-        inputs[i] = &copy;
+        inputs[i] = CopyMKLDNNArray(in_arr.arr);
       }
+
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
         for (int i = 0; i < forward_attrs.num_outputs; i++) {

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -680,7 +680,7 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
 // compares output of fcompute with fcomputex
 void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   std::vector<NDArray*> inputs(forward_attrs.num_inputs);
-  // need second copy of temp fix as batch norm cpu modifies input. will remove when BN CPU fixed
+  std::vector<NDArray*> inputs2(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
   std::vector<OpReqType> req(forward_attrs.num_outputs);
@@ -689,6 +689,7 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   std::vector<mkldnn::memory::primitive_desc> pds = tas.pds;
 
   std::vector<NDArrayAttrs> in_arrs = GetTestInputArrays(forward_attrs.input_types, true);
+  std::vector<NDArrayAttrs> in_arrs2 = GetTestInputArrays(forward_attrs.input_types, true);
   std::vector<std::vector<NDArrayAttrs>> out_arrs(forward_attrs.num_outputs);
   std::vector<std::vector<NDArrayAttrs>> ex_out_arrs(forward_attrs.num_outputs);
 
@@ -712,8 +713,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
 
         NDArray copy;
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
-          copy = CopyMKLDNNArray(in_arr.arr);
-          inputs[i] = &copy;
+          inputs[i] = &in_arr.arr;
+          inputs2[i] = &in_arr2.arr;
         }
 
 
@@ -729,7 +730,7 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
             Context(), forward_attrs.attrs, inputs, outputs, req,
             DispatchMode::kFCompute, mxnet::OpStatePtr());
         Imperative::Get()->InvokeOp(
-            Context(), forward_attrs.attrs, inputs, ex_outputs, req,
+            Context(), forward_attrs.attrs, inputs2, ex_outputs, req,
             DispatchMode::kFComputeEx, mxnet::OpStatePtr());
         Engine::Get()->WaitForAll();
         AssertEqual(outputs, ex_outputs);

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -675,10 +675,8 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
     for (size_t i = 0; i < backwards_attrs.num_outputs; i++) {
       backwards_buffer.emplace_back(tmp_output.Copy(Context()));
       backwards_buffer2.emplace_back(tmp_output.Copy(Context()));
-      backwards_mem.emplace_back(tmp_output.GetMKLDNNData());
-      backwards2_mem.emplace_back(tmp_output.GetMKLDNNData());
-      backwards_buffer.back().CopyFrom(*backwards_mem.back());
-      backwards_buffer2.back().CopyFrom(*backwards2_mem.back());
+      backwards_buffer.back().CopyFrom(*tmp_output.GetMKLDNNData());
+      backwards_buffer2.back().CopyFrom(*tmp_output.GetMKLDNNData());
       backwards_outputs[i] = &backwards_buffer.back();
       backwards_ex_outputs[i] = &backwards_buffer2.back();
       Engine::Get()->WaitForAll();
@@ -750,10 +748,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
           inputs_buffer.emplace_back(tmp.Copy(Context()));
           inputs2_buffer.emplace_back(tmp.Copy(Context()));
-          inputs_mem.emplace_back(tmp.GetMKLDNNData());
-          inputs2_mem.emplace_back(tmp.GetMKLDNNData());
-          inputs_buffer.back().CopyFrom(*inputs_mem.back());
-          inputs2_buffer.back().CopyFrom(*inputs2_mem.back());
+          inputs_buffer.back().CopyFrom(*tmp.GetMKLDNNData());
+          inputs2_buffer.back().CopyFrom(*tmp.GetMKLDNNData());
           inputs[i] = &inputs_buffer.back();
           inputs2[i] = &inputs2_buffer.back();
           Engine::Get()->WaitForAll();

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -715,6 +715,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
           inputs_buffer[i].CopyFrom(*in_arr.arr.GetMKLDNNData());
           inputs2_buffer[i] = in_arr.arr.Copy(Context());
           inputs2_buffer[i].CopyFrom(*in_arr.arr.GetMKLDNNData());
+          inputs_buffer[i].WaitToRead();
+          inputs2_buffer[i].WaitToRead();
           inputs[i] = &inputs_buffer[i];
           inputs2[i] = &inputs2_buffer[i];
         }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -651,14 +651,14 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
     // backwards test performed same time since output needed
 
     if (forward_attrs.attrs.op->name.compare("BatchNorm") == 0) {
-      backwards_input[0] = outputs[0];  // output grad
-      backwards_input[1] = outputs[1]; // mean
-      backwards_input[2] = outputs[2];  // var
-      backwards_input[3] = inputs[0]; // data
-      backwards_input[4] = inputs[1]; // gamma
-      backwards_input[5] = inputs[2]; // beta
-      backwards_input[6] = inputs[3]; // moving mean
-      backwards_input[7] = inputs[4]; // moving var
+      backwards_input[0] = outputs[0];  //  output grad
+      backwards_input[1] = outputs[1]; //  mean
+      backwards_input[2] = outputs[2];  //  var
+      backwards_input[3] = inputs[0]; //  data
+      backwards_input[4] = inputs[1]; //  gamma
+      backwards_input[5] = inputs[2]; //  beta
+      backwards_input[6] = inputs[3]; //  moving mean
+      backwards_input[7] = inputs[4]; //  moving var
     } else {
       backwards_input[0] = outputs[0];  // output grad
       backwards_input[1] = inputs[0];  // input
@@ -673,7 +673,6 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
       backwards_buffer2.back().CopyFrom(*tmp_output.GetMKLDNNData());
       backwards_outputs[i] = &backwards_buffer.back();
       backwards_ex_outputs[i] = &backwards_buffer.back();
-
     }
 
 
@@ -730,7 +729,6 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
       }
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
-
         inputs_buffer.clear();
         inputs2_buffer.clear();
         inputs_mem.clear();

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -857,7 +857,6 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
           if (in_arr.arr.IsMKLDNNData()) {
             inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
             inputs2_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
-
           }
           Engine::Get()->WaitForAll();
           inputs[i] = &inputs_buffer.back();

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -668,11 +668,11 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
       backwards_input[2] = outputs[1];  // out norm
     }
 
+    auto tmp_output = in_arr.arr;
+    if (tmp_output.IsMKLDNNData() && tmp_output.IsView()) {
+      tmp_output = tmp_output.Reorder2Default();
+    }
     for (size_t i = 0; i < backwards_attrs.num_outputs; i++) {
-      auto tmp_output = in_arr.arr;
-      if (tmp_output.IsMKLDNNData() && tmp_output.IsView()) {
-        tmp_output = tmp_output.Reorder2Default();
-      }
       backwards_buffer.emplace_back(tmp_output.Copy(Context()));
       backwards_buffer2.emplace_back(tmp_output.Copy(Context()));
       backwards_mem.emplace_back(backwards_buffer.back().GetMKLDNNData());
@@ -743,11 +743,11 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
         inputs_mem.clear();
         inputs2_mem.clear();
 
+        auto tmp = in_arr.arr;
+        if (tmp.IsMKLDNNData() && tmp.IsView()) {
+          tmp = tmp.Reorder2Default();
+        }
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
-          auto tmp = in_arr.arr;
-          if (tmp.IsMKLDNNData() && tmp.IsView()) {
-            tmp = tmp.Reorder2Default();
-          }
           inputs_buffer.emplace_back(tmp.Copy(Context()));
           inputs2_buffer.emplace_back(tmp.Copy(Context()));
           inputs_mem.emplace_back(tmp.GetMKLDNNData());

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -715,8 +715,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
           inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
-          inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
-          inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
+          inputs_buffer2.emplace_back(in_arr.arr.Copy(Context()));
+          inputs_buffer2.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
           inputs[i] = &inputs_buffer[i];
           inputs2[i] = &inputs2_buffer[i];
         }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -675,8 +675,8 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
     for (size_t i = 0; i < backwards_attrs.num_outputs; i++) {
       backwards_buffer.emplace_back(tmp_output.Copy(Context()));
       backwards_buffer2.emplace_back(tmp_output.Copy(Context()));
-      backwards_mem.emplace_back(backwards_buffer.back().GetMKLDNNData());
-      backwards2_mem.emplace_back(backwards_buffer2.back().GetMKLDNNData());
+      backwards_mem.emplace_back(tmp_output.GetMKLDNNData());
+      backwards2_mem.emplace_back(tmp_output.GetMKLDNNData());
       backwards_buffer.back().CopyFrom(*backwards_mem.back());
       backwards_buffer2.back().CopyFrom(*backwards2_mem.back());
       backwards_outputs[i] = &backwards_buffer.back();

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -676,8 +676,8 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
       backwards_buffer2.emplace_back(tmp_output.Copy(Context()));
       backwards_buffer.back().CopyFrom(*tmp_output.GetMKLDNNData());
       backwards_buffer2.back().CopyFrom(*tmp_output.GetMKLDNNData());
-      backwards_outputs[i] = &tmp_output;
-      backwards_ex_outputs[i] = &tmp_output;
+      backwards_outputs[i] = &backwards_buffer.back();
+      backwards_ex_outputs[i] = &backwards_buffer.back();
 
     }
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -711,9 +711,11 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
 
         NDArray copy;
-        for (int i = 0; i < forward_attrs.num_inputs; i++)
+        for (int i = 0; i < forward_attrs.num_inputs; i++) {
           copy = CopyMKLDNNArray(in_arr.arr);
-          inputs[i] = *copy;
+          inputs[i] = &copy;
+        }
+
 
         for (int i = 0; i < forward_attrs.num_outputs; i++) {
           req[i] = kWriteTo;

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -369,7 +369,7 @@ OpAttrs GetBNOp() {
 OpAttrs GetBNBackwardOp() {
   OpAttrs attrs;
   attrs.attrs.op = Op::Get("_backward_BatchNorm");
-  attrs.num_inputs = 3;
+  attrs.num_inputs = 8;
   attrs.num_outputs = 3;
   attrs.dispatches.resize(2);
   attrs.attrs.op->attr_parser(&attrs.attrs);

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -655,7 +655,7 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
   if (req == kWriteTo) {
     // backwards test performed same time since output needed
 
-    if (forward_attrs.attrs.op->name.compare("BatchNorm")) {
+    if (forward_attrs.attrs.op->name.compare("BatchNorm") == 0) {
       backwards_input[0] = outputs[0];  // output grad
       backwards_input[1] = outputs[1]; // mean
       backwards_input[2] = outputs[2];  // var

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -714,8 +714,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
 
         NDArray copy;
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
-          inputs[i] = CopyMKLDNNArray(in_arr.arr);
-          inputs2[i] = CopyMKLDNNArray(in_arr2.arr);
+          inputs[i] = &in_arr.arr;
+          inputs2[i] = &in_arr2.arr;
         }
 
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -792,8 +792,6 @@ void TestOpExBNBackward(const OpAttrs &forward_attrs,
       auto tmp_output = in_arr.arr;
       backwards_buffer.emplace_back(tmp_output.Copy(Context()));
       backwards_buffer2.emplace_back(tmp_output.Copy(Context()));
-      backwards_buffer.back().CopyFrom(*tmp_output.GetMKLDNNData());
-      backwards_buffer2.back().CopyFrom(*tmp_output.GetMKLDNNData());
       backwards_outputs[i] = &backwards_buffer.back();
       backwards_ex_outputs[i] = &backwards_buffer2.back();
       Engine::Get()->WaitForAll();
@@ -854,10 +852,6 @@ void TestOpExBN(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
           inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
           inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
-          if (in_arr.arr.IsMKLDNNData()) {
-            inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
-            inputs2_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
-          }
           Engine::Get()->WaitForAll();
           inputs[i] = &inputs_buffer.back();
           inputs2[i] = &inputs2_buffer.back();

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -705,8 +705,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   std::vector<NDArray*> inputs2(forward_attrs.num_inputs);
   std::vector<NDArray> inputs_buffer(forward_attrs.num_inputs);
   std::vector<NDArray> inputs2_buffer(forward_attrs.num_inputs);
-  std::vector<mkldnn::memory*> inputs_mem(forward_attrs.num_inputs);
-  std::vector<mkldnn::memory*> inputs2_mem(forward_attrs.num_inputs);
+  std::vector<const mkldnn::memory*> inputs_mem(forward_attrs.num_inputs);
+  std::vector<const mkldnn::memory*> inputs2_mem(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
   std::vector<OpReqType> req(forward_attrs.num_outputs);

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -651,14 +651,14 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
     // backwards test performed same time since output needed
 
     if (forward_attrs.attrs.op->name.compare("BatchNorm") == 0) {
-      backwards_input[0] = outputs[0];  //  output grad
-      backwards_input[1] = outputs[1]; //  mean
-      backwards_input[2] = outputs[2];  //  var
-      backwards_input[3] = inputs[0]; //  data
-      backwards_input[4] = inputs[1]; //  gamma
-      backwards_input[5] = inputs[2]; //  beta
-      backwards_input[6] = inputs[3]; //  moving mean
-      backwards_input[7] = inputs[4]; //  moving var
+      backwards_input[0] = outputs[0];  // output grad
+      backwards_input[1] = outputs[1];  // mean
+      backwards_input[2] = outputs[2];  // var
+      backwards_input[3] = inputs[0];  // data
+      backwards_input[4] = inputs[1];  // gamma
+      backwards_input[5] = inputs[2];  // beta
+      backwards_input[6] = inputs[3];  // moving mean
+      backwards_input[7] = inputs[4];  // moving var
     } else {
       backwards_input[0] = outputs[0];  // output grad
       backwards_input[1] = inputs[0];  // input

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -710,8 +710,10 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
 
       for (size_t output_i = 0; output_i < out_arrs[0].size(); output_i++) {
 
+        NDArray copy;
         for (int i = 0; i < forward_attrs.num_inputs; i++)
-          inputs[i] = CopyMKLDNNArray(in_arr.arr);
+          copy = CopyMKLDNNArray(in_arr.arr);
+          inputs[i] = *copy;
 
         for (int i = 0; i < forward_attrs.num_outputs; i++) {
           req[i] = kWriteTo;

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -644,6 +644,10 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
   std::vector<OpReqType> back_req(backwards_attrs.num_outputs);
 
   if (req == kWriteTo) {
+
+    auto tmp_output = in_arr.arr;
+    backwards_outputs[0] = &tmp_output;
+    backwards_ex_outputs[0] = &tmp_output;
     // backwards test performed same time since output needed
     backwards_input[0] = outputs[0];  // output grad
     backwards_input[1] = inputs[0];  // input

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -681,6 +681,7 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
       backwards_buffer2.back().CopyFrom(*backwards2_mem.back());
       backwards_outputs[i] = &backwards_buffer.back();
       backwards_ex_outputs[i] = &backwards_buffer2.back();
+      Engine::Get()->WaitForAll();
     }
 
 
@@ -755,6 +756,7 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
           inputs2_buffer.back().CopyFrom(*inputs2_mem.back());
           inputs[i] = &inputs_buffer.back();
           inputs2[i] = &inputs2_buffer.back();
+          Engine::Get()->WaitForAll();
         }
 
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -673,8 +673,8 @@ void TestOpExBackward(const OpAttrs &forward_attrs,
       backwards_buffer.emplace_back(tmp_output.Copy(Context()));
       backwards_buffer2.emplace_back(tmp_output.Copy(Context()));
       if (in_arr.arr.IsMKLDNNData()) {
-        backwards_mem.emplace_back(tmp_output.GetMKLDNNData());
-        backwards2_mem.emplace_back(tmp_output.GetMKLDNNData());
+        backwards_mem.emplace_back(backwards_buffer.back().GetMKLDNNData());
+        backwards2_mem.emplace_back(backwards_buffer2.back().GetMKLDNNData());
         backwards_buffer.back().CopyFrom(*backwards_mem.back());
         backwards_buffer2.back().CopyFrom(*backwards2_mem.back());
       }

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -355,14 +355,14 @@ OpAttrs GetBNOp() {
   attrs.dispatches.resize(2);
   attrs.accept_dims.insert(4);
   attrs.requests.insert(OpReqType::kWriteTo);
-  attrs.requests.insert(OpReqType::kWriteInplace);
   attrs.attrs.op->attr_parser(&attrs.attrs);
   attrs.input_types = ArrayTypes::Normal |
       ArrayTypes::MKLDNN |
       ArrayTypes::NormalReshaped |
       ArrayTypes::MKLDNNReshaped;
   attrs.output_types = ArrayTypes::Normal |
-      ArrayTypes::MKLDNN;
+      ArrayTypes::MKLDNN |
+      ArrayTypes::NormalReshaped;
   return attrs;
 }
 

--- a/tests/cpp/operator/mkldnn_operator_test.cc
+++ b/tests/cpp/operator/mkldnn_operator_test.cc
@@ -705,8 +705,8 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
   std::vector<NDArray*> inputs2(forward_attrs.num_inputs);
   std::vector<NDArray> inputs_buffer(forward_attrs.num_inputs);
   std::vector<NDArray> inputs2_buffer(forward_attrs.num_inputs);
-  std::vector<NDArray> inputs_mem(forward_attrs.num_inputs);
-  std::vector<NDArray> inputs2_mem(forward_attrs.num_inputs);
+  std::vector<mkldnn::memory*> inputs_mem(forward_attrs.num_inputs);
+  std::vector<mkldnn::memory*> inputs2_mem(forward_attrs.num_inputs);
   std::vector<NDArray*> outputs(forward_attrs.num_outputs);
   std::vector<NDArray*> ex_outputs(forward_attrs.num_outputs);
   std::vector<OpReqType> req(forward_attrs.num_outputs);
@@ -738,15 +738,22 @@ void TestOpEx(const OpAttrs &forward_attrs, const OpAttrs &backwards_attrs) {
 
         inputs_buffer.clear();
         inputs2_buffer.clear();
+        inputs_mem.clear();
+        inputs2_mem.clear();
 
         for (int i = 0; i < forward_attrs.num_inputs; i++) {
           inputs_buffer.emplace_back(in_arr.arr.Copy(Context()));
-          inputs_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
           inputs2_buffer.emplace_back(in_arr.arr.Copy(Context()));
-          inputs2_buffer.back().CopyFrom(*in_arr.arr.GetMKLDNNData());
+
+          inputs_mem.emplace_back(in_arr.arr.GetMKLDNNData());
+          inputs2_mem.emplace_back(in_arr.arr.GetMKLDNNData());
+
+
+          inputs_buffer.back().CopyFrom(*inputs_mem.back());
+          inputs2_buffer.back().CopyFrom(*inputs2_mem.back());
           Engine::Get()->WaitForAll();
-          inputs[i] = &inputs_buffer[i];
-          inputs2[i] = &inputs2_buffer[i];
+          inputs[i] = &inputs_buffer.back();
+          inputs2[i] = &inputs2_buffer.back();
         }
 
 


### PR DESCRIPTION
## Description ##
Add tests for MKLDNN batch norm operator The creates ndarray inputs and then runs it separately through the native CPU BN operator and MKLDNN BN operator. Creating the BN test requires a different helper as the BN operation writes to the input, so identical arrays of equal value must be created and then ran through the native / MKLDNN operators.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Add tests for MKLDNN BN operator


## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
