### PR TITLE
Fix warnings in CLang.

### DIFF
--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -128,7 +128,7 @@ class NaiveEngine final : public Engine {
             attrs.reset(new profiler::ProfileOperator::Attributes());
           }
           opr->opr_profile.reset(new profiler::ProfileOperator(opr->opr_name, attrs.release()));
-          opr->opr_profile->start(exec_ctx.dev_type, exec_ctx.dev_id);
+          opr->opr_profile->startForDevice(exec_ctx.dev_type, exec_ctx.dev_id);
         }
         opr->fn(ctx, on_complete);
         if (opr->profiling) {
@@ -176,8 +176,8 @@ class NaiveEngine final : public Engine {
       if (profiler->AggregateEnabled()) {
         attrs.reset(new profiler::ProfileOperator::Attributes());
       }
-      opr->opr_profile.reset(new profiler::ProfileOperator(display_name, attrs.release()));
-      opr->opr_profile->start(exec_ctx.dev_type, exec_ctx.dev_id);
+      opr->opr_profile.reset(new profiler::ProfileOperator(opr->opr_name, attrs.release()));
+      opr->opr_profile->startForDevice(exec_ctx.dev_type, exec_ctx.dev_id);
     }
     if (exec_ctx.dev_mask() == gpu::kDevMask) {
 #if MXNET_USE_CUDA

--- a/src/engine/threaded_engine.h
+++ b/src/engine/threaded_engine.h
@@ -359,7 +359,7 @@ class ThreadedEngine : public Engine {
       const Context& ctx = opr_block->ctx;
       opr_block->opr_profile.reset(new profiler::ProfileOperator(threaded_opr->opr_name,
                                                                  attrs.release()));
-      opr_block->opr_profile->start(ctx.dev_type, ctx.dev_id);
+      opr_block->opr_profile->startForDevice(ctx.dev_type, ctx.dev_id);
     }
     CallbackOnComplete callback =
         this->CreateCallback(ThreadedEngine::OnCompleteStatic, opr_block);

--- a/src/kvstore/kvstore_local.h
+++ b/src/kvstore/kvstore_local.h
@@ -278,7 +278,7 @@ class KVStoreLocal : public KVStore {
                                 std::vector<std::vector<NDArray>> *grouped_vals,
                                 bool ignore_sparse) {
     // check if the storage type of a value is valid
-    auto validator = [this](const int key, const NDArray& nd, bool ignore_sparse) -> bool {
+    auto validator = [](const int key, const NDArray& nd, bool ignore_sparse) -> bool {
       CHECK(!ignore_sparse) << "Cannot ignore sparse arrays for push";
       auto stype = nd.storage_type();
       // valid NDArray
@@ -323,7 +323,7 @@ class KVStoreLocal : public KVStore {
                                    std::vector<std::vector<RSPVal>> *grouped_vals,
                                    bool ignore_sparse) {
     // check if the storage type of a value is valid
-    auto validator = [this](const int key, const RSPVal& val_rowid, bool ignore_sparse) -> bool {
+    auto validator = [](const int key, const RSPVal& val_rowid, bool ignore_sparse) -> bool {
       CHECK(!ignore_sparse) << "Cannot ignore sparse arrays in row_sparse_pull";
       auto val_stype = val_rowid.first->storage_type();
       auto rowid_stype = val_rowid.second.storage_type();

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -1187,7 +1187,7 @@ struct ProfileOperator : public ProfileEvent {
    * \param dev_type Device type that the profiling will occur on
    * \param dev_id Device id associated with this opr
    */
-  void start(mxnet::Context::DeviceType dev_type, uint32_t dev_id) {
+  void startForDevice(mxnet::Context::DeviceType dev_type, uint32_t dev_id) {
     dev_type_ = dev_type;
     dev_id_ = dev_id;
     if (profiling_) {
@@ -1247,7 +1247,7 @@ struct ProfileOperator : public ProfileEvent {
    */
   void SendStat() override {
     Profiler::Get()->AddNewProfileStat<OprExecStat>(
-      [this](OprExecStat *stat) {}, name_.c_str(), dev_type_, dev_id_,
+      [](OprExecStat *stat) {}, name_.c_str(), dev_type_, dev_id_,
       start_time_, ProfileStat::NowInMicrosec(),
       attributes_.get());
   }


### PR DESCRIPTION
## Description ##

In file included from ../src/kvstore/kvstore.cc:28:
../src/kvstore/./kvstore_local.h:281:23: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
    auto validator = [this](const int key, const NDArray& nd, bool ignore_sparse) -> bool {
                      ^
../src/kvstore/./kvstore_local.h:326:23: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
    auto validator = [this](const int key, const RSPVal& val_rowid, bool ignore_sparse) -> bool {
                      ^
In file included from ../src/c_api/c_api_profile.cc:35:
../src/c_api/../profiler/./profiler.h:1160:8: warning: 'mxnet::profiler::ProfileOperator::start' hides overloaded virtual function [-Woverloaded-virtual]
  void start(mxnet::Context::DeviceType dev_type, uint32_t dev_id) {
       ^
../src/c_api/../profiler/./profiler.h:870:8: note: hidden overloaded virtual function 'mxnet::profiler::ProfileEvent::start' declared here: different number of parameters (0 vs 2)
  void start() override {
       ^
../src/c_api/../profiler/./profiler.h:1212:8: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
      [this](OprExecStat *stat) {}, name_.c_str(), dev_type_, dev_id_,
       ^

See also #14940

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

