### PR TITLE
[MXNet-1349][Fit API]Add validation support and unit tests for fit() API

### DIFF
--- a/python/mxnet/gluon/estimator/__init__.py
+++ b/python/mxnet/gluon/estimator/__init__.py
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: disable=wildcard-import
+"""Gluon Estimator Module"""
+from .estimator import *
+from .event_handler import *

--- a/python/mxnet/gluon/estimator/estimator.py
+++ b/python/mxnet/gluon/estimator/estimator.py
@@ -65,8 +65,10 @@ class Estimator(object):
             self.loss = [loss]
         else:
             self.loss = loss or []
+            if not self.loss:
+                raise ValueError("No loss specified, refer to gluon.loss.Loss")
             for l in self.loss:
-                if not isinstance(loss, gluon.loss.Loss):
+                if not isinstance(l, gluon.loss.Loss):
                     raise ValueError("loss must be a Loss or a list of Loss, refer to gluon.loss.Loss")
 
         if isinstance(metrics, EvalMetric):
@@ -138,11 +140,13 @@ class Estimator(object):
             self.trainers = [trainers]
         else:
             self.trainers = trainers or []
-        if not self.trainers:
-            warnings.warn("No trainer specified, default SGD optimizer "
-                          "with learning rate 0.001 is used.")
-            self.trainers = [gluon.Trainer(self.net.collect_params(),
-                                           'sgd', {'learning_rate': 0.001})]
+            if not self.trainers:
+                warnings.warn("No trainer specified, default SGD optimizer "
+                              "with learning rate 0.001 is used.")
+                self.trainers = [gluon.Trainer(self.net.collect_params(),
+                                               'sgd', {'learning_rate': 0.001})]
+            else:
+                raise ValueError("Invalid trainer specified, please provide a valid gluon.Trainer")
 
     def _is_initialized(self):
         param_dict = self.net.collect_params()

--- a/python/mxnet/gluon/estimator/estimator.py
+++ b/python/mxnet/gluon/estimator/estimator.py
@@ -172,7 +172,7 @@ class Estimator(object):
         for metric in self.test_metrics + self.test_loss_metrics:
             metric.reset()
 
-        for i, batch in enumerate(val_data):
+        for _, batch in enumerate(val_data):
             if not batch_fn:
                 if isinstance(val_data, gluon.data.DataLoader):
                     data, label = self._batch_fn(batch, self.context)

--- a/python/mxnet/gluon/estimator/estimator.py
+++ b/python/mxnet/gluon/estimator/estimator.py
@@ -19,6 +19,7 @@
 # pylint: disable=wildcard-import
 """Gluon Estimator"""
 
+import copy
 import warnings
 
 from .event_handler import LoggingHandler
@@ -26,7 +27,6 @@ from ... import gluon, autograd
 from ...context import Context, cpu, gpu, num_gpus
 from ...io import DataIter
 from ...metric import EvalMetric, Loss
-import copy
 
 __all__ = ['Estimator']
 

