### PR TITLE
Profiler API Enhancements

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -321,15 +321,17 @@ MXNET_DLL int MXDumpProcessProfile(int finished, int profile_process, KVStoreHan
 MXNET_DLL int MXDumpProfile(int finished);
 
 /*!
- * \brief Print aggregate stats to the a string
- * \param out_str will receive a pointer to the output string
- * \param reset clear the aggregate stats after printing
- * \param format whether to return in tabluar or json format
- * \param sort_by sort by avg, min, max, or count
- * \param ascending whether to sort ascendingly
- * \return 0 when success, -1 when failure happens.
- * \note
- */
+	 * \brief Print aggregate stats to the a string
+	 * \param out_str Will receive a pointer to the output string
+	 * \param reset Clear the aggregate stats after printing
+	 * \param out_str will receive a pointer to the output string
+	 * \param reset clear the aggregate stats after printing
+	 * \param format whether to return in tabluar or json format
+	 * \param sort_by sort by avg, min, max, or count
+	 * \param ascending whether to sort ascendingly
+	 * \return 0 when success, -1 when failure happens.
+	 * \note
+	 */
 MXNET_DLL int MXAggregateProfileStatsPrint(const char **out_str, int reset, int format, int sort_by, int ascending);
 
 /*!
@@ -821,10 +823,12 @@ MXNET_DLL int MXNDArrayToDLPack(NDArrayHandle handle,
 * The memory is retained until the NDArray went out of scope.
 *
 * \param dlpack the pointer of the input DLManagedTensor
+* \param transient_handle whether the handle will be destructed before calling the deleter
 * \param out_handle pointer holder to get pointer of NDArray
 * \return 0 when success, -1 when failure happens
 */
 MXNET_DLL int MXNDArrayFromDLPack(DLManagedTensorHandle dlpack,
+                                  const bool transient_handle,
                                   NDArrayHandle *out_handle);
 
 /*!
@@ -1068,14 +1072,14 @@ MXNET_DLL int MXAutogradIsTraining(bool* curr);
  * \param curr returns the current status
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXIsNumpyCompatible(bool* curr);
+MXNET_DLL int MXIsNumpyShape(bool* curr);
 /*!
  * \brief set numpy compatibility switch
- * \param is_np_comp 1 when numpy compatibility is on, 0 when off
+ * \param is_np_shape 1 when numpy shape semantics is on, 0 when off
  * \param prev returns the previous status before this set
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXSetIsNumpyCompatible(int is_np_comp, int* prev);
+MXNET_DLL int MXSetIsNumpyShape(int is_np_shape, int* prev);
 /*!
  * \brief mark NDArrays as variables to compute gradient for autograd
  * \param num_var number of variable NDArrays
@@ -1294,6 +1298,13 @@ MXNET_DLL int MXSymbolCreateFromFile(const char *fname, SymbolHandle *out);
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolCreateFromJSON(const char *json, SymbolHandle *out);
+/*!
+ * \brief Remove the operators amp_cast and amp_multicast
+ * \param sym_handle the input symbol.
+ * \param ret_sym_handle the output symbol.
+ * \return 0 when success, -1 when failure happens
+ */
+MXNET_DLL int MXSymbolRemoveAmpCast(SymbolHandle sym_handle, SymbolHandle* ret_sym_handle);
 /*!
  * \brief Save a symbol into a json file.
  * \param symbol the input symbol.
@@ -1749,6 +1760,14 @@ MXNET_DLL int MXSetCalibTableToQuantizedSymbol(SymbolHandle qsym_handle,
  */
 MXNET_DLL int MXGenBackendSubgraph(SymbolHandle sym_handle, const char *backend,
                                    SymbolHandle *ret_sym_handle);
+
+/*!
+ * \brief Generate atomic symbol (able to be composed) from a source symbol
+ * \param sym_handle source symbol
+ * \param ret_sym_handle returned atomic symbol
+ */
+MXNET_DLL int MXGenAtomicSymbolFromSymbol(SymbolHandle sym_handle, SymbolHandle *ret_sym_handle);
+
 
 //--------------------------------------------
 // Part 4: Executor interface
@@ -2732,6 +2751,12 @@ MXNET_DLL int MXNDArrayGetSharedMemHandle(NDArrayHandle handle, int* shared_pid,
 MXNET_DLL int MXNDArrayCreateFromSharedMem(int shared_pid, int shared_id, const mx_uint *shape,
                                            mx_uint ndim, int dtype, NDArrayHandle *out);
 
+/*!
+ * \brief Release all unreferenced memory from the devices storage managers memory pool
+ * \param dev_type device type, specify device we want to take
+ * \param dev_id the device id of the specific device
+ */
+MXNET_DLL int MXStorageEmptyCache(int dev_type, int dev_id);
 
 /*!
  * \brief Reconstruct NDArray from shared memory handle

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -322,8 +322,7 @@ MXNET_DLL int MXDumpProfile(int finished);
 
 
 /*!
- * \brief Print sorted aggregate stats to the a string
- *        How aggregate stats are stored will not change
+ * \brief Deprecated, use MXAggregateProfileStatsPrintEx instead.
  * \param out_str Will receive a pointer to the output string
  * \param reset Clear the aggregate stats after printing
  * \return 0 when success, -1 when failure happens.

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -320,27 +320,26 @@ MXNET_DLL int MXDumpProcessProfile(int finished, int profile_process, KVStoreHan
  */
 MXNET_DLL int MXDumpProfile(int finished);
 
+
 /*!
-	 * \brief Print aggregate stats to the a string
-	 * \param out_str Will receive a pointer to the output string
-	 * \param reset Clear the aggregate stats after printing
-	 * \return 0 when success, -1 when failure happens.
-	 * \note
-	 */
+ * \brief Print aggregate stats to the a string
+ * \param out_str Will receive a pointer to the output string
+ * \param reset Clear the aggregate stats after printing
+ * \return 0 when success, -1 when failure happens.
+ * \note
+ */
 MXNET_DLL int MXAggregateProfileStatsPrint(const char **out_str, int reset);
 
 /*!
-	 * \brief Print aggregate stats to the a string
-	 * \param out_str Will receive a pointer to the output string
-	 * \param reset Clear the aggregate stats after printing
-	 * \param out_str will receive a pointer to the output string
-	 * \param reset clear the aggregate stats after printing
-	 * \param format whether to return in tabluar or json format
-	 * \param sort_by sort by avg, min, max, or count
-	 * \param ascending whether to sort ascendingly
-	 * \return 0 when success, -1 when failure happens.
-	 * \note
-	 */
+ * \brief Print aggregate stats to the a string
+ * \param out_str will receive a pointer to the output string
+ * \param reset clear the aggregate stats after printing
+ * \param format whether to return in tabular or json format
+ * \param sort_by sort by avg, min, max, or count
+ * \param ascending whether to sort ascendingly
+ * \return 0 when success, -1 when failure happens.
+ * \note
+ */
 MXNET_DLL int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format,
                                             int sort_by, int ascending);
 

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -322,12 +322,15 @@ MXNET_DLL int MXDumpProfile(int finished);
 
 /*!
  * \brief Print aggregate stats to the a string
- * \param out_str Will receive a pointer to the output string
- * \param reset Clear the aggregate stats after printing
+ * \param out_str will receive a pointer to the output string
+ * \param reset clear the aggregate stats after printing
+ * \param format whether to return in tabluar or json format
+ * \param sort_by sort by avg, min, max, or count
+ * \param ascending whether to sort ascendingly
  * \return 0 when success, -1 when failure happens.
  * \note
  */
-MXNET_DLL int MXAggregateProfileStatsPrint(const char **out_str, int reset);
+MXNET_DLL int MXAggregateProfileStatsPrint(const char **out_str, int reset, int format, int sort_by, int ascending);
 
 /*!
  * \brief Pause profiler tuning collection
@@ -818,12 +821,10 @@ MXNET_DLL int MXNDArrayToDLPack(NDArrayHandle handle,
 * The memory is retained until the NDArray went out of scope.
 *
 * \param dlpack the pointer of the input DLManagedTensor
-* \param transient_handle whether the handle will be destructed before calling the deleter
 * \param out_handle pointer holder to get pointer of NDArray
 * \return 0 when success, -1 when failure happens
 */
 MXNET_DLL int MXNDArrayFromDLPack(DLManagedTensorHandle dlpack,
-                                  const bool transient_handle,
                                   NDArrayHandle *out_handle);
 
 /*!
@@ -1067,14 +1068,14 @@ MXNET_DLL int MXAutogradIsTraining(bool* curr);
  * \param curr returns the current status
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXIsNumpyShape(bool* curr);
+MXNET_DLL int MXIsNumpyCompatible(bool* curr);
 /*!
  * \brief set numpy compatibility switch
- * \param is_np_shape 1 when numpy shape semantics is on, 0 when off
+ * \param is_np_comp 1 when numpy compatibility is on, 0 when off
  * \param prev returns the previous status before this set
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXSetIsNumpyShape(int is_np_shape, int* prev);
+MXNET_DLL int MXSetIsNumpyCompatible(int is_np_comp, int* prev);
 /*!
  * \brief mark NDArrays as variables to compute gradient for autograd
  * \param num_var number of variable NDArrays
@@ -1293,13 +1294,6 @@ MXNET_DLL int MXSymbolCreateFromFile(const char *fname, SymbolHandle *out);
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolCreateFromJSON(const char *json, SymbolHandle *out);
-/*!
- * \brief Remove the operators amp_cast and amp_multicast
- * \param sym_handle the input symbol.
- * \param ret_sym_handle the output symbol.
- * \return 0 when success, -1 when failure happens
- */
-MXNET_DLL int MXSymbolRemoveAmpCast(SymbolHandle sym_handle, SymbolHandle* ret_sym_handle);
 /*!
  * \brief Save a symbol into a json file.
  * \param symbol the input symbol.
@@ -1755,14 +1749,6 @@ MXNET_DLL int MXSetCalibTableToQuantizedSymbol(SymbolHandle qsym_handle,
  */
 MXNET_DLL int MXGenBackendSubgraph(SymbolHandle sym_handle, const char *backend,
                                    SymbolHandle *ret_sym_handle);
-
-/*!
- * \brief Generate atomic symbol (able to be composed) from a source symbol
- * \param sym_handle source symbol
- * \param ret_sym_handle returned atomic symbol
- */
-MXNET_DLL int MXGenAtomicSymbolFromSymbol(SymbolHandle sym_handle, SymbolHandle *ret_sym_handle);
-
 
 //--------------------------------------------
 // Part 4: Executor interface
@@ -2746,12 +2732,6 @@ MXNET_DLL int MXNDArrayGetSharedMemHandle(NDArrayHandle handle, int* shared_pid,
 MXNET_DLL int MXNDArrayCreateFromSharedMem(int shared_pid, int shared_id, const mx_uint *shape,
                                            mx_uint ndim, int dtype, NDArrayHandle *out);
 
-/*!
- * \brief Release all unreferenced memory from the devices storage managers memory pool
- * \param dev_type device type, specify device we want to take
- * \param dev_id the device id of the specific device
- */
-MXNET_DLL int MXStorageEmptyCache(int dev_type, int dev_id);
 
 /*!
  * \brief Reconstruct NDArray from shared memory handle

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -324,6 +324,15 @@ MXNET_DLL int MXDumpProfile(int finished);
 	 * \brief Print aggregate stats to the a string
 	 * \param out_str Will receive a pointer to the output string
 	 * \param reset Clear the aggregate stats after printing
+	 * \return 0 when success, -1 when failure happens.
+	 * \note
+	 */
+	MXNET_DLL int MXAggregateProfileStatsPrint(const char **out_str, int reset);
+
+/*!
+	 * \brief Print aggregate stats to the a string
+	 * \param out_str Will receive a pointer to the output string
+	 * \param reset Clear the aggregate stats after printing
 	 * \param out_str will receive a pointer to the output string
 	 * \param reset clear the aggregate stats after printing
 	 * \param format whether to return in tabluar or json format
@@ -332,7 +341,7 @@ MXNET_DLL int MXDumpProfile(int finished);
 	 * \return 0 when success, -1 when failure happens.
 	 * \note
 	 */
-MXNET_DLL int MXAggregateProfileStatsPrint(const char **out_str, int reset, int format, int sort_by, int ascending);
+MXNET_DLL int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format, int sort_by, int ascending);
 
 /*!
  * \brief Pause profiler tuning collection

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -327,7 +327,7 @@ MXNET_DLL int MXDumpProfile(int finished);
 	 * \return 0 when success, -1 when failure happens.
 	 * \note
 	 */
-	MXNET_DLL int MXAggregateProfileStatsPrint(const char **out_str, int reset);
+MXNET_DLL int MXAggregateProfileStatsPrint(const char **out_str, int reset);
 
 /*!
 	 * \brief Print aggregate stats to the a string
@@ -341,7 +341,8 @@ MXNET_DLL int MXDumpProfile(int finished);
 	 * \return 0 when success, -1 when failure happens.
 	 * \note
 	 */
-MXNET_DLL int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format, int sort_by, int ascending);
+MXNET_DLL int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format, int sort_by,
+                                            int ascending);
 
 /*!
  * \brief Pause profiler tuning collection

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -341,8 +341,8 @@ MXNET_DLL int MXAggregateProfileStatsPrint(const char **out_str, int reset);
 	 * \return 0 when success, -1 when failure happens.
 	 * \note
 	 */
