### PR TITLE
Fix Sphinx errors

### DIFF
--- a/python/mxnet/gluon/contrib/rnn/conv_rnn_cell.py
+++ b/python/mxnet/gluon/contrib/rnn/conv_rnn_cell.py
@@ -255,7 +255,7 @@ class Conv1DRNNCell(_ConvRNNCell):
         If argument type is string, it's equivalent to nn.Activation(act_type=str). See
         :func:`~mxnet.ndarray.Activation` for available choices.
         Alternatively, other activation blocks such as nn.LeakyReLU can be used.
-    prefix : str, default 'conv_rnn_'
+    prefix : str, default ``'conv_rnn_``'
         Prefix for name of layers (and name of weight if params is None).
     params : RNNParams, default None
         Container for weight sharing between cells. Created if None.
@@ -322,7 +322,7 @@ class Conv2DRNNCell(_ConvRNNCell):
         If argument type is string, it's equivalent to nn.Activation(act_type=str). See
         :func:`~mxnet.ndarray.Activation` for available choices.
         Alternatively, other activation blocks such as nn.LeakyReLU can be used.
-    prefix : str, default 'conv_rnn_'
+    prefix : str, default ``'conv_rnn_``'
         Prefix for name of layers (and name of weight if params is None).
     params : RNNParams, default None
         Container for weight sharing between cells. Created if None.
@@ -389,7 +389,7 @@ class Conv3DRNNCell(_ConvRNNCell):
         If argument type is string, it's equivalent to nn.Activation(act_type=str). See
         :func:`~mxnet.ndarray.Activation` for available choices.
         Alternatively, other activation blocks such as nn.LeakyReLU can be used.
-    prefix : str, default 'conv_rnn_'
+    prefix : str, default ``'conv_rnn_``'
         Prefix for name of layers (and name of weight if params is None).
     params : RNNParams, default None
         Container for weight sharing between cells. Created if None.
@@ -519,7 +519,7 @@ class Conv1DLSTMCell(_ConvLSTMCell):
         If argument type is string, it's equivalent to nn.Activation(act_type=str). See
         :func:`~mxnet.ndarray.Activation` for available choices.
         Alternatively, other activation blocks such as nn.LeakyReLU can be used.
-    prefix : str, default 'conv_lstm_'
+    prefix : str, default ``'conv_lstm_``'
         Prefix for name of layers (and name of weight if params is None).
     params : RNNParams, default None
         Container for weight sharing between cells. Created if None.
@@ -596,7 +596,7 @@ class Conv2DLSTMCell(_ConvLSTMCell):
         If argument type is string, it's equivalent to nn.Activation(act_type=str). See
         :func:`~mxnet.ndarray.Activation` for available choices.
         Alternatively, other activation blocks such as nn.LeakyReLU can be used.
-    prefix : str, default 'conv_lstm_'
+    prefix : str, default ``'conv_lstm_``'
         Prefix for name of layers (and name of weight if params is None).
     params : RNNParams, default None
         Container for weight sharing between cells. Created if None.
@@ -673,7 +673,7 @@ class Conv3DLSTMCell(_ConvLSTMCell):
         If argument type is string, it's equivalent to nn.Activation(act_type=str). See
         :func:`~mxnet.ndarray.Activation` for available choices.
         Alternatively, other activation blocks such as nn.LeakyReLU can be used.
-    prefix : str, default 'conv_lstm_'
+    prefix : str, default ``'conv_lstm_``'
         Prefix for name of layers (and name of weight if params is None).
     params : RNNParams, default None
         Container for weight sharing between cells. Created if None.
@@ -803,7 +803,7 @@ class Conv1DGRUCell(_ConvGRUCell):
         If argument type is string, it's equivalent to nn.Activation(act_type=str). See
         :func:`~mxnet.ndarray.Activation` for available choices.
         Alternatively, other activation blocks such as nn.LeakyReLU can be used.
-    prefix : str, default 'conv_gru_'
+    prefix : str, default ``'conv_gru_``'
         Prefix for name of layers (and name of weight if params is None).
     params : RNNParams, default None
         Container for weight sharing between cells. Created if None.
@@ -875,7 +875,7 @@ class Conv2DGRUCell(_ConvGRUCell):
         If argument type is string, it's equivalent to nn.Activation(act_type=str). See
         :func:`~mxnet.ndarray.Activation` for available choices.
         Alternatively, other activation blocks such as nn.LeakyReLU can be used.
-    prefix : str, default 'conv_gru_'
+    prefix : str, default ``'conv_gru_``'
         Prefix for name of layers (and name of weight if params is None).
     params : RNNParams, default None
         Container for weight sharing between cells. Created if None.
@@ -947,7 +947,7 @@ class Conv3DGRUCell(_ConvGRUCell):
         If argument type is string, it's equivalent to nn.Activation(act_type=str). See
         :func:`~mxnet.ndarray.Activation` for available choices.
         Alternatively, other activation blocks such as nn.LeakyReLU can be used.
