### PR TITLE
Add imresize and copyMakeBorder to mx.image

### DIFF
--- a/docs/api/python/image/image.md
+++ b/docs/api/python/image/image.md
@@ -20,6 +20,7 @@ images provided in
     image.imdecode
     image.imresize
     image.scale_down
+    image.copyMakeBorder
     image.resize_short
     image.fixed_crop
     image.random_crop
@@ -169,6 +170,7 @@ and a list of augmenters specific for `Object detection` is provided
 .. automethod:: mxnet.image.imdecode
 .. automethod:: mxnet.image.imresize
 .. automethod:: mxnet.image.scale_down
+.. automethod:: mxnet.image.copyMakeBorder
 .. automethod:: mxnet.image.resize_short
 .. automethod:: mxnet.image.fixed_crop
 .. automethod:: mxnet.image.random_crop

--- a/docs/api/python/image/image.md
+++ b/docs/api/python/image/image.md
@@ -18,6 +18,7 @@ images provided in
 
     image.imread
     image.imdecode
+    image.imresize
     image.scale_down
     image.resize_short
     image.fixed_crop
@@ -166,6 +167,7 @@ and a list of augmenters specific for `Object detection` is provided
 
 .. automethod:: mxnet.image.imread
 .. automethod:: mxnet.image.imdecode
+.. automethod:: mxnet.image.imresize
 .. automethod:: mxnet.image.scale_down
 .. automethod:: mxnet.image.resize_short
 .. automethod:: mxnet.image.fixed_crop

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -38,7 +38,6 @@ except ImportError:
 from ..base import numeric_types
 from .. import ndarray as nd
 from ..ndarray import _internal
-from ..ndarray._internal import _cvcopyMakeBorder as copyMakeBorder
 from .. import io
 from .. import recordio
 
@@ -136,7 +135,7 @@ def imresize(src, w, h, *args, **kwargs):
     <NDArray 2321x3482x3 @cpu(0)>
     >>> new_image = mx.img.resize(image, 240, 360)
     >>> new_image
-    <NDArray 2321x3482x3 @cpu(0)>
+    <NDArray 240x360x3 @cpu(0)>
     """
     return _internal._cvimresize(src, w, h, *args, **kwargs)
 
@@ -232,6 +231,59 @@ def scale_down(src_size, size):
     if sw < w:
         w, h = sw, float(h * sw) / w
     return int(w), int(h)
+
+
+def copyMakeBorder(src, top, bot, left, right, *args, **kwargs):
+    """Pad image border with OpenCV.
+
+    Parameters
+    ----------
+    src : NDArray
+        source image
+    top : int, required
+        Top margin.
+    bot : int, required
+        Bottom margin.
+    left : int, required
+        Left margin.
+    right : int, required
+        Right margin.
+    type : int, optional, default='0'
+        Filling type (default=cv2.BORDER_CONSTANT).
+        0 - cv2.BORDER_CONSTANT - Adds a constant colored border.
+        1 - cv2.BORDER_REFLECT - Border will be mirror reflection of the
+        border elements, like this : fedcba|abcdefgh|hgfedcb
+        2 - cv2.BORDER_REFLECT_101 or cv.BORDER_DEFAULT - Same as above,
+        but with a slight change, like this : gfedcb|abcdefgh|gfedcba
+        3 - cv2.BORDER_REPLICATE - Last element is replicated throughout,
+        like this: aaaaaa|abcdefgh|hhhhhhh
+        4 - cv2.BORDER_WRAP - it will look like this : cdefgh|abcdefgh|abcdefg
+    value : double, optional, default=0
+        (Deprecated! Use ``values`` instead.) Fill with single value.
+    values : tuple of <double>, optional, default=[]
+        Fill with value(RGB[A] or gray), up to 4 channels.
+
+    out : NDArray, optional
+        The output NDArray to hold the result.
+
+    Returns
+    -------
+    out : NDArray or list of NDArrays
+        The output of this function.
+
+    Example
+    --------
+    >>> with open("flower.jpeg", 'rb') as fp:
+    ...     str_image = fp.read()
+    ...
+    >>> image = mx.img.imdecode(str_image)
+    >>> image
+    <NDArray 2321x3482x3 @cpu(0)>
+    >>> new_image = mx_border = mx.image.copyMakeBorder(mx_img, 1, 2, 3, 4, type=0)
+    >>> new_image
+    <NDArray 2324x3489x3 @cpu(0)>
+    """
+    return _internal._cvcopyMakeBorder(src, top, bot, left, right, *args, **kwargs)
 
 
 def _get_interp_method(interp, sizes=()):

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -38,7 +38,6 @@ except ImportError:
 from ..base import numeric_types
 from .. import ndarray as nd
 from ..ndarray import _internal
-from ..ndarray._internal import _cvimresize as imresize
 from ..ndarray._internal import _cvcopyMakeBorder as copyMakeBorder
 from .. import io
 from .. import recordio
@@ -83,6 +82,46 @@ def imread(filename, *args, **kwargs):
     <NDArray 224x224x3 @cpu(0)>
     """
     return _internal._cvimread(filename, *args, **kwargs)
