### PR TITLE
implement random resize crop as operator

### DIFF
--- a/python/mxnet/gluon/data/vision/transforms.py
+++ b/python/mxnet/gluon/data/vision/transforms.py
@@ -168,7 +168,7 @@ class Normalize(HybridBlock):
         return F.image.normalize(x, self._mean, self._std)
 
 
-class RandomResizedCrop(Block):
+class RandomResizedCrop(HybridBlock):
     """Crop the input image with random scale and aspect ratio.
 
     Makes a crop of the original image with random size (default: 0.08
@@ -198,12 +198,13 @@ class RandomResizedCrop(Block):
     def __init__(self, size, scale=(0.08, 1.0), ratio=(3.0/4.0, 4.0/3.0),
                  interpolation=1):
         super(RandomResizedCrop, self).__init__()
-        if isinstance(size, numeric_types):
-            size = (size, size)
-        self._args = (size, scale, ratio, interpolation)
+        self._size = size
+        self._scale = scale
+        self._ratio = ratio
+        self._interp = interpolation
 
-    def forward(self, x):
-        return image.random_size_crop(x, *self._args)[0]
+    def hybrid_forward(self, F, x):
+        return F.image.random_resize_crop(x, self._size, self._scale, self._ratio, self._interp)
 
 
 class CenterCrop(Block):

--- a/src/operator/image/random_resize_crop-inl.h
+++ b/src/operator/image/random_resize_crop-inl.h
@@ -1,0 +1,163 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file random_resize_crop-inl.h
+ * \brief the image random_resize_crop operator implementation
+ */
+
+#ifndef MXNET_OPERATOR_IMAGE_RANDOM_RESIZE_CROP_INL_H_
+#define MXNET_OPERATOR_IMAGE_RANDOM_RESIZE_CROP_INL_H_
+
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+#include <math.h>
+
+#include "mxnet/base.h"
+#include "dmlc/optional.h"
+
+#include "../mxnet_op.h"
+#include "../operator_common.h"
+#include "image_utils.h"
+
+namespace mxnet {
+namespace op {
+namespace image {
+
+struct RandomResizeCropParam : public dmlc::Parameter<RandomResizeCropParam> {
+  nnvm::Tuple<int> size;
+  nnvm::Tuple<float> scale;
+  nnvm::Tuple<float> ratio;
+  int interp;
+  DMLC_DECLARE_PARAMETER(RandomResizeCropParam) {
+    DMLC_DECLARE_FIELD(size)
+    .set_default(nnvm::Tuple<int>())
+    .describe("Size of the final output.");
+    DMLC_DECLARE_FIELD(scale)
+    .set_default(nnvm::Tuple<float>())
+    .describe("If scale is `(min_area, max_area)`, the cropped image's area will"
+        "range from min_area to max_area of the original image's area");
+    DMLC_DECLARE_FIELD(ratio)
+    .set_default(nnvm::Tuple<float>())
+    .describe("Range of aspect ratio of the cropped image before resizing.");
+    DMLC_DECLARE_FIELD(interp)
+    .describe("Interpolation method for resizing. By default uses bilinear"
+        "interpolation. See OpenCV's resize function for available choices.");
+  }
+};
+
+bool RandomResizeCropShape(const nnvm::NodeAttrs& attrs,
+                             std::vector<TShape> *in_attrs,
+                             std::vector<TShape> *out_attrs) {
+  // input attrs should only be (h, w, c) or (n, h, w, c)
+  CHECK((in_attrs->at(0).ndim() == 3U) || (in_attrs->at(0).ndim() == 4U))
+    << "Input image dimension should be 3 or 4 but got "
+    << in_attrs->at(0).ndim();
+  const auto& ishape = (*in_attrs)[0];
+  const RandomResizeCropParam& param = nnvm::get<RandomResizeCropParam>(attrs.parsed);
+  const auto size = GetHeightAndWidthFromSize(param);
+
+  CHECK((size.height > 0) && (size.width > 0))
+      << "Input height and width must be greater than 0";
+  if (ishape.ndim() == 3) {
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, TShape({size.height, size.width, ishape[C]}));
+  } else {
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, TShape({ishape[N], size.height, size.width, ishape[kC]}));
+  }
+
+  return true;
+}
+
+void RandomResizeCrop(const nnvm::NodeAttrs &attrs,
+                   const OpContext &ctx,
+                   const std::vector<TBlob> &inputs,
+                   const std::vector<OpReqType> &req,
+                   const std::vector<TBlob> &outputs) {
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK((inputs[0].ndim() == 3) || (inputs[0].ndim() == 4))
+      << "Input data must be (h, w, c) or (n, h, w, c)";
+  const RandomResizeCropParam& param = nnvm::get<RandomResizeCropParam>(attrs.parsed);
+  
+  auto h = inputs[0].shape_[inputs[0].ndim() == 3 ? H : kH];
+  auto w = inputs[0].shape_[inputs[0].ndim() == 3 ? W : kW];
+  auto src_area = h * w;
+
+  CHECK(param.scale.ndim() == 1 || param.scale.ndim() == 2)
+         << "Input scale must be float in (0, 1] or tuple of (float, float)";
+  std::pair<float, float> area;
+  if (param.scale.ndim() == 1) {
+    area = std::make_pair(param.scale[0], 1.0f);
+  } else {
+    area = std::make_pair(param.scale[0], param.scale[1]);
+  }
+  mshadow::Stream<cpu> *s = ctx.get_stream<cpu>();
+  mshadow::Random<cpu> *prnd = ctx.requested[0].get_random<cpu, float>(s);
+  for (auto i = 0; i < 10; ++i) {
+    float target_area = static_cast<float>(std::uniform_real_distribution<float>(
+      area.first, area.second)(prnd->GetRndEngine()) * src_area);
+    float new_ratio = static_cast<float>(std::uniform_real_distribution<float>(
+      param.ratio[0], param.ratio[1])(prnd->GetRndEngine()));
+
+    int new_w = static_cast<int>(round(sqrt(target_area * new_ratio)));
+    int new_h = static_cast<int>(round(sqrt(target_area / new_ratio)));
+
+    if (std::uniform_real_distribution<float>(0.0, 1.0)(prnd->GetRndEngine()) < 0.5) {
+      new_h = new_w;
+      new_w = new_h;
+    }
+
+    if (new_w <= w && new_h <= h) {
+      int x0 = std::uniform_int_distribution<int>(0, w - new_w)(prnd->GetRndEngine());
+      int y0 = std::uniform_int_distribution<int>(0, h - new_h)(prnd->GetRndEngine());
+      SizeParam size = GetHeightAndWidthFromSize(param);
+      bool need_resize = false;
+
+      if ((size.height != new_h) || (size.width != new_w)) {
+        need_resize = true;
+      }
+      if (inputs[0].ndim() == 3) {
+        CropImpl(inputs, outputs, x0, y0, new_h, new_w, size, param.interp);
+      } else {
+        const auto batch_size = inputs[0].shape_[0];
+        const auto input_offset = inputs[0].shape_[kH] * inputs[0].shape_[kW] * inputs[0].shape_[kC];
+        int output_offset;
+        if (need_resize) {
+          output_offset = size.height * size.width * outputs[0].shape_[kC];
+        } else {
+          output_offset = new_h * new_w * outputs[0].shape_[kC];
+        }
+        #pragma omp parallel for
+        for (auto i = 0; i < batch_size; ++i) {
+          CropImpl(inputs, outputs, x0, y0, new_h, new_w, size, param.interp, input_offset * i, output_offset * i);
+        }
+      }
+      return ;
+    }
+  }
+  // fall back to center_crop
+  return CenterCropImpl(inputs, outputs, GetHeightAndWidthFromSize(param), param.interp);
+}
+}  // namespace image
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_IMAGE_RANDOM_RESIZE_CROP_INL_H_

--- a/src/operator/image/random_resize_crop.cc
+++ b/src/operator/image/random_resize_crop.cc
@@ -1,0 +1,55 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+/*!
+ *  Copyright (c) 2018 by Contributors
+ * \file random_resize_crop
+ * \brief the image random_resize_crop operator registration
+ */
+
+#include "mxnet/base.h"
+#include "random_resize_crop-inl.h"
+#include "../operator_common.h"
+#include "../elemwise_op_common.h"
+
+namespace mxnet {
+namespace op {
+namespace image {
+
+DMLC_REGISTER_PARAMETER(RandomResizeCropParam);
+
+NNVM_REGISTER_OP(_image_random_resize_crop)
+.describe("Crop the input image with random scale and aspect ratio.")
+.set_num_inputs(1)
+.set_num_outputs(1)
+.set_attr_parser(ParamParser<RandomResizeCropParam>)
+.set_attr<nnvm::FInferShape>("FInferShape", RandomResizeCropShape)
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)
+.set_attr<FCompute>("FCompute<cpu>", RandomResizeCrop)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const NodeAttrs& attrs) {        
+    return std::vector<ResourceRequest>{ResourceRequest::kRandom};
+})
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{ "_copy" })
+.add_argument("data", "NDArray-or-Symbol", "The input.")
+.add_arguments(RandomResizeCropParam::__FIELDS__());
+
+}  // namespace image
+}  // namespace op
+}  // namespace mxnet

--- a/tests/python/unittest/test_gluon_data_vision.py
+++ b/tests/python/unittest/test_gluon_data_vision.py
@@ -46,6 +46,30 @@ def test_normalize():
 
 
 @with_seed()
+def test_random_resize_crop():
+    def _test_random_resize_crop_with_diff_type(dtype):
+        # test normal case
+        data_in = nd.random.uniform(0, 255, (300, 200, 3)).astype(dtype)
+        out_nd = transforms.RandomResizedCrop((100, 120))(data_in)
+        assert out_nd.shape == (120, 100, 3), out_nd.shape
+        # test 4D input
+        data_bath_in = nd.random.uniform(0, 255, (3, 300, 200, 3)).astype(dtype)
+        out_batch_nd = transforms.RandomResizedCrop((50, 70))(data_bath_in)
+        assert out_batch_nd.shape == (3, 70, 50, 3), out_nd.shape
+        # test normal case
+        data_in = nd.random.uniform(0, 255, (50, 30, 3)).astype(dtype)
+        out_nd = transforms.RandomResizedCrop((140, 100))(data_in)
+        assert out_nd.shape == (100, 140, 3), out_nd.shape
+         # test size is larger than input image 4D
+        data_in = nd.random.uniform(0, 255, (4, 50, 30, 3)).astype(dtype)
+        out_nd = transforms.RandomResizedCrop((100, 140))(data_in)
+        assert out_nd.shape == (4, 140, 100, 3), out_nd.shape
+
+    for dtype in ['uint8', 'int8', 'float32', 'float64']:
+        _test_random_resize_crop_with_diff_type(dtype)
+
+
+@with_seed()
 def test_flip_left_right():
     data_in = np.random.uniform(0, 255, (300, 300, 3)).astype(dtype=np.uint8)
     flip_in = data_in[:, ::-1, :]


### PR DESCRIPTION
## Description ##
1. make random resize crop as operator
2. support 3D and 4D input
3. add unit test

* note that the PR use the image_utils.h in resize PR so the CI won't pass

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

## Comments ##
