### PR TITLE
[CI Fix] Disable Some Clojure Integration tests that are having connection problems

### DIFF
--- a/contrib/clojure-package/integration-tests.sh
+++ b/contrib/clojure-package/integration-tests.sh
@@ -26,7 +26,7 @@ lein install
 # then run through the examples 
 EXAMPLES_HOME=${MXNET_HOME}/contrib/clojure-package/examples
 # use AWK pattern for blacklisting
-TEST_CASES=`find ${EXAMPLES_HOME} -name test | awk '!/dontselect1|cnn-text-classification/'`
+TEST_CASES=`find ${EXAMPLES_HOME} -name test | awk '!/dontselect1|cnn-text-classification|gan|neural-style|infer|pre-trained-models/'`
 for i in $TEST_CASES ; do
  cd ${i} && lein test
 done


### PR DESCRIPTION
The dependencies in some of the examples are having trouble connecting to the repo

```Could not transfer artifact origami:origami:pom:4.0.0-3 from/to vendredi (https://repository.hellonico.info/repository/hellonico/): Failed to transfer file: https://repository.hellonico.info/repository/hellonico/origami/origami/4.0.0-3/origami-4.0.0-3.pom. Return code is: 502 , ReasonPhrase:Bad Gateway```

Example:
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/PR-14377/1/pipeline

This will temporarily disable them until we can troubleshoot what is going on