### PR TITLE
Proper bulking of ops not using FCompute

### DIFF
--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -464,7 +464,7 @@ inline void PushFComputeEx(const FComputeEx& fn,
       InvalidateOutputs(outputs, req);
 #endif
       fn(attrs, opctx, inputs, req, outputs);
-      if (ctx.dev_mask() == gpu::kDevMask && exec_type == ExecType::kSync) {
+      if (ctx.dev_mask() == gpu::kDevMask && exec_type == ExecType::kSync && !rctx.is_bulk) {
         rctx.get_stream<gpu>()->Wait();
       }
     };
@@ -512,7 +512,7 @@ inline void PushOperator(const OpStatePtr& state,
 #endif
       fcompute_ex(state, opctx, inputs, req, outputs);
       if (ctx.dev_mask() == gpu::kDevMask && exec_type == ExecType::kSync
-          && rctx.get_stream<gpu>()) {
+          && rctx.get_stream<gpu>() && !rctx.is_bulk) {
         rctx.get_stream<gpu>()->Wait();
       }
     };
@@ -562,7 +562,7 @@ inline void PushOperator(const OpStatePtr& state,
         // post-fcompute fallback, cast to original storage type, if necessary
         CastNonDefaultStorage(post_temp_src, post_temp_dst, opctx, is_gpu);
         if (is_gpu && exec_type == ExecType::kSync
-            && rctx.get_stream<gpu>()) {
+            && rctx.get_stream<gpu>() && !rctx.is_bulk) {
           rctx.get_stream<gpu>()->Wait();
         }
       };


### PR DESCRIPTION
## Description ##
PR #13890 made bulking of ops more performant in the hybridized models with `static_alloc=True`. However, it was limited to ops using FCompute function (and so not FComputeEx nor the operator class). This PR changes that.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
