### PR TITLE
fix slice operator for following inputs: (1) begin=end and (2) end=-1, step=-1

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -725,7 +725,9 @@ inline void SetSliceOpOutputDimSize(const index_t i, const int b,
                      << e << ", and step[" << i << "]=" << s << " is invalid";
       (*oshape)[i] = (b - e - 1) / (-s) + 1;
     }
-  }  // else leave oshape[i] as 0 for partial infer
+  } else {
+    (*oshape)[i] = 0;
+  }
 }
 
 inline bool SliceOpShape(const nnvm::NodeAttrs& attrs,
@@ -748,7 +750,7 @@ inline bool SliceOpShape(const nnvm::NodeAttrs& attrs,
   });
 
   SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);
-  return !shape_is_none(dshape) && !shape_is_none(oshape);
+  return true;
 }
 
 template<int ndim, int req, typename xpu>

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -679,10 +679,18 @@ inline void GetIndexRange(const TShape& dshape,
 
       if (param_end[i].has_value()) {
         e = param_end[i].value();
-        if (e < 0) {
-          e += len;
-          CHECK_GE(e, 0) << "slicing with end[" << i << "]="
-                         << e - len << " exceeds limit of " << len;
+        if (s > 0) {
+          if (e < 0) {
+            e += len;
+            CHECK_GE(e, 0) << "slicing with end[" << i << "]="
+                           << e - len << " exceeds limit of " << len;
+          }
+        } else {
+          if (e < -1) {
+            e += len;
+            CHECK_GE(e, -1) << "slicing with end[" << i << "]="
+                           << e - len << " exceeds limit of " << len;
+          }
         }
       } else if (s < 0) {
         e = -1;

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -431,6 +431,8 @@ void SliceExCPU(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(outputs.size(), 1);
   const SliceParam& param = nnvm::get<SliceParam>(attrs.parsed);
   auto in_stype = inputs[0].storage_type();
+  auto out_size = outputs[0].shape().Size();
+  if (out_size == 0) return;
   if (in_stype == kCSRStorage) {
     SliceCsrImpl<cpu>(param, ctx, inputs[0], req[0], outputs[0]);
 #if MXNET_USE_MKLDNN == 1

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6523,7 +6523,9 @@ def test_slice():
                   (slice(1, 10), slice(2, 5), slice(3, 6), slice(7, 10)),
                   (slice(1, 10, 2), slice(2, 9, 3), slice(3, 6, 5), slice(7, 10, 2)),
                   (slice(None, None, -1), slice(None, None, -1), slice(None, None, -1)),
-                  (slice(10, 0, -2), slice(5, 2, -1), slice(7, None, 3), slice(None, 12, 4))]
+                  (slice(10, 0, -2), slice(5, 2, -1), slice(7, None, 3), slice(None, 12, 4)),
+                  (slice(4, -1, -2), slice(4, -1, -1), slice(0, 5, 1), slice(7, -1, -1)),
+                  (slice(0, 0, -2), slice(0, 5, 1), slice(3, 3, 1), slice(7, -1, -1))]
     for index in index_list:
         test_slice_forward_backward(arr, index)
 


### PR DESCRIPTION
## Description ##
This PR fixes nd.slice for erroneous output in the following cases:
(1) begin=end ( fixes #13760 )
(2) end=-1, step=-1 ( fixes #14105 )

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
