### PR TITLE
[Fit-API] Adress PR comments

### DIFF
--- a/python/mxnet/gluon/contrib/estimator/estimator.py
+++ b/python/mxnet/gluon/contrib/estimator/estimator.py
@@ -40,17 +40,17 @@ class Estimator(object):
     Parameters
     ----------
     net : Block
-        The model used for training
+        The model used for training.
     loss : gluon.loss.Loss or list of gluon.loss.Loss
-        Loss(objective functions) to calculate during training
+        Loss(objective functions) to calculate during training.
     metrics : EvalMetric or list of EvalMetric
-        Metrics for evaluating models
+        Metrics for evaluating models.
     initializer : Initializer
-        Initializer to initialize the network
+        Initializer to initialize the network.
     trainer : Trainer
-        Trainer to apply optimizer on network parameters
+        Trainer to apply optimizer on network parameters.
     context : Context or list of Context
-        Device(s) to run the training on
+        Device(s) to run the training on.
     """
 
     def __init__(self, net,
@@ -188,8 +188,8 @@ class Estimator(object):
                 self.train_metrics.append(Loss(loss.name.rstrip('1234567890')))
             for metric in self.train_metrics:
                 val_metric = copy.deepcopy(metric)
-                metric.name = "Train " + metric.name
-                val_metric.name = "Validation " + val_metric.name
+                metric.name = "train " + metric.name
+                val_metric.name = "validation " + val_metric.name
                 self.val_metrics.append(val_metric)
         return self.train_metrics, self.val_metrics
 
@@ -202,11 +202,11 @@ class Estimator(object):
          Parameters
          ----------
          val_data : DataLoader
-             Validation data loader with data and labels
+             Validation data loader with data and labels.
          val_metrics : EvalMetric or list of EvalMetrics
-             Metrics to update validation result
+             Metrics to update validation result.
          batch_axis : int, default 0
-             Batch axis to split the validation data into devices
+             Batch axis to split the validation data into devices.
          """
         if not isinstance(val_data, gluon.data.DataLoader):
             raise ValueError("Estimator only support input as Gluon DataLoader. Alternatively, you "
@@ -233,26 +233,26 @@ class Estimator(object):
             event_handlers=None,
             batches=None,
             batch_axis=0):
-        """Trains the model on a given dataset for a specified
-        number of epochs. Also, the batch size is inferred from the
-        DataLoader's batch_size.
+        """Trains the model with a given :py:class:`DataLoader` for a specified
+        number of epochs or batches. The batch size is inferred from the
+        data loader's batch_size.
 
         Parameters
         ----------
         train_data : DataLoader
-            Training data loader with data and labels
-        val_data : DataLoader
-            Validation data loader with data and labels
+            Training data loader with data and labels.
+        val_data : DataLoader, default None
+            Validation data loader with data and labels.
         epochs : int, default None
             Number of epochs to iterate on the training data.
-            You can only specify one and only one of epochs or batches.
+            You can only specify one and only one type of iteration(epochs or batches).
         event_handlers : EventHandler or list of EventHandler
-            List of EventHandlers to apply during training
+            List of :py:class:`EventHandlers` to apply during training.
         batches : int, default None
             Number of batches to iterate on the training data.
-            You can only specify one and only one of epochs or batches
+            You can only specify one and only one type of iteration(epochs or batches).
         batch_axis : int, default 0
