### PR TITLE
Fix nightly build of 1.4.x

### DIFF
--- a/docs/tutorials/gluon/mnist.md
+++ b/docs/tutorials/gluon/mnist.md
@@ -279,6 +279,7 @@ trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.03})
 
 ```python
 # Use Accuracy as the evaluation metric.
+epoch = 10
 metric = mx.metric.Accuracy()
 softmax_cross_entropy_loss = gluon.loss.SoftmaxCrossEntropyLoss()
 


### PR DESCRIPTION
## Description ##
Nightly build of 1.4.x keeps failing - http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/NightlyTestsForBinaries/detail/v1.4.x/114/pipeline/

In 1.5.0 there is a major rewrite of this tutorial, but since 1.4.0 is already published, I made the smallest change possible to fix the failing build. 

I checked the build after this change on my EC2 instance - all good.