### PR TITLE
Be more explicit about the exit status of the container

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -326,6 +326,10 @@ def container_run(platform: str,
                 wait_result = container.wait(timeout=container_wait_s)
                 logging.info("Container exit status: %s", wait_result)
                 ret = wait_result.get('StatusCode', 200)
+                if ret != 0:
+                    logging.error("Container exited with an error 😞")
+                else:
+                    logging.info("Container exited with success 👍")
             except Exception as e:
                 logging.exception(e)
                 ret = 150
@@ -384,11 +388,15 @@ def script_name() -> str:
     """:returns: script name with leading paths removed"""
     return os.path.split(sys.argv[0])[1]
 
-
-def main() -> int:
+def config_logging():
+    import time
     logging.getLogger().setLevel(logging.INFO)
     logging.getLogger("requests").setLevel(logging.WARNING)
-    logging.basicConfig(format='{}: %(asctime)-15s %(message)s'.format(script_name()))
+    logging.basicConfig(format='{}: %(asctime)sZ %(levelname)s %(message)s'.format(script_name()))
+    logging.Formatter.converter = time.gmtime
+
+def main() -> int:
+    config_logging()
 
     logging.info("MXNet container based build tool.")
     log_environment()


### PR DESCRIPTION
## Description ##

Minor modification to build.py so the status of the container is more clear.
Changed the time to GMT in log output.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
