### PR TITLE
compatibility with opencv4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,11 @@ endif
 # setup opencv
 ifeq ($(USE_OPENCV), 1)
 	CFLAGS += -DMXNET_USE_OPENCV=1
-	LDFLAGS += -lopencv_core -lopencv_imgcodecs -lopencv_imgproc
 	ifneq ($(USE_OPENCV_PATH), )
 		CFLAGS += -I$(USE_OPENCV_PATH)
+		ifneq ($(USE_OPENCV_LIB_PATH), )
+			LDFLAGS += -L$(USE_OPENCV_LIB_PATH)
+		endif
 	else
 		ifeq ("$(shell pkg-config --exists opencv4; echo $$?)", "0")
 			OPENCV_LIB = opencv4
@@ -157,7 +159,10 @@ ifeq ($(USE_OPENCV), 1)
 			OPENCV_LIB = opencv
 		endif
 		CFLAGS += $(shell pkg-config --cflags $(OPENCV_LIB))
+		LDFLAGS += $(shell pkg-config --libs-only-L $(OPENCV_LIB))
 	endif
+	LDFLAGS += -lopencv_core -lopencv_imgcodecs -lopencv_imgproc
+
 	BIN += bin/im2rec
 else
 	CFLAGS += -DMXNET_USE_OPENCV=0

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ ifdef CAFFE_PATH
 endif
 
 ifndef LINT_LANG
-	LINT_LANG="all"
+	LINT_LANG = "all"
 endif
 
 ifeq ($(USE_MKLDNN), 1)

--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,16 @@ endif
 # setup opencv
 ifeq ($(USE_OPENCV), 1)
 	CFLAGS += -DMXNET_USE_OPENCV=1
-	ifneq ($(USE_OPENCV_PATH), )
-		CFLAGS += -I$(USE_OPENCV_PATH)
-		ifneq ($(USE_OPENCV_LIB_PATH), )
-			LDFLAGS += -L$(USE_OPENCV_LIB_PATH)
+	ifneq ($(USE_OPENCV_DEP_PATH), NONE)
+		CFLAGS += -I$(USE_OPENCV_DEP_PATH)/include
+		ifeq ($(USE_OPENCV_LIB_PATH), NONE)
+			USE_OPENCV_LIB_PATH = $(USE_OPENCV_DEP_PATH)/lib
+		endif
+		LDFLAGS += -L$(USE_OPENCV_LIB_PATH)
+		LDFLAGS += -lopencv_core -lopencv_imgproc
+		# Add flag -lopencv_imgcodecs for OpenCV 3+
+		ifneq ($(wildcard $(USE_OPENCV_LIB_PATH)/libopencv_imgcodecs.*), )
+			LDFLAGS += -lopencv_imgcodecs
 		endif
 	else
 		ifeq ("$(shell pkg-config --exists opencv4; echo $$?)", "0")
@@ -160,9 +166,9 @@ ifeq ($(USE_OPENCV), 1)
 		endif
 		CFLAGS += $(shell pkg-config --cflags $(OPENCV_LIB))
 		LDFLAGS += $(shell pkg-config --libs-only-L $(OPENCV_LIB))
+		LDFLAGS += -lopencv_core -lopencv_imgproc
+		LDFLAGS += $(filter -lopencv_imgcodecs, $(shell pkg-config --libs-only-l $(OPENCV_LIB)))
 	endif
-	LDFLAGS += -lopencv_core -lopencv_imgcodecs -lopencv_imgproc
-
 	BIN += bin/im2rec
 else
 	CFLAGS += -DMXNET_USE_OPENCV=0

--- a/Makefile
+++ b/Makefile
@@ -146,15 +146,18 @@ endif
 
 # setup opencv
 ifeq ($(USE_OPENCV), 1)
-	ifeq ("$(shell pkg-config --exists opencv4; echo $$?)", "0")
-		OPENCV_LIB = opencv4
+	CFLAGS += -DMXNET_USE_OPENCV=1
+	LDFLAGS += -lopencv_core -lopencv_imgcodecs -lopencv_imgproc
+	ifneq ($(USE_OPENCV_PATH), NONE)
+		CFLAGS += -I$(USE_OPENCV_PATH)
 	else
