### PR TITLE
Performance improvement in Normalize GPU Kernel

### DIFF
--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -279,7 +279,7 @@ template<typename DType, int req>
 inline void Normalize(DType* out_data,
                       const DType* in_data,
                       const int length,
-                      const uint32_t channels,
+                      const int channels,
                       const int step,
                       const std::vector<float> mean,
                       const std::vector<float> std) {
@@ -289,7 +289,7 @@ inline void Normalize(DType* out_data,
   #else
     #pragma omp parallel for collapse(2)
   #endif  // _MSC_VER
-  for (uint32_t c = 0; c < channels; ++c) {
+  for (int c = 0; c < channels; ++c) {
     for (int i = 0; i < length; ++i) {
       KERNEL_ASSIGN(out_data[step + c*length + i], req,
                     (in_data[step + c*length + i] - mean[c]) / std[c]);
@@ -301,7 +301,7 @@ inline void NormalizeImpl(const std::vector<TBlob> &inputs,
                           const std::vector<TBlob> &outputs,
                           const std::vector<OpReqType> &req,
                           const int length,
-                          const uint32_t channels,
+                          const int channels,
                           const int step,
                           const std::vector<float> mean,
                           const std::vector<float> std) {
@@ -372,14 +372,14 @@ void NormalizeOpForward(const nnvm::NodeAttrs &attrs,
   } else if (inputs[0].ndim() == 3) {
     // 3D input (c, h, w)
     const int length = inputs[0].shape_[1] * inputs[0].shape_[2];
-    const uint32_t channel = inputs[0].shape_[0];
+    const int channel = static_cast<int>(inputs[0].shape_[0]);
     const int step = 0;
     NormalizeImpl(inputs, outputs, req, length, channel, step, mean, std);
   } else if (inputs[0].ndim() == 4) {
     // 4D input (n, c, h, w)
     const int batch_size = inputs[0].shape_[0];
     const int length = inputs[0].shape_[2] * inputs[0].shape_[3];
-    const uint32_t channel = inputs[0].shape_[1];
+    const int channel = static_cast<int>(inputs[0].shape_[1]);
     const int step = channel * length;
 
     #pragma omp parallel for
@@ -394,7 +394,7 @@ template<typename DType, int req>
 inline void NormalizeBackward(const DType* out_grad,
                               DType* in_grad,
                               const int length,
-                              const uint32_t channels,
+                              const int channels,
                               const int step,
                               const std::vector<float> std) {
   // Microsoft Visual C++ compiler does not support omp collapse
@@ -403,7 +403,7 @@ inline void NormalizeBackward(const DType* out_grad,
   #else
     #pragma omp parallel for collapse(2)
   #endif  // _MSC_VER
-  for (uint32_t c = 0; c < channels; ++c) {
+  for (int c = 0; c < channels; ++c) {
     for (int i = 0; i < length; ++i) {
       KERNEL_ASSIGN(in_grad[step + c*length + i], req,
                     out_grad[step + c*length + i] * (1.0 / std[c]));
@@ -415,7 +415,7 @@ inline void NormalizeBackwardImpl(const std::vector<TBlob> &inputs,
                                   const std::vector<TBlob> &outputs,
                                   const std::vector<OpReqType> &req,
                                   const int length,
-                                  const uint32_t channels,
+                                  const int channels,
                                   const int step,
                                   const std::vector<float> std
                                   ) {
@@ -477,14 +477,14 @@ void NormalizeOpBackward(const nnvm::NodeAttrs &attrs,
   } else if (in_data.ndim() == 3) {
     // 3D input (c, h, w)
     const int length = in_data.shape_[1] * in_data.shape_[2];
-    const uint32_t channel = in_data.shape_[0];
+    const int channel = static_cast<int>(in_data.shape_[0]);
     const int step = 0;
     NormalizeBackwardImpl(inputs, outputs, req, length, channel, step, std);
   } else if (in_data.ndim() == 4) {
     // 4D input (n, c, h, w)
     const int batch_size = in_data.shape_[0];
     const int length = in_data.shape_[2] * in_data.shape_[3];
-    const uint32_t channel = in_data.shape_[1];
+    const int channel = static_cast<int>(in_data.shape_[1]);
     const int step = channel * length;
 
     #pragma omp parallel for

--- a/src/operator/image/image_random.cu
+++ b/src/operator/image/image_random.cu
@@ -114,7 +114,7 @@ void ToTensorImplCUDA(mshadow::Stream<gpu> *s,
     }
 
     ToTensorCudaKernel<gpu, DType>
-            <<<blocks, dim3(H, cuda::kMaxThreadsPerBlock / H), 0, stream>>>(input, output,
+            <<<blocks, dim3(32, 32), 0, stream>>>(input, output,
                 req, N, H, W, C, normalize_factor);
         MSHADOW_CUDA_POST_KERNEL_CHECK(ToTensorCudaKernel);
 }

--- a/src/operator/image/image_random.cu
+++ b/src/operator/image/image_random.cu
@@ -99,7 +99,6 @@ void ToTensorImplCUDA(mshadow::Stream<gpu> *s,
         W = input.size(2);
         C = input.size(3);
         blocks = N > 0 ? N : 1;
-        blocks = N;
     }
     // One block per image.
     // Number of threads = (32, 32) is optimal, because,
@@ -109,6 +108,232 @@ void ToTensorImplCUDA(mshadow::Stream<gpu> *s,
             <<<blocks, dim3(32, 32), 0, stream>>>(input, output,
                 req, N, H, W, C, normalize_factor);
         MSHADOW_CUDA_POST_KERNEL_CHECK(ToTensorCudaKernel);
+}
+
+// Normalize Kernel for 3D input
+template<typename xpu, typename DType>
+__global__ void NormalizeCudaKernel(const Tensor<xpu, 3, DType> input,
+                                    const Tensor<xpu, 3, DType> output,
+                                    const int req,
+                                    const int N,
+                                    const int H,
+                                    const int W,
+                                    const int C,
+                                    const float mean_d0,
+                                    const float mean_d1,
+                                    const float mean_d2,
+                                    const float std_d0,
+                                    const float std_d1,
+                                    const float std_d2) {
+    // We process one image per thread block.
+    // In 3D case, we have only 1 block i.e., blockIdx.x
+    // We do not use it.
+
+    float mean = mean_d0;
+    float std = std_d0;
+    for (int c = 0; c < C; ++c) {
+        switch (c) {
+            case 0 : mean = mean_d0;
+                     std = std_d0;
+                     break;
+            case 1 : mean = mean_d1;
+                     std = std_d1;
+                     break;
+            case 2 : mean = mean_d2;
+                     std = std_d2;
+                     break;
+        }
+        for (int h = threadIdx.y; h < H; h += blockDim.y) {
+            for (int w = threadIdx.x; w < W; w += blockDim.x) {
+                KERNEL_ASSIGN(output[c][h][w], req,
+                              (input[c][h][w] - mean) / std);
+            }
+        }
+    }
+}
+
+// Normalize Kernel for 4D input
+template<typename xpu, typename DType>
+__global__ void NormalizeCudaKernel(const Tensor<xpu, 4, DType> input,
+                                    const Tensor<xpu, 4, DType> output,
+                                    const int req,
+                                    const int N,
+                                    const int H,
+                                    const int W,
+                                    const int C,
+                                    const float mean_d0,
+                                    const float mean_d1,
+                                    const float mean_d2,
+                                    const float std_d0,
+                                    const float std_d1,
+                                    const float std_d2) {
+    // We process one image per thread block.
+    const int n = blockIdx.x;
+
+    float mean = mean_d0;
+    float std = std_d0;
+    for (int c = 0; c < C; ++c) {
+        switch (c) {
+            case 0 : mean = mean_d0;
+                     std = std_d0;
+                     break;
+            case 1 : mean = mean_d1;
+                     std = std_d1;
+                     break;
+            case 2 : mean = mean_d2;
+                     std = std_d2;
+                     break;
+        }
+        for (int h = threadIdx.y; h < H; h += blockDim.y) {
+            for (int w = threadIdx.x; w < W; w += blockDim.x) {
+                KERNEL_ASSIGN(output[n][c][h][w], req,
+                              (input[n][c][h][w] -  mean) / std);
+            }
+        }
+    }
+}
+
+template<typename DType, typename T>
+void NormalizeImplCUDA(mshadow::Stream<gpu> *s,
+                       const T input,
+                       const T output,
+                       const int req,
+                       const float mean_d0,
+                       const float mean_d1,
+                       const float mean_d2,
+                       const float std_d0,
+                       const float std_d1,
+                       const float std_d2) {
+    int blocks, H, W, C, N;
+    cudaStream_t stream = mshadow::Stream<gpu>::GetStream(s);
+    if (std::is_same<T, Tensor<gpu, 3, DType>>::value) {
+        // 3D Input - (C, H, W)
+        N = 0;
+        C = input.size(0);
+        H = input.size(1);
+        W = input.size(2);
+        blocks = 1;
+    } else {
+        // 4D Input - (N, C, H, W)
+        N = input.size(0);
+        C = input.size(1);
+        H = input.size(2);
+        W = input.size(3);
+        blocks = N > 0 ? N : 1;
+    }
+    // One block per image.
+    // Number of threads = (16, 16) is optimal, because,
+    // computation is minimal and overhead of CUDA preparing
+    // all threads is minimal.
+    NormalizeCudaKernel<gpu, DType>
+        <<<blocks, dim3(16, 16), 0, stream>>>(input, output,
+            req, N, H, W, C, mean_d0, mean_d1, mean_d2,
+            std_d0, std_d1, std_d2);
+    MSHADOW_CUDA_POST_KERNEL_CHECK(NormalizeCudaKernel);
+}
+
+// Normalize Backward Kernel for 3D input
+template<typename xpu, typename DType>
+__global__ void NormalizeBackwardCudaKernel(const Tensor<xpu, 3, DType> out_grad,
+                                            const Tensor<xpu, 3, DType> in_grad,
+                                            const int req,
+                                            const int N,
+                                            const int H,
+                                            const int W,
+                                            const int C,
+                                            const float std_d0,
+                                            const float std_d1,
+                                            const float std_d2) {
+    // We process one image per thread block.
+    // In 3D case, we have only 1 block i.e., blockIdx.x
+    // We do not use it.
+
+    float std = std_d0;
+    for (int c = 0; c < C; ++c) {
+        switch (c) {
+            case 0 : std = std_d0;
+                     break;
+            case 1 : std = std_d1;
+                     break;
+            case 2 : std = std_d2;
+                     break;
+        }
+        for (int h = threadIdx.y; h < H; h += blockDim.y) {
+            for (int w = threadIdx.x; w < W; w += blockDim.x) {
+                KERNEL_ASSIGN(in_grad[c][h][w], req,
+                              out_grad[c][h][w] * (1 / std));
+            }
+        }
+    }
+}
+
+// Normalize Backward Kernel for 3D input
+template<typename xpu, typename DType>
+__global__ void NormalizeBackwardCudaKernel(const Tensor<xpu, 4, DType> out_grad,
+                                            const Tensor<xpu, 4, DType> in_grad,
+                                            const int req,
+                                            const int N,
+                                            const int H,
+                                            const int W,
+                                            const int C,
+                                            const float std_d0,
+                                            const float std_d1,
+                                            const float std_d2) {
+    // We process one image per thread block.
+    const int n = blockIdx.x;
+
+    float std = std_d0;
+    for (int c = 0; c < C; ++c) {
+        switch (c) {
+            case 0 : std = std_d0;
+                     break;
+            case 1 : std = std_d1;
+                     break;
+            case 2 : std = std_d2;
+                     break;
+        }
+        for (int h = threadIdx.y; h < H; h += blockDim.y) {
+            for (int w = threadIdx.x; w < W; w += blockDim.x) {
+                KERNEL_ASSIGN(in_grad[n][c][h][w], req,
+                              out_grad[n][c][h][w] * (1 / std));
+            }
+        }
+    }
+}
+
+template<typename DType, typename T>
+void NormalizeBackwardImplCUDA(mshadow::Stream<gpu> *s,
+                               const T out_grad,
+                               const T in_grad,
+                               const int req,
+                               const float std_d0,
+                               const float std_d1,
+                               const float std_d2) {
+    int blocks, H, W, C, N;
+    cudaStream_t stream = mshadow::Stream<gpu>::GetStream(s);
+    if (std::is_same<T, Tensor<gpu, 3, DType>>::value) {
+        // 3D Input - (C, H, W)
+        N = 0;
+        C = out_grad.size(0);
+        H = out_grad.size(1);
+        W = out_grad.size(2);
+        blocks = 1;
+    } else {
+        // 4D Input - (N, C, H, W)
+        N = out_grad.size(0);
+        C = out_grad.size(1);
+        H = out_grad.size(2);
+        W = out_grad.size(3);
+        blocks = N > 0 ? N : 1;
+    }
+    // One block per image.
+    // Number of threads = (16, 16) is optimal, because,
+    // computation is minimal and overhead of CUDA preparing
+    // all threads is minimal.
+    NormalizeBackwardCudaKernel<gpu, DType>
+        <<<blocks, dim3(16, 16), 0, stream>>>(out_grad, in_grad,
+            req, N, H, W, C, std_d0, std_d1, std_d2);
+    MSHADOW_CUDA_POST_KERNEL_CHECK(NormalizeBackwardCudaKernel);
 }
 
 NNVM_REGISTER_OP(_image_to_tensor)

--- a/src/operator/instance_norm-inl.h
+++ b/src/operator/instance_norm-inl.h
@@ -36,6 +36,10 @@
 #include "./operator_common.h"
 #include "./mshadow_op.h"
 
+#ifdef _MSC_VER
+  #pragma warning(disable:4503)  // disable warning: decorated name length exceeded.
+#endif
+
 namespace mxnet {
 namespace op {
 

--- a/src/operator/instance_norm-inl.h
+++ b/src/operator/instance_norm-inl.h
@@ -36,10 +36,6 @@
 #include "./operator_common.h"
 #include "./mshadow_op.h"
 
-#ifdef _MSC_VER
-  #pragma warning(disable:4503)  // disable warning: decorated name length exceeded.
-#endif
-
 namespace mxnet {
 namespace op {
 


### PR DESCRIPTION
## Description ##
Similar to perf improvements of ToTensor GPU kernel  in PR - https://github.com/apache/incubator-mxnet/pull/14099
In this PR, I wrote a separate CUDA kernel for GPU and moved out of Kernel launch/map.

Benchmarks below.

**Benchmarks**
Ran 500 Normalize operation on (3, 512, 512) sample input.

**GPU**

Before: ('Average time per Normalize 3,512,512 - ', 38.19581985473633)
After: ('Average time per Normalize 3,512,512 - ', 0.5398507118225098)

**CPU**

Before: ('Average time per Normalize 3,512,512 - ', 1.8209707736968994)
After: ('Average time per Normalize 3,512,512 - ', 1.2644755840301514)

('Total time for CPU ToTensor - ', 1264.4755840301514)
('Average time per Normalize 3,512,512 - ', 1.2644755840301514)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Remove Kernel Launch/Map for Normalize operator
- Make independent kernel for CPU Normalize
- Add 2 separate CUDA kernel for Normalize Forward operator (3D and 4D) inputs.
- Add 2 separate CUDA kernel for Normalize Backward operator (3D and 4D) inputs.

@stu1130 @zhreshold 
