### PR TITLE
turn on Sphinx warnings as errors

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1218,7 +1218,7 @@ deploy_docs() {
     set -ex
     pushd .
 
-    make docs -W
+    make docs SPHINXOPTS=-W
 
     popd
 }

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1188,7 +1188,7 @@ nightly_straight_dope_python3_multi_gpu_tests() {
 nightly_tutorial_test_ubuntu_python3_gpu() {
     set -ex
     cd /work/mxnet/docs
-    export BUILD_VER=tutorial 
+    export BUILD_VER=tutorial
     export MXNET_DOCS_BUILD_MXNET=0
     make html
     export MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
@@ -1218,7 +1218,7 @@ deploy_docs() {
     set -ex
     pushd .
 
-    make docs
+    make docs -W
 
     popd
 }
@@ -1274,5 +1274,3 @@ EOF
     declare -F | cut -d' ' -f3
     echo
 fi
-
-

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -74,7 +74,7 @@ livehtml:
 html:
 	export BUILD_VER=$(BUILD_VER)
 	@echo "Env var set for BUILD_VER: $(BUILD_VER)"
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -74,7 +74,7 @@ livehtml:
 html:
 	export BUILD_VER=$(BUILD_VER)
 	@echo "Env var set for BUILD_VER: $(BUILD_VER)"
-	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,8 +17,12 @@ git clone --recursive https://github.com/apache/incubator-mxnet.git mxnet
 cd mxnet/docs/build_version_doc
 ./setup_docs_ubuntu.sh
 cd ../../
-make docs USE_OPENMP=1
+make docs USE_OPENMP=1 SPHINXOPTS=-W
 ```
+
+OpenMP speeds things up and will work on Ubuntu if you used the `setup_docs_ubuntu.sh` script.
+The `-W` Sphinx option enforces "warnings as errors". This will help you debug your builds and get them through CI.
+**CI will not let a PR through if it breaks the website.** Refer to the [MXNet Developer wiki's documentation guide](https://cwiki.apache.org/confluence/display/MXNET/Documentation+Guide) for troubleshooting tips.
 
 For more information on each API's documentation dependencies, how to serve the docs, or how to build the full website with each legacy MXNet version, refer to the following links:
 

--- a/docs/build_version_doc/build_all_version.sh
+++ b/docs/build_version_doc/build_all_version.sh
@@ -43,7 +43,7 @@
 set -e
 set -x
 
-# Set OPT to any Sphinx build options, like -W for "warnings as errors"
+# Set OPTS to any Sphinx build options, like -W for "warnings as errors"
 OPTS=
 
 # $1 is the list of branches/tags to build

--- a/docs/build_version_doc/build_all_version.sh
+++ b/docs/build_version_doc/build_all_version.sh
@@ -43,6 +43,9 @@
 set -e
 set -x
 
+# Set OPT to any Sphinx build options, like -W for "warnings as errors"
+OPTS=
+
 # $1 is the list of branches/tags to build
 if [ -z "$1" ]
   then
@@ -117,6 +120,8 @@ function checkout () {
   git checkout "$repo_folder" || git branch $repo_folder "upstream/$repo_folder" && git checkout "$repo_folder" || exit 1
   if [ $tag == 'master' ]; then
     git pull
+    # master gets warnings as errors for Sphinx builds
+    OPTS="-W"
   fi
   git submodule update --init --recursive
   cd ..
@@ -160,7 +165,7 @@ for key in ${!build_arr[@]}; do
 
     echo "Building $tag..."
     cd $tag/docs
-    make html USE_OPENMP=1 BUILD_VER=$tag || exit 1
+    make html USE_OPENMP=1 BUILD_VER=$tag SPHINXOPTS=$OPTS || exit 1
     # Navigate back to build_version_doc folder
     cd ../../../
     # Use the display tag name for the folder name

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -46,7 +46,7 @@ def imread(filename, *args, **kwargs):
     """Read and decode an image to an NDArray.
 
     .. note:: `imread` uses OpenCV (not the CV2 Python library).
-    MXNet must have been built with USE_OPENCV=1 for `imdecode` to work.
+       MXNet must have been built with USE_OPENCV=1 for `imdecode` to work.
 
     Parameters
     ----------
@@ -87,7 +87,7 @@ def imresize(src, w, h, *args, **kwargs):
     r"""Resize image with OpenCV.
 
     .. note:: `imresize` uses OpenCV (not the CV2 Python library). MXNet must have been built
-    with USE_OPENCV=1 for `imresize` to work.
+       with USE_OPENCV=1 for `imresize` to work.
 
     Parameters
     ----------
@@ -144,7 +144,7 @@ def imdecode(buf, *args, **kwargs):
     """Decode an image to an NDArray.
 
     .. note:: `imdecode` uses OpenCV (not the CV2 Python library).
-    MXNet must have been built with USE_OPENCV=1 for `imdecode` to work.
+       MXNet must have been built with USE_OPENCV=1 for `imdecode` to work.
 
     Parameters
     ----------
@@ -345,7 +345,7 @@ def resize_short(src, size, interp=2):
     """Resizes shorter edge to size.
 
     .. note:: `resize_short` uses OpenCV (not the CV2 Python library).
-    MXNet must have been built with OpenCV for `resize_short` to work.
+       MXNet must have been built with OpenCV for `resize_short` to work.
 
     Resizes the original image by setting the shorter edge to size
     and setting the longer edge accordingly.


### PR DESCRIPTION
## Description ##
This PR updates the website build trigger sphinx-build with the `-W` switch. This turns on the "warnings as errors" feature in Sphinx.

*edit*: This needs to be considered carefully as it may impact several people as they get used to the change. Also, the website build process exempts the old versions as they are still error-riddled. 
Are there any other exemptions needed before proceeding with this PR?

## What This Means
Once merged, anyone that submits a PR that breaks the docs - particularly the Python docs - **their PR will fail CI**. 

If you create a C operator that has docs strings that bubble up into the Python docs and break there, your PR will fail CI.

## Testing Your Code Prior to a PR
But let's not fail in CI all of the time. You can test it out first.

1. Turn off the doc sets you don't need to test in `docs/settings.ini`. Most of the time you just need to update the `[document_sets_default]` section. I tend to turn everything off for faster cycles on testing the build, then turn everything back on for a final test if my change messed with something that might trigger a Doxygen issue (C or C++ change) or Scala/Java docs issue (.scala or .java change).
2. Run `make html USE_OPENMP=1 SPHINXOPTS=-W` from the docs folder. (or `make docs` with the same parameters from mxnet root)
If it fails, read the error and fix it. Once you get a successful build, you're ready to submit your PR.

For documentation help, check out the [documentation guide](https://cwiki.apache.org/confluence/display/MXNET/Documentation+Guide).
For details on building the website, check out [how to build the website](https://cwiki.apache.org/confluence/display/MXNET/How+to+Build+the+Website)

## Testing & CI Deployment
I tested this with `./build_all_version.sh "v1.4.x;master" "1.4.0;master"`. The script will run the older version branch (that still has docs errors in it) and then runs master. Since the script only enables `-W` for master, it will show the warnings, but not stop the build when building the `v1.4.x` branch. When it eventually works on `master`, the `-W` flag is enabled, and if there are any Sphinx warnings it stops the build with an error.

Currently the Jenkins job for the website deployment builds master first. I could switch that to last, but actually, I think it is better that the job fails quickly if it is going to fail.


If you have questions, please ask!