### PR TITLE
[MXNet-1348][WIP][Fit API]Adding CNN examples for fit() API

### DIFF
--- a/example/gluon/estimator_example/alexnet.py
+++ b/example/gluon/estimator_example/alexnet.py
@@ -1,0 +1,156 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This example is inspired from
+# https://github.com/d2l-ai/d2l-en/blob/master/chapter_convolutional-neural-networks/alexnet.md
+# Model definition is from
+# https://github.com/dmlc/gluon-cv/blob/master/gluoncv/model_zoo/alexnet.py
+
+
+import os
+import sys
+import argparse
+import mxnet as mx
+from mxnet import gluon
+from mxnet.gluon import nn, data
+from mxnet.gluon.block import HybridBlock
+from mxnet.gluon.estimator import estimator, event_handler
+
+def parse_args():
+    '''
+    Command Line Interface
+    '''
+    parser = argparse.ArgumentParser(description='Train ResNet18 on Fashion-MNIST')
+    parser.add_argument('--batch-size', type=int, default=128,
+                        help='training batch size per device (CPU/GPU).')
+    parser.add_argument('--num-epochs', type=int, default=1,
+                        help='number of training epochs.')
+    parser.add_argument('--input-size', type=int, default=224,
+                        help='size of the input image size. default is 224')
+    parser.add_argument('--lr', type=float, default=0.001,
+                        help='learning rate. default is 0.001')
+    parser.add_argument('-j', '--num-workers', default=None, type=int,
+                        help='number of preprocessing workers')
+    opt = parser.parse_args()
+    return opt
+
+class AlexNet(HybridBlock):
+    r"""AlexNet model from the `"One weird trick..." <https://arxiv.org/abs/1404.5997>`_ paper.
+    Parameters
+    ----------
+    classes : int, default 1000
+        Number of classes for the output layer.
+    """
+    def __init__(self, classes=1000, **kwargs):
+        super(AlexNet, self).__init__(**kwargs)
+        with self.name_scope():
+            self.features = nn.HybridSequential(prefix='')
+            with self.features.name_scope():
+                self.features.add(nn.Conv2D(64, kernel_size=11, strides=4,
+                                            padding=2, activation='relu'))
+                self.features.add(nn.MaxPool2D(pool_size=3, strides=2))
+                self.features.add(nn.Conv2D(192, kernel_size=5, padding=2,
+                                            activation='relu'))
+                self.features.add(nn.MaxPool2D(pool_size=3, strides=2))
+                self.features.add(nn.Conv2D(384, kernel_size=3, padding=1,
+                                            activation='relu'))
+                self.features.add(nn.Conv2D(256, kernel_size=3, padding=1,
+                                            activation='relu'))
+                self.features.add(nn.Conv2D(256, kernel_size=3, padding=1,
+                                            activation='relu'))
+                self.features.add(nn.MaxPool2D(pool_size=3, strides=2))
+                self.features.add(nn.Flatten())
+                self.features.add(nn.Dense(4096, activation='relu'))
+                self.features.add(nn.Dropout(0.5))
+                self.features.add(nn.Dense(4096, activation='relu'))
+                self.features.add(nn.Dropout(0.5))
+
+            self.output = nn.Dense(classes)
+
+    def hybrid_forward(self, F, x):
+        x = self.features(x)
+        x = self.output(x)
+        return x
+
+def load_data_mnist(batch_size, resize=None, num_workers=None,
+                    root=os.path.join('~', '.mxnet', 'datasets', 'mnist')):
+    '''
+    Load MNIST dataset
+    '''
+    root = os.path.expanduser(root)  # Expand the user path '~'.
+    transformer = []
+    if resize:
+        transformer += [data.vision.transforms.Resize(resize)]
+    transformer += [data.vision.transforms.ToTensor()]
+    transformer = data.vision.transforms.Compose(transformer)
+    mnist_train = data.vision.MNIST(root=root, train=True)
+    mnist_test = data.vision.MNIST(root=root, train=False)
+
+    if num_workers is None:
+        num_workers = 0 if sys.platform.startswith('win32') else 4
+
+    train_iter = data.DataLoader(
+        mnist_train.transform_first(transformer), batch_size, shuffle=True,
+        num_workers=num_workers)
+    test_iter = data.DataLoader(
+        mnist_test.transform_first(transformer), batch_size, shuffle=False,
+        num_workers=num_workers)
+    return train_iter, test_iter
+
+
+def main():
+    # Parse CLI arguments
+    opt = parse_args()
+    batch_size = opt.batch_size
+    num_epochs = opt.num_epochs
+    input_size = opt.input_size
+    lr = opt.lr
+    num_workers = opt.num_workers
+    # Set context
+    if mx.context.num_gpus() > 0:
+        context = mx.gpu(0)
+    else:
+        context = mx.cpu()
+    # Get AlexNet model
+    net = AlexNet(classes=10)
+    # Load train and validation data
+    train_data, test_data = load_data_mnist(batch_size, resize=input_size,
+                                            num_workers=num_workers)
+    # Define loss and evaluation metrics
+    loss = gluon.loss.SoftmaxCrossEntropyLoss()
+    acc = mx.metric.Accuracy()
+    # Hybridize and initialize net
+    net.hybridize()
+    net.initialize(mx.init.MSRAPrelu(), ctx=context)
+    # Define trainer
+    trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': lr})
+    # Define estimator
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              metrics=acc,
+                              trainers=trainer,
+                              context=context)
+    # Call fit() to begin training
+    est.fit(train_data=train_data,
+            val_data=test_data,
+            epochs=num_epochs,
+            batch_size=batch_size,
+            event_handlers=[event_handler.LoggingHandler(est, 'alexnet_log', 'alexnet_log')])
+
+
+if __name__ == '__main__':
+    main()

