### PR TITLE
Enforce determinism for backwards compatibility checker

### DIFF
--- a/tests/nightly/model_backwards_compatibility_check/model_backward_compat_checker.sh
+++ b/tests/nightly/model_backwards_compatibility_check/model_backward_compat_checker.sh
@@ -27,4 +27,5 @@ cd tests/nightly/model_backwards_compatibility_check
 echo `pwd`
 
 echo '=========================='
+export MXNET_ENFORCE_DETERMINISM=1
 python model_backwards_compat_inference.py

--- a/tests/nightly/model_backwards_compatibility_check/train_mxnet_legacy_models.sh
+++ b/tests/nightly/model_backwards_compatibility_check/train_mxnet_legacy_models.sh
@@ -25,6 +25,7 @@ run_models() {
 	echo '=========================='
 	echo "Running training files and preparing models"
 	echo '=========================='
+  export MXNET_ENFORCE_DETERMINISM=1
 	python model_backwards_compat_train.py
 	echo '=========================='
 }


### PR DESCRIPTION
## Description ##
Adds the enforce determinism setting when running the backwards compatibility checker to avoid flaky issues due to non-deterministic operators. This was made based on discussion of #14234.

@marcoabreu @piyushghai @samskalicky

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change