### PR TITLE
Reenable the test_kvstore_gpu.test_rsp_push_pull

### DIFF
--- a/tests/python/gpu/test_kvstore_gpu.py
+++ b/tests/python/gpu/test_kvstore_gpu.py
@@ -39,11 +39,12 @@ def init_kv_with_str(stype='default', kv_type='local'):
     kv.init(str_keys, [mx.nd.zeros(shape=shape, stype=stype)] * len(keys))
     return kv
 
-# Test seed 89411477 (module seed 1829754103) resulted in a py3-gpu CI runner core dump.
-# Not reproducible, so this test is back on random seeds.
+# 1. Test seed 89411477 (module seed 1829754103) resulted in a py3-gpu CI runner core dump.
+# 2. Test seed 1155716252 (module seed 1032824746) resulted in py3-mkldnn-gpu have error 
+# src/operator/nn/mkldnn/mkldnn_base.cc:567: Check failed: similar
+# Both of them are not reproducible, so this test is back on random seeds.
 @with_seed()
 @unittest.skipIf(mx.context.num_gpus() < 2, "test_rsp_push_pull needs more than 1 GPU")
-@unittest.skip("Flaky test https://github.com/apache/incubator-mxnet/issues/14189")
 def test_rsp_push_pull():
     def check_rsp_push_pull(kv_type, sparse_pull, is_push_cpu=True):
         kv = init_kv_with_str('row_sparse', kv_type)


### PR DESCRIPTION
## Description ##
Fixes #14189
Ran 10k with latest MXNet code.
```
TOTAL                                              18749  13965   6519     94    20%
[success] 100.00% test_kvstore_gpu.test_rsp_push_pull: 22578.5869s
----------------------------------------------------------------------
Ran 1 test in 22578.592s

OK
```
also test with seed 89411477 (module seed 1829754103),  seed 1155716252 (module seed 1032824746), all passed

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###


## Comments ##