--- a/python/mxnet/gluon/estimator/estimator.py
+++ b/python/mxnet/gluon/estimator/estimator.py
@@ -1,0 +1,310 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# coding: utf-8
+# pylint: disable=wildcard-import
+"""Gluon Estimator"""
+
+import warnings
+
+from .event_handler import LoggingHandler
+from ... import gluon, autograd
+from ...context import Context, cpu, gpu, num_gpus
+from ...io import DataIter
+from ...metric import EvalMetric, Loss
+import copy
+
+__all__ = ['Estimator']
+
+
+class Estimator(object):
+    """Estimator Class for easy model training
+
+    :py:class:`Estimator` can be used to facilitate the training & validation process
+
+
+    Parameters
+    ----------
+    loss : Loss or list of Loss
+        Loss(objective functions) to calculate during training
+    metrics : EvalMetric or list of EvalMetric
+        Metrics for evaluating models
+    initializer : Initializer
+        initializer to initialize the network
+    trainers : Trainer or list of Trainer
+        Trainers to apply optimizers on network parameters
+    context : Context or list of Context
+        devices to run the training on
+    """
+
+    def __init__(self, net,
+                 loss=None,
+                 metrics=None,
+                 initializer=None,
+                 trainers=None,
+                 context=None):
+
+        self.net = net
+        self.stop_training = False
+
+        if isinstance(loss, gluon.loss.Loss):
+            self.loss = [loss]
+        else:
+            self.loss = loss or []
+            for l in self.loss:
+                if not isinstance(loss, gluon.loss.Loss):
+                    raise ValueError("loss must be a Loss or a list of Loss, refer to gluon.loss.Loss")
+
+        if isinstance(metrics, EvalMetric):
+            self.train_metrics = [metrics]
+        else:
+            self.train_metrics = metrics or []
+            for metric in self.train_metrics:
+                if not isinstance(metric, EvalMetric):
+                    raise ValueError("metrics must be a Metric or a list of Metric, refer to mxnet.metric.EvalMetric")
+        # Use same metrics for validation
+        self.test_metrics = copy.deepcopy(self.train_metrics)
+
+        self.initializer = initializer
+        # store training statistics
+        self.train_stats = {}
+        self.train_stats['epochs'] = []
+        self.train_stats['learning_rate'] = []
+        # current step of the epoch
+        self.train_stats['step'] = ''
+        for metric in self.train_metrics:
+            # record a history of metrics over each epoch
+            self.train_stats['train_' + metric.name] = []
+            # only record the latest metric numbers after each batch
+            self.train_stats['batch_' + metric.name] = 0.
+        for metric in self.test_metrics:
+            self.train_stats['test_' + metric.name] = []
+        self.train_loss_metrics = []
+        self.test_loss_metrics = []
+        # using the metric wrapper for loss to record loss value
+        for l in self.loss:
+            self.train_loss_metrics.append(Loss(l.name))
+            self.test_loss_metrics.append(Loss(l.name))
+            self.train_stats['train_' + l.name] = []
+            self.train_stats['test_' + l.name] = []
+            # only record the latest loss numbers after each batch
+            self.train_stats['batch_' + l.name] = 0.
+
+        # handle context
+        if isinstance(context, Context):
+            self.context = [context]
+        if not context:
+            if num_gpus() > 0:
+                # only use 1 GPU by default
+                if num_gpus() > 1:
+                    warnings.warn("You have multiple GPUs, gpu(0) will be used by default."
+                                  "To utilize all your GPUs, specify context as a list of gpus, "
+                                  "e.g. context=[mx.gpu(0), mx.gpu(1)] ")
+                self.context = [gpu(0)]
+            else:
+                self.context = [cpu()]
+
+        # initialize the network
+        if self.initializer:
+            if self._is_initialized():
+                # if already initialized, re-init with user specified initializer
+                warnings.warn("Network already initialized, re-initializing with %s. "
+                              "You don't need to pass initializer if you already "
+                              "initialized your net."% type(self.initializer).__name__)
+                self.net.initialize(init=self.initializer, ctx=self.context, force_reinit=True)
+            else:
+                # initialize with user specified initializer
+                self.net.initialize(init=self.initializer, ctx=self.context, force_reinit=False)
+        else:
+            if not self._is_initialized():
+                self.net.initialize(ctx=self.context)
+
+        # handle trainers
+        if isinstance(trainers, gluon.Trainer):
+            self.trainers = [trainers]
+        else:
+            self.trainers = trainers or []
+        if not self.trainers:
+            warnings.warn("No trainer specified, default SGD optimizer "
+                          "with learning rate 0.001 is used.")
+            self.trainers = [gluon.Trainer(self.net.collect_params(),
+                                           'sgd', {'learning_rate': 0.001})]
+
+    def _is_initialized(self):
+        param_dict = self.net.collect_params()
+        for param in param_dict:
+            try:
+                param_dict[param].list_ctx()
+            except RuntimeError:
+                return False
+        return True
+
+    def _batch_fn(self, batch, ctx, is_iterator=False):
+        if is_iterator:
+            data = batch.data[0]
+            label = batch.label[0]
+        else:
+            data = batch[0]
+            label = batch[1]
+        data = gluon.utils.split_and_load(data, ctx_list=ctx, batch_axis=0)
+        label = gluon.utils.split_and_load(label, ctx_list=ctx, batch_axis=0)
+        return data, label
+
+    def _test(self, val_data, batch_fn=None):
+        for metric in self.test_metrics + self.test_loss_metrics:
+            metric.reset()
+
+        for i, batch in enumerate(val_data):
+            if not batch_fn:
+                if isinstance(val_data, gluon.data.DataLoader):
+                    data, label = self._batch_fn(batch, self.context)
+                elif isinstance(val_data, DataIter):
+                    data, label = self._batch_fn(batch, self.context, is_iterator=True)
+                else:
+                    raise ValueError("You are using a custom iteration, please also provide "
+                                     "batch_fn to extract data and label")
+            else:
+                data, label = batch_fn(batch, self.context)
+            pred = [self.net(x) for x in data]
+            losses = []
+            for loss in self.loss:
+                losses.append([loss(y_hat, y) for y_hat, y in zip(pred, label)])
+            # update metrics
+            for metric in self.test_metrics:
+                metric.update(label, pred)
+            for loss, loss_metric, in zip(losses, self.test_loss_metrics):
+                loss_metric.update(0, [l for l in loss])
+
+        for metric in self.test_metrics + self.test_loss_metrics:
+            self.train_stats['test_' + metric.name].append(metric.get()[1])
+
+    def fit(self, train_data,
+            val_data=None,
+            epochs=1,
+            batch_size=None,
+            event_handlers=None,
+            batch_fn=None):
+        """Main training loop
+
+        Parameters
+        ----------
+        train_data : DataLoader or DataIter
+            training data with data and labels
+        val_data : DataLoader or DataIter
+            validation data with data and labels
+        epochs : int, default 1
+            number of epochs to iterate on the training data.
+        batch_size : int
+            number of samples per gradient update.
+            default will be 32 per device
+        event_handlers : EventHandler or list of EventHandler
+            list of EventHandlers to apply during training
+        batch_fn : function
+            custom batch function to extract data and label
+            from a data batch and load into contexts(devices)
+        """
+
+
+        self.epochs = epochs
+        if not batch_size:
+            batch_size = 32 * len(self.context)
+
+        event_handlers = event_handlers or []
+        # provide default logging handler
+        if not event_handlers or \
+                not any(isinstance(handler, LoggingHandler) for handler in event_handlers):
+            event_handlers.append(LoggingHandler(self))
+
+        # Check for validation data
+        do_validation = True if val_data else False
+
+        # training begin
+        for handler in event_handlers:
+            handler.train_begin()
+
+        for epoch in range(epochs):
+            # epoch begin
+            self.train_stats['epochs'].append(epoch)
+            self.train_stats['learning_rate'].append(self.trainers[0].learning_rate)
+
+            for handler in event_handlers:
+                handler.epoch_begin()
+
+            for metric in self.train_metrics + self.train_loss_metrics:
+                metric.reset()
+
+            for i, batch in enumerate(train_data):
+                if not batch_fn:
+                    if isinstance(train_data, gluon.data.DataLoader):
+                        data, label = self._batch_fn(batch, self.context)
+                    elif isinstance(train_data, DataIter):
+                        data, label = self._batch_fn(batch, self.context, is_iterator=True)
+                    else:
+                        raise ValueError("You are using a custom iteration, please also provide "
+                                         "batch_fn to extract data and label")
+                else:
+                    data, label = batch_fn(batch, self.context)
+
+                # batch begin
+                for handler in event_handlers:
+                    handler.batch_begin()
+
+                with autograd.record():
+                    pred = [self.net(x) for x in data]
+                    losses = []
+                    for loss in self.loss:
+                        losses.append([loss(y_hat, y) for y_hat, y in zip(pred, label)])
+
+                for loss in losses:
+                    for l in loss:
+                        l.backward()
+
+                # update train metrics
+                for metric in self.train_metrics:
+                    metric.update(label, pred)
+                    self.train_stats['batch_' + metric.name] = metric.get()[1]
+                for loss, loss_metric, in zip(losses, self.train_loss_metrics):
+                    loss_metric.update(0, [l for l in loss])
+                    self.train_stats['batch_' + loss_metric.name] = loss_metric.get()[1]
+
+                try:
+                    self.train_stats['step'] = "{}/{}".format(batch_size * (i + 1), len(train_data._dataset))
+                except AttributeError:
+                    self.train_stats['step'] = i
+
+                for trainer in self.trainers:
+                    trainer.step(batch_size)
+
+                # batch end
+                for handler in event_handlers:
+                    handler.batch_end()
+
+            if do_validation:
+                self._test(val_data, batch_fn)
+
+            for metric in self.train_metrics + self.train_loss_metrics:
+                self.train_stats['train_' + metric.name].append(metric.get()[1])
+            # epoch end
+            for handler in event_handlers:
+                handler.epoch_end(do_validation)
+
+            if self.stop_training:
+                break
+
+        # train end
+        for handler in event_handlers:
+            handler.train_end()

