### PR TITLE
fix doc for the op sort() and argsort()

### DIFF
--- a/src/operator/tensor/ordering_op.cc
+++ b/src/operator/tensor/ordering_op.cc
@@ -114,7 +114,7 @@ Examples::
              [ 1.,  3.]]
 
   // flattens and then sorts
-  sort(x) = [ 1.,  1.,  3.,  4.]
+  sort(x, axis=None) = [ 1.,  1.,  3.,  4.]
 
   // sorts along the first axis
   sort(x, axis=0) = [[ 1.,  1.],
@@ -173,7 +173,7 @@ Examples::
                         [ 0.,  1.,  0.]]
 
   // flatten and then sort
-  argsort(x) = [ 3.,  1.,  5.,  0.,  4.,  2.]
+  argsort(x, axis=None) = [ 3.,  1.,  5.,  0.,  4.,  2.]
 )code" ADD_FILELINE)
 .set_num_inputs(1)
 .set_num_outputs(1)


### PR DESCRIPTION
## Description ##
Errors in the example of `sort()` and `argsort()`. Those op flatten and sort the array only when `axis=None` is given explicitly.

## Checklist ##
* [x] Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-15317/1/index.html