### PR TITLE
build docs with CPP package

### DIFF
--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -87,10 +87,10 @@ def generate_doxygen(app):
 def build_mxnet(app):
     """Build mxnet .so lib"""
     if not os.path.exists(os.path.join(app.builder.srcdir, '..', 'config.mk')):
-        _run_cmd("cd %s/.. && cp make/config.mk config.mk && make -j$(nproc) DEBUG=1 USE_MKLDNN=0" %
+        _run_cmd("cd %s/.. && cp make/config.mk config.mk && make -j$(nproc) DEBUG=1 USE_MKLDNN=0 USE_CPP_PACKAGE=1" %
                 app.builder.srcdir)
     else:
-        _run_cmd("cd %s/.. && make -j$(nproc) DEBUG=1 USE_MKLDNN=0" %
+        _run_cmd("cd %s/.. && make -j$(nproc) DEBUG=1 USE_MKLDNN=0 USE_CPP_PACKAGE=1" %
                 app.builder.srcdir)
 
 def build_r_docs(app):


### PR DESCRIPTION
## Description ##
Fixes #13920
This PR will generate docs for the functions in `op.h` which is created only if you build MXNet with `USE_CPP_PACKAGE=1`.

## Comments
This generates a lot of warnings, but C++ pipeline hasn't been cleaned up yet anyway, so it's not a big deal at the moment. Having the APIs documented is more important than getting a bunch of warnings. That being said, it would be great if someone familiar with the C++ code can figure out why Doxygen is not happy with the `op.h`'s docstrings.

## Preview
http://34.201.8.176/versions/c_op/doxygen/op_8h.html