### PR TITLE
[MXNET-1403] Disable numpy's writability of NDArray once it is zero-copied to MXNet

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -4212,7 +4212,12 @@ def dl_managed_tensor_deleter(dl_managed_tensor_handle):
 
 
 def from_numpy(ndarray, zero_copy=True):
-    """Returns an MXNet's NDArray backed by Numpy's ndarray.
+    """Returns an MXNet's ndarray backed by numpy's ndarray.
+    When `zero_copy` is set to be true,
+    this API consumes numpy's ndarray and produces MXNet's ndarray
+    without having to copy the content. In this case, we disallow
+    users to modify the given numpy ndarray, and it is suggested
+    not to read the numpy ndarray as well for internal correctness.
 
     Parameters
     ----------

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -4261,6 +4261,7 @@ def from_numpy(ndarray, zero_copy=True):
 
     if not ndarray.flags['C_CONTIGUOUS']:
         raise ValueError("Only c-contiguous arrays are supported for zero-copy")
+    ndarray.flags['WRITEABLE'] = False
     c_obj = _make_dl_managed_tensor(ndarray)
     address = ctypes.addressof(c_obj)
     address = ctypes.cast(address, ctypes.c_void_p)

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1687,10 +1687,8 @@ def test_zero_from_numpy():
             mx.test_utils.assert_almost_equal(np_array, mx_array.asnumpy())
     np_array = arrays[0]
     mx_array = mx.nd.from_numpy(np_array)
-    try:
-        np_array[2, 1] = 0
-    except ValueError:
-        pass
+    assertRaises(ValueError, np_array.__setitem__, (2, 1), 0)
+
     mx_array[2, 1] = 100
     mx.test_utils.assert_almost_equal(np_array, mx_array.asnumpy())
     np_array = np.array([[1, 2], [3, 4], [5, 6]]).transpose()

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1687,8 +1687,10 @@ def test_zero_from_numpy():
             mx.test_utils.assert_almost_equal(np_array, mx_array.asnumpy())
     np_array = arrays[0]
     mx_array = mx.nd.from_numpy(np_array)
-    np_array[2, 1] = 0
-    mx.test_utils.assert_almost_equal(np_array, mx_array.asnumpy())
+    try:
+        np_array[2, 1] = 0
+    except ValueError:
+        pass
     mx_array[2, 1] = 100
     mx.test_utils.assert_almost_equal(np_array, mx_array.asnumpy())
     np_array = np.array([[1, 2], [3, 4], [5, 6]]).transpose()


### PR DESCRIPTION
## Description ##
Per discussion with @szha , we decided that we do not allow ndarrays to be manipulated on the numpy side to ensure correctness.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Set up writable flags to be False.

## Comments ##
None