-MXNET_DLL int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format, int sort_by,
-                                            int ascending);
+MXNET_DLL int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format,
+                                            int sort_by, int ascending);
 
 /*!
  * \brief Pause profiler tuning collection

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -322,7 +322,8 @@ MXNET_DLL int MXDumpProfile(int finished);
 
 
 /*!
- * \brief Print aggregate stats to the a string
+ * \brief Print sorted aggregate stats to the a string
+ *        How aggregate stats are stored will not change
  * \param out_str Will receive a pointer to the output string
  * \param reset Clear the aggregate stats after printing
  * \return 0 when success, -1 when failure happens.
@@ -331,7 +332,8 @@ MXNET_DLL int MXDumpProfile(int finished);
 MXNET_DLL int MXAggregateProfileStatsPrint(const char **out_str, int reset);
 
 /*!
- * \brief Print aggregate stats to the a string
+ * \brief Print sorted aggregate stats to the a string
+ *        How aggregate stats are stored will not change
  * \param out_str will receive a pointer to the output string
  * \param reset clear the aggregate stats after printing
  * \param format whether to return in tabular or json format

--- a/python/mxnet/profiler.py
+++ b/python/mxnet/profiler.py
@@ -172,6 +172,10 @@ def dumps(reset=False, format='table', sort_by='avg', ascending=False):
     format_to_int = {'table': 0, 'json': 1}
     sort_by_to_int = {'avg': 0, 'min': 1, 'max': 2, 'count': 3}
     asc_to_int = {False: 0, True: 1}
+    assert format in format_to_int, "Invalid parameter value provided for format. Support: 'table', 'json'"
+    assert sort_by in sort_by_to_int, "Invalid parameter value provided for sort_by. Support: 'avg', 'min', 'max', 'count'"
+    assert  ascending in asc_to_int, "Invalid parameter value provided for ascending. Support: False, True"
+    assert  reset in reset_to_int, "Invalid parameter value provided for reset. Support: False, True"
     check_call(_LIB.MXAggregateProfileStatsPrintEx(ctypes.byref(debug_str),
                                                    reset_to_int[reset],
                                                    format_to_int[format],

--- a/python/mxnet/profiler.py
+++ b/python/mxnet/profiler.py
@@ -148,7 +148,7 @@ def dump_profile():
     dump(True)
 
 
-def dumps(reset=False, format = 'table', sort_by = 'avg', ascending = False):
+def dumps(reset=False, format='table', sort_by='avg', ascending=False):
     """Return a printable string of aggregate profile stats.
 
     Parameters
@@ -169,12 +169,11 @@ def dumps(reset=False, format = 'table', sort_by = 'avg', ascending = False):
     format_to_int = {'table': 0, 'json': 1}
     sort_by_to_int = {'avg': 0, 'min': 1, 'max': 2, 'count': 3}
     asc_to_int = {False: 0, True: 1}
-    check_call(_LIB.MXAggregateProfileStatsPrintEx(ctypes.byref(debug_str), 
-                                                reset_to_int[reset],
-                                                format_to_int[format],
-                                                sort_by_to_int[sort_by],
-                                                asc_to_int[ascending]
-                                                ))
+    check_call(_LIB.MXAggregateProfileStatsPrintEx(ctypes.byref(debug_str),
+                                                   reset_to_int[reset],
+                                                   format_to_int[format],
+                                                   sort_by_to_int[sort_by],
+                                                   asc_to_int[ascending]))
     return py_str(debug_str.value)
 
 

--- a/python/mxnet/profiler.py
+++ b/python/mxnet/profiler.py
@@ -148,17 +148,33 @@ def dump_profile():
     dump(True)
 
 
-def dumps(reset=False):
+def dumps(reset=False, format = 'table', sort_by = 'avg', ascending = False):
     """Return a printable string of aggregate profile stats.
 
     Parameters
     ----------
     reset: boolean
-        Indicates whether to clean aggeregate statistical data collected up to this point
+        indicates whether to clean aggeregate statistical data collected up to this point
+    format: string
+        whether to return the aggregate stats in table of json format
+        can take 'table' or 'json'
+    sort_by: string
+        can take 'avg', 'min', 'max', or 'count'
+        by which stat to sort the entries in each category
+    ascending: boolean
+        whether to sort ascendingly
     """
     debug_str = ctypes.c_char_p()
-    do_reset = 1 if reset is True else 0
-    check_call(_LIB.MXAggregateProfileStatsPrint(ctypes.byref(debug_str), int(do_reset)))
+    reset_to_int = {False: 0, True: 1}
+    format_to_int = {'table': 0, 'json': 1}
+    sort_by_to_int = {'avg': 0, 'min': 1, 'max': 2, 'count': 3}
+    asc_to_int = {False: 0, True: 1}
+    check_call(_LIB.MXAggregateProfileStatsPrint(ctypes.byref(debug_str), 
+                                                reset_to_int[reset],
+                                                format_to_int[format],
+                                                sort_by_to_int[sort_by],
+                                                asc_to_int[ascending]
+                                                ))
     return py_str(debug_str.value)
 
 

--- a/python/mxnet/profiler.py
+++ b/python/mxnet/profiler.py
@@ -169,7 +169,7 @@ def dumps(reset=False, format = 'table', sort_by = 'avg', ascending = False):
     format_to_int = {'table': 0, 'json': 1}
     sort_by_to_int = {'avg': 0, 'min': 1, 'max': 2, 'count': 3}
     asc_to_int = {False: 0, True: 1}
-    check_call(_LIB.MXAggregateProfileStatsPrint(ctypes.byref(debug_str), 
+    check_call(_LIB.MXAggregateProfileStatsPrintEx(ctypes.byref(debug_str), 
                                                 reset_to_int[reset],
                                                 format_to_int[format],
                                                 sort_by_to_int[sort_by],

--- a/python/mxnet/profiler.py
+++ b/python/mxnet/profiler.py
@@ -172,10 +172,15 @@ def dumps(reset=False, format='table', sort_by='avg', ascending=False):
     format_to_int = {'table': 0, 'json': 1}
     sort_by_to_int = {'avg': 0, 'min': 1, 'max': 2, 'count': 3}
     asc_to_int = {False: 0, True: 1}
-    assert format in format_to_int, "Invalid parameter value provided for format. Support: 'table', 'json'"
-    assert sort_by in sort_by_to_int, "Invalid parameter value provided for sort_by. Support: 'avg', 'min', 'max', 'count'"
-    assert  ascending in asc_to_int, "Invalid parameter value provided for ascending. Support: False, True"
-    assert  reset in reset_to_int, "Invalid parameter value provided for reset. Support: False, True"
+    assert format in format_to_int.keys(),\
+            "Invalid value provided for format: {0}. Support: 'table', 'json'".format(format)
+    assert sort_by in sort_by_to_int.keys(),\
+            "Invalid value provided for sort_by: {0}. Support: 'avg', 'min', 'max', 'count'"\
+            .format(sort_by)
+    assert  ascending in asc_to_int.keys(),\
+            "Invalid value provided for ascending: {0}. Support: False, True".format(ascending)
+    assert  reset in reset_to_int.keys(),\
+            "Invalid value provided for reset: {0}. Support: False, True".format(reset)
     check_call(_LIB.MXAggregateProfileStatsPrintEx(ctypes.byref(debug_str),
                                                    reset_to_int[reset],
                                                    format_to_int[format],

--- a/python/mxnet/profiler.py
+++ b/python/mxnet/profiler.py
@@ -158,11 +158,14 @@ def dumps(reset=False, format='table', sort_by='avg', ascending=False):
     format: string
         whether to return the aggregate stats in table of json format
         can take 'table' or 'json'
+        defaults to 'table'
     sort_by: string
         can take 'avg', 'min', 'max', or 'count'
         by which stat to sort the entries in each category
+        defaults to 'avg'
     ascending: boolean
         whether to sort ascendingly
+        defaults to False
     """
     debug_str = ctypes.c_char_p()
     reset_to_int = {False: 0, True: 1}

--- a/src/c_api/c_api_profile.cc
+++ b/src/c_api/c_api_profile.cc
@@ -327,6 +327,8 @@ int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format, 
         stats->DumpTable(os, sort_by, ascending);
       else if (static_cast<PrintFormat>(format) == PrintFormat::json)
         stats->DumpJson(os, sort_by, ascending);
+      else
+        LOG(FATAL) << "Invliad value for parameter format";
     }
     if (reset != 0)
       stats->clear();

--- a/src/c_api/c_api_profile.cc
+++ b/src/c_api/c_api_profile.cc
@@ -302,7 +302,11 @@ int MXSetProfilerConfig(int num_params, const char* const* keys, const char* con
   return MXSetProcessProfilerConfig(num_params, keys, vals, nullptr);
 }
 
-int MXAggregateProfileStatsPrint(const char **out_str, int reset, int format, int sort_by, int ascending) {
+int MXAggregateProfileStatsPrint(const char **out_str, int reset) {
+  return MXAggregateProfileStatsPrintEx(out_str, reset, 0, 0, 0);
+}
+
+int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format, int sort_by, int ascending) {
   MXAPIThreadLocalEntry *ret = MXAPIThreadLocalStore::Get();
   API_BEGIN();
     CHECK_NOTNULL(out_str);

--- a/src/c_api/c_api_profile.cc
+++ b/src/c_api/c_api_profile.cc
@@ -306,7 +306,8 @@ int MXAggregateProfileStatsPrint(const char **out_str, int reset) {
   return MXAggregateProfileStatsPrintEx(out_str, reset, 0, 0, 0);
 }
 
-int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format, int sort_by, int ascending) {
+int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format, int sort_by,
+                                  int ascending) {
   MXAPIThreadLocalEntry *ret = MXAPIThreadLocalStore::Get();
   API_BEGIN();
     CHECK_NOTNULL(out_str);

--- a/src/c_api/c_api_profile.cc
+++ b/src/c_api/c_api_profile.cc
@@ -302,7 +302,7 @@ int MXSetProfilerConfig(int num_params, const char* const* keys, const char* con
   return MXSetProcessProfilerConfig(num_params, keys, vals, nullptr);
 }
 
-int MXAggregateProfileStatsPrint(const char **out_str, int reset) {
+int MXAggregateProfileStatsPrint(const char **out_str, int reset, int format, int sort_by, int ascending) {
   MXAPIThreadLocalEntry *ret = MXAPIThreadLocalStore::Get();
   API_BEGIN();
     CHECK_NOTNULL(out_str);
@@ -314,8 +314,13 @@ int MXAggregateProfileStatsPrint(const char **out_str, int reset) {
     std::shared_ptr<profiler::AggregateStats> stats = profiler->GetAggregateStats();
     std::ostringstream os;
     if (stats) {
-      stats->Dump(os, reset != 0);
+      if (format == 0)
+        stats->DumpTable(os, sort_by, ascending);
+      else if (format == 1)
+        stats->DumpJson(os, sort_by, ascending);
     }
+    if (reset == 1)
+      stats->clear();
     ret->ret_str = os.str();
     *out_str = (ret->ret_str).c_str();
   API_END();

--- a/src/c_api/c_api_profile.cc
+++ b/src/c_api/c_api_profile.cc
@@ -198,6 +198,10 @@ enum class ProfileProcess {
   kWorker, kServer
 };
 
+enum class PrintFormat {
+  table, json
+};
+
 struct ProfileConfigParam : public dmlc::Parameter<ProfileConfigParam> {
   bool profile_all;
   bool profile_symbolic;
@@ -319,12 +323,12 @@ int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format, 
     std::shared_ptr<profiler::AggregateStats> stats = profiler->GetAggregateStats();
     std::ostringstream os;
     if (stats) {
-      if (format == 0)
+      if (static_cast<PrintFormat>(format) == PrintFormat::table)
         stats->DumpTable(os, sort_by, ascending);
-      else if (format == 1)
+      else if (static_cast<PrintFormat>(format) == PrintFormat::json)
         stats->DumpJson(os, sort_by, ascending);
     }
-    if (reset == 1)
+    if (reset != 0)
       stats->clear();
     ret->ret_str = os.str();
     *out_str = (ret->ret_str).c_str();

--- a/src/c_api/c_api_profile.cc
+++ b/src/c_api/c_api_profile.cc
@@ -328,7 +328,7 @@ int MXAggregateProfileStatsPrintEx(const char **out_str, int reset, int format, 
       else if (static_cast<PrintFormat>(format) == PrintFormat::json)
         stats->DumpJson(os, sort_by, ascending);
       else
-        LOG(FATAL) << "Invliad value for parameter format";
+        LOG(FATAL) << "Invalid value for parameter format";
     }
     if (reset != 0)
       stats->clear();

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -29,7 +29,7 @@
 #include <thread>
 #include <iomanip>
 #include <queue>
-#include <utility> 
+#include <utility>
 #include "./profiler.h"
 
 namespace mxnet {
@@ -56,10 +56,10 @@ inline std::priority_queue<pi>
     const AggregateStats::StatData &data = iter.second;
     double value = 0;
     switch (sort_by) {
-      case 0: 
+      case 0:
         if (data.type_ == AggregateStats::StatData::kCounter)
           value = (data.max_aggregate_ - data.min_aggregate_) / 2;
-        else 
+        else
           value = static_cast<double>(data.total_aggregate_)
                                 / data.total_count_;
         break;
@@ -75,7 +75,6 @@ inline std::priority_queue<pi>
     }
     if (ascending == 1)
       value = -value;
-    
     heap.push(std::make_pair(value, name));
   }
   return heap;
@@ -130,20 +129,14 @@ void AggregateStats::DumpTable(std::ostream& os, int sort_by, int ascending) {
         << "-------------"
         << std::endl;
     auto heap = BuildHeap(mm, sort_by, ascending);
-    while(!heap.empty()){
+    while (!heap.empty()) {
       const std::string& name = heap.top().second;
       const StatData &data = mm.at(name);
-      
-    // for (auto &it : mm) {
-    //   const std::string& name = it.first;
-    //   const StatData &data = it.second;
-    
       if (data.type_ == StatData::kDuration || data.type_ == StatData::kCounter) {
         os << std::setw(25) << std::left << name
-            << std::setw(16) << std::right << data.total_count_;
-        os << " "
-            << std::fixed << (is_memory ? std::setw(0) : std::setw(16))
-            << std::setprecision(4) << std::right;
+           << std::setw(16) << std::right << data.total_count_ << " "
+           << std::fixed << (is_memory ? std::setw(0) : std::setw(16))
+           << std::setprecision(4) << std::right;
         if (!is_memory)
           os << MicroToMilli(data.total_aggregate_) << " ";
         os << std::fixed << std::setw(16) << std::setprecision(4) << std::right
@@ -177,31 +170,41 @@ void AggregateStats::DumpJson(std::ostream& os, int sort_by, int ascending) {
     const std::unordered_map<std::string, StatData>& mm = stat.second;
     bool is_memory = (type == "Device Storage"  || type == "Pool Memory");
     ss = is_memory ? &memory_ss : &time_ss;
-    if (ss->tellp() != std::streampos(0)) 
+    if (ss->tellp() != std::streampos(0))
       *ss << "        ," << std::endl;
     *ss << "        \"" << type << "\": {" << std::endl;
     auto heap = BuildHeap(mm, sort_by, ascending);
     bool first_pass = true;
-    while(!heap.empty()){
+    while (!heap.empty()) {
       const std::string& name = heap.top().second;
       const StatData &data = mm.at(name);
-      if (data.type_ == AggregateStats::StatData::kDuration || 
+      if (data.type_ == AggregateStats::StatData::kDuration ||
           data.type_ == AggregateStats::StatData::kCounter) {
         if (!first_pass)
           *ss << "            ," << std::endl;
-        first_pass = false;   
+        first_pass = false;
         *ss << "            \"" << name << "\": {" << std::endl
-            << "                \"Count\": " << data.total_count_ << "," << std::endl;
+            << "                \"Count\": "
+            << data.total_count_
+            << "," << std::endl;
         if (!is_memory)
-          *ss << "                \"Total\": " << MicroToMilli(data.total_aggregate_) << "," << std::endl;
-        *ss << "                \"Min\": " << (is_memory ? ByteToKilobyte(data.min_aggregate_) : 
-                                              MicroToMilli(data.min_aggregate_)) 
+          *ss << "                \"Total\": "
+              << MicroToMilli(data.total_aggregate_)
+              << "," << std::endl;
+        *ss << "                \"Min\": " 
+            << (is_memory ?
+                ByteToKilobyte(data.min_aggregate_) :
+                MicroToMilli(data.min_aggregate_)) 
             << "," << std::endl
-            << "                \"Max\": " << (is_memory ? 
-                                              ByteToKilobyte(data.max_aggregate_) : MicroToMilli(data.max_aggregate_))
+            << "                \"Max\": "
+            << (is_memory ?
+                ByteToKilobyte(data.max_aggregate_) :
+                MicroToMilli(data.max_aggregate_))
             << "," << std::endl
-            << "                \"Avg\": " << (is_memory ? ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
-                                                          MicroToMilli(static_cast<double>(data.total_aggregate_) / data.total_count_)) 
+            << "                \"Avg\": "
+            << (is_memory ?
+                ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
+                MicroToMilli(static_cast<double>(data.total_aggregate_) / data.total_count_))
             << std::endl
             << "            }" << std::endl;
       }

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -73,7 +73,7 @@ inline std::priority_queue<pi>
         value = data.total_count_;
         break;
       default:
-        LOG(FATAL) << "Invliad value for parameter sort_by";
+        LOG(FATAL) << "Invalid value for parameter sort_by";
         break;
     }
     if (ascending != 0)

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -55,25 +55,25 @@ inline std::priority_queue<pi>
     const std::string& name = iter.first;
     const AggregateStats::StatData& data = iter.second;
     double value = 0;
-    switch (sort_by) {
-      case 0:
+    switch (static_cast<AggregateStats::SortBy>(sort_by)) {
+      case AggregateStats::SortBy::Avg:
         if (data.type_ == AggregateStats::StatData::kCounter)
           value = (data.max_aggregate_ - data.min_aggregate_) / 2;
         else
           value = static_cast<double>(data.total_aggregate_)
                                 / data.total_count_;
         break;
-      case 1:
+      case AggregateStats::SortBy::Min:
         value = data.min_aggregate_;
         break;
-      case 2:
+      case AggregateStats::SortBy::Max:
         value = data.max_aggregate_;
         break;
-      case 3:
+      case AggregateStats::SortBy::Count:
         value = data.total_count_;
         break;
     }
-    if (ascending == 1)
+    if (ascending != 0)
       value = -value;
     heap.push(std::make_pair(value, name));
   }
@@ -105,13 +105,13 @@ void AggregateStats::DumpTable(std::ostream& os, int sort_by, int ascending) {
         << (is_memory ? "" : "Time (ms)")
         << (is_memory ? "" : " ")
         << std::setw(16) << std::right
-        << (is_memory ? "Min Use  (kb)" : "Min Time (ms)")
+        << (is_memory ? "Min Use  (kB)" : "Min Time (ms)")
         << " "
         << std::setw(16) << std::right
-        << (is_memory ? "Max Use  (kb)" : "Max Time (ms)")
+        << (is_memory ? "Max Use  (kB)" : "Max Time (ms)")
         << " "
         << std::setw(16) << std::right
-        << (is_memory ? "Avg Use  (kb)" : "Avg Time (ms)")
+        << (is_memory ? "Avg Use  (kB)" : "Avg Time (ms)")
         << std::endl;
     os << std::setw(25) << std::left  << "----"
         << std::setw(16) << std::right << "-----------"
@@ -228,7 +228,7 @@ void AggregateStats::DumpJson(std::ostream& os, int sort_by, int ascending) {
      << "," << std::endl
      << "    \"Unit\": {" << std::endl
      << "        \"Time\": \"ms\"," << std::endl
-     << "        \"Memory\": \"kb\"" << std::endl
+     << "        \"Memory\": \"kB\"" << std::endl
      << "    }" << std::endl
      << "}" << std::endl
      << std::flush;

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -204,7 +204,7 @@ void AggregateStats::DumpJson(std::ostream& os, int sort_by, int ascending) {
             << "                \"Avg\": "
             << (is_memory ?
                 ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
-                MicroToMilli(static_cast<double>(data.total_aggregate_) / data.total_count_))
+                MicroToMilli(static_cast<double>(data.total_aggregate_) /  data.total_count_))
             << std::endl
             << "            }" << std::endl;
       }

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -146,7 +146,8 @@ void AggregateStats::DumpTable(std::ostream& os, int sort_by, int ascending) {
            << (is_memory ? ByteToKilobyte(data.max_aggregate_) : MicroToMilli(data.max_aggregate_))
            << " "
            << std::fixed << std::setw(16) << std::setprecision(4) << std::right
-           << (is_memory ? ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
+           << (data.type_ == AggregateStats::StatData::kCounter ?
+                    ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
                     MicroToMilli(static_cast<double>(data.total_aggregate_)/ data.total_count_));
         os << std::endl;
       }
@@ -202,9 +203,10 @@ void AggregateStats::DumpJson(std::ostream& os, int sort_by, int ascending) {
                 MicroToMilli(data.max_aggregate_))
             << "," << std::endl
             << "                \"Avg\": "
-            << (is_memory ?
-                ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
-                MicroToMilli(static_cast<double>(data.total_aggregate_) /  data.total_count_))
+            << std::setprecision(4)
+            << (data.type_ == AggregateStats::StatData::kCounter ?
+                 ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
+                 MicroToMilli(static_cast<double>(data.total_aggregate_) /  data.total_count_))
             << std::endl
             << "            }" << std::endl;
       }
@@ -223,7 +225,8 @@ void AggregateStats::DumpJson(std::ostream& os, int sort_by, int ascending) {
      << "," << std::endl
      << "    \"Unit\": {" << std::endl
      << "        \"Time\": \"ms\"," << std::endl
-     << "        \"Memory\": \"kb\"," << std::endl
+     << "        \"Memory\": \"kb\"" << std::endl
+     << "    }" << std::endl
      << "}" << std::endl
      << std::flush;
   os.copyfmt(state);

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -28,14 +28,57 @@
 #include <fstream>
 #include <thread>
 #include <iomanip>
+#include <queue>
+#include <utility> 
 #include "./profiler.h"
 
 namespace mxnet {
 namespace profiler {
 
+using pi = std::pair<double, std::string>;
+
 template<typename DType>
 inline float MicroToMilli(const DType micro) {
   return static_cast<float>(static_cast<double>(micro) / 1000);
+}
+
+template<typename DType>
+inline float ByteToKilobyte(const DType micro) {
+  return static_cast<float>(static_cast<double>(micro) / 100);
+}
+
+inline std::priority_queue<pi>
+  BuildHeap(const std::unordered_map<std::string, AggregateStats::StatData>& mm,
+            int sort_by, int ascending) {
+  std::priority_queue<pi> heap;
+  for (const auto& iter : mm) {
+    const std::string& name = iter.first;
+    const AggregateStats::StatData &data = iter.second;
+    double value;
+    switch (sort_by) {
+      case 0: 
+        if (data.type_ == AggregateStats::StatData::kCounter)
+          value = (data.max_aggregate_ - data.min_aggregate_) / 2;
+        else 
+          value = static_cast<double>(data.total_aggregate_)
+                                / data.total_count_;
+        break;
+      case 1:
+        value = data.min_aggregate_;
+        break;
+      case 2:
+        value = data.max_aggregate_;
+        break;
+      case 3:
+        value = data.total_count_;
+        break;
+    }
+    if (ascending == 1)
+      value = -value;
+    
+    heap.push(std::make_pair(value, name));
+  }
+  return heap;
 }
 
 void AggregateStats::OnProfileStat(const ProfileStat& stat) {
@@ -43,85 +86,143 @@ void AggregateStats::OnProfileStat(const ProfileStat& stat) {
   stat.SaveAggregate(&stats_[stat.categories_.c_str()][stat.name_.c_str()]);
 }
 
-void AggregateStats::Dump(std::ostream& os, bool clear) {
+void AggregateStats::DumpTable(std::ostream& os, int sort_by, int ascending) {
   std::ios state(nullptr);
   state.copyfmt(os);
   os << std::endl
-     << "Profile Statistics." << std::endl
-     << "\tNote that counter items are counter values and not time units."
+     << "Profile Statistics:" << std::endl
+     << "\tNote the difference in units for different entries."
      << std::endl;
   std::unique_lock<std::mutex> lk(m_);
   for (const auto& stat : stats_) {
     const std::string& type = stat.first;
     const std::unordered_map<std::string, StatData>& mm = stat.second;
-    if (!mm.empty()) {
-      os << type << std::endl << "=================" << std::endl;
-      os << std::setw(25) << std::left  << "Name"
-         << std::setw(16) << std::right << "Total Count"
-         << " "
-         << std::setw(16) << std::right
-         << "Time (ms)"
-         << " "
-         << std::setw(16) << std::right
-         << "Min Time (ms)"
-         << " "
-         << std::setw(16) << std::right
-         << "Max Time (ms)"
-         << " "
-         << std::setw(16) << std::right
-         << "Avg Time (ms)"
-         << std::endl;
-      os << std::setw(25) << std::left  << "----"
-         << std::setw(16) << std::right << "-----------"
-         << " "
-         << std::setw(16) << std::right
-         << "---------"
-         << " "
-         << std::setw(16) << std::right
-         << "-------------"
-         << " "
-         << std::setw(16) << std::right
-         << "-------------"
-         << " "
-         << std::setw(16) << std::right
-         << "-------------"
-         << std::endl;
-      for (const auto& iter : mm) {
-        const StatData &data = iter.second;
-        if (data.type_ == StatData::kDuration || data.type_ == StatData::kCounter) {
-          const std::string &name = iter.first;
-          os << std::setw(25) << std::left << name
-             << std::setw(16) << std::right << data.total_count_;
-          os << " "
-             << std::fixed << std::setw(16) << std::setprecision(4) << std::right
-             << MicroToMilli(data.total_aggregate_)
-             << " "
-             << std::fixed << std::setw(16) << std::setprecision(4) << std::right
-             << MicroToMilli(data.min_aggregate_)
-             << " "
-             << std::fixed << std::setw(16) << std::setprecision(4) << std::right
-             << MicroToMilli(data.max_aggregate_);
-          if (data.type_ == StatData::kCounter) {
-            os << " "
-               << std::fixed << std::setw(16) << std::setprecision(4) << std::right
-               << (MicroToMilli(data.max_aggregate_ - data.min_aggregate_) / 2);
-          } else {
-            os << " "
-               << std::fixed << std::setw(16) << std::setprecision(4) << std::right
-               << (MicroToMilli(static_cast<double>(data.total_aggregate_)
-                                / data.total_count_));
-          }
-          os << std::endl;
-        }
+    bool is_memory = (type == "Device Storage"  || type == "Pool Memory");
+    os << type << std::endl << "=================" << std::endl;
+    os << std::setw(25) << std::left  << "Name"
+        << std::setw(16) << std::right << "Total Count"
+        << " "
+        << (is_memory ? std::setw(0) : std::setw(16)) << std::right
+        << (is_memory ? "" : "Time (ms)")
+        << (is_memory ? "" : " ")
+        << std::setw(16) << std::right
+        << (is_memory ? "Min Use  (kb)" : "Min Time (ms)")
+        << " "
+        << std::setw(16) << std::right
+        << (is_memory ? "Max Use  (kb)" : "Max Time (ms)")
+        << " "
+        << std::setw(16) << std::right
+        << (is_memory ? "Avg Use  (kb)" : "Avg Time (ms)")
+        << std::endl;
+    os << std::setw(25) << std::left  << "----"
+        << std::setw(16) << std::right << "-----------"
+        << " "
+        << (is_memory ? std::setw(0) : std::setw(16)) << std::right
+        << (is_memory ? "" : "---------")
+        << (is_memory ? "" : " ")
+        << std::setw(16) << std::right
+        << "-------------"
+        << " "
+        << std::setw(16) << std::right
+        << "-------------"
+        << " "
+        << std::setw(16) << std::right
+        << "-------------"
+        << std::endl;
+    auto heap = BuildHeap(mm, sort_by, ascending);
+    while(!heap.empty()){
+      const std::string& name = heap.top().second;
+      const StatData &data = mm.at(name);
+      
+    // for (auto &it : mm) {
+    //   const std::string& name = it.first;
+    //   const StatData &data = it.second;
+    
+      if (data.type_ == StatData::kDuration || data.type_ == StatData::kCounter) {
+        os << std::setw(25) << std::left << name
+            << std::setw(16) << std::right << data.total_count_;
+        os << " "
+            << std::fixed << (is_memory ? std::setw(0) : std::setw(16)) << std::setprecision(4) << std::right;
+        if (!is_memory)
+          os << MicroToMilli(data.total_aggregate_) << " ";
+        os << std::fixed << std::setw(16) << std::setprecision(4) << std::right
+            << (is_memory ? ByteToKilobyte(data.min_aggregate_) : MicroToMilli(data.min_aggregate_))
+            << " "
+            << std::fixed << std::setw(16) << std::setprecision(4) << std::right
+            << (is_memory ? ByteToKilobyte(data.max_aggregate_) : MicroToMilli(data.max_aggregate_))
+            << " "
+            << std::fixed << std::setw(16) << std::setprecision(4) << std::right
+            << (is_memory ? ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
+                    MicroToMilli(static_cast<double>(data.total_aggregate_)/ data.total_count_));
+        os << std::endl;
+        heap.pop();
       }
-      os << std::endl;
     }
+    os << std::endl;
   }
   os << std::flush;
   os.copyfmt(state);
-  if (clear) {
-    stats_.clear();
+}
+
+void AggregateStats::DumpJson(std::ostream& os, int sort_by, int ascending) {
+  std::ios state(nullptr);
+  state.copyfmt(os);
+  std::unique_lock<std::mutex> lk(m_);
+  std::stringstream memory_ss;
+  std::stringstream time_ss;
+  std::stringstream *ss;
+  for (const auto& stat : stats_) {
+    const std::string& type = stat.first;
+    const std::unordered_map<std::string, StatData>& mm = stat.second;
+    bool is_memory = (type == "Device Storage"  || type == "Pool Memory");
+    ss = is_memory ? &memory_ss : &time_ss;
+    if (ss->tellp() != std::streampos(0)) 
+      *ss << "        ," << std::endl;
+    *ss << "        \"" << type << "\": {" << std::endl;
+    auto heap = BuildHeap(mm, sort_by, ascending);
+    bool first_pass = true;
+    while(!heap.empty()){
+      const std::string& name = heap.top().second;
+      const StatData &data = mm.at(name);
+      if (data.type_ == AggregateStats::StatData::kDuration || data.type_ == AggregateStats::StatData::kCounter) {
+        if (!first_pass) 
+          *ss << "            ," << std::endl;
+        first_pass = false;        
+        *ss << "            \"" << name << "\": {" << std::endl
+            << "                \"Count\": " << data.total_count_ << "," << std::endl;
+        if (!is_memory) 
+          *ss << "                \"Total\": " << MicroToMilli(data.total_aggregate_) << "," << std::endl;
+        *ss << "                \"Min\": " << (is_memory ? ByteToKilobyte(data.min_aggregate_) : MicroToMilli(data.min_aggregate_)) << "," << std::endl
+            << "                \"Max\": " << (is_memory ? ByteToKilobyte(data.max_aggregate_) : MicroToMilli(data.max_aggregate_)) << "," << std::endl
+            << "                \"Avg\": " << (is_memory ? ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
+                                                          MicroToMilli(static_cast<double>(data.total_aggregate_) / data.total_count_)) << std::endl
+
+            << "            }" << std::endl;
+      }
+      heap.pop();
+    }
+    *ss << "        }" << std::endl;
   }
+  os << "{" << std::endl
+     << "    \"Time\": {" << std::endl
+     << time_ss.str()
+     << "    }" << std::endl
+     << "    ," << std::endl
+     << "    \"Memory\": {" << std::endl
+     << memory_ss.str()
+     << "    }" << std::endl
+     << "," << std::endl
+     << "    \"Unit\": {" << std::endl
+     << "        \"Time\": \"ms\"," << std::endl
+     << "        \"Memory\": \"kb\"," << std::endl
+     << "}" << std::endl
+     << std::flush;
+  os.copyfmt(state);
+}
+
+void AggregateStats::clear() {
+  std::unique_lock<std::mutex> lk(m_);
+  stats_.clear();
 }
 
 }  // namespace profiler

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -191,10 +191,10 @@ void AggregateStats::DumpJson(std::ostream& os, int sort_by, int ascending) {
           *ss << "                \"Total\": "
               << MicroToMilli(data.total_aggregate_)
               << "," << std::endl;
-        *ss << "                \"Min\": " 
+        *ss << "                \"Min\": "
             << (is_memory ?
                 ByteToKilobyte(data.min_aggregate_) :
-                MicroToMilli(data.min_aggregate_)) 
+                MicroToMilli(data.min_aggregate_))
             << "," << std::endl
             << "                \"Max\": "
             << (is_memory ?

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -53,7 +53,7 @@ inline std::priority_queue<pi>
   std::priority_queue<pi> heap;
   for (const auto& iter : map) {
     const std::string& name = iter.first;
-    const AggregateStats::StatData &data = iter.second;
+    const AggregateStats::StatData& data = iter.second;
     double value = 0;
     switch (sort_by) {
       case 0:
@@ -190,19 +190,23 @@ void AggregateStats::DumpJson(std::ostream& os, int sort_by, int ascending) {
             << "," << std::endl;
         if (!is_memory)
           *ss << "                \"Total\": "
+              << std::setprecision(4)
               << MicroToMilli(data.total_aggregate_)
               << "," << std::endl;
         *ss << "                \"Min\": "
+            << std::setprecision(4)
             << (is_memory ?
                 ByteToKilobyte(data.min_aggregate_) :
                 MicroToMilli(data.min_aggregate_))
             << "," << std::endl
             << "                \"Max\": "
+            << std::setprecision(4)
             << (is_memory ?
                 ByteToKilobyte(data.max_aggregate_) :
                 MicroToMilli(data.max_aggregate_))
             << "," << std::endl
             << "                \"Avg\": "
+            << std::setprecision(4)
             << (data.type_ == AggregateStats::StatData::kCounter ?
                  ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
                  MicroToMilli(static_cast<double>(data.total_aggregate_) /  data.total_count_))

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -203,7 +203,6 @@ void AggregateStats::DumpJson(std::ostream& os, int sort_by, int ascending) {
                 MicroToMilli(data.max_aggregate_))
             << "," << std::endl
             << "                \"Avg\": "
-            << std::setprecision(4)
             << (data.type_ == AggregateStats::StatData::kCounter ?
                  ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
                  MicroToMilli(static_cast<double>(data.total_aggregate_) /  data.total_count_))

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -54,7 +54,7 @@ inline std::priority_queue<pi>
   for (const auto& iter : mm) {
     const std::string& name = iter.first;
     const AggregateStats::StatData &data = iter.second;
-    double value;
+    double value = 0;
     switch (sort_by) {
       case 0: 
         if (data.type_ == AggregateStats::StatData::kCounter)
@@ -142,17 +142,18 @@ void AggregateStats::DumpTable(std::ostream& os, int sort_by, int ascending) {
         os << std::setw(25) << std::left << name
             << std::setw(16) << std::right << data.total_count_;
         os << " "
-            << std::fixed << (is_memory ? std::setw(0) : std::setw(16)) << std::setprecision(4) << std::right;
+            << std::fixed << (is_memory ? std::setw(0) : std::setw(16))
+            << std::setprecision(4) << std::right;
         if (!is_memory)
           os << MicroToMilli(data.total_aggregate_) << " ";
         os << std::fixed << std::setw(16) << std::setprecision(4) << std::right
-            << (is_memory ? ByteToKilobyte(data.min_aggregate_) : MicroToMilli(data.min_aggregate_))
-            << " "
-            << std::fixed << std::setw(16) << std::setprecision(4) << std::right
-            << (is_memory ? ByteToKilobyte(data.max_aggregate_) : MicroToMilli(data.max_aggregate_))
-            << " "
-            << std::fixed << std::setw(16) << std::setprecision(4) << std::right
-            << (is_memory ? ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
+           << (is_memory ? ByteToKilobyte(data.min_aggregate_) : MicroToMilli(data.min_aggregate_))
+           << " "
+           << std::fixed << std::setw(16) << std::setprecision(4) << std::right
+           << (is_memory ? ByteToKilobyte(data.max_aggregate_) : MicroToMilli(data.max_aggregate_))
+           << " "
+           << std::fixed << std::setw(16) << std::setprecision(4) << std::right
+           << (is_memory ? ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
                     MicroToMilli(static_cast<double>(data.total_aggregate_)/ data.total_count_));
         os << std::endl;
         heap.pop();
@@ -184,19 +185,24 @@ void AggregateStats::DumpJson(std::ostream& os, int sort_by, int ascending) {
     while(!heap.empty()){
       const std::string& name = heap.top().second;
       const StatData &data = mm.at(name);
-      if (data.type_ == AggregateStats::StatData::kDuration || data.type_ == AggregateStats::StatData::kCounter) {
-        if (!first_pass) 
+      if (data.type_ == AggregateStats::StatData::kDuration || 
+          data.type_ == AggregateStats::StatData::kCounter) {
+        if (!first_pass)
           *ss << "            ," << std::endl;
-        first_pass = false;        
+        first_pass = false;   
         *ss << "            \"" << name << "\": {" << std::endl
             << "                \"Count\": " << data.total_count_ << "," << std::endl;
-        if (!is_memory) 
+        if (!is_memory)
           *ss << "                \"Total\": " << MicroToMilli(data.total_aggregate_) << "," << std::endl;
-        *ss << "                \"Min\": " << (is_memory ? ByteToKilobyte(data.min_aggregate_) : MicroToMilli(data.min_aggregate_)) << "," << std::endl
-            << "                \"Max\": " << (is_memory ? ByteToKilobyte(data.max_aggregate_) : MicroToMilli(data.max_aggregate_)) << "," << std::endl
+        *ss << "                \"Min\": " << (is_memory ? ByteToKilobyte(data.min_aggregate_) : 
+                                              MicroToMilli(data.min_aggregate_)) 
+            << "," << std::endl
+            << "                \"Max\": " << (is_memory ? 
+                                              ByteToKilobyte(data.max_aggregate_) : MicroToMilli(data.max_aggregate_))
+            << "," << std::endl
             << "                \"Avg\": " << (is_memory ? ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
-                                                          MicroToMilli(static_cast<double>(data.total_aggregate_) / data.total_count_)) << std::endl
-
+                                                          MicroToMilli(static_cast<double>(data.total_aggregate_) / data.total_count_)) 
+            << std::endl
             << "            }" << std::endl;
       }
       heap.pop();

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -43,8 +43,8 @@ inline float MicroToMilli(const DType micro) {
 }
 
 template<typename DType>
-inline float ByteToKilobyte(const DType micro) {
-  return static_cast<float>(static_cast<double>(micro) / 1000);
+inline float ByteToKilobyte(const DType byte) {
+  return static_cast<float>(static_cast<double>(byte) / 1000);
 }
 
 inline std::priority_queue<pi>

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -44,14 +44,14 @@ inline float MicroToMilli(const DType micro) {
 
 template<typename DType>
 inline float ByteToKilobyte(const DType micro) {
-  return static_cast<float>(static_cast<double>(micro) / 100);
+  return static_cast<float>(static_cast<double>(micro) / 1000);
 }
 
 inline std::priority_queue<pi>
-  BuildHeap(const std::unordered_map<std::string, AggregateStats::StatData>& mm,
+  BuildHeap(const std::unordered_map<std::string, AggregateStats::StatData>& map,
             int sort_by, int ascending) {
   std::priority_queue<pi> heap;
-  for (const auto& iter : mm) {
+  for (const auto& iter : map) {
     const std::string& name = iter.first;
     const AggregateStats::StatData &data = iter.second;
     double value = 0;

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -149,8 +149,8 @@ void AggregateStats::DumpTable(std::ostream& os, int sort_by, int ascending) {
            << (is_memory ? ByteToKilobyte((data.max_aggregate_ - data.min_aggregate_) / 2) :
                     MicroToMilli(static_cast<double>(data.total_aggregate_)/ data.total_count_));
         os << std::endl;
-        heap.pop();
       }
+      heap.pop();
     }
     os << std::endl;
   }

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -72,6 +72,9 @@ inline std::priority_queue<pi>
       case AggregateStats::SortBy::Count:
         value = data.total_count_;
         break;
+      default:
+        LOG(FATAL) << "Invliad value for parameter sort_by";
+        break;
     }
     if (ascending != 0)
       value = -value;

--- a/src/profiler/aggregate_stats.h
+++ b/src/profiler/aggregate_stats.h
@@ -76,7 +76,7 @@ class AggregateStats {
   enum class SortBy {
     Avg, Min, Max, Count
   };
-  
+
  private:
   /*! \brief Should rarely collide, so most locks should occur only in user-space (futex) */
   std::mutex m_;

