### PR TITLE
[Dependency Update] Update libjpeg-turbo to 2.0.2

### DIFF
--- a/tools/dependencies/libturbojpeg.sh
+++ b/tools/dependencies/libturbojpeg.sh
@@ -20,7 +20,7 @@
 # This script builds the static library of libturbojpeg that can be used as dependency of
 # mxnet/opencv.
 set -ex
-TURBO_JPEG_VERSION=1.5.90
+TURBO_JPEG_VERSION=2.0.2
 if [[ $PLATFORM == 'darwin' ]]; then
     JPEG_NASM_OPTION="-D CMAKE_ASM_NASM_COMPILER=/usr/local/bin/nasm"
 fi


### PR DESCRIPTION
## Description ##

Upgrade the libjpeg-turbo to **2.0.2** due to the issue at 1.5.90
1. [divide by zero when processing a crafted BMP image](https://github.com/libjpeg-turbo/libjpeg-turbo/commit/43e84cff1bb2bd8293066f6ac4eb0df61ddddbc6)

Version 2.0.2 also fixes the performance issue 

> Fixed a severe performance issue in the Loongson MMI SIMD extensions that occurred when compressing RGB images whose image rows were not 64-bit-aligned.

as stated in the [release note](https://github.com/libjpeg-turbo/libjpeg-turbo/releases)

## Checklist ##
### Essentials ###
 - [x] CI check for scala publish build
 - [x] CI check for python publish build
 - [x] CI check for python gpu publish build
 - [x] Ubuntu 16.04 cu100mkl publish build
 - [x] Ubuntu 16.04 mkl publish build
- [x] No Performance regression on Imdecode (the script is shown below)
```
with open('image.jpg', 'rb') as fp:
    str_image = fp.read()

    start = time.time()
for i in range(100):
    image = mx.img.imdecode(str_image)
    image.asnumpy()
print(time.time() - start)
```

### Changes ###


## Comments ##
