### PR TITLE
[MXNET-1415]Add MXEnginePushAsyncND and MXEnginePushSyncND C APIs

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -2774,9 +2774,9 @@ MXNET_DLL int MXNDArrayCreateFromSharedMemEx(int shared_pid, int shared_id, cons
   * \param ctx_handle Execution context.
   * \param const_vars_handle The variables that current operation will use
   *                          but not mutate.
-  * \param num_const_vars The number of const_vars.
+  * \param num_const_vars The number of const_vars_handle.
   * \param mutable_vars_handle The variables that current operation will mutate.
-  * \param num_mutable_vars The number of mutable_vars.
+  * \param num_mutable_vars The number of mutable_vars_handle.
   * \param prop_handle Property of the function.
   * \param priority Priority of the action, as hint to the engine.
   * \param opr_name The operation name.
@@ -2798,9 +2798,9 @@ MXNET_DLL int MXEnginePushAsync(EngineAsyncFunc async_func, void* func_param,
   * \param ctx_handle Execution context.
   * \param const_vars_handle The variables that current operation will use
   *                          but not mutate.
-  * \param num_const_vars The number of const_vars.
+  * \param num_const_vars The number of const_vars_handle.
   * \param mutable_vars_handle The variables that current operation will mutate.
-  * \param num_mutable_vars The number of mutable_vars.
+  * \param num_mutable_vars The number of mutable_vars_handle.
   * \param prop_handle Property of the function.
   * \param priority Priority of the action, as hint to the engine.
   * \param opr_name The operation name.
@@ -2809,6 +2809,53 @@ MXNET_DLL int MXEnginePushSync(EngineSyncFunc sync_func, void* func_param,
                                EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
                                EngineVarHandle const_vars_handle, int num_const_vars,
                                EngineVarHandle mutable_vars_handle, int num_mutable_vars,
+                               EngineFnPropertyHandle prop_handle DEFAULT(NULL),
+                               int priority DEFAULT(0), const char* opr_name DEFAULT(NULL));
+
+/*!
+  * \brief Push an asynchronous operation to the engine.
+  * \param async_func Execution function whici takes a parameter on_complete
+  *                   that must be called when the execution ompletes.
+  * \param func_param The parameter set on calling async_func, can be NULL.
+  * \param deleter The callback to free func_param, can be NULL.
+  * \param ctx_handle Execution context.
+  * \param const_nds_handle The NDArrays that current operation will use
+  *                          but not mutate.
+  * \param num_const_nds The number of const_nds_handle.
+  * \param mutable_nds_handle The NDArrays that current operation will mutate.
+  * \param num_mutable_nds The number of mutable_nds_handle.
+  * \param prop_handle Property of the function.
+  * \param priority Priority of the action, as hint to the engine.
+  * \param opr_name The operation name.
+  * \param wait Whether this is a WaitForVar operation.
+  */
+MXNET_DLL int MXEnginePushAsyncND(EngineAsyncFunc async_func, void* func_param,
+                                EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
+                                NDArrayHandle const_nds_handle, int num_const_nds,
+                                NDArrayHandle mutable_nds_handle, int num_mutable_nds,
+                                EngineFnPropertyHandle prop_handle DEFAULT(NULL),
+                                int priority DEFAULT(0), const char* opr_name DEFAULT(NULL),
+                                bool wait DEFAULT(false));
+
+/*!
+  * \brief Push a synchronous operation to the engine.
+  * \param sync_func Execution function that executes the operation.
+  * \param func_param The parameter set on calling sync_func, can be NULL.
+  * \param deleter The callback to free func_param, can be NULL.
+  * \param ctx_handle Execution context.
+  * \param const_nds_handle The NDArrays that current operation will use
+  *                          but not mutate.
+  * \param num_const_nds The number of const_nds_handle.
+  * \param mutable_nds_handle The NDArrays that current operation will mutate.
+  * \param num_mutable_nds The number of mutable_nds_handle.
+  * \param prop_handle Property of the function.
+  * \param priority Priority of the action, as hint to the engine.
+  * \param opr_name The operation name.
+  */
+MXNET_DLL int MXEnginePushSyncND(EngineSyncFunc sync_func, void* func_param,
+                               EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
+                               NDArrayHandle const_nds_handle, int num_const_nds,
+                               NDArrayHandle mutable_nds_handle, int num_mutable_nds,
                                EngineFnPropertyHandle prop_handle DEFAULT(NULL),
                                int priority DEFAULT(0), const char* opr_name DEFAULT(NULL));
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1542,10 +1542,10 @@ int MXEnginePushAsyncND(EngineAsyncFunc async_func, void* func_param,
   for (int i = 0; i < num_const_nds; ++i) const_var_vec[i] = (const_nds+i)->var();
   std::vector<VarHandle> mutable_var_vec(num_mutable_nds);
   for (int i = 0; i < num_mutable_nds; ++i) mutable_var_vec[i] = (mutable_nds+i)->var();
-  MXEnginePushAsync(async_func, func_param, deleter, ctx_handle,
-                    const_var_vec.data(), num_const_nds,
-                    mutable_var_vec.data(), num_mutable_nds,
-                    prop_handle, priority, opr_name, wait);
+  return MXEnginePushAsync(async_func, func_param, deleter, ctx_handle,
+                           const_var_vec.data(), num_const_nds,
+                           mutable_var_vec.data(), num_mutable_nds,
+                           prop_handle, priority, opr_name, wait);
   API_END();
 }
 
@@ -1562,10 +1562,10 @@ int MXEnginePushSyncND(EngineSyncFunc sync_func, void* func_param,
   for (int i = 0; i < num_const_nds; ++i) const_var_vec[i] = (const_nds+i)->var();
   std::vector<VarHandle> mutable_var_vec(num_mutable_nds);
   for (int i = 0; i < num_mutable_nds; ++i) mutable_var_vec[i] = (mutable_nds+i)->var();
-  MXEnginePushSync(sync_func, func_param, deleter, ctx_handle,
-                   const_var_vec.data(), num_const_nds,
-                   mutable_var_vec.data(), num_mutable_nds,
-                   prop_handle, priority, opr_name);
+  return MXEnginePushSync(sync_func, func_param, deleter, ctx_handle,
+                          const_var_vec.data(), num_const_nds,
+                          mutable_var_vec.data(), num_mutable_nds,
+                          prop_handle, priority, opr_name);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1529,6 +1529,46 @@ int MXEnginePushSync(EngineSyncFunc sync_func, void* func_param,
   API_END();
 }
 
+int MXEnginePushAsyncND(EngineAsyncFunc async_func, void* func_param,
+                      EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
+                      NDArrayHandle const_nds_handle, int num_const_nds,
+                      NDArrayHandle mutable_nds_handle, int num_mutable_nds,
+                      EngineFnPropertyHandle prop_handle, int priority,
+                      const char* opr_name, bool wait) {
+  API_BEGIN();
+  NDArray* const_nds = static_cast<NDArray*>(const_nds_handle);
+  NDArray* mutable_nds = static_cast<NDArray*>(mutable_nds_handle);
+  std::vector<VarHandle> const_var_vec(num_const_nds);
+  for (int i = 0; i < num_const_nds; ++i) const_var_vec[i] = (const_nds+i)->var();
+  std::vector<VarHandle> mutable_var_vec(num_mutable_nds);
+  for (int i = 0; i < num_mutable_nds; ++i) mutable_var_vec[i] = (mutable_nds+i)->var();
+  MXEnginePushAsync(async_func, func_param, deleter, ctx_handle,
+                    const_var_vec.data(), num_const_nds,
+                    mutable_var_vec.data(), num_mutable_nds,
+                    prop_handle, priority, opr_name, wait);
+  API_END();
+}
+
+int MXEnginePushSyncND(EngineSyncFunc sync_func, void* func_param,
+                     EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
+                     NDArrayHandle const_nds_handle, int num_const_nds,
+                     NDArrayHandle mutable_nds_handle, int num_mutable_nds,
+                     EngineFnPropertyHandle prop_handle, int priority,
+                     const char* opr_name) {
+  API_BEGIN();
+  NDArray* const_nds = static_cast<NDArray*>(const_nds_handle);
+  NDArray* mutable_nds = static_cast<NDArray*>(mutable_nds_handle);
+  std::vector<VarHandle> const_var_vec(num_const_nds);
+  for (int i = 0; i < num_const_nds; ++i) const_var_vec[i] = (const_nds+i)->var();
+  std::vector<VarHandle> mutable_var_vec(num_mutable_nds);
+  for (int i = 0; i < num_mutable_nds; ++i) mutable_var_vec[i] = (mutable_nds+i)->var();
+  MXEnginePushSync(sync_func, func_param, deleter, ctx_handle,
+                   const_var_vec.data(), num_const_nds,
+                   mutable_var_vec.data(), num_mutable_nds,
+                   prop_handle, priority, opr_name);
+  API_END();
+}
+
 int MXStorageEmptyCache(int dev_type, int dev_id) {
   API_BEGIN();
   Context ctx = Context::Create(static_cast<Context::DeviceType>(dev_type), dev_id);

--- a/tests/cpp/engine/threaded_engine_test.cc
+++ b/tests/cpp/engine/threaded_engine_test.cc
@@ -29,6 +29,7 @@
 #include <gtest/gtest.h>
 #include <mxnet/c_api.h>
 #include <mxnet/engine.h>
+#include <mxnet/ndarray.h>
 #include <dmlc/timer.h>
 #include <cstdio>
 #include <thread>
@@ -256,47 +257,47 @@ TEST(Engine, PushFunc) {
 
 TEST(Engine, PushFuncND) {
   auto ctx = mxnet::Context{};
-  NDArray nd({1}, ctx);
+  mxnet::NDArray nd(ctx);
 
   // Test #1
-  LOG(INFO) << "===== Test #1: PushAsync param and deleter =====";
+  LOG(INFO) << "===== Test #1: PushAsyncND param and deleter =====";
   int* a = new int(100);
   int res = MXEnginePushAsyncND(FooAsyncFunc, a, FooFuncDeleter, &ctx, &nd, 1, nullptr, 0);
   EXPECT_EQ(res, 0);
 
   // Test #2
-  LOG(INFO) << "===== Test #2: PushAsync NULL param and NULL deleter =====";
+  LOG(INFO) << "===== Test #2: PushAsyncND NULL param and NULL deleter =====";
   res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, 0);
   EXPECT_EQ(res, 0);
 
   // Test #3
-  LOG(INFO) << "===== Test #3: PushAsync invalid number of const nds =====";
+  LOG(INFO) << "===== Test #3: PushAsyncND invalid number of const nds =====";
   res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, &nd, -1, nullptr, 0);
   EXPECT_EQ(res, -1);
 
   // Test #4
-  LOG(INFO) << "===== Test #4: PushAsync invalid number of mutable nds =====";
+  LOG(INFO) << "===== Test #4: PushAsyncND invalid number of mutable nds =====";
   res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, -1);
   EXPECT_EQ(res, -1);
 
   // Test #5
-  LOG(INFO) << "===== Test #5: PushSync param and deleter =====";
+  LOG(INFO) << "===== Test #5: PushSyncND param and deleter =====";
   int* b = new int(101);
   res = MXEnginePushSyncND(FooSyncFunc, b, FooFuncDeleter, &ctx, &nd, 1, nullptr, 0);
   EXPECT_EQ(res, 0);
 
   // Test #6
-  LOG(INFO) << "===== Test #6: PushSync NULL param and NULL deleter =====";
+  LOG(INFO) << "===== Test #6: PushSyncND NULL param and NULL deleter =====";
   res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, 1);
   EXPECT_EQ(res, 0);
 
   // Test #7
-  LOG(INFO) << "===== Test #7: PushSync invalid number of const nds =====";
+  LOG(INFO) << "===== Test #7: PushSyncND invalid number of const nds =====";
   res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, &nd, -1, nullptr, 0);
   EXPECT_EQ(res, -1);
 
   // Test #8
-  LOG(INFO) << "===== Test #8: PushSync invalid number of mutable nds =====";
+  LOG(INFO) << "===== Test #8: PushSyncND invalid number of mutable nds =====";
   res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, -1);
   EXPECT_EQ(res, -1);
 }

