### PR TITLE
Set install path for libmxnet.so dynamic lib on Mac OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -486,6 +486,11 @@ build/plugin/%.o: plugin/%.cc
 	@mkdir -p $(@D)
 	$(CXX) -std=c++11 -c $(CFLAGS) -MMD -Isrc/operator -c $< -o $@
 
+# Set install path for libmxnet.so on Mac OS
+ifeq ($(UNAME_S), Darwin)
+        LDFLAGS += -Wl,-install_name,@rpath/libmxnet.so
+endif
+
 # NOTE: to statically link libmxnet.a we need the option
 # --Wl,--whole-archive -lmxnet --Wl,--no-whole-archive
 lib/libmxnet.a: $(ALLX_DEP)


### PR DESCRIPTION
Add a linker flag in Makefile to set the install path for libmxnet.so dynamic library on Mac OS. With this change, any clients linked against libmxnet.so will automatically record the path as the way dyld should locate it on Mac OS. One use case for this is to run Horovod with MXNet on Mac OS without changing the install path for libmxnet manually after installing Horovod.

