### PR TITLE
Speedup _contrib_index_copy

### DIFF
--- a/src/operator/contrib/index_copy-inl.h
+++ b/src/operator/contrib/index_copy-inl.h
@@ -37,108 +37,19 @@
 namespace mxnet {
 namespace op {
 
-template<int req>
-struct index_copy_forward {
-  template<typename DType, typename IType>
-  MSHADOW_XINLINE static void Map(int i,
-                                  int dim,
-                                  IType* index,
-                                  DType* new_tensor,
-                                  DType* out_tensor) {
-    DType* out_ptr = out_tensor + static_cast<int>(index[i]) * dim;
-    DType* new_ptr = new_tensor + i * dim;
-    for (int idx = 0; idx < dim; ++idx) {
-      KERNEL_ASSIGN(out_ptr[idx], req, new_ptr[idx]);
-    }
-  }
-};
-
 template<typename xpu>
 void IndexCopyForward(const nnvm::NodeAttrs& attrs,
                       const OpContext& ctx,
                       const std::vector<TBlob>& inputs,
                       const std::vector<OpReqType>& req,
-                      const std::vector<TBlob>& outputs) {
-  CHECK_EQ(inputs.size(), 3U);
-  CHECK_EQ(outputs.size(), 1U);
-  CHECK_EQ(req.size(), 1U);
-  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  const TBlob& out = outputs[0];
-  const TBlob& original_tensor = inputs[0];
-  const TBlob& idx_vector = inputs[1];
-  const TBlob& copied_tensor = inputs[2];
-  int dim = inputs[2].Size() / inputs[1].Size();
-  // copy original tensor to output
-  mxnet_op::copy(s, out, original_tensor);
-  // index copy
-  MSHADOW_TYPE_SWITCH(out.type_flag_, DType, {
-    MSHADOW_TYPE_SWITCH(idx_vector.type_flag_, IType, {
-      MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
-        mxnet_op::Kernel<index_copy_forward<req_type>, xpu>::Launch(s,
-                              idx_vector.Size(), dim,
-                              idx_vector.dptr<IType>(),
-                              copied_tensor.dptr<DType>(),
-                              out.dptr<DType>());
-      });
-    });
-  });
-}
-
-struct index_copy_backward {
-  template<typename DType, typename IType>
-  MSHADOW_XINLINE static void Map(int i,
-                                  int dim,
-                                  int index_size,
-                                  int req1, int req2,
-                                  DType* out_grad,
-                                  IType* index,
-                                  DType* in_grad_1,
-                                  DType* in_grad_2) {
-    // Copy to in_grad_2
-    for (int p = 0; p < index_size; ++p) {
-      int idx = static_cast<int>(index[p]);
-      if (i >= idx*dim && i < (idx+1)*dim) {
-        int offset = i - idx*dim;
-        KERNEL_ASSIGN(in_grad_2[p*dim+offset], req2, out_grad[i]);
-        return;
-      }
-    }
-    // Copy to in_grad_1
-    KERNEL_ASSIGN(in_grad_1[i], req1, out_grad[i]);
-  }
-};
+                      const std::vector<TBlob>& outputs);
 
 template<typename xpu>
 void IndexCopyBackward(const nnvm::NodeAttrs& attrs,
                        const OpContext& ctx,
                        const std::vector<TBlob>& inputs,
                        const std::vector<OpReqType>& req,
-                       const std::vector<TBlob>& outputs) {
-  CHECK_EQ(inputs.size(), 4U);
-  CHECK_EQ(outputs.size(), 3U);
-  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
-  const TBlob& out_grad = inputs[0];
-  const TBlob& index = inputs[2];
-  const TBlob& in_grad_1 = outputs[0];
-  const TBlob& in_grad_2 = outputs[2];
-  int dim = inputs[3].Size() / inputs[2].Size();
-  int index_size = inputs[2].Size();
-  Fill<false>(s, outputs[0], req[0], 0);
-  Fill<false>(s, outputs[2], req[2], 0);
-  // index_copy_backward
-  MSHADOW_TYPE_SWITCH(out_grad.type_flag_, DType, {
-    MSHADOW_TYPE_SWITCH(index.type_flag_, IType, {
-      mxnet_op::Kernel<index_copy_backward, xpu>::Launch(s,
-                                      out_grad.Size(),
-                                      dim, index_size,
-                                      req[0], req[2],
-                                      out_grad.dptr<DType>(),
-                                      index.dptr<IType>(),
-                                      in_grad_1.dptr<DType>(),
-                                      in_grad_2.dptr<DType>());
-    });
-  });
-}
+                       const std::vector<TBlob>& outputs);
 
 inline bool IndexCopyShape(const nnvm::NodeAttrs& attrs,
                            mxnet::ShapeVector *in_attrs,

--- a/src/operator/contrib/index_copy.cu
+++ b/src/operator/contrib/index_copy.cu
@@ -69,7 +69,6 @@ void IndexCopyForward<gpu>(const nnvm::NodeAttrs& attrs,
   });
 }
 
