### PR TITLE
fix engine crash in shutdown phase

### DIFF
--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -38,6 +38,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <mxnet/storage.h>
 #include "./engine_impl.h"
 #include "../profiler/profiler.h"
 #include "./openmp.h"
@@ -306,6 +307,8 @@ class ThreadedEngine : public Engine {
     objpool_varblk_ref_ = common::ObjectPool<VersionedVarBlock>::_GetSharedRef();
     objpool_var_ref_    = common::ObjectPool<ThreadedVar>::_GetSharedRef();
 
+    storage_ref_ = Storage::_GetSharedRef();
+
     // Get a ref to the profiler so that it doesn't get killed before us
     profiler::Profiler::Get(&profiler_);
   }
@@ -548,6 +551,12 @@ class ThreadedEngine : public Engine {
   std::shared_ptr<common::ObjectPool<OprBlock> >          objpool_blk_ref_;
   std::shared_ptr<common::ObjectPool<VersionedVarBlock> > objpool_varblk_ref_;
   std::shared_ptr<common::ObjectPool<ThreadedVar> >       objpool_var_ref_;
+
+  /*!
+   * \brief Async destruction of some objects is relied on storage,
+   *  prevent it from being destructed too early
+   */
+  std::shared_ptr<Storage> storage_ref_;
 
 #if MXNET_USE_CUDA
   /*! \brief Number of GPU devices available */

--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -30,6 +30,7 @@
 #include <dmlc/base.h>
 #include <dmlc/logging.h>
 #include <dmlc/omp.h>
+#include <mxnet/storage.h>
 #include <vector>
 #include <functional>
 #include <condition_variable>
@@ -38,7 +39,6 @@
 #include <mutex>
 #include <string>
 #include <thread>
-#include <mxnet/storage.h>
 #include "./engine_impl.h"
 #include "../profiler/profiler.h"
 #include "./openmp.h"

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -547,18 +547,8 @@ def _conv_with_num_streams(seed):
 
 @with_seed()
 def test_convolution_multiple_streams():
-    engines = ['NaiveEngine', 'ThreadedEngine', 'ThreadedEnginePerDevice']
-
-    if os.getenv('MXNET_ENGINE_TYPE') is not None:
-        engines = [os.getenv('MXNET_ENGINE_TYPE'),]
-        print("Only running against '%s'" % engines[0], file=sys.stderr, end='')
-    # Remove this else clause when the ThreadedEngine can handle this test
-    else:
-        engines.remove('ThreadedEngine')
-        print("SKIP: 'ThreadedEngine', only running against %s" % engines, file=sys.stderr, end='')
-
     for num_streams in [1, 2]:
-        for engine in engines:
+        for engine in ['NaiveEngine', 'ThreadedEngine', 'ThreadedEnginePerDevice']:
             print("Starting engine %s with %d streams." % (engine, num_streams), file=sys.stderr)
             run_in_spawned_process(_conv_with_num_streams,
                 {'MXNET_GPU_WORKER_NSTREAMS' : num_streams, 'MXNET_ENGINE_TYPE' : engine})


### PR DESCRIPTION
## Description ##
@DickJC123 has reported the engine crash in #14329 which is related to my early PR on ASAN fix (#14223), this PR tries to fix the crash and restores the CI bypass in #14338.

After reproducing the crash in docker, I found it happens when trying to destruct resources using `Storage` singleton in engine shutdown phase. So I added shared_ptr in threaded engine to force `Storage` to destruct after engine cleanup.

Thus, the crash has two properties:
1. It doesn't happen all the time and is hard to reproduce because the destruction order of static variable is almost undefined in c++, which causes many similar bugs, #309 for example. For the time being, we can only add patches of shared_ptr when crash happens.
2. It happens in `test_convolution_multiple_streams` because sub-process is used to run tests, leading to 6 engine shutdown phases in one single test.

In order to verify the fix, 100 times of `test_convolution_multiple_streams` is executed without crash.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
