### PR TITLE
Fix nightly build warning

### DIFF
--- a/docs/tutorials/gluon/multi_gpu.md
+++ b/docs/tutorials/gluon/multi_gpu.md
@@ -162,7 +162,7 @@ for epoch in range(num_epochs):
 
         # Update the parameters by stepping the trainer; the batch size
         # is required to normalize the gradients by `1 / batch_size`.
-        trainer.step(batch_size=actual_batch_size)
+        trainer.step(batch_size=actual_batch_size, ignore_stale_grad=True)
 
     # Print the evaluation metric and reset it for the next epoch
     name, acc = metric.get()


### PR DESCRIPTION
## Description ##
My [previous PR ](https://github.com/apache/incubator-mxnet/pull/15158) causes warning during nightly build as it is running multigpu tutorial on a single GPU machine. Fixed it by ignoring stale gradient - this solution overrides warning.