### PR TITLE
Copy the gradient to the new context when as_in_context() is called

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -2097,7 +2097,7 @@ fixed-size items.
         if copy_grad:
             grad = self.grad
             if grad is not None:
-                setattr(self, '_grad', grad.copyto(other, copy_grad=False))
+                setattr(data, '_old_grad', grad.copyto(other, copy_grad=False))
         return data
 
     def copy(self):
@@ -2186,7 +2186,7 @@ fixed-size items.
         hdl = NDArrayHandle()
         check_call(_LIB.MXNDArrayGetGrad(self.handle, ctypes.byref(hdl)))
         if hdl.value is None:
-            return getattr(self, '_grad', None)
+            return getattr(self, '_old_grad', None)
         return _ndarray_cls(hdl)
 
     def detach(self):

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1611,7 +1611,11 @@ def test_as_in_context():
             copy_grad = attr.get('copy_grad', True)
             assert_almost_equal(data.asnumpy(), rtn_data.asnumpy(),
                                 rtol=0, atol=0)
-            if copy_grad or ori_ctx == target_ctx:
+            if ori_ctx == target_ctx:
+                assert rtn_data is data
+                continue
+            if copy_grad:
+                assert rtn_data is not data
                 assert rtn_data.grad.context == target_ctx
                 assert_almost_equal(data.grad.asnumpy(),
                                     rtn_data.grad.asnumpy(),

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1599,6 +1599,7 @@ def test_as_in_context():
             loss = data * data2
             loss.backward()
         # check gradient
+        assert data.grad.context == ori_ctx
         assert_almost_equal(data.grad.asnumpy(),
                             data2.asnumpy(),
                             rtol=0, atol=0)
@@ -1611,6 +1612,7 @@ def test_as_in_context():
             assert_almost_equal(data.asnumpy(), rtn_data.asnumpy(),
                                 rtol=0, atol=0)
             if copy_grad or ori_ctx == target_ctx:
+                assert rtn_data.grad.context == target_ctx
                 assert_almost_equal(data.grad.asnumpy(),
                                     rtn_data.grad.asnumpy(),
                                     rtol=0, atol=0)


### PR DESCRIPTION
## Description ##
Hi! there.
Fixed: https://github.com/apache/incubator-mxnet/issues/14391
Now, ndarray.as_in_context() copies the gradient to the new context.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add a new arguments `copy_grad` in `mx.nd.as_in_context` and `mx.nd.copyto`
- [x] Add unit-test in `test_ndarray.py`

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
