### PR TITLE
Add copyrights for third party licenses to license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -216,24 +216,56 @@
     The following components are provided under an Apache 2.0 license.
 
     1. MXNet Cpp-package - For details, /cpp-package/LICENSE
+         Copyright (c) 2015-2016 by Contributors 
     2. MXNet rcnn - For details, see, example/rcnn/LICENSE
+         Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
     3. MXNet scala-package - For details, see, scala-package/LICENSE
+         Copyright (c) 2014, 2015, the respective contributors
     4. Warp-CTC - For details, see, 3rdparty/ctc_include/LICENSE
+         Copyright 2015-2016, Baidu USA LLC.
     5. 3rdparty/dlpack - For details, see, 3rdparty/dlpack/LICENSE
+         Copyright 2017 by Contributors
     6. 3rdparty/dmlc-core - For details, see, 3rdparty/dmlc-core/LICENSE
+         Copyright (c) 2015 by Contributors 
+         Copyright 2015 by dmlc-core developers
+         Copyright by Contributors 
     7. 3rdparty/mshadow - For details, see, 3rdparty/mshadow/LICENSE
+         Copyright (c) 2014-2016 by Contributors
+         Copyright by Contributors
     8. 3rdparty/tvm - For details, see, 3rdparty/tvm/LICENSE
+         Copyright (c) 2016-2018 by Contributors
+         Copyright 2018 by Contributors
+         Copyright (c) 2018 by Xilinx, Contributors
     9. 3rdparty/tvm/dmlc-core - For details, see, 3rdparty/tvm/3rdparty/dmlc-core/LICENSE
+         Copyright (c) 2015 by Contributors 
     10. 3rdparty/tvm/dlpack - For details, see, 3rdparty/tvm/3rdparty/dlpack/LICENSE
+         Copyright (c) 2015-2017 by Contributors
+         Copyright by Contributors
     11. 3rdparty/ps-lite - For details, see, 3rdparty/ps-lite/LICENSE
+          Copyright 2015 Carnegie Mellon University
+          Copyright 2016, ps-lite developers
+          Copyright (c) 2015-2016 by Contributors
+          Copyright by Contributors
     12. 3rdparty/mkldnn - For details, see, 3rdparty/mkldnn/LICENSE
+          Copyright (c) 2017-2018 Intel Corporation
+          Copyright 2016-2018 Intel Corporation
+          Copyright 2018 YANDEX LLC
     13. googlemock scripts/generator - For details, see, 3rdparty/googletest/googlemock/scripts/generator/LICENSE
+          Copyright [2007-2009] Neal Norwitz
+          Portions Copyright [2007-2009] Google Inc.
     14. MXNet clojure-package - For details, see, contrib/clojure-package/LICENSE
+          Copyright 2018 by Contributors
     15. MXNet R-package - For details, see, R-package/LICENSE
+          Copyright (c) 2015 by Contributors
     16. ONNX-TensorRT benchmark package - For details, see, 3rdparty/onnx-tensorrt/third_party/onnx/third_party/benchmark/LICENSE
+          Copyright 2015 Google Inc. All rights reserved.
+          Copyright 2016 Ismael Jimenez Martinez. All rights reserved.
+          Copyright 2017 Roman Lebedev. All rights reserved.
     17. Dockerfiles - For details, see docker/Dockerfiles/License.md
     18. MXNet Julia Package - For details, see julia/LICENSE.md
+          Copyright (c) 2015-2018 by Chiyuan Zhang
     19. Benchdnn - For details, see 3rdparty/mkldnn/tests/benchdnn/README.md
+          Copyright 2017-2018 Intel Corporation
     20. MXNet perl-package - For details, see perl-package/README
     21. MXNet perl-package AI-MXNET - For details, see perl-package/AI-MXNet/README
     22. MXNet perl-package AI-MXNET Gluon Contrib - For details, see perl-package/AI-MXNet-Gluon-Contrib/README
@@ -241,6 +273,8 @@
     24. MXNet perl-package AI-MXNETCAPI - For details, see perl-package/AI-MXNetCAPI/README
     25. MXNet perl-package AI-NNVMCAPI - For details, see perl-package/AI-NNVMCAPI/README
     26. Cephes Library Functions - For details, see src/operator/special_functions-inl.h
+          Copyright (c) 2015 by Contributors
+          Copyright 1984, 1987, 1992 by Stephen L. Moshier
 
 
     =======================================================================================
@@ -248,14 +282,26 @@
     =======================================================================================
 
     1. Fast R-CNN  - For details, see example/rcnn/LICENSE
+         Copyright (c) Microsoft Corporation
     2. Faster R-CNN - For details, see example/rcnn/LICENSE
