### PR TITLE
[MXNET-1323] CPP GPU test running too long

### DIFF
--- a/cpp-package/example/mlp.cpp
+++ b/cpp-package/example/mlp.cpp
@@ -49,7 +49,7 @@ void OutputAccuracy(mx_float* pred, mx_float* target) {
   std::cout << "Accuracy: " << right / 128.0 << std::endl;
 }
 
-void MLP() {
+void MLP(int max_epoch) {
   auto sym_x = Symbol::Variable("X");
   auto sym_label = Symbol::Variable("label");
 
@@ -144,7 +144,6 @@ void MLP() {
                                grad_req_type, aux_states);
 
   std::cout << "Training" << std::endl;
-  int max_epoch = 15000;
   mx_float learning_rate = 0.0001;
   for (int epoch_num = 0; epoch_num < max_epoch; ++epoch_num) {
     exe->Forward(true);
@@ -173,8 +172,8 @@ void MLP() {
 }
 
 int main(int argc, char** argv) {
-  MLP();
+  int max_epoch = argc > 1 ? strtol(argv[1], NULL, 10) : 15000;
+  MLP(max_epoch);
   MXNotifyShutdown();
   return 0;
 }
-

--- a/cpp-package/tests/ci_test.sh
+++ b/cpp-package/tests/ci_test.sh
@@ -25,22 +25,22 @@ ls -l ../../lib/
 ./get_data.sh
 
 cp ../../build/cpp-package/example/lenet .
-./lenet 10
+./lenet 1
 
 cp ../../build/cpp-package/example/alexnet .
 ./alexnet 1
 
 cp ../../build/cpp-package/example/lenet_with_mxdataiter .
-./lenet_with_mxdataiter 5
+./lenet_with_mxdataiter 1
 
 cp ../../build/cpp-package/example/resnet .
-./resnet 5
+./resnet 1
 
 cp ../../build/cpp-package/example/inception_bn .
-./inception_bn 5
+./inception_bn 1
 
 cp ../../build/cpp-package/example/mlp .
-./mlp
+./mlp 150
 
 cp ../../build/cpp-package/example/mlp_cpu .
 ./mlp_cpu


### PR DESCRIPTION
## Description ##
CPP GPU test running too long.  The examples in ci_test.sh are taking longer time to finish. Reduced the number of epochs for which examples were running. Updated mlp example to accept the number of epochs to run. By default the example was running for 15000 epochs.
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

Note that the change is made to reduce the time to run the examples in ci_tests.sh. 
