### PR TITLE
Fix amalgamation failure.

### DIFF
--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -473,7 +473,7 @@ bool CachedOp::SetForwardGraph(
     storage[idx.entry_id(idx.outputs()[i])] = exec::kExternalStorageID;
   }
 
-  auto mem_plan = PlanMemory(
+  auto mem_plan = MXPlanMemory(
       &g, std::move(storage), g.GetAttr<std::vector<uint32_t> >(AddPrefix(prefix, REF_COUNT)),
       AddPrefix(prefix, STORAGE_PLAN));
   g.attrs[AddPrefix(prefix, MEM_PLAN)] =
@@ -601,7 +601,7 @@ bool CachedOp::SetBackwardGraph(
   for (const auto i : idx.input_nodes()) storage[idx.entry_id(i, 0)] = exec::kExternalStorageID;
   for (const auto i : idx.outputs()) storage[idx.entry_id(i)] = exec::kExternalStorageID;
 
-  auto mem_plan = PlanMemory(
+  auto mem_plan = MXPlanMemory(
       &g, std::move(storage),
       g.GetAttr<std::vector<uint32_t> >(AddPrefix(BACKWARD, REF_COUNT)),
       AddPrefix(BACKWARD, STORAGE_PLAN),

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -830,7 +830,7 @@ inline std::vector<Context> PlaceDevice(const nnvm::IndexedGraph& idx) {
 }
 
 
-inline MemoryPlanVector PlanMemory(
+inline MemoryPlanVector MXPlanMemory(
     nnvm::Graph* p_g,
     nnvm::StorageVector&& storage,
     const std::vector<uint32_t>& ref_count,

--- a/src/nnvm/graph_algorithm.h
+++ b/src/nnvm/graph_algorithm.h
@@ -42,7 +42,7 @@ namespace pass {
  * \param path the output path of nodes.
  * \return the total reward of best path.
  */
-inline uint32_t FindBestPath(
+inline uint32_t MXFindBestPath(
     const IndexedGraph& graph,
     const std::vector<uint32_t>& node_reward,
     std::vector<uint32_t>* path) {
@@ -89,7 +89,7 @@ inline uint32_t FindBestPath(
  * \param color the color index of each of the node.
  * \return the total number of colors.
  */
-inline uint32_t ColorNodeGroup(
+inline uint32_t MXColorNodeGroup(
     const IndexedGraph &graph,
     std::vector<uint32_t> node_importance,
     uint32_t max_ncolor,
@@ -105,7 +105,7 @@ inline uint32_t ColorNodeGroup(
   // All the nodes in the path cannot run in parallel.
   for (cindex = 0; cindex < max_ncolor - 1; ++cindex) {
     std::vector<uint32_t> path;
-    uint32_t reward = FindBestPath(graph, node_importance, &path);
+    uint32_t reward = MXFindBestPath(graph, node_importance, &path);
     if (reward == 0) break;
     for (uint32_t nid : path) {
       if (node_importance[nid] != 0) {


### PR DESCRIPTION
Referring to issue [#14808](https://github.com/apache/incubator-mxnet/issues/14808)

amalgamation predict api fails when loading a network. The error messages are attached.

```
mxnet_predict-all.cc:32818: Check failed: reg != nullptr: Cannot find pass MXPlanMemory in the registry
```
However, changing MXPlanMemory to PlanMemory would not resolve the issue. Because amalgamation uses tvm/nnvm. and mxnet core engine uses its own customized nnvm version.
Simply using tvm/nnvm/plan_memory would cause Check failure.
```
mxnet_predict-all.cc:4289: Check failed: strcmp(type_->ptype_info->name(), typeid(T).name()) == 0: The stored type name mismatch stored=NSt3__16vectorIN5mxnet6TShapeENS_9allocatorIS2_EEEE requested=NSt3__16vectorIN4nnvm6TShapeENS_9allocatorIS2_EEEE
```

Therefore I added mxnet/nnvm to the C predict API amalgamation list.
And refactored some names to avoid redeclaration.