### PR TITLE
[v1.4.x] Get the correct include path in pip package (#13452)

### DIFF
--- a/python/mxnet/libinfo.py
+++ b/python/mxnet/libinfo.py
@@ -96,10 +96,18 @@ def find_include_path():
             logging.warning("MXNET_INCLUDE_PATH '%s' doesn't exist", incl_from_env)
 
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    incl_path = os.path.join(curr_path, '../../include/')
-    if not os.path.isdir(incl_path):
-        raise RuntimeError('Cannot find the MXNet include path.\n')
-    return incl_path
+    # include path in pip package
+    pip_incl_path = os.path.join(curr_path, 'include/')
+    if os.path.isdir(pip_incl_path):
+        return pip_incl_path
+    else:
+        # include path if build from source
+        src_incl_path = os.path.join(curr_path, '../../include/')
+        if os.path.isdir(src_incl_path):
+            return src_incl_path
+        else:
+            raise RuntimeError('Cannot find the MXNet include path in either ' + pip_incl_path +
+                               ' or ' + src_incl_path + '\n')
 
 
 # current version


### PR DESCRIPTION
* add find_include_path API

* address reviewer comment

* change return type from list to string

* add unit test

* address reviewer comment

* address reviewer comment

* address reviewer comment

* address reviewer comment

* fix include path problem in pip package

* add comment

* fix lint error

* address reviewer comment

* address reviewer comment

## Description ##
This PR fixes a reporting API that returns the include header path in pip package. The earlier version only returns the include path when MXNet is built from source. The relative path is different if MXNet is built from pip.

This PR is needed by Horovod MXNet integration. The API only returns the include path so it should not impact MXNet performance or functionality.