### PR TITLE
Memory fixes. Resolves #10867, and resolves #14080

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/Executor.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Executor.scala
@@ -167,7 +167,6 @@ class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
                   "If this is intended, set partialShaping = true to suppress this warning.")
       }
     }
-
     if (this._gradsReq.isInstanceOf[Seq[_]]) {
       this.symbol.bind(this._ctx,
                           newArgDict,

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Executor.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Executor.scala
@@ -71,16 +71,6 @@ class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
   override val bytesAllocated: Long = 0
   override val ref: NativeResourceRef = super.register()
 
-  private[mxnet] def updateDepResourceScope(): Unit = {
-    if (argArrays != null) {argArrays.foreach(a => a.moveToScopeOf(this))}
-    if (gradArrays != null) {gradArrays.foreach(
-      // Symbol will sometimes fill this with nulls so we've got to check the elements too
-      a => if (a != null) {a.moveToScopeOf(this)})
-    }
-    if (auxArrays != null) {auxArrays.foreach(a => a.moveToScopeOf(this))}
-    outputs.foreach(o => o.moveToScopeOf(this))
-  }
-
   override def dispose(): Unit = {
     if (!super.isDisposed) {
       super.dispose()

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Executor.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Executor.scala
@@ -45,18 +45,20 @@ object Executor {
  * @see Symbol.bind : to create executor
  */
 class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
-                              private[mxnet] val symbol: Symbol) extends NativeResource {
-  private[mxnet] var argArrays: Array[NDArray] = null
-  private[mxnet] var gradArrays: Array[NDArray] = null
-  private[mxnet] var auxArrays: Array[NDArray] = null
+                              private[mxnet] val symbol: Symbol,
+                              private[mxnet] var argArrays: Array[NDArray] = null,
+                              private[mxnet] var gradArrays: Array[NDArray] = null,
+                              private[mxnet] var auxArrays: Array[NDArray] = null,
+                              private var _ctx: Context = null,
+                              private var _gradsReq: Iterable[_] = null,
+                              private var _group2ctx: Map[String, Context] = null
+                             ) extends NativeResource {
+
   val outputs: Array[NDArray] = getOutputs
   protected var _argDict: Map[String, NDArray] = null
   protected var _gradDict: Map[String, NDArray] = null
   protected var _auxDict: Map[String, NDArray] = null
   protected var monitorCallback: MXMonitorCallback = null
-  private[mxnet] var _ctx: Context = null
-  private[mxnet] var _gradsReq: Iterable[_] = null
-  private[mxnet] var _group2ctx: Map[String, Context] = null
   private val logger: Logger = LoggerFactory.getLogger(classOf[Executor])
 
   override def nativeAddress: CPtrAddress = handle
@@ -64,10 +66,30 @@ class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
   // cannot determine the off-heap size of this object
   override val bytesAllocated: Long = 0
   override val ref: NativeResourceRef = super.register()
+
+  private[mxnet] def updateDepResourceScope(): Unit = {
+    if (argArrays != null) {argArrays.foreach(a => a.moveToScopeOf(this))}
+    if (gradArrays != null) {gradArrays.foreach(
+      // Symbol will sometimes fill this with nulls so we've got to check the elements too
+      a => if (a != null) {a.moveToScopeOf(this)})
+    }
+    if (auxArrays != null) {auxArrays.foreach(a => a.moveToScopeOf(this))}
+    outputs.foreach(o => o.moveToScopeOf(this))
+  }
+
   override def dispose(): Unit = {
     if (!super.isDisposed) {
       super.dispose()
       outputs.foreach(o => o.dispose())
+      if (argArrays != null) {argArrays.foreach(a => a.dispose())}
+      if (gradArrays != null) {gradArrays.foreach(
+        // Symbol will sometimes fill this with nulls so we've got to check the elements too
+        a => if (a != null) {a.dispose()})
+      }
+      if (auxArrays != null) {auxArrays.foreach(a => a.dispose())}
+      if (_argDict != null) {_argDict.foreach(a => a._2.dispose())}
+      if (_gradDict != null) {_gradDict.foreach(a => a._2.dispose())}
+      if (_auxDict != null) {_auxDict.foreach(a => a._2.dispose())}
     }
   }
 
@@ -145,6 +167,7 @@ class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
                   "If this is intended, set partialShaping = true to suppress this warning.")
       }
     }
+
     if (this._gradsReq.isInstanceOf[Seq[_]]) {
       this.symbol.bind(this._ctx,
                           newArgDict,

--- a/scala-package/core/src/main/scala/org/apache/mxnet/NativeResource.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NativeResource.scala
@@ -109,6 +109,18 @@ private[mxnet] trait NativeResource
     }
   }
 
+  /**
+    * This method will move the NativeResource from it's current scope and add it to the
+    * scope of another NativeResource. Useful for when a new resource is made internally and needs
+    * to be coupled to an existing resource.
+    * @param nativeResource the native resource which has the desired destination resourceScope
+    */
+  private [mxnet] def moveToScopeOf(nativeResource: NativeResource): Unit = {
+    if (scope.isDefined) scope.get.remove(this)
+    scope = nativeResource.scope
+    if (scope.isDefined) scope.get.add(this)
+  }
+
   /*
   this is used by the WarnIfNotDisposed finalizer,
   the object could be disposed by the GC without the need for explicit disposal

--- a/scala-package/core/src/main/scala/org/apache/mxnet/NativeResource.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NativeResource.scala
@@ -109,29 +109,6 @@ private[mxnet] trait NativeResource
     }
   }
 
-  /**
-    * This method will move the NativeResource from it's current scope and add it to the
-    * scope of another NativeResource. Useful for when a new resource is made internally and needs
-    * to be coupled to an existing resource. Only moves scopes down, never up since that could cause
-    * resources to be cleared sooner than they should be.
-    * @param nativeResource the native resource which has the desired destination resourceScope
-    */
-  private [mxnet] def moveToScopeOf(nativeResource: NativeResource): Unit = {
-    if (scope.isDefined && nativeResource.scope.isDefined) {
-      val curScope = scope.get
-      val newScope = nativeResource.scope.get
-      if (ResourceScope.getIndexOfScope(curScope) > ResourceScope.getIndexOfScope(newScope)) {
-        curScope.remove(this)
-        scope = nativeResource.scope
-        newScope.add(this)
-      }
-    } else if (scope.isDefined) {
-      val curScope = scope.get
-      curScope.remove(this)
-      scope = nativeResource.scope
-    }
-  }
-
   /*
   this is used by the WarnIfNotDisposed finalizer,
   the object could be disposed by the GC without the need for explicit disposal

--- a/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
@@ -137,7 +137,7 @@ object ResourceScope {
           // don't de-allocate if returning any collection that contains NativeResource.
         case resInGeneric: scala.collection.Iterable[_] => resourceInGeneric(resInGeneric)
         case nRes: NativeResource => curScope.moveToOuterScope(nRes)
-        case ndRet: NDArrayFuncReturn => ndRet.arr.foreach(nd => curScope.moveToOuterScope(nd))
+        case ndRet: NDArrayFuncReturn => ndRet.arr.foreach( nd => curScope.moveToOuterScope(nd) )
         case _ => // do nothing
       }
       ret
@@ -147,9 +147,7 @@ object ResourceScope {
         null.asInstanceOf[A] // we'll throw in finally
     } finally {
       var toThrow: Throwable = retThrowable
-      if (retThrowable eq null) {
-        curScope.close
-      }
+      if (retThrowable eq null) curScope.close
       else {
         try {
           curScope.close
@@ -194,7 +192,6 @@ object ResourceScope {
     * @param r ResourceScope to remove
     */
   private[mxnet] def removeFromThreadLocal(r: ResourceScope): Unit = {
-    // threadLocalScopes.get() -= r
     threadLocalScopes.get().remove(threadLocalScopes.get().lastIndexOf(r))
   }
 

--- a/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
@@ -134,14 +134,12 @@ object ResourceScope {
 
     try {
       val ret = body
-      if (scope == null) {
-        ret match {
+       ret match {
           // don't de-allocate if returning any collection that contains NativeResource.
-          case resInGeneric: scala.collection.Iterable[_] => resourceInGeneric(resInGeneric)
-          case nRes: NativeResource => curScope.moveToOuterScope(nRes)
-          case ndRet: NDArrayFuncReturn => ndRet.arr.foreach(nd => curScope.moveToOuterScope(nd))
-          case _ => // do nothing
-        }
+        case resInGeneric: scala.collection.Iterable[_] => resourceInGeneric(resInGeneric)
+        case nRes: NativeResource => curScope.moveToOuterScope(nRes)
+        case ndRet: NDArrayFuncReturn => ndRet.arr.foreach(nd => curScope.moveToOuterScope(nd))
+        case _ => // do nothing
       }
       ret
     } catch {

--- a/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
@@ -182,6 +182,11 @@ object ResourceScope {
     threadLocalScopes.get() -= r
   }
 
+  private[mxnet] def getIndexOfScope(resourceScope: ResourceScope): Int = {
+    val scopes = threadLocalScopes.get()
+    scopes.indexOf(resourceScope)
+  }
+
   /**
     * Get the latest Scope in the stack
     * @return

--- a/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
@@ -48,8 +48,10 @@ class ResourceScope extends AutoCloseable {
     */
   override def close(): Unit = {
     ResourceScope.removeFromThreadLocal(this)
-    resourceQ.foreach(resource => if (resource != null) resource.dispose(false) )
-    resourceQ.clear()
+    if (!ResourceScope.threadLocalScopes.get().contains(this)) {
+      resourceQ.foreach(resource => if (resource != null) resource.dispose(false))
+      resourceQ.clear()
+    }
   }
 
   /**
@@ -105,10 +107,7 @@ object ResourceScope {
   // TODO: we should move to the Scala util's Using method when we move to Scala 2.13
   def using[A](scope: ResourceScope = null)(body: => A): A = {
 
-    val curScope = if (scope != null) {
-      ResourceScope.addToThreadLocal(scope)
-      scope
-    } else new ResourceScope()
+    val curScope = if (scope != null) scope else new ResourceScope()
 
     @inline def resourceInGeneric(g: scala.collection.Iterable[_]) = {
       g.foreach( n =>
@@ -149,19 +148,11 @@ object ResourceScope {
     } finally {
       var toThrow: Throwable = retThrowable
       if (retThrowable eq null) {
-        if (scope == null) {
-          curScope.close()
-        } else {
-          ResourceScope.removeFromThreadLocal(scope)
-        }
+        curScope.close
       }
       else {
         try {
-          if (scope == null) {
-            curScope.close
-          } else {
-            ResourceScope.removeFromThreadLocal(scope)
-          }
+          curScope.close
         } catch {
           case closeThrowable: Throwable =>
             if (NonFatal(retThrowable) && !NonFatal(closeThrowable)) toThrow = closeThrowable
@@ -177,6 +168,7 @@ object ResourceScope {
     if (scope == None) {
       body
     } else {
+      ResourceScope.addToThreadLocal(scope.get)
       ResourceScope.using(scope.get){
         body
       }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/ResourceScope.scala
@@ -145,10 +145,12 @@ object ResourceScope {
         null.asInstanceOf[A] // we'll throw in finally
     } finally {
       var toThrow: Throwable = retThrowable
-      if (retThrowable eq null) curScope.close()
+      if (retThrowable eq null) {
+        if (scope == null) curScope.close()
+      }
       else {
         try {
-          curScope.close
+          if (scope == null) curScope.close
         } catch {
           case closeThrowable: Throwable =>
             if (NonFatal(retThrowable) && !NonFatal(closeThrowable)) toThrow = closeThrowable
@@ -180,11 +182,6 @@ object ResourceScope {
     */
   private[mxnet] def removeFromThreadLocal(r: ResourceScope): Unit = {
     threadLocalScopes.get() -= r
-  }
-
-  private[mxnet] def getIndexOfScope(resourceScope: ResourceScope): Int = {
-    val scopes = threadLocalScopes.get()
-    scopes.indexOf(resourceScope)
   }
 
   /**

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
@@ -810,8 +810,11 @@ class Symbol private(private[mxnet] val handle: SymbolHandle) extends NativeReso
         key -> new Context(value.deviceType, value.deviceId)
       }
 
-    val newSymbol = this.clone()
-    newSymbol.moveToScopeOf(this)
+    var newSymbol: Symbol = null
+    ResourceScope.using(this.scope.get) {
+      newSymbol = this.clone()
+    }
+
     new Executor(execHandle.value, newSymbol, argsNDArray, argsGradNDArray,
                                 auxStatesNDArray, new Context(ctx.deviceType, ctx.deviceId),
                                 gradsReq, executorGroup2ctx)

--- a/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Symbol.scala
@@ -810,8 +810,9 @@ class Symbol private(private[mxnet] val handle: SymbolHandle) extends NativeReso
         key -> new Context(value.deviceType, value.deviceId)
       }
 
+    // If this is in a scope then we want to create the clone in the same scope
     var newSymbol: Symbol = null
-    ResourceScope.using(this.scope.get) {
+    ResourceScope.usingIfScopeExists(this.scope) {
       newSymbol = this.clone()
     }
 

--- a/scala-package/core/src/main/scala/org/apache/mxnet/module/DataParallelExecutorGroup.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/module/DataParallelExecutorGroup.scala
@@ -299,7 +299,7 @@ class DataParallelExecutorGroup private[module](
 
   private var batchSize: Int = -1
   private var slices: Array[(Int, Int)] = null
-  private var _defaultExecs: Array[Executor] = null
+  // private var _defaultExecs: Array[Executor] = null
   private var execs: Array[Executor] = null
   private var dataArrays: Seq[Array[((Int, Int), NDArray)]] = null
   private var labelArrays: Option[Seq[Array[((Int, Int), NDArray)]]] = None
@@ -373,7 +373,11 @@ class DataParallelExecutorGroup private[module](
         val labelShapesSliced = labelShapes.map(slicedShape(_, i, labelLayouts))
         val inputShapes
           = dataShapesSliced.toMap ++ labelShapesSliced.getOrElse(Map.empty[String, Shape])
-        execs(i) = _defaultExecs(i).reshape(allowUpSizing = true, kwargs = inputShapes)
+        val tmpExec = execs(i).reshape(allowUpSizing = true, kwargs = inputShapes)
+        tmpExec.moveToScopeOf(execs(i))
+        tmpExec.updateDepResourceScope()
+        execs(i).dispose()
+        execs(i) = tmpExec
       }
     } else {
       execs = (0 until contexts.length).map(i =>
@@ -434,9 +438,9 @@ class DataParallelExecutorGroup private[module](
    */
   def reshape(dataShapes: IndexedSeq[DataDesc], labelShapes: Option[IndexedSeq[DataDesc]]): Unit = {
     if (!(dataShapes == this.dataShapes && labelShapes == this.labelShapes)) {
-      if (this._defaultExecs == null) {
-        this._defaultExecs = this.execs.map(x => x)
-      }
+      // if (this._defaultExecs == null) {
+      //   this._defaultExecs = this.execs.map(x => x)
+      // }
       this.bindExec(dataShapes, labelShapes, None, reshape = true)
     }
   }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/module/DataParallelExecutorGroup.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/module/DataParallelExecutorGroup.scala
@@ -299,7 +299,6 @@ class DataParallelExecutorGroup private[module](
 
   private var batchSize: Int = -1
   private var slices: Array[(Int, Int)] = null
-  // private var _defaultExecs: Array[Executor] = null
   private var execs: Array[Executor] = null
   private var dataArrays: Seq[Array[((Int, Int), NDArray)]] = null
   private var labelArrays: Option[Seq[Array[((Int, Int), NDArray)]]] = None
@@ -438,9 +437,6 @@ class DataParallelExecutorGroup private[module](
    */
   def reshape(dataShapes: IndexedSeq[DataDesc], labelShapes: Option[IndexedSeq[DataDesc]]): Unit = {
     if (!(dataShapes == this.dataShapes && labelShapes == this.labelShapes)) {
-      // if (this._defaultExecs == null) {
-      //   this._defaultExecs = this.execs.map(x => x)
-      // }
       this.bindExec(dataShapes, labelShapes, None, reshape = true)
     }
   }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/module/DataParallelExecutorGroup.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/module/DataParallelExecutorGroup.scala
@@ -372,7 +372,8 @@ class DataParallelExecutorGroup private[module](
         val labelShapesSliced = labelShapes.map(slicedShape(_, i, labelLayouts))
         val inputShapes
           = dataShapesSliced.toMap ++ labelShapesSliced.getOrElse(Map.empty[String, Shape])
-        ResourceScope.using(execs(i).scope.get) {
+
+        ResourceScope.usingIfScopeExists(execs(i).scope) {
           val tmpExec = execs(i).reshape(allowUpSizing = true, kwargs = inputShapes)
           execs(i).dispose()
           execs(i) = tmpExec

--- a/scala-package/core/src/main/scala/org/apache/mxnet/optimizer/Adam.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/optimizer/Adam.scala
@@ -17,8 +17,6 @@
 
 package org.apache.mxnet.optimizer
 
-import org.apache.log4j.lf5.util.Resource
-import org.apache.mxnet.NDArrayConversions._
 import org.apache.mxnet.util.SerializerUtils
 import org.apache.mxnet.{LRScheduler, NDArray, Optimizer, ResourceScope}
 

--- a/scala-package/core/src/main/scala/org/apache/mxnet/optimizer/Adam.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/optimizer/Adam.scala
@@ -17,6 +17,7 @@
 
 package org.apache.mxnet.optimizer
 
+import org.apache.mxnet.NDArrayConversions._
 import org.apache.mxnet.util.SerializerUtils
 import org.apache.mxnet.{LRScheduler, NDArray, Optimizer, ResourceScope}
 

--- a/scala-package/core/src/main/scala/org/apache/mxnet/optimizer/Adam.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/optimizer/Adam.scala
@@ -17,9 +17,10 @@
 
 package org.apache.mxnet.optimizer
 
+import org.apache.log4j.lf5.util.Resource
 import org.apache.mxnet.NDArrayConversions._
 import org.apache.mxnet.util.SerializerUtils
-import org.apache.mxnet.{LRScheduler, NDArray, Optimizer}
+import org.apache.mxnet.{LRScheduler, NDArray, Optimizer, ResourceScope}
 
 /**
  * Adam optimizer as described in [King2014]
@@ -57,63 +58,57 @@ class Adam(val learningRate: Float = 0.002f, beta1: Float = 0.9f, beta2: Float =
    *              The auxiliary state used in optimization.
    */
   override def update(index: Int, weight: NDArray, grad: NDArray, state: AnyRef): Unit = {
-    var lr =
-      (if (lrScheduler != null) {
-        val scheduledLr = lrScheduler(numUpdate)
-        updateCount(index)
-        scheduledLr
-      } else {
-        this.learningRate
-      })
-    lr = getLr(index, lr)
+    ResourceScope.using() {
+      var lr =
+        (if (lrScheduler != null) {
+          val scheduledLr = lrScheduler(numUpdate)
+          updateCount(index)
+          scheduledLr
+        } else {
+          this.learningRate
+        })
+      lr = getLr(index, lr)
 
-    val (mean, variance) = state.asInstanceOf[(NDArray, NDArray)]
+      val (mean, variance) = state.asInstanceOf[(NDArray, NDArray)]
 
-    // increment time only when the first parameters is called
-    timeFirstIndex match {
-      case Some(idx) =>
-        if (idx == index) time += 1
-      case None =>
-        timeFirstIndex = Option(index)
-        time = 0 // all parameters share the same time
+      // increment time only when the first parameters is called
+      timeFirstIndex match {
+        case Some(idx) =>
+          if (idx == index) time += 1
+        case None =>
+          timeFirstIndex = Option(index)
+          time = 0 // all parameters share the same time
+      }
+
+      val t1: Int = time + 1
+      val learningRate = (lr *
+        math.sqrt(1.0 - math.pow(beta2, t1)) /
+        (1.0 - math.pow(beta1, t1))).toFloat
+      val beta1t = beta1 * math.pow(decayFactor, t1 - 1).toFloat
+
+      var resdGrad = grad * rescaleGrad
+      if (clipGradient != 0f) {
+        val oldResdGrad = resdGrad
+        resdGrad = NDArray.clip(resdGrad, -clipGradient, clipGradient)
+      }
+
+      val meanT = (beta1t * mean + (1.0 - beta1t) * resdGrad)
+      val varianceT = (beta2 * variance + (1.0f - beta2) * resdGrad * resdGrad)
+      val step = (learningRate * meanT / (NDArray.sqrt(varianceT) + epsilon))
+
+      val wd = this.getWd(index, this.wd)
+      if (wd > 0.0f) {
+        val stepDelta = lr * wd * weight
+        step += stepDelta
+      }
+
+      weight -= step
+      mean.set(meanT)
+      variance.set(varianceT)
+
+      mean.moveToScopeOf(state.asInstanceOf[(NDArray, NDArray)]._1)
+      variance.moveToScopeOf(state.asInstanceOf[(NDArray, NDArray)]._2)
     }
-
-    val t1: Int = time + 1
-    val learningRate = (lr *
-      math.sqrt(1.0 - math.pow(beta2, t1)) /
-      (1.0 - math.pow(beta1, t1))).toFloat
-    val beta1t = beta1 * math.pow(decayFactor, t1 - 1).toFloat
-
-    var resdGrad = grad * rescaleGrad
-    if (clipGradient != 0f) {
-      val oldResdGrad = resdGrad
-      resdGrad = NDArray.clip(resdGrad, -clipGradient, clipGradient)
-      oldResdGrad.dispose()
-    }
-
-    val meanT = (beta1t * mean + (1.0 - beta1t) * resdGrad)
-      .disposeDepsExcept(mean, resdGrad)
-    val varianceT = (beta2 * variance + (1.0f - beta2) * resdGrad * resdGrad)
-      .disposeDepsExcept(variance, resdGrad)
-
-    val step = (learningRate * meanT / (NDArray.sqrt(varianceT) + epsilon))
-      .disposeDepsExcept(meanT, varianceT)
-
-    val wd = this.getWd(index, this.wd)
-    if (wd > 0.0f) {
-      val stepDelta = lr * wd * weight
-      step += stepDelta
-      stepDelta.dispose()
-    }
-
-    weight -= step
-    mean.set(meanT)
-    variance.set(varianceT)
-
-    meanT.dispose()
-    varianceT.dispose()
-    step.dispose()
-    resdGrad.dispose()
   }
 
   // Create additional optimizer state: mean, variance

--- a/scala-package/core/src/main/scala/org/apache/mxnet/optimizer/Adam.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/optimizer/Adam.scala
@@ -57,56 +57,54 @@ class Adam(val learningRate: Float = 0.002f, beta1: Float = 0.9f, beta2: Float =
    *              The auxiliary state used in optimization.
    */
   override def update(index: Int, weight: NDArray, grad: NDArray, state: AnyRef): Unit = {
-    ResourceScope.using() {
-      var lr =
-        (if (lrScheduler != null) {
-          val scheduledLr = lrScheduler(numUpdate)
-          updateCount(index)
-          scheduledLr
-        } else {
-          this.learningRate
-        })
-      lr = getLr(index, lr)
-
+    ResourceScope.using(state.asInstanceOf[(NDArray, NDArray)]._1.scope.get) {
       val (mean, variance) = state.asInstanceOf[(NDArray, NDArray)]
+      ResourceScope.using() {
+        var lr =
+          (if (lrScheduler != null) {
+            val scheduledLr = lrScheduler(numUpdate)
+            updateCount(index)
+            scheduledLr
+          } else {
+            this.learningRate
+          })
+        lr = getLr(index, lr)
 
-      // increment time only when the first parameters is called
-      timeFirstIndex match {
-        case Some(idx) =>
-          if (idx == index) time += 1
-        case None =>
-          timeFirstIndex = Option(index)
-          time = 0 // all parameters share the same time
+        // increment time only when the first parameters is called
+        timeFirstIndex match {
+          case Some(idx) =>
+            if (idx == index) time += 1
+          case None =>
+            timeFirstIndex = Option(index)
+            time = 0 // all parameters share the same time
+        }
+
+        val t1: Int = time + 1
+        val learningRate = (lr *
+          math.sqrt(1.0 - math.pow(beta2, t1)) /
+          (1.0 - math.pow(beta1, t1))).toFloat
+        val beta1t = beta1 * math.pow(decayFactor, t1 - 1).toFloat
+
+        var resdGrad = grad * rescaleGrad
+        if (clipGradient != 0f) {
+          val oldResdGrad = resdGrad
+          resdGrad = NDArray.clip(resdGrad, -clipGradient, clipGradient)
+        }
+
+        val meanT = (beta1t * mean + (1.0 - beta1t) * resdGrad)
+        val varianceT = (beta2 * variance + (1.0f - beta2) * resdGrad * resdGrad)
+        val step = (learningRate * meanT / (NDArray.sqrt(varianceT) + epsilon))
+
+        val wd = this.getWd(index, this.wd)
+        if (wd > 0.0f) {
+          val stepDelta = lr * wd * weight
+          step += stepDelta
+        }
+
+        weight -= step
+        mean.set(meanT)
+        variance.set(varianceT)
       }
-
-      val t1: Int = time + 1
-      val learningRate = (lr *
-        math.sqrt(1.0 - math.pow(beta2, t1)) /
-        (1.0 - math.pow(beta1, t1))).toFloat
-      val beta1t = beta1 * math.pow(decayFactor, t1 - 1).toFloat
-
-      var resdGrad = grad * rescaleGrad
-      if (clipGradient != 0f) {
-        val oldResdGrad = resdGrad
-        resdGrad = NDArray.clip(resdGrad, -clipGradient, clipGradient)
-      }
-
-      val meanT = (beta1t * mean + (1.0 - beta1t) * resdGrad)
-      val varianceT = (beta2 * variance + (1.0f - beta2) * resdGrad * resdGrad)
-      val step = (learningRate * meanT / (NDArray.sqrt(varianceT) + epsilon))
-
-      val wd = this.getWd(index, this.wd)
-      if (wd > 0.0f) {
-        val stepDelta = lr * wd * weight
-        step += stepDelta
-      }
-
-      weight -= step
-      mean.set(meanT)
-      variance.set(varianceT)
-
-      mean.moveToScopeOf(state.asInstanceOf[(NDArray, NDArray)]._1)
-      variance.moveToScopeOf(state.asInstanceOf[(NDArray, NDArray)]._2)
     }
   }
 

--- a/scala-package/core/src/test/scala/org/apache/mxnet/ResourceScopeSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/ResourceScopeSuite.scala
@@ -102,12 +102,13 @@ class ResourceScopeSuite extends FunSuite with BeforeAndAfterAll with Matchers {
   }
 
   /**
-    * Goes multiple scopes deep to make sure we can move across multiple levels correctly
+    * Tests passing a scope to using and creating new resources within.
     */
   test("test moving scope of native resource to scope of another") {
     var a: TestNativeResource = null
     var b: TestNativeResource = null
     var c: TestNativeResource = null
+    var d: TestNativeResource = null
 
     ResourceScope.using() {
       a = new TestNativeResource()
@@ -115,6 +116,10 @@ class ResourceScopeSuite extends FunSuite with BeforeAndAfterAll with Matchers {
         b = new TestNativeResource()
         ResourceScope.using(a.scope.get) {
           c = new TestNativeResource()
+          ResourceScope.using() {
+            d = new TestNativeResource()
+          }
+          assert(d.isDisposed == true)
         }
         assert(b.isDisposed == false)
         assert(c.isDisposed == false)

--- a/scala-package/core/src/test/scala/org/apache/mxnet/ResourceScopeSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/ResourceScopeSuite.scala
@@ -109,22 +109,23 @@ class ResourceScopeSuite extends FunSuite with BeforeAndAfterAll with Matchers {
     var b: TestNativeResource = null
     var c: TestNativeResource = null
     var d: TestNativeResource = null
-
+    var notinAScope: TestNativeResource = new TestNativeResource()
     ResourceScope.using() {
       a = new TestNativeResource()
       ResourceScope.using() {
         b = new TestNativeResource()
-        b.moveToScopeOf(a)
+        b.moveToScopeOf(notinAScope)
         ResourceScope.using() {
           c = new TestNativeResource()
           ResourceScope.using() {
             d = new TestNativeResource()
+            // Should fail to move c since d is in a higher scope
             c.moveToScopeOf(d)
             d.moveToScopeOf(a)
             assert(c.isDisposed == false)
             assert(d.isDisposed == false)
           }
-          assert(c.isDisposed == true)
+          assert(c.isDisposed == false)
           assert(d.isDisposed == false)
         }
         assert(b.isDisposed == false)
@@ -137,7 +138,7 @@ class ResourceScopeSuite extends FunSuite with BeforeAndAfterAll with Matchers {
       assert(d.isDisposed == false)
     }
     assert(a.isDisposed == true)
-    assert(b.isDisposed == true)
+    assert(b.isDisposed == false)
     assert(c.isDisposed == true)
     assert(d.isDisposed == true)
   }

--- a/scala-package/core/src/test/scala/org/apache/mxnet/ResourceScopeSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/ResourceScopeSuite.scala
@@ -118,6 +118,7 @@ class ResourceScopeSuite extends FunSuite with BeforeAndAfterAll with Matchers {
           c = new TestNativeResource()
           ResourceScope.using() {
             d = new TestNativeResource()
+            assert(c.scope == a.scope)
           }
           assert(d.isDisposed == true)
         }

--- a/scala-package/core/src/test/scala/org/apache/mxnet/ResourceScopeSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/ResourceScopeSuite.scala
@@ -114,7 +114,7 @@ class ResourceScopeSuite extends FunSuite with BeforeAndAfterAll with Matchers {
       a = new TestNativeResource()
       ResourceScope.using() {
         b = new TestNativeResource()
-        ResourceScope.using(a.scope.get) {
+        ResourceScope.usingIfScopeExists(a.scope) {
           c = new TestNativeResource()
           ResourceScope.using() {
             d = new TestNativeResource()

--- a/scala-package/core/src/test/scala/org/apache/mxnet/ResourceScopeSuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/ResourceScopeSuite.scala
@@ -108,39 +108,24 @@ class ResourceScopeSuite extends FunSuite with BeforeAndAfterAll with Matchers {
     var a: TestNativeResource = null
     var b: TestNativeResource = null
     var c: TestNativeResource = null
-    var d: TestNativeResource = null
-    var notinAScope: TestNativeResource = new TestNativeResource()
+
     ResourceScope.using() {
       a = new TestNativeResource()
       ResourceScope.using() {
         b = new TestNativeResource()
-        b.moveToScopeOf(notinAScope)
-        ResourceScope.using() {
+        ResourceScope.using(a.scope.get) {
           c = new TestNativeResource()
-          ResourceScope.using() {
-            d = new TestNativeResource()
-            // Should fail to move c since d is in a higher scope
-            c.moveToScopeOf(d)
-            d.moveToScopeOf(a)
-            assert(c.isDisposed == false)
-            assert(d.isDisposed == false)
-          }
-          assert(c.isDisposed == false)
-          assert(d.isDisposed == false)
         }
         assert(b.isDisposed == false)
-        assert(c.isDisposed == true)
-        assert(d.isDisposed == false)
+        assert(c.isDisposed == false)
       }
       assert(a.isDisposed == false)
-      assert(b.isDisposed == false)
-      assert(c.isDisposed == true)
-      assert(d.isDisposed == false)
+      assert(b.isDisposed == true)
+      assert(c.isDisposed == false)
     }
     assert(a.isDisposed == true)
-    assert(b.isDisposed == false)
+    assert(b.isDisposed == true)
     assert(c.isDisposed == true)
-    assert(d.isDisposed == true)
   }
 
   test(testName = "test NativeResources in returned Lists are not disposed") {


### PR DESCRIPTION
## Description ##
There were a few memory leaks in executor and some instances of where ResourceScope was causing problems. This should fix those known issues.

To elaborate on the ResourceScope issue: there are some times when classes such as Executor creates other NativeResources (usually NDArrays) after the Executor has been instantiated. The executor then has a dependency on that new NativeResource. Since these happen at different times, they could potentially be created at different ResourceScope levels. The result is an unstable state where exiting the scope would cause a crash. Fixed this by adding a method to NativeResource which allows moving a resource to the same scope as another. This allows the parent class to control the scope of their dependencies.

Resolves #10867, and resolves #14080.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
