### PR TITLE
website publish updates

### DIFF
--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -50,6 +50,7 @@ _JAVA_DOCS = parser.getboolean(_DOC_SET, 'java_docs')
 _CLOJURE_DOCS = parser.getboolean(_DOC_SET, 'clojure_docs')
 _DOXYGEN_DOCS = parser.getboolean(_DOC_SET,  'doxygen_docs')
 _R_DOCS = parser.getboolean(_DOC_SET, 'r_docs')
+_ARTIFACTS = parser.getboolean(_DOC_SET, 'artifacts')
 
 # white list to evaluate the code block output, such as ['tutorials/gluon']
 _EVAL_WHILTELIST = []
@@ -88,10 +89,10 @@ def generate_doxygen(app):
 def build_mxnet(app):
     """Build mxnet .so lib"""
     if not os.path.exists(os.path.join(app.builder.srcdir, '..', 'config.mk')):
-        _run_cmd("cd %s/.. && cp make/config.mk config.mk && make -j$(nproc) DEBUG=1 USE_MKLDNN=0 USE_CPP_PACKAGE=1" %
+        _run_cmd("cd %s/.. && cp make/config.mk config.mk && make -j$(nproc) USE_MKLDNN=0 USE_CPP_PACKAGE=1 " %
                 app.builder.srcdir)
     else:
-        _run_cmd("cd %s/.. && make -j$(nproc) DEBUG=1 USE_MKLDNN=0 USE_CPP_PACKAGE=1" %
+        _run_cmd("cd %s/.. && make -j$(nproc) USE_MKLDNN=0 USE_CPP_PACKAGE=1 " %
                 app.builder.srcdir)
 
 def build_r_docs(app):
@@ -438,17 +439,17 @@ def add_buttons(app, docname, source):
 
 def copy_artifacts(app):
     """Copies artifacts needed for website presentation"""
-    print("Copying artifacts...")
     dest_path = app.builder.outdir + '/error'
+    source_path = app.builder.srcdir + '/build_version_doc/artifacts'
     _run_cmd('cd ' + app.builder.srcdir)
     _run_cmd('rm -rf ' + dest_path)
     _run_cmd('mkdir -p ' + dest_path)
-    _run_cmd('cp build_version_doc/artifacts/404.html ' + dest_path)
-    _run_cmd('cp build_version_doc/artifacts/api.html ' + dest_path)
+    _run_cmd('cp ' + source_path + '/404.html ' + dest_path)
+    _run_cmd('cp ' + source_path + '/api.html ' + dest_path)
     dest_path = app.builder.outdir + '/_static'
     _run_cmd('rm -rf ' + dest_path)
     _run_cmd('mkdir -p ' + dest_path)
-    _run_cmd('cp _static/mxnet.css ' + dest_path)
+    _run_cmd('cp ' + app.builder.srcdir + '/_static/mxnet.css ' + dest_path)
 
 
 def setup(app):
@@ -475,7 +476,9 @@ def setup(app):
     if _R_DOCS:
         print("Building R Docs!")
         app.connect("builder-inited", build_r_docs)
-    app.connect("builder-inited", copy_artifacts)
+    if _ARTIFACTS:
+        print("Copying Artifacts!")
+        app.connect("builder-inited", copy_artifacts)
     app.connect('source-read', convert_table)
     app.connect('source-read', add_buttons)
     app.add_config_value('recommonmark_config', {

--- a/docs/settings.ini
+++ b/docs/settings.ini
@@ -2,6 +2,7 @@
 build_mxnet = 0
 
 [document_sets_tutorial]
+artifacts = 0
 clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
@@ -9,6 +10,23 @@ r_docs = 0
 scala_docs = 0
 
 [document_sets_default]
+artifacts = 1
+clojure_docs = 1
+doxygen_docs = 1
+java_docs = 1
+r_docs = 0
+scala_docs = 1
+
+[document_sets_1.4.0]
+artifacts = 0
+clojure_docs = 1
+doxygen_docs = 1
+java_docs = 1
+r_docs = 0
+scala_docs = 1
+
+[document_sets_v1.4.x]
+artifacts = 0
 clojure_docs = 1
 doxygen_docs = 1
 java_docs = 1
@@ -16,6 +34,7 @@ r_docs = 0
 scala_docs = 1
 
 [document_sets_1.3.1]
+artifacts = 0
 clojure_docs = 1
 doxygen_docs = 1
 java_docs = 0
@@ -23,6 +42,7 @@ r_docs = 0
 scala_docs = 1
 
 [document_sets_1.3.0]
+artifacts = 0
 clojure_docs = 1
 doxygen_docs = 1
 java_docs = 0
@@ -30,13 +50,15 @@ r_docs = 0
 scala_docs = 1
 
 [document_sets_v1.3.x]
-clojure_docs = 1
+artifacts = 0
+clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
-scala_docs = 1
+scala_docs = 0
 
 [document_sets_1.2.0]
+artifacts = 0
 clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
@@ -44,6 +66,7 @@ r_docs = 0
 scala_docs = 1
 
 [document_sets_v1.2.0]
+artifacts = 0
 clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
@@ -51,6 +74,7 @@ r_docs = 0
 scala_docs = 1
 
 [document_sets_1.1.0]
+artifacts = 0
 clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
@@ -58,6 +82,7 @@ r_docs = 0
 scala_docs = 0
 
 [document_sets_v1.1.0]
+artifacts = 0
 clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
@@ -65,6 +90,7 @@ r_docs = 0
 scala_docs = 0
 
 [document_sets_1.0.0]
+artifacts = 0
 clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
@@ -72,6 +98,7 @@ r_docs = 0
 scala_docs = 0
 
 [document_sets_v1.0.0]
+artifacts = 0
 clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
@@ -79,6 +106,7 @@ r_docs = 0
 scala_docs = 0
 
 [document_sets_0.12.0]
+artifacts = 0
 clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
@@ -86,6 +114,7 @@ r_docs = 0
 scala_docs = 0
 
 [document_sets_v0.12.0]
+artifacts = 0
 clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
@@ -93,6 +122,7 @@ r_docs = 0
 scala_docs = 0
 
 [document_sets_0.11.0]
+artifacts = 0
 clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
@@ -100,6 +130,7 @@ r_docs = 0
 scala_docs = 0
 
 [document_sets_v0.11.0]
+artifacts = 0
 clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0


### PR DESCRIPTION
## Description ##
This PR removes the debug flag during build, adds support for v1.4.x docs, and fixes a publish bug (that I introduced).

Regarding the bug, I needed to add an artifacts flag to `settings.ini` so that I could skip trying to copy artifacts from branches where they don't exist. I could have put this logic in post processing in `update_all_version.sh`, but I liked the fact that the artifact step happens with the rest of the docs generation, so you get in with a local single version build and with a full multi-version site build.

## Comments
Anyone testing this might run into an error with the java/scala docs generation step. Something seems to have caused locally cached build files to break the docs generation (unrelated to this PR), so delete your `build_version_doc/apache_mxnet` folder and try again. 