-template<int orig_req, int new_req>
 struct index_copy_bwd_gpu {
   template<typename DType, typename IType>
   MSHADOW_XINLINE static void Map(int i,
@@ -78,7 +77,9 @@ struct index_copy_bwd_gpu {
                                   DType* new_grad,
                                   const IType* idx,
                                   int dim_size,
-                                  int idx_size) {
+                                  int idx_size,
+                                  OpReqType orig_req,
+                                  OpReqType new_req) {
     int index = idx[i / dim_size];
     KERNEL_ASSIGN(new_grad[i], new_req, out_grad[index * dim_size + i % dim_size]);
     if (orig_req == kAddTo) {
@@ -108,29 +109,27 @@ void IndexCopyBackward<gpu>(const nnvm::NodeAttrs& attrs,
   const TBlob& in_grad_2 = outputs[2];
   int dim_size = inputs[3].Size() / inputs[2].Size();
   int index_size = inputs[2].Size();
+  OpReqType orig_req = req[0];
+  OpReqType new_req = req[2];
   // index_copy_backward
   MSHADOW_TYPE_SWITCH(out_grad.type_flag_, DType, {
     MSHADOW_TYPE_SWITCH(index.type_flag_, IType, {
-      MXNET_REQ_TYPE_SWITCH(req[0], orig_req, {
-        MXNET_REQ_TYPE_SWITCH(req[2], new_req, {
-          switch (orig_req) {
-            case kNullOp:
-              break;
-            case kWriteTo:
-            case kWriteInplace:
-              copy(s, in_grad_1, out_grad);
-              break;
-            case kAddTo:
-              Kernel<op_with_req<op::mshadow_op::plus, kWriteInplace>, gpu>::Launch(
-                s, out_grad.Size(), in_grad_1.dptr<DType>(),
-                out_grad.dptr<DType>(), in_grad_1.dptr<DType>());
-          }
-          Kernel<index_copy_bwd_gpu<orig_req, new_req>, gpu>::Launch(
-            s, in_grad_2.Size(), out_grad.dptr<DType>(),
-            in_grad_1.dptr<DType>(), in_grad_2.dptr<DType>(),
-            index.dptr<IType>(), dim_size, index_size);
-        });
-      });
+      switch (orig_req) {
+        case kNullOp:
+          break;
+        case kWriteTo:
+        case kWriteInplace:
+          copy(s, in_grad_1, out_grad);
+          break;
+        case kAddTo:
+          Kernel<op_with_req<op::mshadow_op::plus, kWriteInplace>, gpu>::Launch(
+            s, out_grad.Size(), in_grad_1.dptr<DType>(),
+            out_grad.dptr<DType>(), in_grad_1.dptr<DType>());
+      }
+      Kernel<index_copy_bwd_gpu, gpu>::Launch(
+        s, in_grad_2.Size(), out_grad.dptr<DType>(),
+        in_grad_1.dptr<DType>(), in_grad_2.dptr<DType>(),
+        index.dptr<IType>(), dim_size, index_size, orig_req, new_req);
     });
   });
 }

--- a/src/operator/contrib/index_copy.cu
+++ b/src/operator/contrib/index_copy.cu
@@ -18,13 +18,100 @@
  */
 
 /*!
- * \file index_copy.cc
+ * \file index_copy.cu
  * \brief
  */
 #include "./index_copy-inl.h"
 
 namespace mxnet {
 namespace op {
+
+struct index_copy_fwd_gpu {
+  template<typename DType, typename IType>
+  MSHADOW_XINLINE static void Map(int i,
+                                  const DType* new_tensor,
+                                  const IType* idx,
+                                  DType* out_tensor,
+                                  int dim_size) {
+    int index = static_cast<int>(idx[i / dim_size]);
+    out_tensor[index * dim_size + i % dim_size] = new_tensor[i];
+  }
+};
+
+template<>
+void IndexCopyForward<gpu>(const nnvm::NodeAttrs& attrs,
+                           const OpContext& ctx,
+                           const std::vector<TBlob>& inputs,
+                           const std::vector<OpReqType>& req,
+                           const std::vector<TBlob>& outputs) {
+  using namespace mshadow;
+  using namespace mxnet_op;
+  CHECK_EQ(inputs.size(), 3U);
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+  mshadow::Stream<gpu> *s = ctx.get_stream<gpu>();
+  const TBlob& out = outputs[0];
+  const TBlob& original_tensor = inputs[0];
+  const TBlob& idx_vector = inputs[1];
+  const TBlob& copied_tensor = inputs[2];
+  int dim_size = inputs[2].Size() / inputs[1].Size();
+  // copy original tensor to output
+  copy(s, out, original_tensor);
+  // index copy
+  MSHADOW_TYPE_SWITCH(out.type_flag_, DType, {
+    MSHADOW_TYPE_SWITCH(idx_vector.type_flag_, IType, {
+      Kernel<index_copy_fwd_gpu, gpu>::Launch(
+        s, copied_tensor.Size(), copied_tensor.dptr<DType>(),
+        idx_vector.dptr<IType>(), out.dptr<DType>(), dim_size);
+    });
+  });
+}
+
+struct index_copy_bwd_gpu {
+  template<typename DType, typename IType>
+  MSHADOW_XINLINE static void Map(int i,
+                                  const DType* out_grad,
+                                  DType* orig_grad,
+                                  DType* new_grad,
+                                  const IType* idx,
+                                  int dim_size,
+                                  int idx_size) {
+    orig_grad[i] = out_grad[i];
+    if (i / dim_size < idx_size) {
+      int index = idx[i / dim_size];
+      new_grad[i] = orig_grad[index * dim_size + i % dim_size];
+      orig_grad[index * dim_size + i % dim_size] = 0;
+    }
+  }
+};
+
+template<>
+void IndexCopyBackward<gpu>(const nnvm::NodeAttrs& attrs,
+                            const OpContext& ctx,
+                            const std::vector<TBlob>& inputs,
+                            const std::vector<OpReqType>& req,
+                            const std::vector<TBlob>& outputs) {
+  using namespace mshadow;
+  using namespace mxnet_op;
+  CHECK_EQ(inputs.size(), 4U);
+  CHECK_EQ(outputs.size(), 3U);
+  Stream<gpu> *s = ctx.get_stream<gpu>();
+  const TBlob& out_grad = inputs[0];
+  const TBlob& index = inputs[2];
+  const TBlob& in_grad_1 = outputs[0];
+  const TBlob& in_grad_2 = outputs[2];
+  int dim_size = inputs[3].Size() / inputs[2].Size();
+  int index_size = inputs[2].Size();
+  // index_copy_backward
+  MSHADOW_TYPE_SWITCH(out_grad.type_flag_, DType, {
+    MSHADOW_TYPE_SWITCH(index.type_flag_, IType, {
+      Kernel<index_copy_bwd_gpu, gpu>::Launch(
+        s, out_grad.Size(), out_grad.dptr<DType>(),
+        in_grad_1.dptr<DType>(), in_grad_2.dptr<DType>(),
+        index.dptr<IType>(), dim_size, index_size);
+    });
+  });
+}
 
 NNVM_REGISTER_OP(_contrib_index_copy)
 .set_attr<FCompute>("FCompute<gpu>", IndexCopyForward<gpu>);


### PR DESCRIPTION
## Description ##
Re-writing the Map kernel of contrib.index_copy to speed up index_copy operator for DGL usage.
Plus a small fix to operator registration to fix problem with symbolic API.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Custom CPU kernel for best performance on CPU
- [x] Custom GPU kernel for best performance on GPU

## Comments ##
benchmark results:
CPU
- forward only (ms): 26.154723167419434->25.8462176322937  ~1x speedup
- forward+backward (ms): 63094.7536945343->79.10973119735718 ~800x speedup
GPU:
- forward only (ms): 52.20915079116821->4.262630462646484 ~12.25x speedup
- forward+backward (ms): 36445.19102573395->14.284788131713867 ~2551x speedup
```Python
import mxnet as mx

# uncomment line to use corresponding ctx
# ctx = mx.cpu()
# ctx = mx.gpu(0)

orig_row = 40000
new_row = 20000
col = 512

import random

indices = [i for i in range(orig_row)]
random.shuffle(indices)
indices = mx.nd.array(indices[0:new_row], ctx=ctx, dtype='int32')

from mxnet.test_utils import check_speed, rand_ndarray

mx_orig = rand_ndarray((orig_row, col)).as_in_context(ctx)
mx_new = rand_ndarray((new_row, col)).as_in_context(ctx)

orig = mx.sym.Variable("orig")
idx = mx.sym.Variable("idx")
new = mx.sym.Variable("new")
mx_sym = mx.sym.contrib.index_copy(old_tensor=orig, index_vector=idx, new_tensor=new)

print(check_speed(mx_sym, typ='forward', location={"orig": mx_orig, "idx": indices, "new": mx_new}, ctx=ctx, N=1000) * 1000)
print(check_speed(mx_sym, typ='whole', location={"orig": mx_orig, "idx": indices, "new": mx_new}, ctx=ctx, N=10) * 1000)
```
