### PR TITLE
[MXNET-1263] Unit Tests for Java Predictor and Object Detector APIs

### DIFF
--- a/scala-package/core/pom.xml
+++ b/scala-package/core/pom.xml
@@ -13,6 +13,10 @@
   <artifactId>mxnet-core</artifactId>
   <name>MXNet Scala Package - Core</name>
 
+  <properties>
+    <skipTests>false</skipTests>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
@@ -112,16 +116,6 @@
           <argLine>
             -Djava.library.path=${project.parent.basedir}/native/target \
             -Dlog4j.configuration=file://${project.basedir}/src/test/resources/log4j.properties
-          </argLine>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
-        <configuration>
-          <argLine>
-            -Djava.library.path=${project.parent.basedir}/native/target
           </argLine>
         </configuration>
       </plugin>

--- a/scala-package/core/pom.xml
+++ b/scala-package/core/pom.xml
@@ -14,7 +14,7 @@
   <name>MXNet Scala Package - Core</name>
 
   <properties>
-    <skipTests>false</skipTests>
+    <skipJavaTests>false</skipJavaTests>
   </properties>
 
   <build>

--- a/scala-package/infer/pom.xml
+++ b/scala-package/infer/pom.xml
@@ -31,6 +31,16 @@
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.0</version>
+        <configuration>
+          <argLine>
+            -Djava.library.path=${project.parent.basedir}/native/target
+          </argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
         <configuration>

--- a/scala-package/infer/pom.xml
+++ b/scala-package/infer/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <properties>
-    <skipTests>false</skipTests>
+    <skipJavaTests>false</skipJavaTests>
   </properties>
 
   <artifactId>mxnet-infer</artifactId>

--- a/scala-package/infer/pom.xml
+++ b/scala-package/infer/pom.xml
@@ -10,6 +10,10 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
+  <properties>
+    <skipTests>false</skipTests>
+  </properties>
+
   <artifactId>mxnet-infer</artifactId>
   <name>MXNet Scala Package - Inference</name>
 
@@ -29,16 +33,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
-        <configuration>
-          <argLine>
-            -Djava.library.path=${project.parent.basedir}/native/target
-          </argLine>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.scalatest</groupId>

--- a/scala-package/infer/pom.xml
+++ b/scala-package/infer/pom.xml
@@ -60,5 +60,13 @@
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/ObjectDetectorOutputTest.java
+++ b/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/ObjectDetectorOutputTest.java
@@ -17,23 +17,29 @@
 
 package org.apache.mxnet.infer.javaapi;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ObjectDetectorOutputTest {
+
+    private String predictedClassName = "lion";
+
+    private float delta = 0.00001f;
 
     @Test
     public void testConstructor() {
 
         float[] arr = new float[]{0f, 1f, 2f, 3f, 4f};
 
-        ObjectDetectorOutput odOutput = new ObjectDetectorOutput("simba", arr);
+        ObjectDetectorOutput odOutput = new ObjectDetectorOutput(predictedClassName, arr);
 
-        assert (odOutput.getClassName().equals("simba"));
-        assert (odOutput.getProbability() == 0);
-        assert (odOutput.getXMin() == 1);
-        assert (odOutput.getXMax() == 2);
-        assert (odOutput.getYMin() == 3);
-        assert (odOutput.getYMax() == 4);
+        Assert.assertEquals(odOutput.getClassName(), predictedClassName);
+        Assert.assertEquals("Threshold not matching", odOutput.getProbability(), 0f, delta);
+        Assert.assertEquals("Threshold not matching", odOutput.getXMin(), 1f, delta);
+        Assert.assertEquals("Threshold not matching", odOutput.getXMax(), 2f, delta);
+        Assert.assertEquals("Threshold not matching", odOutput.getYMin(), 3f, delta);
+        Assert.assertEquals("Threshold not matching", odOutput.getYMax(), 4f, delta);
+
     }
 
     @Test (expected = ArrayIndexOutOfBoundsException.class)
@@ -41,8 +47,13 @@ public class ObjectDetectorOutputTest {
 
         float[] arr = new float[]{0f, 1f};
 
-        ObjectDetectorOutput odOutput = new ObjectDetectorOutput("simba", arr);
+        ObjectDetectorOutput odOutput = new ObjectDetectorOutput(predictedClassName, arr);
 
-        odOutput.getYMax();
+        Assert.assertEquals(odOutput.getClassName(), predictedClassName);
+        Assert.assertEquals("Threshold not matching", odOutput.getProbability(), 0f, delta);
+        Assert.assertEquals("Threshold not matching", odOutput.getXMin(), 1f, delta);
+
+        // This is where exception will be thrown
+        odOutput.getXMax();
     }
 }

