### PR TITLE
[clojure]: add comp-metric based on CompositeEvalMetric

### DIFF
--- a/contrib/clojure-package/src/org/apache/clojure_mxnet/eval_metric.clj
+++ b/contrib/clojure-package/src/org/apache/clojure_mxnet/eval_metric.clj
@@ -84,7 +84,11 @@
 (defn get
   "Get the values of the metric in as a map of {name value} pairs"
   [metric]
-  (apply zipmap (-> (.get metric) util/tuple->vec)))
+  (let [m (apply zipmap (-> (.get metric)
+                            util/tuple->vec))]
+    (if-not (instance? CompositeEvalMetric metric)
+      (first m)
+      m)))
 
 (defn reset
   "clear the internal statistics to an initial state"

--- a/contrib/clojure-package/src/org/apache/clojure_mxnet/eval_metric.clj
+++ b/contrib/clojure-package/src/org/apache/clojure_mxnet/eval_metric.clj
@@ -18,7 +18,7 @@
 (ns org.apache.clojure-mxnet.eval-metric
   (:refer-clojure :exclude [get update])
   (:require [org.apache.clojure-mxnet.util :as util])
-  (:import (org.apache.mxnet Accuracy TopKAccuracy F1 Perplexity MAE MSE RMSE CustomMetric)))
+  (:import (org.apache.mxnet Accuracy TopKAccuracy F1 Perplexity MAE MSE RMSE CustomMetric CompositeEvalMetric)))
 
 (defn accuracy
   "Basic Accuracy Metric"
@@ -74,11 +74,17 @@
   [f-eval mname]
   `(new CustomMetric (util/scala-fn ~f-eval) ~mname))
 
+(defn comp-metric
+  "Create a metric instance composed out of several metrics"
+  [metrics]
+  (let [cm (CompositeEvalMetric.)]
+    (doseq [m metrics] (.add cm m))
+    cm))
+
 (defn get
-  "Get the values of the metric in a vector form (name and value)"
+  "Get the values of the metric in as a map of {name value} pairs"
   [metric]
-  (let [[[mname] [mvalue]] (util/tuple->vec (.get metric))]
-    [mname mvalue]))
+  (apply zipmap (-> (.get metric) util/tuple->vec)))
 
 (defn reset
   "clear the internal statistics to an initial state"

--- a/contrib/clojure-package/test/org/apache/clojure_mxnet/eval_metric_test.clj
+++ b/contrib/clojure-package/test/org/apache/clojure_mxnet/eval_metric_test.clj
@@ -57,3 +57,12 @@
                                           "my-metric")]
     (eval-metric/update metric [(ndarray/ones [2])] [(ndarray/ones [2])])
     (is (= ["my-metric" 0.0] (eval-metric/get metric)))))
+
+(deftest test-comp-metric
+  (let [metric (eval-metric/comp-metric [(eval-metric/accuracy)
+                                         (eval-metric/f1)
+                                         (eval-metric/top-k-accuracy 2)])]
+    (eval-metric/update metric [(ndarray/ones [2])] [(ndarray/ones [2 3])])
+    (is (= {"accuracy" 0.0
+            "f1" 0.0
+            "top_k_accuracy" 1.0} (eval-metric/get metric)))))


### PR DESCRIPTION
## Description ##
In order to be able to collect multiple metrics added a `comp-metric` function that can be used as:

```clojure
=> (require '[org.apache.clojure-mxnet.eval-metric :as em])

=> (def metric (em/comp-metric [(em/accuracy)
                                (em/f1)
                                (em/top-k-accuracy 2)]))

=> (fit ... {:eval-metric metric})
```
```
Speed: 5.34 samples/sec	Train-accuracy=0.704545
Speed: 5.34 samples/sec	Train-f1=0.819692
Speed: 5.34 samples/sec	Train-top_k_accuracy=1.000000
Speed: 5.24 samples/sec	Train-accuracy=0.764881
Speed: 5.24 samples/sec	Train-f1=0.861308
Speed: 5.24 samples/sec	Train-top_k_accuracy=1.000000
...
```

comp metrics are read with the same `(eval-metric/get)`:

```clojure
=> (em/get metric)
{"accuracy" 0.71634614, "f1" 0.8284848, "top_k_accuracy" 1.0}
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] add `comp-metric`, tests, doc

## Comments ##
- to remain backwards compatible `(eval-metric/get metric)` would keep returning vector for anything but `CompositeEvalMetric`, for which it will return a map
