### PR TITLE
[DOC] Clarify that global pooling is going to reset padding

### DIFF
--- a/src/operator/nn/pooling.cc
+++ b/src/operator/nn/pooling.cc
@@ -389,8 +389,8 @@ The definition of *f* depends on ``pooling_convention``, which has two options:
 
     f(x, k, p, s) = ceil((x+2*p-k)/s)+1
 
-But ``global_pool`` is set to be true, then do a global pooling, namely reset
-``kernel=(height, width)``.
+When ``global_pool`` is set to be true, then global pooling is performed. It will reset
+``kernel=(height, width)`` and set the appropiate padding to 0.
 
 Three pooling options are supported by ``pool_type``:
 


### PR DESCRIPTION
This behaviour changed from older MXNet versions in which global pooling
would consider padding. This clarifies the user documentation.

See also #14421

@aaronmarkham 