### PR TITLE
Improve CCache handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,10 +167,6 @@ python/.eggs
 tests/Makefile
 tests/mxnet_unit_tests
 
-# generated wrappers for ccache
-cc
-cxx
-
 # Code coverage related
 .coverage
 *.gcov

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,6 +152,25 @@ utils.assign_node_labels(utility: 'utility', linux_cpu: 'mxnetlinux-cpu', linux_
 
 utils.main_wrapper(
 core_logic: {
+  stage('Sanity Check') {
+    parallel 'Lint': {
+      node(NODE_LINUX_CPU) {
+        ws('workspace/sanity-lint') {
+          utils.init_git()
+          utils.docker_run('ubuntu_cpu', 'sanity_check', false)
+        }
+      }
+    },
+    'RAT License': {
+      node(NODE_LINUX_CPU) {
+        ws('workspace/sanity-rat') {
+          utils.init_git()
+          utils.docker_run('ubuntu_rat', 'nightly_test_rat_check', false)
+        }
+      }
+    }
+  }
+
   stage('Build') {
     parallel 'CPU: CentOS 7': {
       node(NODE_LINUX_CPU) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,25 +152,6 @@ utils.assign_node_labels(utility: 'utility', linux_cpu: 'mxnetlinux-cpu', linux_
 
 utils.main_wrapper(
 core_logic: {
-  stage('Sanity Check') {
-    parallel 'Lint': {
-      node(NODE_LINUX_CPU) {
-        ws('workspace/sanity-lint') {
-          utils.init_git()
-          utils.docker_run('ubuntu_cpu', 'sanity_check', false)
-        }
-      }
-    },
-    'RAT License': {
-      node(NODE_LINUX_CPU) {
-        ws('workspace/sanity-rat') {
-          utils.init_git()
-          utils.docker_run('ubuntu_rat', 'nightly_test_rat_check', false)
-        }
-      }
-    }
-  }
-
   stage('Build') {
     parallel 'CPU: CentOS 7': {
       node(NODE_LINUX_CPU) {

--- a/Makefile
+++ b/Makefile
@@ -463,7 +463,7 @@ build/src/%.o: src/%.cc | mkldnn
 
 build/src/%_gpu.o: src/%.cu | mkldnn
 	@mkdir -p $(@D)
-	$(NVCC) $(NVCCFLAGS) $(CUDA_ARCH) -Xcompiler "$(CFLAGS)" -M -MT build/src/$*_gpu.o $< >build/src/$*_gpu.d
+	$(NVCC) $(NVCCFLAGS) $(CUDA_ARCH) -Xcompiler "$(CFLAGS)" --generate-dependencies -MT build/src/$*_gpu.o $< >build/src/$*_gpu.d
 	$(NVCC) -c -o $@ $(NVCCFLAGS) $(CUDA_ARCH) -Xcompiler "$(CFLAGS)" $<
 
 # A nvcc bug cause it to generate "generic/xxx.h" dependencies from torch headers.
@@ -479,7 +479,7 @@ build/plugin/%.o: plugin/%.cc
 
 %_gpu.o: %.cu
 	@mkdir -p $(@D)
-	$(NVCC) $(NVCCFLAGS) $(CUDA_ARCH) -Xcompiler "$(CFLAGS) -Isrc/operator" -M -MT $*_gpu.o $< >$*_gpu.d
+	$(NVCC) $(NVCCFLAGS) $(CUDA_ARCH) -Xcompiler "$(CFLAGS) -Isrc/operator" --generate-dependencies -MT $*_gpu.o $< >$*_gpu.d
 	$(NVCC) -c -o $@ $(NVCCFLAGS) $(CUDA_ARCH) -Xcompiler "$(CFLAGS) -Isrc/operator" $<
 
 %.o: %.cc $(CORE_INC)
@@ -664,7 +664,7 @@ rclean:
 
 ifneq ($(EXTRA_OPERATORS),)
 clean: rclean cyclean $(EXTRA_PACKAGES_CLEAN)
-	$(RM) -r build lib bin *~ */*~ */*/*~ */*/*/*~ 
+	$(RM) -r build lib bin deps *~ */*~ */*/*~ */*/*/*~ 
 	cd $(DMLC_CORE); $(MAKE) clean; cd -
 	cd $(PS_PATH); $(MAKE) clean; cd -
 	cd $(NNVM_PATH); $(MAKE) clean; cd -

--- a/ci/docker/Dockerfile.build.android_armv7
+++ b/ci/docker/Dockerfile.build.android_armv7
@@ -75,6 +75,11 @@ ENV OpenBLAS_DIR=${CROSS_ROOT}
 
 WORKDIR /work
 
+ARG USER_ID=0
+ARG GROUP_ID=0
+COPY install/ubuntu_adduser.sh /work/
+RUN /work/ubuntu_adduser.sh
+
 COPY runtime_functions.sh /work/
 WORKDIR /work/mxnet
 

--- a/ci/docker/Dockerfile.build.android_armv8
+++ b/ci/docker/Dockerfile.build.android_armv8
@@ -74,7 +74,6 @@ ENV CXX=${CROSS_ROOT}/bin/${CROSS_TRIPLE}-clang++
 COPY install/android_arm64_openblas.sh /work/
 RUN /work/android_arm64_openblas.sh
 ENV CPLUS_INCLUDE_PATH /work/deps/OpenBLAS
-WORKDIR /work/build
 
 ARG USER_ID=0
 ARG GROUP_ID=0
@@ -82,3 +81,5 @@ COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
 COPY runtime_functions.sh /work/
+
+WORKDIR /work/build

--- a/ci/docker/Dockerfile.build.android_armv8
+++ b/ci/docker/Dockerfile.build.android_armv8
@@ -76,4 +76,9 @@ RUN /work/android_arm64_openblas.sh
 ENV CPLUS_INCLUDE_PATH /work/deps/OpenBLAS
 WORKDIR /work/build
 
+ARG USER_ID=0
+ARG GROUP_ID=0
+COPY install/ubuntu_adduser.sh /work/
+RUN /work/ubuntu_adduser.sh
+
 COPY runtime_functions.sh /work/

--- a/ci/docker/Dockerfile.build.armv6
+++ b/ci/docker/Dockerfile.build.armv6
@@ -38,5 +38,10 @@ ENV OpenBLAS_DIR=${CROSS_ROOT}
 COPY install/deb_ubuntu_ccache.sh /work/
 RUN /work/deb_ubuntu_ccache.sh
 
+ARG USER_ID=0
+ARG GROUP_ID=0
+COPY install/ubuntu_adduser.sh /work/
+RUN /work/ubuntu_adduser.sh
+
 COPY runtime_functions.sh /work/
 WORKDIR /work/mxnet

--- a/ci/docker/Dockerfile.build.armv7
+++ b/ci/docker/Dockerfile.build.armv7
@@ -38,5 +38,10 @@ ENV OpenBLAS_DIR=${CROSS_ROOT}
 COPY install/deb_ubuntu_ccache.sh /work/
 RUN /work/deb_ubuntu_ccache.sh
 
+ARG USER_ID=0
+ARG GROUP_ID=0
+COPY install/ubuntu_adduser.sh /work/
+RUN /work/ubuntu_adduser.sh
+
 COPY runtime_functions.sh /work/
 WORKDIR /work/mxnet

--- a/ci/docker/Dockerfile.build.armv8
+++ b/ci/docker/Dockerfile.build.armv8
@@ -42,5 +42,10 @@ ENV OpenBLAS_DIR=${CROSS_ROOT}
 COPY install/deb_ubuntu_ccache.sh /work/
 RUN /work/deb_ubuntu_ccache.sh
 
+ARG USER_ID=0
+ARG GROUP_ID=0
+COPY install/ubuntu_adduser.sh /work/
+RUN /work/ubuntu_adduser.sh
+
 COPY runtime_functions.sh /work/
 WORKDIR /work/build

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -82,5 +82,10 @@ ENV NVCCFLAGS "-m64"
 ENV CUDA_ARCH "-gencode arch=compute_53,code=sm_53 -gencode arch=compute_62,code=sm_62"
 ENV NVCC /usr/local/cuda/bin/nvcc
 
+ARG USER_ID=0
+ARG GROUP_ID=0
+COPY install/ubuntu_adduser.sh /work/
+RUN /work/ubuntu_adduser.sh
+
 COPY runtime_functions.sh /work/
 WORKDIR /work/mxnet

--- a/ci/docker/install/centos7_adduser.sh
+++ b/ci/docker/install/centos7_adduser.sh
@@ -34,4 +34,9 @@ then
     mkdir /work/mxnet
     mkdir /work/build
     chown -R jenkins_slave /work/
+
+    # Later on, we have to override the links because underlying build systems ignore our compiler settings. Thus,
+    # we have to give the process the proper permission to these files. This is hacky, but unfortunately 
+    # there's no better way to do this without patching all our submodules.
+    chown -R jenkins_slave /usr/local/bin
 fi

--- a/ci/docker/install/ubuntu_adduser.sh
+++ b/ci/docker/install/ubuntu_adduser.sh
@@ -40,4 +40,9 @@ then
     mkdir /work/mxnet
     mkdir /work/build
     chown -R jenkins_slave /work/
+
+    # Later on, we have to override the links because underlying build systems ignore our compiler settings. Thus,
+    # we have to give the process the proper permission to these files. This is hacky, but unfortunately 
+    # there's no better way to do this without patching all our submodules.
+    chown -R jenkins_slave /usr/local/bin
 fi

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -39,6 +39,15 @@ clean_repo() {
 build_ccache_wrappers() {
     set -ex
 
+    if [ -z ${CC+x} ]; then
+        echo "No \$CC set, defaulting to gcc";
+        export CC=gcc
+    fi
+     if [ -z ${CXX+x} ]; then
+       echo "No \$CXX set, defaulting to g++";
+       export CXX=g++
+    fi
+
     # Recommended by CCache: https://ccache.samba.org/manual.html#_run_modes
     # Add to the beginning of path to ensure this redirection is picked up instead
     # of the original ones. Especially CUDA/NVCC appends itself to the beginning of the
@@ -52,7 +61,19 @@ build_ccache_wrappers() {
     # But in the beginning, we'll make this opt-in. In future, loads of processes like
     # the scala make step or numpy compilation and other pip package generations
     # could be heavily sped up by using ccache as well.
-    export PATH=/usr/local/bin:$PATH
+    mkdir /tmp/ccache-redirects
+    export PATH=/tmp/ccache-redirects:$PATH
+    ln -s ccache /tmp/ccache-redirects/gcc
+    ln -s ccache /tmp/ccache-redirects/g++
+    ln -s ccache /tmp/ccache-redirects/g++-8
+    ln -s ccache /tmp/ccache-redirects/gcc-8
+    ln -s ccache /tmp/ccache-redirects/nvcc
+    ln -s ccache /tmp/ccache-redirects/clang++-3.9
+    ln -s ccache /tmp/ccache-redirects/clang-3.9
+    ln -s ccache /tmp/ccache-redirects/clang++-5.0
+    ln -s ccache /tmp/ccache-redirects/clang-5.0
+    ln -s ccache /tmp/ccache-redirects/clang++-6.0
+    ln -s ccache /tmp/ccache-redirects/clang-6.0
     ln -s ccache /usr/local/bin/gcc
     ln -s ccache /usr/local/bin/g++
     ln -s ccache /usr/local/bin/g++-8

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -65,7 +65,6 @@ build_ccache_wrappers() {
     export PATH=/tmp/ccache-redirects:$PATH
     ln -s ccache /tmp/ccache-redirects/gcc
     ln -s ccache /tmp/ccache-redirects/g++
-    ln -s ccache /tmp/ccache-redirects/g++-8
     ln -s ccache /tmp/ccache-redirects/gcc-8
     ln -s ccache /tmp/ccache-redirects/nvcc
     ln -s ccache /tmp/ccache-redirects/clang++-3.9
@@ -76,7 +75,6 @@ build_ccache_wrappers() {
     ln -s ccache /tmp/ccache-redirects/clang-6.0
     ln -s ccache /usr/local/bin/gcc
     ln -s ccache /usr/local/bin/g++
-    ln -s ccache /usr/local/bin/g++-8
     ln -s ccache /usr/local/bin/gcc-8
     ln -s ccache /usr/local/bin/nvcc
     ln -s ccache /usr/local/bin/clang++-3.9
@@ -388,7 +386,7 @@ build_ubuntu_cpu_cmake_asan() {
     cd /work/build
     export CXX=g++-8
     export CC=g++-8
-    
+    build_ccache_wrappers
     cmake \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -88,6 +88,7 @@ build_ccache_wrappers() {
 
     # TODO: Remove
     export CCACHE_LOGFILE=/work/mxnet/ccache-log
+    export CCACHE_DEBUG=1
 }
 
 build_wheel() {
@@ -660,9 +661,11 @@ build_ubuntu_gpu_cmake_mkldnn() {
 build_ubuntu_gpu_cmake() {
     set -ex
     cd /work/build
+    build_ccache_wrappers
     cmake \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache    \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache      \
+        -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache   \
         -DENABLE_TESTCOVERAGE=ON                \
         -DUSE_CUDA=1                            \
         -DUSE_CUDNN=1                           \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -86,6 +86,8 @@ build_ccache_wrappers() {
     ln -s ccache /usr/local/bin/clang++-6.0
     ln -s ccache /usr/local/bin/clang-6.0
 
+    export NVCC=ccache
+
     # Uncomment if you would like to debug CCache hit rates.
     # You can monitor using tail -f ccache-log
     # export CCACHE_LOGFILE=/work/mxnet/ccache-log

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -388,7 +388,7 @@ build_ubuntu_cpu_cmake_asan() {
     cd /work/build
     export CXX=g++-8
     export CC=g++-8
-    build_ccache_wrappers
+    
     cmake \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -64,8 +64,9 @@ build_ccache_wrappers() {
     mkdir /tmp/ccache-redirects
     export PATH=/tmp/ccache-redirects:$PATH
     ln -s ccache /tmp/ccache-redirects/gcc
-    ln -s ccache /tmp/ccache-redirects/g++
     ln -s ccache /tmp/ccache-redirects/gcc-8
+    ln -s ccache /tmp/ccache-redirects/g++
+    ln -s ccache /tmp/ccache-redirects/g++-8
     ln -s ccache /tmp/ccache-redirects/nvcc
     ln -s ccache /tmp/ccache-redirects/clang++-3.9
     ln -s ccache /tmp/ccache-redirects/clang-3.9
@@ -74,8 +75,9 @@ build_ccache_wrappers() {
     ln -s ccache /tmp/ccache-redirects/clang++-6.0
     ln -s ccache /tmp/ccache-redirects/clang-6.0
     ln -s ccache /usr/local/bin/gcc
-    ln -s ccache /usr/local/bin/g++
     ln -s ccache /usr/local/bin/gcc-8
+    ln -s ccache /usr/local/bin/g++
+    ln -s ccache /usr/local/bin/g++-8
     ln -s ccache /usr/local/bin/nvcc
     ln -s ccache /usr/local/bin/clang++-3.9
     ln -s ccache /usr/local/bin/clang-3.9
@@ -385,7 +387,7 @@ build_ubuntu_cpu_cmake_asan() {
     pushd .
     cd /work/build
     export CXX=g++-8
-    export CC=g++-8
+    export CC=gcc-8
     build_ccache_wrappers
     cmake \
         -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \


### PR DESCRIPTION
This PR improves our ccache access. Particularly, we are now able to able to cache NVCC calls (which are super expensive) and also add caching to the compilation of submodules (especially ps-lites' submodule zeroMQ likes to hardcode its compilers).

Just to give some numbers:
- ARMv8 improved from 35s to 14s.
- Dependency compilation on cpu and gpu got recuced from 7 minutes to 10 seconds
- TODO: Expand


Full NVCC Ccache support for CMake is blocked by #13459 