### PR TITLE
fix kvstore nightly failure

### DIFF
--- a/docs/tutorials/python/kvstore.md
+++ b/docs/tutorials/python/kvstore.md
@@ -54,7 +54,7 @@ print(a.asnumpy())
 The data for pushing can be stored on any device. Furthermore, you can push multiple
 values into the same key, where KVStore will first sum all of these
 values and then push the aggregated value. Here we will just demonstrate pushing a list of values on CPU.
-Please note when the sum will only happen if length of the value list is larger than 1.
+Please note summation only happens if the value list is longer than one
 
 ```python
 contexts = [mx.cpu(i) for i in range(4)]

--- a/docs/tutorials/python/kvstore.md
+++ b/docs/tutorials/python/kvstore.md
@@ -75,9 +75,9 @@ For each push, KVStore combines the pushed value with the value stored using an
 control how data is merged:
 
 ```python
-def update(key, input, stored):
+def update(key, value, stored):
     print("update on key: %d" % key)
-    stored += input * 2
+    stored += value * 2
 kv._set_updater(update)
 kv.pull(3, out=a)
 print(a.asnumpy())
@@ -86,7 +86,7 @@ print(a.asnumpy())
 `[[ 4.  4.  4.],[ 4.  4.  4.]]`<!--notebook-skip-line-->
 
 ```python
-kv.push(3, mx.nd.ones(shape))
+kv.push(3, mx.nd.ones(shape, mx.gpu(0)))
 #
 kv.pull(3, out=a)
 print(a.asnumpy())

--- a/docs/tutorials/python/kvstore.md
+++ b/docs/tutorials/python/kvstore.md
@@ -53,15 +53,11 @@ print(a.asnumpy())
 
 The data for pushing can be stored on any device. Furthermore, you can push multiple
 values into the same key, where KVStore will first sum all of these
-values and then push the aggregated value:
+values and then push the aggregated value. Here we will just demonstrate pushing a list of values on CPU.
+Please note when the sum will only happen if length of the value list is larger than 1.
 
 ```python
-# The numbers used below assume 4 GPUs
-gpus = mx.context.num_gpus()
-if gpus > 0:
-    contexts = [mx.gpu(i) for i in range(gpus)]
-else:
-    contexts = [mx.cpu(i) for i in range(4)]
+contexts = [mx.cpu(i) for i in range(4)]
 b = [mx.nd.ones(shape, ctx) for ctx in contexts]
 kv.push(3, b)
 kv.pull(3, out = a)
@@ -86,8 +82,7 @@ print(a.asnumpy())
 `[[ 4.  4.  4.],[ 4.  4.  4.]]`<!--notebook-skip-line-->
 
 ```python
-kv.push(3, mx.nd.ones(shape, contexts[0]))
-#
+kv.push(3, mx.nd.ones(shape))
 kv.pull(3, out=a)
 print(a.asnumpy())
 ```

--- a/docs/tutorials/python/kvstore.md
+++ b/docs/tutorials/python/kvstore.md
@@ -75,9 +75,9 @@ For each push, KVStore combines the pushed value with the value stored using an
 control how data is merged:
 
 ```python
-def update(key, value, stored):
+def update(key, input, stored):
     print("update on key: %d" % key)
-    stored += value * 2
+    stored += input * 2
 kv._set_updater(update)
 kv.pull(3, out=a)
 print(a.asnumpy())
@@ -86,7 +86,7 @@ print(a.asnumpy())
 `[[ 4.  4.  4.],[ 4.  4.  4.]]`<!--notebook-skip-line-->
 
 ```python
-kv.push(3, mx.nd.ones(shape, mx.gpu(0)))
+kv.push(3, mx.nd.ones(shape, contexts[0]))
 #
 kv.pull(3, out=a)
 print(a.asnumpy())


### PR DESCRIPTION
## Description ##
fix https://github.com/apache/incubator-mxnet/issues/15152

**In summary:**
root cause of failure is num of GPUs changed from 2 to 1. NODE_LINUX_GPU is G3.8x wiht 2 GPUs and NODE_LINUX_GPU_P3 is P3.2x with 1 GPU

so

contexts =[mx.gpu(0), mx.gpu(1)]  ->  [mx.gpu(0)] 
b length changed from 2 to 1
b = [mx.nd.ones(shape, ctx) for ctx in contexts]

It seems in kvstore, when pushing a list, only len list lenght >1 , aggregation happens, and everything will be on the same context during update. But when lenght = 1, the sum/aggregation won't happen, causing update with ndarray on different context failed. User should make sure ndarrays are on the same device.

more details and reproduciable code at https://github.com/apache/incubator-mxnet/issues/15152#issuecomment-499193612