--- a/src/profiler/aggregate_stats.h
+++ b/src/profiler/aggregate_stats.h
@@ -57,13 +57,13 @@ class AggregateStats {
    */
   void OnProfileStat(const ProfileStat& stat);
   /*!
-   * \brief Print profliing statistics to console in a tabular fasion
+   * \brief Print profliing statistics to console in a tabular format
    * \param sort_by by which stat to sort the entries, can be "avg", "min", "max", or "count"
    * \param ascending whether to sort ascendingly
    */
   void DumpTable(std::ostream& os, int sort_by, int ascending);
   /*!
-   * \brief Print profliing statistics to console in json
+   * \brief Print profliing statistics to console in json format
    *    * \param sort_by by which stat to sort the entries, can be "avg", "min", "max", or "count"
    * \param ascending whether to sort ascendingly
    */
@@ -72,19 +72,15 @@ class AggregateStats {
    * \brief Delete all of the current statistics
    */
   void clear();
-
+  /* !\brief by which stat to sort */
+  enum class SortBy {
+    Avg, Min, Max, Count
+  };
  private:
   /*! \brief Should rarely collide, so most locks should occur only in user-space (futex) */
   std::mutex m_;
   /* !\brief Stat type -> State name -> Stats */
   std::map<std::string, std::unordered_map<std::string, StatData>> stats_;
-  // /* !\brief Sort by which stat */
-  // enum SortBy{
-  //   avg = 0,
-  //   min = 1,
-  //   max = 2,
-  //   count = 3
-  // };
 };
 
 }  // namespace profiler

