### PR TITLE
Fix sphinx docstring warnings.

### DIFF
--- a/python/mxnet/contrib/io.py
+++ b/python/mxnet/contrib/io.py
@@ -37,8 +37,8 @@ class DataLoaderIter(DataIter):
     dtype : str, optional
         The dtype specifier, can be float32 or float16
 
-    Example usage:
-    ----------
+    Examples
+    --------
     >>> import mxnet as mx
     >>> from mxnet.gluon.data.vision import MNIST
     >>> from mxnet.gluon.data import DataLoader

--- a/python/mxnet/contrib/svrg_optimization/svrg_module.py
+++ b/python/mxnet/contrib/svrg_optimization/svrg_module.py
@@ -37,8 +37,7 @@ class SVRGModule(Module):
     data_names : list of str
         Defaults to `('data')` for a typical model used in image classification.
     label_names : list of str
-        Defaults to `('softmax_label')` for a typical model used in image
-        classification.
+        Defaults to `('softmax_label')` for a typical model used in image classification.
     logger : Logger
         Defaults to `logging`.
     context : Context or list of Context
@@ -48,18 +47,19 @@ class SVRGModule(Module):
     fixed_param_names: list of str
         Default ``None``, indicating no network parameters are fixed.
     state_names : list of str
-        states are similar to data and label, but not provided by data iterator.
+        states are similar to data and label, but not provided by data iterator. \
         Instead they are initialized to 0 and can be set by `set_states()`.
     group2ctxs : dict of str to context or list of context, or list of dict of str to context
         Default is `None`. Mapping the `ctx_group` attribute to the context assignment.
     compression_params : dict
-        Specifies type of gradient compression and additional arguments depending
-        on the type of compression being used. For example, 2bit compression requires a threshold.
-        Arguments would then be {'type':'2bit', 'threshold':0.5}
-        See mxnet.KVStore.set_gradient_compression method for more details on gradient compression.
+        Specifies type of gradient compression and additional arguments depending \
+        on the type of compression being used. For example, 2bit compression requires a threshold. \
+        Arguments would then be {'type':'2bit', 'threshold':0.5} \
+        See mxnet.KVStore.set_gradient_compression method for more details on gradient compression. \
     update_freq: int
-        Specifies the number of times to update the full gradients to be used in the SVRG optimization. For instance,
+        Specifies the number of times to update the full gradients to be used in the SVRG optimization. For instance, \
         update_freq = 2 will calculates the gradients over all data every two epochs
+
     Examples
     --------
     >>> # An example of declaring and using SVRGModule.

