### PR TITLE
Disables flaky test test_gluon_rnn.test_layer_bidirectional

### DIFF
--- a/tests/python/unittest/test_gluon_rnn.py
+++ b/tests/python/unittest/test_gluon_rnn.py
@@ -244,6 +244,7 @@ def test_bidirectional():
 
 
 @assert_raises_cudnn_not_satisfied(min_version='5.1.10')
+@unittest.skip('https://github.com/apache/incubator-mxnet/issues/13103')
 def test_layer_bidirectional():
     class RefBiLSTM(gluon.Block):
         def __init__(self, size, **kwargs):


### PR DESCRIPTION
## Description ##

Disables flaky test `test_gluon_rnn.test_layer_bidirectional`. See #13103 for more details.