### PR TITLE
[MXNET-1083] Add the example to demonstrate the inference workflow using C++ API

### DIFF
--- a/cpp-package/example/inference/Makefile
+++ b/cpp-package/example/inference/Makefile
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+prebuild :
+	$(shell cp -r ../../../lib ./)
+	$(shell wget -nc -O mean_224.nd https://github.com/dmlc/web-data/raw/master/mxnet/example/feature_extract/mean_224.nd)
+CPPEX_SRC = $(wildcard *.cpp)
+CPPEX_EXE = $(patsubst %.cpp, %, $(CPPEX_SRC))
+OPENCV_CFLAGS=`pkg-config --cflags opencv`
+OPENCV_LDFLAGS=`pkg-config --libs opencv`
+
+CXX=g++
+
+
+CFLAGS=$(COMMFLAGS) -I../../../3rdparty/tvm/nnvm/include -I../../../3rdparty/dmlc-core/include -I ../../include -I ../../../include -Wall -O3 -msse3 -funroll-loops -Wno-unused-parameter -Wno-unknown-pragmas
+CPPEX_EXTRA_LDFLAGS := -L../../../lib -lmxnet $(OPENCV_LDFLAGS)
+
+all: prebuild  $(CPPEX_EXE)
+
+debug: CPPEX_CFLAGS += -DDEBUG -g
+debug: prebuild all
+
+
+$(CPPEX_EXE):% : %.cpp
+	$(CXX) -std=c++0x $(CFLAGS)  $(CPPEX_CFLAGS) -o $@ $(filter %.cpp %.a, $^) $(CPPEX_EXTRA_LDFLAGS)
+
+clean:
+	rm -f $(CPPEX_EXE)

--- a/cpp-package/example/inference/inception_inference.cpp
+++ b/cpp-package/example/inference/inception_inference.cpp
@@ -1,0 +1,456 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * This example demonstrates image classification workflow with pre-trained models using MXNet C++ API.
+ * The example performs following tasks.
+ * 1. Load the pre-trained model,
+ * 2. Load the parameters of pre-trained model,
+ * 3. Load the image to be classified  in to NDArray.
+ * 4. Normalize the image using the mean of images that were used for training.
+ * 5. Run the forward pass and predict the input image.
+ */
+
+#include <iostream>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+#include "mxnet-cpp/MxNetCpp.h"
+#include <opencv2/opencv.hpp>
+using namespace std;
+using namespace mxnet::cpp;
+
+
+/*
+ * class Predictor
+ *
+ * This class encapsulates the functionality to load the model, process input image and run the forward pass.
+ */
+
+class Predictor {
+ public:
+    Predictor() {}
+<<<<<<< HEAD
+    Predictor(const std::string& model_json,
+              const std::string& model_params,
+=======
+    Predictor(const std::string model_json,
+              const std::string model_params,
+>>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
+              const Shape& input_shape,
+              bool gpu_context_type = false,
+              const std::string& synset_file = "",
+              const std::string& mean_image_file = "");
+    void PredictImage(const std::string& image_file);
+    ~Predictor();
+
+ private:
+    void LoadModel(const std::string& model_json_file);
+    void LoadParameters(const std::string& model_parameters_file);
+    void LoadSynset(const std::string& synset_file);
+<<<<<<< HEAD
+    NDArray LoadInputImage(const std::string& image_file);
+    void LoadMeanImageData();
+=======
+    void LoadInputImage(const std::string& image_file);
+>>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
+    void NormalizeInput(const std::string& mean_image_file);
+
+    NDArray mean_img;
+    map<string, NDArray> args_map;
+    map<string, NDArray> aux_map;
+    std::vector<std::string> output_labels;
+    Symbol net;
+    Executor *executor;
+    Shape input_shape;
+<<<<<<< HEAD
+    NDArray mean_image_data;
+=======
+    NDArray image_data;
+>>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
+    Context global_ctx = Context::cpu();
+    string mean_image_file;
+};
+
+
+/*
+ * The constructor takes following parameters as input:
+ * 1. model_json:  The model in json formatted file.
+ * 2. model_params: File containing model parameters
+ * 3. synset_file: File containing the list of image labels
+ * 4. input_shape: Shape of input data to the model. Since this class will be running one inference at a time,
+ *                 the input shape is required to be in format Shape(1, number_of_channels, height, width)
+ * The input image will be resized to (height x width) size before running the inference.
+ * The constructor will:
+ *  1. Load the model and parameter files.
+ *  2. Load the synset file.
+ *  3. Invoke the SimpleBind to bind the input argument to the model and create an executor.
+ *
+ *  The SimpleBind is expected to be invoked only once.
+ */
+<<<<<<< HEAD
+Predictor::Predictor(const std::string& model_json,
+                     const std::string& model_params,
+=======
+Predictor::Predictor(const std::string model_json,
+                     const std::string model_params,
+>>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
+                     const Shape& input_shape,
+                     bool gpu_context_type,
+                     const std::string& synset_file,
+                     const std::string& mean_image_file):
+                     input_shape(input_shape),
+                     mean_image_file(mean_image_file) {
+  if (gpu_context_type) {
+    global_ctx = Context::gpu();
+  }
+<<<<<<< HEAD
+
+=======
+>>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
+  // Load the model
+  LoadModel(model_json);
+
+  // Load the model parameters.
+  LoadParameters(model_params);
+
+  /*
+   * Load the synset file containing the image labels, if provided.
+   * The data will be used to output the exact label that matches highest output of the model.
+   */
+  if (!synset_file.empty()) {
+    LoadSynset(synset_file);
+  }
+<<<<<<< HEAD
+
+  /*
+   * Load the mean image data if specified.
+   */
+  if (!mean_image_file.empty()) {
+    LoadMeanImageData();
+  }
+
+=======
+>>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
+  // Create an executor after binding the model to input parameters.
+  args_map["data"] = NDArray(input_shape, global_ctx, false);
+  executor = net.SimpleBind(global_ctx, args_map, map<string, NDArray>(),
+                              map<string, OpReqType>(), aux_map);
+}
+
+<<<<<<< HEAD
+
+=======
+>>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
+/*
+ * The following function loads the model from json file.
+ */
+void Predictor::LoadModel(const std::string& model_json_file) {
+  LG << "Loading the model from " << model_json_file << std::endl;
+  net = Symbol::Load(model_json_file);
+}
+
+
+/*
+ * The following function loads the model parameters.
+ */
+void Predictor::LoadParameters(const std::string& model_parameters_file) {
+    LG << "Loading the model parameters from " << model_parameters_file << std::endl;
+    map<string, NDArray> paramters;
+    NDArray::Load(model_parameters_file, 0, &paramters);
+    for (const auto &k : paramters) {
+      if (k.first.substr(0, 4) == "aux:") {
+        auto name = k.first.substr(4, k.first.size() - 4);
+        aux_map[name] = k.second.Copy(global_ctx);
+      }
+      if (k.first.substr(0, 4) == "arg:") {
+        auto name = k.first.substr(4, k.first.size() - 4);
+        args_map[name] = k.second.Copy(global_ctx);
+      }
+    }
+    /*WaitAll is need when we copy data between GPU and the main memory*/
+    NDArray::WaitAll();
+}
+
+
+/*
+ * The following function loads the synset file.
+ * This information will be used later to report the label of input image.
+ */
+void Predictor::LoadSynset(const string& synset_file) {
+  LG << "Loading the synset file.";
+  std::ifstream fi(synset_file.c_str());
+  if (!fi.is_open()) {
+    std::cerr << "Error opening synset file " << synset_file << std::endl;
+    assert(false);
+  }
+  std::string synset, lemma;
+  while (fi >> synset) {
+    getline(fi, lemma);
+    output_labels.push_back(lemma);
+  }
+  fi.close();
+}
+
+
+/*
+<<<<<<< HEAD
+ * The following function loads the mean data from mean image file.
+ * This data will be used for normalizing the image before running the forward
+ * pass.
+ *
+ */
+void Predictor::LoadMeanImageData() {
+  LG << "Load the mean image data that will be used to normalize "
+     << "the image before running forward pass.";
+  mean_image_data = NDArray(input_shape, global_ctx, false);
+  mean_image_data.SyncCopyFromCPU(
+        NDArray::LoadToMap(mean_image_file)["mean_img"].GetData(),
+        input_shape.Size());
+  NDArray::WaitAll();
+}
+
+
+/*
+ * The following function loads the input image.
+ */
+NDArray Predictor::LoadInputImage(const std::string& image_file) {
+=======
+ * The following function loads the input image.
+ */
+void Predictor::LoadInputImage(const std::string& image_file) {
+>>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
+  LG << "Loading the image " << image_file << std::endl;
+  vector<float> array;
+  cv::Mat mat = cv::imread(image_file);
+  /*resize pictures to (224, 224) according to the pretrained model*/
+  int height = input_shape[2];
+  int width = input_shape[3];
+  int channels = input_shape[1];
+  cv::resize(mat, mat, cv::Size(height, width));
+  for (int c = 0; c < channels; ++c) {
+    for (int i = 0; i < height; ++i) {
+      for (int j = 0; j < width; ++j) {
+        array.push_back(static_cast<float>(mat.data[(i * height + j) * 3 + c]));
+      }
+    }
+  }
+<<<<<<< HEAD
+  NDArray image_data = NDArray(input_shape, global_ctx, false);
+  image_data.SyncCopyFromCPU(array.data(), input_shape.Size());
+  NDArray::WaitAll();
+  return image_data;
+=======
+  image_data = NDArray(input_shape, global_ctx, false);
+  image_data.SyncCopyFromCPU(array.data(), input_shape.Size());
+  NDArray::WaitAll();
+}
+
+
+/*
+ * The following function normalizes input image data by substracting the
+ * mean data.
+ */
+void Predictor::NormalizeInput(const std::string& mean_image_file) {
+  LG << "Normalizing image using " << mean_image_file;
+  mean_img = NDArray(input_shape, global_ctx, false);
+  mean_img.SyncCopyFromCPU(
+        NDArray::LoadToMap(mean_image_file)["mean_img"].GetData(),
+        input_shape.Size());
+  NDArray::WaitAll();
+  image_data.Slice(0, 1) -= mean_img;
+  return;
+>>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
+}
+
+
+/*
+ * The following function runs the forward pass on the model.
+ * The executor is created in the constructor.
+ *
+ */
+void Predictor::PredictImage(const std::string& image_file) {
+  // Load the input image
+<<<<<<< HEAD
+  NDArray image_data = LoadInputImage(image_file);
+
+  // Normalize the image
+  if (!mean_image_file.empty()) {
+    image_data.Slice(0, 1) -= mean_image_data;
+=======
+  LoadInputImage(image_file);
+
+  // Normalize the image
+  if (!mean_image_file.empty()) {
+    NormalizeInput(mean_image_file);
+>>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
+  }
+
+  LG << "Running the forward pass on model to predict the image";
+  /*
+   * The executor->arg_arrays represent the arguments to the model.
+   *
+   * Copying the image_data that contains the NDArray of input image
+   * to the arg map of the executor. The input is stored with the key "data" in the map.
+   *
+   */
+  image_data.CopyTo(&(executor->arg_dict()["data"]));
+  NDArray::WaitAll();
+
+  // Run the forward pass.
+  executor->Forward(false);
+
+  // The output is available in executor->outputs.
+  auto array = executor->outputs[0].Copy(global_ctx);
+  NDArray::WaitAll();
+
+  float best_accuracy = 0.0;
+  std::size_t best_idx = 0;
+
+  // Find out the maximum accuracy and the index associated with that accuracy.
+  for (std::size_t i = 0; i < array.Size(); ++i) {
+    if (array.At(0, i) > best_accuracy) {
+      best_accuracy = array.At(0, i);
+      best_idx = i;
+    }
+  }
+
+  if (output_labels.empty()) {
+    LG << "The model predicts the highest accuracy of " << best_accuracy << " at index "
+       << best_idx;
+  } else {
+    LG << "The model predicts the input image to be a [" << output_labels[best_idx]
+       << " ] with Accuracy = " << array.At(0, best_idx) << std::endl;
+  }
+}
+
+
+Predictor::~Predictor() {
+  if (executor) {
+    delete executor;
+  }
+  MXNotifyShutdown();
+}
+
+
+/*
+ * Convert the input string of number of hidden units into the vector of integers.
+ */
+std::vector<index_t> getShapeDimensions(const std::string& hidden_units_string) {
+    std::vector<index_t> dimensions;
+    char *pNext;
+    int num_unit = strtol(hidden_units_string.c_str(), &pNext, 10);
+    dimensions.push_back(num_unit);
+    while (*pNext) {
+        num_unit = strtol(pNext, &pNext, 10);
+        dimensions.push_back(num_unit);
+    }
+    return dimensions;
+}
+
+void printUsage() {
+    std::cout << "Usage:" << std::endl;
+    std::cout << "inception_inference --symbol <model symbol file in json format>  "
+              << "--params <model params file> "
+              << "--image <path to the image used for prediction "
+              << "[--input_shape <dimensions of input image e.g \"3 224 224\"]"
+              << "[--synset file containing labels for prediction] "
+              << "[--mean file containing mean image for normalizing the input image "
+              << "[--gpu]  Specify this option if workflow needs to be run in gpu context "
+              << std::endl;
+}
+
+int main(int argc, char** argv) {
+  string model_file_json;
+  string model_file_params;
+  string synset_file = "";
+  string mean_image = "";
+  string input_image = "";
+  bool gpu_context_type = false;
+
+  std::string input_shape = "3 224 224";
+    int index = 1;
+    while (index < argc) {
+        if (strcmp("--symbol", argv[index]) == 0) {
+            index++;
+            model_file_json = argv[index];
+        } else if (strcmp("--params", argv[index]) == 0) {
+            index++;
+            model_file_params = argv[index];
+        } else if (strcmp("--synset", argv[index]) == 0) {
+            index++;
+            synset_file = argv[index];
+        } else if (strcmp("--mean", argv[index]) == 0) {
+            index++;
+            mean_image = argv[index];
+        } else if (strcmp("--image", argv[index]) == 0) {
+            index++;
+            input_image = argv[index];
+        } else if (strcmp("--input_shape", argv[index]) == 0) {
+            index++;
+            input_shape = argv[index];
+        } else if (strcmp("--gpu", argv[index]) == 0) {
+            gpu_context_type = true;
+        } else if (strcmp("--help", argv[index]) == 0) {
+            printUsage();
+            return 0;
+        }
+        index++;
+    }
+
+  if (model_file_json.empty() || model_file_params.empty()) {
+    LG << "ERROR: Model details such as symbols and/or param files are not specified";
+    printUsage();
+    return 1;
+  }
+
+  if (input_image.empty()) {
+    LG << "ERROR: Path to the input image is not specified.";
+    printUsage();
+    return 1;
+  }
+
+  std::vector<index_t> input_dimensions = getShapeDimensions(input_shape);
+
+  /*
+   * Since we are running inference for 1 image, add 1 to the input_dimensions so that
+   * the shape of input data for the model will be
+   * {no. of images, channels, height, width}
+   */
+  input_dimensions.insert(input_dimensions.begin(), 1);
+
+  Shape input_data_shape(input_dimensions);
+
+  try {
+    // Initialize the predictor object
+    Predictor predict(model_file_json, model_file_params, input_data_shape, gpu_context_type,
+                      synset_file, mean_image);
+
+    // Run the forward pass to predict the image.
+    predict.PredictImage(input_image);
+  } catch (...) {
+    /*
+     * If underlying MXNet code has thrown an exception the error message is
+     * accessible through MXGetLastError() function.
+     */
+    LG << MXGetLastError();
+  }
+  return 0;
+}

--- a/cpp-package/example/inference/inception_inference.cpp
+++ b/cpp-package/example/inference/inception_inference.cpp
@@ -47,13 +47,8 @@ using namespace mxnet::cpp;
 class Predictor {
  public:
     Predictor() {}
-<<<<<<< HEAD
     Predictor(const std::string& model_json,
               const std::string& model_params,
-=======
-    Predictor(const std::string model_json,
-              const std::string model_params,
->>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
               const Shape& input_shape,
               bool gpu_context_type = false,
               const std::string& synset_file = "",
@@ -65,12 +60,8 @@ class Predictor {
     void LoadModel(const std::string& model_json_file);
     void LoadParameters(const std::string& model_parameters_file);
     void LoadSynset(const std::string& synset_file);
-<<<<<<< HEAD
     NDArray LoadInputImage(const std::string& image_file);
     void LoadMeanImageData();
-=======
-    void LoadInputImage(const std::string& image_file);
->>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
     void NormalizeInput(const std::string& mean_image_file);
 
     NDArray mean_img;
@@ -80,11 +71,7 @@ class Predictor {
     Symbol net;
     Executor *executor;
     Shape input_shape;
-<<<<<<< HEAD
     NDArray mean_image_data;
-=======
-    NDArray image_data;
->>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
     Context global_ctx = Context::cpu();
     string mean_image_file;
 };
@@ -105,13 +92,8 @@ class Predictor {
  *
  *  The SimpleBind is expected to be invoked only once.
  */
-<<<<<<< HEAD
 Predictor::Predictor(const std::string& model_json,
                      const std::string& model_params,
-=======
-Predictor::Predictor(const std::string model_json,
-                     const std::string model_params,
->>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
                      const Shape& input_shape,
                      bool gpu_context_type,
                      const std::string& synset_file,
@@ -121,10 +103,6 @@ Predictor::Predictor(const std::string model_json,
   if (gpu_context_type) {
     global_ctx = Context::gpu();
   }
-<<<<<<< HEAD
-
-=======
->>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
   // Load the model
   LoadModel(model_json);
 
@@ -138,7 +116,6 @@ Predictor::Predictor(const std::string model_json,
   if (!synset_file.empty()) {
     LoadSynset(synset_file);
   }
-<<<<<<< HEAD
 
   /*
    * Load the mean image data if specified.
@@ -147,18 +124,12 @@ Predictor::Predictor(const std::string model_json,
     LoadMeanImageData();
   }
 
-=======
->>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
   // Create an executor after binding the model to input parameters.
   args_map["data"] = NDArray(input_shape, global_ctx, false);
   executor = net.SimpleBind(global_ctx, args_map, map<string, NDArray>(),
                               map<string, OpReqType>(), aux_map);
 }
 
-<<<<<<< HEAD
-
-=======
->>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
 /*
  * The following function loads the model from json file.
  */
@@ -211,7 +182,6 @@ void Predictor::LoadSynset(const string& synset_file) {
 
 
 /*
-<<<<<<< HEAD
  * The following function loads the mean data from mean image file.
  * This data will be used for normalizing the image before running the forward
  * pass.
@@ -232,11 +202,6 @@ void Predictor::LoadMeanImageData() {
  * The following function loads the input image.
  */
 NDArray Predictor::LoadInputImage(const std::string& image_file) {
-=======
- * The following function loads the input image.
- */
-void Predictor::LoadInputImage(const std::string& image_file) {
->>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
   LG << "Loading the image " << image_file << std::endl;
   vector<float> array;
   cv::Mat mat = cv::imread(image_file);
@@ -252,32 +217,10 @@ void Predictor::LoadInputImage(const std::string& image_file) {
       }
     }
   }
-<<<<<<< HEAD
   NDArray image_data = NDArray(input_shape, global_ctx, false);
   image_data.SyncCopyFromCPU(array.data(), input_shape.Size());
   NDArray::WaitAll();
   return image_data;
-=======
-  image_data = NDArray(input_shape, global_ctx, false);
-  image_data.SyncCopyFromCPU(array.data(), input_shape.Size());
-  NDArray::WaitAll();
-}
-
-
-/*
- * The following function normalizes input image data by substracting the
- * mean data.
- */
-void Predictor::NormalizeInput(const std::string& mean_image_file) {
-  LG << "Normalizing image using " << mean_image_file;
-  mean_img = NDArray(input_shape, global_ctx, false);
-  mean_img.SyncCopyFromCPU(
-        NDArray::LoadToMap(mean_image_file)["mean_img"].GetData(),
-        input_shape.Size());
-  NDArray::WaitAll();
-  image_data.Slice(0, 1) -= mean_img;
-  return;
->>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
 }
 
 
@@ -288,19 +231,11 @@ void Predictor::NormalizeInput(const std::string& mean_image_file) {
  */
 void Predictor::PredictImage(const std::string& image_file) {
   // Load the input image
-<<<<<<< HEAD
   NDArray image_data = LoadInputImage(image_file);
 
   // Normalize the image
   if (!mean_image_file.empty()) {
     image_data.Slice(0, 1) -= mean_image_data;
-=======
-  LoadInputImage(image_file);
-
-  // Normalize the image
-  if (!mean_image_file.empty()) {
-    NormalizeInput(mean_image_file);
->>>>>>> 04c8b404a1c35fa9b5ee4db0695cd8e235f63d52
   }
 
   LG << "Running the forward pass on model to predict the image";

--- a/cpp-package/example/inference/unit_test_inception_inference.sh
+++ b/cpp-package/example/inference/unit_test_inception_inference.sh
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Downloading the data and model
+mkdir -p model
+wget -nc http://data.dmlc.ml/mxnet/models/imagenet/inception-bn.tar.gz
+wget -nc -O model/dog.jpg https://github.com/dmlc/web-data/blob/master/mxnet/doc/tutorials/python/predict_image/dog.jpg?raw=true
+wget -nc -O model/mean_224.nd https://github.com/dmlc/web-data/raw/master/mxnet/example/feature_extract/mean_224.nd
+tar -xvzf inception-bn.tar.gz -C model
+
+# Building
+make all
+
+
+# Running the example with dog image.
+LD_LIBRARY_PATH=../../../lib ./inception_inference --symbol "./model/Inception-BN-symbol.json" --params "./model/Inception-BN-0126.params" --synset "./model/synset.txt" --mean "./model/mean_224.nd" --image "./model/dog.jpg" 2&> inception_inference.log
+result=`grep -c "pug-dog" inception_inference.log`
+if [ $result == 1 ];
+then
+    echo "PASS: inception_inference correctly identified the image."
+    exit 0
+else
+    echo "FAIL: inception_inference FAILED to identify the image."
+    exit 1
+fi


### PR DESCRIPTION
## Description ##
The PR includes an example that demonstrates the inference workflow using C++ API.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [y] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
The example demonstrates how to load the pre-trained model and associated parameter files.
The model and parameter files can be specified as command line arguments.

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
