### PR TITLE
Fix website scala doc

### DIFF
--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -106,7 +106,7 @@ def build_r_docs(app):
 
 def build_scala(app):
     """build scala for scala docs, java docs, and clojure docs to use"""
-    if any(v in _BUILD_VER for v in ['1.2.', '1.3.', '1.4.']) in _BUILD_VER:
+    if any(v in _BUILD_VER for v in ['1.2.', '1.3.', '1.4.']):
         _run_cmd("cd %s/.. && make scalapkg" % app.builder.srcdir)
         _run_cmd("cd %s/.. && make scalainstall" % app.builder.srcdir)
     else:
@@ -123,7 +123,7 @@ def build_scala_docs(app):
         '`find infer -name "*.jar" | tr "\\n" ":" `'
     ])
     # There are unresolvable errors on mxnet 1.2.x. We are ignoring those errors while aborting the ci on newer versions
-    scala_ignore_errors = '; exit 0' if any(v in _BUILD_VER for v in ['1.2.', '1.3.']) in _BUILD_VER else ''
+    scala_ignore_errors = '; exit 0' if any(v in _BUILD_VER for v in ['1.2.', '1.3.']) else ''
     _run_cmd('cd {}; scaladoc `{}` -classpath {} -feature -deprecation {}'
              .format(scala_path, scala_doc_sources, scala_doc_classpath, scala_ignore_errors))
     dest_path = app.builder.outdir + '/api/scala/docs'

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -106,7 +106,11 @@ def build_r_docs(app):
 
 def build_scala(app):
     """build scala for scala docs, java docs, and clojure docs to use"""
-    _run_cmd("cd %s/../scala-package && mvn -B install -DskipTests" % app.builder.srcdir)
+    if any(v in _BUILD_VER for v in ['1.2.', '1.3.', '1.4.']) in _BUILD_VER:
+        _run_cmd("cd %s/.. && make scalapkg" % app.builder.srcdir)
+        _run_cmd("cd %s/.. && make scalainstall" % app.builder.srcdir)
+    else:
+        _run_cmd("cd %s/../scala-package && mvn -B install -DskipTests" % app.builder.srcdir)
 
 def build_scala_docs(app):
     """build scala doc and then move the outdir"""
@@ -119,7 +123,7 @@ def build_scala_docs(app):
         '`find infer -name "*.jar" | tr "\\n" ":" `'
     ])
     # There are unresolvable errors on mxnet 1.2.x. We are ignoring those errors while aborting the ci on newer versions
-    scala_ignore_errors = '; exit 0' if '1.2.' or '1.3.' in _BUILD_VER else ''
+    scala_ignore_errors = '; exit 0' if any(v in _BUILD_VER for v in ['1.2.', '1.3.']) in _BUILD_VER else ''
     _run_cmd('cd {}; scaladoc `{}` -classpath {} -feature -deprecation {}'
              .format(scala_path, scala_doc_sources, scala_doc_classpath, scala_ignore_errors))
     dest_path = app.builder.outdir + '/api/scala/docs'


### PR DESCRIPTION
## Description ##
Fix for Scala doc building on website for older versions

I tested this with `./build_all_version.sh "mxdoc;v1.3.x;v1.2.0;v1.1.0;v1.0.0;v0.12.0;v0.11.0" "mxdoc;1.3.1;1.2.1;1.1.0;1.0.0;0.12.1;0.11.0" https://github.com/zachgk/incubator-mxnet.git`

@aaronmarkham @lanking520 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change