### PR TITLE
add backgroud class in box_nms

### DIFF
--- a/src/operator/contrib/bounding_box-common.h
+++ b/src/operator/contrib/bounding_box-common.h
@@ -114,12 +114,32 @@ struct nms_impl {
 
 namespace mshadow_op {
 struct less_than : public mxnet_op::tunable {
-  // a is x, b is sigma
   template<typename DType>
   MSHADOW_XINLINE static DType Map(DType a, DType b) {
     return static_cast<DType>(a < b);
   }
-};  // struct equal_to
+};
+
+struct greater_than : public mxnet_op::tunable {
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return static_cast<DType>(a > b);
+  }
+};
+
+struct not_equal : public mxnet_op::tunable {
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return static_cast<DType>(a != b);
+  }
+};
+
+struct bool_and : public mxnet_op::tunable {
+  template<typename DType>
+  MSHADOW_XINLINE static DType Map(DType a, DType b) {
+    return static_cast<DType>(a && b);
+  }
+};
 }   // namespace mshadow_op
 
 }  // namespace op

--- a/src/operator/contrib/bounding_box.cc
+++ b/src/operator/contrib/bounding_box.cc
@@ -62,7 +62,7 @@ additional elements are allowed.
   we will skip highly overlapped boxes if one is `apple` while the other is `car`.
 
 - `background_id`: optional, default=-1, class id for background boxes, useful
-  when `id_index >= 0`， which means boxes with background id will be filtered before nms.
+  when `id_index >= 0` which means boxes with background id will be filtered before nms.
 
 - `coord_start`: required, default=2, the starting index of the 4 coordinates.
   Two formats are supported:

--- a/src/operator/contrib/bounding_box.cc
+++ b/src/operator/contrib/bounding_box.cc
@@ -38,8 +38,9 @@ NNVM_REGISTER_OP(_contrib_box_nms)
 .describe(R"code(Apply non-maximum suppression to input.
 
 The output will be sorted in descending order according to `score`. Boxes with
-overlaps larger than `overlap_thresh` and smaller scores will be removed and
-filled with -1, the corresponding position will be recorded for backward propogation.
+overlaps larger than `overlap_thresh`, smaller scores and background boxes
+will be removed and filled with -1, the corresponding position will be recorded
+for backward propogation.
 
 During back-propagation, the gradient will be copied to the original
 position according to the input index. For positions that have been suppressed,
@@ -59,6 +60,9 @@ additional elements are allowed.
 
 - `id_index`: optional, use -1 to ignore, useful if `force_suppress=False`, which means
   we will skip highly overlapped boxes if one is `apple` while the other is `car`.
+
+- `background_id`: optional, default=-1, class id for background boxes, useful
+  when `id_index >= 0`， which means boxes with background id will be filtered before nms.
 
 - `coord_start`: required, default=2, the starting index of the 4 coordinates.
   Two formats are supported:


### PR DESCRIPTION
## Description ##
This PR is mentioned in #14057 

What I have done in box_nms operator:
1. add background_id argument
2. filter out background boxes before sorting operation

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
