### PR TITLE
support auto mode for BatchNorm use_global_stats 

### DIFF
--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -353,8 +353,21 @@ class BatchNorm(HybridBlock):
         super(BatchNorm, self).cast(dtype)
 
     def hybrid_forward(self, F, x, gamma, beta, running_mean, running_var):
+        use_global_stats = self._kwargs['use_global_stats']
+        if isinstance(use_global_stats, str):
+            if use_global_stats == "auto":
+                from ... import autograd
+                use_global_stats = not autograd.is_training()
+                the_kwargs = dict(**self._kwargs)
+                the_kwargs['use_global_stats'] = use_global_stats
+            else:
+                raise ValueError('unrecognzied use_global_stats')
+        else:
+            the_kwargs = self._kwargs
+
         return F.BatchNorm(x, gamma, beta, running_mean, running_var,
-                           name='fwd', **self._kwargs)
+                           name='fwd', **the_kwargs)
+
 
     def __repr__(self):
         s = '{name}({content}'

--- a/python/mxnet/gluon/nn/basic_layers.py
+++ b/python/mxnet/gluon/nn/basic_layers.py
@@ -294,10 +294,12 @@ class BatchNorm(HybridBlock):
         When the next layer is linear (also e.g. `nn.relu`),
         this can be disabled since the scaling
         will be done by the next layer.
-    use_global_stats: bool, default False
+    use_global_stats: bool or 'auto', default False
         If True, use global moving statistics instead of local batch-norm. This will force
         change batch-norm into a scale shift operator.
         If False, use local batch-norm.
+        if 'auto', use_global_stats = False when autograd.is_training() == True; and, 
+        use_global_stats = True, otherwise.
     beta_initializer: str or `Initializer`, default 'zeros'
         Initializer for the beta weight.
     gamma_initializer: str or `Initializer`, default 'ones'


### PR DESCRIPTION
This PR is to make BatchNorm support "auto" mode for `use_global_stats`. When `autograd.is_training()==True`, it `use_global_stats=False`; otherwise, `use_global_stats=True`.
