### PR TITLE
Fixing duplication in operator profiling

### DIFF
--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -85,7 +85,9 @@ inline std::priority_queue<pi>
 
 void AggregateStats::OnProfileStat(const ProfileStat& stat) {
   std::unique_lock<std::mutex> lk(m_);
-  stat.SaveAggregate(&stats_[stat.categories_.c_str()][stat.name_.c_str()]);
+  if (stat.enable_aggregate_) {
+    stat.SaveAggregate(&stats_[stat.categories_.c_str()][stat.name_.c_str()]);
+  }
 }
 
 void AggregateStats::DumpTable(std::ostream& os, int sort_by, int ascending) {

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -128,7 +128,7 @@ struct ProfileStat {
   /*! \brief operation categories (comma-delimited) */
   profile_stat_string categories_;
 
-  /*! \breif whether to add this stat to AggregateStats */
+  /*! \brief whether to add this stat to AggregateStats */
   bool enable_aggregate_ = true;
 
   /* !\brief Process id */
@@ -854,7 +854,7 @@ struct ProfileTask : public ProfileDuration {
   VTUNE_ONLY_CODE(std::unique_ptr<vtune::VTuneTask> vtune_task_);
   /*! \brief NVTX duration object */
   NVTX_ONLY_CODE(std::unique_ptr<nvtx::NVTXDuration> nvtx_duration_);
-  /*! \breif not to add this stat to AggregateStats */
+  /*! \brief not to add this stat to AggregateStats */
   bool enable_aggregate_ = true;
 
  protected:

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -1161,13 +1161,13 @@ struct ProfileOperator : public ProfileEvent {
     dev_type_ = dev_type;
     dev_id_ = dev_id;
     ProfileEvent::start();
-    as_task_.start();
+    // as_task_.start();
   }
   /*!
    * \brief Stop the profiling scope
    */
   void stop() override {
-    as_task_.stop();
+    // as_task_.stop();
     ProfileEvent::stop();
   }
 

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -813,7 +813,7 @@ struct ProfileTask : public ProfileDuration {
   /*!
    * \brief Whether to add stat to AggregateStats
    */
-  void enableAggregateStats(const bool enabled = true) {
+  void enableAggregateStats(bool enabled = true) {
     enable_aggregate_ = enabled;
   }
 

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -813,7 +813,7 @@ struct ProfileTask : public ProfileDuration {
   /*!
    * \brief Whether to add stat to AggregateStats
    */
-  void enableAggregateStats(bool enabled) {
+  void enableAggregateStats(const bool enabled = true) {
     enable_aggregate_ = enabled;
   }
 
@@ -854,7 +854,7 @@ struct ProfileTask : public ProfileDuration {
   VTUNE_ONLY_CODE(std::unique_ptr<vtune::VTuneTask> vtune_task_);
   /*! \brief NVTX duration object */
   NVTX_ONLY_CODE(std::unique_ptr<nvtx::NVTXDuration> nvtx_duration_);
-  /*! \brief not to add this stat to AggregateStats */
+  /*! \brief whether to add this stat to AggregateStats */
   bool enable_aggregate_ = true;
 
  protected:

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -278,7 +278,7 @@ def test_aggregate_duplication():
     inp = inp + 1
     inp = inp + 1
     mx.nd.waitall()
-    profiler.dump()
+    profiler.dump(False)
     debug_str = profiler.dumps(format = 'json')
     target_dict = json.loads(debug_str)
     assert 'Time' in target_dict and 'operator' in target_dict['Time'] \

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -286,7 +286,7 @@ def test_aggregate_duplication():
         and 'Count' in target_dict['Time']['operator']['sqrt'] \
         and '_plus_scalar' in target_dict['Time']['operator'] \
         and 'Count' in target_dict['Time']['operator']['_plus_scalar']
-    # thet are called once and twice respectively
+    # they are called once and twice respectively
     assert target_dict['Time']['operator']['sqrt']['Count'] == 1
     assert target_dict['Time']['operator']['_plus_scalar']['Count'] == 2
     profiler.set_state('stop')

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -271,7 +271,8 @@ def test_aggregate_stats_sorting():
 
 def test_aggregate_duplication():
     file_name = 'test_aggregate_duplication.json'
-    enable_profiler(file_name, True, True, True)
+    enable_profiler(profile_filename = file_name, run=True, continuous_dump=True, \
+                    aggregate_stats=True)
     inp = mx.nd.zeros(shape=(100, 100))
     y = mx.nd.sqrt(inp)
     inp = inp + 1

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -280,15 +280,14 @@ def test_aggregate_duplication():
     profiler.dump()
     debug_str = profiler.dumps(format = 'json')
     target_dict = json.loads(debug_str)
-    print(target_dict)
-    assert "Time" in target_dict and "operator" in target_dict["Time"] \
-        and "sqrt" in target_dict["Time"]["operator"] \
-        and "Count" in target_dict["Time"]["operator"]["sqrt"] \
-        and "_plus_scalar" in target_dict["Time"]["operator"] \
-        and "Count" in target_dict["Time"]["operator"]["_plus_scalar"]
+    assert 'Time' in target_dict and 'operator' in target_dict['Time'] \
+        and 'sqrt' in target_dict['Time']['operator'] \
+        and 'Count' in target_dict['Time']['operator']['sqrt'] \
+        and '_plus_scalar' in target_dict['Time']['operator'] \
+        and 'Count' in target_dict['Time']['operator']['_plus_scalar']
     # thet are called once and twice respectively
-    assert target_dict["Time"]["operator"]["sqrt"]["Count"] == 1
-    assert target_dict["Time"]["operator"]["_plus_scalar"]["Count"] == 2
+    assert target_dict['Time']['operator']['sqrt']['Count'] == 1
+    assert target_dict['Time']['operator']['_plus_scalar']['Count'] == 2
     profiler.set_state('stop')
     
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
fix: https://github.com/apache/incubator-mxnet/issues/10520
fix: https://github.com/apache/incubator-mxnet/issues/15243
For detailed explanations of the cause as well the proposed fix of the issue, please refer to https://cwiki.apache.org/confluence/display/MXNET/Fixing+Duplication+in+Operator+Profiling?moved=true

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

