### PR TITLE
Showing proper error when csr array is not 2D in shape.

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -2227,6 +2227,10 @@ fixed-size items.
         NDArray, CSRNDArray or RowSparseNDArray
             A copy of the array with the chosen storage stype
         """
+        if stype == 'csr' and len(self.shape) != 2:
+            raise ValueError("To convert to a CSR, the NDArray should be 2 Dimensional. Current "
+                             "shape is %s" % str(self.shape))
+
         return op.cast_storage(self, stype=stype)
 
     def to_dlpack_for_read(self):

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -964,9 +964,9 @@ def test_sparse_nd_check_format():
     a = mx.nd.sparse.csr_matrix((data_list, indices_list, indptr_list), shape=shape)
     assertRaises(mx.base.MXNetError, a.check_format)
     # CSR format should be 2 Dimensional.
-    a = mx.nd.array([1, 2, 3]).tostype('csr')
+    a = mx.nd.array([1, 2, 3])
     assertRaises(ValueError, a.tostype, 'csr')
-    a = mx.nd.array([[[1, 2, 3]]]).tostype('csr')
+    a = mx.nd.array([[[1, 2, 3]]])
     assertRaises(ValueError, a.tostype, 'csr')
     # Row Sparse format indices should be less than the number of rows
     shape = (3, 2)

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -963,6 +963,11 @@ def test_sparse_nd_check_format():
     indptr_list = [0, -2, 2, 3]
     a = mx.nd.sparse.csr_matrix((data_list, indices_list, indptr_list), shape=shape)
     assertRaises(mx.base.MXNetError, a.check_format)
+    # CSR format should be 2 Dimensional.
+    a = mx.nd.array([1, 2, 3]).tostype('csr')
+    assertRaises(ValueError, a.tostype, 'csr')
+    a = mx.nd.array([[[1, 2, 3]]]).tostype('csr')
+    assertRaises(ValueError, a.tostype, 'csr')
     # Row Sparse format indices should be less than the number of rows
     shape = (3, 2)
     data_list = [[1, 2], [3, 4]]


### PR DESCRIPTION
## Description ##
Fixes #15239 We were allowing non 2D NDArrays to be created as a CSR that caused inconsistencies and also caused a crash when one tried to access .data on a CSR Matrix. The crash was coming from here : https://github.com/apache/incubator-mxnet/blob/master/src/operator/tensor/cast_storage-inl.h#L238.
The other places constructing CSRNDArray are already guarded by the shape checks.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
