### PR TITLE
Fix Sphinx python docstring error: text contrib module (#12949)

### DIFF
--- a/python/mxnet/contrib/text/embedding.py
+++ b/python/mxnet/contrib/text/embedding.py
@@ -161,7 +161,7 @@ class _TokenEmbedding(vocab.Vocabulary):
     pre-trained token embedding file, are taken as the indexed tokens of the embedding.
 
 
-    Properties
+    Attributes
     ----------
     token_to_idx : dict mapping str to int
         A dict mapping each token to its index integer.
@@ -506,25 +506,6 @@ class GloVe(_TokenEmbedding):
         embedding vectors, such as loaded from a pre-trained token embedding file. If None, all the
         tokens from the loaded embedding vectors, such as loaded from a pre-trained token embedding
         file, will be indexed.
-
-
-    Properties
-    ----------
-    token_to_idx : dict mapping str to int
-        A dict mapping each token to its index integer.
-    idx_to_token : list of strs
-        A list of indexed tokens where the list indices and the token indices are aligned.
-    unknown_token : hashable object
-        The representation for any unknown token. In other words, any unknown token will be indexed
-        as the same representation.
-    reserved_tokens : list of strs or None
-        A list of reserved tokens that will always be indexed.
-    vec_len : int
-        The length of the embedding vector for each token.
-    idx_to_vec : mxnet.ndarray.NDArray
-        For all the indexed tokens in this embedding, this NDArray maps each token's index to an
-        embedding vector. The largest valid index maps to the initialized embedding vector for every
-        reserved token, such as an unknown_token token and a padding token.
     """
 
     # Map a pre-trained token embedding archive file and its SHA-1 hash.
@@ -610,25 +591,6 @@ class FastText(_TokenEmbedding):
         embedding vectors, such as loaded from a pre-trained token embedding file. If None, all the
         tokens from the loaded embedding vectors, such as loaded from a pre-trained token embedding
         file, will be indexed.
-
-
-    Properties
-    ----------
-    token_to_idx : dict mapping str to int
-        A dict mapping each token to its index integer.
-    idx_to_token : list of strs
-        A list of indexed tokens where the list indices and the token indices are aligned.
-    unknown_token : hashable object
-        The representation for any unknown token. In other words, any unknown token will be indexed
-        as the same representation.
-    reserved_tokens : list of strs or None
-        A list of reserved tokens that will always be indexed.
-    vec_len : int
-        The length of the embedding vector for each token.
-    idx_to_vec : mxnet.ndarray.NDArray
-        For all the indexed tokens in this embedding, this NDArray maps each token's index to an
-        embedding vector. The largest valid index maps to the initialized embedding vector for every
-        reserved token, such as an unknown_token token and a padding token.
     """
 
     # Map a pre-trained token embedding archive file and its SHA-1 hash.
@@ -687,25 +649,6 @@ class CustomEmbedding(_TokenEmbedding):
         embedding vectors, such as loaded from a pre-trained token embedding file. If None, all the
         tokens from the loaded embedding vectors, such as loaded from a pre-trained token embedding
         file, will be indexed.
-
-
-    Properties
-    ----------
-    token_to_idx : dict mapping str to int
-        A dict mapping each token to its index integer.
-    idx_to_token : list of strs
-        A list of indexed tokens where the list indices and the token indices are aligned.
-    unknown_token : hashable object
-        The representation for any unknown token. In other words, any unknown token will be indexed
-        as the same representation.
-    reserved_tokens : list of strs or None
-        A list of reserved tokens that will always be indexed.
-    vec_len : int
-        The length of the embedding vector for each token.
-    idx_to_vec : mxnet.ndarray.NDArray
-        For all the indexed tokens in this embedding, this NDArray maps each token's index to an
-        embedding vector. The largest valid index maps to the initialized embedding vector for every
-        reserved token, such as an unknown_token token and a padding token.
     """
 
     def __init__(self, pretrained_file_path, elem_delim=' ', encoding='utf8',
@@ -735,25 +678,6 @@ class CompositeEmbedding(_TokenEmbedding):
     token_embeddings : instance or list of `mxnet.contrib.text.embedding._TokenEmbedding`
         One or multiple pre-trained token embeddings to load. If it is a list of multiple
         embeddings, these embedding vectors will be concatenated for each token.
-
-
-    Properties
-    ----------
-    token_to_idx : dict mapping str to int
-        A dict mapping each token to its index integer.
-    idx_to_token : list of strs
-        A list of indexed tokens where the list indices and the token indices are aligned.
-    unknown_token : hashable object
-        The representation for any unknown token. In other words, any unknown token will be indexed
-        as the same representation.
-    reserved_tokens : list of strs or None
-        A list of reserved tokens that will always be indexed.
-    vec_len : int
-        The length of the embedding vector for each token.
-    idx_to_vec : mxnet.ndarray.NDArray
-        For all the indexed tokens in this embedding, this NDArray maps each token's index to an
-        embedding vector. The largest valid index maps to the initialized embedding vector for every
-        reserved token, such as an unknown_token token and a padding token.
     """
     def __init__(self, vocabulary, token_embeddings):
 

--- a/python/mxnet/contrib/text/vocab.py
+++ b/python/mxnet/contrib/text/vocab.py
@@ -63,12 +63,8 @@ class Vocabulary(object):
         `reserved_tokens` must be of the same hashable type. Examples: str, int, and tuple.
 
 
-    Properties
+    Attributes
     ----------
-    token_to_idx : dict mapping str to int
-        A dict mapping each token to its index integer.
-    idx_to_token : list of strs
-        A list of indexed tokens where the list indices and the token indices are aligned.
     unknown_token : hashable object
         The representation for any unknown token. In other words, any unknown token will be indexed
         as the same representation.
@@ -143,10 +139,16 @@ class Vocabulary(object):
 
     @property
     def token_to_idx(self):
+        """
+        dict mapping str to int: A dict mapping each token to its index integer.
+        """
         return self._token_to_idx
 
     @property
     def idx_to_token(self):
+        """
+        list of strs:  A list of indexed tokens where the list indices and the token indices are aligned.
+        """
         return self._idx_to_token
 
     @property


### PR DESCRIPTION
## Description ##
1. Fix invalid docstring section header.
2. Remove copy pasted docstrings.
3. Move property docstring to getter method.
Fixes #12949

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
