### PR TITLE
[MXNET-1411] solve pylint error issue#14851

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_export_helper.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_export_helper.py
@@ -42,24 +42,24 @@ def load_module(sym_filepath, params_filepath):
     """
     if not (os.path.isfile(sym_filepath) and os.path.isfile(params_filepath)):
         raise ValueError("Symbol and params files provided are invalid")
-    else:
-        try:
-            # reads symbol.json file from given path and
-            # retrieves model prefix and number of epochs
-            model_name = sym_filepath.rsplit('.', 1)[0].rsplit('-', 1)[0]
-            params_file_list = params_filepath.rsplit('.', 1)[0].rsplit('-', 1)
-            # Setting num_epochs to 0 if not present in filename
-            num_epochs = 0 if len(params_file_list) == 1 else int(params_file_list[1])
-        except IndexError:
-            logging.info("Model and params name should be in format: "
-                         "prefix-symbol.json, prefix-epoch.params")
-            raise
 
-        sym, arg_params, aux_params = mx.model.load_checkpoint(model_name, num_epochs)
+    try:
+        # reads symbol.json file from given path and
+        # retrieves model prefix and number of epochs
+        model_name = sym_filepath.rsplit('.', 1)[0].rsplit('-', 1)[0]
+        params_file_list = params_filepath.rsplit('.', 1)[0].rsplit('-', 1)
+        # Setting num_epochs to 0 if not present in filename
+        num_epochs = 0 if len(params_file_list) == 1 else int(params_file_list[1])
+    except IndexError:
+        logging.info("Model and params name should be in format: "
+                     "prefix-symbol.json, prefix-epoch.params")
+        raise
 
-        # Merging arg and aux parameters
-        params = {}
-        params.update(arg_params)
-        params.update(aux_params)
+    sym, arg_params, aux_params = mx.model.load_checkpoint(model_name, num_epochs)
 
-        return sym, params
+    # Merging arg and aux parameters
+    params = {}
+    params.update(arg_params)
+    params.update(aux_params)
+
+    return sym, params

--- a/python/mxnet/contrib/onnx/mx2onnx/_export_helper.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_export_helper.py
@@ -40,7 +40,7 @@ def load_module(sym_filepath, params_filepath):
     params : params object
         Model weights including both arg and aux params.
     """
-    if not (os.path.isfile(sym_filepath) and os.path.isfile(params_filepath)): # pylint: disable=no-else-raise
+    if not (os.path.isfile(sym_filepath) and os.path.isfile(params_filepath)):
         raise ValueError("Symbol and params files provided are invalid")
     else:
         try:

--- a/python/mxnet/contrib/onnx/onnx2mx/_translation_utils.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_translation_utils.py
@@ -180,21 +180,21 @@ def _fix_channels(op_name, attrs, inputs, proto_obj):
     weight_name = inputs[1].name
     if not weight_name in proto_obj._params:
         raise ValueError("Unable to get channels/units attr from onnx graph.")
-    else:
-        wshape = proto_obj._params[weight_name].shape
-        assert len(wshape) >= 2, "Weights shape is invalid: {}".format(wshape)
 
-        if op_name == 'FullyConnected':
-            attrs['num_hidden'] = wshape[0]
-        else:
-            if op_name == 'Convolution':
-                # Weight shape for Conv and FC: (M x C x kH x kW) : M is number of
-                # feature maps/hidden  and C is number of channels
-                attrs['num_filter'] = wshape[0]
-            elif op_name == 'Deconvolution':
-                # Weight shape for DeConv : (C x M x kH x kW) : M is number of
-                # feature maps/filters and C is number of channels
-                attrs['num_filter'] = wshape[1]
+    wshape = proto_obj._params[weight_name].shape
+    assert len(wshape) >= 2, "Weights shape is invalid: {}".format(wshape)
+
+    if op_name == 'FullyConnected':
+        attrs['num_hidden'] = wshape[0]
+    else:
+        if op_name == 'Convolution':
+            # Weight shape for Conv and FC: (M x C x kH x kW) : M is number of
+            # feature maps/hidden  and C is number of channels
+            attrs['num_filter'] = wshape[0]
+        elif op_name == 'Deconvolution':
+            # Weight shape for DeConv : (C x M x kH x kW) : M is number of
+            # feature maps/filters and C is number of channels
+            attrs['num_filter'] = wshape[1]
     return attrs
 
 

