### PR TITLE
[MXNET-891] Support tuple of scales in upsample operator

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2059,6 +2059,11 @@ def convert_upsample(node, **kwargs):
     sample_type = attrs.get('sample_type', 'nearest')
     sample_type = 'linear' if sample_type == 'bilinear' else sample_type
     scale = convert_string_to_list(attrs.get('scale'))
+    scaleh = scalew = float(scale[0])
+    if len(scale) > 1:
+        scaleh = float(scale[0])
+        scalew = float(scale[1])
+    scale = [1.0, 1.0, scaleh, scalew]
 
     node = onnx.helper.make_node(
         'Upsample',

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -2047,3 +2047,25 @@ def convert_broadcast_to(node, **kwargs):
     )
 
     return [tensor_node, expand_node]
+
+
+@mx_op.register("UpSampling")
+def convert_upsample(node, **kwargs):
+    """Map MXNet's UpSampling operator attributes to onnx's Upsample operator
+    and return the created node.
+    """
+    name, input_nodes, attrs = get_inputs(node, kwargs)
+
+    sample_type = attrs.get('sample_type', 'nearest')
+    sample_type = 'linear' if sample_type == 'bilinear' else sample_type
+    scale = convert_string_to_list(attrs.get('scale'))
+
+    node = onnx.helper.make_node(
+        'Upsample',
+        input_nodes,
+        [name],
+        scales=scale,
+        mode=sample_type,
+        name=name
+    )
+    return [node]

--- a/python/mxnet/contrib/onnx/onnx2mx/_import_helper.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_import_helper.py
@@ -23,7 +23,7 @@ from ._op_translations import add, subtract, multiply, divide, absolute, negativ
 from ._op_translations import tanh, arccos, arcsin, arctan, _cos, _sin, _tan
 from ._op_translations import softplus, shape, gather, lp_pooling, size
 from ._op_translations import ceil, floor, hardsigmoid, global_lppooling
-from ._op_translations import concat, hardmax
+from ._op_translations import concat, hardmax, upsampling
 from ._op_translations import leaky_relu, _elu, _prelu, _selu, softmax, fully_connected
 from ._op_translations import global_avgpooling, global_maxpooling, linalg_gemm
 from ._op_translations import sigmoid, pad, relu, matrix_multiplication, batch_norm
@@ -147,5 +147,6 @@ _convert_map = {
     'DepthToSpace'      : depthtospace,
     'SpaceToDepth'      : spacetodepth,
     'Hardmax'           : hardmax,
-    'LpNormalization'   : lpnormalization
+    'LpNormalization'   : lpnormalization,
+    'UpSampling'        : upsampling
 }

--- a/python/mxnet/contrib/onnx/onnx2mx/_import_helper.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_import_helper.py
@@ -148,5 +148,5 @@ _convert_map = {
     'SpaceToDepth'      : spacetodepth,
     'Hardmax'           : hardmax,
     'LpNormalization'   : lpnormalization,
-    'UpSampling'        : upsampling
+    'Upsample'          : upsampling
 }

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -777,3 +777,14 @@ def lpnormalization(attrs, inputs, proto_obj):
     axis = int(attrs.get("axis", -1))
     new_attrs.update(axis=axis)
     return 'norm', new_attrs, inputs
+
+
+def upsampling(attrs, inputs, proto_obj):
+    """Rearranges blocks of spatial data into depth."""
+    new_attrs = translation_utils._fix_attribute_names(attrs, {'scales':'scale',
+                                                               'mode':'sample_type'})
+    sample_type = new_attrs.get('sample_type', 'nearest')
+    if sample_type == 'linear':
+        new_attrs.update(sample_type=sample_type)
+
+    return "UpSampling", new_attrs, inputs

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -781,10 +781,20 @@ def lpnormalization(attrs, inputs, proto_obj):
 
 def upsampling(attrs, inputs, proto_obj):
     """Rearranges blocks of spatial data into depth."""
-    new_attrs = translation_utils._fix_attribute_names(attrs, {'scales':'scale',
-                                                               'mode':'sample_type'})
+    new_attrs = translation_utils._fix_attribute_names(attrs, {'scales': 'scale',
+                                                               'mode': 'sample_type'})
     sample_type = new_attrs.get('sample_type', 'nearest')
