### PR TITLE
Set idx2name for Optimizer object

### DIFF
--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -884,6 +884,8 @@ class FeedForward(BASE_ESTIMATOR):
                                    rescale_grad=(1.0/batch_size),
                                    **(self.kwargs))
         elif isinstance(self.optimizer, opt.Optimizer):
+            if not optimizer.idx2name:
+                optimizer.idx2name = param_idx2name.copy()
             optimizer = self.optimizer
 
         # do training

--- a/tests/python/unittest/test_module.py
+++ b/tests/python/unittest/test_module.py
@@ -931,6 +931,34 @@ def test_module_update_no_pragram():
     mod.update()
     assert(mod.get_outputs()[0].shape == data_shape)
 
+
+def test_module_init_optimizer():
+    def get_module_idx2name(mod):
+        idx2name = {}
+        idx2name.update(enumerate(mod._exec_group.param_names))
+        return idx2name
+
+    data = mx.sym.Variable('data')
+    sym = mx.sym.FullyConnected(data, num_hidden=20, name='fc')
+    batch_size = 8
+    opt_params = {'learning_rate': 1, 'rescale_grad': 1.0 / batch_size}
+
+    # Pass an optimizer str
+    mod1 = mx.mod.Module(sym, ('data',), None, context=mx.cpu(0))
+    mod1.bind(data_shapes=[('data', (batch_size, 20))])
+    mod1.init_params()
+    mod1.init_optimizer(optimizer='sgd', optimizer_params=opt_params)
+    assert mod1._optimizer.idx2name == get_module_idx2name(mod1)
+
+    # Pass an Optimizer object
+    mod2 = mx.mod.Module(sym, ('data',), None, context=mx.cpu(0))
+    mod2.bind(data_shapes=[('data', (batch_size, 20))])
+    mod2.init_params()
+    opt = mx.optimizer.SGD(**opt_params)
+    mod2.init_optimizer(optimizer=opt)
+    assert mod2._optimizer.idx2name == get_module_idx2name(mod2)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
Currently when we use `module.fit()`, we can pass a str or an Optimizer object as the [optimizer](https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/module/base_module.py#L440). When we pass an Optimizer object that is created outside before calling `module.fit()`, we are not checking and setting `optimizer.idx2name` which is used to mask out entries in update for weight decay in [module.init_optimizer](https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/module/module.py#L522) method. If `idx2name` is not set when creating the optimizer object outside, it can impact the convergence behavior as weight decay is applied to all parameters in this case.

This PR checks if `idx2name` is set if an Optimizer object is given. If not, we are setting it to the proper values. Fixes #9511 as @wkcn pointed out.