--- a/src/profiler/aggregate_stats.h
+++ b/src/profiler/aggregate_stats.h
@@ -58,11 +58,14 @@ class AggregateStats {
   void OnProfileStat(const ProfileStat& stat);
   /*!
    * \brief Print profliing statistics to console in a tabular fasion
-   * \param clear Delete all of the current statistics after printing
+   * \param sort_by by which stat to sort the entries, can be "avg", "min", "max", or "count"
+   * \param ascending whether to sort ascendingly
    */
   void DumpTable(std::ostream& os, int sort_by, int ascending);
   /*!
    * \brief Print profliing statistics to console in json
+   *    * \param sort_by by which stat to sort the entries, can be "avg", "min", "max", or "count"
+   * \param ascending whether to sort ascendingly
    */
   void DumpJson(std::ostream& os, int sort_by, int ascending);
   /*!

--- a/src/profiler/aggregate_stats.h
+++ b/src/profiler/aggregate_stats.h
@@ -57,16 +57,31 @@ class AggregateStats {
    */
   void OnProfileStat(const ProfileStat& stat);
   /*!
-   * \brief Print profliing statistics to console
+   * \brief Print profliing statistics to console in a tabular fasion
    * \param clear Delete all of the current statistics after printing
    */
-  void Dump(std::ostream& os, bool clear);
+  void DumpTable(std::ostream& os, int sort_by, int ascending);
+  /*!
+   * \brief Print profliing statistics to console in json
+   */
+  void DumpJson(std::ostream& os, int sort_by, int ascending);
+  /*!
+   * \brief Delete all of the current statistics
+   */
+  void clear();
 
  private:
   /*! \brief Should rarely collide, so most locks should occur only in user-space (futex) */
   std::mutex m_;
   /* !\brief Stat type -> State name -> Stats */
   std::map<std::string, std::unordered_map<std::string, StatData>> stats_;
+  // /* !\brief Sort by which stat */
+  // enum SortBy{
+  //   avg = 0,
+  //   min = 1,
+  //   max = 2,
+  //   count = 3
+  // };
 };
 
 }  // namespace profiler

