### PR TITLE
Fix generated html docs javascript error.

### DIFF
--- a/docs/api/python/gluon/model_zoo.md
+++ b/docs/api/python/gluon/model_zoo.md
@@ -233,7 +233,6 @@ The following table summarizes the available models.
 .. automodule:: mxnet.gluon.model_zoo.vision
     :members:
     :imported-members:
-    :noindex:
 
 ```
 

--- a/docs/api/python/io/io.md
+++ b/docs/api/python/io/io.md
@@ -154,7 +154,6 @@ The backend engine will recognize the index of `N` in the `layout` as the axis f
 
 ```eval_rst
 .. automodule:: mxnet.io
-    :noindex:
     :members: NDArrayIter, CSVIter, LibSVMIter, ImageRecordIter, ImageRecordUInt8Iter, MNISTIter
 ```
 
@@ -162,7 +161,6 @@ The backend engine will recognize the index of `N` in the `layout` as the axis f
 
 ```eval_rst
 .. automodule:: mxnet.io
-    :noindex:
     :members: DataBatch, DataDesc, DataIter, MXDataIter, PrefetchingIter, ResizeIter
 ```
 


### PR DESCRIPTION
## Description ##
Extra :noindex causes javascript error in html pages, which renders an empty page.
Remove extra :noidex in the model_zoo.md and io.md file.

Verified output html pages are working fine locally.

Build output can be found:
http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-13240/1/api/python/index.html#io-api

http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-13240/1/api/python/gluon/model_zoo.html

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