-            Batch axis to split the validation data into devices
+            Batch axis to split the training data into devices.
         """
         if not isinstance(train_data, gluon.data.DataLoader):
             raise ValueError("Estimator only support input as Gluon DataLoader. Alternatively, you "
@@ -355,6 +355,7 @@ class Estimator(object):
                   "Please use the same set of metrics for all your other handlers." % \
                   ", ".join(default_handlers)
             warnings.warn(msg)
+            # check if all handlers has the same set of references to loss and metrics
             references = []
             for handler in event_handlers:
                 for attribute in dir(handler):
@@ -364,8 +365,10 @@ class Estimator(object):
                             references += reference
                         else:
                             references.append(reference)
+            # remove None metric references
+            references = set([ref for ref in references if ref])
             for metric in references:
-                if metric and metric not in train_metrics + val_metrics:
+                if metric not in train_metrics + val_metrics:
                     msg = "We have added following default handlers for you: %s and used " \
                           "estimator.prepare_loss_and_metrics() to pass metrics to " \
                           "those handlers. Please use the same set of metrics " \

--- a/python/mxnet/gluon/contrib/estimator/estimator.py
+++ b/python/mxnet/gluon/contrib/estimator/estimator.py
@@ -21,7 +21,6 @@
 
 import copy
 import warnings
-import weakref
 
 from .event_handler import MetricHandler, ValidationHandler, LoggingHandler
 from .event_handler import TrainBegin, EpochBegin, BatchBegin, BatchEnd, EpochEnd, TrainEnd
@@ -40,6 +39,8 @@ class Estimator(object):
 
     Parameters
     ----------
+    net : Block
+        The model used for training
     loss : gluon.loss.Loss or list of gluon.loss.Loss
         Loss(objective functions) to calculate during training
     metrics : EvalMetric or list of EvalMetric
@@ -70,7 +71,7 @@ class Estimator(object):
     def _check_loss(self, loss):
         if isinstance(loss, gluon.loss.Loss):
             loss = [loss]
-        elif isinstance(loss, list) or all([isinstance(l, gluon.loss.Loss) for l in loss]):
+        elif isinstance(loss, list) and all([isinstance(l, gluon.loss.Loss) for l in loss]):
             loss = loss
         else:
             raise ValueError("loss must be a Loss or a list of Loss, "
@@ -122,19 +123,23 @@ class Estimator(object):
 
     def _initialize(self, initializer):
         # initialize the network
-        if initializer:
-            if self._is_initialized():
-                # if already initialized, re-init with user specified initializer
-                warnings.warn("Network already initialized, re-initializing with %s. "
-                              "You don't need to pass initializer if you already "
-                              "initialized your net." % type(initializer).__name__)
-                self.net.initialize(init=initializer, ctx=self.context, force_reinit=True)
+        if not self._is_initialized():
+            # net is partially or not initialized,
+            # initialize with user specified initializer
+            # if initializer is None, default initializer will be used
+            # do not re-init layers already initialized
+            if initializer:
+                self.net.initialize(init=initializer, ctx=self.context)
             else:
-                # initialize with user specified initializer
-                self.net.initialize(init=initializer, ctx=self.context, force_reinit=False)
-        else:
-            if not self._is_initialized():
                 self.net.initialize(ctx=self.context)
+        elif initializer:
+            # net is fully initialized, and user passed not None initializer
+            # do not force reinitialize, give warning
+            warnings.warn("Network already fully initialized, skipping initialization. "
+                          "You don't need to pass initializer if you already "
+                          "initialized your net. "
+                          "You can use net.initialize(init=your_initializer, force_reinit=True)"
+                          "to force re-initialize.")
 
     def _check_trainer(self, trainer):
         # handle trainer
@@ -157,11 +162,11 @@ class Estimator(object):
                 return False
         return True
 
-    def _get_data_and_label(self, batch, ctx):
+    def _get_data_and_label(self, batch, ctx, batch_axis=0):
         data = batch[0]
         label = batch[1]
-        data = gluon.utils.split_and_load(data, ctx_list=ctx, batch_axis=0)
-        label = gluon.utils.split_and_load(label, ctx_list=ctx, batch_axis=0)
+        data = gluon.utils.split_and_load(data, ctx_list=ctx, batch_axis=batch_axis)
+        label = gluon.utils.split_and_load(label, ctx_list=ctx, batch_axis=batch_axis)
         return data, label
 
     def prepare_loss_and_metrics(self):
@@ -190,26 +195,29 @@ class Estimator(object):
 
     def evaluate(self,
                  val_data,
-                 val_metrics):
+                 val_metrics,
+                 batch_axis=0):
         """Evaluate model on validation data
 
          Parameters
          ----------
          val_data : DataLoader
-             validation data with data and labels
+             validation data loader with data and labels
+         batch_axis : int, default 0
+             batch axis to split the validation data into devices
          val_metrics : EvalMetric or list of EvalMetrics
              metrics to update validation result
          """
+        if not isinstance(val_data, gluon.data.DataLoader):
+            raise ValueError("Estimator only support input as Gluon DataLoader. Alternatively, you "
+                             "can transform your DataIter or any NDArray into Gluon DataLoader. "
+                             "Refer to gluon.data.dataloader")
 
         for metric in val_metrics:
             metric.reset()
 
         for _, batch in enumerate(val_data):
-            if not isinstance(val_data, gluon.data.DataLoader):
-                raise ValueError("Estimator only support input as Gluon DataLoader. Alternatively, you "
-                                 "can transform your DataIter or any NDArray into Gluon DataLoader. "
-                                 "Refer to gluon.data.dataloader")
-            data, label = self._get_data_and_label(batch, self.context)
+            data, label = self._get_data_and_label(batch, self.context, batch_axis)
             pred = [self.net(x) for x in data]
             loss = [self.loss[0](y_hat, y) for y_hat, y in zip(pred, label)]
             # update metrics
@@ -222,7 +230,8 @@ class Estimator(object):
     def fit(self, train_data,
             val_data=None,
             epochs=1,
-            event_handlers=None):
+            event_handlers=None,
+            batch_axis=0):
         """Trains the model on a given dataset for a specified
         number of epochs. Also, the batch size is inferred from the
         DataLoader's batch_size.
