### PR TITLE
Whitelist symbols for using MXNet error handling externally

### DIFF
--- a/make/config/libmxnet.sym
+++ b/make/config/libmxnet.sym
@@ -10,3 +10,6 @@ Java_org_apache_mxnet*
 *NDArray*
 *Engine*Get*
 *Storage*Get*
+*on_enter_api*;
+*on_exit_api*;
+*MXAPISetLastError*;

--- a/make/config/libmxnet.ver
+++ b/make/config/libmxnet.ver
@@ -12,5 +12,8 @@
         *NDArray*;
         *Engine*Get*;
         *Storage*Get*;
+        *on_enter_api*;
+        *on_exit_api*;
+        *MXAPISetLastError*;
     local: *;
 };


### PR DESCRIPTION
[#13795](https://github.com/apache/incubator-mxnet/pull/13795)  exported MXNet error handling header file for third-party library like Horovod to consume. We need to expose related symbols when building libmxnet.so share library to avoid undefined symbol error.

