### PR TITLE
Replace mxnetci dockcross with public dockcross due to missing image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -428,16 +428,16 @@ core_logic: {
         }
       }
     },
-    'NVidia Jetson / ARMv8':{
-      node(NODE_LINUX_CPU) {
-        ws('workspace/build-jetson-armv8') {
-          timeout(time: max_time, unit: 'MINUTES') {
-            utils.init_git()
-            utils.docker_run('jetson', 'build_jetson', false)
-          }
-        }
-      }
-    },
+    //'NVidia Jetson / ARMv8':{
+    //  node(NODE_LINUX_CPU) {
+    //    ws('workspace/build-jetson-armv8') {
+    //      timeout(time: max_time, unit: 'MINUTES') {
+    //        utils.init_git()
+    //        utils.docker_run('jetson', 'build_jetson', false)
+    //      }
+    //    }
+    //  }
+    //},
     'ARMv7':{
       node(NODE_LINUX_CPU) {
         ws('workspace/build-ARMv7') {

--- a/ci/docker/Dockerfile.build.android_armv7
+++ b/ci/docker/Dockerfile.build.android_armv7
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for Android ARMv7
 
-FROM dockcross/base
+FROM mxnetcipinned/dockcross-base:11262018
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 
 # The cross-compiling emulator

--- a/ci/docker/Dockerfile.build.android_armv7
+++ b/ci/docker/Dockerfile.build.android_armv7
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for Android ARMv7
 
-FROM mxnetci/dockcross-linux-base:08212018
+FROM dockcross/base
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 
 # The cross-compiling emulator

--- a/ci/docker/Dockerfile.build.android_armv8
+++ b/ci/docker/Dockerfile.build.android_armv8
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for Android ARM64/ARMv8
 
-FROM dockcross/base
+FROM mxnetcipinned/dockcross-base:11262018
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 
 RUN apt-get update && apt-get install -y \

--- a/ci/docker/Dockerfile.build.android_armv8
+++ b/ci/docker/Dockerfile.build.android_armv8
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for Android ARM64/ARMv8
 
-FROM mxnetci/dockcross-linux-base:08212018
+FROM dockcross/base
 MAINTAINER Pedro Larroy "pllarroy@amazon.com"
 
 RUN apt-get update && apt-get install -y \

--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for ARMv6
 
-FROM dockcross/linux-armv6
+FROM mxnetcipinned/dockcross-linux-armv6:11262018
 
 ENV ARCH armv6l
 ENV HOSTCC gcc

--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for ARMv6
 
-FROM mxnetci/dockcross-linux-armv6:08212018
+FROM dockcross/linux-armv6
 
 ENV ARCH armv6l
 ENV HOSTCC gcc

--- a/ci/docker/Dockerfile.build.armv7
+++ b/ci/docker/Dockerfile.build.armv7
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for Android ARMv7
 
-FROM dockcross/linux-armv7
+FROM mxnetcipinned/dockcross-linux-armv7:11262018
 
 ENV ARCH armv7l
 ENV HOSTCC gcc

--- a/ci/docker/Dockerfile.build.armv7
+++ b/ci/docker/Dockerfile.build.armv7
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for Android ARMv7
 
-FROM mxnetci/dockcross-linux-armv7:09182018
+FROM dockcross/linux-armv7
 
 ENV ARCH armv7l
 ENV HOSTCC gcc

--- a/ci/docker/Dockerfile.build.armv8
+++ b/ci/docker/Dockerfile.build.armv8
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for ARM64/ARMv8
 
-FROM dockcross/linux-arm64
+FROM mxnetcipinned/dockcross-linux-arm64:11262018
 
 ENV ARCH aarch64
 ENV HOSTCC gcc

--- a/ci/docker/Dockerfile.build.armv8
+++ b/ci/docker/Dockerfile.build.armv8
@@ -27,8 +27,8 @@ ENV TARGET ARMV8
 WORKDIR /work/deps
 
 # gh issue #11567 https://github.com/apache/incubator-mxnet/issues/11567
-RUN sed -i '\#deb http://cdn-fastly.deb.debian.org/debian-security jessie/updates main#d' /etc/apt/sources.list
-RUN sed -i 's/cdn-fastly.//' /etc/apt/sources.list
+#RUN sed -i '\#deb http://cdn-fastly.deb.debian.org/debian-security jessie/updates main#d' /etc/apt/sources.list
+#RUN sed -i 's/cdn-fastly.//' /etc/apt/sources.list
 
 COPY install/ubuntu_arm.sh /work/
 RUN /work/ubuntu_arm.sh

--- a/ci/docker/Dockerfile.build.armv8
+++ b/ci/docker/Dockerfile.build.armv8
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build MXNet for ARM64/ARMv8
 
-FROM mxnetci/dockcross-linux-arm64:08212018
+FROM dockcross/linux-arm64
 
 ENV ARCH aarch64
 ENV HOSTCC gcc

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -22,7 +22,7 @@
 
 FROM nvidia/cuda:9.0-cudnn7-devel as cudabuilder
 
-FROM dockcross/linux-arm64
+FROM mxnetcipinned/dockcross-linux-arm64:11262018
 
 ENV ARCH aarch64
 ENV HOSTCC gcc

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -29,8 +29,8 @@ ENV HOSTCC gcc
 ENV TARGET ARMV8
 
 # gh issue #11567 https://github.com/apache/incubator-mxnet/issues/11567
-RUN sed -i '\#deb http://cdn-fastly.deb.debian.org/debian-security jessie/updates main#d' /etc/apt/sources.list
-RUN sed -i 's/cdn-fastly.//' /etc/apt/sources.list
+#RUN sed -i '\#deb http://cdn-fastly.deb.debian.org/debian-security jessie/updates main#d' /etc/apt/sources.list
+#RUN sed -i 's/cdn-fastly.//' /etc/apt/sources.list
 
 
 WORKDIR /work/deps

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -22,7 +22,7 @@
 
 FROM nvidia/cuda:9.0-cudnn7-devel as cudabuilder
 
-FROM mxnetci/dockcross-linux-arm64:05082018
+FROM dockcross/linux-arm64
 
 ENV ARCH aarch64
 ENV HOSTCC gcc

--- a/ci/jenkins/Jenkinsfile_edge
+++ b/ci/jenkins/Jenkinsfile_edge
@@ -34,7 +34,7 @@ utils.assign_node_labels(utility: 'utility', linux_cpu: 'mxnetlinux-cpu', linux_
 utils.main_wrapper(
 core_logic: {
   utils.parallel_stage('Build', [
-    custom_steps.compile_armv8_jetson_gpu(),
+//    custom_steps.compile_armv8_jetson_gpu(),
     custom_steps.compile_armv7_cpu(),
     custom_steps.compile_armv6_cpu(),
     custom_steps.compile_armv8_cpu(),


### PR DESCRIPTION
We had to get rid of our pinned dockcross images. This revealed some problems that are going to be addressed by this PR.

Jetson is being disabled right now because the compilation reports the following:

```
/work/mxnet/3rdparty/mshadow/mshadow/./base.h:179:21: fatal error: cudnn.h: No such file or directory

   #include <cudnn.h>

                     ^

compilation terminated.
```



Install log:
```
Step 18/24 : RUN JETPACK_DOWNLOAD_PREFIX=https://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/3.3/lw.xd42/JetPackL4T_33_b39 &&     CUDA_REPO_PREFIX=/var/cuda-repo-9-0-local &&     ARM_CUDA_INSTALLER_PACKAGE=cuda-repo-l4t-9-0-local_9.0.252-1_arm64.deb &&     ARM_CUDNN_INSTALLER_PACKAGE=libcudnn7_7.1.5.14-1+cuda9.0_arm64.deb &&     ARM_CUDNN_DEV_INSTALLER_PACKAGE=libcudnn7-dev_7.1.5.14-1+cuda9.0_arm64.deb &&     ARM_LICENSE_INSTALLER=cuda-license-9-0_9.0.252-1_arm64.deb &&     ARM_CUBLAS_INSTALLER=cuda-cublas-9-0_9.0.252-1_arm64.deb &&     ARM_NVINFER_INSTALLER_PACKAGE=libnvinfer4_4.1.3-1+cuda9.0_arm64.deb &&     ARM_NVINFER_DEV_INSTALLER_PACKAGE=libnvinfer-dev_4.1.3-1+cuda9.0_arm64.deb &&     dpkg --add-architecture arm64 &&     wget -nv $JETPACK_DOWNLOAD_PREFIX/$ARM_CUDA_INSTALLER_PACKAGE &&     wget -nv $JETPACK_DOWNLOAD_PREFIX/$ARM_CUDNN_INSTALLER_PACKAGE &&     wget -nv $JETPACK_DOWNLOAD_PREFIX/$ARM_CUDNN_DEV_INSTALLER_PACKAGE &&     wget -nv $JETPACK_DOWNLOAD_PREFIX/$ARM_NVINFER_INSTALLER_PACKAGE &&     wget -nv $JETPACK_DOWNLOAD_PREFIX/$ARM_NVINFER_DEV_INSTALLER_PACKAGE &&     dpkg -i --force-architecture  $ARM_CUDA_INSTALLER_PACKAGE &&     apt-key add $CUDA_REPO_PREFIX/7fa2af80.pub &&     dpkg -i --force-architecture  $ARM_CUDNN_INSTALLER_PACKAGE &&     dpkg -i --force-architecture  $ARM_CUDNN_DEV_INSTALLER_PACKAGE &&     dpkg -i --force-architecture  $CUDA_REPO_PREFIX/$ARM_LICENSE_INSTALLER &&     dpkg -i --force-architecture  $CUDA_REPO_PREFIX/$ARM_CUBLAS_INSTALLER &&     dpkg -i --force-architecture  $ARM_NVINFER_INSTALLER_PACKAGE &&     dpkg -i --force-architecture  $ARM_NVINFER_DEV_INSTALLER_PACKAGE &&     apt update -y || true && apt install -y cuda-libraries-dev-9-0 libcudnn7-dev libnvinfer-dev

 ---> Running in 2a393dd9c0f4

2018-11-25 18:22:01 URL:https://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/3.3/lw.xd42/JetPackL4T_33_b39/cuda-repo-l4t-9-0-local_9.0.252-1_arm64.deb [604852294/604852294] -> "cuda-repo-l4t-9-0-local_9.0.252-1_arm64.deb" [1]

2018-11-25 18:22:02 URL:https://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/3.3/lw.xd42/JetPackL4T_33_b39/libcudnn7_7.1.5.14-1+cuda9.0_arm64.deb [89552864/89552864] -> "libcudnn7_7.1.5.14-1+cuda9.0_arm64.deb" [1]

2018-11-25 18:22:04 URL:https://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/3.3/lw.xd42/JetPackL4T_33_b39/libcudnn7-dev_7.1.5.14-1+cuda9.0_arm64.deb [84211230/84211230] -> "libcudnn7-dev_7.1.5.14-1+cuda9.0_arm64.deb" [1]

2018-11-25 18:22:05 URL:https://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/3.3/lw.xd42/JetPackL4T_33_b39/libnvinfer4_4.1.3-1+cuda9.0_arm64.deb [27384730/27384730] -> "libnvinfer4_4.1.3-1+cuda9.0_arm64.deb" [1]

2018-11-25 18:22:06 URL:https://developer.download.nvidia.com/devzone/devcenter/mobile/jetpack_l4t/3.3/lw.xd42/JetPackL4T_33_b39/libnvinfer-dev_4.1.3-1+cuda9.0_arm64.deb [28841752/28841752] -> "libnvinfer-dev_4.1.3-1+cuda9.0_arm64.deb" [1]

Selecting previously unselected package cuda-repo-l4t-9-0-local.

(Reading database ... 20833 files and directories currently installed.)

Preparing to unpack cuda-repo-l4t-9-0-local_9.0.252-1_arm64.deb ...

Unpacking cuda-repo-l4t-9-0-local (9.0.252-1) ...

Setting up cuda-repo-l4t-9-0-local (9.0.252-1) ...



The public CUDA GPG key does not appear to be installed.

To install the key, run this command:

sudo apt-key add /var/cuda-repo-9-0-local/7fa2af80.pub



OK

Selecting previously unselected package libcudnn7.

(Reading database ... 20873 files and directories currently installed.)

Preparing to unpack libcudnn7_7.1.5.14-1+cuda9.0_arm64.deb ...

Unpacking libcudnn7 (7.1.5.14-1+cuda9.0) ...

Setting up libcudnn7 (7.1.5.14-1+cuda9.0) ...

Processing triggers for libc-bin (2.19-18+deb8u10) ...

Selecting previously unselected package libcudnn7-dev.

(Reading database ... 20881 files and directories currently installed.)

Preparing to unpack libcudnn7-dev_7.1.5.14-1+cuda9.0_arm64.deb ...

Unpacking libcudnn7-dev (7.1.5.14-1+cuda9.0) ...

Setting up libcudnn7-dev (7.1.5.14-1+cuda9.0) ...

update-alternatives: using /usr/include/aarch64-linux-gnu/cudnn_v7.h to provide /usr/include/cudnn.h (libcudnn) in auto mode

Selecting previously unselected package cuda-license-9-0.

(Reading database ... 20888 files and directories currently installed.)

Preparing to unpack .../cuda-license-9-0_9.0.252-1_arm64.deb ...

Unpacking cuda-license-9-0 (9.0.252-1) ...

Setting up cuda-license-9-0 (9.0.252-1) ...

*** LICENSE AGREEMENT ***

By using this software you agree to fully comply with the terms and 

conditions of the EULA (End User License Agreement). The EULA is located

at /usr/local/cuda-9.0/doc/EULA.txt. The EULA can also be found at

http://docs.nvidia.com/cuda/eula/index.html. If you do not agree to the

terms and conditions of the EULA, do not use the software.



Selecting previously unselected package cuda-cublas-9-0.

(Reading database ... 20898 files and directories currently installed.)

Preparing to unpack .../cuda-cublas-9-0_9.0.252-1_arm64.deb ...

Unpacking cuda-cublas-9-0 (9.0.252-1) ...

Setting up cuda-cublas-9-0 (9.0.252-1) ...

Processing triggers for libc-bin (2.19-18+deb8u10) ...

Selecting previously unselected package libnvinfer4.

(Reading database ... 20909 files and directories currently installed.)

Preparing to unpack libnvinfer4_4.1.3-1+cuda9.0_arm64.deb ...

Unpacking libnvinfer4 (4.1.3-1+cuda9.0) ...

Setting up libnvinfer4 (4.1.3-1+cuda9.0) ...

Processing triggers for libc-bin (2.19-18+deb8u10) ...

Selecting previously unselected package libnvinfer-dev.

(Reading database ... 20923 files and directories currently installed.)

Preparing to unpack libnvinfer-dev_4.1.3-1+cuda9.0_arm64.deb ...

Unpacking libnvinfer-dev (4.1.3-1+cuda9.0) ...

Setting up libnvinfer-dev (4.1.3-1+cuda9.0) ...



WARNING: apt does not have a stable CLI interface yet. Use with caution in scripts.



Ign file:  InRelease

Ign http://cdn-fastly.deb.debian.org jessie InRelease

Hit http://cdn-fastly.deb.debian.org jessie-updates InRelease

Hit http://cdn-fastly.deb.debian.org jessie/updates InRelease

Hit http://ftp.debian.org jessie-backports InRelease

Get:1 file:  Release.gpg [819 B]

Get:2 file:  Release [574 B]

Hit http://cdn-fastly.deb.debian.org jessie Release.gpg

Hit http://cdn-fastly.deb.debian.org jessie Release

Get:3 http://cdn-fastly.deb.debian.org jessie-updates/main amd64 Packages [23.0 kB]

Get:4 http://cdn-fastly.deb.debian.org jessie-updates/contrib amd64 Packages [20 B]

Get:5 http://cdn-fastly.deb.debian.org jessie-updates/non-free amd64 Packages [449 B]

Get:6 http://cdn-fastly.deb.debian.org jessie-updates/main arm64 Packages [22.8 kB]

Get:7 http://cdn-fastly.deb.debian.org jessie-updates/contrib arm64 Packages [20 B]

Get:8 http://cdn-fastly.deb.debian.org jessie-updates/non-free arm64 Packages [449 B]

Get:9 http://cdn-fastly.deb.debian.org jessie/updates/main amd64 Packages [778 kB]

Get:10 http://cdn-fastly.deb.debian.org jessie/main amd64 Packages [9098 kB]

Get:11 http://ftp.debian.org jessie-backports/main amd64 Packages [1172 kB]

Get:12 http://cdn-fastly.deb.debian.org jessie/contrib amd64 Packages [59.2 kB]

Get:13 http://cdn-fastly.deb.debian.org jessie/non-free amd64 Packages [101 kB]

Get:14 http://cdn-fastly.deb.debian.org jessie/main arm64 Packages [8593 kB]

Get:15 http://cdn-fastly.deb.debian.org jessie/contrib arm64 Packages [41.2 kB]

Get:16 http://cdn-fastly.deb.debian.org jessie/non-free arm64 Packages [68.6 kB]

Get:17 http://ftp.debian.org jessie-backports/main arm64 Packages [1115 kB]

Fetched 21.1 MB in 7s (2976 kB/s)

W: Failed to fetch http://cdn-fastly.deb.debian.org/debian-security/dists/jessie/updates/InRelease  Unable to find expected entry 'main/binary-arm64/Packages' in Release file (Wrong sources.list entry or malformed file)



E: Some index files failed to download. They have been ignored, or old ones used instead.



WARNING: apt does not have a stable CLI interface yet. Use with caution in scripts.



Reading package lists...

Building dependency tree...

Reading state information...

libnvinfer-dev:arm64 is already the newest version.

libcudnn7-dev:arm64 is already the newest version.

The following extra packages will be installed:

  cuda-cublas-dev-9-0:arm64 cuda-cudart-9-0:arm64 cuda-cudart-dev-9-0:arm64

  cuda-cufft-9-0:arm64 cuda-cufft-dev-9-0:arm64 cuda-curand-9-0:arm64

  cuda-curand-dev-9-0:arm64 cuda-cusolver-9-0:arm64

  cuda-cusolver-dev-9-0:arm64 cuda-cusparse-9-0:arm64

  cuda-cusparse-dev-9-0:arm64 cuda-driver-dev-9-0:arm64

  cuda-misc-headers-9-0:arm64 cuda-npp-9-0:arm64 cuda-npp-dev-9-0:arm64

  cuda-nvgraph-9-0:arm64 cuda-nvgraph-dev-9-0:arm64 cuda-nvrtc-9-0:arm64

  cuda-nvrtc-dev-9-0:arm64

The following NEW packages will be installed:

  cuda-cublas-dev-9-0:arm64 cuda-cudart-9-0:arm64 cuda-cudart-dev-9-0:arm64

  cuda-cufft-9-0:arm64 cuda-cufft-dev-9-0:arm64 cuda-curand-9-0:arm64

  cuda-curand-dev-9-0:arm64 cuda-cusolver-9-0:arm64

  cuda-cusolver-dev-9-0:arm64 cuda-cusparse-9-0:arm64

  cuda-cusparse-dev-9-0:arm64 cuda-driver-dev-9-0:arm64

  cuda-libraries-dev-9-0:arm64 cuda-misc-headers-9-0:arm64 cuda-npp-9-0:arm64

  cuda-npp-dev-9-0:arm64 cuda-nvgraph-9-0:arm64 cuda-nvgraph-dev-9-0:arm64

  cuda-nvrtc-9-0:arm64 cuda-nvrtc-dev-9-0:arm64

debconf: delaying package configuration, since apt-utils is not installed

0 upgraded, 20 newly installed, 0 to remove and 12 not upgraded.

Need to get 0 B/408 MB of archives.

After this operation, 1170 MB of additional disk space will be used.

Selecting previously unselected package cuda-cublas-dev-9-0.

(Reading database ... 
(Reading database ... 5%
(Reading database ... 10%
(Reading database ... 15%
(Reading database ... 20%
(Reading database ... 25%
(Reading database ... 30%
(Reading database ... 35%
(Reading database ... 40%
(Reading database ... 45%
(Reading database ... 50%
(Reading database ... 55%
(Reading database ... 60%
(Reading database ... 65%
(Reading database ... 70%
(Reading database ... 75%
(Reading database ... 80%
(Reading database ... 85%
(Reading database ... 90%
(Reading database ... 95%
(Reading database ... 100%
(Reading database ... 20947 files and directories currently installed.)

Preparing to unpack .../cuda-cublas-dev-9-0_9.0.252-1_arm64.deb ...

Unpacking cuda-cublas-dev-9-0 (9.0.252-1) ...

Selecting previously unselected package cuda-cudart-9-0.

Preparing to unpack .../cuda-cudart-9-0_9.0.252-1_arm64.deb ...

Unpacking cuda-cudart-9-0 (9.0.252-1) ...

Selecting previously unselected package cuda-driver-dev-9-0.

Preparing to unpack .../cuda-driver-dev-9-0_9.0.252-1_arm64.deb ...

Unpacking cuda-driver-dev-9-0 (9.0.252-1) ...

Selecting previously unselected package cuda-cudart-dev-9-0.

Preparing to unpack .../cuda-cudart-dev-9-0_9.0.252-1_arm64.deb ...

Unpacking cuda-cudart-dev-9-0 (9.0.252-1) ...

Selecting previously unselected package cuda-cufft-9-0.

Preparing to unpack .../cuda-cufft-9-0_9.0.252-1_arm64.deb ...

Unpacking cuda-cufft-9-0 (9.0.252-1) ...

Selecting previously unselected package cuda-cufft-dev-9-0.

Preparing to unpack .../cuda-cufft-dev-9-0_9.0.252-1_arm64.deb ...

Unpacking cuda-cufft-dev-9-0 (9.0.252-1) ...

Selecting previously unselected package cuda-curand-9-0.

Preparing to unpack .../cuda-curand-9-0_9.0.252-1_arm64.deb ...

Unpacking cuda-curand-9-0 (9.0.252-1) ...

Selecting previously unselected package cuda-curand-dev-9-0.

[...]
```