### PR TITLE
[BUGFIX] Fix a bug in Auto Function.

### DIFF
--- a/python/mxnet/autograd.py
+++ b/python/mxnet/autograd.py
@@ -493,14 +493,13 @@ class Function(object):
                                       POINTER(CFUNCTYPE(c_int))),
                                  cast(c_array(c_void_p, [None]*len(callbacks)),
                                       POINTER(c_void_p)))
+        Function._registry.ref_holder[key] = context
         check_call(_LIB.MXCustomFunctionRecord(
             c_int(len(inputs)),
             c_handle_array(inputs),
             c_int(len(outputs)),
             c_handle_array(outputs),
             ctypes.byref(context)))
-
-        Function._registry.ref_holder[key] = context
 
         return ret_outputs
 

--- a/tests/python/unittest/test_autograd.py
+++ b/tests/python/unittest/test_autograd.py
@@ -396,6 +396,7 @@ def test_function1():
         for i in range(5):
             f = Foo()
             X = f(X)
+        X.wait_to_read()
 
 
 @with_seed()

--- a/tests/python/unittest/test_autograd.py
+++ b/tests/python/unittest/test_autograd.py
@@ -379,6 +379,26 @@ def test_function():
 
 
 @with_seed()
+def test_function1():
+    class Foo(mx.autograd.Function):
+        def __init__(self):
+            super(Foo, self).__init__()
+
+        def forward(self, X):
+            return X + 1;
+
+        def backward(self, dY):
+            return dY
+
+    with mx.autograd.record():
+        X = mx.nd.zeros((3, 4))
+        #X.attach_grad()  # uncommenting this line works
+        for i in range(5):
+            f = Foo()
+            X = f(X)
+
+
+@with_seed()
 def test_get_symbol():
     x = mx.nd.ones((1,))
     x.attach_grad()


### PR DESCRIPTION
## Description ##
This PR is to fix this issue: https://github.com/apache/incubator-mxnet/issues/15183
The callback function `delete_entry` is invoked in the CAPI. In the original code, the callback function may be invoked before the context is registered. So we need to switch this two lines to make sure the context has been registered.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
