### PR TITLE
Fix argmax error with default axis

### DIFF
--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -88,11 +88,11 @@ struct ReduceAxisParam : public dmlc::Parameter<ReduceAxisParam> {
   dmlc::optional<int> axis;
   bool keepdims;
   DMLC_DECLARE_PARAMETER(ReduceAxisParam) {
-    DMLC_DECLARE_FIELD(axis).set_default(dmlc::optional<int>())
+    DMLC_DECLARE_FIELD(axis).set_default(dmlc::optional<int>(-1))
       .describe("The axis along which to perform the reduction. "
                 "Negative values means indexing from right to left. "
-                "``Requires axis to be set as int, because global reduction "
-                "is not supported yet.``");
+                "``The axis need to be set as an int. If the axis is "
+                "not set, the rightmost axis will be reduced.``");
     DMLC_DECLARE_FIELD(keepdims).set_default(false)
       .describe("If this is set to `True`, the reduced axis is left "
                 "in the result as dimension with size one.");

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -477,7 +477,6 @@ def test_dot():
     C = mx.nd.dot(A, B, transpose_a=True, transpose_b=True)
     assert_almost_equal(c, C.asnumpy(), atol=atol)
 
-
 @with_seed()
 def test_reduce():
     sample_num = 200
@@ -523,6 +522,31 @@ def test_reduce():
     test_reduce_inner(lambda data, axis,
                              keepdims:np_reduce(np.float32(data), axis, keepdims, np.argmin),
                       mx.nd.argmin, False)
+
+@with_seed()
+def test_argmax_argmin():
+    # test optional parameters
+    # test name : input data, argmax result, argmin result
+    tests = {
+        'axis_0' : [[[1, 2, 3], [4, 5, 6]], [1, 1, 1], [0, 0, 0]],
+        'keep_dims' : [[[1, 2, 3], [4, 5, 6]], [[2], [2]], [[0], [0]]],
+        'axis_none' : [[1, 2, 3, 4], 3, 0]
+    }
+
+    arg_max = mx.nd.array(tests['axis_0'][0]).argmax(axis=0)
+    arg_min = mx.nd.array(tests['axis_0'][0]).argmin(axis=0)
+    assert_almost_equal(arg_max.asnumpy(), tests['axis_0'][1])
+    assert_almost_equal(arg_min.asnumpy(), tests['axis_0'][2])
+
+    arg_max = mx.nd.array(tests['keep_dims'][0]).argmax(axis=1, keepdims=True)
+    arg_min = mx.nd.array(tests['keep_dims'][0]).argmin(axis=1, keepdims=True)
+    assert_almost_equal(arg_max.asnumpy(), tests['keep_dims'][1])
+    assert_almost_equal(arg_min.asnumpy(), tests['keep_dims'][2])
+
+    arg_max = mx.nd.array(tests['axis_none'][0]).argmax()
+    arg_min = mx.nd.array(tests['axis_none'][0]).argmin()
+    assert_almost_equal(arg_max.asnumpy(), tests['axis_none'][1])
+    assert_almost_equal(arg_min.asnumpy(), tests['axis_none'][2])
 
 @with_seed()
 def test_broadcast():


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)
Small fix on the issue that ndarray argmax doesn't support default axis for one dimension array
Description: https://github.com/apache/incubator-mxnet/issues/10358

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
