### PR TITLE
Fix descriptions in scaladocs for macro ndarray/sybmol APIs

### DIFF
--- a/scala-package/macros/src/main/scala/org/apache/mxnet/APIDocGenerator.scala
+++ b/scala-package/macros/src/main/scala/org/apache/mxnet/APIDocGenerator.scala
@@ -90,11 +90,20 @@ private[mxnet] object APIDocGenerator extends GeneratorBase {
   }
 
   def generateAPIDocFromBackend(func: Func, withParam: Boolean = true): String = {
-    val desc = func.desc.split("\n")
-      .mkString("  * <pre>\n", "\n  * ", "  * </pre>\n")
+    def fixDesc(desc: String): String = {
+      var curDesc = desc
+      var prevDesc = ""
+      while ( curDesc != prevDesc ) {
+        prevDesc = curDesc
+        curDesc = curDesc.replace("[[", "`[ [").replace("]]", "] ]")
+      }
+      curDesc
+    }
+    val desc = fixDesc(func.desc).split("\n")
+      .mkString("  *\n  * {{{\n  *\n  * ", "\n  * ", "\n  * }}}\n  * ")
 
     val params = func.listOfArgs.map { absClassArg =>
-      s"  * @param ${absClassArg.safeArgName}\t\t${absClassArg.argDesc}"
+      s"  * @param ${absClassArg.safeArgName}\t\t${fixDesc(absClassArg.argDesc)}"
     }
 
     val returnType = s"  * @return ${func.returnType}"


### PR DESCRIPTION
## Description ##
This fixes the Scala API docs page issues with the macro generated docs noted under https://github.com/apache/incubator-mxnet/issues/12657. 

There were two major fixes:
- Replace the \<pre\> tags used earlier with scaladoc code blocks
- Add spaces to convert [[ to [ [. They are used for giving examples of NDArrays in python docs, but scaladocs treats [[ as a link which causes a warning since the link can't be resolved.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

@lanking520 @andrewfayres @aaronmarkham @nswamy