### PR TITLE
Support multi-threading for Custom Operator

### DIFF
--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -60,6 +60,9 @@ $env:MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
 * MXNET_MP_OPENCV_NUM_THREADS
   - Values: Int ```(default=0)```
   - The number of OpenCV execution threads given to multiprocess workers. OpenCV multithreading is disabled if `MXNET_MP_OPENCV_NUM_THREADS` < 1 (default). Enlarge this number may boost the performance of individual workers when executing underlying OpenCV functions but please consider reducing the overall `num_workers` to avoid thread contention (not available on Windows).
+* MXNET_CUSTOM_OP_NUM_THREADS
+  - Values: Int ```(default=4)```
+  - The number of threads given to custom operators.
 
 ## Memory Options
 

--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -61,8 +61,8 @@ $env:MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
   - Values: Int ```(default=0)```
   - The number of OpenCV execution threads given to multiprocess workers. OpenCV multithreading is disabled if `MXNET_MP_OPENCV_NUM_THREADS` < 1 (default). Enlarge this number may boost the performance of individual workers when executing underlying OpenCV functions but please consider reducing the overall `num_workers` to avoid thread contention (not available on Windows).
 * MXNET_CUSTOM_OP_NUM_THREADS
-  - Values: Int ```(default=4)```
-  - The number of threads given to custom operators.
+  - Values: Int ```(default=16)```
+  - The maximum number of threads given to custom operators.
 
 ## Memory Options
 

--- a/src/operator/custom/custom-inl.h
+++ b/src/operator/custom/custom-inl.h
@@ -31,6 +31,7 @@
 #include <mxnet/operator.h>
 #include <mxnet/c_api.h>
 #include <mxnet/imperative.h>
+#include <algorithm>
 #include <map>
 #include <vector>
 #include <string>
@@ -154,7 +155,6 @@ class CustomOperator {
     naive_engine_ = true;
     if (std::string("NaiveEngine") != dmlc::GetEnv("MXNET_ENGINE_TYPE", std::string())) {
       naive_engine_ = false;
-      SetNumThreads(1);
     }
   }
   void ThreadTarget() {


### PR DESCRIPTION
## Description ##
Hi! I found that there was single-thread to execute custom operator. It drops the performance.
Is it a better way to support custom operator in multi-thread?

Test Case:
```python
import mxnet as mx
import time

class TestOP(mx.operator.CustomOp):
    def __init__(self):
        super(TestOP, self).__init__()
    def forward(self, is_train, req, in_data, out_data, aux):
        print("sleep 5s")
        time.sleep(5)
        print("sleep finished")
        out_data[0][:] = in_data[0]
    def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
        pass

@mx.operator.register("test_op")
class TestOPProp(mx.operator.CustomOpProp):
    def __init__(self):
        super(TestOPProp, self).__init__()
    def list_arguments(self):
        return ['x']
    def list_outputs(self):
        return ['y']
    def infer_shape(self, in_shape):
        return in_shape, in_shape
    def create_operator(self, ctx, shapes, dtypes):
        return TestOP()

a = mx.nd.array([1,2,3])
tic = time.time()
b = mx.nd.Custom(a, op_type='test_op')
c = mx.nd.Custom(a, op_type='test_op')
d = mx.nd.Custom(a, op_type='test_op')
mx.nd.waitall()
print(time.time() - tic)
```

Cost Time:
Before: 15s
After: 5s

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Support multi-threading for Custom Operator
- [x] Add environmental variable `MXNET_CUSTOM_OP_NUM_THREADS`

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
