### PR TITLE
[WIP] Add test for gemm overflow.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "3rdparty/mshadow"]
 	path = 3rdparty/mshadow
-	url = https://github.com/dmlc/mshadow.git
+	url = https://github.com/larroy/mshadow.git
 [submodule "3rdparty/dmlc-core"]
 	path = 3rdparty/dmlc-core
 	url = https://github.com/dmlc/dmlc-core.git

--- a/tests/cpp/mshadow/test_overflow.cc
+++ b/tests/cpp/mshadow/test_overflow.cc
@@ -1,0 +1,41 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "mshadow/base.h"
+
+using namespace std;
+using namespace mshadow;
+
+/*
+ * Test that enum and string values are in sync
+ */
+TEST(Overflow, OverflowTest) {
+  EXPECT_TRUE(mult_not_overflow_binary<int>(200,400));
+  EXPECT_FALSE(mult_not_overflow_binary<int>(1<<31,4));
+  EXPECT_FALSE(mult_not_overflow_binary<int>(1<<30,1<<5));
+  EXPECT_TRUE(mult_not_overflow<int>(2, 200,400));
+  EXPECT_FALSE(mult_not_overflow<int>(2, 1<<31,1<<31));
+  EXPECT_TRUE(mult_not_overflow<int>(2, 1<<31,1));
+  EXPECT_FALSE(mult_not_overflow<int>(3, 1<<31,1,2));
+  EXPECT_TRUE(mult_not_overflow<int>(2, 0, 0));
+  EXPECT_TRUE(mult_not_overflow<int>(1, 0));
+}
+

--- a/tests/cpp/mshadow/test_overflow.cc
+++ b/tests/cpp/mshadow/test_overflow.cc
@@ -37,5 +37,20 @@ TEST(Overflow, OverflowTest) {
   EXPECT_FALSE(mult_not_overflow<int>(3, 1<<31,1,2));
   EXPECT_TRUE(mult_not_overflow<int>(2, 0, 0));
   EXPECT_TRUE(mult_not_overflow<int>(1, 0));
+  bool not_overflow = false;
+  not_overflow = narrow_not_overflow<size_t, int>(0);
+  EXPECT_TRUE(not_overflow);
+  not_overflow = narrow_not_overflow<size_t, int>((1ULL<<31)-1);
+  EXPECT_TRUE(not_overflow);
+  not_overflow = narrow_not_overflow<size_t, int>((1ULL<<32)-1);
+  EXPECT_FALSE(not_overflow);
+  not_overflow = narrow_not_overflow<size_t, int>(1ULL << 40);
+  EXPECT_FALSE(not_overflow);
+  not_overflow = narrow_not_overflow<int64_t, int>(1LL << 40);
+  EXPECT_FALSE(not_overflow);
+  not_overflow = narrow_not_overflow<int64_t, int8_t>(1LL << 40);
+  EXPECT_FALSE(not_overflow);
+  not_overflow = narrow_not_overflow<int64_t, unsigned>(-1);
+  EXPECT_FALSE(not_overflow);
 }
 

