### PR TITLE
[CI Fix] Disable Some Clojure Integration tests that are having connection problems

### DIFF
--- a/contrib/clojure-package/integration-tests.sh
+++ b/contrib/clojure-package/integration-tests.sh
@@ -26,7 +26,7 @@ lein install
 # then run through the examples 
 EXAMPLES_HOME=${MXNET_HOME}/contrib/clojure-package/examples
 # use AWK pattern for blacklisting
-TEST_CASES=`find ${EXAMPLES_HOME} -name test | awk '!/dontselect1|cnn-text-classification/'`
+TEST_CASES=`find ${EXAMPLES_HOME} -name test | awk '!/dontselect1|cnn-text-classification|gan|neural-style|infer|pre-trained-models/'`
 for i in $TEST_CASES ; do
  cd ${i} && lein test
 done


### PR DESCRIPTION
## Description ##

Origami repo seems to have trouble again. Disabling the tests that rely on it. This is the same code change that was submitted #14379 but never pushed because the repo recovered. A long term solution is being discussed in issue #14394
```
Retrieving nrepl/bencode/1.0.0/bencode-1.0.0.jar from clojars
Retrieving nrepl/nrepl/0.5.3/nrepl-0.5.3.jar from clojars
Could not find artifact origami:origami:jar:4.0.0-3 in central (https://repo1.maven.org/maven2/)
Could not find artifact origami:origami:jar:4.0.0-3 in clojars (https://repo.clojars.org/)
Could not transfer artifact origami:origami:jar:4.0.0-3 from/to vendredi (https://repository.hellonico.info/repository/hellonico/): Read timed out
Could not transfer artifact origami:origami:pom:4.0.0-3 from/to vendredi (https://repository.hellonico.info/repository/hellonico/): Read timed out
This could be due to a typo in :dependencies, file system permissions, or network issues.
If you are behind a proxy, try setting the 'http_proxy' environment variable.
build.py: 2019-03-16 02:29:56,836Z INFO Waiting for status of container a02552a4b9e1 for 600 s.
build.py: 2019-03-16 02:29:57,086Z INFO Container exit status: {'StatusCode': 1, 'Error': None}
```
Example:
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/PR-14445/2/pipeline