### PR TITLE
Set _scale in Trainer using Optimizer rescale_grad

### DIFF
--- a/python/mxnet/gluon/trainer.py
+++ b/python/mxnet/gluon/trainer.py
@@ -95,10 +95,10 @@ class Trainer(object):
             if param._grad_stype != 'default':
                 self._contains_sparse_grad = True
         self._compression_params = compression_params
-        optimizer_params = optimizer_params if optimizer_params else {}
-        self._scale = float(optimizer_params.get('rescale_grad', 1.0))
         self._contexts = self._check_contexts()
+        optimizer_params = optimizer_params if optimizer_params else {}
         self._init_optimizer(optimizer, optimizer_params)
+        self._scale = self._optimizer.rescale_grad
         self._kvstore_params = {'kvstore': kvstore, 'update_on_kvstore': update_on_kvstore}
         self._kv_initialized = False
         self._kvstore = None


### PR DESCRIPTION
Currently `_scale` is set based on the value of rescale_grad in optimizer_params when creating Trainer. However, users can use optimizer_params to create an Optimizer object and pass this object to Trainer. In this case, `_scale` may not be correctly set since optimizer_params is None.

In this PR, we set `_scale` by reading the rescale_grad value from optimizer after optimizer is initialized in Trainer.
