### PR TITLE
Add url and license to clojure package project

### DIFF
--- a/contrib/clojure-package/project.clj
+++ b/contrib/clojure-package/project.clj
@@ -17,6 +17,9 @@
 
 (defproject org.apache.mxnet.contrib.clojure/clojure-mxnet "1.3.1-SNAPSHOT"
   :description "Clojure package for MXNet"
+  :url "https://github.com/apache/incubator-mxnet"
+  :license {:name "Apache License"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [t6/from-scala "0.3.0"]
 


### PR DESCRIPTION
## Description ##

This adds the data of the url and license to the Clojure package description. This is important when it comes time for deployment of the jars since the information is used to produce the poms as in here:

https://search.maven.org/artifact/org.apache.mxnet.contrib.clojure/clojure-mxnet-linux-cpu/1.3.0/jar

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
