### PR TITLE
disable error checking when building old versions

### DIFF
--- a/docs/build_version_doc/build_all_version.sh
+++ b/docs/build_version_doc/build_all_version.sh
@@ -122,6 +122,8 @@ function checkout () {
     git pull
     # master gets warnings as errors for Sphinx builds
     OPTS="-W"
+  else
+    OPTS=
   fi
   git submodule update --init --recursive
   cd ..


### PR DESCRIPTION
## Description ##
This PR fixes a bug in the options settings for the docs build for the website publishing job in CI. If you ran master first the error checking would get turned on and then never turn off for the older versions.

## Testing
This will fail now:
./build_all_version.sh "master;v1.3.x" "master;1.3.1"
So the workaround is to run master last, but with this PR, it will work generating different versions in any order.