### PR TITLE
fix broken Python IO API docs (v1.3.x)

### DIFF
--- a/docs/api/python/io/io.md
+++ b/docs/api/python/io/io.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This document summarizes supported data formats and iterator APIs to read the
-data including
+data including:
 
 ```eval_rst
 .. autosummary::
@@ -68,8 +68,7 @@ A detailed tutorial is available at
 
 ## Helper classes and functions
 
-
-Data structures and other iterators provided in the ``mxnet.io`` packages.
+### Data structures and other iterators
 
 ```eval_rst
 .. autosummary::
@@ -83,7 +82,7 @@ Data structures and other iterators provided in the ``mxnet.io`` packages.
     io.MXDataIter
 ```
 
-Functions to read and write RecordIO files.
+### Functions to read and write RecordIO files
 
 ```eval_rst
 .. autosummary::
@@ -95,7 +94,7 @@ Functions to read and write RecordIO files.
     recordio.pack_img
 ```
 
-## Develop a new iterator
+## How to develop a new iterator
 
 Writing a new data iterator in Python is straightforward. Most MXNet
 training/inference programs accept an iterable object with ``provide_data``
@@ -133,7 +132,7 @@ Parsing and performing another pre-processing such as augmentation may be expens
 If performance is critical, we can implement a data iterator in C++. Refer to
 [src/io](https://github.com/dmlc/mxnet/tree/master/src/io) for examples.
 
-### Change batch layout
+### How to change the batch layout
 
 By default, the backend engine treats the first dimension of each data and label variable in data
 iterators as the batch size (i.e. `NCHW` or `NT` layout). In order to override the axis for batch size,
@@ -151,10 +150,35 @@ The backend engine will recognize the index of `N` in the `layout` as the axis f
 
 <script type="text/javascript" src='../../../_static/js/auto_module_index.js'></script>
 
+### mxnet.io - Data Iterators
+
 ```eval_rst
 .. automodule:: mxnet.io
-    :members:
+    :members: NDArrayIter, CSVIter, LibSVMIter, ImageRecordIter, ImageRecordUInt8Iter, MNISTIter
+```
+
+### mxnet.io - Helper Classes & Functions
+
+```eval_rst
+.. automodule:: mxnet.io
+   :members: DataBatch, DataDesc, DataIter, MXDataIter, PrefetchingIter, ResizeIter
+
+```
+
+### mxnet.recordio
+
+```eval_rst
+.. currentmodule:: mxnet.recordio
+
 .. automodule:: mxnet.recordio
     :members:
+
 ```
+
+```eval_rst
+.. _name: mxnet.symbol.Symbol.name
+.. _shape: mxnet.ndarray.NDArray.shape
+
+```
+
 <script>auto_index("api-reference");</script>

--- a/python/mxnet/io.py
+++ b/python/mxnet/io.py
@@ -106,8 +106,8 @@ class DataDesc(namedtuple('DataDesc', ['name', 'shape'])):
 
         Parameters
         ----------
-        shapes : a tuple of (name, shape)
-        types : a tuple of  (name, type)
+        shapes : a tuple of (name_, shape_)
+        types : a tuple of  (name_, np.dtype)
         """
         if types is not None:
             type_dict = dict(types)


### PR DESCRIPTION
## Description ##

Port of https://github.com/apache/incubator-mxnet/pull/12871/commits to the v1.3.x release branch.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
