### PR TITLE
[WIP] fix nd.slice for following inputs: (1) begin=end and (2) end=-1, step=-1

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -675,14 +675,22 @@ inline void GetIndexRange(const mxnet::TShape& dshape,
         b = len - 1;
       }
       CHECK_LT(b, len) << "slicing with begin[" << i << "]="
-                       << b << " exceends limit of " << len;
+                       << b << " exceeds limit of " << len;
 
       if (param_end[i].has_value()) {
         e = param_end[i].value();
-        if (e < 0) {
-          e += len;
-          CHECK_GE(e, 0) << "slicing with end[" << i << "]="
-                         << e - len << " exceeds limit of " << len;
+        if (s > 0) {
+          if (e < 0) {
+            e += len;
+            CHECK_GE(e, 0) << "slicing with end[" << i << "]="
+                           << e - len << " exceeds limit of " << len;
+          }
+        } else {
+          if (e < -1) {
+            e += len;
+            CHECK_GE(e, -1) << "slicing with end[" << i << "]="
+                           << e - len << " exceeds limit of " << len;
+          }
         }
       } else if (s < 0) {
         e = -1;

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -697,6 +697,9 @@ inline void GetIndexRange(const mxnet::TShape& dshape,
       }
       CHECK_LE(e, len) << "slicing with end[" << i << "]="
                        << e << " exceeds limit of " << len;
+
+      CHECK_NE(b, e) << "slicing with begin[" << i << "]=end[" << i << "]="
+                     << e << " results in an empty tensor";
     } else {
       b = 0;
       e = 0;

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6606,6 +6606,31 @@ def test_slice():
     for index in index_list:
         test_slice_forward_backward(arr, index)
 
+    def test_begin_equals_end():
+        shape = (2, 4)
+        begin = (None, 2)
+        end = (None, 2)
+        step = (1, -1)
+        in_arr = mx.nd.arange(np.prod(shape)).reshape(shape=shape)
+        out_arr = mx.nd.slice(in_arr, begin=begin, end=end, step=step)
+
+    assert_raises(MXNetError, test_begin_equals_end)
+
+    # check for end=-1 and negative step
+    shape = (4, 3)
+    begin = (1, 2)
+    end = (-1, -1)
+    step = (-1, -2)
+    in_arr = mx.nd.arange(np.prod(shape)).reshape(shape=shape)
+    out_arr = mx.nd.slice(in_arr, begin=begin, end=end, step=step)
+    out_exp = np.array([[5., 3.],[2., 0.]])
+    assert same(out_arr.asnumpy(), out_exp)
+    data = mx.sym.Variable('data')
+    slice_sym = mx.sym.slice(data, begin=begin, end=end, step=step)
+    grad_exp = np.zeros(shape)
+    grad_exp[(slice(None, 2, 1),slice(None, None, 2))] = np.array([[0., 2.],[3., 5.]])
+    check_symbolic_backward(slice_sym, [in_arr.asnumpy()], [out_exp], [grad_exp])
+
     # check numeric gradient
     in_data = np.arange(36).reshape(2, 2, 3, 3)
     data = mx.sym.Variable('data')


### PR DESCRIPTION
## Description ##
This PR fixes nd.slice for erroneous output in the following cases:
(1) begin=end ( fixes #13760 ). Throws invalid input error.
(2) end=-1, step=-1 ( fixes #14105 ). Added tests for the same.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fixed nd.slice for erroneous outputs

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