-		OPENCV_LIB = opencv
+		ifeq ("$(shell pkg-config --exists opencv4; echo $$?)", "0")
+			OPENCV_LIB = opencv4
+		else
+			OPENCV_LIB = opencv
+		endif
+		CFLAGS += $(shell pkg-config --cflags $(OPENCV_LIB))
 	endif
-
-	CFLAGS += -DMXNET_USE_OPENCV=1 $(shell pkg-config --cflags $(OPENCV_LIB))
-	LDFLAGS += $(filter-out -lopencv_ts, $(shell pkg-config --libs $(OPENCV_LIB)))
-
 	BIN += bin/im2rec
 else
 	CFLAGS += -DMXNET_USE_OPENCV=0

--- a/Makefile
+++ b/Makefile
@@ -146,18 +146,18 @@ endif
 
 # setup opencv
 ifeq ($(USE_OPENCV), 1)
-
 	ifeq ("$(shell pkg-config --exists opencv4; echo $$?)", "0")
-		CFLAGS += -DMXNET_USE_OPENCV=1 $(shell pkg-config --cflags opencv4)
-		LDFLAGS += $(filter-out -lopencv_ts, $(shell pkg-config --libs opencv4))
+		OPENCV_LIB = opencv4
 	else
-		CFLAGS += -DMXNET_USE_OPENCV=1 $(shell pkg-config --cflags opencv)
-		LDFLAGS += $(filter-out -lopencv_ts, $(shell pkg-config --libs opencv))
+		OPENCV_LIB = opencv
 	endif
+
+	CFLAGS += -DMXNET_USE_OPENCV=1 $(shell pkg-config --cflags $(OPENCV_LIB))
+	LDFLAGS += $(filter-out -lopencv_ts, $(shell pkg-config --libs $(OPENCV_LIB)))
 
 	BIN += bin/im2rec
 else
-	CFLAGS+= -DMXNET_USE_OPENCV=0
+	CFLAGS += -DMXNET_USE_OPENCV=0
 endif
 
 ifeq ($(USE_OPENMP), 1)

--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ endif
 ifeq ($(USE_OPENCV), 1)
 	CFLAGS += -DMXNET_USE_OPENCV=1
 	LDFLAGS += -lopencv_core -lopencv_imgcodecs -lopencv_imgproc
-	ifneq ($(USE_OPENCV_PATH), NONE)
+	ifneq ($(USE_OPENCV_PATH), )
 		CFLAGS += -I$(USE_OPENCV_PATH)
 	else
 		ifeq ("$(shell pkg-config --exists opencv4; echo $$?)", "0")

--- a/Makefile
+++ b/Makefile
@@ -147,15 +147,17 @@ endif
 # setup opencv
 ifeq ($(USE_OPENCV), 1)
 	CFLAGS += -DMXNET_USE_OPENCV=1
-	ifneq ($(USE_OPENCV_DEP_PATH), NONE)
-		CFLAGS += -I$(USE_OPENCV_DEP_PATH)/include
+	ifneq ($(USE_OPENCV_INC_PATH), NONE)
+		CFLAGS += -I$(USE_OPENCV_INC_PATH)/include
 		ifeq ($(USE_OPENCV_LIB_PATH), NONE)
-			USE_OPENCV_LIB_PATH = $(USE_OPENCV_DEP_PATH)/lib
+$(error Please add the path of OpenCV shared library path into `USE_OPENCV_LIB_PATH`, when `USE_OPENCV_INC_PATH` is not NONE)
 		endif
 		LDFLAGS += -L$(USE_OPENCV_LIB_PATH)
-		# Add flag -lopencv_imgcodecs for OpenCV 3+
-		ifneq ($(wildcard $(USE_OPENCV_LIB_PATH)/libopencv_imgcodecs.*), )
+		ifneq ($(wildcard $(USE_OPENCV_LIB_PATH)/libopencv_imgcodecs.*),)
 			LDFLAGS += -lopencv_imgcodecs
+		endif
+		ifneq ($(wildcard $(USE_OPENCV_LIB_PATH)/libopencv_highgui.*),)
+			LDFLAGS += -lopencv_highgui
 		endif
 	else
 		ifeq ("$(shell pkg-config --exists opencv4; echo $$?)", "0")
@@ -165,9 +167,9 @@ ifeq ($(USE_OPENCV), 1)
 		endif
 		CFLAGS += $(shell pkg-config --cflags $(OPENCV_LIB))
 		LDFLAGS += $(shell pkg-config --libs-only-L $(OPENCV_LIB))
