### PR TITLE
Use CPUPinned context in ImageRecordIOParser2

### DIFF
--- a/src/io/image_iter_common.h
+++ b/src/io/image_iter_common.h
@@ -125,11 +125,13 @@ struct ImageRecParserParam : public dmlc::Parameter<ImageRecParserParam> {
   bool verbose;
   /*! \brief partition the data into multiple parts */
   int num_parts;
-  /*! \brief the index of the part will read*/
+  /*! \brief the index of the part will read */
   int part_index;
-  /*! \brief the size of a shuffle chunk*/
+  /*! \brief device id on which to store the data */
+  int device_id;
+  /*! \brief the size of a shuffle chunk */
   size_t shuffle_chunk_size;
-  /*! \brief the seed for chunk shuffling*/
+  /*! \brief the seed for chunk shuffling */
   int shuffle_chunk_seed;
   /*! \brief random seed for augmentations */
   dmlc::optional<int> seed_aug;
@@ -163,6 +165,8 @@ struct ImageRecParserParam : public dmlc::Parameter<ImageRecParserParam> {
         .describe("Virtually partition the data into these many parts.");
     DMLC_DECLARE_FIELD(part_index).set_default(0)
         .describe("The *i*-th virtual partition to be read.");
+    DMLC_DECLARE_FIELD(device_id).set_default(0)
+        .describe("The device id on which to store the data.");
     DMLC_DECLARE_FIELD(shuffle_chunk_size).set_default(0)
         .describe("The data shuffle buffer size in MB. Only valid if shuffle is true.");
     DMLC_DECLARE_FIELD(shuffle_chunk_seed).set_default(0)

--- a/src/io/image_iter_common.h
+++ b/src/io/image_iter_common.h
@@ -127,7 +127,7 @@ struct ImageRecParserParam : public dmlc::Parameter<ImageRecParserParam> {
   int num_parts;
   /*! \brief the index of the part will read */
   int part_index;
-  /*! \brief device id used to create CPUPinned context for internal NDArray */
+  /*! \brief device id used to create context for internal NDArray */
   int device_id;
   /*! \brief the size of a shuffle chunk */
   size_t shuffle_chunk_size;
@@ -166,7 +166,9 @@ struct ImageRecParserParam : public dmlc::Parameter<ImageRecParserParam> {
     DMLC_DECLARE_FIELD(part_index).set_default(0)
         .describe("The *i*-th virtual partition to be read.");
     DMLC_DECLARE_FIELD(device_id).set_default(0)
-        .describe("The device id used to create CPUPinned context for internal NDArray.");
+        .describe("The device id used to create context for internal NDArray. "\
+                  "-1 will create Context::CPU(0). Valid positive device "\
+                  "id will create Context::CPUPinned(device_id). Default is 0." );
     DMLC_DECLARE_FIELD(shuffle_chunk_size).set_default(0)
         .describe("The data shuffle buffer size in MB. Only valid if shuffle is true.");
     DMLC_DECLARE_FIELD(shuffle_chunk_seed).set_default(0)

--- a/src/io/image_iter_common.h
+++ b/src/io/image_iter_common.h
@@ -167,8 +167,9 @@ struct ImageRecParserParam : public dmlc::Parameter<ImageRecParserParam> {
         .describe("The *i*-th virtual partition to be read.");
     DMLC_DECLARE_FIELD(device_id).set_default(0)
         .describe("The device id used to create context for internal NDArray. "\
-                  "-1 will create Context::CPU(0). Valid positive device "\
-                  "id will create Context::CPUPinned(device_id). Default is 0." );
+                  "Setting device_id to -1 will create Context::CPU(0). Setting "
+                  "device_id to valid positive device id will create "
+                  "Context::CPUPinned(device_id). Default is 0.");
     DMLC_DECLARE_FIELD(shuffle_chunk_size).set_default(0)
         .describe("The data shuffle buffer size in MB. Only valid if shuffle is true.");
     DMLC_DECLARE_FIELD(shuffle_chunk_seed).set_default(0)

--- a/src/io/image_iter_common.h
+++ b/src/io/image_iter_common.h
@@ -127,7 +127,7 @@ struct ImageRecParserParam : public dmlc::Parameter<ImageRecParserParam> {
   int num_parts;
   /*! \brief the index of the part will read */
   int part_index;
-  /*! \brief device id on which to store the data */
+  /*! \brief device id used to create CPUPinned context for internal NDArray */
   int device_id;
   /*! \brief the size of a shuffle chunk */
   size_t shuffle_chunk_size;
@@ -166,7 +166,7 @@ struct ImageRecParserParam : public dmlc::Parameter<ImageRecParserParam> {
     DMLC_DECLARE_FIELD(part_index).set_default(0)
         .describe("The *i*-th virtual partition to be read.");
     DMLC_DECLARE_FIELD(device_id).set_default(0)
-        .describe("The device id on which to store the data.");
+        .describe("The device id used to create CPUPinned context for internal NDArray.");
     DMLC_DECLARE_FIELD(shuffle_chunk_size).set_default(0)
         .describe("The data shuffle buffer size in MB. Only valid if shuffle is true.");
     DMLC_DECLARE_FIELD(shuffle_chunk_seed).set_default(0)

--- a/src/io/iter_image_recordio_2.cc
+++ b/src/io/iter_image_recordio_2.cc
@@ -285,10 +285,14 @@ inline bool ImageRecordIOParser2<DType>::ParseNext(DataBatch *out) {
     shape_vec.push_back(param_.label_width);
     TShape label_shape(shape_vec.begin(), shape_vec.end());
 
+    auto ctx = Context::CPU(0);
     auto dev_id = param_.device_id;
-    out->data.at(0) = NDArray(data_shape, Context::CPUPinned(dev_id), false,
+    if (dev_id != -1) {
+      ctx = Context::CPUPinned(dev_id);
+    }
+    out->data.at(0) = NDArray(data_shape, ctx, false,
       mshadow::DataType<DType>::kFlag);
-    out->data.at(1) = NDArray(label_shape, Context::CPUPinned(dev_id), false,
+    out->data.at(1) = NDArray(label_shape, ctx, false,
       mshadow::DataType<real_t>::kFlag);
     unit_size_[0] = param_.data_shape.Size();
     unit_size_[1] = param_.label_width;

--- a/src/io/iter_image_recordio_2.cc
+++ b/src/io/iter_image_recordio_2.cc
@@ -285,9 +285,10 @@ inline bool ImageRecordIOParser2<DType>::ParseNext(DataBatch *out) {
     shape_vec.push_back(param_.label_width);
     TShape label_shape(shape_vec.begin(), shape_vec.end());
 
-    out->data.at(0) = NDArray(data_shape, Context::CPU(0), false,
+    auto dev_id = param_.device_id;
+    out->data.at(0) = NDArray(data_shape, Context::CPUPinned(dev_id), false,
       mshadow::DataType<DType>::kFlag);
-    out->data.at(1) = NDArray(label_shape, Context::CPU(0), false,
+    out->data.at(1) = NDArray(label_shape, Context::CPUPinned(dev_id), false,
       mshadow::DataType<real_t>::kFlag);
     unit_size_[0] = param_.data_shape.Size();
     unit_size_[1] = param_.label_width;


### PR DESCRIPTION
This PR is to fix performance regression introduced by [#12666](https://github.com/apache/incubator-mxnet/pull/12666).

We observed the following performance regression from 1.3.1 to 1.4.x to master when training resnet50_v1 (symbolic_fp16) with MXNet kvstore on a single p3.xlarge instance:

**===1.3.1===**
```
INFO:root:Epoch[0] Batch [50]   Speed: 5749.09 samples/sec      accuracy=0.008119
INFO:root:Epoch[0] Batch [100]  Speed: 6180.00 samples/sec      accuracy=0.018252
INFO:root:Epoch[0] Batch [150]  Speed: 6243.93 samples/sec      accuracy=0.026289
INFO:root:Epoch[0] Batch [200]  Speed: 6234.02 samples/sec      accuracy=0.036436
INFO:root:Epoch[0] Batch [250]  Speed: 6135.59 samples/sec      accuracy=0.043975
INFO:root:Epoch[0] Batch [300]  Speed: 6169.00 samples/sec      accuracy=0.053945
INFO:root:Epoch[0] Batch [350]  Speed: 6076.10 samples/sec      accuracy=0.061250
INFO:root:Epoch[0] Batch [400]  Speed: 6134.20 samples/sec      accuracy=0.071016
INFO:root:Epoch[0] Batch [450]  Speed: 6201.94 samples/sec      accuracy=0.076260
INFO:root:Epoch[0] Batch [500]  Speed: 6140.77 samples/sec      accuracy=0.082266
INFO:root:Epoch[0] Batch [550]  Speed: 6149.55 samples/sec      accuracy=0.088701
INFO:root:Epoch[0] Batch [600]  Speed: 6149.39 samples/sec      accuracy=0.088584
```

**===1.4.x===**
```
INFO:root:Epoch[0] Batch [0-50] Speed: 4606.70 samples/sec      accuracy=0.008004
INFO:root:Epoch[0] Batch [50-100]       Speed: 4776.33 samples/sec      accuracy=0.018809
INFO:root:Epoch[0] Batch [100-150]      Speed: 4747.80 samples/sec      accuracy=0.027314
INFO:root:Epoch[0] Batch [150-200]      Speed: 4812.72 samples/sec      accuracy=0.036582
INFO:root:Epoch[0] Batch [200-250]      Speed: 5090.36 samples/sec      accuracy=0.046816
INFO:root:Epoch[0] Batch [250-300]      Speed: 4885.30 samples/sec      accuracy=0.055801
INFO:root:Epoch[0] Batch [300-350]      Speed: 4912.66 samples/sec      accuracy=0.064531
INFO:root:Epoch[0] Batch [350-400]      Speed: 4897.15 samples/sec      accuracy=0.073496
INFO:root:Epoch[0] Batch [400-450]      Speed: 4957.09 samples/sec      accuracy=0.080127
INFO:root:Epoch[0] Batch [450-500]      Speed: 4875.13 samples/sec      accuracy=0.085576
INFO:root:Epoch[0] Batch [500-550]      Speed: 4943.11 samples/sec      accuracy=0.092383
INFO:root:Epoch[0] Batch [550-600]      Speed: 4873.64 samples/sec      accuracy=0.094678
```

**===master===**
```
INFO:root:Epoch[0] Batch [0-50] Speed: 4957.82 samples/sec      accuracy=0.008464
INFO:root:Epoch[0] Batch [50-100]       Speed: 5011.30 samples/sec      accuracy=0.018232
INFO:root:Epoch[0] Batch [100-150]      Speed: 4903.28 samples/sec      accuracy=0.026904
INFO:root:Epoch[0] Batch [150-200]      Speed: 4871.87 samples/sec      accuracy=0.036299
INFO:root:Epoch[0] Batch [200-250]      Speed: 4793.67 samples/sec      accuracy=0.044736
INFO:root:Epoch[0] Batch [250-300]      Speed: 4835.09 samples/sec      accuracy=0.054385
INFO:root:Epoch[0] Batch [300-350]      Speed: 4732.73 samples/sec      accuracy=0.062266
INFO:root:Epoch[0] Batch [350-400]      Speed: 4794.80 samples/sec      accuracy=0.070781
INFO:root:Epoch[0] Batch [400-450]      Speed: 4785.00 samples/sec      accuracy=0.077178
INFO:root:Epoch[0] Batch [450-500]      Speed: 4776.88 samples/sec      accuracy=0.082549
INFO:root:Epoch[0] Batch [500-550]      Speed: 4795.37 samples/sec      accuracy=0.088789
INFO:root:Epoch[0] Batch [550-600]      Speed: 4718.87 samples/sec      accuracy=0.090850
```

By changing the default context to CPUPinned(0) in ImageRecordIoParser2 in this PR, the performance is comparable with 1.3.1 using the same training settings.

In addition, we add a device_id parameter to the ImageRecParserParam struct such that we can set the device id for the CPUPinned context when creating ImageRecordIter. This newly exposed device_id allows training with large batch_size using Horovod. Users can also set device_id to -1 indicating that they want to use CPU(0) context which saves memory usage on GPU.

**===1.4.x with this PR===**
```
INFO:root:Epoch[0] Batch [0-50]	Speed: 5870.13 samples/sec	accuracy=0.008301
INFO:root:Epoch[0] Batch [50-100]	Speed: 6316.20 samples/sec	accuracy=0.017910
INFO:root:Epoch[0] Batch [100-150]	Speed: 6344.68 samples/sec	accuracy=0.028066
INFO:root:Epoch[0] Batch [150-200]	Speed: 6272.05 samples/sec	accuracy=0.037432
INFO:root:Epoch[0] Batch [200-250]	Speed: 6311.87 samples/sec	accuracy=0.046504
INFO:root:Epoch[0] Batch [250-300]	Speed: 6214.49 samples/sec	accuracy=0.056309
INFO:root:Epoch[0] Batch [300-350]	Speed: 6267.78 samples/sec	accuracy=0.062568
INFO:root:Epoch[0] Batch [350-400]	Speed: 6259.29 samples/sec	accuracy=0.071963
INFO:root:Epoch[0] Batch [400-450]	Speed: 6273.53 samples/sec	accuracy=0.080605
INFO:root:Epoch[0] Batch [450-500]	Speed: 6255.01 samples/sec	accuracy=0.087021
INFO:root:Epoch[0] Batch [500-550]	Speed: 6314.75 samples/sec	accuracy=0.091787
INFO:root:Epoch[0] Batch [550-600]	Speed: 6302.38 samples/sec	accuracy=0.093311
```
