### PR TITLE
Fix inconsistent handling for FResourceRequestEx for imperative and symbolic executor

### DIFF
--- a/include/mxnet/op_attr_types.h
+++ b/include/mxnet/op_attr_types.h
@@ -238,6 +238,8 @@ using FResourceRequest = std::function<
 /*!
  * \brief The resource request from the operator.
  *        An operator could register ResourceRequestEx, or ResourceRequest, or neither.
+ *        If an operator registers both ResourceRequestEx and ResourceRequest,
+ *        ResourceRequest is ignored.
  *
  * \note Register under "FResourceRequestEx"
  */

--- a/src/executor/attach_op_resource_pass.cc
+++ b/src/executor/attach_op_resource_pass.cc
@@ -55,8 +55,6 @@ void AttachOpResources(
     const auto op = inode.source->op();
     const bool rsc_req = (fresource.count(op) != 0);
     const bool rsc_ex_req = (fresource_ex.count(op) != 0);
-    CHECK(!(rsc_req && rsc_ex_req))
-      << "An operator could not register both ResourceRequestEx and ResourceRequest";
     if (rsc_req || rsc_ex_req) {
       auto reqs = rsc_ex_req ? fresource_ex[op](inode.source->attrs,
                                                 dev_masks[nid],


### PR DESCRIPTION
## Description ##
During imperative execution, if an op registers both FResourceRequestEx and FResourceRequest, FResourceRequestEx is used. 
However, during symbolic execution, such behavior causes a fatal message. 

This PR removes the fatal message in symbolic execution so that it is consistent with the imperative execution. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
