### PR TITLE
split_and_load can now handle num_ctx > num_data. Github Issue #13909

### DIFF
--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -63,10 +63,6 @@ def split_data(data, num_slice, batch_axis=0, even_split=True):
         Return value is a list even if `num_slice` is 1.
     """
     size = data.shape[batch_axis]
-    if size < num_slice:
-        raise ValueError(
-            "Too many slices for data with shape %s. Arguments are " \
-            "num_slice=%d and batch_axis=%d."%(str(data.shape), num_slice, batch_axis))
     if even_split and size % num_slice != 0:
         raise ValueError(
             "data with shape %s cannot be evenly split into %d slices along axis %d. " \
@@ -75,6 +71,12 @@ def split_data(data, num_slice, batch_axis=0, even_split=True):
                 str(data.shape), num_slice, batch_axis, num_slice))
 
     step = size // num_slice
+
+    # If size < num_slice, make fewer slices
+    if not even_split and size < num_slice:
+        step = 1
+        num_slice = size
+
     if batch_axis == 0:
         slices = [data[i*step:(i+1)*step] if i < num_slice - 1 else data[i*step:size]
                   for i in range(num_slice)]


### PR DESCRIPTION
## Description ##
Handles Issue #13909
when last batch size is smaller than the number of contexts, 
the previous utility function` gluon.utils.split_and_load` throws an exception `ValueError: Too many slices for data with shape ....`
However, we can just put one data per context and ignore the remaining contexts.
This integrates nicely with the given reproducing example code. (User does not need to modify the code)
```
for d, l in zip(data, label):
    with autograd.record():
        out = net(d)
        losses.append(loss_fn(out, l))
for loss in losses:
    loss.backward()
```
where `data` and `label` will only output data that exists in the first few of the given context.
the forward / backward pass is only done in the contexts where needed. (remaining contexts does not need to do a fake forward/backward pass)
My concern is people can make mistakes when calculating mean of the losses.

So it would be nice if we add this behavior to the documentation. (`split_and_load` can output a list that has a size less than number of contexts when even_split=False)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
-> I believe this PR is just tiny change

