### PR TITLE
Correct update count with Gluon trainer and update_on_kvstore=False

### DIFF
--- a/python/mxnet/gluon/trainer.py
+++ b/python/mxnet/gluon/trainer.py
@@ -241,10 +241,10 @@ class Trainer(object):
                 kvstore.set_optimizer(self._optimizer)
             self._kvstore = kvstore
             self._update_on_kvstore = update_on_kvstore
-            if self._optimizer.lr_scheduler and not self._update_on_kvstore:
-                raise ValueError("update_on_kvstore=False does not support " \
-                                 "optimizer with LRScheduler. Please " \
-                                 "consider setting learning rate manually.")
+            #if self._optimizer.lr_scheduler and not self._update_on_kvstore:
+            #    raise ValueError("update_on_kvstore=False does not support " \
+            #                     "optimizer with LRScheduler. Please " \
+            #                     "consider setting learning rate manually.")
         else:
             self._kvstore = None
             self._update_on_kvstore = None

--- a/python/mxnet/gluon/trainer.py
+++ b/python/mxnet/gluon/trainer.py
@@ -241,10 +241,6 @@ class Trainer(object):
                 kvstore.set_optimizer(self._optimizer)
             self._kvstore = kvstore
             self._update_on_kvstore = update_on_kvstore
-            #if self._optimizer.lr_scheduler and not self._update_on_kvstore:
-            #    raise ValueError("update_on_kvstore=False does not support " \
-            #                     "optimizer with LRScheduler. Please " \
-            #                     "consider setting learning rate manually.")
         else:
             self._kvstore = None
             self._update_on_kvstore = None

--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -106,7 +106,8 @@ class Optimizer(object):
         self.wd_mult = {}
         self.begin_num_update = begin_num_update
         self.num_update = begin_num_update
-        self._index_update_count = {}
+        self._all_index_update_counts = {0 : {}}
+        self._index_update_count = self._all_index_update_counts[0]
         self.clip_gradient = clip_gradient
         self.multi_precision = multi_precision
         self.aggregate_num = 0
@@ -379,6 +380,11 @@ class Optimizer(object):
                 if name in attr and '__wd_mult__' in attr[name]:
                     self.wd_mult[name] = float(attr[name]['__wd_mult__'])
         self.wd_mult.update(args_wd_mult)
+
+    def set_current_context(self, ctx):
+        if ctx not in self._all_index_update_counts:
+            self._all_index_update_counts[ctx] = {}
+        self._index_update_count = self._all_index_update_counts[ctx]
 
     def _update_count(self, index):
         """Updates num_update.
@@ -1623,6 +1629,8 @@ class Updater(object):
             indices = index
             grads = grad
             weights = weight
+        if weights:
+            self.optimizer.set_current_context(weights[0].context.device_id)
         for i, idx in enumerate(indices):
             # convert ctypes.char_p.value back to python str if needed
             if isinstance(idx, bytes):

--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -381,10 +381,17 @@ class Optimizer(object):
                     self.wd_mult[name] = float(attr[name]['__wd_mult__'])
         self.wd_mult.update(args_wd_mult)
 
-    def set_current_context(self, ctx):
-        if ctx not in self._all_index_update_counts:
-            self._all_index_update_counts[ctx] = {}
-        self._index_update_count = self._all_index_update_counts[ctx]
+    def _set_current_context(self, device_id):
+        """Sets the number of the currently handled device.
+
+        Parameters
+        ----------
+        device_id : int
+            The number of current device.
+        """
+        if device_id not in self._all_index_update_counts:
+            self._all_index_update_counts[device_id] = {}
+        self._index_update_count = self._all_index_update_counts[device_id]
 
     def _update_count(self, index):
         """Updates num_update.
@@ -1630,7 +1637,7 @@ class Updater(object):
             grads = grad
             weights = weight
         if weights:
-            self.optimizer.set_current_context(weights[0].context.device_id)
+            self.optimizer._set_current_context(weights[0].context.device_id)
         for i, idx in enumerate(indices):
             # convert ctypes.char_p.value back to python str if needed
             if isinstance(idx, bytes):


### PR DESCRIPTION
## Description ##
This PR fixes the update count when Gluon trainer is created with multiple devices and `update_on_kvstore=False`.
Fixes #13752, fixes #12713

@eric-haibin-lin This slightly hacky but should work for all cases. Thoughts?

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- The real fix here should be moving the _index_update_count to Updater (which is per device) from optimizer (which is common to all updaters), but that would require breaking API change. FYI @szha 