### PR TITLE
fix nightly

### DIFF
--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -90,7 +90,7 @@ core_logic: {
       node(NODE_LINUX_GPU) {
         ws('workspace/large_tensor-gpu') {
             utils.unpack_and_init('gpu_int64', mx_cmake_lib)
-            utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_large_tensor', true)
+            utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_large_tensor', true, '10G')
         }
       }
     },
@@ -127,7 +127,7 @@ core_logic: {
       }
     },
     'Tutorial: Python2': {
-      node(NODE_LINUX_GPU) {
+      node(NODE_LINUX_GPU_P3) {
         ws('workspace/tutorial-test-python2') {
           utils.unpack_and_init('gpu', mx_lib)
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_tutorial_test_ubuntu_python2_gpu', true, '1500m')
@@ -135,7 +135,7 @@ core_logic: {
       }
     },
     'Tutorial: Python3': {
-      node(NODE_LINUX_GPU) {
+      node(NODE_LINUX_GPU_P3) {
         ws('workspace/tutorial-test-python3') {
           utils.unpack_and_init('gpu', mx_lib)
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_tutorial_test_ubuntu_python3_gpu', true, '1500m')

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -86,7 +86,7 @@ core_logic: {
         }
       }
     },*/
-    // https://github.com/apache/incubator-mxnet/issues/14980
+    // https://github.com/apache/incubator-mxnet/issues/14981
     /*'Test Large Tensor Size: GPU': {
       node(NODE_LINUX_GPU) {
         ws('workspace/large_tensor-gpu') {

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -86,14 +86,15 @@ core_logic: {
         }
       }
     },*/
-    'Test Large Tensor Size: GPU': {
+    // https://github.com/apache/incubator-mxnet/issues/14980
+    /*'Test Large Tensor Size: GPU': {
       node(NODE_LINUX_GPU) {
         ws('workspace/large_tensor-gpu') {
             utils.unpack_and_init('gpu_int64', mx_cmake_lib)
-            utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_large_tensor', true, '10G')
+            utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_large_tensor', true)
         }
       }
-    },
+    },*/
     'StraightDope: Python2 Single-GPU': {
       node(NODE_LINUX_GPU_P3) {
         ws('workspace/straight_dope-single_gpu') {


### PR DESCRIPTION
## Description ##
Fix nightly test failure: http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/NightlyTestsForBinaries/detail/master/333/pipeline/143
 
1. large tensor requires more shared memory (docker OOM)-> increase size to 10G
2. tutorial test requires more GPU memory (cuda malloc OOM) -> change to P3 instances with larger GPU memory

We should really enforece nightly test to run for PRs changing nightly tests.
Fixing it afterwards take long time for contributors not familiar with CI
