### PR TITLE
Add license check to dev_menu, docs build with docker

### DIFF
--- a/dev_menu.py
+++ b/dev_menu.py
@@ -118,10 +118,13 @@ COMMANDS = OrderedDict([
     ('[Local] Python Unit tests',
         "./py3_venv/bin/nosetests -v tests/python/unittest/"
     ),
-    ('[Website and docs build] Will build to docs/_build/html/',
-        "ci/docker/runtime_functions.sh deploy_docs"),
-    ('[Docker] sanity_check. Check for linting and code formatting.',
-        "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh sanity_check"),
+    ('[Docker] Website and docs build outputs to "docs/_build/html/"',
+        "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh deploy_docs"),
+    ('[Docker] sanity_check. Check for linting and code formatting and licenses.',
+    [
+        "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh sanity_check",
+        "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh nightly_test_rat_check",
+    ]),
     ('[Docker] Python3 CPU unittests',
     [
         "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_openblas",


### PR DESCRIPTION
## Description ##

Improve dev_menu.py adding license checks and docs built with docker.

dev_menu.py is used as a menu tool to reproduce and run some of the main CI tasks locally and ease development workflow.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
