### PR TITLE
[MXNET-978] Support higher order gradient for `log`.

### DIFF
--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -1069,13 +1069,72 @@ The storage type of ``log2`` output is always dense
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_log2"});
 
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log,
-                                                  unary_bwd<mshadow_op::log_grad>);
+                                                  unary_bwd<mshadow_op::log_grad>)
+.set_attr<nnvm::FGradient>("FGradient",
+  [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
+    // For g(x) -> g = log
+    // g''(x) = -1 * (g'(x) * g'(x))
+    auto gx = nnvm::NodeEntry{n, 0, 0};
+    auto ggx_mid = MakeNode("elemwise_mul", n->attrs.name + "_backward_mid_grad_grad",
+                            {gx, gx}, nullptr, &n);
+    auto ggx = MakeNode("negative", n->attrs.name + "_backward_grad_grad",
+                        {nnvm::NodeEntry{ggx_mid, 0, 0}}, nullptr, &n);
+
+    std::vector<nnvm::NodeEntry> ret;
+
+    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad",
+                             {ograds[0], gx}, nullptr, &n));
+    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad_inp",
+                             {ograds[0], nnvm::NodeEntry{ggx, 0, 0}}, nullptr, &n));
+    return ret;
+  });
 
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log10,
-                                                  unary_bwd<mshadow_op::log10_grad>);
+                                                  unary_bwd<mshadow_op::log10_grad>)
+.set_attr<nnvm::FGradient>("FGradient",
+  [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
+    // For g(x) -> g = log10
+    // g'(x) = 1 / (log(10) * x)
+    // g''(x) = -1 * (g'(x) * 1/x)
+    auto gx = nnvm::NodeEntry{n, 0, 0};
+    auto g_lx = MakeNode("reciprocal", n->attrs.name + "_backward_log_grad",
+                            {n->inputs[1]}, nullptr, &n);
+    auto ggx_mid = MakeNode("elemwise_mul", n->attrs.name + "_backward_mid_grad_grad",
+                            {gx, nnvm::NodeEntry{g_lx, 0, 0}}, nullptr, &n);
+    auto ggx = MakeNode("negative", n->attrs.name + "_backward_grad_grad",
+                        {nnvm::NodeEntry{ggx_mid, 0, 0}}, nullptr, &n);
+
+    std::vector<nnvm::NodeEntry> ret;
+
+    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad",
+                             {ograds[0], gx}, nullptr, &n));
+    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad_inp",
+                             {ograds[0], nnvm::NodeEntry{ggx, 0, 0}}, nullptr, &n));
+    return ret;
+  });
 
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log2,
-                                                  unary_bwd<mshadow_op::log2_grad>);
+                                                  unary_bwd<mshadow_op::log2_grad>)
+.set_attr<nnvm::FGradient>("FGradient",
+  [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
+    // For g(x) -> g = log2
+    // g'(x) = 1 / (log(2) * x)
+    // g''(x) = -1 * (g'(x) * 1/x)
+    auto gx = nnvm::NodeEntry{n, 0, 0};
+    auto g_lx = MakeNode("reciprocal", n->attrs.name + "_backward_log_grad",
+                            {n->inputs[1]}, nullptr, &n);
+    auto ggx_mid = MakeNode("elemwise_mul", n->attrs.name + "_backward_mid_grad_grad",
+                            {gx, nnvm::NodeEntry{g_lx, 0, 0}}, nullptr, &n);
+    auto ggx = MakeNode("negative", n->attrs.name + "_backward_grad_grad",
+                        {nnvm::NodeEntry{ggx_mid, 0, 0}}, nullptr, &n);
+
+    std::vector<nnvm::NodeEntry> ret;
+    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad",
+                             {ograds[0], gx}, nullptr, &n));
+    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad_inp",
+                             {ograds[0], nnvm::NodeEntry{ggx, 0, 0}}, nullptr, &n));
+    return ret;
+  });
 
 // log1p
 MXNET_OPERATOR_REGISTER_UNARY_WITH_RSP_CSR(log1p, cpu, mshadow_op::log1p)

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -1074,18 +1074,18 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log,
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
     // For g(x) -> g = log
     // g''(x) = -1 * (g'(x) * g'(x))
