### PR TITLE
Fix R installation instructions (windows / mac)

### DIFF
--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -767,7 +767,10 @@ To ensure MXNet R package runs with the version of OpenBLAS installed, create a 
 ln -sf /usr/local/opt/openblas/lib/libopenblas.dylib /usr/local/opt/openblas/lib/libopenblasp-r0.3.1.dylib
 ```
 
-Install the latest version (3.5.1+) of R from [CRAN](https://cran.r-project.org/bin/macosx/).
+Note: packages for 3.6.x are not yet available.
+
+Install 3.5.x of R from [CRAN](https://cran.r-project.org/bin/macosx/). The latest is [v3.5.3](https://cran.r-project.org/bin/macosx/R-3.6.0.pkg).
+
 You can [build MXNet-R from source](osx_setup.html#install-the-mxnet-package-for-r), or you can use a pre-built binary:
 
 ```r
@@ -1127,7 +1130,9 @@ To build from source, refer to the <a href="windows_setup.html">MXNet Windows in
 <div class="cpu">
 </br>
 
-Install the latest version (3.5.1+) of R from [CRAN](https://cran.r-project.org/bin/windows/).
+Note: packages for 3.6.x are not yet available.
+Install 3.5.x of R from [CRAN](https://cran.r-project.org/bin/windows/base/old/).
+
 You can [build MXNet-R from source](windows_setup.html#install-mxnet-package-for-r), or you can use a pre-built binary:
 
 ```r

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -769,7 +769,7 @@ ln -sf /usr/local/opt/openblas/lib/libopenblas.dylib /usr/local/opt/openblas/lib
 
 Note: packages for 3.6.x are not yet available.
 
-Install 3.5.x of R from [CRAN](https://cran.r-project.org/bin/macosx/). The latest is [v3.5.3](https://cran.r-project.org/bin/macosx/R-3.6.0.pkg).
+Install 3.5.x of R from [CRAN](https://cran.r-project.org/bin/macosx/). The latest is [v3.5.3](https://cran.r-project.org/bin/macosx/R-3.5.3.pkg).
 
 You can [build MXNet-R from source](osx_setup.html#install-the-mxnet-package-for-r), or you can use a pre-built binary:
 

--- a/docs/install/osx_setup.md
+++ b/docs/install/osx_setup.md
@@ -171,7 +171,10 @@ Add a soft link to the OpenBLAS installation. This example links the 0.3.1 versi
 ln -sf /usr/local/opt/openblas/lib/libopenblasp-r0.3.* /usr/local/opt/openblas/lib/libopenblasp-r0.3.1.dylib
 ```
 
-Install the latest version (3.5.1+) of R from [CRAN](https://cran.r-project.org/bin/macosx/).
+Note: packages for 3.6.x are not yet available.
+
+Install 3.5.x of R from [CRAN](https://cran.r-project.org/bin/macosx/). The latest is [v3.5.3](https://cran.r-project.org/bin/macosx/R-3.6.0.pkg).
+
 For OS X (Mac) users, MXNet provides a prebuilt binary package for CPUs. The prebuilt package is updated weekly. You can install the package directly in the R console using the following commands:
 
 ```r

--- a/docs/install/osx_setup.md
+++ b/docs/install/osx_setup.md
@@ -173,7 +173,7 @@ ln -sf /usr/local/opt/openblas/lib/libopenblasp-r0.3.* /usr/local/opt/openblas/l
 
 Note: packages for 3.6.x are not yet available.
 
-Install 3.5.x of R from [CRAN](https://cran.r-project.org/bin/macosx/). The latest is [v3.5.3](https://cran.r-project.org/bin/macosx/R-3.6.0.pkg).
+Install 3.5.x of R from [CRAN](https://cran.r-project.org/bin/macosx/). The latest is [v3.5.3](https://cran.r-project.org/bin/macosx/R-3.5.3.pkg).
 
 For OS X (Mac) users, MXNet provides a prebuilt binary package for CPUs. The prebuilt package is updated weekly. You can install the package directly in the R console using the following commands:
 

--- a/docs/install/windows_setup.md
+++ b/docs/install/windows_setup.md
@@ -270,6 +270,9 @@ To install MXNet on a computer with a CPU processor, choose from two options:
 For Windows users, MXNet provides prebuilt binary packages.
 You can install the package directly in the R console.
 
+Note: packages for 3.6.x are not yet available.
+Install 3.5.x of R from [CRAN](https://cran.r-project.org/bin/windows/base/old/).
+
 For CPU-only package:
 
 ```r
@@ -378,6 +381,9 @@ Note: A pre-requisite to above softwares is [Nvidia-drivers](http://www.nvidia.c
 #### Installing MXNet-R with the Prebuilt Binary Package(GPU)
 For Windows users, MXNet provides prebuilt binary packages.
 You can install the package directly in the R console after you have the above software installed.
+
+Note: packages for 3.6.x are not yet available.
+Install 3.5.x of R from [CRAN](https://cran.r-project.org/bin/windows/base/old/).
 
 For GPU package:
 


### PR DESCRIPTION
## Description ##
Shows a warning about R v3.6 and provides links to installation archives for older versions of R.

This is a workaround for:
* #14967
* #14922

We should leave those open as a reminder that the community would like R v3.6 support.