### PR TITLE
[MXNET-922] Fix memleak in profiler (v1.3.x)

### DIFF
--- a/src/profiler/profiler.cc
+++ b/src/profiler/profiler.cc
@@ -67,7 +67,7 @@ Profiler::Profiler()
   this->gpu_num_ = 0;
 #endif
 
-  this->profile_stat = new DeviceStats[cpu_num_ + gpu_num_ + 2];
+  this->profile_stat = std::unique_ptr<DeviceStats[]>(new DeviceStats[cpu_num_ + gpu_num_ + 2]);
   for (unsigned int i = 0; i < cpu_num_; ++i) {
     this->profile_stat[i].dev_name_ = "cpu/" + std::to_string(i);
   }

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -455,7 +455,7 @@ class Profiler {
   /*! \brief filename to output profile file */
   std::string filename_ = "profile.json";
   /*! \brief profile statistics consist of multiple device statistics */
-  DeviceStats* profile_stat;
+  std::unique_ptr<DeviceStats[], std::default_delete<DeviceStats[]>> profile_stat;
   /*! \brief Stats not associated directly with a device */
   DeviceStats  general_stats_;
   /*! \brief Map category -> pid */

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -455,7 +455,7 @@ class Profiler {
   /*! \brief filename to output profile file */
   std::string filename_ = "profile.json";
   /*! \brief profile statistics consist of multiple device statistics */
-  std::unique_ptr<DeviceStats[], std::default_delete<DeviceStats[]>> profile_stat;
+  std::unique_ptr<DeviceStats[]> profile_stat;
   /*! \brief Stats not associated directly with a device */
   DeviceStats  general_stats_;
   /*! \brief Map category -> pid */


### PR DESCRIPTION
## Description ##

A port of https://github.com/apache/incubator-mxnet/pull/12499 to the 1.3.x release branch.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
