### PR TITLE
[Dependency Update] Upgrade CI to use latest cuDNN

### DIFF
--- a/ci/docker/Dockerfile.build.centos7_gpu
+++ b/ci/docker/Dockerfile.build.centos7_gpu
@@ -20,8 +20,6 @@
 
 FROM nvidia/cuda:10.0-devel-centos7
 
-ENV CUDNN_VERSION=7.5.1.10
-
 WORKDIR /work/deps
 
 COPY install/centos7_core.sh /work/
@@ -31,7 +29,7 @@ RUN /work/centos7_ccache.sh
 COPY install/centos7_python.sh /work/
 RUN /work/centos7_python.sh
 
-ENV CUDNN_VERSION=7.3.1.20
+ENV CUDNN_VERSION=7.5.1.10
 COPY install/centos7_cudnn.sh /work/
 RUN /work/centos7_cudnn.sh
 

--- a/ci/docker/Dockerfile.build.centos7_gpu
+++ b/ci/docker/Dockerfile.build.centos7_gpu
@@ -20,6 +20,8 @@
 
 FROM nvidia/cuda:10.0-devel-centos7
 
+ENV CUDNN_VERSION=7.5.1.10
+
 WORKDIR /work/deps
 
 COPY install/centos7_core.sh /work/

--- a/ci/docker/Dockerfile.build.ubuntu_base_gpu
+++ b/ci/docker/Dockerfile.build.ubuntu_base_gpu
@@ -21,6 +21,8 @@
 
 FROM nvidia/cuda:10.0-devel-ubuntu16.04
 
+ENV CUDNN_VERSION=7.5.1.10
+
 WORKDIR /work/deps
 
 RUN apt-get update && apt-get -y install sudo

--- a/ci/docker/Dockerfile.build.ubuntu_build_cuda
+++ b/ci/docker/Dockerfile.build.ubuntu_build_cuda
@@ -23,7 +23,7 @@
 
 FROM nvidia/cuda:10.0-devel-ubuntu16.04
 
-ENV CUDNN_VERSION=7.3.1.20
+ENV CUDNN_VERSION=7.5.1.10
 
 WORKDIR /work/deps
 

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu100
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu100
@@ -77,12 +77,9 @@ ARG GROUP_ID=0
 COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
-<<<<<<< HEAD
-=======
 ENV CUDNN_VERSION=7.5.1.10
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
->>>>>>> remove the duplicate one
 
 COPY runtime_functions.sh /work/
 

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu100
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu100
@@ -20,8 +20,6 @@
 
 FROM nvidia/cuda:10.0-devel-ubuntu16.04
 
-ENV CUDNN_VERSION=7.5.1.10
-
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/
@@ -79,6 +77,12 @@ ARG GROUP_ID=0
 COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
+<<<<<<< HEAD
+=======
+ENV CUDNN_VERSION=7.5.1.10
+COPY install/ubuntu_cudnn.sh /work/
+RUN /work/ubuntu_cudnn.sh
+>>>>>>> remove the duplicate one
 
 COPY runtime_functions.sh /work/
 

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu100
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu100
@@ -20,6 +20,8 @@
 
 FROM nvidia/cuda:10.0-devel-ubuntu16.04
 
+ENV CUDNN_VERSION=7.5.1.10
+
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu90
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu90
@@ -20,11 +20,6 @@
 
 FROM nvidia/cuda:9.0-devel-ubuntu16.04
 
-<<<<<<< HEAD
-=======
-ENV CUDNN_VERSION=7.5.1.10
-
->>>>>>> bump up the cuDNN version
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/
@@ -82,6 +77,13 @@ ARG GROUP_ID=0
 COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
+<<<<<<< HEAD
+=======
+ENV CUDNN_VERSION=7.5.1.10
+COPY install/ubuntu_cudnn.sh /work/
+RUN /work/ubuntu_cudnn.sh
+
+>>>>>>> remove the duplicate one
 COPY runtime_functions.sh /work/
 
 WORKDIR /work/mxnet

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu90
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu90
@@ -20,6 +20,11 @@
 
 FROM nvidia/cuda:9.0-devel-ubuntu16.04
 
+<<<<<<< HEAD
+=======
+ENV CUDNN_VERSION=7.5.1.10
+
+>>>>>>> bump up the cuDNN version
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu90
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu90
@@ -77,13 +77,10 @@ ARG GROUP_ID=0
 COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
-<<<<<<< HEAD
-=======
 ENV CUDNN_VERSION=7.5.1.10
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
 
->>>>>>> remove the duplicate one
 COPY runtime_functions.sh /work/
 
 WORKDIR /work/mxnet

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu92
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu92
@@ -20,6 +20,11 @@
 
 FROM nvidia/cuda:9.2-devel-ubuntu16.04
 
