### PR TITLE
Accelerate DGL csr neighbor sampling

### DIFF
--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -667,23 +667,15 @@ static void SampleSubgraph(const NDArray &csr,
     out[i] = sub_vers[i].first;
     out_layer[i] = sub_vers[i].second;
   }
-  for (size_t i = sub_vers.size(); i < max_num_vertices; i++) {
-    out[i] = -1;
-    out_layer[i] = -1;
-  }
   // The last element stores the actual
   // number of vertices in the subgraph.
   out[max_num_vertices] = sub_ver_mp.size();
 
   // Copy sub_probability
   if (sub_prob != nullptr) {
-    for (size_t i = 0; i < max_num_vertices; ++i) {
+    for (size_t i = 0; i < sub_ver_mp.size(); ++i) {
       dgl_id_t idx = out[i];
-      if (idx != -1) {
-        sub_prob[i] = probability[idx];
-      } else {
-        sub_prob[i] = -1;
-      }
+      sub_prob[i] = probability[idx];
     }
   }
   // Construct sub_csr_graph

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -649,7 +649,8 @@ static void SampleSubgraph(const NDArray &csr,
   // Let's check if there is a vertex that we haven't sampled its neighbors.
   for (; idx < sub_vers.size(); idx++) {
     if (sub_vers[idx].second < num_hops) {
-      LOG(WARNING) << "The sampling is truncated because we have reached the max number of vertices\n"
+      LOG(WARNING)
+        << "The sampling is truncated because we have reached the max number of vertices\n"
         << "Please use a smaller number of seeds or a small neighborhood";
       break;
     }

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -659,7 +659,7 @@ static void SampleSubgraph(const NDArray &csr,
     order_map.push_back(std::pair<dgl_id_t, dgl_id_t>(data.first, data.second));
   size_t num_vertices = sub_ver_mp.size();
   std::sort(order_map.begin(), order_map.end(), [](const std::pair<dgl_id_t, dgl_id_t> &a1, std::pair<dgl_id_t, dgl_id_t> &a2) {
-    return a1.first < a2.second;
+    return a1.first < a2.first;
   });
   for (size_t i = 0; i < order_map.size(); i++) {
     out[i] = order_map[i].first;

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -651,8 +651,10 @@ static void SampleSubgraph(const NDArray &csr,
     }
     node_queue.pop();
   }
-  if (!node_queue.empty())
-    LOG(WARNING) << "The sampling is truncated because we have reached the max number of vertices";
+  if (!node_queue.empty()) {
+    LOG(WARNING) << "The sampling is truncated because we have reached the max number of vertices\n"
+      << "Please use a smaller number of seeds or a small neighborhood";
+  }
 
   // Copy sub_ver_mp to output[0]
   // Copy layer
@@ -661,7 +663,8 @@ static void SampleSubgraph(const NDArray &csr,
   for (auto& data : sub_ver_mp)
     order_map.push_back(std::pair<dgl_id_t, dgl_id_t>(data.first, data.second));
   size_t num_vertices = sub_ver_mp.size();
-  std::sort(order_map.begin(), order_map.end(), [](const std::pair<dgl_id_t, dgl_id_t> &a1, std::pair<dgl_id_t, dgl_id_t> &a2) {
+  std::sort(order_map.begin(), order_map.end(),
+            [](const std::pair<dgl_id_t, dgl_id_t> &a1, std::pair<dgl_id_t, dgl_id_t> &a2) {
     return a1.first < a2.first;
   });
   for (size_t i = 0; i < order_map.size(); i++) {
@@ -709,7 +712,8 @@ static void SampleSubgraph(const NDArray &csr,
   order_map_with_neighs.reserve(neigh_pos.size());
   for (auto& data : neigh_pos)
     order_map_with_neighs.push_back(std::pair<dgl_id_t, dgl_id_t>(data.first, data.second));
-  std::sort(order_map_with_neighs.begin(), order_map_with_neighs.end(), [](const std::pair<dgl_id_t, dgl_id_t> &a1, std::pair<dgl_id_t, dgl_id_t> &a2) {
+  std::sort(order_map_with_neighs.begin(), order_map_with_neighs.end(),
+            [](const std::pair<dgl_id_t, dgl_id_t> &a1, std::pair<dgl_id_t, dgl_id_t> &a2) {
     return a1.first < a2.first;
   });
 

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -661,7 +661,7 @@ static void SampleSubgraph(const NDArray &csr,
   std::vector<std::pair<dgl_id_t, dgl_id_t> > order_map;
   order_map.reserve(sub_ver_mp.size());
   for (auto& data : sub_ver_mp)
-    order_map.push_back(std::pair<dgl_id_t, dgl_id_t>(data.first, data.second));
+    order_map.emplace_back(data.first, data.second);
   size_t num_vertices = sub_ver_mp.size();
   std::sort(order_map.begin(), order_map.end(),
             [](const std::pair<dgl_id_t, dgl_id_t> &a1, const std::pair<dgl_id_t, dgl_id_t> &a2) {
@@ -711,7 +711,7 @@ static void SampleSubgraph(const NDArray &csr,
   std::vector<std::pair<dgl_id_t, dgl_id_t> > order_map_with_neighs;
   order_map_with_neighs.reserve(neigh_pos.size());
   for (auto& data : neigh_pos)
-    order_map_with_neighs.push_back(std::pair<dgl_id_t, dgl_id_t>(data.first, data.second));
+    order_map_with_neighs.push_back(data.first, data.second);
   std::sort(order_map_with_neighs.begin(), order_map_with_neighs.end(),
             [](const std::pair<dgl_id_t, dgl_id_t> &a1, const std::pair<dgl_id_t, dgl_id_t> &a2) {
     return a1.first < a2.first;

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -451,24 +451,20 @@ static void NegateSet(const std::vector<size_t> &idxs,
  */
 static void GetUniformSample(const dgl_id_t* val_list,
                              const dgl_id_t* col_list,
-                             const dgl_id_t* indptr,
-                             const dgl_id_t dst_id,
+                             const size_t ver_len,
                              const size_t max_num_neighbor,
                              std::vector<dgl_id_t>* out_ver,
                              std::vector<dgl_id_t>* out_edge,
                              unsigned int* seed) {
-  size_t ver_len = *(indptr+dst_id+1) - *(indptr+dst_id);
   // Copy ver_list to output
   if (ver_len <= max_num_neighbor) {
-    for (dgl_id_t i = *(indptr+dst_id); i < *(indptr+dst_id+1); ++i) {
+    for (size_t i = 0; i < ver_len; ++i) {
       out_ver->push_back(col_list[i]);
       out_edge->push_back(val_list[i]);
     }
     return;
   }
   // If we just sample a small number of elements from a large neighbor list.
-  const dgl_id_t* col_ptr = col_list + *(indptr + dst_id);
-  const dgl_id_t* val_ptr = val_list + *(indptr + dst_id);
   std::vector<size_t> sorted_idxs;
   if (ver_len > max_num_neighbor * 2) {
     sorted_idxs.reserve(max_num_neighbor);
@@ -488,8 +484,8 @@ static void GetUniformSample(const dgl_id_t* val_list,
     CHECK_GT(sorted_idxs[i], sorted_idxs[i - 1]);
   }
   for (auto idx : sorted_idxs) {
-    out_ver->push_back(col_ptr[idx]);
-    out_edge->push_back(val_ptr[idx]);
+    out_ver->push_back(col_list[idx]);
+    out_edge->push_back(val_list[idx]);
   }
 }
 
@@ -499,28 +495,24 @@ static void GetUniformSample(const dgl_id_t* val_list,
 static void GetNonUniformSample(const float* probability,
                                 const dgl_id_t* val_list,
                                 const dgl_id_t* col_list,
-                                const dgl_id_t* indptr,
-                                const dgl_id_t dst_id,
+                                const size_t ver_len,
                                 const size_t max_num_neighbor,
                                 std::vector<dgl_id_t>* out_ver,
                                 std::vector<dgl_id_t>* out_edge,
                                 unsigned int* seed) {
-  size_t ver_len = *(indptr+dst_id+1) - *(indptr+dst_id);
   // Copy ver_list to output
   if (ver_len <= max_num_neighbor) {
-    for (dgl_id_t i = *(indptr+dst_id); i < *(indptr+dst_id+1); ++i) {
+    for (size_t i = 0; i < ver_len; ++i) {
       out_ver->push_back(col_list[i]);
       out_edge->push_back(val_list[i]);
     }
     return;
   }
   // Make sample
-  const dgl_id_t* col_ptr = col_list + *(indptr + dst_id);
-  const dgl_id_t* val_ptr = val_list + *(indptr + dst_id);
   std::vector<size_t> sp_index(max_num_neighbor);
   std::vector<float> sp_prob(ver_len);
   for (size_t i = 0; i < ver_len; ++i) {
-    sp_prob[i] = probability[col_ptr[i]];
+    sp_prob[i] = probability[col_list[i]];
   }
   ArrayHeap arrayHeap(sp_prob);
   arrayHeap.SampleWithoutReplacement(max_num_neighbor, &sp_index, seed);
@@ -528,8 +520,8 @@ static void GetNonUniformSample(const float* probability,
   out_edge->resize(max_num_neighbor);
   for (size_t i = 0; i < max_num_neighbor; ++i) {
     size_t idx = sp_index[i];
-    out_ver->at(i) = col_ptr[idx];
-    out_edge->at(i) = val_ptr[idx];
+    out_ver->at(i) = col_list[idx];
+    out_edge->at(i) = val_list[idx];
   }
   sort(out_ver->begin(), out_ver->end());
   sort(out_edge->begin(), out_edge->end());
@@ -609,21 +601,20 @@ static void SampleSubgraph(const NDArray &csr,
       }
       tmp_sampled_src_list.clear();
       tmp_sampled_edge_list.clear();
+      dgl_id_t ver_len = *(indptr+dst_id+1) - *(indptr+dst_id);
       if (probability == nullptr) {  // uniform-sample
-        GetUniformSample(val_list,
-                       col_list,
-                       indptr,
-                       dst_id,
+        GetUniformSample(val_list + *(indptr + dst_id),
+                       col_list + *(indptr + dst_id),
+                       ver_len,
                        num_neighbor,
                        &tmp_sampled_src_list,
                        &tmp_sampled_edge_list,
                        &time_seed);
       } else {  // non-uniform-sample
         GetNonUniformSample(probability,
-                       val_list,
-                       col_list,
-                       indptr,
-                       dst_id,
+                       val_list + *(indptr + dst_id),
+                       col_list + *(indptr + dst_id),
+                       ver_len,
                        num_neighbor,
                        &tmp_sampled_src_list,
                        &tmp_sampled_edge_list,

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -664,7 +664,7 @@ static void SampleSubgraph(const NDArray &csr,
     order_map.push_back(std::pair<dgl_id_t, dgl_id_t>(data.first, data.second));
   size_t num_vertices = sub_ver_mp.size();
   std::sort(order_map.begin(), order_map.end(),
-            [](const std::pair<dgl_id_t, dgl_id_t> &a1, std::pair<dgl_id_t, dgl_id_t> &a2) {
+            [](const std::pair<dgl_id_t, dgl_id_t> &a1, const std::pair<dgl_id_t, dgl_id_t> &a2) {
     return a1.first < a2.first;
   });
   for (size_t i = 0; i < order_map.size(); i++) {
@@ -713,7 +713,7 @@ static void SampleSubgraph(const NDArray &csr,
   for (auto& data : neigh_pos)
     order_map_with_neighs.push_back(std::pair<dgl_id_t, dgl_id_t>(data.first, data.second));
   std::sort(order_map_with_neighs.begin(), order_map_with_neighs.end(),
-            [](const std::pair<dgl_id_t, dgl_id_t> &a1, std::pair<dgl_id_t, dgl_id_t> &a2) {
+            [](const std::pair<dgl_id_t, dgl_id_t> &a1, const std::pair<dgl_id_t, dgl_id_t> &a2) {
     return a1.first < a2.first;
   });
 

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -711,7 +711,7 @@ static void SampleSubgraph(const NDArray &csr,
   std::vector<std::pair<dgl_id_t, dgl_id_t> > order_map_with_neighs;
   order_map_with_neighs.reserve(neigh_pos.size());
   for (auto& data : neigh_pos)
-    order_map_with_neighs.push_back(data.first, data.second);
+    order_map_with_neighs.emplace_back(data.first, data.second);
   std::sort(order_map_with_neighs.begin(), order_map_with_neighs.end(),
             [](const std::pair<dgl_id_t, dgl_id_t> &a1, const std::pair<dgl_id_t, dgl_id_t> &a2) {
     return a1.first < a2.first;

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -756,8 +756,16 @@ static void CSRNeighborUniformSampleComputeExCPU(const nnvm::NodeAttrs& attrs,
 }
 
 NNVM_REGISTER_OP(_contrib_dgl_csr_neighbor_uniform_sample)
-.describe(R"code(This operator samples sub-graph from a csr graph via an
-uniform probability. 
+.describe(R"code(This operator samples sub-graphs from a csr graph via an
+uniform probability. The operator is designed for DGL.
+
+The operator outputs three sets of NDArrays to represent the sampled results
+(the number of NDArrays in each set is the same as the number of seed NDArrays):
+1) a set of 1D NDArrays containing the sampled vertices, 2) a set of CSRNDArrays representing
+the sampled edges, 3) a set of 1D NDArrays indicating the layer where a vertex is sampled.
+The first set of 1D NDArrays have a length of max_num_vertices+1. The last element in an NDArray
+indicate the acutal number of vertices in a subgraph. The third set of NDArrays have a length
+of max_num_vertices, and the valid number of vertices is the same as the ones in the first set.
 
 Example:
 
@@ -843,7 +851,16 @@ static void CSRNeighborNonUniformSampleComputeExCPU(const nnvm::NodeAttrs& attrs
 
 NNVM_REGISTER_OP(_contrib_dgl_csr_neighbor_non_uniform_sample)
 .describe(R"code(This operator samples sub-graph from a csr graph via an
-uniform probability. 
+non-uniform probability. The operator is designed for DGL.
+
+The operator outputs four sets of NDArrays to represent the sampled results
+(the number of NDArrays in each set is the same as the number of seed NDArrays):
+1) a set of 1D NDArrays containing the sampled vertices, 2) a set of CSRNDArrays representing
+the sampled edges, 3) a set of 1D NDArrays with the probability that vertices are sampled,
+4) a set of 1D NDArrays indicating the layer where a vertex is sampled.
+The first set of 1D NDArrays have a length of max_num_vertices+1. The last element in an NDArray
+indicate the acutal number of vertices in a subgraph. The third and fourth set of NDArrays have a length
+of max_num_vertices, and the valid number of vertices is the same as the ones in the first set.
 
 Example:
 

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -629,7 +629,7 @@ static void SampleSubgraph(const NDArray &csr,
                        &tmp_sampled_edge_list,
                        &time_seed);
       }
-      CHECK_EQ(tmp_sampled_src_list.size(), 
+      CHECK_EQ(tmp_sampled_src_list.size(),
                tmp_sampled_edge_list.size());
       size_t pos = neighbor_list.size();
       neigh_pos[dst_id] = pos;
@@ -722,11 +722,11 @@ static void SampleSubgraph(const NDArray &csr,
     size_t pos = neigh_pos[dst_id];
     size_t edge_size = neighbor_list[pos];
     if (edge_size != 0) {
-      std::copy_n(neighbor_list.begin() + pos + 1, 
-                  edge_size, 
+      std::copy_n(neighbor_list.begin() + pos + 1,
+                  edge_size,
                   col_list_out + collected_nedges);
-      std::copy_n(neighbor_list.begin() + pos + edge_size + 1, 
-                  edge_size, 
+      std::copy_n(neighbor_list.begin() + pos + edge_size + 1,
+                  edge_size,
                   val_list_out + collected_nedges);
       collected_nedges += edge_size;
     }

--- a/tests/python/unittest/test_dgl_graph.py
+++ b/tests/python/unittest/test_dgl_graph.py
@@ -37,7 +37,7 @@ def check_uniform(out, num_hops, max_num_vertices):
     sub_csr.check_format(full_check=True)
     assert np.all((sub_csr.indptr[num_vertices:] == sub_csr.indptr[num_vertices]).asnumpy())
     # check layer
-    for data in layer:
+    for data in layer[:num_vertices]:
         assert(data <= num_hops)
 
 def check_non_uniform(out, num_hops, max_num_vertices):
@@ -54,7 +54,7 @@ def check_non_uniform(out, num_hops, max_num_vertices):
     # check prob
     assert (len(prob) == max_num_vertices)
     # check layer
-    for data in layer:
+    for data in layer[:num_vertices]:
         assert(data <= num_hops)
 
 def check_compact(csr, id_arr, num_nodes):

--- a/tests/python/unittest/test_dgl_graph.py
+++ b/tests/python/unittest/test_dgl_graph.py
@@ -32,13 +32,10 @@ def check_uniform(out, num_hops, max_num_vertices):
     layer = out[2]
     # check sample_id
     assert (len(sample_id) == max_num_vertices+1)
-    count = 0
-    for data in sample_id:
-        if data != -1:
-            count = count + 1
-    assert (mx.nd.array([count-1], dtype=np.int64) == sample_id[-1])
+    num_vertices = sample_id[-1].asnumpy()[0]
     # check sub_csr
     sub_csr.check_format(full_check=True)
+    assert np.all((sub_csr.indptr[num_vertices:] == sub_csr.indptr[num_vertices]).asnumpy())
     # check layer
     for data in layer:
         assert(data <= num_hops)
@@ -50,13 +47,10 @@ def check_non_uniform(out, num_hops, max_num_vertices):
     layer = out[3]
     # check sample_id
     assert (len(sample_id) == max_num_vertices+1)
-    count = 0
-    for data in sample_id:
-        if data != -1:
-            count = count + 1
-    assert (mx.nd.array([count-1], dtype=np.int64) == sample_id[-1])
+    num_vertices = sample_id[-1].asnumpy()[0]
     # check sub_csr
     sub_csr.check_format(full_check=True)
+    assert np.all((sub_csr.indptr[num_vertices:] == sub_csr.indptr[num_vertices]).asnumpy())
     # check prob
     assert (len(prob) == max_num_vertices)
     # check layer

--- a/tests/python/unittest/test_dgl_graph.py
+++ b/tests/python/unittest/test_dgl_graph.py
@@ -101,9 +101,9 @@ def test_uniform_sample():
     check_compact(out[1], out[0], num_nodes)
 
     seed = mx.nd.array([0], dtype=np.int64)
-    out = mx.nd.contrib.dgl_csr_neighbor_uniform_sample(a, seed, num_args=2, num_hops=2, num_neighbor=1, max_num_vertices=4)
+    out = mx.nd.contrib.dgl_csr_neighbor_uniform_sample(a, seed, num_args=2, num_hops=2, num_neighbor=1, max_num_vertices=3)
     assert (len(out) == 3)
-    check_uniform(out, num_hops=2, max_num_vertices=4)
+    check_uniform(out, num_hops=2, max_num_vertices=3)
     num_nodes = out[0][-1].asnumpy()
     assert num_nodes > 0
     assert num_nodes < len(out[0])


### PR DESCRIPTION
## Description ##
The DGL csr neighbor sampling has many hashtable lookups. Hashtable lookups turn out to be expensive operations. This PR tries to accelerate sampling by reducing hashtable lookups.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
