### PR TITLE
[MXNET-1416] Fix inception inference example for potential index out of range error.

### DIFF
--- a/cpp-package/example/inference/inception_inference.cpp
+++ b/cpp-package/example/inference/inception_inference.cpp
@@ -302,13 +302,11 @@ void Predictor::PredictImage(const std::string& image_file) {
 
   // The output is available in executor->outputs.
   auto array = executor->outputs[0].Copy(Context::cpu());
-
   /*
    * Find out the maximum accuracy and the index associated with that accuracy.
    * This is done by using the argmax operator on NDArray.
    */
   auto predicted = array.ArgmaxChannel();
-
   /*
    * Wait until all the previous write operations on the 'predicted'
    * NDArray to be complete before we read it.
@@ -317,7 +315,7 @@ void Predictor::PredictImage(const std::string& image_file) {
    */
   predicted.WaitToRead();
 
-  int best_idx = predicted.At(0, 0);
+  int best_idx = predicted.At(0);
   float best_accuracy = array.At(0, best_idx);
 
   if (output_labels.empty()) {

--- a/cpp-package/include/mxnet-cpp/ndarray.h
+++ b/cpp-package/include/mxnet-cpp/ndarray.h
@@ -321,6 +321,12 @@ class NDArray {
    */
   size_t Offset(size_t c, size_t h, size_t w) const;
   /*!
+  * \brief return value of the element at (index)
+  * \param index  position
+  * \return value of one dimensions array
+  */
+  mx_float At(size_t index) const;
+  /*!
   * \brief return value of the element at (h, w)
   * \param h height position
   * \param w width position

--- a/cpp-package/include/mxnet-cpp/ndarray.hpp
+++ b/cpp-package/include/mxnet-cpp/ndarray.hpp
@@ -398,8 +398,8 @@ inline mx_float NDArray::At(size_t c, size_t h, size_t w) const {
 inline mx_float NDArray::At(size_t index) const {
   auto shape = GetShape();
   CHECK_EQ(shape.size(), 1) << "The NDArray needs to be 1 dimensional.";
-  auto offset = index * shape[0];
-  return GetData()[offset];
+  CHECK_LT(index, shape[0]) << "Specified index is out of range.";
+  return GetData()[index];
 }
 
 inline size_t NDArray::Size() const {

--- a/cpp-package/include/mxnet-cpp/ndarray.hpp
+++ b/cpp-package/include/mxnet-cpp/ndarray.hpp
@@ -375,11 +375,15 @@ inline void NDArray::Save(const std::string &file_name,
 }
 
 inline size_t NDArray::Offset(size_t h, size_t w) const {
-  return (h * GetShape()[1]) + w;
+  auto const shape = GetShape();
+  CHECK_EQ(shape.size(), 2) << "The NDArray needs to be 2 dimensional.";
+
+  return (h * shape[1]) + w;
 }
 
 inline size_t NDArray::Offset(size_t c, size_t h, size_t w) const {
   auto const shape = GetShape();
+  CHECK_EQ(shape.size(), 3) << "The NDArray needs to be 3 dimensional.";
   return h * shape[0] * shape[2] + w * shape[0] + c;
 }
 
@@ -389,6 +393,13 @@ inline mx_float NDArray::At(size_t h, size_t w) const {
 
 inline mx_float NDArray::At(size_t c, size_t h, size_t w) const {
   return GetData()[Offset(c, h, w)];
+}
+
+inline mx_float NDArray::At(size_t index) const {
+  auto shape = GetShape();
+  CHECK_EQ(shape.size(), 1) << "The NDArray needs to be 1 dimensional.";
+  auto offset = index * shape[0];
+  return GetData()[offset];
 }
 
 inline size_t NDArray::Size() const {


### PR DESCRIPTION
## Description ##
Fix inception inference example for potential index out of range error. The PR also adds a helper method in NDArray to retrieve the elements from 1 D array.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [y] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [y] Changes are complete (i.e. I finished coding on this PR)
- [y] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [y] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
