### PR TITLE
Fixes libjpeg-turbo dependecy under Ubuntu 16.04

### DIFF
--- a/ci/docker/install/ubuntu_core.sh
+++ b/ci/docker/install/ubuntu_core.sh
@@ -39,12 +39,18 @@ apt-get install -y \
     liblapack-dev \
     libopenblas-dev \
     libopencv-dev \
+    libturbojpeg \
     libzmq3-dev \
     ninja-build \
     software-properties-common \
     sudo \
     unzip \
     wget
+
+# Use libturbojpeg package as it is correctly compiled with -fPIC flag
+# https://github.com/HaxeFoundation/hashlink/issues/147 
+ln -s /usr/lib/x86_64-linux-gnu/libturbojpeg.so.0.1.0 /usr/lib/x86_64-linux-gnu/libturbojpeg.so
+
 
 # Note: we specify an exact cmake version to work around a cmake 3.10 CUDA 10 issue.
 # Reference: https://github.com/clab/dynet/issues/1457

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -365,6 +365,7 @@ build_ubuntu_cpu_openblas() {
         USE_BLAS=openblas             \
         USE_MKLDNN=0                  \
         USE_DIST_KVSTORE=1            \
+        USE_LIBJPEG_TURBO=1           \
         -j$(nproc)
 }
 


### PR DESCRIPTION
## Description ##
Currently we cannot build mxnet on ubuntu 16.04 with USE_LIBJPEG_TURBO=1 because the library was compiled without PIC in the libturbo-jpeg library. Another package libjpegturbo fixes this issue.
see [this](https://github.com/HaxeFoundation/hashlink/issues/147).

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Adds libjpeg-turbo dependency to ubuntu based builds appropriately. 
Adds libjpeg-turbo flag to ubuntu builds. This is inline with the build flags used in the shipped version of mxnet, for instance,  see [this](https://github.com/apache/incubator-mxnet/blob/master/make/pip/pip_linux_cpu.mk#L83).

Now the CI and CD will be slightly more congruent.
