### PR TITLE
[MXNET-1299] Perl: sync with Python API

### DIFF
--- a/perl-package/AI-MXNet/Changes
+++ b/perl-package/AI-MXNet/Changes
@@ -1,5 +1,11 @@
 Revision history for Perl extension AI::MXNet
 
+1.4     Mon Feb 18 11:54:07 PST 2019
+        - Two more gluon loss classes
+        - Visualization fixes
+        - Gluon rnn rework, including hybridization
+        - Exposed GPU memory info to perl level.
+
 1.33    Thu Oct  4 13:25:56 PDT 2018
         - Added randn function.
         - Internal SELU function on C++ layer.

--- a/perl-package/AI-MXNet/META.json
+++ b/perl-package/AI-MXNet/META.json
@@ -30,7 +30,7 @@
       },
       "runtime" : {
          "requires" : {
-            "AI::MXNetCAPI" : "1.33",
+            "AI::MXNetCAPI" : "1.4",
             "AI::NNVMCAPI" : "1.3",
             "Function::Parameters" : "1.0705",
             "Hash::Ordered" : "0.012",
@@ -45,5 +45,5 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.33"
+   "version" : "1.4"
 }

--- a/perl-package/AI-MXNet/META.yml
+++ b/perl-package/AI-MXNet/META.yml
@@ -34,7 +34,7 @@ no_index:
     - t
     - inc
 requires:
-  AI::MXNetCAPI: '1.33'
+  AI::MXNetCAPI: '1.4'
   AI::NNVMCAPI: '1.3'
   Function::Parameters: '1.0705'
   Hash::Ordered: '0.012'
@@ -42,4 +42,4 @@ requires:
   Mouse: v2.1.0
   PDL: '2.007'
   PDL::CCS: '1.23.4'
-version: '1.33'
+version: '1.4'

--- a/perl-package/AI-MXNet/Makefile.PL
+++ b/perl-package/AI-MXNet/Makefile.PL
@@ -36,7 +36,7 @@ my %WriteMakefileArgs = (
   "LICENSE" => "apache_2_0",
   "NAME" => "AI::MXNet",
   "PREREQ_PM" => {
-    "AI::MXNetCAPI" => "1.33",
+    "AI::MXNetCAPI" => "1.4",
     "AI::NNVMCAPI" => "1.3",
     "Function::Parameters" => "1.0705",
     "Hash::Ordered" => "0.012",
@@ -46,7 +46,7 @@ my %WriteMakefileArgs = (
     "GraphViz" => "2.14"
   },
   "TEST_REQUIRES" => {},
-  "VERSION" => "1.33",
+  "VERSION" => "1.4",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/perl-package/AI-MXNet/README
+++ b/perl-package/AI-MXNet/README
@@ -1,5 +1,5 @@
 This archive contains the distribution AI-MXNet,
-version 1.33:
+version 1.4:
 
   Perl interface to MXNet machine learning library
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet.pm
@@ -51,7 +51,7 @@ use AI::MXNet::Gluon;
 use AI::MXNet::NDArray::Sparse;
 use AI::MXNet::Symbol::Sparse;
 use AI::MXNet::Engine;
-our $VERSION = '1.33';
+our $VERSION = '1.4';
 
 sub import
 {

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Context.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Context.pm
@@ -190,6 +190,30 @@ method num_gpus()
     return scalar(check_call(AI::MXNetCAPI::GetGPUCount()));
 }
 
+=head2 gpu_memory_info
+
+    Query CUDA for the free and total bytes of GPU global memory.
+
+    Parameters
+    ----------
+    $device_id=0 : int, optional
+        The device id of the GPU device.
+
+    Raises
+    ------
+    Will raise an exception on any CUDA error.
+
+    Returns
+    -------
+    ($free, $total) : (int, int)
+        Free and total memory in bytes.
+=cut
+
+method gpu_memory_info($device_id=0)
+{
+    return check_call(AI::MXNetCAPI::GetGPUMemoryInformation64($device_id));
+}
+
 method current_ctx()
 {
     return $AI::MXNet::current_ctx;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/RNN/Cell.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/RNN/Cell.pm
@@ -57,6 +57,7 @@ method _get_begin_state(GluonClass $F, $begin_state, GluonInput $inputs, $batch_
     return $begin_state;
 }
 
+
 method _format_sequence($length, $inputs, $layout, $merge, $in_layout=)
 {
     assert(
@@ -118,7 +119,7 @@ method _format_sequence($length, $inputs, $layout, $merge, $in_layout=)
         if($merge)
         {
             $inputs  = [map { $F->expand_dims($_, axis => $axis) } @{ $inputs }];
-            $inputs  = $F->concat(@{ $inputs }, dim => $axis);
+            $inputs  = $F->stack(@{ $inputs }, axis => $axis);
             $in_axis = $axis;
         }
     }
@@ -127,6 +128,54 @@ method _format_sequence($length, $inputs, $layout, $merge, $in_layout=)
         $inputs = $F->swapaxes($inputs, dim1=>$axis, dim2=>$in_axis);
     }
     return ($inputs, $axis, $F, $batch_size);
+}
+
+method _mask_sequence_variable_length($F, $data, $length, $valid_length, $time_axis, $merge)
+{
+    assert(defined $valid_length);
+    if(not blessed $data)
+    {
+        $data = $F->stack(@$data, axis=>$time_axis);
+    }
+    my $outputs = $F->SequenceMask($data, { sequence_length=>$valid_length, use_sequence_length=>1,
+                             axis=>$time_axis});
+    if(not $merge)
+    {
+        $outputs = $F->split($outputs, { num_outputs=>$length, axis=>$time_axis,
+                                   squeeze_axis=>1});
+        if(not ref $outputs eq 'ARRAY')
+        {
+            $outputs = [$outputs];
+        }
+    }
+    return $outputs;
+}
+
+method _reverse_sequences($sequences, $unroll_step, $valid_length=)
+{
+    my $F;
+    if($sequences->[0]->isa('AI::MXNet::Symbol'))
+    {
+        $F = 'AI::MXNet::Symbol';
+    }
+    else
+    {
+        $F = 'AI::MXNet::NDArray';
+    }
+
+    my $reversed_sequences;
+    if(not defined $valid_length)
+    {
+        $reversed_sequences = [reverse(@$sequences)];
+    }
+    else
+    {
+        $reversed_sequences = $F->SequenceReverse($F->stack(@$sequences, axis=>0),
+                                               {sequence_length=>$valid_length,
+                                               use_sequence_length=>1});
+        $reversed_sequences = $F->split($reversed_sequences, {axis=>0, num_outputs=>$unroll_step, squeeze_axis=>1});
+    }
+    return $reversed_sequences;
 }
 
 =head1 NAME
@@ -280,21 +329,39 @@ method unroll(
     Maybe[GluonInput] $inputs,
     Maybe[GluonInput] :$begin_state=,
     Str :$layout='NTC',
-    Maybe[Bool] :$merge_outputs=
+    Maybe[Bool] :$merge_outputs=,
+    Maybe[Bool] :$valid_length=
 )
 {
     $self->reset();
-    my ($F, $batch_size);
-    ($inputs, undef, $F, $batch_size) = $self->_format_sequence($length, $inputs, $layout, 0);
+    my ($F, $batch_size, $axis);
+    ($inputs, $axis, $F, $batch_size) = $self->_format_sequence($length, $inputs, $layout, 0);
     $begin_state //= $self->_get_begin_state($F, $begin_state, $inputs, $batch_size);
 
     my $states = $begin_state;
     my $outputs = [];
+    my $all_states = [];
     for my $i (0..$length-1)
     {
         my $output;
         ($output, $states) = $self->($inputs->[$i], $states);
         push @$outputs, $output;
+        if(defined $valid_length)
+        {
+            push @$all_states, $states;
+        }
+    }
+    if(defined $valid_length)
+    {
+        $states = [];
+        for(zip(@$all_states))
+        {
+            push @$states, $F->SequenceLast($F->stack(@$_, axis=>0),
+                                     sequence_length=>$valid_length,
+                                     use_sequence_length=>1,
+                                     axis=>0);
+        }
+        $outputs = $self->_mask_sequence_variable_length($F, $outputs, $length, $valid_length, $axis, 1);
     }
     ($outputs) = $self->_format_sequence($length, $outputs, $layout, $merge_outputs);
     return ($outputs, $states);
@@ -304,7 +371,16 @@ method _get_activation(GluonClass $F, GluonInput $inputs, Activation $activation
 {
     if(not blessed $activation)
     {
+        my %act = map { $_ => 1 } qw(tanh relu sigmoid softsign);
+        if(exists $act{$activation})
+        {
+            return $F->$activation($inputs, %kwargs)
+        }
         return $F->Activation($inputs, act_type=>$activation, %kwargs);
+    }
+    elsif(ref($activation) =~ /LeakyReLU/)
+    {
+        return $F->LeakyReLU($inputs, act_type=>'leaky', slope => $activation->alpha, %kwargs);
     }
     else
     {
@@ -430,7 +506,7 @@ has [qw/
 method python_constructor_arguments()
 {
     [qw/
-        hidden_size activation 
+        hidden_size activation
         i2h_weight_initializer h2h_weight_initializer
         i2h_bias_initializer h2h_bias_initializer
         input_size
@@ -476,16 +552,17 @@ method hybrid_forward(
 {
     my $prefix = "t${\ $self->counter}_";
     my $i2h = $F->FullyConnected(
-        $inputs, $i2h_weight, $i2h_bias,
+        data => $inputs, weight => $i2h_weight, bias => $i2h_bias,
         num_hidden => $self->hidden_size,
         name => "${prefix}i2h"
     );
     my $h2h = $F->FullyConnected(
-        $states->[0], $h2h_weight, $h2h_bias,
+        data => $states->[0], weight => $h2h_weight, bias => $h2h_bias,
         num_hidden => $self->hidden_size,
         name => "${prefix}h2h"
     );
-    my $output = $self->_get_activation($F, $i2h + $h2h, $self->activation, name => "${prefix}out");
+    my $i2h_plus_h2h = $F->elemwise_add($i2h, $h2h, name => "${prefix}plus0");
+    my $output = $self->_get_activation($F, $i2h_plus_h2h, $self->activation, name => "${prefix}out");
     return ($output, [$output]);
 }
 
@@ -555,6 +632,7 @@ method python_constructor_arguments()
     /];
 }
 
+
 sub BUILD
 {
     my $self = shift;
@@ -606,14 +684,18 @@ method hybrid_forward(
         num_hidden => $self->hidden_size*4,
         name => "${prefix}h2h"
     );
-    my $gates = $i2h + $h2h;
+    my $gates = $F->elemwise_add($i2h, $h2h, name => "${prefix}plus0");
     my @slice_gates = @{ $F->SliceChannel($gates, num_outputs => 4, name => "${prefix}slice") };
     my $in_gate = $F->Activation($slice_gates[0], act_type=>"sigmoid", name => "${prefix}i");
     my $forget_gate = $F->Activation($slice_gates[1], act_type=>"sigmoid", name => "${prefix}f");
     my $in_transform = $F->Activation($slice_gates[2], act_type=>"tanh", name => "${prefix}c");
     my $out_gate = $F->Activation($slice_gates[3], act_type=>"sigmoid", name => "${prefix}o");
-    my $next_c = $F->_plus($forget_gate * $states->[1], $in_gate * $in_transform, name => "${prefix}state");
-    my $next_h = $F->_mul($out_gate, $F->Activation($next_c, act_type=>"tanh"), name => "${prefix}out");
+    my $next_c = $F->_plus(
+        $F->elemwise_mul($forget_gate, $states->[1], name => "${prefix}mul0"),
+        $F->elemwise_mul($in_gate, $in_transform, name => "${prefix}mul1"),
+        name => "${prefix}state"
+    );
+    my $next_h = $F->_mul($out_gate, $F->Activation($next_c, act_type=>"tanh", name => "${prefix}activation0"), name => "${prefix}out");
     return ($next_h, [$next_h, $next_c]);
 }
 
@@ -735,10 +817,29 @@ method hybrid_forward(
     my ($i2h_r, $i2h_z, $h2h_r, $h2h_z);
     ($i2h_r, $i2h_z, $i2h) = @{ $F->SliceChannel($i2h, num_outputs => 3, name => "${prefix}i2h_slice") };
     ($h2h_r, $h2h_z, $h2h) = @{ $F->SliceChannel($h2h, num_outputs => 3, name => "${prefix}h2h_slice") };
-    my $reset_gate  = $F->Activation($i2h_r + $h2h_r, act_type=>"sigmoid", name => "${prefix}r_act");
-    my $update_gate = $F->Activation($i2h_z + $h2h_z, act_type=>"sigmoid", name => "${prefix}z_act");
-    my $next_h_tmp = $F->Activation($i2h + $reset_gate * $h2h, act_type => "tanh", name => "${prefix}h_act");
-    my $next_h = $F->_plus((1 - $update_gate) * $next_h_tmp, $update_gate * $prev_state_h, name => "${prefix}out");
+    my $reset_gate  = $F->Activation($F->elemwise_add($i2h_r, $h2h_r, name => "${prefix}plus0"), act_type=>"sigmoid", name => "${prefix}r_act");
+    my $update_gate = $F->Activation($F->elemwise_add($i2h_z, $h2h_z, name => "${prefix}plus1"), act_type=>"sigmoid", name => "${prefix}z_act");
+    my $next_h_tmp = $F->Activation(
+        $F->elemwise_add(
+            $i2h,
+            $F->elemwise_mul(
+                $reset_gate, $h2h, name => "${prefix}mul0"
+            ),
+            name => "${prefix}plus2"
+        ),
+        act_type => "tanh",
+        name => "${prefix}h_act"
+    );
+    my $ones = $F->ones_like($update_gate, name => "${prefix}ones_like0");
+    my $next_h = $F->_plus(
+        $F->elemwise_mul(
+            $F->elemwise_sub($ones, $update_gate, name => "${prefix}minus0"),
+            $next_h_tmp,
+            name => "${prefix}mul1"
+        ),
+        $F->elemwise_mul($update_gate, $prev_state_h, name => "${prefix}mul2"),
+        name => "${prefix}out"
+    );
     return ($next_h, [$next_h]);
 }
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Initializer.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Initializer.pm
@@ -191,6 +191,16 @@ method call(Str|AI::MXNet::InitDesc $desc, AI::MXNet::NDArray $arr)
             $self->$method($desc, $arr);
             $self->_verbose_print($desc, $1, $arr);
         }
+        elsif($desc =~ /min$/)
+        {
+            $self->_init_zero($desc, $arr);
+            $self->_verbose_print($desc, 'min', $arr);
+        }
+        elsif($desc =~ /max$/)
+        {
+            $self->_init_one($desc, $arr);
+            $self->_verbose_print($desc, 'max', $arr);
+        }
         else
         {
             $self->_init_default($desc, $arr)
@@ -249,6 +259,14 @@ method _legacy_init(Str $name, AI::MXNet::NDArray $arr)
     elsif($name =~ /moving_avg$/)
     {
         $self->_init_zero($name, $arr);
+    }
+    elsif($name =~ /min$/)
+    {
+        $self->_init_zero($name, $arr);
+    }
+    elsif($name =~ /max$/)
+    {
+        $self->_init_one($name, $arr);
     }
     else
     {

--- a/perl-package/AI-MXNet/lib/AI/MXNet/NDArray.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/NDArray.pm
@@ -1226,6 +1226,9 @@ method concatenate(ArrayRef[AI::MXNet::NDArray] $arrays, Index :$axis=0, :$alway
     :$repeat=1 : number, optional
         The repeating time of all elements.
         E.g repeat=3, the element a will be repeated three times --> a, a, a.
+    :$infer_range=0 : Bool
+        When set to 1, infer stop position from start, step, repeat, and
+        output tensor size.
     :$ctx : Context, optional
         The context of the NDArray, defaultw to current default context.
     :$dtype : data type, optional
@@ -1237,7 +1240,7 @@ method concatenate(ArrayRef[AI::MXNet::NDArray] $arrays, Index :$axis=0, :$alway
         The created NDArray
 =cut
 
-method arange(Index :$start=0, Maybe[Index] :$stop=, Index :$step=1, Index :$repeat=1,
+method arange(Index :$start=0, Maybe[Index] :$stop=, Index :$step=1, Index :$repeat=1, Bool :$infer_range=0,
               AI::MXNet::Context :$ctx=AI::MXNet::Context->current_ctx, Dtype :$dtype='float32')
 {
     return __PACKAGE__->_arange({
@@ -1246,6 +1249,7 @@ method arange(Index :$start=0, Maybe[Index] :$stop=, Index :$step=1, Index :$rep
                 step => $step,
                 repeat => $repeat,
                 dtype => $dtype,
+                infer_range => $infer_range,
                 ctx => "$ctx"
     });
 }

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Symbol.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Symbol.pm
@@ -1411,16 +1411,19 @@ method ones(Shape :$shape, Dtype :$dtype='float32', Maybe[Str] :$name=, Maybe[St
 
     Parameters
     ----------
-    start : number
+    :$start=0 : number
         Start of interval. The interval includes this value. The default start value is 0.
-    stop : number, optional
+    :$stop= : number, optional
         End of interval. The interval does not include this value.
-    step : number, optional
+    :$step=1.0 : number, optional
         Spacing between values
-    repeat : int, optional
+    :$repeat=1 : int, optional
         "The repeating time of all elements.
         E.g repeat=3, the element a will be repeated three times --> a, a, a.
-    dtype : type, optional
+    :$infer_range=0 : Bool
+        When set to 1, infer stop position from start, step, repeat, and
+        output tensor size.
+    :$dtype='float32' : type, optional
         The value type of the NDArray, default to np.float32
 
     Returns
@@ -1429,11 +1432,12 @@ method ones(Shape :$shape, Dtype :$dtype='float32', Maybe[Str] :$name=, Maybe[St
         The created Symbol
 =cut
 
-method arange(Index :$start=0, Index :$stop=, Num :$step=1.0, Index :$repeat=1, Maybe[Str] :$name=, Dtype :$dtype='float32')
+method arange(Index :$start=0, Index :$stop=, Num :$step=1.0, Index :$repeat=1, Bool :$infer_range=0, Maybe[Str] :$name=, Dtype :$dtype='float32')
 {
     return __PACKAGE__->_arange({
                  start => $start, (defined $stop ? (stop => $stop) : ()),
-                 step => $step, repeat => $repeat, name => $name, dtype => $dtype
+                 step => $step, repeat => $repeat, name => $name, dtype => $dtype,
+                 infer_range => $infer_range
     });
 }
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Visualization.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Visualization.pm
@@ -172,6 +172,10 @@ method print_summary(
                 $cur_param = $num_filter * 2;
             }
         }
+        elsif($op eq 'Embedding')
+        {
+            $cur_param = $node->{attrs}{input_dim} * $node->{attrs}{output_dim};
+        }
         my $first_connection;
         if(not $pre_node)
         {

--- a/perl-package/AI-MXNetCAPI/Changes
+++ b/perl-package/AI-MXNetCAPI/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension AI::MXNetCAPI
 
+1.4     Mon Feb 18 11:54:07 PST 2019
+        - Support for 64bit integers
+
 1.33    Thu Oct  4 13:25:56 PDT 2018
         - Gluon: Better sparse support for KVStore.
         - Gpu memory info via mxnet api call.

--- a/perl-package/AI-MXNetCAPI/META.json
+++ b/perl-package/AI-MXNetCAPI/META.json
@@ -37,5 +37,5 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.33"
+   "version" : "1.4"
 }

--- a/perl-package/AI-MXNetCAPI/META.yml
+++ b/perl-package/AI-MXNetCAPI/META.yml
@@ -36,4 +36,4 @@ no_index:
     - inc
 requires:
   Test::More: '0'
-version: '1.33'
+version: '1.4'

--- a/perl-package/AI-MXNetCAPI/README
+++ b/perl-package/AI-MXNetCAPI/README
@@ -1,4 +1,4 @@
-AI-MXNetCAPI version 1.33
+AI-MXNetCAPI version 1.4
 =====================
 
 Swig interface to MXNet c api.

--- a/perl-package/AI-MXNetCAPI/lib/AI/MXNetCAPI.pm
+++ b/perl-package/AI-MXNetCAPI/lib/AI/MXNetCAPI.pm
@@ -18,7 +18,7 @@
 package AI::MXNetCAPI;
 use base qw(DynaLoader);
 bootstrap AI::MXNetCAPI;
-our $VERSION = '1.33';
+our $VERSION = '1.4';
 1;
 __END__
 

--- a/perl-package/AI-MXNetCAPI/mxnet_typemaps.i
+++ b/perl-package/AI-MXNetCAPI/mxnet_typemaps.i
@@ -115,7 +115,7 @@
     }
 }
 
-%typemap(in,numinputs=0) (int *out) (int temp), (bool *out) (bool temp)
+%typemap(in,numinputs=0) (int *out) (int temp), (bool *out) (bool temp), (uint64_t *out) (uint64_t temp)
 {
     temp = 0;
     $1 = &temp;
@@ -130,6 +130,17 @@
         argvi++;
     }
 }
+
+%typemap(argout) (uint64_t *out)
+{
+    if(!result)
+    {
+        $result = newSVnv((double)(*$1));
+        sv_2mortal($result);
+        argvi++;
+    }
+}
+
 
 %typemap(in,numinputs=0) (const int **out_stypes) (int* temp)
 {


### PR DESCRIPTION
## Description ##
Two more gluon loss classes.
Visualization fixes.
Gluon RNN rework, including hybridization.
Exposed GPU memory info to perl level.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Two more gluon loss classes.
Visualization fixes.
Gluon RNN rework, including hybridization.
Exposed GPU memory info to perl level.

## Comments ##

