### PR TITLE
Performance improvement in ToTensor GPU Kernel

### DIFF
--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -93,7 +93,7 @@ inline void ToTensor(float* out_data, const DType* in_data,
                      const int length,
                      const int channels,
                      const float normalize_factor,
-                     const int step = 0) {
+                     const int step) {
   #pragma omp parallel for collapse(2)
   for (int c = 0; c < channels; ++c) {
       for (int i = 0; i < length; ++i) {
@@ -109,12 +109,13 @@ inline void ToTensorImpl(const std::vector<TBlob> &inputs,
                          const int length,
                          const int channel,
                          const float normalize_factor,
-                         const int step = 0) {
+                         const int step) {
   MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, DType, {
     MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
       float* output = outputs[0].dptr<float>();
       DType* input = inputs[0].dptr<DType>();
-      ToTensor<DType, req_type>(output, input, length, channel, step);
+      ToTensor<DType, req_type>(output, input, length, channel,
+                                normalize_factor, step);
     });
   });
 }
@@ -159,8 +160,9 @@ void ToTensorOpForward(const nnvm::NodeAttrs &attrs,
     // 3D Input - (h, w, c)
     const int length = inputs[0].shape_[0] * inputs[0].shape_[1];
     const int channel = static_cast<int>(inputs[0].shape_[2]);
+    const int step = 0;
     ToTensorImpl(inputs, outputs, req, length,
-                 channel, normalize_factor);
+                 channel, normalize_factor, step);
   } else if (inputs[0].ndim() == 4) {
     // 4D input (n, h, w, c)
     const int batch_size = inputs[0].shape_[0];

--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -94,12 +94,12 @@ inline void ToTensor(float* out_data, const DType* in_data,
                      const int channels,
                      const float normalize_factor,
                      const int step) {
-  // Visual C++ compiler does not support omp collapse
+  // Microsoft Visual C++ compiler does not support omp collapse
   #ifdef _MSC_VER
     #pragma omp parallel for
   #else
     #pragma omp parallel for collapse(2)
-  #endif
+  #endif // _MSC_VER
   for (int c = 0; c < channels; ++c) {
       for (int i = 0; i < length; ++i) {
         KERNEL_ASSIGN(out_data[step + c*length + i], req,

--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -43,8 +43,17 @@ namespace mxnet {
 namespace op {
 namespace image {
 
-// There are no parameters for this operator.
-// Hence, no arameter registration.
+using namespace mshadow;
+
+#if MXNET_USE_CUDA
+// NOTE: Kernel launch/map was extremely costly.
+// Hence, we use separate CUDA kernels for these operators.
+template<typename DType, typename T1, typename T2>
+void ToTensorImplCUDA(mshadow::Stream<gpu> *s,
+                      const T1 input,
+                      const T2 output,
+                      const int req);
+#endif  // MXNET_USE_CUDA
 
 // Shape and Type inference for image to tensor operator
 inline bool ToTensorShape(const nnvm::NodeAttrs& attrs,
@@ -84,7 +93,6 @@ inline void ToTensor(float* out_data, const DType* in_data,
                          const int channels,
                          const int step = 0,
                          const float normalize_factor = 255.0f) {
-
   #pragma omp parallel for collapse(2)
   for (int c = 0; c < channels; ++c) {
       for (int i = 0; i < length; ++i) {
@@ -119,19 +127,34 @@ void ToTensorOpForward(const nnvm::NodeAttrs &attrs,
   CHECK_EQ(outputs.size(), 1U);
   CHECK_EQ(req.size(), 1U);
 
+  // We do not use temp buffer when performance the operation.
+  // Hence, this check is necessary.
   CHECK_EQ(req[0], kWriteTo)
     << "`to_tensor` does not support inplace updates";
 
-  // 3D Input - (h, w, c)
-  if (inputs[0].ndim() == 3) {
+  if (std::is_same<xpu, gpu>::value) {
+  #if MXNET_USE_CUDA
+      mshadow::Stream<gpu> *s = ctx.get_stream<gpu>();
+      MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, DType, {
+        MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+          if (inputs[0].ndim() == 3) {
+            Tensor<gpu, 3, DType> input = inputs[0].get<gpu, 3, DType>(s);
+            Tensor<gpu, 3, float> output = outputs[0].get<gpu, 3, float>(s);
+            ToTensorImplCUDA<DType, Tensor<gpu, 3, DType>, Tensor<gpu, 3, float>>(s, input, output, req_type);
+          }
+        });
+      });
+#endif  // MXNET_USE_CUDA
+  } else if (inputs[0].ndim() == 3) {
+    // 3D Input - (h, w, c)
     const int length = inputs[0].shape_[0] * inputs[0].shape_[1];
-    const int channel = (int)inputs[0].shape_[2];
+    const int channel = static_cast<int>(inputs[0].shape_[2]);
     ToTensorImpl(inputs, outputs, req, length, channel);
   } else if (inputs[0].ndim() == 4) {
     // 4D input (n, h, w, c)
     const int batch_size = inputs[0].shape_[0];
     const int length = inputs[0].shape_[1] * inputs[0].shape_[2];
-    const int channel = (int)inputs[0].shape_[3];
+    const int channel = static_cast<int>(inputs[0].shape_[3]);
     const int step = channel * length;
 
     #pragma omp parallel for

--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -25,9 +25,6 @@
 #ifndef MXNET_OPERATOR_IMAGE_IMAGE_RANDOM_INL_H_
 #define MXNET_OPERATOR_IMAGE_IMAGE_RANDOM_INL_H_
 
-#ifdef _MSC_VER
-  #pragma warning(disable:4503)  // disable warning: decorated name length exceeded.
-#endif
 
 #include <algorithm>
 #include <cmath>

--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -25,6 +25,9 @@
 #ifndef MXNET_OPERATOR_IMAGE_IMAGE_RANDOM_INL_H_
 #define MXNET_OPERATOR_IMAGE_IMAGE_RANDOM_INL_H_
 
+#ifdef _MSC_VER
+  #pragma warning(disable:4503)  // disable warning: decorated name length exceeded.
+#endif
 
 #include <algorithm>
 #include <cmath>

--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -94,7 +94,12 @@ inline void ToTensor(float* out_data, const DType* in_data,
                      const int channels,
                      const float normalize_factor,
                      const int step) {
-  #pragma omp parallel for collapse(2)
+  // Visual C++ compiler does not support omp collapse
+  #ifdef _MSC_VER
+    #pragma omp parallel for
+  #else
+    #pragma omp parallel for collapse(2)
+  #endif
   for (int c = 0; c < channels; ++c) {
       for (int i = 0; i < length; ++i) {
         KERNEL_ASSIGN(out_data[step + c*length + i], req,

--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -99,7 +99,7 @@ inline void ToTensor(float* out_data, const DType* in_data,
     #pragma omp parallel for
   #else
     #pragma omp parallel for collapse(2)
-  #endif // _MSC_VER
+  #endif  // _MSC_VER
   for (int c = 0; c < channels; ++c) {
       for (int i = 0; i < length; ++i) {
         KERNEL_ASSIGN(out_data[step + c*length + i], req,

--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -160,6 +160,8 @@ void ToTensorOpForward(const nnvm::NodeAttrs &attrs,
           }
         });
       });
+  #else
+    LOG(FATAL) << "Compile with USE_CUDA=1 to use ToTensor operator on GPU.";
   #endif  // MXNET_USE_CUDA
   } else if (inputs[0].ndim() == 3) {
     // 3D Input - (h, w, c)

--- a/src/operator/image/image_random.cu
+++ b/src/operator/image/image_random.cu
@@ -21,12 +21,77 @@
 * \file image_random.cu
 * \brief GPU Implementation of image transformation operators
 */
+#include <cuda_runtime_api.h>
 #include "./image_random-inl.h"
 #include "../elemwise_op_common.h"
 
 namespace mxnet {
 namespace op {
 namespace image {
+
+using namespace mshadow;
+
+template<typename xpu, typename Dtype>
+__global__ void ToTensorCudaKernel(const Tensor<xpu, 3, Dtype> input,
+                                   const Tensor<xpu, 3, float> output,
+                                   const int req,
+                                   int N, int H, int W, int C,
+                                   const float normalize_factor = 255.0f) {
+    // We process one image per thread block.
+    // In 3D case, we have only 1 block i.e., blockIdx.x
+    // We do not use it.
+    /*
+    const int n = blockIdx.x;
+    const int stride = H*W*C;
+
+    // Get pointer to my blocks image
+    int step = 0;
+    if (N > 0) {
+        step = n * stride;
+    }
+    */
+    for (int c = 0; c < C; ++c) {
+        for (int h = threadIdx.y; h < H; h += blockDim.y) {
+            for (int w = threadIdx.x; w < W; w += blockDim.x) {
+                KERNEL_ASSIGN(output[c][h][w], req,
+                              input[h][w][c] / normalize_factor);
+            }
+        }
+    }
+}
+
+template<typename DType, typename T1, typename T2>
+void ToTensorImplCUDA(mshadow::Stream<gpu> *s,
+                      const T1 input,
+                      const T2 output,
+                      const int req,
+                      const float normalize_factor = 255.0f) {
+    int blocks, H, W, C, N;
+    cudaStream_t stream = mshadow::Stream<gpu>::GetStream(s);
+    if (std::is_same<T1, Tensor<gpu, 3, DType>>::value) {
+        // 3D Input - (H, W, C)
+        N = 0;
+        H = input.size(0);
+        W = input.size(1);
+        C = input.size(2);
+        blocks = 1;
+    } /*else {
+        // 4D Input - (N, H, W, C)
+        N = input.size()[0];
+        H = input.size()[1];
+        W = input.size()[2];
+        C = input.size()[3];
+        // blocks = N > 0 ? N : 1;
+        blocks = N;
+    }*/
+    // One block per image.
+    // Number of threads = (32, 32) is optimal, because,
+    // computation is minimal and overhead of CUDA preparing
+    // all threads is minimal.
+    ToTensorCudaKernel<<<blocks, dim3(32, 32), 0, stream>>>(input,
+        output, req, N, H, W, C, normalize_factor);
+    MSHADOW_CUDA_POST_KERNEL_CHECK(ToTensorCudaKernel);
+}
 
 NNVM_REGISTER_OP(_image_to_tensor)
 .set_attr<FCompute>("FCompute<gpu>", ToTensorOpForward<gpu>);

--- a/src/operator/instance_norm-inl.h
+++ b/src/operator/instance_norm-inl.h
@@ -36,6 +36,10 @@
 #include "./operator_common.h"
 #include "./mshadow_op.h"
 
+#ifdef _MSC_VER
+  #pragma warning(disable:4503)  // disable warning: decorated name length exceeded.
+#endif
+
 namespace mxnet {
 namespace op {
 

--- a/src/operator/instance_norm-inl.h
+++ b/src/operator/instance_norm-inl.h
@@ -36,10 +36,6 @@
 #include "./operator_common.h"
 #include "./mshadow_op.h"
 
-#ifdef _MSC_VER
-  #pragma warning(disable:4503)  // disable warning: decorated name length exceeded.
-#endif
-
 namespace mxnet {
 namespace op {
 


### PR DESCRIPTION
## Description ##
Earlier, we were using Kernel Launch/Map way of launching kernel to write common CPU and GPU code for ToTensor operator. However, I observed there are too many threads and blocks being launched with kernel causing significant performance implication.

To overcome, I wrote a separate CUDA kernel for GPU and moved out of Kernel launch/map.
Benchmarks below.

**Benchmarks**

Ran 1000 ToTensor operation on (512, 512, 3)

**GPU**
Before 

('Average time per ToTensor 512,512,3 - ', 39.17948246002197)

After

('Average time per ToTensor 512,512,3 - ', 0.44632863998413086)

**CPU**

Before
('Average time per ToTensor 512,512,3 - ', 3.7258052825927734)
After
('Averagetime per ToTensor 512,512,3 - ', 1.8473007678985596)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [X] Code is well-documented: 
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Remove Kernel Launch/Map for ToTensor operator
- Make independent kernel for CPU ToTensor
- Add 2 separate CUDA kernel for ToTensor operator (3D and 4D) inputs.

@zhreshold @stu1130 