### PR TITLE
Fix aspect ratio sampling for RandomResizedCrop

### DIFF
--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -27,7 +27,6 @@ import random
 import logging
 import json
 import warnings
-import math
 import numpy as np
 
 
@@ -586,8 +585,8 @@ def random_size_crop(src, size, area, ratio, interp=2, **kwargs):
         area = (area, 1.0)
     for _ in range(10):
         target_area = random.uniform(area[0], area[1]) * src_area
-        log_ratio = (math.log(ratio[0]), math.log(ratio[1]))
-        new_ratio = math.exp(random.uniform(*log_ratio))
+        log_ratio = (np.log(ratio[0]), np.log(ratio[1]))
+        new_ratio = np.exp(random.uniform(*log_ratio))
 
         new_w = int(round(np.sqrt(target_area * new_ratio)))
         new_h = int(round(np.sqrt(target_area / new_ratio)))

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -27,6 +27,7 @@ import random
 import logging
 import json
 import warnings
+import math
 import numpy as np
 
 
@@ -585,13 +586,11 @@ def random_size_crop(src, size, area, ratio, interp=2, **kwargs):
         area = (area, 1.0)
     for _ in range(10):
         target_area = random.uniform(area[0], area[1]) * src_area
-        new_ratio = random.uniform(*ratio)
+        log_ratio = (math.log(ratio[0]), math.log(ratio[1]))
+        new_ratio = math.exp(random.uniform(*log_ratio))
 
         new_w = int(round(np.sqrt(target_area * new_ratio)))
         new_h = int(round(np.sqrt(target_area / new_ratio)))
-
-        if random.random() < 0.5:
-            new_h, new_w = new_w, new_h
 
         if new_w <= w and new_h <= h:
             x0 = random.randint(0, w - new_w)

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -357,6 +357,7 @@ class TestImage(unittest.TestCase):
 
     @with_seed()
     def test_random_size_crop(self):
+        # test aspect ratio within bounds
         width = np.random.randint(100, 500)
         height = np.random.randint(100, 500)
         src = np.random.rand(height, width, 3) * 255.

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -365,7 +365,7 @@ class TestImage(unittest.TestCase):
         out, (x0, y0, new_w, new_h) = mx.image.random_size_crop(mx.nd.array(src), size=(width, height), area=0.08, ratio=ratio)
         _, pts = mx.image.center_crop(mx.nd.array(src), size=(width, height))
         if (x0, y0, new_w, new_h) != pts:
-            assert ratio[0] <= new_w/new_h <= ratio[1]
+            assert ratio[0] <= float(new_w)/new_h <= ratio[1]
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -361,7 +361,7 @@ class TestImage(unittest.TestCase):
         width = np.random.randint(100, 500)
         height = np.random.randint(100, 500)
         src = np.random.rand(height, width, 3) * 255.
-        ratio = (3/4, 1)
+        ratio = (0.75, 1)
         out, (x0, y0, new_w, new_h) = mx.image.random_size_crop(mx.nd.array(src), size=(width, height), area=0.08, ratio=ratio)
         _, pts = mx.image.center_crop(mx.nd.array(src), size=(width, height))
         if (x0, y0, new_w, new_h) != pts:

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -355,6 +355,18 @@ class TestImage(unittest.TestCase):
         for batch in det_iter:
             pass
 
+    @with_seed()
+    def test_random_size_crop(self):
+        width = np.random.randint(100, 500)
+        height = np.random.randint(100, 500)
+        src = np.random.rand(height, width, 3) * 255.
+        ratio = (3/4, 1)
+        out, (x0, y0, new_w, new_h) = mx.image.random_size_crop(mx.nd.array(src), size=(width, height), area=0.08, ratio=ratio)
+        _, pts = mx.image.center_crop(mx.nd.array(src), size=(width, height))
+        if (x0, y0, new_w, new_h) != pts:
+            assert ratio[0] <= new_w/new_h <= ratio[1]
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
Fixes #14505 

Aspect ratio goes out of bounds when the bounds are not reciprocals. Fixed by sampling from log scale instead of linear scale. When sampling from log scale, random swapping of width/height is not required since the distribution is centered at 1.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
