### PR TITLE
Addressed sphinx build issue

### DIFF
--- a/docs/_static/js/auto_module_index.js
+++ b/docs/_static/js/auto_module_index.js
@@ -10,12 +10,14 @@ function auto_index(module) {
     var html = "<ul>";
 
     for (var i = 0; i < targets.length; ++i) {
-      var id = $(targets[i]).attr('id');
-      // remove 'mxnet.' prefix to make menus shorter
-      var id_simple = id.replace(/^mxnet\./, '');
-      html += "<li><a class='reference internal' href='#";
-      html += id;
-      html += "'>" + id_simple + "</a></li>";
+	var id = $(targets[i]).attr('id');
+	if ( id ) {
+	    // remove 'mxnet.' prefix to make menus shorter
+	    var id_simple = id.replace(/^mxnet\./, '');
+	    html += "<li><a class='reference internal' href='#";
+	    html += id;
+	    html += "'>" + id_simple + "</a></li>";
+	}
     }
 
     html += "</ul>";

--- a/docs/api/python/ndarray/ndarray.md
+++ b/docs/api/python/ndarray/ndarray.md
@@ -706,9 +706,14 @@ The `ndarray` package provides several classes:
     :members:
     :imported-members:
     :special-members:
-    :exclude-members: CachedOp, NDArray
+    :exclude-members: CachedOp, NDArray, save, load
+
+.. automodule:: mxnet.ndarray
+    :noindex:
+    :members: save, load
 
 .. automodule:: mxnet.random
+    :noindex:
     :members:
 
 ```

--- a/docs/api/python/ndarray/random.md
+++ b/docs/api/python/ndarray/random.md
@@ -51,6 +51,7 @@ In the rest of this document, we list routines provided by the `ndarray.random` 
 
 .. automodule:: mxnet.random
     :members:
+    :noindex:
 
 ```
 


### PR DESCRIPTION
## Description ##
Fixes sphinx build errors.
The java-script was breaking the pages from being redered, since sphinx seems to remove target id's when `:noindex:` is used in `automodule`. This crashes the javascript since the target-id retrieved in the script is undefined and the script seems to use it to remove the leading `mxnet.` from the target-ID. I added a check to do this substitution only if the given `taget-id` is  valid. 

1. This renders the pages if `:noindex:` is used in sphinx pages. 
2. If all the members in the `automodule` are under `:noindex:`, the link anchors between `autosummary` and `automodule` might not work, since these `automodule` doesn't generate any ID for the `autosummary` tables to link to. This was the side effect that I saw, but this is still better than having a broken page.


I also addressed a few `:noindex:` warnings from docs where a few members were being referenced multiple times in the doc. 

Fixes #13028
Fixes #13029
Fixes #13024

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
