### PR TITLE
Speedup concat op

### DIFF
--- a/src/operator/nn/concat.cu
+++ b/src/operator/nn/concat.cu
@@ -25,9 +25,94 @@
 */
 
 #include "./concat-inl.h"
+#include "../tensor/matrix_op-inl.h"
 
 namespace mxnet {
 namespace op {
+
+template<typename DType>
+void ConcatForwardImpl(const OpContext &ctx,
+                       std::vector<mshadow::Tensor<gpu, 3, DType>>& data,
+                       mshadow::Tensor<gpu, 3, DType>& out) {
+  using namespace mshadow;
+  using namespace mxnet_op;
+  Stream<gpu> *s = ctx.get_stream<gpu>();
+  std::vector<size_t> sizes(data.size(), 0);
+  std::vector<size_t> indices(data.size() + 1, 0);
+  std::vector<DType*> data_ptrs(data.size(), nullptr);
+  size_t leading = out.shape_[0];
+  size_t out_mid_size = out.shape_[1];
+  size_t trailing = out.shape_[2];
+  size_t num_inputs = data.size();
+  size_t restsize = trailing * leading;
+  for (size_t i = 0; i < num_inputs; ++i) {
+    sizes[i] = data[i].shape_.Size() / restsize;
+    data_ptrs[i] = data[i].dptr_;
+  }
+  for (size_t i = 0; i < num_inputs; ++i) {
+    indices[i + 1] = indices[i] + sizes[i];
+  }
+
+  size_t workspace_size = num_inputs * sizeof(DType*) + (num_inputs + 1) * sizeof(size_t);
+  Tensor<gpu, 1, char> workspace =
+    ctx.requested[0].get_space_typed<gpu, 1, char>(Shape1(workspace_size), s);
+  DType **data_ptrs_gpu_ptr = reinterpret_cast<DType**>(workspace.dptr_);
+  size_t *indices_gpu_ptr = reinterpret_cast<size_t*>(workspace.dptr_ + num_inputs * sizeof(DType*));
+  Tensor<cpu, 1, DType*> data_ptrs_cpu(data_ptrs.data(), Shape1(num_inputs));
+  Tensor<gpu, 1, DType*> data_ptrs_gpu(data_ptrs_gpu_ptr, Shape1(num_inputs), s);
+  Tensor<cpu, 1, size_t> indices_cpu(indices.data(), Shape1(num_inputs + 1));
+  Tensor<gpu, 1, size_t> indices_gpu(indices_gpu_ptr, Shape1(num_inputs + 1), s);
+
+  // copy necessary data to GPU for kernel launch
+  Copy(data_ptrs_gpu, data_ptrs_cpu, s);
+  Copy(indices_gpu, indices_cpu, s);
+
+  Kernel<ConcatenateKernel, gpu>::Launch(
+    s, out.shape_.Size(), data_ptrs_gpu.dptr_, out.dptr_, indices_gpu.dptr_,
+    data.size(), out_mid_size, trailing);
+}
+
+template<typename DType>
+void ConcatBackwardImpl(const OpContext &ctx,
+                        std::vector<mshadow::Tensor<gpu, 3, DType>>& grad_in,
+                        mshadow::Tensor<gpu, 3, DType>& grad) {
+  using namespace mshadow;
+  using namespace mxnet_op;
+  Stream<gpu> *s = ctx.get_stream<gpu>();
+  std::vector<size_t> sizes(grad_in.size(), 0);
+  std::vector<size_t> indices(grad_in.size() + 1, 0);
+  std::vector<DType*> grad_in_ptrs(grad_in.size(), nullptr);
+  size_t leading = grad.shape_[0];
+  size_t grad_mid_size = grad.shape_[1];
+  size_t trailing = grad.shape_[2];
+  size_t num_inputs = grad_in.size();
+  size_t restsize = trailing * leading;
+  for (size_t i = 0; i < num_inputs; ++i) {
+    sizes[i] = grad_in[i].shape_.Size() / restsize;
+    grad_in_ptrs[i] = grad_in[i].dptr_;
+  }
+  for (size_t i = 0; i < num_inputs; ++i) {
+    indices[i + 1] = indices[i] + sizes[i];
+  }
+
+  size_t workspace_size = num_inputs * sizeof(DType*) + (num_inputs + 1) * sizeof(size_t);
+  Tensor<gpu, 1, char> workspace =
+    ctx.requested[0].get_space_typed<gpu, 1, char>(Shape1(workspace_size), s);
+  DType **grad_in_ptrs_gpu_ptr = reinterpret_cast<DType**>(workspace.dptr_);
+  size_t *indices_gpu_ptr = reinterpret_cast<size_t*>(workspace.dptr_ + num_inputs * sizeof(DType*));
+  Tensor<cpu, 1, DType*> grad_in_ptrs_cpu(grad_in_ptrs.data(), Shape1(num_inputs));
+  Tensor<gpu, 1, DType*> grad_in_ptrs_gpu(grad_in_ptrs_gpu_ptr, Shape1(num_inputs), s);
+  Tensor<cpu, 1, size_t> indices_cpu(indices.data(), Shape1(num_inputs + 1));
+  Tensor<gpu, 1, size_t> indices_gpu(indices_gpu_ptr, Shape1(num_inputs + 1), s);
+
+  // copy necessary data to GPU for kernel launch
+  Copy(grad_in_ptrs_gpu, grad_in_ptrs_cpu, s);
+  Copy(indices_gpu, indices_cpu, s);
+
+  Kernel<SplitKernel, gpu>::Launch(
+    s, grad.shape_.Size(), grad.dptr_, grad_in_ptrs_gpu.dptr_, indices_gpu.dptr_,
+    grad_in.size(), grad_mid_size, trailing);
+}
 
 static void ConcatComputeExGPU(const nnvm::NodeAttrs& attrs,
                                const OpContext& op_ctx,


### PR DESCRIPTION
## Description ##
As title.
Migration from using mshadow to new fused kernel.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] New fused kernel

## Comments ##
Previously concat was [based on mshadow](https://github.com/apache/incubator-mxnet/blob/master/src/operator/channel_op_common.h#L36-L55), which loops over all the input tensors and assign to a slice of the output tensor. The new kernel is a fused one to parallelize this part of the assignment.