### PR TITLE
Fixed C++ inference tutorial

### DIFF
--- a/cpp-package/example/inference/inception_inference.cpp
+++ b/cpp-package/example/inference/inception_inference.cpp
@@ -38,9 +38,9 @@
 
 using namespace mxnet::cpp;
 
-static mx_float DEFAULT_MEAN_R = 123.675;
-static mx_float DEFAULT_MEAN_G = 116.28;
-static mx_float DEFAULT_MEAN_B = 103.53;
+static mx_float DEFAULT_MEAN_R = 0.485;
+static mx_float DEFAULT_MEAN_G = 0.456;
+static mx_float DEFAULT_MEAN_B = 0.406;
 
 static mx_float DEFAULT_STD_R = 0.229;
 static mx_float DEFAULT_STD_G = 0.224;

--- a/cpp-package/example/inference/unit_test_inception_inference.sh
+++ b/cpp-package/example/inference/unit_test_inception_inference.sh
@@ -19,6 +19,7 @@
 
 # Downloading the data and model
 mkdir -p model
+
 python - <<EOF
 import mxnet as mx
 import gluoncv

--- a/docs/tutorials/c++/mxnet_cpp_inference_tutorial.md
+++ b/docs/tutorials/c++/mxnet_cpp_inference_tutorial.md
@@ -226,7 +226,7 @@ void Predictor::PredictImage(const std::string& image_file) {
   auto predicted = array.ArgmaxChannel();
   NDArray::WaitAll();
 
-  int best_idx = predicted.At(0, 0);
+  int best_idx = predicted.At(0);
   float best_accuracy = array.At(0, best_idx);
 
   if (output_labels.empty()) {


### PR DESCRIPTION
## Description ##
Tutorial did not properly preprocess images and as such produce incorrect predictions. The example would set default values for mean but not for std_dev. So if the user does not provide the file that contains those values, the example would crash. The C++ example predicts now the same class as in the Python example. However, the probabilities differ (9.72 versus 10.411) and we should to look into that