### PR TITLE
fix add_n bug: when input mem overlap with output mem, results is wrong

### DIFF
--- a/src/ndarray/ndarray_function.cc
+++ b/src/ndarray/ndarray_function.cc
@@ -207,7 +207,8 @@ void ElementwiseSumContainsDnsImpl(mshadow::Stream<cpu>* s,
   using namespace mxnet::op::mxnet_op;
   const TBlob& out_data = out->data();
   MSHADOW_TYPE_SWITCH(out->dtype(), DType, {  // data type
-    // Do not set_zero if output mem inplace with input mem: elemwise_sum.cc FInplaceOption
+    // Do not set_zero when output mem inplace with input[0] mem
+    // Now for add_n OP, output mem can be in-placed with the first input
     if (nds[0].data().dptr<DType>() != out_data.dptr<DType>()) {
       Kernel<set_zero, cpu>::Launch(s, out_data.Size(), out_data.dptr<DType>());
     }

--- a/src/ndarray/ndarray_function.cc
+++ b/src/ndarray/ndarray_function.cc
@@ -207,7 +207,10 @@ void ElementwiseSumContainsDnsImpl(mshadow::Stream<cpu>* s,
   using namespace mxnet::op::mxnet_op;
   const TBlob& out_data = out->data();
   MSHADOW_TYPE_SWITCH(out->dtype(), DType, {  // data type
-    Kernel<set_zero, cpu>::Launch(s, out_data.Size(), out_data.dptr<DType>());
+    // Do not set_zero if output mem inplace with input mem: elemwise_sum.cc FInplaceOption
+    if (nds[0].data().dptr<DType>() != out_data.dptr<DType>()) {
+      Kernel<set_zero, cpu>::Launch(s, out_data.Size(), out_data.dptr<DType>());
+    }
     for (size_t i = 0; i < nds.size(); ++i) {
       const NDArray& nd = nds[i];
       const TBlob& nd_data = nd.data();

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8285,14 +8285,14 @@ def test_np_compat_decorator():
 
 
 @with_seed()
-def test_elemwise_sum_add_n():
+def test_add_n():
     data_shape = (2, 2)
     input_num = 5
     data = [mx.nd.random.uniform(shape=data_shape) for i in range(input_num)]
     rslt = mx.nd.zeros(shape=data_shape)
     for i in range(input_num):
         rslt += data[i]
-    add_n_rslt = mx.nd.add_n(*data,out=data[0])
+    add_n_rslt = mx.nd.add_n(*data, out=data[0])
     assert_almost_equal(rslt.asnumpy(), add_n_rslt.asnumpy(), atol=1e-5)
 
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8284,6 +8284,18 @@ def test_np_compat_decorator():
         check_concat((8, 0, 0), (8, 0, 0), 2)
 
 
+@with_seed()
+def test_elemwise_sum_add_n():
+    data_shape = (2, 2)
+    input_num = 5
+    data = [mx.nd.random.uniform(shape=data_shape) for i in range(input_num)]
+    rslt = mx.nd.zeros(shape=data_shape)
+    for i in range(input_num):
+        rslt += data[i]
+    add_n_rslt = mx.nd.add_n(*data,out=data[0])
+    assert_almost_equal(rslt.asnumpy(), add_n_rslt.asnumpy(), atol=1e-5)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
Fix add_n forword bug
Due to "FInplaceOption" is active, output memory should not set_zero before actually do "add_n" which will make inputs memory set zero too when overlap.
Fix issue for https://github.com/apache/incubator-mxnet/issues/14858

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
@pengzhao-intel @TaoLv 