### PR TITLE
Add proper exception message for negative shape in array creation routines

### DIFF
--- a/src/operator/tensor/init_op.h
+++ b/src/operator/tensor/init_op.h
@@ -214,6 +214,11 @@ inline bool InitShape(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(in_attrs->size(), 0U);
   CHECK_EQ(out_attrs->size(), 1U);
   if ((*out_attrs)[0].ndim() != 0 && param.shape.ndim() == 0) return true;
+  for (unsigned int i=0 ; i < param.shape.ndim() ; ++i) {
+    if (param.shape[i] < 0U) {
+      LOG(FATAL) << "Shape cannot contain negative values " << param.shape;
+    }
+  }
   SHAPE_ASSIGN_CHECK(*out_attrs, 0, param.shape);
   return true;
 }


### PR DESCRIPTION
## Description ##
Fixes https://github.com/apache/incubator-mxnet/issues/9166
Addresses @apeforest 's comment and adds a relevant exception message when negative shapes are passed to operators like `ones` and `zeros` 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- add a LOG(FATAL) message

## Comments ##
- @anirudh2290 
