### PR TITLE
Force APT cache update before executing install

### DIFF
--- a/ci/docker/install/ubuntu_caffe.sh
+++ b/ci/docker/install/ubuntu_caffe.sh
@@ -18,6 +18,7 @@
 # under the License.
 set -ex
 
+apt-get update || true
 apt-get install -y \
     libgflags-dev \
     libgoogle-glog-dev \

--- a/ci/docker/install/ubuntu_clang.sh
+++ b/ci/docker/install/ubuntu_clang.sh
@@ -21,6 +21,8 @@
 # the whole docker cache for the image
 
 set -ex
+
+apt-get update || true
 # Install clang 3.9 (the same version as in XCode 8.*) and 6.0 (latest major release)
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" && \

--- a/ci/docker/install/ubuntu_core.sh
+++ b/ci/docker/install/ubuntu_core.sh
@@ -21,7 +21,7 @@
 # the whole docker cache for the image
 
 set -ex
-apt-get update
+apt-get update || true
 apt-get install -y \
     apt-transport-https \
     build-essential \

--- a/ci/docker/install/ubuntu_docs.sh
+++ b/ci/docker/install/ubuntu_docs.sh
@@ -23,6 +23,7 @@
 set -ex
 # Install dependencies
 echo 'Installing dependencies...'
+apt-get update || true
 apt-get install -y \
     doxygen \
     pandoc

--- a/ci/docker/install/ubuntu_emscripten.sh
+++ b/ci/docker/install/ubuntu_emscripten.sh
@@ -25,6 +25,7 @@
 
 set -ex
 
+apt-get update || true
 apt-get -y install nodejs
 
 git clone -b 1.38.6 https://github.com/kripken/emscripten.git

--- a/ci/docker/install/ubuntu_gcc8.sh
+++ b/ci/docker/install/ubuntu_gcc8.sh
@@ -19,5 +19,5 @@
 
 sudo add-apt-repository ppa:jonathonf/gcc-8.0
 sudo add-apt-repository ppa:jonathonf/gcc-7.3
-sudo apt-get update
+sudo apt-get update || true
 sudo apt-get install -y gcc-8 g++-8

--- a/ci/docker/install/ubuntu_llvm.sh
+++ b/ci/docker/install/ubuntu_llvm.sh
@@ -23,4 +23,5 @@ echo deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main\
      >> /etc/apt/sources.list.d/llvm.list
 
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-apt-get update && apt-get install -y --force-yes llvm-5.0
+apt-get update || true
+apt-get install -y --force-yes llvm-5.0

--- a/ci/docker/install/ubuntu_nightly_tests.sh
+++ b/ci/docker/install/ubuntu_nightly_tests.sh
@@ -25,7 +25,7 @@ set -ex
 # Adding ppas frequently fails due to busy gpg servers, retry 5 times with 5 minute delays.
 for i in 1 2 3 4 5; do add-apt-repository -y ppa:ubuntu-toolchain-r/test && break || sleep 300; done
 
-apt-get update
+apt-get update || true
 apt-get -y install time
 
 # Install for RAT License Check Nightly Test

--- a/ci/docker/install/ubuntu_npm_blc.sh
+++ b/ci/docker/install/ubuntu_npm_blc.sh
@@ -22,7 +22,7 @@
 
 set -ex
 echo 'Installing npm...'
-apt-get update
+apt-get update || true
 apt-get install -y npm
 
 echo "Obtaining NodeJS version 8.x"

--- a/ci/docker/install/ubuntu_nvidia.sh
+++ b/ci/docker/install/ubuntu_nvidia.sh
@@ -18,6 +18,7 @@
 # under the License.
 
 set -ex
+apt-get update || true
 apt install -y software-properties-common
 
 # Adding ppas frequently fails due to busy gpg servers, retry 5 times with 5 minute delays.

--- a/ci/docker/install/ubuntu_onnx.sh
+++ b/ci/docker/install/ubuntu_onnx.sh
@@ -27,6 +27,7 @@ set -e
 set -x
 
 echo "Installing libprotobuf-dev and protobuf-compiler ..."
