### PR TITLE
[MXNET-1305] Scala interpreter instructions

### DIFF
--- a/docs/install/scala_setup.md
+++ b/docs/install/scala_setup.md
@@ -22,6 +22,7 @@
 The following instructions are provided for macOS and Ubuntu. Windows is not yet available.
 
 **Note:** If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial](../tutorials/scala/mxnet_scala_on_intellij.html) instead of these instructions.
+**Note:** Currently, we only support scala 2.11
 
 <hr>
 
@@ -115,6 +116,33 @@ mvn install
 ```
 
 <hr>
+
+## Interpreter
+
+To run the scala interpreter, first download and install scala 2.11.x (run `scala -version` to make sure you have the right version installed.**
+
+### Installing the Interpreter
+
+**Ubuntu***
+
+```
+sudo apt-get install scala
+```
+
+**macOS***
+
+```
+brew install scala@2.11
+```
+
+Then, add scala to your path by following the instructions output by homebrew.
+
+### Running the Interpreter
+
+To run the interpreter, download the appropriate mxnet jar from [the maven repository](https://search.maven.org/search?q=g:org.apache.mxnet) or build from source following the instructions above.
+
+Then, run `scala -cp {path/to/mxnet-full_2.11-os-version.jar}` to start it.
+If you receive a "NumberFormatException" when running the interpreter, run `export TERM=xterm-color` before starting the interpreter.
 
 ## Documentation
 

--- a/docs/tutorials/scala/char_lstm.md
+++ b/docs/tutorials/scala/char_lstm.md
@@ -73,11 +73,7 @@ In this tutorial, you will accomplish the following:
 
 ## Prerequisites
 
-To complete this tutorial, you need:
-
-- MXNet. See the instructions for your operating system in [Setup and Installation](http://mxnet.io/install/index.html)
-- [Scala 2.11.8](https://www.scala-lang.org/download/2.11.8.html)
-- [Maven 3](https://maven.apache.org/install.html)
+To complete this tutorial, setup and run the scala interpreter by following the [instructions](https://mxnet.incubator.apache.org/install/scala_setup.html#interpreter).
 
 ## Download the Data
 


### PR DESCRIPTION
## Description ##
Add instructions to the scala_setup page for using the interpreter and link to in the only example featuring the interpreter. It also adds a note that we only support scala 2.11. This should address the problem seen in #13468.

@lanking520 @piyushghai @andrewfayres @aaronmarkham 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

