### PR TITLE
[CI] Disables large tensor size cpu test step

### DIFF
--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -77,14 +77,15 @@ core_logic: {
         }
       }
     },
-    'Test Large Tensor Size: CPU': {
+    // https://github.com/apache/incubator-mxnet/issues/14980
+    /*'Test Large Tensor Size: CPU': {
       node(NODE_LINUX_CPU) {
         ws('workspace/large_tensor-cpu') {
             utils.unpack_and_init('cpu_int64', mx_cmake_lib)
             utils.docker_run('ubuntu_nightly_cpu', 'nightly_test_large_tensor', false)
         }
       }
-    },
+    },*/
     'Test Large Tensor Size: GPU': {
       node(NODE_LINUX_GPU) {
         ws('workspace/large_tensor-gpu') {


### PR DESCRIPTION
## Description ##
The Large Tensor Size: CPU test step in the NightlyTestsForBinaries is killing the underlying CI node (see #14980).

This PR disables that step until a solution can be found.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
