### PR TITLE
Add batchify transformer to help end to end models

### DIFF
--- a/python/mxnet/gluon/data/vision/transforms.py
+++ b/python/mxnet/gluon/data/vision/transforms.py
@@ -487,10 +487,13 @@ class RandomLighting(HybridBlock):
         return F.image.random_lighting(x, self._alpha)
 
 
-class ListToBatch(HybridBlock):
+class Batchify(HybridBlock):
     """Joins a list of tensors of shape (C x H x W) into a single 
     tensor of shape (N x C x H x W) where N is the number of input
-    tensors.
+    tensors. 
+
+    If the input is a single tensor of shape (C x H x W) it is bathchified
+    to a tensor of shape (1 x C x H x W).
 
     This transformer is useful when transformation pipeline is fused into
     neural network graph resulting in single model/graph. When running 
@@ -501,7 +504,7 @@ class ListToBatch(HybridBlock):
 
     For example, a typical graph can look like below:
 
-    Imdecode -> Resize -> ListToBatch -> ToTensor -> Normalize -> Network
+    Imdecode -> Resize -> Batchify -> ToTensor -> Normalize -> Network
     
     Parameters
     ----------
@@ -517,7 +520,7 @@ class ListToBatch(HybridBlock):
     
     Examples
     --------
-    >>> transformer = transforms.ListToBatch()
+    >>> transformer = transforms.Batchify()
     >>> image1 = mx.nd.random.uniform(0, 1, shape=(3, 28, 28))
     >>> image2 = mx.nd.random.uniform(0, 1, shape=(3, 28, 28))
     >>> image3 = mx.nd.random.uniform(0, 1, shape=(3, 28, 28))

--- a/python/mxnet/gluon/data/vision/transforms.py
+++ b/python/mxnet/gluon/data/vision/transforms.py
@@ -488,15 +488,15 @@ class RandomLighting(HybridBlock):
 
 
 class Batchify(HybridBlock):
-    """Joins a list of tensors of shape (C x H x W) into a single 
+    """Joins a list of tensors of shape (C x H x W) into a single
     tensor of shape (N x C x H x W) where N is the number of input
-    tensors. 
+    tensors.
 
     If the input is a single tensor of shape (C x H x W) it is bathchified
     to a tensor of shape (1 x C x H x W).
 
     This transformer is useful when transformation pipeline is fused into
-    neural network graph resulting in single model/graph. When running 
+    neural network graph resulting in single model/graph. When running
     mini batch inference on such graph, raw input tensors, before transformations,
     can be of different shapes, hence, cannot be batched into single tensor. Hence,
     input to the graph will be list of Tensors that can be batched after Resize
@@ -505,7 +505,7 @@ class Batchify(HybridBlock):
     For example, a typical graph can look like below:
 
     Imdecode -> Resize -> Batchify -> ToTensor -> Normalize -> Network
-    
+
     Parameters
     ----------
     axis : int, optional, default=0
@@ -517,7 +517,7 @@ class Batchify(HybridBlock):
 
     Outputs:
         - **out**: output stacked tensor with the shape as (N x C x H x W).
-    
+
     Examples
     --------
     >>> transformer = transforms.Batchify()

--- a/python/mxnet/gluon/data/vision/transforms.py
+++ b/python/mxnet/gluon/data/vision/transforms.py
@@ -529,7 +529,7 @@ class Batchify(HybridBlock):
     (3, 3, 28, 28)
     """
     def __init__(self, axis=0):
-        super(ListToBatch, self).__init__()
+        super(Batchify, self).__init__()
         self._axis = axis
 
     def hybrid_forward(self, F, *data):

--- a/python/mxnet/gluon/data/vision/transforms.py
+++ b/python/mxnet/gluon/data/vision/transforms.py
@@ -488,12 +488,15 @@ class RandomLighting(HybridBlock):
 
 
 class Batchify(HybridBlock):