--- a/example/gluon/estimator_example/fcn.py
+++ b/example/gluon/estimator_example/fcn.py
@@ -1,0 +1,226 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This example is compiled from
+# https://github.com/d2l-ai/d2l-en/blob/master/chapter_computer-vision/fcn.md
+
+import tarfile
+import os
+import sys
+import argparse
+import numpy as np
+import mxnet as mx
+from mxnet import gluon, image, init, nd
+from mxnet.gluon import data as gdata, model_zoo, nn
+from mxnet.gluon.estimator import estimator, event_handler
+
+def parse_args():
+    '''
+    Command Line Interface
+    '''
+    parser = argparse.ArgumentParser(description='Train ResNet18 on Fashion-MNIST')
+    parser.add_argument('--batch-size', type=int, default=32,
+                        help='training batch size per device (CPU/GPU).')
+    parser.add_argument('--num-epochs', type=int, default=1,
+                        help='number of training epochs.')
+    parser.add_argument('--input-size', type=tuple, default=(320, 480),
+                        help='size of the input image size. default is (320, 480)')
+    parser.add_argument('--lr', type=float, default=0.1,
+                        help='learning rate. default is 0.1')
+    parser.add_argument('-j', '--num-workers', default=None, type=int,
+                        help='number of preprocessing workers')
+    opt = parser.parse_args()
+    return opt
+
+
+def FCN(num_classes=21, ctx=None):
+    '''
+    FCN model for semantic segmentation
+    '''
+    pretrained_net = model_zoo.vision.resnet18_v2(pretrained=True, ctx=ctx)
+
+    net = nn.HybridSequential()
+    for layer in pretrained_net.features[:-2]:
+        net.add(layer)
+
+    net.add(nn.Conv2D(num_classes, kernel_size=1),
+            nn.Conv2DTranspose(num_classes, kernel_size=64, padding=16, strides=32))
+    return net
+
+def bilinear_kernel(in_channels, out_channels, kernel_size):
+    '''
+    Bilinear interpolation using transposed convolution
+    '''
+    factor = (kernel_size + 1) // 2
+    if kernel_size % 2 == 1:
+        center = factor - 1
+    else:
+        center = factor - 0.5
+    og = np.ogrid[:kernel_size, :kernel_size]
+    filt = (1 - abs(og[0] - center) / factor) * (1 - abs(og[1] - center) / factor)
+    weight = np.zeros((in_channels, out_channels, kernel_size, kernel_size), dtype='float32')
+    weight[range(in_channels), range(out_channels), :, :] = filt
+    return nd.array(weight)
+
+def download_voc_pascal(data_dir='../data'):
+    """Download the Pascal VOC2012 Dataset."""
+    voc_dir = os.path.join(data_dir, 'VOCdevkit/VOC2012')
+    url = ('http://host.robots.ox.ac.uk/pascal/VOC/voc2012'
+           '/VOCtrainval_11-May-2012.tar')
+    sha1 = '4e443f8a2eca6b1dac8a6c57641b67dd40621a49'
+    fname = gluon.utils.download(url, data_dir, sha1_hash=sha1)
+    with tarfile.open(fname, 'r') as f:
+        f.extractall(data_dir)
+    return voc_dir
+
+def read_voc_images(root='../data/VOCdevkit/VOC2012', is_train=True):
+    """Read VOC images."""
+    txt_fname = '%s/ImageSets/Segmentation/%s' % (root, 'train.txt' if is_train else 'val.txt')
+    with open(txt_fname, 'r') as f:
+        images = f.read().split()
+    features, labels = [None] * len(images), [None] * len(images)
+    for i, fname in enumerate(images):
+        features[i] = image.imread('%s/JPEGImages/%s.jpg' % (root, fname))
+        labels[i] = image.imread('%s/SegmentationClass/%s.png' % (root, fname))
+    return features, labels
+
+def voc_label_indices(colormap, colormap2label):
+    """Assign label indices for Pascal VOC2012 Dataset."""
+    colormap = colormap.astype('int32')
+    idx = ((colormap[:, :, 0] * 256 + colormap[:, :, 1]) * 256
+           + colormap[:, :, 2])
+    return colormap2label[idx]
+
+
+def voc_rand_crop(feature, label, height, width):
+    """Random cropping for images of the Pascal VOC2012 Dataset."""
+    feature, rect = image.random_crop(feature, (width, height))
+    label = image.fixed_crop(label, *rect)
+    return feature, label
+
+VOC_CLASSES = ['background', 'aeroplane', 'bicycle', 'bird', 'boat',
+               'bottle', 'bus', 'car', 'cat', 'chair', 'cow',
+               'diningtable', 'dog', 'horse', 'motorbike', 'person',
+               'potted plant', 'sheep', 'sofa', 'train', 'tv/monitor']
+
+
+VOC_COLORMAP = [[0, 0, 0], [128, 0, 0], [0, 128, 0], [128, 128, 0],
+                [0, 0, 128], [128, 0, 128], [0, 128, 128], [128, 128, 128],
+                [64, 0, 0], [192, 0, 0], [64, 128, 0], [192, 128, 0],
+                [64, 0, 128], [192, 0, 128], [64, 128, 128], [192, 128, 128],
+                [0, 64, 0], [128, 64, 0], [0, 192, 0], [128, 192, 0],
+                [0, 64, 128]]
+
+class VOCSegDataset(gdata.Dataset):
+    """The Pascal VOC2012 Dataset."""
+
+    def __init__(self, is_train, crop_size, voc_dir, colormap2label):
+        self.rgb_mean = nd.array([0.485, 0.456, 0.406])
+        self.rgb_std = nd.array([0.229, 0.224, 0.225])
+        self.crop_size = crop_size
+        data, labels = read_voc_images(root=voc_dir, is_train=is_train)
+        self.data = [self.normalize_image(im) for im in self.filter(data)]
+        self.labels = self.filter(labels)
+        self.colormap2label = colormap2label
+        print('read ' + str(len(self.data)) + ' examples')
+
+    def normalize_image(self, data):
+        return (data.astype('float32') / 255 - self.rgb_mean) / self.rgb_std
+
+    def filter(self, images):
+        return [im for im in images if (
+            im.shape[0] >= self.crop_size[0] and
+            im.shape[1] >= self.crop_size[1])]
+
+    def __getitem__(self, idx):
+        data, labels = voc_rand_crop(self.data[idx], self.labels[idx],
+                                     *self.crop_size)
+        return (data.transpose((2, 0, 1)),
+                voc_label_indices(labels, self.colormap2label))
+
+    def __len__(self):
+        return len(self.data)
+
+def load_data_pascal_voc(batch_size, crop=None, num_workers=None):
+    '''
+    Load Pascal VOC dataset
+    '''
+    crop_size, batch_size, colormap2label = crop, batch_size, nd.zeros(256 ** 3)
+    for i, cm in enumerate(VOC_COLORMAP):
+        colormap2label[(cm[0] * 256 + cm[1]) * 256 + cm[2]] = i
+
+    if os.path.isdir('../data'):
+        voc_dir = '../data/VOCdevkit/VOC2012'
+    else:
+        os.mkdir('../data')
+        voc_dir = download_voc_pascal(data_dir='../data')
+
+    if num_workers is None:
+        num_workers = 0 if sys.platform.startswith('win32') else 4
+
+    train_iter = gdata.DataLoader(
+        VOCSegDataset(True, crop_size, voc_dir, colormap2label), batch_size,
+        shuffle=True, last_batch='discard', num_workers=num_workers)
+    test_iter = gdata.DataLoader(
+        VOCSegDataset(False, crop_size, voc_dir, colormap2label), batch_size,
+        last_batch='discard', num_workers=num_workers)
+    return train_iter, test_iter
+
+def main():
+    # Parse CLI arguments
+    opt = parse_args()
+    batch_size = opt.batch_size
+    num_epochs = opt.num_epochs
+    input_size = opt.input_size
+    lr = opt.lr
+    num_workers = opt.num_workers
+    # Set context
+    if mx.context.num_gpus() > 0:
+        context = mx.gpu(0)
+    else:
+        context = mx.cpu()
+    # Get FCN model
+    num_classes = 21
+    net = FCN(num_classes, ctx=context)
+    # Load train and validation data
+    train_data, test_data = load_data_pascal_voc(batch_size, crop=input_size,
+                                                 num_workers=num_workers)
+    # Define loss and evaluation metrics
+    loss = gluon.loss.SoftmaxCrossEntropyLoss(axis=1)
+    acc = mx.metric.Accuracy()
+    # Hybridize and initialize net
+    net.hybridize()
+    net[-1].initialize(init.Constant(bilinear_kernel(num_classes, num_classes, 64)), ctx=context)
+    net[-2].initialize(init=init.Xavier(), ctx=context)
+    # Define trainer
+    trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': lr, 'wd': 1e-3})
+    # Define estimator
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              metrics=acc,
+                              trainers=trainer,
+                              context=context)
+    # Call fit() to begin training
+    est.fit(train_data=train_data,
+            val_data=test_data,
+            epochs=num_epochs,
+            batch_size=batch_size,
+            event_handlers=[event_handler.LoggingHandler(est, 'fcn_log', 'fcn_log')])
+
+
+if __name__ == '__main__':
+    main()

