### PR TITLE
Fixes static build script given cub directory rename

### DIFF
--- a/tools/staticbuild/build_lib.sh
+++ b/tools/staticbuild/build_lib.sh
@@ -53,7 +53,7 @@ if [[ $VARIANT == *mkl ]]; then
 fi
 
 if [[ $VARIANT == cu* ]]; then
-    cp 3rdparty/cub/LICENSE.TXT ./CUB_LICENSE
+    cp 3rdparty/nvidia_cub/LICENSE.TXT ./CUB_LICENSE
 fi
 
 >&2 echo "Now building mxnet..."


### PR DESCRIPTION
## Description ##

The cub 3rd-party repository has been recently renamed to nvidia-cub. This PR updates the static library compilation script to reflect these changes.