### PR TITLE
Fix Misspell in Profiler

### DIFF
--- a/python/mxnet/profiler.py
+++ b/python/mxnet/profiler.py
@@ -47,7 +47,7 @@ def set_config(**kwargs):
         whether to profile memory usage
     profile_api : boolean,
         whether to profile the C API
-    contiguous_dump : boolean,
+    continuous_dump : boolean,
         whether to periodically dump profiling data to file
     dump_period : float,
         seconds between profile data dumps


### PR DESCRIPTION
## Description ##
In python/mxnet/profiler.py parameter "continuous_dump" of function set_config() was spelled wrong as "contiguous_dump". This PR fixes it.