+         Copyright (c) 2015 Microsoft Corporation
     3. tree_lstm - For details, see example/gluon/tree_lstm/LICENSE
+         Copyright (c) 2017 Riddhiman Dasgupta, Sheng Zha
     4. OpenMP - For details, see 3rdparty/openmp/LICENSE.txt
+         Copyright (c) 1997-2016 Intel Corporation
     6. HalideIR - For details, see 3rdparty/tvm/3rdparty/HalideIR/LICENSE
+         Copyright (c) 2016 HalideIR contributors
+         Copyright (c) 2012-2014 MIT CSAIL, Google Inc., and other contributors
+         Copyright (c) 2016-2018 by Contributors
     7. ONNX-TensorRT - For details, see 3rdparty/onnx-tensorrt/LICENSE
+         Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
+         Copyright (c) 2018 Open Neural Network Exchange
     8. ONNX-TensorRT - For details, see 3rdparty/onnx-tensorrt/third_party/onnx/LICENSE
+         Copyright (c) Facebook, Inc. and Microsoft Corporation.
     9. clipboard.js - Refer to https://zenorocha.github.io/clipboard.js
+         Licensed MIT © Zeno Rocha
     10. clipboard.min.js - Refer to https://zenorocha.github.io/clipboard.js
+         Licensed MIT © Zeno Rocha
 
 
     =======================================================================================
@@ -263,12 +309,23 @@
     =======================================================================================
 
     1. Xbyak - For details, see 3rdparty/mkldnn/src/cpu/xbyak/COPYRIGHT
+         Copyright (c) 2007 MITSUNARI Shigeo
+         Copyright 2016-2018 Intel Corporation
     2. gtest - For details, see, 3rdparty/mkldnn/tests/gtests/gtest/LICENSE
+         Copyright 2005-2008, Google Inc.
     3. Moderngpu - For details, see, 3rdparty/ctc_include/contrib/moderngpu/LICENSE
+         Copyright (c) 2013, NVIDIA CORPORATION.  All rights reserved.
     4. CUB Library - For details, see, 3rdparty/cub/LICENSE.TXT
-    5. Googlemock - For details, see, 3rdparty/googletest/googlemock/LICENSE
-    6. Googletest - For details, see, 3rdparty/googletest/googletest/LICENSE
-    7. OpenMP Testsuite - For details, see, 3rdparty/openmp/testsuite/LICENSE
+         Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+         Copyright (c) 2011-2016, NVIDIA CORPORATION.  All rights reserved.
+    5. CUB mersenne.h - For details, see 3rdparty/cub/test/mersenne.h
+         Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+    6. Googlemock - For details, see, 3rdparty/googletest/googlemock/LICENSE
+         Copyright 2006-2015, Google Inc.
+    7. Googletest - For details, see, 3rdparty/googletest/googletest/LICENSE
+         Copyright 2005-2015, Google Inc.
+    8. OpenMP Testsuite - For details, see, 3rdparty/openmp/testsuite/LICENSE
+         Copyright (c) 2011, 2012 University of Houston System
 
 
     =======================================================================================
@@ -276,9 +333,21 @@
     =======================================================================================
 
     1. Sphinx JavaScript utilties for the full-text search - For details, see, docs/_static/searchtools_custom.js
+         Copyright (c) 2007-2017 by the Sphinx team
     2. blockingconcurrentqueue.h - For details, see, 3rdparty/dmlc-core/include/dmlc/blockingconcurrentqueue.h
+         ©2015-2016 Cameron Desrochers
     3. concurrentqueue.h - For details, see, 3rdparty/dmlc-core/include/dmlc/concurrentqueue.h
+         Copyright (c) 2013-2016, Cameron Desrochers.
     4. MSCOCO Toolbox - For details, see, example/ssd/dataset/pycocotools/coco.py
+         Code written by Piotr Dollar and Tsung-Yi Lin, 2014.
+    5. PyBind11 FindEigen3.cmake - For details, see 3rdparty/onnx-tensorrt/third_party/onnx/third_party/pybind11/tools/FindEigen3.cmake
+         Copyright (c) 2006, 2007 Montel Laurent, <montel@kde.org>
+         Copyright (c) 2008, 2009 Gael Guennebaud, <g.gael@free.fr>
+         Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
+    6. PyBind11 FindPythonLibsNew.cmake - For details, see 3rdparty/onnx-tensorrt/third_party/onnx/third_party/pybind11/tools/FindPythonLibsNew.cmake
+         Copyright 2001-2009 Kitware, Inc.
+         Copyright 2012 Continuum Analytics, Inc.
+
 
 
     =======================================================================================
