### PR TITLE
fix a bug in inception_inference.cpp

### DIFF
--- a/cpp-package/example/inference/inception_inference.cpp
+++ b/cpp-package/example/inference/inception_inference.cpp
@@ -301,7 +301,7 @@ void Predictor::PredictImage(const std::string& image_file) {
   executor->Forward(false);
 
   // The output is available in executor->outputs.
-  auto array = executor->outputs[0].Copy(global_ctx);
+  auto array = executor->outputs[0].Copy(Context::cpu());
 
   /*
    * Find out the maximum accuracy and the index associated with that accuracy.


### PR DESCRIPTION
## Description ##
Fix a bug when use --gpu.
When i type: 
`./inception_inference --symbol "./model/Inception-BN-symbol.json" --params "./model/Inception-BN-0126.params" --synset "./model/synset.txt" --image "./model/dog.jpg" --gpu`
there will be segmentation fault. Maybe because the data should be transfer from gpu to cpu. So i change the code from
`auto array = executor->outputs[0].Copy(global_ctx);`
to
`auto array = executor->outputs[0].Copy(Context::cpu());`
And the bug of Segmentation Fault fixed. 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
