### PR TITLE
fix SoftmaxOutput resource bug

### DIFF
--- a/src/operator/softmax_output-inl.h
+++ b/src/operator/softmax_output-inl.h
@@ -426,11 +426,6 @@ class SoftmaxOutputProp : public OperatorProperty {
     return {{in_data[softmaxout_enum::kData], out_data[softmaxout_enum::kOut]}};
   }
 
-  std::vector<ResourceRequest> BackwardResource(
-      const mxnet::ShapeVector &in_shape) const override {
-    return {ResourceRequest::kTempSpace};
-  }
-
   Operator* CreateOperator(Context ctx) const override {
     LOG(FATAL) << "Not Implemented.";
     return NULL;

--- a/src/operator/softmax_output.cc
+++ b/src/operator/softmax_output.cc
@@ -262,6 +262,9 @@ NNVM_REGISTER_OP(_backward_SoftmaxOutput)
 .set_attr<nnvm::FInplaceOption>("FInplaceOption", [](const NodeAttrs& attrs){
   return std::vector<std::pair<int, int> >{{0, 0}};
 })
+.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n){
+  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+})
 .set_attr_parser(ParamParser<SoftmaxOutputParam>)
 .set_attr<FCompute>("FCompute<cpu>", SoftmaxOutputGradCompute<cpu>);
 }  // namespace op

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6522,7 +6522,7 @@ def test_softmax_output_normalization():
         if use_ignore:
             kwargs.update(use_ignore=True, ignore_label=ignore_label)
 
-        with autograd.record():
+        with mx.autograd.record():
             out = mx.nd.SoftmaxOutput(data=data, label=label, **kwargs)
         out.backward(mx.nd.ones_like(data))
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6502,7 +6502,7 @@ def test_SoftmaxOutput_normalization():
         grad_scale = np.random.random()
         batch_size = 8
         num_labels = 6
-        ignore_label = np.random.randint(0, num_labels)
+        ignore_label = np.random.randint(0, num_labels) if use_ignore else -1
 
         data = mx.nd.random.uniform(-1, 1, shape=(batch_size, num_labels))
         data.attach_grad()
@@ -6532,10 +6532,7 @@ def test_SoftmaxOutput_normalization():
         if normalization == 'batch':
             valid_cnt = batch_size
         elif normalization == 'valid':
-            if use_ignore:
-                valid_cnt = mx.nd.maximum(1, (label != ignore_label).sum())
-            else:
-                valid_cnt = batch_size
+            valid_cnt = mx.nd.maximum(1, (label != ignore_label).sum())
 
         data_grad *= (grad_scale / valid_cnt)
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6497,7 +6497,7 @@ def test_softmax():
 
 
 @with_seed()
-def test_SoftmaxOutput_normalization():
+def test_softmax_output_normalization():
     def _softmaxoutput_normalization(multi_output, use_ignore, normalization):
         grad_scale = np.random.random()
         batch_size = 8


### PR DESCRIPTION
## Description ##
Fix https://github.com/apache/incubator-mxnet/issues/14301

It seems that `BackwardResource` in `src/operator/softmax_output-inl.h` is not used in SoftmaxOutput since it is not a legacy operator.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Tiny change. The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Remove `BackwardResource` in `src/operator/softmax_output-inl.h`
- [x] Add `ResourceRequest` in  `src/operator/softmax_output.cc`
- [x] Add the testcase for SoftmaxOutput.

## Comments ##
`SoftmaxOutput` is not a legacy operator, which is registered by `NNVM_REGISTER_OP` rather than `MXNET_REGISTER_OP_PROPERTY`, so `BackwardResource` is not used for it.
Meanwhile, I check all operators. Only `SoftmaxOutput` has the problem.
