### PR TITLE
Adding Java to ubuntu setup install page and minor fixes to docs

### DIFF
--- a/docs/install/java_setup.md
+++ b/docs/install/java_setup.md
@@ -41,41 +41,48 @@ Go to the [MXNet-Java demo project's README](https://github.com/apache/incubator
 
 #### Maven Repository
 
-Package information can be found in this [Maven Repository](https://repository.apache.org/#nexus-search;gav~org.apache.mxnet~~1.3.1-SNAPSHOT~~)
+MXNet-Java can be easily included in your Maven managed project. The Java packages are currently available as nightly builds on Maven. Add the following Maven repository to your `pom.xml` to fetch the Java packages :
+
+```html
+<repositories>
+    <repository>
+      <id>Apache Snapshot</id>
+      <url>https://repository.apache.org/content/groups/snapshots</url>
+    </repository>
+</repositories>
+```
+
+Also, add the dependency which corresponds to your platform to the `dependencies` tag :
 
 **Linux CPU**
 ```html
-<!-- https://mvnrepository.com/artifact/org.apache.mxnet/mxnet-full_2.11-linux-x86_64-cpu -->
 <dependency>
-    <groupId>org.apache.mxnet</groupId>
-    <artifactId>mxnet-full_2.11-linux-x86_64-cpu</artifactId>
-    <scope>system</scope>
-    <systemPath>/system/path/to/jar/mxnet-full_2.11-linux-x86_64-cpu-1.3.1-SNAPSHOT.jar</systemPath>
+  <groupId>org.apache.mxnet</groupId>
+  <artifactId>mxnet-full_2.11-linux-x86_64-cpu</artifactId>
+  <version>1.3.1-SNAPSHOT</version>
 </dependency>
 ```
 
 **Linux GPU**
 ```html
-<!-- https://mvnrepository.com/artifact/org.apache.mxnet/mxnet-full_2.11-linux-x86_64-gpu -->
 <dependency>
-    <groupId>org.apache.mxnet</groupId>
-    <artifactId>mxnet-full_2.11-linux-x86_64-gpu</artifactId>
-    <scope>system</scope>
-    <systemPath>/system/path/to/jar/mxnet-full_2.11-linux-x86_64-gpu-1.3.1-SNAPSHOT.jar</systemPath>
+  <groupId>org.apache.mxnet</groupId>
+  <artifactId>mxnet-full_2.11-linux-x86_64-gpu</artifactId>
+  <version>1.3.1-SNAPSHOT</version>
 </dependency>
 ```
 
 **macOS CPU**
 ```html
-<!-- https://mvnrepository.com/artifact/org.apache.mxnet/mxnet-full_2.11-osx-x86_64-cpu -->
 <dependency>
-    <groupId>org.apache.mxnet</groupId>
-    <artifactId>mxnet-full_2.11-osx-x86_64-cpu</artifactId>
-    <scope>system</scope>
-    <systemPath>/system/path/to/jar/mxnet-full_2.11-osx-x86_64-cpu-1.3.1-SNAPSHOT.jar</systemPath>
+  <groupId>org.apache.mxnet</groupId>
+  <artifactId>mxnet-full_2.11-osx-x86_64-cpu</artifactId>
+  <version>1.3.1-SNAPSHOT</version>
 </dependency>
 ```
 
+
+The official Java Packages will be released with the release of MXNet 1.4 and will be available on  [MXNet Maven package repository](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.mxnet%22).
 <hr>
 
 ## Source

--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -14,6 +14,7 @@ The following installation instructions are for installing MXNet on computers ru
     * [R](#install-the-mxnet-package-for-r)
     * [Julia](#install-the-mxnet-package-for-julia)
     * [Scala](#install-the-mxnet-package-for-scala)
+    * [Java](#install-the-mxnet-package-for-java)    
     * [Perl](#install-the-mxnet-package-for-perl)
   * [Contributions](#contributions)
   * [Next Steps](#next-steps)
@@ -100,7 +101,7 @@ To install an older version of MXNet with one of the packages in the previous ta
 
 ## Build MXNet from Source
 
-You can build MXNet from source, and then you have the option of installing language-specific bindings, such as Scala, Julia, R or Perl. This is a two-step process:
+You can build MXNet from source, and then you have the option of installing language-specific bindings, such as Scala, Java, Julia, R or Perl. This is a two-step process:
 
 1. Build the shared library from the MXNet C++ source code.
 2. (optional) Install the supported language-specific packages for MXNet. Be sure to check that section first, as some scripts may be available to handle all of the dependencies, MXNet build, and language bindings for you. Here they are again for quick access:
@@ -108,6 +109,7 @@ You can build MXNet from source, and then you have the option of installing lang
 * [R](#install-the-mxnet-package-for-r)
 * [Julia](#install-the-mxnet-package-for-julia)
 * [Scala](#install-the-mxnet-package-for-scala)
+* [Java](#install-the-mxnet-package-for-java)
 * [Perl](#install-the-mxnet-package-for-perl)
 
 **Note:** To change the compilation options for your build, edit the ```make/config.mk``` file prior to building MXNet. More information on this is mentioned in the different language package instructions.
@@ -207,6 +209,7 @@ After you have installed the MXNet core library. You may install MXNet interface
 - [Perl](#install-the-mxnet-package-for-perl)
 - [R](#install-the-mxnet-package-for-r)
 - [Scala](#install-the-mxnet-package-for-scala)
+- [Java](#install-the-mxnet-package-for-java)
 
 <hr>
 
@@ -397,6 +400,14 @@ Further information is in the [MXNet-Scala Setup Instructions](scala_setup.html)
 If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial](../tutorials/scala/mxnet_scala_on_intellij.html) instead.
 <hr>
 
+### Install the MXNet Package for Java
+
+To use the MXNet-Java package, you can acquire the Maven package as a dependency.
+
+Further information is in the [MXNet-Java Setup Instructions](java.html).
+
+If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Java on IntelliJ tutorial](../tutorials/java/mxnet_java_on_intellij.html) instead.
+<hr>
 
 ## Contributions
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -160,7 +160,7 @@ Select API:&nbsp;
 * Getting Started
     * [Developer Environment Setup on IntelliJ IDE](/tutorials/java/mxnet_java_on_intellij.html)
 * [Multi Object Detection using pre-trained Single Shot Detector (SSD) Model](/tutorials/java/ssd_inference.html)
-* [MXNet-Java  Examples](https://github.com/apache/incubator-mxnet/tree/master/scala-package/examples/src/main/java/org/apache/mxnetexamples)
+* [MXNet-Java  Examples](https://github.com/apache/incubator-mxnet/tree/master/scala-package/examples/src/main/java/org/apache/mxnetexamples/javaapi/infer)
 <hr>
 
 ## C++ Tutorials


### PR DESCRIPTION
## Description ##
Added Java to ubuntu's setup install page.

Improving maven instructions for the java_setup page which gives better detail on what the xml is for and adds the repo so that the user doesn't have to manually download the jar. 

Pointing the examples link on the java tutorials page to a more appropriate location.
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
