### PR TITLE
float32 -> float16 cast consistency across implementations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "3rdparty/mshadow"]
 	path = 3rdparty/mshadow
-	url = https://github.com/dmlc/mshadow.git
+	url = https://github.com/DickJC123/mshadow.git
 [submodule "3rdparty/dmlc-core"]
 	path = 3rdparty/dmlc-core
 	url = https://github.com/dmlc/dmlc-core.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "3rdparty/mshadow"]
 	path = 3rdparty/mshadow
-	url = https://github.com/DickJC123/mshadow.git
+	url = https://github.com/dmlc/mshadow.git
 [submodule "3rdparty/dmlc-core"]
 	path = 3rdparty/dmlc-core
 	url = https://github.com/dmlc/dmlc-core.git


### PR DESCRIPTION
## Description ##
While trying to get all the CI runners to pass for PR #13749, I discovered that the handling of the float32->float16 cast on the CPU varies based on whether the f16c library is available and enabled.  If the f16c library is not available, as is the case for the Windows CI runner using a MSVC++ compiler, then the mshadow float2half() routine is used and the cast is performed by truncating the bits that don't fit in the float16 representation.  The _cvtss_sh(data, 0) call employed by mshadow when the f16c library is present performs a round-to-nearest conversion, with ties rounded to the value with a 0 LSB.  This round-to-nearest-even policy also is employed by the default GPU context implementation and numpy.

In order to improve MXNet model and CI consistency across all backends, I'm correcting the mshadow float2half() implementation to perform matching round-to-nearest-even rounding. The first commit introduces only a test that demonstrates the problem, which I am expecting to fail on the Windows CI runner.  Then I'll work up an mshadow PR with the new float2half() routine.  Next, I'll change the mshadow commit used by MXNet to point to this PR, to demonstrate its effectiveness.  Once the mshadow PR has been accepted, I'll change the mshadow commit used by MXNet once again so the PR can be accepted.

This PR should only effect models run without the f16c library on a CPU.  I intend to make the round-to-nearest-even behavior the new default for these scenarios, bringing them in line with other systems.  I'll provide a simple build flag to restore the legacy behavior.  My new float2half() implementation is 50% faster on the cpu despite the additional rounding logic.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [X ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
