### PR TITLE
Ignore generated nnvm.cc template. This file is created whenever `make` is run

### DIFF
--- a/amalgamation/.gitignore
+++ b/amalgamation/.gitignore
@@ -1,1 +1,4 @@
 *-all.cc
+
+# Generated nnvm template
+nnvm.cc


### PR DESCRIPTION
Ignore generated nnvm.cc template in amalgamation dir.