### PR TITLE
Allow dataloader iterator to be reused

### DIFF
--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -268,9 +268,7 @@ class _MultiWorkerIter(object):
         self._fetcher.daemon = True
         self._fetcher.start()
 
-        # pre-fetch
-        for _ in range(2 * self._num_workers):
-            self._push_next()
+        self._reset()
 
     def __len__(self):
         return len(self._batch_sampler)
@@ -278,8 +276,9 @@ class _MultiWorkerIter(object):
     def __del__(self):
         self.shutdown()
 
-    def reset(self):
+    def _reset(self):
         """Reset iterator with multiprocessing workers alive."""
+        assert not self._shutdown, "call reset after shutdown is forbidden"
         # clear key queue
         removed_idx = set()
         while True:
@@ -333,6 +332,7 @@ class _MultiWorkerIter(object):
         return self.__next__()
 
     def __iter__(self):
+        self._reset()
         return self
 
     def shutdown(self):

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -41,7 +41,6 @@ except ImportError:
 
 from . import sampler as _sampler
 from ... import nd, context
-from ...recordio import MXRecordIO
 
 if sys.platform == 'darwin' or sys.platform == 'win32':
     def rebuild_ndarray(*args):
@@ -164,29 +163,9 @@ def _as_in_context(data, ctx):
         return [_as_in_context(d, ctx) for d in data]
     return data
 
-def _recursive_fork_recordio(obj, depth, max_depth=1000):
-    """Recursively find instance of MXRecordIO and reset file handler.
-    This is required for MXRecordIO which holds a C pointer to a opened file after fork.
-    """
-    if depth >= max_depth:
-        return
-    if isinstance(obj, MXRecordIO):
-        obj.close()
-        obj.open()  # re-obtain file hanlder in new process
-    elif (hasattr(obj, '__dict__')):
-        for _, v in obj.__dict__.items():
-            _recursive_fork_recordio(v, depth + 1, max_depth)
 
 def worker_loop(dataset, key_queue, data_queue, batchify_fn):
     """Worker loop for multiprocessing DataLoader."""
-    # re-fork a new recordio handler in new process if applicable
-    # for a dataset with transform function, the depth of MXRecordIO is 1
-    # for a lazy transformer, the depth is 2
-    # for a user defined transformer, the depth is unknown, try a reasonable depth
-    # limit = sys.getrecursionlimit()
-    # max_recursion_depth = min(limit - 5, max(10, limit // 2))
-    # _recursive_fork_recordio(dataset, 0, max_recursion_depth)
-
     while True:
         idx, samples = key_queue.get()
         if idx is None:

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -377,13 +377,13 @@ class _SameProcessIter(object):
         self._dataset = dataset
         self._batchify_fn = batchify_fn
         self._batch_sampler = batch_sampler
-        self._iter = iter(self._batch_sampler)
         self._pin_memory = pin_memory
+        self._reset()
 
     def __len__(self):
         return len(self._batch_sampler)
 
-    def reset(self):
+    def _reset(self):
         """Reset iterator."""
         self._iter = iter(self._batch_sampler)
 
@@ -402,6 +402,7 @@ class _SameProcessIter(object):
         return self.__next__()
 
     def __iter__(self):
+        self._reset()
         return self
 
 

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -281,11 +281,11 @@ class _MultiWorkerIter(object):
     def reset(self):
         """Reset iterator with multiprocessing workers alive."""
         # clear key queue
-        removed_idx = []
+        removed_idx = set()
         while True:
             try:
                 idx, _ = self._key_queue.get(False)