+<<<<<<< HEAD
+=======
+ENV CUDNN_VERSION=7.5.1.10
+
+>>>>>>> bump up the cuDNN version
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu92
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu92
@@ -20,11 +20,6 @@
 
 FROM nvidia/cuda:9.2-devel-ubuntu16.04
 
-<<<<<<< HEAD
-=======
-ENV CUDNN_VERSION=7.5.1.10
-
->>>>>>> bump up the cuDNN version
 WORKDIR /work/deps
 
 COPY install/ubuntu_core.sh /work/
@@ -81,6 +76,13 @@ ARG GROUP_ID=0
 COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
+<<<<<<< HEAD
+=======
+ENV CUDNN_VERSION=7.5.1.10
+COPY install/ubuntu_cudnn.sh /work/
+RUN /work/ubuntu_cudnn.sh
+
+>>>>>>> remove the duplicate one
 COPY runtime_functions.sh /work/
 
 WORKDIR /work/mxnet

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu92
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu92
@@ -76,13 +76,10 @@ ARG GROUP_ID=0
 COPY install/ubuntu_adduser.sh /work/
 RUN /work/ubuntu_adduser.sh
 
-<<<<<<< HEAD
-=======
 ENV CUDNN_VERSION=7.5.1.10
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
 
->>>>>>> remove the duplicate one
 COPY runtime_functions.sh /work/
 
 WORKDIR /work/mxnet

--- a/ci/docker/Dockerfile.build.ubuntu_nightly_gpu
+++ b/ci/docker/Dockerfile.build.ubuntu_nightly_gpu
@@ -20,7 +20,7 @@
 
 FROM nvidia/cuda:10.0-devel-ubuntu16.04
 
-ENV CUDNN_VERSION=7.3.1.20
+ENV CUDNN_VERSION=7.5.1.10
 
 WORKDIR /work/deps
 

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -406,6 +406,11 @@ class RNNOp {
     #if MXNET_USE_CUDNN_RNN
     init_cudnn_ = false;
     dtype_ = mshadow::DataType<DType>::kCudnnFlag;
+#if __CUDA_ARCH__ < 530 && CUDNN_MAJOR >=7 && CUDNN_MINOR >= 5
+    if (dtype_ == CUDNN_DATA_HALF) {
+      dtype_ = CUDNN_DATA_FLOAT;
+    }
+#endif    
     // TensorCore algos only allowed on fp16-I/O convolutions if permitted by the global policy.
     // No tests in place for fp16 RNNs, so leave TensorCore disabled for now.
     cudnn_tensor_core_ = false;
@@ -1388,7 +1393,7 @@ class RNNOp {
                                        x_desc_vec_[0],
                                        &cudnn_param_size,
                                        dtype_));
-      CHECK_EQ(w.shape_[0] * sizeof(DType), cudnn_param_size);
+      // CHECK_EQ(w.shape_[0] * sizeof(DType), cudnn_param_size);
       // Set param descriptors
       int dim_w[3] = {1, 1, 1};
       dim_w[0] = w.shape_[0];

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -1398,7 +1398,7 @@ class RNNOp {
                                        x_desc_vec_[0],
                                        &cudnn_param_size,
                                        dtype_));
-      // CHECK_EQ(w.shape_[0] * sizeof(DType), cudnn_param_size);
+      CHECK_EQ(w.shape_[0] * sizeof(DType), cudnn_param_size);
       // Set param descriptors
       int dim_w[3] = {1, 1, 1};
       dim_w[0] = w.shape_[0];

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -1318,6 +1318,9 @@ class RNNOp {
       cudnnDataType_t dtype_with_fallback_;
       #if CUDNN_MAJOR >= 6
       cudnnRNNAlgo_t rnn_algo = CUDNN_RNN_ALGO_STANDARD;
+      // On arch's 50 and 52(Maxwell), the gpu doesn't support native fp16 compute.
+      // Before cuDNN 7.5.0, when running fp16, cuDNN fallback to fp32 under the hood on Maxwell.
+      // That's not the case begining from 7.5.0. Thereby adding fallback explicitly here.
       #if __CUDA_ARCH__ < 530 && CUDNN_MAJOR >=7 && CUDNN_MINOR >= 5
       if (dtype_ == CUDNN_DATA_HALF) {
         dtype_with_fallback_ = CUDNN_DATA_FLOAT;

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -1329,7 +1329,7 @@ class RNNOp {
       }
       #else
         dtype_with_fallback_ = dtype_;
-      #endif    
+      #endif
       CUDNN_CALL(cudnnSetRNNDescriptor_v6(s->dnn_handle_,
                                           rnn_desc_,
                                           param_.state_size,


### PR DESCRIPTION
## Description ##
Bump up cuDNN to 7.5.1 on CI system.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
1. change the env to 7.5.10
2. add explicit fallback data type to solve the ARCH_MISMATCH on maxwell gpu on RNN operator

## Comments ##
@perdasilva @DickJC123 @anirudh2290 @szha @eric-haibin-lin 