### PR TITLE
Reduce maven verbosity which is filling up the logs of the builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -614,13 +614,13 @@ scalaclean:
 	(cd $(ROOTDIR)/scala-package && mvn clean)
 
 scalapkg:
-	(cd $(ROOTDIR)/scala-package && mvn install -DskipTests)
+	(cd $(ROOTDIR)/scala-package && mvn install -q -DskipTests)
 
 scalainstall:
-	(cd $(ROOTDIR)/scala-package && mvn install)
+	(cd $(ROOTDIR)/scala-package && mvn install -q)
 
 scalaunittest:
-	(cd $(ROOTDIR)/scala-package && mvn install)
+	(cd $(ROOTDIR)/scala-package && mvn install -q)
 
 scalaintegrationtest:
 	(cd $(ROOTDIR)/scala-package && mvn integration-test -DskipTests=false)


### PR DESCRIPTION
## Description ##

Maven is too verbose and is producing tons of output while downloading dependencies etc. This is a known issue. This PR reduces maven verbosity in the invocations from the Makefile so the logs are not overflowed.

https://blogs.itemis.com/en/in-a-nutshell-removing-artifact-messages-from-maven-log-output

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
