### PR TITLE
Fix install commands for Raspbian instructions

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1205,7 +1205,7 @@ ARMv7. The resulting artifact will be located in `build/mxnet-x.x.x-py2.py3-none
 file to your Raspberry Pi.
 
 ```
-ci/build.py -p armv7
+./ci/build.py -p armv7
 ```
 
 ## Install
@@ -1298,7 +1298,7 @@ Note that the `-e` flag is optional. It is equivalent to `--editable` and means 
 
 Alternatively you can create a whl package installable with pip with the following command:
 ```
-ci/docker/runtime_functions.sh build_wheel python/ $(realpath build)
+./ci/docker/runtime_functions.sh build_wheel python/ $(realpath build)
 ```
 
 


### PR DESCRIPTION
## Description ##
This fixes doc commands in the raspbian install instructions that don't work in bash (but maybe do in other shells) and have caused some confusion (see https://github.com/apache/incubator-mxnet/issues/13790).

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

@mxnet-label-bot add [Doc, Installation, Edge Devices]