### PR TITLE
[MXNET-244] Work around likely compiler bug on nested inlines and temporary acces…

### DIFF
--- a/src/operator/c_lapack_api.cc
+++ b/src/operator/c_lapack_api.cc
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "c_lapack_api.h"
+
+#if (MSHADOW_USE_MKL && MXNET_USE_LAPACK)
+#elif MXNET_USE_LAPACK
+#else
+  // Define compilable stubs.
+  #define MXNET_LAPACK_CWRAPPER1(func, dtype) \
+  int MXNET_LAPACK_##func(int matrix_layout, char uplo, int n, dtype* a, int lda) { \
+    LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
+    return 1; \
+  }
+
+  #define MXNET_LAPACK_CWRAPPER2(func, dtype) \
+  int MXNET_LAPACK_##func(int matrix_layout, int m, int n, dtype* a, \
+                                 int lda, dtype* tau, dtype* work, int lwork) { \
+    LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
+    return 1; \
+  }
+
+  #define MXNET_LAPACK_CWRAPPER3(func, dtype) \
+  int MXNET_LAPACK_##func(int matrix_layout, char uplo, int n, dtype *a, \
+                                 int lda, dtype *w, dtype *work, int lwork, \
+                                 int *iwork, int liwork) { \
+    LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
+    return 1; \
+  }
+
+  #define MXNET_LAPACK_UNAVAILABLE(func) \
+  int mxnet_lapack_##func(...) { \
+    LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
+    return 1; \
+  }
+  MXNET_LAPACK_CWRAPPER1(spotrf, float)
+  MXNET_LAPACK_CWRAPPER1(dpotrf, double)
+  MXNET_LAPACK_CWRAPPER1(spotri, float)
+  MXNET_LAPACK_CWRAPPER1(dpotri, double)
+
+  MXNET_LAPACK_UNAVAILABLE(sposv)
+  MXNET_LAPACK_UNAVAILABLE(dposv)
+
+  MXNET_LAPACK_CWRAPPER2(sgelqf, float)
+  MXNET_LAPACK_CWRAPPER2(dgelqf, double)
+  MXNET_LAPACK_CWRAPPER2(sorglq, float)
+  MXNET_LAPACK_CWRAPPER2(dorglq, double)
+
+  MXNET_LAPACK_CWRAPPER3(ssyevd, float)
+  MXNET_LAPACK_CWRAPPER3(dsyevd, double)
+#endif  // MSHADOW_USE_MKL == 0

--- a/src/operator/c_lapack_api.cc
+++ b/src/operator/c_lapack_api.cc
@@ -22,6 +22,11 @@
 #if (MSHADOW_USE_MKL && MXNET_USE_LAPACK)
 #elif MXNET_USE_LAPACK
 #else
+  // use pragma message instead of warning
+  #pragma message("Warning: lapack usage not enabled, linalg-operators will not be available." \
+     " Ensure that lapack library is installed and build with USE_LAPACK=1 to get lapack" \
+     " functionalities.")
+
   // Define compilable stubs.
   #define MXNET_LAPACK_CWRAPPER1(func, dtype) \
   int MXNET_LAPACK_##func(int matrix_layout, char uplo, int n, dtype* a, int lda) { \

--- a/src/operator/c_lapack_api.h
+++ b/src/operator/c_lapack_api.h
@@ -325,41 +325,30 @@ inline void flip(int m, int n, DType *b, int ldb, DType *a, int lda) {
 #else
 
   // use pragma message instead of warning
+  /*
   #pragma message("Warning: lapack usage not enabled, linalg-operators will not be available." \
      " Ensure that lapack library is installed and build with USE_LAPACK=1 to get lapack" \
      " functionalities.")
+     */
 
   #define MXNET_LAPACK_ROW_MAJOR 101
   #define MXNET_LAPACK_COL_MAJOR 102
 
   // Define compilable stubs.
   #define MXNET_LAPACK_CWRAPPER1(func, dtype) \
-  inline int MXNET_LAPACK_##func(int matrix_layout, char uplo, int n, dtype* a, int lda) { \
-    LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
-    return 1; \
-  }
+  int MXNET_LAPACK_##func(int matrix_layout, char uplo, int n, dtype* a, int lda);
 
   #define MXNET_LAPACK_CWRAPPER2(func, dtype) \
-  inline int MXNET_LAPACK_##func(int matrix_layout, int m, int n, dtype* a, \
-                                 int lda, dtype* tau, dtype* work, int lwork) { \
-    LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
-    return 1; \
-  }
+  int MXNET_LAPACK_##func(int matrix_layout, int m, int n, dtype* a, \
+                                 int lda, dtype* tau, dtype* work, int lwork);
 
   #define MXNET_LAPACK_CWRAPPER3(func, dtype) \
-  inline int MXNET_LAPACK_##func(int matrix_layout, char uplo, int n, dtype *a, \
+  int MXNET_LAPACK_##func(int matrix_layout, char uplo, int n, dtype *a, \
                                  int lda, dtype *w, dtype *work, int lwork, \
-                                 int *iwork, int liwork) { \
-    LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
-    return 1; \
-  }
+                                 int *iwork, int liwork);
 
   #define MXNET_LAPACK_UNAVAILABLE(func) \