--- a/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/ObjectDetectorOutputTest.java
+++ b/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/ObjectDetectorOutputTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.mxnet.infer.javaapi;
+
+import org.junit.Test;
+
+public class ObjectDetectorOutputTest {
+
+    @Test
+    public void testConstructor() {
+
+        float[] arr = new float[]{0f, 1f, 2f, 3f, 4f};
+
+        ObjectDetectorOutput odOutput = new ObjectDetectorOutput("simba", arr);
+
+        assert (odOutput.getClassName().equals("simba"));
+        assert (odOutput.getProbability() == 0);
+        assert (odOutput.getXMin() == 1);
+        assert (odOutput.getXMax() == 2);
+        assert (odOutput.getYMin() == 3);
+        assert (odOutput.getYMax() == 4);
+    }
+
+    @Test (expected = ArrayIndexOutOfBoundsException.class)
+    public void testIncompleteArgsConstructor() {
+
+        float[] arr = new float[]{0f, 1f};
+
+        ObjectDetectorOutput odOutput = new ObjectDetectorOutput("simba", arr);
+
+        odOutput.getYMax();
+    }
+}

--- a/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/ObjectDetectorTest.java
+++ b/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/ObjectDetectorTest.java
@@ -33,32 +33,51 @@ import java.util.List;
 
 public class ObjectDetectorTest {
 
-    List<DataDesc> inputDesc;
-    BufferedImage inputImage;
+    private List<DataDesc> inputDesc;
+    private BufferedImage inputImage;
 
-    List<List<ObjectDetectorOutput>> result;
+    private List<List<ObjectDetectorOutput>> expectedResult;
 
-    ObjectDetector objectDetector;
+    private ObjectDetector objectDetector;
+
+    private int batchSize = 1;
+
+    private int channels = 3;
+
+    private int imageHeight = 512;
+
+    private int imageWidth = 512;
+
+    private String dataName = "data";
+
+    private int topK = 5;
+
+    private String predictedClassName = "lion"; // Random string
+
+    private Shape getTestShape() {
+
+        return new Shape(new int[] {batchSize, channels, imageHeight, imageWidth});
+    }
 
     @Before
     public void setUp() {
 
         inputDesc = new ArrayList<>();
-        inputDesc.add(new DataDesc("", new Shape(new int[]{1, 3, 512, 512}), DType.Float32(), Layout.NCHW()));
-        inputImage = new BufferedImage(512, 512, BufferedImage.TYPE_INT_RGB);
+        inputDesc.add(new DataDesc(dataName, getTestShape(), DType.Float32(), Layout.NCHW()));
+        inputImage = new BufferedImage(imageWidth, imageHeight, BufferedImage.TYPE_INT_RGB);
         objectDetector = Mockito.mock(ObjectDetector.class);
-        result = new ArrayList<>();
-        result.add(new ArrayList<ObjectDetectorOutput>());
-        result.get(0).add(new ObjectDetectorOutput("simbaa", new float[]{}));
+        expectedResult = new ArrayList<>();
+        expectedResult.add(new ArrayList<ObjectDetectorOutput>());
+        expectedResult.get(0).add(new ObjectDetectorOutput(predictedClassName, new float[]{}));
     }
 
     @Test
     public void testObjectDetectorWithInputImage() {
 
-        Mockito.when(objectDetector.imageObjectDetect(inputImage, 5)).thenReturn(result);
-        List<List<ObjectDetectorOutput>> actualResult = objectDetector.imageObjectDetect(inputImage, 5);
-        Mockito.verify(objectDetector, Mockito.times(1)).imageObjectDetect(inputImage, 5);
-        Assert.assertEquals(result, actualResult);
+        Mockito.when(objectDetector.imageObjectDetect(inputImage, topK)).thenReturn(expectedResult);
+        List<List<ObjectDetectorOutput>> actualResult = objectDetector.imageObjectDetect(inputImage, topK);
+        Mockito.verify(objectDetector, Mockito.times(1)).imageObjectDetect(inputImage, topK);
+        Assert.assertEquals(expectedResult, actualResult);
     }
 
 
@@ -67,21 +86,21 @@ public class ObjectDetectorTest {
 
         List<BufferedImage> batchImage = new ArrayList<>();
         batchImage.add(inputImage);
-        Mockito.when(objectDetector.imageBatchObjectDetect(batchImage, 5)).thenReturn(result);
-        List<List<ObjectDetectorOutput>> actualResult = objectDetector.imageBatchObjectDetect(batchImage, 5);
-        Mockito.verify(objectDetector, Mockito.times(1)).imageBatchObjectDetect(batchImage, 5);
-        Assert.assertEquals(result, actualResult);
+        Mockito.when(objectDetector.imageBatchObjectDetect(batchImage, topK)).thenReturn(expectedResult);
+        List<List<ObjectDetectorOutput>> actualResult = objectDetector.imageBatchObjectDetect(batchImage, topK);
+        Mockito.verify(objectDetector, Mockito.times(1)).imageBatchObjectDetect(batchImage, topK);
+        Assert.assertEquals(expectedResult, actualResult);
     }
 
     @Test
     public void testObjectDetectorWithNDArrayInput() {
 
-        NDArray inputArr = ObjectDetector.bufferedImageToPixels(inputImage, new Shape(new int[] {1, 3, 512, 512}));
+        NDArray inputArr = ObjectDetector.bufferedImageToPixels(inputImage, getTestShape());
         List<NDArray> inputL = new ArrayList<>();
         inputL.add(inputArr);
-        Mockito.when(objectDetector.objectDetectWithNDArray(inputL, 5)).thenReturn(result);
-        List<List<ObjectDetectorOutput>> actualResult = objectDetector.objectDetectWithNDArray(inputL, 5);
-        Mockito.verify(objectDetector, Mockito.times(1)).objectDetectWithNDArray(inputL, 5);
-        Assert.assertEquals(result, actualResult);
+        Mockito.when(objectDetector.objectDetectWithNDArray(inputL, 5)).thenReturn(expectedResult);
+        List<List<ObjectDetectorOutput>> actualResult = objectDetector.objectDetectWithNDArray(inputL, topK);
+        Mockito.verify(objectDetector, Mockito.times(1)).objectDetectWithNDArray(inputL, topK);
+        Assert.assertEquals(expectedResult, actualResult);
     }
 }

