### PR TITLE
Fix memory leak for size-zero ndarray

### DIFF
--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -986,9 +986,8 @@ class NDArray {
 #endif
         delay_alloc = false;
       } else if (shandle.size < dbytes) {
-        // free storage if necessary and alloc again
-        if (shandle.size > 0) Storage::Get()->Free(shandle);
-        // init storage
+        // free storage and alloc again
+        Storage::Get()->Free(shandle);
         shandle = Storage::Get()->Alloc(dbytes, shandle.ctx);
 #if MXNET_USE_MKLDNN == 1
         mkl_mem_ = nullptr;
@@ -1055,9 +1054,8 @@ class NDArray {
       }
       size_t aux_bytes = shape.Size() * mshadow::mshadow_sizeof(aux_types[i]);
       if (aux_handles[i].size < aux_bytes) {
-        // free storage if necessary and alloc again
-        if (aux_handles[i].size > 0) Storage::Get()->Free(aux_handles[i]);
-        // init aux storage
+        // free storage and alloc again
+        Storage::Get()->Free(aux_handles[i]);
         aux_handles[i] = Storage::Get()->Alloc(aux_bytes, ctx);
       }
       // init shape

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -909,9 +909,6 @@ class NDArray {
       // aux_handles always reflect the correct number of aux data
       for (size_t i = 0; i < aux_shapes.size(); i++) {
         CheckAndAllocAuxData(i, aux_shapes[i]);
-        // this line is needed in case when aux_shapes[i].Size() = 0
-        // aux_handles[i] will not be updated and take only default value.
-        aux_handles[i].ctx = ctx;
       }
       if (!delay_alloc) {
         CheckAndAllocData(storage_shape, dtype);
@@ -986,8 +983,9 @@ class NDArray {
 #endif
         delay_alloc = false;
       } else if (shandle.size < dbytes) {
-        // free storage and alloc again
+        // free storage
         Storage::Get()->Free(shandle);
+        // init storage
         shandle = Storage::Get()->Alloc(dbytes, shandle.ctx);
 #if MXNET_USE_MKLDNN == 1
         mkl_mem_ = nullptr;
@@ -1051,15 +1049,14 @@ class NDArray {
         << "storage type cannot be kDefaultStorage in CheckAndAllocAuxData";
       if (aux_handles.size() <= i) {
         aux_handles.resize(i + 1);
+        // set context for the newly created aux handle
+        aux_handles[i].ctx = ctx;
       }
       size_t aux_bytes = shape.Size() * mshadow::mshadow_sizeof(aux_types[i]);
       if (aux_handles[i].size < aux_bytes) {
-        // set the context for aux handle to make sure we free it to the right device.
-        if (aux_handles[i].ctx.dev_type != ctx.dev_type) {
-          aux_handles[i].ctx = ctx;
-        }
-        // free storage and alloc again
+        // free storage
         Storage::Get()->Free(aux_handles[i]);
+        // init storage
         aux_handles[i] = Storage::Get()->Alloc(aux_bytes, ctx);
       }
       // init shape

--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -1054,6 +1054,10 @@ class NDArray {
       }
       size_t aux_bytes = shape.Size() * mshadow::mshadow_sizeof(aux_types[i]);
       if (aux_handles[i].size < aux_bytes) {
+        // set the context for aux handle to make sure we free it to the right device.
+        if (aux_handles[i].ctx.dev_type != ctx.dev_type) {
+          aux_handles[i].ctx = ctx;
+        }
         // free storage and alloc again
         Storage::Get()->Free(aux_handles[i]);
         aux_handles[i] = Storage::Get()->Alloc(aux_bytes, ctx);

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -134,8 +134,9 @@ void NDArray::Chunk::CheckAndAllocData(const mxnet::TShape &shape, int dtype) {
       << "data is expected to be allocated after aux_data";
   auto dbytes = shape.Size() * mshadow::mshadow_sizeof(dtype);
   if (shandle.size < dbytes) {
-    // free storage and alloc again
+    // free storage
     Storage::Get()->Free(shandle);
+    // init storage
     shandle = Storage::Get()->Alloc(dbytes, ctx);
 #if MXNET_USE_MKLDNN == 1
     mkl_mem_ = nullptr;

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -121,9 +121,9 @@ NDArray::Chunk::~Chunk() {
         CHECK_EQ(mem.mem->GetDataHandle(), mem.h.dptr);
       }
 #endif
-      if (mem.h.size > 0) Storage::Get()->Free(mem.h);
+      Storage::Get()->Free(mem.h);
       for (const auto& aux : mem.aux_h) {
-        if (aux.size > 0) Storage::Get()->Free(aux);
+        Storage::Get()->Free(aux);
       }
     }
   }, shandle.ctx, var);
@@ -134,9 +134,8 @@ void NDArray::Chunk::CheckAndAllocData(const mxnet::TShape &shape, int dtype) {
       << "data is expected to be allocated after aux_data";
   auto dbytes = shape.Size() * mshadow::mshadow_sizeof(dtype);
   if (shandle.size < dbytes) {
-    // free storage if necessary and alloc again
-    if (shandle.size > 0) Storage::Get()->Free(shandle);
-    // init storage
+    // free storage and alloc again
+    Storage::Get()->Free(shandle);
     shandle = Storage::Get()->Alloc(dbytes, ctx);
 #if MXNET_USE_MKLDNN == 1
     mkl_mem_ = nullptr;

--- a/src/storage/pooled_storage_manager.h
+++ b/src/storage/pooled_storage_manager.h
@@ -155,6 +155,10 @@ void GPUPooledStorageManager::Alloc(Storage::Handle* handle) {
 }
 
 void GPUPooledStorageManager::Free(Storage::Handle handle) {
+  // Do nothing if dptr is nullptr. Otherwise, nullptr may be reused
+  // which can cause illegal memory access error.
+  if (handle.dptr == nullptr) return;
+
   std::lock_guard<std::mutex> lock(Storage::Get()->GetMutex(Context::kGPU));
   size_t size = RoundAllocSize(handle.size);
   auto&& reuse_pool = memory_pool_[size];
@@ -312,6 +316,10 @@ void GPUPooledRoundedStorageManager::Alloc(Storage::Handle* handle) {
 }
 
 void GPUPooledRoundedStorageManager::Free(Storage::Handle handle) {
+  // Do nothing if dptr is nullptr. Otherwise, nullptr may be reused
+  // which can cause illegal memory access error.
+  if (handle.dptr == nullptr) return;
+
   std::lock_guard<std::mutex> lock(Storage::Get()->GetMutex(Context::kGPU));
   int bucket = get_bucket(handle.size);
   auto&& reuse_pool = memory_pool_[bucket];


### PR DESCRIPTION
Fixes #13951 Fixes #14358 

For size-zero ndarray (e.g. mx.nd.array([]), mx.nd.ones(0)), the storage handle size is 0. Currently we only free handles which size is larger than 0. This leads to memory leak for size-zero ndarray.

In this PR, we remove the check on storage handle size which was used to decide if we need to free a storage handle. After relaxing the check, we need to make sure nullptr is not reused in pooled storage manager and the context for aux handle is correctly set for sparse ndarray. 

With this PR, the memory leak issues mentioned above are fixed.
