### PR TITLE
Infer dtype in SymbolBlock import from input symbol (v1.3.x)

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -26,6 +26,7 @@ import warnings
 import re
 from collections import OrderedDict
 
+from ..base import mx_real_t
 from .. import symbol, ndarray, initializer
 from ..symbol import Symbol
 from ..ndarray import NDArray
@@ -1058,29 +1059,15 @@ class SymbolBlock(HybridBlock):
         arg_params = out.list_arguments()
         aux_params = out.list_auxiliary_states()
 
-        infer_type_success, arg_types, aux_types = _infer_param_types(inputs[0],
-                                                                      out,
-                                                                      arg_params,
-                                                                      aux_params)
+        arg_types, aux_types = _infer_param_types(inputs[0], out, arg_params, aux_params)
 
-        if infer_type_success:
-            # Use inferred types for params
-            for i, arg in enumerate(arg_params):
-                if arg not in input_names:
-                    self.params.get(arg, allow_deferred_init=True, dtype=arg_types[i])
+        for i, arg in enumerate(arg_params):
+            if arg not in input_names:
+                self.params.get(arg, allow_deferred_init=True, dtype=arg_types[i])
 
-            for i, aux in enumerate(aux_params):
-                if aux not in input_names:
-                    self.params.get(aux, grad_req='null', allow_deferred_init=True, dtype=aux_types[i])
-        else:
-            # Use default types for params
-            for i, arg in enumerate(arg_params):
-                if arg not in input_names:
-                    self.params.get(arg, allow_deferred_init=True)
-
-            for i, aux in enumerate(aux_params):
-                if aux not in input_names:
-                    self.params.get(aux, grad_req='null', allow_deferred_init=True)
+        for i, aux in enumerate(aux_params):
+            if aux not in input_names:
+                self.params.get(aux, grad_req='null', allow_deferred_init=True, dtype=aux_types[i])
 
         self._cached_graph = syms, out
         len_prefix = len(_common_prefix(list(self._params.keys())))
@@ -1108,7 +1095,7 @@ class SymbolBlock(HybridBlock):
     def hybrid_forward(self, F, x, *args, **kwargs):
         raise NotImplementedError
 
-def _infer_param_types(in_params, out_params, arg_params, aux_params):
+def _infer_param_types(in_params, out_params, arg_params, aux_params, default_dtype=mx_real_t):
     """Utility function that helps in inferring DType of args and auxs params
     from given input param.
 
@@ -1122,20 +1109,18 @@ def _infer_param_types(in_params, out_params, arg_params, aux_params):
         List of names of argument parametrs.
     aux_params: List of Str
         List of names of auxiliary parameters.
+    default_dtype: numpy.dtype or str, default 'float32'
+        Default data type for arg_params and aux_params, if unable to infer the type.
 
     Returns
     -------
-    infer_type_success: Boolean
-        True if able to infer types for all given arg_params and aux_params.
-        False, otherwise.
     arg_types: List of numpy.dtype
         List of arg_params type. Order is same as arg_params.
-        None if unable to infer type.
+        Defaults to 'float32', if unable to infer type.
     aux_types: List of numpy.dtype
         List of aux_params type. Order is same as aux_params.
-        None if unable to infer type.
+        Defaults to 'float32', if unable to infer type.
     """
-    infer_type_success = False
     arg_types = None
     aux_types = None
 
@@ -1148,8 +1133,15 @@ def _infer_param_types(in_params, out_params, arg_params, aux_params):
     if input_sym_arg_type and len(input_sym_arg_type) > 0:
         params = {input_sym_name:input_sym_arg_type[0]}
         arg_types, _, aux_types = out_params.infer_type(**params)
-        if arg_types is not None and len(arg_types) == len(arg_params) and \
-           aux_types is not None and len(aux_types) == len(aux_params):
-            infer_type_success = True
 
-    return (infer_type_success, arg_types, aux_types)
+    if arg_types is None or len(arg_types) != len(arg_params):
+        arg_types = []
+        for _ in arg_params:
+            arg_types.append(default_dtype)
+
+    if aux_types is None or len(aux_types) != len(aux_params):
+        aux_types = []
+        for _ in aux_params:
+            aux_types.append(default_dtype)
+
+    return (arg_types, aux_types)

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1058,8 +1058,7 @@ class SymbolBlock(HybridBlock):
         arg_params = out.list_arguments()
         aux_params = out.list_auxiliary_states()
 
