### PR TITLE
Add mkldnn_version.h to pip package

### DIFF
--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -152,6 +152,8 @@ if variant.endswith('MKL'):
         package_data['mxnet'].append('mxnet/libmkldnn.so.0')
     shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet-build/3rdparty/mkldnn/include'),
                     os.path.join(CURRENT_DIR, 'mxnet/include/mkldnn'))
+    shutil.copy(os.path.join(CURRENT_DIR, 'mxnet-build/3rdparty/mkldnn/build/include/mkldnn_version.h'),
+                os.path.join(CURRENT_DIR, 'mxnet/include/mkldnn'))
 if platform.system() == 'Linux':
     shutil.copy(os.path.join(os.path.dirname(LIB_PATH[0]), 'libgfortran.so.3'), os.path.join(CURRENT_DIR, 'mxnet'))
     package_data['mxnet'].append('mxnet/libgfortran.so.3')

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -150,10 +150,8 @@ if variant.endswith('MKL'):
         package_data['mxnet'].append('mxnet/libmklml_intel.so')
         package_data['mxnet'].append('mxnet/libiomp5.so')
         package_data['mxnet'].append('mxnet/libmkldnn.so.0')
-    shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet-build/3rdparty/mkldnn/include'),
+    shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet-build/3rdparty/mkldnn/build/install/include'),
                     os.path.join(CURRENT_DIR, 'mxnet/include/mkldnn'))
-    shutil.copy(os.path.join(CURRENT_DIR, 'mxnet-build/3rdparty/mkldnn/build/include/mkldnn_version.h'),
-                os.path.join(CURRENT_DIR, 'mxnet/include/mkldnn'))
 if platform.system() == 'Linux':
     shutil.copy(os.path.join(os.path.dirname(LIB_PATH[0]), 'libgfortran.so.3'), os.path.join(CURRENT_DIR, 'mxnet'))
     package_data['mxnet'].append('mxnet/libgfortran.so.3')


### PR DESCRIPTION
Per changes in #13668, we generate a new header file `mkldnn_version.h` during MXNet compilation based on the template file [mkldnn_version.h.in](https://github.com/intel/mkl-dnn/blob/7de7e5d02bf687f971e7668963649728356e0c20/include/mkldnn_version.h.in). This dynamically generated header file needs to be added to the MXNet pip package to prevent compilation failure for building Horovod with MKLDNN enabled MXNet pip package.
