### PR TITLE
Doc Fix: added note about cuda9.2 requirement to Java example

### DIFF
--- a/scala-package/mxnet-demo/java-demo/README.md
+++ b/scala-package/mxnet-demo/java-demo/README.md
@@ -9,6 +9,8 @@ This command will pick the default values specified in the [pom](https://github.
 
 Note: If you are planning to use GPU, please add `-Dmxnet.profile=linux-x86_64-gpu`
 
+Note: The Maven package is built with CUDA 9.2.
+
 ### Use customized version set
 You can use the following instruction as an alternative to achieve the same result:
 You may use `mvn package` to build the package,


### PR DESCRIPTION
## Description ##
example requires CUDA 9.2 but this wasnt mentioned anywhere in the instructions


### Changes ###
Added note to clarify the CUDA 9.2 requirement
