### PR TITLE
Fixes #13386 - Refer Warnings

### DIFF
--- a/contrib/clojure-package/src/dev/generator.clj
+++ b/contrib/clojure-package/src/dev/generator.clj
@@ -212,11 +212,11 @@
     (.write w "\n"))))
 
 (def symbol-gen-ns "(ns org.apache.clojure-mxnet.symbol
-    (:refer-clojure :exclude [* - + > >= < <= / cast concat identity flatten load max
-                              min repeat reverse set sort take to-array empty sin
-                              get apply shuffle])
-    (:require [org.apache.clojure-mxnet.util :as util])
-    (:import (org.apache.mxnet Symbol)))")
+  (:refer-clojure :exclude [* - + > >= < <= / cast concat identity flatten load max
+                            min repeat reverse set sort take to-array empty sin
+                            get apply shuffle ref])
+  (:require [org.apache.clojure-mxnet.util :as util])
+  (:import (org.apache.mxnet Symbol)))")
 
 
 (defn generate-symbol-file []
@@ -307,7 +307,8 @@
 
 (def ndarray-gen-ns "(ns org.apache.clojure-mxnet.ndarray
   (:refer-clojure :exclude [* - + > >= < <= / cast concat flatten identity load max
-                            min repeat reverse set sort take to-array empty shuffle])
+                            min repeat reverse set sort take to-array empty shuffle
+                            ref])
   (:import (org.apache.mxnet NDArray Shape)))")
 
 

--- a/contrib/clojure-package/src/org/apache/clojure_mxnet/ndarray.clj
+++ b/contrib/clojure-package/src/org/apache/clojure_mxnet/ndarray.clj
@@ -17,7 +17,8 @@
 
 (ns org.apache.clojure-mxnet.ndarray
   (:refer-clojure :exclude [* - + > >= < <= / cast concat flatten identity load max
-                            min repeat reverse set sort take to-array empty shuffle])
+                            min repeat reverse set sort take to-array empty shuffle
+                            ref])
   (:require [org.apache.clojure-mxnet.base :as base]
             [org.apache.clojure-mxnet.context :as mx-context]
             [org.apache.clojure-mxnet.shape :as mx-shape]

--- a/contrib/clojure-package/src/org/apache/clojure_mxnet/symbol.clj
+++ b/contrib/clojure-package/src/org/apache/clojure_mxnet/symbol.clj
@@ -18,7 +18,7 @@
 (ns org.apache.clojure-mxnet.symbol
   (:refer-clojure :exclude [* - + > >= < <= / cast concat identity flatten load max
                             min repeat reverse set sort take to-array empty sin
-                            get apply shuffle])
+                            get apply shuffle ref])
   (:require [org.apache.clojure-mxnet.base :as base]
             [org.apache.clojure-mxnet.context :as mx-context]
             [org.apache.clojure-mxnet.executor :as ex]

--- a/contrib/clojure-package/test/good-test-ndarray.clj
+++ b/contrib/clojure-package/test/good-test-ndarray.clj
@@ -1,6 +1,7 @@
 (ns org.apache.clojure-mxnet.ndarray
   (:refer-clojure :exclude [* - + > >= < <= / cast concat flatten identity load max
-                            min repeat reverse set sort take to-array empty shuffle])
+                            min repeat reverse set sort take to-array empty shuffle
+                            ref])
   (:import (org.apache.mxnet NDArray Shape)))
 
 ;; Do not edit - this is auto-generated

--- a/contrib/clojure-package/test/good-test-symbol.clj
+++ b/contrib/clojure-package/test/good-test-symbol.clj
@@ -1,9 +1,9 @@
 (ns org.apache.clojure-mxnet.symbol
-    (:refer-clojure :exclude [* - + > >= < <= / cast concat identity flatten load max
-                              min repeat reverse set sort take to-array empty sin
-                              get apply shuffle])
-    (:require [org.apache.clojure-mxnet.util :as util])
-    (:import (org.apache.mxnet Symbol)))
+  (:refer-clojure :exclude [* - + > >= < <= / cast concat identity flatten load max
+                            min repeat reverse set sort take to-array empty sin
+                            get apply shuffle ref])
+  (:require [org.apache.clojure-mxnet.util :as util])
+  (:import (org.apache.mxnet Symbol)))
 
 ;; Do not edit - this is auto-generated
 


### PR DESCRIPTION
## Description ##
Fixes refer warnings as suggested by @gigasquid in https://github.com/apache/incubator-mxnet/issues/13386

Test run no longer has ``refer`` warnings-

