### PR TITLE
Julia: rename `mx.clip` to `clamp` for `NDArray`

### DIFF
--- a/julia/NEWS.md
+++ b/julia/NEWS.md
@@ -2,8 +2,6 @@
 
 * Following material from `mx` module got exported (#TBD):
     * `NDArray`
-        * `clip()`
-        * `clip!()`
         * `context()`
         * `expand_dims()`
         * `@inplace`
@@ -356,11 +354,12 @@
    99.9889  100.533  100.072
   ```
 
-* Signature of `clip` changed, it doesn't require any keyword argument now.
+* Signature of `clip` changed and renamed to `clamp`.
+  It doesn't require any keyword argument now.
   (#TBD)
 
   Before: `clip(x, a_min = -4, a_max = 4)`
-  After: `clip(x, -4, 4)`
+  After: `clamp(x, -4, 4)`
 
 ### Optimizer
 

--- a/julia/src/MXNet.jl
+++ b/julia/src/MXNet.jl
@@ -50,8 +50,6 @@ export SymbolicNode,
 
 # ndarray.jl
 export NDArray,
-       clip,
-       clip!,
        context,
        expand_dims,
        @inplace,

--- a/julia/src/deprecated.jl
+++ b/julia/src/deprecated.jl
@@ -72,8 +72,6 @@ end
 @deprecate softmax(x::NDArray; axis = ndims(x))     softmax.(x, axis)
 @deprecate log_softmax(x::NDArray; axis = ndims(x)) log_softmax.(x, axis)
 
-@deprecate clip(x; a_min = 0, a_max = 0) clip(x, a_min, a_max)
-
 function broadcast_plus(x::NDArray, y::NDArray)
   @warn("broadcast_plus(x, y) is deprecated, use x .+ y instead.")
   x .+ y
@@ -194,3 +192,9 @@ function empty(dims::Int...)
         "use `NDArray(undef, dims...)` instead.")
   NDArray(undef, dims...)
 end
+
+# replaced by Base.clamp
+@deprecate clip(x::NDArray, lo::Real, hi::Real)  clamp(x, lo, hi)
+@deprecate clip!(x::NDArray, lo::Real, hi::Real) clamp!(x, lo, hi)
+@deprecate clip(x; a_min = 0, a_max = 0) clamp(x, a_min, a_max)
+

--- a/julia/src/ndarray/remap.jl
+++ b/julia/src/ndarray/remap.jl
@@ -67,6 +67,18 @@ function _docsig(fname::Symbol, sig::Expr, opname::String)
   end
 end
 
+"""
+    @_remap(sig::Expr, imp::Expr)
+
+Creating a function in signature `sig` with the function implementation `imp`.
+
+## Arguments
+- `sig` is the function signature.
+  If the function name ends with `!`, it will invoke the corresponding inplace
+  call.
+- `imp` is the underlying libmxnet API call
+
+"""
 macro _remap(sig::Expr, imp::Expr)
   d = splitdef(:($sig = $imp))
   @capture d[:name] (M_.fname_|fname_)

--- a/julia/src/optimizer.jl
+++ b/julia/src/optimizer.jl
@@ -291,7 +291,7 @@ function normgrad!(opt::AbstractOptimizer, W::NDArray, ∇::NDArray)
   !iszero(s) && @inplace ∇ .*= s
   # gradient clipping
   c = opt.clip
-  c > 0 && clip!(∇, -c, c)
+  c > 0 && clamp!(∇, -c, c)
   # weight decay
   λ = opt.λ
   λ > 0 && @inplace ∇ += λ .* W

--- a/julia/test/unittest/ndarray.jl
+++ b/julia/test/unittest/ndarray.jl
@@ -885,24 +885,24 @@ function test_saveload()
   rm(fname)
 end
 
-function test_clip()
+function test_clamp()
   dims = rand_dims()
-  @info("NDArray::clip::dims = $dims")
+  @info("NDArray::clamp::dims = $dims")
 
   j_array, nd_array = rand_tensors(dims)
   clip_up   = maximum(abs.(j_array)) / 2
   clip_down = 0
-  clipped   = clip(nd_array, clip_down, clip_up)
+  clipped   = clamp(nd_array, clip_down, clip_up)
 
   # make sure the original array is not modified
   @test copy(nd_array) ≈ j_array
 
   @test all(clip_down .<= copy(clipped) .<= clip_up)
 
-  @info("NDArray::clip!")
+  @info("NDArray::clamp!")
   let
     x = NDArray(1.0:20)
-    clip!(x, 5, 15)
+    clamp!(x, 5, 15)
     @test all(5 .<= copy(x) .<= 15)
   end
 end
@@ -1571,7 +1571,7 @@ end
   test_mod()
   test_gd()
   test_saveload()
-  test_clip()
+  test_clamp()
   test_power()
   test_sqrt()
   test_eltype()


### PR DESCRIPTION
- in order to match Base interface

- depwarn for `mx.clip` included


## Checklist ##

- [x] Changes are complete
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