-        infer_type_success, arg_types, aux_types = _infer_param_types(self,
-                                                                      inputs[0],
+        infer_type_success, arg_types, aux_types = _infer_param_types(inputs[0],
                                                                       out,
                                                                       arg_params,
                                                                       aux_params)
@@ -1077,10 +1076,9 @@ class SymbolBlock(HybridBlock):
             # Use default types for params
             for i, arg in enumerate(arg_params):
                 if arg not in input_names:
-                    dt = inputs[0].infer_type()[0]
                     self.params.get(arg, allow_deferred_init=True)
 
-            for i, aux in out.list_auxiliary_states():
+            for i, aux in enumerate(aux_params):
                 if aux not in input_names:
                     self.params.get(aux, grad_req='null', allow_deferred_init=True)
 
@@ -1110,7 +1108,7 @@ class SymbolBlock(HybridBlock):
     def hybrid_forward(self, F, x, *args, **kwargs):
         raise NotImplementedError
 
-def _infer_param_types(self, in_params, out_params, arg_params, aux_params):
+def _infer_param_types(in_params, out_params, arg_params, aux_params):
     """Utility function that helps in inferring DType of args and auxs params
     from given input param.
 

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1092,6 +1092,10 @@ class SymbolBlock(HybridBlock):
         super(SymbolBlock, self)._clear_cached_op()
         self._cached_graph = tmp
 
+    def cast(self, dtype):
+        self._clear_cached_op()
+        super(SymbolBlock, self).cast(dtype)
+
     def hybrid_forward(self, F, x, *args, **kwargs):
         raise NotImplementedError
 
@@ -1126,12 +1130,12 @@ def _infer_param_types(in_params, out_params, arg_params, aux_params, default_dt
 
     # Get Input symbol details. This will be used to infer types of
     # other parameters.
-    input_sym_name = in_params.name
+    input_sym_names = in_params.list_inputs()
     input_sym_arg_type = in_params.infer_type()[0]
 
     # Try to infer types of other parameters.
     if input_sym_arg_type and len(input_sym_arg_type) > 0:
-        params = {input_sym_name:input_sym_arg_type[0]}
+        params = {k:v for k, v in zip(input_sym_names, input_sym_arg_type)}
         arg_types, _, aux_types = out_params.infer_type(**params)
 
     if arg_types is None or len(arg_types) != len(arg_params):

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1059,7 +1059,7 @@ class SymbolBlock(HybridBlock):
         arg_params = out.list_arguments()
         aux_params = out.list_auxiliary_states()
 
-        arg_types, aux_types = _infer_param_types(inputs[0], out, arg_params, aux_params)
+        arg_types, aux_types = _infer_param_types(syms, out, arg_params, aux_params)
 
         for i, arg in enumerate(arg_params):
             if arg not in input_names:
@@ -1105,8 +1105,8 @@ def _infer_param_types(in_params, out_params, arg_params, aux_params, default_dt
 
     Parameters
     ----------
-    in_params: Symbol
-        Input symbol variable.
+    in_params: List of Symbol
+        List of input symbol variables.
     out_params: Symbol
         Output symbol variable.
     arg_params: List of Str
@@ -1130,12 +1130,23 @@ def _infer_param_types(in_params, out_params, arg_params, aux_params, default_dt
 
     # Get Input symbol details. This will be used to infer types of
     # other parameters.
-    input_sym_names = in_params.list_inputs()
-    input_sym_arg_type = in_params.infer_type()[0]
+    input_sym_names = [in_param.name for in_param in in_params]
+
+    # Try to infer input types. If not successful, we will set default dtype.
+    # If successful, we will try to infer other params in the graph.
+    input_sym_arg_types = []
+    can_infer_input_type = True
+    for in_param in in_params:
+        input_sym_arg_type = in_param.infer_type()[0]
+        if not input_sym_arg_type or len(input_sym_arg_type) < 1:
+            can_infer_input_type = False
+            break
+        else:
+            input_sym_arg_types.append(in_param.infer_type()[0][0])
 
     # Try to infer types of other parameters.
-    if input_sym_arg_type and len(input_sym_arg_type) > 0:
-        params = {k:v for k, v in zip(input_sym_names, input_sym_arg_type)}
+    if can_infer_input_type:
+        params = {k:v for k, v in zip(input_sym_names, input_sym_arg_types)}
         arg_types, _, aux_types = out_params.infer_type(**params)
 
     if arg_types is None or len(arg_types) != len(arg_params):

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -727,6 +727,8 @@ class ParameterDict(object):
                         if matched:
                             param._shape = tuple(inferred_shape)
                             continue
+                    elif k == 'dtype' and np.dtype(v) == np.dtype(existing):
+                        continue
 
                     assert v is None or v == existing, \
                         "Cannot retrieve Parameter '%s' because desired attribute " \

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -222,7 +222,12 @@ def test_symbol_block_fp16():
     inputs = mx.sym.var('data', dtype='float16')
     net_fp16 = mx.gluon.SymbolBlock(sm, inputs)
     net_fp16.collect_params().load(tmpfile + '-0000.params', ctx=ctx)
-    assert np.dtype(net_fp16.params['resnetv20_conv0_weight'].dtype) == np.dtype(np.float16)
+    # 3. Get a conv layer's weight parameter name. Conv layer's weight param is
+    # expected to be of dtype casted, fp16.
+    for param_name in net_fp16.params.keys():
+        if 'conv' in param_name and 'weight' in param_name:
+            break
+    assert np.dtype(net_fp16.params[param_name].dtype) == np.dtype(np.float16)
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -209,7 +209,7 @@ def test_symbol_block_fp16():
     tmpfile = os.path.join(tmp, 'resnet34_fp16')
     ctx = mx.gpu(0)
 
-    net_fp32 = mx.gluon.model_zoo.vision.resnet34_v2(pretrained=True, ctx=ctx)
+    net_fp32 = mx.gluon.model_zoo.vision.resnet34_v2(pretrained=True, ctx=ctx, root=tmp)
     net_fp32.cast('float16')
     net_fp32.hybridize()
     data = mx.nd.zeros((1,3,224,224), dtype='float16', ctx=ctx)

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -18,6 +18,7 @@
 from __future__ import print_function
 import sys
 import os
+import tempfile
 import time
 import multiprocessing as mp
 import unittest
@@ -197,6 +198,31 @@ def test_sync_batchnorm():
     for i in range(10):
         _check_batchnorm_result(mx.nd.random.uniform(shape=(4, 1, 4, 4)),
                                 num_devices=ndev, cuda=True)
+
+@with_seed()
+def test_symbol_block_fp16():
+    # Test case to verify if initializing the SymbolBlock from a model with params
+    # other than fp32 param dtype.
+
+    # 1. Load a resnet model, cast it to fp16 and export
+    tmp = tempfile.mkdtemp()
+    tmpfile = os.path.join(tmp, 'resnet34_fp16')
+    ctx = mx.gpu(0)
+
+    net_fp32 = mx.gluon.model_zoo.vision.resnet34_v2(pretrained=True, ctx=ctx)
+    net_fp32.cast('float16')
+    net_fp32.hybridize()
+    data = mx.nd.zeros((1,3,224,224), dtype='float16', ctx=ctx)
+    net_fp32.forward(data)
+    net_fp32.export(tmpfile, 0)
+
+    # 2. Load the saved model and verify if all the params are loaded correctly.
+    # and choose one of the param to verify the type if fp16.
+    sm = mx.sym.load(tmpfile + '-symbol.json')
+    inputs = mx.sym.var('data', dtype='float16')
+    net_fp64 = mx.gluon.SymbolBlock(sm, inputs)
+    net_fp64.collect_params().load(tmpfile + '-0000.params', ctx=ctx)
+    assert (net_fp64.params['resnetv20_stage1_conv2_weight'].dtype is np.float16)
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -220,9 +220,9 @@ def test_symbol_block_fp16():
     # and choose one of the param to verify the type if fp16.
     sm = mx.sym.load(tmpfile + '-symbol.json')
     inputs = mx.sym.var('data', dtype='float16')
-    net_fp64 = mx.gluon.SymbolBlock(sm, inputs)
-    net_fp64.collect_params().load(tmpfile + '-0000.params', ctx=ctx)
-    assert (net_fp64.params['resnetv20_stage1_conv2_weight'].dtype is np.float16)
+    net_fp16 = mx.gluon.SymbolBlock(sm, inputs)
+    net_fp16.collect_params().load(tmpfile + '-0000.params', ctx=ctx)
+    assert (net_fp16.params[list(net_fp16.params.keys())[0]].dtype is np.float16)
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -222,7 +222,7 @@ def test_symbol_block_fp16():
     inputs = mx.sym.var('data', dtype='float16')
     net_fp16 = mx.gluon.SymbolBlock(sm, inputs)
     net_fp16.collect_params().load(tmpfile + '-0000.params', ctx=ctx)
-    assert (net_fp16.params[list(net_fp16.params.keys())[0]].dtype is np.float16)
+    assert np.dtype(net_fp16.params['resnetv20_conv0_weight'].dtype) == np.dtype(np.float16)
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -360,7 +360,12 @@ def test_symbol_block():
     inputs = mx.sym.var('data', dtype='float64')
     net_fp64 = mx.gluon.SymbolBlock(sm, inputs)
     net_fp64.collect_params().load(tmpfile + '-0000.params', ctx=ctx)
-    assert np.dtype(net_fp64.params['resnetv20_stage1_conv2_weight'].dtype) == np.dtype(np.float64)
+    # 3. Get a conv layer's weight parameter name. Conv layer's weight param is
+    # expected to be of dtype casted, fp64.
+    for param_name in net_fp64.params.keys():
+        if 'conv' in param_name and 'weight' in param_name:
+            break
+    assert np.dtype(net_fp64.params[param_name].dtype) == np.dtype(np.float64)
 
 @with_seed()
 @raises(AssertionError)

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -347,7 +347,7 @@ def test_symbol_block():
     tmpfile = os.path.join(tmp, 'resnet34_fp64')
     ctx = mx.cpu(0)
 
-    net_fp32 = mx.gluon.model_zoo.vision.resnet34_v2(pretrained=True, ctx=ctx)
+    net_fp32 = mx.gluon.model_zoo.vision.resnet34_v2(pretrained=True, ctx=ctx, root=tmp)
     net_fp32.cast('float64')
     net_fp32.hybridize()
     data = mx.nd.zeros((1,3,224,224), dtype='float64', ctx=ctx)

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -360,7 +360,7 @@ def test_symbol_block():
     inputs = mx.sym.var('data', dtype='float64')
     net_fp64 = mx.gluon.SymbolBlock(sm, inputs)
     net_fp64.collect_params().load(tmpfile + '-0000.params', ctx=ctx)
-    assert (net_fp64.params[list(net_fp64.params.keys())[0]].dtype is np.float64)
+    assert np.dtype(net_fp64.params['resnetv20_stage1_conv2_weight'].dtype) == np.dtype(np.float64)
 
 @with_seed()
 @raises(AssertionError)

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -336,6 +336,24 @@ def test_symbol_block():
     net.hybridize()
     assert isinstance(net(mx.nd.zeros((16, 10))), mx.nd.NDArray)
 
+    # Test case to verify if initializing the SymbolBlock from a model with params 
+    # other than fp32 param dtype.
+    # Load a resnet model, cast it to fp64 and export
+    net_fp32 = mx.gluon.model_zoo.vision.resnet34_v2(pretrained=True)
+    net_fp32.cast('float64')
+    net_fp32.hybridize()
+    data = mx.nd.zeros((1,3,224,224), dtype='float64')
+    net_fp32.forward(data)
+    net_fp32.export('resnet34_fp64', 0)
+
+    # Load the saved model and verify if all the params are loaded correctly.
+    # and choose one of the param to verify the type.
+    sm = mx.sym.load('resnet34_fp64-symbol.json')
+    inputs = mx.sym.var('data', dtype='float64')
+    net_fp64 = mx.gluon.SymbolBlock(sm, inputs)
+    net_fp64.collect_params().load('resnet34_fp64-0000.params')
+    assert (net_fp64.params['resnetv20_stage1_conv2_weight'].dtype is np.float64)
+
 @with_seed()
 @raises(AssertionError)
 def test_sparse_symbol_block():

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -360,7 +360,7 @@ def test_symbol_block():
     inputs = mx.sym.var('data', dtype='float64')
     net_fp64 = mx.gluon.SymbolBlock(sm, inputs)
     net_fp64.collect_params().load(tmpfile + '-0000.params', ctx=ctx)
-    assert (net_fp64.params['resnetv20_stage1_conv2_weight'].dtype is np.float64)
+    assert (net_fp64.params[list(net_fp64.params.keys())[0]].dtype is np.float64)
 
 @with_seed()
 @raises(AssertionError)

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -341,7 +341,8 @@ def test_symbol_block():
 
     # Test case to verify if initializing the SymbolBlock from a model with params 
     # other than fp32 param dtype.
-    # Load a resnet model, cast it to fp64 and export
+
+    # 1. Load a resnet model, cast it to fp64 and export
     tmp = tempfile.mkdtemp()
     tmpfile = os.path.join(tmp, 'resnet34_fp64')
     ctx = mx.cpu(0)
@@ -353,8 +354,8 @@ def test_symbol_block():
     net_fp32.forward(data)
     net_fp32.export(tmpfile, 0)
 
-    # Load the saved model and verify if all the params are loaded correctly.
-    # and choose one of the param to verify the type.
+    # 2. Load the saved model and verify if all the params are loaded correctly.
+    # and choose one of the param to verify the type if fp64.
     sm = mx.sym.load(tmpfile + '-symbol.json')
     inputs = mx.sym.var('data', dtype='float64')
     net_fp64 = mx.gluon.SymbolBlock(sm, inputs)

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -367,6 +367,13 @@ def test_symbol_block():
             break
     assert np.dtype(net_fp64.params[param_name].dtype) == np.dtype(np.float64)
 
+    # Cast the symbol block to FP32 and try to forward a FP32 data.
+    # This will verify SymbolBlock.cast() functionality.
+    net_fp64.cast('float32')
+    fp32_data = mx.nd.zeros((1,3,224,224), dtype='float32', ctx=ctx)
+    prediction = net_fp64.forward(fp32_data)
+    assert np.dtype(prediction.dtype) == np.dtype(np.float32)
+
 @with_seed()
 @raises(AssertionError)
 def test_sparse_symbol_block():

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -344,11 +344,12 @@ def test_symbol_block():
     # Load a resnet model, cast it to fp64 and export
     tmp = tempfile.mkdtemp()
     tmpfile = os.path.join(tmp, 'resnet34_fp64')
+    ctx = mx.cpu(0)
 
-    net_fp32 = mx.gluon.model_zoo.vision.resnet34_v2(pretrained=True)
+    net_fp32 = mx.gluon.model_zoo.vision.resnet34_v2(pretrained=True, ctx=ctx)
     net_fp32.cast('float64')
     net_fp32.hybridize()
-    data = mx.nd.zeros((1,3,224,224), dtype='float64')
+    data = mx.nd.zeros((1,3,224,224), dtype='float64', ctx=ctx)
     net_fp32.forward(data)
     net_fp32.export(tmpfile, 0)
 
@@ -357,7 +358,7 @@ def test_symbol_block():
     sm = mx.sym.load(tmpfile + '-symbol.json')
     inputs = mx.sym.var('data', dtype='float64')
     net_fp64 = mx.gluon.SymbolBlock(sm, inputs)
-    net_fp64.collect_params().load(tmpfile + '-0000.params')
+    net_fp64.collect_params().load(tmpfile + '-0000.params', ctx=ctx)
     assert (net_fp64.params['resnetv20_stage1_conv2_weight'].dtype is np.float64)
 
 @with_seed()


### PR DESCRIPTION
## Description ##

A port of https://github.com/apache/incubator-mxnet/pull/12412 to 1.3.x branch.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
