### PR TITLE
Remove semicolon in libmxnet.sym file

### DIFF
--- a/make/config/libmxnet.sym
+++ b/make/config/libmxnet.sym
@@ -10,6 +10,6 @@ Java_org_apache_mxnet*
 *NDArray*
 *Engine*Get*
 *Storage*Get*
-*on_enter_api*;
-*on_exit_api*;
-*MXAPISetLastError*;
+*on_enter_api*
+*on_exit_api*
+*MXAPISetLastError*


### PR DESCRIPTION
Remove unnecessary semicolon from libmxnet.sym file, which was accidentally added in [#13812](https://github.com/apache/incubator-mxnet/pull/13812).
