### PR TITLE
[FIX] replace shuffle method 

### DIFF
--- a/src/io/image_aug_default.cc
+++ b/src/io/image_aug_default.cc
@@ -462,7 +462,7 @@ class DefaultImageAugmenter : public ImageAugmenter {
       float alpha_s = 1.0 + std::uniform_real_distribution<float>(-param_.saturation,
                                                                   param_.saturation)(*prnd);
       int rand_order[3] = {0, 1, 2};
-      std::random_shuffle(std::begin(rand_order), std::end(rand_order));
+      std::shuffle(std::begin(rand_order), std::end(rand_order), *prnd);
       for (int i : rand_order) {
         if (i == 0) {
           // brightness


### PR DESCRIPTION
## Description ##
I replaced shuffle method `std::random_shuffle` to `std::shuffle` because It can not build with c++17.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