--- a/python/mxnet/contrib/onnx/onnx2mx/_translation_utils.py
+++ b/python/mxnet/contrib/onnx/onnx2mx/_translation_utils.py
@@ -178,7 +178,7 @@ def _fix_channels(op_name, attrs, inputs, proto_obj):
     these attributes. We check the shape of weights provided to get the number.
     """
     weight_name = inputs[1].name
-    if not weight_name in proto_obj._params: # pylint: disable=no-else-raise
+    if not weight_name in proto_obj._params:
         raise ValueError("Unable to get channels/units attr from onnx graph.")
     else:
         wshape = proto_obj._params[weight_name].shape

--- a/python/mxnet/contrib/text/vocab.py
+++ b/python/mxnet/contrib/text/vocab.py
@@ -212,7 +212,6 @@ class Vocabulary(object):
         for idx in indices:
             if not isinstance(idx, int) or idx > max_idx:
                 raise ValueError('Token index %d in the provided `indices` is invalid.' % idx)
-            else:
-                tokens.append(self.idx_to_token[idx])
+            tokens.append(self.idx_to_token[idx])
 
         return tokens[0] if to_reduce else tokens

--- a/python/mxnet/contrib/text/vocab.py
+++ b/python/mxnet/contrib/text/vocab.py
@@ -210,7 +210,7 @@ class Vocabulary(object):
 
         tokens = []
         for idx in indices:
-            if not isinstance(idx, int) or idx > max_idx: # pylint: disable=no-else-raise
+            if not isinstance(idx, int) or idx > max_idx:
                 raise ValueError('Token index %d in the provided `indices` is invalid.' % idx)
             else:
                 tokens.append(self.idx_to_token[idx])

--- a/python/mxnet/gluon/trainer.py
+++ b/python/mxnet/gluon/trainer.py
@@ -252,8 +252,8 @@ class Trainer(object):
         if not isinstance(self._optimizer, opt.Optimizer):
             raise UserWarning("Optimizer has to be defined before its learning "
                               "rate can be accessed.")
-        else:
-            return self._optimizer.learning_rate
+
+        return self._optimizer.learning_rate
 
     @property
     def optimizer(self):
@@ -273,8 +273,8 @@ class Trainer(object):
         if not isinstance(self._optimizer, opt.Optimizer):
             raise UserWarning("Optimizer has to be defined before its learning "
                               "rate is mutated.")
-        else:
-            self._optimizer.set_learning_rate(lr)
+
+        self._optimizer.set_learning_rate(lr)
 
     def _row_sparse_pull(self, parameter, out, row_id, full_idx=False):
         """Internal method to invoke pull operations on KVStore. If `full_idx` is set to True,

--- a/python/mxnet/gluon/trainer.py
+++ b/python/mxnet/gluon/trainer.py
@@ -249,7 +249,7 @@ class Trainer(object):
 
     @property
     def learning_rate(self):
-        if not isinstance(self._optimizer, opt.Optimizer): # pylint: disable=no-else-raise
+        if not isinstance(self._optimizer, opt.Optimizer):
             raise UserWarning("Optimizer has to be defined before its learning "
                               "rate can be accessed.")
         else:
