### PR TITLE
ONNX export: Slice op - Handle None value for ends

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -56,7 +56,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import re, sys
+import re
+import sys
 import logging
 import numpy as np
 from .export_onnx import MXNetGraph as mx_op

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1502,7 +1502,7 @@ def convert_slice_axis(node, **kwargs):
     ends = attrs.get("end", None)
     if not ends or ends == 'None':
         # ONNX doesn't support None for ends. Since ends=None depicts
-        # length of dimension, passing INT_MAX in this case.
+        # length of dimension, passing dimension in this case.
         in_shape = kwargs['in_shape'][0]
         ends = in_shape[axes]
 

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -57,7 +57,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import re
-import sys
 import logging
 import numpy as np
 from .export_onnx import MXNetGraph as mx_op
@@ -1504,7 +1503,8 @@ def convert_slice_axis(node, **kwargs):
     if not ends or ends == 'None':
         # ONNX doesn't support None for ends. Since ends=None depicts
         # length of dimension, passing INT_MAX in this case.
-        ends = sys.maxsize
+        in_shape = kwargs['in_shape'][0]
+        ends = in_shape[axes]
 
     node = onnx.helper.make_node(
         "Slice",

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -56,7 +56,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import re
+import re, sys
 import logging
 import numpy as np
 from .export_onnx import MXNetGraph as mx_op
@@ -1499,9 +1499,11 @@ def convert_slice_axis(node, **kwargs):
 
     axes = int(attrs.get("axis"))
     starts = int(attrs.get("begin"))
-    ends = int(attrs.get("end", None))
-    if not ends:
-        raise ValueError("Slice: ONNX doesnt't support 'None' in 'end' attribute")
+    ends = attrs.get("end", None)
+    if not ends or ends == 'None':
+        # ONNX doesn't support None for ends. Since ends=None depicts
+        # length of dimension, passing INT_MAX in this case.
+        ends = sys.maxsize
 
     node = onnx.helper.make_node(
         "Slice",
@@ -1509,7 +1511,7 @@ def convert_slice_axis(node, **kwargs):
         [name],
         axes=[axes],
         starts=[starts],
-        ends=[ends],
+        ends=[int(ends)],
         name=name,
     )
     return [node]

--- a/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_op_translations.py
@@ -499,6 +499,8 @@ def split(attrs, inputs, proto_obj):
 
 def _slice(attrs, inputs, proto_obj):
     """Returns a slice of the input tensor along multiple axes."""
+    input_tensor_data = proto_obj.model_metadata.get('input_tensor_data')[0]
+    input_shape = input_tensor_data[1]
     new_attrs = translation_utils._fix_attribute_names(attrs,
                                                        {'axes' : 'axis',
                                                         'ends' : 'end',
@@ -506,8 +508,10 @@ def _slice(attrs, inputs, proto_obj):
     # onnx slice provides slicing on multiple axis. Adding multiple slice_axis operator
     # for multiple axes from mxnet
     begin = new_attrs.get('begin')
-    end = new_attrs.get('end')
+    end = list(new_attrs.get('end'))
     axes = new_attrs.get('axis', tuple(range(len(begin))))
+    for i, axis in enumerate(axes):
+        end[i] = None if end[i] >= input_shape[axis] else end[i]
     slice_op = symbol.slice_axis(inputs[0], axis=axes[0], begin=begin[0], end=end[0])
     if len(axes) > 1:
         for i, axis in enumerate(axes):

--- a/tests/python-pytest/onnx/test_cases.py
+++ b/tests/python-pytest/onnx/test_cases.py
@@ -41,6 +41,7 @@ IMPLEMENTED_OPERATORS_TEST = {
              'test_globalaveragepool',
              'test_slice_cpu',
              'test_slice_neg',
+             'test_slice_end',
              'test_reciprocal',
              'test_sqrt',
              'test_pow',

--- a/tests/python-pytest/onnx/test_node.py
+++ b/tests/python-pytest/onnx/test_node.py
@@ -274,11 +274,7 @@ test_cases = [
     ("test_random_normal", mx.sym.random_normal, "RandomNormal", [],
      {'shape': (2, 2), 'loc': 0, 'scale': 1}, False, {'modify': {'loc': 'mean'}}, False, True),
     ("test_random_uniform", mx.sym.random_uniform, "RandomUniform", [],
-     {'shape': (2, 2), 'low': 0.5, 'high': 1.0}, False, {}, False, True),
-    ("test_slice_axis", mx.sym.slice_axis, "Slice", [get_rnd((2, 3, 20, 20))],
-     {'axis': 0, 'begin': 0, 'end': None}, False,
-     {'remove': ['axis', 'begin', 'end'],
-      'add': {'axes': [0], 'starts': [0], 'ends': [sys.maxsize]}}, True, False)
+     {'shape': (2, 2), 'low': 0.5, 'high': 1.0}, False, {}, False, True)
 ]
 
 test_scalar_ops = ['Add', 'Sub', 'rSub' 'Mul', 'Div', 'Pow']

--- a/tests/python-pytest/onnx/test_node.py
+++ b/tests/python-pytest/onnx/test_node.py
@@ -274,7 +274,11 @@ test_cases = [
     ("test_random_normal", mx.sym.random_normal, "RandomNormal", [],
      {'shape': (2, 2), 'loc': 0, 'scale': 1}, False, {'modify': {'loc': 'mean'}}, False, True),
     ("test_random_uniform", mx.sym.random_uniform, "RandomUniform", [],
-     {'shape': (2, 2), 'low': 0.5, 'high': 1.0}, False, {}, False, True)
+     {'shape': (2, 2), 'low': 0.5, 'high': 1.0}, False, {}, False, True),
+    ("test_slice_axis", mx.sym.slice_axis, "Slice", [get_rnd((2, 3, 20, 20))],
+     {'axis': 0, 'begin': 0, 'end': None}, False,
+     {'remove': ['axis', 'begin', 'end'],
+      'add': {'axes': [0], 'starts': [0], 'ends': [sys.maxsize]}}, True, False)
 ]
 
 test_scalar_ops = ['Add', 'Sub', 'rSub' 'Mul', 'Div', 'Pow']


### PR DESCRIPTION
## Description ##
Fixes https://github.com/apache/incubator-mxnet/issues/14875

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Handle ends=None in Slip_axis export to ONNX

## Comments ##
- All ONNX export tests passed