@@ -286,22 +355,31 @@
     =======================================================================================
 
     1. Caffe - For details, see, example/rcnn/LICENSE
+         Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
+         Copyright (c) 2014, 2015, the respective contributors
     2. pool.h - For details, see, src/operator/nn/pool.h
+         Copyright (c) 2014-2017 The Regents of the University of California (Regents)
+         Copyright (c) 2014-2017, the respective contributors
     3. pool.cuh - For details, see, src/operator/nn/pool.cuh
+         Copyright (c) 2014-2017 The Regents of the University of California (Regents)
+         Copyright (c) 2014-2017, the respective contributors
     4. im2col.h - For details, see, src/operator/nn/im2col.h
+         Copyright (c) 2014-2017 The Regents of the University of California (Regents)
+         Copyright (c) 2014-2017, the respective contributors
     5. im2col.cuh - For details, see, src/operator/nn/im2col.cuh
+         Copyright (c) 2014-2017 The Regents of the University of California (Regents)
+         Copyright (c) 2014-2017, the respective contributors
+
     6. deformable_im2col.h - For details, see, src/operator/contrib/nn/deformable_im2col.h
+         Copyright (c) 2014-2017 The Regents of the University of California (Regents)
+         Copyright (c) 2014-2017, the respective contributors
+
     7. deformable_im2col.cuh - For details, see, src/operator/contrib/nn/deformable_im2col.cuh
+         Copyright (c) 2014-2017 The Regents of the University of California (Regents)
+         Copyright (c) 2014-2017, the respective contributors
+
 
     COPYRIGHT
-
-    All contributions by the University of California:
-    Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2014, 2015, the respective contributors
-    All rights reserved.
 
     Caffe uses a shared copyright model: each contributor holds copyright over
     their contributions to Caffe. The project versioning records all such
@@ -342,6 +420,7 @@
 
     8. MS COCO API
     For details, see, example/rcnn/LICENSE
+    Copyright (c) 2014, Piotr Dollar and Tsung-Yi Lin
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
@@ -372,6 +451,7 @@
     9. Semaphore implementation in blockingconcurrentqueue.h
     This file uses a semaphore implementation under the terms of its separate zlib license.
     For details, see, 3rdparty/dmlc-core/include/dmlc/blockingconcurrentqueue.h
+    Copyright Jeff Preshing
 
     =======================================================================================
 
@@ -427,8 +507,17 @@
 
     11. ONNX python bindings
     For details, see, 3rdparty/onnx-tensorrt/third_party/onnx/third_party/pybind11/LICENSE
-
-    Copyright (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>, All rights reserved.
+      Copyright (c) 2015-2017 Wenzel Jakob <wenzel.jakob@epfl.ch>, All rights reserved.
+      Copyright (c) 2016 Trent Houliston <trent@houliston.me> and Wenzel Jakob <wenzel.jakob@epfl.ch>
+      Copyright (c) 2016-2017 Jason Rhinelander <jason@imaginary.ca>
+      Copyright (c) 2016 Klemens Morgenstern <klemens.morgenstern@ed-chemnitz.de> and Wenzel Jakob <wenzel.jakob@epfl.ch>
+      Copyright (c) 2017 Henry F. Schreiner
+      Copyright (c) 2016 Sergey Lyskov and Wenzel Jakob
+      Copyright (c) 2016 Ben North <ben@redfrontdoor.org>
+      Copyright (c) 2016 Klemens D. Morgenstern
+      Copyright (c) 2016 Pim Schellart <P.Schellart@princeton.edu>
+      Copyright (c) 2016 Ivan Smirnov <i.s.smirnov@gmail.com>
+      Copyright (c) 2016 Sergey Lyskov
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
@@ -533,7 +622,7 @@
     =======================================================================================
 
     13. MKL BLAS
-    For details, see, [Intel® Simplified license](https://software.intel.com/en-us/license/intel-simplified-software-license).
+    For details, see, [Intel® Simplified license](https://software.intel.com/en-us/license/intel-simplified-software-license) and MKLDNN_README.md
 
     Copyright (c) 2018 Intel Corporation.
 

--- a/R-package/LICENSE
+++ b/R-package/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright (c) 2015 by Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/contrib/clojure-package/LICENSE
+++ b/contrib/clojure-package/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2018 by Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description ##
Based on feedback from Justin Mclean as part of the 1.4 release, we should include copyright notices in our license (https://mail-archives.apache.org/mod_mbox/incubator-general/201901.mbox/browser). This PR adds them.

@aaronmarkham @frankfliu @lanking520 @andrewfayres @srochel

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change