### PR TITLE
[MXNET-1287] Up scala comp

### DIFF
--- a/scala-package/assembly/src/main/assembly/assembly.xml
+++ b/scala-package/assembly/src/main/assembly/assembly.xml
@@ -33,7 +33,7 @@
         <exclude>org.slf4j:slf4j-api</exclude>
         <exclude>args4j:args4j</exclude>
       </excludes>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>.</outputDirectory>
       <useProjectArtifact>true</useProjectArtifact>
       <unpack>true</unpack>
       <scope>runtime</scope>
@@ -71,7 +71,7 @@
         <include>cub/LICENSE.TXT</include>
         <include>mkldnn/external/mklml_mac_2019.0.1.20180928/license.txt</include>
       </includes>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>.</outputDirectory>
     </fileSet>
   </fileSets>
 </assembly>

--- a/scala-package/assembly/src/main/assembly/assembly.xml
+++ b/scala-package/assembly/src/main/assembly/assembly.xml
@@ -34,7 +34,7 @@
         <exclude>args4j:args4j</exclude>
       </excludes>
       <outputDirectory>.</outputDirectory>
-      <useProjectArtifact>true</useProjectArtifact>
+      <useProjectArtifact>false</useProjectArtifact>
       <unpack>true</unpack>
       <scope>runtime</scope>
     </dependencySet>

--- a/scala-package/assembly/src/main/assembly/javadoc.xml
+++ b/scala-package/assembly/src/main/assembly/javadoc.xml
@@ -25,7 +25,7 @@
   <fileSets>
     <fileSet>
       <directory>${rootdir}/core/target/site/scaladocs</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>.</outputDirectory>
     </fileSet>
   </fileSets>
 </assembly>

--- a/scala-package/assembly/src/main/assembly/source.xml
+++ b/scala-package/assembly/src/main/assembly/source.xml
@@ -29,7 +29,7 @@
       <includes>
         <include>**\/*.scala</include>
       </includes>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory>.</outputDirectory>
     </fileSet>
   </fileSets>
 </assembly>

--- a/scala-package/core/pom.xml
+++ b/scala-package/core/pom.xml
@@ -102,10 +102,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-clean-plugin</artifactId>
         <version>3.1.0</version>
         <configuration>
@@ -141,6 +137,7 @@
       </plugin>
     </plugins>
   </build>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.mxnet</groupId>

--- a/scala-package/deploy/src/main/deploy/deploy.xml
+++ b/scala-package/deploy/src/main/deploy/deploy.xml
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.scala-lang.modules</groupId>
       <artifactId>scala-parser-combinators_2.11</artifactId>
-      <version>1.0.4</version>
+      <version>1.0.5</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/scala-package/examples/pom.xml
+++ b/scala-package/examples/pom.xml
@@ -83,10 +83,6 @@
         <artifactId>maven-jar-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
       </plugin>

--- a/scala-package/infer/pom.xml
+++ b/scala-package/infer/pom.xml
@@ -47,10 +47,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
         <configuration>

--- a/scala-package/macros/pom.xml
+++ b/scala-package/macros/pom.xml
@@ -52,10 +52,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>org.scalatest</groupId>
         <artifactId>scalatest-maven-plugin</artifactId>
         <configuration>

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -421,7 +421,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_2.11</artifactId>
-      <version>3.0.4</version>
+      <version>3.0.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -456,7 +456,12 @@
     <dependency>
       <groupId>org.scala-lang.modules</groupId>
       <artifactId>scala-parser-combinators_2.11</artifactId>
-      <version>1.0.4</version>
+      <version>1.0.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-xml_2.11</artifactId>
+      <version>1.0.6</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -348,7 +348,6 @@
         <artifactId>scala-maven-plugin</artifactId>
         <version>3.4.4</version>
         <configuration>
-          <recompileMode>incremental</recompileMode>
           <source>${java.version}</source>
           <target>${java.version}</target>
           <compilerPlugins>

--- a/scala-package/pom.xml
+++ b/scala-package/pom.xml
@@ -53,8 +53,11 @@
   </scm>
 
   <properties>
+    <java.version>1.7</java.version>
     <scala.version>2.11.8</scala.version>
     <build.platform/>
+    <scala.binary.version>2.11</scala.binary.version>
+    <build.platform />
     <cxx>g++</cxx>
     <dollar>$</dollar>
     <MXNET_DIR>${project.basedir}/..</MXNET_DIR>
@@ -252,9 +255,11 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
           <encoding>UTF-8</encoding>
+          <skipMain>true</skipMain>
+          <skip>true</skip>
         </configuration>
       </plugin>
       <plugin>
@@ -339,11 +344,13 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.scala-tools</groupId>
-        <artifactId>maven-scala-plugin</artifactId>
-        <version>2.15.2</version>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.4.4</version>
         <configuration>
           <recompileMode>incremental</recompileMode>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
           <compilerPlugins>
             <compilerPlugin>
               <groupId>org.scalamacros</groupId>
@@ -354,25 +361,19 @@
         </configuration>
         <executions>
           <execution>
+            <id>compile</id>
             <goals>
+              <goal>add-source</goal>
               <goal>compile</goal>
               <goal>testCompile</goal>
+              <goal>doc-jar</goal>
             </goals>
           </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>net.alchim31.maven</groupId>
-        <artifactId>scala-maven-plugin</artifactId>
-        <version>3.3.2</version>
-        <configuration>
-        </configuration>
-        <executions>
           <execution>
-            <phase>package</phase>
-            <id>attach-javadocs</id>
+            <id>presite</id>
+            <phase>pre-site</phase>
             <goals>
-              <goal>doc-jar</goal>
+              <goal>add-source</goal>
             </goals>
           </execution>
         </executions>
@@ -388,6 +389,7 @@
       </plugin>
     </plugins>
   </build>
+
   <dependencies>
     <dependency>
       <groupId>commons-codec</groupId>

--- a/scala-package/spark/pom.xml
+++ b/scala-package/spark/pom.xml
@@ -50,5 +50,10 @@
       <artifactId>args4j</artifactId>
       <version>2.33</version>
     </dependency>
+    <dependency>
+        <groupId>org.json4s</groupId>
+        <artifactId>json4s-core_2.11</artifactId>
+        <version>3.5.1</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
## Description ##
This PR contains a number of improvements to the Maven configuration. Most notably, it switches to a set of dependencies all using Scala version 2.11.8 and upgrading the Scala compiler plugin from the deprecated scala-maven-plugin to the current maven-scala-plugin. Contains a part of #13995.

@lanking520 @andrewfayres 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change