--- a/python/mxnet/gluon/estimator/estimator.py
+++ b/python/mxnet/gluon/estimator/estimator.py
@@ -73,10 +73,9 @@ class Estimator(object):
             self.train_metrics = [metrics]
         else:
             self.train_metrics = metrics or []
-            for metric in self.train_metrics:
-                if not isinstance(metric, EvalMetric):
-                    raise ValueError("metrics must be a Metric or a list of Metric, "
-                                     "refer to mxnet.metric.EvalMetric:{}".format(metric))
+            if not all([isinstance(metric, EvalMetric) for metric in self.train_metrics]):
+                raise ValueError("metrics must be a Metric or a list of Metric, "
+                                 "refer to mxnet.metric.EvalMetric:{}".format(metrics))
 
         # Use same metrics for validation
         self.val_metrics = copy.deepcopy(self.train_metrics)
@@ -193,7 +192,9 @@ class Estimator(object):
                     data, label = self._batch_fn(batch, self.context, is_iterator=True)
                 else:
                     raise ValueError("You are using a custom iteration, please also provide "
-                                     "batch_fn to extract data and label")
+                                     "batch_fn to extract data and label. Alternatively, you "
+                                     "can provide the data as gluon.data.DataLoader or "
+                                     "mx.io.DataIter")
             else:
                 data, label = batch_fn(batch, self.context)
             pred = [self.net(x) for x in data]
@@ -266,7 +267,9 @@ class Estimator(object):
                         data, label = self._batch_fn(batch, self.context, is_iterator=True)
                     else:
                         raise ValueError("You are using a custom iteration, please also provide "
-                                         "batch_fn to extract data and label")
+                                         "batch_fn to extract data and label. Alternatively, you "
+                                         "can provide the data as gluon.data.DataLoader or "
+                                         "mx.io.DataIter")
                 else:
                     data, label = batch_fn(batch, self.context)
 

