### PR TITLE
[MXNET-1215] Allow dynamic shape exists in imperative mode

### DIFF
--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -109,7 +109,7 @@ class NDArray {
    * \param ctx context of NDArray
    * \param dtype data type of this ndarray
    */
-  NDArray(Context ctx, int dtype = mshadow::default_type_flag) {
+  explicit NDArray(Context ctx, int dtype = mshadow::default_type_flag) {
     ptr_ = std::make_shared<Chunk>(TShape(mshadow::Shape1(0)), ctx, true, dtype);
     dtype_ = dtype;
     storage_type_ = kDefaultStorage;
@@ -984,7 +984,7 @@ class NDArray {
 #endif
       }
     }
-    /*! \brief initialize the shape and dtype for this Chunk, assuming it is not initialized before. */
+    /*! \brief initialize the shape and dtype, assuming it is not initialized before. */
     void Init(const TShape &shape, int dtype) {
       auto size = shape.Size();
       storage_shape = shape;

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -103,7 +103,18 @@ class NDArray {
           bool delay_alloc = true, int dtype = mshadow::default_type_flag,
           std::vector<int> aux_types = {}, std::vector<TShape> aux_shapes = {},
           TShape storage_shape = TShape(mshadow::Shape1(0)));
-
+  /*!
+   * \brief constructs a new dynamic NDArray whose shape is unknown,
+   *        hence the NDArray is inherently lazily created
+   * \param ctx context of NDArray
+   * \param dtype data type of this ndarray
+   */
+  NDArray(Context ctx, int dtype = mshadow::default_type_flag) {
+    ptr_ = std::make_shared<Chunk>(TShape(mshadow::Shape1(0)), ctx, true, dtype);
+    dtype_ = dtype;
+    storage_type_ = kDefaultStorage;
+    entry_ = {nullptr, 0, 0};
+  }
   /*!
    * \brief constructing a static NDArray that shares data with TBlob
    *  Use with caution: allocate ONLY ONE NDArray for each TBlob,
@@ -157,7 +168,20 @@ class NDArray {
       : ptr_(std::make_shared<Chunk>(stype, data, aux_data, dev_id)), shape_(shape),
         dtype_(data.type_flag_), storage_type_(stype), entry_({nullptr, 0, 0}) {
   }
-
+  /*!
+   * \brief initialize the NDArray, assuming it is not assigned a meaningful shape before
+   * \param shape the shape of the NDArray
+   */
+  void Init(const TShape &shape) {
+    ptr_->Init(shape, this->dtype_);
+    this->shape_ = shape;
+  }
+  /*!
+   * \brief set the correct shape of NDArray directly from the storage_shape of its own chunk.
+   */
+  void SetShapeFromChunk() {
+    shape_ = ptr_->storage_shape;
+  }
   /*
    * This indicates whether an array is a view of another array (created by
    * reshape or slice). If an array is a view and the the data is stored in
@@ -960,7 +984,13 @@ class NDArray {
 #endif
       }
     }
-
+    /*! \brief initialize the shape and dtype for this Chunk, assuming it is not initialized before. */
+    void Init(const TShape &shape, int dtype) {
+      auto size = shape.Size();
+      storage_shape = shape;
+      shandle.size = size * mshadow::mshadow_sizeof(dtype);
+      this->CheckAndAlloc();
+    }
     inline void CheckAndAlloc(const TShape &shape, const std::vector<TShape> &aux_shapes,
                               int dtype) {
       // calculate size, perform allocation

--- a/src/imperative/imperative.cc
+++ b/src/imperative/imperative.cc
@@ -114,7 +114,6 @@ OpStatePtr Imperative::Invoke(
       outputs[i]->WaitToRead();
       outputs[i]->SetShapeFromChunk();
     }
-    CHECK(outputs[i]->shape().ndim());
   }
   return ret;
 }

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -117,14 +117,13 @@ inline void SetShapeType(const Context& ctx,
   for (auto& i : outputs) {
     out_shapes.push_back(i->shape());
   }
-  const bool dynamic_shape_exists = [&]() {
-    if (!infershape.count(attrs.op)) {
-      return true;
-    }
+  bool is_dynamic_shape_existing = false;
+  if (!infershape.count(attrs.op)) {
+    is_dynamic_shape_existing = true;
+  } else {
     CHECK(infershape[attrs.op](attrs, &in_shapes, &out_shapes));
     CHECK_EQ(out_shapes.size(), outputs.size());
-    return false;
-  }();
+  }
   // infer type
   std::vector<int>& in_types = ret->arg_types;
   in_types.clear();
@@ -181,7 +180,7 @@ inline void SetShapeType(const Context& ctx,
   for (size_t i = 0; i < outputs.size(); ++i) {
     NDArrayStorageType storage_type = static_cast<NDArrayStorageType>(out_storage_types[i]);
     if (outputs[i]->is_none()) {
-      if (dynamic_shape_exists) {
+      if (is_dynamic_shape_existing) {
         // once there is dynamic shape somewhere, we could not pre-determine the shape.
         *outputs[i] = NDArray(ctx, out_types[i]);
       } else if (storage_type == kDefaultStorage) {

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -117,11 +117,14 @@ inline void SetShapeType(const Context& ctx,
   for (auto& i : outputs) {
     out_shapes.push_back(i->shape());
   }
-  CHECK(infershape.count(attrs.op))
-    << "Operator " << attrs.op->name << " is missing FInferShape attribute";
-  CHECK(infershape[attrs.op](attrs, &in_shapes, &out_shapes));
-  CHECK_EQ(out_shapes.size(), outputs.size());
-
+  const bool dynamic_shape_exists = [&]() {
+    if (!infershape.count(attrs.op)) {
+      return true;
+    }
+    CHECK(infershape[attrs.op](attrs, &in_shapes, &out_shapes));
+    CHECK_EQ(out_shapes.size(), outputs.size());
+    return false;
+  }();
   // infer type
   std::vector<int>& in_types = ret->arg_types;
   in_types.clear();
@@ -178,7 +181,10 @@ inline void SetShapeType(const Context& ctx,
   for (size_t i = 0; i < outputs.size(); ++i) {
     NDArrayStorageType storage_type = static_cast<NDArrayStorageType>(out_storage_types[i]);
     if (outputs[i]->is_none()) {
-      if (storage_type == kDefaultStorage) {
+      if (dynamic_shape_exists) {
+        // once there is dynamic shape somewhere, we could not pre-determine the shape.
+        *outputs[i] = NDArray(ctx, out_types[i]);
+      } else if (storage_type == kDefaultStorage) {
         *outputs[i] = NDArray(out_shapes[i], ctx, true, out_types[i]);
       } else {
         *outputs[i] = NDArray(storage_type, out_shapes[i], ctx, true, out_types[i]);

--- a/src/operator/contrib/boolean_mask-inl.h
+++ b/src/operator/contrib/boolean_mask-inl.h
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file boolean_mask-inl.h
+*/
+
+#ifndef MXNET_OPERATOR_CONTRIB_BOOLEAN_MASK_INL_H_
+#define MXNET_OPERATOR_CONTRIB_BOOLEAN_MASK_INL_H_
+
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include <mxnet/ndarray.h>
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+#include "../operator_common.h"
+#include "../mxnet_op.h"
+#include "../mshadow_op.h"
+
+namespace mxnet {
+namespace op {
+
+struct BooleanMaskParam : public dmlc::Parameter<BooleanMaskParam> {
+  int axis;
+  DMLC_DECLARE_PARAMETER(BooleanMaskParam) {
+    DMLC_DECLARE_FIELD(axis).set_default(0)
+    .describe("An integer that represents the axis in NDArray to mask from.");
+  }
+};
+
+template <typename xpu>
+inline void BooleanMaskForward(const nnvm::NodeAttrs& attrs,
+                               const OpContext &ctx,
+                               const std::vector<NDArray> &inputs,
+                               const std::vector<OpReqType> &req,
+                               const std::vector<NDArray> &outputs) {
+  CHECK_EQ(inputs.size(), 2U);
+  CHECK_EQ(outputs.size(), 1U);
+  const BooleanMaskParam& param = nnvm::get<BooleanMaskParam>(attrs.parsed);
+  CHECK_EQ(param.axis, 0);
+  CHECK_EQ(inputs[0].shape()[param.axis], inputs[1].shape()[0]);
+  CHECK_EQ(inputs[1].shape().ndim(), 1U);
+  size_t valid_num = 0;
+  const TBlob &idx = inputs[1].data();
+  MSHADOW_TYPE_SWITCH(inputs[1].dtype(), DType, {
+    for (int i = 0; i < inputs[1].shape()[0]; i++) {
+      if (idx.dptr<DType>()[i])
+        valid_num++;
+    }
+  });
+  TShape s = inputs[0].shape();
+  s[0] = valid_num;
+  const_cast<NDArray &>(outputs[0]).Init(s);
+  size_t j = 0;
+  size_t ele_size = mshadow::mshadow_sizeof(inputs[0].dtype());
+  MSHADOW_TYPE_SWITCH(inputs[1].dtype(), DType, {
+  for (int i = 0; i < inputs[1].shape()[0]; i++) {
+    if (idx.dptr<DType>()[i]) {
+      NDArray src = inputs[0].At(i);
+      NDArray dst = outputs[0].At(j);
+      CHECK(src.shape() == dst.shape());
+      memcpy(dst.data().dptr_, src.data().dptr_, src.shape().Size() * ele_size);
+      j++;
+    }
+  }
+  });
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_CONTRIB_BOOLEAN_MASK_INL_H_

--- a/src/operator/contrib/boolean_mask-inl.h
+++ b/src/operator/contrib/boolean_mask-inl.h
@@ -112,7 +112,10 @@ inline void BooleanMaskBackward(const nnvm::NodeAttrs& attrs,
     int length = idx.shape()[0];
     mshadow::Stream<cpu> *stream = ctx.get_stream<cpu>();
     MSHADOW_TYPE_SWITCH(igrad_data.dtype(), igrad_data_DType, {
-      mxnet_op::Kernel<mxnet_op::set_zero, cpu>::Launch(stream, igrad_data.data().Size(), igrad_data.data().dptr<igrad_data_DType>());
+      mxnet_op::Kernel<mxnet_op::set_zero, cpu>::Launch(
+        stream,
+        igrad_data.data().Size(),
+        igrad_data.data().dptr<igrad_data_DType>());
     });
     for (int i = 0, j = 0; i < length; ++i) {
       if (idx_dptr[i]) {

--- a/src/operator/contrib/boolean_mask-inl.h
+++ b/src/operator/contrib/boolean_mask-inl.h
@@ -49,6 +49,7 @@ struct BooleanMaskParam : public dmlc::Parameter<BooleanMaskParam> {
   }
 };
 
+template<typename xpu>
 inline void BooleanMaskForward(const nnvm::NodeAttrs& attrs,
                                const OpContext &ctx,
                                const std::vector<NDArray> &inputs,
@@ -83,7 +84,7 @@ inline void BooleanMaskForward(const nnvm::NodeAttrs& attrs,
   MSHADOW_TYPE_SWITCH(idx.dtype(), DType, {
     DType* idx_dptr = idx.data().dptr<DType>();
     int length = idx.shape()[0];
-    mshadow::Stream<cpu> *stream = ctx.get_stream<cpu>();
+    mshadow::Stream<xpu> *stream = ctx.get_stream<xpu>();
     for (int i = 0, j = 0; i < length; ++i) {
       if (idx_dptr[i]) {
         NDArray src = data.At(i);
@@ -95,6 +96,7 @@ inline void BooleanMaskForward(const nnvm::NodeAttrs& attrs,
   });
 }
 
+template<typename xpu>
 inline void BooleanMaskBackward(const nnvm::NodeAttrs& attrs,
                                 const OpContext &ctx,
                                 const std::vector<NDArray> &inputs,
@@ -110,9 +112,9 @@ inline void BooleanMaskBackward(const nnvm::NodeAttrs& attrs,
   MSHADOW_TYPE_SWITCH(idx.dtype(), DType, {
     DType* idx_dptr = idx.data().dptr<DType>();
     int length = idx.shape()[0];
-    mshadow::Stream<cpu> *stream = ctx.get_stream<cpu>();
+    mshadow::Stream<xpu> *stream = ctx.get_stream<xpu>();
     MSHADOW_TYPE_SWITCH(igrad_data.dtype(), igrad_data_DType, {
-      mxnet_op::Kernel<mxnet_op::set_zero, cpu>::Launch(
+      mxnet_op::Kernel<mxnet_op::set_zero, xpu>::Launch(
         stream,
         igrad_data.data().Size(),
         igrad_data.data().dptr<igrad_data_DType>());

--- a/src/operator/contrib/boolean_mask.cc
+++ b/src/operator/contrib/boolean_mask.cc
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*!
+ * Copyright (c) 2018 by Contributors
+ * \file boolean_mask.cc
+*/
+
+#include "./boolean_mask-inl.h"
+
+namespace mxnet {
+namespace op {
+
+DMLC_REGISTER_PARAMETER(BooleanMaskParam);
+
+bool BooleanMaskStorageType(const nnvm::NodeAttrs& attrs,
+                            const int dev_mask,
+                            DispatchMode* dispatch_mode,
+                            std::vector<int> *in_attrs,
+                            std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 2);
+  CHECK_EQ(out_attrs->size(), 1);
+  for (size_t i = 0; i < out_attrs->size(); i++)
+    out_attrs->at(i) = kDefaultStorage;
+  *dispatch_mode = DispatchMode::kFComputeEx;
+  return true;
+}
+
+NNVM_REGISTER_OP(_contrib_BooleanMask)
+.describe(R"code(
+)code" ADD_FILELINE)
+.set_attr_parser(ParamParser<BooleanMaskParam>)
+.set_num_inputs(2)
+.set_num_outputs(1)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskForward<cpu>)
+.set_attr<FInferStorageType>("FInferStorageType", BooleanMaskStorageType)
+//.set_attr<nnvm::FGradient>("FGradient",
+//  ElemwiseGradUseNone{"_backward_contrib_BooleanMask"})
+.add_argument("data", "NDArray-or-Symbol", "Data")
+.add_argument("index", "NDArray-or-Symbol", "Mask")
+.add_arguments(BooleanMaskParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/contrib/boolean_mask.cc
+++ b/src/operator/contrib/boolean_mask.cc
@@ -46,8 +46,12 @@ bool BooleanMaskStorageType(const nnvm::NodeAttrs& attrs,
                             std::vector<int> *out_attrs) {
   CHECK_EQ(in_attrs->size(), 2);
   CHECK_EQ(out_attrs->size(), 1);
-  for (size_t i = 0; i < out_attrs->size(); i++)
-    out_attrs->at(i) = kDefaultStorage;
+  for (int &attr : *in_attrs) {
+    CHECK_EQ(attr, kDefaultStorage) << "Only default storage is supported";
+  }
+  for (int &attr : *out_attrs) {
+    attr = kDefaultStorage;
+  }
   *dispatch_mode = DispatchMode::kFComputeEx;
   return true;
 }
@@ -59,19 +63,33 @@ bool BooleanMaskBackStorageType(const nnvm::NodeAttrs& attrs,
                                 std::vector<int> *out_attrs) {
   CHECK_EQ(in_attrs->size(), 3);
   CHECK_EQ(out_attrs->size(), 2);
+  for (int &attr : *in_attrs) {
+    CHECK_EQ(attr, kDefaultStorage) << "Only default storage is supported";
+  }
+  for (int &attr : *out_attrs) {
+    attr = kDefaultStorage;
+  }
   for (size_t i = 0; i < out_attrs->size(); i++)
     out_attrs->at(i) = kDefaultStorage;
   *dispatch_mode = DispatchMode::kFComputeEx;
   return true;
 }
 
-// TODO(@junrushao1994): update the docstring after the PR is almost done.
 NNVM_REGISTER_OP(_contrib_boolean_mask)
 .describe(R"code(
 Experimental CPU-only support for boolean masking.
-Given an NDArray x, and a 1-d NDArray index,
-the operator produces an un-predeterminable shaped 2-d NDArray y,
+Given an n-d NDArray x, and a 1-d NDArray index,
+the operator produces an un-predeterminable shaped n-d NDArray y,
 which stands for the rows in x where the corresonding element in index is non-zero.
+
+>>> x = mx.nd.array([[1, 2, 3],[4, 5, 6],[7, 8, 9]])
+>>> index = mx.nd.array([0, 1, 0])
+>>> y = mx.nd.contrib.boolean_mask(data, index)
+>>> y
+
+[[4. 5. 6.]]
+<NDArray 1x3 @cpu(0)>
+
 )code" ADD_FILELINE)
 .set_attr_parser(ParamParser<BooleanMaskParam>)
 .set_num_inputs(2)

--- a/src/operator/contrib/boolean_mask.cc
+++ b/src/operator/contrib/boolean_mask.cc
@@ -54,8 +54,16 @@ which stands for the rows in x where the corresonding element in index is non-ze
 .set_num_outputs(1)
 .set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskForward)
 .set_attr<FInferStorageType>("FInferStorageType", BooleanMaskStorageType)
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_contrib_BooleanMask"})
 .add_argument("data", "NDArray-or-Symbol", "Data")
 .add_argument("index", "NDArray-or-Symbol", "Mask")
+.add_arguments(BooleanMaskParam::__FIELDS__());
+
+NNVM_REGISTER_OP(_backward_contrib_BooleanMask)
+.set_num_inputs(3)
+.set_num_outputs(2)
+.set_attr<nnvm::TIsBackward>("TIsBackward", true)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskBackward)
 .add_arguments(BooleanMaskParam::__FIELDS__());
 
 }  // namespace op

--- a/src/operator/contrib/boolean_mask.cc
+++ b/src/operator/contrib/boolean_mask.cc
@@ -28,6 +28,17 @@ namespace op {
 
 DMLC_REGISTER_PARAMETER(BooleanMaskParam);
 
+
+bool BooleanMaskType(const nnvm::NodeAttrs& attrs,
+                     std::vector<int> *in_attrs,
+                     std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 2);
+  CHECK_EQ(out_attrs->size(), 1);
+  TYPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
+  TYPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
+  return out_attrs->at(0) != -1;
+}
+
 bool BooleanMaskStorageType(const nnvm::NodeAttrs& attrs,
                             const int dev_mask,
                             DispatchMode* dispatch_mode,
@@ -65,7 +76,8 @@ which stands for the rows in x where the corresonding element in index is non-ze
 .set_attr_parser(ParamParser<BooleanMaskParam>)
 .set_num_inputs(2)
 .set_num_outputs(1)
-.set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskForward)
+.set_attr<nnvm::FInferType>("FInferType", BooleanMaskType)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskForward<cpu>)
 .set_attr<FInferStorageType>("FInferStorageType", BooleanMaskStorageType)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_contrib_boolean_mask"})
 .add_argument("data", "NDArray-or-Symbol", "Data")
@@ -77,7 +89,7 @@ NNVM_REGISTER_OP(_backward_contrib_boolean_mask)
 .set_num_outputs(2)
 .set_attr<nnvm::TIsBackward>("TIsBackward", true)
 .set_attr<FInferStorageType>("FInferStorageType", BooleanMaskBackStorageType)
-.set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskBackward)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskBackward<cpu>)
 .add_arguments(BooleanMaskParam::__FIELDS__());
 
 }  // namespace op

--- a/src/operator/contrib/boolean_mask.cc
+++ b/src/operator/contrib/boolean_mask.cc
@@ -41,8 +41,21 @@ bool BooleanMaskStorageType(const nnvm::NodeAttrs& attrs,
   return true;
 }
 
+bool BooleanMaskBackStorageType(const nnvm::NodeAttrs& attrs,
+                                const int dev_mask,
+                                DispatchMode* dispatch_mode,
+                                std::vector<int> *in_attrs,
+                                std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 3);
+  CHECK_EQ(out_attrs->size(), 2);
+  for (size_t i = 0; i < out_attrs->size(); i++)
+    out_attrs->at(i) = kDefaultStorage;
+  *dispatch_mode = DispatchMode::kFComputeEx;
+  return true;
+}
+
 // TODO(@junrushao1994): update the docstring after the PR is almost done.
-NNVM_REGISTER_OP(_contrib_BooleanMask)
+NNVM_REGISTER_OP(_contrib_boolean_mask)
 .describe(R"code(
 Experimental CPU-only support for boolean masking.
 Given an NDArray x, and a 1-d NDArray index,
@@ -54,15 +67,16 @@ which stands for the rows in x where the corresonding element in index is non-ze
 .set_num_outputs(1)
 .set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskForward)
 .set_attr<FInferStorageType>("FInferStorageType", BooleanMaskStorageType)
-.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_contrib_BooleanMask"})
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_contrib_boolean_mask"})
 .add_argument("data", "NDArray-or-Symbol", "Data")
 .add_argument("index", "NDArray-or-Symbol", "Mask")
 .add_arguments(BooleanMaskParam::__FIELDS__());
 
-NNVM_REGISTER_OP(_backward_contrib_BooleanMask)
+NNVM_REGISTER_OP(_backward_contrib_boolean_mask)
 .set_num_inputs(3)
 .set_num_outputs(2)
 .set_attr<nnvm::TIsBackward>("TIsBackward", true)
+.set_attr<FInferStorageType>("FInferStorageType", BooleanMaskBackStorageType)
 .set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskBackward)
 .add_arguments(BooleanMaskParam::__FIELDS__());
 

--- a/src/operator/contrib/boolean_mask.cc
+++ b/src/operator/contrib/boolean_mask.cc
@@ -78,14 +78,14 @@ bool BooleanMaskBackStorageType(const nnvm::NodeAttrs& attrs,
 NNVM_REGISTER_OP(_contrib_boolean_mask)
 .describe(R"code(
 Experimental CPU-only support for boolean masking.
-Given an n-d NDArray x, and a 1-d NDArray index,
-the operator produces an un-predeterminable shaped n-d NDArray y,
+Given an n-d NDArray data, and a 1-d NDArray index,
+the operator produces an un-predeterminable shaped n-d NDArray out,
 which stands for the rows in x where the corresonding element in index is non-zero.
 
->>> x = mx.nd.array([[1, 2, 3],[4, 5, 6],[7, 8, 9]])
+>>> data = mx.nd.array([[1, 2, 3],[4, 5, 6],[7, 8, 9]])
 >>> index = mx.nd.array([0, 1, 0])
->>> y = mx.nd.contrib.boolean_mask(data, index)
->>> y
+>>> out = mx.nd.contrib.boolean_mask(data, index)
+>>> out
 
 [[4. 5. 6.]]
 <NDArray 1x3 @cpu(0)>

--- a/src/operator/contrib/boolean_mask.cc
+++ b/src/operator/contrib/boolean_mask.cc
@@ -41,16 +41,19 @@ bool BooleanMaskStorageType(const nnvm::NodeAttrs& attrs,
   return true;
 }
 
+// TODO(@junrushao1994): update the docstring after the PR is almost done.
 NNVM_REGISTER_OP(_contrib_BooleanMask)
 .describe(R"code(
+Experimental CPU-only support for boolean masking.
+Given an NDArray x, and a 1-d NDArray index,
+the operator produces an un-predeterminable shaped 2-d NDArray y,
+which stands for the rows in x where the corresonding element in index is non-zero.
 )code" ADD_FILELINE)
 .set_attr_parser(ParamParser<BooleanMaskParam>)
 .set_num_inputs(2)
 .set_num_outputs(1)
-.set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskForward<cpu>)
+.set_attr<FComputeEx>("FComputeEx<cpu>", BooleanMaskForward)
 .set_attr<FInferStorageType>("FInferStorageType", BooleanMaskStorageType)
-//.set_attr<nnvm::FGradient>("FGradient",
-//  ElemwiseGradUseNone{"_backward_contrib_BooleanMask"})
 .add_argument("data", "NDArray-or-Symbol", "Data")
 .add_argument("index", "NDArray-or-Symbol", "Mask")
 .add_arguments(BooleanMaskParam::__FIELDS__());

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4795,6 +4795,8 @@ def test_index_copy():
 
 @with_seed()
 def test_boolean_mask():
+    if default_context().device_type != 'cpu':
+        return
     data = mx.nd.array([[1, 2, 3],[4, 5, 6],[7, 8, 9]])
     index = mx.nd.array([0, 1, 0])
     data.attach_grad()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -4792,6 +4792,22 @@ def test_index_copy():
     assert same(t.grad.asnumpy(), t_grad.asnumpy())
     assert same(index.grad.asnumpy(), index_grad.asnumpy())
 
+
+@with_seed()
+def test_boolean_mask():
+    data = mx.nd.array([[1, 2, 3],[4, 5, 6],[7, 8, 9]])
+    index = mx.nd.array([0, 1, 0])
+    data.attach_grad()
+    with mx.autograd.record():
+        out = mx.nd.contrib.boolean_mask(data, index)
+    out.backward()
+    data.grad.wait_to_read()
+    expected = np.array([[4, 5, 6]])
+    expected_grad = np.array([[0, 0, 0], [1, 1, 1], [0, 0, 0]])
+    assert same(out.asnumpy(), expected)
+    assert same(data.grad.asnumpy(), expected_grad)
+
+
 @with_seed()
 def test_div_sqrt_dim():
     data_tmp = np.random.normal(0, 1, (5, 10, 8))


### PR DESCRIPTION
## Description ##
It is the PR I took over from @zheng-da at #12400. All credits go to Da Zheng.

This PR relaxes the constraint on NDArrays that shape used to be pre-determined. For unittesting, this PR introduces an operator called `BooleanMask` in contrib, which is a practical use case that actually produces dynamic shape. Note that the support for boolean mask is very experimental, which only allows 2-d inputs, and 1-d mask, because it serves only the functionality of testing. We could improve its better in future PRs. 

This is an initial step for the roadmap #12732.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Introducing new methods in NDArray allowing delayed assignment of their shapes.
- [x] Introducing boolean mask operator, which we believe will be useful in the future.
- [x] Add unit test.

## Comments ##
No comments.

## TODO ##
- [x] Refactor the boolean index operator
- [x] Write backward pass of the boolean index operator
- [x] Test coverage
