### PR TITLE
adding graceful exit for begin=end case for nd.slice

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -717,7 +717,9 @@ inline void SetSliceOpOutputDimSize(const index_t i, const int b,
                      << e << ", and step[" << i << "]=" << s << " is invalid";
       (*oshape)[i] = (b - e - 1) / (-s) + 1;
     }
-  }  // else leave oshape[i] as 0 for partial infer
+  } else {
+    CHECK_NE(b, e) << "slicing with begin[" << i << "]=end[" << i << "]=" << e << " is invalid";
+  }
 }
 
 inline bool SliceOpShape(const nnvm::NodeAttrs& attrs,


### PR DESCRIPTION
## Description ##
nd.slice outputs unexpectedly (throws incorrect output/ error message) when begin=end. This PR allows graceful exit for this case. This PR fixes #13760 .

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Adding graceful exit for begin=end case for nd.slice

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
