### PR TITLE
Avoid adding SegfaultLogger if process already has sig handler.

### DIFF
--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -44,7 +44,11 @@ class LibraryInitializer {
   LibraryInitializer() {
     dmlc::InitLogging("mxnet");
 #if MXNET_USE_SIGNAL_HANDLER && DMLC_LOG_STACK_TRACE
-    signal(SIGSEGV, SegfaultLogger);
+    struct sigaction sa;
+    sigaction(SIGSEGV, NULL, &sa);
+    if (sa.sa_handler == NULL) {
+        signal(SIGSEGV, SegfaultLogger);
+    }
 #endif
 
 // disable openmp for multithreaded workers


### PR DESCRIPTION
## Description ##
In current implemenation, we override signal handler regardless if MXNET_USE_SIGNAL_HANDLER=1.
This breaks caller process behavior and cause process exit unexpectedly.
The example use case is libmxnet.so is loadded into java process via JNI or JNA. JVM will crash
due to SegfaultLogger.

In this PR, we will not register SegfaultLogger if there is a signal handler registered.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
