### PR TITLE
Restore save/load ndarray to 1.4.1

### DIFF
--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -1581,6 +1581,9 @@ static const uint32_t NDARRAY_V1_MAGIC = 0xF993fac8;
 static const uint32_t NDARRAY_V2_MAGIC = 0xF993fac9;
 
 void NDArray::Save(dmlc::Stream *strm) const {
+  // TODO(junwu): Support this after NumPy operators are merged
+  CHECK(!Imperative::Get()->is_np_comp())
+      << "Saving ndarray within the scope of np_shape is not supported.";
   // write magic number to mark this version
   // for storage type
   strm->Write(NDARRAY_V2_MAGIC);
@@ -1698,6 +1701,9 @@ bool NDArray::LegacyLoad(dmlc::Stream *strm, const uint32_t magic) {
 }
 
 bool NDArray::Load(dmlc::Stream *strm) {
+  // TODO(junwu): Support this after NumPy operators are merged
+  CHECK(!Imperative::Get()->is_np_comp())
+      << "Loading ndarray within the scope of np_shape is not supported.";
   uint32_t magic;
   if (strm->Read(&magic, sizeof(uint32_t)) != sizeof(uint32_t)) return false;
   if (magic != NDARRAY_V2_MAGIC) {
@@ -1718,10 +1724,7 @@ bool NDArray::Load(dmlc::Stream *strm) {
   // load shape
   mxnet::TShape shape;
   if (!shape.Load(strm)) return false;
-  if (!Imperative::Get()->is_np_comp()) {
-    common::ConvertToNumpyShape(&shape);
-  }
-  if (mxnet::op::shape_is_none(shape)) {
+  if (shape.ndim() == 0) {
     *this = NDArray(); return true;
   }
 

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -1701,6 +1701,20 @@ def test_zero_from_numpy():
         assert False
 
 
+@with_seed()
+def test_save_load_zero_size_ndarrays():
+    shapes = [(2, 0, 1), (0,), (0, 4), (3, 0, 0, 0), (2, 1), (0, 5, 0)]
+    array_list = [np.random.randint(0, 10, size=shape) for shape in shapes]
+    array_list = [mx.nd.array(arr) for arr in array_list]
+    with TemporaryDirectory() as work_dir:
+        fname = os.path.join(work_dir, 'dataset')
+        mx.nd.save(fname, array_list)
+        array_list_loaded = mx.nd.load(fname)
+        assert len(array_list) == len(array_list_loaded)
+        for a1, a2 in zip(array_list, array_list_loaded):
+            assert np.array_equal(a1.asnumpy(), a2.asnumpy())
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
This PR restores the `NDArray::Save/Load` functions to 1.4.1 for keeping backward compatibility for saving/loading zero-size tensors. The issue was reported in https://github.com/apache/incubator-mxnet/issues/14954#issuecomment-492867737 by @DickJC123.

This PR depends on https://github.com/apache/incubator-mxnet/pull/15063. I will rebase this PR after https://github.com/apache/incubator-mxnet/pull/15063 is merged.

@DickJC123 Since we are not going to have the NumPy shape semantics in the next release, I simply reverted the changes for serialization functions introduced by https://github.com/apache/incubator-mxnet/pull/14661. After careful thinking, I find that it's required to depend on the compatibility mode to save/load ndarrays in legacy/numpy shape semantics (we will also need a magic version number to guard this when loading). We will deal with it after introducing NumPy operators. Right now, I added `CHECK` in save/load functions indicating that numpy shape semantics cannot be turned on.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
