### PR TITLE
Julia: enable integration test

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -922,6 +922,7 @@ unittest_ubuntu_cpu_julia() {
     export PATH="$1/bin:$PATH"
     export MXNET_HOME='/work/mxnet'
     export JULIA_DEPOT_PATH='/work/julia-depot'
+    export INTEGRATION_TEST=1
 
     julia -e 'using InteractiveUtils; versioninfo()'
 

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1014,7 +1014,7 @@ def test_unix_r_gpu() {
 def test_unix_julia07_cpu() {
     return ['Julia 0.7: CPU': {
       node(NODE_LINUX_CPU) {
-        ws('workspace/ut-julia07-cpu') {
+        ws('workspace/ut-it-julia07-cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('cpu', mx_lib)
             utils.docker_run('ubuntu_cpu', 'unittest_ubuntu_cpu_julia07', false)
@@ -1027,7 +1027,7 @@ def test_unix_julia07_cpu() {
 def test_unix_julia10_cpu() {
     return ['Julia 1.0: CPU': {
       node(NODE_LINUX_CPU) {
-        ws('workspace/ut-julia10-cpu') {
+        ws('workspace/ut-it-julia10-cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init('cpu', mx_lib)
             utils.docker_run('ubuntu_cpu', 'unittest_ubuntu_cpu_julia10', false)

--- a/julia/src/executor.jl
+++ b/julia/src/executor.jl
@@ -169,7 +169,7 @@ function simple_bind(self::SymbolicNode, ctx::Context;
     end
   end
 
-  aux_arrays = [zeros(shape, ctx) for shape in aux_shapes]
+  aux_arrays = NDArray[zeros(shape, ctx) for shape in aux_shapes]
   return bind(self, ctx, arg_arrays, args_grad=grad_arrays, grad_req=grad_req, aux_states=aux_arrays)
 end
 

--- a/julia/test/runtests.jl
+++ b/julia/test/runtests.jl
@@ -39,7 +39,7 @@ include(joinpath(@__DIR__, "common.jl"))
   test_dir(joinpath(@__DIR__, "unittest"))
 
   # run the basic MNIST mlp example
-  if haskey(ENV, "CONTINUOUS_INTEGRATION")
+  if haskey(ENV, "INTEGRATION_TEST")
     @testset "MNIST Test" begin
       include(joinpath(BASEDIR, "examples", "mnist", "mlp-test.jl"))
     end


### PR DESCRIPTION
Although the coverage of integration test is quite poor, it's better than nothing.
It runs the mnist training example via SymbolicNode API with different optimizer.