### PR TITLE
Update inference sample make file.

### DIFF
--- a/cpp-package/example/inference/Makefile
+++ b/cpp-package/example/inference/Makefile
@@ -15,6 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
+ifeq ($(OS),Windows_NT)
+	UNAME_S := Windows
+else
+	UNAME_S := $(shell uname -s)
+endif
+
+MXNET_PATH := $(shell cd ../../..; pwd)
 
 CPPEX_SRC = $(wildcard *.cpp)
 CPPEX_EXE = $(patsubst %.cpp, %, $(CPPEX_SRC))
@@ -23,9 +30,8 @@ OPENCV_LDFLAGS=`pkg-config --libs opencv`
 
 CXX=g++
 
-
-CFLAGS=$(COMMFLAGS) -I../../../3rdparty/tvm/nnvm/include -I../../../3rdparty/dmlc-core/include -I ../../include -I ../../../include -Wall -O3 -msse3 -funroll-loops -Wno-unused-parameter -Wno-unknown-pragmas
-CPPEX_EXTRA_LDFLAGS := -L../../../lib -lmxnet $(OPENCV_LDFLAGS)
+CFLAGS=$(COMMFLAGS) -I ../../include -I$(MXNET_PATH)/3rdparty/tvm/nnvm/include -I$(MXNET_PATH)/3rdparty/dmlc-core/include -I$(MXNET_PATH)/include -Wall -O3 -msse3 -funroll-loops -Wno-unused-parameter -Wno-unknown-pragmas
+CPPEX_EXTRA_LDFLAGS := -L$(MXNET_PATH)/lib -lmxnet $(OPENCV_LDFLAGS)
 
 all: $(CPPEX_EXE)
 
@@ -34,7 +40,12 @@ debug: all
 
 
 $(CPPEX_EXE):% : %.cpp
-	$(CXX) -std=c++0x $(CFLAGS)  $(CPPEX_CFLAGS) -o $@ $(filter %.cpp %.a, $^) $(CPPEX_EXTRA_LDFLAGS)
+	@mkdir -p build
+	$(CXX) -std=c++0x $(CFLAGS)  $(CPPEX_CFLAGS) -o build/$@ $(filter %.cpp %.a, $^) $(CPPEX_EXTRA_LDFLAGS)
+ifeq ($(UNAME_S), Darwin)
+	install_name_tool -add_rpath @loader_path build/$@
+	install_name_tool -add_rpath $(MXNET_PATH)/lib build/$@
+endif
 
 clean:
-	rm -f $(CPPEX_EXE)
+	rm -rf build

--- a/cpp-package/example/inference/unit_test_inception_inference.sh
+++ b/cpp-package/example/inference/unit_test_inception_inference.sh
@@ -25,11 +25,11 @@ tar -xvzf inception-bn.tar.gz -C model
 
 # Running the example with dog image.
 if [ "$(uname)" == "Darwin" ]; then
-    DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:../../../lib ./inception_inference --symbol "./model/Inception-BN-symbol.json" --params "./model/Inception-BN-0126.params" --synset "./model/synset.txt" --mean "./model/mean_224.nd" --image "./model/dog.jpg" 2&> inception_inference.log
+    build/inception_inference --symbol "./model/Inception-BN-symbol.json" --params "./model/Inception-BN-0126.params" --synset "./model/synset.txt" --mean "./model/mean_224.nd" --image "./model/dog.jpg" 2&> build/inception_inference.log
 else
-    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:../../../lib ./inception_inference --symbol "./model/Inception-BN-symbol.json" --params "./model/Inception-BN-0126.params" --synset "./model/synset.txt" --mean "./model/mean_224.nd" --image "./model/dog.jpg" 2&> inception_inference.log
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:../../../lib build/inception_inference --symbol "./model/Inception-BN-symbol.json" --params "./model/Inception-BN-0126.params" --synset "./model/synset.txt" --mean "./model/mean_224.nd" --image "./model/dog.jpg" 2&> build/inception_inference.log
 fi
-result=`grep -c "pug-dog" inception_inference.log`
+result=`grep -c "pug-dog" build/inception_inference.log`
 if [ $result == 1 ];
 then
     echo "PASS: inception_inference correctly identified the image."

--- a/cpp-package/example/inference/unit_test_sentiment_analysis_rnn.sh
+++ b/cpp-package/example/inference/unit_test_sentiment_analysis_rnn.sh
@@ -20,15 +20,15 @@ function compare_range() {
 }
 
 set -e # exit on the first error
-export EXE_NAME="sentiment_analysis_rnn"
+EXE_NAME="sentiment_analysis_rnn"
 
 # Running the example with a movie review.
 if [ "$(uname)" == "Darwin" ]; then
-    DYLD_LIBRARY_PATH=${DYLD_LIBRARY_PATH}:../../../lib ./${EXE_NAME}  --input "This movie is the best." 2&> ${EXE_NAME}.log
+    build/${EXE_NAME}  --input "This movie is the best." 2&> build/${EXE_NAME}.log
 else
-    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:../../../lib ./${EXE_NAME}  --input "This movie is the best." 2&> ${EXE_NAME}.log
+    LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:../../../lib build/${EXE_NAME}  --input "This movie is the best." 2&> build/${EXE_NAME}.log
 fi
-result=`grep "The sentiment score between 0 and 1.*\=" ${EXE_NAME}.log | cut -d '=' -f2`
+result=`grep "The sentiment score between 0 and 1.*\=" build/${EXE_NAME}.log | cut -d '=' -f2`
 lower_bound=0.8
 upper_bound=0.99
 if [ $(compare_range $result $lower_bound $upper_bound) == 1 ];


### PR DESCRIPTION
## Description ##
Current CPP inference examples on OSX cannot be executed. They failed to load libmxnet.so file.
This PR will fix rpath issue for OSX.

1. put all output files into build folder.
2. set rpath location for osx build.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
