### PR TITLE
Added optional parameters to BilinearResize2D to do relative scaling

### DIFF
--- a/src/operator/contrib/bilinear_resize-inl.h
+++ b/src/operator/contrib/bilinear_resize-inl.h
@@ -50,11 +50,17 @@ namespace op {
 struct BilinearSampleParam : public dmlc::Parameter<BilinearSampleParam> {
   int height;
   int width;
+  dmlc::optional<float> scale_height;
+  dmlc::optional<float> scale_width;
   DMLC_DECLARE_PARAMETER(BilinearSampleParam) {
-    DMLC_DECLARE_FIELD(height).set_range(1, 10000)
-    .describe("output height (required)");
-    DMLC_DECLARE_FIELD(width).set_range(1, 10000)
-    .describe("output width (required)");
+    DMLC_DECLARE_FIELD(height).set_default(1).set_range(1, 10000)
+    .describe("output height (required, but ignored if scale_height is defined)");
+    DMLC_DECLARE_FIELD(width).set_default(1).set_range(1, 10000)
+    .describe("output width (required, but ignored if scale_width is defined)");
+    DMLC_DECLARE_FIELD(scale_height).set_default(dmlc::optional<float>())
+    .describe("sampling scale of the height (optional, ignores height if defined)");
+    DMLC_DECLARE_FIELD(scale_width).set_default(dmlc::optional<float>())
+    .describe("sampling scale of the scale_width (optional, ignores width if defined)");
   }
 };
 
@@ -129,8 +135,18 @@ static bool BilinearSampleOpInferShape(const nnvm::NodeAttrs& attrs,
   const BilinearSampleParam& param = nnvm::get<BilinearSampleParam>(attrs.parsed);
   TShape dshape(in_shape->at(0));
   if (dshape.ndim() == 0) return false;
-  dshape[2] = param.height;
-  dshape[3] = param.width;
+  if (param.scale_height.has_value()) {
+    dshape[2] = int(param.scale_height.value() * in_shape->at(0)[2]);
+  } else {
+    dshape[2] = param.height;
+  }
+
+  if (param.scale_height.has_value()) {
+    dshape[3] = int(param.scale_width.value() * in_shape->at(0)[3]);
+  } else {
+    dshape[3] = param.width;
+  }
+
   out_shape->clear();
   out_shape->push_back(dshape);
   return true;

--- a/src/operator/contrib/bilinear_resize-inl.h
+++ b/src/operator/contrib/bilinear_resize-inl.h
@@ -136,13 +136,13 @@ static bool BilinearSampleOpInferShape(const nnvm::NodeAttrs& attrs,
   TShape dshape(in_shape->at(0));
   if (dshape.ndim() == 0) return false;
   if (param.scale_height.has_value()) {
-    dshape[2] = int(param.scale_height.value() * in_shape->at(0)[2]);
+    dshape[2] = static_cast<int>(param.scale_height.value() * in_shape->at(0)[2]);
   } else {
     dshape[2] = param.height;
   }
 
   if (param.scale_height.has_value()) {
-    dshape[3] = int(param.scale_width.value() * in_shape->at(0)[3]);
+    dshape[3] = static_cast<int>(param.scale_width.value() * in_shape->at(0)[3]);
   } else {
     dshape[3] = param.width;
   }

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6533,6 +6533,12 @@ def test_bilinear_resize_op():
         x = mx.nd.random.uniform(shape=shape)
         y = mx.nd.contrib.BilinearResize2D(x, height=height, width=width)
         assert_almost_equal(y.asnumpy(), py_bilinear_resize(x.asnumpy(), height, width))
+
+        x_scale = width / shape[-1]
+        y_scale = height / shape[-2]
+        y = mx.nd.contrib.BilinearResize2D(x, height=1, width=1, scale_height=y_scale,
+                                           scale_width=x_scale)
+        assert_almost_equal(y.asnumpy(), py_bilinear_resize(x.asnumpy(), height, width))
     shape = (2, 2, 10, 10)
     check_bilinear_resize_op(shape, 5, 5)
     check_bilinear_resize_op(shape, 10, 10)

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6536,8 +6536,7 @@ def test_bilinear_resize_op():
 
         x_scale = width / shape[-1]
         y_scale = height / shape[-2]
-        y = mx.nd.contrib.BilinearResize2D(x, height=1, width=1, scale_height=y_scale,
-                                           scale_width=x_scale)
+        y = mx.nd.contrib.BilinearResize2D(x, scale_height=y_scale, scale_width=x_scale)
         assert_almost_equal(y.asnumpy(), py_bilinear_resize(x.asnumpy(), height, width))
     shape = (2, 2, 10, 10)
     check_bilinear_resize_op(shape, 5, 5)


### PR DESCRIPTION
## Description ##
This PR adds 2 additional optional parameters to the contrib.BilinearResize2D operator to do relative down/upsampling. This will help situations where the the required output size depends on the input size and input size is not available runtime (symbolic).
The change is fully backward-compatible.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
