### PR TITLE
Fix infoGan Gluon tutorial errors (fix NightlyTestsForBinaries breakage)

### DIFF
--- a/ci/docker/install/ubuntu_tutorials.sh
+++ b/ci/docker/install/ubuntu_tutorials.sh
@@ -23,5 +23,5 @@
 set -ex
 apt-get update || true
 apt-get install graphviz python-opencv
-pip2 install jupyter matplotlib Pillow opencv-python scikit-learn graphviz tqdm
-pip3 install jupyter matplotlib Pillow opencv-python scikit-learn graphviz tqdm
+pip2 install jupyter matplotlib Pillow opencv-python scikit-learn graphviz tqdm mxboard
+pip3 install jupyter matplotlib Pillow opencv-python scikit-learn graphviz tqdm mxboard

--- a/docs/tutorials/gluon/info_gan.md
+++ b/docs/tutorials/gluon/info_gan.md
@@ -311,18 +311,18 @@ with SummaryWriter(logdir='./logs/') as sw:
 
             # logging
             if idx % 10 == 0:
-           
+                count = idx + 1
                 logging.info('speed: {} samples/s'.format(batch_size / (time.time() - starttime)))
                 logging.info('discriminator loss = %f, generator loss = %f at iter %d epoch %d'
-                         %(d_error_epoch.asscalar()/idx,g_error_epoch.asscalar()/idx, idx, epoch))
+                         %(d_error_epoch.asscalar()/count,g_error_epoch.asscalar()/count, count, epoch))
 
                 g_input,_,_ = create_generator_input()
                 
                 # create some fake image for logging in MXBoard
                 fake_image = generator(g_input)
 
-                sw.add_scalar(tag='Loss_D', value={'test':d_error_epoch.asscalar()/idx}, global_step=counter)
-                sw.add_scalar(tag='Loss_G', value={'test':d_error_epoch.asscalar()/idx}, global_step=counter)
+                sw.add_scalar(tag='Loss_D', value={'test':d_error_epoch.asscalar()/count}, global_step=counter)
+                sw.add_scalar(tag='Loss_G', value={'test':d_error_epoch.asscalar()/count}, global_step=counter)
                 sw.add_image(tag='data_image', image=((fake_image[0]+ 1.0) * 127.5).astype(np.uint8)  , global_step=counter)
                 sw.flush()
         


### PR DESCRIPTION
## Description ##
This change fixes a broken tutorial by adding a missing dependency and avoiding a divide by 0 warning.
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Update notebook to avoid divide by 0 causing a warning.
- [x] Add MXBoard dependency which was missing.