### PR TITLE
[MXNET-1396][Fit-API] Update default handler logic

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1296,18 +1296,12 @@ nightly_scala_demo_test_cpu() {
     bash bin/run_im.sh
 }
 
-nightly_estimator_gpu() {
+nightly_estimator() {
     set -ex
     cd /work/mxnet/tests/nightly/estimator
     export PYTHONPATH=/work/mxnet/python/
     python test_estimator_cnn.py --type gpu
     python test_sentiment_rnn.py --type gpu
-}
-
-nightly_estimator_cpu() {
-    set -ex
-    cd /work/mxnet/tests/nightly/estimator
-    export PYTHONPATH=/work/mxnet/python/
     python test_estimator_cnn.py --type cpu
     python test_sentiment_rnn.py --type cpu
 }

--- a/python/mxnet/gluon/contrib/estimator/estimator.py
+++ b/python/mxnet/gluon/contrib/estimator/estimator.py
@@ -157,6 +157,8 @@ class Estimator(object):
         Based on loss functions and training metrics in estimator
         Create metric wrappers to record loss values,
         Create copies of train loss/metric objects to record validation values
+        Returns train_metrics and val_metrics
+
         """
         if any(not hasattr(self, attribute) for attribute in
                ['train_metrics', 'val_metrics']):
@@ -165,8 +167,7 @@ class Estimator(object):
                 self.train_metrics = [Accuracy()]
             self.val_metrics = []
             for loss in self.loss:
-                self.train_metrics.append(Loss("Train " + ''.join([i for i in loss.name if not i.isdigit()])))
-                self.val_metrics.append(Loss("Validation " + ''.join([i for i in loss.name if not i.isdigit()])))
+                self.train_metrics.append(Loss(''.join([i for i in loss.name if not i.isdigit()])))
             for metric in self.train_metrics:
                 val_metric = copy.deepcopy(metric)
                 metric.name = "Train " + metric.name
@@ -231,21 +232,9 @@ class Estimator(object):
             from a data batch and load into contexts(devices)
         """
         self.max_epochs = epochs
-        event_handlers = event_handlers or []
-        # provide default logging handler
-        if not event_handlers:
-            train_metrics, val_metrics = self.prepare_loss_and_metrics()
-            event_handlers.append(MetricHandler(train_metrics=train_metrics))
-            if val_data:
-                event_handlers.append(ValidationHandler(val_data=val_data, eval_fn=self.evaluate,
-                                                        val_metrics=val_metrics))
-            event_handlers.append(LoggingHandler(train_metrics=train_metrics,
-                                                 val_metrics=val_metrics))
-            warnings.warn("No Event Handler specified, default %s are used. "
-                          "Please look at gluon.contrib.estimator.event_handler for more detail." %
-                          ", ".join([handler.__class__.__name__ for handler in event_handlers]))
 
-        event_handlers.sort(key=lambda handler: getattr(handler, 'rank', 0), reverse=True)
+        # provide default handlers
+        event_handlers = self._prepare_default_handlers(val_data, event_handlers)
 
         train_begin, epoch_begin, batch_begin, \
         batch_end, epoch_end, train_end = self._categorize_handlers(event_handlers)
@@ -296,6 +285,54 @@ class Estimator(object):
         # train end
         for handler in train_end:
             handler.train_end(estimator_ref)
+
+    def _prepare_default_handlers(self, val_data, event_handlers):
+        event_handlers = event_handlers or []
+        default_handlers = []
+        train_metrics, val_metrics = self.prepare_loss_and_metrics()
+
+        if not any(isinstance(handler, MetricHandler) for handler in event_handlers):
+            event_handlers.append(MetricHandler(train_metrics=train_metrics))
+            default_handlers.append("MetricHandler")
+
+        if val_data and not any(isinstance(handler, ValidationHandler) for handler in event_handlers):
+            event_handlers.append(ValidationHandler(val_data=val_data, eval_fn=self.evaluate,
+                                                    val_metrics=val_metrics))
+            default_handlers.append("ValidationHandler")
+
+        if not any(isinstance(handler, LoggingHandler) for handler in event_handlers):
+            event_handlers.append(LoggingHandler(train_metrics=train_metrics,
+                                                 val_metrics=val_metrics))
+            default_handlers.append("LoggingHandler")
+
+        # if there is a mix of user defined event handlers and default event handlers
+        # they should have the save set of loss and metrics
+        if default_handlers:
+            msg = "You are training with the following default event handlers: %s. " \
+                  "They use loss and metrics from estimator.prepare_loss_and_metrics(). " \
+                  "Please use the same set of metrics for all your other handlers." % \
+                  ", ".join(default_handlers)
+            warnings.warn(msg)
+            for handler in event_handlers:
+                for attribute in dir(handler):
+                    if any(keyword in attribute for keyword in ['metric' or 'monitor']):
+                        reference = getattr(handler, attribute)
+                        msg = "We have added following default handlers for you: %s and used " \
+                              "estimator.prepare_loss_and_metrics() to pass metrics to " \
+                              "those handlers. Please use the same set of metrics " \
+                              "for all your handlers. You have used %s in handler %s, " \
+                              "which is not prepared by estimator." \
+                              "in " % \
+                              (", ".join(default_handlers), attribute, handler.__class__.__name__)
+                        if isinstance(reference, list):
+                            for item in reference:
+                                if item and item not in train_metrics + val_metrics:
+                                    raise ValueError(msg)
+                        elif reference and reference not in train_metrics + val_metrics:
+                            raise ValueError(msg)
+
+        event_handlers.sort(key=lambda handler: getattr(handler, 'priority', 0))
+        return event_handlers
 
     def _categorize_handlers(self, event_handlers):
         """

--- a/python/mxnet/gluon/contrib/estimator/estimator.py
+++ b/python/mxnet/gluon/contrib/estimator/estimator.py
@@ -313,23 +313,23 @@ class Estimator(object):
                   "Please use the same set of metrics for all your other handlers." % \
                   ", ".join(default_handlers)
             warnings.warn(msg)
+            references = []
             for handler in event_handlers:
                 for attribute in dir(handler):
                     if any(keyword in attribute for keyword in ['metric' or 'monitor']):
                         reference = getattr(handler, attribute)
-                        msg = "We have added following default handlers for you: %s and used " \
-                              "estimator.prepare_loss_and_metrics() to pass metrics to " \
-                              "those handlers. Please use the same set of metrics " \
-                              "for all your handlers. You have used %s in handler %s, " \
-                              "which is not prepared by estimator." \
-                              "in " % \
-                              (", ".join(default_handlers), attribute, handler.__class__.__name__)
                         if isinstance(reference, list):
-                            for item in reference:
-                                if item and item not in train_metrics + val_metrics:
-                                    raise ValueError(msg)
-                        elif reference and reference not in train_metrics + val_metrics:
-                            raise ValueError(msg)
+                            references += reference
+                        else:
+                            references.append(reference)
+            for metric in references:
+                if metric and metric not in train_metrics + val_metrics:
+                    msg = "We have added following default handlers for you: %s and used " \
+                          "estimator.prepare_loss_and_metrics() to pass metrics to " \
+                          "those handlers. Please use the same set of metrics " \
+                          "for all your handlers." % \
+                          ", ".join(default_handlers)
+                    raise ValueError(msg)
 
         event_handlers.sort(key=lambda handler: getattr(handler, 'priority', 0))
         return event_handlers

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -299,7 +299,7 @@ class CheckpointHandler(BatchEnd, EpochEnd):
         self.save_best_only = save_best_only
         if self.save_best_only and not isinstance(self.monitor, EvalMetric):
             raise ValueError("To save best model only, please provide one of the metric objects as monitor, "
-                             "You can create these objects using estimator.prepare_loss_and_metric()")
+                             "You can get these objects using estimator.prepare_loss_and_metric()")
         self.epoch_period = epoch_period
         self.batch_period = batch_period
         self.num_batches = 0

--- a/tests/nightly/Jenkinsfile
+++ b/tests/nightly/Jenkinsfile
@@ -136,22 +136,6 @@ core_logic: {
           utils.docker_run('ubuntu_nightly_cpu', 'nightly_test_javascript', false)
         }
       }
-    },
-    'Gluon estimator: GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/estimator-test-gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator_gpu', true)
-        }
-      }
-    },
-    'Gluon estimator: CPU': {
-      node(NODE_LINUX_CPU) {
-        ws('workspace/estimator-test-cpu') {
-          utils.unpack_and_init('cpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_cpu', 'nightly_estimator_cpu', false)
-        }
-      }
     }
   }
 }

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -106,6 +106,14 @@ core_logic: {
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_tutorial_test_ubuntu_python3_gpu', true, '1500m')
         }
       }
+    },
+    'Gluon estimator: GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/estimator-test-gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
+        }
+      }
     }
   }
 }

--- a/tests/python/unittest/test_gluon_event_handler.py
+++ b/tests/python/unittest/test_gluon_event_handler.py
@@ -19,10 +19,11 @@ import os
 import tempfile
 
 import mxnet as mx
+from common import TemporaryDirectory
 from mxnet import nd
 from mxnet.gluon import nn, loss
 from mxnet.gluon.contrib.estimator import estimator, event_handler
-from common import TemporaryDirectory
+
 
 def _get_test_network():
     net = nn.Sequential()
@@ -92,10 +93,12 @@ def test_logging():
 
         net = _get_test_network()
         ce_loss = loss.SoftmaxCrossEntropyLoss()
-        ce_loss_metric = mx.metric.Loss(ce_loss.name)
         acc = mx.metric.Accuracy()
         est = estimator.Estimator(net, loss=ce_loss, metrics=acc)
+        train_metrics, val_metrics = est.prepare_loss_and_metrics()
         logging_handler = [event_handler.LoggingHandler(file_name=file_name,
-                                                        file_location=tmpdir, train_metrics=[acc, ce_loss_metric])]
+                                                        file_location=tmpdir,
+                                                        train_metrics=train_metrics,
+                                                        val_metrics=val_metrics)]
         est.fit(test_data, event_handlers=logging_handler, epochs=1)
         assert os.path.isfile(output_dir)


### PR DESCRIPTION
## Description ##
Currently the fit api [provide user with default event handlers](https://github.com/apache/incubator-mxnet/blob/fit-api/python/mxnet/gluon/contrib/estimator/estimator.py#L236)(metric, validation, logging) if none is specified. 
It could be troublesome for users if they want to use a different logging handler but have to write the code for metric and validation handler again.
We can provide default handlers one by one, but default handlers use metrics prepared by `estimator.prepare_loss_and_metrics()`, if user used another set of metrics for user defined handlers ([example](https://github.com/apache/incubator-mxnet/pull/14765/files#diff-2fbf07e4152ad556d0023ed58c33646fR346) in test case). The metrics may not be updated correctly. We need to give a warning and add relevant checks if a mix of default and user defined handlers are used.

Changes:
1. provide default handlers one by one
2. check whether default handler and user created handler are using the same set of metrics
3. added unit test, update unit test helper function name
4. further combined nightly test into one runtime function and run under nightly for binaries.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-1396](https://issues.apache.org/jira/browse/MXNET-1396) created
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
1. provide default handlers one by one
2. check whether default handler and user created handler are using the same set of metrics
3. added unit test, update unit test helper function name
4. further combined nightly test into one runtime function and run under nightly for binaries.

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
