### PR TITLE
ignore auto-generated file 'nnvm.cc' under amalgamation

### DIFF
--- a/amalgamation/.gitignore
+++ b/amalgamation/.gitignore
@@ -1,1 +1,2 @@
+nnvm.cc
 *-all.cc


### PR DESCRIPTION
## Description ##

ignore auto-generated file 'nnvm.cc' when under amalgamation

```bash
cd amalgamation
make
```
