### PR TITLE
[BUGFIX] fix ELU function will appear nan when calculating the gradient

### DIFF
--- a/python/mxnet/gluon/nn/activations.py
+++ b/python/mxnet/gluon/nn/activations.py
@@ -158,7 +158,7 @@ class ELU(HybridBlock):
         self._alpha = alpha
 
     def hybrid_forward(self, F, x):
-         F.LeakyReLU(x, act_type='elu', slope=self._alpha)
+         return F.LeakyReLU(x, act_type='elu', slope=self._alpha)
 
 
 class SELU(HybridBlock):

--- a/python/mxnet/gluon/nn/activations.py
+++ b/python/mxnet/gluon/nn/activations.py
@@ -158,8 +158,7 @@ class ELU(HybridBlock):
         self._alpha = alpha
 
     def hybrid_forward(self, F, x):
-        _x = F.where(x < 0, x, F.zeros_like(x))
-        return F.where(x > 0, x, self._alpha * (F.exp(_x) - 1.0))
+         F.LeakyReLU(x, act_type='elu', slope=self._alpha)
 
 
 class SELU(HybridBlock):

--- a/python/mxnet/gluon/nn/activations.py
+++ b/python/mxnet/gluon/nn/activations.py
@@ -158,7 +158,7 @@ class ELU(HybridBlock):
         self._alpha = alpha
 
     def hybrid_forward(self, F, x):
-         return F.LeakyReLU(x, act_type='elu', slope=self._alpha)
+        return F.LeakyReLU(x, act_type='elu', slope=self._alpha)
 
 
 class SELU(HybridBlock):

--- a/python/mxnet/gluon/nn/activations.py
+++ b/python/mxnet/gluon/nn/activations.py
@@ -158,7 +158,8 @@ class ELU(HybridBlock):
         self._alpha = alpha
 
     def hybrid_forward(self, F, x):
-        return F.where(x > 0, x, self._alpha * (F.exp(x) - 1.0))
+        _x = F.where(x < 0, x, F.zeros_like(x))
+        return F.where(x > 0, x, self._alpha * (F.exp(_x) - 1.0))
 
 
 class SELU(HybridBlock):

--- a/python/mxnet/gluon/nn/activations.py
+++ b/python/mxnet/gluon/nn/activations.py
@@ -153,6 +153,7 @@ class ELU(HybridBlock):
     Outputs:
         - **out**: output tensor with the same shape as `data`.
     """
+
     def __init__(self, alpha=1.0, **kwargs):
         super(ELU, self).__init__(**kwargs)
         self._alpha = alpha

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1180,7 +1180,7 @@ def test_activations():
     elu = mx.gluon.nn.ELU()
     def elu_test(x):
         def elu(x):
-            return 1.0 * (mx.nd.exp(x) - 1) if x < 0 else x
+            return mx.nd.expm1(x) if x <= 0.0 else x
         return [elu(x_i) for x_i in x]
 
     for test_point, ref_point in zip(elu_test(point_to_validate), elu(point_to_validate)):


### PR DESCRIPTION
## Description ##
fix ELU function will appear `nan` when calculating the gradient

e.g:
```python
elu = nn.ELU()
elu.initialize()
x = nd.ones((2, 3))
x.attach_grad()
x[0] = 100
x[1] = -1
with autograd.record():
    y = elu(x)

y.backward()
print(y)
print(x.grad)
```
output is 
```
[[100.         100.         100.        ]
 [ -0.63212055  -0.63212055  -0.63212055]]
<NDArray 2x3 @cpu(0)>

[[       nan        nan        nan]
 [0.36787945 0.36787945 0.36787945]]
<NDArray 2x3 @cpu(0)>
```
After experiments, it was found that the `where` and the `exp` were used together and that this bug would occur

e.g:

```python
x = nd.ones((2, 3))
x.attach_grad()
x[0] = 100
x[1] = 5

with autograd.record():
    y = nd.where(x > 0, x, nd.exp(x))
y.backward()
print(y)
print(x.grad)
```
output:
```
[[100. 100. 100.]
 [  5.   5.   5.]]
<NDArray 2x3 @cpu(0)>

[[nan nan nan]
 [ 1.  1.  1.]]
<NDArray 2x3 @cpu(0)>
```
When the `exp` calculation appears `inf`, even if `where` does not select the value, but the gradient will still be `nan`,so this PR does not completely fix the problem, but based on this, modified the ELU calculation method so that it does not appear `nan`