### PR TITLE
Add timeout/retry logic to docker cache download

### DIFF
--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -180,6 +180,10 @@ def load_docker_cache(registry, docker_tag) -> None:
 
             # Linear backoff
             time.sleep(DOCKERHUB_RETRY_SECONDS * (i + 1))
+    else:
+        logging.error('Could not download docker cache after %d retries, aborting',
+                      DOCKER_CACHE_NUM_RETRIES)
+        raise Exception('Unable to download docker cache')
 
 
 def delete_local_docker_cache(docker_tag):

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -30,10 +30,9 @@ import argparse
 import sys
 import subprocess
 import json
-import time
 from typing import *
 import build as build_util
-from ci.util import retry
+from util import retry
 
 DOCKERHUB_LOGIN_NUM_RETRIES = 5
 DOCKERHUB_RETRY_SECONDS = 5

--- a/ci/docker_cache.py
+++ b/ci/docker_cache.py
@@ -134,7 +134,7 @@ def _login_dockerhub():
             logging.error(p.stderr)
 
             # Linear backoff
-            time.sleep(1000 * DOCKERHUB_RETRY_SECONDS * (i + 1))
+            time.sleep(DOCKERHUB_RETRY_SECONDS * (i + 1))
         else:
             logging.info('Successfully logged in to DockerHub')
             break
@@ -179,7 +179,7 @@ def load_docker_cache(registry, docker_tag) -> None:
             logging.info(str(e))
 
             # Linear backoff
-            time.sleep(1000 * DOCKERHUB_RETRY_SECONDS * (i + 1))
+            time.sleep(DOCKERHUB_RETRY_SECONDS * (i + 1))
 
 
 def delete_local_docker_cache(docker_tag):


### PR DESCRIPTION
Dockerhub sometimes has unstable behavior, causing downloads to take much longer than they should. Average download time is below 2min, but in some rare cases it can take more than 1h (see http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/master/2033/pipeline/ for example)

This PR wraps the cache download call with timeout/retry logic as a fix