### PR TITLE
[MXNET-1383] Java new use of ParamObject

### DIFF
--- a/scala-package/core/src/test/java/org/apache/mxnet/javaapi/NDArrayTest.java
+++ b/scala-package/core/src/test/java/org/apache/mxnet/javaapi/NDArrayTest.java
@@ -86,7 +86,7 @@ public class NDArrayTest {
         NDArray$ NDArray = NDArray$.MODULE$;
         float[] arr = new float[]{1.0f, 2.0f, 3.0f};
         NDArray nd = new NDArray(arr, new Shape(new int[]{3}), new Context("cpu", 0));
-        float result = NDArray.norm(NDArray.new normParam(nd))[0].toArray()[0];
+        float result = NDArray.norm(new normParam(nd))[0].toArray()[0];
         float cal = 0.0f;
         for (float ele : arr) {
             cal += ele * ele;
@@ -94,7 +94,7 @@ public class NDArrayTest {
         cal = (float) Math.sqrt(cal);
         assertTrue(Math.abs(result - cal) < 1e-5);
         NDArray dotResult = new NDArray(new float[]{0}, new Shape(new int[]{1}), new Context("cpu", 0));
-        NDArray.dot(NDArray.new dotParam(nd, nd).setOut(dotResult));
+        NDArray.dot(new dotParam(nd, nd).setOut(dotResult));
         assertTrue(Arrays.equals(dotResult.toArray(), new float[]{14.0f}));
     }
 }

--- a/scala-package/examples/src/main/java/org/apache/mxnetexamples/javaapi/infer/bert/BertQA.java
+++ b/scala-package/examples/src/main/java/org/apache/mxnetexamples/javaapi/infer/bert/BertQA.java
@@ -68,15 +68,15 @@ public class BertQA {
      */
     static List<String> postProcessing(NDArray result, List<String> tokens) {
         NDArray[] output = NDArray.split(
-                NDArray.new splitParam(result, 2).setAxis(2));
+                new splitParam(result, 2).setAxis(2));
         // Get the formatted logits result
         NDArray startLogits = output[0].reshape(new int[]{0, -3});
         NDArray endLogits = output[1].reshape(new int[]{0, -3});
         // Get Probability distribution
         float[] startProb = NDArray.softmax(
-                NDArray.new softmaxParam(startLogits))[0].toArray();
+                new softmaxParam(startLogits))[0].toArray();
         float[] endProb = NDArray.softmax(
-                NDArray.new softmaxParam(endLogits))[0].toArray();
+                new softmaxParam(endLogits))[0].toArray();
         int startIdx = argmax(startProb);
         int endIdx = argmax(endProb);
         return tokens.subList(startIdx, endIdx + 1);

--- a/scala-package/mxnet-demo/java-demo/src/main/java/mxnet/NDArrayCreation.java
+++ b/scala-package/mxnet-demo/java-demo/src/main/java/mxnet/NDArrayCreation.java
@@ -37,7 +37,7 @@ public class NDArrayCreation {
 
         // random
         NDArray random = NDArray.random_uniform(
-                NDArray.new random_uniformParam()
+                new random_uniformParam()
                         .setLow(0.0f)
                         .setHigh(2.0f)
                         .setShape(new Shape(new int[]{10, 10}))

--- a/scala-package/mxnet-demo/java-demo/src/main/java/mxnet/NDArrayOperation.java
+++ b/scala-package/mxnet-demo/java-demo/src/main/java/mxnet/NDArrayOperation.java
@@ -38,7 +38,7 @@ public class NDArrayOperation {
         System.out.println(eleAdd);
 
         // norm (L2 Norm)
-        NDArray normed = NDArray.norm(NDArray.new normParam(nd))[0];
+        NDArray normed = NDArray.norm(new normParam(nd))[0];
         System.out.println(normed);
     }
 }


### PR DESCRIPTION
## Description ##
Previously paramObj are created in a weird way. This is a fix to that:
`NDArray.new paramObj` -> `new paramObj`

The trick is to put these param classes outside of NDArray Base and it made it accessible to the public directly under `org.apache.mxnet.javaapi`

@andrewfayres @zachgk @yzhliu @nswamy 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
