### PR TITLE
example/ssd/evaluate/eval_metric.py

### DIFF
--- a/example/ssd/evaluate/eval_metric.py
+++ b/example/ssd/evaluate/eval_metric.py
@@ -140,7 +140,6 @@ class MApMetric(mx.metric.EvalMetric):
                 dets = pred[indices]
                 pred = np.delete(pred, indices, axis=0)
                 # sort by score, desceding
-               # dets[dets[:,1].argsort()[::-1]]
                 dets = dets[dets[:,1].argsort()[::-1]]
                 records = np.hstack((dets[:, 1][:, np.newaxis], np.zeros((dets.shape[0], 1))))
                 # ground-truths

--- a/example/ssd/evaluate/eval_metric.py
+++ b/example/ssd/evaluate/eval_metric.py
@@ -140,7 +140,7 @@ class MApMetric(mx.metric.EvalMetric):
                 dets = pred[indices]
                 pred = np.delete(pred, indices, axis=0)
                 # sort by score, desceding
-                dets[dets[:,1].argsort()[::-1]]
+               # dets[dets[:,1].argsort()[::-1]]
                 records = np.hstack((dets[:, 1][:, np.newaxis], np.zeros((dets.shape[0], 1))))
                 # ground-truths
                 label_indices = np.where(label[:, 0].astype(int) == cid)[0]

--- a/example/ssd/evaluate/eval_metric.py
+++ b/example/ssd/evaluate/eval_metric.py
@@ -141,6 +141,7 @@ class MApMetric(mx.metric.EvalMetric):
                 pred = np.delete(pred, indices, axis=0)
                 # sort by score, desceding
                # dets[dets[:,1].argsort()[::-1]]
+                dets = dets[dets[:,1].argsort()[::-1]]
                 records = np.hstack((dets[:, 1][:, np.newaxis], np.zeros((dets.shape[0], 1))))
                 # ground-truths
                 label_indices = np.where(label[:, 0].astype(int) == cid)[0]


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)
<img width="625" alt="image" src="https://user-images.githubusercontent.com/38203631/55227706-2818fc00-5253-11e9-9632-ab8097efcc1b.png">
 this sort nothing to do  gets,after sort gets didn't change

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here