### PR TITLE
[clojure][generator] ndarray/symbol api random merged

### DIFF
--- a/contrib/clojure-package/src/dev/generator.clj
+++ b/contrib/clojure-package/src/dev/generator.clj
@@ -29,6 +29,7 @@
 
 
 (defn clojure-case
+  "Transforms a scala string (function name) to clojure case"
   [string]
   (-> string
       (clojure.string/replace #"(\s+)([A-Z][a-z]+)" "$1-$2")
@@ -57,10 +58,9 @@
        count
        pos?))
 
-
 (defn increment-param-name [pname]
   (if-let [num-str (re-find #"-\d" pname)]
-    (str 
+    (str
      (first (clojure.string/split pname #"-"))
      "-"
      (inc (Integer/parseInt (last (clojure.string/split num-str #"-")))))
@@ -130,15 +130,33 @@
       (.write w fstr))
     (.write w "\n"))))
 
+(defn remove-prefix
+  [prefix s]
+  (let [regex (re-pattern (str prefix "(.*)"))
+        replacement "$1"]
+  (clojure.string/replace s regex replacement)))
+
+(defn in-namespace-random? [op-name]
+  (or (clojure.string/includes? op-name "random_")
+      (clojure.string/includes? op-name "sample_")))
+
+(defn op-name->namespace-type [op-name]
+  (cond
+    (#{"uniform" "normal"} op-name)              :deprecated
+    (clojure.string/includes? op-name "random_") :random
+    (clojure.string/includes? op-name "sample_") :random
+    :else                                        :core))
+
 ;;;;;;; Common operations
 
 (def libinfo (Base/_LIB))
+
 (def op-names
   (let [l ($ ListBuffer/empty)]
-    (do (.mxListAllOpNames libinfo l)
-        (remove #(or (= "Custom" %)
-                     (re-matches #"^_.*" %))
-                (util/buffer->vec l)))))
+    (.mxListAllOpNames libinfo l)
+    (->> l
+         (util/buffer->vec)
+         (remove #(or (= "Custom" %) (re-matches #"^_.*" %))))))
 
 (defn- parse-arg-type [s]
   (let [[_ var-arg-type _ set-arg-type arg-spec _ type-req _ default-val] (re-find #"(([\w-\[\]\s]+)|\{([^}]+)\})\s*(\([^)]+\))?(,\s*(optional|required)(,\s*default=(.*))?)?" s)]
@@ -288,8 +306,6 @@
      `(~'defn ~function-name
        ~@(remove nil? (gen-symbol-function-arity op-name op-values function-name))))))
 
-
-
 (def symbol-gen-ns "(ns org.apache.clojure-mxnet.symbol
   (:refer-clojure :exclude [* - + > >= < <= / cast concat identity flatten load max
                             min repeat reverse set sort take to-array empty sin
@@ -300,7 +316,9 @@
 
 (defn generate-symbol-file []
   (println "Generating symbol file")
-  (write-to-file all-symbol-functions symbol-gen-ns "src/org/apache/clojure_mxnet/gen/symbol.clj"))
+  (write-to-file all-symbol-functions
+                 symbol-gen-ns
+                 "src/org/apache/clojure_mxnet/gen/symbol.clj"))
 
 ;;;;;;; NDArray
 
@@ -322,20 +340,16 @@
        count
        pos?))
 
-
 (def ndarray-public-to-hand-gen
   (filter is-ndarray-hand-gen? ndarray-public-no-default))
 (def ndarray-public-to-gen
   (get-public-to-gen-methods ndarray-public-to-hand-gen
                              ndarray-public-no-default))
 
-
 (count ndarray-public-to-hand-gen) ;=> 15
 (count ndarray-public-to-gen) ;=> 486
 
 (->> ndarray-public-to-hand-gen (map :name) (into #{}))
-
-
 
 (defn gen-ndarray-function-arity [op-name op-values]
   (for [[param-count info] op-values]
@@ -380,7 +394,8 @@
 (def all-ndarray-functions
   (gen-ndarray-functions ndarray-public-to-gen))
 
-(def ndarray-gen-ns "(ns org.apache.clojure-mxnet.ndarray
+(def ndarray-gen-ns
+  "(ns org.apache.clojure-mxnet.ndarray
   (:refer-clojure :exclude [* - + > >= < <= / cast concat flatten identity load max
                             min repeat reverse set sort take to-array empty shuffle
                             ref])
@@ -394,6 +409,17 @@
                  "src/org/apache/clojure_mxnet/gen/ndarray.clj"))
 
 ;;;;;;; SymbolAPI
+
+(defn fn-name->random-fn-name
+  [fn-name]
+  (cond
+    (clojure.string/starts-with? fn-name "-random-")
+    (remove-prefix "-random-" fn-name)
+
+    (clojure.string/starts-with? fn-name "-sample-")
+    (str (remove-prefix "-sample-" fn-name) "-like")
+
+    :else fn-name))
 
 (defn symbol-api-coerce-param
   [{:keys [name sym type optional?]}]
@@ -435,47 +461,80 @@
        (~(symbol (str "SymbolAPI/" op-name))
         ~@coerced-params)))))
 
-(defn gen-symbol-api-function [op-name]
-  (let [{:keys [fn-name fn-description args]} (gen-op-info op-name)
-        params (mapv (fn [{:keys [name type optional?] :as opts}]
-                       (assoc opts
-                              :sym (symbol name)
-                              :optional? (or optional?
-                                             (= "NDArray-or-Symbol" type))))
-                     (conj args
-                           {:name "name"
-                            :type "String"
-                            :optional? true
-                            :description "Name of the symbol"}
-                           {:name "attr"
-                            :type "Map[String, String]"
-                            :optional? true
-                            :description "Attributes of the symbol"}))
-        doc (clojure.string/join
-             "\n\n  "
-             (-> (gen-symbol-api-doc fn-description params)
-                 (clojure.string/split #"\n")))
-        default-call (gen-symbol-api-default-arity op-name params)]
-    `(~'defn ~(symbol fn-name)
-      ~doc
-      ~@default-call)))
+(defn symbol-api-gen-ns
+  [random-namespace?]
+  (str
+    "(ns\n"
+    "  ^{:doc \"Experimental\"}\n"
+    (if random-namespace?
+      "  org.apache.clojure-mxnet.symbol-random-api\n"
+      "  org.apache.clojure-mxnet.symbol-api\n")
+    "  (:refer-clojure :exclude [* - + > >= < <= / cast concat identity flatten load max\n"
+    "                            min repeat reverse set sort take to-array empty sin\n"
+    "                            get apply shuffle ref])\n"
+    "  (:require [org.apache.clojure-mxnet.util :as util]\n"
+    "            [org.apache.clojure-mxnet.shape :as mx-shape])\n"
+    "  (:import (org.apache.mxnet SymbolAPI)))"))
 
-(def all-symbol-api-functions
-  (mapv gen-symbol-api-function op-names))
+(defn make-gen-symbol-api-function
+  [{:keys [fn-name->fn-name] :or {fn-name->fn-name identity}}]
+  (fn [op-name]
+    (let [{:keys [fn-name fn-description args]}
+          (-> op-name (gen-op-info) (update :fn-name fn-name->fn-name))
+          params (mapv (fn [{:keys [name type optional?] :as opts}]
+                         (assoc opts
+                                :sym (symbol name)
+                                :optional? (or optional?
+                                               (= "NDArray-or-Symbol" type))))
+                       (conj args
+                             {:name "name"
+                              :type "String"
+                              :optional? true
+                              :description "Name of the symbol"}
+                             {:name "attr"
+                              :type "Map[String, String]"
+                              :optional? true
+                              :description "Attributes of the symbol"}))
+          doc (clojure.string/join
+                "\n\n  "
+                (-> (gen-symbol-api-doc fn-description params)
+                    (clojure.string/split #"\n")))
+          default-call (gen-symbol-api-default-arity op-name params)]
+      `(~'defn ~(symbol fn-name)
+         ~doc
+         ~@default-call))))
 
-(def symbol-api-gen-ns "(ns
-  ^{:doc \"Experimental\"}
-  org.apache.clojure-mxnet.symbol-api
-  (:refer-clojure :exclude [* - + > >= < <= / cast concat identity flatten load max
-                            min repeat reverse set sort take to-array empty sin
-                            get apply shuffle ref])
-  (:require [org.apache.clojure-mxnet.util :as util]
-            [org.apache.clojure-mxnet.shape :as mx-shape])
-  (:import (org.apache.mxnet SymbolAPI)))")
+(def gen-symbol-api-function
+  (make-gen-symbol-api-function {}))
 
-(defn generate-symbol-api-file []
+(def gen-symbol-random-api-function
+  (make-gen-symbol-api-function {:fn-name->fn-name fn-name->random-fn-name}))
+
+(defn all-symbol-api-functions [op-names]
+  (->> op-names
+       (filter #(= :core (op-name->namespace-type %)))
+       (mapv gen-symbol-api-function)))
+
+(count (all-symbol-api-functions op-names)) ;215
+
+(defn all-symbol-random-api-functions [op-names]
+  (->> op-names
+       (filter #(= :random (op-name->namespace-type %)))
+       (mapv gen-symbol-random-api-function)))
+
+(count (all-symbol-random-api-functions op-names)) ;16
+
+(defn generate-symbol-api-file [op-names]
   (println "Generating symbol-api file")
-  (write-to-file all-symbol-api-functions symbol-api-gen-ns "src/org/apache/clojure_mxnet/gen/symbol_api.clj"))
+  (write-to-file (all-symbol-api-functions op-names)
+                 (symbol-api-gen-ns false)
+                 "src/org/apache/clojure_mxnet/gen/symbol_api.clj"))
+
+(defn generate-symbol-random-api-file [op-names]
+  (println "Generating symbol-random-api file")
+  (write-to-file (all-symbol-random-api-functions op-names)
+                 (symbol-api-gen-ns true)
+                 "src/org/apache/clojure_mxnet/gen/symbol_random_api.clj"))
 
 ;;;;;;; NDArrayAPI
 
@@ -519,57 +578,94 @@
     `(~(mapv :sym req-params)
       (~(symbol fn-name) ~req-args))))
 
-(defn gen-ndarray-api-function [op-name]
-  (let [{:keys [fn-name fn-description args]} (gen-op-info op-name)
-        params (mapv (fn [{:keys [name] :as opts}]
-                       (assoc opts :sym (symbol name)))
-                     (conj args {:name "out"
-                                 :type "NDArray-or-Symbol"
-                                 :optional? true
-                                 :description "Output array."}))
-        doc (clojure.string/join
-             "\n\n  "
-             (-> (gen-ndarray-api-doc fn-description params)
-                 (clojure.string/split #"\n")))
-        opt-params (filter :optional? params)
-        req-params (remove :optional? params)
-        req-call (gen-ndarray-api-required-arity fn-name req-params)
-        default-call (gen-ndarray-api-default-arity op-name params)]
-    (if (= 1 (count req-params))
-      `(~'defn ~(symbol fn-name)
-        ~doc
-        ~@default-call)
-      `(~'defn ~(symbol fn-name)
-        ~doc
-        ~req-call
-        ~default-call))))
+(defn make-gen-ndarray-api-function
+  [{:keys [fn-name->fn-name] :or {fn-name->fn-name identity}}]
+  (fn [op-name]
+    (let [{:keys [fn-name fn-description args]}
+          (-> op-name (gen-op-info) (update :fn-name fn-name->fn-name))
+          params (mapv (fn [{:keys [name] :as opts}]
+                         (assoc opts :sym (symbol name)))
+                       (conj args {:name "out"
+                                   :type "NDArray-or-Symbol"
+                                   :optional? true
+                                   :description "Output array."}))
+          doc (clojure.string/join
+                "\n\n  "
+                (-> (gen-ndarray-api-doc fn-description params)
+                    (clojure.string/split #"\n")))
+          opt-params (filter :optional? params)
+          req-params (remove :optional? params)
+          req-call (gen-ndarray-api-required-arity fn-name req-params)
+          default-call (gen-ndarray-api-default-arity op-name params)]
+      (if (= 1 (count req-params))
+        `(~'defn ~(symbol fn-name)
+           ~doc
+           ~@default-call)
+        `(~'defn ~(symbol fn-name)
+           ~doc
+           ~req-call
+           ~default-call)))))
 
-(def all-ndarray-api-functions
-  (mapv gen-ndarray-api-function op-names))
+(def gen-ndarray-api-function
+  (make-gen-ndarray-api-function {}))
 
-(def ndarray-api-gen-ns "(ns
-  ^{:doc \"Experimental\"}
-  org.apache.clojure-mxnet.ndarray-api
-  (:refer-clojure :exclude [* - + > >= < <= / cast concat flatten identity load max
-                            min repeat reverse set sort take to-array empty shuffle
-                            ref])
-  (:require [org.apache.clojure-mxnet.shape :as mx-shape]
-            [org.apache.clojure-mxnet.util :as util])
-  (:import (org.apache.mxnet NDArrayAPI)))")
+(def gen-ndarray-random-api-function
+  (make-gen-ndarray-api-function {:fn-name->fn-name fn-name->random-fn-name}))
 
+(defn all-ndarray-api-functions [op-names]
+  (->> op-names
+       (filter #(= :core (op-name->namespace-type %)))
+       (mapv gen-ndarray-api-function)))
 
-(defn generate-ndarray-api-file []
+(count (all-ndarray-api-functions op-names)) ; 213
+
+(defn all-ndarray-random-api-functions [op-names]
+  (->> op-names
+       (filter #(= :random (op-name->namespace-type %)))
+       (mapv gen-ndarray-random-api-function)))
+
+(count (all-ndarray-random-api-functions op-names)) ;16
+
+(defn ndarray-api-gen-ns [random-namespace?]
+  (str
+    "(ns\n"
+    "  ^{:doc \"Experimental\"}\n"
+    (if random-namespace?
+      "  org.apache.clojure-mxnet.ndarray-random-api\n"
+      "  org.apache.clojure-mxnet.ndarray-api\n")
+    "  (:refer-clojure :exclude [* - + > >= < <= / cast concat flatten identity load max\n"
+    "                            min repeat reverse set sort take to-array empty shuffle\n"
+    "                            ref])\n"
+    "  (:require [org.apache.clojure-mxnet.shape :as mx-shape]\n"
+    "            [org.apache.clojure-mxnet.util :as util])\n"
+    "  (:import (org.apache.mxnet NDArrayAPI)))"))
+
+(defn generate-ndarray-api-file [op-names]
   (println "Generating ndarray-api file")
-  (write-to-file all-ndarray-api-functions
-                 ndarray-api-gen-ns
+  (write-to-file (all-ndarray-api-functions op-names)
+                 (ndarray-api-gen-ns false)
                  "src/org/apache/clojure_mxnet/gen/ndarray_api.clj"))
+
+(defn generate-ndarray-random-api-file [op-names]
+  (println "Generating ndarray-random-api file")
+  (write-to-file (all-ndarray-random-api-functions op-names)
+                 (ndarray-api-gen-ns true)
+                 "src/org/apache/clojure_mxnet/gen/ndarray_random_api.clj"))
+
 
 ;;; autogen the files
 (do
   (generate-ndarray-file)
-  (generate-ndarray-api-file)
+
+  ;; NDArrayAPI
+  (generate-ndarray-api-file op-names)
+  (generate-ndarray-random-api-file op-names)
+
   (generate-symbol-file)
-  (generate-symbol-api-file))
+
+  ;; SymbolAPI
+  (generate-symbol-api-file op-names)
+  (generate-symbol-random-api-file op-names))
 
 
 (comment
@@ -580,8 +676,14 @@
 
   (gen-symbol-api-function "Activation")
 
+  (gen-ndarray-random-api-function "random_randint")
+
+  (gen-ndarray-random-api-function "sample_normal")
+
+  (gen-symbol-random-api-function "random_poisson")
+
   ;; This generates a file with the bulk of the nd-array functions
   (generate-ndarray-file)
 
   ;; This generates a file with the bulk of the symbol functions
-  (generate-symbol-file)  )
+  (generate-symbol-file))

--- a/contrib/clojure-package/src/org/apache/clojure_mxnet/ndarray_random_api.clj
+++ b/contrib/clojure-package/src/org/apache/clojure_mxnet/ndarray_random_api.clj
@@ -14,12 +14,8 @@
 ;; limitations under the License.
 ;;
 
-(ns org.apache.clojure-mxnet.ndarray-api
-  "Experimental NDArray API"
-  (:refer-clojure
-    :exclude [* - + > >= < <= / cast concat flatten identity load max
-              min repeat reverse set sort take to-array empty shuffle
-              ref])
+(ns org.apache.clojure-mxnet.ndarray-random-api
+  "Experimental NDArray Random API"
   (:require [org.apache.clojure-mxnet.base :as base]
             [org.apache.clojure-mxnet.context :as mx-context]
             [org.apache.clojure-mxnet.shape :as mx-shape]
@@ -29,4 +25,4 @@
   (:import (org.apache.mxnet NDArrayAPI)))
 
 ;; loads the generated functions into the namespace
-(do (clojure.core/load "gen/ndarray_api"))
+(do (clojure.core/load "gen/ndarray_random_api"))

--- a/contrib/clojure-package/src/org/apache/clojure_mxnet/symbol_random_api.clj
+++ b/contrib/clojure-package/src/org/apache/clojure_mxnet/symbol_random_api.clj
@@ -14,19 +14,19 @@
 ;; limitations under the License.
 ;;
 
-(ns org.apache.clojure-mxnet.ndarray-api
-  "Experimental NDArray API"
-  (:refer-clojure
-    :exclude [* - + > >= < <= / cast concat flatten identity load max
-              min repeat reverse set sort take to-array empty shuffle
-              ref])
+(ns org.apache.clojure-mxnet.symbol-random-api
+  "Experimental Symbol Random API"
+  (:refer-clojure :exclude [* - + > >= < <= / cast concat identity flatten load max
+                            min repeat reverse set sort take to-array empty sin
+                            get apply shuffle ref])
   (:require [org.apache.clojure-mxnet.base :as base]
             [org.apache.clojure-mxnet.context :as mx-context]
+            [org.apache.clojure-mxnet.executor :as ex]
             [org.apache.clojure-mxnet.shape :as mx-shape]
             [org.apache.clojure-mxnet.util :as util]
-            [clojure.reflect :as r]
-            [t6.from-scala.core :refer [$] :as $])
-  (:import (org.apache.mxnet NDArrayAPI)))
+            [t6.from-scala.core :refer [$] :as $]
+            [org.apache.clojure-mxnet.ndarray :as ndarray])
+  (:import (org.apache.mxnet SymbolAPI)))
 
 ;; loads the generated functions into the namespace
-(do (clojure.core/load "gen/ndarray_api"))
+(do (clojure.core/load "gen/symbol_random_api"))

--- a/contrib/clojure-package/test/dev/generator_test.clj
+++ b/contrib/clojure-package/test/dev/generator_test.clj
@@ -27,6 +27,20 @@
   (is (= "foo-bar" (gen/clojure-case "Foo_Bar")))
   (is (= "div+" (gen/clojure-case "/+"))))
 
+(deftest fn-name->random-fn-name
+  (is (= "poisson" (gen/fn-name->random-fn-name "-random-poisson")))
+  (is (= "poisson-like" (gen/fn-name->random-fn-name "-sample-poisson"))))
+
+(deftest remove-prefix
+  (is (= "randint" (gen/remove-prefix "-random-" "-random-randint")))
+  (is (= "exponential" (gen/remove-prefix "-sample-" "-sample-exponential"))))
+
+(deftest in-namespace-random?
+  (is (gen/in-namespace-random? "random_randint"))
+  (is (gen/in-namespace-random? "sample_poisson"))
+  (is (not (gen/in-namespace-random? "rnn")))
+  (is (not (gen/in-namespace-random? "activation"))))
+
 (defn ndarray-reflect-info [name]
   (->> gen/ndarray-public-no-default
        (filter #(= name (str (:name %))))
@@ -317,13 +331,24 @@
 (deftest test-write-to-file
   (testing "symbol-api"
     (let [fname "test/test-symbol-api.clj"
-          _ (gen/write-to-file [(first gen/all-symbol-api-functions)
-                                (second gen/all-symbol-api-functions)]
-                               gen/symbol-api-gen-ns
+          fns (gen/all-symbol-api-functions gen/op-names)
+          _ (gen/write-to-file [(first fns) (second fns)]
+                               (gen/symbol-api-gen-ns false)
                                fname)
           good-contents (slurp "test/good-test-symbol-api.clj")
           contents (slurp fname)]
       (is (= good-contents contents))))
+
+  (testing "symbol-random-api"
+    (let [fname "test/test-symbol-random-api.clj"
+          fns (gen/all-symbol-random-api-functions gen/op-names)
+          _ (gen/write-to-file [(first fns) (second fns)]
+                               (gen/symbol-api-gen-ns true)
+                               fname)
+          good-contents (slurp "test/good-test-symbol-random-api.clj")
+          contents (slurp fname)]
+      (is (= good-contents contents))))
+
 
  (testing "symbol"
     (let [fname "test/test-symbol.clj"
@@ -336,11 +361,21 @@
 
   (testing "ndarray-api"
     (let [fname "test/test-ndarray-api.clj"
-          _ (gen/write-to-file [(first gen/all-ndarray-api-functions)
-                                (second gen/all-ndarray-api-functions)]
-                               gen/ndarray-api-gen-ns
+          fns (gen/all-ndarray-api-functions gen/op-names)
+          _ (gen/write-to-file [(first fns) (second fns)]
+                               (gen/ndarray-api-gen-ns false)
                                fname)
           good-contents (slurp "test/good-test-ndarray-api.clj")
+          contents (slurp fname)]
+      (is (= good-contents contents))))
+
+  (testing "ndarray-random-api"
+    (let [fname "test/test-ndarray-random-api.clj"
+          fns (gen/all-ndarray-random-api-functions gen/op-names)
+          _ (gen/write-to-file [(first fns) (second fns)]
+                               (gen/ndarray-api-gen-ns true)
+                               fname)
+          good-contents (slurp "test/good-test-ndarray-random-api.clj")
           contents (slurp fname)]
       (is (= good-contents contents))))
 

--- a/contrib/clojure-package/test/good-test-ndarray-random-api.clj
+++ b/contrib/clojure-package/test/good-test-ndarray-random-api.clj
@@ -1,0 +1,62 @@
+(ns
+  ^{:doc "Experimental"}
+  org.apache.clojure-mxnet.ndarray-random-api
+  (:refer-clojure :exclude [* - + > >= < <= / cast concat flatten identity load max
+                            min repeat reverse set sort take to-array empty shuffle
+                            ref])
+  (:require [org.apache.clojure-mxnet.shape :as mx-shape]
+            [org.apache.clojure-mxnet.util :as util])
+  (:import (org.apache.mxnet NDArrayAPI)))
+
+;; Do not edit - this is auto-generated
+
+;; Licensed to the Apache Software Foundation (ASF) under one or more
+;; contributor license agreements.  See the NOTICE file distributed with
+;; this work for additional information regarding copyright ownership.
+;; The ASF licenses this file to You under the Apache License, Version 2.0
+;; (the "License"); you may not use this file except in compliance with
+;; the License.  You may obtain a copy of the License at
+;;
+;;    http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+
+
+
+(defn
+ exponential
+ "Draw random samples from an exponential distribution.\n\nSamples are distributed according to an exponential distribution parametrized by *lambda* (rate).\n\nExample::\n\n   exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],\n                                      [ 0.04146638,  0.31715935]]\n\n\nDefined in src/operator/random/sample_op.cc:L137\n\n`lam`: Lambda parameter (rate) of the exponential distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`out`: Output array. (optional)\n"
+ ([] (exponential {}))
+ ([{:keys [lam shape ctx dtype out],
+    :or {lam nil, shape nil, ctx nil, dtype nil, out nil},
+    :as opts}]
+  (util/coerce-return
+   (NDArrayAPI/random_exponential
+    (util/->option lam)
+    (util/->option (clojure.core/when shape (mx-shape/->shape shape)))
+    (util/->option ctx)
+    (util/->option dtype)
+    (util/->option out)))))
+
+(defn
+ gamma
+ "Draw random samples from a gamma distribution.\n\nSamples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).\n\nExample::\n\n   gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],\n                                            [ 3.91697288,  3.65933681]]\n\n\nDefined in src/operator/random/sample_op.cc:L125\n\n`alpha`: Alpha parameter (shape) of the gamma distribution. (optional)\n`beta`: Beta parameter (scale) of the gamma distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`out`: Output array. (optional)\n"
+ ([] (gamma {}))
+ ([{:keys [alpha beta shape ctx dtype out],
+    :or {alpha nil, beta nil, shape nil, ctx nil, dtype nil, out nil},
+    :as opts}]
+  (util/coerce-return
+   (NDArrayAPI/random_gamma
+    (util/->option alpha)
+    (util/->option beta)
+    (util/->option (clojure.core/when shape (mx-shape/->shape shape)))
+    (util/->option ctx)
+    (util/->option dtype)
+    (util/->option out)))))
+

--- a/contrib/clojure-package/test/good-test-ndarray-random-api.clj
+++ b/contrib/clojure-package/test/good-test-ndarray-random-api.clj
@@ -31,7 +31,23 @@
 
 (defn
  exponential
- "Draw random samples from an exponential distribution.\n\nSamples are distributed according to an exponential distribution parametrized by *lambda* (rate).\n\nExample::\n\n   exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],\n                                      [ 0.04146638,  0.31715935]]\n\n\nDefined in src/operator/random/sample_op.cc:L137\n\n`lam`: Lambda parameter (rate) of the exponential distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`out`: Output array. (optional)\n"
+ "Draw random samples from an exponential distribution.
+  
+  Samples are distributed according to an exponential distribution parametrized by *lambda* (rate).
+  
+  Example::
+  
+     exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],
+                                        [ 0.04146638,  0.31715935]]
+  
+  
+  Defined in src/operator/random/sample_op.cc:L137
+  
+  `lam`: Lambda parameter (rate) of the exponential distribution. (optional)
+  `shape`: Shape of the output. (optional)
+  `ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)
+  `dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)
+  `out`: Output array. (optional)"
  ([] (exponential {}))
  ([{:keys [lam shape ctx dtype out],
     :or {lam nil, shape nil, ctx nil, dtype nil, out nil},
@@ -46,7 +62,24 @@
 
 (defn
  gamma
- "Draw random samples from a gamma distribution.\n\nSamples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).\n\nExample::\n\n   gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],\n                                            [ 3.91697288,  3.65933681]]\n\n\nDefined in src/operator/random/sample_op.cc:L125\n\n`alpha`: Alpha parameter (shape) of the gamma distribution. (optional)\n`beta`: Beta parameter (scale) of the gamma distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`out`: Output array. (optional)\n"
+ "Draw random samples from a gamma distribution.
+  
+  Samples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).
+  
+  Example::
+  
+     gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],
+                                              [ 3.91697288,  3.65933681]]
+  
+  
+  Defined in src/operator/random/sample_op.cc:L125
+  
+  `alpha`: Alpha parameter (shape) of the gamma distribution. (optional)
+  `beta`: Beta parameter (scale) of the gamma distribution. (optional)
+  `shape`: Shape of the output. (optional)
+  `ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)
+  `dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)
+  `out`: Output array. (optional)"
  ([] (gamma {}))
  ([{:keys [alpha beta shape ctx dtype out],
     :or {alpha nil, beta nil, shape nil, ctx nil, dtype nil, out nil},

--- a/contrib/clojure-package/test/good-test-symbol-random-api.clj
+++ b/contrib/clojure-package/test/good-test-symbol-random-api.clj
@@ -31,7 +31,24 @@
 
 (defn
  exponential
- "Draw random samples from an exponential distribution.\n\nSamples are distributed according to an exponential distribution parametrized by *lambda* (rate).\n\nExample::\n\n   exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],\n                                      [ 0.04146638,  0.31715935]]\n\n\nDefined in src/operator/random/sample_op.cc:L137\n\n`lam`: Lambda parameter (rate) of the exponential distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`name`: Name of the symbol (optional)\n`attr`: Attributes of the symbol (optional)\n"
+ "Draw random samples from an exponential distribution.
+  
+  Samples are distributed according to an exponential distribution parametrized by *lambda* (rate).
+  
+  Example::
+  
+     exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],
+                                        [ 0.04146638,  0.31715935]]
+  
+  
+  Defined in src/operator/random/sample_op.cc:L137
+  
+  `lam`: Lambda parameter (rate) of the exponential distribution. (optional)
+  `shape`: Shape of the output. (optional)
+  `ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)
+  `dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)
+  `name`: Name of the symbol (optional)
+  `attr`: Attributes of the symbol (optional)"
  [{:keys [lam shape ctx dtype name attr],
    :or {lam nil, shape nil, ctx nil, dtype nil, name nil, attr nil},
    :as opts}]
@@ -53,7 +70,25 @@
 
 (defn
  gamma
- "Draw random samples from a gamma distribution.\n\nSamples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).\n\nExample::\n\n   gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],\n                                            [ 3.91697288,  3.65933681]]\n\n\nDefined in src/operator/random/sample_op.cc:L125\n\n`alpha`: Alpha parameter (shape) of the gamma distribution. (optional)\n`beta`: Beta parameter (scale) of the gamma distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`name`: Name of the symbol (optional)\n`attr`: Attributes of the symbol (optional)\n"
+ "Draw random samples from a gamma distribution.
+  
+  Samples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).
+  
+  Example::
+  
+     gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],
+                                              [ 3.91697288,  3.65933681]]
+  
+  
+  Defined in src/operator/random/sample_op.cc:L125
+  
+  `alpha`: Alpha parameter (shape) of the gamma distribution. (optional)
+  `beta`: Beta parameter (scale) of the gamma distribution. (optional)
+  `shape`: Shape of the output. (optional)
+  `ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)
+  `dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)
+  `name`: Name of the symbol (optional)
+  `attr`: Attributes of the symbol (optional)"
  [{:keys [alpha beta shape ctx dtype name attr],
    :or
    {alpha nil,

--- a/contrib/clojure-package/test/good-test-symbol-random-api.clj
+++ b/contrib/clojure-package/test/good-test-symbol-random-api.clj
@@ -1,0 +1,83 @@
+(ns
+  ^{:doc "Experimental"}
+  org.apache.clojure-mxnet.symbol-random-api
+  (:refer-clojure :exclude [* - + > >= < <= / cast concat identity flatten load max
+                            min repeat reverse set sort take to-array empty sin
+                            get apply shuffle ref])
+  (:require [org.apache.clojure-mxnet.util :as util]
+            [org.apache.clojure-mxnet.shape :as mx-shape])
+  (:import (org.apache.mxnet SymbolAPI)))
+
+;; Do not edit - this is auto-generated
+
+;; Licensed to the Apache Software Foundation (ASF) under one or more
+;; contributor license agreements.  See the NOTICE file distributed with
+;; this work for additional information regarding copyright ownership.
+;; The ASF licenses this file to You under the Apache License, Version 2.0
+;; (the "License"); you may not use this file except in compliance with
+;; the License.  You may obtain a copy of the License at
+;;
+;;    http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+
+
+
+(defn
+ exponential
+ "Draw random samples from an exponential distribution.\n\nSamples are distributed according to an exponential distribution parametrized by *lambda* (rate).\n\nExample::\n\n   exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],\n                                      [ 0.04146638,  0.31715935]]\n\n\nDefined in src/operator/random/sample_op.cc:L137\n\n`lam`: Lambda parameter (rate) of the exponential distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`name`: Name of the symbol (optional)\n`attr`: Attributes of the symbol (optional)\n"
+ [{:keys [lam shape ctx dtype name attr],
+   :or {lam nil, shape nil, ctx nil, dtype nil, name nil, attr nil},
+   :as opts}]
+ (util/coerce-return
+  (SymbolAPI/random_exponential
+   (util/->option lam)
+   (util/->option (clojure.core/when shape (mx-shape/->shape shape)))
+   (util/->option ctx)
+   (util/->option dtype)
+   name
+   (clojure.core/when
+    attr
+    (clojure.core/->>
+     attr
+     (clojure.core/mapv
+      (clojure.core/fn [[k v]] [k (clojure.core/str v)]))
+     (clojure.core/into {})
+     util/convert-map)))))
+
+(defn
+ gamma
+ "Draw random samples from a gamma distribution.\n\nSamples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).\n\nExample::\n\n   gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],\n                                            [ 3.91697288,  3.65933681]]\n\n\nDefined in src/operator/random/sample_op.cc:L125\n\n`alpha`: Alpha parameter (shape) of the gamma distribution. (optional)\n`beta`: Beta parameter (scale) of the gamma distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`name`: Name of the symbol (optional)\n`attr`: Attributes of the symbol (optional)\n"
+ [{:keys [alpha beta shape ctx dtype name attr],
+   :or
+   {alpha nil,
+    beta nil,
+    shape nil,
+    ctx nil,
+    dtype nil,
+    name nil,
+    attr nil},
+   :as opts}]
+ (util/coerce-return
+  (SymbolAPI/random_gamma
+   (util/->option alpha)
+   (util/->option beta)
+   (util/->option (clojure.core/when shape (mx-shape/->shape shape)))
+   (util/->option ctx)
+   (util/->option dtype)
+   name
+   (clojure.core/when
+    attr
+    (clojure.core/->>
+     attr
+     (clojure.core/mapv
+      (clojure.core/fn [[k v]] [k (clojure.core/str v)]))
+     (clojure.core/into {})
+     util/convert-map)))))
+

--- a/contrib/clojure-package/test/test-ndarray-random-api.clj
+++ b/contrib/clojure-package/test/test-ndarray-random-api.clj
@@ -1,0 +1,62 @@
+(ns
+  ^{:doc "Experimental"}
+  org.apache.clojure-mxnet.ndarray-random-api
+  (:refer-clojure :exclude [* - + > >= < <= / cast concat flatten identity load max
+                            min repeat reverse set sort take to-array empty shuffle
+                            ref])
+  (:require [org.apache.clojure-mxnet.shape :as mx-shape]
+            [org.apache.clojure-mxnet.util :as util])
+  (:import (org.apache.mxnet NDArrayAPI)))
+
+;; Do not edit - this is auto-generated
+
+;; Licensed to the Apache Software Foundation (ASF) under one or more
+;; contributor license agreements.  See the NOTICE file distributed with
+;; this work for additional information regarding copyright ownership.
+;; The ASF licenses this file to You under the Apache License, Version 2.0
+;; (the "License"); you may not use this file except in compliance with
+;; the License.  You may obtain a copy of the License at
+;;
+;;    http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+
+
+
+(defn
+ exponential
+ "Draw random samples from an exponential distribution.\n\nSamples are distributed according to an exponential distribution parametrized by *lambda* (rate).\n\nExample::\n\n   exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],\n                                      [ 0.04146638,  0.31715935]]\n\n\nDefined in src/operator/random/sample_op.cc:L137\n\n`lam`: Lambda parameter (rate) of the exponential distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`out`: Output array. (optional)\n"
+ ([] (exponential {}))
+ ([{:keys [lam shape ctx dtype out],
+    :or {lam nil, shape nil, ctx nil, dtype nil, out nil},
+    :as opts}]
+  (util/coerce-return
+   (NDArrayAPI/random_exponential
+    (util/->option lam)
+    (util/->option (clojure.core/when shape (mx-shape/->shape shape)))
+    (util/->option ctx)
+    (util/->option dtype)
+    (util/->option out)))))
+
+(defn
+ gamma
+ "Draw random samples from a gamma distribution.\n\nSamples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).\n\nExample::\n\n   gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],\n                                            [ 3.91697288,  3.65933681]]\n\n\nDefined in src/operator/random/sample_op.cc:L125\n\n`alpha`: Alpha parameter (shape) of the gamma distribution. (optional)\n`beta`: Beta parameter (scale) of the gamma distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`out`: Output array. (optional)\n"
+ ([] (gamma {}))
+ ([{:keys [alpha beta shape ctx dtype out],
+    :or {alpha nil, beta nil, shape nil, ctx nil, dtype nil, out nil},
+    :as opts}]
+  (util/coerce-return
+   (NDArrayAPI/random_gamma
+    (util/->option alpha)
+    (util/->option beta)
+    (util/->option (clojure.core/when shape (mx-shape/->shape shape)))
+    (util/->option ctx)
+    (util/->option dtype)
+    (util/->option out)))))
+

--- a/contrib/clojure-package/test/test-ndarray-random-api.clj
+++ b/contrib/clojure-package/test/test-ndarray-random-api.clj
@@ -31,7 +31,23 @@
 
 (defn
  exponential
- "Draw random samples from an exponential distribution.\n\nSamples are distributed according to an exponential distribution parametrized by *lambda* (rate).\n\nExample::\n\n   exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],\n                                      [ 0.04146638,  0.31715935]]\n\n\nDefined in src/operator/random/sample_op.cc:L137\n\n`lam`: Lambda parameter (rate) of the exponential distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`out`: Output array. (optional)\n"
+ "Draw random samples from an exponential distribution.
+  
+  Samples are distributed according to an exponential distribution parametrized by *lambda* (rate).
+  
+  Example::
+  
+     exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],
+                                        [ 0.04146638,  0.31715935]]
+  
+  
+  Defined in src/operator/random/sample_op.cc:L137
+  
+  `lam`: Lambda parameter (rate) of the exponential distribution. (optional)
+  `shape`: Shape of the output. (optional)
+  `ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)
+  `dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)
+  `out`: Output array. (optional)"
  ([] (exponential {}))
  ([{:keys [lam shape ctx dtype out],
     :or {lam nil, shape nil, ctx nil, dtype nil, out nil},
@@ -46,7 +62,24 @@
 
 (defn
  gamma
- "Draw random samples from a gamma distribution.\n\nSamples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).\n\nExample::\n\n   gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],\n                                            [ 3.91697288,  3.65933681]]\n\n\nDefined in src/operator/random/sample_op.cc:L125\n\n`alpha`: Alpha parameter (shape) of the gamma distribution. (optional)\n`beta`: Beta parameter (scale) of the gamma distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`out`: Output array. (optional)\n"
+ "Draw random samples from a gamma distribution.
+  
+  Samples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).
+  
+  Example::
+  
+     gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],
+                                              [ 3.91697288,  3.65933681]]
+  
+  
+  Defined in src/operator/random/sample_op.cc:L125
+  
+  `alpha`: Alpha parameter (shape) of the gamma distribution. (optional)
+  `beta`: Beta parameter (scale) of the gamma distribution. (optional)
+  `shape`: Shape of the output. (optional)
+  `ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)
+  `dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)
+  `out`: Output array. (optional)"
  ([] (gamma {}))
  ([{:keys [alpha beta shape ctx dtype out],
     :or {alpha nil, beta nil, shape nil, ctx nil, dtype nil, out nil},

--- a/contrib/clojure-package/test/test-symbol-random-api.clj
+++ b/contrib/clojure-package/test/test-symbol-random-api.clj
@@ -31,7 +31,24 @@
 
 (defn
  exponential
- "Draw random samples from an exponential distribution.\n\nSamples are distributed according to an exponential distribution parametrized by *lambda* (rate).\n\nExample::\n\n   exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],\n                                      [ 0.04146638,  0.31715935]]\n\n\nDefined in src/operator/random/sample_op.cc:L137\n\n`lam`: Lambda parameter (rate) of the exponential distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`name`: Name of the symbol (optional)\n`attr`: Attributes of the symbol (optional)\n"
+ "Draw random samples from an exponential distribution.
+  
+  Samples are distributed according to an exponential distribution parametrized by *lambda* (rate).
+  
+  Example::
+  
+     exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],
+                                        [ 0.04146638,  0.31715935]]
+  
+  
+  Defined in src/operator/random/sample_op.cc:L137
+  
+  `lam`: Lambda parameter (rate) of the exponential distribution. (optional)
+  `shape`: Shape of the output. (optional)
+  `ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)
+  `dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)
+  `name`: Name of the symbol (optional)
+  `attr`: Attributes of the symbol (optional)"
  [{:keys [lam shape ctx dtype name attr],
    :or {lam nil, shape nil, ctx nil, dtype nil, name nil, attr nil},
    :as opts}]
@@ -53,7 +70,25 @@
 
 (defn
  gamma
- "Draw random samples from a gamma distribution.\n\nSamples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).\n\nExample::\n\n   gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],\n                                            [ 3.91697288,  3.65933681]]\n\n\nDefined in src/operator/random/sample_op.cc:L125\n\n`alpha`: Alpha parameter (shape) of the gamma distribution. (optional)\n`beta`: Beta parameter (scale) of the gamma distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`name`: Name of the symbol (optional)\n`attr`: Attributes of the symbol (optional)\n"
+ "Draw random samples from a gamma distribution.
+  
+  Samples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).
+  
+  Example::
+  
+     gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],
+                                              [ 3.91697288,  3.65933681]]
+  
+  
+  Defined in src/operator/random/sample_op.cc:L125
+  
+  `alpha`: Alpha parameter (shape) of the gamma distribution. (optional)
+  `beta`: Beta parameter (scale) of the gamma distribution. (optional)
+  `shape`: Shape of the output. (optional)
+  `ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)
+  `dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)
+  `name`: Name of the symbol (optional)
+  `attr`: Attributes of the symbol (optional)"
  [{:keys [alpha beta shape ctx dtype name attr],
    :or
    {alpha nil,

--- a/contrib/clojure-package/test/test-symbol-random-api.clj
+++ b/contrib/clojure-package/test/test-symbol-random-api.clj
@@ -1,0 +1,83 @@
+(ns
+  ^{:doc "Experimental"}
+  org.apache.clojure-mxnet.symbol-random-api
+  (:refer-clojure :exclude [* - + > >= < <= / cast concat identity flatten load max
+                            min repeat reverse set sort take to-array empty sin
+                            get apply shuffle ref])
+  (:require [org.apache.clojure-mxnet.util :as util]
+            [org.apache.clojure-mxnet.shape :as mx-shape])
+  (:import (org.apache.mxnet SymbolAPI)))
+
+;; Do not edit - this is auto-generated
+
+;; Licensed to the Apache Software Foundation (ASF) under one or more
+;; contributor license agreements.  See the NOTICE file distributed with
+;; this work for additional information regarding copyright ownership.
+;; The ASF licenses this file to You under the Apache License, Version 2.0
+;; (the "License"); you may not use this file except in compliance with
+;; the License.  You may obtain a copy of the License at
+;;
+;;    http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+;;
+
+
+
+
+(defn
+ exponential
+ "Draw random samples from an exponential distribution.\n\nSamples are distributed according to an exponential distribution parametrized by *lambda* (rate).\n\nExample::\n\n   exponential(lam=4, shape=(2,2)) = [[ 0.0097189 ,  0.08999364],\n                                      [ 0.04146638,  0.31715935]]\n\n\nDefined in src/operator/random/sample_op.cc:L137\n\n`lam`: Lambda parameter (rate) of the exponential distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`name`: Name of the symbol (optional)\n`attr`: Attributes of the symbol (optional)\n"
+ [{:keys [lam shape ctx dtype name attr],
+   :or {lam nil, shape nil, ctx nil, dtype nil, name nil, attr nil},
+   :as opts}]
+ (util/coerce-return
+  (SymbolAPI/random_exponential
+   (util/->option lam)
+   (util/->option (clojure.core/when shape (mx-shape/->shape shape)))
+   (util/->option ctx)
+   (util/->option dtype)
+   name
+   (clojure.core/when
+    attr
+    (clojure.core/->>
+     attr
+     (clojure.core/mapv
+      (clojure.core/fn [[k v]] [k (clojure.core/str v)]))
+     (clojure.core/into {})
+     util/convert-map)))))
+
+(defn
+ gamma
+ "Draw random samples from a gamma distribution.\n\nSamples are distributed according to a gamma distribution parametrized by *alpha* (shape) and *beta* (scale).\n\nExample::\n\n   gamma(alpha=9, beta=0.5, shape=(2,2)) = [[ 7.10486984,  3.37695289],\n                                            [ 3.91697288,  3.65933681]]\n\n\nDefined in src/operator/random/sample_op.cc:L125\n\n`alpha`: Alpha parameter (shape) of the gamma distribution. (optional)\n`beta`: Beta parameter (scale) of the gamma distribution. (optional)\n`shape`: Shape of the output. (optional)\n`ctx`: Context of output, in format [cpu|gpu|cpu_pinned](n). Only used for imperative calls. (optional)\n`dtype`: DType of the output in case this can't be inferred. Defaults to float32 if not defined (dtype=None). (optional)\n`name`: Name of the symbol (optional)\n`attr`: Attributes of the symbol (optional)\n"
+ [{:keys [alpha beta shape ctx dtype name attr],
+   :or
+   {alpha nil,
+    beta nil,
+    shape nil,
+    ctx nil,
+    dtype nil,
+    name nil,
+    attr nil},
+   :as opts}]
+ (util/coerce-return
+  (SymbolAPI/random_gamma
+   (util/->option alpha)
+   (util/->option beta)
+   (util/->option (clojure.core/when shape (mx-shape/->shape shape)))
+   (util/->option ctx)
+   (util/->option dtype)
+   name
+   (clojure.core/when
+    attr
+    (clojure.core/->>
+     attr
+     (clojure.core/mapv
+      (clojure.core/fn [[k v]] [k (clojure.core/str v)]))
+     (clojure.core/into {})
+     util/convert-map)))))
+


### PR DESCRIPTION
Reopened from PR #14750

## Description ##

Split random functions in their own generated namespace.

* `ndarray_random_api`
* `symbol_random_api`

It renames the following functions to be as close as possible to the scala names:
* `-random-randint` into `randint` 
* `sample-randint` into `randint-like`for instance and put them under `ndarray-random-api` namespace.

## TODO

* Unify random and sample functions (mu vs loc and sigma)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
