### PR TITLE
Do not touch GPU 0 during ReleaseAll

### DIFF
--- a/src/storage/pooled_storage_manager.h
+++ b/src/storage/pooled_storage_manager.h
@@ -56,11 +56,11 @@ class GPUPooledStorageManager final : public StorageManager {
    *
    * \param initial_context context used by this Storage Manager
    */
-  explicit GPUPooledStorageManager(Context initial_context) {
+  explicit GPUPooledStorageManager(Context initial_context) :
+    initial_context_(initial_context) {
     reserve_ = dmlc::GetEnv("MXNET_GPU_MEM_POOL_RESERVE", 5);
     page_size_ = dmlc::GetEnv("MXNET_GPU_MEM_POOL_PAGE_SIZE", 4096);
     large_alloc_round_size_ = dmlc::GetEnv("MXNET_GPU_MEM_LARGE_ALLOC_ROUND_SIZE", 2 * 1024 * 1024);
-    initial_context_ = initial_context;
     if (large_alloc_round_size_ <= 0) {
       LOG(FATAL) << "MXNET_GPU_MEM_LARGE_ALLOC_ROUND_SIZE cannot be set to a value <= 0, found: "
                  << large_alloc_round_size_;
@@ -127,7 +127,7 @@ class GPUPooledStorageManager final : public StorageManager {
   // number of devices
   const size_t NDEV = 32;
   // context used by this Storage Manager
-  Context initial_context_;
+  const Context initial_context_;
   // memory pool
   std::unordered_map<size_t, std::vector<void*>> memory_pool_;
   DISALLOW_COPY_AND_ASSIGN(GPUPooledStorageManager);
@@ -210,11 +210,11 @@ class GPUPooledRoundedStorageManager final : public StorageManager {
    *
    * \param initial_context context used by this Storage Manager
    */
-  explicit GPUPooledRoundedStorageManager(Context initial_context) {
+  explicit GPUPooledRoundedStorageManager(Context initial_context) :
+    initial_context_(initial_context) {
     reserve_ = dmlc::GetEnv("MXNET_GPU_MEM_POOL_RESERVE", 5);
     page_size_ = dmlc::GetEnv("MXNET_GPU_MEM_POOL_PAGE_SIZE", 4096);
     cut_off_ = dmlc::GetEnv("MXNET_GPU_MEM_POOL_ROUND_LINEAR_CUTOFF", 24);
-    initial_context_ = initial_context;
     if (page_size_ < 32) {
       LOG(FATAL) << "MXNET_GPU_MEM_POOL_PAGE_SIZE cannot be set to a value smaller than 32. " \
                  << "Got: " << page_size_ << ".";
@@ -300,7 +300,7 @@ class GPUPooledRoundedStorageManager final : public StorageManager {
   // percentage of reserved memory
   int reserve_;
   // context used by this Storage Manager
-  Context initial_context_;
+  const Context initial_context_;
   // memory pool
   std::vector<std::vector<void*>> memory_pool_;
   DISALLOW_COPY_AND_ASSIGN(GPUPooledRoundedStorageManager);

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -104,13 +104,13 @@ void StorageImpl::Alloc(Storage::Handle* handle) {
             std::string strategy = type;
 
             if (strategy == "Round") {
-              ptr = new storage::GPUPooledRoundedStorageManager(handle->ctx.real_dev_id());
+              ptr = new storage::GPUPooledRoundedStorageManager(handle->ctx);
               LOG(INFO) << "Using GPUPooledRoundedStorageManager.";
             } else {
               if (strategy != "Naive") {
                 LOG(FATAL) << "Unknown memory pool strategy specified: " << strategy << ".";
               }
-              ptr = new storage::GPUPooledStorageManager(handle->ctx.real_dev_id());
+              ptr = new storage::GPUPooledStorageManager(handle->ctx);
             }
 #else
             LOG(FATAL) << "Compile with USE_CUDA=1 to enable GPU usage";

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -104,13 +104,13 @@ void StorageImpl::Alloc(Storage::Handle* handle) {
             std::string strategy = type;
 
             if (strategy == "Round") {
-              ptr = new storage::GPUPooledRoundedStorageManager();
+              ptr = new storage::GPUPooledRoundedStorageManager(handle->ctx.real_dev_id());
               LOG(INFO) << "Using GPUPooledRoundedStorageManager.";
             } else {
               if (strategy != "Naive") {
                 LOG(FATAL) << "Unknown memory pool strategy specified: " << strategy << ".";
               }
-              ptr = new storage::GPUPooledStorageManager();
+              ptr = new storage::GPUPooledStorageManager(handle->ctx.real_dev_id());
             }
 #else
             LOG(FATAL) << "Compile with USE_CUDA=1 to enable GPU usage";


### PR DESCRIPTION
## Description ##
Currently, during call to ReleaseAll (either in pooled allocator destructor or when the memory is full and the allocator needs to release cached allocations) the memory handle is not fully populated (only ptr and size are populated, not context information), which makes the DirectFreeNoLock method to switch to GPU 0 (since 0 is the default constructed Context's dev_id). In the case of multi process training (e.g. with Horovod) this could produce Out of Memory errors due to context creation on GPU 0, or it could outright fail, crashing the application, if the exclusive mode is set on GPU 0.

This PR fixes that by adding `initial_context_` parameter to pooled storage managers and populating the handle with it in ReleaseAll method.

@apeforest @yuxihu FYI

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
