### PR TITLE
Updates python setup.py for recent license changes

### DIFF
--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -66,12 +66,8 @@ shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet-build/3rdparty/dmlc-core/tracke
 shutil.copy(LIB_PATH[0], os.path.join(CURRENT_DIR, 'mxnet'))
 
 # copy license and notice
-shutil.copy(os.path.join(CURRENT_DIR, 'mxnet-build/LICENSE'),
-            os.path.join(CURRENT_DIR, 'mxnet/LICENSE'))
-shutil.copy(os.path.join(CURRENT_DIR, 'mxnet-build/DISCLAIMER'),
-            os.path.join(CURRENT_DIR, 'mxnet/DISCLAIMER'))
-shutil.copy(os.path.join(CURRENT_DIR, 'mxnet-build/NOTICE'),
-            os.path.join(CURRENT_DIR, 'mxnet/NOTICE'))
+shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet-build/licenses'),
+            os.path.join(CURRENT_DIR, 'mxnet/licenses'))
 
 # copy tools to mxnet package
 shutil.rmtree(os.path.join(CURRENT_DIR, 'mxnet/tools'), ignore_errors=True)
@@ -154,20 +150,17 @@ if variant.endswith('MKL'):
         package_data['mxnet'].append('mxnet/libmklml_intel.so')
         package_data['mxnet'].append('mxnet/libiomp5.so')
         package_data['mxnet'].append('mxnet/libmkldnn.so.0')
-    shutil.copy(os.path.join(os.path.dirname(LIB_PATH[0]), '../MKLML_LICENSE'), os.path.join(CURRENT_DIR, 'mxnet'))
     shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet-build/3rdparty/mkldnn/include'),
                     os.path.join(CURRENT_DIR, 'mxnet/include/mkldnn'))
-    package_data['mxnet'].append('mxnet/MKLML_LICENSE')
 if platform.system() == 'Linux':
     shutil.copy(os.path.join(os.path.dirname(LIB_PATH[0]), 'libgfortran.so.3'), os.path.join(CURRENT_DIR, 'mxnet'))
     package_data['mxnet'].append('mxnet/libgfortran.so.3')
     shutil.copy(os.path.join(os.path.dirname(LIB_PATH[0]), 'libquadmath.so.0'), os.path.join(CURRENT_DIR, 'mxnet'))
     package_data['mxnet'].append('mxnet/libquadmath.so.0')
 
-# copy licenses
-if variant.startswith('CU'):
-    shutil.copy(os.path.join(os.path.dirname(LIB_PATH[0]), '../CUB_LICENSE'), os.path.join(CURRENT_DIR, 'mxnet'))
-    package_data['mxnet'].append('mxnet/CUB_LICENSE')
+# Copy licenses and notice
+for f in os.listdir('mxnet/licenses'):
+  package_data['mxnet'].append('mxnet/licenses/{}'.format(f))
 
 from mxnet.base import _generate_op_module_signature
 from mxnet.ndarray.register import _generate_ndarray_function_code

--- a/tools/staticbuild/build.sh
+++ b/tools/staticbuild/build.sh
@@ -69,6 +69,7 @@ mkdir -p licenses
 cp tools/dependencies/LICENSE.binary.dependencies licenses/
 cp NOTICE licenses/
 cp LICENSE licenses/
+cp DISCLAIMER licenses/
 
 
 # Build mxnet


### PR DESCRIPTION
## Description ##
A recent PR #14726 has altered the way the static build deals with licenses. This has broken the `setup.py` script for building the release pip packages. This PR fixes this problem.

I've re-added some of the removed licenses, this should be confirmed to be OK by the submitters of the aforementioned PR. @lanking520 could you please take a look?
