### PR TITLE
Fix unary operator ceil/floor/trunc when data type is integer

### DIFF
--- a/src/operator/math_functions-inl.h
+++ b/src/operator/math_functions-inl.h
@@ -41,13 +41,18 @@ namespace math {
 //   and returns double
 
 #define MXNET_UNARY_MATH_FUNC(name) \
-template<typename DType> MSHADOW_XINLINE \
-float name(DType a) { \
-  return ::name##f(static_cast<float>(a)); \
+MSHADOW_XINLINE \
+float name(float a) { \
+  return ::name##f(a); \
 } \
 MSHADOW_XINLINE \
 double name(double a) { \
   return ::name(a); \
+} \
+template<typename DType> MSHADOW_XINLINE \
+typename std::enable_if<std::is_integral<DType>::value, double>::type \
+name(DType a) { \
+  return ::name(static_cast<double>(a)); \
 }
 
 #define MXNET_BINARY_MATH_FUNC(name) \

--- a/src/operator/math_functions-inl.h
+++ b/src/operator/math_functions-inl.h
@@ -35,9 +35,9 @@ namespace op {
 namespace math {
 
 // Wrappers for math.h unary and binary functions
-// - For DType != double: math::name(a) does computation in float
+// - For DType == float: math::name(a) does computation in float
 //   and returns float
-// - For DType == double: math::name(a) does computation in double
+// - For DType == double or DType == integer: math::name(a) does computation in double
 //   and returns double
 
 #define MXNET_UNARY_MATH_FUNC(name) \

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1952,6 +1952,25 @@ def test_update_ops_mutation():
             {'rescale_grad': 0.1, 'lr': 0.01, 'wd': 1e-3})
 
 
+def test_large_int_rounding():
+    large_integer = 50000001
+
+    a = mx.nd.array([large_integer], dtype='int32')
+    assert np.all(a == large_integer)
+
+    a = mx.nd.array([large_integer], dtype='int32').floor()
+    assert np.all(a == large_integer)
+
+    a = mx.nd.array([large_integer], dtype='int32').round()
+    assert np.all(a == large_integer)
+
+    a = mx.nd.array([large_integer], dtype='int32').ceil()
+    assert np.all(a == large_integer)
+
+    a = mx.nd.array([large_integer], dtype='int32').trunc()
+    assert np.all(a == large_integer)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
Many operators implicitly cast data to float and return inaccurate results. This PR fixes https://github.com/apache/incubator-mxnet/issues/13220. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###


## Comments ##
