### PR TITLE
Fix Sphinx python docstring error: initializer.InitDesc (#12939)

### DIFF
--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -32,10 +32,11 @@ from . import ndarray
 
 # inherit str for backward compatibility
 class InitDesc(str):
-    """Descriptor for the initialization pattern.
+    """
+    Descriptor for the initialization pattern.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     name : str
         Name of variable.
     attrs : dict of str to str
@@ -67,7 +68,7 @@ class Initializer(object):
         print_func : function
             A function that computes statistics of initialized arrays.
             Takes an `NDArray` and returns an `str`. Defaults to mean
-            absolute value str((|x|/size(x)).asscalar()).
+            absolute value str((abs(x)/size(x)).asscalar()).
         """
         self._verbose = verbose
         if print_func is None:


### PR DESCRIPTION
## Description ##
1. Fix python docstring formatting issue.
2. Workaround Sphinx parsing error.
Fixes #12939

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
