### PR TITLE
Softmax with length

### DIFF
--- a/src/operator/mxnet_op.h
+++ b/src/operator/mxnet_op.h
@@ -363,6 +363,57 @@ inline int get_num_threads<cpu>(const int N) {
     LOG(FATAL) << "Unknown type enum " << type;            \
   }
 
+#define MXNET_INT_TYPE_SWITCH(type, DType, ...)\
+  switch (type) {                                          \
+  case mshadow::kFloat32:                                  \
+    {                                                      \
+      typedef float DType;                                 \
+      LOG(FATAL) << "This operation only support "         \
+                    "integer types, not float32";          \
+    }                                                      \
+    break;                                                 \
+  case mshadow::kFloat64:                                  \
+    {                                                      \
+      typedef double DType;                                \
+      LOG(FATAL) << "This operation only support "         \
+                    "integer types, not float64";          \
+    }                                                      \
+    break;                                                 \
+  case mshadow::kFloat16:                                  \
+    {                                                      \
+      typedef mshadow::half::half_t DType;                 \
+      LOG(FATAL) << "This operation only support "         \
+                    "integer types, not float16";          \
+    }                                                      \
+    break;                                                 \
+  case mshadow::kUint8:                                    \
+    {                                                      \
+      typedef uint8_t DType;                               \
+      {__VA_ARGS__}                                        \
+    }                                                      \
+    break;                                                 \
+  case mshadow::kInt8:                                     \
+    {                                                      \
+      typedef int8_t DType;                                \
+      {__VA_ARGS__}                                        \
+    }                                                      \
+    break;                                                 \
+  case mshadow::kInt32:                                    \
+    {                                                      \
+      typedef int32_t DType;                               \
+      {__VA_ARGS__}                                        \
+    }                                                      \
+    break;                                                 \
+  case mshadow::kInt64:                                    \
+    {                                                      \
+      typedef int64_t DType;                               \
+      {__VA_ARGS__}                                        \
+    }                                                      \
+    break;                                                 \
+  default:                                                 \
+    LOG(FATAL) << "Unknown type enum " << type;            \
+  }
+
 /*!
  * \brief assign the val to out according
  * to request in Kernel::Launch

--- a/src/operator/nn/softmax-inl.h
+++ b/src/operator/nn/softmax-inl.h
@@ -521,7 +521,7 @@ struct SoftmaxParam : public dmlc::Parameter<SoftmaxParam> {
     .describe("DType of the output in case this can't be inferred. "
               "Defaults to the same as input's dtype if not defined (dtype=None).");
     DMLC_DECLARE_FIELD(use_length)
-    .set_default(dmlc::optional<bool>())
+    .set_default(dmlc::optional<bool>(false))
     .describe("Whether to use the length input as a mask over the data input.");
   }
 };
@@ -721,7 +721,7 @@ void SoftmaxCompute(const nnvm::NodeAttrs& attrs,
           }
         }
       } else {
-        MSHADOW_TYPE_SWITCH(inputs[1].type_flag_, IType, {
+        MXNET_INT_TYPE_SWITCH(inputs[1].type_flag_, IType, {
           if (shape.ndim() == 2) {
             SoftmaxWithLength<OP, negate, AType>(
               ctx.get_stream<xpu>(), inputs[0].dptr<DType>(),
@@ -788,7 +788,7 @@ void SoftmaxGradCompute(const nnvm::NodeAttrs& attrs,
             }
           }
         } else {
-          MSHADOW_TYPE_SWITCH(inputs[2].type_flag_, IType, {
+          MXNET_INT_TYPE_SWITCH(inputs[2].type_flag_, IType, {
             if (req[1] != kNullOp) {
               mxnet_op::Kernel<mxnet_op::set_zero, xpu>::Launch(
                 ctx.get_stream<xpu>(), outputs[1].Size(), outputs[1].dptr<IType>());

--- a/src/operator/nn/softmax.cc
+++ b/src/operator/nn/softmax.cc
@@ -118,8 +118,8 @@ Example::
 .set_attr<FComputeEx>("FComputeEx<cpu>", SoftmaxComputeExCPU)
 .set_attr<FInferStorageType>("FInferStorageType", SoftmaxStorageType)
 #endif
-// .set_attr<nnvm::FGradient>("FGradient", SoftmaxFGradient{"_backward_softmax"})
-.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+.set_attr<nnvm::FGradient>("FGradient", SoftmaxFGradient{"_backward_softmax"})
+// .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
 .set_attr<nnvm::FInferType>("FInferType", SoftmaxOpType)
 .set_num_inputs([](const nnvm::NodeAttrs& attrs) {
     const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
@@ -137,7 +137,9 @@ Example::
 
 NNVM_REGISTER_OP(_backward_softmax)
 .set_num_inputs(SoftmaxGradOpNumInputs)
-.set_num_outputs(1)
+.set_num_outputs([](const nnvm::NodeAttrs& attrs) {
+    return (softmax_use_length(attrs) ? 2 : 1);
+  })
 .set_attr<nnvm::FListInputNames>("FListInputNames", SoftmaxGradOpInputNames)
 .set_attr<mxnet::FInferShape>("FInferShape", SoftmaxGradOpShape)
 .set_attr<nnvm::FInferType>("FInferType", SoftmaxGradOpType)

--- a/src/operator/nn/softmax.cc
+++ b/src/operator/nn/softmax.cc
@@ -59,13 +59,22 @@ inline static bool SoftmaxStorageType(const nnvm::NodeAttrs& attrs,
                                       DispatchMode* dispatch_mode,
                                       std::vector<int> *in_attrs,
                                       std::vector<int> *out_attrs) {
-  CHECK_EQ(in_attrs->size(), 1);
-  CHECK_EQ(out_attrs->size(), 1);
+  const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
+  CHECK_EQ(in_attrs->size(), (param.use_length.value()) ? 2U : 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+
+  if (param.use_length.value()) {
+    auto& out_stype = out_attrs->at(0);
+    return storage_type_assign(&out_stype, kDefaultStorage,
+                               dispatch_mode, DispatchMode::kFCompute);
+  }
 
   return MKLDNNStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs,
                            out_attrs);
 }
 #endif
+
+
 
 NNVM_REGISTER_OP(softmax)
 .describe(R"code(Applies the softmax function.
@@ -92,6 +101,13 @@ Example::
 
 )code" ADD_FILELINE)
 .set_attr_parser(ParamParser<SoftmaxParam>)
+.set_attr<nnvm::FListOutputNames>("FListInputNames",
+    [](const NodeAttrs& attrs){
+    const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
+    return (param.use_length.value()) ?
+           std::vector<std::string>{"data", "length"} :
+           std::vector<std::string>{"data"};
+})
 .set_attr<nnvm::FListOutputNames>("FListOutputNames",
     [](const NodeAttrs& attrs) {
     return std::vector<std::string>{"output"};
@@ -102,16 +118,21 @@ Example::
 .set_attr<FComputeEx>("FComputeEx<cpu>", SoftmaxComputeExCPU)
 .set_attr<FInferStorageType>("FInferStorageType", SoftmaxStorageType)
 #endif
-.set_attr<nnvm::FGradient>("FGradient", SoftmaxFGradient{"_backward_softmax"})
+// .set_attr<nnvm::FGradient>("FGradient", SoftmaxFGradient{"_backward_softmax"})
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
 .set_attr<nnvm::FInferType>("FInferType", SoftmaxOpType)
-.set_num_inputs(1)
+.set_num_inputs([](const nnvm::NodeAttrs& attrs) {
+    const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
+    return (param.use_length.value()) ? 2 : 1;
+  })
 .set_num_outputs(1)
-.set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
+.set_attr<mxnet::FInferShape>("FInferShape", SoftmaxOpShape)
 .set_attr<nnvm::FInplaceOption>("FInplaceOption",
   [](const NodeAttrs& attrs){
     return std::vector<std::pair<int, int> >{{0, 0}};
   })
 .add_argument("data", "NDArray-or-Symbol", "The input array.")
+.add_argument("length", "NDArray-or-Symbol", "The length array.")
 .add_arguments(SoftmaxParam::__FIELDS__());
 
 NNVM_REGISTER_OP(_backward_softmax)

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -5125,7 +5125,7 @@ def test_softmax_with_length():
         mx_data = rand_ndarray(shape, dtype=dtype)
         np_data = mx_data.asnumpy()
         np_length = np.random.randint(1, shape[1] + 1, len_shape)
-        mx_length = mx.nd.array(np_length)
+        mx_length = mx.nd.array(np_length, dtype=dtype)
         np_out = np_softmax_with_length(np_data, np_length)
         data = mx.sym.Variable("data")
         length = mx.sym.Variable("length")
@@ -5134,8 +5134,8 @@ def test_softmax_with_length():
         rtol = 1e-2 if dtype == np.float16 else 1e-3
         atol = 1e-4 if dtype == np.float16 else 1e-5
         check_symbolic_forward(mx_sym, location, [np_out], rtol=rtol, atol=atol, dtype=dtype)
-        # check_symbolic_backward(mx_sym, location, [np.ones(shape)], [], rtol=1e-3, atol=1e-5, dtype=dtype)
-        # check_numeric_gradient(mx_sym, location, rtol=1e-3, atol=1e-5, dtype=dtype)
+        check_symbolic_backward(mx_sym, location, [np.ones(shape)],
+                                [np.zeros(shape), np.zeros(len_shape)], rtol=1e-2, atol=1e-3, dtype=dtype)
 
 
 @with_seed()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -7953,7 +7953,6 @@ def test_op_all_names_monitor():
         except mx.base.MXNetError:
             # skip errors since test is to check all names
             pass
-        print(output_names)
         for output_name, expected_name in zip(output_names, expected_names):
             assert output_name == expected_name
 


### PR DESCRIPTION
## Description ##
Softmax with extra length input to specify line length of input on an axis.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Softmax with length
- [x] Unit test

## Comments ##
Flakiness Check:
```
MXNET_TEST_COUNT=10000 nosetests tests/python/unittest/test_operator.py:test_softmax_with_length
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=507099719 to reproduce.
[23:18:55] src/operator/contrib/../tensor/./../../common/utils.h:450: MXNET_SAFE_ACCUMULATION=1 is recommended for softmax with float16 inputs. See https://mxnet.incubator.apache.org/versions/master/faq/env_var.html for more details.
.
----------------------------------------------------------------------
Ran 1 test in 165.490s

OK
MXNET_TEST_COUNT=10000 nosetests tests/python/gpu/test_operator_gpu.py:test_softmax_with_length
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=634837637 to reproduce.
[23:24:32] src/operator/contrib/../tensor/./../../common/utils.h:450: MXNET_SAFE_ACCUMULATION=1 is recommended for softmax with float16 inputs. See https://mxnet.incubator.apache.org/versions/master/faq/env_var.html for more details.
[23:24:32] src/operator/contrib/../tensor/./../../common/utils.h:450: MXNET_SAFE_ACCUMULATION=1 is recommended for softmax with float16 inputs. See https://mxnet.incubator.apache.org/versions/master/faq/env_var.html for more details.
.
----------------------------------------------------------------------
Ran 1 test in 137.404s

OK
```

Benchmark results:
CPU: ~1.82x speedup
GPU: ~1.59x speedup

Benchmark script:
```python
import mxnet as mx
import numpy as np
from mxnet.test_utils import check_speed, rand_ndarray

ctx = mx.gpu(0)
ctx = mx.cpu()

shape = (96, 1024, 1024)

len_shape = (96, 1024)

data = rand_ndarray(shape, ctx=ctx)

np_length = np.zeros(len_shape, dtype=np.int32)

all_length = np.arange(1, 1025, 1, dtype=np.int32)

for i in range(len_shape[0]):
    np_length[i, :] = all_length

length = mx.nd.array(np_length, ctx=ctx, dtype=np.int32)

mx_data = mx.sym.Variable("data")
mx_length = mx.sym.Variable("length")

mx_sym = mx.sym.softmax(data=mx_data, length=mx_length, use_length=True, axis=1)

print(check_speed(mx_sym, location={"data": data, "length": length}, ctx=ctx, N=100, typ='whole'))

mx_sym = mx.sym.softmax(data=mx_data, axis=1)

print(check_speed(mx_sym, location={"data": data}, ctx=ctx, N=100, typ='whole'))
```