+apt-get update || true
 apt-get install -y libprotobuf-dev protobuf-compiler
 
 echo "Installing pytest, pytest-cov, protobuf, Pillow, ONNX and tabulate ..."

--- a/ci/docker/install/ubuntu_perl.sh
+++ b/ci/docker/install/ubuntu_perl.sh
@@ -22,5 +22,6 @@
 
 set -ex
 # install libraries for mxnet's perl package on ubuntu
+apt-get update || true
 apt-get install -y libmouse-perl pdl cpanminus swig libgraphviz-perl
 cpanm -q Function::Parameters Hash::Ordered PDL::CCS

--- a/ci/docker/install/ubuntu_python.sh
+++ b/ci/docker/install/ubuntu_python.sh
@@ -22,6 +22,7 @@
 
 set -ex
 # install libraries for mxnet's python package on ubuntu
+apt-get update || true
 apt-get install -y python-dev python3-dev virtualenv wget
 
 # the version of the pip shipped with ubuntu may be too lower, install a recent version here

--- a/ci/docker/install/ubuntu_r.sh
+++ b/ci/docker/install/ubuntu_r.sh
@@ -34,7 +34,7 @@ apt-key add r.gpg
 # Installing the latest version (3.3+) that is compatible with MXNet
 add-apt-repository 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu xenial/'
 
-apt-get update
+apt-get update || true
 apt-get install -y --allow-unauthenticated \
     libcairo2-dev \
     libssl-dev \

--- a/ci/docker/install/ubuntu_rat.sh
+++ b/ci/docker/install/ubuntu_rat.sh
@@ -20,7 +20,7 @@
 set -ex
 
 echo "Install dependencies"
-apt-get update
+apt-get update || true
 apt-get install -y subversion maven openjdk-8-jdk openjdk-8-jre
 
 echo "download RAT"

--- a/ci/docker/install/ubuntu_scala.sh
+++ b/ci/docker/install/ubuntu_scala.sh
@@ -24,8 +24,9 @@ set -ex
 cd "$(dirname "$0")"
 # install libraries for mxnet's scala package on ubuntu
 echo 'Installing Scala...'
+apt-get update || true
 apt-get install -y software-properties-common
-apt-get update
+apt-get update || true
 apt-get install -y openjdk-8-jdk
 apt-get install -y openjdk-8-jre
 
@@ -34,7 +35,8 @@ echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/
 #apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
 #apt-key adv --keyserver keys.gnupg.net --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
 apt-key add sbt.gpg
-apt-get update && apt-get install -y \
+apt-get update || true
+apt-get install -y \
     maven \
     sbt \
     scala

--- a/ci/docker/install/ubuntu_tutorials.sh
+++ b/ci/docker/install/ubuntu_tutorials.sh
@@ -21,6 +21,7 @@
 # the whole docker cache for the image
 
 set -ex
+apt-get update || true
 apt-get install graphviz python-opencv
 pip2 install jupyter matplotlib Pillow opencv-python scikit-learn graphviz tqdm
 pip3 install jupyter matplotlib Pillow opencv-python scikit-learn graphviz tqdm


### PR DESCRIPTION
Within our Docker caching, the APT cache is being persisted as well. Due to the inconsistent use of ``apt update``, this might lead to the Docker cache being refreshed partially while still using a stale APT cache.

By running ``apt update`` before every ``apt install``, we ensure the repository is always in the latest state if that layer has to be refreshed.

the ``|| true`` is added due to stability reasons. APT is not 100% available and we had problems because of that. By swallowing that error, we increase the tolerance. If the package is **really** missing during the installation stage (because it's not in the APT cache and updating the cache failed due to server errors), we will throw the error anyway. If we still have a good cache with the proper package present even though the update failed, this means that the update wasn't actually necessary and that we can still proceed. We already employed this mechanism in some places. Now we're making everything equal to harden all install scripts.