### PR TITLE
Added javadocs and improved example instructions

### DIFF
--- a/scala-package/examples/src/main/java/org/apache/mxnetexamples/javaapi/infer/objectdetector/README.md
+++ b/scala-package/examples/src/main/java/org/apache/mxnetexamples/javaapi/infer/objectdetector/README.md
@@ -17,8 +17,8 @@ The model is trained on the [Pascal VOC 2012 dataset](http://host.robots.ox.ac.u
 
 ## Prerequisites
 
-1. MXNet
-2. MXNet Scala Package
+1. [Build MXNet](http://mxnet.incubator.apache.org/install/scala_setup.html)
+2. [Build MXNet Scala/Java Package](http://mxnet.incubator.apache.org/install/scala_setup.html)
 3. [IntelliJ IDE (or alternative IDE) project setup](http://mxnet.incubator.apache.org/tutorials/java/mxnet_java_on_intellij.html) with the MXNet Scala/Java Package
 4. wget
 
@@ -64,10 +64,10 @@ The followings is the parameters defined for this example, you can find more inf
 ## How to Run Inference
 After the previous steps, you should be able to run the code using the following script that will pass all of the required parameters to the Infer API.
 
-From the `scala-package/examples/scripts/inferexample/objectdetector/` folder run:
+From the `scala-package/examples/scripts/infer/objectdetector/` folder run:
 
 ```bash
-./run_ssd_example.sh ../models/resnet50_ssd/resnet50_ssd/resnet50_ssd_model ../images/dog.jpg ../images
+./run_ssd_example.sh ../models/resnet50_ssd/resnet50_ssd_model ../images/dog.jpg ../images
 ```
 
 **Notes**:

--- a/scala-package/infer/src/main/scala/org/apache/mxnet/infer/javaapi/ObjectDetectorOutput.scala
+++ b/scala-package/infer/src/main/scala/org/apache/mxnet/infer/javaapi/ObjectDetectorOutput.scala
@@ -17,18 +17,55 @@
 
 package org.apache.mxnet.infer.javaapi
 
+/**
+  * The ObjectDetectorOutput class is a simple POJO helper class that is used to simplify
+  * the interactions with ObjectDetector predict results. The class stores the bounding box
+  * coordinates, name of preicted class, and the probability.
+  */
+
+
 class ObjectDetectorOutput (className: String, args: Array[Float]){
 
+  /**
+    * Gets the predicted class's name.
+    *
+    * @return       String representing the name of the predicted class
+    */
   def getClassName: String = className
 
+  /**
+    * Gets the probability of the predicted class.
+    *
+    * @return       Float representing the probability of predicted class
+    */
   def getProbability: Float = args(0)
 
+  /**
+    * Gets the minimum X coordinate for the bounding box containing the predicted object.
+    *
+    * @return       Float of the min X coordinate for the object bounding box
+    */
   def getXMin: Float = args(1)
 
+  /**
+    * Gets the maximum X coordinate for the bounding box containing the predicted object.
+    *
+    * @return       Float of the max X coordinate for the object bounding box
+    */
   def getXMax: Float = args(2)
 
+  /**
+    * Gets the minimum Y coordinate for the bounding box containing the predicted object.
+    *
+    * @return       Float of the min Y coordinate for the object bounding box
+    */
   def getYMin: Float = args(3)
 
+  /**
+    * Gets the maximum Y coordinate for the bounding box containing the predicted object.
+    *
+    * @return       Float of the max Y coordinate for the object bounding box
+    */
   def getYMax: Float = args(4)
 
 }


### PR DESCRIPTION
## Description ##
Addressing some user feedback on the documentation for ssd java example and some javadoc stuff. 

Specifically:
Making it more clear that in order to run the example, mxnet must first be built.
Fixing a few paths in the readme.
Adding javadocs for ObjectDetectorOutput which is a basic POJO for working with the ObjectDetector inference api.

@piyushghai @zachgk @lanking520 @aaronmarkham 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-13711/1/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
