### PR TITLE
Update maven_darwin_mkl

### DIFF
--- a/make/maven/maven_darwin_mkl.mk
+++ b/make/maven/maven_darwin_mkl.mk
@@ -23,8 +23,8 @@
 # choice of compiler
 #--------------------
 
-export CC = gcc
-export CXX = g++
+export CC = $(brew --prefix llvm)/bin/clang
+export CXX = $(brew --prefix llvm)/bin/clang++
 export NVCC = nvcc
 
 # whether compile with options for MXNet developer
@@ -78,7 +78,7 @@ USE_CUDNN = 0
 USE_NVRTC = 0
 
 # use openmp for parallelization
-USE_OPENMP = 0
+USE_OPENMP = 1
 USE_OPERATOR_TUNING = 1
 USE_LIBJPEG_TURBO = 1
 

--- a/make/maven/maven_darwin_mkl.mk
+++ b/make/maven/maven_darwin_mkl.mk
@@ -23,8 +23,8 @@
 # choice of compiler
 #--------------------
 
-export CC = $(brew --prefix llvm)/bin/clang
-export CXX = $(brew --prefix llvm)/bin/clang++
+export CC = gcc
+export CXX = g++
 export NVCC = nvcc
 
 # whether compile with options for MXNet developer

--- a/tools/dependencies/curl.sh
+++ b/tools/dependencies/curl.sh
@@ -38,6 +38,7 @@ if [[ ! -f $DEPS_PATH/lib/libcurl.a ]]; then
                 --without-zsh-functions-dir \
                 --without-librtmp \
                 --without-libssh2 \
+                --without-libidn2 \
                 --disable-debug \
                 --disable-curldebug \
                 --enable-symbol-hiding=yes \


### PR DESCRIPTION
## Description ##
Update maven build script for mac based on @azai91 build instruction

The problem in here: Mac used a clang with old OpenMP version which may causing the problems with the build. The best way to deal with this without introducing a LLVM dependencies is to upgrade your xcode version (Xcode 9.2 or above)

@szha @marcoabreu @zachgk 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