+
+
+def imresize(src, w, h, interp):
+    r"""Resize image with OpenCV.
+
+    Note: `imread` uses OpenCV (not the CV2 Python library).
+    MXNet must have been built with USE_OPENCV=1 for `imdecode` to work.
+
+    Parameters
+    ----------
+    src : NDArray
+        source image
+    w : int, required
+        Width of resized image.
+    h : int, required
+        Height of resized image.
+    interp : int, optional, default='1'
+        Interpolation method (default=cv2.INTER_LINEAR).
+
+    out : NDArray, optional
+        The output NDArray to hold the result.
+
+    Returns
+    -------
+    out : NDArray or list of NDArrays
+        The output of this function.
+
+    Example
+    -------
+    >>> with open("flower.jpeg", 'rb') as fp:
+    ...     str_image = fp.read()
+    ...
+    >>> image = mx.img.imdecode(str_image)
+    >>> image
+    <NDArray 2321x3482x3 @cpu(0)>
+    >>> new_image = mx.img.resize(image, 240, 360)
+    >>> new_image
+    <NDArray 2321x3482x3 @cpu(0)>
+    """
+    return _internal._cvimresize(src, w, h, interp)
 
 
 def imdecode(buf, *args, **kwargs):

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -46,7 +46,7 @@ from .. import recordio
 def imread(filename, *args, **kwargs):
     """Read and decode an image to an NDArray.
 
-    Note: `imread` uses OpenCV (not the CV2 Python library).
+    .. note:: `imread` uses OpenCV (not the CV2 Python library).
     MXNet must have been built with USE_OPENCV=1 for `imdecode` to work.
 
     Parameters
@@ -84,11 +84,11 @@ def imread(filename, *args, **kwargs):
     return _internal._cvimread(filename, *args, **kwargs)
 
 
-def imresize(src, w, h, interp):
+def imresize(src, w, h, *args, **kwargs):
     r"""Resize image with OpenCV.
 
-    Note: `imread` uses OpenCV (not the CV2 Python library).
-    MXNet must have been built with USE_OPENCV=1 for `imdecode` to work.
+    .. note:: `imresize` uses OpenCV (not the CV2 Python library). MXNet must have been built
+    with USE_OPENCV=1 for `imresize` to work.
 
     Parameters
     ----------
@@ -98,8 +98,25 @@ def imresize(src, w, h, interp):
         Width of resized image.
     h : int, required
         Height of resized image.
-    interp : int, optional, default='1'
+    interp : int, optional, default=1
         Interpolation method (default=cv2.INTER_LINEAR).
+        Possible values:
+        0: Nearest Neighbors Interpolation.
+        1: Bilinear interpolation.
+        2: Area-based (resampling using pixel area relation). It may be a
+        preferred method for image decimation, as it gives moire-free
+        results. But when the image is zoomed, it is similar to the Nearest
+        Neighbors method. (used by default).
+        3: Bicubic interpolation over 4x4 pixel neighborhood.
+        4: Lanczos interpolation over 8x8 pixel neighborhood.
+        9: Cubic for enlarge, area for shrink, bilinear for others
+        10: Random select from interpolation method metioned above.
+        Note:
+        When shrinking an image, it will generally look best with AREA-based
+        interpolation, whereas, when enlarging an image, it will generally look best
+        with Bicubic (slow) or Bilinear (faster but still looks OK).
+        More details can be found in the documentation of OpenCV, please refer to
+        http://docs.opencv.org/master/da/d54/group__imgproc__transform.html.
 
     out : NDArray, optional
         The output NDArray to hold the result.
