### PR TITLE
Fix document for building with MKL-DNN on OS X (Mac)

### DIFF
--- a/MKLDNN_README.md
+++ b/MKLDNN_README.md
@@ -78,7 +78,7 @@ cd incubator-mxnet
 ### Build MXNet with MKL-DNN
 
 ```
-LIBRARY_PATH=$(brew --prefix llvm)/lib/ make -j $(sysctl -n hw.ncpu) CC=$(brew --prefix llvm)/bin/clang++ CXX=$(brew --prefix llvm)/bin/clang++ USE_OPENCV=1 USE_OPENMP=1 USE_MKLDNN=1 USE_BLAS=apple USE_PROFILER=1
+LIBRARY_PATH=$(brew --prefix llvm)/lib/ make -j $(sysctl -n hw.ncpu) CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++ USE_OPENCV=1 USE_OPENMP=1 USE_MKLDNN=1 USE_BLAS=apple USE_PROFILER=1
 ```
 
 <h2 id="3">Windows</h2>

--- a/docs/install/osx_setup.md
+++ b/docs/install/osx_setup.md
@@ -96,7 +96,7 @@ The file called ```osx.mk``` has the configuration required for building MXNet o
 To build with MKLDNN
 
 ```bash
-echo "CC=$(brew --prefix llvm)/bin/clang++" >> ./config.mk
+echo "CC=$(brew --prefix llvm)/bin/clang" >> ./config.mk
 echo "CXX=$(brew --prefix llvm)/bin/clang++" >> ./config.mk
 echo "USE_OPENCV=1" >> ./config.mk
 echo "USE_OPENMP=1" >> ./config.mk


### PR DESCRIPTION
## Description ##
change c compiler from clang++ to clang when building with MKL-DNN on macOS.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
@TaoLv @pengzhao-intel
