### PR TITLE
Relaxing type requirements for slice_like op

### DIFF
--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -667,7 +667,7 @@ Example::
     CHECK_EQ(in_attrs->size(), 2) << " in operator " << attrs.name;
     std::vector<int> checked_in_attrs = { (*in_attrs)[0] };
     bool ret = !type_is_none((*in_attrs)[1]) &&
-               ElemwiseType<1,1>(attrs, &checked_in_attrs, out_attrs);
+               ElemwiseType<1, 1>(attrs, &checked_in_attrs, out_attrs);
     (*in_attrs)[0] = checked_in_attrs[0];
     return ret;
   })

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -661,7 +661,16 @@ Example::
     return std::vector<std::string>{"data", "shape_like"};
   })
 .set_attr<nnvm::FInferShape>("FInferShape", SliceLikeShape)
-.set_attr<nnvm::FInferType>("FInferType", ElemwiseType<2, 1>)
+.set_attr<nnvm::FInferType>("FInferType", [](const nnvm::NodeAttrs& attrs,
+                                             std::vector<int> *in_attrs,
+                                             std::vector<int> *out_attrs) {
+    CHECK_EQ(in_attrs->size(), 2) << " in operator " << attrs.name;
+    std::vector<int> checked_in_attrs = { (*in_attrs)[0] };
+    bool ret = !type_is_none((*in_attrs)[1]) &&
+               ElemwiseType<1,1>(attrs, &checked_in_attrs, out_attrs);
+    (*in_attrs)[0] = checked_in_attrs[0];
+    return ret;
+  })
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_slice_like"})
 .set_attr<FCompute>("FCompute<cpu>", SliceLikeForward<cpu>)
 .add_argument("data", "NDArray-or-Symbol", "Source input")

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2516,6 +2516,20 @@ def test_slice_like():
             assert_allclose(xgrad1.asnumpy(), mx.nd.zeros_like(xgrad1).asnumpy())
 
 @with_seed()
+def test_slice_like_different_types():
+    x = [[  1.,   2.,   3.,   4.],
+         [  5.,   6.,   7.,   8.],
+         [  9.,  10.,  11.,  12.]]
+
+    y = [[  0.,   0.,   0.],
+         [  0.,   0.,   0.]]
+
+    x = mx.nd.array(x)
+    y = mx.nd.array(y).astype('int32')
+    z = mx.nd.slice_like(x, y).asnumpy()
+    assert_allclose(z.asnumpy(), [[1,2,3],[5,6,7]])
+
+@with_seed()
 def test_flip():
     for ndim in range(1, 6):
         for t in range(5):

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2526,7 +2526,7 @@ def test_slice_like_different_types():
 
     x = mx.nd.array(x)
     y = mx.nd.array(y).astype('int32')
-    z = mx.nd.slice_like(x, y).asnumpy()
+    z = mx.nd.slice_like(x, y)
     assert_allclose(z.asnumpy(), [[1,2,3],[5,6,7]])
 
 @with_seed()


### PR DESCRIPTION
## Description ##
Currently the type of the second argument in `slice_like` op (`shape_from` ) needs to be the same as the first argument, even though only its (second argument's) shape is used. This PR relaxes that so `slice_like` accepts any type for the `shape_from` argument.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

