### PR TITLE
fix OOM error during resource allocation

### DIFF
--- a/src/resource.cc
+++ b/src/resource.cc
@@ -432,6 +432,9 @@ void Resource::get_cudnn_dropout_desc(
     // not initialized yet.
     size_t dropout_state_size;
     CUDNN_CALL(cudnnDropoutGetStatesSize(stream->dnn_handle_, &dropout_state_size));
+    // reserve GPU space
+    Storage::Get()->DirectFree(
+      Storage::Get()->Alloc(dropout_state_size, state_space->ctx));
     CUDNN_CALL(cudnnSetDropoutDescriptor(*dropout_desc, stream->dnn_handle_,
                                          dropout,
                                          state_space->GetSpace(dropout_state_size),


### PR DESCRIPTION
## Description ##
fix OOM error during resource allocation for dropout state

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] alloc and direct free for cudnn dropout state space

## Comments ##
- the exact situation for reproducing is hard to achieve so I didn't add a test. the fix follows https://github.com/apache/incubator-mxnet/pull/12804/files#diff-45a531b6c3e468efe09d3a66d99429b1R1016