### PR TITLE
fix custom exception handling

### DIFF
--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -60,9 +60,6 @@ $env:MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
 * MXNET_MP_OPENCV_NUM_THREADS
   - Values: Int ```(default=0)```
   - The number of OpenCV execution threads given to multiprocess workers. OpenCV multithreading is disabled if `MXNET_MP_OPENCV_NUM_THREADS` < 1 (default). Enlarge this number may boost the performance of individual workers when executing underlying OpenCV functions but please consider reducing the overall `num_workers` to avoid thread contention (not available on Windows).
-* MXNET_CUSTOM_OP_NUM_THREADS
-  - Values: Int ```(default=16)```
-  - The maximum number of threads given to custom operators.
 
 ## Memory Options
 

--- a/src/engine/threaded_engine.cc
+++ b/src/engine/threaded_engine.cc
@@ -31,6 +31,7 @@
 #include <utility>
 #include "./threaded_engine.h"
 #include "../common/cuda_utils.h"
+#include "../operator/custom/custom-inl.h"
 
 namespace mxnet {
 namespace engine {
@@ -373,10 +374,12 @@ void ThreadedEngine::DeleteVariable(SyncFn delete_fn,
 }
 
 void ThreadedEngine::WaitForVar(VarHandle var) {
+  using mxnet::op::custom::CustomOperator;
   BulkFlush();
   ThreadedVar* threaded_var = ThreadedVar::CastFromBase(var);
   if (threaded_var->ready_to_read()) {
     ThrowException(threaded_var);
+    CustomOperator::Get()->ThrowException();
     return;
   }
   if (engine_info_) {
@@ -407,6 +410,7 @@ void ThreadedEngine::WaitForVar(VarHandle var) {
   }
 
   ThrowException(threaded_var);
+  CustomOperator::Get()->ThrowException();
 }
 
 void ThreadedEngine::WaitForAll() {

--- a/src/engine/threaded_engine.cc
+++ b/src/engine/threaded_engine.cc
@@ -31,7 +31,6 @@
 #include <utility>
 #include "./threaded_engine.h"
 #include "../common/cuda_utils.h"
-#include "../operator/custom/custom-inl.h"
 
 namespace mxnet {
 namespace engine {
@@ -374,12 +373,10 @@ void ThreadedEngine::DeleteVariable(SyncFn delete_fn,
 }
 
 void ThreadedEngine::WaitForVar(VarHandle var) {
-  using mxnet::op::custom::CustomOperator;
   BulkFlush();
   ThreadedVar* threaded_var = ThreadedVar::CastFromBase(var);
   if (threaded_var->ready_to_read()) {
     ThrowException(threaded_var);
-    CustomOperator::Get()->ThrowException();
     return;
   }
   if (engine_info_) {
@@ -410,7 +407,6 @@ void ThreadedEngine::WaitForVar(VarHandle var) {
   }
 
   ThrowException(threaded_var);
-  CustomOperator::Get()->ThrowException();
 }
 
 void ThreadedEngine::WaitForAll() {

--- a/src/operator/custom/custom-inl.h
+++ b/src/operator/custom/custom-inl.h
@@ -101,8 +101,6 @@ class CustomOperator {
       } catch (dmlc::Error& e) {
         exception_ =
             std::make_shared<std::exception_ptr>(std::current_exception());
-        ctx.async_on_complete();
-        return;
       }
 
       Imperative::Get()->set_is_training(prev_training);
@@ -123,6 +121,13 @@ class CustomOperator {
 
       Engine::Get()->PushSync(
           [=](RunContext rctx) {
+            try {
+              ThrowException();
+            } catch(dmlc::Error& err) {
+              ctx.async_on_complete(&err);
+              return;
+            }
+
             for (size_t i = 0, out_idx = 0; i < arrs.size(); i++) {
               if (arrs[i].storage_type() == kDefaultStorage ||
                   arrs[i].storage_type() == kUndefinedStorage)

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5243,6 +5243,7 @@ def test_custom_op():
     def custom_add_exc():
         a = mx.nd.array([1, 2, 3])
         b = mx.nd.array([4, 5])
+        # trigger exception by providing unmatched operand shapes
         c = mx.nd.Custom(a, b, op_type='AdditionOP')
         c.wait_to_read()
 


### PR DESCRIPTION
## Description ##
This PR fixes Problem 1 in #14522:

> 1. The exception thrown in custom thread cannot be caught in main thread, causing program crash.

It stores exception of custom op and re-throws in sync function.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
