### PR TITLE
Add a DGL operator to compute vertex Ids in layers

### DIFF
--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -1644,6 +1644,9 @@ static void ComputeLayerVid(const TBlob &layer_ids, const TBlob &out,
     int64_t *num_vs = layer_sizes.dptr<int64_t>();
     for (size_t i = 0; i < num_layers; i++)
       num_vs[i] = 0;
+    // Initialize output data.
+    for (size_t i = 0; i < out.shape_.Size(); i++)
+      out_data[i] = -1;
 
     size_t max_size = out.shape_[1];
     size_t size = layer_ids.shape_.Size();
@@ -1695,7 +1698,7 @@ static bool LayerVidShape(const nnvm::NodeAttrs& attrs,
                           std::vector<TShape> *out_attrs) {
   const LayerVidParam& params = nnvm::get<LayerVidParam>(attrs.parsed);
   CHECK_EQ(params.num_layers.ndim(), in_attrs->size());
-  CHECK_EQ(params.num_layers.ndim(), out_attrs->size() * 2);
+  CHECK_EQ(params.num_layers.ndim() * 2, out_attrs->size());
   size_t num_arrs = in_attrs->size();
   for (size_t i = 0; i < num_arrs; i++) {
     CHECK_EQ(in_attrs->at(i).ndim(), 1U);

--- a/tests/python/unittest/test_dgl_graph.py
+++ b/tests/python/unittest/test_dgl_graph.py
@@ -75,6 +75,17 @@ def check_compact(csr, id_arr, num_nodes):
         sub_id = sub_indices[i]
         assert id_arr[sub_id] == indices[i]
 
+def check_layers(layers, num_layers):
+    out = mx.nd.contrib.dgl_layer_vid(layers, num_layers=(num_layers))
+    layers = layers.asnumpy()
+    print(layers)
+    print(num_layers)
+    for i in range(num_layers):
+        ids = np.where(layers == i)[0]
+        num_ids = out[1][i].asnumpy()[0]
+        assert num_ids == len(ids)
+        assert np.all(ids == out[0][i][0:num_ids].asnumpy())
+
 def test_uniform_sample():
     shape = (5, 5)
     data_np = np.array([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], dtype=np.int64)
@@ -90,6 +101,7 @@ def test_uniform_sample():
     assert num_nodes > 0
     assert num_nodes < len(out[0])
     check_compact(out[1], out[0], num_nodes)
+    check_layers(out[2], 1)
 
     seed = mx.nd.array([0], dtype=np.int64)
     out = mx.nd.contrib.dgl_csr_neighbor_uniform_sample(a, seed, num_args=2, num_hops=1, num_neighbor=1, max_num_vertices=4)
@@ -99,6 +111,7 @@ def test_uniform_sample():
     assert num_nodes > 0
     assert num_nodes < len(out[0])
     check_compact(out[1], out[0], num_nodes)
+    check_layers(out[2], 1)
 
     seed = mx.nd.array([0], dtype=np.int64)
     out = mx.nd.contrib.dgl_csr_neighbor_uniform_sample(a, seed, num_args=2, num_hops=2, num_neighbor=1, max_num_vertices=4)
@@ -108,6 +121,7 @@ def test_uniform_sample():
     assert num_nodes > 0
     assert num_nodes < len(out[0])
     check_compact(out[1], out[0], num_nodes)
+    check_layers(out[2], 2)
 
     seed = mx.nd.array([0,2,4], dtype=np.int64)
     out = mx.nd.contrib.dgl_csr_neighbor_uniform_sample(a, seed, num_args=2, num_hops=1, num_neighbor=2, max_num_vertices=5)
@@ -117,6 +131,7 @@ def test_uniform_sample():
     assert num_nodes > 0
     assert num_nodes < len(out[0])
     check_compact(out[1], out[0], num_nodes)
+    check_layers(out[2], 1)
 
     seed = mx.nd.array([0,4], dtype=np.int64)
     out = mx.nd.contrib.dgl_csr_neighbor_uniform_sample(a, seed, num_args=2, num_hops=1, num_neighbor=2, max_num_vertices=5)
@@ -126,6 +141,7 @@ def test_uniform_sample():
     assert num_nodes > 0
     assert num_nodes < len(out[0])
     check_compact(out[1], out[0], num_nodes)
+    check_layers(out[2], 1)
 
     seed = mx.nd.array([0,4], dtype=np.int64)
     out = mx.nd.contrib.dgl_csr_neighbor_uniform_sample(a, seed, num_args=2, num_hops=2, num_neighbor=2, max_num_vertices=5)
@@ -135,6 +151,7 @@ def test_uniform_sample():
     assert num_nodes > 0
     assert num_nodes < len(out[0])
     check_compact(out[1], out[0], num_nodes)
+    check_layers(out[2], 2)
 
     seed = mx.nd.array([0,4], dtype=np.int64)
     out = mx.nd.contrib.dgl_csr_neighbor_uniform_sample(a, seed, num_args=2, num_hops=1, num_neighbor=2, max_num_vertices=5)
@@ -144,6 +161,7 @@ def test_uniform_sample():
     assert num_nodes > 0
     assert num_nodes < len(out[0])
     check_compact(out[1], out[0], num_nodes)
+    check_layers(out[2], 1)
 
 def test_non_uniform_sample():
     shape = (5, 5)

--- a/tests/python/unittest/test_dgl_graph.py
+++ b/tests/python/unittest/test_dgl_graph.py
@@ -77,9 +77,9 @@ def check_compact(csr, id_arr, num_nodes):
 
 def check_layers(layers, num_layers):
     out = mx.nd.contrib.dgl_layer_vid(layers, num_layers=(num_layers))
+    assert len(out[0]) == num_layers
+    assert len(out[1]) == num_layers
     layers = layers.asnumpy()
-    print(layers)
-    print(num_layers)
     for i in range(num_layers):
         ids = np.where(layers == i)[0]
         num_ids = out[1][i].asnumpy()[0]


### PR DESCRIPTION
## Description ##
When we sample a subgraph, a vertex is sampled in a certain layer. This operator is to find what vertices are sampled in different layers.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