--- a/tests/cpp/mshadow/test_overflow.cc
+++ b/tests/cpp/mshadow/test_overflow.cc
@@ -28,13 +28,13 @@ using namespace mshadow;
  * Test that enum and string values are in sync
  */
 TEST(Overflow, OverflowTest) {
-  EXPECT_TRUE(mult_not_overflow_binary<int>(200,400));
-  EXPECT_FALSE(mult_not_overflow_binary<int>(1<<31,4));
-  EXPECT_FALSE(mult_not_overflow_binary<int>(1<<30,1<<5));
-  EXPECT_TRUE(mult_not_overflow<int>(2, 200,400));
-  EXPECT_FALSE(mult_not_overflow<int>(2, 1<<31,1<<31));
-  EXPECT_TRUE(mult_not_overflow<int>(2, 1<<31,1));
-  EXPECT_FALSE(mult_not_overflow<int>(3, 1<<31,1,2));
+  EXPECT_TRUE(mult_not_overflow_binary<int>(200, 400));
+  EXPECT_FALSE(mult_not_overflow_binary<int>(1<<31, 4));
+  EXPECT_FALSE(mult_not_overflow_binary<int>(1<<30, 1<<5));
+  EXPECT_TRUE(mult_not_overflow<int>(2, 200, 400));
+  EXPECT_FALSE(mult_not_overflow<int>(2, 1<<31, 1<<31));
+  EXPECT_TRUE(mult_not_overflow<int>(2, 1<<31, 1));
+  EXPECT_FALSE(mult_not_overflow<int>(3, 1<<31, 1, 2));
   EXPECT_TRUE(mult_not_overflow<int>(2, 0, 0));
   EXPECT_TRUE(mult_not_overflow<int>(1, 0));
   bool not_overflow = false;

--- a/tests/python/unittest/test_gluon_data_vision.py
+++ b/tests/python/unittest/test_gluon_data_vision.py
@@ -42,7 +42,7 @@ def test_to_tensor():
     out_nd = transforms.ToTensor()(nd.array(data_in, dtype='uint8'))
     assert_almost_equal(out_nd.asnumpy(), np.transpose(
                         data_in.astype(dtype=np.float32) / 255.0, (0, 3, 1, 2)))
-    
+
     # Invalid Input
     invalid_data_in = nd.random.uniform(0, 255, (5, 5, 300, 300, 3)).astype(dtype=np.uint8)
     transformer = transforms.ToTensor()
@@ -117,7 +117,7 @@ def test_resize():
         assertRaises(MXNetError, invalid_transform, data_in)
 
     for dtype in ['uint8', 'float32', 'float64']:
-        _test_resize_with_diff_type(dtype)    
+        _test_resize_with_diff_type(dtype)
 
 
 @with_seed()
@@ -149,7 +149,7 @@ def test_crop_resize():
         # test with resize height and width should be greater than 0
         transformer = transforms.CropResize(0, 0, 100, 50, (-25, 25), 2)
         assertRaises(MXNetError, transformer, data_in)
-        # test height and width should be greater than 0 
+        # test height and width should be greater than 0
         transformer = transforms.CropResize(0, 0, -100, -50)
         assertRaises(MXNetError, transformer, data_in)
         # test cropped area is bigger than input data
@@ -158,7 +158,7 @@ def test_crop_resize():
         assertRaises(MXNetError, transformer, data_bath_in)
 
     for dtype in ['uint8', 'float32', 'float64']:
-        _test_crop_resize_with_diff_type(dtype)  
+        _test_crop_resize_with_diff_type(dtype)
 
     # test nd.image.crop backward
     def test_crop_backward(test_nd_arr, TestCase):
@@ -179,7 +179,7 @@ def test_crop_resize():
         data_in = nd.arange(60).reshape((5, 4, 3)).astype(dtype)
         for test_case in test_list:
             test_crop_backward(data_in, test_case)
-        
+
 
 
     # check numeric gradient of nd.image.crop

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -489,6 +489,14 @@ def test_dot():
     assert_almost_equal(c, C.asnumpy(), atol=atol)
 
 
+@raises(mx.base.MXNetError)
+def test_gemm_overflow():
+	# 100 * 6000 * 7000 overflows signed int32
+	a = mx.nd.random.uniform(shape=(100, 6000, 1))
+	b = mx.nd.random.uniform(shape=(100, 1, 7000))
+	c = mx.nd.batch_dot(a, b)
+
+
 @with_seed()
 def test_reduce():
     sample_num = 200

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1,4 +1,4 @@
-# Licensed to the Apache Software Foundation (ASF) under one
+    # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
 # regarding copyright ownership.  The ASF licenses this file
@@ -491,10 +491,11 @@ def test_dot():
 
 @raises(mx.base.MXNetError)
 def test_gemm_overflow():
-	# 100 * 6000 * 7000 overflows signed int32
-	a = mx.nd.random.uniform(shape=(100, 6000, 1))
-	b = mx.nd.random.uniform(shape=(100, 1, 7000))
-	c = mx.nd.batch_dot(a, b)
+    # 100 * 6000 * 7000 overflows signed int32
+    a = mx.nd.random.uniform(shape=(100, 6000, 1))
+    b = mx.nd.random.uniform(shape=(100, 1, 7000))
+    c = mx.nd.batch_dot(a, b)
+    c.wait_to_read()
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##

Add a test for big matrix multiplications that overflow gemm int32 indexes.

This test checks that an exception is thrown instead of calling gemm with wrong indices which causes segfaults or wrong results.

For more info see related issues and PR:

https://github.com/apache/incubator-mxnet/issues/14522 https://github.com/dmlc/mshadow/pull/372

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