-    if sample_type == 'linear':
-        new_attrs.update(sample_type=sample_type)
+    if sample_type != 'nearest':
+        raise NotImplementedError("Operator {} in ONNX supports 'linear' mode "
+                                  "for linear, bilinear, trilinear etc. There is no "
+                                  "way to distinguish these so far. Therefore, supporting "
+                                  "import of only nearest neighbor upsampling for now. "
+                                  "https://github.com/onnx/onnx/issues/1774. "
+                                  "Use contrib.BilinearResize2D for bilinear mode."
+                                  .format('UpSample'))
 
-    return "UpSampling", new_attrs, inputs
+    scale = tuple(new_attrs.get('scale'))[2:]
+    scale = tuple([int(s) for s in scale])
+    mx_op = symbol.UpSampling(inputs[0], scale=scale, sample_type=sample_type)
+
+    return mx_op, new_attrs, inputs

--- a/src/operator/nn/upsampling-inl.h
+++ b/src/operator/nn/upsampling-inl.h
@@ -120,7 +120,6 @@ void SpatialUpSamplingNearestUpdateOutput(mshadow::Stream<cpu> *s,
   int iout[4];  // Output indices
   int iin[4];  // Input indices
 
-  channels = nbatch * channels;
   for (i0 = 0; i0 < osz0; i0++) {
     iout[0] = i0;
     iin[0] = i0;
@@ -138,8 +137,8 @@ void SpatialUpSamplingNearestUpdateOutput(mshadow::Stream<cpu> *s,
           iin[xDim] = iout[xDim] / dW;
           iin[yDim] = iout[yDim] / dH;
 
-          idst = /*i0*otensor.stride_ + i1*otensor.stride_ +*/ i2;//*otensor.stride_;
-          isrc = /*iin[0]*itensor.stride_ + iin[1]*itensor.stride_ +*/ iin[2];//*itensor.stride_;
+          idst = i0*(channels*outputHeight*outputWidth) + i1*(outputHeight*outputWidth) + i2;//*otensor.stride_;
+          isrc = iin[0]*(channels*inputHeight*inputWidth) + iin[1]*(inputHeight*inputWidth) + iin[2];//*itensor.stride_;
           if (idim > 3) {
             idst += i3*otensor.stride_;
             isrc += iin[3]*itensor.stride_;

--- a/src/operator/nn/upsampling-inl.h
+++ b/src/operator/nn/upsampling-inl.h
@@ -67,11 +67,6 @@ struct UpSamplingParam : public dmlc::Parameter<UpSamplingParam> {
     .add_enum("nearest", up_enum::kNearest)
     .add_enum("bilinear", up_enum::kBilinear)
     .describe("upsampling method");
-    DMLC_DECLARE_FIELD(num_args).set_default(1)
-    .describe("Number of inputs to be upsampled. For nearest neighbor "
-    "upsampling, this can be 1-N; the size of output will be"
-    "(scale*h_0,scale*w_0) and all other inputs will be upsampled to the"
-    "same size. For bilinear upsampling this must be 2; 1 input and 1 weight.");
     DMLC_DECLARE_FIELD(multi_input_mode)
     .add_enum("concat", up_enum::kConcat)
     .add_enum("sum", up_enum::kSum)
@@ -79,6 +74,11 @@ struct UpSamplingParam : public dmlc::Parameter<UpSamplingParam> {
     .describe("How to handle multiple input. concat means concatenate upsampled "
     "images along the channel dimension. sum means add all images together, "
     "only available for nearest neighbor upsampling.");
+    DMLC_DECLARE_FIELD(num_args).set_lower_bound(1)
+    .describe("Number of inputs to be upsampled. For nearest neighbor "
+    "upsampling, this can be 1-N; the size of output will be"
+    "(scale*h_0,scale*w_0) and all other inputs will be upsampled to the"
+    "same size. For bilinear upsampling this must be 2; 1 input and 1 weight.");
     DMLC_DECLARE_FIELD(workspace).set_default(512).set_range(0, 8192)
     .describe("Tmp workspace for deconvolution (MB)");
   }

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -56,10 +56,10 @@ static bool UpSamplingShape(const nnvm::NodeAttrs& attrs,
       CHECK_EQ(shape.ndim(), 4U) << \
         "UpSamplingNearest: Input data should be 4D in (batch, channel, y, x)";
       int oh = dshape[2]*scale_h, ow = dshape[3]*scale_w;
-      // CHECK_EQ(oh%shape[2], 0U) << "UpSamplingNearest: input height of " << shape[2] << \
-      //   "does not divide output height of " << oh;
-      // CHECK_EQ(ow%shape[3], 0U) << "UpSamplingNearest: input width of " << shape[3] << \
-      //   "does not divide output width of " << ow;
+      CHECK_EQ(oh%shape[2], 0U) << "UpSamplingNearest: input height of " << shape[2] << \
+        "does not divide output height of " << oh;
+      CHECK_EQ(ow%shape[3], 0U) << "UpSamplingNearest: input width of " << shape[3] << \
+        "does not divide output width of " << ow;
       if (param_.multi_input_mode == up_enum::kSum) {
         CHECK(oshape[1] == 0 || oshape[1] == shape[1]) << \
                          "Number of channels must be the same when multi_input_mode==sum";

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -56,10 +56,10 @@ static bool UpSamplingShape(const nnvm::NodeAttrs& attrs,
       CHECK_EQ(shape.ndim(), 4U) << \
         "UpSamplingNearest: Input data should be 4D in (batch, channel, y, x)";
       int oh = dshape[2]*scale_h, ow = dshape[3]*scale_w;
-      CHECK_EQ(oh%shape[2], 0U) << "UpSamplingNearest: input height of " << shape[2] << \
-        "does not divide output height of " << oh;
-      CHECK_EQ(ow%shape[3], 0U) << "UpSamplingNearest: input width of " << shape[3] << \
-        "does not divide output width of " << ow;
+      // CHECK_EQ(oh%shape[2], 0U) << "UpSamplingNearest: input height of " << shape[2] << \
+      //   "does not divide output height of " << oh;
+      // CHECK_EQ(ow%shape[3], 0U) << "UpSamplingNearest: input width of " << shape[3] << \
+      //   "does not divide output width of " << ow;
       if (param_.multi_input_mode == up_enum::kSum) {
         CHECK(oshape[1] == 0 || oshape[1] == shape[1]) << \
                          "Number of channels must be the same when multi_input_mode==sum";
@@ -75,14 +75,14 @@ static bool UpSamplingShape(const nnvm::NodeAttrs& attrs,
     CHECK_EQ(dshape.ndim(), 4U) << \
       "UpSamplingBilinear: Input data should be 4D in (batch, channel, y, x)";
     if (dshape.ndim() ==  0) return false;
-    int kernel = 2 * scale_h - scale_h % 2;
+    int kernel = static_cast<int>(2.0 * scale_h - ::fmod(scale_h, 2));
     SHAPE_ASSIGN_CHECK(*in_shape,
         up_enum::kWeight,
         mshadow::Shape4(dshape[1], 1, kernel, kernel));
     oshape = dshape;
   }
   oshape[2] = dshape[2] * scale_h;
-  oshape[3] = dshape[3] * scale_h;
+  oshape[3] = dshape[3] * scale_w;
   out_shape->clear();
   out_shape->push_back(oshape);
   return true;

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -37,13 +37,25 @@ static bool UpSamplingShape(const nnvm::NodeAttrs& attrs,
   CHECK_GE(in_shape->size(), 1U);
   const TShape &dshape = (*in_shape)[0];
   TShape oshape = dshape;
+  int scale_h = 1;
+  int scale_w = 1;
+  if (param_.scale.ndim() == 1) {
+    scale_h = param_.scale[0];
+    scale_w = param_.scale[0];
+  } else if (param_.scale.ndim() == 2) {
+    scale_h = param_.scale[0];
+    scale_w = param_.scale[1];
+  } else if (param_.scale.ndim() == 4) {
+    scale_h = param_.scale[2];
+    scale_w = param_.scale[3];
+  }
   if (param_.sample_type == up_enum::kNearest) {
     CHECK_EQ(in_shape->size(), static_cast<size_t>(param_.num_args));
     oshape[1] = 0;
     for (auto& shape : *in_shape) {
       CHECK_EQ(shape.ndim(), 4U) << \
         "UpSamplingNearest: Input data should be 4D in (batch, channel, y, x)";
-      int oh = dshape[2]*param_.scale, ow = dshape[3]*param_.scale;
+      int oh = dshape[2]*scale_h, ow = dshape[3]*scale_w;
       CHECK_EQ(oh%shape[2], 0U) << "UpSamplingNearest: input height of " << shape[2] << \
         "does not divide output height of " << oh;
       CHECK_EQ(ow%shape[3], 0U) << "UpSamplingNearest: input width of " << shape[3] << \
@@ -58,17 +70,19 @@ static bool UpSamplingShape(const nnvm::NodeAttrs& attrs,
     }
   } else {
     CHECK_EQ(in_shape->size(), 2U) << "Input:[data, weight]";
+    CHECK_EQ(scale_h, scale_w) <<
+    "UpSamplingBilinear: Scale should be the same along all dimensions for bilinear upsampling";
     CHECK_EQ(dshape.ndim(), 4U) << \
       "UpSamplingBilinear: Input data should be 4D in (batch, channel, y, x)";
     if (dshape.ndim() ==  0) return false;
-    int kernel = 2 * param_.scale - param_.scale % 2;
+    int kernel = 2 * scale_h - scale_h % 2;
     SHAPE_ASSIGN_CHECK(*in_shape,
         up_enum::kWeight,
         mshadow::Shape4(dshape[1], 1, kernel, kernel));
     oshape = dshape;
   }
-  oshape[2] = dshape[2] * param_.scale;
-  oshape[3] = dshape[3] * param_.scale;
+  oshape[2] = dshape[2] * scale_h;
+  oshape[3] = dshape[3] * scale_h;
   out_shape->clear();
   out_shape->push_back(oshape);
   return true;

--- a/tests/python-pytest/onnx/test_cases.py
+++ b/tests/python-pytest/onnx/test_cases.py
@@ -78,7 +78,8 @@ IMPLEMENTED_OPERATORS_TEST = {
              'test_max_',
              'test_softplus',
              'test_reduce_',
-             'test_split_equal'
+             'test_split_equal',
+             'test_upsample_n'
              ],
     'import': ['test_gather',
                'test_softsign',

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1506,6 +1506,7 @@ def check_nearest_upsampling_with_shape(shapes, scale, root_scale):
     up = mx.sym.UpSampling(*[mx.sym.Variable('arg_%d'%i) for i in range(len(shapes))], sample_type='nearest', scale=root_scale)
     exe = up.bind(default_context(), args=arr, args_grad=arr_grad)
     exe.forward(is_train=True)
+    out = exe.outputs[0].asnumpy()
     exe.backward(exe.outputs)
     for k in range(len(shapes)):
         name = 'arg_%d'%k

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1522,7 +1522,7 @@ def check_bilinear_upsampling_with_shape(shapes, scale, root_scale):
     exe.backward(exe.outputs)
     for k in range(len(shapes)):
         name = 'arg_%d'%k
-        # assert_allclose(arr[name].asnumpy()*root_scale**2*scale**(2*k), arr_grad[name].asnumpy(), rtol=1e-4)
+        assert_allclose(arr[name].asnumpy()*root_scale**2*scale**(2*k), arr_grad[name].asnumpy(), rtol=1e-4)
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
This PR adds the option to specify different scales for different dimensions.
Ref: https://github.com/apache/incubator-mxnet/issues/12602

Fixes https://github.com/apache/incubator-mxnet/issues/12851

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Change scale to tuple
- Add custom nearest neighbor implementation
- Allow same scales for bilinear upsampling
- Add ONNX import/export for Upsampling operator

## Comments ##
- Fix for bilinear upsampling documentation and test are at https://github.com/apache/incubator-mxnet/pull/14035