### PR TITLE
Added logging to GitHub commit status publishing

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -173,9 +173,17 @@ def update_github_commit_status(state, message) {
     //properly and you would see an empty list of repos:
     //[Set GitHub commit status (universal)] PENDING on repos [] (sha:xxxxxxx) with context:test/mycontext
     //See https://cwiki.apache.org/confluence/display/MXNET/Troubleshooting#Troubleshooting-GitHubcommit/PRstatusdoesnotgetpublished
+
+    echo "Publishing commit status..."
+
     repoUrl = get_repo_url()
+    echo "repoUrl=${repoUrl}"
+
     commitSha = get_git_commit_hash()
+    echo "commitSha=${commitSha}"
+    
     context = get_github_context()
+    echo "context=${context}"
 
     step([
       $class: 'GitHubCommitStatusSetter',
@@ -189,6 +197,9 @@ def update_github_commit_status(state, message) {
         results: [[$class: "AnyBuildResult", message: message, state: state]]
       ]
     ])
+
+    echo "Publishing commit status done."
+
   }
 }
 


### PR DESCRIPTION
## Description ##

Currently, sometimes there is a problem with GitHub status updates:

* http://jenkins.mxnet-ci.amazon-ml.com/job/mxnet-validation/job/windows-gpu/view/change-requests/job/PR-13208/4/console
* http://jenkins.mxnet-ci.amazon-ml.com/job/mxnet-validation/job/unix-cpu/view/change-requests/job/PR-13599/3/console

If `repoUrl` is changed to a not valid url the log shows the exact same error:

```
[Set GitHub commit status (universal)] SUCCESS on repos [] (sha:90a0bd0) with context:ci/jenkins/mxnet-validation/windows-gpu
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
