### PR TITLE
Fixes the test_sgld

### DIFF
--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -461,7 +461,6 @@ class PySGLD(mx.optimizer.Optimizer):
 
 
 @with_seed()
-@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/14241")
 def test_sgld():
     opt1 = PySGLD
     opt2 = mx.optimizer.SGLD
@@ -518,7 +517,9 @@ def test_sgld():
                 if (dtype == np.float16 and ('multi_precision' not in kwarg or
                     not kwarg['multi_precision'])):
                     continue
-                compare_optimizer_noise_seeded(opt1(**kwarg), opt2(**kwarg), shape, dtype, seed)
+                atol = 1e-2 if dtype == np.float16 else 1e-3
+                rtol = 1e-4 if dtype == np.float16 else 1e-5
+                compare_optimizer_noise_seeded(opt1(**kwarg), opt2(**kwarg), shape, dtype, seed, atol=atol, rtol=rtol)
 
 
 


### PR DESCRIPTION
## Description ##
Fixes #14241
The original test failed with float16. 
Adjusted the tolerance level of float16 following [Fixing Flaky Tests](https://cwiki.apache.org/confluence/display/MXNET/Fixing+Flaky+Tests)
The test passed after 10k runs.
```
MXNET_TEST_COUNT=10000 nosetests -v test_operator_gpu.py:test_sgld
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=908073956 to reproduce.
test_operator_gpu.test_sgld ... ok

----------------------------------------------------------------------
Ran 1 test in 8554.348s

OK
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

## Comments ##