--- a/python/mxnet/gluon/estimator/event_handler.py
+++ b/python/mxnet/gluon/estimator/event_handler.py
@@ -1,0 +1,311 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# coding: utf-8
+# pylint: disable=wildcard-import
+"""Gluon EventHandlers for Estimators"""
+
+__all__ = ['EventHandler', 'LoggingHandler']
+import logging
+import os
+import time
+import warnings
+
+import numpy as np
+
+
+class EventHandler(object):
+    """Basic for event handlers
+
+        :py:class:`EventHandler` can perform user defined functions at
+        different stages of training: train begin, epoch begin, batch begin,
+        batch end, epoch end, train end.
+
+        Parameters
+        ----------
+        estimator : Estimator
+            The :py:class:`Estimator` to get training statistics
+        """
+    def __init__(self, estimator):
+        self._estimator = estimator
+
+    def train_begin(self):
+        pass
+
+    def train_end(self):
+        pass
+
+    def batch_begin(self):
+        pass
+
+    def batch_end(self):
+        pass
+
+    def epoch_begin(self):
+        pass
+
+    def epoch_end(self):
+        pass
+
+
+class LoggingHandler(EventHandler):
+    """Basic Logging Handler that applies to every Gluon estimator by default.
+
+    :py:class:`LoggingHandler` logs hyper-parameters, training statistics,
+    and other useful information during training
+
+    Parameters
+    ----------
+    estimator : Estimator
+        The :py:class:`Estimator` to get training statistics
+    file_name : str
+        file name to save the logs
+    file_location: str
+        file location to save the logs
+    """
+
+    def __init__(self, estimator, file_name=None, file_location=None, ):
+        super(LoggingHandler, self).__init__(estimator)
+        self.logger = logging.getLogger(__name__)
+        self.logger.setLevel(logging.INFO)
+        stream_handler = logging.StreamHandler()
+        self.logger.addHandler(stream_handler)
+        # save logger to file only if file name or location is specified
+        if file_name or file_location:
+            file_name = file_name or 'estimator_log'
+            file_location = file_location or './'
+            file_handler = logging.FileHandler(os.path.join(file_location, file_name))
+            self.logger.addHandler(file_handler)
+
+    def train_begin(self):
+        pass
+
+    def train_end(self):
+        pass
+
+    def batch_begin(self):
+        self.batch_start = time.time()
+
+    def batch_end(self):
+        batch_time = time.time() - self.batch_start
+        epoch = self._estimator.train_stats['epochs'][-1]
+        step = self._estimator.train_stats['step']
+        msg = '[Epoch %d] [Step %s] time/step: %.3fs ' % (epoch, step, batch_time)
+        for key in self._estimator.train_stats.keys():
+            if key.startswith('batch_'):
+                msg += key[6:] + ': ' + '%.4f ' % self._estimator.train_stats[key]
+        self.logger.info(msg)
+
+    def epoch_begin(self):
+        self.epoch_start = time.time()
+
+    def epoch_end(self, do_validation=False):
+        epoch_time = time.time() - self.epoch_start
+        epoch = self._estimator.train_stats['epochs'][-1]
+        msg = '\n[Epoch %d] finished in %.3fs: ' % (epoch, epoch_time)
+        for key in self._estimator.train_stats.keys():
+            if do_validation:
+                if key.startswith('train_') or key.startswith('test_'):
+                    msg += key + ': ' + '%.4f ' % self._estimator.train_stats[key][epoch]
+            else:
+                if key.startswith('train_'):
+                    msg += key + ': ' + '%.4f ' % self._estimator.train_stats[key][epoch]
+        self.logger.info(msg)
+
+
+class CheckpointHandler(EventHandler):
+    """Save the model after every epoch.
+
+    :py:class:`CheckpointHandler` save the network parameters every epoch
+
+    Parameters
+    ----------
+    estimator : Estimator
+        The :py:class:`Estimator` to get training statistics
+    filepath : str
+        file name to save the parameters, it can contain directories,
+        for example: ./saved_model/resnet.params
+    monitor: str
+        the metrics to monitor
+    verbose: int, default 0
+        verbosity mode
+    save_best_only: bool
+        if True, only save the parameters if monitored value improved
+    mode: str, default 'auto'
+        one of {auto, min, max}, if `save_best_only=True`, the comparison to make
+        and determine if the monitored value has improved
+    period: int, default 1
+        intervals between saving the network
+    """
+
+    def __init__(self, estimator,
+                 filepath,
+                 monitor='val_loss',
+                 verbose=0,
+                 save_best_only=False,
+                 mode='auto',
+                 period=1):
+        super(CheckpointHandler, self).__init__(estimator)
+        self.monitor = monitor
+        self.verbose = verbose
+        self.filepath = filepath
+        self.save_best_only = save_best_only
+        self.period = period
+        self.epochs_since_last_save = 0
+        self.logger = logging.getLogger(__name__)
+
+        if mode not in ['auto', 'min', 'max']:
+            warnings.warn('ModelCheckpoint mode %s is unknown, '
+                          'fallback to auto mode.' % (mode),
+                          RuntimeWarning)
+            mode = 'auto'
+
+        if mode == 'min':
+            self.monitor_op = np.less
+            self.best = np.Inf
+        elif mode == 'max':
+            self.monitor_op = np.greater
+            self.best = -np.Inf
+        else:
+            # use greater for accuracy and less otherwise
+            if 'acc' in self.monitor:
+                self.monitor_op = np.greater
+                self.best = -np.Inf
+            else:
+                self.monitor_op = np.less
+                self.best = np.Inf
+
+    def epoch_end(self, ):
+        epoch = self._estimator.train_stats['epochs'][-1]
+        # add extension for weights
+        if '.params' not in self.filepath:
+            self.filepath += '.params'
+        self.epochs_since_last_save += 1
+        if self.epochs_since_last_save >= self.period:
+            self.epochs_since_last_save = 0
+            if self.save_best_only:
+                # check if monitor exists in train_stats
+                if self.monitor not in self._estimator.train_stats:
+                    warnings.warn(RuntimeWarning('Unable to find %s in training statistics, make sure'
+                                                 'you are passing one of the metric names as monitor', self.monitor))
+                    self._estimator.net.save_parameters(self.filepath)
+                else:
+                    current = self._estimator.train_stats[self.monitor][-1]
+                    if self.monitor_op(current, self.best):
+                        if self.verbose > 0:
+                            self.logger.info('\n[Epoch %d] %s improved from %0.5f to %0.5f,'
+                                             ' saving model to %s',
+                                             epoch, self.monitor, self.best, current, self.filepath)
+                        self.best = current
+                        self._estimator.net.save_parameters(self.filepath)
+                    else:
+                        if self.verbose > 0:
+                            self.logger.info('\n[Epoch %d] %s did not improve from %0.5f, skipping save model',
+                                             epoch, self.monitor, self.best)
+            else:
+                if self.verbose > 0:
+                    logging.info('\nEpoch %d: saving model to %s', epoch, self.filepath)
+                self._estimator.net.save_parameters(self.filepath)
+
+
+class EarlyStoppingHandler(EventHandler):
+    """Early stop training if monitored value is not improving
+
+    Parameters
+    ----------
+    estimator : Estimator
+        The :py:class:`Estimator` to get training statistics
+    monitor: str
+        the metrics to monitor
+    min_delta: float, default 0
+        minimal change in monitored value to be considered as an improvement
+    patience: int, default 0
+        number of epochs to wait for improvement before terminate training
+    mode: str, default 'auto'
+        one of {auto, min, max}, the comparison to make
+        and determine if the monitored value has improved
+    baseline: float
+        baseline value to compare the monitored value with
+    """
+
+    def __init__(self, estimator,
+                 monitor='val_loss',
+                 min_delta=0,
+                 patience=0,
+                 mode='auto',
+                 baseline=None):
+        super(EarlyStoppingHandler, self).__init__(estimator)
+
+        self._estimator = estimator
+        self.monitor = monitor
+        self.baseline = baseline
+        self.patience = patience
+        self.min_delta = min_delta
+        self.wait = 0
+        self.stopped_epoch = 0
+        self.logger = logging.getLogger(__name__)
+
+        if mode not in ['auto', 'min', 'max']:
+            warnings.warn(RuntimeWarning('EarlyStopping mode %s is unknown, '
+                                         'fallback to auto mode.', mode))
+            mode = 'auto'
+
+        if mode == 'min':
+            self.monitor_op = np.less
+        elif mode == 'max':
+            self.monitor_op = np.greater
+        else:
+            if 'acc' in self.monitor:
+                self.monitor_op = np.greater
+            else:
+                self.monitor_op = np.less
+
+        if self.monitor_op == np.greater:
+            self.min_delta *= 1
+        else:
+            self.min_delta *= -1
+
+    def train_begin(self):
+        self.wait = 0
+        self.stopped_epoch = 0
+        if self.baseline is not None:
+            self.best = self.baseline
+        else:
+            self.best = np.Inf if self.monitor_op == np.less else -np.Inf
+
+    def epoch_end(self):
+        epoch = self._estimator.train_stats['epochs'][-1]
+        if self.monitor not in self._estimator.train_stats:
+            warnings.warn(RuntimeWarning('Unable to find %s in training statistics, make sure'
+                                         'you are passing one of the metric names as monitor', self.monitor))
+        else:
+            current = self._estimator.train_stats[self.monitor][-1]
+            if current is None:
+                return
+
+            if self.monitor_op(current - self.min_delta, self.best):
+                self.best = current
+                self.wait = 0
+            else:
+                self.wait += 1
+                if self.wait >= self.patience:
+                    self.stopped_epoch = epoch
+                    self._estimator.stop_training = True
+
+    def train_end(self):
+        if self.stopped_epoch > 0:
+            self.logger.info('Epoch %d: early stopping due to %s not improving', self.stopped_epoch, self.monitor)

