### PR TITLE
Fixed missing break statement in Java Benchmark Example

### DIFF
--- a/scala-package/examples/src/main/java/org/apache/mxnetexamples/javaapi/benchmark/JavaBenchmark.java
+++ b/scala-package/examples/src/main/java/org/apache/mxnetexamples/javaapi/benchmark/JavaBenchmark.java
@@ -96,6 +96,7 @@ public class JavaBenchmark {
                 ObjectDetectionBenchmark inst = new ObjectDetectionBenchmark();
                 parse(inst, args);
                 model = inst;
+                break;
             default:
                 System.err.println("Model name not found! " + modelName);
                 System.exit(1);


### PR DESCRIPTION
## Description ##
Added a missing break statement in switch case. 

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)

@lanking520 @andrewfayres 