-		LDFLAGS += $(filter -lopencv_imgcodecs, $(shell pkg-config --libs-only-l $(OPENCV_LIB)))
+		LDFLAGS += $(filter -lopencv_imgcodecs -lopencv_highgui, $(shell pkg-config --libs-only-l $(OPENCV_LIB)))
 	endif
-	LDFLAGS += -lopencv_core -lopencv_imgproc -lopencv_highgui
+	LDFLAGS += -lopencv_core -lopencv_imgproc
 	BIN += bin/im2rec
 else
 	CFLAGS += -DMXNET_USE_OPENCV=0

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,6 @@ ifeq ($(USE_OPENCV), 1)
 			USE_OPENCV_LIB_PATH = $(USE_OPENCV_DEP_PATH)/lib
 		endif
 		LDFLAGS += -L$(USE_OPENCV_LIB_PATH)
-		LDFLAGS += -lopencv_core -lopencv_imgproc
 		# Add flag -lopencv_imgcodecs for OpenCV 3+
 		ifneq ($(wildcard $(USE_OPENCV_LIB_PATH)/libopencv_imgcodecs.*), )
 			LDFLAGS += -lopencv_imgcodecs
@@ -166,9 +165,9 @@ ifeq ($(USE_OPENCV), 1)
 		endif
 		CFLAGS += $(shell pkg-config --cflags $(OPENCV_LIB))
 		LDFLAGS += $(shell pkg-config --libs-only-L $(OPENCV_LIB))
-		LDFLAGS += -lopencv_core -lopencv_imgproc
 		LDFLAGS += $(filter -lopencv_imgcodecs, $(shell pkg-config --libs-only-l $(OPENCV_LIB)))
 	endif
+	LDFLAGS += -lopencv_core -lopencv_imgproc -lopencv_highgui
 	BIN += bin/im2rec
 else
 	CFLAGS += -DMXNET_USE_OPENCV=0

--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,15 @@ endif
 
 # setup opencv
 ifeq ($(USE_OPENCV), 1)
-	CFLAGS += -DMXNET_USE_OPENCV=1 $(shell pkg-config --cflags opencv)
-	LDFLAGS += $(filter-out -lopencv_ts, $(shell pkg-config --libs opencv))
+
+	ifeq ("$(shell pkg-config --exists opencv4; echo $$?)", "0")
+		CFLAGS += -DMXNET_USE_OPENCV=1 $(shell pkg-config --cflags opencv4)
+		LDFLAGS += $(filter-out -lopencv_ts, $(shell pkg-config --libs opencv4))
+	else
+		CFLAGS += -DMXNET_USE_OPENCV=1 $(shell pkg-config --cflags opencv)
+		LDFLAGS += $(filter-out -lopencv_ts, $(shell pkg-config --libs opencv))
+	endif
+
 	BIN += bin/im2rec
 else
 	CFLAGS+= -DMXNET_USE_OPENCV=0

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,6 @@ ifeq ($(USE_OPENCV), 1)
 $(error Please add the path of OpenCV shared library path into `USE_OPENCV_LIB_PATH`, when `USE_OPENCV_INC_PATH` is not NONE)
 		endif
 		LDFLAGS += -L$(USE_OPENCV_LIB_PATH)
-		LDFLAGS += -lopencv_core -lopencv_imgproc
 		ifneq ($(wildcard $(USE_OPENCV_LIB_PATH)/libopencv_imgcodecs.*),)
 			LDFLAGS += -lopencv_imgcodecs
 		endif