-    auto gx = nnvm::NodeEntry{n, 0, 0};
+    auto gx = nnvm::NodeEntry{n};
     auto ggx_mid = MakeNode("elemwise_mul", n->attrs.name + "_backward_mid_grad_grad",
                             {gx, gx}, nullptr, &n);
     auto ggx = MakeNode("negative", n->attrs.name + "_backward_grad_grad",
-                        {nnvm::NodeEntry{ggx_mid, 0, 0}}, nullptr, &n);
+                        {nnvm::NodeEntry{ggx_mid}}, nullptr, &n);
 
     std::vector<nnvm::NodeEntry> ret;
 
     ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad",
                              {ograds[0], gx}, nullptr, &n));
     ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad_inp",
-                             {ograds[0], nnvm::NodeEntry{ggx, 0, 0}}, nullptr, &n));
+                             {ograds[0], nnvm::NodeEntry{ggx}}, nullptr, &n));
     return ret;
   });
 
@@ -1100,16 +1100,16 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log10,
     auto g_lx = MakeNode("reciprocal", n->attrs.name + "_backward_log_grad",
                             {n->inputs[1]}, nullptr, &n);
     auto ggx_mid = MakeNode("elemwise_mul", n->attrs.name + "_backward_mid_grad_grad",
-                            {gx, nnvm::NodeEntry{g_lx, 0, 0}}, nullptr, &n);
+                            {gx, nnvm::NodeEntry{g_lx}}, nullptr, &n);
     auto ggx = MakeNode("negative", n->attrs.name + "_backward_grad_grad",
-                        {nnvm::NodeEntry{ggx_mid, 0, 0}}, nullptr, &n);
+                        {nnvm::NodeEntry{ggx_mid}}, nullptr, &n);
 
     std::vector<nnvm::NodeEntry> ret;
 
     ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad",
                              {ograds[0], gx}, nullptr, &n));
     ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad_inp",
-                             {ograds[0], nnvm::NodeEntry{ggx, 0, 0}}, nullptr, &n));
+                             {ograds[0], nnvm::NodeEntry{ggx}}, nullptr, &n));
     return ret;
   });
 
@@ -1120,19 +1120,20 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log2,
     // For g(x) -> g = log2
     // g'(x) = 1 / (log(2) * x)
     // g''(x) = -1 * (g'(x) * 1/x)
-    auto gx = nnvm::NodeEntry{n, 0, 0};
+    auto gx = nnvm::NodeEntry{n};
     auto g_lx = MakeNode("reciprocal", n->attrs.name + "_backward_log_grad",
                             {n->inputs[1]}, nullptr, &n);
     auto ggx_mid = MakeNode("elemwise_mul", n->attrs.name + "_backward_mid_grad_grad",
-                            {gx, nnvm::NodeEntry{g_lx, 0, 0}}, nullptr, &n);
+                            {gx, nnvm::NodeEntry{g_lx}}, nullptr, &n);
     auto ggx = MakeNode("negative", n->attrs.name + "_backward_grad_grad",
-                        {nnvm::NodeEntry{ggx_mid, 0, 0}}, nullptr, &n);
+                        {nnvm::NodeEntry{ggx_mid}}, nullptr, &n);
 
     std::vector<nnvm::NodeEntry> ret;
+
     ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad",
                              {ograds[0], gx}, nullptr, &n));
     ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad_inp",
-                             {ograds[0], nnvm::NodeEntry{ggx, 0, 0}}, nullptr, &n));
+                             {ograds[0], nnvm::NodeEntry{ggx}}, nullptr, &n));
     return ret;
   });
 

