### PR TITLE
[C++] fix type inconsistent issue when loading quantized parameters

### DIFF
--- a/cpp-package/example/test_ndarray.cpp
+++ b/cpp-package/example/test_ndarray.cpp
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * 
+ * The file is used for testing if there exist type inconsistency 
+ * when using Copy API to create a new NDArray.
+ * By running: build/test_ndarray.
+ */
+#include <vector>
+#include "mxnet/c_api.h"
+#include "dmlc/logging.h"
+#include "mxnet-cpp/MxNetCpp.h"
+using namespace mxnet::cpp;
+
+enum TypeFlag {
+  kFloat32 = 0,
+  kFloat16 = 1,
+  kInt8 = 2
+};
+
+int main(int argc, char** argv){
+    std::vector<mx_uint> shape1{128, 2, 32};
+    Shape shape2(32, 8, 64);
+
+    int gpu_count = 0;
+    if(MXGetGPUCount(&gpu_count) != 0){
+      LOG(ERROR) << "MXGetGPUCount failed";
+      return -1;
+    }
+
+    Context context = (gpu_count > 0) ? Context::gpu() : Context::cpu();
+    
+    NDArray src1(shape1, context, true, kFloat16);
+    NDArray src2(shape2, context, false, kInt8);
+    NDArray dst1, dst2;
+    dst1 = src1.Copy(context);
+    dst2 = src2.Copy(context);
+
+    CHECK_EQ(src1.GetDType(), dst1.GetDType());
+    CHECK_EQ(src2.GetDType(), dst2.GetDType());
+    return 0;
+}

--- a/cpp-package/example/test_ndarray.cpp
+++ b/cpp-package/example/test_ndarray.cpp
@@ -16,9 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  * 
- * The file is used for testing if there exist type inconsistency 
- * when using Copy API to create a new NDArray.
- * By running: build/test_ndarray.
  */
 #include <vector>
 #include "mxnet/c_api.h"
@@ -32,24 +29,28 @@ enum TypeFlag {
   kInt8 = 2
 };
 