--- a/python/mxnet/contrib/text/embedding.py
+++ b/python/mxnet/contrib/text/embedding.py
@@ -475,7 +475,8 @@ class GloVe(_TokenEmbedding):
     the resulting representations showcase interesting linear substructures of the word vector
     space. (Source from https://nlp.stanford.edu/projects/glove/)
 
-    Reference:
+    References
+    ----------
 
     GloVe: Global Vectors for Word Representation.
     Jeffrey Pennington, Richard Socher, and Christopher D. Manning.
@@ -545,7 +546,8 @@ class FastText(_TokenEmbedding):
     representations and text classifiers. It works on standard, generic hardware. Models can later
     be reduced in size to even fit on mobile devices. (Source from https://fasttext.cc/)
 
-    References:
+    References
+    ----------
 
     Enriching Word Vectors with Subword Information.
     Piotr Bojanowski, Edouard Grave, Armand Joulin, and Tomas Mikolov.

--- a/python/mxnet/gluon/data/vision/datasets.py
+++ b/python/mxnet/gluon/data/vision/datasets.py
@@ -47,7 +47,7 @@ class MNIST(dataset._DownloadedDataset):
     transform : function, default None
         A user defined callback that transforms each sample. For example::
 
-        transform=lambda data, label: (data.astype(np.float32)/255, label)
+            transform=lambda data, label: (data.astype(np.float32)/255, label)
 
     """
     def __init__(self, root=os.path.join(base.data_dir(), 'datasets', 'mnist'),
@@ -107,7 +107,7 @@ class FashionMNIST(MNIST):
     transform : function, default None
         A user defined callback that transforms each sample. For example::
 
-        transform=lambda data, label: (data.astype(np.float32)/255, label)
+            transform=lambda data, label: (data.astype(np.float32)/255, label)
 
     """
     def __init__(self, root=os.path.join(base.data_dir(), 'datasets', 'fashion-mnist'),
@@ -139,7 +139,7 @@ class CIFAR10(dataset._DownloadedDataset):
     transform : function, default None
         A user defined callback that transforms each sample. For example::
 
-        transform=lambda data, label: (data.astype(np.float32)/255, label)
+            transform=lambda data, label: (data.astype(np.float32)/255, label)
 
     """
     def __init__(self, root=os.path.join(base.data_dir(), 'datasets', 'cifar10'),
@@ -203,7 +203,7 @@ class CIFAR100(CIFAR10):
     transform : function, default None
         A user defined callback that transforms each sample. For example::
 
-        transform=lambda data, label: (data.astype(np.float32)/255, label)
+            transform=lambda data, label: (data.astype(np.float32)/255, label)
 
     """
     def __init__(self, root=os.path.join(base.data_dir(), 'datasets', 'cifar100'),
@@ -234,13 +234,12 @@ class ImageRecordDataset(dataset.RecordFileDataset):
     filename : str
         Path to rec file.
     flag : {0, 1}, default 1
-        If 0, always convert images to greyscale.
-
+        If 0, always convert images to greyscale. \
         If 1, always convert images to colored (RGB).
     transform : function, default None
         A user defined callback that transforms each sample. For example::
 
-        transform=lambda data, label: (data.astype(np.float32)/255, label)
+            transform=lambda data, label: (data.astype(np.float32)/255, label)
 
     """
     def __init__(self, filename, flag=1, transform=None):
@@ -257,7 +256,9 @@ class ImageRecordDataset(dataset.RecordFileDataset):
 
 
 class ImageFolderDataset(dataset.Dataset):
-    """A dataset for loading image files stored in a folder structure like::
+    """A dataset for loading image files stored in a folder structure.
+
+    like::
 
         root/car/0001.jpg
         root/car/xxxa.jpg
@@ -276,7 +277,7 @@ class ImageFolderDataset(dataset.Dataset):
     transform : callable, default None
         A function that takes data and label and transforms them::
 
-        transform = lambda data, label: (data.astype(np.float32)/255, label)
+            transform = lambda data, label: (data.astype(np.float32)/255, label)
 
     Attributes
     ----------

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -1322,8 +1322,8 @@ class ImageIter(io.DataIter):
 
     def read_image(self, fname):
         """Reads an input image `fname` and returns the decoded raw bytes.
-        Example usage:
-        ----------
+        Examples
+        --------
         >>> dataIter.read_image('Face.jpg') # returns decoded raw bytes.
         """
         with open(os.path.join(self.path_root, fname), 'rb') as fin:

--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -564,7 +564,8 @@ class Signum(Optimizer):
         state = momentum * state + (1-momentum)*rescaled_grad
         weight = (1 - lr * wd_lh) * weight - lr * sign(state)
 
-    Reference:
+    References
+    ----------
     Jeremy Bernstein, Yu-Xiang Wang, Kamyar Azizzadenesheli & Anima Anandkumar. (2018).
     signSGD: Compressed Optimisation for Non-Convex Problems. In ICML'18.
 

--- a/python/mxnet/rnn/rnn_cell.py
+++ b/python/mxnet/rnn/rnn_cell.py
@@ -1253,7 +1253,8 @@ class ConvRNNCell(BaseConvRNNCell):
 class ConvLSTMCell(BaseConvRNNCell):
     """Convolutional LSTM network cell.
 
-    Reference:
+    References
+    ----------
         Xingjian et al. NIPS2015
 
     Parameters

--- a/python/mxnet/symbol/contrib.py
+++ b/python/mxnet/symbol/contrib.py
@@ -236,15 +236,15 @@ def foreach(body, data, init_states, name="foreach"):
     output data, the body function can return (out, []).
 
     The computation done by this operator is equivalent to the pseudo code below
-    when the input data is NDArray:
+    when the input data is NDArray::
 
-    states = init_states
-    outs = []
-    for i in data.shape[0]:
-        s = data[i]
-        out, states = body(s, states)
-        outs.append(out)
-    outs = stack(*outs)
+        states = init_states
+        outs = []
+        for i in data.shape[0]:
+            s = data[i]
+            out, states = body(s, states)
+            outs.append(out)
+        outs = stack(*outs)
 
 
     Parameters

--- a/python/mxnet/torch.py
+++ b/python/mxnet/torch.py
@@ -85,7 +85,7 @@ def _make_torch_function(handle):
                 'Invoke with\n{res}= mxnet.th.{name}(Parameters)\nor\n'+
                 'mxnet.th.{name}({res}, Parameters).\n\n' +
                 '{param_str}\n' +
-                'Reference: ' +
+                'References: ' +
                 'https://github.com/torch/torch7/blob/master/doc/maths.md\n').format(
                     name=func_name[4:], param_str=param_str,
                     res=res))

--- a/src/operator/contrib/adaptive_avg_pooling.cc
+++ b/src/operator/contrib/adaptive_avg_pooling.cc
@@ -205,10 +205,10 @@ NNVM_REGISTER_OP(_contrib_AdaptiveAvgPooling2D)
 Applies a 2D adaptive average pooling over a 4D input with the shape of (NCHW).
 The pooling kernel and stride sizes are automatically chosen for desired output sizes.
 
-- If a single integer is provided for output_size, the output size is
+- If a single integer is provided for output_size, the output size is \
   (N x C x output_size x output_size) for any input (NCHW).
 
-- If a tuple of integers (height, width) are provided for output_size, the output size is
+- If a tuple of integers (height, width) are provided for output_size, the output size is \
   (N x C x height x width) for any input (NCHW).
 
 )code" ADD_FILELINE)


### PR DESCRIPTION
## Description ##
Address Sphinx docstring warnings. Following files are updated:

	python/mxnet/contrib/io.py
	python/mxnet/contrib/svrg_optimization/svrg_module.py
	python/mxnet/contrib/text/embedding.py
	python/mxnet/gluon/data/vision/datasets.py
	python/mxnet/image/image.py
	python/mxnet/optimizer/optimizer.py
	python/mxnet/rnn/rnn_cell.py
	python/mxnet/symbol/contrib.py
	python/mxnet/torch.py
	src/operator/contrib/adaptive_avg_pooling.cc

HTML output can be found:
	http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-13315/2/api/python/contrib/svrg_optimization.html
	http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-13315/2/api/python/contrib/text.html
	http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-13315/2/api/python/gluon/data.html
	http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-13315/2/api/python/symbol/contrib.html
	http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-13315/2/api/python/ndarray/contrib.html?highlight=adaptiveavgpooling2d#mxnet.ndarray.contrib.AdaptiveAvgPooling2D


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
