### PR TITLE
fix custom op fork test

### DIFF
--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -48,6 +48,7 @@ from test_contrib_operator import test_multibox_target_op
 set_default_context(mx.gpu(0))
 del test_support_vector_machine_l1_svm  # noqa
 del test_support_vector_machine_l2_svm  # noqa
+del test_custom_op_fork  #noqa
 
 
 def check_countsketch(in_dim,out_dim,n):

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5393,6 +5393,9 @@ def test_custom_op():
         x = mx.nd.Custom(length=10, depth=10, op_type="no_input_op")
     assert_almost_equal(x.asnumpy(), np.ones(shape=(10, 10), dtype=np.float32))
 
+
+@with_seed()
+def test_custom_op_fork():
     # test custom operator fork
     # see https://github.com/apache/incubator-mxnet/issues/14396
     class AdditionOP(mx.operator.CustomOp):
@@ -5430,7 +5433,7 @@ def test_custom_op():
         p.daemon = True
         p.start()
         p.join(5)
-        assert not p.is_alive(), "deadlock may exist in custom operator"
+        assert not p.is_alive() and p.exitcode == 0
 
 
 def _build_dot_custom(fun_forward, name):


### PR DESCRIPTION
## Description ##
The custom op fork test introduced in #14451 will cause error when running with gpu. The common situation is:
```
test_operator_gpu.test_custom_op ... terminate called after throwing an instance of 'dmlc::Error'

  what():  [04:22:53] /work/mxnet/3rdparty/mshadow/mshadow/./tensor_gpu-inl.h:35: Check failed: e == cudaSuccess: CUDA: initialization error

Stack trace:

  [bt] (0) /work/mxnet/python/mxnet/../../lib/libmxnet.so(dmlc::LogMessageFatal::~LogMessageFatal()+0x35) [0x7f8ca52e2bd5]

  [bt] (1) /work/mxnet/python/mxnet/../../lib/libmxnet.so(void mshadow::SetDevice<mshadow::gpu>(int)+0x11a) [0x7f8ca8775a2a]

  [bt] (2) /work/mxnet/python/mxnet/../../lib/libmxnet.so(void mxnet::engine::ThreadedEnginePerDevice::GPUWorker<(dmlc::ConcurrentQueueType)1>(mxnet::Context, bool, mxnet::engine::ThreadedEnginePerDevice::ThreadWorkerBlock<(dmlc::ConcurrentQueueType)1>*, std::shared_ptr<dmlc::ManualEvent> const&)+0xa2) [0x7f8ca87a3d92]

  [bt] (3) /work/mxnet/python/mxnet/../../lib/libmxnet.so(std::_Function_handler<void (std::shared_ptr<dmlc::ManualEvent>), mxnet::engine::ThreadedEnginePerDevice::PushToExecute(mxnet::engine::OprBlock*, bool)::{lambda()#2}::operator()() const::{lambda(std::shared_ptr<dmlc::ManualEvent>)#1}>::_M_invoke(std::_Any_data const&, std::shared_ptr<dmlc::ManualEvent>)+0x4e) [0x7f8ca87a43de]

  [bt] (4) /work/mxnet/python/mxnet/../../lib/libmxnet.so(std::thread::_Impl<std::_Bind_simple<std::function<void (std::shared_ptr<dmlc::ManualEvent>)> (std::shared_ptr<dmlc::ManualEvent>)> >::_M_run()+0x5c) [0x7f8ca878626c]

  [bt] (5) /usr/lib64/libstdc++.so.6(+0xb5070) [0x7f8d0b256070]

  [bt] (6) /usr/lib64/libpthread.so.0(+0x7dd5) [0x7f8d19461dd5]

  [bt] (7) /usr/lib64/libc.so.6(clone+0x6d) [0x7f8d18a81ead]

ok (0.6177s)
```

When CUDA context is created in main process, the forking process tries to access the same context, causing initialization error.

This PR adds checking on exitcode of forking process and removes this test in gpu tests.

BTW, right now the correct way to fork mxnet is to do it when the CUDA context is not created, otherwise CUDA error is very likely to happen, maybe we should add some warning in docs?

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
