### PR TITLE
ImageDetIter: fix property not updating bug

### DIFF
--- a/python/mxnet/image/detection.py
+++ b/python/mxnet/image/detection.py
@@ -745,9 +745,11 @@ class ImageDetIter(ImageIter):
         if data_shape is not None:
             self.check_data_shape(data_shape)
             self.provide_data = [(self.provide_data[0][0], (self.batch_size,) + data_shape)]
+            self.data_shape = data_shape
         if label_shape is not None:
             self.check_label_shape(label_shape)
             self.provide_label = [(self.provide_label[0][0], (self.batch_size,) + label_shape)]
+            self.label_shape = label_shape
 
     def next(self):
         """Override the function for returning next batch."""

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -154,14 +154,14 @@ class TestImage(unittest.TestCase):
             with open(fname, 'w') as f:
                 for line in file_list:
                     f.write(line + '\n')
-            
+
             test_list = ['imglist', 'path_imglist']
 
             for test in test_list:
                 imglist = im_list if test == 'imglist' else None
                 path_imglist = fname if test == 'path_imglist' else None
-                
-                test_iter = mx.image.ImageIter(2, (3, 224, 224), label_width=1, imglist=imglist, 
+
+                test_iter = mx.image.ImageIter(2, (3, 224, 224), label_width=1, imglist=imglist,
                     path_imglist=path_imglist, path_root='', dtype=dtype)
                 # test batch data shape
                 for _ in range(3):
@@ -176,7 +176,7 @@ class TestImage(unittest.TestCase):
                     i += 1
                 assert i == 5
                 # test last_batch_handle(pad)
-                test_iter = mx.image.ImageIter(3, (3, 224, 224), label_width=1, imglist=imglist, 
+                test_iter = mx.image.ImageIter(3, (3, 224, 224), label_width=1, imglist=imglist,
                     path_imglist=path_imglist, path_root='', dtype=dtype, last_batch_handle='pad')
                 i = 0
                 for batch in test_iter:
@@ -260,6 +260,8 @@ class TestImage(unittest.TestCase):
 
         val_iter = mx.image.ImageDetIter(2, (3, 300, 300), imglist=im_list, path_root='')
         det_iter = val_iter.sync_label_shape(det_iter)
+        assert det_iter.data_shape == val_iter.data_shape
+        assert det_iter.label_shape == val_iter.label_shape
 
         # test file list
         fname = './data/test_imagedetiter.lst'


### PR DESCRIPTION
## Description ##
Fix a minor property bug that label_shape is not properly updated during reshape. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

