### PR TITLE
Optimize C++ API

### DIFF
--- a/cpp-package/example/utils.h
+++ b/cpp-package/example/utils.h
@@ -42,7 +42,7 @@ bool check_datafiles(const std::vector<std::string> &data_files) {
   return true;
   }
 
-bool setDataIter(MXDataIter *iter , std::string useType,
+bool setDataIter(MXDataIter *iter , const std::string &useType,
               const std::vector<std::string> &data_files, int batch_size) {
     if (!check_datafiles(data_files))
         return false;

--- a/cpp-package/include/mxnet-cpp/operator.h
+++ b/cpp-package/include/mxnet-cpp/operator.h
@@ -86,7 +86,7 @@ class Operator {
   * \param symbol the input symbol
   * \return reference of self
   */
-  Operator &SetInput(const std::string &name, Symbol symbol);
+  Operator &SetInput(const std::string &name, const Symbol &symbol);
   /*!
   * \brief add an input symbol
   * \param symbol the input symbol
@@ -133,7 +133,7 @@ class Operator {
   * \param ndarray the input ndarray
   * \return reference of self
   */
-  Operator &SetInput(const std::string &name, NDArray ndarray);
+  Operator &SetInput(const std::string &name, const NDArray &ndarray);
   /*!
   * \brief add an input ndarray
   * \param ndarray the input ndarray

--- a/cpp-package/include/mxnet-cpp/operator.hpp
+++ b/cpp-package/include/mxnet-cpp/operator.hpp
@@ -158,7 +158,7 @@ inline void Operator::Invoke(NDArray &output) {
   Invoke(outputs);
 }
 
-inline Operator &Operator::SetInput(const std::string &name, Symbol symbol) {
+inline Operator &Operator::SetInput(const std::string &name, const Symbol &symbol) {
     if (symbol.GetHandle()) {
       input_keys_.push_back(name.c_str());
       input_symbols_.push_back(symbol.GetHandle());
@@ -166,7 +166,7 @@ inline Operator &Operator::SetInput(const std::string &name, Symbol symbol) {
     return *this;
 }
 
-inline Operator &Operator::SetInput(const std::string &name, NDArray ndarray) {
+inline Operator &Operator::SetInput(const std::string &name, const NDArray &ndarray) {
   input_keys_.push_back(name.c_str());
   input_ndarrays_.push_back(ndarray.GetHandle());
   return *this;


### PR DESCRIPTION
Pass parameter with reference instead of value.
Add const as well as it is not changed.

## Description ##
Optimize some functions to pass reference instead of value. This could avoid unnecessary construction/destruction and copy.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
-  tiny changes
- did a successful build
- For user-facing API changes, API doc string has been updated. 
  Didn't find the API doc in mxnet.io/doxygen
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

## Comments ##
I am not sure I could run a sanity test with it or how to run a unit test/sanity test against the change. But pass value -> pass reference, should be transparent to C++, although not like C's pass value->pass pointer.