### PR TITLE
[WIP][MXNET-1302,MXNET-1331] Backport fix to v1.3.x branch

### DIFF
--- a/scala-package/assembly/linux-x86_64-cpu/pom.xml
+++ b/scala-package/assembly/linux-x86_64-cpu/pom.xml
@@ -67,9 +67,30 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <inherited>false</inherited>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
+        <executions>
+          <execution>
+            <id>deploy-file</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>deploy-file</goal>
+            </goals>
+            <configuration>
+              <description>
+                Scala Package for Apache MXNet (Incubating) - flexible and efficient library for deep learning.
+              </description>
+              <repositoryId>apache.snapshots.https</repositoryId>
+              <url>https://github.com/apache/incubator-mxnet/</url>
+              <groupId>org.apache.mxnet</groupId>
+              <artifactId>mxnet-full_2.11-linux-x86_64-cpu</artifactId>
+              <version>1.3.1-SNAPSHOT</version>
+              <packaging>jar</packaging>
+              <pomFile>${basedir}/src/main/deploy/deploy.xml</pomFile>
+              <file>${basedir}/target/mxnet-full_2.11-linux-x86_64-cpu-1.3.1-SNAPSHOT.jar</file>
+              <sources>${basedir}/target/mxnet-full_2.11-linux-x86_64-cpu-1.3.1-SNAPSHOT-src.jar</sources>
+              <javadoc>${basedir}/target/mxnet-full_2.11-linux-x86_64-cpu-1.3.1-SNAPSHOT-bundle.jar</javadoc>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/scala-package/assembly/linux-x86_64-cpu/src/main/assembly/assembly.xml
+++ b/scala-package/assembly/linux-x86_64-cpu/src/main/assembly/assembly.xml
@@ -9,6 +9,14 @@
       <includes>
         <include>*:*:jar</include>
       </includes>
+      <excludes>
+        <exclude>org.scala-lang:*</exclude>
+        <exclude>org.scala-lang.modules:*</exclude>
+        <exclude>commons-io:commons-io</exclude>
+        <exclude>commons-codec:commons-codec</exclude>
+        <exclude>org.slf4j:slf4j-api</exclude>
+        <exclude>args4j:args4j</exclude>
+      </excludes>
       <outputDirectory>/</outputDirectory>
       <useProjectArtifact>true</useProjectArtifact>
       <unpack>true</unpack>

--- a/scala-package/assembly/linux-x86_64-cpu/src/main/deploy/deploy.xml
+++ b/scala-package/assembly/linux-x86_64-cpu/src/main/deploy/deploy.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.mxnet</groupId>
+    <artifactId>mxnet-full-parent_2.11</artifactId>
+    <version>1.3.1-SNAPSHOT</version>
+    <description>{project.description}</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-parser-combinators_2.11</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.10</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+            <version>2.0.29</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/scala-package/assembly/linux-x86_64-gpu/pom.xml
+++ b/scala-package/assembly/linux-x86_64-gpu/pom.xml
@@ -67,9 +67,30 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <inherited>false</inherited>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
+        <executions>
+          <execution>
+            <id>deploy-file</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>deploy-file</goal>
+            </goals>
+            <configuration>
+              <description>
+                Scala Package for Apache MXNet (Incubating) - flexible and efficient library for deep learning.
+              </description>
+              <repositoryId>apache.snapshots.https</repositoryId>
+              <url>https://github.com/apache/incubator-mxnet/</url>
+              <groupId>org.apache.mxnet</groupId>
+              <artifactId>mxnet-full_2.11-linux-x86_64-gpu</artifactId>
+              <version>1.3.1-SNAPSHOT</version>
+              <packaging>jar</packaging>
+              <pomFile>${basedir}/src/main/deploy/deploy.xml</pomFile>
+              <file>${basedir}/target/mxnet-full_2.11-linux-x86_64-gpu-1.3.1-SNAPSHOT.jar</file>
+              <sources>${basedir}/target/mxnet-full_2.11-linux-x86_64-gpu-1.3.1-SNAPSHOT-src.jar</sources>
+              <javadoc>${basedir}/target/mxnet-full_2.11-linux-x86_64-gpu-1.3.1-SNAPSHOT-bundle.jar</javadoc>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/scala-package/assembly/linux-x86_64-gpu/src/main/assembly/assembly.xml
+++ b/scala-package/assembly/linux-x86_64-gpu/src/main/assembly/assembly.xml
@@ -9,6 +9,14 @@
       <includes>
         <include>*:*:jar</include>
       </includes>
