### PR TITLE
[Scala][Clojure] Fix problem with some OSX not handling the cast on imDecode

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/Image.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Image.scala
@@ -42,7 +42,7 @@ object Image {
   def imDecode(buf: Array[Byte], flag: Int,
                to_rgb: Boolean,
                out: Option[NDArray]): NDArray = {
-    val nd = NDArray.array(buf.map(_.toFloat), Shape(buf.length))
+    val nd = NDArray.array(buf.map( x => (x & 0xFF).toFloat), Shape(buf.length))
     val byteND = NDArray.api.cast(nd, "uint8")
     val args : ListBuffer[Any] = ListBuffer()
     val map : mutable.Map[String, Any] = mutable.Map()


### PR DESCRIPTION
## Description ##

My OSX system was having a problem running the Scala function in the Image package `imDecode`.
When running the Scala unit tests it would error out with:

```
ImageSuite:
- Test load image
[19:13:09] src/io/image_io.cc:147: Decoding failed. Invalid image file.
2018-11-07 19:13:09,666 [ScalaTest-main-running-ImageSuite] [org.apache.mxnet.ImageSuite] [INFO] - OpenCV load image with shape: ()
2018-11-07 19:13:09,671 [ScalaTest-main-running-ImageSuite] [org.apache.mxnet.ImageSuite] [INFO] - OpenCV resize image with shape: (224,224,3)
- Test load image from Socket *** FAILED ***
  java.lang.IllegalArgumentException: requirement failed: image shape not Match!
  at scala.Predef$.require(Predef.scala:224)
  at org.apache.mxnet.ImageSuite$$anonfun$3.apply$mcV$sp(ImageSuite.scala:69)
  at org.apache.mxnet.ImageSuite$$anonfun$3.apply(ImageSuite.scala:64)
  at org.apache.mxnet.ImageSuite$$anonfun$3.apply(ImageSuite.scala:64)
```

After some investigation with @lanking520 , I found that adding an explicit conversion of the byte to an int before creating the NDArray solved the issue.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.

- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

Small tweak to the Scala function in `imDecode`

This is also relevant to https://github.com/apache/incubator-mxnet/pull/13107

