### PR TITLE
[clojure] clojurify function names in image.clj namespace

### DIFF
--- a/contrib/clojure-package/src/org/apache/clojure_mxnet/image.clj
+++ b/contrib/clojure-package/src/org/apache/clojure_mxnet/image.clj
@@ -39,7 +39,7 @@
 (s/def ::decode-image-opts
   (s/keys :opt-un [::color-flag ::to-rgb ::output]))
 
-(defn decode-image ^:deprecated
+(defn ^:deprecated decode-image
   "DEPRECATED: use `decode` instead.
 
    Decodes an image from an input stream with OpenCV
@@ -91,7 +91,7 @@
 (s/def ::optional-to-rgb
   (s/or :none nil? :some ::to-rgb))
 
-(defn read-image ^:deprecated
+(defn ^:deprecated read-image
   "DEPRECATED: use `read` instead.
 
    Reads an image file and returns an ndarray with OpenCV. It returns image in
@@ -154,7 +154,7 @@
 (s/def ::int int?)
 (s/def ::optional-int (s/or :none nil? :some int?))
 
-(defn resize-image ^:deprecated
+(defn ^:deprecated resize-image
   "DEPRECATED: use `resize` instead.
 
    Resizes the image array to (width, height)
@@ -275,7 +275,7 @@
 (s/def ::to-image-ndarray
   (s/and ::ndarray ::all-bytes ::rgb-array))
 
-(defn to-image ^:deprecated
+(defn ^:deprecated to-image
   "DEPRECATED: user `ndarray->image` instead.
 
    Convert a NDArray image in RGB format to a real image.

--- a/contrib/clojure-package/src/org/apache/clojure_mxnet/image.clj
+++ b/contrib/clojure-package/src/org/apache/clojure_mxnet/image.clj
@@ -17,6 +17,7 @@
 
 (ns org.apache.clojure-mxnet.image
   "Image API of Clojure package."
+  (:refer-clojure :exclude [read])
   (:require [t6.from-scala.core :refer [$ $$] :as $]
             [org.apache.clojure-mxnet.dtype :as dtype]
             [org.apache.clojure-mxnet.ndarray :as ndarray]
@@ -38,8 +39,10 @@
 (s/def ::decode-image-opts
   (s/keys :opt-un [::color-flag ::to-rgb ::output]))
 
-(defn decode-image
-  "Decodes an image from an input stream with OpenCV
+(defn decode-image ^:deprecated
+  "DEPRECATED: use `decode` instead.
+
+   Decodes an image from an input stream with OpenCV
     `input-stream`: `InputStream` - Contains the binary encoded image
     `color-flag`: 0 or 1 - Convert decoded image to grayscale (0) or color (1)
     `to-rgb`: boolean - Whether to convert decoded image to mxnet's default RGB
@@ -60,14 +63,38 @@
   ([input-stream]
    (decode-image input-stream {})))
 
+(defn decode
+  "Decodes an image from an input stream with OpenCV.
+    `input-stream`: `InputStream` - Contains the binary encoded image
+    `color-flag`: 0 or 1 - Convert decoded image to grayscale (0) or color (1)
+    `to-rgb`: boolean - Whether to convert decoded image to mxnet's default RGB
+            format (instead of opencv's default BGR)
+    `output`: nil or `NDArray`
+    returns: `NDArray` with dtype uint8
+
+  Ex:
+    (decode input-stream)
+    (decode input-stream {:color-flag 1})
+    (decode input-stream {:color-flag 0 :output nd})"
+  ([input-stream {:keys [color-flag to-rgb output]
+                  :or {color-flag COLOR to-rgb true output nil}
+                  :as opts}]
+   (util/validate! ::input-stream input-stream "Invalid input stream")
+   (util/validate! ::decode-image-opts opts "Invalid options for decoding")
+   (Image/imDecode input-stream color-flag to-rgb ($/option output)))
+  ([input-stream]
+   (decode input-stream {})))
+
 (s/def ::filename string?)
 (s/def ::optional-color-flag
   (s/or :none nil? :some ::color-flag))
 (s/def ::optional-to-rgb
   (s/or :none nil? :some ::to-rgb))
 
-(defn read-image
-  "Reads an image file and returns an ndarray with OpenCV. It returns image in
+(defn read-image ^:deprecated
+  "DEPRECATED: use `read` instead.
+
+   Reads an image file and returns an ndarray with OpenCV. It returns image in
    RGB by default instead of OpenCV's default BGR.
     `filename`: string - Name of the image file to be loaded
     `color-flag`: 0 or 1 - Convert decoded image to grayscale (0) or color (1)
@@ -95,11 +122,42 @@
   ([filename]
    (read-image filename {})))
 
+(defn read
+  "Reads an image file and returns an ndarray with OpenCV. It returns image in
+   RGB by default instead of OpenCV's default BGR.
+    `filename`: string - Name of the image file to be loaded
+    `color-flag`: 0 or 1 - Convert decoded image to grayscale (0) or color (1)
+    `to-rgb`: boolean - Whether to convert decoded image to mxnet's default RGB
+            format (instead of opencv's default BGR)
+    `output`: nil or `NDArray`
+    returns: `NDArray` with dtype uint8
+
+   Ex:
+     (read \"cat.jpg\")
+     (read \"cat.jpg\" {:color-flag 0})
+     (read \"cat.jpg\" {:color-flag 1 :output nd})"
+  ([filename {:keys [color-flag to-rgb output]
+              :or {color-flag nil to-rgb nil output nil}
+              :as opts}]
+   (util/validate! ::filename filename "Invalid filename")
+   (util/validate! ::optional-color-flag color-flag "Invalid color flag")
+   (util/validate! ::optional-to-rgb to-rgb "Invalid conversion flag")
+   (util/validate! ::output output "Invalid output")
+   (Image/imRead
+    filename
+    ($/option color-flag)
+    ($/option to-rgb)
+    ($/option output)))
+  ([filename]
+   (read filename {})))
+
 (s/def ::int int?)
 (s/def ::optional-int (s/or :none nil? :some int?))
 
-(defn resize-image
-  "Resizes the image array to (width, height)
+(defn resize-image ^:deprecated
+  "DEPRECATED: use `resize` instead.
+
+   Resizes the image array to (width, height)
    `input`: `NDArray` - source image in NDArray
    `w`: int - Width of resized image
    `h`: int - Height of resized image
@@ -121,6 +179,30 @@
    (Image/imResize input w h ($/option interpolation) ($/option output)))
   ([input w h]
    (resize-image input w h {})))
+
+(defn resize
+  "Resizes the image array to (width, height)
+   `input`: `NDArray` - source image in NDArray
+   `w`: int - Width of resized image
+   `h`: int - Height of resized image
+   `interpolation`: Interpolation method. Default is INTER_LINEAR
+   `ouput`: nil or `NDArray`
+   returns: `NDArray`
+
+   Ex:
+     (resize nd-img 300 300)
+     (resize nd-img 28 28 {:output nd})"
+  ([input w h {:keys [interpolation output]
+               :or {interpolation nil output nil}
+               :as opts}]
+   (util/validate! ::ndarray input "Invalid input array")
+   (util/validate! ::int w "Invalid width")
+   (util/validate! ::int h "Invalid height")
+   (util/validate! ::optional-int interpolation "Invalid interpolation")
+   (util/validate! ::output output "Invalid output")
+   (Image/imResize input w h ($/option interpolation) ($/option output)))
+  ([input w h]
+   (resize input w h {})))
 
 (defn apply-border
   "Pad image border with OpenCV.
@@ -193,7 +275,17 @@
 (s/def ::to-image-ndarray
   (s/and ::ndarray ::all-bytes ::rgb-array))
 
-(defn to-image
+(defn to-image ^:deprecated
+  "DEPRECATED: user `ndarray->image` instead.
+
+   Convert a NDArray image in RGB format to a real image.
+   `input`: `NDArray` - Source image in NDArray
+   returns: `BufferedImage`"
+  [input]
+  (util/validate! ::to-image-ndarray input "Invalid input array")
+  (Image/toImage input))
+
+(defn ndarray->image
   "Convert a NDArray image in RGB format to a real image.
    `input`: `NDArray` - Source image in NDArray
    returns: `BufferedImage`"

--- a/contrib/clojure-package/src/org/apache/clojure_mxnet/image.clj
+++ b/contrib/clojure-package/src/org/apache/clojure_mxnet/image.clj
@@ -66,9 +66,8 @@
 (s/def ::color #{:grayscale :color})
 (s/def ::decode-image-opts-2 (s/keys :opt-un [::color ::to-rgb ::output]))
 
-(defn- color->int
-  [color-flag]
-  (case color-flag
+(defn- color->int [color]
+  (case color
     :grayscale 0
     :color 1))
 

--- a/contrib/clojure-package/test/org/apache/clojure_mxnet/image_test.clj
+++ b/contrib/clojure-package/test/org/apache/clojure_mxnet/image_test.clj
@@ -44,7 +44,8 @@
   [src-path dest-path]
   (fn [f]
     (cp src-path dest-path)
-    (f)))
+    (f)
+    (rm dest-path)))
 
 (use-fixtures :once (with-file image-src-path image-path))
 

--- a/contrib/clojure-package/test/org/apache/clojure_mxnet/image_test.clj
+++ b/contrib/clojure-package/test/org/apache/clojure_mxnet/image_test.clj
@@ -58,6 +58,15 @@
     (is (= [576 1024 3] (ndarray/shape-vec img-arr)))
     (is (= [576 1024 1] (ndarray/shape-vec img-arr-2)))))
 
+(deftest test-decode
+  (let [img-arr (image/decode
+                 (io/input-stream image-path))
+        img-arr-2 (image/decode
+                   (io/input-stream image-path)
+                   {:color-flag image/GRAYSCALE})]
+    (is (= [576 1024 3] (ndarray/shape-vec img-arr)))
+    (is (= [576 1024 1] (ndarray/shape-vec img-arr-2)))))
+
 (deftest test-read-image
   (let [img-arr (image/read-image image-path)
         img-arr-2 (image/read-image
@@ -66,34 +75,54 @@
     (is (= [576 1024 3] (ndarray/shape-vec img-arr)))
     (is (= [576 1024 1] (ndarray/shape-vec img-arr-2)))))
 
+(deftest test-read
+  (let [img-arr (image/read image-path)
+        img-arr-2 (image/read
+                   image-path
+                   {:color-flag image/GRAYSCALE})]
+    (is (= [576 1024 3] (ndarray/shape-vec img-arr)))
+    (is (= [576 1024 1] (ndarray/shape-vec img-arr-2)))))
+
 (deftest test-resize-image
-  (let [img-arr (image/read-image image-path)
+  (let [img-arr (image/read image-path)
         resized-arr (image/resize-image img-arr 224 224)]
     (is (= [224 224 3] (ndarray/shape-vec resized-arr)))))
 
-(deftest test-crop-image
-  (let [img-arr (image/read-image image-path)
+(deftest test-resize
+  (let [img-arr (image/read image-path)
+        resized-arr (image/resize img-arr 224 224)]
+    (is (= [224 224 3] (ndarray/shape-vec resized-arr)))))
+
+(deftest test-fixed-crop
+  (let [img-arr (image/read image-path)
         cropped-arr (image/fixed-crop img-arr 0 0 224 224)]
     (is (= [224 224 3] (ndarray/shape-vec cropped-arr)))))
 
 (deftest test-apply-border
-  (let [img-arr (image/read-image image-path)
+  (let [img-arr (image/read image-path)
         padded-arr (image/apply-border img-arr 1 1 1 1)]
     (is (= [578 1026 3] (ndarray/shape-vec padded-arr)))))
 
 (deftest test-to-image
-  (let [img-arr (image/read-image image-path)
-        resized-arr (image/resize-image img-arr 224 224)
+  (let [img-arr (image/read image-path)
+        resized-arr (image/resize img-arr 224 224)
         new-img (image/to-image resized-arr)]
+    (is (ImageIO/write new-img "png" (io/file tmp-dir "out.png")))))
+
+(deftest test-ndarray->image
+  (let [img-arr (image/read image-path)
+        resized-arr (image/resize img-arr 224 224)
+        new-img (image/ndarray->image resized-arr)]
     (is (ImageIO/write new-img "png" (io/file tmp-dir "out.png")))))
 
 (deftest test-draw-bounding-box!
   (let [orig-img (ImageIO/read (new File image-path))
-        new-img  (-> orig-img
-                     (image/draw-bounding-box! [{:x-min 190 :x-max 850 :y-min 50 :y-max 450}
-                                                {:x-min 200 :x-max 350 :y-min 440 :y-max 530}]
-                                               {:stroke 2
-                                                :names ["pug" "cookie"]
-                                                :transparency 0.8
-                                                :font-size-mult 2.0}))]
+        new-img  (image/draw-bounding-box!
+                   orig-img
+                   [{:x-min 190 :x-max 850 :y-min 50 :y-max 450}
+                    {:x-min 200 :x-max 350 :y-min 440 :y-max 530}]
+                   {:stroke 2
+                    :names ["pug" "cookie"]
+                    :transparency 0.8
+                    :font-size-mult 2.0})]
     (is (ImageIO/write new-img "png" (io/file tmp-dir "out.png")))))

--- a/contrib/clojure-package/test/org/apache/clojure_mxnet/image_test.clj
+++ b/contrib/clojure-package/test/org/apache/clojure_mxnet/image_test.clj
@@ -44,42 +44,33 @@
   [src-path dest-path]
   (fn [f]
     (cp src-path dest-path)
-    (f)
-    (rm dest-path)))
+    (f)))
 
 (use-fixtures :once (with-file image-src-path image-path))
 
 (deftest test-decode-image
-  (let [img-arr (image/decode-image
-                 (io/input-stream image-path))
-        img-arr-2 (image/decode-image
-                   (io/input-stream image-path)
-                   {:color-flag image/GRAYSCALE})]
+  (let [img-arr (image/decode-image (io/input-stream image-path))
+        img-arr-2 (image/decode-image (io/input-stream image-path)
+                                      {:color-flag image/GRAYSCALE})]
     (is (= [576 1024 3] (ndarray/shape-vec img-arr)))
     (is (= [576 1024 1] (ndarray/shape-vec img-arr-2)))))
 
 (deftest test-decode
-  (let [img-arr (image/decode
-                 (io/input-stream image-path))
-        img-arr-2 (image/decode
-                   (io/input-stream image-path)
-                   {:color-flag image/GRAYSCALE})]
+  (let [img-arr (image/decode (io/input-stream image-path))
+        img-arr-2 (image/decode (io/input-stream image-path)
+                                {:color :grayscale})]
     (is (= [576 1024 3] (ndarray/shape-vec img-arr)))
     (is (= [576 1024 1] (ndarray/shape-vec img-arr-2)))))
 
 (deftest test-read-image
   (let [img-arr (image/read-image image-path)
-        img-arr-2 (image/read-image
-                   image-path
-                   {:color-flag image/GRAYSCALE})]
+        img-arr-2 (image/read-image image-path {:color-flag image/GRAYSCALE})]
     (is (= [576 1024 3] (ndarray/shape-vec img-arr)))
     (is (= [576 1024 1] (ndarray/shape-vec img-arr-2)))))
 
 (deftest test-read
   (let [img-arr (image/read image-path)
-        img-arr-2 (image/read
-                   image-path
-                   {:color-flag image/GRAYSCALE})]
+        img-arr-2 (image/read image-path {:color :grayscale})]
     (is (= [576 1024 3] (ndarray/shape-vec img-arr)))
     (is (= [576 1024 1] (ndarray/shape-vec img-arr-2)))))
 


### PR DESCRIPTION
## Description ##

The `image` namespace is using some functions that are not named the `clojure way`. It is an attempt to clojurify these functions.
The namespaces are supposed to be imported qualified and having the suffix `-image` in the following functions is redundant
* `resize-image`
* `decode-image`
* `read-image`

One should be able to call `image/resize`, `image/decode`, `image/read` instead.

The function `to-image` is misleading as we dont know what is turned into an image. I suggest to name it `ndarray->image` instead.

* `deprecated` is added in metadata
* `deprecated` is added in docstrings