### PR TITLE
Use cudnn for dropout by default

### DIFF
--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -77,7 +77,7 @@ struct DropoutParam : public dmlc::Parameter<DropoutParam> {
     .describe("Whether to only turn on dropout during training or to also turn on for inference.");
     DMLC_DECLARE_FIELD(axes).set_default(TShape())
     .describe("Axes for variational dropout kernel.");
-    DMLC_DECLARE_FIELD(cudnn_off).set_default(dmlc::optional<bool>(true))
+    DMLC_DECLARE_FIELD(cudnn_off).set_default(dmlc::optional<bool>(false))
     .describe("Whether to turn off cudnn in dropout operator. "
               "This option is ignored if axes is specified.");
   }

--- a/tests/cpp/include/test_op.h
+++ b/tests/cpp/include/test_op.h
@@ -72,7 +72,7 @@ struct GPUStreamScope {
     : opContext_(*opContext) {
     CHECK_EQ(opContext_.run_ctx.stream == nullptr, true)
       << "Invalid runtime context stream state";
-    opContext_.run_ctx.stream = mshadow::NewStream<gpu>(true, true, 0);
+    opContext_.run_ctx.stream = mshadow::NewStream<gpu>(true, true, opContext_.run_ctx.ctx.dev_id);
     CHECK_EQ(opContext_.run_ctx.stream != nullptr, true)
       << "Unable to allocate a GPU stream";
   }

--- a/tests/cpp/include/test_op.h
+++ b/tests/cpp/include/test_op.h
@@ -72,7 +72,7 @@ struct GPUStreamScope {
     : opContext_(*opContext) {
     CHECK_EQ(opContext_.run_ctx.stream == nullptr, true)
       << "Invalid runtime context stream state";
-    opContext_.run_ctx.stream = mshadow::NewStream<gpu>(true, true);
+    opContext_.run_ctx.stream = mshadow::NewStream<gpu>(true, true, 0);
     CHECK_EQ(opContext_.run_ctx.stream != nullptr, true)
       << "Unable to allocate a GPU stream";
   }


### PR DESCRIPTION
## Description ##
enable cuddn for dropout after https://github.com/apache/incubator-mxnet/pull/13896
This was turned on only in Gluon dropout layers, but not in mx.nd.Dropout.

Test:
After setting changing the flag, ran the sample code in  #13896, was able to get the same speed reported.

```
import mxnet as mx
a = mx.nd.ones((10, 200, 300, 500), ctx=mx.gpu(0))
a.attach_grad()
mx.autograd.set_recording(True)
%timeit mx.nd.Dropout(a, 0.5, mode='always').wait_to_read()

4.24 ms ± 4.35 µs per loop (mean ± std. dev. of 7 runs, 100 loops each
```


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.

- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
set cudnn_off default as false