--- a/python/mxnet/gluon/estimator/event_handler.py
+++ b/python/mxnet/gluon/estimator/event_handler.py
@@ -113,17 +113,13 @@ class LoggingHandler(EventHandler):
     def epoch_begin(self):
         self.epoch_start = time.time()
 
-    def epoch_end(self, do_validation=False):
+    def epoch_end(self):
         epoch_time = time.time() - self.epoch_start
         epoch = self._estimator.train_stats['epochs'][-1]
         msg = '\n[Epoch %d] finished in %.3fs: ' % (epoch, epoch_time)
         for key in self._estimator.train_stats.keys():
-            if do_validation:
-                if key.startswith('train_') or key.startswith('test_'):
-                    msg += key + ': ' + '%.4f ' % self._estimator.train_stats[key][epoch]
-            else:
-                if key.startswith('train_'):
-                    msg += key + ': ' + '%.4f ' % self._estimator.train_stats[key][epoch]
+            if key.startswith('train_') or key.startswith('val_'):
+                msg += key + ': ' + '%.4f ' % self._estimator.train_stats[key][epoch]
         self.logger.info(msg)
 
 

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -17,6 +17,8 @@
 
 ''' Unit tests for Gluon Estimator '''
 
+import unittest
+import sys
 import warnings
 from nose.tools import assert_raises
 import mxnet as mx
@@ -24,10 +26,12 @@ from mxnet import gluon
 from mxnet.gluon import nn
 from mxnet.gluon.estimator import estimator
 
+
 def get_model():
     net = nn.Sequential()
     net.add(nn.Dense(4, activation='relu', flatten=False))
     return net
