### PR TITLE
Fixes test_operator_gpu.test_multinomial_generator

### DIFF
--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -641,6 +641,11 @@ def test_multinomial_generator():
         quantized_probs = quantize_probs(probs, dtype)
         generator_mx = lambda x: mx.nd.random.multinomial(data=mx.nd.array(quantized_probs, ctx=ctx, dtype=dtype),
                                                           shape=x).asnumpy()
+        # success_rate was set to 0.15 since PR #13498 and became flaky
+        # both of previous issues(#14457, #14158) failed with success_rate 0.25
+        # In func verify_generator inside test_utilis.py
+        # it raise the error when success_num(1) < nrepeat(5) * success_rate(0.25)
+        # by changing the 0.25 -> 0.2 solve these edge case but still have strictness
         verify_generator(generator=generator_mx, buckets=buckets, probs=quantized_probs,
                          nsamples=samples, nrepeat=trials, success_rate=0.20)
         generator_mx_same_seed = \

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -642,14 +642,14 @@ def test_multinomial_generator():
         generator_mx = lambda x: mx.nd.random.multinomial(data=mx.nd.array(quantized_probs, ctx=ctx, dtype=dtype),
                                                           shape=x).asnumpy()
         verify_generator(generator=generator_mx, buckets=buckets, probs=quantized_probs,
-                         nsamples=samples, nrepeat=trials)
+                         nsamples=samples, nrepeat=trials, success_rate=0.20)
         generator_mx_same_seed = \
             lambda x: np.concatenate(
                 [mx.nd.random.multinomial(data=mx.nd.array(quantized_probs, ctx=ctx, dtype=dtype),
                                                           shape=x // 10).asnumpy()
                  for _ in range(10)])
         verify_generator(generator=generator_mx_same_seed, buckets=buckets, probs=quantized_probs,
-                         nsamples=samples, nrepeat=trials)
+                         nsamples=samples, nrepeat=trials, success_rate=0.20)
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
Fixes #14457, Fixes #14158
success_rate of the verify_generator function was changing from 0.15 to 0.25 after the this #13498. Since then the test became flaky. Reassign the success_rate to 0.2.
```
# in func verify_generator inside test_utilis.py
success_num = (np.array(cs_ret_l) > alpha).sum()
    if success_num < nrepeat * success_rate:
# here both of the issue failed with 1 < 5 * 0.25
# by changing the 0.25 -> 0.2 solve these edge case but still have strictness
```

Run 9606 times pass the test.
```
MXNET_TEST_COUNT=10000 nosetests -v test_operator_gpu.py:test_multinomial_generator
^C[INFO] 9609 of 10000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=262122728 to reproduce.

----------------------------------------------------------------------
Ran 1 test in 95632.373s

OK
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###


## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
