### PR TITLE
[v1.4.x] export exception handling APIs in MXNet

### DIFF
--- a/include/mxnet/c_api_error.h
+++ b/include/mxnet/c_api_error.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file c_api_error.h
+ * \brief Error handling for C API.
+ */
+#ifndef MXNET_C_API_ERROR_H_
+#define MXNET_C_API_ERROR_H_
+
+/*!
+ * \brief Macros to guard beginning and end section of all functions
+ * every function starts with API_BEGIN()
+ * and finishes with API_END() or API_END_HANDLE_ERROR()
+ * The finally clause contains procedure to cleanup states when an error happens.
+ */
+#define MX_API_BEGIN() try { on_enter_api(__FUNCTION__);
+#define MX_API_END() } catch(dmlc::Error &_except_) { on_exit_api(); return MXAPIHandleException(_except_); } on_exit_api(); return 0;  // NOLINT(*)
+#define MX_API_END_HANDLE_ERROR(Finalize) } catch(dmlc::Error &_except_) { Finalize; on_exit_api(); return MXAPIHandleException(_except_); } on_exit_api(); return 0; // NOLINT(*)
+/*!
+ * \brief Set the last error message needed by C API
+ * \param msg The error message to set.
+ */
+void MXAPISetLastError(const char* msg);
+/*!
+ * \brief handle exception throwed out
+ * \param e the exception
+ * \return the return value of API after exception is handled
+ */
+inline int MXAPIHandleException(const dmlc::Error &e) {
+  MXAPISetLastError(e.what());
+  return -1;
+}
+
+namespace mxnet {
+extern void on_enter_api(const char *function);
+extern void on_exit_api();
+}
+#endif  // MXNET_C_API_ERROR_H_

--- a/python/mxnet/libinfo.py
+++ b/python/mxnet/libinfo.py
@@ -96,10 +96,18 @@ def find_include_path():
             logging.warning("MXNET_INCLUDE_PATH '%s' doesn't exist", incl_from_env)
 
     curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
-    incl_path = os.path.join(curr_path, '../../include/')
-    if not os.path.isdir(incl_path):
-        raise RuntimeError('Cannot find the MXNet include path.\n')
-    return incl_path
+    # include path in pip package
+    pip_incl_path = os.path.join(curr_path, 'include/')
+    if os.path.isdir(pip_incl_path):
+        return pip_incl_path
+    else:
+        # include path if build from source
+        src_incl_path = os.path.join(curr_path, '../../include/')
+        if os.path.isdir(src_incl_path):
+            return src_incl_path
+        else:
+            raise RuntimeError('Cannot find the MXNet include path in either ' + pip_incl_path +
+                               ' or ' + src_incl_path + '\n')
 
 
 # current version

--- a/src/c_api/c_api_common.h
+++ b/src/c_api/c_api_common.h
@@ -29,37 +29,29 @@
 #include <dmlc/logging.h>
 #include <dmlc/thread_local.h>
 #include <mxnet/c_api.h>
+#include <mxnet/c_api_error.h>
 #include <mxnet/base.h>
 #include <nnvm/graph.h>
 #include <vector>
 #include <string>
 
-/*! \brief  macro to guard beginning and end section of all functions */
-#define API_BEGIN() try { on_enter_api(__FUNCTION__);
-/*! \brief every function starts with API_BEGIN();
-     and finishes with API_END() or API_END_HANDLE_ERROR */
-#define API_END() } catch(dmlc::Error &_except_) { on_exit_api(); return MXAPIHandleException(_except_); } on_exit_api(); return 0;  // NOLINT(*)
 /*!
- * \brief every function starts with API_BEGIN();
- *   and finishes with API_END() or API_END_HANDLE_ERROR
- *   The finally clause contains procedure to cleanup states when an error happens.
+ * \brief Macros to guard beginning and end section of all functions
+ * every function starts with API_BEGIN()
+ * and finishes with API_END() or API_END_HANDLE_ERROR()
+ * The finally clause contains procedure to cleanup states when an error happens.
  */
-#define API_END_HANDLE_ERROR(Finalize) } catch(dmlc::Error &_except_) { Finalize; on_exit_api(); return MXAPIHandleException(_except_); } on_exit_api(); return 0; // NOLINT(*)
+#ifndef API_BEGIN
+#define API_BEGIN MX_API_BEGIN
+#endif
 
-/*!
- * \brief Set the last error message needed by C API
- * \param msg The error message to set.
- */
-void MXAPISetLastError(const char* msg);
-/*!
- * \brief handle exception throwed out
- * \param e the exception
- * \return the return value of API after exception is handled
- */
-inline int MXAPIHandleException(const dmlc::Error &e) {
-  MXAPISetLastError(e.what());
-  return -1;
-}
+#ifndef API_END
+#define API_END MX_API_END
+#endif
+
+#ifndef API_END_HANDLE_ERROR
+#define API_END_HANDLE_ERROR MX_API_END_HANDLE_ERROR
+#endif
 
 using namespace mxnet;
 
@@ -137,10 +129,6 @@ inline void CopyAttr(const nnvm::IndexedGraph& idx,
 
 // stores keys that will be converted to __key__
 extern const std::vector<std::string> kHiddenKeys;
-
-extern void on_enter_api(const char *function);
-extern void on_exit_api();
-
 }  // namespace mxnet
 
 #endif  // MXNET_C_API_C_API_COMMON_H_


### PR DESCRIPTION
## Description ##
Export this header file to catch exceptions thrown in MXNet elegantly in 3rd party application that uses MXNet libraries. One use case of this is MXNet integration in Horovod.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.eated (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Exporting header file c_api_error.h