### PR TITLE
Fix crashes on visualization

### DIFF
--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -339,7 +339,12 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs
         elif op == "BatchNorm":
             attr["fillcolor"] = cm[3]
         elif op in ('Activation', 'LeakyReLU'):
-            label = r"%s\n%s" % (op, node["attrs"]["act_type"])
+            if op == "LeakyReLU":
+                attrs = node.get("attrs")
+                act_type = attrs.get("act_type", "Leaky") if attrs else "Leaky"
+            else:
+                act_type = node["attrs"]["act_type"]
+            label = r"%s\n%s" % (op, str(act_type))
             attr["fillcolor"] = cm[2]
         elif op == "Pooling":
             label = r"Pooling\n%s, %s/%s" % (node["attrs"]["pool_type"],

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -343,7 +343,8 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs
             attr["fillcolor"] = cm[2]
         elif op == "Pooling":
             label = r"Pooling\n%s, %s/%s" % (node["attrs"]["pool_type"],
-                                             "x".join(_str2tuple(node["attrs"]["kernel"])),
+                                             "x".join(_str2tuple(node["attrs"]["kernel"]))
+                                             if "kernel" in node["attrs"] else "[]",
                                              "x".join(_str2tuple(node["attrs"]["stride"]))
                                              if "stride" in node["attrs"] else "1")
             attr["fillcolor"] = cm[4]

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -351,10 +351,10 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs
             attr["fillcolor"] = cm[2]
         elif op == "Pooling":
             label = "Pooling\n{pooltype}, {kernel}/{stride}".format(pooltype=node["attrs"]["pool_type"],
-                                             kernel="x".join(_str2tuple(node["attrs"]["kernel"]))
-                                             if "kernel" in node["attrs"] else "[]",
-                                             stride="x".join(_str2tuple(node["attrs"]["stride"]))
-                                             if "stride" in node["attrs"] else "1")
+                                                                    kernel="x".join(_str2tuple(node["attrs"]["kernel"]))
+                                                                    if "kernel" in node["attrs"] else "[]",
+                                                                    stride="x".join(_str2tuple(node["attrs"]["stride"]))
+                                                                    if "stride" in node["attrs"] else "1")
             attr["fillcolor"] = cm[4]
         elif op in ("Concat", "Flatten", "Reshape"):
             attr["fillcolor"] = cm[5]

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -205,7 +205,7 @@ def print_summary(symbol, shape=None, line_length=120, positions=[.44, .64, .74,
             print('=' * line_length)
         else:
             print('_' * line_length)
-    print('Total params: %s' % total_params)
+    print("Total params: {params}".format(params=total_params))
     print('_' * line_length)
 
 def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs={},
@@ -328,30 +328,32 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs
             label = node["name"]
             attr["fillcolor"] = cm[0]
         elif op == "Convolution":
-            label = r"Convolution\n%s/%s, %s" % ("x".join(_str2tuple(node["attrs"]["kernel"])),
-                                                 "x".join(_str2tuple(node["attrs"]["stride"]))
-                                                 if "stride" in node["attrs"] else "1",
-                                                 node["attrs"]["num_filter"])
+            label = "Convolution\n{kernel}/{stride}, {filter}".format(
+                kernel="x".join(_str2tuple(node["attrs"]["kernel"])),
+                stride="x".join(_str2tuple(node["attrs"]["stride"]))
+                if "stride" in node["attrs"] else "1",
+                filter=node["attrs"]["num_filter"]
+            )
             attr["fillcolor"] = cm[1]
         elif op == "FullyConnected":
-            label = r"FullyConnected\n%s" % node["attrs"]["num_hidden"]
+            label = "FullyConnected\n{hidden}".format(hidden=node["attrs"]["num_hidden"])
             attr["fillcolor"] = cm[1]
         elif op == "BatchNorm":
             attr["fillcolor"] = cm[3]
         elif op == 'Activation':
             act_type = node["attrs"]["act_type"]
-            label = '{operator}\n{activation}'.format(operator=op, activation=act_type)
+            label = 'Activation\n{activation}'.format(activation=act_type)
             attr["fillcolor"] = cm[2]
         elif op == 'LeakyReLU':
             attrs = node.get("attrs")
             act_type = attrs.get("act_type", "Leaky") if attrs else "Leaky"
-            label = '{operator}\n{activation}'.format(operator=op, activation=act_type)
+            label = 'LeakyReLU\n{activation}'.format(activation=act_type)
             attr["fillcolor"] = cm[2]
         elif op == "Pooling":
-            label = r"Pooling\n%s, %s/%s" % (node["attrs"]["pool_type"],
-                                             "x".join(_str2tuple(node["attrs"]["kernel"]))
+            label = "Pooling\n{pooltype}, {kernel}/{stride}".format(pooltype=node["attrs"]["pool_type"],
+                                             kernel="x".join(_str2tuple(node["attrs"]["kernel"]))
                                              if "kernel" in node["attrs"] else "[]",
-                                             "x".join(_str2tuple(node["attrs"]["stride"]))
+                                             stride="x".join(_str2tuple(node["attrs"]["stride"]))
                                              if "stride" in node["attrs"] else "1")
             attr["fillcolor"] = cm[4]
         elif op in ("Concat", "Flatten", "Reshape"):

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -338,13 +338,14 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, node_attrs
             attr["fillcolor"] = cm[1]
         elif op == "BatchNorm":
             attr["fillcolor"] = cm[3]
-        elif op in ('Activation', 'LeakyReLU'):
-            if op == "LeakyReLU":
-                attrs = node.get("attrs")
-                act_type = attrs.get("act_type", "Leaky") if attrs else "Leaky"
-            else:
-                act_type = node["attrs"]["act_type"]
-            label = r"%s\n%s" % (op, str(act_type))
+        elif op == 'Activation':
+            act_type = node["attrs"]["act_type"]
+            label = '{operator}\n{activation}'.format(operator=op, activation=act_type)
+            attr["fillcolor"] = cm[2]
+        elif op == 'LeakyReLU':
+            attrs = node.get("attrs")
+            act_type = attrs.get("act_type", "Leaky") if attrs else "Leaky"
+            label = '{operator}\n{activation}'.format(operator=op, activation=act_type)
             attr["fillcolor"] = cm[2]
         elif op == "Pooling":
             label = r"Pooling\n%s, %s/%s" % (node["attrs"]["pool_type"],


### PR DESCRIPTION
## Description ##
Fixes https://github.com/apache/incubator-mxnet/issues/14245
Fixes https://github.com/apache/incubator-mxnet/issues/10416

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Add a check for the presence of kernel in attrs

## Comments ##
Test code for Pooling visualization crash (after fix):
```
import mxnet as mx
data=mx.sym.Variable('data')
symbol = mx.sym.Pooling(data = data, global_pool = True, pool_type = 'avg')
graph = mx.viz.plot_network(symbol)
graph
```
![image](https://user-images.githubusercontent.com/9017059/54325373-0d8e2400-45bf-11e9-922e-9c7097ae427d.png)

Test code for LeakyRelu visualization crash (after fix):
```
import mxnet as mx
data=mx.sym.Variable('data')
symbol = mx.sym.LeakyReLU(data=data)
graph = mx.viz.plot_network(symbol)
graph
```

![image](https://user-images.githubusercontent.com/9017059/54325859-8a220200-45c1-11e9-9ec0-85c9c5abbdad.png)

Test after changing to str.format:
```
import mxnet as mx
data=mx.sym.Variable('data')
symbol = mx.sym.Convolution(data=data, kernel=(3,3), stride=(1,1), num_filter=3)
graph = mx.viz.plot_network(symbol)
graph
```
![image](https://user-images.githubusercontent.com/9017059/54381330-b766c280-464a-11e9-9d9a-eb55645c6a58.png)
```
import mxnet as mx
data=mx.sym.Variable('data')
symbol = mx.sym.FullyConnected(data=data, num_hidden=3)
graph = mx.viz.plot_network(symbol)
graph
```
![image](https://user-images.githubusercontent.com/9017059/54381369-cea5b000-464a-11e9-900b-da91c2053075.png)

Change in print_summary tested with 
```
nosetests tests/python/unittest/test_viz.py:test_print_summary
.
----------------------------------------------------------------------
Ran 1 test in 0.015s

OK

```