### PR TITLE
[WIP] Drop ccache for build_ubuntu_cpu_clang39_mkldnn (v1.3.x)

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -368,6 +368,8 @@ build_ubuntu_cpu_clang60() {
 build_ubuntu_cpu_clang39_mkldnn() {
     set -ex
 
+    export CCACHE_RECACHE=1
+
     export CXX=clang++-3.9
     export CC=clang-3.9
 


### PR DESCRIPTION
## Description ##

Trying to clean ccache due to a build failure:

http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/v1.3.x/98/pipeline

```
/work/mxnet/3rdparty/mkldnn/install/lib//libmklml_gnu.so: file not recognized: File truncated
clang: error: linker command failed with exit code 1 (use -v to see invocation)
Makefile:486: recipe for target 'lib/libmxnet.so' failed
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
