### PR TITLE
Version switching user experience improvements

### DIFF
--- a/docs/_static/js/docversion.js
+++ b/docs/_static/js/docversion.js
@@ -18,16 +18,23 @@
  */
 
 /* Set the version of the website */
-function setVersion(){
-        let doc = window.location.pathname.match(/^\/(api\/.*)$/) || window.location.pathname.match(/^\/versions\/[^*]+\/(api\/.*)$/);
+function setVersion(anchor){
+        if (arguments.length==0) {
+            anchor = window.location.hash
+        };
+        console.log('anchor: ', anchor, arguments.length, window.location.hash, window.location.search);
+        //let doc = window.location.pathname.match(/^\/(api\/.*)$/) || window.location.pathname.match(/^\/versions\/[^*]+\/(api\/.*)$/);
+        let doc = window.location.pathname.match(/^\/versions\/[^\/]+\/([^*]+.*)$/);
         if (doc) {
             if (document.getElementById('dropdown-menu-position-anchor-version')) {
                     versionNav = $('#dropdown-menu-position-anchor-version a.main-nav-link');
                     $(versionNav).each( function( index, el ) {
                             currLink = $( el ).attr('href');
-                            version = currLink.match(/\/versions\/([0-9.master]+)\//);
+                            version = currLink.match(/\/versions\/([^\/]+)\//);
+                            console.log(version);
                             if (version) {
-                                    versionedDoc = '/versions/' + version[1] + '/' + doc[1] + (window.location.hash || '');
+                                    versionedDoc = '/versions/' + version[1] + '/' + doc[1] + (anchor || '') + (window.location.search || '');
+                                    console.log(versionedDoc);
                                     $( el ).attr('href', versionedDoc);
                             }
                     });
@@ -40,5 +47,5 @@ $(document).ready(function () {
 });
 
 $('a.reference.internal').click(function(){
-    setVersion();
+    setVersion($(this).attr("href"));
 });

--- a/docs/_static/js/docversion.js
+++ b/docs/_static/js/docversion.js
@@ -22,8 +22,6 @@ function setVersion(anchor){
         if (arguments.length==0) {
             anchor = window.location.hash
         };
-        console.log('anchor: ', anchor, arguments.length, window.location.hash, window.location.search);
-        //let doc = window.location.pathname.match(/^\/(api\/.*)$/) || window.location.pathname.match(/^\/versions\/[^*]+\/(api\/.*)$/);
         let doc = window.location.pathname.match(/^\/versions\/[^\/]+\/([^*]+.*)$/);
         if (doc) {
             if (document.getElementById('dropdown-menu-position-anchor-version')) {
@@ -31,10 +29,8 @@ function setVersion(anchor){
                     $(versionNav).each( function( index, el ) {
                             currLink = $( el ).attr('href');
                             version = currLink.match(/\/versions\/([^\/]+)\//);
-                            console.log(version);
                             if (version) {
                                     versionedDoc = '/versions/' + version[1] + '/' + doc[1] + (anchor || '') + (window.location.search || '');
-                                    console.log(versionedDoc);
                                     $( el ).attr('href', versionedDoc);
                             }
                     });

--- a/docs/_static/searchtools_custom.js
+++ b/docs/_static/searchtools_custom.js
@@ -570,7 +570,7 @@ var Search = {
         }
         Search.title.text(_('Search Results'));
         if (!resultCount)
-          Search.status.text(_('Your search did not match any documents. Please make sure that all words are spelled correctly and that you\'ve selected enough categories.'));
+          Search.status.text(_('Your search did not match any documents in this version of the documentation. You can use the dropdown selector in the navigation bar to try another version. Please make sure that all words are spelled correctly and that you\'ve selected enough categories.'));
         else
             Search.status.text(_('Search finished, found %s page(s) matching the search query.').replace('%s', resultCount));
         Search.status.fadeIn(500);

--- a/docs/_static/searchtools_custom.js
+++ b/docs/_static/searchtools_custom.js
@@ -457,7 +457,7 @@ var Search = {
                 highlightstring + item[2]).html(item[1]));
             } else {
                 // normal html builders
-                var baseURL = 'https://' + window.location.hostname + '/';
+                var baseURL = window.location.protocol + '//' + window.location.hostname + '/';
                 var urlHref = window.location.href;
                 let urlSplits = urlHref.split("/");
                 let versionString = '';

--- a/docs/build_version_doc/artifacts/.htaccess
+++ b/docs/build_version_doc/artifacts/.htaccess
@@ -4,15 +4,11 @@ RewriteRule ^get_started/why_mxnet.html$ %{ENV:default_version}/faq/why_mxnet.ht
 RewriteRule ^get_started.*$ %{ENV:default_version}/install/ [R=301,L]
 RewriteRule ^how_to.*$ %{ENV:default_version}/faq/ [R=301,L]
 RewriteRule ^api/python/symbol.html$ %{ENV:default_version}/api/python/symbol/symbol.html [R=301,L]
-RewriteRule ^community/index.html$ %{ENV:default_version}/community/contribute.html [R=301,L]
+RewriteRule ^(?:versions\/[^\/]+\/)?community/index.html$ %{ENV:default_version}/community/contribute.html [R=301,L]
 
 # Navigation bar redirects to latest info
-RewriteRule ^versions\/[0-9.]+\/architecture/(.*)$ %{ENV:default_version}/architecture/$1 [R=301,L]
-RewriteRule ^versions\/[0-9.]+\/community/(.*)$ %{ENV:default_version}/community/$1 [R=301,L]
-RewriteRule ^versions\/[0-9.]+\/faq/(.*)$ %{ENV:default_version}/faq/$1 [R=301,L]
-RewriteRule ^versions\/[0-9.]+\/gluon/(.*)$ %{ENV:default_version}/gluon/$1 [R=301,L]
-RewriteRule ^versions\/[0-9.]+\/install/(.*)$ %{ENV:default_version}/install/$1 [R=301,L]
-RewriteRule ^versions\/[0-9.]+\/tutorials/(.*)$ %{ENV:default_version}/tutorials/$1 [R=301,L]
+RewriteCond %{ENV:default_version}#\/$1 !^([^#]+)#\1$
+RewriteRule ^(versions\/[^\/]+)?(?:\/)?(faq|community|install|gluon|tutorials|architecture)(.*)?$ %{ENV:default_version}/$2$3 [R=301,L]
 
 # Redirect navbar APIs that did not exist
 RewriteRule ^versions/0.11.0/api/python/contrib/onnx.html %{ENV:default_version}/error/api.html [R=301,L]


### PR DESCRIPTION
## Description ##
This PR fixes some usability problems with the version selector. You tend to lose your place when you use the search feature or when browsing the APIs looking for stuff. If you switch versions, you don't always end up where you were or get redirected to the home page. 

**EDIT**: It also fixes a search bug for developers that try to use the search feature in their dev versions of the website.

## Preview for Search
When you search for something on the website in an older version, don't find it, then switch to a newer version, you are redirected to the root of the website. 

For example:
1. Search for "taco": http://mxnet.incubator.apache.org/versions/1.0.0/search.html?q=taco&check_keywords=yes&area=default
No 🌮 ! What if master has 🌮 ? 
2. Use the versions dropdown and change to master.
You lost your search! 😭 and still no 🌮 .

Now try to search for 🌮 on the preview:
1. http://34.201.8.176/versions/1.3.1/search.html?q=taco
No 🌮 . 
2. Change to master. 
Still no 🌮 but 🌤 you didn't get bounced to the home page.

## Preview for Anchors
It seems to work now when the page is loaded anew. However, I noticed that using in-page anchors the page didn't provide a new `window.location.hash` to the function in `docversion.js` that updates the version dropdown's links, so the when switching versions you don't load the last anchor you were on. 

1. Go look at ndarray docs: http://34.201.8.176/versions/1.3.1/api/python/ndarray/ndarray.html
2. Scroll down and click the link for `ndarray.shape`.
3. You jump down to the docs for shape. But you decide you don't like it, and you want to know if master has more features. Your current location is now http://34.201.8.176/versions/1.3.1/api/python/ndarray/ndarray.html#mxnet.ndarray.NDArray.shape
4. Use the version dropdown to change to Master.
5. Witness 👀  that you are now on: http://34.201.8.176/versions/master/api/python/ndarray/ndarray.html#mxnet.ndarray.NDArray.shape

If you try this flow in production you see that it is kind of broken.

## Comments
The redirects update and overview of intentions and test links are on the wiki: https://cwiki.apache.org/confluence/display/MXNET/Redirects+on+the+Website

The search feature on the website is buggy. Today it shows results in an old version that shouldn't be there. For example "allreduce" shouldn't appear <v1.2.1, but it does today. I'm not trying to fix Sphinx's search in this PR.