### PR TITLE
[MXNET-1331] Removal of non-MXNET classes from JAR

### DIFF
--- a/scala-package/assembly/src/main/assembly/assembly.xml
+++ b/scala-package/assembly/src/main/assembly/assembly.xml
@@ -30,6 +30,8 @@
         <exclude>org.scala-lang.modules:*</exclude>
         <exclude>commons-io:commons-io</exclude>
         <exclude>commons-codec:commons-codec</exclude>
+        <exclude>org.slf4j:slf4j-api</exclude>
+        <exclude>args4j:args4j</exclude>
       </excludes>
       <outputDirectory>/</outputDirectory>
       <useProjectArtifact>true</useProjectArtifact>

--- a/scala-package/deploy/src/main/deploy/deploy.xml
+++ b/scala-package/deploy/src/main/deploy/deploy.xml
@@ -55,5 +55,15 @@
       <artifactId>commons-io</artifactId>
       <version>2.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.5</version>
+    </dependency>
+    <dependency>
+      <groupId>args4j</groupId>
+      <artifactId>args4j</artifactId>
+      <version>2.0.29</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Consumers of MXNet are exposed to the library versions MXNet uses internally. This change excludes those JARs from the JARs created with `make scalapkg`.

## Description ##
This PR removes 3rd party libraries from the assembled JAR and adds both packages as dependencies in deploy.xml

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues/MXNET-1302) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] slf4j-api and args4j remove from assembled JAR
- [x] slf4j-api and args4j added as dependencies to deploy.xml

## Comments ##
My Maven knowledge is sparse so I may have missed something.

For testing:
* The JAR no longer contains non-org.apache.mxnetclasses
* make scalapkg && make scalaunittests && make scalaintegrationtests passed on my Ubuntu 18.04 machine (JDK 8).

Related to https://github.com/apache/incubator-mxnet/pull/14000