### PR TITLE
Fixes installation nightly test

### DIFF
--- a/tests/jenkins/run_test_installation_docs.sh
+++ b/tests/jenkins/run_test_installation_docs.sh
@@ -250,6 +250,29 @@ function set_instruction_set() {
         ${sorted_indexes[$end_buildfromsource_command_index]})
 }
 
+# given a $buildfromsource_commands string, filter out any build commands that should not be executed
+# during the build from source tests. An example, the build from source instructions include the commands:
+# $ git clone --recursive https://github.com/apache/incubator-mxnet 
+# $ cd incubator-mxnet 
+# if these commands get executed in the jenkins job, we will be testing the build from source instructions
+# against the master branch and not against the version of the repository that Jenkins checksout for testing.
+# This presents a particularly big problem for the version branches and their nightly builds. Because, 
+# we would, in effect, be testing the build from source instructions for one version of MXNet against
+# the master branch.
+# in this function we target the commands cited in the example above, but leave it open for expantion
+# in the future.
+# See also gh issue: https://github.com/apache/incubator-mxnet/issues/13800
+function filter_build_commands() {
+    filtered_build_commands="${1}"
+
+    # Remove git commands
+    filtered_build_commands=`echo "${filtered_build_commands}" | perl -pe 's/git .*?;//g'`
+
+    # Remove 'cd incubator-mxnet'
+    filtered_build_commands=`echo "${filtered_build_commands}" | perl -pe 's/cd incubator-mxnet;//'`
+
+    echo "${filtered_build_commands}"
+}
 
 ########################LINUX-PYTHON-CPU############################
 echo
@@ -302,8 +325,8 @@ ubuntu_python_cpu_source()
     set -e
     echo
     echo "### Testing Build From Source ###"
-    echo "${buildfromsource_commands}"
-    echo
+    buildfromsource_commands=$(filter_build_commands "${buildfromsource_commands}")
+    echo ${buildfromsource_commands}
     eval ${buildfromsource_commands}
     echo "ubuntu_python_cpu_source: MXNet Installed Successfully"
 
@@ -363,8 +386,8 @@ ubuntu_python_gpu_source()
     set -e
     echo
     echo "### Testing Build From Source ###"
-    echo "${buildfromsource_commands}"
-    echo
+    buildfromsource_commands=$(filter_build_commands "${buildfromsource_commands}")
+    echo ${buildfromsource_commands}
     eval ${buildfromsource_commands}
     echo "ubuntu_python_gpu_source: MXNet Installed Successfully"
 


### PR DESCRIPTION
## Description ##
The nightly job was failing because the installation instructions test was testing v1.3.x instructions against the `master` branch. I've updated the underlying script to filter out the git calls from the set of operations it extracts from the instruction document.
Targets #13800

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Fixes nightly job by filtering some commands when running the installation guide test.

## Comments ##
This commit was cherry-picked to be merged to branch `v1.3.x` on PR #14145 
