### PR TITLE
Reorder module import orders for dist-kvstore

### DIFF
--- a/python/mxnet/__init__.py
+++ b/python/mxnet/__init__.py
@@ -54,7 +54,6 @@ from . import callback
 from . import lr_scheduler
 # use mx.kv as short for kvstore
 from . import kvstore as kv
-from . import kvstore_server
 # Runtime compile module
 from . import rtc
 # Attribute scope to add attributes to symbolic graphs
@@ -82,3 +81,7 @@ from . import rnn
 from . import gluon
 
 __version__ = base.__version__
+
+# dist kvstore module which launches a separate process when role is set to "server".
+# this should be done after other modules are initialized.
+from . import kvstore_server


### PR DESCRIPTION
## Description ##
For distributed training, a new process is launched when importing the `kvstore_server` module. This should be imported at last so that other MXNet modules are initialized correctly. Otherwise this may result in error when unpickling custom LR scheduler/optimizers. For example, the LRScheduler in gluoncv https://github.com/dmlc/gluon-cv/blob/master/gluoncv/utils/lr_scheduler.py#L8 depends on a specific version of MXNet, and checks the `__version__` attr of MXNet, which is not set on kvstore server due to the fact that kvstore-server module is imported before the `__version__` attr is set. 

@hetong007 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
End to end tested with a gluon-cv example. 