-  inline int mxnet_lapack_##func(...) { \
-    LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
-    return 1; \
-  }
-
+  int mxnet_lapack_##func(...);
   MXNET_LAPACK_CWRAPPER1(spotrf, float)
   MXNET_LAPACK_CWRAPPER1(dpotrf, double)
   MXNET_LAPACK_CWRAPPER1(spotri, float)
@@ -375,7 +364,10 @@ inline void flip(int m, int n, DType *b, int ldb, DType *a, int lda) {
 
   MXNET_LAPACK_CWRAPPER3(ssyevd, float)
   MXNET_LAPACK_CWRAPPER3(dsyevd, double)
-
+  #undef MXNET_LAPACK_CWRAPPER1
+  #undef MXNET_LAPACK_CWRAPPER2
+  #undef MXNET_LAPACK_CWRAPPER3
+  #undef MXNET_LAPACK_UNAVAILABLE
 #endif
 
 template <typename DType>

--- a/src/operator/c_lapack_api.h
+++ b/src/operator/c_lapack_api.h
@@ -324,12 +324,7 @@ inline void flip(int m, int n, DType *b, int ldb, DType *a, int lda) {
 
 #else
 
-  // use pragma message instead of warning
-  /*
-  #pragma message("Warning: lapack usage not enabled, linalg-operators will not be available." \
-     " Ensure that lapack library is installed and build with USE_LAPACK=1 to get lapack" \
-     " functionalities.")
-     */
+
 
   #define MXNET_LAPACK_ROW_MAJOR 101
   #define MXNET_LAPACK_COL_MAJOR 102

--- a/tests/cpp/operator/krprod_test.cc
+++ b/tests/cpp/operator/krprod_test.cc
@@ -250,6 +250,8 @@ TEST(row_wise_kronecker, FourInputMatrices) {
   FreeSpace(&result);
 }
 
+
+#if MXNET_USE_LAPACK == 1
 TEST(khatri_rao, OneInputMatrix) {
   // Input matrices of shape (2, 4) which is also the expected result
   DType mat[8] {1, 2, 3, 4, 5, 6, 7, 8};
@@ -444,5 +446,6 @@ TEST(inv_khatri_rao, ThreeInputMatricesTranposed) {
   FreeSpace(&kr_t);
   FreeSpace(&actual_dot);
 }
+#endif  // MXNET_USE_LAPACK == 1
 }  // namespace op
 }  // namespace mxnet


### PR DESCRIPTION
…s to stream

## Description ##

This fixes a segfault in ARMv7 on throwing a fatal error on the lapack undefined functions. 

Addresses  #13342  
We don't crash as before, the test fails which is expected.

I think this is a bug in the compiler due to the temporary LogMessageFatal created on unwrapping the macro https://github.com/apache/incubator-mxnet/blob/master/src/operator/c_lapack_api.h#L369 and too many inlined functions. The segfault is inside the ostream in libc, could be related to the lifetime of the temporary variable with a reference to the stream which is a very corner case of temporary variable lifetime.

Having the functions not inlined solves the problem.

```
qemu@qemu:~/mxnet/build/tests$ ./mxnet_unit_tests --gtest_filter="inv_khatri_rao.OneInputMatrixTransposed"

Note: Google Test filter = inv_khatri_rao.OneInputMatrixTransposed
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from inv_khatri_rao
[ RUN      ] inv_khatri_rao.OneInputMatrixTransposed
unknown file: Failure
C++ exception with description "[13:27:04] /work/mxnet/src/operator/c_lapack_api.cc:42: MXNet build without lapack. Function dposv is not available.

Stack trace returned 10 entries:
[bt] (0) ./mxnet_unit_tests(dmlc::StackTrace()+0x40) [0x1291afc]
[bt] (1) ./mxnet_unit_tests(dmlc::LogMessageFatal::~LogMessageFatal()+0x40) [0x1291e2c]
[bt] (2) ./mxnet_unit_tests(mxnet_lapack_dposv(...)+0x88) [0x19466dc]
[bt] (3) ./mxnet_unit_tests(int MXNET_LAPACK_posv<double>(int, char, int, int, double*, int, double*, int)+0x58) [0x13d7070]
[bt] (4) ./mxnet_unit_tests(void mxnet::op::inv_khatri_rao<double>(mshadow::Tensor<mshadow::cpu, 2, double>, std::vector<mshadow::Tensor<mshadow::cpu, 2, double>, std::allocator<mshadow::Tensor<mshadow::cpu, 2, double> > > const&, bool)+0x394) [0x13da000]
[bt] (5) ./mxnet_unit_tests(mxnet::op::inv_khatri_rao_OneInputMatrixTransposed_Test::TestBody()+0x238) [0x13cf0e8]
[bt] (6) ./mxnet_unit_tests(void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)+0x74) [0x1491b50]
[bt] (7) ./mxnet_unit_tests(void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)+0x4c) [0x148bb10]
[bt] (8) ./mxnet_unit_tests(testing::Test::Run()+0xe8) [0x146d9f8]
[bt] (9) ./mxnet_unit_tests(testing::TestInfo::Run()+0x138) [0x146e310]

" thrown in the test body.
[  FAILED  ] inv_khatri_rao.OneInputMatrixTransposed (70 ms)
[----------] 1 test from inv_khatri_rao (74 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (90 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] inv_khatri_rao.OneInputMatrixTransposed

 1 FAILED TEST
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
