### PR TITLE
Fix documentation for bilinear upsampling and add unit test

### DIFF
--- a/src/operator/nn/upsampling-inl.h
+++ b/src/operator/nn/upsampling-inl.h
@@ -59,7 +59,9 @@ struct UpSamplingParam : public dmlc::Parameter<UpSamplingParam> {
     .set_range(1, 1000)
     .describe("Up sampling scale");
     DMLC_DECLARE_FIELD(num_filter)
-    .describe("Input filter. Only used by bilinear sample_type.")
+    .describe("Input filter. Only used by bilinear sample_type."
+              "Since bilinear upsampling uses deconvolution, num_filters "
+              "is set to the number of channels.")
     .set_default(0);
     DMLC_DECLARE_FIELD(sample_type)
     .add_enum("nearest", up_enum::kNearest)

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -151,8 +151,8 @@ NNVM_REGISTER_OP(UpSampling)
 .set_attr<FCompute>("FCompute<cpu>", UpSamplingCompute<cpu>)
 .set_attr<nnvm::FGradient>("FGradient", UpSamplingGrad{"_backward_UpSampling"})
 .set_attr<std::string>("key_var_num_args", "num_args")
-.add_argument("data", "NDArray-or-Symbol[]",
-              "Array of tensors to upsample. For bilinear upsampling, there should be 2 inputs - 1 data and 1 weight.")
+.add_argument("data", "NDArray-or-Symbol[]", "Array of tensors to upsample. "
+              "For bilinear upsampling, there should be 2 inputs - 1 data and 1 weight.")
 .add_arguments(UpSamplingParam::__FIELDS__())
 .set_attr<nnvm::FSetInputVarAttrOnCompose>("FSetInputVarAttrOnCompose",
     [](const nnvm::NodeAttrs& attrs, nnvm::NodePtr var, const int index) {

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -121,7 +121,9 @@ struct UpSamplingGrad {
 DMLC_REGISTER_PARAMETER(UpSamplingParam);
 
 NNVM_REGISTER_OP(UpSampling)
-.describe("Performs nearest neighbor/bilinear up sampling to inputs.")
+.describe("Performs nearest neighbor/bilinear up sampling to inputs. "
+          "Bilinear upsampling makes use of deconvolution. Therefore, "
+          "provide 2 inputs - data and weight. ")
 .set_num_inputs([](const NodeAttrs& attrs) {
   const UpSamplingParam& params = nnvm::get<UpSamplingParam>(attrs.parsed);
   return params.sample_type == up_enum::kNearest ? params.num_args : 2;
@@ -149,7 +151,8 @@ NNVM_REGISTER_OP(UpSampling)
 .set_attr<FCompute>("FCompute<cpu>", UpSamplingCompute<cpu>)
 .set_attr<nnvm::FGradient>("FGradient", UpSamplingGrad{"_backward_UpSampling"})
 .set_attr<std::string>("key_var_num_args", "num_args")
-.add_argument("data", "NDArray-or-Symbol[]", "Array of tensors to upsample")
+.add_argument("data", "NDArray-or-Symbol[]",
+              "Array of tensors to upsample. For bilinear upsampling, there should be 2 inputs - 1 data and 1 weight.")
 .add_arguments(UpSamplingParam::__FIELDS__())
 .set_attr<nnvm::FSetInputVarAttrOnCompose>("FSetInputVarAttrOnCompose",
     [](const nnvm::NodeAttrs& attrs, nnvm::NodePtr var, const int index) {

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1506,7 +1506,9 @@ def check_bilinear_upsampling_with_shape(data_shape, weight_shape, scale, root_s
     arr = {'data': mx.random.uniform(-10.0, 10.0, data_shape, ctx=mx.cpu()).copyto(default_context()),
         'weight':  mx.nd.array(_init_bilinear(mx.ndarray.empty(weight_shape).asnumpy(), root_scale))}
 
-    up = mx.sym.UpSampling(mx.sym.Variable('data'),
+    out_grad = arr['data']
+    data = mx.sym.Variable(name="data")
+    up = mx.sym.UpSampling(data,
         mx.sym.Variable('weight'), sample_type='bilinear', scale=root_scale,
         num_filter=num_filter, num_args=2)
     arg_shapes, out_shapes, _ = up.infer_shape(data=data_shape)
@@ -1514,8 +1516,7 @@ def check_bilinear_upsampling_with_shape(data_shape, weight_shape, scale, root_s
     exe = up.bind(default_context(), args=arr, args_grad=arr_grad)
     exe.forward(is_train=True)
     out = exe.outputs[0].asnumpy()
-    exe.backward(exe.outputs)
-
+    exe.backward(out_grad)
 
 @with_seed()
 def test_nearest_upsampling():

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1530,17 +1530,19 @@ def test_nearest_upsampling():
 
 @with_seed()
 def test_bilinear_upsampling():
-    for root_scale in [2,3]:
-        for scale in [1,2,3]:
-            for num_filter in [1,2,3]:
-                for base in [1,2,3]:
-                    # bilinear upsampling takes only 1 data and 1 weight
-                    # multi input mode is not applicable
-                    dimension = base*root_scale*scale
-                    kernel = 2 * root_scale - root_scale % 2
-                    data_shape = (1, num_filter, dimension, dimension)
-                    weight_shape = (num_filter, 1, kernel, kernel)
-                    check_bilinear_upsampling_with_shape(data_shape, weight_shape, scale, root_scale, num_filter)
+    rootscale = [2,3]
+    scales = [1,2,3]
+    filters = [1,2,3]
+    bases = [1,2,3]
+    for params in itertools.product(rootscale, scales, filters, bases):
+        root_scale, scale, num_filter, base = params
+        # bilinear upsampling takes only 1 data and 1 weight
+        # multi input mode is not applicable
+        dimension = base*root_scale*scale
+        kernel = 2 * root_scale - root_scale % 2
+        data_shape = (1, num_filter, dimension, dimension)
+        weight_shape = (1, num_filter, kernel, kernel)
+        check_bilinear_upsampling_with_shape(data_shape, weight_shape, scale, root_scale, num_filter)
 
 @with_seed()
 def test_batchnorm_training():


### PR DESCRIPTION
## Description ##
Fixes https://github.com/apache/incubator-mxnet/issues/13078

Future work/alternate approaches:
1. Initialize weight in the backend, so that the user doesn't have to give weights as input.
2. Change backend to call contrib.BilinearResize2D


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Additional documentation
- test

## Comments ##
Ref:
https://github.com/apache/incubator-mxnet/issues/9138
https://stackoverflow.com/questions/47897924/implementing-bilinear-interpolation-with-mxnet-ndarray-upsampling
https://github.com/apache/incubator-mxnet/issues/12970
https://github.com/apache/incubator-mxnet/pull/12983
https://github.com/apache/incubator-mxnet/issues/1412
https://discuss.mxnet.io/t/use-mx-nd-upsampling-with-bilinear-sample-type/2067/2
