### PR TITLE
[Dependency Update] Upgrade the libpng to 1.6.35

### DIFF
--- a/tools/dependencies/libpng.sh
+++ b/tools/dependencies/libpng.sh
@@ -19,7 +19,7 @@
 
 # This script builds the static library of libpng that can be used as dependency of mxnet/opencv.
 set -ex
-PNG_VERSION=1.6.34
+PNG_VERSION=1.6.35
 if [[ ! -f $DEPS_PATH/lib/libpng.a ]]; then
     # download and build libpng
     >&2 echo "Building libpng..."


### PR DESCRIPTION
## Description ##

Upgrade the libpng package to **1.6.35** due to following issues at 1.6.34.
1. [SEGV in function png_free_data](https://github.com/glennrp/libpng/issues/238) more on [link1](https://github.com/fouzhe/security/tree/master/libpng), [link2](http://www.oracle.com/technetwork/security-advisory/cpuoct2018-4428296.html)
2. [Division by zero causes LibPNG to crash](https://sourceforge.net/p/libpng/bugs/278/) more on [link](https://www.cvedetails.com/cve/CVE-2018-13785/)

Note that the latest stable version is **1.6.36** but has one memory leak issue
[memory leak in png_create_info_struct](https://github.com/glennrp/libpng/issues/269)


## Checklist ##
### Essentials ###
- [x] CI check for scala publish build
- [x] CI check for python publish build
- [x] CI check for python gpu publish build
- [x] Ubuntu 16.04 cu100mkl publish build
- [x] Ubuntu 16.04 mkl publish build
- [x] No Performance regression on Imdecode (the script is shown below)
```
with open('image.jpg', 'rb') as fp:
    str_image = fp.read()

    start = time.time()
for i in range(100):
    image = mx.img.imdecode(str_image)
    image.asnumpy()
print(time.time() - start)
```
### Changes ###

## Comments ##

