### PR TITLE
[clojure][generator][WIP] add proper newlines in generated files

### DIFF
--- a/contrib/clojure-package/src/dev/generator.clj
+++ b/contrib/clojure-package/src/dev/generator.clj
@@ -176,6 +176,18 @@
                      (util/buffer->vec arg-descs))
          :key-var-num-args (clojure-case (.value key-var-num-args))})))
 
+;;;;;;; Util
+
+(defn format-newline!
+  "Changes `filename` content from `\n` to actual newlines."
+  [filename]
+  (let [content (slurp filename)
+        formatted-content (-> content
+                              (clojure.string/replace #"\\n" "\n")
+                              (print)
+                              (with-out-str))]
+    (spit filename formatted-content)))
+
 ;;;;;;; Symbol
 
 (def symbol-public-no-default
@@ -467,8 +479,10 @@
   (:import (org.apache.mxnet SymbolAPI)))")
 
 (defn generate-symbol-api-file []
-  (println "Generating symbol-api file")
-  (write-to-file all-symbol-api-functions symbol-api-gen-ns "src/org/apache/clojure_mxnet/gen/symbol_api.clj"))
+  (let [filename "src/org/apache/clojure_mxnet/gen/symbol_api.clj"]
+    (println "Generating symbol-api file")
+    (write-to-file all-symbol-api-functions symbol-api-gen-ns filename)
+    (format-newline! filename)))
 
 ;;;;;;; NDArrayAPI
 
@@ -547,12 +561,13 @@
             [org.apache.clojure-mxnet.util :as util])
   (:import (org.apache.mxnet NDArrayAPI)))")
 
-
 (defn generate-ndarray-api-file []
-  (println "Generating ndarray-api file")
-  (write-to-file all-ndarray-api-functions
-                 ndarray-api-gen-ns
-                 "src/org/apache/clojure_mxnet/gen/ndarray_api.clj"))
+  (let [filename "src/org/apache/clojure_mxnet/gen/ndarray_api.clj"]
+    (println "Generating ndarray-api file")
+    (write-to-file all-ndarray-api-functions
+                   ndarray-api-gen-ns
+                   filename)
+    (format-newline! filename)))
 
 ;;; autogen the files
 (do


### PR DESCRIPTION
## Description ##

It will reformat the current `ndarray-api` and `symbol-api` with proper newlines.

Example:
```clojure
(defn
 activation
 "Applies an activation function element-wise to the input.

The following activation functions are supported:

- `relu`: Rectified Linear Unit, :math:`y = max(x, 0)`
- `sigmoid`: :math:`y = \\frac{1}{1 + exp(-x)}`
- `tanh`: Hyperbolic tangent, :math:`y = \\frac{exp(x) - exp(-x)}{exp(x) + exp(-x)}`
- `softrelu`: Soft ReLU, or SoftPlus, :math:`y = log(1 + exp(x))`
- `softsign`: :math:`y = \\frac{x}{1 + abs(x)}`



Defined in src/operator/nn/activation.cc:L167

`data`: The input array.
`act-type`: Activation function to be applied.
`out`: Output array. (optional)
"
 ([data act-type] (activation {:data data, :act-type act-type}))
 ([{:keys [data act-type out], :or {out nil}, :as opts}]
  (util/coerce-return
   (NDArrayAPI/Activation data act-type (util/->option out)))))
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
