### PR TITLE
Fix jar path and add missing ones for spark jobs

### DIFF
--- a/scala-package/spark/src/test/scala/org/apache/mxnet/spark/SharedSparkContext.scala
+++ b/scala-package/spark/src/test/scala/org/apache/mxnet/spark/SharedSparkContext.scala
@@ -80,14 +80,18 @@ trait SharedSparkContext extends FunSuite with BeforeAndAfterEach with BeforeAnd
     System.getProperty("user.dir")
   }
 
-  private def getJarFilePath(root: String): String = {
-    val jarFiles = new File(s"$root/target/").listFiles(new FileFilter {
+  private def findJars(root: String): Array[File] = {
+    val excludedSuffixes = List("bundle", "src", "javadoc", "sources")
+    new File(root).listFiles(new FileFilter {
       override def accept(pathname: File) = {
         pathname.getAbsolutePath.endsWith(".jar") &&
-          !pathname.getAbsolutePath.contains("bundle") &&
-          !pathname.getAbsolutePath.contains("src")
+          excludedSuffixes.map(!pathname.getAbsolutePath.contains(_)).forall(identity)
       }
     })
+  }
+
+  private def getJarFilePath(root: String): String = {
+    val jarFiles = findJars(s"$root/target/")
     if (jarFiles != null && jarFiles.nonEmpty) {
       jarFiles.head.getAbsolutePath
     } else {
@@ -96,13 +100,7 @@ trait SharedSparkContext extends FunSuite with BeforeAndAfterEach with BeforeAnd
   }
 
   private def getSparkJar: String = {
-    val jarFiles = new File(s"$composeWorkingDirPath/target/").listFiles(new FileFilter {
-      override def accept(pathname: File) = {
-        pathname.getAbsolutePath.endsWith(".jar") &&
-          !pathname.getAbsolutePath.contains("javadoc") &&
-          !pathname.getAbsolutePath.contains("sources")
-      }
-    })
+    val jarFiles = findJars(s"$composeWorkingDirPath/target/")
     if (jarFiles != null && jarFiles.nonEmpty) {
       jarFiles.head.getAbsolutePath
     } else {

--- a/scala-package/spark/src/test/scala/org/apache/mxnet/spark/SharedSparkContext.scala
+++ b/scala-package/spark/src/test/scala/org/apache/mxnet/spark/SharedSparkContext.scala
@@ -89,9 +89,10 @@ trait SharedSparkContext extends FunSuite with BeforeAndAfterEach with BeforeAnd
       }
     })
     if (jarFiles != null && jarFiles.nonEmpty) {
-      return jarFiles.head.getAbsolutePath
+      jarFiles.head.getAbsolutePath
+    } else {
+      null
     }
-    null
   }
 
   private def getSparkJar: String = {
@@ -109,7 +110,8 @@ trait SharedSparkContext extends FunSuite with BeforeAndAfterEach with BeforeAnd
     }
   }
 
-  private def getNativeJars(root:String): String = new File(root).listFiles().map(_.toPath).mkString(",")
+  private def getNativeJars(root: String): String =
+    new File(root).listFiles().map(_.toPath).mkString(",")
 
   protected def buildLeNet(): MXNet = {
     val workingDir = composeWorkingDirPath
@@ -130,7 +132,7 @@ trait SharedSparkContext extends FunSuite with BeforeAndAfterEach with BeforeAnd
   protected def buildMlp(): MXNet = {
     val workingDir = composeWorkingDirPath
     val assemblyRoot = s"$workingDir/../assembly"
-    val nativeRoot =s"$workingDir/../native/target/lib"
+    val nativeRoot = s"$workingDir/../native/target/lib"
 
     new MXNet()
       .setBatchSize(128)

--- a/scala-package/spark/src/test/scala/org/apache/mxnet/spark/SharedSparkContext.scala
+++ b/scala-package/spark/src/test/scala/org/apache/mxnet/spark/SharedSparkContext.scala
@@ -81,17 +81,15 @@ trait SharedSparkContext extends FunSuite with BeforeAndAfterEach with BeforeAnd
   }
 
   private def getJarFilePath(root: String): String = {
-    for (platform <- List("linux-x86_64-cpu", "linux-x86_64-gpu", "osx-x86_64-cpu")) {
-      val jarFiles = new File(s"$root/$platform/target/").listFiles(new FileFilter {
-        override def accept(pathname: File) = {
-          pathname.getAbsolutePath.endsWith(".jar") &&
-            !pathname.getAbsolutePath.contains("javadoc") &&
-            !pathname.getAbsolutePath.contains("sources")
-        }
-      })
-      if (jarFiles != null && jarFiles.nonEmpty) {
-        return jarFiles.head.getAbsolutePath
+    val jarFiles = new File(s"$root/target/").listFiles(new FileFilter {
+      override def accept(pathname: File) = {
+        pathname.getAbsolutePath.endsWith(".jar") &&
+          !pathname.getAbsolutePath.contains("bundle") &&
+          !pathname.getAbsolutePath.contains("src")
       }
+    })
+    if (jarFiles != null && jarFiles.nonEmpty) {
+      return jarFiles.head.getAbsolutePath
     }
     null
   }
@@ -110,6 +108,8 @@ trait SharedSparkContext extends FunSuite with BeforeAndAfterEach with BeforeAnd
       null
     }
   }
+
+  private def getNativeJars(root:String): String = new File(root).listFiles().map(_.toPath).mkString(",")
 
   protected def buildLeNet(): MXNet = {
     val workingDir = composeWorkingDirPath
@@ -130,6 +130,8 @@ trait SharedSparkContext extends FunSuite with BeforeAndAfterEach with BeforeAnd
   protected def buildMlp(): MXNet = {
     val workingDir = composeWorkingDirPath
     val assemblyRoot = s"$workingDir/../assembly"
+    val nativeRoot =s"$workingDir/../native/target/lib"
+
     new MXNet()
       .setBatchSize(128)
       .setLabelName("softmax_label")
@@ -139,7 +141,7 @@ trait SharedSparkContext extends FunSuite with BeforeAndAfterEach with BeforeAnd
       .setNumEpoch(10)
       .setNumServer(1)
       .setNumWorker(numWorkers)
-      .setExecutorJars(s"${getJarFilePath(assemblyRoot)},$getSparkJar")
+      .setExecutorJars(s"${getJarFilePath(assemblyRoot)},$getSparkJar,${getNativeJars(nativeRoot)}")
       .setJava("java")
       .setTimeout(0)
   }

--- a/scala-package/spark/src/test/scala/org/apache/mxnet/spark/SharedSparkContext.scala
+++ b/scala-package/spark/src/test/scala/org/apache/mxnet/spark/SharedSparkContext.scala
@@ -85,7 +85,7 @@ trait SharedSparkContext extends FunSuite with BeforeAndAfterEach with BeforeAnd
     new File(root).listFiles(new FileFilter {
       override def accept(pathname: File) = {
         pathname.getAbsolutePath.endsWith(".jar") &&
-          excludedSuffixes.map(!pathname.getAbsolutePath.contains(_)).forall(identity)
+          excludedSuffixes.forall(!pathname.getAbsolutePath.contains(_))
       }
     })
   }


### PR DESCRIPTION
Fix path of jars / add missing jars in spark job

remove print, reduce clutter

## Description ##
Path of jar files in tests for MXNet on Spark are incorrect. This PR fixes it.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
