### PR TITLE
[DON'T MERGE]PoC for Conversion from FP32 to mixed precision model

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -95,10 +95,22 @@ typedef void *CudaKernelHandle;
 typedef void *ProfileHandle;
 /*! \brief handle to DLManagedTensor*/
 typedef void *DLManagedTensorHandle;
+/*! \brief handle to Context */
+typedef const void *ContextHandle;
+/*! \brief handle to Engine FnProperty */
+typedef const void *EngineFnPropertyHandle;
+/*! \brief handle to Engine VarHandle */
+typedef void *EngineVarHandle;
 
+/*! \brief Engine asynchronous operation */
+typedef void (*EngineAsyncFunc)(void*, void*, void*);
+/*! \brief Engine synchronous operation */
+typedef void (*EngineSyncFunc)(void*, void*);
+/*! \brief Callback to free the param for EngineAsyncFunc/EngineSyncFunc */
+typedef void (*EngineFuncParamDeleter)(void*);
 typedef void (*ExecutorMonitorCallback)(const char*,
                                         NDArrayHandle,
-                                        void *);
+                                        void*);
 
 struct NativeOpInfo {
   void (*forward)(int, float**, int*, unsigned**, int*, void*);
@@ -2550,6 +2562,51 @@ MXNET_DLL int MXNDArrayGetSharedMemHandle(NDArrayHandle handle, int* shared_pid,
 MXNET_DLL int MXNDArrayCreateFromSharedMem(int shared_pid, int shared_id, const mx_uint *shape,
                                            mx_uint ndim, int dtype, NDArrayHandle *out);
 
+/*!
+  * \brief Push an asynchronous operation to the engine.
+  * \param async_func Execution function whici takes a parameter on_complete
+  *                   that must be called when the execution ompletes.
+  * \param func_param The parameter set on calling async_func, can be NULL.
+  * \param deleter The callback to free func_param, can be NULL.
+  * \param ctx_handle Execution context.
+  * \param const_vars_handle The variables that current operation will use
+  *                          but not mutate.
+  * \param num_const_vars The number of const_vars.
+  * \param mutable_vars_handle The variables that current operation will mutate.
+  * \param num_mutable_vars The number of mutable_vars.
+  * \param prop_handle Property of the function.
+  * \param priority Priority of the action, as hint to the engine.
+  * \param opr_name The operation name.
+  * \param wait Whether this is a WaitForVar operation.
+  */
+MXNET_DLL int MXEnginePushAsync(EngineAsyncFunc async_func, void* func_param,
+                                EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
+                                EngineVarHandle const_vars_handle, int num_const_vars,
+                                EngineVarHandle mutable_vars_handle, int num_mutable_vars,
+                                EngineFnPropertyHandle prop_handle = NULL, int priority = 0,
+                                const char* opr_name = NULL, bool wait = false);
+
+/*!
+  * \brief Push a synchronous operation to the engine.
+  * \param sync_func Execution function that executes the operation.
+  * \param func_param The parameter set on calling sync_func, can be NULL.
+  * \param deleter The callback to free func_param, can be NULL.
+  * \param ctx_handle Execution context.
+  * \param const_vars_handle The variables that current operation will use
+  *                          but not mutate.
+  * \param num_const_vars The number of const_vars.
+  * \param mutable_vars_handle The variables that current operation will mutate.
+  * \param num_mutable_vars The number of mutable_vars.
+  * \param prop_handle Property of the function.
+  * \param priority Priority of the action, as hint to the engine.
+  * \param opr_name The operation name.
+  */
+MXNET_DLL int MXEnginePushSync(EngineSyncFunc sync_func, void* func_param,
+                               EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
+                               EngineVarHandle const_vars_handle, int num_const_vars,
+                               EngineVarHandle mutable_vars_handle, int num_mutable_vars,
+                               EngineFnPropertyHandle prop_handle = NULL, int priority = 0,
+                               const char* opr_name = NULL);
 
 #ifdef __cplusplus
 }

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1627,25 +1627,27 @@ MXNET_DLL int MXQuantizeSymbol(SymbolHandle sym_handle, SymbolHandle *ret_sym_ha
  * \brief Convert a symbol into a mixed precision symbol with cast operators for target dtype casting
  * \param sym_handle symbol to be converted
  * \param ret_sym_handle mixed precision symbol result
+ * \param target_dtype target_dtype for the mixed precision model
  * \param num_target_dtype_op_names number of ops to be casted to target_dtype
- * \param target_dtype_op_names op names to be casted to target_dtype
  * \param num_fp32_op_names number of ops to be casted to FP32
- * \param fp32_op_names op names to be casted to FP32
  * \param num_widest_dtype_op_names number of ops to be casted to widest dtype
- * \param widest_dtype_op_names names to be casted to widest dtype
  * \param num_conditional_fp32_op_names number of ops to be cast to fp32 based on condition
+ * \param target_dtype_op_names op names to be casted to target_dtype
+ * \param fp32_op_names op names to be casted to FP32
+ * \param widest_dtype_op_names names to be casted to widest dtype
+ * \param conditional_fp32_op_names names to be casted to FP32 conditionally
  */
 MXNET_DLL int MXReducePrecisionSymbol(SymbolHandle sym_handle,
                                       SymbolHandle *ret_sym_handle,
+                                      const int* target_dtype,
                                       const mx_uint num_target_dtype_op_names,
-                                      const char **target_dtype_op_names,
                                       const mx_uint num_fp32_op_names,
-                                      const char **fp32_op_names,
                                       const mx_uint num_widest_dtype_op_names,
-                                      const char **widest_dtype_op_names,
                                       const mx_uint num_conditional_fp32_op_names,
-                                      const char **conditional_fp32_op_names,
-                                      const char *target_dtype);
+                                      const char **target_dtype_op_names,
+                                      const char **fp32_op_names,
+                                      const char **widest_dtype_op_names,
+                                      const char **conditional_fp32_op_names);
 
 /*!
  * \brief Set calibration table to node attributes in the sym

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -95,22 +95,10 @@ typedef void *CudaKernelHandle;
 typedef void *ProfileHandle;
 /*! \brief handle to DLManagedTensor*/
 typedef void *DLManagedTensorHandle;
-/*! \brief handle to Context */
-typedef const void *ContextHandle;
-/*! \brief handle to Engine FnProperty */
-typedef const void *EngineFnPropertyHandle;
-/*! \brief handle to Engine VarHandle */
-typedef void *EngineVarHandle;
 
-/*! \brief Engine asynchronous operation */
-typedef void (*EngineAsyncFunc)(void*, void*, void*);
-/*! \brief Engine synchronous operation */
-typedef void (*EngineSyncFunc)(void*, void*);
-/*! \brief Callback to free the param for EngineAsyncFunc/EngineSyncFunc */
-typedef void (*EngineFuncParamDeleter)(void*);
 typedef void (*ExecutorMonitorCallback)(const char*,
                                         NDArrayHandle,
-                                        void*);
+                                        void *);
 
 struct NativeOpInfo {
   void (*forward)(int, float**, int*, unsigned**, int*, void*);
@@ -1623,6 +1611,15 @@ MXNET_DLL int MXQuantizeSymbol(SymbolHandle sym_handle, SymbolHandle *ret_sym_ha
                                const mx_uint num_offline, const char **offline_params,
                                const char *quantized_dtype, const bool calib_quantize);
 
+MXNET_DLL int MXReducePrecisionSymbol(SymbolHandle sym_handle,
+                                      SymbolHandle *ret_sym_handle,
+                                      const mx_uint num_fp16,
+                                      const char **fp16_op_names,
+                                      const mx_uint num_fp32,
+                                      const char **fp32_op_names,
+                                      const mx_uint num_widest,
+                                      const char **widest_type_op_names);
+
 /*!
  * \brief Set calibration table to node attributes in the sym
  * \param sym_handle symbol whose node attributes are to be set by calibration table
@@ -2553,51 +2550,6 @@ MXNET_DLL int MXNDArrayGetSharedMemHandle(NDArrayHandle handle, int* shared_pid,
 MXNET_DLL int MXNDArrayCreateFromSharedMem(int shared_pid, int shared_id, const mx_uint *shape,
                                            mx_uint ndim, int dtype, NDArrayHandle *out);
 
-/*!
-  * \brief Push an asynchronous operation to the engine.
-  * \param async_func Execution function whici takes a parameter on_complete
-  *                   that must be called when the execution ompletes.
-  * \param func_param The parameter set on calling async_func, can be NULL.
-  * \param deleter The callback to free func_param, can be NULL.
-  * \param ctx_handle Execution context.
-  * \param const_vars_handle The variables that current operation will use
-  *                          but not mutate.
-  * \param num_const_vars The number of const_vars.
-  * \param mutable_vars_handle The variables that current operation will mutate.
-  * \param num_mutable_vars The number of mutable_vars.
-  * \param prop_handle Property of the function.
-  * \param priority Priority of the action, as hint to the engine.
-  * \param opr_name The operation name.
-  * \param wait Whether this is a WaitForVar operation.
-  */
-MXNET_DLL int MXEnginePushAsync(EngineAsyncFunc async_func, void* func_param,
-                                EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
-                                EngineVarHandle const_vars_handle, int num_const_vars,
-                                EngineVarHandle mutable_vars_handle, int num_mutable_vars,
-                                EngineFnPropertyHandle prop_handle = NULL, int priority = 0,
-                                const char* opr_name = NULL, bool wait = false);
-
-/*!
-  * \brief Push a synchronous operation to the engine.
-  * \param sync_func Execution function that executes the operation.
-  * \param func_param The parameter set on calling sync_func, can be NULL.
-  * \param deleter The callback to free func_param, can be NULL.
-  * \param ctx_handle Execution context.
-  * \param const_vars_handle The variables that current operation will use
-  *                          but not mutate.
-  * \param num_const_vars The number of const_vars.
-  * \param mutable_vars_handle The variables that current operation will mutate.
-  * \param num_mutable_vars The number of mutable_vars.
-  * \param prop_handle Property of the function.
-  * \param priority Priority of the action, as hint to the engine.
-  * \param opr_name The operation name.
-  */
-MXNET_DLL int MXEnginePushSync(EngineSyncFunc sync_func, void* func_param,
-                               EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
-                               EngineVarHandle const_vars_handle, int num_const_vars,
-                               EngineVarHandle mutable_vars_handle, int num_mutable_vars,
-                               EngineFnPropertyHandle prop_handle = NULL, int priority = 0,
-                               const char* opr_name = NULL);
 
 #ifdef __cplusplus
 }

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1644,10 +1644,12 @@ MXNET_DLL int MXReducePrecisionSymbol(SymbolHandle sym_handle,
                                       const mx_uint num_fp32_op_names,
                                       const mx_uint num_widest_dtype_op_names,
                                       const mx_uint num_conditional_fp32_op_names,
+                                      const mx_uint num_excluded_symbols,
                                       const char **target_dtype_op_names,
                                       const char **fp32_op_names,
                                       const char **widest_dtype_op_names,
-                                      const char **conditional_fp32_op_names);
+                                      const char **conditional_fp32_op_names,
+                                      const char **excluded_symbols);
 
 /*!
  * \brief Set calibration table to node attributes in the sym

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1623,14 +1623,29 @@ MXNET_DLL int MXQuantizeSymbol(SymbolHandle sym_handle, SymbolHandle *ret_sym_ha
                                const mx_uint num_offline, const char **offline_params,
                                const char *quantized_dtype, const bool calib_quantize);
 
+/*!
+ * \brief Convert a symbol into a mixed precision symbol with cast operators for target dtype casting
+ * \param sym_handle symbol to be converted
+ * \param ret_sym_handle mixed precision symbol result
+ * \param num_target_dtype_op_names number of ops to be casted to target_dtype
+ * \param target_dtype_op_names op names to be casted to target_dtype
+ * \param num_fp32_op_names number of ops to be casted to FP32
+ * \param fp32_op_names op names to be casted to FP32
+ * \param num_widest_dtype_op_names number of ops to be casted to widest dtype
+ * \param widest_dtype_op_names names to be casted to widest dtype
+ * \param num_conditional_fp32_op_names number of ops to be cast to fp32 based on condition
+ */
 MXNET_DLL int MXReducePrecisionSymbol(SymbolHandle sym_handle,
                                       SymbolHandle *ret_sym_handle,
-                                      const mx_uint num_fp16,
-                                      const char **fp16_op_names,
-                                      const mx_uint num_fp32,
+                                      const mx_uint num_target_dtype_op_names,
+                                      const char **target_dtype_op_names,
+                                      const mx_uint num_fp32_op_names,
                                       const char **fp32_op_names,
-                                      const mx_uint num_widest,
-                                      const char **widest_type_op_names);
+                                      const mx_uint num_widest_dtype_op_names,
+                                      const char **widest_dtype_op_names,
+                                      const mx_uint num_conditional_fp32_op_names,
+                                      const char **conditional_fp32_op_names,
+                                      const char *target_dtype);
 
 /*!
  * \brief Set calibration table to node attributes in the sym

--- a/python/mxnet/contrib/__init__.py
+++ b/python/mxnet/contrib/__init__.py
@@ -33,3 +33,4 @@ from . import io
 from . import quantization
 from . import quantization as quant
 from . import tensorrt
+from . import amp

--- a/python/mxnet/contrib/amp.py
+++ b/python/mxnet/contrib/amp.py
@@ -32,8 +32,8 @@ from ..context import cpu, Context
 from ..module import Module
 
 
-def _convert_symbol(sym, target_dtype="float16", target_precision_ops=None,
-                    fp32_ops=None, widest_precision_ops=None, conditional_fp32_ops=None,
+def _convert_symbol(sym, target_dtype="float16", target_dtype_ops=None,
+                    fp32_ops=None, widest_dtype_ops=None, conditional_fp32_ops=None,
                     excluded_sym_names=None):
     """Given a symbol object representing a neural network of data type FP32 and target_dtype,
     add cast layers according to the op lists (target_precision_ops, fp32_ops,
@@ -70,33 +70,34 @@ def _convert_symbol(sym, target_dtype="float16", target_precision_ops=None,
     if target_dtype != "float16":
         raise ValueError("Only target_dtype float16 is supported currently")
     num_target_dtype_ops = 0
-    num_original_dtype_ops = 0
+    num_fp32_ops = 0
     num_widest_dtype_ops = 0
-    num_condition_dtype_ops = 0
+    num_conditional_fp32_ops = 0
 
-    if target_precision_ops is not None:
-        assert isinstance(target_precision_ops, list)
-        num_target_dtype_ops = len(target_dtype_op_names)
+    if target_dtype_ops is not None:
+        assert isinstance(target_dtype_ops, list)
+        num_target_dtype_ops = len(target_dtype_ops)
     else:
         target_dtype_ops = []
 
-    if original_precision_ops is not None:
-        assert isinstance(original_precision_ops, list)
-        num_original_dtype_ops = len(num_original_dtype_op_names)
+    if fp32_ops is not None:
+        assert isinstance(fp32_ops, list)
+        num_fp32_ops = len(fp32_ops)
     else:
-        original_dtype_ops = []
+        fp32_ops = []
 
-    if widest_precision_ops is not None:
-        assert isinstance(widest_precision_ops, list)
-        num_widest_dtype_ops = len(widest_precision_ops)
+    if widest_dtype_ops is not None:
+        assert isinstance(widest_dtype_ops, list)
+        num_widest_dtype_ops = len(widest_dtype_ops)
     else:
         widest_dtype_ops = []
 
-    if conditional_input_precision_ops is not None:
-        assert isinstance(conditional_input_precision_ops, list)
-        num_cond_original_dtype_ops = len(conditional_input_precision_ops)
+    if conditional_fp32_ops is not None:
+        assert isinstance(conditional_fp32_ops, list)
+        num_conditional_fp32_ops = len(conditional_fp32_ops)
     else:
-        conditional_input_dtype_ops = []
+        conditional_fp32_ops = []
+    print num_conditional_fp32_ops
 
 
     out = SymbolHandle()
@@ -104,10 +105,13 @@ def _convert_symbol(sym, target_dtype="float16", target_precision_ops=None,
                                             ctypes.byref(out),
                                             mx_uint(num_target_dtype_ops),
                                             c_str_array(target_dtype_ops),
-                                            mx_uint(num_original_dtype_ops),
-                                            c_str_array(original_dtype_ops),
+                                            mx_uint(num_fp32_ops),
+                                            c_str_array(fp32_ops),
                                             mx_uint(num_widest_dtype_ops),
-                                            c_str_array(widest_dtype_ops)))
+                                            c_str_array(widest_dtype_ops)),
+                                            mx_uint(len(num_conditional_fp32_ops)),
+                                            c_str_array(conditional_fp32_ops),
+                                            c_str(target_dtype))
     return Symbol(out)
 
 

--- a/python/mxnet/contrib/amp.py
+++ b/python/mxnet/contrib/amp.py
@@ -1,0 +1,167 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import ctypes
+import logging
+import os
+import numpy as np
+from ..base import _LIB, check_call, py_str
+from ..base import c_array, c_str, mx_uint, c_str_array
+from ..base import NDArrayHandle, SymbolHandle
+from ..symbol import Symbol
+from ..symbol import load as sym_load
+from .. import ndarray
+from ..ndarray import load as nd_load
+from ..ndarray import NDArray
+from ..io import DataIter
+from ..context import cpu, Context
+from ..module import Module
+
+
+def _convert_symbol(sym, target_dtype="float16", target_precision_ops=None,
+                    fp32_ops=None, widest_precision_ops=None, conditional_fp32_ops=None,
+                    excluded_sym_names=None):
+    """Given a symbol object representing a neural network of data type FP32 and target_dtype,
+    add cast layers according to the op lists (target_precision_ops, fp32_ops,
+    widest_precision_ops, conditional_fp32_ops) if provided, otherwise use the default
+    lists provided by the framework.
+
+    Parameters
+    ----------
+    sym : Symbol
+        FP32 neural network symbol
+    target_dtype : str
+        currently only supports float16. The target dtype indicates to add cast layers
+        when possible so that lower precision computation can be leveraged.
+    target_precision_ops : list of strs
+        Override the list of operator names casted to target_dtype.
+        If None, uses the framework's default list to be casted to target dtype.
+    fp32_ops : list of strs
+        Override the lists of operator names casted to FP32.
+        If None, uses the framework's default list to be casted to FP32.
+    widest_precision_ops : list of strs
+        Override the list of operator names which should run in widest precision among its
+        input arguments.
+        If None, uses the framework's default list of widest_precision_ops.
+    conditional_fp32_ops : list of (string, string, list of string)
+        Override the list of functions casted to FP32.
+        The format of the list is
+        (name of the function, name of the parameter,
+         list of values of the parameter that make the operator to be casted to
+        fp32)
+    excluded_sym_names : list of strs
+        A list of strings that represent the names of symbols that users want to exclude
+        from being quantized.
+    """
+    if target_dtype != "float16":
+        raise ValueError("Only target_dtype float16 is supported currently")
+    num_target_dtype_ops = 0
+    num_original_dtype_ops = 0
+    num_widest_dtype_ops = 0
+    num_condition_dtype_ops = 0
+
+    if target_precision_ops is not None:
+        assert isinstance(target_precision_ops, list)
+        num_target_dtype_ops = len(target_dtype_op_names)
+    else:
+        target_dtype_ops = []
+
+    if original_precision_ops is not None:
+        assert isinstance(original_precision_ops, list)
+        num_original_dtype_ops = len(num_original_dtype_op_names)
+    else:
+        original_dtype_ops = []
+
+    if widest_precision_ops is not None:
+        assert isinstance(widest_precision_ops, list)
+        num_widest_dtype_ops = len(widest_precision_ops)
+    else:
+        widest_dtype_ops = []
+
+    if conditional_input_precision_ops is not None:
+        assert isinstance(conditional_input_precision_ops, list)
+        num_cond_original_dtype_ops = len(conditional_input_precision_ops)
+    else:
+        conditional_input_dtype_ops = []
+
+
+    out = SymbolHandle()
+    check_call(_LIB.MXReducePrecisionSymbol(sym.handle,
+                                            ctypes.byref(out),
+                                            mx_uint(num_target_dtype_ops),
+                                            c_str_array(target_dtype_ops),
+                                            mx_uint(num_original_dtype_ops),
+                                            c_str_array(original_dtype_ops),
+                                            mx_uint(num_widest_dtype_ops),
+                                            c_str_array(widest_dtype_ops)))
+    return Symbol(out)
+
+
+def convert_model(sym, arg_params, aux_params, target_dtype="float16", target_precision_ops=None,
+                  fp32_ops=None, widest_precision_ops=None,
+                  conditional_fp32_ops=None, excluded_sym_names=None):
+    """API for converting a model from FP32 model to a mixed precision model.
+    MXNet tries to convert the FP32 model to mixed precision model by adding
+    cast layers using amp_cast and amp_multicast operators. The decision on
+    which cast layer to add is based on hardcoded lists for Automatic Mixed Precision
+    in MXNet. These lists can be overridden by the user by providing their own lists
+    using : targe_precision_ops, fp32_ops, widest_precision_ops, conditional_fp32_ops
+
+    Parameters
+    ----------
+    sym : str or Symbol
+        Defines the structure of a neural network for FP32 types.
+    arg_params : dict
+        Dictionary of name to `NDArray`.
+    aux_params : dict
+        Dictionary of name to `NDArray`.
+    target_dtype : str
+        Currently only supports float16. The target dtype indicates to add cast layers
+        when possible so that lower precision computation can be leveraged.
+    target_precision_ops : list of strs
+        Override the list of operator names casted to target_dtype.
+        If None, uses the framework's default list to be casted to target dtype.
+    fp32_ops : list of strs
+        Override the lists of operator names casted to FP32.
+        If None, uses the framework's default list to be casted to FP32.
+    widest_precision_ops : list of strs
+        A list of op names provided by user which should run in widest precision among its inputs.
+        If None, uses the framework's default list of widest_precision_ops.
+    conditional_fp32_ops : list of (string, string, list of string)
+        Override the list of operators to be casted to FP32.
+        The format of the list is
+        (name of the function, name of the parameter,
+         list of values of the parameter that make the operator to be casted to
+        fp32)
+    excluded_sym_names : list of strs
+        A list of strings that represent the names of symbols that users want to exclude
+        from being quantized.
+    """
+    if excluded_sym_names is None:
+        excluded_sym_names = []
+        if not isinstance(excluded_sym_names, list):
+            raise ValueError('excluded_sym_names must be a list of strings representing'
+                             ' the names of the symbols that should not be casted,'
+                             ' while received type %s' % str(type(excluded_sym_names)))
+
+    if target_dtype != "float16":
+        raise ValueError("Only target_dtype float16 is supported currently")
+
+    sym = _convert_symbol(sym, target_dtype, target_precision_ops,
+                          fp32_ops, widest_precision_ops, conditional_fp32_ops,
+                          excluded_sym_names)
+    return sym, arg_params, aux_params

--- a/python/mxnet/contrib/amp.py
+++ b/python/mxnet/contrib/amp.py
@@ -100,6 +100,7 @@ def _convert_symbol(sym, target_dtype="float16", target_dtype_ops=None,
     target_dtype = _DTYPE_NP_TO_MX[np.dtype(target_dtype).type]
 
     out = SymbolHandle()
+    # currently this passes str for conditional_fp32_ops for PoC, this will change
     check_call(_LIB.MXReducePrecisionSymbol(sym.handle,
                                             ctypes.byref(out),
                                             ctypes.byref(ctypes.c_int(target_dtype)),

--- a/python/mxnet/visualization.py
+++ b/python/mxnet/visualization.py
@@ -369,6 +369,10 @@ def plot_network(symbol, title="plot", save_format='pdf', shape=None, dtype=None
             attr["fillcolor"] = cm[5]
         elif op == "Softmax":
             attr["fillcolor"] = cm[6]
+        elif op == "amp_multicast":
+            label = "amp_multicast"
+        elif op == "amp_cast":
+            label = "amp_cast"
         else:
             attr["fillcolor"] = cm[7]
             if op == "Custom":

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -756,14 +756,15 @@ int MXGenBackendSubgraph(SymbolHandle sym_handle, const char *backend,
   API_BEGIN();
   nnvm::Symbol *sym = static_cast<nnvm::Symbol *>(sym_handle);
   *s = sym->Copy();
+  std::vector<mxnet::op::SubgraphPropertyPtr> properties =
+      mxnet::op::SubgraphPropertyRegistry::Get()->CreateSubgraphProperty(backend);
+  for (auto property : properties) {
   nnvm::Graph g = Symbol2Graph(*s);
-  mxnet::op::SubgraphPropertyPtr property =
-      mxnet::op::SubgraphPropertyRegistry::Get()->CreateSubgraphProperty(
-          backend);
-  g.attrs["subgraph_property"] =
-      std::make_shared<nnvm::any>(std::move(property));
-  g = ApplyPass(std::move(g), "PartitionGraph");
+    property->SetAttr("graph", g);
+    g.attrs["subgraph_property"] = std::make_shared<nnvm::any>(std::move(property));
+    g = ApplyPass(std::move(g), "BuildSubgraph");
   s->outputs = g.outputs;
+  }
   *ret_sym_handle = s;
   API_END_HANDLE_ERROR(delete s);
 }

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -697,15 +697,15 @@ int MXQuantizeSymbol(SymbolHandle sym_handle,
 
 int MXReducePrecisionSymbol(SymbolHandle sym_handle,
                             SymbolHandle *ret_sym_handle,
+                            const int* target_dtype,
                             const mx_uint num_target_dtype_op_names,
-                            const char **target_dtype_op_names,
                             const mx_uint num_fp32_op_names,
-                            const char **fp32_op_names,
                             const mx_uint num_widest_dtype_op_names,
-                            const char **widest_dtype_op_names,
                             const mx_uint num_conditional_fp32_op_names,
-                            const char **conditional_fp32_op_names,
-                            const char *target_dtype) {
+                            const char **target_dtype_op_names,
+                            const char **fp32_op_names,
+                            const char **widest_dtype_op_names,
+                            const char **conditional_fp32_op_names) {
   nnvm::Symbol *s = new nnvm::Symbol();
   API_BEGIN();
   nnvm::Symbol *sym = static_cast<nnvm::Symbol*>(sym_handle);
@@ -714,6 +714,7 @@ int MXReducePrecisionSymbol(SymbolHandle sym_handle,
   std::unordered_set<std::string> fp32_ops;
   std::unordered_set<std::string> widest_dtype_ops;
   std::unordered_set<std::string> conditional_fp32_ops;
+  int target_dt = *target_dtype;
   for (size_t i = 0; i < num_target_dtype_op_names; ++i) {
     target_dtype_ops.emplace(target_dtype_op_names[i]);
   }
@@ -723,16 +724,14 @@ int MXReducePrecisionSymbol(SymbolHandle sym_handle,
   for (size_t i = 0; i < num_widest_dtype_op_names; ++i) {
     widest_dtype_ops.emplace(widest_dtype_op_names[i]);
   }
-  LOG(INFO) << "conditional_fp32_ops len is " << num_conditional_fp32_op_names;
   for (size_t i = 0; i < num_conditional_fp32_op_names; ++i) {
     conditional_fp32_ops.emplace(conditional_fp32_op_names[i]);
   }
-  std::string target_dtype(target_dtype);
   g.attrs["target_dtype_ops"] = std::make_shared<nnvm::any>(std::move(target_dtype_ops));
   g.attrs["fp32_ops"] = std::make_shared<nnvm::any>(std::move(fp32_ops));
   g.attrs["widest_dtype_ops"] = std::make_shared<nnvm::any>(std::move(widest_dtype_ops));
   g.attrs["conditional_fp32_ops"] = std::make_shared<nnvm::any>(std::move(conditional_fp32_ops));
-  g.attrs["target_dtype"] = std::make_shared<nnvm::any>(std::move(target_dtype));
+  g.attrs["target_dtype"] = std::make_shared<nnvm::any>(target_dt);
   g = ApplyPass(std::move(g), "ReducePrecision");
   s->outputs = g.outputs;
   *ret_sym_handle = s;

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -697,31 +697,42 @@ int MXQuantizeSymbol(SymbolHandle sym_handle,
 
 int MXReducePrecisionSymbol(SymbolHandle sym_handle,
                             SymbolHandle *ret_sym_handle,
-                            const mx_uint num_fp16_op_names,
-                            const char **fp16_op_names,
+                            const mx_uint num_target_dtype_op_names,
+                            const char **target_dtype_op_names,
                             const mx_uint num_fp32_op_names,
                             const char **fp32_op_names,
-                            const mx_uint num_widest_type_op_names,
-                            const char **widest_type_op_names) {
+                            const mx_uint num_widest_dtype_op_names,
+                            const char **widest_dtype_op_names,
+                            const mx_uint num_conditional_fp32_op_names,
+                            const char **conditional_fp32_op_names,
+                            const char *target_dtype) {
   nnvm::Symbol *s = new nnvm::Symbol();
   API_BEGIN();
   nnvm::Symbol *sym = static_cast<nnvm::Symbol*>(sym_handle);
   nnvm::Graph g = Symbol2Graph(*sym);
-  std::unordered_set<std::string> fp16_node_names;
-  std::unordered_set<std::string> fp32_node_names;
-  std::unordered_set<std::string> widest_node_names;
-  for (size_t i = 0; i < num_fp16_op_names; ++i) {
-    fp16_node_names.emplace(fp16_op_names[i]);
+  std::unordered_set<std::string> target_dtype_ops;
+  std::unordered_set<std::string> fp32_ops;
+  std::unordered_set<std::string> widest_dtype_ops;
+  std::unordered_set<std::string> conditional_fp32_ops;
+  for (size_t i = 0; i < num_target_dtype_op_names; ++i) {
+    target_dtype_ops.emplace(target_dtype_op_names[i]);
   }
   for (size_t i = 0; i < num_fp32_op_names; ++i) {
-    fp32_node_names.emplace(fp32_op_names[i]);
+    fp32_ops.emplace(fp32_op_names[i]);
   }
-  for (size_t i = 0; i < num_widest_type_op_names; ++i) {
-    widest_node_names.emplace(widest_type_op_names[i]);
+  for (size_t i = 0; i < num_widest_dtype_op_names; ++i) {
+    widest_dtype_ops.emplace(widest_dtype_op_names[i]);
   }
-  g.attrs["fp16_op_names"] = std::make_shared<nnvm::any>(std::move(fp16_node_names));
-  g.attrs["fp32_op_names"] = std::make_shared<nnvm::any>(std::move(fp32_node_names));
-  g.attrs["widest_type_op_names"] = std::make_shared<nnvm::any>(std::move(widest_node_names));
+  LOG(INFO) << "conditional_fp32_ops len is " << num_conditional_fp32_op_names;
+  for (size_t i = 0; i < num_conditional_fp32_op_names; ++i) {
+    conditional_fp32_ops.emplace(conditional_fp32_op_names[i]);
+  }
+  std::string target_dtype(target_dtype);
+  g.attrs["target_dtype_ops"] = std::make_shared<nnvm::any>(std::move(target_dtype_ops));
+  g.attrs["fp32_ops"] = std::make_shared<nnvm::any>(std::move(fp32_ops));
+  g.attrs["widest_dtype_ops"] = std::make_shared<nnvm::any>(std::move(widest_dtype_ops));
+  g.attrs["conditional_fp32_ops"] = std::make_shared<nnvm::any>(std::move(conditional_fp32_ops));
+  g.attrs["target_dtype"] = std::make_shared<nnvm::any>(std::move(target_dtype));
   g = ApplyPass(std::move(g), "ReducePrecision");
   s->outputs = g.outputs;
   *ret_sym_handle = s;

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -702,10 +702,12 @@ int MXReducePrecisionSymbol(SymbolHandle sym_handle,
                             const mx_uint num_fp32_op_names,
                             const mx_uint num_widest_dtype_op_names,
                             const mx_uint num_conditional_fp32_op_names,
+                            const mx_uint num_excluded_symbols,
                             const char **target_dtype_op_names,
                             const char **fp32_op_names,
                             const char **widest_dtype_op_names,
-                            const char **conditional_fp32_op_names) {
+                            const char **conditional_fp32_op_names,
+                            const char **excluded_symbols) {
   nnvm::Symbol *s = new nnvm::Symbol();
   API_BEGIN();
   nnvm::Symbol *sym = static_cast<nnvm::Symbol*>(sym_handle);
@@ -714,6 +716,7 @@ int MXReducePrecisionSymbol(SymbolHandle sym_handle,
   std::unordered_set<std::string> fp32_ops;
   std::unordered_set<std::string> widest_dtype_ops;
   std::unordered_set<std::string> conditional_fp32_ops;
+  std::unordered_set<std::string> excluded_syms;
   int target_dt = *target_dtype;
   for (size_t i = 0; i < num_target_dtype_op_names; ++i) {
     target_dtype_ops.emplace(target_dtype_op_names[i]);
@@ -727,10 +730,14 @@ int MXReducePrecisionSymbol(SymbolHandle sym_handle,
   for (size_t i = 0; i < num_conditional_fp32_op_names; ++i) {
     conditional_fp32_ops.emplace(conditional_fp32_op_names[i]);
   }
+  for (size_t i = 0; i < num_excluded_symbols; ++i) {
+    excluded_syms.emplace(excluded_symbols[i]);
+  }
   g.attrs["target_dtype_ops"] = std::make_shared<nnvm::any>(std::move(target_dtype_ops));
   g.attrs["fp32_ops"] = std::make_shared<nnvm::any>(std::move(fp32_ops));
   g.attrs["widest_dtype_ops"] = std::make_shared<nnvm::any>(std::move(widest_dtype_ops));
   g.attrs["conditional_fp32_ops"] = std::make_shared<nnvm::any>(std::move(conditional_fp32_ops));
+  g.attrs["excluded_syms"] = std::make_shared<nnvm::any>(std::move(excluded_syms));
   g.attrs["target_dtype"] = std::make_shared<nnvm::any>(target_dt);
   g = ApplyPass(std::move(g), "ReducePrecision");
   s->outputs = g.outputs;

--- a/src/nnvm/low_precision_pass.cc
+++ b/src/nnvm/low_precision_pass.cc
@@ -116,8 +116,8 @@ Graph ReducePrecision(Graph&& src) {
       src.GetAttr<std::unordered_set<std::string>>("widest_dtype_ops");
   const auto conditional_fp32_ops =
       src.GetAttr<std::unordered_set<std::string>>("conditional_fp32_ops");
-  const auto target_dtype = src.GetAttr<std::string>("target_dtype");
-  CHECK(target_dtype == "float16") << "Only float16 target dtype is supported";
+  const auto target_dtype = src.GetAttr<int>("target_dtype");
+  CHECK(target_dtype == mshadow::kFloat16) << "Only float16 target dtype is supported";
   std::unordered_map<Node*, NodePtr> mirror_map;
   nnvm::NodeEntryMap<NodeEntry> mirror_entry_map;
   DFSVisit(src.outputs, [&](const NodePtr &node) {

--- a/src/nnvm/low_precision_pass.cc
+++ b/src/nnvm/low_precision_pass.cc
@@ -82,7 +82,7 @@ void AddCastNode(const nnvm::NodeEntry &e, const std::string &suffix,
                  input);
   cast_node->attrs.dict["dtype"] = dtype;
   cast_node->op()->attr_parser(&(cast_node->attrs));
-  mirror_entry_map[e] = NodeEntry{cast_node, 0, e.version};
+  (*mirror_entry_map)[e] = NodeEntry{cast_node, 0, e.version};
   return;
 }
 

--- a/src/nnvm/low_precision_pass.cc
+++ b/src/nnvm/low_precision_pass.cc
@@ -88,7 +88,6 @@ void AddCastNode(const nnvm::NodeEntry &e, const std::string &suffix,
 
 void AddMultiCastNode(const std::vector<NodeEntry>& inputs, const std::string& node_name,
                       const std::unordered_map<Node*, NodePtr>& mirror_map,
-                      nnvm::NodeEntryMap<NodeEntry>* mirror_entry_map,
                       NodePtr curr_node) {
   NodePtr node = CreateNode("amp_multicast", node_name);
   for (size_t i = 0; i < inputs.size(); ++i) {
@@ -154,7 +153,7 @@ Graph ReducePrecision(Graph&& src) {
             << "op name " << node->op()->name << "has no inputs";
         const auto &e = node->inputs[0];
         std::string suffix = GetSuffix(e, mirror_map);
-        AddMultiCastNode(node->inputs, suffix, mirror_map, &mirror_entry_map, new_node);
+        AddMultiCastNode(node->inputs, suffix, mirror_map, new_node);
     }
     mirror_map[node.get()] = std::move(new_node);
   });

--- a/src/nnvm/low_precision_pass.cc
+++ b/src/nnvm/low_precision_pass.cc
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <nnvm/node.h>
+#include <nnvm/graph.h>
+#include <nnvm/pass.h>
+#include <nnvm/op_attr_types.h>
+#include <mxnet/base.h>
+#include <algorithm>
+#include <functional>
+
+namespace mxnet {
+using nnvm::Symbol;
+using nnvm::Node;
+using nnvm::NodePtr;
+using nnvm::NodeEntry;
+using nnvm::Graph;
+
+NodePtr CreateNode(std::string op_name, std::string node_name) {
+  NodePtr node = Node::Create();
+  node->attrs.name = node_name;
+  if (op_name == "nullptr") {
+    node->attrs.op = nullptr;
+    // ugly workaround because VariableParam is not exposed
+    node->attrs.parsed = nnvm::Symbol::CreateVariable(node->attrs.name)
+                             .outputs[0]
+                             .node->attrs.parsed;
+  } else {
+    node->attrs.op = Op::Get(op_name);
+  }
+  return node;
+}
+
+NodePtr InsertNode(std::string op_name, std::string node_name, NodePtr current,
+                   NodeEntry previous) {
+  NodePtr node = CreateNode(op_name, node_name);
+  node->inputs.emplace_back(previous);
+  current->inputs.emplace_back(NodeEntry{node, 0, 0});
+  return node;
+}
+
+std::string GetSuffix(const nnvm::NodeEntry &e,
+                      const std::unordered_map<Node*, NodePtr>& mirror_map) {
+  static const auto &flist_outputs = nnvm::Op::GetAttr<nnvm::FListOutputNames>("FListOutputNames");
+  std::string suffix = "";
+  NodePtr mirror_node = mirror_map.at(e.node.get());
+  if (mirror_node->op() != nullptr) {
+    auto list_output_names_func = flist_outputs.get(e.node->op(), nullptr);
+    if (list_output_names_func != nullptr) {
+      std::vector<std::string> names = list_output_names_func(e.node->attrs);
+      suffix = "_" + names[e.index];
+    } else {
+      suffix = "_" + std::to_string(e.index);
+    }
+  }
+  return suffix;
+}
+
+void AddCastNode(const nnvm::NodeEntry &e, const std::string &suffix,
+                 const nnvm::NodeEntry &input,
+                 const std::string dtype,
+                 nnvm::NodeEntryMap<NodeEntry> &mirror_entry_map,
+                 NodePtr curr_node) {
+  NodePtr cast_node =
+      InsertNode("amp_cast", e.node->attrs.name + suffix + "_cast", curr_node,
+                 input);
+  cast_node->attrs.dict["dtype"] = dtype;
+  cast_node->op()->attr_parser(&(cast_node->attrs));
+  mirror_entry_map[e] = NodeEntry{cast_node, 0, e.version};
+  return;
+}
+
+void AddMultiCastNode(const std::vector<NodeEntry>& inputs, const std::string& node_name,
+                      const std::unordered_map<Node*, NodePtr>& mirror_map,
+                      nnvm::NodeEntryMap<NodeEntry> &mirror_entry_map,
+                      NodePtr curr_node) {
+  NodePtr node = CreateNode("amp_multicast", node_name);
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    const auto &e = inputs[i];
+    NodePtr mirror_node = mirror_map.at(e.node.get());
+    NodeEntry mirror_entry = NodeEntry{mirror_node, e.index, e.version};
+    node->inputs.emplace_back(mirror_entry);
+  }
+  node->attrs.dict["num_outputs"] = std::to_string(inputs.size());
+  node->op()->attr_parser(&(node->attrs));
+  for (uint32_t i = 0; i < inputs.size(); ++i) {
+    const auto &e = inputs[i];
+    curr_node->inputs.emplace_back(NodeEntry{node, static_cast<uint32_t>(i), e.version});
+  }
+  return;
+}
+
+Graph ReducePrecision(Graph&& src) {
+  static const auto &flist_outputs = nnvm::Op::GetAttr<nnvm::FListOutputNames>("FListOutputNames");
+  const auto fp16_op_names =
+      src.GetAttr<std::unordered_set<std::string>>("fp16_op_names");
+  const auto fp32_op_names =
+      src.GetAttr<std::unordered_set<std::string>>("fp32_op_names");
+  const auto widest_type_op_names =
+      src.GetAttr<std::unordered_set<std::string>>("widest_type_op_names");
+  std::unordered_map<Node*, NodePtr> mirror_map;
+  nnvm::NodeEntryMap<NodeEntry> mirror_entry_map;
+  DFSVisit(src.outputs, [&](const NodePtr &node) {
+    NodePtr new_node = Node::Create();
+    *new_node = *node;
+    new_node->inputs.clear();
+    if (!node->is_variable() && fp32_op_names.count(node->op()->name) > 0) {
+      for (size_t i = 0; i < node->inputs.size(); ++i) {
+        const auto &e = node->inputs[i];
+        if (mirror_entry_map.count(e)) {
+          new_node->inputs.emplace_back(mirror_entry_map[e]);
+        } else {
+          NodePtr mirror_node = mirror_map.at(e.node.get());
+          NodeEntry mirror_entry = NodeEntry{mirror_node, e.index, e.version};
+          std::string suffix = GetSuffix(e, mirror_map);
+          AddCastNode(e, suffix, mirror_entry, "float32", mirror_entry_map, new_node);
+        }
+      }
+    } else if (!node->is_variable() && fp16_op_names.count(node->op()->name) > 0) {
+      for (size_t i = 0; i < node->inputs.size(); ++i) {
+        const auto &e = node->inputs[i];
+        if (mirror_entry_map.count(e)) {
+          new_node->inputs.emplace_back(mirror_entry_map[e]);
+        } else {
+          NodePtr mirror_node = mirror_map.at(e.node.get());
+          NodeEntry mirror_entry = NodeEntry{mirror_node, e.index, e.version};
+          std::string suffix = GetSuffix(e, mirror_map);
+          AddCastNode(e, suffix, mirror_entry, "float16", mirror_entry_map, new_node);
+        }
+      }
+    } else if (!node->is_variable() && widest_type_op_names.count(node->op()->name) > 0) {
+        CHECK(node->inputs.size() > 0)
+            << "Please check the symbol. node name " << node << node->attrs.name
+            << "op name " << node->op()->name << "has no inputs";
+        const auto &e = node->inputs[0];
+        std::string suffix = GetSuffix(e, mirror_map);
+        AddMultiCastNode(node->inputs, suffix, mirror_map, mirror_entry_map, new_node);
+    }
+    mirror_map[node.get()] = std::move(new_node);
+  });
+
+  std::vector<NodeEntry> outputs;
+  for (const auto& e : src.outputs) {
+    outputs.emplace_back(NodeEntry{mirror_map.at(e.node.get()), e.index, e.version});
+  }
+
+  Graph ret;
+  ret.outputs = std::move(outputs);
+  return ret;
+}
+
+NNVM_REGISTER_PASS(ReducePrecision)
+    .describe("add cast layers for low precision inference")
+    .set_body(ReducePrecision)
+    .set_change_graph(true);
+} // namespace mxnet

--- a/src/operator/tensor/amp_cast.cc
+++ b/src/operator/tensor/amp_cast.cc
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file amp_cast.cc
+ * \brief Casts used by AMP
+ */
+
+#include "./amp_cast.h"
+
+namespace mxnet {
+namespace op {
+
+DMLC_REGISTER_PARAMETER(AMPCastParam);
+DMLC_REGISTER_PARAMETER(AMPMultiCastParam);
+
+NNVM_REGISTER_OP(amp_cast)
+.describe(R"code(Cast function between FP16/FP32 used by AMP.
+
+It casts only between FP16/FP32 and does not do anything for other types.
+)code" ADD_FILELINE)
+.set_attr_parser(ParamParser<AMPCastParam>)
+.set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
+.set_attr<nnvm::FInferType>("FInferType", AMPCastType)
+.set_attr<nnvm::FInplaceOption>("FInplaceOption",
+  [](const NodeAttrs& attrs){
+    return std::vector<std::pair<int, int> >{{0, 0}};
+  })
+.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+  [](const NodeAttrs& attrs){
+    return std::vector<bool>{true};
+  })
+.set_attr<FCompute>("FCompute<cpu>", AMPCastCompute<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_amp_cast"})
+.add_argument("data", "NDArray-or-Symbol", "The input.")
+.add_arguments(AMPCastParam::__FIELDS__());
+
+NNVM_REGISTER_OP(_backward_amp_cast)
+.set_attr<nnvm::TIsBackward>("TIsBackward", true)
+.set_attr<nnvm::FInplaceOption>("FInplaceOption",
+  [](const NodeAttrs& attrs){
+    return std::vector<std::pair<int, int> >{{0, 0}};
+  })
+.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+  [](const NodeAttrs& attrs){
+    return std::vector<bool>{true};
+  })
+.set_attr<FCompute>("FCompute<cpu>", AMPCastCompute<cpu>);
+
+NNVM_REGISTER_OP(amp_multicast)
+.describe(R"code(Cast function used by AMP, that casts its inputs to the common widest type.
+
+It casts only between FP16/FP32 and does not do anything for other types.
+
+)code" ADD_FILELINE)
+.set_num_inputs([](const nnvm::NodeAttrs& attrs) {
+    const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
+    return static_cast<uint32_t>(param.num_outputs);
+  })
+.set_num_outputs([](const nnvm::NodeAttrs& attrs) {
+    const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
+    return static_cast<uint32_t>(param.num_outputs);
+  })
+.set_attr_parser(ParamParser<AMPMultiCastParam>)
+.set_attr<mxnet::FInferShape>("FInferShape", AMPMultiCastShape)
+.set_attr<nnvm::FInferType>("FInferType", AMPMultiCastType)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    uint32_t num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+    std::vector<std::string> ret;
+    for (uint32_t i = 0; i < num_args; ++i) {
+      ret.push_back(std::string("data_") + std::to_string(i));
+    }
+    return ret;
+  })
+.set_attr<nnvm::FInplaceOption>("FInplaceOption",
+  [](const NodeAttrs& attrs){
+    int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+    std::vector<std::pair<int, int>> ret;
+    for (int i = 0; i < num_args; ++i) {
+      ret.push_back(std::make_pair(i, i));
+    }
+    return ret;
+  })
+.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+  [](const NodeAttrs& attrs){
+    int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+    return std::vector<bool>(num_args, true);
+  })
+.set_attr<FCompute>("FCompute<cpu>", AMPMultiCastCompute<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_amp_multicast"})
+.add_argument("data", "NDArray-or-Symbol[]", "Weights")
+.add_arguments(AMPMultiCastParam::__FIELDS__());
+
+NNVM_REGISTER_OP(_backward_amp_multicast)
+.set_attr<nnvm::TIsBackward>("TIsBackward", true)
+.set_num_inputs([](const nnvm::NodeAttrs& attrs) {
+    const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
+    return static_cast<uint32_t>(param.num_outputs);
+  })
+.set_num_outputs([](const nnvm::NodeAttrs& attrs) {
+    const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
+    return static_cast<uint32_t>(param.num_outputs);
+  })
+.set_attr_parser(ParamParser<AMPMultiCastParam>)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    uint32_t num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+    std::vector<std::string> ret;
+    for (uint32_t i = 0; i < num_args; ++i) {
+      ret.push_back(std::string("grad_") + std::to_string(i));
+    }
+    return ret;
+  })
+.set_attr<nnvm::FInplaceOption>("FInplaceOption",
+  [](const NodeAttrs& attrs){
+    int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+    std::vector<std::pair<int, int>> ret;
+    for (int i = 0; i < num_args; ++i) {
+      ret.push_back(std::make_pair(i, i));
+    }
+    return ret;
+  })
+.set_attr<nnvm::FInplaceIdentity>("FInplaceIdentity",
+  [](const NodeAttrs& attrs){
+    int num_args = dmlc::get<AMPMultiCastParam>(attrs.parsed).num_outputs;
+    return std::vector<bool>(num_args, true);
+  })
+.set_attr<FCompute>("FCompute<cpu>", AMPMultiCastCompute<cpu>)
+.add_argument("grad", "NDArray-or-Symbol[]", "Gradients")
+.add_arguments(AMPMultiCastParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/tensor/amp_cast.cu
+++ b/src/operator/tensor/amp_cast.cu
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file amp_cast.cu
+ * \brief Casts used by AMP (GPU operators)
+ */
+
+#include "./amp_cast.h"
+
+namespace mxnet {
+namespace op {
+
+NNVM_REGISTER_OP(amp_cast)
+.set_attr<FCompute>("FCompute<gpu>", AMPCastCompute<gpu>);
+NNVM_REGISTER_OP(_backward_amp_cast)
+.set_attr<FCompute>("FCompute<gpu>", AMPCastCompute<gpu>);
+
+NNVM_REGISTER_OP(amp_multicast)
+.set_attr<FCompute>("FCompute<gpu>", AMPMultiCastCompute<gpu>);
+NNVM_REGISTER_OP(_backward_amp_multicast)
+.set_attr<FCompute>("FCompute<gpu>", AMPMultiCastCompute<gpu>);
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/tensor/amp_cast.h
+++ b/src/operator/tensor/amp_cast.h
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file amp_cast.h
+ * \brief Function definition of casts used by AMP
+ */
+
+#ifndef MXNET_OPERATOR_TENSOR_AMP_CAST_H_
+#define MXNET_OPERATOR_TENSOR_AMP_CAST_H_
+
+#include <vector>
+#include <utility>
+#include <algorithm>
+#include "../mshadow_op.h"
+#include "../mxnet_op.h"
+#include "../elemwise_op_common.h"
+#include "../operator_common.h"
+
+namespace mxnet {
+namespace op {
+
+struct AMPCastParam : public dmlc::Parameter<AMPCastParam> {
+  // use int for enumeration
+  int dtype;
+  DMLC_DECLARE_PARAMETER(AMPCastParam) {
+    DMLC_DECLARE_FIELD(dtype)
+    MXNET_ADD_ALL_TYPES
+    .describe("Output data type.");
+  }
+};
+
+struct AMPMultiCastParam : public dmlc::Parameter<AMPMultiCastParam> {
+  int num_outputs;
+
+  DMLC_DECLARE_PARAMETER(AMPMultiCastParam) {
+    DMLC_DECLARE_FIELD(num_outputs)
+    .describe("Number of input/output pairs to be casted to the widest type.");
+  }
+};
+
+inline bool AMPCastType(const nnvm::NodeAttrs& attrs,
+                        std::vector<int> *in_attrs,
+                        std::vector<int> *out_attrs) {
+  using mshadow::kFloat32;
+  using mshadow::kFloat16;
+  const AMPCastParam& param = nnvm::get<AMPCastParam>(attrs.parsed);
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  if ((*in_attrs)[0] == kFloat32 || (*in_attrs)[0] == kFloat16) {
+    TYPE_ASSIGN_CHECK(*out_attrs, 0, param.dtype);
+  } else {
+    TYPE_ASSIGN_CHECK(*out_attrs, 0, (*in_attrs)[0]);
+  }
+  return (*in_attrs)[0] != -1;
+}
+
+inline bool AMPMultiCastType(const nnvm::NodeAttrs& attrs,
+                        std::vector<int> *in_attrs,
+                        std::vector<int> *out_attrs) {
+  using mshadow::kFloat32;
+  using mshadow::kFloat16;
+  const AMPMultiCastParam& param = nnvm::get<AMPMultiCastParam>(attrs.parsed);
+  CHECK_EQ(in_attrs->size(), param.num_outputs);
+  CHECK_EQ(out_attrs->size(), param.num_outputs);
+  bool ret = true;
+  int widest_type = kFloat16;
+  for (int i = 0; i < param.num_outputs; ++i) {
+    if ((*in_attrs)[i] == kFloat32 || (*out_attrs)[i] == kFloat32) {
+      widest_type = kFloat32;
+    }
+  }
+  for (int i = 0; i < param.num_outputs; ++i) {
+    if ((*in_attrs)[i] == kFloat32 || (*in_attrs)[i] == kFloat16) {
+      TYPE_ASSIGN_CHECK(*out_attrs, i, widest_type);
+    } else {
+      TYPE_ASSIGN_CHECK(*out_attrs, i, (*in_attrs)[i]);
+    }
+    ret = ret && ((*in_attrs)[i] != -1);
+  }
+  return ret;
+}
+
+inline bool AMPMultiCastShape(const nnvm::NodeAttrs& attrs,
+                              std::vector<TShape> *in_attrs,
+                              std::vector<TShape> *out_attrs) {
+  const AMPMultiCastParam& param = dmlc::get<AMPMultiCastParam>(attrs.parsed);
+  CHECK_EQ(in_attrs->size(), param.num_outputs);
+  CHECK_EQ(out_attrs->size(), param.num_outputs);
+
+  bool all_inferred = true;
+  for (size_t i = 0; i < in_attrs->size(); ++i) {
+    // forward inference
+    SHAPE_ASSIGN_CHECK(*out_attrs, i, (*in_attrs)[i]);
+    // backward inference
+    SHAPE_ASSIGN_CHECK(*in_attrs, i, (*out_attrs)[i]);
+    all_inferred = all_inferred && !shape_is_none((*in_attrs)[i]);
+  }
+  return all_inferred;
+}
+
+template<typename xpu>
+void AMPCastCompute(const nnvm::NodeAttrs& attrs,
+                    const OpContext& ctx,
+                    const std::vector<TBlob>& inputs,
+                    const std::vector<OpReqType>& req,
+                    const std::vector<TBlob>& outputs) {
+  using namespace mshadow;
+  using namespace mshadow::expr;
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+  MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DstDType, {
+    Tensor<xpu, 1, DstDType> out = outputs[0].FlatTo1D<xpu, DstDType>(s);
+    MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, SrcDType, {
+      Tensor<xpu, 1, SrcDType> data = inputs[0].FlatTo1D<xpu, SrcDType>(s);
+      if (outputs[0].type_flag_ != inputs[0].type_flag_ ||
+          req[0] != kWriteInplace) {
+        Assign(out, req[0], tcast<DstDType>(data));
+      }
+    });
+  });
+}
+
+template<typename xpu>
+void AMPMultiCastCompute(const nnvm::NodeAttrs& attrs,
+                    const OpContext& ctx,
+                    const std::vector<TBlob>& inputs,
+                    const std::vector<OpReqType>& req,
+                    const std::vector<TBlob>& outputs) {
+  using namespace mshadow;
+  using namespace mshadow::expr;
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    MSHADOW_TYPE_SWITCH(outputs[i].type_flag_, DstDType, {
+      Tensor<xpu, 1, DstDType> out = outputs[i].FlatTo1D<xpu, DstDType>(s);
+      MSHADOW_TYPE_SWITCH(inputs[i].type_flag_, SrcDType, {
+        Tensor<xpu, 1, SrcDType> data = inputs[i].FlatTo1D<xpu, SrcDType>(s);
+        if (outputs[i].type_flag_ != inputs[i].type_flag_ ||
+            req[i] != kWriteInplace) {
+          Assign(out, req[i], tcast<DstDType>(data));
+        }
+      });
+    });
+  }
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_TENSOR_AMP_CAST_H_

--- a/test_amp_convert.py
+++ b/test_amp_convert.py
@@ -9,8 +9,9 @@ x2 = mx.sym.sin(data)
 x3 = mx.sym.cos(data)
 sym = x + x2 + x3
 result = mx.sym.add_n(sym, data2, data3)
-x = mx.viz.plot_network(result)
-casted_result = mx.contrib.amp._convert_symbol(result, fp32_op_names=["elemwise_add"], fp16_op_names=["sin", "cos", "exp"], widest_type_op_names=["add_n"])
-y = mx.viz.plot_network(casted_result, use_op_names=True)
-#x.render('test-output/round-table.gv', view=False)
-y.render('test-output/round-table.gv', view=False)
+#x = mx.viz.plot_network(result)
+casted_result = mx.contrib.amp._convert_symbol(result, target_dtype="float16",
+                                               target_dtype_ops=["sin", "cos", "exp"], fp32_ops=["elemwise_add"],
+                                               widest_dtype_ops=["add_n"], conditional_fp32_ops=None)
+#y = mx.viz.plot_network(casted_result, use_op_names=True)
+#y.render('test-output/round-table.gv', view=False)

--- a/test_amp_convert.py
+++ b/test_amp_convert.py
@@ -13,5 +13,5 @@ result = mx.sym.add_n(sym, data2, data3)
 casted_result = mx.contrib.amp._convert_symbol(result, target_dtype="float16",
                                                target_dtype_ops=["sin", "cos", "exp"], fp32_ops=["elemwise_add"],
                                                widest_dtype_ops=["add_n"], conditional_fp32_ops=None)
-#y = mx.viz.plot_network(casted_result, use_op_names=True)
-#y.render('test-output/round-table.gv', view=False)
+y = mx.viz.plot_network(casted_result)
+y.render('test-output/round-table.gv', view=False)

--- a/test_amp_convert.py
+++ b/test_amp_convert.py
@@ -11,6 +11,6 @@ sym = x + x2 + x3
 result = mx.sym.add_n(sym, data2, data3)
 x = mx.viz.plot_network(result)
 casted_result = mx.contrib.amp._convert_symbol(result, fp32_op_names=["elemwise_add"], fp16_op_names=["sin", "cos", "exp"], widest_type_op_names=["add_n"])
-y = mx.viz.plot_network(casted_result)
+y = mx.viz.plot_network(casted_result, use_op_names=True)
 #x.render('test-output/round-table.gv', view=False)
 y.render('test-output/round-table.gv', view=False)

--- a/test_amp_convert.py
+++ b/test_amp_convert.py
@@ -1,0 +1,16 @@
+import mxnet as mx
+
+#sym = mx.sym.load("resnet50_v1-symbol.json")
+data = mx.sym.var("data")
+data2 = mx.sym.var("data2")
+data3 = mx.sym.var("data3")
+x = mx.sym.exp(data)
+x2 = mx.sym.sin(data)
+x3 = mx.sym.cos(data)
+sym = x + x2 + x3
+result = mx.sym.add_n(sym, data2, data3)
+x = mx.viz.plot_network(result)
+casted_result = mx.contrib.amp._convert_symbol(result, fp32_op_names=["elemwise_add"], fp16_op_names=["sin", "cos", "exp"], widest_type_op_names=["add_n"])
+y = mx.viz.plot_network(casted_result)
+#x.render('test-output/round-table.gv', view=False)
+y.render('test-output/round-table.gv', view=False)


### PR DESCRIPTION
## Description ##

This is a PoC for https://github.com/apache/incubator-mxnet/issues/14584
prereq is the AMP PR: https://github.com/apache/incubator-mxnet/pull/14173
I have pulled some of the operator code for amp_cast and amp_multicast etc. into my branch for now.

### Approach ###

- Currently, the pass uses the fp16_op_names, fp32_op_names and widest_op_names to make decisions on operators to insert in the computation graph.
- The logic for casting currently follows the PR: #14173.
- For fp16_ops an amp_cast with target_dtype of fp16 is inserted before the op, fp32 is inserted before op for fp32 ops,  for widest_type_casts, amp_multicast is used.
- The code is currently specific to fp16 and fp32 ops but i plan to change it to use target_dtype, low_precision_ops, full_precision_ops.

### Testing ###

Test script for the PoC:
```
import mxnet as mx

data = mx.sym.var("data")
data2 = mx.sym.var("data2")
data3 = mx.sym.var("data3")
x = mx.sym.exp(data)
x2 = mx.sym.sin(data)
x3 = mx.sym.cos(data)
sym = x + x2 + x3
result = mx.sym.add_n(sym, data2, data3)
x = mx.viz.plot_network(result)
casted_result = mx.contrib.amp._convert_symbol(result, fp32_op_names=["elemwise_add"], fp16_op_names=["sin", "cos", "exp"], widest_type_op_names=["add_n"])
y = mx.viz.plot_network(casted_result)
x.render('test-output/round-table.gv', view=False)
y.render('test-output/round-table.gv', view=False)
```

Model before:

![round-table-before gv](https://user-images.githubusercontent.com/1522319/56123511-74d62580-5f29-11e9-9dc2-2833a07e153d.png)


Model after:

![model_after](https://user-images.githubusercontent.com/1522319/56451202-7617a180-62df-11e9-8603-d61656188a23.png)


@ptrendx @DickJC123 @Caenorst @ZhennanQin @pengzhao-intel 