@@ -121,13 +138,13 @@ def imresize(src, w, h, interp):
     >>> new_image
     <NDArray 2321x3482x3 @cpu(0)>
     """
-    return _internal._cvimresize(src, w, h, interp)
+    return _internal._cvimresize(src, w, h, *args, **kwargs)
 
 
 def imdecode(buf, *args, **kwargs):
     """Decode an image to an NDArray.
 
-    Note: `imdecode` uses OpenCV (not the CV2 Python library).
+    .. note:: `imdecode` uses OpenCV (not the CV2 Python library).
     MXNet must have been built with USE_OPENCV=1 for `imdecode` to work.
 
     Parameters
@@ -275,7 +292,7 @@ def _get_interp_method(interp, sizes=()):
 def resize_short(src, size, interp=2):
     """Resizes shorter edge to size.
 
-    Note: `resize_short` uses OpenCV (not the CV2 Python library).
+    .. note:: `resize_short` uses OpenCV (not the CV2 Python library).
     MXNet must have been built with OpenCV for `resize_short` to work.
 
     Resizes the original image by setting the shorter edge to size

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -141,7 +141,7 @@ class TestImage(unittest.TestCase):
         try:
             import cv2
         except ImportError:
-            return
+            raise unittest.SkipTest("Unable to import cv2.")
         for img in TestImage.IMAGES:
             with open(img, 'rb') as fp:
                 str_image = fp.read()
@@ -175,11 +175,12 @@ class TestImage(unittest.TestCase):
         assert mx.image.scale_down((360, 1000), (480, 500)) == (360, 375)
         assert mx.image.scale_down((300, 400), (0, 0)) == (0, 0)
 
+    @with_seed()
     def test_resize_short(self):
         try:
             import cv2
         except ImportError:
-            return
+            raise unittest.SkipTest("Unable to import cv2")
         for img in TestImage.IMAGES:
             cv_img = cv2.imread(img)
             mx_img = mx.nd.array(cv_img[:, :, (2, 1, 0)])
@@ -196,21 +197,25 @@ class TestImage(unittest.TestCase):
                     mx_resized = mx.image.resize_short(mx_img, new_size, interp)
                     assert_almost_equal(mx_resized.asnumpy()[:, :, (2, 1, 0)], cv_resized, atol=3)
 
+    @with_seed()
     def test_imresize(self):
         try:
             import cv2
         except ImportError:
-            return
+            raise unittest.SkipTest("Unable to import cv2")
         for img in TestImage.IMAGES:
             cv_img = cv2.imread(img)
             mx_img = mx.nd.array(cv_img[:, :, (2, 1, 0)])
             for _ in range(3):
                 new_h = np.random.randint(1, 1000)
                 new_w = np.random.randint(1, 1000)
-                for interp in range(0, 2):
-                    cv_resized = cv2.resize(cv_img, (new_w, new_h), interpolation=interp)
-                    mx_resized = mx.image.imresize(mx_img, new_w, new_h, interp)
+                for interp_val in range(0, 2):
+                    cv_resized = cv2.resize(cv_img, (new_w, new_h), interpolation=interp_val)
+                    mx_resized = mx.image.imresize(mx_img, new_w, new_h, interp=interp_val)
                     assert_almost_equal(mx_resized.asnumpy()[:, :, (2, 1, 0)], cv_resized, atol=3)
+                    out_img = mx.nd.zeros((new_h, new_w, 3), dtype=mx_img.dtype)
+                    mx.image.imresize(mx_img, new_w, new_h, interp=interp_val, out=out_img)
+                    assert_almost_equal(out_img.asnumpy()[:, :, (2, 1, 0)], cv_resized, atol=3)
 
     def test_color_normalize(self):
         for _ in range(10):

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -196,6 +196,22 @@ class TestImage(unittest.TestCase):
                     mx_resized = mx.image.resize_short(mx_img, new_size, interp)
                     assert_almost_equal(mx_resized.asnumpy()[:, :, (2, 1, 0)], cv_resized, atol=3)
 
+    def test_imresize(self):
+        try:
+            import cv2
+        except ImportError:
+            return
+        for img in TestImage.IMAGES:
+            cv_img = cv2.imread(img)
+            mx_img = mx.nd.array(cv_img[:, :, (2, 1, 0)])
+            for _ in range(3):
+                new_h = np.random.randint(1, 1000)
+                new_w = np.random.randint(1, 1000)
+                for interp in range(0, 2):
+                    cv_resized = cv2.resize(cv_img, (new_w, new_h), interpolation=interp)
+                    mx_resized = mx.image.imresize(mx_img, new_w, new_h, interp)
+                    assert_almost_equal(mx_resized.asnumpy()[:, :, (2, 1, 0)], cv_resized, atol=3)
+
     def test_color_normalize(self):
         for _ in range(10):
             mean = np.random.rand(3) * 255

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -206,16 +206,15 @@ class TestImage(unittest.TestCase):
         for img in TestImage.IMAGES:
             cv_img = cv2.imread(img)
             mx_img = mx.nd.array(cv_img[:, :, (2, 1, 0)])
-            for _ in range(3):
-                new_h = np.random.randint(1, 1000)
-                new_w = np.random.randint(1, 1000)
-                for interp_val in range(0, 2):
-                    cv_resized = cv2.resize(cv_img, (new_w, new_h), interpolation=interp_val)
-                    mx_resized = mx.image.imresize(mx_img, new_w, new_h, interp=interp_val)
-                    assert_almost_equal(mx_resized.asnumpy()[:, :, (2, 1, 0)], cv_resized, atol=3)
-                    out_img = mx.nd.zeros((new_h, new_w, 3), dtype=mx_img.dtype)
-                    mx.image.imresize(mx_img, new_w, new_h, interp=interp_val, out=out_img)
-                    assert_almost_equal(out_img.asnumpy()[:, :, (2, 1, 0)], cv_resized, atol=3)
+            new_h = np.random.randint(1, 1000)
+            new_w = np.random.randint(1, 1000)
+            for interp_val in range(0, 2):
+                cv_resized = cv2.resize(cv_img, (new_w, new_h), interpolation=interp_val)
+                mx_resized = mx.image.imresize(mx_img, new_w, new_h, interp=interp_val)
+                assert_almost_equal(mx_resized.asnumpy()[:, :, (2, 1, 0)], cv_resized, atol=3)
+                out_img = mx.nd.zeros((new_h, new_w, 3), dtype=mx_img.dtype)
+                mx.image.imresize(mx_img, new_w, new_h, interp=interp_val, out=out_img)
+                assert_almost_equal(out_img.asnumpy()[:, :, (2, 1, 0)], cv_resized, atol=3)
 
     def test_color_normalize(self):
         for _ in range(10):
@@ -255,6 +254,31 @@ class TestImage(unittest.TestCase):
                         path_imglist=path_imglist, path_root='', dtype=dtype, last_batch_handle='pad')
                 ]
                 _test_imageiter_last_batch(imageiter_list, (2, 3, 224, 224))
+
+    @with_seed()
+    def test_copyMakeBorder(self):
+        try:
+            import cv2
+        except ImportError:
+            raise unittest.SkipTest("Unable to import cv2")
+        for img in TestImage.IMAGES:
+            cv_img = cv2.imread(img)
+            mx_img = mx.nd.array(cv_img)
+            top = np.random.randint(1, 10)
+            bot = np.random.randint(1, 10)
+            left = np.random.randint(1, 10)
+            right = np.random.randint(1, 10)
+            new_h, new_w, _ = mx_img.shape
+            new_h += top + bot
+            new_w += left + right
+            val = [np.random.randint(1, 255)] * 3
+            for type_val in range(0, 5):
+                cv_border = cv2.copyMakeBorder(cv_img, top, bot, left, right, borderType=type_val, value=val)
+                mx_border = mx.image.copyMakeBorder(mx_img, top, bot, left, right, type=type_val, values=val)
+                assert_almost_equal(mx_border.asnumpy(), cv_border)
+                out_img = mx.nd.zeros((new_h , new_w, 3), dtype=mx_img.dtype)
+                mx.image.copyMakeBorder(mx_img, top, bot, left, right, type=type_val, values=val, out=out_img)
+                assert_almost_equal(out_img.asnumpy(), cv_border)
 
     @with_seed()
     def test_augmenters(self):


### PR DESCRIPTION
## Description ##
Though mx.image.imresize and mx.image.copyMakeBorder is currently available for external use, it does not show up in the docs because it was hidden behind an internal function call.

reference - https://github.com/apache/incubator-mxnet/pull/12831#issuecomment-440093759

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

