### PR TITLE
MXNET-1302 Exclude commons-codec and commons-io from assembled JAR

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -212,6 +212,7 @@ List of Contributors
 * [Xiao Wang](https://github.com/BeyonderXX)
 * [Piyush Ghai](https://github.com/piyushghai)
 * [Zach Boldyga](https://github.com/zboldyga)
+* [Gordon Reid](https://github.com/gordon1992)
 
 * [Ming Yang](http://ufoym.com)
 

--- a/scala-package/assembly/src/main/assembly/assembly.xml
+++ b/scala-package/assembly/src/main/assembly/assembly.xml
@@ -28,6 +28,8 @@
       <excludes>
         <exclude>org.scala-lang:*</exclude>
         <exclude>org.scala-lang.modules:*</exclude>
+        <exclude>commons-io:commons-io</exclude>
+        <exclude>commons-codec:commons-codec</exclude>
       </excludes>
       <outputDirectory>/</outputDirectory>
       <useProjectArtifact>true</useProjectArtifact>

--- a/scala-package/core/pom.xml
+++ b/scala-package/core/pom.xml
@@ -154,11 +154,6 @@
       <version>INTERNAL</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.1</version>
-    </dependency>
     <!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
     <dependency>
       <groupId>org.mockito</groupId>

--- a/scala-package/deploy/src/main/deploy/deploy.xml
+++ b/scala-package/deploy/src/main/deploy/deploy.xml
@@ -45,5 +45,15 @@
       <artifactId>scala-compiler</artifactId>
       <version>SCALA_VERSION</version>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.10</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.1</version>
+    </dependency>
   </dependencies>
 </project>

--- a/scala-package/macros/pom.xml
+++ b/scala-package/macros/pom.xml
@@ -36,11 +36,6 @@
       <version>INTERNAL</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.1</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -395,6 +395,11 @@
       <version>1.10</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>2.11.1</version>


### PR DESCRIPTION
Consumers of MXNet are exposed to the commons-codec and commons-io library versions MXNet uses internally. This change excludes those JARs from the JARs created with `make scalapkg`.

## Description ##
This PR removes commons-codec and commons-io from the assembled JAR and adds both packages as dependencies in deploy.xml

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues/MXNET-1302) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] commons-io and commons-codec remove from assembled JAR
- [x] commons-io and commons-codec added as dependencies to deploy.xml

## Comments ##
My Maven knowledge is sparse so I may have missed something.

For testing:
* The JAR no longer contains org.apache.commons classes
* make scalapkg && make scalaunittests && make scalaintegrationtests passed on my Ubuntu 18.04 machine (JDK 8).

Originally reported in #13929 