### PR TITLE
[Dependency Update] Upgrade openssl to 1.1.1b

### DIFF
--- a/tools/dependencies/openssl.sh
+++ b/tools/dependencies/openssl.sh
@@ -19,7 +19,7 @@
 
 # This script builds the static library of openssl that can be used as dependency of mxnet.
 set -ex
-OPENSSL_VERSION=1.1.0k
+OPENSSL_VERSION=1.1.0j
 if [[ ! -f $DEPS_PATH/lib/libssl.a ]] || [[ ! -f $DEPS_PATH/lib/libcrypto.a ]]; then
     # download and build openssl
     >&2 echo "Building openssl..."

--- a/tools/dependencies/openssl.sh
+++ b/tools/dependencies/openssl.sh
@@ -19,7 +19,7 @@
 
 # This script builds the static library of openssl that can be used as dependency of mxnet.
 set -ex
-OPENSSL_VERSION=1.0.2l
+OPENSSL_VERSION=1.1.0k
 if [[ ! -f $DEPS_PATH/lib/libssl.a ]] || [[ ! -f $DEPS_PATH/lib/libcrypto.a ]]; then
     # download and build openssl
     >&2 echo "Building openssl..."

--- a/tools/dependencies/openssl.sh
+++ b/tools/dependencies/openssl.sh
@@ -19,7 +19,7 @@
 
 # This script builds the static library of openssl that can be used as dependency of mxnet.
 set -ex
-OPENSSL_VERSION=1.1.0j
+OPENSSL_VERSION=1.1.1b
 if [[ ! -f $DEPS_PATH/lib/libssl.a ]] || [[ ! -f $DEPS_PATH/lib/libcrypto.a ]]; then
     # download and build openssl
     >&2 echo "Building openssl..."

--- a/tools/staticbuild/build_lib.sh
+++ b/tools/staticbuild/build_lib.sh
@@ -44,6 +44,9 @@ if [[ $VARIANT == *mkl ]]; then
         MKLDNN_LIBFILE='libmkldnn.0.dylib'
     fi
     $MAKE DEPS_PATH=$DEPS_PATH mkldnn
+    if [ ! -d lib ]; then
+        mkdir lib
+    fi
     cp 3rdparty/mkldnn/build/install/lib/$IOMP_LIBFILE lib
     cp 3rdparty/mkldnn/build/install/lib/$MKLML_LIBFILE lib
     cp 3rdparty/mkldnn/build/install/lib/$MKLDNN_LIBFILE lib


### PR DESCRIPTION
## Description ##
Upgrade the openssl package to **1.1.1b** due to the [issue list](https://www.openssl.org/news/vulnerabilities-1.0.2.html) at 1.0.2l
And the openssl < 1.1.0 didn't support -j (multithreading)
Also fix a bug where the lib folder is missing when we done compiling the mkldnn


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] CI check for scala publish build
- [x] CI check for python publish build
- [x] Ubuntu 16.04 cu100mkl build
- [x] Ubuntu 16.04 mkl build

### Changes ###


## Comments ##