--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -1072,8 +1072,8 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log,
                                                   unary_bwd<mshadow_op::log_grad>)
 .set_attr<nnvm::FGradient>("FGradient",
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
-    // For g(x) -> g = log
-    // g''(x) = -1 * (g'(x) * g'(x))
+    // For f(x) -> f = log
+    // f''(x) = -1 * (f'(x) * f'(x))
     auto gx = nnvm::NodeEntry{n};
     auto ggx_mid = MakeNode("elemwise_mul", n->attrs.name + "_backward_mid_grad_grad",
                             {gx, gx}, nullptr, &n);
@@ -1093,9 +1093,9 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log10,
                                                   unary_bwd<mshadow_op::log10_grad>)
 .set_attr<nnvm::FGradient>("FGradient",
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
-    // For g(x) -> g = log10
-    // g'(x) = 1 / (log(10) * x)
-    // g''(x) = -1 * (g'(x) * 1/x)
+    // For f(x) -> f = log10
+    // f'(x) = 1 / (log(10) * x)
+    // f''(x) = -1 * (f'(x) * 1/x)
     auto gx = nnvm::NodeEntry{n, 0, 0};
     auto g_lx = MakeNode("reciprocal", n->attrs.name + "_backward_log_grad",
                             {n->inputs[1]}, nullptr, &n);
@@ -1117,9 +1117,9 @@ MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(_backward_log2,
                                                   unary_bwd<mshadow_op::log2_grad>)
 .set_attr<nnvm::FGradient>("FGradient",
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
-    // For g(x) -> g = log2
-    // g'(x) = 1 / (log(2) * x)
-    // g''(x) = -1 * (g'(x) * 1/x)
+    // For f(x) -> f = log2
+    // f'(x) = 1 / (log(2) * x)
+    // f''(x) = -1 * (f'(x) * 1/x)
     auto gx = nnvm::NodeEntry{n};
     auto g_lx = MakeNode("reciprocal", n->attrs.name + "_backward_log_grad",
                             {n->inputs[1]}, nullptr, &n);

--- a/tests/python/unittest/test_higher_order_grad.py
+++ b/tests/python/unittest/test_higher_order_grad.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import math
+
+from mxnet import nd, autograd
+from mxnet.test_utils import assert_almost_equal, random_arrays
+from common import with_seed
+
+
+@with_seed()
+def test_log():
+    def log(x):
+        return nd.log(x)
+
+    def grad_grad_op(x):
+        return -1/(x**2)
+
+    arrays = random_arrays((2, 2), (2, 3), (4, 5, 2), (3, 1, 4, 5))
+
+    for array in arrays:
+        check_second_order_unary(array, log, grad_grad_op)
+
+
+@with_seed()
+def test_log2():
+    def log2(x):
+        return nd.log2(x)
+
+    def grad_grad_op(x):
+        return -1/((x**2) * math.log(2))
+
+    arrays = random_arrays((2, 2), (2, 3), (4, 5, 2), (3, 1, 4, 5))
+
+    for array in arrays:
+        check_second_order_unary(array, log2, grad_grad_op)
+
+
+@with_seed()
+def test_log10():
+    def log10(x):
+        return nd.log10(x)
+
+    def grad_grad_op(x):
+        return -1/((x**2) * math.log(10))
+
+    arrays = random_arrays((2, 2), (2, 3), (4, 5, 2), (3, 1, 4, 5))
+
+    for array in arrays:
+        check_second_order_unary(array, log10, grad_grad_op)
+
+
+def check_second_order_unary(x, op, grad_grad_op):
+    x = nd.array(x)
+    expect_grad_grad = grad_grad_op(x)
+    x.attach_grad()
+    with autograd.record():
+        y = op(x)
+        y_grad = autograd.grad(y, x, create_graph=True, retain_graph=True)[0]
+    y_grad.backward()
+    assert_almost_equal(expect_grad_grad.asnumpy(), x.grad.asnumpy())
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule()


### PR DESCRIPTION
## Description ##
With reference to #14613,  #10002 , this PR intends to add support for higher order gradient for `log` { and ideally for `log2, log10` } as well.

Tests are based totally on #14613 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/browse/MXNET-978) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] higher order gradient for a `log`.
- [x] unit test for the same.
