### PR TITLE
Use dynamic omp schedule for sparse dot with large matrix

### DIFF
--- a/src/operator/mxnet_op.h
+++ b/src/operator/mxnet_op.h
@@ -529,9 +529,9 @@ struct Kernel<OP, cpu> {
    * for irregular workloads such as spmv.
    * When using this for a new kernel op, add declaration and tuning objects to
    * operator_tune.cc
-   * \tparam Args Varargs type to eventually pass to the OP::Map() functoion
+   * \tparam Args Varargs type to eventually pass to the OP::Map() function
    * \param N Number of iterations
-   * \param args Varargs to eventually pass to the OP::Map() functoion
+   * \param args Varargs to eventually pass to the OP::Map() function
    */
   template<typename ...Args>
   inline static bool LaunchDynamic(mshadow::Stream<cpu> *, const int64_t N, Args... args) {

--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -792,7 +792,8 @@ inline void DotCsrDnsDnsImpl(const OpContext& ctx,
         }
         num_threads = mxnet_op::get_num_threads<cpu>(data_out.shape_[0]);
         bool dynamic = false;
-        if (data_out.shape_[0] > 1024 * 10) {
+        const dim_t large_matrix_threshold = 1024 * 10;
+        if (data_out.shape_[0] > large_matrix_threshold) {
           dynamic = true;
           // each unit of work processes at least 1024 elements in the output
           const dim_t unit_work_per_thread = 1024;

--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -794,7 +794,9 @@ inline void DotCsrDnsDnsImpl(const OpContext& ctx,
         bool dynamic = false;
         if (data_out.shape_[0] > 1024 * 10) {
           dynamic = true;
-          num_threads = data_out.Size() / 1024;
+          // each unit of work processes at least 1024 elements in the output
+          const dim_t unit_work_per_thread = 1024;
+          num_threads = data_out.Size() / unit_work_per_thread;
         }
         dim_t seg_len = (data_out.shape_[0] + num_threads - 1) / num_threads;
         if (trans_lhs) {


### PR DESCRIPTION
## Description ##
The default kernel launch method doesn't use the dynamic openmp scheduling primitive, which suffers from workload balance problem when doing sparse matrix multiplication. This PR add LaunchDynamic method to the original Kernel class. 

@zheng-da 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
