### PR TITLE
[Example] fix train mnist for inception-bn and resnet

### DIFF
--- a/example/image-classification/train_mnist.py
+++ b/example/image-classification/train_mnist.py
@@ -72,6 +72,7 @@ if __name__ == '__main__':
                         help='the number of training examples')
 
     parser.add_argument('--add_stn',  action="store_true", default=False, help='Add Spatial Transformer Network Layer (lenet only)')
+    parser.add_argument('--image_shape', default='1, 28, 28', help='shape of training images')
 
     fit.add_fit_args(parser)
     parser.set_defaults(


### PR DESCRIPTION
## Description ##
fix https://github.com/apache/incubator-mxnet/issues/13238

Now the following command works fine:
```
python train_mnist.py --network inception-bn --gpus 0,1,2,3

python train_mnist.py --network resnet --num-layers 110  --gpus 0,1,2,3
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Add `image_shape` in argument

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
