### PR TITLE
[BUGFIX] fix unknown parameter shapes when np_shape is turned on.

### DIFF
--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -160,6 +160,9 @@ class Parameter(object):
         if self._shape is None:
             return None
         elif is_np_shape():
+            # Parameters shouldn't be zero-size. If one of its dimension is 0,
+            # it means the parameter isn't initialized. In the NumPy semantics,
+            # the unknown dimension should be marked with -1.
             return tuple(i if i != 0 else -1 for i in self._shape)
         else:
             return self._shape

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -157,6 +157,11 @@ class Parameter(object):
 
     @property
     def shape(self):
+        """The shape of the parameter.
+
+        By default, an unknown dimension size is 0. However, when the NumPy semantic
+        is turned on, unknown dimension size is -1.
+        """
         if self._shape is None:
             return None
         elif is_np_shape():

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -157,7 +157,9 @@ class Parameter(object):
 
     @property
     def shape(self):
-        if is_np_shape():
+        if self._shape is None:
+            return None
+        elif is_np_shape():
             return tuple(i if i != 0 else -1 for i in self._shape)
         else:
             return self._shape

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -31,6 +31,7 @@ from .. import symbol, ndarray, initializer, context
 from ..context import Context, cpu
 from .. import autograd
 from .utils import _indent, _brief_print_list
+from .. import is_np_shape
 
 # pylint: disable= invalid-name
 tensor_types = (symbol.Symbol, ndarray.NDArray)
@@ -156,7 +157,10 @@ class Parameter(object):
 
     @property
     def shape(self):
-        return self._shape
+        if is_np_shape():
+            return tuple(i if i != 0 else -1 for i in self._shape)
+        else:
+            return self._shape
 
     @shape.setter
     def shape(self, new_shape):

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -30,7 +30,7 @@ from ..base import mx_real_t, MXNetError
 from .. import symbol, ndarray, initializer, context
 from ..context import Context, cpu
 from .. import autograd
-from .utils import _indent, _brief_print_list
+from .utils import _indent, _brief_print_list, shape_is_known
 from .. import is_np_shape
 
 # pylint: disable= invalid-name
@@ -273,7 +273,7 @@ class Parameter(object):
             return
         init, ctx, default_init, data = self._deferred_init
         self._deferred_init = ()
