### PR TITLE
Exclude concat layer  for gpu quantization

### DIFF
--- a/example/quantization/imagenet_gen_qsym.py
+++ b/example/quantization/imagenet_gen_qsym.py
@@ -155,6 +155,16 @@ if __name__ == '__main__':
         if args.ctx == 'gpu':
             calib_layer = lambda name: name.endswith('_output') and (name.find('conv') != -1
                                                                      or name.find('fc') != -1)
+            excluded_sym_names += ['ch_concat_3a_chconcat',
+                                   'ch_concat_3b_chconcat',
+                                   'ch_concat_3c_chconcat',
+                                   'ch_concat_4a_chconcat',
+                                   'ch_concat_4b_chconcat',
+                                   'ch_concat_4c_chconcat',
+                                   'ch_concat_4d_chconcat',
+                                   'ch_concat_4e_chconcat',
+                                   'ch_concat_5a_chconcat',
+                                   'ch_concat_5b_chconcat']
         else:
             calib_layer = lambda name: name.endswith('_output') and (name.find('conv') != -1)
             excluded_sym_names += ['flatten', 'fc1']

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -593,8 +593,7 @@ def test_quantize_model_with_forward():
             excluded_names = []
             if mx.current_context() == mx.cpu():
                excluded_names += ['fc']
-            else:
-               excluded_names += ['concat']
+            excluded_names += ['concat']
 
             optional_names = ['pool0']
             for skip_optional_names in [False, True]:

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -593,7 +593,8 @@ def test_quantize_model_with_forward():
             excluded_names = []
             if mx.current_context() == mx.cpu():
                excluded_names += ['fc']
-            excluded_names += ['concat']
+            else:
+               excluded_names += ['concat']
 
             optional_names = ['pool0']
             for skip_optional_names in [False, True]:


### PR DESCRIPTION
## Description ##
Exclude concat layer for gpu quantization since #13297 enable quantizaed_concat op for cpu.
below is the error log before this fix:
```
python imagenet_inference.py --symbol-file=./model/imagenet1k-inception-bn-quantized-5batches-naive-symbol.json --param-file=./model/imagenet1k-inception-bn-quantized-0000.params --rgb-mean=123.68,116.779,103.939 --num-skipped-batches=50 --num-inference-batches=500 --dataset=./data/val_256_q90.rec
INFO:logger:batch size = 32 for inference
INFO:logger:rgb_mean = 123.68,116.779,103.939
INFO:logger:rgb_std = 1,1,1
INFO:logger:label_name = softmax_label
INFO:logger:Input data shape = (3, 224, 224)
INFO:logger:Dataset for inference: ./data/val_256_q90.rec
[10:15:59] src/io/iter_image_recordio_2.cc:172: ImageRecordIOParser2: ./data/val_256_q90.rec, use 39 threads for decoding..
INFO:logger:Skipping the first 50 batches
INFO:logger:Running model ./model/imagenet1k-inception-bn-quantized-5batches-naive-symbol.json for inference
[10:16:04] src/executor/attach_op_execs_pass.cc:351: Neither FCompute nor FComputeEx registered _contrib_quantized_concat
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
