### PR TITLE
[MXNET-1225] Always use config.mk in make install instructions

### DIFF
--- a/docs/install/build_from_source.md
+++ b/docs/install/build_from_source.md
@@ -2,6 +2,7 @@
 
 This document explains how to build MXNet from source code.
 
+**For Java/Scala/Clojure, please follow [this guide instead](./scala_setup.md)**
 
 ## Overview
 
@@ -27,7 +28,6 @@ MXNet's newest and most popular API is Gluon. Gluon is built into the Python bin
     - [Python (includes Gluon)](../api/python/index.html)
     - [C++](../api/c++/index.html)
     - [Clojure](../api/clojure/index.html)
-    - Java (coming soon)
     - [Julia](../api/julia/index.html)
     - [Perl](../api/perl/index.html)
     - [R](../api/r/index.html)
@@ -35,6 +35,7 @@ MXNet's newest and most popular API is Gluon. Gluon is built into the Python bin
     - [Java](../api/java/index.html)
 
 <hr>
+
 ## Build Instructions by Operating System
 
 Detailed instructions are provided per operating system. Each of these guides also covers how to install the specific [Language Bindings](#installing-mxnet-language-bindings) you require.
@@ -160,7 +161,7 @@ More information on turning these features on or off are found in the following 
 ## Build Configurations
 
 There is a configuration file for make,
-[`make/config.mk`](https://github.com/apache/incubator-mxnet/blob/master/make/config.mk), that contains all the compilation options. You can edit it and then run `make` or `cmake`. `cmake` is recommended for building MXNet (and is required to build with MKLDNN), however you may use `make` instead.
+[`make/config.mk`](https://github.com/apache/incubator-mxnet/blob/master/make/config.mk), that contains all the compilation options. You can edit it and then run `make` or `cmake`. `cmake` is recommended for building MXNet (and is required to build with MKLDNN), however you may use `make` instead. For building with Java/Scala/Clojure, only `make` is supported.
 
 <hr>
 
@@ -214,7 +215,7 @@ It is recommended to set environment variable NCCL_LAUNCH_MODE to PARALLEL when 
 For example, you can specify using all cores on Linux as follows:
 
 ```bash
-cmake -j $(nproc) .
+cmake -j$(nproc)
 ```
 
 
@@ -222,44 +223,28 @@ cmake -j $(nproc) .
 * Build MXNet with `cmake` and install with MKL DNN, GPU, and OpenCV support:
 
 ```bash
-echo "USE_OPENCV = 1" >> ./config.mk
-echo "USE_CUDA = 1" >> ./config.mk
-echo "USE_CUDA_PATH = /usr/local/cuda" >> ./config.mk
-echo "USE_CUDNN = 1" >> ./config.mk
-echo "USE_MKLDNN = 1" >> ./config.mk
-cmake -j $(nproc) USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 USE_MKLDNN=1 .
+cmake -j USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 USE_MKLDNN=1
 ```
 
 #### Recommended for Systems with NVIDIA GPUs
 * Build with both OpenBLAS, GPU, and OpenCV support:
 
 ```bash
-echo "USE_BLAS = openblas" >> ./config.mk
-echo "USE_OPENCV = 1" >> ./config.mk
-echo "USE_CUDA = 1" >> ./config.mk
-echo "USE_CUDA_PATH = /usr/local/cuda" >> ./config.mk
-echo "USE_CUDNN = 1" >> ./config.mk
-cmake -j $(nproc) BLAS=open USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 .
+cmake -j BLAS=open USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1
 ```
 
 #### Recommended for Systems with Intel CPUs
 * Build MXNet with `cmake` and install with MKL DNN, and OpenCV support:
 
 ```bash
-echo "USE_CUDA = 0" >> ./config.mk
-echo "USE_OPENCV = 1" >> ./config.mk
-echo "USE_MKLDNN = 1" >> ./config.mk
-cmake -j $(nproc) USE_CUDA=0 USE_MKLDNN=1 .
+cmake -j USE_CUDA=0 USE_MKLDNN=1
 ```
 
 #### Recommended for Systems with non-Intel CPUs
 * Build MXNet with `cmake` and install with OpenBLAS and OpenCV support:
 
 ```bash
-echo "USE_BLAS = openblas" >> ./config.mk
-echo "USE_OPENCV = 1" >> ./config.mk
-echo "USE_CUDA = 0" >> ./config.mk
-cmake -j $(nproc) USE_CUDA=0 BLAS=open .
+cmake -j USE_CUDA=0 BLAS=open
 ```
 
 #### Other Examples
@@ -267,26 +252,20 @@ cmake -j $(nproc) USE_CUDA=0 BLAS=open .
 * Build without using OpenCV:
 
 ```bash
-echo "USE_OPENCV = 0" >> ./config.mk
-cmake -j $(nproc) USE_OPENCV=0 .
+cmake USE_OPENCV=0
 ```
 
 * Build on **macOS** with the default BLAS library (Apple Accelerate) and Clang installed with `xcode` (OPENMP is disabled because it is not supported by the Apple version of Clang):
 
 ```bash
-echo "USE_BLAS = openblas" >> ./config.mk
-echo "USE_OPENCV = 0" >> ./config.mk
-echo "USE_OPENMP = 0" >> ./config.mk
-cmake -j $(sysctl -n hw.ncpu) BLAS=apple USE_OPENCV=0 USE_OPENMP=0 .
+cmake -j BLAS=apple USE_OPENCV=0 USE_OPENMP=0
 ```
 
 * To use OpenMP on **macOS** you need to install the Clang compiler, `llvm` (the one provided by Apple does not support OpenMP):
 
 ```bash
 brew install llvm
-echo "USE_BLAS = openblas" >> ./config.mk
-echo "USE_OPENMP = 1" >> ./config.mk
-cmake -j $(sysctl -n hw.ncpu) BLAS=apple USE_OPENMP=1 .
+cmake -j BLAS=apple USE_OPENMP=1
 ```
 
 <hr>

--- a/docs/install/build_from_source.md
+++ b/docs/install/build_from_source.md
@@ -204,18 +204,17 @@ It is recommended to set environment variable NCCL_LAUNCH_MODE to PARALLEL when 
 
 ### Build MXNet with C++
 
-* To enable C++ package, just add `USE_CPP_PACKAGE=1` when you run `make` or `cmake`.
+* To enable C++ package, just add `USE_CPP_PACKAGE=1` when you run `make` or `cmake` (see examples).
 
 <hr>
 
 ### Usage Examples
 
-* `-j` runs multiple jobs against multi-core CPUs.
-
 For example, you can specify using all cores on Linux as follows:
 
 ```bash
-cmake -j$(nproc)
+cmake -GNinja .
+ninja -v
 ```
 
 
@@ -223,28 +222,32 @@ cmake -j$(nproc)
 * Build MXNet with `cmake` and install with MKL DNN, GPU, and OpenCV support:
 
 ```bash
-cmake -j USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 USE_MKLDNN=1
+cmake -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -DUSE_MKLDNN=1 -GNinja .
+ninja -v
 ```
 
 #### Recommended for Systems with NVIDIA GPUs
 * Build with both OpenBLAS, GPU, and OpenCV support:
 
 ```bash
-cmake -j BLAS=open USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1
+cmake -DBLAS=open -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -GNinja .
+ninja -v
 ```
 
 #### Recommended for Systems with Intel CPUs
 * Build MXNet with `cmake` and install with MKL DNN, and OpenCV support:
 
 ```bash
-cmake -j USE_CUDA=0 USE_MKLDNN=1
+cmake -DUSE_CUDA=0 -DUSE_MKLDNN=1 -GNinja .
+ninja -v
 ```
 
 #### Recommended for Systems with non-Intel CPUs
 * Build MXNet with `cmake` and install with OpenBLAS and OpenCV support:
 
 ```bash
-cmake -j USE_CUDA=0 BLAS=open
+cmake -DUSE_CUDA=0 -DBLAS=open -GNinja .
+ninja -v
 ```
 
 #### Other Examples
@@ -252,20 +255,23 @@ cmake -j USE_CUDA=0 BLAS=open
 * Build without using OpenCV:
 
 ```bash
-cmake USE_OPENCV=0
+cmake -DUSE_OPENCV=0 -GNinja .
+ninja -v
 ```
 
 * Build on **macOS** with the default BLAS library (Apple Accelerate) and Clang installed with `xcode` (OPENMP is disabled because it is not supported by the Apple version of Clang):
 
 ```bash
-cmake -j BLAS=apple USE_OPENCV=0 USE_OPENMP=0
+cmake -DBLAS=apple -DUSE_OPENCV=0 -DUSE_OPENMP=0 -GNinja .
+ninja -v
 ```
 
 * To use OpenMP on **macOS** you need to install the Clang compiler, `llvm` (the one provided by Apple does not support OpenMP):
 
 ```bash
 brew install llvm
-cmake -j BLAS=apple USE_OPENMP=1
+cmake -DBLAS=apple -DUSE_OPENMP=1 -GNinja .
+ninja -v
 ```
 
 <hr>

--- a/docs/install/build_from_source.md
+++ b/docs/install/build_from_source.md
@@ -213,6 +213,7 @@ It is recommended to set environment variable NCCL_LAUNCH_MODE to PARALLEL when 
 For example, you can specify using all cores on Linux as follows:
 
 ```bash
+mkdir build && cd build
 cmake -GNinja .
 ninja -v
 ```
@@ -222,6 +223,7 @@ ninja -v
 * Build MXNet with `cmake` and install with MKL DNN, GPU, and OpenCV support:
 
 ```bash
+mkdir build && cd build
 cmake -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -DUSE_MKLDNN=1 -GNinja .
 ninja -v
 ```
@@ -230,6 +232,7 @@ ninja -v
 * Build with both OpenBLAS, GPU, and OpenCV support:
 
 ```bash
+mkdir build && cd build
 cmake -DBLAS=open -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -GNinja .
 ninja -v
 ```
@@ -238,6 +241,7 @@ ninja -v
 * Build MXNet with `cmake` and install with MKL DNN, and OpenCV support:
 
 ```bash
+mkdir build && cd build
 cmake -DUSE_CUDA=0 -DUSE_MKLDNN=1 -GNinja .
 ninja -v
 ```
@@ -246,6 +250,7 @@ ninja -v
 * Build MXNet with `cmake` and install with OpenBLAS and OpenCV support:
 
 ```bash
+mkdir build && cd build
 cmake -DUSE_CUDA=0 -DBLAS=open -GNinja .
 ninja -v
 ```
@@ -255,6 +260,7 @@ ninja -v
 * Build without using OpenCV:
 
 ```bash
+mkdir build && cd build
 cmake -DUSE_OPENCV=0 -GNinja .
 ninja -v
 ```
@@ -262,6 +268,7 @@ ninja -v
 * Build on **macOS** with the default BLAS library (Apple Accelerate) and Clang installed with `xcode` (OPENMP is disabled because it is not supported by the Apple version of Clang):
 
 ```bash
+mkdir build && cd build
 cmake -DBLAS=apple -DUSE_OPENCV=0 -DUSE_OPENMP=0 -GNinja .
 ninja -v
 ```
@@ -270,6 +277,7 @@ ninja -v
 
 ```bash
 brew install llvm
+mkdir build && cd build
 cmake -DBLAS=apple -DUSE_OPENMP=1 -GNinja .
 ninja -v
 ```

--- a/docs/install/build_from_source.md
+++ b/docs/install/build_from_source.md
@@ -214,7 +214,7 @@ It is recommended to set environment variable NCCL_LAUNCH_MODE to PARALLEL when 
 For example, you can specify using all cores on Linux as follows:
 
 ```bash
-cmake -j$(nproc)
+cmake -j $(nproc) .
 ```
 
 
@@ -222,28 +222,44 @@ cmake -j$(nproc)
 * Build MXNet with `cmake` and install with MKL DNN, GPU, and OpenCV support:
 
 ```bash
-cmake -j USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 USE_MKLDNN=1
+echo "USE_OPENCV = 1" >> ./config.mk
+echo "USE_CUDA = 1" >> ./config.mk
+echo "USE_CUDA_PATH = /usr/local/cuda" >> ./config.mk
+echo "USE_CUDNN = 1" >> ./config.mk
+echo "USE_MKLDNN = 1" >> ./config.mk
+cmake -j $(nproc) USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 USE_MKLDNN=1 .
 ```
 
 #### Recommended for Systems with NVIDIA GPUs
 * Build with both OpenBLAS, GPU, and OpenCV support:
 
 ```bash
-cmake -j BLAS=open USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1
+echo "USE_BLAS = openblas" >> ./config.mk
+echo "USE_OPENCV = 1" >> ./config.mk
+echo "USE_CUDA = 1" >> ./config.mk
+echo "USE_CUDA_PATH = /usr/local/cuda" >> ./config.mk
+echo "USE_CUDNN = 1" >> ./config.mk
+cmake -j $(nproc) BLAS=open USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1 .
 ```
 
 #### Recommended for Systems with Intel CPUs
 * Build MXNet with `cmake` and install with MKL DNN, and OpenCV support:
 
 ```bash
-cmake -j USE_CUDA=0 USE_MKLDNN=1
+echo "USE_CUDA = 0" >> ./config.mk
+echo "USE_OPENCV = 1" >> ./config.mk
+echo "USE_MKLDNN = 1" >> ./config.mk
+cmake -j $(nproc) USE_CUDA=0 USE_MKLDNN=1 .
 ```
 
 #### Recommended for Systems with non-Intel CPUs
 * Build MXNet with `cmake` and install with OpenBLAS and OpenCV support:
 
 ```bash
-cmake -j USE_CUDA=0 BLAS=open
+echo "USE_BLAS = openblas" >> ./config.mk
+echo "USE_OPENCV = 1" >> ./config.mk
+echo "USE_CUDA = 0" >> ./config.mk
+cmake -j $(nproc) USE_CUDA=0 BLAS=open .
 ```
 
 #### Other Examples
@@ -251,20 +267,26 @@ cmake -j USE_CUDA=0 BLAS=open
 * Build without using OpenCV:
 
 ```bash
-cmake USE_OPENCV=0
+echo "USE_OPENCV = 0" >> ./config.mk
+cmake -j $(nproc) USE_OPENCV=0 .
 ```
 
 * Build on **macOS** with the default BLAS library (Apple Accelerate) and Clang installed with `xcode` (OPENMP is disabled because it is not supported by the Apple version of Clang):
 
 ```bash
-cmake -j BLAS=apple USE_OPENCV=0 USE_OPENMP=0
+echo "USE_BLAS = openblas" >> ./config.mk
+echo "USE_OPENCV = 0" >> ./config.mk
+echo "USE_OPENMP = 0" >> ./config.mk
+cmake -j $(sysctl -n hw.ncpu) BLAS=apple USE_OPENCV=0 USE_OPENMP=0 .
 ```
 
 * To use OpenMP on **macOS** you need to install the Clang compiler, `llvm` (the one provided by Apple does not support OpenMP):
 
 ```bash
 brew install llvm
-cmake -j BLAS=apple USE_OPENMP=1
+echo "USE_BLAS = openblas" >> ./config.mk
+echo "USE_OPENMP = 1" >> ./config.mk
+cmake -j $(sysctl -n hw.ncpu) BLAS=apple USE_OPENMP=1 .
 ```
 
 <hr>

--- a/docs/install/c_plus_plus.md
+++ b/docs/install/c_plus_plus.md
@@ -6,7 +6,11 @@ To enable C++ package, just add `USE_CPP_PACKAGE=1` in the [build from source](b
 For example to build MXNet with GPU support and the C++ package, OpenCV, and OpenBLAS, from the project root you would run:
 
 ```bash
-make -j USE_CPP_PACKAGE=1 USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1
+echo "USE_CPP_PACKAGE=1" >> ./config.mk
+echo "USE_OPENCV=1" >> ./config.mk
+echo "USE_BLAS=openblas" >> ./config.mk
+echo "USE_CUDA=1" >> ./config.mk
+make -j $(nproc)
 ```
 
 You may also want to add the MXNet shared library to your `LD_LIBRARY_PATH`:

--- a/docs/install/c_plus_plus.md
+++ b/docs/install/c_plus_plus.md
@@ -6,11 +6,8 @@ To enable C++ package, just add `USE_CPP_PACKAGE=1` in the [build from source](b
 For example to build MXNet with GPU support and the C++ package, OpenCV, and OpenBLAS, from the project root you would run:
 
 ```bash
-echo "USE_CPP_PACKAGE=1" >> ./config.mk
-echo "USE_OPENCV=1" >> ./config.mk
-echo "USE_BLAS=openblas" >> ./config.mk
-echo "USE_CUDA=1" >> ./config.mk
-make -j $(nproc)
+cmake -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -DUSE_MKLDNN=1 -DUSE_CPP_PACKAGE=1 -GNinja .
+ninja -v
 ```
 
 You may also want to add the MXNet shared library to your `LD_LIBRARY_PATH`:

--- a/docs/install/java_setup.md
+++ b/docs/install/java_setup.md
@@ -89,11 +89,13 @@ The official Java Packages will be released with the release of MXNet 1.4 and wi
 
 The previously mentioned setup with Maven is recommended. Otherwise, the following instructions for macOS and Ubuntu are provided for reference only:
 
+**If you have already built mxnet from source using `cmake`, run `make clean` and then follow the appropriate guide below***
+
 | OS | Step 1 | Step 2 |
 |---|---|---|
 |macOS | [Shared Library for macOS](../install/osx_setup.html#build-the-shared-library) | [Scala Package for macOS](http://mxnet.incubator.apache.org/install/osx_setup.html#install-the-mxnet-package-for-scala) |
 | Ubuntu | [Shared Library for Ubuntu](../install/ubuntu_setup.html#installing-mxnet-on-ubuntu) | [Scala Package for Ubuntu](http://mxnet.incubator.apache.org/install/ubuntu_setup.html#install-the-mxnet-package-for-scala) |
-| Windows | [Shared Library for Windows](../install/windows_setup.html#build-the-shared-library) | <a class="github-button" href="https://github.com/apache/incubator-mxnet/issues/10549" data-size="large" data-show-count="true" aria-label="Issue apache/incubator-mxnet on GitHub">Call for Contribution</a> |
+| Windows | <a class="github-button" href="https://github.com/apache/incubator-mxnet/issues/10549" data-size="large" data-show-count="true" aria-label="Issue apache/incubator-mxnet on GitHub"> | <a class="github-button" href="https://github.com/apache/incubator-mxnet/issues/10549" data-size="large" data-show-count="true" aria-label="Issue apache/incubator-mxnet on GitHub">Call for Contribution</a> |
 
 
 #### Build Java from an Existing MXNet Installation

--- a/docs/install/osx_setup.md
+++ b/docs/install/osx_setup.md
@@ -96,7 +96,14 @@ The file called ```osx.mk``` has the configuration required for building MXNet o
 To build with MKLDNN
 
 ```bash
-LIBRARY_PATH=$(brew --prefix llvm)/lib/ make -j $(sysctl -n hw.ncpu) CC=$(brew --prefix llvm)/bin/clang++ CXX=$(brew --prefix llvm)/bin/clang++ USE_OPENCV=1 USE_OPENMP=1 USE_MKLDNN=1 USE_BLAS=apple USE_PROFILER=1
+echo "CC=$(brew --prefix llvm)/bin/clang++" >> ./config.mk
+echo "CXX=$(brew --prefix llvm)/bin/clang++" >> ./config.mk
+echo "USE_OPENCV=1" >> ./config.mk
+echo "USE_OPENMP=1" >> ./config.mk
+echo "USE_MKLDNN=1" >> ./config.mk
+echo "USE_BLAS=apple" >> ./config.mk
+echo "USE_PROFILER=1" >> ./config.mk
+LIBRARY_PATH=$(brew --prefix llvm)/lib/ make -j $(sysctl -n hw.ncpu)
 ```
 
 If building with ```GPU``` support, add the following configuration to config.mk and build:

--- a/docs/install/scala_setup.md
+++ b/docs/install/scala_setup.md
@@ -79,11 +79,13 @@ https://mvnrepository.com/artifact/org.apache.mxnet
 
 The previously mentioned setup with Maven is recommended. Otherwise, the following instructions for macOS, Ubuntu, and Windows are provided for reference only:
 
+**If you have already built mxnet from source using `cmake`, run `make clean` and then follow the appropriate guide below***
+
 | OS | Step 1 | Step 2 |
 |---|---|---|
 |macOS | [Shared Library for macOS](http://mxnet.incubator.apache.org/install/osx_setup.html#build-the-shared-library) | [Scala Package for macOS](http://mxnet.incubator.apache.org/install/osx_setup.html#install-the-mxnet-package-for-scala) |
 | Ubuntu | [Shared Library for Ubuntu](http://mxnet.incubator.apache.org/install/ubuntu_setup.html#installing-mxnet-on-ubuntu) | [Scala Package for Ubuntu](http://mxnet.incubator.apache.org/install/ubuntu_setup.html#install-the-mxnet-package-for-scala) |
-| Windows | [Shared Library for Windows](http://mxnet.incubator.apache.org/install/windows_setup.html#build-the-shared-library) | <a class="github-button" href="https://github.com/apache/incubator-mxnet/issues/10549" data-size="large" data-show-count="true" aria-label="Issue apache/incubator-mxnet on GitHub">Call for Contribution</a> |
+| Windows | <a class="github-button" href="https://github.com/apache/incubator-mxnet/issues/10549" data-size="large" data-show-count="true" aria-label="Issue apache/incubator-mxnet on GitHub"> | <a class="github-button" href="https://github.com/apache/incubator-mxnet/issues/10549" data-size="large" data-show-count="true" aria-label="Issue apache/incubator-mxnet on GitHub">Call for Contribution</a> |
 
 
 #### Build Scala from an Existing MXNet Installation

--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -165,7 +165,9 @@ If building on CPU and using OpenBLAS:
 ```bash
     git clone --recursive https://github.com/apache/incubator-mxnet.git
     cd incubator-mxnet
-    make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas
+    echo "USE_OPENCV = 1" >> ./config.mk
+    echo "USE_BLAS = openblas" >> ./config.mk
+    make -j $(nproc)
 ```
 
 If building on CPU and using MKL and MKL-DNN (make sure MKL is installed according to [Math Library Selection](build_from_source.html#math-library-selection) and [MKL-DNN README](https://github.com/apache/incubator-mxnet/blob/master/MKLDNN_README.md)):
@@ -173,7 +175,10 @@ If building on CPU and using MKL and MKL-DNN (make sure MKL is installed accordi
 ```bash
     git clone --recursive https://github.com/apache/incubator-mxnet.git
     cd incubator-mxnet
-    make -j $(nproc) USE_OPENCV=1 USE_BLAS=mkl USE_MKLDNN=1
+    echo "USE_OPENCV = 1" >> ./config.mk
+    echo "USE_BLAS = openblas" >> ./config.mk
+    echo "USE_MKLDNN = 1" >> ./config.mk
+    make -j $(nproc)
 ```
 
 If building on GPU and you want OpenCV and OpenBLAS (make sure you have installed the [CUDA dependencies first](#cuda-dependencies)):
@@ -181,7 +186,12 @@ If building on GPU and you want OpenCV and OpenBLAS (make sure you have installe
 ```bash
     git clone --recursive https://github.com/apache/incubator-mxnet.git
     cd incubator-mxnet
-    make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas USE_CUDA=1 USE_CUDA_PATH=/usr/local/cuda USE_CUDNN=1
+    echo "USE_OPENCV = 1" >> ./config.mk
+    echo "USE_BLAS = openblas" >> ./config.mk
+    echo "USE_CUDA = 1" >> ./config.mk
+    echo "USE_CUDA_PATH = /usr/local/cuda" >> ./config.mk
+    echo "USE_CUDNN = 1" >> ./config.mk
+    make -j $(nproc)
 ```
 
 *Note* - USE_OPENCV and USE_BLAS are make file flags to set compilation options to use OpenCV and BLAS library. You can explore and use more compilation options in `make/config.mk` and also review common [usage examples](build_from_source.html#usage-examples).
@@ -351,7 +361,9 @@ $ sudo apt-get install -y libopencv-dev
 ```bash
 $ git clone --recursive https://github.com/apache/incubator-mxnet
 $ cd incubator-mxnet
-$ make -j $(nproc) USE_OPENCV=1 USE_BLAS=openblas
+$ echo "USE_OPENCV = 1" >> ./config.mk
+$ echo "USE_BLAS = openblas" >> ./config.mk
+$ make -j $(nproc)
 ```
 
 *Note* - USE_OPENCV and USE_BLAS are make file flags to set compilation options to use OpenCV and BLAS library. You can explore and use more compilation options in `make/config.mk`.

--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -177,6 +177,7 @@ If building on CPU and using MKL and MKL-DNN (make sure MKL is installed accordi
     cd incubator-mxnet
     echo "USE_OPENCV = 1" >> ./config.mk
     echo "USE_BLAS = openblas" >> ./config.mk
+    echo "USE_CUDA = 0" >> ./config.mk
     echo "USE_MKLDNN = 1" >> ./config.mk
     make -j $(nproc)
 ```


### PR DESCRIPTION
## Description ##
Arguments to make for the mxnet build can be passed either directly through the command line or through config.mk. The install instructions are inconsistent and use both options. However, some frontends such as scala require the arguments as well so they must be passed to both the initial make and the following "make scalapkg". Failure to pass the arguments to the scalapkg make can result in an improper configuration and slower performance. To resolve this, I am switching the install instructions to consistently use the config.mk because it is automatically used by all make commands which resolves the potential frontend problems.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

@nswamy @lanking520 @yzhliu @andrewfayres @piyushghai 