+
 
 def test_fit():
     ''' test estimator with different train data types '''
@@ -106,6 +110,8 @@ def test_validation():
                 epochs=num_epochs,
                 batch_size=batch_size)
 
+
+@unittest.skipIf(sys.version_info.major < 3, 'Test on python 3')
 def test_initializer():
     ''' test with no initializer, inconsistent initializer '''
     net = get_model()
@@ -144,6 +150,8 @@ def test_initializer():
             epochs=num_epochs,
             batch_size=batch_size)
 
+
+@unittest.skipIf(sys.version_info.major < 3, 'Test on python 3')
 def test_trainer():
     ''' test with no trainer and invalid trainer '''
     net = get_model()
@@ -176,6 +184,7 @@ def test_trainer():
                                   metrics=acc,
                                   trainers=trainer,
                                   context=ctx)
+
 
 def test_metric():
     ''' test with no metric, list of metrics, invalid metric '''
@@ -216,6 +225,7 @@ def test_metric():
                                   trainers=trainer,
                                   context=ctx)
 
+
 def test_loss():
     ''' test with no loss, invalid loss '''
     net = get_model()
@@ -236,3 +246,9 @@ def test_loss():
                                   metrics=acc,
                                   trainers=trainer,
                                   context=ctx)
+
+
+if __name__ == 'main':
+    import nose
+
+    nose.runmodule()

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -139,7 +139,7 @@ def test_initializer():
                                   initializer=mx.init.MSRAPrelu(),
                                   trainers=trainer,
                                   context=ctx)
-        assert len(w) == 1
+        assert 'Network already initialized' in str(w[-1].message)
     est.fit(train_data=train_data,
             epochs=num_epochs,
             batch_size=batch_size)
@@ -163,7 +163,7 @@ def test_trainer():
                                   loss=loss,
                                   metrics=acc,
                                   context=ctx)
-        assert len(w) == 1
+        assert 'No trainer specified' in str(w[-1].message)
     est.fit(train_data=train_data,
             epochs=num_epochs,
             batch_size=batch_size)

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -21,7 +21,7 @@ import mxnet as mx
 from mxnet import gluon
 from mxnet.gluon import nn
 from mxnet.gluon.estimator import estimator
-from common import (with_seed)
+from common import setup_module, with_seed, assertRaises
 
 def get_model():
     net = nn.Sequential()
@@ -124,7 +124,6 @@ def test_initializer():
         est = estimator.Estimator(net=net,
                                   loss=loss,
                                   metrics=acc,
-                                  trainers=trainer,
                                   context=ctx)
         assert len(w) == 2
     est.fit(train_data=train_data,
@@ -157,7 +156,6 @@ def test_initializer():
                                   trainers=trainer,
                                   context=ctx)
 
-
 @with_seed()
 def test_trainer():
     net = get_model()