@@ -270,7 +270,7 @@ class Trainer(object):
         lr : float
             The new learning rate of the optimizer.
         """
-        if not isinstance(self._optimizer, opt.Optimizer): # pylint: disable=no-else-raise
+        if not isinstance(self._optimizer, opt.Optimizer):
             raise UserWarning("Optimizer has to be defined before its learning "
                               "rate is mutated.")
         else:

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -341,7 +341,7 @@ def download(url, path=None, overwrite=False, sha1_hash=None, retries=5, verify_
                 break
             except Exception as e:
                 retries -= 1
-                if retries <= 0: # pylint: disable=no-else-raise
+                if retries <= 0:
                     raise e
                 else:
                     print('download failed due to {}, retrying, {} attempt{} left'

--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -343,9 +343,9 @@ def download(url, path=None, overwrite=False, sha1_hash=None, retries=5, verify_
                 retries -= 1
                 if retries <= 0:
                     raise e
-                else:
-                    print('download failed due to {}, retrying, {} attempt{} left'
-                          .format(repr(e), retries, 's' if retries > 1 else ''))
+
+                print('download failed due to {}, retrying, {} attempt{} left'
+                      .format(repr(e), retries, 's' if retries > 1 else ''))
 
     return fname
 

--- a/python/mxnet/image/detection.py
+++ b/python/mxnet/image/detection.py
@@ -809,7 +809,7 @@ class ImageDetIter(ImageIter):
         pad = batch_size - i
         # handle padding for the last batch
         if pad != 0:
-            if self.last_batch_handle == 'discard': # pylint: disable=no-else-raise
+            if self.last_batch_handle == 'discard':
                 raise StopIteration
             # if the option is 'roll_over', throw StopIteration and cache the data
             elif self.last_batch_handle == 'roll_over' and \

--- a/python/mxnet/image/detection.py
+++ b/python/mxnet/image/detection.py
@@ -812,20 +812,20 @@ class ImageDetIter(ImageIter):
             if self.last_batch_handle == 'discard':
                 raise StopIteration
             # if the option is 'roll_over', throw StopIteration and cache the data
-            elif self.last_batch_handle == 'roll_over' and \
+            if self.last_batch_handle == 'roll_over' and \
                 self._cache_data is None:
                 self._cache_data = batch_data
                 self._cache_label = batch_label
                 self._cache_idx = i
                 raise StopIteration
+
+            _ = self._batchify(batch_data, batch_label, i)
+            if self.last_batch_handle == 'pad':
+                self._allow_read = False
             else:
-                _ = self._batchify(batch_data, batch_label, i)
-                if self.last_batch_handle == 'pad':
-                    self._allow_read = False
-                else:
-                    self._cache_data = None
-                    self._cache_label = None
-                    self._cache_idx = None
+                self._cache_data = None
+                self._cache_label = None
+                self._cache_idx = None
 
         return io.DataBatch([batch_data], [batch_label], pad=pad)
 

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -1198,10 +1198,10 @@ class ImageIter(io.DataIter):
             logging.info('%s: loading recordio %s...',
                          class_name, path_imgrec)
             if path_imgidx:
-                self.imgrec = recordio.MXIndexedRecordIO(path_imgidx, path_imgrec, 'r')  # pylint: disable=redefined-variable-type
+                self.imgrec = recordio.MXIndexedRecordIO(path_imgidx, path_imgrec, 'r')
                 self.imgidx = list(self.imgrec.keys)
             else:
-                self.imgrec = recordio.MXRecordIO(path_imgrec, 'r')  # pylint: disable=redefined-variable-type
+                self.imgrec = recordio.MXRecordIO(path_imgrec, 'r')
                 self.imgidx = None
         else:
             self.imgrec = None
@@ -1224,7 +1224,7 @@ class ImageIter(io.DataIter):
             imgkeys = []
             index = 1
             for img in imglist:
-                key = str(index)  # pylint: disable=redefined-variable-type
+                key = str(index)
                 index += 1
                 if len(img) > 2:
                     label = nd.array(img[:-1], dtype=dtype)
@@ -1374,7 +1374,7 @@ class ImageIter(io.DataIter):
         pad = batch_size - i
         # handle padding for the last batch
         if pad != 0:
-            if self.last_batch_handle == 'discard': # pylint: disable=no-else-raise
+            if self.last_batch_handle == 'discard':
                 raise StopIteration
             # if the option is 'roll_over', throw StopIteration and cache the data
             elif self.last_batch_handle == 'roll_over' and \

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -1377,20 +1377,20 @@ class ImageIter(io.DataIter):
             if self.last_batch_handle == 'discard':
                 raise StopIteration
             # if the option is 'roll_over', throw StopIteration and cache the data
-            elif self.last_batch_handle == 'roll_over' and \
+            if self.last_batch_handle == 'roll_over' and \
                 self._cache_data is None:
                 self._cache_data = batch_data
                 self._cache_label = batch_label
                 self._cache_idx = i
                 raise StopIteration
+
+            _ = self._batchify(batch_data, batch_label, i)
+            if self.last_batch_handle == 'pad':
+                self._allow_read = False
             else:
-                _ = self._batchify(batch_data, batch_label, i)
-                if self.last_batch_handle == 'pad':
-                    self._allow_read = False
-                else:
-                    self._cache_data = None
-                    self._cache_label = None
-                    self._cache_idx = None
+                self._cache_data = None
+                self._cache_label = None
+                self._cache_idx = None
 
         return io.DataBatch([batch_data], [batch_label], pad=pad)
 

--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -642,7 +642,7 @@ class FeedForward(BASE_ESTIMATOR):
         """Initialize the iterator given input."""
         if isinstance(X, (np.ndarray, nd.NDArray)):
             if y is None:
-                if is_train: # pylint: disable=no-else-raise
+                if is_train:
                     raise ValueError('y must be specified when X is numpy.ndarray')
                 else:
                     y = np.zeros(X.shape[0])

--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -644,8 +644,7 @@ class FeedForward(BASE_ESTIMATOR):
             if y is None:
                 if is_train:
                     raise ValueError('y must be specified when X is numpy.ndarray')
-                else:
-                    y = np.zeros(X.shape[0])
+                y = np.zeros(X.shape[0])
             if not isinstance(y, (np.ndarray, nd.NDArray)):
                 raise TypeError('y must be ndarray when X is numpy.ndarray')
             if X.shape[0] != y.shape[0]:

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -641,8 +641,8 @@ class RowSparseNDArray(BaseSparseNDArray):
         if isinstance(key, py_slice):
             if key.step is not None or key.start is not None or key.stop is not None:
                 raise Exception('RowSparseNDArray only supports [:] for __getitem__')
-            else:
-                return self
+
+            return self
         if isinstance(key, tuple):
             raise ValueError('Multi-dimension indexing is not supported')
         raise ValueError('Undefined behaviour for {}'.format(key))
@@ -1104,7 +1104,7 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
         arg_len = len(arg1)
         if arg_len < 2:
             raise ValueError("Unexpected length of input tuple: " + str(arg_len))
-        elif arg_len > 2:
+        if arg_len > 2:
             # empty ndarray with shape
             _check_shape(arg1, shape)
             return empty('row_sparse', arg1, ctx=ctx, dtype=dtype)

--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -639,7 +639,7 @@ class RowSparseNDArray(BaseSparseNDArray):
         if isinstance(key, int):
             raise Exception("__getitem__ with int key is not implemented for RowSparseNDArray yet")
         if isinstance(key, py_slice):
-            if key.step is not None or key.start is not None or key.stop is not None: # pylint: disable=no-else-raise
+            if key.step is not None or key.start is not None or key.stop is not None:
                 raise Exception('RowSparseNDArray only supports [:] for __getitem__')
             else:
                 return self
@@ -1102,7 +1102,7 @@ def row_sparse_array(arg1, shape=None, ctx=None, dtype=None):
     # construct a row sparse array from (D0, D1 ..) or (data, indices)
     if isinstance(arg1, tuple):
         arg_len = len(arg1)
-        if arg_len < 2: # pylint: disable=no-else-raise
+        if arg_len < 2:
             raise ValueError("Unexpected length of input tuple: " + str(arg_len))
         elif arg_len > 2:
             # empty ndarray with shape

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -215,8 +215,8 @@ def _get_powerlaw_dataset_csr(num_rows, num_cols, density=0.1, dtype=None):
     if unused_nnz > 0:
         raise ValueError("not supported for this density: %s"
                          " for this shape (%s,%s)" % (density, num_rows, num_cols))
-    else:
-        return mx.nd.array(output_arr).tostype("csr")
+
+    return mx.nd.array(output_arr).tostype("csr")
 
 
 def assign_each(the_input, function):
@@ -1409,8 +1409,8 @@ def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
                 traceback.print_exc()
                 if raise_on_err:
                     raise e
-                else:
-                    print(str(e))
+
+                print(str(e))
 
     # train
     if grad_req != 'null':
@@ -1436,8 +1436,8 @@ def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
                     traceback.print_exc()
                     if raise_on_err:
                         raise e
-                    else:
-                        print(str(e))
+
+                    print(str(e))
 
     return gt
 
@@ -1516,9 +1516,9 @@ def download(url, fname=None, dirname=None, overwrite=False, retries=5):
             retries -= 1
             if retries <= 0:
                 raise e
-            else:
-                print("download failed, retrying, {} attempt{} left"
-                      .format(retries, 's' if retries > 1 else ''))
+
+            print("download failed, retrying, {} attempt{} left"
+                  .format(retries, 's' if retries > 1 else ''))
     logging.info("downloaded %s into %s successfully", url, fname)
     return fname
 

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -212,7 +212,7 @@ def _get_powerlaw_dataset_csr(num_rows, num_cols, density=0.1, dtype=None):
                 return mx.nd.array(output_arr).tostype("csr")
         col_max = col_max * 2
 
-    if unused_nnz > 0: # pylint: disable=no-else-raise
+    if unused_nnz > 0:
         raise ValueError("not supported for this density: %s"
                          " for this shape (%s,%s)" % (density, num_rows, num_cols))
     else:
@@ -1407,7 +1407,7 @@ def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
             except AssertionError as e:
                 print('Predict Err: ctx %d vs ctx %d at %s'%(i, max_idx, name))
                 traceback.print_exc()
-                if raise_on_err: # pylint: disable=no-else-raise
+                if raise_on_err:
                     raise e
                 else:
                     print(str(e))
@@ -1434,7 +1434,7 @@ def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
                 except AssertionError as e:
                     print('Train Err: ctx %d vs ctx %d at %s'%(i, max_idx, name))
                     traceback.print_exc()
-                    if raise_on_err: # pylint: disable=no-else-raise
+                    if raise_on_err:
                         raise e
                     else:
                         print(str(e))
@@ -1514,7 +1514,7 @@ def download(url, fname=None, dirname=None, overwrite=False, retries=5):
                 break
         except Exception as e:
             retries -= 1
-            if retries <= 0: # pylint: disable=no-else-raise
+            if retries <= 0:
                 raise e
             else:
                 print("download failed, retrying, {} attempt{} left"
@@ -1661,7 +1661,7 @@ def get_mnist_iterator(batch_size, input_shape, num_parts=1, part_index=0):
     """
 
     get_mnist_ubyte()
-    flat = False if len(input_shape) == 3 else True # pylint: disable=simplifiable-if-expression
+    flat = False if len(input_shape) == 3 else True
 
     train_dataiter = mx.io.MNISTIter(
         image="data/train-images-idx3-ubyte",

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1661,7 +1661,7 @@ def get_mnist_iterator(batch_size, input_shape, num_parts=1, part_index=0):
     """
 
     get_mnist_ubyte()
-    flat = False if len(input_shape) == 3 else True
+    flat = not bool(len(input_shape) == 3)
 
     train_dataiter = mx.io.MNISTIter(
         image="data/train-images-idx3-ubyte",


### PR DESCRIPTION
## Description ##
Pylint error 'Bad option value 'no-else-raise' (bad-option-value)' was reported by issue 14851, therefore, I check the code and remove the statement '# pylint: disable=redefined-variable-type' for solving the issue.

My environment:
(venv) cch:incubator-mxnet cch$ pylint --version
pylint 2.1.1
astroid 2.1.0
Python 3.5.1 (default, Jan 22 2016, 17:08:33) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.57)]

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-1411], where MXNET-1411 refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
