### PR TITLE
R-Package Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -607,11 +607,7 @@ rpkg:
 	fi
 
 	mkdir -p R-package/inst/include
-	cp -rf include/* R-package/inst/include
-	rm R-package/inst/include/dmlc
-	rm R-package/inst/include/nnvm
-	cp -rf 3rdparty/dmlc-core/include/* R-package/inst/include/
-	cp -rf 3rdparty/tvm/nnvm/include/* R-package/inst/include
+	cp -rl include/* R-package/inst/include
 	Rscript -e "if(!require(devtools)){install.packages('devtools', repo = 'https://cloud.r-project.org/')}"
 	Rscript -e "if(!require(roxygen2)||packageVersion('roxygen2') < '6.1.1'){install.packages('roxygen2', repo = 'https://cloud.r-project.org/')}"
 	Rscript -e "library(devtools); library(methods); options(repos=c(CRAN='https://cloud.r-project.org/')); install_deps(pkg='R-package', dependencies = TRUE)"

--- a/Makefile
+++ b/Makefile
@@ -616,7 +616,7 @@ rpkg:
 	R CMD INSTALL R-package
 	Rscript -e "require(mxnet); mxnet:::mxnet.export('R-package'); warnings()"
 	rm R-package/NAMESPACE
-	Rscript -e "devtools::document('R-package'); warnings()"
+	Rscript -e "devtools::document('R-package');warnings()"
 	R CMD INSTALL R-package
 
 rpkgtest:


### PR DESCRIPTION
Adapt the rpkg Makefile for 3rdparties symlink. 
Performs the copy of the actual files in the R-package installations directory rather than the symlink. 