### PR TITLE
Enhancement of split op with indices option

### DIFF
--- a/cpp-package/example/charRNN.cpp
+++ b/cpp-package/example/charRNN.cpp
@@ -69,7 +69,7 @@ LSTMState LSTM(int num_hidden, const Symbol& indata, const LSTMState& prev_state
   auto h2h = FullyConnected(prefix + "_h2h", prev_state.h, param.h2h_weight, param.h2h_bias,
       num_hidden * 4);
   auto gates = i2h + h2h;
-  auto slice_gates = SliceChannel(prefix + "_slice", gates, 4);
+  auto slice_gates = SliceChannel(prefix + "_slice", gates, dmlc::optional<int>(4));
   auto in_gate = Activation(slice_gates[0], ActivationActType::kSigmoid);
   auto in_transform = Activation(slice_gates[1], ActivationActType::kTanh);
   auto forget_gate = Activation(slice_gates[2], ActivationActType::kSigmoid);
@@ -89,7 +89,11 @@ Symbol LSTMUnroll(int num_lstm_layer, int sequence_length, int input_dim,
     data = transpose(data);
   auto embed_weight = Symbol::Variable("embed_weight");
   auto embed = Embedding("embed", data, embed_weight, input_dim, num_embed);
-  auto wordvec = isTrain? SliceChannel(embed, sequence_length, TIME_MAJOR? 0 : 1, true) : embed;
+  auto wordvec =
+    isTrain?
+    SliceChannel(embed, dmlc::optional<int>(sequence_length),
+                 dmlc::optional<mxnet::cpp::Shape>(), TIME_MAJOR? 0 : 1, true) :
+    embed;
 
   std::vector<LSTMState> last_states;
   std::vector<LSTMParam> param_cells;

--- a/src/operator/slice_channel-inl.h
+++ b/src/operator/slice_channel-inl.h
@@ -36,6 +36,7 @@
 #include <utility>
 #include "./operator_common.h"
 #include "./channel_op_common.h"
+#include "./mxnet_op.h"
 
 namespace mxnet {
 namespace op {
@@ -45,12 +46,16 @@ enum SliceChannelOpInputs {kData};
 }  // namespace slice_enum
 
 struct SliceChannelParam : public dmlc::Parameter<SliceChannelParam> {
-  int num_outputs;
+  dmlc::optional<int> num_outputs;
+  dmlc::optional<TShape> indices;
   int axis;
   bool squeeze_axis;
   DMLC_DECLARE_PARAMETER(SliceChannelParam) {
-    DMLC_DECLARE_FIELD(num_outputs).set_lower_bound(1)
+    DMLC_DECLARE_FIELD(num_outputs).set_default(dmlc::optional<int>())
     .describe("Number of splits. Note that this should evenly divide the length of the `axis`.");
+    DMLC_DECLARE_FIELD(indices).set_default(dmlc::optional<TShape>())
+    .describe("Indices of splits. The elements should denote the boundaries of at which split"
+              " is performed along the `axis`.");
     DMLC_DECLARE_FIELD(axis).set_default(1)
     .describe("Axis along which to split.");
     DMLC_DECLARE_FIELD(squeeze_axis).set_default(0)
@@ -62,11 +67,86 @@ struct SliceChannelParam : public dmlc::Parameter<SliceChannelParam> {
   }
 };  // struct SliceChannelParam
 
+struct SplitKernel {
+  /*!
+   * \brief Map function for split operator indices option
+   * \param i              global thread id
+   * \param in_data        ptr to input buffer
+   * \param out_data       ptr to ptr of outputs buffer
+   * \param indices        ptr to indices buffer
+   * \param num_sections   # of sections after split
+   * \param axis_size      size of axis to be splitted on
+   * \param trailing_size  step size within the data buffer of the axis to be splitted on
+   */
+  template<typename DType>
+  static MSHADOW_XINLINE void Map(size_t i,
+                                  const DType *in_data, DType** out_data, const size_t* indices,
+                                  const size_t num_sections, const size_t axis_size,
+                                  const size_t trailing_size) {
+    size_t idx = i / trailing_size % axis_size;
+    size_t target = 0;
+    for (size_t section = 0; section < num_sections; target = section++) {
+      if (indices[section] > idx) {
+        break;
+      }
+    }
+    DType* target_data = out_data[target];
+    const size_t mid_idx = idx - indices[target];
+    const size_t head_idx = i / (trailing_size * axis_size);
+    const size_t tail_idx = i % trailing_size;
+    const size_t section_size = indices[target + 1] - indices[target];
+    const size_t target_idx =
+      head_idx * trailing_size * section_size + mid_idx * trailing_size + tail_idx;
+    target_data[target_idx] = in_data[i];
+  }
+};
+
+struct ConcatenateKernel {
+  /*!
+   * \brief Map function for split operator indices option
+   * \param i              global thread id
+   * \param out_grad       ptr to ptr of out grads buffer
+   * \param in_grad        ptr to input grad buffer
+   * \param indices        ptr to indices buffer
+   * \param num_sections   # of sections after split
+   * \param axis_size      size of axis to be splitted on
+   * \param trailing_size  step size within the data buffer of the axis to be splitted on
+   */
+  template<typename DType>
+  static MSHADOW_XINLINE void Map(size_t i,
+                                  DType** out_grad, DType* in_grad, const size_t* indices,
+                                  const size_t num_sections, const size_t axis_size,
+                                  const size_t trailing_size) {
+    size_t idx = i / trailing_size % axis_size;
+    size_t src = 0;
+    for (size_t section = 0; section < num_sections; src = section++) {
+      if (indices[section] > idx) {
+        break;
+      }
+    }
+    DType* src_grad = out_grad[src];
+    const size_t mid_idx = idx - indices[src];
+    const size_t head_idx = i / (trailing_size * axis_size);
+    const size_t tail_idx = i % trailing_size;
+    const size_t section_size = indices[src + 1] - indices[src];
+    const size_t src_idx =
+      head_idx * trailing_size * section_size + mid_idx * trailing_size + tail_idx;
+    in_grad[i] = src_grad[src_idx];
+  }
+};
+
 template<typename xpu, typename DType>
 class SliceChannelOp : public Operator {
  public:
   explicit SliceChannelOp(SliceChannelParam param)
-    : size_(param.num_outputs), axis_(param.axis) {}
+    : param_(param), axis_(param.axis) {
+    CHECK(param.indices.has_value() ^ param.num_outputs.has_value())
+      << "Only one of indices and num_outputs can have value";
+    size_ = (param.num_outputs.has_value()) ?
+            param.num_outputs.value() :
+            param.indices.value().ndim() + 1;
+    equal_split = param.num_outputs.has_value();
+  }
 
   virtual void Forward(const OpContext &ctx,
                        const std::vector<TBlob> &in_data,
@@ -92,14 +172,46 @@ class SliceChannelOp : public Operator {
       trailing *= in_data[slice_enum::kData].shape_[i];
     }
     Shape<3> dshape = Shape3(leading, mid, trailing);
-    Shape<3> slice_shape = Shape3(leading, mid / size_, trailing);
-    Tensor<xpu, 3, DType> data = in_data[slice_enum::kData].get_with_shape<xpu, 3, DType>(
-        dshape, s);
-    std::vector<Tensor<xpu, 3, DType> > outputs(size_);
-    for (int i = 0; i < size_; ++i) {
-      outputs[i] = out_data[i].get_with_shape<xpu, 3, DType>(slice_shape, s);
+    if (equal_split) {
+      Shape<3> slice_shape = Shape3(leading, mid / size_, trailing);
+      Tensor<xpu, 3, DType> data = in_data[slice_enum::kData].get_with_shape<xpu, 3, DType>(
+          dshape, s);
+      std::vector<Tensor<xpu, 3, DType> > outputs(size_);
+      for (int i = 0; i < size_; ++i) {
+        outputs[i] = out_data[i].get_with_shape<xpu, 3, DType>(slice_shape, s);
+      }
+      Split(data, &outputs, 1, req);
+    } else {
+      using namespace mxnet_op;
+      const TBlob& input_data = in_data[slice_enum::kData];
+      size_t workspace_size = 0;
+      std::vector<size_t> indices;
+      indices.push_back(0);
+      for (const auto& section : param_.indices.value()) {
+        indices.push_back(section);
+      }
+      indices.push_back(mid);
+      workspace_size += indices.size() * sizeof(size_t);
+      std::vector<DType*> output_data;
+      for (const TBlob& data : out_data) {
+        output_data.push_back(data.dptr<DType>());
+      }
+      workspace_size += output_data.size() * sizeof(DType*);
+      Tensor<xpu, 1, char> workspace =
+        ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size), s);
+      Tensor<cpu, 1, size_t> indices_cpu_tensor(indices.data(), Shape1(indices.size()));
+      Tensor<xpu, 1, size_t> indices_xpu_tensor(
+        reinterpret_cast<size_t*>(workspace.dptr_), Shape1(indices.size()));
+      Tensor<cpu, 1, DType*> ptrs_cpu_tensor(output_data.data(), Shape1(output_data.size()));
+      Tensor<xpu, 1, DType*> ptrs_xpu_tensor(
+        reinterpret_cast<DType**>(workspace.dptr_ + indices.size() * sizeof(size_t)),
+        Shape1(output_data.size()));
+      mshadow::Copy(indices_xpu_tensor, indices_cpu_tensor, s);
+      mshadow::Copy(ptrs_xpu_tensor, ptrs_cpu_tensor, s);
+      Kernel<SplitKernel, xpu>::Launch(
+        s, input_data.Size(), input_data.dptr<DType>(), ptrs_xpu_tensor.dptr_,
+        indices_xpu_tensor.dptr_, indices.size() - 1, mid, trailing);
     }
-    Split(data, &outputs, 1, req);
   }
 
   virtual void Backward(const OpContext &ctx,
@@ -128,19 +240,55 @@ class SliceChannelOp : public Operator {
       trailing *= in_grad[slice_enum::kData].shape_[i];
     }
     Shape<3> dshape = Shape3(leading, mid, trailing);
-    Shape<3> slice_shape = Shape3(leading, mid / size_, trailing);
-    Tensor<xpu, 3, DType> grad = in_grad[slice_enum::kData].get_with_shape<xpu, 3, DType>(
-        dshape, s);
-    std::vector<Tensor<xpu, 3, DType> > grad_out(size_);
-    for (int i = 0; i < size_; ++i) {
-      grad_out[i] = out_grad[i].get_with_shape<xpu, 3, DType>(slice_shape, s);
+    if (equal_split) {
+      Shape<3> slice_shape = Shape3(leading, mid / size_, trailing);
+      Tensor<xpu, 3, DType> grad = in_grad[slice_enum::kData].get_with_shape<xpu, 3, DType>(
+          dshape, s);
+      std::vector<Tensor<xpu, 3, DType> > grad_out(size_);
+      for (int i = 0; i < size_; ++i) {
+        grad_out[i] = out_grad[i].get_with_shape<xpu, 3, DType>(slice_shape, s);
+      }
+      Concatenate(grad_out, &grad, 1, req[slice_enum::kData]);
+    } else {
+      CHECK(param_.indices.has_value())
+        << "indices should have value!";
+      using namespace mxnet_op;
+      TBlob input_grad = in_grad[slice_enum::kData];
+      size_t workspace_size = 0;
+      std::vector<size_t> indices;
+      indices.push_back(0);
+      for (const auto& section : param_.indices.value()) {
+        indices.push_back(section);
+      }
+      indices.push_back(mid);
+      workspace_size += indices.size() * sizeof(size_t);
+      std::vector<DType*> out_grads;
+      for (const TBlob& output_grad : out_grad) {
+        out_grads.push_back(output_grad.dptr<DType>());
+      }
+      workspace_size += out_grads.size() * sizeof(DType*);
+      Tensor<xpu, 1, char> workspace =
+        ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size), s);
+      Tensor<cpu, 1, size_t> indices_cpu_tensor(indices.data(), Shape1(indices.size()));
+      Tensor<xpu, 1, size_t> indices_xpu_tensor(
+        reinterpret_cast<size_t*>(workspace.dptr_), Shape1(indices.size()));
+      Tensor<cpu, 1, DType*> ptrs_cpu_tensor(out_grads.data(), Shape1(out_grads.size()));
+      Tensor<xpu, 1, DType*> ptrs_xpu_tensor(
+        reinterpret_cast<DType**>(workspace.dptr_ + indices.size() * sizeof(size_t)),
+        Shape1(out_grads.size()));
+      mshadow::Copy(indices_xpu_tensor, indices_cpu_tensor, s);
+      mshadow::Copy(ptrs_xpu_tensor, ptrs_cpu_tensor, s);
+      Kernel<ConcatenateKernel, xpu>::Launch(
+        s, input_grad.Size(), ptrs_xpu_tensor.dptr_, input_grad.dptr<DType>(),
+        indices_xpu_tensor.dptr_, indices.size() - 1, mid, trailing);
     }
-    Concatenate(grad_out, &grad, 1, req[slice_enum::kData]);
   }
 
  private:
+  SliceChannelParam param_;
   int size_;
   int axis_;
+  bool equal_split;
 };  // class SliceChannelOp
 
 
@@ -161,7 +309,13 @@ class SliceChannelProp : public OperatorProperty {
 
   std::vector<std::string> ListOutputs() const override {
     std::vector<std::string> ret;
-    for (int i = 0; i < param_.num_outputs; ++i) {
+    CHECK(param_.num_outputs.has_value() ^ param_.indices.has_value())
+      << "Only one of num_outputs and indices should have value";
+    int num_outputs = (param_.num_outputs.has_value()) ?
+                      param_.num_outputs.value() :
+                      param_.indices.value().ndim() + 1;
+    CHECK_NE(num_outputs, -1);
+    for (int i = 0; i < num_outputs; ++i) {
       std::ostringstream os;
       os << "output" << i;
       ret.push_back(os.str());
@@ -170,7 +324,11 @@ class SliceChannelProp : public OperatorProperty {
   }
 
   int NumOutputs() const override {
-    return param_.num_outputs;
+    CHECK(param_.num_outputs.has_value() ^ param_.indices.has_value())
+      << "Only one of indices and num_outputs can have value";
+    return (param_.num_outputs.has_value()) ?
+           param_.num_outputs.value() :
+           param_.indices.value().ndim() + 1;
   }
 
   bool InferType(std::vector<int> *in_type,
@@ -180,8 +338,13 @@ class SliceChannelProp : public OperatorProperty {
     int dtype = (*in_type)[0];
     CHECK_NE(dtype, -1) << "First input must have specified type";
     out_type->clear();
-    out_type->reserve(param_.num_outputs);
-    for (int i = 0; i < param_.num_outputs; ++i) {
+    CHECK(param_.num_outputs.has_value() ^ param_.indices.has_value())
+      << "Only one of num_outputs and indices should have value";
+    int num_outputs = (param_.num_outputs.has_value()) ?
+                      param_.num_outputs.value() :
+                      param_.indices.value().ndim() + 1;
+    out_type->reserve(num_outputs);
+    for (int i = 0; i < num_outputs; ++i) {
       out_type->push_back(dtype);
     }
     aux_type->clear();
@@ -205,47 +368,80 @@ class SliceChannelProp : public OperatorProperty {
     if (real_axis < 0) {
       real_axis += dshape.ndim();
     }
-    CHECK_EQ(dshape[real_axis] % param_.num_outputs, 0U)
-      << "You are trying to split the " << real_axis
-      << "-th axis of input tensor with shape " << dshape
-      << " into num_outputs=" << param_.num_outputs
-      << " evenly sized chunks, but this is not possible because "
-      << param_.num_outputs << " does not evenly divide "
-      << dshape[real_axis];
-    if (param_.squeeze_axis && ishape[real_axis] != 0) {
-      CHECK_EQ(ishape[real_axis], static_cast<size_t>(param_.num_outputs))
-        << "If squeeze axis is True, the size of the sliced axis must be the same as num_outputs."
-        << " Input shape=" << ishape << ", axis=" << real_axis
-        << ", num_outputs=" << param_.num_outputs << ".";
-    }
-    dshape[real_axis] /= param_.num_outputs;
-    if (param_.squeeze_axis && (dshape[real_axis] == 1 || ishape[real_axis] == 0)) {
-      for (int d = real_axis; d < static_cast<int>(dshape.ndim()) - 1; ++d) {
-        dshape[d] = dshape[d+1];
+    CHECK(param_.num_outputs.has_value() ^ param_.indices.has_value())
+      << "Only one of num_outputs and indices should have value";
+    int num_outputs = (param_.num_outputs.has_value()) ?
+                      param_.num_outputs.value() :
+                      param_.indices.value().ndim() + 1;
+    if (param_.num_outputs.has_value()) {
+      CHECK_EQ(dshape[real_axis] % num_outputs, 0U)
+        << "You are trying to split the " << real_axis
+        << "-th axis of input tensor with shape " << dshape
+        << " into num_outputs=" << num_outputs
+        << " evenly sized chunks, but this is not possible because "
+        << num_outputs << " does not evenly divide "
+        << dshape[real_axis];
+      if (param_.squeeze_axis && ishape[real_axis] != 0) {
+        CHECK_EQ(ishape[real_axis], static_cast<size_t>(num_outputs))
+          << "If squeeze axis is True, the size of the sliced axis must be the same as num_outputs."
+          << " Input shape=" << ishape << ", axis=" << real_axis
+          << ", num_outputs=" << num_outputs << ".";
       }
-      dshape = TShape(&dshape[0], &dshape[dshape.ndim()-1]);
-    }
-    CHECK_EQ(static_cast<int>((*out_shape).size()), param_.num_outputs)
-      << "Size of output shape mismatch!";
-    for (int i = 0; i < param_.num_outputs; ++i) {
-      SHAPE_ASSIGN_CHECK(*out_shape, i, dshape);
-      // Perform incomplete shape inference.
-      // We can back-calculate the inshape based on the out_shape.
-      TShape back_calculate_dshape = ishape;
-      if (param_.squeeze_axis && (dshape.ndim() == ishape.ndim() - 1)) {
-        for (int d = 0; d < real_axis; ++d) {
-          back_calculate_dshape[d] = (*out_shape)[i][d];
+      dshape[real_axis] /= num_outputs;
+      if (param_.squeeze_axis && (dshape[real_axis] == 1 || ishape[real_axis] == 0)) {
+        for (int d = real_axis; d < static_cast<int>(dshape.ndim()) - 1; ++d) {
+          dshape[d] = dshape[d+1];
         }
-        back_calculate_dshape[real_axis] = param_.num_outputs;
-        for (int d = real_axis + 1; d < static_cast<int>(ishape.ndim()); ++d) {
-          back_calculate_dshape[d] = (*out_shape)[i][d - 1];
-        }
-      } else {
-        for (int d = 0; d < static_cast<int>(ishape.ndim()); ++d) {
-          back_calculate_dshape[d] = (*out_shape)[i][d];
-          if (d == real_axis) {
-            back_calculate_dshape[d] *= param_.num_outputs;
+        dshape = TShape(&dshape[0], &dshape[dshape.ndim()-1]);
+      }
+      CHECK_EQ(static_cast<int>((*out_shape).size()), num_outputs)
+        << "Size of output shape mismatch!";
+      for (int i = 0; i < num_outputs; ++i) {
+        SHAPE_ASSIGN_CHECK(*out_shape, i, dshape);
+        // Perform incomplete shape inference.
+        // We can back-calculate the inshape based on the out_shape.
+        TShape back_calculate_dshape = ishape;
+        if (param_.squeeze_axis && (dshape.ndim() == ishape.ndim() - 1)) {
+          for (int d = 0; d < real_axis; ++d) {
+            back_calculate_dshape[d] = (*out_shape)[i][d];
           }
+          back_calculate_dshape[real_axis] = num_outputs;
+          for (int d = real_axis + 1; d < static_cast<int>(ishape.ndim()); ++d) {
+            back_calculate_dshape[d] = (*out_shape)[i][d - 1];
+          }
+        } else {
+          for (int d = 0; d < static_cast<int>(ishape.ndim()); ++d) {
+            back_calculate_dshape[d] = (*out_shape)[i][d];
+            if (d == real_axis) {
+              back_calculate_dshape[d] *= num_outputs;
+            }
+          }
+        }
+        SHAPE_ASSIGN_CHECK(*in_shape, slice_enum::kData, back_calculate_dshape);
+      }
+    } else if (param_.indices.has_value()) {
+      CHECK(!param_.squeeze_axis)
+        << "squeeze_axis not implemented for indices option";
+      const TShape& indices = param_.indices.value();
+      for (int i = 0; i < num_outputs; ++i) {
+        int start = (i == 0) ? 0 : indices[i-1];
+        int end = (i == num_outputs - 1) ? ishape[real_axis] : indices[i];
+        CHECK(start < end)
+          << "start " << start << " is not less than end " << end << "for subarray " << i;
+        CHECK(end <= ishape[real_axis])
+          << "end " << end << " is no less than the size of the axis " << ishape[real_axis];
+        dshape[real_axis] = (end - start);
+        SHAPE_ASSIGN_CHECK(*out_shape, i, dshape);
+      }
+      TShape back_calculate_dshape = ishape;
+      back_calculate_dshape[real_axis] = 0;
+      for (int d = 0; d < static_cast<int>(ishape.ndim()); ++d) {
+        if (d == real_axis) {
+          for (int i = 0; i < num_outputs; ++i) {
+            back_calculate_dshape[d] += (*out_shape)[i][d];
+          }
+        } else {
+          back_calculate_dshape[d] = (*out_shape)[0][d];
         }
       }
       SHAPE_ASSIGN_CHECK(*in_shape, slice_enum::kData, back_calculate_dshape);
@@ -273,6 +469,16 @@ class SliceChannelProp : public OperatorProperty {
   Operator* CreateOperator(Context ctx) const override {
     LOG(FATAL) << "Not Implemented.";
     return nullptr;
+  }
+
+  std::vector<ResourceRequest> ForwardResource(
+    const std::vector<TShape> &in_shape) const override {
+    return {ResourceRequest::kTempSpace};
+  }
+
+  std::vector<ResourceRequest> BackwardResource(
+    const std::vector<TShape> &in_shape) const override {
+    return {ResourceRequest::kTempSpace};
   }
 
   Operator* CreateOperatorEx(Context ctx, std::vector<TShape> *in_shape,

--- a/src/operator/slice_channel.cc
+++ b/src/operator/slice_channel.cc
@@ -86,6 +86,19 @@ Example::
 
    z[0].shape = (1, 2, 1)
 
+   w = split(x, axis=0, indices=(1,)) // a list of 2 arrays with shape [(1, 2, 1), (2, 2, 1)]
+   w = [[[ 1.]
+         [ 2.]]]
+
+       [[[3.]
+         [4.]]
+
+        [[5.]
+         [6.]]]
+
+  w[0].shape = (1, 2, 1)
+  w[1].shape = (2, 2, 1)
+
 `squeeze_axis=1` removes the axis with length 1 from the shapes of the output arrays.
 **Note** that setting `squeeze_axis` to ``1`` removes axis with length 1 only
 along the `axis` which it is split.

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1093,6 +1093,7 @@ def test_ndarray_fluent():
     check_fluent_regular('repeat', {'repeats': 3})
     check_fluent_regular('transpose', {'axes': (1,0,2)})
     check_fluent_regular('split', {'axis': 2, 'num_outputs': 3}, shape=(5, 17, 6))
+    check_fluent_regular('split', {'axis': 2, 'indices': (1, 3, 5)}, shape=(5, 17, 6))
     check_fluent_regular('slice', {'begin': (2, 5, 1), 'end': (4, 7, 6)}, shape=(5, 17, 6))
     check_fluent_regular('slice_axis', {'axis': 1, 'begin': 5, 'end': 7})
     check_fluent_regular('slice_like', {'axes': (0, -2), 'shape_like': mx.nd.zeros((3, 3))})

--- a/tests/python/unittest/test_symbol.py
+++ b/tests/python/unittest/test_symbol.py
@@ -207,6 +207,7 @@ def test_symbol_fluent():
     check_fluent_regular('repeat', {'repeats': 3})
     check_fluent_regular('transpose', {'axes': (1,0,2)})
     check_fluent_regular('split', {'axis': 2, 'num_outputs': 3}, shape=(5, 17, 6))
+    check_fluent_regular('split', {'axis': 2, 'indices': (1, 3, 5)}, shape=(5, 17, 6))
     check_fluent_regular('slice', {'begin': (2, 5, 1), 'end': (4, 7, 6)}, shape=(5, 17, 6))
     check_fluent_regular('slice_axis', {'axis': 1, 'begin': 5, 'end': 7})
     check_fluent_regular('slice_like', {'axes': (0, -2), 'shape_like': mx.sym.zeros((3, 3))})


### PR DESCRIPTION
## Description ##
Support split by arbitrary ranges through addition of indices option.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Indices option for split op
- [x] Unit tests

## Comments ##