--- a/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/ObjectDetectorTest.java
+++ b/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/ObjectDetectorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.mxnet.infer.javaapi;
+
+import org.apache.mxnet.Layout;
+import org.apache.mxnet.javaapi.DType;
+import org.apache.mxnet.javaapi.DataDesc;
+import org.apache.mxnet.javaapi.NDArray;
+import org.apache.mxnet.javaapi.Shape;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ObjectDetectorTest {
+
+    List<DataDesc> inputDesc;
+    BufferedImage inputImage;
+
+    List<List<ObjectDetectorOutput>> result;
+
+    ObjectDetector objectDetector;
+
+    @Before
+    public void setUp() {
+
+        inputDesc = new ArrayList<>();
+        inputDesc.add(new DataDesc("", new Shape(new int[]{1, 3, 512, 512}), DType.Float32(), Layout.NCHW()));
+        inputImage = new BufferedImage(512, 512, BufferedImage.TYPE_INT_RGB);
+        objectDetector = Mockito.mock(ObjectDetector.class);
+        result = new ArrayList<>();
+        result.add(new ArrayList<ObjectDetectorOutput>());
+        result.get(0).add(new ObjectDetectorOutput("simbaa", new float[]{}));
+    }
+
+    @Test
+    public void testObjectDetectorWithInputImage() {
+
+        Mockito.when(objectDetector.imageObjectDetect(inputImage, 5)).thenReturn(result);
+        List<List<ObjectDetectorOutput>> actualResult = objectDetector.imageObjectDetect(inputImage, 5);
+        Mockito.verify(objectDetector, Mockito.times(1)).imageObjectDetect(inputImage, 5);
+        Assert.assertEquals(result, actualResult);
+    }
+
+
+    @Test
+    public void testObjectDetectorWithBatchImage() {
+
+        List<BufferedImage> batchImage = new ArrayList<>();
+        batchImage.add(inputImage);
+        Mockito.when(objectDetector.imageBatchObjectDetect(batchImage, 5)).thenReturn(result);
+        List<List<ObjectDetectorOutput>> actualResult = objectDetector.imageBatchObjectDetect(batchImage, 5);
+        Mockito.verify(objectDetector, Mockito.times(1)).imageBatchObjectDetect(batchImage, 5);
+        Assert.assertEquals(result, actualResult);
+    }
+
+    @Test
+    public void testObjectDetectorWithNDArrayInput() {
+
+        NDArray inputArr = ObjectDetector.bufferedImageToPixels(inputImage, new Shape(new int[] {1, 3, 512, 512}));
+        List<NDArray> inputL = new ArrayList<>();
+        inputL.add(inputArr);
+        Mockito.when(objectDetector.objectDetectWithNDArray(inputL, 5)).thenReturn(result);
+        List<List<ObjectDetectorOutput>> actualResult = objectDetector.objectDetectWithNDArray(inputL, 5);
+        Mockito.verify(objectDetector, Mockito.times(1)).objectDetectWithNDArray(inputL, 5);
+        Assert.assertEquals(result, actualResult);
+    }
+}

