### PR TITLE
Fix github status context if running inside a folder

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -195,8 +195,8 @@ def update_github_commit_status(state, message) {
 
 def get_github_context() {
   // Since we use multi-branch pipelines, Jenkins appends the branch name to the job name
-  if (JOB_NAME.contains('/')) {
-    short_job_name = JOB_NAME.split('/')[0] 
+  if (env.BRANCH_NAME) {
+    short_job_name = JOB_NAME.substring(0, JOB_NAME.lastIndexOf('/')) 
   } else {
     short_job_name = JOB_NAME
   }


### PR DESCRIPTION
This PR resolves problems with the status context if the job is deployed within a Jenkins folder. This then cuts off the job-name, resulting in all status updates overlapping.
