### PR TITLE
Fix performance regression in normalize operator

### DIFF
--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -218,11 +218,11 @@ template<int req>
 struct normalize_forward {
     template<typename DType>
     MSHADOW_XINLINE static void Map(uint32_t c, DType* out_data, const DType* in_data,
-                                    const NormalizeParam &param, const int length, 
+                                    const NormalizeParam &param, const int length,
                                     const int step) {
         DType mean = param.mean[param.mean.ndim() > c ? c : 0];
         DType std_dev = param.std[param.std.ndim() > c ? c : 0];
-        
+
         #pragma omp parallel for
         for (int i = 0; i < length; ++i) {
           KERNEL_ASSIGN(out_data[step + c*length + i], req,

--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -220,8 +220,20 @@ struct normalize_forward {
     MSHADOW_XINLINE static void Map(uint32_t c, DType* out_data, const DType* in_data,
                                     const NormalizeParam &param, const int length,
                                     const int step) {
-        DType mean = param.mean[param.mean.ndim() > c ? c : 0];
-        DType std_dev = param.std[param.std.ndim() > c ? c : 0];
+        int mean_idx, std_idx;
+        if (param.mean.ndim() > c) {
+          mean_idx = c;
+        } else {
+          mean_idx = 0;
+        }
+
+        if (param.std.ndim() > c) {
+          std_idx = c;
+        } else {
+          std_idx = 0;
+        }
+        DType mean = param.mean[mean_idx];
+        DType std_dev = param.std[std_idx];
 
         #pragma omp parallel for
         for (int i = 0; i < length; ++i) {

--- a/tests/python/gpu/test_gluon_transforms.py
+++ b/tests/python/gpu/test_gluon_transforms.py
@@ -80,32 +80,15 @@ def test_to_tensor():
         data_in.astype(dtype=np.float32) / 255.0, (2, 0, 1)))
 
     # 4D Input
-    data_in_4d = nd.random.uniform(0, 1, (2, 3, 300, 300))
-    out_nd_4d = transforms.Normalize(mean=(0, 1, 2), std=(3, 2, 1))(data_in_4d)
-    data_expected_4d = data_in_4d.asnumpy()
-    data_expected_4d[0][:][:][0] = data_expected_4d[0][:][:][0] / 3.0
-    data_expected_4d[0][:][:][1] = (data_expected_4d[0][:][:][1] - 1.0) / 2.0
-    data_expected_4d[0][:][:][2] = data_expected_4d[0][:][:][2] - 2.0
-    data_expected_4d[1][:][:][0] = data_expected_4d[1][:][:][0] / 3.0
-    data_expected_4d[1][:][:][1] = (data_expected_4d[1][:][:][1] - 1.0) / 2.0
-    data_expected_4d[1][:][:][2] = data_expected_4d[1][:][:][2] - 2.0
-    assert_almost_equal(data_expected_4d, out_nd_4d.asnumpy())
+    data_in = np.random.uniform(0, 255, (5, 300, 300, 3)).astype(dtype=np.uint8)
+    out_nd = transforms.ToTensor()(nd.array(data_in, dtype='uint8'))
+    assert_almost_equal(out_nd.asnumpy(), np.transpose(
+                        data_in.astype(dtype=np.float32) / 255.0, (0, 3, 1, 2)))
 
-    # Default normalize values i.e., mean=0, std=1
-    data_in_3d_def = nd.random.uniform(0, 1, (3, 300, 300))
-    out_nd_3d_def = transforms.Normalize()(data_in_3d_def)
-    data_expected_3d_def = data_in_3d_def.asnumpy()
-    assert_almost_equal(data_expected_3d_def, out_nd_3d_def.asnumpy())
-
-    # Invalid Input - Neither 3D or 4D input
-    invalid_data_in = nd.random.uniform(0, 1, (5, 5, 3, 300, 300))
-    normalize_transformer = transforms.Normalize(mean=(0, 1, 2), std=(3, 2, 1))
-    assertRaises(MXNetError, normalize_transformer, invalid_data_in)
-
-    # Invalid Input - Channel neither 1 or 3
-    invalid_data_in = nd.random.uniform(0, 1, (5, 4, 300, 300))
-    normalize_transformer = transforms.Normalize(mean=(0, 1, 2), std=(3, 2, 1))
-    assertRaises(MXNetError, normalize_transformer, invalid_data_in)
+    # Invalid Input
+    invalid_data_in = nd.random.uniform(0, 255, (5, 5, 300, 300, 3)).astype(dtype=np.uint8)
+    transformer = transforms.ToTensor()
+    assertRaises(MXNetError, transformer, invalid_data_in)
 
 @with_seed()
 def test_resize():


### PR DESCRIPTION
## Description ##
1. In PR #13802 we added additional support for normalize operator and also re-organized with kernel launch/map functionality.
2. However, PR #13802 introduced performance regression.
3. In this PR, I fix the performance issue and bring it close to the original performance.
4. Earlier, I was parallelizing kernel launch based on length (h*w) and hence, there was a significant overhead compared to simple operation being performance in the kernel (x-mean/std)
5. Main changes in this PR includes - Parallelizing kernel launch based on number of channels rather than length, using omp parallel in the kernel. 

## Before regressing PR #13802 
Total time for 50000 images of shape (3,300,300) to do normalization - 67.39s
Total time for 100000  images of shape (3,300,300) to do normalization - 134.72s

## After regressing PR #13802
Total time for 50000 images of shape (3,300,300) to do normalization - 104.09s
Total time for 100000  images of shape (3,300,300) to do normalization - 203.78s

## With changes in this PR
Total time for 50000 images of shape (3,300,300) to do normalization - 68.54s
Total time for 100000  images of shape (3,300,300) to do normalization - 136.12s


**NOTE** I have a revert PR #14054 , just in case, this PR gets delayed to be merged.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.

- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [X] Code is well-documented: 
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Parallelize kernel launch in normalize operator based on channel.

@nswamy @zhreshold @stu1130 