@@ -230,20 +239,21 @@ class Estimator(object):
         Parameters
         ----------
         train_data : DataLoader
-            training data with data and labels
+            training data loader with data and labels
         val_data : DataLoader
-            validation data with data and labels
+            validation data loader with data and labels
         epochs : int, default 1
             number of epochs to iterate on the training data.
-        batch_size : int
-            number of samples per gradient update.
-            default will be 32 per device
         event_handlers : EventHandler or list of EventHandler
             list of EventHandlers to apply during training
-        batch_fn : function
-            custom batch function to extract data and label
-            from a data batch and load into contexts(devices)
+        batch_axis : int, default 0
+             batch axis to split the validation data into devices
         """
+        if not isinstance(train_data, gluon.data.DataLoader):
+            raise ValueError("Estimator only support input as Gluon DataLoader. Alternatively, you "
+                             "can transform your DataIter or any NDArray into Gluon DataLoader. "
+                             "Refer to gluon.data.dataloader")
+
         self.max_epochs = epochs
 
         # provide default handlers
@@ -252,8 +262,8 @@ class Estimator(object):
         train_begin, epoch_begin, batch_begin, \
         batch_end, epoch_end, train_end = self._categorize_handlers(event_handlers)
 
-        # only pass a weak reference to all event handlers
-        estimator_ref = weakref.proxy(self)
+        # pass a reference to all event handlers
+        estimator_ref = self
         # training begin
         for handler in train_begin:
             handler.train_begin(estimator_ref)
@@ -264,11 +274,7 @@ class Estimator(object):
                 handler.epoch_begin(estimator_ref)
 
             for i, batch in enumerate(train_data):
-                if not isinstance(train_data, gluon.data.DataLoader):
-                    raise ValueError("Estimator only support input as Gluon DataLoader. Alternatively, you "
-                                     "can transform your DataIter or any NDArray into Gluon DataLoader. "
-                                     "Refer to gluon.data.dataloader")
-                data, label = self._get_data_and_label(batch, self.context)
+                data, label = self._get_data_and_label(batch, self.context, batch_axis)
 
                 batch_size = batch[0].shape[0]
 

--- a/python/mxnet/gluon/contrib/estimator/estimator.py
+++ b/python/mxnet/gluon/contrib/estimator/estimator.py
@@ -268,7 +268,7 @@ class Estimator(object):
         for handler in train_begin:
             handler.train_begin(estimator_ref)
 
-        for epoch in range(epochs):
+        for epoch in range(self.max_epochs):
             # epoch begin
             for handler in epoch_begin:
                 handler.epoch_begin(estimator_ref)

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -341,6 +341,7 @@ def test_default_handlers():
         assert 'You are training with the' in str(w[-1].message)
 
     # handler with prepared loss and metrics
+    # use mix of default and user defined handlers
     train_metrics, val_metrics = est.prepare_loss_and_metrics()
     logging = LoggingHandler(train_metrics=train_metrics, val_metrics=val_metrics)
     with warnings.catch_warnings(record=True) as w:
@@ -350,15 +351,14 @@ def test_default_handlers():
         assert 'MetricHandler' in str(w[-1].message)
 
     # handler with all user defined metrics
-    val_metrics = [mx.metric.RMSE("val acc")]
+    # use mix of default and user defined handlers
     metric = MetricHandler(train_metrics=[train_acc])
-    logging = LoggingHandler(train_metrics=train_metrics, val_metrics=val_metrics)
+    logging = LoggingHandler(train_metrics=[train_acc], val_metrics=[mx.metric.RMSE("val acc")])
     est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[metric, logging])
 
     # handler with mixed metrics, some handler use metrics prepared by estimator
     # some handler use metrics user prepared
-    val_metrics = [mx.metric.RMSE("val acc")]
-    logging = LoggingHandler(train_metrics=train_metrics, val_metrics=val_metrics)
+    logging = LoggingHandler(train_metrics=train_metrics, val_metrics=[mx.metric.RMSE("val acc")])
     with assert_raises(ValueError):
         est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[logging])
 

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -363,8 +363,9 @@ def test_default_handlers():
         est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[logging])
 
     # test handler order
+    train_metrics, val_metrics = est.prepare_loss_and_metrics()
     early_stopping = EarlyStoppingHandler(monitor=val_metrics[0])
     handlers = est._prepare_default_handlers(val_data=None, event_handlers=[early_stopping])
-    assert len(handlers) == 3
+    assert len(handlers) == 4
     assert isinstance(handlers[0], MetricHandler)
-    assert isinstance(handlers[2], LoggingHandler)
+    assert isinstance(handlers[3], LoggingHandler)

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -139,7 +139,13 @@ def test_initializer():
                         initializer=mx.init.MSRAPrelu(),
                         trainer=trainer,
                         context=ctx)
-        assert 'Network already initialized' in str(w[-1].message)
+        assert 'Network already fully initialized' in str(w[-1].message)
+    # net partially initialized, fine tuning use case
+    net = gluon.model_zoo.vision.resnet18_v1(pretrained=True, ctx=ctx)
+    net.output = gluon.nn.Dense(10) #last layer not initialized
+    est = Estimator(net, loss=loss, metrics=acc, context=ctx)
+    dataset =  gluon.data.ArrayDataset(mx.nd.zeros((10, 3, 224, 224)), mx.nd.zeros((10, 10)))
+    train_data = gluon.data.DataLoader(dataset=dataset, batch_size=5)
     est.fit(train_data=train_data,
             epochs=num_epochs)
 

--- a/tests/python/unittest/test_gluon_event_handler.py
+++ b/tests/python/unittest/test_gluon_event_handler.py
@@ -25,8 +25,7 @@ from mxnet.gluon import nn, loss
 from mxnet.gluon.contrib.estimator import estimator, event_handler
 
 
-def _get_test_network():
-    net = nn.Sequential()
+def _get_test_network(net=nn.Sequential()):
     net.add(nn.Dense(128, activation='relu', in_units=100, flatten=False),
             nn.Dense(64, activation='relu', in_units=128),
             nn.Dense(10, activation='relu', in_units=64))
@@ -62,6 +61,9 @@ def test_checkpoint_handler():
 
         model_prefix = 'test_batch'
         file_path = os.path.join(tmpdir, model_prefix)
+        net = _get_test_network(nn.HybridSequential())
+        net.hybridize()
+        est = estimator.Estimator(net, loss=ce_loss, metrics=acc)
         checkpoint_handler = [event_handler.CheckpointHandler(model_dir=tmpdir,
                                                               model_prefix=model_prefix,
                                                               epoch_period=None,
@@ -72,6 +74,7 @@ def test_checkpoint_handler():
         assert not os.path.isfile(file_path + 'best.states')
         assert not os.path.isfile(file_path + '-batch0.params')
         assert not os.path.isfile(file_path + '-batch0.states')
+        assert os.path.isfile(file_path + '-symbol.json')
         assert os.path.isfile(file_path + '-batch1.params')
         assert os.path.isfile(file_path + '-batch1.states')
         assert os.path.isfile(file_path + '-batch2.params')

--- a/tests/python/unittest/test_gluon_event_handler.py
+++ b/tests/python/unittest/test_gluon_event_handler.py
@@ -45,7 +45,7 @@ def test_checkpoint_handler():
     file_path = os.path.join(tmpdir, "model.params")
     test_data = _get_test_data()
 
-    save_best_only = False
+    save_best_only = True
     mode = 'auto'
 
     net = _get_test_network()
@@ -60,6 +60,17 @@ def test_checkpoint_handler():
     est.fit(test_data, event_handlers=checkpoint_handler, epochs=1)
     assert os.path.isfile(file_path)
     os.remove(file_path)
+
+    checkpoint_handler = [event_handler.CheckpointHandler(file_path,
+                                                          monitor=acc,
+                                                          save_best_only=save_best_only,
+                                                          mode=mode,
+                                                          epoch_period=None,
+                                                          batch_period=1)]
+    est.fit(test_data, event_handlers=checkpoint_handler, epochs=2)
+    assert os.path.isfile(file_path)
+    os.remove(file_path)
+
 
 
 def test_early_stopping():


### PR DESCRIPTION
## Description ##
To address PR comments in https://github.com/apache/incubator-mxnet/pull/14629
1. Check train_data and val_data only supports dataloader, give proper error msg
2. exposed batch_axis and set default 0
3.  updated initialization logic, so fine-tuning use case (net partially initialized) will not get forced re-init.
4. explained auto mode in checkpoint and early stopping, added docstring, warning and logging message when auto mode is used and np.greater/np.less is determined in auto mode.
5. log learning rate every epoch
6. update logic to save checkpoint based on epoch_period(default 1) and batch_period (default None)
7. update checkpoint handler to save the following: symbol (1 time after first batch, if net is hybridizable), params and states per epcoh or batch, only keep a maximum number of checkpoints(default 5)
8. added feature to resume training from checkpoints

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
