### PR TITLE
fix for params with no dims in onnx

### DIFF
--- a/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
@@ -88,7 +88,7 @@ class GraphProto(object): # pylint: disable=too-few-public-methods
         params : dict
             A dict of name: nd.array pairs, used as pretrained weights
         """
-        # get input, output shapes
+        #get input, output shapes
         self.model_metadata = self.get_graph_metadata(graph)
         # parse network inputs, aka parameters
         for init_tensor in graph.initializer:

--- a/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
@@ -201,7 +201,7 @@ class GraphProto(object): # pylint: disable=too-few-public-methods
             np_array = to_array(tensor_proto).reshape(tuple(tensor_proto.dims))
         else:
             np_array = np.array([to_array(tensor_proto)])
-            return nd.array(np_array)
+        return nd.array(np_array)
 
     def _parse_attr(self, attr_proto):
         """Convert a list of AttributeProto to a dict, with names as keys."""

--- a/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
@@ -200,6 +200,7 @@ class GraphProto(object): # pylint: disable=too-few-public-methods
         if len(tuple(tensor_proto.dims)) > 0:
             np_array = to_array(tensor_proto).reshape(tuple(tensor_proto.dims))
         else:
+            # If onnx's params are scalar values without dims mentioned.
             np_array = np.array([to_array(tensor_proto)])
         return nd.array(np_array)
 

--- a/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
@@ -23,6 +23,7 @@ from .... import symbol
 from .... import ndarray as nd
 from ....base import string_types
 from ._import_helper import _convert_map as convert_map
+import numpy as np
 
 class GraphProto(object): # pylint: disable=too-few-public-methods
     """A helper class for handling mxnet symbol copying from pb2.GraphProto.
@@ -87,7 +88,7 @@ class GraphProto(object): # pylint: disable=too-few-public-methods
         params : dict
             A dict of name: nd.array pairs, used as pretrained weights
         """
-        #get input, output shapes
+        # get input, output shapes
         self.model_metadata = self.get_graph_metadata(graph)
         # parse network inputs, aka parameters
         for init_tensor in graph.initializer:
@@ -196,8 +197,11 @@ class GraphProto(object): # pylint: disable=too-few-public-methods
         except ImportError:
             raise ImportError("Onnx and protobuf need to be installed. "
                               + "Instructions to install - https://github.com/onnx/onnx")
-        np_array = to_array(tensor_proto).reshape(tuple(tensor_proto.dims))
-        return nd.array(np_array)
+        if len(tuple(tensor_proto.dims)) > 0:
+            np_array = to_array(tensor_proto).reshape(tuple(tensor_proto.dims))
+        else:
+            np_array = np.array([to_array(tensor_proto)])
+            return nd.array(np_array)
 
     def _parse_attr(self, attr_proto):
         """Convert a list of AttributeProto to a dict, with names as keys."""

--- a/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
@@ -88,7 +88,7 @@ class GraphProto(object): # pylint: disable=too-few-public-methods
         params : dict
             A dict of name: nd.array pairs, used as pretrained weights
         """
-        #get input, output shapes
+        # get input, output shapes
         self.model_metadata = self.get_graph_metadata(graph)
         # parse network inputs, aka parameters
         for init_tensor in graph.initializer:

--- a/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/import_onnx.py
@@ -19,11 +19,11 @@
 # pylint: disable=invalid-name,too-many-locals,no-self-use
 """ Support import export formats."""
 from __future__ import absolute_import as _abs
+import numpy as np
 from .... import symbol
 from .... import ndarray as nd
 from ....base import string_types
 from ._import_helper import _convert_map as convert_map
-import numpy as np
 
 class GraphProto(object): # pylint: disable=too-few-public-methods
     """A helper class for handling mxnet symbol copying from pb2.GraphProto.

--- a/tests/python-pytest/onnx/test_models.py
+++ b/tests/python-pytest/onnx/test_models.py
@@ -51,6 +51,7 @@ URLS = {
         'https://s3.amazonaws.com/download.onnx/models/opset_8/inception_v2.tar.gz'
 }
 
+test_model_path = "https://s3.amazonaws.com/onnx-mxnet/test_model.onnx"
 
 def get_test_files(name):
     """Extract tar file and returns model path and input, output data"""
@@ -152,6 +153,16 @@ class TestModel(unittest.TestCase):
 
                 logging.info(model_name + " conversion successful")
 
+    def test_nodims_import(self):
+        # Download test model without dims mentioned in params
+        test_model = download(test_model_path, dirname=CURR_PATH.__str__())
+        input_data = np.array([0.2, 0.5])
+        nd_data = mx.nd.array(input_data).expand_dims(0)
+        sym, arg_params, aux_params = onnx_mxnet.import_model(test_model)
+        model_metadata = onnx_mxnet.get_model_metadata(test_model)
+        input_names = [inputs[0] for inputs in model_metadata.get('input_tensor_data')]
+        output_data = forward_pass(sym, arg_params, aux_params, input_names, nd_data)
+        assert(output_data.shape == (1,1))
 
 # test_case = ("model name", input shape, output shape)
 test_cases = [


### PR DESCRIPTION
## Description ##
input tensor_proto can be a numeric variable and sometimes it can have  tensor_proto.dims parameter empty. In this case, as the shape cannot be infered, and reshape will throw an error. Adding a fix for it

Fixes #13300
@thomelane @vandanavk 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change