--- a/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/PredictorTest.java
+++ b/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/PredictorTest.java
@@ -39,7 +39,7 @@ public class PredictorTest {
     }
 
     @Test
-    public void testPredictWithFloatArry() {
+    public void testPredictWithFloatArray() {
 
         float tmp[][] = new float[1][224];
         for (int x = 0; x < 1; x++) {
@@ -50,23 +50,6 @@ public class PredictorTest {
         float [][] expectedResult = new float[][] {{1f, 2f}};
         Mockito.when(mockPredictor.predict(tmp)).thenReturn(expectedResult);
         float[][] actualResult = mockPredictor.predict(tmp);
-
-        Mockito.verify(mockPredictor, Mockito.times(1)).predict(tmp);
-        Assert.assertArrayEquals(expectedResult, actualResult);
-    }
-
-    @Test
-    public void testPredictWithDoubleArry() {
-
-        double tmp[][] = new double[1][224];
-        for (int x = 0; x < 1; x++) {
-            for (int y = 0; y < 224; y++)
-                tmp[x][y] = (int) (Math.random() * 10);
-        }
-
-        double [][] expectedResult = new double[][] {{1d, 2d}};
-        Mockito.when(mockPredictor.predict(tmp)).thenReturn(expectedResult);
-        double[][] actualResult = mockPredictor.predict(tmp);
 
         Mockito.verify(mockPredictor, Mockito.times(1)).predict(tmp);
         Assert.assertArrayEquals(expectedResult, actualResult);

--- a/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/PredictorTest.java
+++ b/scala-package/infer/src/test/java/org/apache/mxnet/infer/javaapi/PredictorTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.mxnet.infer.javaapi;
+
+import org.apache.mxnet.javaapi.Context;
+import org.apache.mxnet.javaapi.NDArray;
+import org.apache.mxnet.javaapi.Shape;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class PredictorTest {
+
+    Predictor mockPredictor;
+
+    @Before
+    public void setUp() {
+        mockPredictor = Mockito.mock(Predictor.class);
+    }
+
+    @Test
+    public void testPredictWithFloatArry() {
+
+        float tmp[][] = new float[1][224];
+        for (int x = 0; x < 1; x++) {
+            for (int y = 0; y < 224; y++)
+                tmp[x][y] = (int) (Math.random() * 10);
+        }
+
+        float [][] expectedResult = new float[][] {{1f, 2f}};
+        Mockito.when(mockPredictor.predict(tmp)).thenReturn(expectedResult);
+        float[][] actualResult = mockPredictor.predict(tmp);
+
+        Mockito.verify(mockPredictor, Mockito.times(1)).predict(tmp);
+        Assert.assertArrayEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testPredictWithDoubleArry() {
+
+        double tmp[][] = new double[1][224];
+        for (int x = 0; x < 1; x++) {
+            for (int y = 0; y < 224; y++)
+                tmp[x][y] = (int) (Math.random() * 10);
+        }
+
+        double [][] expectedResult = new double[][] {{1d, 2d}};
+        Mockito.when(mockPredictor.predict(tmp)).thenReturn(expectedResult);
+        double[][] actualResult = mockPredictor.predict(tmp);
+
+        Mockito.verify(mockPredictor, Mockito.times(1)).predict(tmp);
+        Assert.assertArrayEquals(expectedResult, actualResult);
+    }
+
+    @Test
+    public void testPredictWithNDArray() {
+
+        float[] tmpArr = new float[224];
+            for (int y = 0; y < 224; y++)
+                tmpArr[y] = (int) (Math.random() * 10);
+
+        NDArray arr = new org.apache.mxnet.javaapi.NDArray(tmpArr, new Shape(new int[] {1, 1, 1, 224}), new Context("cpu", 0));
+
+        List<NDArray> inputList = new ArrayList<>();
+        inputList.add(arr);
+
+        NDArray expected = new NDArray(tmpArr, new Shape(new int[] {1, 1, 1, 224}), new Context("cpu", 0));
+        List<NDArray> expectedResult = new ArrayList<>();
+        expectedResult.add(expected);
+
+        Mockito.when(mockPredictor.predictWithNDArray(inputList)).thenReturn(expectedResult);
+
+        List<NDArray> actualOutput = mockPredictor.predictWithNDArray(inputList);
+
+        Mockito.verify(mockPredictor, Mockito.times(1)).predictWithNDArray(inputList);
+
+        Assert.assertEquals(expectedResult, actualOutput);
+    }
+
+    @Test
+    public void testPredictWithListOfFloatsAsInput() {
+        List<List<Float>> input = new ArrayList<>();
+
+        input.add(Arrays.asList(new Float[] {1f, 2f}));
+
+        List<List<Float>> expectedOutput = new ArrayList<>(input);
+
+        Mockito.when(mockPredictor.predict(input)).thenReturn(expectedOutput);
+
+        List<List<Float>> actualOutput = mockPredictor.predict(input);
+
+        Mockito.verify(mockPredictor, Mockito.times(1)).predict(input);
+
+        Assert.assertEquals(expectedOutput, actualOutput);
+
+    }
+}

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -42,6 +42,7 @@
     <cxx>g++</cxx>
     <dollar>$</dollar>
     <MXNET_DIR>${project.basedir}/..</MXNET_DIR>
+    <skipTests>true</skipTests>
   </properties>
 
   <packaging>pom</packaging>
@@ -228,8 +229,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19</version>
+        <version>2.22.0</version>
         <configuration>
+          <skipTests>${skipTests}</skipTests>
+            <argLine>
+              -Djava.library.path=${project.parent.basedir}/native/target
+            </argLine>
           <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -42,7 +42,7 @@
     <cxx>g++</cxx>
     <dollar>$</dollar>
     <MXNET_DIR>${project.basedir}/..</MXNET_DIR>
-    <skipTests>true</skipTests>
+    <skipJavaTests>true</skipJavaTests>
   </properties>
 
   <packaging>pom</packaging>
@@ -231,7 +231,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.0</version>
         <configuration>
-          <skipTests>${skipTests}</skipTests>
+          <skipTests>${skipJavaTests}</skipTests>
             <argLine>
               -Djava.library.path=${project.parent.basedir}/native/target
             </argLine>


### PR DESCRIPTION
## Description ##
Added unit tests for Java Predictor API and Object Detector API.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

@lanking520 @andrewfayres @zachgk 