### PR TITLE
Chi_square_check for discrete distribution fix

### DIFF
--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1911,12 +1911,15 @@ def chi_square_check(generator, buckets, probs, nsamples=1000000):
     if continuous_dist:
         sample_bucket_ids = np.searchsorted(buckets_npy, samples, side='right')
     else:
-        sample_bucket_ids = samples
+        sample_bucket_ids = np.array(samples)
     if continuous_dist:
         sample_bucket_ids = sample_bucket_ids // 2
     obs_freq = np.zeros(shape=len(buckets), dtype=np.int)
     for i, _ in enumerate(buckets):
-        obs_freq[i] = (sample_bucket_ids == buckets[i]).sum()
+        if continuous_dist:
+            obs_freq[i] = (sample_bucket_ids == i).sum()
+        else:
+            obs_freq[i] = (sample_bucket_ids == buckets[i]).sum()
     _, p = ss.chisquare(f_obs=obs_freq, f_exp=expected_freq)
     return p, obs_freq, expected_freq
 

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1916,7 +1916,7 @@ def chi_square_check(generator, buckets, probs, nsamples=1000000):
         sample_bucket_ids = sample_bucket_ids // 2
     obs_freq = np.zeros(shape=len(buckets), dtype=np.int)
     for i, _ in enumerate(buckets):
-        obs_freq[i] = (sample_bucket_ids == buckets[i]).astype('uint8').sum()
+        obs_freq[i] = sample_bucket_ids.count(buckets[i])
     _, p = ss.chisquare(f_obs=obs_freq, f_exp=expected_freq)
     return p, obs_freq, expected_freq
 

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1915,8 +1915,8 @@ def chi_square_check(generator, buckets, probs, nsamples=1000000):
     if continuous_dist:
         sample_bucket_ids = sample_bucket_ids // 2
     obs_freq = np.zeros(shape=len(buckets), dtype=np.int)
-    for i in range(len(buckets)):
-        obs_freq[i] = (sample_bucket_ids == buckets[i]).sum()
+    for i, _ in enumerate(buckets):
+        obs_freq[i] = (sample_bucket_ids == buckets[i]).astype('uint8').sum()
     _, p = ss.chisquare(f_obs=obs_freq, f_exp=expected_freq)
     return p, obs_freq, expected_freq
 

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1916,7 +1916,7 @@ def chi_square_check(generator, buckets, probs, nsamples=1000000):
         sample_bucket_ids = sample_bucket_ids // 2
     obs_freq = np.zeros(shape=len(buckets), dtype=np.int)
     for i in range(len(buckets)):
-        obs_freq[i] = (sample_bucket_ids == i).sum()
+        obs_freq[i] = (sample_bucket_ids == buckets[i]).sum()
     _, p = ss.chisquare(f_obs=obs_freq, f_exp=expected_freq)
     return p, obs_freq, expected_freq
 

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1916,7 +1916,7 @@ def chi_square_check(generator, buckets, probs, nsamples=1000000):
         sample_bucket_ids = sample_bucket_ids // 2
     obs_freq = np.zeros(shape=len(buckets), dtype=np.int)
     for i, _ in enumerate(buckets):
-        obs_freq[i] = sample_bucket_ids.count(buckets[i])
+        obs_freq[i] = (sample_bucket_ids == buckets[i]).sum()
     _, p = ss.chisquare(f_obs=obs_freq, f_exp=expected_freq)
     return p, obs_freq, expected_freq
 


### PR DESCRIPTION
## Description ##
check for bucket instead of the bucket index

It was incorrectly checking for index
```
for i in range(len(buckets)):
    obs_freq[i] = (sample_bucket_ids == i).sum()
```

It should be checking for the value at the index

Bucketing for discrete and continuous distributions is different and hence has to be handled differently.

Moreover this change passes the verify_generator tests for both discrete distribution (randint) as well as continuous ones (normal, uniform, ... etc)