### PR TITLE
Remove test for non existing index copy operator (v1.3.x)

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4752,30 +4752,7 @@ def test_quantization_op():
 
     assert same(qa.asnumpy(), qa_real.asnumpy())
     assert same(a_.asnumpy(),  a_real.asnumpy())
-
-@with_seed()
-def test_index_copy():
-    x = mx.nd.zeros((5,3))
-    t = mx.nd.array([[1,2,3],[4,5,6],[7,8,9]])
-    index = mx.nd.array([0,4,2], dtype=np.int64)
-
-    x.attach_grad()
-    t.attach_grad()
-    index.attach_grad()
-
-    with mx.autograd.record():
-        out = mx.nd.contrib.index_copy(x, index, t)
-    out.backward()
-
-    tensor = mx.nd.array([[1,2,3],[0,0,0],[7,8,9],[0,0,0],[4,5,6]])
-    x_grad = mx.nd.array([[0,0,0],[1,1,1],[0,0,0],[1,1,1],[0,0,0]])
-    t_grad = mx.nd.array([[1,1,1],[1,1,1],[1,1,1]])
-    index_grad = mx.nd.array([0,0,0])
-
-    assert same(out.asnumpy(), tensor.asnumpy())
-    assert same(x.grad.asnumpy(), x_grad.asnumpy())
-    assert same(t.grad.asnumpy(), t_grad.asnumpy())
-    assert same(index.grad.asnumpy(), index_grad.asnumpy())
+    
 
 @with_seed()
 def test_div_sqrt_dim():


### PR DESCRIPTION
## Description ##

The [test](https://github.com/apache/incubator-mxnet/pull/13129/files#diff-cb652780258e73a9cd08568f38929aa2R4756
) has been added by mistake in the following PR:

Gluon LSTM Projection and Clipping Support (#13055) v1.3.x
https://github.com/apache/incubator-mxnet/pull/13129


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
