### PR TITLE
onnx export slope for prelu operator corrected

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -662,20 +662,20 @@ def convert_leakyrelu(node, **kwargs):
     dims = np.shape(reshape_value)
 
     shape_node = onnx.helper.make_tensor_value_info(reshape_val_name, input_type, dims)
-    initializer.append(
-        onnx.helper.make_tensor(
-            name=reshape_val_name,
-            data_type=input_type,
-            dims=dims,
-            vals=reshape_value,
-            raw=False,
-        )
-    )
 
     slope_op_name = 'slope' + str(kwargs["idx"])
 
     lr_node = []
-    if act_type == "prelu" or act_type == "selu":
+    if act_type == "prelu":
+        initializer.append(
+            onnx.helper.make_tensor(
+                name=reshape_val_name,
+                data_type=input_type,
+                dims=dims,
+                vals=reshape_value,
+                raw=False,
+            )
+        )
         reshape_slope_node = onnx.helper.make_node(
             'Reshape',
             inputs=[input_nodes[1], reshape_val_name],
@@ -691,6 +691,13 @@ def convert_leakyrelu(node, **kwargs):
 
         lr_node.append(shape_node)
         lr_node.append(reshape_slope_node)
+        lr_node.append(node)
+    elif act_type == "selu":
+        node = onnx.helper.make_node(
+            act_name[act_type],
+            inputs=input_nodes,
+            outputs=[name],
+            name=name)
         lr_node.append(node)
     else:
         node = onnx.helper.make_node(

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -264,8 +264,13 @@ def _elu(attrs, inputs, proto_obj):
 def _prelu(attrs, inputs, proto_obj):
     """PRelu function"""
     new_attrs = translation_utils._add_extra_attributes(attrs, {'act_type': 'prelu'})
-    new_gamma = symbol.squeeze(inputs[1])
-    return 'LeakyReLU', new_attrs, [inputs[0], new_gamma]
+    gamma_shape = proto_obj._params[inputs[1].name].shape
+    gamma = inputs[1]
+    # Gamma should be either a vector of size 1, or the same size
+    # as the second dimension of data.
+    if gamma_shape != (1,):
+        gamma = symbol.squeeze(gamma, axis=(0, 2, 3))
+    return 'LeakyReLU', new_attrs, [inputs[0], gamma]
 
 def _selu(attrs, inputs, proto_obj):
     """Selu function"""

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -264,7 +264,8 @@ def _elu(attrs, inputs, proto_obj):
 def _prelu(attrs, inputs, proto_obj):
     """PRelu function"""
     new_attrs = translation_utils._add_extra_attributes(attrs, {'act_type': 'prelu'})
-    return 'LeakyReLU', new_attrs, inputs
+    new_gamma = symbol.squeeze(inputs[1])
+    return 'LeakyReLU', new_attrs, [inputs[0], new_gamma]
 
 def _selu(attrs, inputs, proto_obj):
     """Selu function"""


### PR DESCRIPTION
## Description ##
Slope for onnx's prelu operator neeeds to be unidirectional broadcastable. Reshaping gamma.
onnx/models#91 (comment)

@vandanavk 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