-    """Joins a list of tensors of shape (C x H x W) into a single
-    tensor of shape (N x C x H x W) where N is the number of input
-    tensors.
+    """Joins a list of tensors of shape (C x H x W) or (H x W x C) into a
+    single tensor of shape (N x C x H x W) or (N x H x W x C) respectively,
+    where N is the number of input tensors.
 
     If the input is a single tensor of shape (C x H x W) it is bathchified
     to a tensor of shape (1 x C x H x W).
+
+    If the input is a single tensor of shape (H x W x C) it is bathchified
+    to a tensor of shape (1 x H x W x C).
 
     This transformer is useful when transformation pipeline is fused into
     neural network graph resulting in single model/graph. When running
@@ -501,6 +504,9 @@ class Batchify(HybridBlock):
     can be of different shapes, hence, cannot be batched into single tensor. Hence,
     input to the graph will be list of Tensors that can be batched after Resize
     transformation.
+
+    NOTE: This transformer is usually not required during the mode training,
+    Dataset and DataLoader handles the batchifying of input tensors.
 
     For example, a typical graph can look like below:
 
@@ -513,10 +519,11 @@ class Batchify(HybridBlock):
         are stacked.
 
     Inputs:
-        - **data**: input tensors with (C x H x W) shape.
+        - **data**: input tensors with (H x W x C) or (C x H x W) shape.
 
     Outputs:
-        - **out**: output stacked tensor with the shape as (N x C x H x W).
+        - **out**: output stacked tensor with the shape as (N x H x W x C) or
+        (N x C x H x W) respectively.
 
     Examples
     --------

--- a/tests/python/unittest/test_gluon_data_vision.py
+++ b/tests/python/unittest/test_gluon_data_vision.py
@@ -83,7 +83,7 @@ def test_transformer():
     transform(mx.nd.ones((245, 480, 3), dtype='uint8')).wait_to_read()
 
 
-@with_seed
+@with_seed()
 def test_batchify():
     transformer = transforms.Batchify()
     im1 = nd.random.uniform(0, 1, (3, 28, 28))
@@ -93,10 +93,14 @@ def test_batchify():
     # Single input batchify
     batchified = transformer(im1)
     assert (batchified.shape == (1,) + im1.shape)
+    assert_almost_equal(im1.asnumpy(), batchified[0].asnumpy())
 
     # Multiple input batchify
     batchified = transformer(im1, im2, im3)
     assert (batchified.shape == (3,) + im1.shape)
+    assert_almost_equal(im1.asnumpy(), batchified[0].asnumpy())
+    assert_almost_equal(im2.asnumpy(), batchified[1].asnumpy())
+    assert_almost_equal(im3.asnumpy(), batchified[2].asnumpy())
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_gluon_data_vision.py
+++ b/tests/python/unittest/test_gluon_data_vision.py
@@ -83,6 +83,21 @@ def test_transformer():
     transform(mx.nd.ones((245, 480, 3), dtype='uint8')).wait_to_read()
 
 
+@with_seed
+def test_batchify():
+    transformer = transforms.Batchify()
+    im1 = nd.random.uniform(0, 1, (3, 28, 28))
+    im2 = nd.random.uniform(0, 1, (3, 28, 28))
+    im3 = nd.random.uniform(0, 1, (3, 28, 28))
+
+    # Single input batchify
+    batchified = transformer(im1)
+    assert (batchified.shape == (1,) + im1.shape)
+
+    # Multiple input batchify
+    batchified = transformer(im1, im2, im3)
+    assert (batchified.shape == (3,) + im1.shape)
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
Add new transformer in Gluon "Batchify". This transformer joins/batchify a list of tensors of shape (C x H x W) into a single tensor of shape (N x C x H x W).

This will be helpful when users have created a fused end to end model (transformers + network), saved the graph and this end to end model is deployed in production for "single request inference" or "mini-batch inference". The raw input can be of different shapes, till the input reaches resize transformation, if running a mini batch inference, then input will be a list of NDArrays. After Resize, these individual NDArrays will batched with this transformer.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Add new transformer Batchify to take list of NDArrays and batchify them in to 1 NDArray

@stu1130 