```
% lein test                                                                                                                                                                                     18-11-24 - 0:20:05
Generating ndarray file
Generating symbol file
INFO  MXNetJVM: Try loading mxnet-scala from native path.
INFO  MXNetJVM: Try loading mxnet-scala-linux-x86_64-gpu from native path.
INFO  MXNetJVM: Try loading mxnet-scala-linux-x86_64-cpu from native path.
WARN  MXNetJVM: MXNet Scala native library not found in path. Copying native library from the archive. Consider installing the library somewhere in the path (for Windows: PATH, for Linux: LD_LIBRARY_PATH), or specifying by Java cmd option -Djava.library.path=[lib path].
INFO  org.apache.mxnet.util.NativeLibraryLoader: Loading libmxnet-scala.so from /lib/native/ copying to mxnet-scala
[00:22:03] src/io/iter_mnist.cc:113: MNISTIter: load 60000 images, shuffle=1, shape=[100,1,28,28]
[00:22:03] src/io/iter_mnist.cc:113: MNISTIter: load 10000 images, shuffle=1, shape=[100,1,28,28]
WARN  org.apache.mxnet.WarnIfNotDisposed: LEAK: [one-time warning] An instance of org.apache.mxnet.NDArray was not disposed. Set property mxnet.traceLeakedObjects to true to enable tracing

lein test dev.generator-test

lein test org.apache.clojure-mxnet.callback-test
INFO  org.apache.mxnet.Callback$Speedometer: Epoch[0] Batch [50]        Speed: Infinity samples/sec     Train-accuracy=0.000000
INFO  org.apache.mxnet.Callback$Speedometer: Epoch[0] Batch [100]       Speed: Infinity samples/sec     Train-accuracy=0.000000

lein test org.apache.clojure-mxnet.conv-test
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.WarnIfNotDisposed: LEAK: [one-time warning] An instance of org.apache.mxnet.Symbol was not disposed. Set property mxnet.traceLeakedObjects to true to enable tracing
INFO  org.apache.mxnet.module.BaseModule: Epoch[0] Train-accuracy=0.9292167
INFO  org.apache.mxnet.module.BaseModule: Epoch[0] Time cost=12368
INFO  org.apache.mxnet.module.BaseModule: Epoch[0] Validation-accuracy=0.9557
Score [accuracy 0.9557]

lein test org.apache.clojure-mxnet.eval-metric-test
Testing eval metric accuracy
Testing eval metric top_k_accuracy
Testing eval metric f1
Testing eval metric Perplexity
Testing eval metric mae
Testing eval metric mse
Testing eval metric rmse

lein test org.apache.clojure-mxnet.executor-test

lein test org.apache.clojure-mxnet.image-test
WARN  org.apache.mxnet.WarnIfNotDisposed: LEAK: [one-time warning] An instance of org.apache.mxnet.Executor was not disposed. Set property mxnet.traceLeakedObjects to true to enable tracing

lein test org.apache.clojure-mxnet.initializer-test

lein test org.apache.clojure-mxnet.io-test
[00:22:27] src/io/iter_mnist.cc:110: MNISTIter: load 60000 images, shuffle=1, shape=(100,784)
[00:22:28] src/io/iter_mnist.cc:110: MNISTIter: load 60000 images, shuffle=1, shape=(100,784)
[00:22:29] src/io/iter_image_recordio_2.cc:172: ImageRecordIOParser2: data/cifar/train.rec, use 1 threads for decoding..
[00:22:31] src/io/iter_mnist.cc:113: MNISTIter: load 60000 images, shuffle=1, shape=[100,1,28,28]
[00:22:33] src/io/iter_mnist.cc:110: MNISTIter: load 60000 images, shuffle=1, shape=(100,784)
[00:22:34] src/io/iter_mnist.cc:110: MNISTIter: load 60000 images, shuffle=1, shape=(100,784)
[00:22:36] src/io/iter_mnist.cc:110: MNISTIter: load 60000 images, shuffle=1, shape=(100,784)

lein test org.apache.clojure-mxnet.kvstore-test

lein test org.apache.clojure-mxnet.lr-scheduler-test

lein test org.apache.clojure-mxnet.module-test
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
INFO  org.apache.mxnet.module.Module: Saved checkpoint to test-0000.params
INFO  org.apache.mxnet.module.Module: Saved optimizer state to test-0000.states
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
INFO  org.apache.mxnet.Model: Auto - select kvstore type = local_update_cpu
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
INFO  org.apache.mxnet.Model: Auto - select kvstore type = local_update_cpu
INFO  org.apache.mxnet.module.Module: Saved checkpoint to test-0000.params
INFO  org.apache.mxnet.module.Module: Saved optimizer state to test-0000.states
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis

lein test org.apache.clojure-mxnet.ndarray

lein test org.apache.clojure-mxnet.ndarray-test
[00:22:36] src/ndarray/./ndarray_function-inl.h:97: The operator onehot_encode is deprecated; use one_hot instead.

lein test org.apache.clojure-mxnet.operator-test
WARN  org.apache.mxnet.WarnIfNotDisposed: LEAK: [one-time warning] An instance of org.apache.mxnet.KVStore was not disposed. Set property mxnet.traceLeakedObjects to true to enable tracing
WARN  org.apache.mxnet.WarnIfNotDisposed: LEAK: [one-time warning] An instance of org.apache.mxnet.io.MXDataIter was not disposed. Set property mxnet.traceLeakedObjects to true to enable tracing
Embedded symbol: {
  "nodes": [
    {
      "op": "null", 
      "name": "data", 
      "inputs": []
    }, 
    {
      "op": "null", 
      "name": "embed_weight", 
      "attrs": {
        "input_dim": "10", 
        "output_dim": "4"
      }, 
      "inputs": []
    }, 
    {
      "op": "Embedding", 
      "name": "embed", 
      "attrs": {
        "input_dim": "10", 
        "output_dim": "4"
      }, 
      "inputs": [[0, 0, 0], [1, 0, 0]]
    }
  ], 
  "arg_nodes": [0, 1], 
  "node_row_ptr": [0, 1, 2, 3], 
  "heads": [[2, 0, 0]], 
  "attrs": {"mxnet_version": ["int", 10400]}
}

lein test org.apache.clojure-mxnet.optimizer-test
Testing optimizer -  sgd
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
Testing optimizer -  dcasgd
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
Testing optimizer -  nag
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
Testing optimizer -  ada-delta
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
Testing optimizer -  rms-prop
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
Testing optimizer -  ada-grad
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
Testing optimizer -  adam
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis
Testing optimizer -  sgld
WARN  org.apache.mxnet.DataDesc: Found Undefined Layout, will use default index 0 for batch axis

lein test org.apache.clojure-mxnet.profiler-test

lein test org.apache.clojure-mxnet.random-test

lein test org.apache.clojure-mxnet.shape-test

lein test org.apache.clojure-mxnet.symbol

lein test org.apache.clojure-mxnet.symbol-test
Symbol Outputs:
        output[0]=composed(0)
Variable:data
Variable:fc1_weight
Variable:fc1_bias
--------------------
Op:FullyConnected, Name=fc1
Inputs:
        arg[0]=data(0) version=0
        arg[1]=fc1_weight(0) version=0
        arg[2]=fc1_bias(0) version=0
Attrs:
        num_hidden=10
Variable:fc2_weight
Variable:fc2_bias
--------------------
Op:FullyConnected, Name=fc2
Inputs:
        arg[0]=fc1(0)
        arg[1]=fc2_weight(0) version=0
        arg[2]=fc2_bias(0) version=0
Attrs:
        num_hidden=100
Variable:fc3_weight
Variable:fc3_bias
--------------------
Op:FullyConnected, Name=fc3
Inputs:
        arg[0]=fc2(0)
        arg[1]=fc3_weight(0) version=0
        arg[2]=fc3_bias(0) version=0
Attrs:
        num_hidden=10
--------------------
Op:Activation, Name=activation0
Inputs:
        arg[0]=fc3(0)
Attrs:
        act_type=relu
Variable:fc4_weight
Variable:fc4_bias
--------------------
Op:FullyConnected, Name=composed
Inputs:
        arg[0]=activation0(0)
        arg[1]=fc4_weight(0) version=0
        arg[2]=fc4_bias(0) version=0
Attrs:
        num_hidden=20


lein test org.apache.clojure-mxnet.test-util

lein test org.apache.clojure-mxnet.util-test
val: 1 fails spec: :org.apache.clojure-mxnet.util-test/x predicate: string?

lein test org.apache.clojure-mxnet.visualization-test

Ran 197 tests containing 654 assertions.
0 failures, 0 errors.
INFO  org.apache.mxnet.util.NativeLibraryLoader: Deleting /tmp/mxnet3368754892352415330/mxnet-scala
INFO  org.apache.mxnet.util.NativeLibraryLoader: Deleting /tmp/mxnet3368754892352415330
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Excludes ``ref`` from ``generator.clj``, ``ndarray.clj`` and ``symbol.clj``
- [x] Updates ``good-test-ndarray.clj`` and ``good-test-symbol.clj`` as well for test cases

## Comments ##
- Validated the fix with a local run of test cases. Test cases no-longer show the ``refers`` warnings.
