### PR TITLE
fix bug in nag optimizer

### DIFF
--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -973,10 +973,9 @@ class NAG(Optimizer):
 
         if state is not None:
             mom = state
-            mom[:] *= self.momentum
-            mom[:] += grad + wd * weight
+            mom[:] = self.momentum * mom[:] + grad + wd * weight
             grad[:] += self.momentum * mom
-            weight[:] += -lr * grad
+            weight[:] -= lr * grad
         else:
             assert self.momentum == 0.0
             weight[:] += -lr * (grad + wd * weight)

--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -973,7 +973,9 @@ class NAG(Optimizer):
 
         if state is not None:
             mom = state
-            mom[:] = self.momentum * mom[:] + grad + wd * weight
+            mom[:] *= self.momentum
+            mom[:] += grad
+            mom[:] += wd * weight
             grad[:] += self.momentum * mom
             weight[:] -= lr * grad
         else:

--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -974,8 +974,7 @@ class NAG(Optimizer):
         if state is not None:
             mom = state
             mom[:] *= self.momentum
-            grad += wd * weight
-            mom[:] += grad
+            mom[:] += grad + wd * weight
             grad[:] += self.momentum * mom
             weight[:] += -lr * grad
         else:

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -384,7 +384,9 @@ class PyNAG(PySGD):
                 weight[:] += -lr * (grad + wd * weight)
             else:
               mom = state
-              mom[:] = self.momentum * mom[:] + grad + wd * weight
+              mom[:] *= self.momentum
+              mom[:] += grad
+              mom[:] += wd * weight
               grad[:] += self.momentum * mom
               weight[:] -= lr * grad
         else:
@@ -397,7 +399,9 @@ class PyNAG(PySGD):
             if self.momentum == 0.0:
                 weight32[:] += -lr * (grad32 + wd * weight32)
             else:
-                mom[:] = self.momentum * mom[:] + grad32 + wd * weight32
+                mom[:] *= self.momentum
+                mom[:] += grad32
+                mom[:] += wd * weight32
                 grad32[:] += self.momentum * mom
                 weight32[:] -= lr * grad32
             tmp = weight32.astype(weight.dtype)

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -384,10 +384,9 @@ class PyNAG(PySGD):
                 weight[:] += -lr * (grad + wd * weight)
             else:
               mom = state
-              mom[:] *= self.momentum
-              mom[:] += grad + wd * weight
+              mom[:] = self.momentum * mom[:] + grad + wd * weight
               grad[:] += self.momentum * mom
-              weight[:] += -lr * grad
+              weight[:] -= lr * grad
         else:
             grad32 = array(grad, ctx=grad.context, dtype=np.float32)
             grad32 = grad32 * self.rescale_grad
@@ -398,10 +397,9 @@ class PyNAG(PySGD):
             if self.momentum == 0.0:
                 weight32[:] += -lr * (grad32 + wd * weight32)
             else:
-                mom[:] *= self.momentum
-                mom[:] += grad32 + wd * weight32
+                mom[:] = self.momentum * mom[:] + grad32 + wd * weight32
                 grad32[:] += self.momentum * mom
-                weight32[:] += -lr * grad32
+                weight32[:] -= lr * grad32
             tmp = weight32.astype(weight.dtype)
             tmp.copyto(weight)
 

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -385,8 +385,7 @@ class PyNAG(PySGD):
             else:
               mom = state
               mom[:] *= self.momentum
-              grad += wd * weight
-              mom[:] += grad
+              mom[:] += grad + wd * weight
               grad[:] += self.momentum * mom
               weight[:] += -lr * grad
         else:
@@ -400,8 +399,7 @@ class PyNAG(PySGD):
                 weight32[:] += -lr * (grad32 + wd * weight32)
             else:
                 mom[:] *= self.momentum
-                grad32 += wd * weight32
-                mom[:] += grad32
+                mom[:] += grad32 + wd * weight32
                 grad32[:] += self.momentum * mom
                 weight32[:] += -lr * grad32
             tmp = weight32.astype(weight.dtype)


### PR DESCRIPTION
```
grad += wd * weight
mom[:] += grad
grad[:] += self.momentum * mom
weight[:] += -lr * grad
```
This will minus wd*weight twice, but in formula
```
state = momentum * state + grad + wd * weight 
weight = weight - (lr * (grad + momentum * state)) 
````
only minus once.

