### PR TITLE
add cpp example inception to nightly test

### DIFF
--- a/cpp-package/example/mlp.cpp
+++ b/cpp-package/example/mlp.cpp
@@ -144,11 +144,11 @@ void MLP() {
                                grad_req_type, aux_states);
 
   std::cout << "Training" << std::endl;
-  int max_iters = 10;
+  int max_epoch = 20000;
   mx_float learning_rate = 0.0001;
-  for (int iter = 0; iter < max_iters; ++iter) {
+  for (int iter = 0; iter < max_epoch; ++iter) {
     exe->Forward(true);
-
+    // print accuracy every 100 epoch
     if (iter % 100 == 0) {
       std::cout << "epoch " << iter << std::endl;
       std::vector<NDArray>& out = exe->outputs;

--- a/cpp-package/example/mlp.cpp
+++ b/cpp-package/example/mlp.cpp
@@ -144,13 +144,13 @@ void MLP() {
                                grad_req_type, aux_states);
 
   std::cout << "Training" << std::endl;
-  int max_epoch = 20000;
+  int max_epoch = 15000;
   mx_float learning_rate = 0.0001;
-  for (int iter = 0; iter < max_epoch; ++iter) {
+  for (int epoch_num = 0; epoch_num < max_epoch; ++epoch_num) {
     exe->Forward(true);
     // print accuracy every 100 epoch
-    if (iter % 100 == 0) {
-      std::cout << "epoch " << iter << std::endl;
+    if (epoch_num % 100 == 0) {
+      std::cout << "epoch " << epoch_num << std::endl;
       std::vector<NDArray>& out = exe->outputs;
       float* cptr = new float[128 * 10];
       out[0].SyncCopyToCPU(cptr, 128 * 10);

--- a/cpp-package/example/mlp.cpp
+++ b/cpp-package/example/mlp.cpp
@@ -144,7 +144,7 @@ void MLP() {
                                grad_req_type, aux_states);
 
   std::cout << "Training" << std::endl;
-  int max_iters = 20000;
+  int max_iters = 10;
   mx_float learning_rate = 0.0001;
   for (int iter = 0; iter < max_iters; ++iter) {
     exe->Forward(true);

--- a/cpp-package/tests/ci_test.sh
+++ b/cpp-package/tests/ci_test.sh
@@ -36,6 +36,9 @@ cp ../../build/cpp-package/example/lenet_with_mxdataiter .
 cp ../../build/cpp-package/example/resnet .
 ./resnet 5
 
+cp ../../build/cpp-package/example/inception_bn .
+./inception_bn 5
+
 cp ../../build/cpp-package/example/mlp .
 ./mlp
 


### PR DESCRIPTION
## Description ##
replace https://github.com/apache/incubator-mxnet/pull/13367
a follow up to add inception into nightly test after fix in https://github.com/apache/incubator-mxnet/pull/13284

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- add cpp example test on inception

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
