### PR TITLE
[WIP] Fix ndarray index out of bound

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -527,6 +527,10 @@ fixed-size items.
             return not isinstance(index, py_slice)
 
         if isinstance(key, (NDArray, np.ndarray, list, integer_types, py_slice)):
+            # check if key is out of bound
+            for k in key:
+                if k >= self.shape[0]:
+                    raise IndexError('index {} is out of bounds for axis 0 with size {}'.format(k, self.shape[0]))
             key = (key,)
 
         assert isinstance(key, tuple),\

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -130,6 +130,32 @@ def test_ndarray_setitem():
 
 
 @with_seed()
+def test_ndarray_getitem():
+    x = mx.nd.array(range(5))
+    # test normal case with ndarray as index
+    idx = mx.nd.array(range(5))
+    same(x.asnumpy(), x[idx].asnumpy())
+    # test normal case with ndarray as index
+    idx = np.array(range(5))
+    same(x.asnumpy(), x[idx].asnumpy())
+    # test normal case with python slice
+    idx = slice(0, 5, 1)
+    same(x.asnumpy(), x[idx].asnumpy())
+    # test normal case with python list
+    idx = list(range(5))
+    same(x.asnumpy(), x[idx].asnumpy())
+    # test invalid index
+    def _test_list_out_of_bound(idx):
+        x[idx]
+    assertRaises(IndexError, _test_list_out_of_bound, 6)
+    assertRaises(IndexError, _test_list_out_of_bound, [6])
+    assertRaises(IndexError, _test_list_out_of_bound, [2,6,1])
+    assertRaises(IndexError, _test_list_out_of_bound, mx.nd.array([1,2,3,6]))
+    assertRaises(IndexError, _test_list_out_of_bound, np.array([1,2,3,6]))
+    assertRaises(IndexError, _test_list_out_of_bound, slice(7))
+
+
+@with_seed()
 def test_ndarray_elementwise():
     nrepeat = 10
     maxdim = 4


### PR DESCRIPTION
## Description ##
Fixes #12389
Add index out of bound check before make key tuple in _get_index_nd used by _get_nd_advanced_indexing
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

## Comments ##
