### PR TITLE
Deprecate NDArrayCollector and instead use ResourceScope

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
@@ -741,10 +741,16 @@ object NDArray extends NDArrayBase {
   * </b>
   */
 class NDArray private[mxnet](private[mxnet] val handle: NDArrayHandle,
-                             val writable: Boolean = true,
-                             addToCollector: Boolean = true) extends NativeResource {
-  if (addToCollector) {
-    NDArrayCollector.collect(this)
+                             val writable: Boolean) extends NativeResource {
+
+  @deprecated("Please use ResourceScope instead", "1.5.0")
+  def this(handle: NDArrayHandle,
+           writable: Boolean = true,
+           addToCollector: Boolean = true) {
+    this(handle, writable)
+    if (addToCollector) {
+      NDArrayCollector.collect(this)
+    }
   }
 
   override def nativeAddress: CPtrAddress = handle

--- a/scala-package/core/src/main/scala/org/apache/mxnet/NDArrayCollector.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NDArrayCollector.scala
@@ -64,6 +64,7 @@ import scala.collection.mutable
  *  });
  *  </pre>
  */
+@deprecated("Please use ResourceScope instead", "1.5.0")
 object NDArrayCollector {
   private val logger = LoggerFactory.getLogger(classOf[NDArrayCollector])
 
@@ -75,12 +76,14 @@ object NDArrayCollector {
    * Create a collector which will dispose the collected NDArrays automatically.
    * @return an auto-disposable collector.
    */
+  @deprecated("Please use ResourceScope instead", "1.5.0")
   def auto(): NDArrayCollector = new NDArrayCollector(true)
 
   /**
    * Create a collector allows users to later dispose the collected NDArray manually.
    * @return a manually-disposable collector.
    */
+  @deprecated("Please use ResourceScope instead", "1.5.0")
   @Experimental
   def manual(): NDArrayCollector = new NDArrayCollector(false)
 
@@ -88,11 +91,13 @@ object NDArrayCollector {
    * Collect the NDArrays into the collector of the current thread.
    * @param ndArray NDArrays need to be collected.
    */
+  @deprecated("Please use ResourceScope instead", "1.5.0")
   @varargs def collect(ndArray: NDArray*): Unit = {
     currCollector.get().add(ndArray: _*)
   }
 }
 
+@deprecated("Please use ResourceScope instead", "1.5.0")
 class NDArrayCollector private(private val autoDispose: Boolean = true,
                                private val doCollect: Boolean = true) {
   // native ptr (handle) of the NDArray -> NDArray
@@ -142,6 +147,7 @@ class NDArrayCollector private(private val autoDispose: Boolean = true,
    * @return The result of function <em>codeBlock</em>.
    */
   @Experimental
+  @deprecated("Please use ResourceScope instead", "1.5.0")
   def withScope[T](codeBlock: => T): T = {
     val old = NDArrayCollector.currCollector.get()
     NDArrayCollector.currCollector.set(this)

--- a/scala-package/core/src/main/scala/org/apache/mxnet/io/NDArrayIter.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/io/NDArrayIter.scala
@@ -177,7 +177,7 @@ class NDArrayIter(data: IndexedSeq[(DataDesc, NDArray)],
     val shape = Shape(dataBatchSize) ++ ndArray.shape.slice(1, ndArray.shape.size)
     // The new NDArray  has to be created such that it inherits dtype from the passed in array
     val newArray = NDArray.zeros(shape, dtype = ndArray.dtype)
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       val batch = ndArray.slice(cursor, numData)
       val padding = ndArray.slice(0, padNum)
       newArray.slice(0, dataBatchSize - padNum).set(batch)

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/benchmark/ScalaInferenceBenchmark.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/benchmark/ScalaInferenceBenchmark.scala
@@ -50,7 +50,7 @@ object ScalaInferenceBenchmark {
   List[Long] = {
     var inferenceTimes: List[Long] = List()
     for (i <- 1 to totalRuns) {
-      NDArrayCollector.auto().withScope {
+      ResourceScope.using() {
         val startTimeSingle = System.currentTimeMillis()
         objectToRun.runSingleInference(loadedModel, dataSet)
         val estimatedTimeSingle = System.currentTimeMillis() - startTimeSingle
@@ -67,7 +67,7 @@ object ScalaInferenceBenchmark {
 
     var inferenceTimes: List[Long] = List()
     for (batch <- dataSetBatches) {
-      NDArrayCollector.auto().withScope {
+      ResourceScope.using() {
         val loadedBatch = objecToRun.loadInputBatch(batch)
         val startTimeSingle = System.currentTimeMillis()
         objecToRun.runBatchInference(loadedModel, loadedBatch)
@@ -133,7 +133,7 @@ object ScalaInferenceBenchmark {
 
       logger.info("Running single inference call")
       // Benchmarking single inference call
-      NDArrayCollector.auto().withScope {
+      ResourceScope.using() {
         val loadedModel = loadModel(exampleToBenchmark, context, false)
         val dataSet = loadDataSet(exampleToBenchmark)
         val inferenceTimes = runInference(exampleToBenchmark, loadedModel, dataSet, baseCLI.count)
@@ -143,7 +143,7 @@ object ScalaInferenceBenchmark {
       if (baseCLI.batchSize != 0) {
         logger.info("Running for batch inference call")
         // Benchmarking batch inference call
-        NDArrayCollector.auto().withScope {
+        ResourceScope.using() {
           val loadedModel = loadModel(exampleToBenchmark, context, true)
           val batchDataSet = loadBatchDataSet(exampleToBenchmark, baseCLI.batchSize)
           val inferenceTimes = runBatchInference(exampleToBenchmark, loadedModel, batchDataSet)

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/cnntextclassification/CNNTextClassification.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/cnntextclassification/CNNTextClassification.scala
@@ -18,7 +18,7 @@
 package org.apache.mxnetexamples.cnntextclassification
 
 import org.apache.mxnet.optimizer.RMSProp
-import org.apache.mxnet.{Context, Executor, Model, NDArray, NDArrayCollector, Optimizer, Shape, Symbol, Uniform}
+import org.apache.mxnet.{Context, Executor, Model, NDArray, Optimizer, ResourceScope, Shape, Symbol, Uniform}
 import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.LoggerFactory
 
@@ -131,7 +131,7 @@ object CNNTextClassification {
       numTotal = 0f
       updateRate = 0
 
-      NDArrayCollector.auto().withScope {
+      ResourceScope.using() {
         for (begin <- 0 until trainBatches.length by batchSize) {
           val (batchD, batchL) = {
             if (begin + batchSize <= trainBatches.length) {
@@ -239,7 +239,7 @@ object CNNTextClassification {
 
   def test(w2vFilePath : String, mrDatasetPath: String,
            ctx : Context, saveModelPath: String) : Float = {
-    val output = NDArrayCollector.auto().withScope {
+    val output = ResourceScope.using() {
       val (numEmbed, word2vec) = DataHelper.loadGoogleModel(w2vFilePath)
       val (datas, labels) = DataHelper.loadMSDataWithWord2vec(
         mrDatasetPath, numEmbed, word2vec)

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/customop/ExampleCustomOp.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/customop/ExampleCustomOp.scala
@@ -19,7 +19,7 @@ package org.apache.mxnetexamples.customop
 
 import org.apache.mxnet.Callback.Speedometer
 import org.apache.mxnet.DType.DType
-import org.apache.mxnet.{Accuracy, Context, CustomOp, CustomOpProp, NDArray, NDArrayCollector, Operator, Shape, Symbol, Xavier}
+import org.apache.mxnet.{Accuracy, Context, CustomOp, CustomOpProp, NDArray, Operator, ResourceScope, Shape, Symbol, Xavier}
 import org.apache.mxnet.optimizer.RMSProp
 import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.LoggerFactory
@@ -141,7 +141,7 @@ object ExampleCustomOp {
       evalMetric.reset()
       var nBatch = 0
       var epochDone = false
-      NDArrayCollector.auto().withScope {
+      ResourceScope.using() {
         trainIter.reset()
         while (!epochDone) {
           var doReset = true

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/gan/GanMnist.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/gan/GanMnist.scala
@@ -17,7 +17,7 @@
 
 package org.apache.mxnetexamples.gan
 
-import org.apache.mxnet.{Context, CustomMetric, DataBatch, IO, NDArray, NDArrayCollector, Shape, Symbol, Xavier}
+import org.apache.mxnet.{Context, CustomMetric, DataBatch, IO, NDArray, ResourceScope, Shape, Symbol, Xavier}
 import org.apache.mxnet.optimizer.Adam
 import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.LoggerFactory
@@ -104,7 +104,7 @@ object GanMnist {
 
   def runTraining(dataPath : String, context : Context,
                   outputPath : String, numEpoch : Int): Float = {
-    val output = NDArrayCollector.auto().withScope {
+    val output = ResourceScope.using() {
       val lr = 0.0005f
       val beta1 = 0.5f
       val batchSize = 100
@@ -147,7 +147,7 @@ object GanMnist {
         t = 0
         while (mnistIter.hasNext) {
           dataBatch = mnistIter.next()
-          NDArrayCollector.auto().withScope {
+          ResourceScope.using() {
             gMod.update(dataBatch)
             gMod.dLabel.set(0f)
             metricAcc.update(Array(gMod.dLabel), gMod.outputsFake)

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/imageclassifier/ImageClassifierExample.scala
@@ -49,7 +49,7 @@ object ImageClassifierExample {
   def runInferenceOnSingleImage(modelPathPrefix: String, inputImagePath: String,
                                 context: Array[Context]):
   IndexedSeq[IndexedSeq[(String, Float)]] = {
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       val dType = DType.Float32
       val inputShape = Shape(1, 3, 224, 224)
 
@@ -71,7 +71,7 @@ object ImageClassifierExample {
   def runInferenceOnBatchOfImage(modelPathPrefix: String, inputImageDir: String,
                                  context: Array[Context]):
   IndexedSeq[IndexedSeq[(String, Float)]] = {
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       val dType = DType.Float32
       val inputShape = Shape(1, 3, 224, 224)
 

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/infer/objectdetector/SSDClassifierExample.scala
@@ -51,7 +51,7 @@ object SSDClassifierExample {
   def runObjectDetectionSingle(modelPathPrefix: String, inputImagePath: String,
                                context: Array[Context]):
   IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       val dType = DType.Float32
       val inputShape = Shape(1, 3, 512, 512)
       // ssd detections, numpy.array([[id, score, x1, y1, x2, y2]...])
@@ -68,7 +68,7 @@ object SSDClassifierExample {
   def runObjectDetectionBatch(modelPathPrefix: String, inputImageDir: String,
                               context: Array[Context]):
   IndexedSeq[IndexedSeq[(String, Array[Float])]] = {
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       val dType = DType.Float32
       val inputShape = Shape(1, 3, 512, 512)
       // ssd detections, numpy.array([[id, score, x1, y1, x2, y2]...])

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/multitask/ExampleMultiTask.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/multitask/ExampleMultiTask.scala
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory
 
 import scala.collection.JavaConverters._
 import org.apache.commons.io.FileUtils
-import org.apache.mxnet.{Context, DataBatch, DataDesc, DataIter, EvalMetric, Executor, NDArray, NDArrayCollector, Shape, Symbol, Xavier}
+import org.apache.mxnet.{Context, DataBatch, DataDesc, DataIter, EvalMetric, Executor, NDArray, ResourceScope, Shape, Symbol, Xavier}
 import org.apache.mxnet.DType.DType
 import org.apache.mxnet.optimizer.RMSProp
 import org.apache.mxnetexamples.Util
@@ -222,7 +222,7 @@ object ExampleMultiTask {
 
   def train(batchSize: Int, numEpoch: Int, ctx: Context, modelDirPath: String):
   (Executor, MultiAccuracy) = {
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       val lr = 0.001f
       val network = ExampleMultiTask.buildNetwork()
       val (trainIter, valIter) =

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyle.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyle.scala
@@ -170,7 +170,7 @@ object NeuralStyle {
                   contentWeight : Float, tvWeight : Float, gaussianRadius : Int,
                   lr: Float, maxNumEpochs: Int, maxLongEdge: Int,
                   saveEpochs : Int, stopEps: Float) : Unit = {
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       val contentNp = preprocessContentImage(contentImage, maxLongEdge, dev)
       val styleNp = preprocessStyleImage(styleImage, contentNp.shape, dev)
       val size = (contentNp.shape(2), contentNp.shape(3))

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostInference.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostInference.scala
@@ -17,7 +17,7 @@
 
 package org.apache.mxnetexamples.neuralstyle.end2end
 
-import org.apache.mxnet.{Context, NDArrayCollector, Shape}
+import org.apache.mxnet.{Context, ResourceScope, Shape}
 import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.LoggerFactory
 
@@ -29,7 +29,7 @@ object BoostInference {
 
   def runInference(modelPath: String, outputPath: String, guassianRadius : Int,
                    inputImage : String, ctx : Context): Unit = {
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       val dShape = Shape(1, 3, 480, 640)
       val clipNorm = 1.0f * dShape.product
       // generator
@@ -47,7 +47,7 @@ object BoostInference {
         DataProcessing.preprocessContentImage(s"$inputImage", dShape, ctx)
       var data = Array(contentNp)
       for (i <- 0 until gens.length) {
-        NDArrayCollector.auto().withScope {
+        ResourceScope.using() {
           gens(i).forward(data.takeRight(1))
           val newImg = gens(i).getOutputs()(0)
           data :+= newImg

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostTrain.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/neuralstyle/end2end/BoostTrain.scala
@@ -19,7 +19,7 @@ package org.apache.mxnetexamples.neuralstyle.end2end
 
 import java.io.File
 
-import org.apache.mxnet.{Context, Executor, NDArray, NDArrayCollector, Shape, Symbol}
+import org.apache.mxnet.{Context, Executor, NDArray, ResourceScope, Shape, Symbol}
 import org.apache.mxnet.optimizer.SGD
 import org.kohsuke.args4j.{CmdLineParser, Option}
 import org.slf4j.LoggerFactory
@@ -56,7 +56,7 @@ object BoostTrain {
 
   def runTraining(dataPath : String, vggModelPath: String, ctx : Context,
                   styleImage : String, saveModelPath : String) : Unit = {
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       // params
       val vggParams = NDArray.load2Map(vggModelPath)
       val styleWeight = 1.2f
@@ -117,7 +117,7 @@ object BoostTrain {
 
       // train
       for (i <- startEpoch until endEpoch) {
-        NDArrayCollector.auto().withScope {
+        ResourceScope.using() {
           filelist = Random.shuffle(filelist)
           for (idx <- filelist.indices) {
             var dataArray = Array[NDArray]()

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/LstmBucketing.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/LstmBucketing.scala
@@ -62,7 +62,7 @@ object LstmBucketing {
 
   def runTraining(trainData : String, validationData : String,
                   ctx : Array[Context], numEpoch : Int): Unit = {
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       val batchSize = 32
       val buckets = Array(10, 20, 30, 40, 50, 60)
       val numHidden = 200

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TestCharRnn.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TestCharRnn.scala
@@ -34,7 +34,7 @@ object TestCharRnn {
   private val logger = LoggerFactory.getLogger(classOf[TrainCharRnn])
 
   def runInferenceCharRNN(dataPath: String, modelPrefix: String, starterSentence : String): Unit = {
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       // The batch size for training
       val batchSize = 32
       // We can support various length input

--- a/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TrainCharRnn.scala
+++ b/scala-package/examples/src/main/scala/org/apache/mxnetexamples/rnn/TrainCharRnn.scala
@@ -33,7 +33,7 @@ object TrainCharRnn {
 
   def runTrainCharRnn(dataPath: String, saveModelPath: String,
                       ctx : Context, numEpoch : Int): Unit = {
-    NDArrayCollector.auto().withScope {
+    ResourceScope.using() {
       // The batch size for training
       val batchSize = 32
       // We can support various length input

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/cnntextclassification/CNNClassifierExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/cnntextclassification/CNNClassifierExampleSuite.scala
@@ -21,7 +21,7 @@ import java.io.File
 import java.net.URL
 
 import org.apache.commons.io.FileUtils
-import org.apache.mxnet.{Context, NDArrayCollector}
+import org.apache.mxnet.Context
 import org.apache.mxnetexamples.Util
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.slf4j.LoggerFactory

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/gan/GanExampleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/gan/GanExampleSuite.scala
@@ -19,7 +19,7 @@ package org.apache.mxnetexamples.gan
 
 import java.io.File
 
-import org.apache.mxnet.{Context, NDArrayCollector}
+import org.apache.mxnet.Context
 import org.apache.mxnetexamples.Util
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Ignore}
 import org.slf4j.LoggerFactory

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyleSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/neuralstyle/NeuralStyleSuite.scala
@@ -17,7 +17,7 @@
 
 package org.apache.mxnetexamples.neuralstyle
 
-import org.apache.mxnet.{Context, NDArrayCollector}
+import org.apache.mxnet.Context
 import org.apache.mxnetexamples.Util
 import org.apache.mxnetexamples.neuralstyle.end2end.{BoostInference, BoostTrain}
 import org.scalatest.{BeforeAndAfterAll, FunSuite}

--- a/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
+++ b/scala-package/examples/src/test/scala/org/apache/mxnetexamples/rnn/ExampleRNNSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.mxnetexamples.rnn
 
 
-import org.apache.mxnet.{Context, NDArrayCollector}
+import org.apache.mxnet.Context
 import org.apache.mxnetexamples.Util
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Ignore}
 import org.slf4j.LoggerFactory


### PR DESCRIPTION
## Description ##
This PR now removes all usages of NDArrayCollector throughout the code and deprecates it as of the 1.5.0 release.

It also updates the ResourceScope to recursively move NDArrays to outer scope when in hierarchical structure of Traversables (list, set, map, etc.) and Products (tuples). It adds a method to check if the ResourceScope contains a value and fixes a bug where moveToOuterScope would move a value to the outer scope despite it not being in the inner scope in the first place.

This contains additions originally part of #14666 that were split out.

@lanking520 @andrewfayres @nswamy 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change