### PR TITLE
Julia: fix filename quoting in docstring

### DIFF
--- a/julia/src/util.jl
+++ b/julia/src/util.jl
@@ -183,15 +183,14 @@ end
 Extract the line of `Defined in ...`
 
 julia> mx._getdocdefine("sgd_update")
-"Defined in src/operator/optimizer_op.cc:L53"
-```
+"Defined in `src/operator/optimizer_op.cc:L53`"
 """
 function _getdocdefine(name::String)
   op = _get_libmx_op_handle(name)
   str = _get_libmx_op_description(name, op)[1]
   lines = split(str, '\n')
-  for m ∈ match.(Ref(r"^Defined in .*$"), lines)
-    m != nothing && return m.match
+  for m ∈ match.(Ref(r"^Defined in ([\S]+)$"), lines)
+    m != nothing && return "Defined in `$(m.captures[1])`"
   end
   ""
 end


### PR DESCRIPTION
Quoting filename with backticks to prevent markdown from mis-rendering it with underscore.