### PR TITLE
moveaxis operator now accepts negative indices and sequence of ints as well.

### DIFF
--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -60,6 +60,7 @@ def check_with_uniform(uf, arg_shapes, dim=None, npuf=None, rmin=-10, type_list=
         else:
             assert_almost_equal(out1, out2, atol=1e-5)
 
+
 def random_ndarray(dim):
     shape = tuple(np.random.randint(1, int(1000**(1.0/dim)), size=dim))
     data = mx.nd.array(np.random.uniform(-10, 10, shape))

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -530,6 +530,7 @@ def test_reduce():
                              keepdims:np_reduce(np.float32(data), axis, keepdims, np.argmin),
                       mx.nd.argmin, False)
 
+
 @with_seed()
 def test_broadcast():
     sample_num = 1000

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -721,6 +721,7 @@ def test_arange():
                         dtype="int32").asnumpy()
     assert_almost_equal(pred, gt)
 
+
 @with_seed()
 def test_order():
     ctx = default_context()

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -165,6 +165,7 @@ def test_ndarray_negate():
     # we compute (-arr)
     assert_almost_equal(npy, arr.asnumpy())
 
+
 @with_seed()
 def test_ndarray_reshape():
     tensor = (mx.nd.arange(30) + 1).reshape(2, 3, 5)

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -950,6 +950,7 @@ def test_order():
                      k=dat_size*dat_size*dat_size*dat_size, is_ascend=False)
         assert_almost_equal(nd_ret_sort, gt)
 
+
 @with_seed()
 def test_ndarray_equal():
     x = mx.nd.zeros((2, 3))

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -698,10 +698,10 @@ def test_moveaxis():
         assert_exception(mx.nd.moveaxis, ValueError, x, 0, [0, 1])
         assert_exception(mx.nd.moveaxis, ValueError, x, [0, 1], [0])
 
-    #test_move_to_end()
-    #test_move_new_position()
-    #test_preserve_order()
-    #test_move_multiples()
+    test_move_to_end()
+    test_move_new_position()
+    test_preserve_order()
+    test_move_multiples()
     #test_errors()
 
 

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -698,11 +698,11 @@ def test_moveaxis():
         assert_exception(mx.nd.moveaxis, ValueError, x, 0, [0, 1])
         assert_exception(mx.nd.moveaxis, ValueError, x, [0, 1], [0])
 
-    test_move_to_end()
-    test_move_new_position()
-    test_preserve_order()
-    test_move_multiples()
-    test_errors()
+    #test_move_to_end()
+    #test_move_new_position()
+    #test_preserve_order()
+    #test_move_multiples()
+    #test_errors()
 
 
 @with_seed()

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -396,6 +396,7 @@ def test_ndarray_slice():
         assert same(A[:, i].asnumpy(), A2[:, i])
         assert same(A[i, :].asnumpy(), A2[i, :])
 
+
 @with_seed()
 def test_ndarray_crop():
     # get crop

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -144,6 +144,7 @@ def test_ndarray_elementwise():
             check_with_uniform(mx.nd.square, 1, dim, np.square, rmin=0)
             check_with_uniform(lambda x: mx.nd.norm(x).asscalar(), 1, dim, np.linalg.norm)
 
+
 @with_seed()
 def test_ndarray_elementwisesum():
     ones = mx.nd.ones((10,), dtype=np.int32)

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -364,6 +364,7 @@ def test_buffer_load():
                 # test garbage values
                 assertRaises(mx.base.MXNetError,  mx.nd.load_frombuffer, buf_single_ndarray[:-10])
 
+
 @with_seed()
 def test_ndarray_slice():
     shape = (10,)

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -32,6 +32,7 @@ from mxnet.test_utils import random_sample, rand_shape_nd
 from numpy.testing import assert_allclose
 import mxnet.autograd
 
+
 def check_with_uniform(uf, arg_shapes, dim=None, npuf=None, rmin=-10, type_list=[np.float32]):
     """check function consistency with uniform random numbers"""
     if isinstance(arg_shapes, int):

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -677,13 +677,13 @@ def test_moveaxis():
             assert actual == (1, 2, 3, 4)
 
     def test_move_multiples():
-        x = mx.nd.zeros((0, 1, 2, 3))
+        x = mx.nd.zeros((4, 1, 2, 3))
         for source, destination, expected in [
-            ([0, 1], [2, 3], (2, 3, 0, 1)),
-            ([2, 3], [0, 1], (2, 3, 0, 1)),
-            ([0, 1, 2], [2, 3, 0], (2, 3, 0, 1)),
-            ([3, 0], [1, 0], (0, 3, 1, 2)),
-            ([0, 3], [0, 1], (0, 3, 1, 2)),
+            ([0, 1], [2, 3], (2, 3, 4, 1)),
+            ([2, 3], [0, 1], (2, 3, 4, 1)),
+            ([0, 1, 2], [2, 3, 0], (2, 3, 4, 1)),
+            ([3, 0], [1, 0], (4, 3, 1, 2)),
+            ([0, 3], [0, 1], (4, 3, 1, 2)),
         ]:
             actual = mx.nd.moveaxis(x, source, destination).shape
             assert actual == expected
@@ -702,7 +702,7 @@ def test_moveaxis():
     test_move_new_position()
     test_preserve_order()
     test_move_multiples()
-    #test_errors()
+    test_errors()
 
 
 @with_seed()

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -152,6 +152,7 @@ def test_ndarray_elementwisesum():
     res = mx.nd.ElementWiseSum(ones, ones*2, ones*4, ones*8)
     assert same(res.asnumpy(), ones.asnumpy()*15)
 
+
 @with_seed()
 def test_ndarray_negate():
     npy = np.random.uniform(-10, 10, (2,3,4))


### PR DESCRIPTION
## Description ##
The moveaxis operator is now numpy compatible by accepting negative indices and tuples as well. Added a series of unit tests based on the original numpy repo.

Adds request from https://github.com/apache/incubator-mxnet/issues/13563

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)

- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
