### PR TITLE
Disables flaky scala NDArray arange test

### DIFF
--- a/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
@@ -334,7 +334,8 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
     assert(res.toArray === Array(11f))
   }
 
-  test("arange") {
+  // Skipping flaky test: https://github.com/apache/incubator-mxnet/issues/14402
+  ignore("arange") {
     for (i <- 0 until 5) {
       val start = scala.util.Random.nextFloat() * 5
       val stop = start + scala.util.Random.nextFloat() * 100


### PR DESCRIPTION
## Description ##

Disables flay scala NDArray arange test. Related to #14402.

Failure example:
http://jenkins.mxnet-ci.amazon-ml.com/blue/rest/organizations/jenkins/pipelines/mxnet-validation/pipelines/unix-cpu/branches/master/runs/406/nodes/254/steps/734/log/?start=0