### PR TITLE
Fix cpp examples build on Mac.

### DIFF
--- a/cpp-package/example/Makefile
+++ b/cpp-package/example/Makefile
@@ -15,6 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+ifeq ($(OS),Windows_NT)
+	UNAME_S := Windows
+else
+	UNAME_S := $(shell uname -s)
+endif
+
 prebuild :
 	@mkdir -p build
 	$(shell ./get_data.sh)
@@ -30,6 +36,7 @@ endif
 
 # CPPEX_CFLAGS += -I../include
 CPPEX_EXTRA_LDFLAGS := -L../../lib -lmxnet
+MXNET_LIB_PATH := $(shell cd ../../lib; pwd)
 
 .PHONY: all clean
 
@@ -38,10 +45,12 @@ all: prebuild  $(CPPEX_EXE)
 debug: CPPEX_CFLAGS += -DDEBUG -g
 debug: prebuild all
 
-
-
 $(CPPEX_EXE):% : %.cpp
 	$(CXX) -std=c++11 $(CFLAGS)  $(CPPEX_CFLAGS) -o build/$@ $(filter %.cpp %.a, $^) $(CPPEX_EXTRA_LDFLAGS)
+ifeq ($(UNAME_S), Darwin)
+	install_name_tool -add_rpath @loader_path build/$@
+	install_name_tool -add_rpath $(MXNET_LIB_PATH) build/$@
+endif
 
 clean:
 	@rm -rf build


### PR DESCRIPTION
## Description ##

This is a regression of adding @rpath name to libmxnet.so on Mac,
example executable is not able to find libmxnet.so anymore.
Add @rpath search path to fix this issue.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
