### PR TITLE
Speedup and fix bug for dgl_csr_sampling op

### DIFF
--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -646,13 +646,10 @@ static void SampleSubgraph(const NDArray &csr,
         if (new_node.level < num_hops) {
           node_queue.push(new_node);
         } else {
-          auto ret = sub_ver_mp.find(new_node.vertex_id);
-          if (ret == sub_ver_mp.end()) {
-            size_t pos = neighbor_list.size();
-            neigh_pos[new_node.vertex_id] = pos;
-            neighbor_list.push_back(0);
-            sub_ver_mp[new_node.vertex_id] = new_node.level;
-          }
+          size_t pos = neighbor_list.size();
+          neigh_pos[new_node.vertex_id] = pos;
+          neighbor_list.push_back(0);
+          sub_ver_mp[new_node.vertex_id] = new_node.level;
         }
       }
     }

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -629,7 +629,7 @@ static void SampleSubgraph(const NDArray &csr,
                        &tmp_sampled_edge_list,
                        &time_seed);
       }
-      CHECK_EQ(tmp_sampled_src_list.size(), 
+      CHECK_EQ(tmp_sampled_src_list.size(),
                tmp_sampled_edge_list.size());
       size_t pos = neighbor_list.size();
       neigh_pos[dst_id] = pos;
@@ -722,11 +722,11 @@ static void SampleSubgraph(const NDArray &csr,
     size_t pos = neigh_pos[dst_id];
     size_t edge_size = neighbor_list[pos];
     if (edge_size != 0) {
-      std::copy_n(neighbor_list.begin() + pos + 1, 
-                  edge_size, 
+      std::copy_n(neighbor_list.begin() + pos + 1,
+                  edge_size,
                   col_list_out + collected_nedges);
-      std::copy_n(neighbor_list.begin() + pos + edge_size + 1, 
-                  edge_size, 
+      std::copy_n(neighbor_list.begin() + pos + edge_size + 1,
+                  edge_size,
                   val_list_out + collected_nedges);
       collected_nedges += edge_size;
     }

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -102,9 +102,7 @@ class ArrayHeap {
   /*
    * Sample a vector by given the size n
    */
-  void SampleWithoutReplacement(size_t n,
-                                std::vector<size_t>* samples,
-                                unsigned int* seed) {
+  void SampleWithoutReplacement(size_t n, std::vector<size_t>* samples, unsigned int* seed) {
     // sample n elements
     for (size_t i = 0; i < n; ++i) {
       samples->at(i) = this->Sample(seed);
@@ -453,20 +451,24 @@ static void NegateSet(const std::vector<size_t> &idxs,
  */
 static void GetUniformSample(const dgl_id_t* val_list,
                              const dgl_id_t* col_list,
-                             const size_t ver_len,
+                             const dgl_id_t* indptr,
+                             const dgl_id_t dst_id,
                              const size_t max_num_neighbor,
                              std::vector<dgl_id_t>* out_ver,
                              std::vector<dgl_id_t>* out_edge,
                              unsigned int* seed) {
+  size_t ver_len = *(indptr+dst_id+1) - *(indptr+dst_id);
   // Copy ver_list to output
   if (ver_len <= max_num_neighbor) {
-    for (size_t i = 0; i < ver_len; ++i) {
+    for (dgl_id_t i = *(indptr+dst_id); i < *(indptr+dst_id+1); ++i) {
       out_ver->push_back(col_list[i]);
       out_edge->push_back(val_list[i]);
     }
     return;
   }
   // If we just sample a small number of elements from a large neighbor list.
+  const dgl_id_t* col_ptr = col_list + *(indptr + dst_id);
+  const dgl_id_t* val_ptr = val_list + *(indptr + dst_id);
   std::vector<size_t> sorted_idxs;
   if (ver_len > max_num_neighbor * 2) {
     sorted_idxs.reserve(max_num_neighbor);
@@ -486,8 +488,8 @@ static void GetUniformSample(const dgl_id_t* val_list,
     CHECK_GT(sorted_idxs[i], sorted_idxs[i - 1]);
   }
   for (auto idx : sorted_idxs) {
-    out_ver->push_back(col_list[idx]);
-    out_edge->push_back(val_list[idx]);
+    out_ver->push_back(col_ptr[idx]);
+    out_edge->push_back(val_ptr[idx]);
   }
 }
 
@@ -497,24 +499,28 @@ static void GetUniformSample(const dgl_id_t* val_list,
 static void GetNonUniformSample(const float* probability,
                                 const dgl_id_t* val_list,
                                 const dgl_id_t* col_list,
-                                const size_t ver_len,
+                                const dgl_id_t* indptr,
+                                const dgl_id_t dst_id,
                                 const size_t max_num_neighbor,
                                 std::vector<dgl_id_t>* out_ver,
                                 std::vector<dgl_id_t>* out_edge,
                                 unsigned int* seed) {
+  size_t ver_len = *(indptr+dst_id+1) - *(indptr+dst_id);
   // Copy ver_list to output
   if (ver_len <= max_num_neighbor) {
-    for (size_t i = 0; i < ver_len; ++i) {
+    for (dgl_id_t i = *(indptr+dst_id); i < *(indptr+dst_id+1); ++i) {
       out_ver->push_back(col_list[i]);
       out_edge->push_back(val_list[i]);
     }
     return;
   }
   // Make sample
+  const dgl_id_t* col_ptr = col_list + *(indptr + dst_id);
+  const dgl_id_t* val_ptr = val_list + *(indptr + dst_id);
   std::vector<size_t> sp_index(max_num_neighbor);
   std::vector<float> sp_prob(ver_len);
   for (size_t i = 0; i < ver_len; ++i) {
-    sp_prob[i] = probability[col_list[i]];
+    sp_prob[i] = probability[col_ptr[i]];
   }
   ArrayHeap arrayHeap(sp_prob);
   arrayHeap.SampleWithoutReplacement(max_num_neighbor, &sp_index, seed);
@@ -522,8 +528,8 @@ static void GetNonUniformSample(const float* probability,
   out_edge->resize(max_num_neighbor);
   for (size_t i = 0; i < max_num_neighbor; ++i) {
     size_t idx = sp_index[i];
-    out_ver->at(i) = col_list[idx];
-    out_edge->at(i) = val_list[idx];
+    out_ver->at(i) = col_ptr[idx];
+    out_edge->at(i) = val_ptr[idx];
   }
   sort(out_ver->begin(), out_ver->end());
   sort(out_edge->begin(), out_edge->end());
@@ -590,68 +596,74 @@ static void SampleSubgraph(const NDArray &csr,
   std::unordered_map<dgl_id_t, size_t> neigh_pos;
   std::vector<dgl_id_t> neighbor_list;
   size_t num_edges = 0;
-  // BFS traverse
+
   while (!node_queue.empty() &&
-         sub_vertices_count < max_num_vertices) {
+    sub_vertices_count < max_num_vertices) {
     ver_node& cur_node = node_queue.front();
     dgl_id_t dst_id = cur_node.vertex_id;
-    auto ret = sub_ver_mp.find(dst_id);
-    if (ret != sub_ver_mp.end()) {
-      node_queue.pop();
-      continue;
-    }
-    tmp_sampled_src_list.clear();
-    tmp_sampled_edge_list.clear();
-    dgl_id_t ver_len = *(indptr+dst_id+1) - *(indptr+dst_id);
-    if (probability == nullptr) {  // uniform-sample
-      GetUniformSample(val_list + *(indptr + dst_id),
-                       col_list + *(indptr + dst_id),
-                       ver_len,
+    if (cur_node.level < num_hops) {
+      auto ret = sub_ver_mp.find(dst_id);
+      if (ret != sub_ver_mp.end()) {
+        node_queue.pop();
+        continue;
+      }
+      tmp_sampled_src_list.clear();
+      tmp_sampled_edge_list.clear();
+      if (probability == nullptr) {  // uniform-sample
+        GetUniformSample(val_list,
+                       col_list,
+                       indptr,
+                       dst_id,
                        num_neighbor,
                        &tmp_sampled_src_list,
                        &tmp_sampled_edge_list,
                        &time_seed);
-    } else {  // non-uniform-sample
-      GetNonUniformSample(probability,
-                       val_list + *(indptr + dst_id),
-                       col_list + *(indptr + dst_id),
-                       ver_len,
+      } else {  // non-uniform-sample
+        GetNonUniformSample(probability,
+                       val_list,
+                       col_list,
+                       indptr,
+                       dst_id,
                        num_neighbor,
                        &tmp_sampled_src_list,
                        &tmp_sampled_edge_list,
                        &time_seed);
-    }
-    CHECK_EQ(tmp_sampled_src_list.size(),
-             tmp_sampled_edge_list.size());
-    size_t pos = neighbor_list.size();
-    neigh_pos[dst_id] = pos;
-    // First we push the size of neighbor vector
-    neighbor_list.push_back(tmp_sampled_edge_list.size());
-    // Then push the vertices
-    for (size_t i = 0; i < tmp_sampled_src_list.size(); ++i) {
-      neighbor_list.push_back(tmp_sampled_src_list[i]);
-    }
-    // Finally we push the edge list
-    for (size_t i = 0; i < tmp_sampled_edge_list.size(); ++i) {
-      neighbor_list.push_back(tmp_sampled_edge_list[i]);
-    }
-    num_edges += tmp_sampled_src_list.size();
-    sub_ver_mp[cur_node.vertex_id] = cur_node.level;
-    for (size_t i = 0; i < tmp_sampled_src_list.size(); ++i) {
-      auto ret = sub_ver_mp.find(tmp_sampled_src_list[i]);
-      if (ret == sub_ver_mp.end()) {
-        ver_node new_node;
-        new_node.vertex_id = tmp_sampled_src_list[i];
-        new_node.level = cur_node.level + 1;
-        if (new_node.level < num_hops) {
+      }
+      CHECK_EQ(tmp_sampled_src_list.size(),
+               tmp_sampled_edge_list.size());
+      size_t pos = neighbor_list.size();
+      neigh_pos[dst_id] = pos;
+      // First we push the size of neighbor vector
+      neighbor_list.push_back(tmp_sampled_edge_list.size());
+      // Then push the vertices
+      for (size_t i = 0; i < tmp_sampled_src_list.size(); ++i) {
+        neighbor_list.push_back(tmp_sampled_src_list[i]);
+      }
+      // Finally we push the edge list
+      for (size_t i = 0; i < tmp_sampled_edge_list.size(); ++i) {
+        neighbor_list.push_back(tmp_sampled_edge_list[i]);
+      }
+      num_edges += tmp_sampled_src_list.size();
+      sub_ver_mp[cur_node.vertex_id] = cur_node.level;
+      for (size_t i = 0; i < tmp_sampled_src_list.size(); ++i) {
+        auto ret = sub_ver_mp.find(tmp_sampled_src_list[i]);
+        if (ret == sub_ver_mp.end()) {
+          ver_node new_node;
+          new_node.vertex_id = tmp_sampled_src_list[i];
+          new_node.level = cur_node.level + 1;
           node_queue.push(new_node);
-        } else {
-          size_t pos = neighbor_list.size();
-          neigh_pos[new_node.vertex_id] = pos;
-          neighbor_list.push_back(0);
-          sub_ver_mp[new_node.vertex_id] = new_node.level;
         }
       }
+    } else {  // vertex without any neighbor
+      auto ret = sub_ver_mp.find(dst_id);
+      if (ret != sub_ver_mp.end()) {
+        node_queue.pop();
+        continue;
+      }
+      size_t pos = neighbor_list.size();
+      neigh_pos[dst_id] = pos;
+      neighbor_list.push_back(0);
+      sub_ver_mp[cur_node.vertex_id] = cur_node.level;
     }
     sub_vertices_count++;
     node_queue.pop();


### PR DESCRIPTION
## Description ##
This pr speedup and fix the bug for dgl_csr_sampling operator

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

