### PR TITLE
[MXNET-1301] Remove the unnecessary WaitAll statements from inception_inference example

### DIFF
--- a/cpp-package/example/inference/inception_inference.cpp
+++ b/cpp-package/example/inference/inception_inference.cpp
@@ -215,7 +215,6 @@ void Predictor::LoadMeanImageData() {
   mean_image_data.SyncCopyFromCPU(
         NDArray::LoadToMap(mean_image_file)["mean_img"].GetData(),
         input_shape.Size());
-  NDArray::WaitAll();
 }
 
 
@@ -244,7 +243,6 @@ void Predictor::LoadDefaultMeanImageData() {
   }
   mean_image_data = NDArray(input_shape, global_ctx, false);
   mean_image_data.SyncCopyFromCPU(array.data(), input_shape.Size());
-  NDArray::WaitAll();
 }
 
 
@@ -273,7 +271,6 @@ NDArray Predictor::LoadInputImage(const std::string& image_file) {
   }
   NDArray image_data = NDArray(input_shape, global_ctx, false);
   image_data.SyncCopyFromCPU(array.data(), input_shape.Size());
-  NDArray::WaitAll();
   return image_data;
 }
 


### PR DESCRIPTION
## Description ##
Th example contains call to WaitAll() function that are not required in some places.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [y] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [y] Changes are complete (i.e. I finished coding on this PR)
- [y] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
The example contains the unit_test_inception_inference.sh. Ensured that the test continues to pass.

