### PR TITLE
[trival fix] fix cmake build cpp examples option

### DIFF
--- a/cpp-package/CMakeLists.txt
+++ b/cpp-package/CMakeLists.txt
@@ -16,7 +16,7 @@ if(USE_CPP_PACKAGE)
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/scripts
   )
 
-  if(NOT DO_NOT_BUILD_EXAMPLES)
+  if(BUILD_CPP_EXAMPLES)
     add_subdirectory(example)
   endif()
 


### PR DESCRIPTION
## Description ##

The CMakeLists.txt in cpp-package do not honor the BUILD_CPP_EXAMPLES option in the top-most CMakeLists.txt

it may be a mistake
fix this issue

https://github.com/apache/incubator-mxnet/blob/84c2ae1c45b1b23aab342ef924a357d66b0546a6/CMakeLists.txt#L47
