### PR TITLE
Fix relative difference scala

### DIFF
--- a/scala-package/core/src/test/scala/org/apache/mxnet/CheckUtils.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/CheckUtils.scala
@@ -21,13 +21,13 @@ object CheckUtils {
   def reldiff(a: NDArray, b: NDArray): Float = {
     val diff = NDArray.sum(NDArray.abs(a - b)).toScalar
     val norm = NDArray.sum(NDArray.abs(a)).toScalar
-    diff / norm
+    if (diff < Float.MinPositiveValue) diff else diff / norm
   }
 
   def reldiff(a: Array[Float], b: Array[Float]): Float = {
     val diff =
       (a zip b).map { case (aElem, bElem) => Math.abs(aElem - bElem) }.sum
     val norm: Float = a.reduce(Math.abs(_) + Math.abs(_))
-    diff / norm
+    if (diff < Float.MinPositiveValue) diff else diff / norm
   }
 }

--- a/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
@@ -355,7 +355,7 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
       val result3 = 0f to stop by 1f
       val range3 = NDArray.arange(stop)
       assert(CheckUtils.reldiff(result3.toArray, range3.toArray) <= 1e-4f)
-      
+
       val stop4 = Math.abs(stop)
       val step4 = stop4 + Math.abs(scala.util.Random.nextFloat())
       val result4 = (0.0 until stop4.toDouble by step4.toDouble)

--- a/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
@@ -335,7 +335,7 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
   }
 
   test("arange") {
-    for (i <- 0 until 10000) {
+    for (i <- 0 until 5) {
       val start = scala.util.Random.nextFloat() * 5
       val stop = start + scala.util.Random.nextFloat() * 100
       val step = scala.util.Random.nextFloat() * 4
@@ -355,6 +355,13 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
       val result3 = 0f to stop by 1f
       val range3 = NDArray.arange(stop)
       assert(CheckUtils.reldiff(result3.toArray, range3.toArray) <= 1e-4f)
+      
+      val stop4 = Math.abs(stop)
+      val step4 = stop4 + Math.abs(scala.util.Random.nextFloat())
+      val result4 = (0.0 until stop4.toDouble by step4.toDouble)
+        .flatMap(x => Array.fill[Float](repeat)(x.toFloat))
+      val range4 = NDArray.arange(stop4, step = step4, repeat = repeat)
+      assert(CheckUtils.reldiff(result4.toArray, range4.toArray) <= 1e-4f)
     }
   }
 

--- a/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
@@ -335,7 +335,7 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
   }
 
   test("arange") {
-    for (i <- 0 until 5) {
+    for (i <- 0 until 10000) {
       val start = scala.util.Random.nextFloat() * 5
       val stop = start + scala.util.Random.nextFloat() * 100
       val step = scala.util.Random.nextFloat() * 4


### PR DESCRIPTION
## Description ##
Fix #14402 where division by zero occurs in relative difference calculation, making `arange` tests fail.
Solution: if `diff` is near 0f, i.e < `Float.MinPositiveValue` just return it instead of dividing by `norm`.

Also ~~increase number of test cases to 10000~~ add test cases where `arange` produces NDArray of [0.0f] to catch this. Test is not flaky anymore.
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

#14413 @lanking520 @perdasilva