@@ -188,7 +186,7 @@ def test_trainer():
         est = estimator.Estimator(net=net,
                                   loss=loss,
                                   metrics=acc,
-                                  trainer=trainer,
+                                  trainers=trainer,
                                   context=ctx)
 
 @with_seed

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -1,0 +1,332 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import warnings
+from nose.tools import assert_raises
+import mxnet as mx
+from mxnet import gluon
+from mxnet.gluon import nn
+from mxnet.gluon.estimator import estimator
+from common import (with_seed)
+
+def get_model():
+    net = nn.Sequential()
+    net.add(nn.Dense(4, activation='tanh', flatten=False))
+    return net
+
+@with_seed()
+def test_fit():
+    net = get_model()
+    num_epochs = 1
+    batch_size = 4
+    ctx = mx.cpu()
+    loss = gluon.loss.L2Loss()
+    acc = mx.metric.Accuracy()
+    net.initialize(ctx=ctx)
+    trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              metrics=acc,
+                              trainers=trainer,
+                              context=ctx)
+    in_data = mx.nd.random.uniform(shape=(10, 3))
+    out_data = mx.nd.random.uniform(shape=(10, 4))
+    # Input dataloader
+    dataset = gluon.data.dataset.ArrayDataset(in_data, out_data)
+    train_dataloader = gluon.data.DataLoader(dataset, batch_size=batch_size)
+    est.fit(train_data=train_dataloader,
+            epochs=num_epochs,
+            batch_size=batch_size)
+
+    # Input dataiter
+    train_dataiter = mx.io.NDArrayIter(data=in_data, label=out_data, batch_size=batch_size)
+    est.fit(train_data=train_dataiter,
+            epochs=num_epochs,
+            batch_size=batch_size)
+
+    # Input NDArray
+    with assert_raises(ValueError):
+        est.fit(train_data=[in_data, out_data],
+                epochs=num_epochs,
+                batch_size=batch_size)
+
+
+@with_seed()
+def test_validation():
+    net = get_model()
+    num_epochs = 1
+    batch_size = 4
+    ctx = mx.cpu()
+    loss = gluon.loss.L2Loss()
+    acc = mx.metric.Accuracy()
+    net.initialize(ctx=ctx)
+    trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              metrics=acc,
+                              trainers=trainer,
+                              context=ctx)
+    in_data = mx.nd.random.uniform(shape=(10, 3))
+    out_data = mx.nd.random.uniform(shape=(10, 4))
+    # Input dataloader
+    dataset = gluon.data.dataset.ArrayDataset(in_data, out_data)
+    train_dataloader = gluon.data.DataLoader(dataset, batch_size=batch_size)
+    val_dataloader = gluon.data.DataLoader(dataset, batch_size=batch_size)
+    est.fit(train_data=train_dataloader,
+            val_data=val_dataloader,
+            epochs=num_epochs,
+            batch_size=batch_size)
+
+    # Input dataiter
+    train_dataiter = mx.io.NDArrayIter(data=in_data, label=out_data, batch_size=batch_size)
+    val_dataiter = mx.io.NDArrayIter(data=in_data, label=out_data, batch_size=batch_size)
+    est.fit(train_data=train_dataiter,
+            val_data=val_dataiter,
+            epochs=num_epochs,
+            batch_size=batch_size)
+    # Input NDArray
+    with assert_raises(ValueError):
+        est.fit(train_data=[in_data, out_data],
+                val_data=[in_data, out_data],
+                epochs=num_epochs,
+                batch_size=batch_size)
+
+
+@with_seed()
+def test_initializer():
+    net = get_model()
+    num_epochs = 1
+    batch_size = 4
+    ctx = mx.cpu()
+    in_data = mx.nd.random.uniform(shape=(10, 3))
+    out_data = mx.nd.random.uniform(shape=(10, 4))
+    dataset = gluon.data.dataset.ArrayDataset(in_data, out_data)
+    train_data = gluon.data.DataLoader(dataset, batch_size=batch_size)
+    loss = gluon.loss.L2Loss()
+    acc = mx.metric.Accuracy()
+    # no initializer
+    # catch no init and no trainer warning
+    with warnings.catch_warnings(record=True) as w:
+        est = estimator.Estimator(net=net,
+                                  loss=loss,
+                                  metrics=acc,
+                                  trainers=trainer,
+                                  context=ctx)
+        assert len(w) == 2
+    est.fit(train_data=train_data,
+            epochs=num_epochs,
+            batch_size=batch_size)
+
+    # different initializer for net and estimator
+    net = get_model()
+    net.initialize(mx.init.Xavier(), ctx=ctx)
+    trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
+    # catch no trainer and reinit warning
+    with warnings.catch_warnings(record=True) as w:
+        est = estimator.Estimator(net=net,
+                                  loss=loss,
+                                  metrics=acc,
+                                  initializer=mx.init.MSRAPrelu(),
+                                  trainers=trainer,
+                                  context=ctx)
+        assert len(w) == 2
+    est.fit(train_data=train_data,
+            epochs=num_epochs,
+            batch_size=batch_size)
+    # input invalid initializer
+    net = get_model()
+    with assert_raises(ValueError):
+        est = estimator.Estimator(net=net,
+                                  loss=loss,
+                                  metrics=acc,
+                                  initializer='xavier',
+                                  trainers=trainer,
+                                  context=ctx)
+
+
+@with_seed()
+def test_trainer():
+    net = get_model()
+    num_epochs = 1
+    batch_size = 4
+    ctx = mx.cpu()
+    in_data = mx.nd.random.uniform(shape=(10, 3))
+    out_data = mx.nd.random.uniform(shape=(10, 4))
+    dataset = gluon.data.dataset.ArrayDataset(in_data, out_data)
+    train_data = gluon.data.DataLoader(dataset, batch_size=batch_size)
+    loss = gluon.loss.L2Loss()
+    acc = mx.metric.Accuracy()
+    net.initialize(ctx=ctx)
+    # input no trainer
+    with warnings.catch_warnings(record=True) as w:
+        est = estimator.Estimator(net=net,
+                                  loss=loss,
+                                  metrics=acc,
+                                  context=ctx)
+        assert len(w) == 1
+    est.fit(train_data=train_data,
+            epochs=num_epochs,
+            batch_size=batch_size)
+
+    # input invalid trainer
+    trainer = 'sgd'
+    with assert_raises(ValueError):
+        est = estimator.Estimator(net=net,
+                                  loss=loss,
+                                  metrics=acc,
+                                  trainer=trainer,
+                                  context=ctx)
+
+@with_seed
+def test_metric():
+    net = get_model()
+    num_epochs = 1
+    batch_size = 4
+    ctx = mx.cpu()
+    in_data = mx.nd.random.uniform(shape=(10, 3))
+    out_data = mx.nd.random.uniform(shape=(10, 4))
+    dataset = gluon.data.dataset.ArrayDataset(in_data, out_data)
+    train_data = gluon.data.DataLoader(dataset, batch_size=batch_size)
+    loss = gluon.loss.L2Loss()
+    net.initialize(ctx=ctx)
+    trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
+    # input no metric
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              trainers=trainer,
+                              context=ctx)
+    est.fit(train_data=train_data,
+            epochs=num_epochs,
+            batch_size=batch_size)
+    # input list of metrics
+    metrics = [mx.metric.Accuracy(), mx.metric.Accuracy()]
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              metrics=metrics,
+                              trainers=trainer,
+                              context=ctx)
+    est.fit(train_data=train_data,
+            epochs=num_epochs,
+            batch_size=batch_size)
+    # input invalid metric
+    with assert_raises(ValueError):
+        est = estimator.Estimator(net=net,
+                                  loss=loss,
+                                  metrics='acc',
+                                  trainers=trainer,
+                                  context=ctx)
+
+@with_seed
+def test_loss():
+    net = get_model()
+    num_epochs = 1
+    batch_size = 4
+    ctx = mx.cpu()
+    in_data = mx.nd.random.uniform(shape=(10, 3))
+    out_data = mx.nd.random.uniform(shape=(10, 4))
+    dataset = gluon.data.dataset.ArrayDataset(in_data, out_data)
+    train_data = gluon.data.DataLoader(dataset, batch_size=batch_size)
+    acc = mx.metric.Accuracy()
+    net.initialize(ctx=ctx)
+    trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
+    # input no loss, catch warning
+    with warnings.catch_warnings(record=True) as w:
+        est = estimator.Estimator(net=net,
+                                  trainers=trainer,
+                                  metrics=acc,
+                                  context=ctx)
+        assert len(w) == 1
+    est.fit(train_data=train_data,
+            epochs=num_epochs,
+            batch_size=batch_size)
+    # input list of losses
+    loss = [gluon.loss.L2Loss(), gluon.loss.L2Loss()]
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              metrics=acc,
+                              trainers=trainer,
+                              context=ctx)
+    est.fit(train_data=train_data,
+            epochs=num_epochs,
+            batch_size=batch_size)
+    # input invalid loss
+    with assert_raises(ValueError):
+        est = estimator.Estimator(net=net,
+                                  loss='mse',
+                                  metrics=acc,
+                                  trainers=trainer,
+                                  context=ctx)
+
+@with_seed()
+def test_batch_size():
+    net = get_model()
+    num_epochs = 1
+    batch_size = 4
+    ctx = mx.cpu()
+    in_data = mx.nd.random.uniform(shape=(10, 3))
+    out_data = mx.nd.random.uniform(shape=(10, 4))
+    dataset = gluon.data.dataset.ArrayDataset(in_data, out_data)
+    train_data = gluon.data.DataLoader(dataset, batch_size=batch_size)
+    loss = gluon.loss.L2Loss()
+    acc = mx.metric.Accuracy()
+    net.initialize(ctx=ctx)
+    trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              metrics=acc,
+                              trainers=trainer,
+                              context=ctx)
+    # check auto infer batch size
+    est.fit(train_data=train_data,
+            epochs=num_epochs)
+
+    # check invalid batch size
+    with assert_raises(ValueError):
+        est.fit(train_data=train_data,
+                epochs=num_epochs,
+                batch_size=batch_size+1)
+
+@with_seed()
+def test_context():
+    # GPU needed??
+    net = get_model()
+    num_epochs = 1
+    batch_size = 4
+    ctx = mx.cpu()
+    in_data = mx.nd.random.uniform(shape=(10, 3))
+    out_data = mx.nd.random.uniform(shape=(10, 4))
+    dataset = gluon.data.dataset.ArrayDataset(in_data, out_data)
+    train_data = gluon.data.DataLoader(dataset, batch_size=batch_size)
+    loss = gluon.loss.L2Loss()
+    acc = mx.metric.Accuracy()
+    net.initialize(ctx=ctx)
+    trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
+    # input no context
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              metrics=acc,
+                              trainers=trainer)
+    est.fit(train_data=train_data,
+            epochs=num_epochs,
+            batch_size=batch_size)
+    # input list of context
+
+    # input invalid context
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule()

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -246,9 +246,3 @@ def test_loss():
                                   metrics=acc,
                                   trainers=trainer,
                                   context=ctx)
