### PR TITLE
Add cpu implementation for Deformable Convolution

### DIFF
--- a/src/operator/contrib/deformable_convolution-inl.h
+++ b/src/operator/contrib/deformable_convolution-inl.h
@@ -61,9 +61,9 @@ struct DeformableConvolutionParam : public dmlc::Parameter<DeformableConvolution
   mxnet::TShape stride;
   mxnet::TShape dilate;
   mxnet::TShape pad;
-  uint32_t num_filter;
-  uint32_t num_group;
-  uint32_t num_deformable_group;
+  index_t num_filter;
+  index_t num_group;
+  index_t num_deformable_group;
   uint64_t workspace;
   bool no_bias;
   dmlc::optional<int> layout;
@@ -232,7 +232,7 @@ class DeformableConvolutionOp : public Operator {
                               in_grad[conv::kData].shape_, col_buffer.shape_,
                               param_.kernel, param_.pad, param_.stride,
                               param_.dilate, param_.num_deformable_group,
-                              in_grad[conv::kOffset].dptr<DType>() + n*input_offset_dim_);
+                              in_grad[conv::kOffset].dptr<DType>() + n * input_offset_dim_);
 
       // gradient w.r.t. input data
       deformable_col2im(s, col_buffer.dptr<DType>(),

--- a/src/operator/contrib/deformable_convolution-inl.h
+++ b/src/operator/contrib/deformable_convolution-inl.h
@@ -232,8 +232,7 @@ class DeformableConvolutionOp : public Operator {
                               in_grad[conv::kData].shape_, col_buffer.shape_,
                               param_.kernel, param_.pad, param_.stride,
                               param_.dilate, param_.num_deformable_group,
-                              in_grad[conv::kOffset].dptr<DType>() + n*input_offset_dim_,
-                              req[conv::kOffset]);
+                              in_grad[conv::kOffset].dptr<DType>() + n*input_offset_dim_);
 
       // gradient w.r.t. input data
       deformable_col2im(s, col_buffer.dptr<DType>(),
@@ -241,8 +240,7 @@ class DeformableConvolutionOp : public Operator {
                         in_grad[conv::kData].shape_, col_buffer.shape_,
                         param_.kernel, param_.pad, param_.stride,
                         param_.dilate, param_.num_deformable_group,
-                        in_grad[conv::kData].dptr<DType>() + n * input_dim_,
-                        req[conv::kData]);
+                        in_grad[conv::kData].dptr<DType>() + n * input_dim_);
 
       // gradient w.r.t. weight, dWeight should accumulate across the batch and group
       deformable_im2col(s, in_data[conv::kData].dptr<DType>() + n * input_dim_,

--- a/src/operator/contrib/deformable_convolution-inl.h
+++ b/src/operator/contrib/deformable_convolution-inl.h
@@ -109,10 +109,10 @@ class DeformableConvolutionOp : public Operator {
   }
 
   virtual void Forward(const OpContext &ctx,
-    const std::vector<TBlob> &in_data,
-    const std::vector<OpReqType> &req,
-    const std::vector<TBlob> &out_data,
-    const std::vector<TBlob> &aux_args) {
+                       const std::vector<TBlob> &in_data,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &out_data,
+                       const std::vector<TBlob> &aux_args) {
     using namespace mshadow;
     using namespace mshadow::expr;
     CHECK_EQ(req[conv::kOut], kWriteTo);
@@ -147,10 +147,11 @@ class DeformableConvolutionOp : public Operator {
       Shape4(num_, group_, M, N), s);
     for (index_t n = 0; n < num_; ++n) {
       // transform image to col_buffer in order to use gemm
-      deformable_im2col(s, in_data[conv::kData].dptr<DType>() + n*input_dim_,
-        in_data[conv::kOffset].dptr<DType>() + n*input_offset_dim_, in_data[conv::kData].shape_,
-        col_buffer.shape_, param_.kernel, param_.pad, param_.stride, param_.dilate,
-        param_.num_deformable_group, col_buffer.dptr<DType>());
+      deformable_im2col(s, in_data[conv::kData].dptr<DType>() + n * input_dim_,
+                        in_data[conv::kOffset].dptr<DType>() + n * input_offset_dim_,
+                        in_data[conv::kData].shape_, col_buffer.shape_,
+                        param_.kernel, param_.pad, param_.stride, param_.dilate,
+                        param_.num_deformable_group, col_buffer.dptr<DType>());
       Tensor<xpu, 3, DType> output_3d = output_4d[n];
       for (index_t g = 0; g < group_; ++g) {
         // Legacy approach shown here for comparison:
@@ -168,12 +169,12 @@ class DeformableConvolutionOp : public Operator {
   }
 
   virtual void Backward(const OpContext &ctx,
-    const std::vector<TBlob>& out_grad,
-    const std::vector<TBlob>& in_data,
-    const std::vector<TBlob>& out_data,
-    const std::vector<OpReqType>& req,
-    const std::vector<TBlob>& in_grad,
-    const std::vector<TBlob>& aux_args) {
+                        const std::vector<TBlob>& out_grad,
+                        const std::vector<TBlob>& in_data,
+                        const std::vector<TBlob>& out_data,
+                        const std::vector<OpReqType>& req,
+                        const std::vector<TBlob>& in_grad,
+                        const std::vector<TBlob>& aux_args) {
     using namespace mshadow;
     using namespace mshadow::expr;
     CHECK_EQ(out_grad.size(), 1U);
@@ -226,26 +227,29 @@ class DeformableConvolutionOp : public Operator {
 
       // gradient w.r.t. input coordinate data
       deformable_col2im_coord(s, col_buffer.dptr<DType>(),
-        in_data[conv::kData].dptr<DType>() + n*input_dim_,
-        in_data[conv::kOffset].dptr<DType>() + n*input_offset_dim_,
-        in_grad[conv::kData].shape_, col_buffer.shape_,
-        param_.kernel, param_.pad, param_.stride, param_.dilate, param_.num_deformable_group,
-        in_grad[conv::kOffset].dptr<DType>() + n*input_offset_dim_,
-        req[conv::kOffset]);
+                              in_data[conv::kData].dptr<DType>() + n * input_dim_,
+                              in_data[conv::kOffset].dptr<DType>() + n * input_offset_dim_,
+                              in_grad[conv::kData].shape_, col_buffer.shape_,
+                              param_.kernel, param_.pad, param_.stride,
+                              param_.dilate, param_.num_deformable_group,
+                              in_grad[conv::kOffset].dptr<DType>() + n*input_offset_dim_,
+                              req[conv::kOffset]);
 
       // gradient w.r.t. input data
       deformable_col2im(s, col_buffer.dptr<DType>(),
-        in_data[conv::kOffset].dptr<DType>() + n*input_offset_dim_,
-        in_grad[conv::kData].shape_, col_buffer.shape_,
-        param_.kernel, param_.pad, param_.stride, param_.dilate, param_.num_deformable_group,
-        in_grad[conv::kData].dptr<DType>() + n*input_dim_,
-        req[conv::kData]);
+                        in_data[conv::kOffset].dptr<DType>() + n * input_offset_dim_,
+                        in_grad[conv::kData].shape_, col_buffer.shape_,
+                        param_.kernel, param_.pad, param_.stride,
+                        param_.dilate, param_.num_deformable_group,
+                        in_grad[conv::kData].dptr<DType>() + n * input_dim_,
+                        req[conv::kData]);
 
       // gradient w.r.t. weight, dWeight should accumulate across the batch and group
-      deformable_im2col(s, in_data[conv::kData].dptr<DType>() + n*input_dim_,
-        in_data[conv::kOffset].dptr<DType>() + n*input_offset_dim_, in_data[conv::kData].shape_,
-        col_buffer.shape_, param_.kernel, param_.pad, param_.stride, param_.dilate,
-        param_.num_deformable_group, col_buffer.dptr<DType>());
+      deformable_im2col(s, in_data[conv::kData].dptr<DType>() + n * input_dim_,
+                        in_data[conv::kOffset].dptr<DType>() + n * input_offset_dim_,
+                        in_data[conv::kData].shape_, col_buffer.shape_, param_.kernel,
+                        param_.pad, param_.stride, param_.dilate,
+                        param_.num_deformable_group, col_buffer.dptr<DType>());
 
       for (index_t g = 0; g < group_; ++g) {
         auto request = (n == 0) ? req[conv::kWeight] : kAddTo;
@@ -327,9 +331,9 @@ class DeformableConvolutionOp : public Operator {
 
 template<typename xpu>
 Operator* CreateOp(DeformableConvolutionParam param, int dtype,
-  mxnet::ShapeVector *in_shape,
-  mxnet::ShapeVector *out_shape,
-  Context ctx);
+                   mxnet::ShapeVector *in_shape,
+                   mxnet::ShapeVector *out_shape,
+                   Context ctx);
 
 #if DMLC_USE_CXX11
 class DeformableConvolutionProp : public OperatorProperty {
@@ -360,8 +364,8 @@ class DeformableConvolutionProp : public OperatorProperty {
   }
 
   bool InferShape(mxnet::ShapeVector *in_shape,
-    mxnet::ShapeVector *out_shape,
-    mxnet::ShapeVector *aux_shape) const override {
+                  mxnet::ShapeVector *out_shape,
+                  mxnet::ShapeVector *aux_shape) const override {
     using namespace mshadow;
     if (!param_.no_bias) {
       CHECK_EQ(in_shape->size(), 4U) << "Input:[data, offset, weight, bias]";
@@ -448,8 +452,8 @@ class DeformableConvolutionProp : public OperatorProperty {
   }
 
   bool InferType(std::vector<int> *in_type,
-    std::vector<int> *out_type,
-    std::vector<int> *aux_type) const override {
+                 std::vector<int> *out_type,
+                 std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1U);
     int dtype = (*in_type)[0];
     CHECK_NE(dtype, -1) << "First input must have specified type";
@@ -475,10 +479,9 @@ class DeformableConvolutionProp : public OperatorProperty {
     return "_contrib_DeformableConvolution";
   }
 
-  std::vector<int> DeclareBackwardDependency(
-    const std::vector<int> &out_grad,
-    const std::vector<int> &in_data,
-    const std::vector<int> &out_data) const override {
+  std::vector<int> DeclareBackwardDependency(const std::vector<int> &out_grad,
+                                             const std::vector<int> &in_data,
+                                             const std::vector<int> &out_data) const override {
     return{ out_grad[conv::kOut], in_data[conv::kData],
             in_data[conv::kOffset], in_data[conv::kWeight] };
   }
@@ -499,7 +502,7 @@ class DeformableConvolutionProp : public OperatorProperty {
   }
 
   Operator* CreateOperatorEx(Context ctx, mxnet::ShapeVector *in_shape,
-    std::vector<int> *in_type) const override;
+                             std::vector<int> *in_type) const override;
 
  private:
   DeformableConvolutionParam param_;

--- a/src/operator/contrib/deformable_convolution-inl.h
+++ b/src/operator/contrib/deformable_convolution-inl.h
@@ -411,8 +411,6 @@ class DeformableConvolutionProp : public OperatorProperty {
       oshape[3] = (dshape[3] + 2 * param_.pad[1] -
         (param_.dilate[1] * (ksize_x - 1) + 1)) / param_.stride[1] + 1;
       SHAPE_ASSIGN_CHECK(*out_shape, 0, ConvertLayout(oshape, kNCHW, param_.layout.value()));
-      CHECK_EQ(oshape[1] % param_.num_deformable_group, 0U) \
-        << "output num_filter must divide deformable group size";
       CHECK_EQ(oshape[2], offsetshape[2]) \
         << "output height must equal to offset map height";
       CHECK_EQ(oshape[3], offsetshape[3]) \

--- a/src/operator/contrib/deformable_convolution.cc
+++ b/src/operator/contrib/deformable_convolution.cc
@@ -62,7 +62,7 @@ The deformable convolution operation is described in https://arxiv.org/abs/1703.
 For 2-D deformable convolution, the shapes are
 
 - **data**: *(batch_size, channel, height, width)*
-- **offset**: *(batch_size, num_deformable_group * kernel[0] * kernel[1], height, width)*
+- **offset**: *(batch_size, num_deformable_group * kernel[0] * kernel[1] * 2, height, width)*
 - **weight**: *(num_filter, channel, kernel[0], kernel[1])*
 - **bias**: *(num_filter,)*
 - **out**: *(batch_size, num_filter, out_height, out_width)*.
@@ -89,9 +89,9 @@ the *g* results.
 
 If ``num_deformable_group`` is larger than 1, denoted by *dg*, then split the
 input ``offset`` evenly into *dg* parts along the channel axis, and also evenly
-split ``out`` evenly into *dg* parts along the channel axis. Next compute the
-deformable convolution, apply the *i*-th part of the offset part on the *i*-th
-out.
+split ``data`` into *dg* parts along the channel axis. Next compute the
+deformable convolution, apply the *i*-th part of the offset on the *i*-th part
+of the data.
 
 
 Both ``weight`` and ``bias`` are learnable parameters.

--- a/src/operator/contrib/nn/deformable_im2col.cuh
+++ b/src/operator/contrib/nn/deformable_im2col.cuh
@@ -86,7 +86,7 @@ __device__ DType deformable_im2col_bilinear(const DType* bottom_data,
   int w_high;
   if (h_low >= height - 1) {
     h_high = h_low = height - 1;
-    h = (DType)h_low;
+    h = static_cast<DType>(h_low);
   }
   else {
     h_high = h_low + 1;
@@ -94,7 +94,7 @@ __device__ DType deformable_im2col_bilinear(const DType* bottom_data,
 
   if (w_low >= width - 1) {
     w_high = w_low = width - 1;
-    w = (DType)w_low;
+    w = static_cast<DType>(w_low);
   }
   else {
     w_high = w_low + 1;
@@ -124,23 +124,23 @@ __device__ DType get_gradient_weight(DType argmax_h, DType argmax_w,
     return 0;
   }
 
-  argmax_h = max(argmax_h, (DType)0.0f);
-  argmax_w = max(argmax_w, (DType)0.0f);
+  argmax_h = max(argmax_h, static_cast<DType>(0.0f));
+  argmax_w = max(argmax_w, static_cast<DType>(0.0f));
 
-  int argmax_h_low = (int)argmax_h;
-  int argmax_w_low = (int)argmax_w;
+  int argmax_h_low = static_cast<int>(argmax_h);
+  int argmax_w_low = static_cast<int>(argmax_w);
   int argmax_h_high;
   int argmax_w_high;
   if (argmax_h_low >= height - 1) {
     argmax_h_high = argmax_h_low = height - 1;
-    argmax_h = (DType)argmax_h_low;
+    argmax_h = static_cast<DType>(argmax_h_low);
   } else {
     argmax_h_high = argmax_h_low + 1;
   }
   if (argmax_w_low >= width - 1)
   {
     argmax_w_high = argmax_w_low = width - 1;
-    argmax_w = (DType)argmax_w_low;
+    argmax_w = static_cast<DType>(argmax_w_low);
   } else {
     argmax_w_high = argmax_w_low + 1;
   }
@@ -177,19 +177,19 @@ __device__ DType get_coordinate_weight(DType argmax_h, DType argmax_w,
   if (argmax_h < 0) argmax_h = 0;
   if (argmax_w < 0) argmax_w = 0;
 
-  int argmax_h_low = (int)argmax_h;
-  int argmax_w_low = (int)argmax_w;
+  int argmax_h_low = static_cast<int>(argmax_h);
+  int argmax_w_low = static_cast<int>(argmax_w);
   int argmax_h_high;
   int argmax_w_high;
   if (argmax_h_low >= height - 1) {
     argmax_h_high = argmax_h_low = height - 1;
-    argmax_h = (DType)argmax_h_low;
+    argmax_h = static_cast<DType>(argmax_h_low);
   } else {
     argmax_h_high = argmax_h_low + 1;
   }
   if (argmax_w_low >= width - 1) {
     argmax_w_high = argmax_w_low = width - 1;
-    argmax_w = (DType)argmax_w_low;
+    argmax_w = static_cast<DType>(argmax_w_low);
   } else {
     argmax_w_high = argmax_w_low + 1;
   }

--- a/src/operator/contrib/nn/deformable_im2col.h
+++ b/src/operator/contrib/nn/deformable_im2col.h
@@ -72,7 +72,9 @@ namespace op {
 
 template <typename DType>
 inline DType im2col_bilinear_cpu(const DType* data,
-    const int height, const int width, DType h, DType w) {
+                                 const int height,
+                                 const int width,
+                                 DType h, DType w) {
   int h_low = floor(h);
   int w_low = floor(w);
   int h_high;
@@ -111,20 +113,22 @@ inline DType im2col_bilinear_cpu(const DType* data,
  * Use the wrapper function im2col() instead.
  */
 template <typename DType>
-inline void deformable_im2col_cpu(const DType* data_im, const DType* data_offset,
-    const int channels, const int height, const int width,
-    const int output_h, const int output_w,
-    const int kernel_h, const int kernel_w,
-    const int pad_h, const int pad_w,
-    const int stride_h, const int stride_w,
-    const int dilation_h, const int dilation_w,
-    const uint32_t deformable_group,
-    DType* data_col) {
+inline void deformable_im2col_cpu(const DType* data_im,
+                                  const DType* data_offset,
+                                  const int channels,
+                                  const int height, const int width,
+                                  const int output_h, const int output_w,
+                                  const int kernel_h, const int kernel_w,
+                                  const int pad_h, const int pad_w,
+                                  const int stride_h, const int stride_w,
+                                  const int dilation_h, const int dilation_w,
+                                  const uint32_t deformable_group,
+                                  DType* data_col) {
   const int channel_size = height * width;
   const int offset_size = 2 * kernel_h * kernel_w * output_h * output_w;
-  const int channel_per_deformable_group = channels / deformable_group;
+  const int channel_per_group = channels / deformable_group;
   for (int channel = 0; channel < channels; channel++, data_im += channel_size) {
-    if (channel % channel_per_deformable_group == 0 && channel != 0) {
+    if (channel % channel_per_group == 0 && channel != 0) {
       data_offset += offset_size;
     }
     for (int kernel_row = 0; kernel_row < kernel_h; kernel_row++) {
@@ -168,19 +172,24 @@ inline void deformable_im2col_cpu(const DType* data_im, const DType* data_offset
  */
 template <typename DType>
 inline void deformable_im2col(mshadow::Stream<cpu>* s,
-  const DType* data_im, const DType* data_offset,
-  const mxnet::TShape& im_shape, const mxnet::TShape& col_shape, const mxnet::TShape& kernel_shape,
-  const mxnet::TShape& pad, const mxnet::TShape& stride, const mxnet::TShape& dilation,
-  const uint32_t deformable_group, DType* data_col) {
+                              const DType* data_im, const DType* data_offset,
+                              const mxnet::TShape& im_shape,
+                              const mxnet::TShape& col_shape,
+                              const mxnet::TShape& kernel_shape,
+                              const mxnet::TShape& pad,
+                              const mxnet::TShape& stride,
+                              const mxnet::TShape& dilation,
+                              const uint32_t deformable_group,
+                              DType* data_col) {
   if (2 == kernel_shape.ndim()) {
     deformable_im2col_cpu(data_im, data_offset,
-        im_shape[1], im_shape[2], im_shape[3],
-        col_shape[1], col_shape[2],
-        kernel_shape[0], kernel_shape[1],
-        pad[0], pad[1],
-        stride[0], stride[1],
-        dilation[0], dilation[1],
-        deformable_group, data_col);
+                          im_shape[1], im_shape[2], im_shape[3],
+                          col_shape[1], col_shape[2],
+                          kernel_shape[0], kernel_shape[1],
+                          pad[0], pad[1],
+                          stride[0], stride[1],
+                          dilation[0], dilation[1],
+                          deformable_group, data_col);
   } else {
     LOG(FATAL) << "not implemented";
   }
@@ -203,11 +212,16 @@ inline void deformable_im2col(mshadow::Stream<cpu>* s,
  */
 template <typename DType>
 inline void deformable_col2im(mshadow::Stream<cpu>* s,
-  const DType* data_col, const DType* data_offset,
-  const mxnet::TShape& im_shape, const mxnet::TShape& col_shape, const mxnet::TShape& kernel_shape,
-  const mxnet::TShape& pad, const mxnet::TShape& stride,
-  const mxnet::TShape& dilation, const uint32_t deformable_group,
-  DType* grad_im, OpReqType req) {
+                              const DType* data_col,
+                              const DType* data_offset,
+                              const mxnet::TShape& im_shape,
+                              const mxnet::TShape& col_shape,
+                              const mxnet::TShape& kernel_shape,
+                              const mxnet::TShape& pad,
+                              const mxnet::TShape& stride,
+                              const mxnet::TShape& dilation,
+                              const uint32_t deformable_group,
+                              DType* grad_im, OpReqType req) {
   LOG(FATAL) << "only implemented in GPU";
 }
 
@@ -227,15 +241,19 @@ inline void deformable_col2im(mshadow::Stream<cpu>* s,
  * \param deformable_group #offset group that deformable convolution use
  * \param grad_offset pointer of the offset (C, H, W,...) in the offset batch
  */
-
 template <typename DType>
 inline void deformable_col2im_coord(mshadow::Stream<cpu>* s,
-  const DType* data_col, const DType* data_im,
-  const DType* data_offset, const mxnet::TShape& im_shape,
-  const mxnet::TShape& col_shape, const mxnet::TShape& kernel_shape,
-  const mxnet::TShape& pad, const mxnet::TShape& stride,
-  const mxnet::TShape& dilation, const uint32_t deformable_group,
-  DType* grad_offset, OpReqType req) {
+                                    const DType* data_col,
+                                    const DType* data_im,
+                                    const DType* data_offset,
+                                    const mxnet::TShape& im_shape,
+                                    const mxnet::TShape& col_shape,
+                                    const mxnet::TShape& kernel_shape,
+                                    const mxnet::TShape& pad,
+                                    const mxnet::TShape& stride,
+                                    const mxnet::TShape& dilation,
+                                    const uint32_t deformable_group,
+                                    DType* grad_offset, OpReqType req) {
   LOG(FATAL) << "only implemented in GPU";
 }
 

--- a/src/operator/contrib/nn/deformable_im2col.h
+++ b/src/operator/contrib/nn/deformable_im2col.h
@@ -73,13 +73,13 @@ namespace op {
 
 template <typename DType>
 inline DType im2col_bilinear_cpu(const DType* data,
-                                 const int height,
-                                 const int width,
+                                 const index_t height,
+                                 const index_t width,
                                  DType h, DType w) {
-  int h_low = floor(h);
-  int w_low = floor(w);
-  int h_high;
-  int w_high;
+  index_t h_low = floor(h);
+  index_t w_low = floor(w);
+  index_t h_high;
+  index_t w_high;
 
   if (h_low >= height - 1) {
     h_high = height - 1;
@@ -111,8 +111,8 @@ inline DType im2col_bilinear_cpu(const DType* data,
 
 template <typename DType>
 inline DType get_gradient_weight_cpu(DType argmax_h, DType argmax_w,
-                                    const int h, const int w,
-                                    const int height, const int width) {
+                                    const index_t h, const index_t w,
+                                    const index_t height, const index_t width) {
   if (argmax_h < 0 || argmax_h > height || argmax_w < 0 || argmax_w > width) {
     // empty
     return 0;
@@ -121,10 +121,10 @@ inline DType get_gradient_weight_cpu(DType argmax_h, DType argmax_w,
   argmax_h = std::max(argmax_h, static_cast<DType>(0.0f));
   argmax_w = std::max(argmax_w, static_cast<DType>(0.0f));
 
-  int argmax_h_low = static_cast<int>(argmax_h);
-  int argmax_w_low = static_cast<int>(argmax_w);
-  int argmax_h_high;
-  int argmax_w_high;
+  index_t argmax_h_low = static_cast<index_t>(argmax_h);
+  index_t argmax_w_low = static_cast<index_t>(argmax_w);
+  index_t argmax_h_high;
+  index_t argmax_w_high;
   if (argmax_h_low >= height - 1) {
     argmax_h_high = argmax_h_low = height - 1;
     argmax_h = static_cast<DType>(argmax_h_low);
@@ -157,9 +157,9 @@ inline DType get_gradient_weight_cpu(DType argmax_h, DType argmax_w,
 
 template <typename DType>
 inline DType get_coordinate_weight_cpu(DType argmax_h, DType argmax_w,
-                                       const int height, const int width,
+                                       const index_t height, const index_t width,
                                        const DType* im_data,
-                                       const int data_width, const int bp_dir) {
+                                       const index_t data_width, const index_t bp_dir) {
   if (argmax_h < 0 || argmax_h > height || argmax_w < 0 || argmax_w > width) {
     // empty
     return 0;
@@ -168,10 +168,10 @@ inline DType get_coordinate_weight_cpu(DType argmax_h, DType argmax_w,
   if (argmax_h < 0) argmax_h = 0;
   if (argmax_w < 0) argmax_w = 0;
 
-  int argmax_h_low = static_cast<int>(argmax_h);
-  int argmax_w_low = static_cast<int>(argmax_w);
-  int argmax_h_high;
-  int argmax_w_high;
+  index_t argmax_h_low = static_cast<index_t>(argmax_h);
+  index_t argmax_w_low = static_cast<index_t>(argmax_w);
+  index_t argmax_h_high;
+  index_t argmax_w_high;
   if (argmax_h_low >= height - 1) {
     argmax_h_high = argmax_h_low = height - 1;
     argmax_h = static_cast<DType>(argmax_h_low);
@@ -214,31 +214,31 @@ inline DType get_coordinate_weight_cpu(DType argmax_h, DType argmax_w,
 template <typename DType>
 inline void deformable_im2col_cpu(const DType* data_im,
                                   const DType* data_offset,
-                                  const int channels,
-                                  const int height, const int width,
-                                  const int kernel_h, const int kernel_w,
-                                  const int pad_h, const int pad_w,
-                                  const int stride_h, const int stride_w,
-                                  const int dilation_h, const int dilation_w,
-                                  const int deformable_group,
-                                  const int height_col, const int width_col,
+                                  const index_t channels,
+                                  const index_t height, const index_t width,
+                                  const index_t kernel_h, const index_t kernel_w,
+                                  const index_t pad_h, const index_t pad_w,
+                                  const index_t stride_h, const index_t stride_w,
+                                  const index_t dilation_h, const index_t dilation_w,
+                                  const index_t deformable_group,
+                                  const index_t height_col, const index_t width_col,
                                   DType* data_col) {
-  const int channel_size = height * width;
-  const int offset_size = 2 * kernel_h * kernel_w * height_col * width_col;
-  const int channel_per_group = channels / deformable_group;
-  for (int channel = 0; channel < channels; channel++, data_im += channel_size) {
+  const index_t channel_size = height * width;
+  const index_t offset_size = 2 * kernel_h * kernel_w * height_col * width_col;
+  const index_t channel_per_group = channels / deformable_group;
+  for (index_t channel = 0; channel < channels; channel++, data_im += channel_size) {
     if (channel % channel_per_group == 0 && channel != 0) {
       data_offset += offset_size;
     }
-    for (int i = 0; i < kernel_h; i++) {
-      for (int j = 0; j < kernel_w; j++) {
-        int input_row = -pad_h + i * dilation_h;
-        for (int h_col = 0; h_col < height_col; h_col++) {
-          int input_col = -pad_w + j * dilation_w;
-          for (int w_col = 0; w_col < width_col; w_col++) {
-            int offset_h_ptr = ((2 * (i * kernel_w + j)) *
+    for (index_t i = 0; i < kernel_h; i++) {
+      for (index_t j = 0; j < kernel_w; j++) {
+        index_t input_row = -pad_h + i * dilation_h;
+        for (index_t h_col = 0; h_col < height_col; h_col++) {
+          index_t input_col = -pad_w + j * dilation_w;
+          for (index_t w_col = 0; w_col < width_col; w_col++) {
+            index_t offset_h_ptr = ((2 * (i * kernel_w + j)) *
               height_col + h_col) * width_col + w_col;
-            int offset_w_ptr = offset_h_ptr + height_col * width_col;
+            index_t offset_w_ptr = offset_h_ptr + height_col * width_col;
             DType im_row = input_row + data_offset[offset_h_ptr];
             DType im_col = input_col + data_offset[offset_w_ptr];
             if (im_row >= 0 && im_col >= 0 && im_row < height && im_col < width) {
@@ -279,7 +279,7 @@ inline void deformable_im2col(mshadow::Stream<cpu>* s,
                               const mxnet::TShape& pad,
                               const mxnet::TShape& stride,
                               const mxnet::TShape& dilation,
-                              const uint32_t deformable_group,
+                              const index_t deformable_group,
                               DType* data_col) {
   if (2 == kernel_shape.ndim()) {
     deformable_im2col_cpu(data_im, data_offset,
@@ -303,43 +303,43 @@ inline void deformable_im2col(mshadow::Stream<cpu>* s,
  */
 template <typename DType>
 inline void deformable_col2im_cpu(const DType* data_col,
-                                  const DType* data_offset, const int channels,
-                                  const int height, const int width,
-                                  const int kernel_h, const int kernel_w,
-                                  const int pad_h, const int pad_w,
-                                  const int stride_h, const int stride_w,
-                                  const int dilation_h, const int dilation_w,
-                                  const int deformable_group,
-                                  const int height_col, const int width_col,
+                                  const DType* data_offset, const index_t channels,
+                                  const index_t height, const index_t width,
+                                  const index_t kernel_h, const index_t kernel_w,
+                                  const index_t pad_h, const index_t pad_w,
+                                  const index_t stride_h, const index_t stride_w,
+                                  const index_t dilation_h, const index_t dilation_w,
+                                  const index_t deformable_group,
+                                  const index_t height_col, const index_t width_col,
                                   DType* grad_im) {
-  int channel_per_group = channels / deformable_group;
-  int count = channels * kernel_h * kernel_w * height_col * width_col;
-  for (int index = 0; index < count; ++index) {
-    const int j = (index / width_col / height_col) % kernel_w;
-    const int i = (index / width_col / height_col / kernel_w) % kernel_h;
-    const int c = index / width_col / height_col / kernel_w / kernel_h;
+  index_t channel_per_group = channels / deformable_group;
+  index_t count = channels * kernel_h * kernel_w * height_col * width_col;
+  for (index_t index = 0; index < count; ++index) {
+    const index_t j = (index / width_col / height_col) % kernel_w;
+    const index_t i = (index / width_col / height_col / kernel_w) % kernel_h;
+    const index_t c = index / width_col / height_col / kernel_w / kernel_h;
     // compute the start and end of the output
 
-    const int group_index = c / channel_per_group;
-    const int group_offset_step = 2 * kernel_h * kernel_w * height_col * width_col;
+    const index_t group_index = c / channel_per_group;
+    const index_t group_offset_step = 2 * kernel_h * kernel_w * height_col * width_col;
 
-    int w_col = index % width_col;
-    int h_col = (index / width_col) % height_col;
-    int w_in = w_col * stride_w - pad_w;
-    int h_in = h_col * stride_h - pad_h;
+    index_t w_col = index % width_col;
+    index_t h_col = (index / width_col) % height_col;
+    index_t w_in = w_col * stride_w - pad_w;
+    index_t h_in = h_col * stride_h - pad_h;
 
     const DType* data_offset_ptr = data_offset + group_index * group_offset_step;
-    const int data_offset_h_ptr = ((2 * (i * kernel_w + j)) *
+    const index_t data_offset_h_ptr = ((2 * (i * kernel_w + j)) *
       height_col + h_col) * width_col + w_col;
-    const int data_offset_w_ptr = data_offset_h_ptr + height_col * width_col;
+    const index_t data_offset_w_ptr = data_offset_h_ptr + height_col * width_col;
     const DType offset_h = data_offset_ptr[data_offset_h_ptr];
     const DType offset_w = data_offset_ptr[data_offset_w_ptr];
     const DType cur_inv_h_data = h_in + i * dilation_h + offset_h;
     const DType cur_inv_w_data = w_in + j * dilation_w + offset_w;
 
     const DType cur_top_grad = data_col[index];
-    const int cur_h = static_cast<int>(cur_inv_h_data);
-    const int cur_w = static_cast<int>(cur_inv_w_data);
+    const index_t cur_h = static_cast<index_t>(cur_inv_h_data);
+    const index_t cur_w = static_cast<index_t>(cur_inv_w_data);
     for (int dy = -2; dy <= 2; dy++) {
       for (int dx = -2; dx <= 2; dx++) {
         if (cur_h + dy >= 0 && cur_h + dy < height &&
@@ -347,7 +347,7 @@ inline void deformable_col2im_cpu(const DType* data_col,
           std::abs(cur_inv_h_data - (cur_h + dy)) < 1 &&
           std::abs(cur_inv_w_data - (cur_w + dx)) < 1
           ) {
-          int cur_bottom_grad_pos = (c * height + cur_h + dy) * width + cur_w + dx;
+          index_t cur_bottom_grad_pos = (c * height + cur_h + dy) * width + cur_w + dx;
           DType weight = get_gradient_weight_cpu(cur_inv_h_data, cur_inv_w_data,
                                                  cur_h + dy, cur_w + dx, height, width);
           grad_im[cur_bottom_grad_pos] += weight * cur_top_grad;
@@ -382,7 +382,7 @@ inline void deformable_col2im(mshadow::Stream<cpu>* s,
                               const mxnet::TShape& pad,
                               const mxnet::TShape& stride,
                               const mxnet::TShape& dilation,
-                              const uint32_t deformable_group,
+                              const index_t deformable_group,
                               DType* grad_im) {
   if (2 == kernel_shape.ndim()) {
     deformable_col2im_cpu(data_col, data_offset,
@@ -407,49 +407,49 @@ template <typename DType>
 inline void deformable_col2im_coord_cpu(const DType* data_col,
                                         const DType* data_im,
                                         const DType* data_offset,
-                                        const int channels,
-                                        const int height, const int width,
-                                        const int kernel_h, const int kernel_w,
-                                        const int pad_h, const int pad_w,
-                                        const int stride_h, const int stride_w,
-                                        const int dilation_h, const int dilation_w,
-                                        const int deformable_group,
-                                        const int height_col, const int width_col,
+                                        const index_t channels,
+                                        const index_t height, const index_t width,
+                                        const index_t kernel_h, const index_t kernel_w,
+                                        const index_t pad_h, const index_t pad_w,
+                                        const index_t stride_h, const index_t stride_w,
+                                        const index_t dilation_h, const index_t dilation_w,
+                                        const index_t deformable_group,
+                                        const index_t height_col, const index_t width_col,
                                         DType* grad_offset) {
-  int channel_per_group = channels * kernel_h * kernel_w / deformable_group;
-  int count = height_col * width_col * 2 * kernel_h * kernel_w * deformable_group;
-  for (int index = 0; index < count; ++index) {
+  index_t channel_per_group = channels * kernel_h * kernel_w / deformable_group;
+  index_t count = height_col * width_col * 2 * kernel_h * kernel_w * deformable_group;
+  for (index_t index = 0; index < count; ++index) {
     DType val = 0;
-    int w = index % width_col;
-    int h = (index / width_col) % height_col;
-    int c = index / width_col / height_col;
+    index_t w = index % width_col;
+    index_t h = (index / width_col) % height_col;
+    index_t c = index / width_col / height_col;
     // compute the start and end of the output
 
-    const int group_index = c / (2 * kernel_h * kernel_w);
-    const int group_col_step = channel_per_group * width_col * height_col;
-    const int group_im_step = channel_per_group / kernel_h / kernel_w * height * width;
-    const int group_offset_step = 2 * kernel_h * kernel_w * height_col * width_col;
-    const int col_step = kernel_h * kernel_w;
+    const index_t group_index = c / (2 * kernel_h * kernel_w);
+    const index_t group_col_step = channel_per_group * width_col * height_col;
+    const index_t group_im_step = channel_per_group / kernel_h / kernel_w * height * width;
+    const index_t group_offset_step = 2 * kernel_h * kernel_w * height_col * width_col;
+    const index_t col_step = kernel_h * kernel_w;
     const DType* data_col_ptr = data_col + group_index * group_col_step;
     const DType* data_im_ptr = data_im + group_index * group_im_step;
     const DType* data_offset_ptr = data_offset + group_index * group_offset_step;
 
-    int cnt = 0;
-    const int offset_c = c - group_index * 2 * kernel_h * kernel_w;
+    index_t cnt = 0;
+    const index_t offset_c = c - group_index * 2 * kernel_h * kernel_w;
 
-    for (int col_c = (offset_c / 2); col_c < channel_per_group; col_c += col_step) {
-      const int col_pos = ((col_c * height_col) + h) * width_col + w;
-      const int bp_dir = offset_c % 2;
+    for (index_t col_c = (offset_c / 2); col_c < channel_per_group; col_c += col_step) {
+      const index_t col_pos = ((col_c * height_col) + h) * width_col + w;
+      const index_t bp_dir = offset_c % 2;
 
-      int j = (col_pos / width_col / height_col) % kernel_w;
-      int i = (col_pos / width_col / height_col / kernel_w) % kernel_h;
-      int w_col = col_pos % width_col;
-      int h_col = (col_pos / width_col) % height_col;
-      int w_in = w_col * stride_w - pad_w;
-      int h_in = h_col * stride_h - pad_h;
-      const int data_offset_h_ptr = ((2 * (i * kernel_w + j)) *
+      index_t j = (col_pos / width_col / height_col) % kernel_w;
+      index_t i = (col_pos / width_col / height_col / kernel_w) % kernel_h;
+      index_t w_col = col_pos % width_col;
+      index_t h_col = (col_pos / width_col) % height_col;
+      index_t w_in = w_col * stride_w - pad_w;
+      index_t h_in = h_col * stride_h - pad_h;
+      const index_t data_offset_h_ptr = ((2 * (i * kernel_w + j)) *
         height_col + h_col) * width_col + w_col;
-      const int data_offset_w_ptr = data_offset_h_ptr + height_col * width_col;
+      const index_t data_offset_w_ptr = data_offset_h_ptr + height_col * width_col;
       const DType offset_h = data_offset_ptr[data_offset_h_ptr];
       const DType offset_w = data_offset_ptr[data_offset_w_ptr];
       DType inv_h = h_in + i * dilation_h + offset_h;
@@ -495,7 +495,7 @@ inline void deformable_col2im_coord(mshadow::Stream<cpu>* s,
                                     const mxnet::TShape& pad,
                                     const mxnet::TShape& stride,
                                     const mxnet::TShape& dilation,
-                                    const uint32_t deformable_group,
+                                    const index_t deformable_group,
                                     DType* grad_offset) {
   if (2 == kernel_shape.ndim()) {
     deformable_col2im_coord_cpu(data_col, data_im, data_offset,

--- a/src/operator/contrib/nn/deformable_im2col.h
+++ b/src/operator/contrib/nn/deformable_im2col.h
@@ -71,7 +71,7 @@ namespace mxnet {
 namespace op {
 
 template <typename DType>
-inline DType deformable_im2col_bilinear_cpu(const DType* data,
+inline DType im2col_bilinear_cpu(const DType* data,
     const int height, const int width, DType h, DType w) {
   int h_low = floor(h);
   int w_low = floor(w);
@@ -139,7 +139,7 @@ inline void deformable_im2col_cpu(const DType* data_im, const DType* data_offset
             DType im_row = input_row + data_offset[offset_h_ptr];
             DType im_col = input_col + data_offset[offset_w_ptr];
             if (im_row >= 0 && im_col >= 0 && im_row < height && im_col < width) {
-              *(data_col++) = deformable_im2col_bilinear_cpu(data_im, height, width, im_row, im_col);
+              *(data_col++) = im2col_bilinear_cpu(data_im, height, width, im_row, im_col);
             } else {
               *(data_col++) = 0;
             }

--- a/src/operator/contrib/nn/deformable_im2col.h
+++ b/src/operator/contrib/nn/deformable_im2col.h
@@ -65,6 +65,7 @@
 #include <mxnet/operator.h>
 #include <cstring>
 #include <vector>
+#include <algorithm>
 #include "../../mxnet_op.h"
 
 namespace mxnet {
@@ -82,14 +83,14 @@ inline DType im2col_bilinear_cpu(const DType* data,
 
   if (h_low >= height - 1) {
     h_high = height - 1;
-    h = (DType)h_low;
+    h = static_cast<DType>(h_low);
   } else {
     h_high = h_low + 1;
   }
 
   if (w_low >= width - 1) {
     w_high = width - 1;
-    w = (DType)w_low;
+    w = static_cast<DType>(w_low);
   } else {
     w_high = w_low + 1;
   }
@@ -113,27 +114,26 @@ inline DType get_gradient_weight_cpu(DType argmax_h, DType argmax_w,
                                     const int h, const int w,
                                     const int height, const int width) {
   if (argmax_h < 0 || argmax_h > height || argmax_w < 0 || argmax_w > width) {
-    //empty
+    // empty
     return 0;
   }
 
-  argmax_h = std::max(argmax_h, (DType)0.0f);
-  argmax_w = std::max(argmax_w, (DType)0.0f);
+  argmax_h = std::max(argmax_h, static_cast<DType>(0.0f));
+  argmax_w = std::max(argmax_w, static_cast<DType>(0.0f));
 
-  int argmax_h_low = (int)argmax_h;
-  int argmax_w_low = (int)argmax_w;
+  int argmax_h_low = static_cast<int>(argmax_h);
+  int argmax_w_low = static_cast<int>(argmax_w);
   int argmax_h_high;
   int argmax_w_high;
   if (argmax_h_low >= height - 1) {
     argmax_h_high = argmax_h_low = height - 1;
-    argmax_h = (DType)argmax_h_low;
+    argmax_h = static_cast<DType>(argmax_h_low);
   } else {
     argmax_h_high = argmax_h_low + 1;
   }
-  if (argmax_w_low >= width - 1)
-  {
+  if (argmax_w_low >= width - 1) {
     argmax_w_high = argmax_w_low = width - 1;
-    argmax_w = (DType)argmax_w_low;
+    argmax_w = static_cast<DType>(argmax_w_low);
   } else {
     argmax_w_high = argmax_w_low + 1;
   }
@@ -161,26 +161,26 @@ inline DType get_coordinate_weight_cpu(DType argmax_h, DType argmax_w,
                                        const DType* im_data,
                                        const int data_width, const int bp_dir) {
   if (argmax_h < 0 || argmax_h > height || argmax_w < 0 || argmax_w > width) {
-    //empty
+    // empty
     return 0;
   }
 
   if (argmax_h < 0) argmax_h = 0;
   if (argmax_w < 0) argmax_w = 0;
 
-  int argmax_h_low = (int)argmax_h;
-  int argmax_w_low = (int)argmax_w;
+  int argmax_h_low = static_cast<int>(argmax_h);
+  int argmax_w_low = static_cast<int>(argmax_w);
   int argmax_h_high;
   int argmax_w_high;
   if (argmax_h_low >= height - 1) {
     argmax_h_high = argmax_h_low = height - 1;
-    argmax_h = (DType)argmax_h_low;
+    argmax_h = static_cast<DType>(argmax_h_low);
   } else {
     argmax_h_high = argmax_h_low + 1;
   }
   if (argmax_w_low >= width - 1) {
     argmax_w_high = argmax_w_low = width - 1;
-    argmax_w = (DType)argmax_w_low;
+    argmax_w = static_cast<DType>(argmax_w_low);
   } else {
     argmax_w_high = argmax_w_low + 1;
   }
@@ -338,8 +338,8 @@ inline void deformable_col2im_cpu(const DType* data_col,
     const DType cur_inv_w_data = w_in + j * dilation_w + offset_w;
 
     const DType cur_top_grad = data_col[index];
-    const int cur_h = (int)cur_inv_h_data;
-    const int cur_w = (int)cur_inv_w_data;
+    const int cur_h = static_cast<int>(cur_inv_h_data);
+    const int cur_w = static_cast<int>(cur_inv_w_data);
     for (int dy = -2; dy <= 2; dy++) {
       for (int dx = -2; dx <= 2; dx++) {
         if (cur_h + dy >= 0 && cur_h + dy < height &&

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1670,15 +1670,26 @@ def test_deformable_convolution_with_type():
                                 'deformable_conv_weight': 'write',
                                 'deformable_conv_bias': 'null'})
 
+    # for cpu mode, only support forward pass now
+    ctx_list.extend([{'ctx': mx.cpu(0),
+                      'deformable_conv_data': (2, 2, 10, 10),
+                      'deformable_conv_offset': (2, 18, 8, 8),
+                      'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
+                     {'ctx': mx.cpu(0),
+                      'deformable_conv_data': (2, 2, 10, 10),
+                      'deformable_conv_offset': (2, 18, 8, 8),
+                      'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}}])
+    check_consistency(sym, ctx_list, scale=0.1, tol=tol, grad_req='null')
 
 @with_seed()
 def test_deformable_convolution_options():
     tol = {np.dtype(np.float32): 1e-1,
            np.dtype(np.float64): 1e-3}
     # 2D convolution
+    # since atomicAdd does not support fp16 (which deformable conv uses in backward), we do not test fp16 here
+    # for cpu mode, only support forward pass now
 
     # Pad > 0
-    # since atomicAdd does not support fp16 (which deformable conv uses in backward), we do not test fp16 here
     ctx_list = [{'ctx': mx.gpu(0),
                  'deformable_conv_data': (2, 2, 7, 7),
                  'deformable_conv_offset': (2, 18, 7, 7),
@@ -1691,8 +1702,17 @@ def test_deformable_convolution_options():
     sym = mx.sym.contrib.DeformableConvolution(num_filter=3, kernel=(3,3), pad=(1,1), name='deformable_conv')
     check_consistency(sym, ctx_list, scale=0.1, tol=tol)
 
+    ctx_list.extend([{'ctx': mx.cpu(0),
+                      'deformable_conv_data': (2, 2, 7, 7),
+                      'deformable_conv_offset': (2, 18, 7, 7),
+                      'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
+                     {'ctx': mx.cpu(0),
+                      'deformable_conv_data': (2, 2, 7, 7),
+                      'deformable_conv_offset': (2, 18, 7, 7),
+                      'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}}])
+    check_consistency(sym, ctx_list, scale=0.1, tol=tol, grad_req='null')
+
     # Stride > 1
-    # since atomicAdd does not support fp16 (which deformable conv uses in backward), we do not test fp16 here
     ctx_list = [{'ctx': mx.gpu(0),
                  'deformable_conv_data': (2, 2, 7, 7),
                  'deformable_conv_offset': (2, 18, 3, 3),
@@ -1705,8 +1725,17 @@ def test_deformable_convolution_options():
     sym = mx.sym.contrib.DeformableConvolution(num_filter=3, kernel=(3,3), stride=(2,2), name='deformable_conv')
     check_consistency(sym, ctx_list, scale=0.1, tol=tol)
 
+    ctx_list.extend([{'ctx': mx.cpu(0),
+                      'deformable_conv_data': (2, 2, 7, 7),
+                      'deformable_conv_offset': (2, 18, 3, 3),
+                      'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
+                     {'ctx': mx.cpu(0),
+                      'deformable_conv_data': (2, 2, 7, 7),
+                      'deformable_conv_offset': (2, 18, 3, 3),
+                      'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}}])
+    check_consistency(sym, ctx_list, scale=0.1, tol=tol, grad_req='null')
+
     # Dilate > 1
-    # since atomicAdd does not support fp16 (which deformable conv uses in backward), we do not test fp16 here
     ctx_list = [{'ctx': mx.gpu(0),
                  'deformable_conv_data': (2, 2, 7, 7),
                  'deformable_conv_offset': (2, 18, 3, 3),
@@ -1719,8 +1748,17 @@ def test_deformable_convolution_options():
     sym = mx.sym.contrib.DeformableConvolution(num_filter=3, kernel=(3,3), dilate=(2,2), name='deformable_conv')
     check_consistency(sym, ctx_list, scale=0.1, tol=tol)
 
+    ctx_list.extend([{'ctx': mx.cpu(0),
+                      'deformable_conv_data': (2, 2, 7, 7),
+                      'deformable_conv_offset': (2, 18, 3, 3),
+                      'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
+                     {'ctx': mx.cpu(0),
+                      'deformable_conv_data': (2, 2, 7, 7),
+                      'deformable_conv_offset': (2, 18, 3, 3),
+                      'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}}])
+    check_consistency(sym, ctx_list, scale=0.1, tol=tol, grad_req='null')
+
     # Deformable group > 1
-    # since atomicAdd does not support fp16 (which deformable conv uses in backward), we do not test fp16 here
     ctx_list = [{'ctx': mx.gpu(0),
                  'deformable_conv_data': (2, 2, 7, 7),
                  'deformable_conv_offset': (2, 36, 5, 5),
@@ -1729,13 +1767,19 @@ def test_deformable_convolution_options():
                  'deformable_conv_data': (2, 2, 7, 7),
                  'deformable_conv_offset': (2, 36, 5, 5),
                  'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}},
-                # {'ctx': mx.gpu(0),
-                #  'deformable_conv_data': (2, 2, 7, 7),
-                #  'deformable_conv_offset': (2, 36, 5, 5),
-                #  'type_dict': {'deformable_conv_data': np.float16, 'deformable_offset': np.float16}},
                 ]
-    sym = mx.sym.contrib.DeformableConvolution(num_filter=4, kernel=(3,3), num_deformable_group=2,
-                                               name='deformable_conv')
+    sym = mx.sym.contrib.DeformableConvolution(num_filter=4, kernel=(3,3), num_deformable_group=2, name='deformable_conv')
+    check_consistency(sym, ctx_list, scale=0.1, tol=tol)
+
+    ctx_list.extend([{'ctx': mx.cpu(0),
+                      'deformable_conv_data': (2, 2, 7, 7),
+                      'deformable_conv_offset': (2, 36, 5, 5),
+                      'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
+                     {'ctx': mx.cpu(0),
+                      'deformable_conv_data': (2, 2, 7, 7),
+                      'deformable_conv_offset': (2, 36, 5, 5),
+                      'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}}])
+    check_consistency(sym, ctx_list, scale=0.1, tol=tol, grad_req='null')
 
 @with_seed()
 @assert_raises_cudnn_not_satisfied(min_version='5.1.10')

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1656,10 +1656,14 @@ def test_deformable_convolution_with_type():
                  'deformable_conv_data': (2, 2, 10, 10),
                  'deformable_conv_offset': (2, 18, 8, 8),
                  'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}},
-                # {'ctx': mx.gpu(0),
-                #  'deformable_conv_data': (2, 2, 10, 10),
-                #  'deformable_conv_offset': (2, 18, 8, 8),
-                #  'type_dict': {'deformable_conv_data': np.float16, 'deformable_conv_offset': np.float16}},
+                {'ctx': mx.cpu(0),
+                 'deformable_conv_data': (2, 2, 10, 10),
+                 'deformable_conv_offset': (2, 18, 8, 8),
+                 'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
+                {'ctx': mx.cpu(0),
+                 'deformable_conv_data': (2, 2, 10, 10),
+                 'deformable_conv_offset': (2, 18, 8, 8),
+                 'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}},
                 ]
 
     check_consistency(sym, ctx_list, scale=0.1, tol=tol)
@@ -1670,16 +1674,6 @@ def test_deformable_convolution_with_type():
                                 'deformable_conv_weight': 'write',
                                 'deformable_conv_bias': 'null'})
 
-    # for cpu mode, only support forward pass now
-    ctx_list.extend([{'ctx': mx.cpu(0),
-                      'deformable_conv_data': (2, 2, 10, 10),
-                      'deformable_conv_offset': (2, 18, 8, 8),
-                      'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
-                     {'ctx': mx.cpu(0),
-                      'deformable_conv_data': (2, 2, 10, 10),
-                      'deformable_conv_offset': (2, 18, 8, 8),
-                      'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}}])
-    check_consistency(sym, ctx_list, scale=0.1, tol=tol, grad_req='null')
 
 @with_seed()
 def test_deformable_convolution_options():
@@ -1687,7 +1681,6 @@ def test_deformable_convolution_options():
            np.dtype(np.float64): 1e-3}
     # 2D convolution
     # since atomicAdd does not support fp16 (which deformable conv uses in backward), we do not test fp16 here
-    # for cpu mode, only support forward pass now
 
     # Pad > 0
     ctx_list = [{'ctx': mx.gpu(0),
@@ -1698,19 +1691,17 @@ def test_deformable_convolution_options():
                  'deformable_conv_data': (2, 2, 7, 7),
                  'deformable_conv_offset': (2, 18, 7, 7),
                  'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}},
+                {'ctx': mx.cpu(0),
+                 'deformable_conv_data': (2, 2, 7, 7),
+                 'deformable_conv_offset': (2, 18, 7, 7),
+                 'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
+                {'ctx': mx.cpu(0),
+                 'deformable_conv_data': (2, 2, 7, 7),
+                 'deformable_conv_offset': (2, 18, 7, 7),
+                 'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}},
                 ]
     sym = mx.sym.contrib.DeformableConvolution(num_filter=3, kernel=(3,3), pad=(1,1), name='deformable_conv')
     check_consistency(sym, ctx_list, scale=0.1, tol=tol)
-
-    ctx_list.extend([{'ctx': mx.cpu(0),
-                      'deformable_conv_data': (2, 2, 7, 7),
-                      'deformable_conv_offset': (2, 18, 7, 7),
-                      'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
-                     {'ctx': mx.cpu(0),
-                      'deformable_conv_data': (2, 2, 7, 7),
-                      'deformable_conv_offset': (2, 18, 7, 7),
-                      'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}}])
-    check_consistency(sym, ctx_list, scale=0.1, tol=tol, grad_req='null')
 
     # Stride > 1
     ctx_list = [{'ctx': mx.gpu(0),
@@ -1721,19 +1712,17 @@ def test_deformable_convolution_options():
                  'deformable_conv_data': (2, 2, 7, 7),
                  'deformable_conv_offset': (2, 18, 3, 3),
                  'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}},
+                {'ctx': mx.cpu(0),
+                 'deformable_conv_data': (2, 2, 7, 7),
+                 'deformable_conv_offset': (2, 18, 3, 3),
+                 'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
+                {'ctx': mx.cpu(0),
+                 'deformable_conv_data': (2, 2, 7, 7),
+                 'deformable_conv_offset': (2, 18, 3, 3),
+                 'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}},
                 ]
     sym = mx.sym.contrib.DeformableConvolution(num_filter=3, kernel=(3,3), stride=(2,2), name='deformable_conv')
     check_consistency(sym, ctx_list, scale=0.1, tol=tol)
-
-    ctx_list.extend([{'ctx': mx.cpu(0),
-                      'deformable_conv_data': (2, 2, 7, 7),
-                      'deformable_conv_offset': (2, 18, 3, 3),
-                      'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
-                     {'ctx': mx.cpu(0),
-                      'deformable_conv_data': (2, 2, 7, 7),
-                      'deformable_conv_offset': (2, 18, 3, 3),
-                      'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}}])
-    check_consistency(sym, ctx_list, scale=0.1, tol=tol, grad_req='null')
 
     # Dilate > 1
     ctx_list = [{'ctx': mx.gpu(0),
@@ -1744,19 +1733,17 @@ def test_deformable_convolution_options():
                  'deformable_conv_data': (2, 2, 7, 7),
                  'deformable_conv_offset': (2, 18, 3, 3),
                  'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}},
+                {'ctx': mx.cpu(0),
+                 'deformable_conv_data': (2, 2, 7, 7),
+                 'deformable_conv_offset': (2, 18, 3, 3),
+                 'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
+                {'ctx': mx.cpu(0),
+                 'deformable_conv_data': (2, 2, 7, 7),
+                 'deformable_conv_offset': (2, 18, 3, 3),
+                 'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}},
                 ]
     sym = mx.sym.contrib.DeformableConvolution(num_filter=3, kernel=(3,3), dilate=(2,2), name='deformable_conv')
     check_consistency(sym, ctx_list, scale=0.1, tol=tol)
-
-    ctx_list.extend([{'ctx': mx.cpu(0),
-                      'deformable_conv_data': (2, 2, 7, 7),
-                      'deformable_conv_offset': (2, 18, 3, 3),
-                      'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
-                     {'ctx': mx.cpu(0),
-                      'deformable_conv_data': (2, 2, 7, 7),
-                      'deformable_conv_offset': (2, 18, 3, 3),
-                      'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}}])
-    check_consistency(sym, ctx_list, scale=0.1, tol=tol, grad_req='null')
 
     # Deformable group > 1
     ctx_list = [{'ctx': mx.gpu(0),
@@ -1767,19 +1754,18 @@ def test_deformable_convolution_options():
                  'deformable_conv_data': (2, 2, 7, 7),
                  'deformable_conv_offset': (2, 36, 5, 5),
                  'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}},
+                {'ctx': mx.cpu(0),
+                 'deformable_conv_data': (2, 2, 7, 7),
+                 'deformable_conv_offset': (2, 36, 5, 5),
+                 'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
+                {'ctx': mx.cpu(0),
+                 'deformable_conv_data': (2, 2, 7, 7),
+                 'deformable_conv_offset': (2, 36, 5, 5),
+                 'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}},
                 ]
     sym = mx.sym.contrib.DeformableConvolution(num_filter=4, kernel=(3,3), num_deformable_group=2, name='deformable_conv')
     check_consistency(sym, ctx_list, scale=0.1, tol=tol)
 
-    ctx_list.extend([{'ctx': mx.cpu(0),
-                      'deformable_conv_data': (2, 2, 7, 7),
-                      'deformable_conv_offset': (2, 36, 5, 5),
-                      'type_dict': {'deformable_conv_data': np.float64, 'deformable_conv_offset': np.float64}},
-                     {'ctx': mx.cpu(0),
-                      'deformable_conv_data': (2, 2, 7, 7),
-                      'deformable_conv_offset': (2, 36, 5, 5),
-                      'type_dict': {'deformable_conv_data': np.float32, 'deformable_conv_offset': np.float32}}])
-    check_consistency(sym, ctx_list, scale=0.1, tol=tol, grad_req='null')
 
 @with_seed()
 @assert_raises_cudnn_not_satisfied(min_version='5.1.10')


### PR DESCRIPTION
## Description ##
Add cpu deformable_im2col implementation, also fix some errors in doc string.

Update:
The whole cpu part is implemented, and the code style is fixed to pass lint check.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
