### PR TITLE
Fix for test always returning true

### DIFF
--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -882,7 +882,7 @@ def test_randint_generator():
 @with_seed()
 def test_randint_without_dtype():
     a = mx.nd.random.randint(low=50000000, high=50000010, ctx=mx.context.current_context())
-    assert(a.dtype, 'int32')
+    assert a.dtype == np.int32
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
Simple change to actually test the value of `a.dtype` in `test_randint_without_dtype`. Without this, nosetests complains: 
```
/opt/mxnet/tests/python/gpu/../unittest/test_random.py:884: SyntaxWarning: assertion is always true, perhaps remove parentheses?
  assert(a.dtype, 'int32')
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
