### PR TITLE
[MXNET-14421] Make global pooling backwards compatible

### DIFF
--- a/src/operator/nn/cudnn/cudnn_pooling-inl.h
+++ b/src/operator/nn/cudnn/cudnn_pooling-inl.h
@@ -296,8 +296,8 @@ class CuDNNPoolingOp {
                                              nan_prop_,
                                              kernel_height,
                                              kernel_width,
-                                             param_.global_pool ? 0 : param_.pad[0],
-                                             param_.global_pool ? 0 : param_.pad[1],
+                                             param_.pad[0],
+                                             param_.pad[1],
                                              param_.global_pool ? 1 : param_.stride[0],
                                              param_.global_pool ? 1 : param_.stride[1]));
       #else
@@ -305,8 +305,8 @@ class CuDNNPoolingOp {
                                              mode_,
                                              kernel_height,
                                              kernel_width,
-                                             param_.global_pool ? 0 : param_.pad[0],
-                                             param_.global_pool ? 0 : param_.pad[1],
+                                             param_.pad[0],
+                                             param_.pad[1],
                                              param_.global_pool ? 1 : param_.stride[0],
                                              param_.global_pool ? 1 : param_.stride[1]));
       #endif
@@ -358,9 +358,9 @@ class CuDNNPoolingOp {
                                      param_.global_pool ? static_cast<int>(dshape_ncdhw[4]) :
                                                           static_cast<int>(param_.kernel[2])};
 
