### PR TITLE
[v1.4.x] Support populating errors back to MXNet engine in callback

### DIFF
--- a/include/mxnet/engine.h
+++ b/include/mxnet/engine.h
@@ -74,15 +74,15 @@ class CallbackOnComplete {
  public:
   // use implicit copy and assign
   /*! \brief involve the callback */
-  inline void operator()(const char* error_msg = nullptr) const {
-    (*callback_)(engine_, param_, error_msg);
+  inline void operator()(const dmlc::Error* error = nullptr) const {
+    (*callback_)(engine_, param_, error);
   }
 
  private:
   /*! \brief engine can see content of callback */
   friend class ::mxnet::Engine;
   /*! \brief the real callback */
-  void (*callback_)(Engine *, void *, const char *);
+  void (*callback_)(Engine *, void *, const dmlc::Error *);
   /*! \brief the engine class passed to callback */
   Engine* engine_;
   /*! \brief the parameter set on callback */
@@ -275,7 +275,7 @@ class MXNET_API Engine {
    * \param param the paramter passed to callback.
    */
   inline CallbackOnComplete CreateCallback(
-      void (*callback)(Engine *, void *, const char *), void *param) {
+      void (*callback)(Engine *, void *, const dmlc::Error *), void *param) {
     CallbackOnComplete ret;
     ret.callback_ = callback;
     ret.engine_ = this;

--- a/include/mxnet/engine.h
+++ b/include/mxnet/engine.h
@@ -74,15 +74,15 @@ class CallbackOnComplete {
  public:
   // use implicit copy and assign
   /*! \brief involve the callback */
-  inline void operator()() const {
-    (*callback_)(engine_, param_);
+  inline void operator()(const char* error_msg = nullptr) const {
+    (*callback_)(engine_, param_, error_msg);
   }
 
  private:
   /*! \brief engine can see content of callback */
   friend class ::mxnet::Engine;
   /*! \brief the real callback */
-  void (*callback_)(Engine *, void *);
+  void (*callback_)(Engine *, void *, const char *);
   /*! \brief the engine class passed to callback */
   Engine* engine_;
   /*! \brief the parameter set on callback */
@@ -275,7 +275,7 @@ class MXNET_API Engine {
    * \param param the paramter passed to callback.
    */
   inline CallbackOnComplete CreateCallback(
-      void (*callback)(Engine *, void *), void *param) {
+      void (*callback)(Engine *, void *, const char *), void *param) {
     CallbackOnComplete ret;
     ret.callback_ = callback;
     ret.engine_ = this;

--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -208,7 +208,7 @@ class NaiveEngine final : public Engine {
 
  private:
   // callback to oncomplete
-  static void OnComplete(Engine *engine, void *param) {
+  static void OnComplete(Engine *engine, void *param, const char* error_msg) {
     static_cast<NaiveEngine*>(engine)->req_completed_ = true;
   }
   // whether action is completed

--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -208,7 +208,8 @@ class NaiveEngine final : public Engine {
 
  private:
   // callback to oncomplete
-  static void OnComplete(Engine *engine, void *param, const char* error_msg) {
+  static void OnComplete(Engine *engine, void *param,
+                         const dmlc::Error* error) {
     static_cast<NaiveEngine*>(engine)->req_completed_ = true;
   }
   // whether action is completed

--- a/src/engine/threaded_engine.cc
+++ b/src/engine/threaded_engine.cc
@@ -479,11 +479,11 @@ inline void ThreadedEngine::ThrowException(ThreadedVar* threaded_var) {
 }
 
 void ThreadedEngine::OnCompleteStatic(Engine *engine, void *opr_block_,
-                                      const char* error_msg) {
+                                      const dmlc::Error* error) {
   OprBlock *opr_block = static_cast<OprBlock*>(opr_block_);
   ThreadedOpr *threaded_opr = opr_block->opr;
-  if (error_msg != nullptr) {
-    auto ex_p = std::make_exception_ptr(dmlc::Error(error_msg));
+  if (error != nullptr) {
+    auto ex_p = std::make_exception_ptr(*error);
     threaded_opr->opr_exception = std::make_shared<std::exception_ptr>(ex_p);
   }
   if (opr_block->profiling && threaded_opr->opr_name) {

--- a/src/engine/threaded_engine.cc
+++ b/src/engine/threaded_engine.cc
@@ -478,10 +478,14 @@ inline void ThreadedEngine::ThrowException(ThreadedVar* threaded_var) {
   return;
 }
 
-void ThreadedEngine::OnCompleteStatic(
-    Engine *engine, void *opr_block_) {
+void ThreadedEngine::OnCompleteStatic(Engine *engine, void *opr_block_,
+                                      const char* error_msg) {
   OprBlock *opr_block = static_cast<OprBlock*>(opr_block_);
   ThreadedOpr *threaded_opr = opr_block->opr;
+  if (error_msg != nullptr) {
+    auto ex_p = std::make_exception_ptr(dmlc::Error(error_msg));
+    threaded_opr->opr_exception = std::make_shared<std::exception_ptr>(ex_p);
+  }
   if (opr_block->profiling && threaded_opr->opr_name) {
     // record operator end timestamp
     opr_block->opr_profile->stop();

--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -466,7 +466,7 @@ class ThreadedEngine : public Engine {
   }
 
   static void OnCompleteStatic(Engine *engine, void *threaded_opr,
-                               const char* error_msg);
+                               const dmlc::Error* error);
   /*! \brief append an operator to bulk */
   inline void BulkAppend(SyncFn exec_fn, Context exec_ctx,
                          std::vector<VarHandle> const& const_vars,

--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -465,7 +465,8 @@ class ThreadedEngine : public Engine {
     }
   }
 
-  static void OnCompleteStatic(Engine *engine, void *threaded_opr);
+  static void OnCompleteStatic(Engine *engine, void *threaded_opr,
+                               const char* error_msg);
   /*! \brief append an operator to bulk */
   inline void BulkAppend(SyncFn exec_fn, Context exec_ctx,
                          std::vector<VarHandle> const& const_vars,


### PR DESCRIPTION
This PR adds an optional dmlc::Error* argument in MXNet engine callback functions. The callers can leverage this argument to populate errors back to MXNet engine through callback such that the errors can be handled properly by MXNet engine. It is needed to populate the errors detected in Horovod back to MXNet engine for Hovorod and MXNet integration (see [PR](https://github.com/ctcyang/horovod/pull/24)). This change does not affect existing use cases.