### PR TITLE
Add repr for SymbolBlock

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1026,7 +1026,7 @@ class SymbolBlock(HybridBlock):
 
     def __repr__(self):
         s = '{name}(\n{modstr}\n)'
-        modstr = '\n'.join(['{block}'.format(block=self.__dict__['_cached_graph'][-1])])
+        modstr = '\n'.join(['{block}'.format(block=self._cached_graph[-1])])
         return s.format(name=self.__class__.__name__,
                         modstr=modstr)
 

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1026,7 +1026,10 @@ class SymbolBlock(HybridBlock):
 
     def __repr__(self):
         s = '{name}(\n{modstr}\n)'
-        modstr = '\n'.join(['{block}'.format(block=self._cached_graph[-1])])
+        modstr = '\n'.join(['{block} : {numinputs} -> {numoutputs}'.format(block=self._cached_graph[1],
+                                                                           numinputs=len(self._cached_graph[0]),
+                                                                           numoutputs=len(self._cached_graph[1].
+                                                                                          list_outputs()))])
         return s.format(name=self.__class__.__name__,
                         modstr=modstr)
 

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1024,6 +1024,11 @@ class SymbolBlock(HybridBlock):
             ret.collect_params().load(param_file, ctx=ctx)
         return ret
 
+    def __repr__(self):
+        s = '{name}(\n{modstr}\n)'
+        modstr = '\n'.join(['{block}'.format(block=self.__dict__['_cached_graph'][-1])])
+        return s.format(name=self.__class__.__name__,
+                        modstr=modstr)
 
     def __init__(self, outputs, inputs, params=None):
         super(SymbolBlock, self).__init__(prefix=None, params=None)

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -882,8 +882,13 @@ def test_import():
     net2 = gluon.SymbolBlock.imports(
         'net1-symbol.json', ['data'], 'net1-0001.params', ctx)
     out2 = net2(data)
+    lines = str(net2).splitlines()
 
     assert_almost_equal(out1.asnumpy(), out2.asnumpy())
+    assert lines[0] == 'SymbolBlock('
+    assert lines[1]
+    assert lines[2] == ')'
+
 
 @with_seed()
 def test_hybrid_stale_cache():


### PR DESCRIPTION
## Description ##
SymbolBlock uses `Block.__repr__` when `print(SymbolBlock)` is executed. In `Block.__repr__`, data is printed only if it is of type Block. Adding a `__repr__` to SymbolBlock class that prints the output symbol. This behavior is similar to printing pure Symbol API.

Fixes https://github.com/apache/incubator-mxnet/issues/13616

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Add a __repr__ for SymbolBlock
Executing
```
import mxnet as mx
from mxnet.gluon.model_zoo import vision

alexnet = vision.alexnet(pretrained=True)
alexnet.initialize()
alexnet.hybridize()
alexnet(mx.random.uniform(shape=(1,3,224,224)))
alexnet.export("./alexnet")

block = mx.gluon.nn.SymbolBlock.imports('alexnet-symbol.json', ['data'], 'alexnet-0000.params')
print(block)
```
gives the output
**Before**
```
SymbolBlock(

)
```
**After change**
```
SymbolBlock(
<Symbol alexnet0_dense2_fwd> : 1 -> 1
)
```

Example with a model with more than one output:

```
import mxnet as mx
from mxnet import gluon

data = mx.sym.Variable('data')
topk = mx.sym.topk(data, k=3, ret_typ='both')
ctx = mx.cpu()

pre_trained = gluon.nn.SymbolBlock(outputs=topk, inputs=data)
print (pre_trained)

```
Output:
```
SymbolBlock(
<Symbol topk2> : 1 -> 2
)
```
## Comments ##
@eric-haibin-lin @Ishitori 