@@ -168,9 +167,9 @@ $(error Please add the path of OpenCV shared library path into `USE_OPENCV_LIB_P
 		endif
 		CFLAGS += $(shell pkg-config --cflags $(OPENCV_LIB))
 		LDFLAGS += $(shell pkg-config --libs-only-L $(OPENCV_LIB))
-		LDFLAGS += -lopencv_core -lopencv_imgproc
 		LDFLAGS += $(filter -lopencv_imgcodecs -lopencv_highgui, $(shell pkg-config --libs-only-l $(OPENCV_LIB)))
 	endif
+	LDFLAGS += -lopencv_imgproc -lopencv_core
 	BIN += bin/im2rec
 else
 	CFLAGS += -DMXNET_USE_OPENCV=0

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,7 @@ ifeq ($(USE_OPENCV), 1)
 $(error Please add the path of OpenCV shared library path into `USE_OPENCV_LIB_PATH`, when `USE_OPENCV_INC_PATH` is not NONE)
 		endif
 		LDFLAGS += -L$(USE_OPENCV_LIB_PATH)
+		LDFLAGS += -lopencv_core -lopencv_imgproc
 		ifneq ($(wildcard $(USE_OPENCV_LIB_PATH)/libopencv_imgcodecs.*),)
 			LDFLAGS += -lopencv_imgcodecs
 		endif
@@ -166,9 +167,10 @@ $(error Please add the path of OpenCV shared library path into `USE_OPENCV_LIB_P
 			OPENCV_LIB = opencv
 		endif
 		CFLAGS += $(shell pkg-config --cflags $(OPENCV_LIB))
+		LDFLAGS += $(shell pkg-config --libs-only-L $(OPENCV_LIB))
+		LDFLAGS += -lopencv_core -lopencv_imgproc
 		LDFLAGS += $(filter -lopencv_imgcodecs -lopencv_highgui, $(shell pkg-config --libs-only-l $(OPENCV_LIB)))
 	endif
-	LDFLAGS += -lopencv_core -lopencv_imgproc
 	BIN += bin/im2rec
 else
 	CFLAGS += -DMXNET_USE_OPENCV=0

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,6 @@ $(error Please add the path of OpenCV shared library path into `USE_OPENCV_LIB_P
 			OPENCV_LIB = opencv
 		endif
 		CFLAGS += $(shell pkg-config --cflags $(OPENCV_LIB))
-		LDFLAGS += $(shell pkg-config --libs-only-L $(OPENCV_LIB))
 		LDFLAGS += $(filter -lopencv_imgcodecs -lopencv_highgui, $(shell pkg-config --libs-only-l $(OPENCV_LIB)))
 	endif
 	LDFLAGS += -lopencv_core -lopencv_imgproc

--- a/make/config.mk
+++ b/make/config.mk
@@ -89,10 +89,14 @@ USE_NCCL_PATH = NONE
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
-#whether use libjpeg-turbo for image decode without OpenCV wrapper
+# whether use libjpeg-turbo for image decode without OpenCV wrapper
 USE_LIBJPEG_TURBO = 0
-#add the path to libjpeg-turbo library
+# add the path to libjpeg-turbo library
 USE_LIBJPEG_TURBO_PATH = NONE
 
 # use openmp for parallelization

--- a/make/config.mk
+++ b/make/config.mk
@@ -89,14 +89,14 @@ USE_NCCL_PATH = NONE
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
-# whether use libjpeg-turbo for image decode without OpenCV wrapper
+#whether use libjpeg-turbo for image decode without OpenCV wrapper
 USE_LIBJPEG_TURBO = 0
-# add the path to libjpeg-turbo library
+#add the path to libjpeg-turbo library
 USE_LIBJPEG_TURBO_PATH = NONE
 
 # use openmp for parallelization

--- a/make/crosscompile.jetson.mk
+++ b/make/crosscompile.jetson.mk
@@ -89,9 +89,9 @@ USE_NCCL_PATH = NONE
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 0
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 #whether use libjpeg-turbo for image decode without OpenCV wrapper

--- a/make/crosscompile.jetson.mk
+++ b/make/crosscompile.jetson.mk
@@ -89,6 +89,10 @@ USE_NCCL_PATH = NONE
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 0
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 #whether use libjpeg-turbo for image decode without OpenCV wrapper
 USE_LIBJPEG_TURBO = 0

--- a/make/maven/maven_darwin_mkl.mk
+++ b/make/maven/maven_darwin_mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=apple
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/maven/maven_darwin_mkl.mk
+++ b/make/maven/maven_darwin_mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=apple
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 0

--- a/make/maven/maven_linux_cu90mkl.mk
+++ b/make/maven/maven_linux_cu90mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/maven/maven_linux_cu90mkl.mk
+++ b/make/maven/maven_linux_cu90mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/maven/maven_linux_cu92mkl.mk
+++ b/make/maven/maven_linux_cu92mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/maven/maven_linux_cu92mkl.mk
+++ b/make/maven/maven_linux_cu92mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/maven/maven_linux_mkl.mk
+++ b/make/maven/maven_linux_mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/maven/maven_linux_mkl.mk
+++ b/make/maven/maven_linux_mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 0

--- a/make/osx.mk
+++ b/make/osx.mk
@@ -75,6 +75,10 @@ USE_CUDNN = 0
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # use openmp for parallelization
 # apple-clang by default does not have openmp built-in

--- a/make/osx.mk
+++ b/make/osx.mk
@@ -75,9 +75,9 @@ USE_CUDNN = 0
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # use openmp for parallelization

--- a/make/pip/pip_darwin_cpu.mk
+++ b/make/pip/pip_darwin_cpu.mk
@@ -58,9 +58,9 @@ USE_BLAS=apple
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_darwin_cpu.mk
+++ b/make/pip/pip_darwin_cpu.mk
@@ -58,6 +58,10 @@ USE_BLAS=apple
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 0

--- a/make/pip/pip_darwin_mkl.mk
+++ b/make/pip/pip_darwin_mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=apple
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_darwin_mkl.mk
+++ b/make/pip/pip_darwin_mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=apple
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 0

--- a/make/pip/pip_linux_cpu.mk
+++ b/make/pip/pip_linux_cpu.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cpu.mk
+++ b/make/pip/pip_linux_cpu.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 0

--- a/make/pip/pip_linux_cu100.mk
+++ b/make/pip/pip_linux_cu100.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu100.mk
+++ b/make/pip/pip_linux_cu100.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_cu100mkl.mk
+++ b/make/pip/pip_linux_cu100mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu100mkl.mk
+++ b/make/pip/pip_linux_cu100mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_cu75.mk
+++ b/make/pip/pip_linux_cu75.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu75.mk
+++ b/make/pip/pip_linux_cu75.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_cu75mkl.mk
+++ b/make/pip/pip_linux_cu75mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu75mkl.mk
+++ b/make/pip/pip_linux_cu75mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_cu80.mk
+++ b/make/pip/pip_linux_cu80.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu80.mk
+++ b/make/pip/pip_linux_cu80.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_cu80mkl.mk
+++ b/make/pip/pip_linux_cu80mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu80mkl.mk
+++ b/make/pip/pip_linux_cu80mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_cu90.mk
+++ b/make/pip/pip_linux_cu90.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu90.mk
+++ b/make/pip/pip_linux_cu90.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_cu90mkl.mk
+++ b/make/pip/pip_linux_cu90mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu90mkl.mk
+++ b/make/pip/pip_linux_cu90mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_cu91.mk
+++ b/make/pip/pip_linux_cu91.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu91.mk
+++ b/make/pip/pip_linux_cu91.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_cu91mkl.mk
+++ b/make/pip/pip_linux_cu91mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu91mkl.mk
+++ b/make/pip/pip_linux_cu91mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_cu92.mk
+++ b/make/pip/pip_linux_cu92.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu92.mk
+++ b/make/pip/pip_linux_cu92.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_cu92mkl.mk
+++ b/make/pip/pip_linux_cu92mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_cu92mkl.mk
+++ b/make/pip/pip_linux_cu92mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 1

--- a/make/pip/pip_linux_mkl.mk
+++ b/make/pip/pip_linux_mkl.mk
@@ -58,9 +58,9 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile

--- a/make/pip/pip_linux_mkl.mk
+++ b/make/pip/pip_linux_mkl.mk
@@ -58,6 +58,10 @@ USE_BLAS=openblas
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 1
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDA during compile
 USE_CUDA = 0

--- a/make/readthedocs.mk
+++ b/make/readthedocs.mk
@@ -36,6 +36,10 @@ USE_CUDA_PATH = NONE
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 0
+# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
+USE_OPENCV_DEP_PATH = NONE
+# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDNN R3 library
 USE_CUDNN = 0

--- a/make/readthedocs.mk
+++ b/make/readthedocs.mk
@@ -36,9 +36,9 @@ USE_CUDA_PATH = NONE
 # you can disable it, however, you will not able to use
 # imbin iterator
 USE_OPENCV = 0
-# Add OpenCV dependency path, the directory `opencv2` is in $(USE_OPENCV_DEP_PATH)/
-USE_OPENCV_DEP_PATH = NONE
-# Add OpenCV shared library path if the shared libraries are not in $(USE_OPENCV_DEP_PATH)/lib
+# Add OpenCV include path, in which the directory `opencv2` exists
+USE_OPENCV_INC_PATH = NONE
+# Add OpenCV shared library path, in which the shared library exists
 USE_OPENCV_LIB_PATH = NONE
 
 # whether use CUDNN R3 library

--- a/src/io/image_aug_default.cc
+++ b/src/io/image_aug_default.cc
@@ -32,6 +32,7 @@
 #include "../common/utils.h"
 
 #if MXNET_USE_OPENCV
+#include "./opencv_compatibility.h"
 // Registers
 namespace dmlc {
 DMLC_REGISTRY_ENABLE(::mxnet::io::ImageAugmenterReg);

--- a/src/io/image_det_aug_default.cc
+++ b/src/io/image_det_aug_default.cc
@@ -203,6 +203,7 @@ std::vector<dmlc::ParamFieldInfo> ListDefaultDetAugParams() {
 }
 
 #if MXNET_USE_OPENCV
+#include "./opencv_compatibility.h"
 using Rect = cv::Rect_<float>;
 
 #ifdef _MSC_VER

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -41,6 +41,7 @@
 
 #if MXNET_USE_OPENCV
   #include <opencv2/opencv.hpp>
+  #include "./opencv_compatibility.h"
 #endif  // MXNET_USE_OPENCV
 
 namespace mxnet {

--- a/src/io/opencv_compatibility.h
+++ b/src/io/opencv_compatibility.h
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ *  Copyright (c) 2019 by Contributors
+ * \file opencv_compatibility.h
+ * \brief To be compatible with multiple versions of opencv
+ */
+#ifndef MXNET_IO_OPENCV_COMPATIBILITY_H_
+#define MXNET_IO_OPENCV_COMPATIBILITY_H_
+
+#if MXNET_USE_OPENCV
+#include <opencv2/core/version.hpp>
+
+#if CV_VERSION_MAJOR >= 4
+#include <opencv2/opencv.hpp>
+#define CV_RGB2GRAY cv::COLOR_RGB2GRAY
+#define CV_BGR2GRAY cv::COLOR_BGR2GRAY
+
+#define CV_GRAY2RGB cv::COLOR_GRAY2RGB
+#define CV_GRAY2BGR cv::COLOR_GRAY2BGR
+
+#define CV_RGB2HLS cv::COLOR_RGB2HLS
+#define CV_BGR2HLS cv::COLOR_BGR2HLS
+
+#define CV_HLS2RGB cv::COLOR_HLS2RGB
+#define CV_HLS2BGR cv::COLOR_HLS2BGR
+
+#define CV_RGB2BGR cv::COLOR_RGB2BGR
+#define CV_BGR2RGB cv::COLOR_BGR2RGB
+
+#define CV_INTER_LINEAR cv::INTER_LINEAR
+#define CV_INTER_NEAREST cv::INTER_NEAREST
+
+#define CV_LOAD_IMAGE_COLOR cv::IMREAD_COLOR
+#define CV_IMWRITE_PNG_COMPRESSION cv::IMWRITE_PNG_COMPRESSION
+#define CV_IMWRITE_JPEG_QUALITY cv::IMWRITE_JPEG_QUALITY
+
+#endif  // CV_VERSION_MAJOR >= 4
+
+#endif  // MXNET_USE_OPENCV
+
+#endif  // MXNET_IO_OPENCV_COMPATIBILITY_H_

--- a/tools/im2rec.cc
+++ b/tools/im2rec.cc
@@ -39,6 +39,7 @@
 #include <dmlc/logging.h>
 #include <dmlc/recordio.h>
 #include <opencv2/opencv.hpp>
+#include "../src/io/opencv_compatibility.h"
 #include "../src/io/image_recordio.h"
 #include <random>
 /*!


### PR DESCRIPTION
## Description ##
To compatible with multiple versions of OpenCV, define the old OpenCV macros to support OpenCV4.

In OpenCV4, `opencv2/imgproc/imgproc_c.h` and `opencv2/videoio/videoio_c.h` define these macros, however I couldn't include them since it would bring redefinition problems.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add a new file `src/io/opencv_compatibility.h` to define the OpenCV macros.
- [x] Modify `Makefile` to find the path of `opencv4`

## Comments ##
There is a similar PR https://github.com/apache/incubator-mxnet/pull/13559, Thank @daleydeng