--- a/tests/cpp/engine/threaded_engine_test.cc
+++ b/tests/cpp/engine/threaded_engine_test.cc
@@ -254,6 +254,53 @@ TEST(Engine, PushFunc) {
   EXPECT_EQ(res, -1);
 }
 
+TEST(Engine, PushFuncND) {
+  auto ctx = mxnet::Context{};
+  NDArray nd({1}, ctx);
+
+  // Test #1
+  LOG(INFO) << "===== Test #1: PushAsync param and deleter =====";
+  int* a = new int(100);
+  int res = MXEnginePushAsyncND(FooAsyncFunc, a, FooFuncDeleter, &ctx, &nd, 1, nullptr, 0);
+  EXPECT_EQ(res, 0);
+
+  // Test #2
+  LOG(INFO) << "===== Test #2: PushAsync NULL param and NULL deleter =====";
+  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, 0);
+  EXPECT_EQ(res, 0);
+
+  // Test #3
+  LOG(INFO) << "===== Test #3: PushAsync invalid number of const nds =====";
+  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, &nd, -1, nullptr, 0);
+  EXPECT_EQ(res, -1);
+
+  // Test #4
+  LOG(INFO) << "===== Test #4: PushAsync invalid number of mutable nds =====";
+  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, -1);
+  EXPECT_EQ(res, -1);
+
+  // Test #5
+  LOG(INFO) << "===== Test #5: PushSync param and deleter =====";
+  int* b = new int(101);
+  res = MXEnginePushSyncND(FooSyncFunc, b, FooFuncDeleter, &ctx, &nd, 1, nullptr, 0);
+  EXPECT_EQ(res, 0);
+
+  // Test #6
+  LOG(INFO) << "===== Test #6: PushSync NULL param and NULL deleter =====";
+  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, 1);
+  EXPECT_EQ(res, 0);
+
+  // Test #7
+  LOG(INFO) << "===== Test #7: PushSync invalid number of const nds =====";
+  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, &nd, -1, nullptr, 0);
+  EXPECT_EQ(res, -1);
+
+  // Test #8
+  LOG(INFO) << "===== Test #8: PushSync invalid number of mutable nds =====";
+  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, -1);
+  EXPECT_EQ(res, -1);
+}
+
 TEST(Engine, basics) {
   auto&& engine = mxnet::Engine::Get();
   auto&& var = engine->NewVariable();


### PR DESCRIPTION
## Description ##
Hi, there.
In the PR #14615, @yuxihu added `Add MXEnginePushAsync` and `MXEnginePushSync` C APIs.

`MXEnginePushAsync` and `MXEnginePushSync` needs `VarHandle`s of `NDArray`s.
However, MXNet doesn't expose the API to get the VarHandle of a NDArray.

After the discussion with @szha, We considered that it's more elegant to add `MXEnginePushAsyncND` and `MXEnginePushSyncND` C APIs, whose arguments are `NDArrayHandle`s, rather than `VarHandle`s.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add MXEnginePushAsyncND and MXEnginePushSyncND C APIs
- [x] Add the related unittest.
- [x] Add a simple example: https://github.com/wkcn/test_mx_sync