### PR TITLE
Fix exception handling api doc

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -157,11 +157,11 @@ def waitall():
     """Wait for all async operations to finish in MXNet.
 
     This function is used for benchmarking only.
-    Rethrowing exceptions as part of mx.nd.waitall is not supported.
-    If your code has exceptions, waitall can cause silent failures.
-    Avoid waitall in your code/precede it with wait_to_read for the outputs
-    unless you are confident about your code not throwing an exception in
-    any scenario.
+    .. warning::
+    If your code has exceptions, `waitall` can cause silent failures.
+    For this reason you should avoid `waitall` in your code.
+    Use it only if you are confident that your code is error free.
+    Then make sure you call `wait_to_read` on all outputs after `waitall`.
     """
     check_call(_LIB.MXNDArrayWaitAll())
 

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -157,6 +157,11 @@ def waitall():
     """Wait for all async operations to finish in MXNet.
 
     This function is used for benchmarking only.
+    Rethrowing exceptions as part of mx.nd.waitall is not supported.
+    If your code has exceptions, waitall can cause silent failures.
+    Avoid waitall in your code/precede it with wait_to_read for the outputs
+    unless you are confident about your code not throwing an exception in
+    any scenario.
     """
     check_call(_LIB.MXNDArrayWaitAll())
 


### PR DESCRIPTION
## Description ##
There were some issues with MXNet users because of not being aware of waitall not rethrowing exceptions. It was documented as a limitation in exception handling doc here: https://mxnet.incubator.apache.org/architecture/exception_handling.html?highlight=exception#limitation but not in the API doc.
Adding it to the API doc.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] API doc change
