### PR TITLE
Add post initialization callback for Gluon Parameter

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -483,7 +483,7 @@ class Block(object):
         return self
 
     def initialize(self, init=initializer.Uniform(), ctx=None, verbose=False,
-                   force_reinit=False):
+                   force_reinit=False, post_init_callback=None):
         """Initializes :py:class:`Parameter` s of this :py:class:`Block` and its children.
         Equivalent to ``block.collect_params().initialize(...)``
 
@@ -498,8 +498,12 @@ class Block(object):
             Whether to verbosely print out details on initialization.
         force_reinit : bool, default False
             Whether to force re-initialization if parameter is already initialized.
+        post_init_callback: function or list of function
+            These will be called after initialization is done on each parameter, with the
+            initialized parameter. Each function will be only called once.
         """
-        self.collect_params().initialize(init, ctx, verbose, force_reinit)
+        self.collect_params().initialize(init, ctx, verbose, force_reinit,
+                                         post_init_callback)
 
     def hybridize(self, active=True, **kwargs):
         """Activates or deactivates :py:class:`HybridBlock` s recursively. Has no effect on


### PR DESCRIPTION
In Gluon, we defer initialization for some parameters until their shapes are known after the first forward pass. This makes it difficult for us to sync parameters among workers when we conduct distributed training using MXNet + Horovod with different random seeds for workers. More details can be found in this [Horovod issue](https://github.com/horovod/horovod/issues/895). 

In this PR, we add a post_init_callback to Gluon Parameter which will be called after the parameter is initialized. With this callback, parameters can be synced among workers once they are initialized. The typical usage of this callback in Horovod will be like this:
```
random.seed(hvd.local_rank())
data = ..
model = mx.gluon.nn.Dense(10)
model.initialize(post_init_callback=hvd.broadcast_parameters)
```
