### PR TITLE
Add API documentation for upsampling operator with examples

### DIFF
--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -123,7 +123,7 @@ DMLC_REGISTER_PARAMETER(UpSamplingParam);
 NNVM_REGISTER_OP(UpSampling)
 .describe(R"code(Upsamples the given input data.
 
-2 algorithms (``sample_type``) are available for upsampling
+Two algorithms (``sample_type``) are available for upsampling:
 
 - Nearest Neighbor
 - Bilinear

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -121,9 +121,67 @@ struct UpSamplingGrad {
 DMLC_REGISTER_PARAMETER(UpSamplingParam);
 
 NNVM_REGISTER_OP(UpSampling)
-.describe("Performs nearest neighbor/bilinear up sampling to inputs. "
-          "Bilinear upsampling makes use of deconvolution. Therefore, "
-          "provide 2 inputs - data and weight. ")
+.describe(R"code(Upsamples the given input data.
+
+2 algorithms (``sample_type``) are available for upsampling
+
+- Nearest Neighbor
+- Bilinear
+
+**Nearest Neighbor Upsampling**
+
+Input data is expected to be 4D of the form `(batch, channel, height, width)`.
+
+Example::
+
+  >>> x = nd.ones((1,1,3,3))
+  >>> x
+  [[[[1. 1. 1.]
+     [1. 1. 1.]
+     [1. 1. 1.]]]]
+  <NDArray 1x1x3x3 @cpu(0)>
+  >>> upsampled_x = nd.UpSampling(x, scale=2, sample_type='nearest') 
+  >>> upsampled_x
+  [[[[1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]
+     [1. 1. 1. 1. 1. 1.]]]]
+  <NDArray 1x1x6x6 @cpu(0)>
+
+**Bilinear Upsampling**
+
+Uses `deconvolution` algorithm under the hood. You need provide both input data and the kernel.
+
+Input data is expected to be 4D of the form `(batch, channel, height, width)`.
+
+`num_filter` is expected to be same as the number of channels.
+
+Example::
+
+  >>> x = nd.ones((1,1,3,3))
+  >>> x
+  [[[[1. 1. 1.]
+     [1. 1. 1.]
+     [1. 1. 1.]]]]
+  <NDArray 1x1x3x3 @cpu(0)>
+  >>> w = nd.ones((1,1,4,4))
+  >>> w
+  [[[[1. 1. 1. 1.]
+     [1. 1. 1. 1.]
+     [1. 1. 1. 1.]
+     [1. 1. 1. 1.]]]]
+  <NDArray 1x1x4x4 @cpu(0)>
+  >>> nd.UpSampling(x, w, scale=2, sample_type='bilinear', num_filter=1)
+  [[[[1. 2. 2. 2. 2. 1.]
+     [2. 4. 4. 4. 4. 2.]
+     [2. 4. 4. 4. 4. 2.]
+     [2. 4. 4. 4. 4. 2.]
+     [2. 4. 4. 4. 4. 2.]
+     [1. 2. 2. 2. 2. 1.]]]]
+  <NDArray 1x1x6x6 @cpu(0)>
+)code" ADD_FILELINE)
 .set_num_inputs([](const NodeAttrs& attrs) {
   const UpSamplingParam& params = nnvm::get<UpSamplingParam>(attrs.parsed);
   return params.sample_type == up_enum::kNearest ? params.num_args : 2;

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -134,21 +134,16 @@ Input data is expected to be NCHW.
 
 Example::
 
-  >>> x = nd.ones((1,1,3,3))
-  >>> x
-  [[[[1. 1. 1.]
-     [1. 1. 1.]
-     [1. 1. 1.]]]]
-  <NDArray 1x1x3x3 @cpu(0)>
-  >>> upsampled_x = nd.UpSampling(x, scale=2, sample_type='nearest') 
-  >>> upsampled_x
-  [[[[1. 1. 1. 1. 1. 1.]
-     [1. 1. 1. 1. 1. 1.]
-     [1. 1. 1. 1. 1. 1.]
-     [1. 1. 1. 1. 1. 1.]
-     [1. 1. 1. 1. 1. 1.]
-     [1. 1. 1. 1. 1. 1.]]]]
-  <NDArray 1x1x6x6 @cpu(0)>
+  x = [[[[1. 1. 1.]
+         [1. 1. 1.]
+         [1. 1. 1.]]]]
+
+  UpSampling(x, scale=2, sample_type='nearest') = [[[[1. 1. 1. 1. 1. 1.]
+                                                     [1. 1. 1. 1. 1. 1.]
+                                                     [1. 1. 1. 1. 1. 1.]
+                                                     [1. 1. 1. 1. 1. 1.]
+                                                     [1. 1. 1. 1. 1. 1.]
+                                                     [1. 1. 1. 1. 1. 1.]]]]
 
 **Bilinear Upsampling**
 
@@ -160,27 +155,21 @@ Input data is expected to be NCHW.
 
 Example::
 
-  >>> x = nd.ones((1,1,3,3))
-  >>> x
-  [[[[1. 1. 1.]
-     [1. 1. 1.]
-     [1. 1. 1.]]]]
-  <NDArray 1x1x3x3 @cpu(0)>
-  >>> w = nd.ones((1,1,4,4))
-  >>> w
-  [[[[1. 1. 1. 1.]
-     [1. 1. 1. 1.]
-     [1. 1. 1. 1.]
-     [1. 1. 1. 1.]]]]
-  <NDArray 1x1x4x4 @cpu(0)>
-  >>> nd.UpSampling(x, w, scale=2, sample_type='bilinear', num_filter=1)
-  [[[[1. 2. 2. 2. 2. 1.]
-     [2. 4. 4. 4. 4. 2.]
-     [2. 4. 4. 4. 4. 2.]
-     [2. 4. 4. 4. 4. 2.]
-     [2. 4. 4. 4. 4. 2.]
-     [1. 2. 2. 2. 2. 1.]]]]
-  <NDArray 1x1x6x6 @cpu(0)>
+  x = [[[[1. 1. 1.]
+         [1. 1. 1.]
+         [1. 1. 1.]]]]
+
+  w = [[[[1. 1. 1. 1.]
+         [1. 1. 1. 1.]
+         [1. 1. 1. 1.]
+         [1. 1. 1. 1.]]]]
+  
+  UpSampling(x, w, scale=2, sample_type='bilinear', num_filter=1) = [[[[1. 2. 2. 2. 2. 1.]
+                                                                       [2. 4. 4. 4. 4. 2.]
+                                                                       [2. 4. 4. 4. 4. 2.]
+                                                                       [2. 4. 4. 4. 4. 2.]
+                                                                       [2. 4. 4. 4. 4. 2.]
+                                                                       [1. 2. 2. 2. 2. 1.]]]]
 )code" ADD_FILELINE)
 .set_num_inputs([](const NodeAttrs& attrs) {
   const UpSamplingParam& params = nnvm::get<UpSamplingParam>(attrs.parsed);

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -154,7 +154,7 @@ Example::
 
 Uses `deconvolution` algorithm under the hood. You need provide both input data and the kernel.
 
-Input data is expected to be 4D of the form `(batch, channel, height, width)`.
+Input data is expected to be NCHW.
 
 `num_filter` is expected to be same as the number of channels.
 

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -130,7 +130,7 @@ Two algorithms (``sample_type``) are available for upsampling:
 
 **Nearest Neighbor Upsampling**
 
-Input data is expected to be 4D of the form `(batch, channel, height, width)`.
+Input data is expected to be NCHW.
 
 Example::
 


### PR DESCRIPTION
## Description ##
Fixes https://github.com/apache/incubator-mxnet/issues/12970
Upsampling operator did not had valid documentation and example usage leading to issues like - #12970

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.

- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Add clear API documentation for upsampling operator

@aaronmarkham @vandanavk  - Can you please help review this?
