### PR TITLE
exclude the error folder from sphinx toc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,6 +109,7 @@ master_doc = 'index'
 # directories to ignore when looking for source files.
 exclude_patterns = ['3rdparty', 'api/python/model.md', 'build_version_doc', 'error', 'README.md', 'tutorial_utils', 'virtualenv']
 
+
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,7 @@ master_doc = 'index'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['3rdparty', 'build_version_doc', 'virtualenv', 'api/python/model.md', 'README.md', 'tutorial_utils']
+exclude_patterns = ['3rdparty', 'api/python/model.md', 'build_version_doc', 'error', 'README.md', 'tutorial_utils', 'virtualenv']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None


### PR DESCRIPTION
## Description ##
Sphinx was throwing two warnings about the files in the error folder not being in a table of contents (toctree). These don't need to be in a toctree since they're just custom error pages.

I've excluded the error folder in the Sphinx `conf.py`, and also sorted the excludes so it's easier to manage.

The html for the error pages still render, and the warnings go away. Now down from 17 warnings/errors to 15 (for Sphinx/website/python specific errors)!

See this preview:
http://34.201.8.176/versions/error/error/404.html
