### PR TITLE
fix the cmake cmd with wrong path

### DIFF
--- a/docs/install/build_from_source.md
+++ b/docs/install/build_from_source.md
@@ -231,7 +231,7 @@ For example, you can specify using all cores on Linux as follows:
 
 ```bash
 mkdir build && cd build
-cmake -GNinja .
+cmake -GNinja ..
 ninja -v
 ```
 
@@ -241,7 +241,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -DUSE_MKLDNN=1 -GNinja .
+cmake -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -DUSE_MKLDNN=1 -GNinja ..
 ninja -v
 ```
 
@@ -250,7 +250,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DBLAS=open -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -GNinja .
+cmake -DBLAS=open -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -GNinja ..
 ninja -v
 ```
 
@@ -259,7 +259,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DUSE_CUDA=0 -DUSE_MKLDNN=1 -GNinja .
+cmake -DUSE_CUDA=0 -DUSE_MKLDNN=1 -GNinja ..
 ninja -v
 ```
 
@@ -268,7 +268,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DUSE_CUDA=0 -DBLAS=open -GNinja .
+cmake -DUSE_CUDA=0 -DBLAS=open -GNinja ..
 ninja -v
 ```
 
@@ -278,7 +278,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DUSE_OPENCV=0 -GNinja .
+cmake -DUSE_OPENCV=0 -GNinja ..
 ninja -v
 ```
 
@@ -286,7 +286,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DBLAS=apple -DUSE_OPENCV=0 -DUSE_OPENMP=0 -GNinja .
+cmake -DBLAS=apple -DUSE_OPENCV=0 -DUSE_OPENMP=0 -GNinja ..
 ninja -v
 ```
 
@@ -295,7 +295,7 @@ ninja -v
 ```bash
 brew install llvm
 mkdir build && cd build
-cmake -DBLAS=apple -DUSE_OPENMP=1 -GNinja .
+cmake -DBLAS=apple -DUSE_OPENMP=1 -GNinja ..
 ninja -v
 ```
 

--- a/docs/install/c_plus_plus.md
+++ b/docs/install/c_plus_plus.md
@@ -23,7 +23,7 @@ To enable C++ package, just add `USE_CPP_PACKAGE=1` in the [build from source](b
 For example to build MXNet with GPU support and the C++ package, OpenCV, and OpenBLAS, from the project root you would run:
 
 ```bash
-cmake -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -DUSE_MKLDNN=1 -DUSE_CPP_PACKAGE=1 -GNinja .
+cmake -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -DUSE_MKLDNN=1 -DUSE_CPP_PACKAGE=1 -GNinja ..
 ninja -v
 ```
 


### PR DESCRIPTION
## Description ##
The examples of CMake is with wrong path

Before change, you will meet following error print:

```
CMake Error: The source directory "/path/to/incubator-mxnet/build" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
```

After change:
```
-- The C compiler identification is GNU 7.4.0
-- The CXX compiler identification is GNU 7.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
```

## Checklist ##
### Essentials ###
### Changes ###
Document is updated
## Comments ##
Fix the wrong path in cmake cmd.