-
-
-if __name__ == 'main':
-    import nose
-
-    nose.runmodule()

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -224,6 +224,13 @@ def test_metric():
                                   metrics='acc',
                                   trainers=trainer,
                                   context=ctx)
+    # test default metric
+    loss = gluon.loss.SoftmaxCrossEntropyLoss()
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              trainers=trainer,
+                              context=ctx)
+    assert isinstance(est.train_metrics[0], mx.metric.Accuracy)
 
 
 def test_loss():
@@ -246,3 +253,25 @@ def test_loss():
                                   metrics=acc,
                                   trainers=trainer,
                                   context=ctx)
+
+def test_context():
+    ''' test with no context, list of context, invalid context '''
+    net = get_model()
+    loss = gluon.loss.L2Loss()
+    metrics = mx.metric.Accuracy()
+    # input no context
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              metrics=metrics)
+    # input list of context
+    ctx = [mx.gpu(0), mx.gpu(1)]
+    est = estimator.Estimator(net=net,
+                              loss=loss,
+                              metrics=metrics,
+                              context=ctx)
+    # input invalid context
+    with assert_raises(ValueError):
+        est = estimator.Estimator(net=net,
+                                  loss=loss,
+                                  metrics=metrics,
+                                  context='cpu')


### PR DESCRIPTION
## Description ##
Adding validation support and unit tests for fit() API.
This PR depends on the parent PR for fit() API #14346 
JIRA epic: https://issues.apache.org/jira/projects/MXNET/issues/MXNET-1333
Design: https://cwiki.apache.org/confluence/display/MXNET/Gluon+Fit+API+-+Tech+Design

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNet-1349](https://issues.apache.org/jira/browse/MXNET-1349)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
1. Added validation support in estimator class, allow users to monitor loss and metrics on validation set during training.
2. Added unit tests for estimator and fit()
3. Added error handlers in estimator

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
