### PR TITLE
[MXNET-1417][Performance] Caching Dynamic Shape Checking Result

### DIFF
--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -100,6 +100,7 @@ CachedOp::CachedOp(
   static const std::vector<const Op*> zero_ops{Op::Get("zeros_like"), Op::Get("_zeros")};
   static const auto _copy_op = Op::Get("_copy");
   config_.Init(flags);
+  this->dynamic_shape_checked_ = false;
 
   if (config_.static_shape) {
     CHECK(config_.static_alloc) << "static_alloc must be True when static_shape is True";
@@ -272,10 +273,10 @@ bool CachedOp::CheckDynamicShapeExists(const Context& default_ctx,
                                        bool erase_result) {
   using namespace nnvm;
   using namespace imperative;
-  if (config_.dynamic_shape_checked) {
+  if (this->dynamic_shape_checked_) {
     return config_.is_dynamic;
   } else {
-    config_.dynamic_shape_checked = true;
+    this->dynamic_shape_checked_ = true;
   }
   CHECK_EQ(inputs.size(), num_inputs());
 

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -272,6 +272,11 @@ bool CachedOp::CheckDynamicShapeExists(const Context& default_ctx,
                                        bool erase_result) {
   using namespace nnvm;
   using namespace imperative;
+  if (config_.dynamic_shape_checked) {
+    return config_.is_dynamic;
+  } else {
+    config_.dynamic_shape_checked = true;
+  }
   CHECK_EQ(inputs.size(), num_inputs());
 
   auto state_ptr = GetCachedOpState(default_ctx);

--- a/src/imperative/cached_op.h
+++ b/src/imperative/cached_op.h
@@ -36,6 +36,7 @@ struct CachedOpConfig : public dmlc::Parameter<CachedOpConfig> {
   bool static_alloc;
   bool static_shape;
   bool is_dynamic;
+  bool dynamic_shape_checked;
   mxnet::Tuple<uint32_t> data_indices;
   mxnet::Tuple<uint32_t> param_indices;
   std::string subgraph;
@@ -70,6 +71,9 @@ struct CachedOpConfig : public dmlc::Parameter<CachedOpConfig> {
     DMLC_DECLARE_FIELD(is_dynamic)
     .set_default(false)
     .describe("Whether the graph contains dynamic shape operators.");
+    DMLC_DECLARE_FIELD(dynamic_shape_checked)
+    .set_default(false)
+    .describe("Whether dynamic shape is checked.");
   }
 };
 

--- a/src/imperative/cached_op.h
+++ b/src/imperative/cached_op.h
@@ -36,7 +36,6 @@ struct CachedOpConfig : public dmlc::Parameter<CachedOpConfig> {
   bool static_alloc;
   bool static_shape;
   bool is_dynamic;
-  bool dynamic_shape_checked;
   mxnet::Tuple<uint32_t> data_indices;
   mxnet::Tuple<uint32_t> param_indices;
   std::string subgraph;
@@ -71,9 +70,6 @@ struct CachedOpConfig : public dmlc::Parameter<CachedOpConfig> {
     DMLC_DECLARE_FIELD(is_dynamic)
     .set_default(false)
     .describe("Whether the graph contains dynamic shape operators.");
-    DMLC_DECLARE_FIELD(dynamic_shape_checked)
-    .set_default(false)
-    .describe("Whether dynamic shape is checked.");
   }
 };
 
@@ -200,6 +196,7 @@ class CachedOp {
   nnvm::Graph grad_graph_;
   nnvm::Graph full_graph_;
   bool inlining_;
+  bool dynamic_shape_checked_;
   std::vector<nnvm::NodeEntry> ograd_entries_;
   std::vector<uint32_t> bwd_in_dep_, bwd_out_dep_, bwd_ograd_dep_;
   std::unordered_map<uint32_t, uint32_t> fwd_input_to_grad_output_;


### PR DESCRIPTION
## Description ##
(Please see appendix for experiment details)

PR #14192  that enables dynamic shapes slows down a model that originally runs in 235.65 ms by 7.26 ms (to 242.91 ms).

Also noted that a seemingly relevant PR #14665 suggesting itself to be improving "[performance]", does not change performance number in any means - It still runs in 242.35 ms.

This PR fixes this by caching the checking result of whether dynamic shape exists. The mechanism itself is quick simple: if the dynamic shape existence has been checked, let's simply don't do it again, because the graph does not change.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Changes ##
- Added a new flag `dynamic_shape_checked` in CachedOp, which indicates whether dynamic shape existence has been checked.

## Comments ##
Experiment environment: EC2 p2.8xlarge, CUDA 10 and cuDNN 7.5. The model itself is confidential.

The detailed benchmark is as below (mean ± stdev). The experiment is conducted in 20 runs, warmup run is excluded. 

0) On commit 39412b37f (right before PR #14192 is merge):
Hybridize w/ static_alloc: 235.65 ± 0.22246 ms

1) On commit 83d2c2d0e (where PR #14192 is merged):
Hybridize w/ static_alloc: 242.91 ms ± 0.71125 ms

2) PR #14665 patched to commit 83d2c2d0e
Hybridize w/ static_alloc: 242.35 ± 0.25124 ms

3) After this patch applied to commit 83d2c2d0e
Hybridize w/ static_alloc: 234.95 ± 0.39334 ms

CC: @szha @zheng-da please review :-)