### PR TITLE
[MXNET-1382] Add the index_array operator

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -239,6 +239,7 @@ List of Contributors
 * [Zhennan Qin](https://github.com/ZhennanQin)
 * [Zhiyuan Huang](https://github.com/huangzhiyuan)
 * [Zak Jost](https://github.com/zjost)
+* [Nick Guletskii](https://github.com/nickguletskii)
 * [Shoubhik Bhattacharya](https://github.com/shoubhik)
 * [Rohit Srivastava](https://github.com/access2rohit)
 * [Caner Turkmen](https://github.com/canerturkmen)

--- a/docs/api/python/ndarray/contrib.md
+++ b/docs/api/python/ndarray/contrib.md
@@ -75,6 +75,7 @@ In the rest of this document, we list routines provided by the `ndarray.contrib`
     isinf
     isfinite
     isnan
+    index_array
     index_copy
     getnnz
     edge_id

--- a/docs/api/python/symbol/contrib.md
+++ b/docs/api/python/symbol/contrib.md
@@ -72,6 +72,7 @@ In the rest of this document, we list routines provided by the `symbol.contrib` 
     foreach
     while_loop
     cond
+    index_array
     index_copy
     getnnz
     edge_id

--- a/python/mxnet/contrib/amp/lists/symbol.py
+++ b/python/mxnet/contrib/amp/lists/symbol.py
@@ -95,6 +95,7 @@ FP16_FP32_FUNCS = [
     '_contrib_gradientmultiplier',
     '_contrib_group_adagrad_update',
     '_contrib_ifft',
+    '_contrib_index_array',
     '_contrib_index_copy',
     '_contrib_quadratic',
     '_contrib_quantize',

--- a/src/operator/contrib/index_array-inl.h
+++ b/src/operator/contrib/index_array-inl.h
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef MXNET_OPERATOR_CONTRIB_INDEX_ARRAY_INL_H_
+#define MXNET_OPERATOR_CONTRIB_INDEX_ARRAY_INL_H_
+
+#include <vector>
+#include <utility>
+#include "../mshadow_op.h"
+#include "../tensor/init_op.h"
+
+namespace mxnet {
+namespace op {
+
+namespace index_array_enum {
+enum IndexArrayOpInputs {kIn};
+enum IndexArrayOpOutputs {kOut};
+enum IndexArrayOpResource {kTempSpace};
+}  // namespace index_array_enum
+
+template<int req>
+struct IndexArrayKernel {
+  MSHADOW_XINLINE static void Map(size_t i,
+                                  int64_t* out_data,
+                                  const uint32_t n,
+                                  const int64_t* workspace) {
+    for (uint32_t j = 0; j < n; j++) {
+      int64_t upper = workspace[2 * j];
+      int64_t lower = workspace[2 * j + 1];
+      KERNEL_ASSIGN(out_data[i * n + j], req, (i % upper) / lower);
+    }
+  }
+};
+
+template<int req>
+struct IndexArrayDefaultKernel {
+  MSHADOW_XINLINE static void Map(size_t i,
+                                  int64_t* out_data,
+                                  const uint32_t ndim,
+                                  const dim_t* shape) {
+    int64_t index = i;
+    for (uint32_t j = ndim; j-- > 0;) {
+      KERNEL_ASSIGN(out_data[i * ndim + j], req, index % shape[j]);
+      index /= shape[j];
+    }
+  }
+};
+
+inline std::vector<int64_t> IndexArrayComputeIndexProducts(const TShape &inshape) {
+  const uint32_t ndim = inshape.ndim();
+
+  std::vector<int64_t> index_products(ndim + 1);
+
+  index_products[ndim] = 1;
+
+  for (uint32_t i = ndim; i-- > 0;) {
+    index_products[i] = index_products[i + 1] * inshape[i];
+  }
+
+  return index_products;
+}
+
+inline void IndexArrayBuildSelectedAxesWorkspace(const TShape &axes,
+                                                 const std::vector<int64_t> &index_products,
+                                                 int64_t* workspace,
+                                                 const uint32_t ndim) {
+  for (uint32_t i = 0; i < axes.ndim(); i++) {
+    // Make sure that the axis is between 0 and ndim.
+    const dim_t axis = ((axes[i] % ndim) + ndim) % ndim;
+
+    workspace[2 * i] = index_products[axis];
+    workspace[2 * i + 1] = index_products[axis + 1];
+  }
+}
+
+template<typename xpu>
+void IndexArrayForward(const nnvm::NodeAttrs &attrs,
+                       const OpContext &ctx,
+                       const std::vector<TBlob> &inputs,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &outputs);
+
+struct IndexArrayParam : public dmlc::Parameter<IndexArrayParam> {
+  dmlc::optional<mxnet::TShape> axes;
+  DMLC_DECLARE_PARAMETER(IndexArrayParam) {
+    DMLC_DECLARE_FIELD(axes).set_default(dmlc::optional<mxnet::TShape>())
+      .describe("The axes to include in the index array. Supports negative values.");
+  }
+};  // struct IndexArrayParam
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_CONTRIB_INDEX_ARRAY_INL_H_

--- a/src/operator/contrib/index_array-inl.h
+++ b/src/operator/contrib/index_array-inl.h
@@ -76,13 +76,13 @@ inline std::vector<int64_t> IndexArrayComputeIndexProducts(const TShape &inshape
   return index_products;
 }
 
-inline void IndexArrayBuildSelectedAxesWorkspace(const TShape &axes,
+inline void IndexArrayBuildSelectedAxesWorkspace(const mxnet::Tuple<int> &axes,
                                                  const std::vector<int64_t> &index_products,
                                                  int64_t* workspace,
                                                  const int ndim) {
   for (int i = 0; i < axes.ndim(); i++) {
     // Make sure that the axis is between 0 and ndim.
-    const dim_t axis = ((axes[i] % ndim) + ndim) % ndim;
+    const int axis = ((axes[i] % ndim) + ndim) % ndim;
 
     workspace[2 * i] = index_products[axis];
     workspace[2 * i + 1] = index_products[axis + 1];
@@ -97,9 +97,9 @@ void IndexArrayForward(const nnvm::NodeAttrs &attrs,
                        const std::vector<TBlob> &outputs);
 
 struct IndexArrayParam : public dmlc::Parameter<IndexArrayParam> {
-  dmlc::optional<mxnet::TShape> axes;
+  dmlc::optional<mxnet::Tuple<int>> axes;
   DMLC_DECLARE_PARAMETER(IndexArrayParam) {
-    DMLC_DECLARE_FIELD(axes).set_default(dmlc::optional<mxnet::TShape>())
+    DMLC_DECLARE_FIELD(axes).set_default(dmlc::optional<mxnet::Tuple<int>>())
       .describe("The axes to include in the index array. Supports negative values.");
   }
 };  // struct IndexArrayParam

--- a/src/operator/contrib/index_array-inl.h
+++ b/src/operator/contrib/index_array-inl.h
@@ -40,10 +40,10 @@ struct IndexArrayKernel {
                                   int64_t* out_data,
                                   const int n,
                                   const int64_t* workspace) {
-    for (int j = 0; j < n; j++) {
-      int64_t upper = workspace[2 * j];
-      int64_t lower = workspace[2 * j + 1];
-      KERNEL_ASSIGN(out_data[i * n + j], req, (i % upper) / lower);
+    for (ptrdiff_t j = 0; j < n; j++) {
+      int64_t upper = workspace[ptrdiff_t(2) * j];
+      int64_t lower = workspace[ptrdiff_t(2) * j + ptrdiff_t(1)];
+      KERNEL_ASSIGN(out_data[ptrdiff_t(i) * ptrdiff_t(n) + j], req, (i % upper) / lower);
     }
   }
 };
@@ -55,8 +55,8 @@ struct IndexArrayDefaultKernel {
                                   const int ndim,
                                   const dim_t* shape) {
     int64_t index = i;
-    for (int j = ndim - 1; j >= 0; j--) {
-      KERNEL_ASSIGN(out_data[i * ndim + j], req, index % shape[j]);
+    for (ptrdiff_t j = ndim - 1; j >= 0; j--) {
+      KERNEL_ASSIGN(out_data[ptrdiff_t(i) * ptrdiff_t(ndim) + j], req, index % shape[j]);
       index /= shape[j];
     }
   }
@@ -84,8 +84,8 @@ inline void IndexArrayBuildSelectedAxesWorkspace(const mxnet::Tuple<int> &axes,
     // Make sure that the axis is between 0 and ndim.
     const int axis = ((axes[i] % ndim) + ndim) % ndim;
 
-    workspace[2 * i] = index_products[axis];
-    workspace[2 * i + 1] = index_products[axis + 1];
+    workspace[ptrdiff_t(2) * ptrdiff_t(i)] = index_products[axis];
+    workspace[ptrdiff_t(2) * ptrdiff_t(i) + ptrdiff_t(1)] = index_products[axis + 1];
   }
 }
 

--- a/src/operator/contrib/index_array-inl.h
+++ b/src/operator/contrib/index_array-inl.h
@@ -89,13 +89,6 @@ inline void IndexArrayBuildSelectedAxesWorkspace(const mxnet::Tuple<int> &axes,
   }
 }
 
-template<typename xpu>
-void IndexArrayForward(const nnvm::NodeAttrs &attrs,
-                       const OpContext &ctx,
-                       const std::vector<TBlob> &inputs,
-                       const std::vector<OpReqType> &req,
-                       const std::vector<TBlob> &outputs);
-
 struct IndexArrayParam : public dmlc::Parameter<IndexArrayParam> {
   dmlc::optional<mxnet::Tuple<int>> axes;
   DMLC_DECLARE_PARAMETER(IndexArrayParam) {

--- a/src/operator/contrib/index_array.cc
+++ b/src/operator/contrib/index_array.cc
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <mshadow/tensor.h>
+#include "./index_array-inl.h"
+
+
+namespace mxnet {
+namespace op {
+
+template<>
+void IndexArrayForward<cpu>(const nnvm::NodeAttrs &attrs,
+                            const OpContext &ctx,
+                            const std::vector<TBlob> &inputs,
+                            const std::vector<OpReqType> &req,
+                            const std::vector<TBlob> &outputs) {
+  using namespace mshadow;
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+  const TBlob& in_data = inputs[0];
+  const TBlob& out_data = outputs[0];
+
+  const IndexArrayParam& param = nnvm::get<IndexArrayParam>(attrs.parsed);
+
+  const TShape inshape = in_data.shape_;
+  const uint32_t ndim = inshape.ndim();
+
+  Stream<cpu> *stream = ctx.get_stream<cpu>();
+
+  using namespace mxnet_op;
+
+  if (param.axes.has_value()) {
+    const TShape& axes = param.axes.value();
+    const uint32_t naxes = axes.ndim();
+
+    std::vector<int64_t> index_products = IndexArrayComputeIndexProducts(inshape);
+
+    Tensor<cpu, 1, int64_t> workspace =
+        ctx.requested[0].get_space_typed<cpu, 1, int64_t>(Shape1(2 * naxes), stream);
+
+    IndexArrayBuildSelectedAxesWorkspace(axes, index_products, workspace.dptr_, ndim);
+
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+      Kernel<IndexArrayKernel<req_type>, cpu>::Launch(stream, in_data.Size(),
+          out_data.dptr<int64_t>(), naxes, workspace.dptr_);
+    });
+  } else {
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+      Kernel<IndexArrayDefaultKernel<req_type>, cpu>::Launch(stream, in_data.Size(),
+          out_data.dptr<int64_t>(), ndim, inshape.data());
+    });
+  }
+}
+
+DMLC_REGISTER_PARAMETER(IndexArrayParam);
+
+NNVM_REGISTER_OP(_contrib_index_array)
+.describe(R"code(Returns an array of indexes of the input array.
+
+For an input array with shape  :math:`(d_1, d_2, ..., d_n)`, `index_array` returns a
+:math:`(d_1, d_2, ..., d_n, n)` array `idx`, where
+:math:`idx[i_1, i_2, ..., i_n, :] = [i_1, i_2, ..., i_n]`.
+
+Additionally, when the parameter `axes` is specified, `idx` will be a
+:math:`(d_1, d_2, ..., d_n, m)` array where `m` is the length of `axes`, and the following
+equality will hold: :math:`idx[i_1, i_2, ..., i_n, j] = i_{axes[j]}`.
+
+Examples::
+
+    x = mx.nd.ones((3, 2))
+
+    mx.nd.contrib.index_array(x) = [[[0 0]
+                                     [0 1]]
+
+                                    [[1 0]
+                                     [1 1]]
+
+                                    [[2 0]
+                                     [2 1]]]
+
+    x = mx.nd.ones((3, 2, 2))
+
+    mx.nd.contrib.index_array(x, axes=(1, 0)) = [[[[0 0]
+                                                   [0 0]]
+
+                                                  [[1 0]
+                                                   [1 0]]]
+
+
+                                                 [[[0 1]
+                                                   [0 1]]
+
+                                                  [[1 1]
+                                                   [1 1]]]
+
+
+                                                 [[[0 2]
+                                                   [0 2]]
+
+                                                  [[1 2]
+                                                   [1 2]]]]
+
+)code" ADD_FILELINE)
+.set_num_inputs(1)
+.set_num_outputs(1)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+                                 [](const NodeAttrs &attrs) {
+                                   return std::vector<std::string>{ "data" };
+                                 })
+.set_attr<nnvm::FListOutputNames>("FListOutputNames",
+                                  [](const NodeAttrs &attrs) {
+                                    return std::vector<std::string>{ "output" };
+                                  })
+.set_attr_parser(ParamParser<IndexArrayParam>)
+.set_attr<mxnet::FInferShape>("FInferShape", [](const nnvm::NodeAttrs &attrs,
+                                                mxnet::ShapeVector *in_shape,
+                                                mxnet::ShapeVector *out_shape) {
+  const IndexArrayParam &param = nnvm::get<IndexArrayParam>(attrs.parsed);
+  CHECK_EQ(in_shape->size(), 1U);
+  CHECK_EQ(out_shape->size(), 1U);
+  mxnet::TShape inshape = in_shape->at(index_array_enum::kIn);
+  mxnet::TShape oshape = mxnet::TShape(inshape.ndim() + 1U);
+
+  for (size_t i = 0; i < inshape.ndim(); i++) {
+    oshape[i] = inshape[i];
+  }
+  if (param.axes.has_value()) {
+    oshape[inshape.ndim()] = param.axes.value().ndim();
+  } else {
+    oshape[inshape.ndim()] = inshape.ndim();
+  }
+  out_shape->clear();
+  out_shape->push_back(oshape);
+  return true;
+})
+.set_attr<nnvm::FInferType>("FInferType", [](const nnvm::NodeAttrs &attrs,
+                                             std::vector<int> *in_attrs,
+                                             std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  TYPE_ASSIGN_CHECK(*out_attrs, 0, mshadow::kInt64);
+  return out_attrs->at(0) != -1;
+})
+.set_attr<FCompute>("FCompute<cpu>", IndexArrayForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
+  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+})
+.add_argument("data", "NDArray-or-Symbol", "Input data")
+.add_arguments(IndexArrayParam::__FIELDS__());
+
+
+}  // namespace op
+}  // namespace mxnet
+

--- a/src/operator/contrib/index_array.cc
+++ b/src/operator/contrib/index_array.cc
@@ -46,7 +46,7 @@ void IndexArrayForward<cpu>(const nnvm::NodeAttrs &attrs,
   using namespace mxnet_op;
 
   if (param.axes.has_value()) {
-    const TShape& axes = param.axes.value();
+    const mxnet::Tuple<int>& axes = param.axes.value();
     const int naxes = axes.ndim();
 
     std::vector<int64_t> index_products = IndexArrayComputeIndexProducts(inshape);

--- a/src/operator/contrib/index_array.cc
+++ b/src/operator/contrib/index_array.cc
@@ -135,6 +135,8 @@ Examples::
   CHECK_EQ(in_shape->size(), 1U);
   CHECK_EQ(out_shape->size(), 1U);
   const mxnet::TShape &inshape = (*in_shape)[index_array_enum::kIn];
+  if (!mxnet::ndim_is_known(inshape)) return false;
+
   mxnet::TShape oshape = mxnet::TShape(inshape.ndim() + 1, 0);
 
   for (int i = 0; i < inshape.ndim(); i++) {
@@ -147,7 +149,7 @@ Examples::
   }
   out_shape->clear();
   out_shape->push_back(oshape);
-  return true;
+  return shape_is_known(oshape);
 })
 .set_attr<nnvm::FInferType>("FInferType", [](const nnvm::NodeAttrs &attrs,
                                              std::vector<int> *in_attrs,

--- a/src/operator/contrib/index_array.cc
+++ b/src/operator/contrib/index_array.cc
@@ -39,7 +39,7 @@ void IndexArrayForward<cpu>(const nnvm::NodeAttrs &attrs,
   const IndexArrayParam& param = nnvm::get<IndexArrayParam>(attrs.parsed);
 
   const TShape inshape = in_data.shape_;
-  const uint32_t ndim = inshape.ndim();
+  const int ndim = inshape.ndim();
 
   Stream<cpu> *stream = ctx.get_stream<cpu>();
 
@@ -47,7 +47,7 @@ void IndexArrayForward<cpu>(const nnvm::NodeAttrs &attrs,
 
   if (param.axes.has_value()) {
     const TShape& axes = param.axes.value();
-    const uint32_t naxes = axes.ndim();
+    const int naxes = axes.ndim();
 
     std::vector<int64_t> index_products = IndexArrayComputeIndexProducts(inshape);
 
@@ -135,9 +135,9 @@ Examples::
   CHECK_EQ(in_shape->size(), 1U);
   CHECK_EQ(out_shape->size(), 1U);
   mxnet::TShape inshape = in_shape->at(index_array_enum::kIn);
-  mxnet::TShape oshape = mxnet::TShape(inshape.ndim() + 1U);
+  mxnet::TShape oshape = mxnet::TShape(inshape.ndim() + 1, 0);
 
-  for (size_t i = 0; i < inshape.ndim(); i++) {
+  for (int i = 0; i < inshape.ndim(); i++) {
     oshape[i] = inshape[i];
   }
   if (param.axes.has_value()) {

--- a/src/operator/contrib/index_array.cc
+++ b/src/operator/contrib/index_array.cc
@@ -147,8 +147,8 @@ Examples::
   } else {
     oshape[inshape.ndim()] = inshape.ndim();
   }
-  out_shape->clear();
-  out_shape->push_back(oshape);
+
+  SHAPE_ASSIGN_CHECK(*out_shape, 0, oshape);
   return shape_is_known(oshape);
 })
 .set_attr<nnvm::FInferType>("FInferType", [](const nnvm::NodeAttrs &attrs,

--- a/src/operator/contrib/index_array.cc
+++ b/src/operator/contrib/index_array.cc
@@ -23,12 +23,11 @@
 namespace mxnet {
 namespace op {
 
-template<>
-void IndexArrayForward<cpu>(const nnvm::NodeAttrs &attrs,
-                            const OpContext &ctx,
-                            const std::vector<TBlob> &inputs,
-                            const std::vector<OpReqType> &req,
-                            const std::vector<TBlob> &outputs) {
+void IndexArrayForwardCPU(const nnvm::NodeAttrs &attrs,
+                          const OpContext &ctx,
+                          const std::vector<TBlob> &inputs,
+                          const std::vector<OpReqType> &req,
+                          const std::vector<TBlob> &outputs) {
   using namespace mshadow;
   CHECK_EQ(inputs.size(), 1U);
   CHECK_EQ(outputs.size(), 1U);
@@ -159,7 +158,7 @@ Examples::
   TYPE_ASSIGN_CHECK(*out_attrs, 0, mshadow::kInt64);
   return out_attrs->at(0) != -1;
 })
-.set_attr<FCompute>("FCompute<cpu>", IndexArrayForward<cpu>)
+.set_attr<FCompute>("FCompute<cpu>", IndexArrayForwardCPU)
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
 .set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& n) {
   return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};

--- a/src/operator/contrib/index_array.cc
+++ b/src/operator/contrib/index_array.cc
@@ -134,7 +134,7 @@ Examples::
   const IndexArrayParam &param = nnvm::get<IndexArrayParam>(attrs.parsed);
   CHECK_EQ(in_shape->size(), 1U);
   CHECK_EQ(out_shape->size(), 1U);
-  mxnet::TShape inshape = in_shape->at(index_array_enum::kIn);
+  const mxnet::TShape &inshape = (*in_shape)[index_array_enum::kIn];
   mxnet::TShape oshape = mxnet::TShape(inshape.ndim() + 1, 0);
 
   for (int i = 0; i < inshape.ndim(); i++) {

--- a/src/operator/contrib/index_array.cu
+++ b/src/operator/contrib/index_array.cu
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include <mshadow/tensor.h>
+#include "./index_array-inl.h"
+
+namespace mxnet {
+namespace op {
+
+using namespace mshadow::cuda;
+
+template<>
+void IndexArrayForward<gpu>(const nnvm::NodeAttrs &attrs,
+                            const OpContext &ctx,
+                            const std::vector<TBlob> &inputs,
+                            const std::vector<OpReqType> &req,
+                            const std::vector<TBlob> &outputs) {
+  using namespace mshadow;
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+  const TBlob& in_data = inputs[0];
+  const TBlob& out_data = outputs[0];
+
+  const IndexArrayParam& param = nnvm::get<IndexArrayParam>(attrs.parsed);
+
+  const TShape inshape = in_data.shape_;
+  const uint32_t ndim = inshape.ndim();
+
+  Stream<gpu> *stream = ctx.get_stream<gpu>();
+
+  using namespace mxnet_op;
+
+  if (param.axes.has_value()) {
+    const TShape& axes = param.axes.value();
+    const uint32_t naxes = axes.ndim();
+
+    std::vector<int64_t> index_products = IndexArrayComputeIndexProducts(inshape);
+
+    std::vector<int64_t> cpu_workspace(2 * naxes);
+    IndexArrayBuildSelectedAxesWorkspace(axes, index_products, cpu_workspace.data(), ndim);
+
+    Tensor<gpu, 1, int64_t> workspace =
+        ctx.requested[0].get_space_typed<gpu, 1, int64_t>(Shape1(2 * naxes), stream);
+
+    CUDA_CALL(cudaMemcpy(workspace.dptr_, cpu_workspace.data(), sizeof(int64_t) * (2 * naxes),
+                         cudaMemcpyHostToDevice));
+
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+      Kernel<IndexArrayKernel<req_type>, gpu>::Launch(stream, in_data.Size(),
+          out_data.dptr<int64_t>(), naxes, workspace.dptr_);
+    });
+  } else {
+    Tensor<gpu, 1, dim_t> workspace =
+        ctx.requested[0].get_space_typed<gpu, 1, dim_t>(Shape1(ndim), stream);
+
+    CUDA_CALL(cudaMemcpy(workspace.dptr_, inshape.data(), sizeof(dim_t) * (ndim),
+        cudaMemcpyHostToDevice));
+
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+      Kernel<IndexArrayDefaultKernel<req_type>, gpu>::Launch(stream, in_data.Size(),
+          out_data.dptr<int64_t>(), ndim, workspace.dptr_);
+    });
+  }
+}
+
+NNVM_REGISTER_OP(_contrib_index_array)
+.set_attr<FCompute>("FCompute<gpu>", IndexArrayForward<gpu>);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/contrib/index_array.cu
+++ b/src/operator/contrib/index_array.cu
@@ -47,7 +47,7 @@ void IndexArrayForward<gpu>(const nnvm::NodeAttrs &attrs,
   using namespace mxnet_op;
 
   if (param.axes.has_value()) {
-    const TShape& axes = param.axes.value();
+    const mxnet::Tuple<int>& axes = param.axes.value();
     const int naxes = axes.ndim();
 
     std::vector<int64_t> index_products = IndexArrayComputeIndexProducts(inshape);

--- a/src/operator/contrib/index_array.cu
+++ b/src/operator/contrib/index_array.cu
@@ -40,7 +40,7 @@ void IndexArrayForward<gpu>(const nnvm::NodeAttrs &attrs,
   const IndexArrayParam& param = nnvm::get<IndexArrayParam>(attrs.parsed);
 
   const TShape inshape = in_data.shape_;
-  const uint32_t ndim = inshape.ndim();
+  const int ndim = inshape.ndim();
 
   Stream<gpu> *stream = ctx.get_stream<gpu>();
 
@@ -48,7 +48,7 @@ void IndexArrayForward<gpu>(const nnvm::NodeAttrs &attrs,
 
   if (param.axes.has_value()) {
     const TShape& axes = param.axes.value();
-    const uint32_t naxes = axes.ndim();
+    const int naxes = axes.ndim();
 
     std::vector<int64_t> index_products = IndexArrayComputeIndexProducts(inshape);
 
@@ -69,7 +69,7 @@ void IndexArrayForward<gpu>(const nnvm::NodeAttrs &attrs,
     Tensor<gpu, 1, dim_t> workspace =
         ctx.requested[0].get_space_typed<gpu, 1, dim_t>(Shape1(ndim), stream);
 
-    CUDA_CALL(cudaMemcpy(workspace.dptr_, inshape.data(), sizeof(dim_t) * (ndim),
+    CUDA_CALL(cudaMemcpy(workspace.dptr_, inshape.data(), sizeof(dim_t) * ndim,
         cudaMemcpyHostToDevice));
 
     MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {

--- a/src/operator/contrib/index_array.cu
+++ b/src/operator/contrib/index_array.cu
@@ -24,12 +24,11 @@ namespace op {
 
 using namespace mshadow::cuda;
 
-template<>
-void IndexArrayForward<gpu>(const nnvm::NodeAttrs &attrs,
-                            const OpContext &ctx,
-                            const std::vector<TBlob> &inputs,
-                            const std::vector<OpReqType> &req,
-                            const std::vector<TBlob> &outputs) {
+void IndexArrayForwardGPU(const nnvm::NodeAttrs &attrs,
+                          const OpContext &ctx,
+                          const std::vector<TBlob> &inputs,
+                          const std::vector<OpReqType> &req,
+                          const std::vector<TBlob> &outputs) {
   using namespace mshadow;
   CHECK_EQ(inputs.size(), 1U);
   CHECK_EQ(outputs.size(), 1U);
@@ -80,7 +79,7 @@ void IndexArrayForward<gpu>(const nnvm::NodeAttrs &attrs,
 }
 
 NNVM_REGISTER_OP(_contrib_index_array)
-.set_attr<FCompute>("FCompute<gpu>", IndexArrayForward<gpu>);
+.set_attr<FCompute>("FCompute<gpu>", IndexArrayForwardGPU);
 
 }  // namespace op
 }  // namespace mxnet

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -2144,6 +2144,30 @@ def test_index_array_default():
         check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
 @with_seed()
+def test_index_array_default_zero_dim():
+    with mx.np_compat(active=True):
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data)
+
+        input_array = np.ones(())
+        expected = np.zeros((0,))
+
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+
+@with_seed()
+def test_index_array_default_zero_size():
+    with mx.np_compat(active=True):
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data)
+
+        input_array = np.ones((0, 0, 0))
+        expected = np.zeros((0, 0, 0, 3))
+
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+
+@with_seed()
 def test_index_array_select_axes():
     shape = (5, 7, 11, 13, 17, 19)
     for axes in [(3,), (4, 1), (5, 1, 3), (-1,), (-5, -1, -3)]:
@@ -2153,6 +2177,18 @@ def test_index_array_select_axes():
         input_array = np.ones(shape)
         mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
         expected = np.stack(mgrid, axis=-1)[..., axes]
+
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+
+@with_seed()
+def test_index_array_select_axes_zero_size():
+    with mx.np_compat(active=True):
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data, axes=(2, 1))
+
+        input_array = np.ones((0, 0, 0, 0))
+        expected = np.zeros((0, 0, 2))
 
         check_symbolic_forward(index_array, [input_array], [expected])
         check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -2130,68 +2130,6 @@ def test_bilinear_sampler_versions():
                 if req_dict['grid'] is 'write':
                     assert_almost_equal(exe.grad_dict['grid'].asnumpy(), exe_list[ref_idx].grad_dict['grid'].asnumpy(), rtol=1e-3, atol=1e-5)
 
-@with_seed()
-def test_index_array_default():
-    for shape in [(10,), (7, 5, 29), (5, 7, 11, 13, 17, 19)]:
-        data  = mx.symbol.Variable("data")
-        index_array = mx.sym.contrib.index_array(data)
-
-        input_array = np.ones(shape)
-        mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
-        expected = np.stack(mgrid, axis=-1)
-
-        check_symbolic_forward(index_array, [input_array], [expected])
-        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
-
-@with_seed()
-def test_index_array_default_zero_dim():
-    with mx.np_compat(active=True):
-        data  = mx.symbol.Variable("data")
-        index_array = mx.sym.contrib.index_array(data)
-
-        input_array = np.ones(())
-        expected = np.zeros((0,))
-
-        check_symbolic_forward(index_array, [input_array], [expected])
-        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
-
-@with_seed()
-def test_index_array_default_zero_size():
-    with mx.np_compat(active=True):
-        data  = mx.symbol.Variable("data")
-        index_array = mx.sym.contrib.index_array(data)
-
-        input_array = np.ones((0, 0, 0))
-        expected = np.zeros((0, 0, 0, 3))
-
-        check_symbolic_forward(index_array, [input_array], [expected])
-        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
-
-@with_seed()
-def test_index_array_select_axes():
-    shape = (5, 7, 11, 13, 17, 19)
-    for axes in [(3,), (4, 1), (5, 1, 3), (-1,), (-5, -1, -3)]:
-        data  = mx.symbol.Variable("data")
-        index_array = mx.sym.contrib.index_array(data, axes=axes)
-
-        input_array = np.ones(shape)
-        mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
-        expected = np.stack(mgrid, axis=-1)[..., axes]
-
-        check_symbolic_forward(index_array, [input_array], [expected])
-        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
-
-@with_seed()
-def test_index_array_select_axes_zero_size():
-    with mx.np_compat(active=True):
-        data  = mx.symbol.Variable("data")
-        index_array = mx.sym.contrib.index_array(data, axes=(2, 1))
-
-        input_array = np.ones((0, 0, 0, 0))
-        expected = np.zeros((0, 0, 2))
-
-        check_symbolic_forward(index_array, [input_array], [expected])
-        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
 # isolated execution bulking test function to be invoked with different env var settings
 def _test_bulking_in_process(seed, time_per_iteration):

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -2136,11 +2136,12 @@ def test_index_array_default():
         data  = mx.symbol.Variable("data")
         index_array = mx.sym.contrib.index_array(data)
 
+        input_array = np.ones(shape)
         mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
         expected = np.stack(mgrid, axis=-1)
-        
-        check_symbolic_forward(index_array, [np.ones(shape)], [expected])
-        check_symbolic_backward(index_array, [np.ones(shape)], [np.ones(shape)], [np.zeros(shape)])
+
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
 @with_seed()
 def test_index_array_select_axes():
@@ -2149,11 +2150,12 @@ def test_index_array_select_axes():
         data  = mx.symbol.Variable("data")
         index_array = mx.sym.contrib.index_array(data, axes=axes)
 
+        input_array = np.ones(shape)
         mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
         expected = np.stack(mgrid, axis=-1)[..., axes]
 
-        check_symbolic_forward(index_array, [np.ones(shape)], [expected])
-        check_symbolic_backward(index_array, [np.ones(shape)], [np.ones(shape)], [np.zeros(shape)])
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
 # isolated execution bulking test function to be invoked with different env var settings
 def _test_bulking_in_process(seed, time_per_iteration):

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -2130,6 +2130,30 @@ def test_bilinear_sampler_versions():
                 if req_dict['grid'] is 'write':
                     assert_almost_equal(exe.grad_dict['grid'].asnumpy(), exe_list[ref_idx].grad_dict['grid'].asnumpy(), rtol=1e-3, atol=1e-5)
 
+@with_seed()
+def test_index_array_default():
+    for shape in [(10,), (7, 5, 29), (5, 7, 11, 13, 17, 19)]:
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data)
+
+        mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
+        expected = np.stack(mgrid, axis=-1)
+        
+        check_symbolic_forward(index_array, [np.ones(shape)], [expected])
+        check_symbolic_backward(index_array, [np.ones(shape)], [np.ones(shape)], [np.zeros(shape)])
+
+@with_seed()
+def test_index_array_select_axes():
+    shape = (5, 7, 11, 13, 17, 19)
+    for axes in [(3,), (4, 1), (5, 1, 3), (-1,), (-5, -1, -3)]:
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data, axes=axes)
+
+        mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
+        expected = np.stack(mgrid, axis=-1)[..., axes]
+
+        check_symbolic_forward(index_array, [np.ones(shape)], [expected])
+        check_symbolic_backward(index_array, [np.ones(shape)], [np.ones(shape)], [np.zeros(shape)])
 
 # isolated execution bulking test function to be invoked with different env var settings
 def _test_bulking_in_process(seed, time_per_iteration):

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8441,6 +8441,30 @@ def test_index_array_default():
         check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
 @with_seed()
+def test_index_array_default_zero_dim():
+    with mx.np_compat(active=True):
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data)
+
+        input_array = np.ones(())
+        expected = np.zeros((0,))
+
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+
+@with_seed()
+def test_index_array_default_zero_size():
+    with mx.np_compat(active=True):
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data)
+
+        input_array = np.ones((0, 0, 0))
+        expected = np.zeros((0, 0, 0, 3))
+
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+
+@with_seed()
 def test_index_array_select_axes():
     shape = (5, 7, 11, 13, 17, 19)
     for axes in [(3,), (4, 1), (5, 1, 3), (-1,), (-5, -1, -3)]:
@@ -8450,6 +8474,18 @@ def test_index_array_select_axes():
         input_array = np.ones(shape)
         mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
         expected = np.stack(mgrid, axis=-1)[..., axes]
+
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+
+@with_seed()
+def test_index_array_select_axes_zero_size():
+    with mx.np_compat(active=True):
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data, axes=(2, 1))
+
+        input_array = np.ones((0, 0, 0, 0))
+        expected = np.zeros((0, 0, 2))
 
         check_symbolic_forward(index_array, [input_array], [expected])
         check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8428,67 +8428,71 @@ def test_image_normalize():
     check_numeric_gradient(img_norm_sym, [data_in_4d], atol=0.001)
 
 @with_seed()
-def test_index_array_default():
-    for shape in [(10,), (7, 5, 29), (5, 7, 11, 13, 17, 19)]:
-        data  = mx.symbol.Variable("data")
-        index_array = mx.sym.contrib.index_array(data)
+def test_index_array():
+    def test_index_array_default():
+        for shape in [(10,), (7, 5, 29), (5, 7, 11, 13, 17, 19)]:
+            data  = mx.symbol.Variable("data")
+            index_array = mx.sym.contrib.index_array(data)
 
-        input_array = np.ones(shape)
-        mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
-        expected = np.stack(mgrid, axis=-1)
+            input_array = np.ones(shape)
+            mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
+            expected = np.stack(mgrid, axis=-1)
 
-        check_symbolic_forward(index_array, [input_array], [expected])
-        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+            check_symbolic_forward(index_array, [input_array], [expected])
+            check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
-@with_seed()
-def test_index_array_default_zero_dim():
-    with mx.np_compat(active=True):
-        data  = mx.symbol.Variable("data")
-        index_array = mx.sym.contrib.index_array(data)
+    def test_index_array_default_zero_dim():
+        with mx.np_compat(active=True):
+            data  = mx.symbol.Variable("data")
+            index_array = mx.sym.contrib.index_array(data)
 
-        input_array = np.ones(())
-        expected = np.zeros((0,))
+            input_array = np.ones(())
+            expected = np.zeros((0,))
 
-        check_symbolic_forward(index_array, [input_array], [expected])
-        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+            check_symbolic_forward(index_array, [input_array], [expected])
+            check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
-@with_seed()
-def test_index_array_default_zero_size():
-    with mx.np_compat(active=True):
-        data  = mx.symbol.Variable("data")
-        index_array = mx.sym.contrib.index_array(data)
+    def test_index_array_default_zero_size():
+        with mx.np_compat(active=True):
+            data  = mx.symbol.Variable("data")
+            index_array = mx.sym.contrib.index_array(data)
 
-        input_array = np.ones((0, 0, 0))
-        expected = np.zeros((0, 0, 0, 3))
+            input_array = np.ones((0, 0, 0))
+            expected = np.zeros((0, 0, 0, 3))
 
-        check_symbolic_forward(index_array, [input_array], [expected])
-        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+            check_symbolic_forward(index_array, [input_array], [expected])
+            check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
-@with_seed()
-def test_index_array_select_axes():
-    shape = (5, 7, 11, 13, 17, 19)
-    for axes in [(3,), (4, 1), (5, 1, 3), (-1,), (-5, -1, -3)]:
-        data  = mx.symbol.Variable("data")
-        index_array = mx.sym.contrib.index_array(data, axes=axes)
+    def test_index_array_select_axes():
+        shape = (5, 7, 11, 13, 17, 19)
+        for axes in [(3,), (4, 1), (5, 1, 3), (-1,), (-5, -1, -3)]:
+            data  = mx.symbol.Variable("data")
+            index_array = mx.sym.contrib.index_array(data, axes=axes)
 
-        input_array = np.ones(shape)
-        mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
-        expected = np.stack(mgrid, axis=-1)[..., axes]
+            input_array = np.ones(shape)
+            mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
+            expected = np.stack(mgrid, axis=-1)[..., axes]
 
-        check_symbolic_forward(index_array, [input_array], [expected])
-        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+            check_symbolic_forward(index_array, [input_array], [expected])
+            check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
-@with_seed()
-def test_index_array_select_axes_zero_size():
-    with mx.np_compat(active=True):
-        data  = mx.symbol.Variable("data")
-        index_array = mx.sym.contrib.index_array(data, axes=(2, 1))
+    def test_index_array_select_axes_zero_size():
+        with mx.np_compat(active=True):
+            data  = mx.symbol.Variable("data")
+            index_array = mx.sym.contrib.index_array(data, axes=(2, 1))
 
-        input_array = np.ones((0, 0, 0, 0))
-        expected = np.zeros((0, 0, 2))
+            input_array = np.ones((0, 0, 0, 0))
+            expected = np.zeros((0, 0, 2))
 
-        check_symbolic_forward(index_array, [input_array], [expected])
-        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+            check_symbolic_forward(index_array, [input_array], [expected])
+            check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+    
+    test_index_array_default()
+    test_index_array_default_zero_dim()
+    test_index_array_default_zero_size()
+    test_index_array_select_axes()
+    test_index_array_select_axes_zero_size()
+
 
 @with_seed()
 def test_scalar_tensor_creation():

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8427,6 +8427,31 @@ def test_image_normalize():
     # check backward using finite difference
     check_numeric_gradient(img_norm_sym, [data_in_4d], atol=0.001)
 
+@with_seed()
+def test_index_array_default():
+    for shape in [(10,), (7, 5, 29), (5, 7, 11, 13, 17, 19)]:
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data)
+
+        mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
+        expected = np.stack(mgrid, axis=-1)
+        
+        check_symbolic_forward(index_array, [np.ones(shape)], [expected])
+        check_symbolic_backward(index_array, [np.ones(shape)], [np.ones(shape)], [np.zeros(shape)])
+
+@with_seed()
+def test_index_array_select_axes():
+    shape = (5, 7, 11, 13, 17, 19)
+    for axes in [(3,), (4, 1), (5, 1, 3), (-1,), (-5, -1, -3)]:
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data, axes=axes)
+
+        mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
+        expected = np.stack(mgrid, axis=-1)[..., axes]
+
+        check_symbolic_forward(index_array, [np.ones(shape)], [expected])
+        check_symbolic_backward(index_array, [np.ones(shape)], [np.ones(shape)], [np.zeros(shape)])
+
 
 @with_seed()
 def test_scalar_tensor_creation():

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8441,27 +8441,27 @@ def test_index_array():
             check_symbolic_forward(index_array, [input_array], [expected])
             check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
+    @mx.use_np_compat
     def test_index_array_default_zero_dim():
-        with mx.np_compat(active=True):
-            data  = mx.symbol.Variable("data")
-            index_array = mx.sym.contrib.index_array(data)
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data)
 
-            input_array = np.ones(())
-            expected = np.zeros((0,))
+        input_array = np.ones(())
+        expected = np.zeros((0,))
 
-            check_symbolic_forward(index_array, [input_array], [expected])
-            check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
+    @mx.use_np_compat
     def test_index_array_default_zero_size():
-        with mx.np_compat(active=True):
-            data  = mx.symbol.Variable("data")
-            index_array = mx.sym.contrib.index_array(data)
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data)
 
-            input_array = np.ones((0, 0, 0))
-            expected = np.zeros((0, 0, 0, 3))
+        input_array = np.ones((0, 0, 0))
+        expected = np.zeros((0, 0, 0, 3))
 
-            check_symbolic_forward(index_array, [input_array], [expected])
-            check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
     def test_index_array_select_axes():
         shape = (5, 7, 11, 13, 17, 19)
@@ -8476,16 +8476,16 @@ def test_index_array():
             check_symbolic_forward(index_array, [input_array], [expected])
             check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
+    @mx.use_np_compat
     def test_index_array_select_axes_zero_size():
-        with mx.np_compat(active=True):
-            data  = mx.symbol.Variable("data")
-            index_array = mx.sym.contrib.index_array(data, axes=(2, 1))
+        data  = mx.symbol.Variable("data")
+        index_array = mx.sym.contrib.index_array(data, axes=(2, 1))
 
-            input_array = np.ones((0, 0, 0, 0))
-            expected = np.zeros((0, 0, 2))
+        input_array = np.ones((0, 0, 0, 0))
+        expected = np.zeros((0, 0, 2))
 
-            check_symbolic_forward(index_array, [input_array], [expected])
-            check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
     
     test_index_array_default()
     test_index_array_default_zero_dim()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8433,11 +8433,12 @@ def test_index_array_default():
         data  = mx.symbol.Variable("data")
         index_array = mx.sym.contrib.index_array(data)
 
+        input_array = np.ones(shape)
         mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
         expected = np.stack(mgrid, axis=-1)
-        
-        check_symbolic_forward(index_array, [np.ones(shape)], [expected])
-        check_symbolic_backward(index_array, [np.ones(shape)], [np.ones(shape)], [np.zeros(shape)])
+
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
 @with_seed()
 def test_index_array_select_axes():
@@ -8446,12 +8447,12 @@ def test_index_array_select_axes():
         data  = mx.symbol.Variable("data")
         index_array = mx.sym.contrib.index_array(data, axes=axes)
 
+        input_array = np.ones(shape)
         mgrid = np.mgrid[tuple(slice(0, x) for x in shape)]
         expected = np.stack(mgrid, axis=-1)[..., axes]
 
-        check_symbolic_forward(index_array, [np.ones(shape)], [expected])
-        check_symbolic_backward(index_array, [np.ones(shape)], [np.ones(shape)], [np.zeros(shape)])
-
+        check_symbolic_forward(index_array, [input_array], [expected])
+        check_symbolic_backward(index_array, [input_array], [np.ones(expected.shape)], [np.zeros_like(input_array)])
 
 @with_seed()
 def test_scalar_tensor_creation():


### PR DESCRIPTION
## Description ##
This pull request implements `index_array`, an operator that returns an array of indexes of the input array.

For an input array with shape `(d_1, d_2, ..., d_n)`, `index_array` returns a `(d_1, d_2, ..., d_n, n)` array `idx`, where `idx[i_1, i_2, ..., i_n, :] = [i_1, i_2, ..., i_n]`.

Additionally, when the parameter `axes` is specified, `idx` will be a `(d_1, d_2, ..., d_n, m)` array where `m` is the length of `axes`, and the following
equality will hold: `idx[i_1, i_2, ..., i_n, j] = i_{axes[j]}`.

### Examples: ###
    x = mx.nd.ones((3, 2))

    mx.nd.contrib.index_array(x) = [[[0 0]
                                     [0 1]]

                                    [[1 0]
                                     [1 1]]

                                    [[2 0]
                                     [2 1]]]

    x = mx.nd.ones((3, 2, 2))

    mx.nd.contrib.index_array(x, axes=(1, 0)) = [[[[0 0]
                                                   [0 0]]

                                                  [[1 0]
                                                   [1 0]]]


                                                 [[[0 1]
                                                   [0 1]]

                                                  [[1 1]
                                                   [1 1]]]

### Motivation ###
This operator can be used to generate meshgrids for tensors without knowing their exact shapes during construction. For instance, this operator can be used to make a makeshift prior box generator for anchor-based computer vision models:

    feature_map = F.ones((8, 128, 128, 256)) # N x H x W x C, no shape information when using the Symbol API.
    prior_box_stride = 16
    box_size=[8, 8]

    template = F.squeeze(F.slice_axis(feature_map, begin=0, end=1, axis=-1), axis=-1) # N x H x W
    box_centres = F.contrib.index_array(template, axes=(-2, -1, -2, -1)).astype("float32") # N x H x W x 4
    box_centres = F.broadcast_mul(box_centres, F.array([prior_box_stride]).reshape((1, 1, 1, 1))) # N x H x W x 4
    corner_offsets = F.array(box_size).reshape((1, 1, 1, 2))
    corner_offsets = F.concat(-corner_offsets/2, corner_offsets/2, dim=-1)
    box_corners = F.broadcast_plus(box_centres, corner_offsets)

Also, this operator can be applied to implement positional encodings for sequence processing, e.g.:

    sequence_embeddings = F.ones((65, 8, 256)) # T x N x C, no shape information when using the Symbol API.
    template = sequence_embeddings.reshape((0, 0, -1, 2)) # T x N x C -> T x N x (C/2) x 2
    pos, i = F.split(
        F.contrib.index_array(template, axes=(0, 2)).astype("float32"), # T x N x (C/2) x 2 x 2
        axis=-1,
        num_outputs=2,
        squeeze_axis=True
    ) # T x N x (C/2) x 2 and T x N x (C/2) x 2
    base = F.ones((1, 1, 1, 1)) * 10000
    dmodel = F.slice_axis(F.shape_array(sequence_embeddings), begin=-1, end=None, axis=0)
    dmodel = dmodel.reshape((1, 1, 1, 1)).astype("float32")
    tmp = F.broadcast_div(pos, F.broadcast_power(base, F.broadcast_div(2 * i,  dmodel))) # T x N x (C/2) x 2
    sin_input, cos_input = F.split(tmp, axis=-1, num_outputs=2, squeeze_axis=True) # T x N x (C/2) and T x N x (C/2)
    positional_encoding = F.stack(F.sin(sin_input), F.cos(cos_input), axis=-1).reshape((0, 0, -3)) # T x N x C

I've also encountered situations where this operator would have been useful for some indexing tricks.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] The IndexArray operator (for the CPU)
- [x] The IndexArray operator (for the GPU)
- [x] Tests for the CPU implementation
- [x] Tests for the GPU implementation
- [x] Entries on the Python API reference pages

## Comments ##
- This operator always returns kInt64.
- The new tests in `test_operator_gpu.py` are exactly the same as in `test_operator.py`. I couldn't find any evidence that `test_operator.py` ever gets called with a GPU `default_context`, so I copied the tests into `test_operator_gpu.py` to make sure that the GPU implementation works too.