### PR TITLE
Fix scala doc build break for v1.3.1

### DIFF
--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -113,9 +113,9 @@ def build_scala_docs(app):
     scala_doc_sources = 'find . -type f -name "*.scala" | egrep \"\.\/core|\.\/infer\" | egrep -v \"\/javaapi\"  | egrep -v \"Suite\"'
     scala_doc_classpath = ':'.join([
         '`find native -name "*.jar" | grep "target/lib/" | tr "\\n" ":" `',
-        '`find macros -name "*-INTERNAL.jar" | tr "\\n" ":" `',
-        '`find core -name "*-INTERNAL.jar" | tr "\\n" ":" `',
-        '`find infer -name "*-INTERNAL.jar" | tr "\\n" ":" `'
+        '`find macros -name "*.jar" | tr "\\n" ":" `',
+        '`find core -name "*.jar" | tr "\\n" ":" `',
+        '`find infer -name "*.jar" | tr "\\n" ":" `'
     ])
     # There are unresolvable errors on mxnet 1.2.x. We are ignoring those errors while aborting the ci on newer versions
     scala_ignore_errors = '; exit 0' if '1.2.' in _BUILD_VER else ''
@@ -135,9 +135,9 @@ def build_java_docs(app):
     java_doc_sources = 'find . -type f -name "*.scala" | egrep \"\.\/core|\.\/infer\" | egrep \"\/javaapi\" | egrep -v \"Suite\"'
     java_doc_classpath = ':'.join([
         '`find native -name "*.jar" | grep "target/lib/" | tr "\\n" ":" `',
-        '`find macros -name "*-INTERNAL.jar" | tr "\\n" ":" `',
-        '`find core -name "*-INTERNAL.jar" | tr "\\n" ":" `',
-        '`find infer -name "*-INTERNAL.jar" | tr "\\n" ":" `'
+        '`find macros -name "*.jar" | tr "\\n" ":" `',
+        '`find core -name "*.jar" | tr "\\n" ":" `',
+        '`find infer -name "*.jar" | tr "\\n" ":" `'
     ])
     _run_cmd('cd {}; scaladoc `{}` -classpath {} -feature -deprecation'
              .format(java_path, java_doc_sources, java_doc_classpath))

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -118,7 +118,7 @@ def build_scala_docs(app):
         '`find infer -name "*.jar" | tr "\\n" ":" `'
     ])
     # There are unresolvable errors on mxnet 1.2.x. We are ignoring those errors while aborting the ci on newer versions
-    scala_ignore_errors = '; exit 0' if '1.2.' in _BUILD_VER else ''
+    scala_ignore_errors = '; exit 0' if '1.2.' or '1.3.' in _BUILD_VER else ''
     _run_cmd('cd {}; scaladoc `{}` -classpath {} -feature -deprecation {}'
              .format(scala_path, scala_doc_sources, scala_doc_classpath, scala_ignore_errors))
     dest_path = app.builder.outdir + '/api/scala/docs'


### PR DESCRIPTION
## Description ##
mxdoc.py was used to build both old and new version of website. scala doc build script need to be backward compatible.

This fix the backward compatibility issue introduced by: https://github.com/apache/incubator-mxnet/pull/13626

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
