### PR TITLE
Allow gluon blocks to register lists of blocks as attributes

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -205,6 +205,9 @@ class Block(object):
                 "If you want to share parameters between blocks, please set " \
                 "'params' at Block construction instead."
             self._reg_params[name] = value
+        elif isinstance(value, list) and all(isinstance(item, Block) for item in value):
+            for i, v in enumerate(value):
+                self.register_child(v, "%s_%d" % (name, i))
 
         super(Block, self).__setattr__(name, value)
 


### PR DESCRIPTION
## Description ##
Currently gluon Blocks (and Hybridblocks) register attributes' parameters if they are of type Parameter or Block. However, in certain cases one wants to add a list of blocks (or parameters) whose size is only known in runtime.

I am proposing here a small improvement, please advise if this idea even makes sense or is already covered by a similar functionality.


