### PR TITLE
fix toctree Sphinx errors

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -6,6 +6,7 @@
 
    c++/index.md
    clojure/index.md
+   java/index.md
    julia/index.md
    perl/index.md
    python/index.md

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -3,12 +3,13 @@
 ```eval_rst
 .. toctree::
    :hidden:
-   
+
    basic/index.md
    c++/index.md
    control_flow/index.md
    embedded/index.md
    gluon/index.md
+   java/index.md
    nlp/index.md
    onnx/index.md
    python/index.md


### PR DESCRIPTION
## Description ##
This PR adds the new Java API pages to the toctree, so Sphinx doesn't complain about them any more.
Removes two Sphinx errors.