### PR TITLE
Link updates for installation pages

### DIFF
--- a/docs/install/build_from_source.md
+++ b/docs/install/build_from_source.md
@@ -42,14 +42,14 @@ Building from source follows this general two-step flow of building the shared l
             * [non-Intel CPUs](#recommended-for-Systems-with-non-Intel-CPUs)
 2. [Install the language API binding(s)](#installing-mxnet-language-bindings) you would like to use for MXNet.
 MXNet's newest and most popular API is Gluon. Gluon is built into the Python binding. If Python isn't your preference, you still have more options. MXNet supports several other language APIs:
-    - [Python (includes Gluon)](../api/python/index.html)
-    - [C++](../api/c++/index.html)
-    - [Clojure](../api/clojure/index.html)
-    - [Java](../api/java/index.html)
-    - [Julia](../api/julia/index.html)
-    - [Perl](../api/perl/index.html)
-    - [R](../api/r/index.html)
-    - [Scala](../api/scala/index.html)
+    - [Python (includes Gluon)](../api/python/index.md)
+    - [C++](../api/c++/index.md)
+    - [Clojure](../api/clojure/index.md)
+    - [Java](../api/java/index.md)
+    - [Julia](../api/julia/index.md)
+    - [Perl](../api/perl/index.md)
+    - [R](../api/r/index.md)
+    - [Scala](../api/scala/index.md)
 
 <hr>
 
@@ -58,12 +58,12 @@ MXNet's newest and most popular API is Gluon. Gluon is built into the Python bin
 Detailed instructions are provided per operating system. Each of these guides also covers how to install the specific [Language Bindings](#installing-mxnet-language-bindings) you require.
 You may jump to those, but it is recommended that you continue reading to understand more general "build from source" options.
 
-* [Amazon Linux / CentOS / RHEL](centos_setup.html)
-* [macOS](osx_setup.html)
-* [Raspbian](raspian_setup.html)
-* [TX2](tx2_setup.html)
-* [Ubuntu](ubuntu_setup.html)
-* [Windows](windows_setup.html)
+* [Amazon Linux / CentOS / RHEL](centos_setup.md)
+* [macOS](osx_setup.md)
+* [Raspbian](raspian_setup.md)
+* [TX2](tx2_setup.md)
+* [Ubuntu](ubuntu_setup.md)
+* [Windows](windows_setup.md)
 
 
 <hr>
@@ -307,13 +307,13 @@ After building MXNet's shared library, you can install other language bindings.
 **NOTE:** The C++ API binding must be built when you build MXNet from source. See [Build MXNet with C++](#build-mxnet-with-c++).
 
 The following table provides links to each language binding by operating system:
-| | [Ubuntu](ubuntu_setup.html) | [macOS](osx_setup.html) | [Windows](windows_setup.html) |
+| | [Ubuntu](ubuntu_setup.md) | [macOS](osx_setup.md) | [Windows](windows_setup.md) |
 | --- | ----  | --- | ------- |
-| Python | [Ubuntu guide](ubuntu_setup.html#install-mxnet-for-python) | [OSX guide](osx_setup.html) | [Windows guide](windows_setup.html#install-mxnet-for-python) |
-| C++ | [C++ guide](c_plus_plus.html) | [C++ guide](c_plus_plus.html) | [C++ guide](c_plus_plus.html) |
+| Python | [Ubuntu guide](ubuntu_setup.md#install-mxnet-for-python) | [OSX guide](osx_setup.md) | [Windows guide](windows_setup.md#install-mxnet-for-python) |
+| C++ | [C++ guide](c_plus_plus.md) | [C++ guide](c_plus_plus.md) | [C++ guide](c_plus_plus.md) |
 | Clojure | [Clojure guide](https://github.com/apache/incubator-mxnet/tree/master/contrib/clojure-package) | [Clojure guide](https://github.com/apache/incubator-mxnet/tree/master/contrib/clojure-package) | n/a |
-| Julia | [Ubuntu guide](ubuntu_setup.html#install-the-mxnet-package-for-julia) | [OSX guide](osx_setup.html#install-the-mxnet-package-for-julia) | [Windows guide](windows_setup.html#install-the-mxnet-package-for-julia) |
-| Perl | [Ubuntu guide](ubuntu_setup.html#install-the-mxnet-package-for-perl) | [OSX guide](osx_setup.html#install-the-mxnet-package-for-perl) | n/a |
-| R | [Ubuntu guide](ubuntu_setup.html#install-the-mxnet-package-for-r) | [OSX guide](osx_setup.html#install-the-mxnet-package-for-r) | [Windows guide](windows_setup.html#install-the-mxnet-package-for-r) |
-| Scala | [Scala guide](scala_setup.html) | [Scala guide](scala_setup.html) | n/a |
-| Java | [Java guide](java_setup.html) | [Java Guide](java_setup.html) | n/a |
+| Julia | [Ubuntu guide](ubuntu_setup.md#install-the-mxnet-package-for-julia) | [OSX guide](osx_setup.md#install-the-mxnet-package-for-julia) | [Windows guide](windows_setup.md#install-the-mxnet-package-for-julia) |
+| Perl | [Ubuntu guide](ubuntu_setup.md#install-the-mxnet-package-for-perl) | [OSX guide](osx_setup.md#install-the-mxnet-package-for-perl) | n/a |
+| R | [Ubuntu guide](ubuntu_setup.md#install-the-mxnet-package-for-r) | [OSX guide](osx_setup.md#install-the-mxnet-package-for-r) | [Windows guide](windows_setup.md#install-the-mxnet-package-for-r) |
+| Scala | [Scala guide](scala_setup.md) | [Scala guide](scala_setup.md) | n/a |
+| Java | [Java guide](java_setup.md) | [Java Guide](java_setup.md) | n/a |

--- a/docs/install/c_plus_plus.md
+++ b/docs/install/c_plus_plus.md
@@ -18,7 +18,7 @@
 ## Build the C++ package
 The C++ package has the same prerequisites as the MXNet library.
 
-To enable C++ package, just add `USE_CPP_PACKAGE=1` in the [build from source](build_from_source.html) options when building the MXNet shared library.
+To enable C++ package, just add `USE_CPP_PACKAGE=1` in the [build from source](build_from_source.md) options when building the MXNet shared library.
 
 For example to build MXNet with GPU support and the C++ package, OpenCV, and OpenBLAS, from the project root you would run:
 
@@ -40,7 +40,7 @@ You can find C++ code examples in the `cpp-package/example` folder of the MXNet 
 
 ## Tutorials
 
-* [MXNet C++ API Basics](https://mxnet.incubator.apache.org/tutorials/c++/basics.html)
+* [MXNet C++ API Basics](../tutorials/c++/basics.md)
 
 ## Related Topics
 

--- a/docs/install/java_setup.md
+++ b/docs/install/java_setup.md
@@ -19,7 +19,7 @@
 
 The following instructions are provided for macOS and Ubuntu. Windows is not yet available.
 
-**Note:** If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Java on IntelliJ tutorial](../tutorials/java/mxnet_java_on_intellij.html) instead of these instructions.
+**Note:** If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Java on IntelliJ tutorial](../tutorials/java/mxnet_java_on_intellij.md) instead of these instructions.
 
 <hr>
 
@@ -99,8 +99,8 @@ The previously mentioned setup with Maven is recommended. Otherwise, the followi
 
 | OS | Step 1 | Step 2 |
 |---|---|---|
-|macOS | [Shared Library for macOS](../install/osx_setup.html#build-the-shared-library) | [Scala Package for macOS](http://mxnet.incubator.apache.org/install/osx_setup.html#install-the-mxnet-package-for-scala) |
-| Ubuntu | [Shared Library for Ubuntu](../install/ubuntu_setup.html#installing-mxnet-on-ubuntu) | [Scala Package for Ubuntu](http://mxnet.incubator.apache.org/install/ubuntu_setup.html#install-the-mxnet-package-for-scala) |
+|macOS | [Shared Library for macOS](osx_setup.md#build-the-shared-library) | [Scala Package for macOS](osx_setup.md#install-the-mxnet-package-for-scala) |
+| Ubuntu | [Shared Library for Ubuntu](ubuntu_setup.md#installing-mxnet-on-ubuntu) | [Scala Package for Ubuntu](ubuntu_setup.md#install-the-mxnet-package-for-scala) |
 | Windows | <a class="github-button" href="https://github.com/apache/incubator-mxnet/issues/10549" data-size="large" data-show-count="true" aria-label="Issue apache/incubator-mxnet on GitHub"> | <a class="github-button" href="https://github.com/apache/incubator-mxnet/issues/10549" data-size="large" data-show-count="true" aria-label="Issue apache/incubator-mxnet on GitHub">Call for Contribution</a> |
 
 
@@ -110,12 +110,12 @@ If you have already built MXNet **from source** and are looking to setup Java fr
 ```
 mvn install
 ```
-This will install both the Java Inference API and the required MXNet-Scala package. 
+This will install both the Java Inference API and the required MXNet-Scala package.
 <hr>
 
 ## Documentation
 
-Javadocs are generated as part of the docs build pipeline. You can find them published in the [Java API](../api/java/index.html) section of the website or by going to the [scaladocs output](https://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.package) directly.
+Javadocs are generated as part of the docs build pipeline. You can find them published in the [Java API](../api/java/index.md) section of the website or by going to the [scaladocs output](https://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.package) directly.
 
 To build the docs yourself, follow the [developer build docs instructions](https://github.com/apache/incubator-mxnet/tree/master/docs/build_version_doc#developer-instructions).
 
@@ -123,6 +123,6 @@ To build the docs yourself, follow the [developer build docs instructions](https
 
 ## Resources
 
-* [Java API](../api/java/index.html)
-* [javadocs](../api/java/docs/index.html#org.apache.mxnet.package)
-* [MXNet-Java Tutorials](../../tutorials/index.html#java-tutorials)
+* [Java API](../api/java/index.md)
+* [javadocs](https://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.package)
+* [MXNet-Java Tutorials](../tutorials/index.md#java-tutorials)

--- a/docs/install/java_setup.md
+++ b/docs/install/java_setup.md
@@ -125,4 +125,4 @@ To build the docs yourself, follow the [developer build docs instructions](https
 
 * [Java API](../api/java/index.md)
 * [javadocs](https://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.package)
-* [MXNet-Java Tutorials](../tutorials/index.md#java-tutorials)
+* [MXNet-Java Tutorials](../tutorials/java/index.md)

--- a/docs/install/java_setup.md
+++ b/docs/install/java_setup.md
@@ -86,9 +86,11 @@ The official Java Packages have been released as part of MXNet 1.4 and are avail
 
 ### Eclipse IDE Support
 You can convert your existing Maven project to a project that can run in Eclipse by:
-```
+
+```bash
 mvn eclipse:eclipse
 ```
+
 This can be done once you have your maven project properly configured.
 
 ## Source

--- a/docs/install/osx_setup.md
+++ b/docs/install/osx_setup.md
@@ -17,7 +17,7 @@
 
 # Installing MXNet from source on OS X (Mac)
 
-**NOTE:** For prebuild MXNet with Python installation, please refer to the [new install guide](http://mxnet.io/install/index.html).
+**NOTE:** For pre-built MXNet with Python, please refer to the [new install guide](index.md).
 
 Installing MXNet is a two-step process:
 
@@ -95,7 +95,7 @@ Install the dependencies, required for MXNet, with the following commands:
 ```
 
 ### Build MXNet Shared Library
-After you have installed the dependencies, pull the MXNet source code from Git and build MXNet to produce an MXNet library called ```libmxnet.so```. You can clone the repository as described in the following code block, or you may try the <a href="download.html">download links</a> for your desired MXNet version.
+After you have installed the dependencies, pull the MXNet source code from Git and build MXNet to produce an MXNet library called ```libmxnet.so```. You can clone the repository as described in the following code block, or you may try the [download links](download.md) for your desired MXNet version.
 
 The file called ```osx.mk``` has the configuration required for building MXNet on OS X. First copy ```make/osx.mk``` into ```config.mk```, which is used by the ```make``` command:
 
@@ -261,6 +261,6 @@ After you build the shared library, run the following command from the MXNet sou
 
 ## Next Steps
 
-* [Tutorials](http://mxnet.io/tutorials/index.html)
-* [How To](http://mxnet.io/faq/index.html)
-* [Architecture](http://mxnet.io/architecture/index.html)
+* [Tutorials](../tutorials/index.md)
+* [How To](../faq/index.md)
+* [Architecture](../architecture/index.md)

--- a/docs/install/scala_setup.md
+++ b/docs/install/scala_setup.md
@@ -19,7 +19,7 @@
 
 The following instructions are provided for macOS and Ubuntu. Windows is not yet available.
 
-**Note:** If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial](../tutorials/scala/mxnet_scala_on_intellij.html) instead of these instructions.
+**Note:** If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial](../tutorials/scala/mxnet_scala_on_intellij.md) instead of these instructions.
 **Note:** Currently, we only support scala 2.11
 
 <hr>
@@ -101,8 +101,8 @@ The previously mentioned setup with Maven is recommended. Otherwise, the followi
 
 | OS | Step 1 | Step 2 |
 |---|---|---|
-|macOS | [Shared Library for macOS](http://mxnet.incubator.apache.org/install/osx_setup.html#build-the-shared-library) | [Scala Package for macOS](http://mxnet.incubator.apache.org/install/osx_setup.html#install-the-mxnet-package-for-scala) |
-| Ubuntu | [Shared Library for Ubuntu](http://mxnet.incubator.apache.org/install/ubuntu_setup.html#installing-mxnet-on-ubuntu) | [Scala Package for Ubuntu](http://mxnet.incubator.apache.org/install/ubuntu_setup.html#install-the-mxnet-package-for-scala) |
+|macOS | [Shared Library for macOS](osx_setup.md#build-the-shared-library) | [Scala Package for macOS](osx_setup.md#install-the-mxnet-package-for-scala) |
+| Ubuntu | [Shared Library for Ubuntu](ubuntu_setup.md#installing-mxnet-on-ubuntu) | [Scala Package for Ubuntu](ubuntu_setup.md#install-the-mxnet-package-for-scala) |
 | Windows | <a class="github-button" href="https://github.com/apache/incubator-mxnet/issues/10549" data-size="large" data-show-count="true" aria-label="Issue apache/incubator-mxnet on GitHub"> | <a class="github-button" href="https://github.com/apache/incubator-mxnet/issues/10549" data-size="large" data-show-count="true" aria-label="Issue apache/incubator-mxnet on GitHub">Call for Contribution</a> |
 
 
@@ -144,7 +144,7 @@ If you receive a "NumberFormatException" when running the interpreter, run `expo
 
 ## Documentation
 
-Scaladocs are generated as part of the docs build pipeline. You can find them published in the [Scala API](http://mxnet.incubator.apache.org/api/scala/index.html) section of the website or by going to the [scaladocs output](https://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.package) directly.
+Scaladocs are generated as part of the docs build pipeline. You can find them published in the [Scala API](../api/scala/index.md) section of the website or by going to the [scaladocs output](https://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.package) directly.
 
 To build the docs yourself, follow the [developer build docs instructions](https://github.com/apache/incubator-mxnet/tree/master/docs/build_version_doc#developer-instructions).
 
@@ -152,6 +152,6 @@ To build the docs yourself, follow the [developer build docs instructions](https
 
 ## Resources
 
-* [Scala API](http://mxnet.incubator.apache.org/api/scala/index.html)
+* [Scala API](../api/scala/index.md)
 * [scaladocs](https://mxnet.incubator.apache.org/api/scala/docs/index.html#org.apache.mxnet.package)
-* [MXNet-Scala Tutorials](../tutorials/scala)
+* [MXNet-Scala Tutorials](../tutorials/scala/index.md)

--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -133,7 +133,7 @@ Or you can go through a manual process described next.
 
 #### Manual MXNet Installation
 
-It is recommended that you review the general [build from source](build_from_source.html) instructions before continuing.
+It is recommended that you review the general [build from source](build_from_source.md) instructions before continuing.
 
 On Ubuntu versions 16.04 or later, you need the following dependencies:
 
@@ -166,7 +166,7 @@ sudo make install
 
 **Step 2:** Install a Math Library.
 
-Details on the different math libraries are found in the build from source guide's [Math Library Selection](build_from_source.html#math-library-selection) section.
+Details on the different math libraries are found in the build from source guide's [Math Library Selection](build_from_source.md#math-library-selection) section.
 
 For OpenBLAS use:
 
@@ -174,7 +174,7 @@ For OpenBLAS use:
     sudo apt-get install -y libopenblas-dev
 ```
 
-For other libraries, visit the [Math Library Selection](build_from_source.html#math-library-selection) section.
+For other libraries, visit the [Math Library Selection](build_from_source.md#math-library-selection) section.
 
 **Step 3:** Install OpenCV.
 
@@ -210,7 +210,7 @@ Build with CMake and ninja, without GPU and without MKL.
     ninja
 ```
 
-If building on CPU and using MKL and MKL-DNN (make sure MKL is installed according to [Math Library Selection](build_from_source.html#math-library-selection) and [MKL-DNN README](https://github.com/apache/incubator-mxnet/blob/master/docs/tutorials/mkldnn/MKLDNN_README.md)):
+If building on CPU and using MKL and MKL-DNN (make sure MKL is installed according to [Math Library Selection](build_from_source.md#math-library-selection) and [MKL-DNN README](https://github.com/apache/incubator-mxnet/blob/master/docs/tutorials/mkldnn/MKLDNN_README.md)):
 
 ```bash
     rm -rf build
@@ -241,7 +241,7 @@ Cuda 10.1 in Ubuntu 18.04 builds fine but is not currently tested in CI.
     ninja
 ```
 
-*Note* - You can explore and use more compilation options as they are delcared in the top of `CMakeLists.txt` and also review common [usage examples](build_from_source.html#usage-examples).
+*Note* - You can explore and use more compilation options as they are delcared in the top of `CMakeLists.txt` and also review common [usage examples](build_from_source.md#usage-examples).
 Optionally, you can also use a higher level, scripted version of the above with an editable CMake options file by doing the
 following:
 
@@ -298,7 +298,7 @@ sudo pip install jupyter
 
 ### Install the MXNet Package for C++
 
-Refer to the [C++ Package setup guide](c_plus_plus.html).
+Refer to the [C++ Package setup guide](c_plus_plus.md).
 <hr>
 
 
@@ -407,7 +407,7 @@ $ sudo apt-get install -y libopenblas-dev liblapack-dev
 $ sudo apt-get install -y libopencv-dev
 ```
 
-**Step 4** Download MXNet sources and build MXNet core shared library. You can clone the repository as described in the following code block, or you may try the <a href="download.html">download links</a> for your desired MXNet version.
+**Step 4** Download MXNet sources and build MXNet core shared library. You can clone the repository as described in the following code block, or you may try the [download links](download.md) for your desired MXNet version.
 
 ```bash
 $ git clone --recursive https://github.com/apache/incubator-mxnet
@@ -458,29 +458,29 @@ You should see the following output:
 
 To use the MXNet-Scala package, you can acquire the Maven package as a dependency.
 
-Further information is in the [MXNet-Scala Setup Instructions](scala_setup.html).
+Further information is in the [MXNet-Scala Setup Instructions](scala_setup.md).
 
-If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial](../tutorials/scala/mxnet_scala_on_intellij.html) instead.
+If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Scala on IntelliJ tutorial](../tutorials/scala/mxnet_scala_on_intellij.md) instead.
 <hr>
 
 ### Install the MXNet Package for Java
 
 To use the MXNet-Java package, you can acquire the Maven package as a dependency.
 
-Further information is in the [MXNet-Java Setup Instructions](java_setup.html).
+Further information is in the [MXNet-Java Setup Instructions](java_setup.md).
 
-If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Java on IntelliJ tutorial](../tutorials/java/mxnet_java_on_intellij.html) instead.
+If you use IntelliJ or a similar IDE, you may want to follow the [MXNet-Java on IntelliJ tutorial](../tutorials/java/mxnet_java_on_intellij.md) instead.
 <hr>
 
 ## Contributions
 
-You are more than welcome to contribute easy installation scripts for other operating systems and programming languages. See the [community contributions page](../community/contribute.html) for further information.
+You are more than welcome to contribute easy installation scripts for other operating systems and programming languages. See the [community contributions page](../community/contribute.md) for further information.
 
 ## Next Steps
 
-* [Tutorials](../tutorials/index.html)
-* [How To](../faq/index.html)
-* [Architecture](../architecture/index.html)
+* [Tutorials](../tutorials/index.md)
+* [How To](../faq/index.md)
+* [Architecture](../architecture/index.md)
 
 
 <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">

--- a/docs/install/windows_setup.md
+++ b/docs/install/windows_setup.md
@@ -497,6 +497,6 @@ MXNet-Scala is not yet available for Windows.
 
 ## Next Steps
 
-* [Tutorials](http://mxnet.io/tutorials/index.html)
-* [How To](http://mxnet.io/faq/index.html)
-* [Architecture](http://mxnet.io/architecture/index.html)
+* [Tutorials](../tutorials/index.md)
+* [How To](../faq/index.md)
+* [Architecture](../architecture/index.md)


### PR DESCRIPTION
## Description ##
This PR updates install page links so that they work on the github repo and on the website.
Notable exclusion is the main install page which doesn't really work for github anyway.

Fixes #14895.
