### PR TITLE
follow up on fix nightly test

### DIFF
--- a/docs/tutorials/gluon/gluon_from_experiment_to_deployment.md
+++ b/docs/tutorials/gluon/gluon_from_experiment_to_deployment.md
@@ -52,7 +52,6 @@ Now let's first import necessary packages:
 import math
 import os
 import time
-from multiprocessing import cpu_count
 
 from mxnet import autograd
 from mxnet import gluon, init
@@ -77,7 +76,8 @@ lr_factor = 0.75
 lr_epochs = [10, 20, 30]
 
 num_gpus = mx.context.num_gpus()
-num_workers = cpu_count()
+# you can replace num_workers with the number of cores on you device
+num_workers = 8
 ctx = [mx.gpu(i) for i in range(num_gpus)] if num_gpus > 0 else [mx.cpu()]
 batch_size = per_device_batch_size * max(num_gpus, 1)
 ```


### PR DESCRIPTION
## Description ##
This is a followup on https://github.com/apache/incubator-mxnet/pull/14119
fixes #14026 

In addition of increase shared memory on docker, I reduced the number of workers. It was using 32 workers and created too large shared memory.

Thanks for the help from the Berlin team, I just attended the office hours and  was able to reproduce the docker environment and test the fix.
This fix is tested and passed on CI docker using AWS Ubuntu DeepLearning Base AMI on g3.8xlarge
running following test passed:
```
ci/build.py --docker-registry mxnetci --nvidiadocker --platform ubuntu_nightly_gpu --docker-build-retries 3 --shm-size 1500m /work/runtime_functions.sh nightly_tutorial_test_ubuntu_python2_gpu
```
output:
```
----------------------------------------------------------------------
Ran 47 tests in 2199.521s

OK
build.py: 2019-02-12 19:42:10,706Z INFO Waiting for status of container a41697b9f1f0 for 600 s.
build.py: 2019-02-12 19:42:10,877Z INFO Container exit status: {'StatusCode': 0, 'Error': None}
build.py: 2019-02-12 19:42:10,878Z INFO Container exited with success 👍
build.py: 2019-02-12 19:42:10,878Z INFO Stopping container: a41697b9f1f0
build.py: 2019-02-12 19:42:10,879Z INFO Removing container: a41697b9f1f0
```

python 3 test also passed
```
ci/build.py --docker-registry mxnetci --nvidiadocker --platform ubuntu_nightly_gpu --docker-build-retries 3 --shm-size 1500m /work/runtime_functions.sh nightly_tutorial_test_ubuntu_python3_gpu
```
output:
```
----------------------------------------------------------------------
Ran 47 tests in 2243.615s

OK
build.py: 2019-02-12 22:45:02,862Z INFO Waiting for status of container b7cdfdae69c3 for 600 s.
build.py: 2019-02-12 22:45:03,055Z INFO Container exit status: {'Error': None, 'StatusCode': 0}
build.py: 2019-02-12 22:45:03,055Z INFO Container exited with success 👍
build.py: 2019-02-12 22:45:03,055Z INFO Stopping container: b7cdfdae69c3
build.py: 2019-02-12 22:45:03,057Z INFO Removing container: b7cdfdae69c3
```
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change



## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
