### PR TITLE
[MXNET-1357] Fix the cpp-examples to add exception handling

### DIFF
--- a/cpp-package/example/alexnet.cpp
+++ b/cpp-package/example/alexnet.cpp
@@ -228,6 +228,7 @@ int main(int argc, char const *argv[]) {
   }
 #endif
 
+  TRY
   /*net symbol*/
   auto Net = AlexnetSymbol(10);
 
@@ -352,5 +353,6 @@ int main(int argc, char const *argv[]) {
   delete exec;
   delete opt;
   MXNotifyShutdown();
+  CATCH
   return 0;
 }

--- a/cpp-package/example/charRNN.cpp
+++ b/cpp-package/example/charRNN.cpp
@@ -42,6 +42,7 @@
 #include <thread>
 #include <chrono>
 #include "mxnet-cpp/MxNetCpp.h"
+#include "utils.h"
 
 using namespace mxnet::cpp;
 
@@ -721,6 +722,7 @@ int main(int argc, char** argv) {
   TIME_MAJOR = task.find("TimeMajor") != std::string::npos;
   std::cout << "use BuiltIn cuDNN RNN: " << builtIn << std::endl
          << "use data as TimeMajor: " << TIME_MAJOR << std::endl;
+  TRY
   if (task.find("train") == 0) {
     std::cout << "train batch size:      " << argv[3] << std::endl
            << "train max epoch:       " << argv[4] << std::endl;
@@ -746,5 +748,6 @@ int main(int argc, char** argv) {
   }
 
   MXNotifyShutdown();
+  CATCH
   return 0;
 }

--- a/cpp-package/example/googlenet.cpp
+++ b/cpp-package/example/googlenet.cpp
@@ -124,6 +124,7 @@ int main(int argc, char const *argv[]) {
   ctx = Context::cpu();;
 #endif
 
+  TRY
   auto googlenet = GoogleNetSymbol(10);
   std::map<std::string, NDArray> args_map;
   std::map<std::string, NDArray> aux_map;
@@ -192,5 +193,6 @@ int main(int argc, char const *argv[]) {
   delete exec;
   delete opt;
   MXNotifyShutdown();
+  CATCH
   return 0;
 }

--- a/cpp-package/example/inception_bn.cpp
+++ b/cpp-package/example/inception_bn.cpp
@@ -172,6 +172,7 @@ int main(int argc, char const *argv[]) {
   }
 #endif
 
+  TRY
   auto inception_bn_net = InceptionSymbol(10);
   std::map<std::string, NDArray> args_map;
   std::map<std::string, NDArray> aux_map;
@@ -255,5 +256,6 @@ int main(int argc, char const *argv[]) {
   delete exec;
   delete opt;
   MXNotifyShutdown();
+  CATCH
   return 0;
 }

--- a/cpp-package/example/lenet.cpp
+++ b/cpp-package/example/lenet.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <cstdlib>
 #include "mxnet-cpp/MxNetCpp.h"
+#include "utils.h"
 
 using namespace mxnet::cpp;
 
@@ -257,8 +258,10 @@ class Lenet {
 };
 
 int main(int argc, char const *argv[]) {
+  TRY
   Lenet lenet;
   lenet.Run(argc > 1 ? strtol(argv[1], NULL, 10) : 100000);
   MXNotifyShutdown();
+  CATCH
   return 0;
 }

--- a/cpp-package/example/lenet_with_mxdataiter.cpp
+++ b/cpp-package/example/lenet_with_mxdataiter.cpp
@@ -94,6 +94,7 @@ int main(int argc, char const *argv[]) {
   }
 #endif
 
+  TRY
   auto lenet = LenetSymbol();
   std::map<std::string, NDArray> args_map;
 
@@ -197,5 +198,6 @@ int main(int argc, char const *argv[]) {
   delete exec;
   delete opt;
   MXNotifyShutdown();
+  CATCH
   return 0;
 }

--- a/cpp-package/example/mlp.cpp
+++ b/cpp-package/example/mlp.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <string>
 #include "mxnet-cpp/MxNetCpp.h"
+#include "utils.h"
 
 using namespace mxnet::cpp;
 
@@ -173,7 +174,9 @@ void MLP(int max_epoch) {
 
 int main(int argc, char** argv) {
   int max_epoch = argc > 1 ? strtol(argv[1], NULL, 10) : 15000;
+  TRY
   MLP(max_epoch);
   MXNotifyShutdown();
+  CATCH
   return 0;
 }

--- a/cpp-package/example/mlp_cpu.cpp
+++ b/cpp-package/example/mlp_cpu.cpp
@@ -72,6 +72,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+  TRY
   auto net = mlp(layers);
 
   Context ctx = Context::cpu();  // Use CPU for training
@@ -141,5 +142,6 @@ int main(int argc, char** argv) {
   delete exec;
   delete opt;
   MXNotifyShutdown();
+  CATCH
   return 0;
 }

--- a/cpp-package/example/mlp_csv.cpp
+++ b/cpp-package/example/mlp_csv.cpp
@@ -156,6 +156,7 @@ int main(int argc, char** argv) {
     .SetParam("shuffle", 0)
     .CreateDataIter();
 
+    TRY
     auto net = mlp(hidden_units);
 
     Context ctx = Context::cpu();
@@ -269,5 +270,6 @@ int main(int argc, char** argv) {
     delete exec;
     delete opt;
     MXNotifyShutdown();
+    CATCH
     return 0;
 }

--- a/cpp-package/example/mlp_gpu.cpp
+++ b/cpp-package/example/mlp_gpu.cpp
@@ -72,6 +72,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+  TRY
   auto net = mlp(layers);
 
   Context ctx = Context::gpu();  // Use GPU for training
@@ -157,5 +158,6 @@ int main(int argc, char** argv) {
   delete exec;
   delete opt;
   MXNotifyShutdown();
+  CATCH
   return 0;
 }

--- a/cpp-package/example/resnet.cpp
+++ b/cpp-package/example/resnet.cpp
@@ -172,6 +172,7 @@ int main(int argc, char const *argv[]) {
   float learning_rate = 1e-4;
   float weight_decay = 1e-4;
 
+  TRY
   auto resnet = ResNetSymbol(10);
   std::map<std::string, NDArray> args_map;
   std::map<std::string, NDArray> aux_map;
@@ -277,5 +278,6 @@ int main(int argc, char const *argv[]) {
   delete exec;
   delete opt;
   MXNotifyShutdown();
+  CATCH
   return 0;
 }

--- a/cpp-package/example/test_score.cpp
+++ b/cpp-package/example/test_score.cpp
@@ -62,6 +62,7 @@ int main(int argc, char** argv) {
   const int max_epoch = 10;
   const float learning_rate = 0.1;
   const float weight_decay = 1e-2;
+  float score = 0;
 
   std::vector<std::string> data_files = { "./data/mnist_data/train-images-idx3-ubyte",
                                           "./data/mnist_data/train-labels-idx1-ubyte",
@@ -79,6 +80,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
+  TRY
   auto net = mlp(layers);
 
   Context ctx = Context::gpu();  // Use GPU for training
@@ -111,7 +113,6 @@ int main(int argc, char** argv) {
   auto *exec = net.SimpleBind(ctx, args);
   auto arg_names = net.ListArguments();
 
-  float score = 0;
   // Start training
   for (int iter = 0; iter < max_epoch; ++iter) {
     int samples = 0;
@@ -158,5 +159,6 @@ int main(int argc, char** argv) {
   delete exec;
   delete opt;
   MXNotifyShutdown();
+  CATCH
   return score >= MIN_SCORE ? 0 : 1;
 }

--- a/cpp-package/example/utils.h
+++ b/cpp-package/example/utils.h
@@ -27,6 +27,15 @@
 
 using namespace mxnet::cpp;
 
+#define TRY \
+  try {
+#define CATCH \
+  } catch(...) { \
+    LG << "Status: FAIL";\
+    LG << "With Error: " << MXGetLastError(); \
+    return 1; \
+  }
+
 bool isFileExists(const std::string &filename) {
   std::ifstream fhandle(filename.c_str());
   return fhandle.good();

--- a/cpp-package/example/utils.h
+++ b/cpp-package/example/utils.h
@@ -30,9 +30,12 @@ using namespace mxnet::cpp;
 #define TRY \
   try {
 #define CATCH \
-  } catch(...) { \
+  } catch(dmlc::Error &err) { \
     LG << "Status: FAIL";\
     LG << "With Error: " << MXGetLastError(); \
+    return 1; \
+  } catch(...) { \
+    LG << "Status: FAIL";\
     return 1; \
   }
 

--- a/cpp-package/example/utils.h
+++ b/cpp-package/example/utils.h
@@ -34,9 +34,6 @@ using namespace mxnet::cpp;
     LG << "Status: FAIL";\
     LG << "With Error: " << MXGetLastError(); \
     return 1; \
-  } catch(...) { \
-    LG << "Status: FAIL";\
-    return 1; \
   }
 
 bool isFileExists(const std::string &filename) {


### PR DESCRIPTION
## Description ##
The scope of this PR is to add missing exception handling to the examples. In future, if the underlying MXNet code throws any exception, the example will catch this exception and fail gracefully instead of crashing due to unhandled exception.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [y] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [y] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [y] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
