### PR TITLE
Correct shapes of images in cifar10 and cifar100

### DIFF
--- a/python/mxnet/gluon/data/vision/datasets.py
+++ b/python/mxnet/gluon/data/vision/datasets.py
@@ -128,7 +128,7 @@ class FashionMNIST(MNIST):
 class CIFAR10(dataset._DownloadedDataset):
     """CIFAR10 image classification dataset from https://www.cs.toronto.edu/~kriz/cifar.html
 
-    Each sample is an image (in 3D NDArray) with shape (32, 32, 1).
+    Each sample is an image (in 3D NDArray) with shape (32, 32, 3).
 
     Parameters
     ----------
@@ -190,7 +190,7 @@ class CIFAR10(dataset._DownloadedDataset):
 class CIFAR100(CIFAR10):
     """CIFAR100 image classification dataset from https://www.cs.toronto.edu/~kriz/cifar.html
 
-    Each sample is an image (in 3D NDArray) with shape (32, 32, 1).
+    Each sample is an image (in 3D NDArray) with shape (32, 32, 3).
 
     Parameters
     ----------


### PR DESCRIPTION
## Description ##
The image shapes of cifar10 and cifar100 must be [32, 32, 3], but the current description says the shapes are [32, 32, 1]. Because of tiny changes, I did not cut JIRA ticker for this.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
