### PR TITLE
Efficient MXNet sampling in the multinomial distribution

### DIFF
--- a/src/operator/random/sample_multinomial_op.h
+++ b/src/operator/random/sample_multinomial_op.h
@@ -124,11 +124,11 @@ struct SampleMultinomialKernel {
   MSHADOW_XINLINE static void Map(int i, index_t K, index_t M,
                                   DType* dist, float* uniform, float* cum_table,
                                   IType* out, DType* prob) {
-    float acc = 0.0;
+    double acc = 0.0;
     // CDF table
     for (index_t c = 0; c < K; ++c) {
       acc += dist[i*K + c];
-      cum_table[i*K + c] = acc;
+      cum_table[i*K + c] = static_cast<float>(acc);
     }
     for (index_t j = 0; j < M; ++j) {
       index_t left = 0, right = K;

--- a/src/operator/random/sample_multinomial_op.h
+++ b/src/operator/random/sample_multinomial_op.h
@@ -122,25 +122,28 @@ inline bool SampleMultinomialOpType(const nnvm::NodeAttrs& attrs,
 struct SampleMultinomialKernel {
   template<typename DType, typename IType>
   MSHADOW_XINLINE static void Map(int i, index_t K, index_t M,
-                                  DType* dist, float* uniform, IType* out,
-                                  DType* prob) {
+                                  DType* dist, float* uniform, float* cum_table,
+                                  IType* out, DType* prob) {
+    cum_table[i*K] = 0.0;
+    // CDF table
+    for (index_t c = 1; c < K + 1; ++c) {
+      cum_table[i*K + c] = cum_table[i*K + c - 1] + dist[i*K + c - 1];
+    }
     for (index_t j = 0; j < M; ++j) {
+      index_t left = 0, right = K;
+      index_t middle = left + (right - left) / 2;
       DType loc = static_cast<DType>(uniform[i*M + j]);
-      DType acc = 0;
-      bool found = false;
-      for (index_t k = 0; k < K; ++k) {
-        acc += dist[i*K + k];
-        if (acc > loc) {
-          found = true;
-          out[i*M + j] = static_cast<IType>(k);
-          if (prob != nullptr) prob[i*M + j] = logf(dist[i*K + k]);
-          break;
+      while (right - left > 0) {
+        middle = left + (right - left) / 2;
+        DType cum_prob = cum_table[i*K + middle];
+        if (cum_prob < loc) {
+          left = middle + 1;
+        } else {
+          right = middle;
         }
       }
-      if (!found) {
-        out[i*M + j] = static_cast<IType>(K-1);
-        if (prob != nullptr) prob[i*M + j] = logf(dist[i*K + K - 1]);
-      }
+      out[i*M + j] = static_cast<IType>(middle);
+      if (prob != nullptr) prob[i*M + j] = logf(dist[i*K + middle - 1]);
     }
   }
 };
@@ -163,12 +166,14 @@ void SampleMultinomialForward(const nnvm::NodeAttrs& attrs,
   Stream<xpu> *s = ctx.get_stream<xpu>();
   MSHADOW_REAL_TYPE_SWITCH(inputs[0].type_flag_, DType, {
     Random<xpu, float> *prnd = ctx.requested[0].get_random<xpu, float>(s);
-    Tensor<xpu, 1, float> uniform =
-      ctx.requested[1].get_space_typed<xpu, 1, float>(Shape1(N*M), s);
+    Tensor<xpu, 1, float> workspace =
+      ctx.requested[1].get_space_typed<xpu, 1, float>(Shape1(N*M + N*(K + 1)), s);
+    Tensor<xpu, 1, float> uniform(workspace.dptr_, Shape1(N*M));
     prnd->SampleUniform(&uniform, 0, 1);
     MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, IType, {
       Kernel<SampleMultinomialKernel, xpu>::Launch(
-        s, N, K, M, inputs[0].dptr<DType>(), uniform.dptr_, outputs[0].dptr<IType>(),
+        s, N, K, M, inputs[0].dptr<DType>(), workspace.dptr_, workspace.dptr_ + N*M,
+        outputs[0].dptr<IType>(),
         param.get_prob ? outputs[1].dptr<DType>() : nullptr);
     });
   });

--- a/src/operator/random/sample_multinomial_op.h
+++ b/src/operator/random/sample_multinomial_op.h
@@ -172,7 +172,7 @@ void SampleMultinomialForward(const nnvm::NodeAttrs& attrs,
     prnd->SampleUniform(&uniform, 0, 1);
     MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, IType, {
       Kernel<SampleMultinomialKernel, xpu>::Launch(
-        s, N, K, M, inputs[0].dptr<DType>(), workspace.dptr_, workspace.dptr_ + N*M,
+        s, N, K, M, inputs[0].dptr<DType>(), uniform.dptr_, workspace.dptr_ + N*M,
         outputs[0].dptr<IType>(),
         param.get_prob ? outputs[1].dptr<DType>() : nullptr);
     });


### PR DESCRIPTION
## Description ##
This PR has solved the problem of low efficiency to sample from the multinomial distribution, especially the distribution with a large number of possible outcomes. As it was described in #15231, it costs ~44 s using `mx.nd.random.multinomial`, while `np.random.multinomial` costs ~0.019 s. After our optimization, it decreases to ~0.054 s.

## Feature changes ##
### New features ###
- Efficient sampling strategy for the multinomial distribution using binary search.
- Use `double` type to define some cumulative variables for high precision with very small probabilities.
- Reserve the CDF array for sampling many times without duplicated addition operations.

### Performance ###
We compared the time costs of `mx.nd.random.multinomial` on branch master(b8b352d) and our PR shown in the table below. The result shows that the time cost of the original sampling strategy rises much more rapidly than that of our PR with the increasing number of outcomes.

| Number of outcomes | Master(b8b352d) Costs (ms) | PR(6c3c49b) Costs (ms) |
|-------------------:|---------------------------:|-----------------------:|
|      10|       0.125                            | 0.066|
|     100|       0.270                            | 0.058|
|    1000|       0.729                            | 0.130|
|   10000|       62.717                           |  0.996|
|  100000|       5372.306                         | 12.125|
| 1000000|    -                                   |173.534|

## Comments ##
@pengzhao-intel @ciyongch @TaoLv Please help me refine this PR and have some review on it. Thanks.

## Check list ##
* [x] Passed code style checking (cpplint).
* [x] Unit test passed.
* [ ]  Code is well-documented.