-    prefix : str, default 'conv_gru_'
+    prefix : str, default ``'conv_gru_``'
         Prefix for name of layers (and name of weight if params is None).
     params : RNNParams, default None
         Container for weight sharing between cells. Created if None.

--- a/python/mxnet/io/io.py
+++ b/python/mxnet/io/io.py
@@ -490,8 +490,8 @@ class NDArrayIter(DataIter):
     """Returns an iterator for ``mx.nd.NDArray``, ``numpy.ndarray``, ``h5py.Dataset``
     ``mx.nd.sparse.CSRNDArray`` or ``scipy.sparse.csr_matrix``.
 
-    Example usage:
-    ----------
+    Examples
+    --------
     >>> data = np.arange(40).reshape((10,2,2))
     >>> labels = np.ones([10, 1])
     >>> dataiter = mx.io.NDArrayIter(data, labels, 3, True, last_batch_handle='discard')

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1844,21 +1844,23 @@ def var_check(generator, sigma, nsamples=1000000):
 
 def chi_square_check(generator, buckets, probs, nsamples=1000000):
     """Run the chi-square test for the generator. The generator can be both continuous and discrete.
-    If the generator is continuous, the buckets should contain tuples of (range_min, range_max) and
-     the probs should be the corresponding ideal probability within the specific ranges.
-    Otherwise, the buckets should be the possible output of the discrete distribution and the probs
-     should be groud-truth probability.
+
+    If the generator is continuous, the buckets should contain tuples of (range_min, range_max) \
+    and the probs should be the corresponding ideal probability within the specific ranges. \
+    Otherwise, the buckets should be the possible output of the discrete distribution and the \
+    probs should be groud-truth probability.
 
     Usually the user is required to specify the probs parameter.
 
-    After obtatining the p value, we could further use the standard p > 0.05 threshold to get
-     the final result.
+    After obtatining the p value, we could further use the standard p > 0.05 threshold to get \
+    the final result.
 
     Examples::
-        buckets, probs = gen_buckets_probs_with_ppf(lambda x: ss.norm.ppf(x, 0, 1), 5)
-        generator = lambda x: np.random.normal(0, 1.0, size=x)
-        p = chi_square_check(generator=generator, buckets=buckets, probs=probs)
-        assert(p > 0.05)
+
+      buckets, probs = gen_buckets_probs_with_ppf(lambda x: ss.norm.ppf(x, 0, 1), 5)
+      generator = lambda x: np.random.normal(0, 1.0, size=x)
+      p = chi_square_check(generator=generator, buckets=buckets, probs=probs)
+      assert(p > 0.05)
 
     Parameters
     ----------
@@ -1867,8 +1869,8 @@ def chi_square_check(generator, buckets, probs, nsamples=1000000):
         generator(N) should generate N random samples.
     buckets: list of tuple or list of number
         The buckets to run the chi-square the test. Make sure that the buckets cover
-         the whole range of the distribution. Also, the buckets must be in ascending order and have
-         no intersection
+        the whole range of the distribution. Also, the buckets must be in ascending order and have
+        no intersection
     probs: list or tuple
         The ground-truth probability of the random value fall in a specific bucket.
     nsamples:int


### PR DESCRIPTION
## Description ##
Fix Sphinx errors that appear on local execution of make html.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Correct section title in io.py
- Correct prefix usage in conv_rnn_cell.py

## Comments ##
Fixes the following errors:
```
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.Conv1DRNNCell:: ERROR: Unknown target name: "conv_rnn".
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.Conv2DRNNCell:: ERROR: Unknown target name: "conv_rnn".
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.Conv3DRNNCell:: ERROR: Unknown target name: "conv_rnn".
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.Conv1DLSTMCell:: ERROR: Unknown target name: "conv_lstm".
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.Conv2DLSTMCell:: ERROR: Unknown target name: "conv_lstm".
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.Conv3DLSTMCell:: ERROR: Unknown target name: "conv_lstm".
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.Conv1DGRUCell:: ERROR: Unknown target name: "conv_gru".
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.Conv2DGRUCell:: ERROR: Unknown target name: "conv_gru".
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.Conv3DGRUCell:: ERROR: Unknown target name: "conv_gru".
incubator-mxnet/python/mxnet/io/__init__.py:docstring of mxnet.io.NDArrayIter:5: SEVERE: Unexpected section title.

Example usage:
----------
incubator-mxnet/python/mxnet/test_utils.py:docstring of mxnet.test_utils.chi_square_check:3: ERROR: Unexpected indentation.
incubator-mxnet/python/mxnet/test_utils.py:docstring of mxnet.test_utils.chi_square_check:4: WARNING: Block quote ends without a blank line; unexpected unindent.
```