+      <excludes>
+        <exclude>org.scala-lang:*</exclude>
+        <exclude>org.scala-lang.modules:*</exclude>
+        <exclude>commons-io:commons-io</exclude>
+        <exclude>commons-codec:commons-codec</exclude>
+        <exclude>org.slf4j:slf4j-api</exclude>
+        <exclude>args4j:args4j</exclude>
+      </excludes>
       <outputDirectory>/</outputDirectory>
       <useProjectArtifact>true</useProjectArtifact>
       <unpack>true</unpack>

--- a/scala-package/assembly/linux-x86_64-gpu/src/main/deploy/deploy.xml
+++ b/scala-package/assembly/linux-x86_64-gpu/src/main/deploy/deploy.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.mxnet</groupId>
+    <artifactId>mxnet-full-parent_2.11</artifactId>
+    <version>1.3.1-SNAPSHOT</version>
+    <description>{project.description}</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-parser-combinators_2.11</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.10</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+            <version>2.0.29</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/scala-package/assembly/osx-x86_64-cpu/pom.xml
+++ b/scala-package/assembly/osx-x86_64-cpu/pom.xml
@@ -67,9 +67,30 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
         <inherited>false</inherited>
-        <configuration>
-          <skip>false</skip>
-        </configuration>
+        <executions>
+          <execution>
+            <id>deploy-file</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>deploy-file</goal>
+            </goals>
+            <configuration>
+              <description>
+                Scala Package for Apache MXNet (Incubating) - flexible and efficient library for deep learning.
+              </description>
+              <repositoryId>apache.snapshots.https</repositoryId>
+              <url>https://github.com/apache/incubator-mxnet/</url>
+              <groupId>org.apache.mxnet</groupId>
+              <artifactId>mxnet-full_2.11-osx-x86_64-cpu</artifactId>
+              <version>1.3.1-SNAPSHOT</version>
+              <packaging>jar</packaging>
+              <pomFile>${basedir}/src/main/deploy/deploy.xml</pomFile>
+              <file>${basedir}/target/mxnet-full_2.11-osx-x86_64-cpu-1.3.1-SNAPSHOT.jar</file>
+              <sources>${basedir}/target/mxnet-full_2.11-osx-x86_64-cpu-1.3.1-SNAPSHOT-src.jar</sources>
+              <javadoc>${basedir}/target/mxnet-full_2.11-osx-x86_64-cpu-1.3.1-SNAPSHOT-bundle.jar</javadoc>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/scala-package/assembly/osx-x86_64-cpu/src/main/assembly/assembly.xml
+++ b/scala-package/assembly/osx-x86_64-cpu/src/main/assembly/assembly.xml
@@ -9,6 +9,14 @@
       <includes>
         <include>*:*:jar</include>
       </includes>
+      <excludes>
+        <exclude>org.scala-lang:*</exclude>
+        <exclude>org.scala-lang.modules:*</exclude>
+        <exclude>commons-io:commons-io</exclude>
+        <exclude>commons-codec:commons-codec</exclude>
+        <exclude>org.slf4j:slf4j-api</exclude>
+        <exclude>args4j:args4j</exclude>
+      </excludes>
       <outputDirectory>/</outputDirectory>
       <useProjectArtifact>true</useProjectArtifact>
       <unpack>true</unpack>

--- a/scala-package/assembly/osx-x86_64-cpu/src/main/deploy/deploy.xml
+++ b/scala-package/assembly/osx-x86_64-cpu/src/main/deploy/deploy.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.apache.mxnet</groupId>
+    <artifactId>mxnet-full-parent_2.11</artifactId>
+    <version>1.3.1-SNAPSHOT</version>
+    <description>{project.description}</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-parser-combinators_2.11</artifactId>
+            <version>1.0.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.10</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.5</version>
+        </dependency>
+        <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+            <version>2.0.29</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/scala-package/core/pom.xml
+++ b/scala-package/core/pom.xml
@@ -104,10 +104,5 @@
       <version>1.3.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.1</version>
-    </dependency>
   </dependencies>
 </project>

--- a/scala-package/macros/pom.xml
+++ b/scala-package/macros/pom.xml
@@ -63,11 +63,6 @@
       <scope>provided</scope>
       <type>${libtype}</type>
     </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.1</version>
-    </dependency>
   </dependencies>
 
 

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -331,6 +331,11 @@
       <version>1.10</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.1</version>
+    </dependency>
+    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>1.2.17</version>


### PR DESCRIPTION
Consumers of MXNet are exposed to the commons-codec and commons-io library versions MXNet uses internally. This change excludes those JARs from the JARs created with `make scalapkg`.

## Description ##
This PR removes commons-codec and commons-io from the assembled JAR and adds both packages as dependencies in deploy.xml

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues/MXNET-1302) created (except PRs with tiny changes)
- [] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] 3rd party libraries removed from assembled JAR
- [] 3rd party libraries added as dependencies to deployed POM

## Comments ##
Backport of pull request 14000 and 14303 to v1.3.x branch

Originally reported in #13929 