-      std::array<int, 3> pad_vec = {param_.global_pool ? 0 : static_cast<int>(param_.pad[0]),
-                                  param_.global_pool ? 0 : static_cast<int>(param_.pad[1]),
-                                  param_.global_pool ? 0 : static_cast<int>(param_.pad[2])};
+      std::array<int, 3> pad_vec = {static_cast<int>(param_.pad[0]),
+                                  static_cast<int>(param_.pad[1]),
+                                  static_cast<int>(param_.pad[2])};
 
       std::array<int, 3> stride_vec = {param_.global_pool ? 1 : static_cast<int>(param_.stride[0]),
                                      param_.global_pool ? 1 : static_cast<int>(param_.stride[1]),

--- a/src/operator/nn/mkldnn/mkldnn_pooling.cc
+++ b/src/operator/nn/mkldnn/mkldnn_pooling.cc
@@ -169,7 +169,6 @@ mkldnn::pooling_forward::primitive_desc GetPoolingFwdPdesc(
 
   const mkldnn::engine engine = CpuEngine::Get()->get_engine();
   if (param.global_pool) {
-    pad_t_ = pad_b_ = pad_l_ = pad_r_ = 0;
     stride_h_ = stride_w_ = 1;
   }
 
@@ -246,7 +245,6 @@ MKLDNNPoolingFwd &GetPoolingFwd(const PoolingParam &param,
     }
 
     if (param.global_pool) {
-      pad_t_ = pad_b_ = pad_l_ = pad_r_ = 0;
       stride_h_ = stride_w_ = 1;
     }
 
@@ -375,7 +373,6 @@ MKLDNNPoolingBwd &GetPoolingBwd(const PoolingParam &param,
     }
 
     if (param.global_pool) {
-      pad_t_ = pad_b_ = pad_l_ = pad_r_ = 0;
       stride_h_ = stride_w_ = 1;
     }
 

--- a/src/operator/nn/pooling-inl.h
+++ b/src/operator/nn/pooling-inl.h
@@ -178,6 +178,11 @@ template<typename xpu, typename DType>
 class PoolingOp {
  public:
   void Init(PoolingParam p) {
+    if (p.global_pool && (p.pad[0] ||  p.pad[1]) ) {
+        LOG(WARNING) << "Using global pooling with padding leads to incorrect results"
+                     << "and is only supported for backwards compatibility.\n"
+                     << "If you are training a new network it is recommended that you set padding to 0.";
+    }
     this->param_ = p;
   }
 

--- a/src/operator/nn/pooling-inl.h
+++ b/src/operator/nn/pooling-inl.h
@@ -178,11 +178,17 @@ template<typename xpu, typename DType>
 class PoolingOp {
  public:
   void Init(PoolingParam p) {
-    if (p.global_pool && (p.pad[0] ||  p.pad[1])) {
-        LOG(WARNING) << "Using global pooling with padding leads to incorrect results "
-                     << "and is only supported for backwards compatibility.\n"
-                     << "If you are training a new network it is recommended "
-                     << "that you set padding to 0.";
+    if (p.global_pool) {
+        has_padding = 0;
+        for (index_t i = 0; i < p.pad.ndim(); i++) {
+            has_padding += p.pad[i];
+        }
+        if (has_padding) {
+            LOG(WARNING) << "Using global pooling with padding leads to incorrect results "
+                         << "and is only supported for backwards compatibility.\n"
+                         << "If you are training a new network it is recommended "
+                         << "that you set padding to 0.";
+                         }
     }
     this->param_ = p;
   }
@@ -205,10 +211,6 @@ class PoolingOp {
       } else {
         kernel = mxnet::TShape(ishape.data() + 2,
                         ishape.data() + ishape.ndim());
-      }
-      padding = mxnet::TShape(ishape.ndim() - 2, 0);
-      for (index_t i = 0; i < ishape.ndim() - 2; i++) {
-        padding[i] = 0;
       }
       stride = mxnet::TShape(ishape.ndim() - 2, 1);
     }
@@ -262,10 +264,6 @@ class PoolingOp {
       } else {
         kernel = mxnet::TShape(ishape.data() + 2,
                         ishape.data() + ishape.ndim());
-      }
-      padding = mxnet::TShape(ishape.ndim() - 2, 0);
-      for (index_t i = 0; i < ishape.ndim() - 2; i++) {
-        padding[i] = 0;
       }
       stride = mxnet::TShape(ishape.ndim() - 2, 1);
     }

--- a/src/operator/nn/pooling-inl.h
+++ b/src/operator/nn/pooling-inl.h
@@ -178,10 +178,11 @@ template<typename xpu, typename DType>
 class PoolingOp {
  public:
   void Init(PoolingParam p) {
-    if (p.global_pool && (p.pad[0] ||  p.pad[1]) ) {
-        LOG(WARNING) << "Using global pooling with padding leads to incorrect results"
+    if (p.global_pool && (p.pad[0] ||  p.pad[1])) {
+        LOG(WARNING) << "Using global pooling with padding leads to incorrect results "
                      << "and is only supported for backwards compatibility.\n"
-                     << "If you are training a new network it is recommended that you set padding to 0.";
+                     << "If you are training a new network it is recommended "
+                     << "that you set padding to 0.";
     }
     this->param_ = p;
   }

--- a/src/operator/pooling_v1-inl.h
+++ b/src/operator/pooling_v1-inl.h
@@ -106,10 +106,6 @@ class PoolingV1Op : public Operator {
     // reset padding size for global pooling
     mxnet::TShape padding = param_.pad;
     // mxnet::TShape kernel = param_.kernel;
-    if (param_.global_pool) {
-      padding[0] = padding[1] = 0;
-      // kernel[0] = kernel[1] = 0;
-    }
 
     Tensor<xpu, 4, DType> data = in_data[pool_v1_enum::kData].get<xpu, 4, DType>(s);
     Tensor<xpu, 4, DType> out = out_data[pool_v1_enum::kOut].get<xpu, 4, DType>(s);
@@ -160,9 +156,6 @@ class PoolingV1Op : public Operator {
 
     // reset padding size for global pooling
     mxnet::TShape padding = param_.pad;
-    if (param_.global_pool) {
-      padding[0] = padding[1] = 0;
-    }
 
     Stream<xpu> *s = ctx.get_stream<xpu>();
     Tensor<xpu, 4, DType> grad = out_grad[pool_v1_enum::kOut].get<xpu, 4, DType>(s);

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1134,7 +1134,7 @@ def test_global_pooling():
     def test_1d_pooling(pool_type, p_value=2):
         data = (2, 3, 20)
         kernel = (4,)
-        pad = (2,)
+        pad = (0,)
         stride = (2,)
 
         ctx_list = []
@@ -1156,7 +1156,8 @@ def test_global_pooling():
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pad=pad, stride=stride, pool_type=pool_type,
-                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value, cudnn_off=False, name='pool'))
+                                       pooling_convention=pooling_convention, global_pool=True, p_value=p_value,
+                                       cudnn_off=False, name='pool'))
 
         ctx_list.append({'ctx': mx.gpu(0), 'pool_data': data, 'type_dict': {'pool_data': np.float32}})
         sym_list.append(mx.sym.Pooling(kernel=kernel, pool_type=pool_type,
@@ -1183,7 +1184,7 @@ def test_global_pooling():
     def test_2d_pooling(pool_type, p_value=2):
         data = (2, 3, 20, 20)
         kernel = (4, 4)
-        pad = (2, 2)
+        pad = (0, 0)
         stride = (2, 2)
 
         ctx_list = []


### PR DESCRIPTION
## Description ##
There was a backward compatibility breaking change (#9730) to pooling where pad is explicitly overwritten causing global pooling to produce different results. This causes issues in any networks trained before this was changed as any layers after a global pooling layer will not get different input and therefore provide incorrect results.
To be clear, it is mathematically correct to have padding == 0.  The PR will not effect anytime the layer is used without setting pad (the default is zero), it will only effect times when global_pool=True and pad is non-zero. It also adds a warning that adding padding with global_pool=True leads to incorrect results and should not be done.  _This PR is to provide backward compatibility only._

Issue: #14421

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-14421], where #14421 refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Re-allow padding values to be passed when global_pool=true in pooling layers instead of forcing them to zero.
- [x] Added a warning that this isn't good to do.

## Comments ##
This is to allow backward compatibility only.  It should not affect anyone unless they have explicitly set global_pool=True and padding to non-zero.  This is for any networks trained before the change was made to work, and should not adversely affect any users.
