### PR TITLE
Add workspace cleaning after job finished

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -264,7 +264,7 @@ def main_wrapper(args) {
       // Call failure handler
       args['failure_handler']()
 
-      wsCleanup()
+      cleanWs()
 
       // Remember to rethrow so the build is marked as failing
       if (err) {

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -263,7 +263,9 @@ def main_wrapper(args) {
     node(NODE_UTILITY) {
       // Call failure handler
       args['failure_handler']()
-      
+
+      wsCleanup()
+
       // Remember to rethrow so the build is marked as failing
       if (err) {
         throw err

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -264,6 +264,7 @@ def main_wrapper(args) {
       // Call failure handler
       args['failure_handler']()
 
+      // Clean workspace to reduce space requirements
       cleanWs()
 
       // Remember to rethrow so the build is marked as failing


### PR DESCRIPTION
Add workspace cleaning after job finished. This recudes the disk usage of Jenkins

TODO: Test if this cleans up master