### PR TITLE
don't check for nullptr before deleting; closes #14580

### DIFF
--- a/cpp-package/example/inference/inception_inference.cpp
+++ b/cpp-package/example/inference/inception_inference.cpp
@@ -331,9 +331,7 @@ void Predictor::PredictImage(const std::string& image_file) {
 
 
 Predictor::~Predictor() {
-  if (executor) {
-    delete executor;
-  }
+  delete executor;
   MXNotifyShutdown();
 }
 

--- a/src/io/iter_mnist.cc
+++ b/src/io/iter_mnist.cc
@@ -84,7 +84,7 @@ class MNISTIter: public IIterator<TBlobBatch> {
     out_.data.resize(2);
   }
   virtual ~MNISTIter(void) {
-    if (img_.dptr_ != nullptr) delete []img_.dptr_;
+    delete []img_.dptr_;
   }
   // intialize iterator loads data in
   virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {

--- a/src/kvstore/kvstore_dist.h
+++ b/src/kvstore/kvstore_dist.h
@@ -141,9 +141,7 @@ class KVStoreDist : public KVStoreLocal {
     }
     if (server_) server_->Run();
     ps::Finalize(0, true);
-    if (server_) {
-      delete server_;
-    }
+    delete server_;
     server_ = nullptr;
   }
 


### PR DESCRIPTION
## Description ##

This PR removes some checks for `nullptr` before deleting the pointer, as described in #14580.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Remove some checks for `nullptr` before deleting the pointer, as described in #14580.

## Comments ##
No new tests are added but the change simply removes some code that is unnecessary according to [the article mentioned in the issue](https://isocpp.org/wiki/faq/freestore-mgmt#delete-handles-null).