--- a/example/gluon/estimator_example/resnet.py
+++ b/example/gluon/estimator_example/resnet.py
@@ -1,0 +1,548 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This example is inspired from
+# https://github.com/d2l-ai/d2l-en/blob/master/chapter_convolutional-neural-networks/resnet.md
+# Model definition is from
+# https://github.com/onnx/models/blob/master/models/image_classification/resnet/train_resnet.ipynb
+
+import os
+import sys
+import argparse
+import mxnet as mx
+from mxnet import gluon
+from mxnet.gluon import nn, data
+from mxnet.gluon.block import HybridBlock
+from mxnet.gluon.estimator import estimator, event_handler
+
+
+def parse_args():
+    '''
+    Command Line Interface
+    '''
+    parser = argparse.ArgumentParser(description='Train ResNet18 on Fashion-MNIST')
+    parser.add_argument('--batch-size', type=int, default=128,
+                        help='training batch size per device (CPU/GPU).')
+    parser.add_argument('--num-epochs', type=int, default=1,
+                        help='number of training epochs.')
+    parser.add_argument('--input-size', type=int, default=224,
+                        help='size of the input image size. default is 224')
+    parser.add_argument('--lr', type=float, default=0.001,
+                        help='learning rate. default is 0.001')
+    parser.add_argument('-j', '--num-workers', default=None, type=int,
+                        help='number of preprocessing workers')
+    opt = parser.parse_args()
+    return opt
+
+# Definition for Resnet v1 and v2
+# Helpers
+def _conv3x3(channels, stride, in_channels):
+    return nn.Conv2D(channels, kernel_size=3, strides=stride, padding=1,
+                     use_bias=False, in_channels=in_channels)
+
+# Blocks
+class BasicBlockV1(HybridBlock):
+    r"""BasicBlock V1 from `"Deep Residual Learning for Image Recognition"
+    <http://arxiv.org/abs/1512.03385>`_ paper.
+    This is used for ResNet V1 for 18, 34 layers.
+    Parameters
+    ----------
+    channels : int
+        Number of output channels.
+    stride : int
+        Stride size.
+    downsample : bool, default False
+        Whether to downsample the input.
+    in_channels : int, default 0
+        Number of input channels. Default is 0, to infer from the graph.
+    """
+
+    def __init__(self, channels, stride, downsample=False, in_channels=0, **kwargs):
+        super(BasicBlockV1, self).__init__(**kwargs)
+        self.body = nn.HybridSequential(prefix='')
+        self.body.add(_conv3x3(channels, stride, in_channels))
+        self.body.add(nn.BatchNorm())
+        self.body.add(nn.Activation('relu'))
+        self.body.add(_conv3x3(channels, 1, channels))
+        self.body.add(nn.BatchNorm())
+        if downsample:
+            self.downsample = nn.HybridSequential(prefix='')
+            self.downsample.add(nn.Conv2D(channels, kernel_size=1, strides=stride,
+                                          use_bias=False, in_channels=in_channels))
+            self.downsample.add(nn.BatchNorm())
+        else:
+            self.downsample = None
+
+    def hybrid_forward(self, F, x):
+        residual = x
+
+        x = self.body(x)
+
+        if self.downsample:
+            residual = self.downsample(residual)
+
+        x = F.Activation(residual + x, act_type='relu')
+
+        return x
+
+
+class BottleneckV1(HybridBlock):
+    r"""Bottleneck V1 from `"Deep Residual Learning for Image Recognition"
+    <http://arxiv.org/abs/1512.03385>`_ paper.
+    This is used for ResNet V1 for 50, 101, 152 layers.
+    Parameters
+    ----------
+    channels : int
+        Number of output channels.
+    stride : int
+        Stride size.
+    downsample : bool, default False
+        Whether to downsample the input.
+    in_channels : int, default 0
+        Number of input channels. Default is 0, to infer from the graph.
+    """
+
+    def __init__(self, channels, stride, downsample=False, in_channels=0, **kwargs):
+        super(BottleneckV1, self).__init__(**kwargs)
+        self.body = nn.HybridSequential(prefix='')
+        self.body.add(nn.Conv2D(channels // 4, kernel_size=1, strides=stride))
+        self.body.add(nn.BatchNorm())
+        self.body.add(nn.Activation('relu'))
+        self.body.add(_conv3x3(channels // 4, 1, channels // 4))
+        self.body.add(nn.BatchNorm())
+        self.body.add(nn.Activation('relu'))
+        self.body.add(nn.Conv2D(channels, kernel_size=1, strides=1))
+        self.body.add(nn.BatchNorm())
+        if downsample:
+            self.downsample = nn.HybridSequential(prefix='')
+            self.downsample.add(nn.Conv2D(channels, kernel_size=1, strides=stride,
+                                          use_bias=False, in_channels=in_channels))
+            self.downsample.add(nn.BatchNorm())
+        else:
+            self.downsample = None
+
+    def hybrid_forward(self, F, x):
+        residual = x
+
+        x = self.body(x)
+
+        if self.downsample:
+            residual = self.downsample(residual)
+
+        x = F.Activation(x + residual, act_type='relu')
+        return x
+
+
+class BasicBlockV2(HybridBlock):
+    r"""BasicBlock V2 from
+    `"Identity Mappings in Deep Residual Networks"
+    <https://arxiv.org/abs/1603.05027>`_ paper.
+    This is used for ResNet V2 for 18, 34 layers.
+    Parameters
+    ----------
+    channels : int
+        Number of output channels.
+    stride : int
+        Stride size.
+    downsample : bool, default False
+        Whether to downsample the input.
+    in_channels : int, default 0
+        Number of input channels. Default is 0, to infer from the graph.
+    """
+
+    def __init__(self, channels, stride, downsample=False, in_channels=0, **kwargs):
+        super(BasicBlockV2, self).__init__(**kwargs)
+        self.bn1 = nn.BatchNorm()
+        self.conv1 = _conv3x3(channels, stride, in_channels)
+        self.bn2 = nn.BatchNorm()
+        self.conv2 = _conv3x3(channels, 1, channels)
+        if downsample:
+            self.downsample = nn.Conv2D(channels, 1, stride, use_bias=False,
+                                        in_channels=in_channels)
+        else:
+            self.downsample = None
+
+    def hybrid_forward(self, F, x):
+        residual = x
+        x = self.bn1(x)
+        x = F.Activation(x, act_type='relu')
+        if self.downsample:
+            residual = self.downsample(x)
+        x = self.conv1(x)
+
+        x = self.bn2(x)
+        x = F.Activation(x, act_type='relu')
+        x = self.conv2(x)
+
+        return x + residual
+
+
+class BottleneckV2(HybridBlock):
+    r"""Bottleneck V2 from
+    `"Identity Mappings in Deep Residual Networks"
+    <https://arxiv.org/abs/1603.05027>`_ paper.
+    This is used for ResNet V2 for 50, 101, 152 layers.
+    Parameters
+    ----------
+    channels : int
+        Number of output channels.
+    stride : int
+        Stride size.
+    downsample : bool, default False
+        Whether to downsample the input.
+    in_channels : int, default 0
+        Number of input channels. Default is 0, to infer from the graph.
+    """
+
+    def __init__(self, channels, stride, downsample=False, in_channels=0, **kwargs):
+        super(BottleneckV2, self).__init__(**kwargs)
+        self.bn1 = nn.BatchNorm()
+        self.conv1 = nn.Conv2D(channels // 4, kernel_size=1, strides=1, use_bias=False)
+        self.bn2 = nn.BatchNorm()
+        self.conv2 = _conv3x3(channels // 4, stride, channels // 4)
+        self.bn3 = nn.BatchNorm()
+        self.conv3 = nn.Conv2D(channels, kernel_size=1, strides=1, use_bias=False)
+        if downsample:
+            self.downsample = nn.Conv2D(channels, 1, stride, use_bias=False,
+                                        in_channels=in_channels)
+        else:
+            self.downsample = None
+
+    def hybrid_forward(self, F, x):
+        residual = x
+        x = self.bn1(x)
+        x = F.Activation(x, act_type='relu')
+        if self.downsample:
+            residual = self.downsample(x)
+        x = self.conv1(x)
+
+        x = self.bn2(x)
+        x = F.Activation(x, act_type='relu')
+        x = self.conv2(x)
+
+        x = self.bn3(x)
+        x = F.Activation(x, act_type='relu')
+        x = self.conv3(x)
+
+        return x + residual
+
+
+# Nets
+class ResNetV1(HybridBlock):
+    r"""ResNet V1 model from
+    `"Deep Residual Learning for Image Recognition"
+    <http://arxiv.org/abs/1512.03385>`_ paper.
+    Parameters
+    ----------
+    block : HybridBlock
+        Class for the residual block. Options are BasicBlockV1, BottleneckV1.
+    layers : list of int
+        Numbers of layers in each block
+    channels : list of int
+        Numbers of channels in each block. Length should be one larger than layers list.
+    classes : int, default 1000
+        Number of classification classes.
+    thumbnail : bool, default False
+        Enable thumbnail.
+    """
+
+    def __init__(self, block, layers, channels, classes=1000, thumbnail=False, **kwargs):
+        super(ResNetV1, self).__init__(**kwargs)
+        assert len(layers) == len(channels) - 1
+        with self.name_scope():
+            self.features = nn.HybridSequential(prefix='')
+            if thumbnail:
+                self.features.add(_conv3x3(channels[0], 1, 0))
+            else:
+                self.features.add(nn.Conv2D(channels[0], 7, 2, 3, use_bias=False))
+                self.features.add(nn.BatchNorm())
+                self.features.add(nn.Activation('relu'))
+                self.features.add(nn.MaxPool2D(3, 2, 1))
+
+            for i, num_layer in enumerate(layers):
+                stride = 1 if i == 0 else 2
+                self.features.add(self._make_layer(block, num_layer, channels[i + 1],
+                                                   stride, i + 1, in_channels=channels[i]))
+            self.features.add(nn.GlobalAvgPool2D())
+
+            self.output = nn.Dense(classes, in_units=channels[-1])
+
+    def _make_layer(self, block, layers, channels, stride, stage_index, in_channels=0):
+        layer = nn.HybridSequential(prefix='stage%d_' % stage_index)
+        with layer.name_scope():
+            layer.add(block(channels, stride, channels != in_channels, in_channels=in_channels,
+                            prefix=''))
+            for _ in range(layers - 1):
+                layer.add(block(channels, 1, False, in_channels=channels, prefix=''))
+        return layer
+
+    def hybrid_forward(self, F, x):
+        x = self.features(x)
+        x = self.output(x)
+
+        return x
+
+
+class ResNetV2(HybridBlock):
+    r"""ResNet V2 model from
+    `"Identity Mappings in Deep Residual Networks"
+    <https://arxiv.org/abs/1603.05027>`_ paper.
+    Parameters
+    ----------
+    block : HybridBlock
+        Class for the residual block. Options are BasicBlockV1, BottleneckV1.
+    layers : list of int
+        Numbers of layers in each block
+    channels : list of int
+        Numbers of channels in each block. Length should be one larger than layers list.
+    classes : int, default 1000
+        Number of classification classes.
+    thumbnail : bool, default False
+        Enable thumbnail.
+    """
+
+    def __init__(self, block, layers, channels, classes=1000, thumbnail=False, **kwargs):
+        super(ResNetV2, self).__init__(**kwargs)
+        assert len(layers) == len(channels) - 1
+        with self.name_scope():
+            self.features = nn.HybridSequential(prefix='')
+            self.features.add(nn.BatchNorm(scale=False, center=False))
+            if thumbnail:
+                self.features.add(_conv3x3(channels[0], 1, 0))
+            else:
+                self.features.add(nn.Conv2D(channels[0], 7, 2, 3, use_bias=False))
+                self.features.add(nn.BatchNorm())
+                self.features.add(nn.Activation('relu'))
+                self.features.add(nn.MaxPool2D(3, 2, 1))
+
+            in_channels = channels[0]
+            for i, num_layer in enumerate(layers):
+                stride = 1 if i == 0 else 2
+                self.features.add(self._make_layer(block, num_layer, channels[i + 1],
+                                                   stride, i + 1, in_channels=in_channels))
+                in_channels = channels[i + 1]
+            self.features.add(nn.BatchNorm())
+            self.features.add(nn.Activation('relu'))
+            self.features.add(nn.GlobalAvgPool2D())
+            self.features.add(nn.Flatten())
+
+            self.output = nn.Dense(classes, in_units=in_channels)
+
+    def _make_layer(self, block, layers, channels, stride, stage_index, in_channels=0):
+        layer = nn.HybridSequential(prefix='stage%d_' % stage_index)
+        with layer.name_scope():
+            layer.add(block(channels, stride, channels != in_channels, in_channels=in_channels,
+                            prefix=''))
+            for _ in range(layers - 1):
+                layer.add(block(channels, 1, False, in_channels=channels, prefix=''))
+        return layer
+
+    def hybrid_forward(self, F, x):
+        x = self.features(x)
+        x = self.output(x)
+        return x
+
+
+# Specification
+resnet_spec = {18: ('basic_block', [2, 2, 2, 2], [64, 64, 128, 256, 512]),
+               34: ('basic_block', [3, 4, 6, 3], [64, 64, 128, 256, 512]),
+               50: ('bottle_neck', [3, 4, 6, 3], [64, 256, 512, 1024, 2048]),
+               101: ('bottle_neck', [3, 4, 23, 3], [64, 256, 512, 1024, 2048]),
+               152: ('bottle_neck', [3, 8, 36, 3], [64, 256, 512, 1024, 2048])}
+
+resnet_net_versions = [ResNetV1, ResNetV2]
+resnet_block_versions = [{'basic_block': BasicBlockV1, 'bottle_neck': BottleneckV1},
+                         {'basic_block': BasicBlockV2, 'bottle_neck': BottleneckV2}]
+
+
+# Constructor
+def get_resnet(version, num_layers, **kwargs):
+    r"""ResNet V1 model from `"Deep Residual Learning for Image Recognition"
+    <http://arxiv.org/abs/1512.03385>`_ paper.
+    ResNet V2 model from `"Identity Mappings in Deep Residual Networks"
+    <https://arxiv.org/abs/1603.05027>`_ paper.
+    Parameters
+    ----------
+    version : int
+        Version of ResNet. Options are 1, 2.
+    num_layers : int
+        Numbers of layers. Options are 18, 34, 50, 101, 152.
+    """
+    assert num_layers in resnet_spec, \
+        "Invalid number of layers: %d. Options are %s" % (
+            num_layers, str(resnet_spec.keys()))
+    block_type, layers, channels = resnet_spec[num_layers]
+    assert version >= 1 and version <= 2, \
+        "Invalid resnet version: %d. Options are 1 and 2." % version
+    resnet_class = resnet_net_versions[version - 1]
+    block_class = resnet_block_versions[version - 1][block_type]
+    net = resnet_class(block_class, layers, channels, **kwargs)
+    return net
+
+
+def resnet18_v1(**kwargs):
+    r"""ResNet-18 V1 model from `"Deep Residual Learning for Image Recognition"
+    <http://arxiv.org/abs/1512.03385>`_ paper.
+    """
+    return get_resnet(1, 18, **kwargs)
+
+
+def resnet34_v1(**kwargs):
+    r"""ResNet-34 V1 model from `"Deep Residual Learning for Image Recognition"
+    <http://arxiv.org/abs/1512.03385>`_ paper.
+    """
+    return get_resnet(1, 34, **kwargs)
+
+
+def resnet50_v1(**kwargs):
+    r"""ResNet-50 V1 model from `"Deep Residual Learning for Image Recognition"
+    <http://arxiv.org/abs/1512.03385>`_ paper.
+    """
+    return get_resnet(1, 50, **kwargs)
+
+
+def resnet101_v1(**kwargs):
+    r"""ResNet-101 V1 model from `"Deep Residual Learning for Image Recognition"
+    <http://arxiv.org/abs/1512.03385>`_ paper.
+    """
+    return get_resnet(1, 101, **kwargs)
+
+
+def resnet152_v1(**kwargs):
+    r"""ResNet-152 V1 model from `"Deep Residual Learning for Image Recognition"
+    <http://arxiv.org/abs/1512.03385>`_ paper.
+    """
+    return get_resnet(1, 152, **kwargs)
+
+
+def resnet18_v2(**kwargs):
+    r"""ResNet-18 V2 model from `"Identity Mappings in Deep Residual Networks"
+    <https://arxiv.org/abs/1603.05027>`_ paper.
+    """
+    return get_resnet(2, 18, **kwargs)
+
+
+def resnet34_v2(**kwargs):
+    r"""ResNet-34 V2 model from `"Identity Mappings in Deep Residual Networks"
+    <https://arxiv.org/abs/1603.05027>`_ paper.
+    """
+    return get_resnet(2, 34, **kwargs)
+
+
+def resnet50_v2(**kwargs):
+    r"""ResNet-50 V2 model from `"Identity Mappings in Deep Residual Networks"
+    <https://arxiv.org/abs/1603.05027>`_ paper.
+    """
+    return get_resnet(2, 50, **kwargs)
+
+
+def resnet101_v2(**kwargs):
+    r"""ResNet-101 V2 model from `"Identity Mappings in Deep Residual Networks"
+    <https://arxiv.org/abs/1603.05027>`_ paper.
+    """
+    return get_resnet(2, 101, **kwargs)
+
+
+def resnet152_v2(**kwargs):
+    r"""ResNet-152 V2 model from `"Identity Mappings in Deep Residual Networks"
+    <https://arxiv.org/abs/1603.05027>`_ paper.
+    """
+    return get_resnet(2, 152, **kwargs)
+
+
+models = {'resnet18_v1': resnet18_v1,
+          'resnet34_v1': resnet34_v1,
+          'resnet50_v1': resnet50_v1,
+          'resnet101_v1': resnet101_v1,
+          'resnet152_v1': resnet152_v1,
+          'resnet18_v2': resnet18_v2,
+          'resnet34_v2': resnet34_v2,
+          'resnet50_v2': resnet50_v2,
+          'resnet101_v2': resnet101_v2,
+          'resnet152_v2': resnet152_v2
+          }
+
+def load_data_mnist(batch_size, resize=None, num_workers=None,
+                            root=os.path.join('~', '.mxnet', 'datasets', 'mnist')):
+    '''
+    Load MNIST dataset
+    '''
+    root = os.path.expanduser(root)  # Expand the user path '~'.
+    transformer = []
+    if resize:
+        transformer += [data.vision.transforms.Resize(resize)]
+    transformer += [data.vision.transforms.ToTensor()]
+    transformer = data.vision.transforms.Compose(transformer)
+    mnist_train = data.vision.MNIST(root=root, train=True)
+    mnist_test = data.vision.MNIST(root=root, train=False)
+
+    if num_workers is None:
+        num_workers = 0 if sys.platform.startswith('win32') else 4
+
+    train_iter = data.DataLoader(
+        mnist_train.transform_first(transformer), batch_size, shuffle=True,
+        num_workers=num_workers)
+    test_iter = data.DataLoader(
+        mnist_test.transform_first(transformer), batch_size, shuffle=False,
+        num_workers=num_workers)
+    return train_iter, test_iter
+
+
+def main():
+    # Parse CLI arguments
+    opt = parse_args()
+    batch_size = opt.batch_size
+    num_epochs = opt.num_epochs
+    input_size = opt.input_size
+    lr = opt.lr
+    num_workers = opt.num_workers
+    # Set context
+    if mx.context.num_gpus() > 0:
+        context = mx.gpu(0)
+    else:
+        context = mx.cpu()
+    # Get ResNet 18 v1 model
+    model_name = 'resnet18_v1'
+    kwargs = {'classes': 10}
+    net = models[model_name](**kwargs)
+    # Load train and validation data
+    train_data, test_data = load_data_mnist(batch_size, resize=input_size,
+                                            num_workers=num_workers)
+    # Define loss and evaluation metrics
+    loss = gluon.loss.SoftmaxCrossEntropyLoss()
+    acc = mx.metric.Accuracy()
+    # Hybridize and initialize net
+    net.hybridize()
+    net.initialize(mx.init.MSRAPrelu(), ctx=context)
+    # Define trainer
+    trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': lr})
+    # Define estimator
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              metrics=acc,
+                              trainers=trainer,
+                              context=context)
+    # Call fit() to begin training
+    est.fit(train_data=train_data,
+            val_data=test_data,
+            epochs=num_epochs,
+            batch_size=batch_size,
+            event_handlers=[event_handler.LoggingHandler(est, 'resnet_log', 'resnet_log')])
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description ##
Adding AlexNet, ResNet and FCN examples for the Gluon fit() API.
This PR depends on its parent PR #14346 
JIRA epic: https://issues.apache.org/jira/projects/MXNET/issues/MXNET-1333

Using the fit() API reduces the number of lines of code in each example from ~40 to ~10

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-1348](https://issues.apache.org/jira/projects/MXNET/issues/MXNET-1348)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Added AlexNet, ResNet and FCN examples for fit() API

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
