### PR TITLE
Add libhdf5-dev to ubuntu_core.sh

### DIFF
--- a/ci/docker/install/ubuntu_core.sh
+++ b/ci/docker/install/ubuntu_core.sh
@@ -35,6 +35,7 @@ apt-get install -y \
     libatlas-base-dev \
     libcurl4-openssl-dev \
     libjemalloc-dev \
+    libhdf5-dev \
     liblapack-dev \
     libopenblas-dev \
     libopencv-dev \


### PR DESCRIPTION
## Description ## 
Package `libhdf5-dev` contains header files needed to build and install `h5py` python package, which is installed by `ubuntu_python.sh` script using pip.

Without `libhdf5-dev` the installation of `h5py` failed with 
```
sudo pip install h5py==2.8.0rc1
...
    In file included from /tmp/pip-install-3klha2xv/h5py/h5py/defs.c:657:0:                                                                                                     
    /tmp/pip-install-3klha2xv/h5py/h5py/api_compat.h:27:18: fatal error: hdf5.h: No such file or directory                                                                      
     #include "hdf5.h" 
```