-        assert self.shape is not None and np.prod(self.shape) > 0, \
+        assert shape_is_known(self.shape), \
             "Cannot initialize Parameter '%s' because it has " \
             "invalid shape: %s. Please specify in_units, " \
             "in_channels, etc for `Block`s."%(
@@ -384,7 +384,7 @@ class Parameter(object):
             ctx = [ctx]
         if init is None:
             init = default_init if self.init is None else self.init
-        if not self.shape or np.prod(self.shape) <= 0:
+        if not shape_is_known(self.shape):
             if self._allow_deferred_init:
                 self._deferred_init = (init, ctx, default_init, None)
                 return

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -415,7 +415,10 @@ class HookHandle(object):
         self.detach()
 
 def shape_is_known(shape):
-    """Check whether a shape is completely known w/ or w/o np semantics."""
+    """Check whether a shape is completely known with or without np semantics.
+
+    Please see the doc of is_np_shape for more details.
+    """
     if shape is None:
         return False
     unknown_dim_size = -1 if is_np_shape() else 0

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -38,6 +38,7 @@ except ImportError:
 import numpy as np
 
 from .. import ndarray
+from ..util import is_np_shape
 
 def split_data(data, num_slice, batch_axis=0, even_split=True):
     """Splits an NDArray into `num_slice` slices along `batch_axis`.
@@ -412,3 +413,17 @@ class HookHandle(object):
 
     def __exit__(self, ptype, value, trace):
         self.detach()
+
+def shape_is_known(shape):
+    """Check whether a shape is completely known w/ or w/o np semantics."""
+    if shape is None:
+        return False
+    unknown_dim_size = -1 if is_np_shape() else 0
+    if len(shape) == 0:
+        return unknown_dim_size == -1
+    for dim_size in shape:
+        if dim_size == unknown_dim_size:
+            return False
+        assert dim_size > unknown_dim_size, "shape dimension size cannot be less than {}, while " \
+                                            "received {}".format(unknown_dim_size, dim_size)
+    return True

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -245,3 +245,17 @@ def use_np_shape(func):
             return func(*args, **kwargs)
 
     return _with_np_shape
+
+def shape_is_known(shape):
+    """Check whether a shape is completely known w/ or w/o np semantics."""
+    if shape is None:
+        return False
+    unknown_dim_size = -1 if is_np_shape() else 0
+    if len(shape) == 0:
+        return unknown_dim_size == -1
+    for dim_size in shape:
+        if dim_size == unknown_dim_size:
+            return False
+        assert dim_size > unknown_dim_size, "shape dimension size cannot be less than {}, while " \
+                                            "received {}".format(unknown_dim_size, dim_size)
+    return True

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -89,6 +89,10 @@ def is_np_shape():
     the shapes of zero-size tensors. This is turned off by default for keeping
     backward compatibility.
 
+    In the NumPy shape semantics, `-1` indicates an unknown size. For example,
+    `(-1, 2, 2)` means that the size of the first dimension is unknown. Its size
+    may be inferred during shape inference.
+
     Please note that this is designed as an infrastructure for the incoming
     MXNet-NumPy operators. Legacy operators registered in the modules
     `mx.nd` and `mx.sym` are not guaranteed to behave like their counterparts

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -245,17 +245,3 @@ def use_np_shape(func):
             return func(*args, **kwargs)
 
     return _with_np_shape
-
-def shape_is_known(shape):
-    """Check whether a shape is completely known w/ or w/o np semantics."""
-    if shape is None:
-        return False
-    unknown_dim_size = -1 if is_np_shape() else 0
-    if len(shape) == 0:
-        return unknown_dim_size == -1
-    for dim_size in shape:
-        if dim_size == unknown_dim_size:
-            return False
-        assert dim_size > unknown_dim_size, "shape dimension size cannot be less than {}, while " \
-                                            "received {}".format(unknown_dim_size, dim_size)
-    return True

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -2729,19 +2729,19 @@ def test_slice_activation_reshape_activation():
 @with_seed()
 def test_np_shape_parameters():
     class Foo(gluon.Block):
-    def __init__(self, **kwargs):
-        super(Foo, self).__init__(**kwargs)
-        self.dense = gluon.nn.Dense(16)
-    def forward(self, x):
-        return self.dense(x)
+        def __init__(self, **kwargs):
+            super(Foo, self).__init__(**kwargs)
+            self.dense = gluon.nn.Dense(16)
+        def forward(self, x):
+            return self.dense(x)
 
-    mx.set_np_compat(True)
+    mx.set_np_shape(True)
     z = mx.nd.zeros((2,2016))
     print(z.shape)
     foo = Foo()
     foo.initialize()
     print(foo(z).shape)
-    mx.set_np_compat(False)
+    mx.set_np_shape(False)
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -2735,13 +2735,12 @@ def test_np_shape_parameters():
         def forward(self, x):
             return self.dense(x)
 
-    mx.set_np_shape(True)
-    z = mx.nd.zeros((2,2016))
-    print(z.shape)
-    foo = Foo()
-    foo.initialize()
-    print(foo(z).shape)
-    mx.set_np_shape(False)
+    with mx.np_shape(True):
+        z = mx.nd.zeros((2,2016))
+        print(z.shape)
+        foo = Foo()
+        foo.initialize()
+        print(foo(z).shape)
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -2726,6 +2726,23 @@ def test_slice_activation_reshape_activation():
             net = Net(act0, act1, shape, slice)
             check_layer_forward_withinput(net, x)
 
+@with_seed()
+def test_np_shape_parameters():
+    class Foo(gluon.Block):
+    def __init__(self, **kwargs):
+        super(Foo, self).__init__(**kwargs)
+        self.dense = gluon.nn.Dense(16)
+    def forward(self, x):
+        return self.dense(x)
+
+    mx.set_np_compat(True)
+    z = mx.nd.zeros((2,2016))
+    print(z.shape)
+    foo = Foo()
+    foo.initialize()
+    print(foo(z).shape)
+    mx.set_np_compat(False)
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
When np_shape is turned on, the unknown parameter shapes should be -1 instead of 0. So when a parameter is created but isn't initialized, the dimension of unknown size is -1 when np_shape is turned on, and is 0, otherwise.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
