### PR TITLE
[WIP] Brings CI GPU images to CUDA v10.0 with latest cuDNN

### DIFF
--- a/ci/docker/Dockerfile.build.centos7_gpu
+++ b/ci/docker/Dockerfile.build.centos7_gpu
@@ -18,7 +18,7 @@
 #
 # Dockerfile to build and run MXNet on CentOS 7 for GPU
 
-FROM nvidia/cuda:9.1-cudnn7-devel-centos7
+FROM nvidia/cuda:10.0-cudnn7-devel-centos7
 
 WORKDIR /work/deps
 

--- a/ci/docker/Dockerfile.build.ubuntu_base_gpu
+++ b/ci/docker/Dockerfile.build.ubuntu_base_gpu
@@ -19,7 +19,7 @@
 # Dockerfile to run the MXNet Installation Tests on Ubuntu 16.04
 # This should run in an empty docker with ubuntu and cuda.
 
-FROM nvidia/cuda:9.1-cudnn7-devel
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
 
 WORKDIR /work/deps
 

--- a/ci/docker/Dockerfile.build.ubuntu_build_cuda
+++ b/ci/docker/Dockerfile.build.ubuntu_build_cuda
@@ -21,7 +21,7 @@
 # package generation, requiring the actual CUDA library to be
 # present
 
-FROM nvidia/cuda:9.1-cudnn7-devel
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
 
 WORKDIR /work/deps
 

--- a/ci/docker/Dockerfile.build.ubuntu_gpu
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu
@@ -18,7 +18,7 @@
 #
 # Dockerfile to run MXNet on Ubuntu 16.04 for GPU
 
-FROM nvidia/cuda:9.1-cudnn7-devel
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
 
 WORKDIR /work/deps
 

--- a/ci/docker/Dockerfile.build.ubuntu_nightly_gpu
+++ b/ci/docker/Dockerfile.build.ubuntu_nightly_gpu
@@ -18,7 +18,7 @@
 #
 # Dockerfile to run MXNet on Ubuntu 16.04 for CPU
 
-FROM nvidia/cuda:9.1-cudnn7-devel
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
 
 WORKDIR /work/deps
 

--- a/ci/docker/install/ubuntu_nvidia.sh
+++ b/ci/docker/install/ubuntu_nvidia.sh
@@ -22,4 +22,4 @@ set -ex
 # Retrieve ppa:graphics-drivers and install nvidia-drivers.
 # Note: DEBIAN_FRONTEND required to skip the interactive setup steps
 apt update
-DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends cuda-9-1
+DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends cuda-10-0

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -24,8 +24,8 @@ set -ex
 
 NOSE_COVERAGE_ARGUMENTS="--with-coverage --cover-inclusive --cover-xml --cover-branches --cover-package=mxnet"
 NOSE_TIMER_ARGUMENTS="--with-timer --timer-ok 1 --timer-warning 15 --timer-filter warning,error"
-CI_CUDA_COMPUTE_CAPABILITIES="-gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_70,code=sm_70"
-CI_CMAKE_CUDA_ARCH_BIN="52,70"
+CI_CUDA_COMPUTE_CAPABILITIES="-gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_70,code=sm_70 -gencode=arch=compute_75,code=sm_75"
+CI_CMAKE_CUDA_ARCH_BIN="52,70,75"
 
 clean_repo() {
     set -ex
@@ -565,7 +565,7 @@ build_ubuntu_cpu_mkldnn_mkl() {
 }
 
 build_ubuntu_gpu() {
-    build_ubuntu_gpu_cuda91_cudnn7
+    build_ubuntu_gpu_cuda100_cudnn7
 }
 
 build_ubuntu_gpu_tensorrt() {
@@ -665,7 +665,7 @@ build_ubuntu_gpu_mkldnn_nocudnn() {
         -j$(nproc)
 }
 
-build_ubuntu_gpu_cuda91_cudnn7() {
+build_ubuntu_gpu_cuda100_cudnn7() {
     set -ex
     # unfortunately this build has problems in 3rdparty dependencies with ccache and make
     # build_ccache_wrappers

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -195,7 +195,7 @@ def compile_unix_full_gpu() {
         ws('workspace/build-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
-            utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_cuda91_cudnn7', false)
+            utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_cuda100_cudnn7', false)
             utils.pack_lib('gpu', mx_lib_cpp_examples, true)
           }
         }

--- a/tests/python/unittest/test_gluon_rnn.py
+++ b/tests/python/unittest/test_gluon_rnn.py
@@ -254,9 +254,9 @@ def test_layer_bidirectional():
 
         def forward(self, inpt):
             fwd = self._lstm_fwd(inpt)
-            bwd_inpt = nd.flip(inpt, 0)
+            bwd_inpt = mx.nd.flip(inpt, 0)
             bwd = self._lstm_bwd(bwd_inpt)
-            bwd = nd.flip(bwd, 0)
+            bwd = mx.nd.flip(bwd, 0)
             return nd.concat(fwd, bwd, dim=2)
 
     size = 7


### PR DESCRIPTION
## Description ##

I'm trying to bring the CI GPU images up to a current version of CUDA. I have attempted this in a previous PR (#14513) but some GPU tests were failing. In order to get it to pass (in that PR) I had to install an earlier version of cudNN (v7.3.1.20). After speaking with a couple of other contributors, we decided the right way forward would be to keep the latest version of cuDNN, disable the failing tests, and create a report detailing them.

