### PR TITLE
Sphinx errors in Gluon

### DIFF
--- a/python/mxnet/autograd.py
+++ b/python/mxnet/autograd.py
@@ -273,8 +273,10 @@ def grad(heads, variables, head_grads=None, retain_graph=None, create_graph=Fals
     returned as new NDArrays instead of stored into `variable.grad`.
     Supports recording gradient graph for computing higher order gradients.
 
-    .. Note: Currently only a very limited set of operators support higher order
-    gradients.
+    .. note::
+
+      Currently only a very limited set of operators support higher order \
+      gradients.
 
     Parameters
     ----------

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -326,8 +326,7 @@ class Block(object):
 
         References
         ----------
-        `Saving and Loading Gluon Models
-
+        `Saving and Loading Gluon Models \
         <https://mxnet.incubator.apache.org/tutorials/gluon/save_load_params.html>`_
         """
         params = self._collect_params_with_prefix()
@@ -372,8 +371,7 @@ class Block(object):
 
         References
         ----------
-        `Saving and Loading Gluon Models
-
+        `Saving and Loading Gluon Models \
         <https://mxnet.incubator.apache.org/tutorials/gluon/save_load_params.html>`_
         """
         loaded = ndarray.load(filename)

--- a/python/mxnet/gluon/contrib/nn/basic_layers.py
+++ b/python/mxnet/gluon/contrib/nn/basic_layers.py
@@ -27,7 +27,7 @@ from ...block import HybridBlock, Block
 from ...nn import Sequential, HybridSequential, BatchNorm
 
 class Concurrent(Sequential):
-    """Lays `Block`s concurrently.
+    """Lays `Block` s concurrently.
 
     This block feeds its input to all children blocks, and
     produce the output by concatenating all the children blocks' outputs
@@ -60,7 +60,7 @@ class Concurrent(Sequential):
 
 
 class HybridConcurrent(HybridSequential):
-    """Lays `HybridBlock`s concurrently.
+    """Lays `HybridBlock` s concurrently.
 
     This block feeds its input to all children blocks, and
     produce the output by concatenating all the children blocks' outputs

--- a/python/mxnet/gluon/contrib/rnn/rnn_cell.py
+++ b/python/mxnet/gluon/contrib/rnn/rnn_cell.py
@@ -26,7 +26,7 @@ from ... import tensor_types
 class VariationalDropoutCell(ModifierCell):
     """
     Applies Variational Dropout on base cell.
-    (https://arxiv.org/pdf/1512.05287.pdf,
+    (https://arxiv.org/pdf/1512.05287.pdf, \
      https://www.stat.berkeley.edu/~tsmoon/files/Conference/asru2015.pdf).
 
     Variational dropout uses the same dropout mask across time-steps. It can be applied to RNN
@@ -197,24 +197,29 @@ class VariationalDropoutCell(ModifierCell):
 class LSTMPCell(HybridRecurrentCell):
     r"""Long-Short Term Memory Projected (LSTMP) network cell.
     (https://arxiv.org/abs/1402.1128)
+
     Each call computes the following function:
+
     .. math::
         \begin{array}{ll}
         i_t = sigmoid(W_{ii} x_t + b_{ii} + W_{ri} r_{(t-1)} + b_{ri}) \\
         f_t = sigmoid(W_{if} x_t + b_{if} + W_{rf} r_{(t-1)} + b_{rf}) \\
-        g_t = \tanh(W_{ig} x_t + b_{ig} + W_{rc} r_{(t-1)} + b_{rg}}) \\
+        g_t = \tanh(W_{ig} x_t + b_{ig} + W_{rc} r_{(t-1)} + b_{rg}) \\
         o_t = sigmoid(W_{io} x_t + b_{io} + W_{ro} r_{(t-1)} + b_{ro}) \\
         c_t = f_t * c_{(t-1)} + i_t * g_t \\
         h_t = o_t * \tanh(c_t) \\
         r_t = W_{hr} h_t
         \end{array}
+
     where :math:`r_t` is the projected recurrent activation at time `t`,
-    math:`h_t` is the hidden state at time `t`, :math:`c_t` is the
+    :math:`h_t` is the hidden state at time `t`, :math:`c_t` is the
     cell state at time `t`, :math:`x_t` is the input at time `t`, and :math:`i_t`,
     :math:`f_t`, :math:`g_t`, :math:`o_t` are the input, forget, cell, and
     out gates, respectively.
+
     Parameters
     ----------
+
     hidden_size : int
         Number of units in cell state symbol.
     projection_size : int
@@ -234,7 +239,7 @@ class LSTMPCell(HybridRecurrentCell):
         to zero.
     h2h_bias_initializer : str or Initializer
         Initializer for the bias vector.
-    prefix : str, default 'lstmp_'
+    prefix : str, default ``'lstmp_``'
         Prefix for name of `Block`s
         (and name of weight if params is `None`).
     params : Parameter or None

--- a/python/mxnet/gluon/data/vision/datasets.py
+++ b/python/mxnet/gluon/data/vision/datasets.py
@@ -45,8 +45,7 @@ class MNIST(dataset._DownloadedDataset):
     train : bool, default True
         Whether to load the training or testing set.
     transform : function, default None
-        A user defined callback that transforms each sample. For example:
-    ::
+        A user defined callback that transforms each sample. For example::
 
         transform=lambda data, label: (data.astype(np.float32)/255, label)
 
@@ -106,8 +105,7 @@ class FashionMNIST(MNIST):
     train : bool, default True
         Whether to load the training or testing set.
     transform : function, default None
-        A user defined callback that transforms each sample. For example:
-    ::
+        A user defined callback that transforms each sample. For example::
 
         transform=lambda data, label: (data.astype(np.float32)/255, label)
 
@@ -139,8 +137,7 @@ class CIFAR10(dataset._DownloadedDataset):
     train : bool, default True
         Whether to load the training or testing set.
     transform : function, default None
-        A user defined callback that transforms each sample. For example:
-    ::
+        A user defined callback that transforms each sample. For example::
 
         transform=lambda data, label: (data.astype(np.float32)/255, label)
 
@@ -204,8 +201,7 @@ class CIFAR100(CIFAR10):
     train : bool, default True
         Whether to load the training or testing set.
     transform : function, default None
-        A user defined callback that transforms each sample. For example:
-    ::
+        A user defined callback that transforms each sample. For example::
 
         transform=lambda data, label: (data.astype(np.float32)/255, label)
 
@@ -242,8 +238,7 @@ class ImageRecordDataset(dataset.RecordFileDataset):
 
         If 1, always convert images to colored (RGB).
     transform : function, default None
-        A user defined callback that transforms each sample. For example:
-    ::
+        A user defined callback that transforms each sample. For example::
 
         transform=lambda data, label: (data.astype(np.float32)/255, label)
 
@@ -279,8 +274,7 @@ class ImageFolderDataset(dataset.Dataset):
         If 0, always convert loaded images to greyscale (1 channel).
         If 1, always convert loaded images to colored (3 channels).
     transform : callable, default None
-        A function that takes data and label and transforms them:
-    ::
+        A function that takes data and label and transforms them::
 
         transform = lambda data, label: (data.astype(np.float32)/255, label)
 

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -621,7 +621,7 @@ class LogisticLoss(Loss):
 
     where `pred` is the classifier prediction and `label` is the target tensor
     containing values -1 or 1 (0 or 1 if `label_format` is binary).
-     `pred` and `label` can have arbitrary shape as long as they have the same number of elements.
+    `pred` and `label` can have arbitrary shape as long as they have the same number of elements.
 
     Parameters
     ----------

--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -75,7 +75,7 @@ class Sequential(Block):
         return len(self._children)
 
     def hybridize(self, active=True, **kwargs):
-        """Activates or deactivates `HybridBlock`s recursively. Has no effect on
+        """Activates or deactivates `HybridBlock` s recursively. Has no effect on
         non-hybrid children.
 
         Parameters

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -580,7 +580,7 @@ class Constant(Parameter):
     will not change during training. But you can still update their values
     manually with the `set_data` method.
 
-    `Constant`s can be created with either::
+    `Constant` s can be created with either::
 
         const = mx.gluon.Constant('const', [[1,2],[3,4]])
 

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -805,10 +805,12 @@ def check_numeric_gradient(sym, location, aux_states=None, numeric_eps=1e-3, rto
     location : list or tuple or dict
         Argument values used as location to compute gradient
 
-        - if type is list of numpy.ndarray
+        - if type is list of numpy.ndarray, \
             inner elements should have the same order as mxnet.sym.list_arguments().
-        - if type is dict of str -> numpy.ndarray
+
+        - if type is dict of str -> numpy.ndarray, \
             maps the name of arguments to the corresponding numpy.ndarray.
+
         *In either case, value of all the arguments must be provided.*
     aux_states : list or tuple or dict, optional
         The auxiliary states required when generating the executor for the symbol.
@@ -829,7 +831,7 @@ def check_numeric_gradient(sym, location, aux_states=None, numeric_eps=1e-3, rto
 
     References
     ---------
-    ..[1] https://github.com/Theano/Theano/blob/master/theano/gradient.py
+    [1] https://github.com/Theano/Theano/blob/master/theano/gradient.py
     """
     assert dtype in (np.float16, np.float32, np.float64)
     # cannot use finite differences with small eps without high precision


### PR DESCRIPTION
## Description ##
Fix Sphinx errors that appear on local execution of make html.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- indentation changes

## Comments ##
- Fixes the following errors:

```
incubator-mxnet/python/mxnet/autograd.py:docstring of mxnet.autograd.grad:6: WARNING: Explicit markup ends without a blank line; unexpected unindent.
incubator-mxnet/python/mxnet/gluon/contrib/nn/__init__.py:docstring of mxnet.gluon.contrib.nn.Concurrent:1: WARNING: Inline interpreted text or phrase reference start-string without end-string.
incubator-mxnet/python/mxnet/gluon/contrib/nn/__init__.py:docstring of mxnet.gluon.contrib.nn.HybridConcurrent:1: WARNING: Inline interpreted text or phrase reference start-string without end-string.
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.VariationalDropoutCell:3: ERROR: Unexpected indentation.
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.LSTMPCell:5: ERROR: Unexpected indentation.
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.LSTMPCell:14: WARNING: Literal block ends without a blank line; unexpected unindent.
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.LSTMPCell:24: ERROR: Unexpected indentation.
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.LSTMPCell:25: WARNING: Block quote ends without a blank line; unexpected unindent.
incubator-mxnet/python/mxnet/gluon/contrib/rnn/__init__.py:docstring of mxnet.gluon.contrib.rnn.LSTMPCell:: ERROR: Unknown target name: "lstmp".
docstring of mxnet.gluon.data.vision.datasets.MNIST:11: WARNING: Field list ends without a blank line; unexpected unindent.
docstring of mxnet.gluon.data.vision.datasets.FashionMNIST:13: WARNING: Field list ends without a blank line; unexpected unindent.
docstring of mxnet.gluon.data.vision.datasets.CIFAR10:11: WARNING: Field list ends without a blank line; unexpected unindent.
docstring of mxnet.gluon.data.vision.datasets.CIFAR100:13: WARNING: Field list ends without a blank line; unexpected unindent.
docstring of mxnet.gluon.data.vision.datasets.ImageRecordDataset:13: WARNING: Field list ends without a blank line; unexpected unindent.
docstring of mxnet.gluon.data.vision.datasets.ImageFolderDataset:17: WARNING: Field list ends without a blank line; unexpected unindent.
incubator-mxnet/python/mxnet/gluon/__init__.py:docstring of mxnet.gluon.Block.load_parameters:15: WARNING: Inline interpreted text or phrase reference start-string without end-string.
incubator-mxnet/python/mxnet/gluon/__init__.py:docstring of mxnet.gluon.Block.save_parameters:12: WARNING: Inline interpreted text or phrase reference start-string without end-string.
incubator-mxnet/python/mxnet/gluon/__init__.py:docstring of mxnet.gluon.Constant:6: WARNING: Inline interpreted text or phrase reference start-string without end-string.
incubator-mxnet/python/mxnet/gluon/nn/basic_layers.py:docstring of mxnet.gluon.nn.Sequential.hybridize:1: WARNING: Inline interpreted text or phrase reference start-string without end-string.
incubator-mxnet/python/mxnet/gluon/loss.py:docstring of mxnet.gluon.loss.LogisticLoss:8: ERROR: Unexpected indentation.
incubator-mxnet/python/mxnet/test_utils.py:docstring of mxnet.test_utils.check_numeric_gradient:13: WARNING: Bullet list ends without a blank line; unexpected unindent.
```