### PR TITLE
Remove all usages of makefile for scala

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -870,8 +870,9 @@ unittest_ubuntu_cpu_clojure() {
 
 unittest_ubuntu_cpu_clojure_integration() {
     set -ex
-    make scalapkg USE_OPENCV=1 USE_BLAS=openblas USE_DIST_KVSTORE=1 ENABLE_TESTCOVERAGE=1
-    make scalainstall USE_OPENCV=1 USE_BLAS=openblas USE_DIST_KVSTORE=1 ENABLE_TESTCOVERAGE=1
+    cd scala-package
+    mvn install
+    cd ..
     ./contrib/clojure-package/integration-tests.sh
 }
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -871,7 +871,7 @@ unittest_ubuntu_cpu_clojure() {
 unittest_ubuntu_cpu_clojure_integration() {
     set -ex
     cd scala-package
-    mvn install
+    mvn -B install
     cd ..
     ./contrib/clojure-package/integration-tests.sh
 }
@@ -1242,7 +1242,7 @@ nightly_tutorial_test_ubuntu_python2_gpu() {
 nightly_java_demo_test_cpu() {
     set -ex
     cd /work/mxnet/scala-package/mxnet-demo/java-demo
-    mvn -Pci-nightly install
+    mvn -B -Pci-nightly install
     bash bin/java_sample.sh
     bash bin/run_od.sh
 }
@@ -1250,7 +1250,7 @@ nightly_java_demo_test_cpu() {
 nightly_scala_demo_test_cpu() {
     set -ex
     cd /work/mxnet/scala-package/mxnet-demo/scala-demo
-    mvn -Pci-nightly install
+    mvn -B -Pci-nightly install
     bash bin/demo.sh
     bash bin/run_im.sh
 }

--- a/docker/Dockerfiles/Dockerfile.in.scala
+++ b/docker/Dockerfiles/Dockerfile.in.scala
@@ -4,4 +4,4 @@
 COPY install/scala.sh install/
 RUN install/scala.sh
 
-RUN cd mxnet && make scalapkg $BUILD_OPTS
+RUN cd mxnet/scala-package && mvn package

--- a/docs/install/java_setup.md
+++ b/docs/install/java_setup.md
@@ -109,7 +109,7 @@ The previously mentioned setup with Maven is recommended. Otherwise, the followi
 If you have already built MXNet **from source** and are looking to setup Java from that point, you may simply run the following from the MXNet `scala-package` folder:
 
 ```
-mvn package
+cd scala-package
 mvn install
 ```
 This will install both the Java Inference API and the required MXNet-Scala package. 

--- a/docs/install/java_setup.md
+++ b/docs/install/java_setup.md
@@ -109,7 +109,6 @@ The previously mentioned setup with Maven is recommended. Otherwise, the followi
 If you have already built MXNet **from source** and are looking to setup Java from that point, you may simply run the following from the MXNet `scala-package` folder:
 
 ```
-cd scala-package
 mvn install
 ```
 This will install both the Java Inference API and the required MXNet-Scala package. 

--- a/docs/install/scala_setup.md
+++ b/docs/install/scala_setup.md
@@ -92,8 +92,8 @@ The previously mentioned setup with Maven is recommended. Otherwise, the followi
 If you have already built MXNet **from source** and are looking to setup Scala from that point, you may simply run the following from the MXNet source root:
 
 ```
-make scalapkg
-make scalainstall
+cd scala-package
+mvn install
 ```
 
 <hr>

--- a/docs/install/scala_setup.md
+++ b/docs/install/scala_setup.md
@@ -89,10 +89,9 @@ The previously mentioned setup with Maven is recommended. Otherwise, the followi
 
 
 #### Build Scala from an Existing MXNet Installation
-If you have already built MXNet **from source** and are looking to setup Scala from that point, you may simply run the following from the MXNet source root:
+If you have already built MXNet **from source** and are looking to setup Scala from that point, you may simply run the following from the MXNet `scala-package` folder:
 
 ```
-cd scala-package
 mvn install
 ```
 

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -105,7 +105,7 @@ def build_r_docs(app):
 
 def build_scala(app):
     """build scala for scala docs, java docs, and clojure docs to use"""
-    _run_cmd("cd %s/../scala-package && mvn install -DskipTests" % app.builder.srcdir)
+    _run_cmd("cd %s/../scala-package && mvn -B install -DskipTests" % app.builder.srcdir)
 
 def build_scala_docs(app):
     """build scala doc and then move the outdir"""

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -105,8 +105,7 @@ def build_r_docs(app):
 
 def build_scala(app):
     """build scala for scala docs, java docs, and clojure docs to use"""
-    _run_cmd("cd %s/.. && make scalapkg" % app.builder.srcdir)
-    _run_cmd("cd %s/.. && make scalainstall" % app.builder.srcdir)
+    _run_cmd("cd %s/.. && mvn install -DskipTests" % app.builder.srcdir)
 
 def build_scala_docs(app):
     """build scala doc and then move the outdir"""

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -105,7 +105,7 @@ def build_r_docs(app):
 
 def build_scala(app):
     """build scala for scala docs, java docs, and clojure docs to use"""
-    _run_cmd("cd %s/.. && mvn install -DskipTests" % app.builder.srcdir)
+    _run_cmd("cd %s/../scala-package && mvn install -DskipTests" % app.builder.srcdir)
 
 def build_scala_docs(app):
     """build scala doc and then move the outdir"""


### PR DESCRIPTION
## Description ##
There were some remaining usages of the main makefile for scala which has been deprecated in favor of using maven directly. I removed all of the remaining ones.

@aaronmarkham @piyushghai @lanking520 @andrewfayres @gigasquid 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
