### PR TITLE
[Clojure] Pin version of leiningen to 2.8.3

### DIFF
--- a/ci/docker/install/ubuntu_clojure.sh
+++ b/ci/docker/install/ubuntu_clojure.sh
@@ -27,3 +27,4 @@ echo 'Installing Clojure...'
 wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
 chmod 775 lein
 sudo cp lein /usr/local/bin
+echo "Y" | sudo lein downgrade 2.8.3

--- a/docs/build_version_doc/setup_docs_ubuntu.sh
+++ b/docs/build_version_doc/setup_docs_ubuntu.sh
@@ -64,6 +64,7 @@ echo "Installing Clojure dependencies..."
 wget https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
 chmod 775 lein
 sudo cp lein /usr/local/bin
+echo "Y" | sudo lein downgrade 2.8.3
 
 
 echo "Installing R dependencies..."


### PR DESCRIPTION
The latest version of leiningen has a dependency issue with the documentation generating library `codox`. This pins the version of leiningen to 2.8.3 for CI and docs generating.

https://github.com/apache/incubator-mxnet/issues/14131