### PR TITLE
Set ImageNet data augmentation by default

### DIFF
--- a/example/image-classification/common/fit.py
+++ b/example/image-classification/common/fit.py
@@ -142,6 +142,8 @@ def add_fit_args(parser):
     train.add_argument('--profile-server-suffix', type=str, default='',
                        help='profile server actions into a file with name like rank1_ followed by this suffix \
                              during distributed training')
+    train.add_argument('--use-imagenet-data-augmentation', type=int, default=0,
+                       help='enable data augmentation of ImageNet data, default disabled')
     return train
 
 

--- a/example/image-classification/train_imagenet.py
+++ b/example/image-classification/train_imagenet.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
     data.add_data_args(parser)
     data.add_data_aug_args(parser)
     # uncomment to set standard augmentations for imagenet training
-    # set_imagenet_aug(parser)
+    set_imagenet_aug(parser)
     parser.set_defaults(
         # network
         network          = 'resnet',

--- a/example/image-classification/train_imagenet.py
+++ b/example/image-classification/train_imagenet.py
@@ -38,8 +38,6 @@ if __name__ == '__main__':
     fit.add_fit_args(parser)
     data.add_data_args(parser)
     data.add_data_aug_args(parser)
-    # uncomment to set standard augmentations for imagenet training
-    set_imagenet_aug(parser)
     parser.set_defaults(
         # network
         network          = 'resnet',
@@ -56,6 +54,8 @@ if __name__ == '__main__':
         dtype            = 'float32'
     )
     args = parser.parse_args()
+    if args.use_imagenet_data_augmentation:
+        set_imagenet_aug(parser)
 
     # load network
     from importlib import import_module


### PR DESCRIPTION
https://github.com/apache/incubator-mxnet/blob/a38278ddebfcc9459d64237086cd7977ec20c70e/example/image-classification/train_imagenet.py#L42

When I try to train imagenet with this line commented, the train-accuracy reaches 99% while the validation-accuracy is only less than 50% (single machine, 8 GPUs, global batchsize=2048, Resnet50, fp32). Absolutely this is overfitting.

Then I uncomment this line and try again with the same experiment settings. This time both train and validation accuracy converge to about 66%, which looks like normal result.

Thus, it seems that this data augmentation is pretty important for ImageNet training. Perhaps it will be better to uncomment this as default, so that future developers won't get confused by the overfitting issue.