-                removed_idx.append(idx)
+                removed_idx.add(idx)
             except QueueEmpty:
                 break
 

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -192,7 +192,8 @@ def fetcher_loop(data_queue, data_buffer, pin_memory=False, data_buffer_lock=Non
 
 class _MultiWorkerIter(object):
     """Interal multi-worker iterator for DataLoader.
-    It allow reset() to reuse iterator with all workers alive.
+    Re-acquiring this iterator by `iter()` function will reset it 
+    with all workers alive in order to save re-initialization overhead.
 
     Parameters
     ----------
@@ -370,7 +371,8 @@ class _MultiWorkerIter(object):
 
 
 class _SameProcessIter(object):
-    """Same Process Iterator, which allow reset().
+    """Same Process Iterator.
+    Re-acquire this iterator by `iter()` function will reset it.
 
     Parameters
     ----------

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -192,7 +192,7 @@ def fetcher_loop(data_queue, data_buffer, pin_memory=False, data_buffer_lock=Non
 
 class _MultiWorkerIter(object):
     """Interal multi-worker iterator for DataLoader.
-    Re-acquiring this iterator by `iter()` function will reset it 
+    Re-acquiring this iterator by `iter()` function will reset it
     with all workers alive in order to save re-initialization overhead.
 
     Parameters

--- a/python/mxnet/gluon/data/dataloader.py
+++ b/python/mxnet/gluon/data/dataloader.py
@@ -183,9 +183,9 @@ def worker_loop(dataset, key_queue, data_queue, batchify_fn):
     # for a dataset with transform function, the depth of MXRecordIO is 1
     # for a lazy transformer, the depth is 2
     # for a user defined transformer, the depth is unknown, try a reasonable depth
-    limit = sys.getrecursionlimit()
-    max_recursion_depth = min(limit - 5, max(10, limit // 2))
-    _recursive_fork_recordio(dataset, 0, max_recursion_depth)
+    # limit = sys.getrecursionlimit()
+    # max_recursion_depth = min(limit - 5, max(10, limit // 2))
+    # _recursive_fork_recordio(dataset, 0, max_recursion_depth)
 
     while True:
         idx, samples = key_queue.get()

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -256,7 +256,7 @@ def test_cached_iterator_in_dataloader():
     data = _DummyData()
     length = len(data)
     expect = np.arange(length)
-    for num_worker in range(2, 4):
+    for num_worker in range(0, 4):
         loader = DataLoader(data, batch_size=2, shuffle=False, num_workers=num_worker)
         it = iter(loader)
         it.reset()

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -244,6 +244,28 @@ def test_multi_worker_forked_data_loader():
         for i, data in enumerate(loader):
             pass
 
+@with_seed()
+def test_cached_iterator_in_dataloader():
+    class _DummyData(object):
+        def __len__(self):
+            return 100
+
+        def __getitem__(self, idx):
+            return idx
+
+    data = _DummyData()
+    length = len(data)
+    expect = np.arange(length)
+    for num_worker in range(2, 4):
+        loader = DataLoader(data, batch_size=2, shuffle=False, num_workers=num_worker)
+        it = iter(loader)
+        it.reset()
+        out = []
+        for i, batch in enumerate(it):
+            print(i, batch)
+            out.append(batch.asnumpy().flatten())
+        np.testing.assert_allclose(np.concatenate(out), expect)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -244,22 +244,22 @@ def test_multi_worker_forked_data_loader():
         for i, data in enumerate(loader):
             pass
 
+
+class _SequentialDummyData(object):
+    def __len__(self):
+        return 100
+
+    def __getitem__(self, idx):
+        return idx
+
 @with_seed()
 def test_cached_iterator_in_dataloader():
-    class _DummyData(object):
-        def __len__(self):
-            return 100
-
-        def __getitem__(self, idx):
-            return idx
-
-    data = _DummyData()
+    data = _SequentialDummyData()
     length = len(data)
     expect = np.arange(length)
     for num_worker in range(0, 4):
         loader = DataLoader(data, batch_size=2, shuffle=False, num_workers=num_worker)
         it = iter(loader)
-        it.reset()
         out = []
         for i, batch in enumerate(it):
             print(i, batch)


### PR DESCRIPTION
## Description ##
In gluon, DataLoader with very large ``num_workers`` can be slow at iteration initialization step, because forking a large number of processes can be expensive. 
This PR allow user to cache and reset to reuse the iterator by:

Updated:

```python

data_loader = mx.gluon.DataLoader(dataset, batch_size, num_workers=100)
it = iter(data_loader) # explicitly cache the iterator

for i in range(num_epochs):
    for batch in it:
        # training code
```

This PR don't affect the existing usage where each iterator is initialized and destroyed on-the-fly:
```python
data_loader = mx.gluon.DataLoader(dataset, batch_size, num_workers=100)
for i in range(epochs):
    for batch in data_loader:
        # training code
```
  


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
