### PR TITLE
Fix iterator over symbol when multiple children have the same name

### DIFF
--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -90,7 +90,7 @@ class Symbol(SymbolBase):
         <Symbol d>
         <Symbol _plus0>
         """
-        return (self[i] for i in self.list_outputs())
+        return (self[i] for i in range(len(self)))
 
     def __add__(self, other):
         """x.__add__(y) <=> x+y

--- a/tests/python/unittest/test_symbol.py
+++ b/tests/python/unittest/test_symbol.py
@@ -367,6 +367,11 @@ def test_simple_bind_gradient_graph_possible_with_cycle():
     res = data + data + data + data + data + data + data + data
     res.simple_bind(ctx=mx.cpu(), data=(1,))
 
+def test_children_same_name():
+    a = mx.sym.Variable('data')
+    b = a + a
+    for c in b.get_children():
+        pass
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
In the current version of MXNet iterating over grouped symbol containing duplicates is impossible:
```
>>> import mxnet as mx
>>> a = mx.sym.Variable('data')
>>> b = a + a
>>> for c in b.get_children();
>>>    pass
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/runner/.local/lib/python3.6/site-packages/mxnet/symbol/symbol.py", line 93, in <genexpr>
    return (self[i] for i in self.list_outputs())
  File "/home/runner/.local/lib/python3.6/site-packages/mxnet/symbol/symbol.py", line 517, in __getitem__
    raise ValueError('There are multiple outputs with name \"%s\"' % index)
ValueError: There are multiple outputs with name "data"
```

This PR fixes that.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)