### PR TITLE
Updates to cudnn package installation

### DIFF
--- a/ci/docker/Dockerfile.build.centos7_gpu
+++ b/ci/docker/Dockerfile.build.centos7_gpu
@@ -20,8 +20,6 @@
 
 FROM nvidia/cuda:10.0-devel-centos7
 
-ENV CUDNN_VERSION=7.3.1.20
-
 WORKDIR /work/deps
 
 COPY install/centos7_core.sh /work/
@@ -30,6 +28,8 @@ COPY install/centos7_ccache.sh /work/
 RUN /work/centos7_ccache.sh
 COPY install/centos7_python.sh /work/
 RUN /work/centos7_python.sh
+
+ENV CUDNN_VERSION=7.3.1.20
 COPY install/centos7_cudnn.sh /work/
 RUN /work/centos7_cudnn.sh
 

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu100
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu100
@@ -20,8 +20,6 @@
 
 FROM nvidia/cuda:10.0-devel-ubuntu16.04
 
-ENV CUDNN_VERSION=7.3.1.20
-
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/
@@ -74,6 +72,7 @@ ARG GROUP_ID=0
 COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
+ENV CUDNN_VERSION=7.3.1.20
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
 

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu90
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu90
@@ -20,8 +20,6 @@
 
 FROM nvidia/cuda:9.0-devel-ubuntu16.04
 
-ENV CUDNN_VERSION=7.3.1.20
-
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/
@@ -74,6 +72,7 @@ ARG GROUP_ID=0
 COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
+ENV CUDNN_VERSION=7.3.1.20
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
 

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu92
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu92
@@ -20,8 +20,6 @@
 
 FROM nvidia/cuda:9.2-devel-ubuntu16.04
 
-ENV CUDNN_VERSION=7.3.1.20
-
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/
@@ -74,6 +72,7 @@ ARG GROUP_ID=0
 COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
+ENV CUDNN_VERSION=7.3.1.20
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
 


### PR DESCRIPTION
## Description ##
Currently, the installation script for centos7 cudnn only installs a single version of cudnn independendly of what is set in the CUDNN_VERSION environment variable. This PR aims to fix it by making it more general by constructing the download url for the cudnn package from the CUDA_VERSION and CUDNN_VERSION environment variables.

Additionally, by having the CUDNN_VERSION defined at the start of the Dockerfile, the whole docker file will be rebuilt if there's a change. Therefore, moving it next to the call to the install cudnn script.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