--- a/src/profiler/aggregate_stats.h
+++ b/src/profiler/aggregate_stats.h
@@ -76,6 +76,7 @@ class AggregateStats {
   enum class SortBy {
     Avg, Min, Max, Count
   };
+  
  private:
   /*! \brief Should rarely collide, so most locks should occur only in user-space (futex) */
   std::mutex m_;

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -241,7 +241,6 @@ def test_aggregate_stats_valid_json_return():
     debug_str = profiler.dumps(format = 'json')
     assert(len(debug_str) > 0)
     target_dict = json.loads(debug_str)
-    print(target_dict)
     assert "Memory" in target_dict and "Time" in target_dict and "Unit" in target_dict
     profiler.set_state('stop')
 

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -240,11 +240,9 @@ def test_aggregate_stats_valid_json_return():
     test_profile_event(False)
     debug_str = profiler.dumps(format = 'json')
     assert(len(debug_str) > 0)
-    print(debug_str)
-    # try:
     target_dict = json.loads(debug_str)
-    # except:
-    # print("Invalid json string")
+    print(target_dict)
+    assert "Memory" in target_dict and "Time" in target_dict and "Unit" in target_dict
     profiler.set_state('stop')
 
 def test_aggregate_stats_sorting():

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -249,7 +249,6 @@ def test_aggregate_stats_sorting():
     sort_by_options = {'avg': "Avg", 'min': "Min", 'max': "Max", 'count': "Count"}
     ascending_options = [False, True]
     def check_ascending(lst, asc):
-        print(lst, sorted(lst, reverse = not asc))
         assert(lst == sorted(lst, reverse = not asc))
 
     def check_sorting(debug_str, sort_by, ascending):
@@ -268,8 +267,6 @@ def test_aggregate_stats_sorting():
     for sb in sort_by_options:
         for asc in ascending_options:
             debug_str = profiler.dumps(format = 'json', sort_by = sb, ascending = asc)
-            print(debug_str)
-            print(sb, asc)
             check_sorting(debug_str, sb, asc)
     profiler.set_state('stop')
 

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -253,7 +253,10 @@ def test_aggregate_stats_sorting():
     def check_sorting(str, sb, asc):
         target_dict = json.loads(debug_str)
         lst = []
-        for domain_name, domain in {**target_dict['Time'], **target_dict['Memory']}.items():
+        for domain_name, domain in target_dict['Time'].items():
+            lst = [item[sort_by_options[sb]] for item_name, item in domain.items()]
+            check_ascending(lst, asc)
+        for domain_name, domain in target_dict['Memory'].items():
             lst = [item[sort_by_options[sb]] for item_name, item in domain.items()]
             check_ascending(lst, asc)
 

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -240,8 +240,10 @@ def test_aggregate_stats_valid_json_return():
     debug_str = profiler.dumps(format = 'json')
     assert(len(debug_str) > 0)
     print(debug_str)
-    # if the format is wrong, an exception will be thrown
+    # try:
     target_dict = json.loads(debug_str)
+    # except:
+    # print("Invalid json string")
     profiler.set_state('stop')
 
 def test_aggregate_stats_sorting():
@@ -267,6 +269,8 @@ def test_aggregate_stats_sorting():
     for sb in sort_by_options:
         for asc in ascending_options:
             debug_str = profiler.dumps(format = 'json', sort_by = sb, ascending = asc)
+            print(debug_str)
+            print(sb, asc)
             check_sorting(debug_str, sb, asc)
     profiler.set_state('stop')
 

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -248,17 +248,18 @@ def test_aggregate_stats_sorting():
     sort_by_options = {'avg': "Avg", 'min': "Min", 'max': "Max", 'count': "Count"}
     ascending_options = [False, True]
     def check_ascending(lst, asc):
+        print(lst, sorted(lst, reverse = not asc))
         assert(lst == sorted(lst, reverse = not asc))
 
-    def check_sorting(str, sb, asc):
+    def check_sorting(debug_str, sort_by, ascending):
         target_dict = json.loads(debug_str)
         lst = []
         for domain_name, domain in target_dict['Time'].items():
-            lst = [item[sort_by_options[sb]] for item_name, item in domain.items()]
-            check_ascending(lst, asc)
+            lst = [item[sort_by_options[sort_by]] for item_name, item in domain.items()]
+            check_ascending(lst, ascending)
         for domain_name, domain in target_dict['Memory'].items():
-            lst = [item[sort_by_options[sb]] for item_name, item in domain.items()]
-            check_ascending(lst, asc)
+            lst = [item[sort_by_options[sort_by]] for item_name, item in domain.items()]
+            check_ascending(lst, ascending)
 
     file_name = 'test_aggregate_stats_sorting.json'
     enable_profiler(file_name, True, True, True)

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -22,6 +22,7 @@ from mxnet import profiler
 import time
 import os
 import json
+from collections import OrderedDict
 
 def enable_profiler(profile_filename, run=True, continuous_dump=False, aggregate_stats=False):
     profiler.set_config(profile_symbolic=True,
@@ -254,7 +255,7 @@ def test_aggregate_stats_sorting():
         assert(lst == sorted(lst, reverse = not asc))
 
     def check_sorting(debug_str, sort_by, ascending):
-        target_dict = json.loads(debug_str)
+        target_dict = json.loads(debug_str, object_pairs_hook=OrderedDict)
         lst = []
         for domain_name, domain in target_dict['Time'].items():
             lst = [item[sort_by_options[sort_by]] for item_name, item in domain.items()]


### PR DESCRIPTION
## Description ##
This is the work in progress of the changes discussed in https://github.com/apache/incubator-mxnet/issues/15069. In stead of the original design which is to add a new api, get_summary(), to return the aggregate stats in JSON, I added a few parameters to the existing dumps().

Now dumps() (MXAggregateProfileStatsPrint) supports new parameters: format which controls the return string format, sort_by which specifies by which stat should the entries be sorted, and ascending which specify whether to sort ascendingly.

New api reset() is removed from the original proposal.
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] adding parameters to dumps()
