### PR TITLE
Fix symbolic example for rand_zipfian function

### DIFF
--- a/python/mxnet/symbol/contrib.py
+++ b/python/mxnet/symbol/contrib.py
@@ -73,17 +73,8 @@ def rand_zipfian(true_classes, num_sampled, range_max):
 
     Examples
     --------
-    >>> true_cls = mx.nd.array([3])
-    >>> samples, exp_count_true, exp_count_sample = mx.nd.contrib.rand_zipfian(true_cls, 4, 5)
-    >>> samples
-    [1 3 3 3]
-    <NDArray 4 @cpu(0)>
-    >>> exp_count_true
-    [ 0.12453879]
-    <NDArray 1 @cpu(0)>
-    >>> exp_count_sample
-    [ 0.22629439  0.12453879  0.12453879  0.12453879]
-    <NDArray 4 @cpu(0)>
+    >>> true_cls = mx.sym.var('true_cls')
+    >>> samples, exp_count_true, exp_count_sample = mx.sym.contrib.rand_zipfian(true_cls, 4, 5)
     """
     assert(isinstance(true_classes, Symbol)), "unexpected type %s" % type(true_classes)
     log_range = math.log(range_max + 1)


### PR DESCRIPTION
## Description ##
`mx.sym.contrib.rand_zipfian` function example fixed
It contained NDArray specific example for a Symbolic API