### PR TITLE
ONNX export: Support equal length splits

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1537,12 +1537,14 @@ def convert_slice_channel(node, **kwargs):
         )
         return [node]
     elif squeeze_axis == 0 and num_outputs > 1:
+        in_shape = kwargs.get('in_shape')[0]
+        split = in_shape[axis] // num_outputs
         node = onnx.helper.make_node(
             "Split",
             input_nodes,
-            [name],
+            [name+'_output'+str(i) for i in range(num_outputs)],
             axis=axis,
-            split=[num_outputs],
+            split=[split for _ in range(num_outputs)],
             name=name,
         )
         return [node]

--- a/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
@@ -262,6 +262,8 @@ class MXNetGraph(object):
                     # If converted node is NodeProto, add it in processed nodes list
                     elif isinstance(converted_node, NodeProto):
                         onnx_processed_nodes.append(converted_node)
+                        # some operators have multiple outputs,
+                        # therefore, check all output node names
                         node_names = list(converted_node.output)
                         for nodename in node_names:
                             if nodename in graph_outputs:

--- a/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
@@ -262,17 +262,18 @@ class MXNetGraph(object):
                     # If converted node is NodeProto, add it in processed nodes list
                     elif isinstance(converted_node, NodeProto):
                         onnx_processed_nodes.append(converted_node)
-                        node_name = converted_node.name if converted_node.name else converted_node.output[0]
-                        if node_name in graph_outputs:
-                            onnx_processed_outputs.append(
-                                make_tensor_value_info(
-                                    name=node_name,
-                                    elem_type=in_type,
-                                    shape=graph_outputs[node_name]
+                        node_names = list(converted_node.output)
+                        for nodename in node_names:
+                            if nodename in graph_outputs:
+                                onnx_processed_outputs.append(
+                                    make_tensor_value_info(
+                                        name=nodename,
+                                        elem_type=in_type,
+                                        shape=graph_outputs[nodename]
+                                    )
                                 )
-                            )
-                            if verbose:
-                                logging.info("Output node is: %s", converted_node.name)
+                                if verbose:
+                                    logging.info("Output node is: %s", nodename)
                     elif isinstance(converted_node, TensorProto):
                         raise ValueError("Did not expect TensorProto")
                     else:

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -484,13 +484,15 @@ def split(attrs, inputs, proto_obj):
     if not split_list:
         num_outputs = len(proto_obj.model_metadata.get('output_tensor_data'))
     else:
-        raise NotImplementedError("Operator {} in MXNet does not support variable splits."
+        if len(set(split_list)) == 1:
+            num_outputs = len(split_list)
+        else:
+            raise NotImplementedError("Operator {} in MXNet does not support variable splits."
                                   "Tracking the issue to support variable split here: "
                                   "https://github.com/apache/incubator-mxnet/issues/11594"
                                   .format('split'))
 
     new_attrs['num_outputs'] = num_outputs
-
     return 'split', new_attrs, inputs
 
 def _slice(attrs, inputs, proto_obj):

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -488,9 +488,9 @@ def split(attrs, inputs, proto_obj):
             num_outputs = len(split_list)
         else:
             raise NotImplementedError("Operator {} in MXNet does not support variable splits."
-                                  "Tracking the issue to support variable split here: "
-                                  "https://github.com/apache/incubator-mxnet/issues/11594"
-                                  .format('split'))
+                                      "Tracking the issue to support variable split here: "
+                                      "https://github.com/apache/incubator-mxnet/issues/11594"
+                                      .format('split'))
 
     new_attrs['num_outputs'] = num_outputs
     return 'split', new_attrs, inputs

--- a/tests/python-pytest/onnx/test_cases.py
+++ b/tests/python-pytest/onnx/test_cases.py
@@ -77,7 +77,8 @@ IMPLEMENTED_OPERATORS_TEST = {
              'test_elu',
              'test_max_',
              'test_softplus',
-             'test_reduce_'
+             'test_reduce_',
+             'test_split_equal'
              ],
     'import': ['test_gather',
                'test_softsign',
@@ -88,7 +89,6 @@ IMPLEMENTED_OPERATORS_TEST = {
                'test_averagepool_2d_precomputed_strides',
                'test_averagepool_2d_strides',
                'test_averagepool_3d',
-               'test_split_equal',
                'test_hardmax'
                ],
     'export': ['test_random_uniform',


### PR DESCRIPTION
## Description ##
Fixes https://github.com/apache/incubator-mxnet/issues/13061

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Support for exporting and importing split operator when the split are of equal length

## Comments ##

