### PR TITLE
Fix SliceLikeBackward

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -1389,13 +1389,15 @@ void SliceLikeBackward(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(inputs.size(), 1U);
   CHECK_EQ(outputs.size(), 2U);
   CHECK_EQ(req.size(), 2U);
-  if (req[0] == kNullOp) return;
   using namespace mshadow;
   Stream<xpu>* s = ctx.get_stream<xpu>();
+  if (req[1] != kNullOp && req[1] != kAddTo) {
+    Fill(s, outputs[1], req[1], 0);  // Second input not relavant to gradients.
+  }
+  if (req[0] == kNullOp) return;
   const TBlob& ograd = inputs[0];
   const TBlob& igrad = outputs[0];
   const SliceLikeParam& param = nnvm::get<SliceLikeParam>(attrs.parsed);
-  Fill(s, outputs[1], req[1], 0);  // Second input not relavant to gradients.
   if (req[0] == kWriteTo) {
     Fill(s, igrad, req[0], 0);
   } else if (req[0] == kWriteInplace) {


### PR DESCRIPTION
## Description ##

This PR fixes a bug in `slice_like` operator, where, if the first input is constant, the backward pass of this operator would not fill the gradient to the second input with zeros, instead passing random memory contents.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Moved the handling of the second input before the early exit for the first input

## Comments ##
- This issue was encountered while working with GluonCV's SSD model, where `slice_like` is used in anchor generator (https://github.com/dmlc/gluon-cv/blob/master/gluoncv/model_zoo/ssd/anchor.py#L70):
```
a = F.slice_like(anchors, x * 0, axes=(2, 3))
```
where the work around was to multiply the second input by 0 (effectively zeroing the gradient). With this PR, this work around is not needed anymore (and it is also not fully safe - NaNs and Infs in the memory returned from SliceLikeBackward would produce NaNs when multiplied by 0 and so would still break the training). @zhreshold FYI

@eric-haibin-lin 