-int main(int argc, char** argv){
+/*
+ * The file is used for testing if there exist type inconsistency
+ * when using Copy API to create a new NDArray.
+ * By running: build/test_ndarray.
+ */
+int main(int argc, char** argv) {
     std::vector<mx_uint> shape1{128, 2, 32};
     Shape shape2(32, 8, 64);
 
     int gpu_count = 0;
-    if(MXGetGPUCount(&gpu_count) != 0){
+    if (MXGetGPUCount(&gpu_count) != 0) {
       LOG(ERROR) << "MXGetGPUCount failed";
       return -1;
     }
 
     Context context = (gpu_count > 0) ? Context::gpu() : Context::cpu();
-    
+
     NDArray src1(shape1, context, true, kFloat16);
     NDArray src2(shape2, context, false, kInt8);
     NDArray dst1, dst2;
     dst1 = src1.Copy(context);
     dst2 = src2.Copy(context);
-
     CHECK_EQ(src1.GetDType(), dst1.GetDType());
     CHECK_EQ(src2.GetDType(), dst2.GetDType());
     return 0;

--- a/cpp-package/example/test_ndarray.cpp
+++ b/cpp-package/example/test_ndarray.cpp
@@ -51,6 +51,7 @@ int main(int argc, char** argv) {
     NDArray dst1, dst2;
     dst1 = src1.Copy(context);
     dst2 = src2.Copy(context);
+    NDArray::WaitAll();
     CHECK_EQ(src1.GetDType(), dst1.GetDType());
     CHECK_EQ(src2.GetDType(), dst2.GetDType());
     return 0;

--- a/cpp-package/example/test_ndarray_copy.cpp
+++ b/cpp-package/example/test_ndarray_copy.cpp
@@ -25,8 +25,12 @@ using namespace mxnet::cpp;
 
 enum TypeFlag {
   kFloat32 = 0,
-  kFloat16 = 1,
-  kInt8 = 2
+  kFloat64 = 1,
+  kFloat16 = 2,
+  kUint8 = 3,
+  kInt32 = 4,
+  kInt8  = 5,
+  kInt64 = 6,
 };
 
 /*

--- a/cpp-package/include/mxnet-cpp/ndarray.h
+++ b/cpp-package/include/mxnet-cpp/ndarray.h
@@ -142,8 +142,9 @@ class NDArray {
   * \param shape the shape of array
   * \param constext context of NDArray
   * \param delay_alloc whether delay the allocation
+  * \param dtype data type of NDArray
   */
-  NDArray(const Shape &shape, const Context &context, 
+  NDArray(const Shape &shape, const Context &context,
           bool delay_alloc = true, int dtype = 0);
   NDArray(const mx_float *data, size_t size);
   /*!

--- a/cpp-package/include/mxnet-cpp/ndarray.h
+++ b/cpp-package/include/mxnet-cpp/ndarray.h
@@ -143,7 +143,8 @@ class NDArray {
   * \param constext context of NDArray
   * \param delay_alloc whether delay the allocation
   */
-  NDArray(const Shape &shape, const Context &context, bool delay_alloc = true);
+  NDArray(const Shape &shape, const Context &context, 
+          bool delay_alloc = true, int dtype = 0);
   NDArray(const mx_float *data, size_t size);
   /*!
   * \brief construct a new dynamic NDArray

--- a/cpp-package/include/mxnet-cpp/ndarray.h
+++ b/cpp-package/include/mxnet-cpp/ndarray.h
@@ -131,11 +131,12 @@ class NDArray {
   /*!
   * \brief construct a new dynamic NDArray
   * \param shape the shape of array
-  * \param constext context of NDArray
+  * \param context context of NDArray
   * \param delay_alloc whether delay the allocation
+  * \param dtype data type of NDArray
   */
   NDArray(const std::vector<mx_uint> &shape, const Context &context,
-          bool delay_alloc = true);
+          bool delay_alloc = true, int dtype = 0);
   /*!
   * \brief construct a new dynamic NDArray
   * \param shape the shape of array

--- a/cpp-package/include/mxnet-cpp/ndarray.hpp
+++ b/cpp-package/include/mxnet-cpp/ndarray.hpp
@@ -47,10 +47,10 @@ inline NDArray::NDArray(const NDArrayHandle &handle) {
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
 inline NDArray::NDArray(const std::vector<mx_uint> &shape, const Context &context,
-                        bool delay_alloc) {
+                        bool delay_alloc, int dtype) {
   NDArrayHandle handle;
-  CHECK_EQ(MXNDArrayCreate(shape.data(), shape.size(), context.GetDeviceType(),
-                           context.GetDeviceId(), delay_alloc, &handle),
+  CHECK_EQ(MXNDArrayCreateEx(shape.data(), shape.size(), context.GetDeviceType(),
+                           context.GetDeviceId(), delay_alloc, dtype, &handle),
            0);
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
@@ -208,7 +208,7 @@ inline void NDArray::SyncCopyToCPU(std::vector<mx_float> *data, size_t size) {
   MXNDArraySyncCopyToCPU(blob_ptr_->handle_, data->data(), size);
 }
 inline NDArray NDArray::Copy(const Context &ctx) const {
-  NDArray ret(GetShape(), ctx);
+  NDArray ret(GetShape(), ctx, true, this->GetDType());
   Operator("_copyto")(*this).Invoke(ret);
   return ret;
 }

--- a/cpp-package/include/mxnet-cpp/ndarray.hpp
+++ b/cpp-package/include/mxnet-cpp/ndarray.hpp
@@ -50,7 +50,7 @@ inline NDArray::NDArray(const std::vector<mx_uint> &shape, const Context &contex
                         bool delay_alloc, int dtype) {
   NDArrayHandle handle;
   CHECK_EQ(MXNDArrayCreateEx(shape.data(), shape.size(), context.GetDeviceType(),
-                           context.GetDeviceId(), delay_alloc, dtype, &handle),
+                             context.GetDeviceId(), delay_alloc, dtype, &handle),
            0);
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
@@ -58,7 +58,7 @@ inline NDArray::NDArray(const Shape &shape, const Context &context,
                         bool delay_alloc, int dtype) {
   NDArrayHandle handle;
   CHECK_EQ(MXNDArrayCreateEx(shape.data(), shape.ndim(), context.GetDeviceType(),
-                           context.GetDeviceId(), delay_alloc, dtype, &handle),
+                             context.GetDeviceId(), delay_alloc, dtype, &handle),
            0);
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }

--- a/cpp-package/include/mxnet-cpp/ndarray.hpp
+++ b/cpp-package/include/mxnet-cpp/ndarray.hpp
@@ -54,7 +54,7 @@ inline NDArray::NDArray(const std::vector<mx_uint> &shape, const Context &contex
            0);
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
-inline NDArray::NDArray(const Shape &shape, const Context &context, 
+inline NDArray::NDArray(const Shape &shape, const Context &context,
                         bool delay_alloc, int dtype) {
   NDArrayHandle handle;
   CHECK_EQ(MXNDArrayCreateEx(shape.data(), shape.ndim(), context.GetDeviceType(),

--- a/cpp-package/include/mxnet-cpp/ndarray.hpp
+++ b/cpp-package/include/mxnet-cpp/ndarray.hpp
@@ -54,10 +54,11 @@ inline NDArray::NDArray(const std::vector<mx_uint> &shape, const Context &contex
            0);
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }
-inline NDArray::NDArray(const Shape &shape, const Context &context, bool delay_alloc) {
+inline NDArray::NDArray(const Shape &shape, const Context &context, 
+                        bool delay_alloc, int dtype) {
   NDArrayHandle handle;
-  CHECK_EQ(MXNDArrayCreate(shape.data(), shape.ndim(), context.GetDeviceType(),
-                           context.GetDeviceId(), delay_alloc, &handle),
+  CHECK_EQ(MXNDArrayCreateEx(shape.data(), shape.ndim(), context.GetDeviceType(),
+                           context.GetDeviceId(), delay_alloc, dtype, &handle),
            0);
   blob_ptr_ = std::make_shared<NDBlob>(handle);
 }

--- a/cpp-package/tests/ci_test.sh
+++ b/cpp-package/tests/ci_test.sh
@@ -57,8 +57,8 @@ cp ../../build/cpp-package/example/test_kvstore .
 cp ../../build/cpp-package/example/test_score .
 ./test_score 0.93
 
-cp ../../build/cpp-package/example/test_ndarray .
-./test_ndarray
+cp ../../build/cpp-package/example/test_ndarray_copy .
+./test_ndarray_copy
 
 sh unittests/unit_test_mlp_csv.sh
 

--- a/cpp-package/tests/ci_test.sh
+++ b/cpp-package/tests/ci_test.sh
@@ -57,6 +57,9 @@ cp ../../build/cpp-package/example/test_kvstore .
 cp ../../build/cpp-package/example/test_score .
 ./test_score 0.93
 
+cp ../../build/cpp-package/example/test_ndarray .
+./test_ndarray
+
 sh unittests/unit_test_mlp_csv.sh
 
 cd inference


### PR DESCRIPTION
## Description ##
@pengzhao-intel @ZhennanQin 
We want to use [inception_inference.cpp](https://github.com/apache/incubator-mxnet/blob/master/cpp-package/example/inference/inception_inference.cpp) to do inference with quantized models. But When I tried to run inference, there always have a type inconsistent error. We found that during loading parameters, new NDArrays will be created with default data type (float32) and copy the original NDArray to this new NDArray by using NDArray.Copy(context). So, the original int8 params will be converted into float32 params and this will raise the type inconsistent issue. 


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
