### PR TITLE
enable TensorRT integration with cpp api

### DIFF
--- a/cpp-package/example/inference/README.md
+++ b/cpp-package/example/inference/README.md
@@ -75,6 +75,7 @@ imagenet_inference  --symbol_file <model symbol file in json format>
 		    --num_inference_batches <number of batches used for inference>
 		    --data_layer_type <default: "float32", choices: ["float32", "int8", "uint8"]>
 		    --gpu <whether to run inference on GPU, default: false>
+		    --enableTRT  <whether to run inference with TensorRT, default: false>"
 		    --benchmark <whether to use dummy data to run inference, default: false>
 ```
 
@@ -133,6 +134,19 @@ imagenet_inference.cpp:282: Loading the model from ./model/resnet50_v1_int8-symb
 imagenet_inference.cpp:372: Running the forward pass on model to evaluate the performance..
 imagenet_inference.cpp:387: benchmark completed!
 imagenet_inference.cpp:388: batch size: 1 num batch: 500 throughput: xxxx imgs/s latency:xxxx ms
+```
+For running this example with TensorRT, you can quickly try the following example to run a benchmark test for testing Inception BN:
+```
+./imagenet_inference --symbol_file "./model/Inception-BN-symbol.json" --params_file "./model/Inception-BN-0126.params" --batch_size 16 --num_inference_batches 500 --benchmark --enableTRT
+```
+Sample output will looks like this (the example is running on a AWS P3.2xl machine):
+```
+imagenet_inference.cpp:302: Loading the model from ./model/Inception-BN-symbol.json
+build_subgraph.cc:686: start to execute partition graph.
+imagenet_inference.cpp:317: Loading the model parameters from ./model/Inception-BN-0126.params
+imagenet_inference.cpp:424: Running the forward pass on model to evaluate the performance..
+imagenet_inference.cpp:439:  benchmark completed!
+imagenet_inference.cpp:440:  batch size: 16 num batch: 500 throughput: 6284.78 imgs/s latency:0.159115 ms
 ```
 
 ## [sentiment_analysis_rnn.cpp](<https://github.com/apache/incubator-mxnet/blob/master/cpp-package/example/inference/sentiment_analysis_rnn.cpp>)

--- a/cpp-package/include/mxnet-cpp/MxNetCpp.h
+++ b/cpp-package/include/mxnet-cpp/MxNetCpp.h
@@ -39,5 +39,6 @@
 #include "mxnet-cpp/io.hpp"
 #include "mxnet-cpp/metric.h"
 #include "mxnet-cpp/initializer.h"
+#include "mxnet-cpp/contrib.h"
 
 #endif  // MXNET_CPP_MXNETCPP_H_

--- a/cpp-package/include/mxnet-cpp/contrib.h
+++ b/cpp-package/include/mxnet-cpp/contrib.h
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+*  Copyright (c) 2019 by Contributors
+* \file contrib.h
+* \brief utility function to enable some contrib features
+* \author Haohuan Wang
+*/
+#ifndef MXNET_CPP_CONTRIB_H_
+#define MXNET_CPP_CONTRIB_H_
+
+#include <iostream>
+#include <string>
+#include <map>
+#include <vector>
+#include "mxnet-cpp/symbol.h"
+
+namespace mxnet {
+namespace cpp {
+namespace details {
+
+  /*!
+   * split a string with the given delimiter
+   * @param str string to be parsed
+   * @param delimiter delimiter
+   * @return delimited list of string
+   */
+  inline std::vector<std::string> split(const std::string& str, const std::string& delimiter) {
+    std::vector<std::string> splitted;
+    size_t last = 0;
+    size_t next = 0;
+    while ((next = str.find(delimiter, last)) != std::string::npos) {
+      splitted.push_back(str.substr(last, next - last));
+      last = next + 1;
+    }
+    splitted.push_back(str.substr(last));
+    return splitted;
+  }
+
+}  // namespace details
+
+namespace contrib {
+
+  // needs to be same with
+  //   https://github.com/apache/incubator-mxnet/blob/1c874cfc807cee755c38f6486e8e0f4d94416cd8/src/operator/subgraph/tensorrt/tensorrt-inl.h#L190
+  static const std::string TENSORRT_SUBGRAPH_PARAM_IDENTIFIER = "subgraph_params_names";
+  // needs to be same with
+  //   https://github.com/apache/incubator-mxnet/blob/master/src/operator/subgraph/tensorrt/tensorrt.cc#L244
+  static const std::string TENSORRT_SUBGRAPH_PARAM_PREFIX = "subgraph_param_";
+  /*!
+   * this is a mimic to https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/contrib/tensorrt.py#L37
+   * @param symbol symbol that already called subgraph api
+   * @param argParams original arg params, params needed by tensorrt will be removed after calling this function
+   * @param auxParams original aux params, params needed by tensorrt will be removed after calling this function
+   */
+  inline void InitTensorRTParams(const mxnet::cpp::Symbol& symbol,
+      std::map<std::string, mxnet::cpp::NDArray> *argParams,
+      std::map<std::string, mxnet::cpp::NDArray> *auxParams) {
+    mxnet::cpp::Symbol internals = symbol.GetInternals();
+    mx_uint numSymbol = internals.GetNumOutputs();
+    for (mx_uint i = 0; i < numSymbol; ++i) {
+        std::map<std::string, std::string> attrs = internals[i].ListAttributes();
+        if (attrs.find(TENSORRT_SUBGRAPH_PARAM_IDENTIFIER) != attrs.end()) {
+            std::string new_params_names;
+            std::map<std::string, mxnet::cpp::NDArray> tensorrtParams;
+            std::vector<std::string> keys = details::split(
+                attrs[TENSORRT_SUBGRAPH_PARAM_IDENTIFIER], ";");
+            for (const auto& key : keys) {
+                if (argParams->find(key) != argParams->end()) {
+                    new_params_names += key + ";";
+                    tensorrtParams[TENSORRT_SUBGRAPH_PARAM_PREFIX + key] = (*argParams)[key];
+                    argParams->erase(key);
+                } else if (auxParams->find(key) != auxParams->end()) {
+                    new_params_names += key + ";";
+                    tensorrtParams[TENSORRT_SUBGRAPH_PARAM_PREFIX + key] = (*auxParams)[key];
+                    auxParams->erase(key);
+                }
+            }
+            std::map<std::string, std::string> new_attrs = {};
+            for (const auto& kv : tensorrtParams) {
+                // passing the ndarray address into TRT node attributes to get the weight
+                uint64_t address = reinterpret_cast<uint64_t>(kv.second.GetHandle());
+                new_attrs[kv.first] = std::to_string(address);
+            }
+            if (!new_attrs.empty()) {
+                internals[i].SetAttributes(new_attrs);
+                internals[i].SetAttribute(TENSORRT_SUBGRAPH_PARAM_IDENTIFIER,
+                    new_params_names.substr(0, new_params_names.length() - 1));
+            }
+        }
+    }
+}
+
+}  // namespace contrib
+}  // namespace cpp
+}  // namespace mxnet
+
+#endif  // MXNET_CPP_CONTRIB_H_

--- a/cpp-package/include/mxnet-cpp/symbol.h
+++ b/cpp-package/include/mxnet-cpp/symbol.h
@@ -178,6 +178,23 @@ class Symbol {
   std::vector<std::string> ListOutputs() const;
   /*! \return get the descriptions of auxiliary data for this symbol */
   std::vector<std::string> ListAuxiliaryStates() const;
+  /*! \return get all attributes for this symbol */
+  std::map<std::string, std::string> ListAttributes() const;
+  /*!
+   * \brief set key-value attribute to the symbol
+   * @param key string represent the key for the attribute
+   * @param value string represent the value for the attribute
+   */
+  void SetAttribute(const std::string& key, const std::string& value);
+  /*!
+   * \brief set a series of key-value attribute to the symbol
+   * @param attrs string:string map represent the key value attributes
+   */
+  void SetAttributes(const std::map<std::string, std::string>& attrs);
+  /*! \return get number of outputs for this symbol */
+  mx_uint GetNumOutputs() const;
+  /*! \return get the new symbol through subgraph API for this symbol */
+  mxnet::cpp::Symbol GetBackendSymbol(const std::string& backendName) const;
   /*! \return get the name of the symbol */
   std::string GetName() const;
   /*!


### PR DESCRIPTION
## Description ##
This PR enables using TensorRT through cpp api

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ x ] Changes are complete (i.e. I finished coding on this PR)
- [ x ] All changes have test coverage: 
- [ x ] Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
     - I have updated the inference test but I don't think this is part of the ci task since I am not sure what is the easiest way to add this test in ci.
- [ x ] Code is well-documented: 
- [ x ]For new C++ functions in header files, their functionalities and arguments are documented. 
- [ x ]For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [ x ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ X ] inception_inference.cpp : update example for bind with TRT
```
./inception_inference --symbol "./model/Inception-BN-symbol.json" --params "./model/Inception-BN-0126.params" --synset "./model/synset.txt" --mean "./model/mean_224.nd" --image "./model/dog.jpg" --enableTRT
...
[17:53:45] /opt/workspace/incubator-mxnet/cpp-package/example/inception_inference.cpp:377: The model predicts the input image to be a [ pug, pug-dog ] with Accuracy = 0.987554

root@0f0b3e022627:/opt/workspace/incubator-mxnet/build/private/cmake/cpp-package/example# LD_LIBRARY_PATH=/opt/workspace/incubator-mxnet/build/lib/:$LD_LIBRARY_PATH ./inception_inference --symbol "./model/Inception-BN-symbol.json" --params "./model/Inception-BN-0126.params" --synset "./model/synset.txt" --mean "./model/mean_224.nd" --image "./model/dog.jpg"            
...
[17:53:52] /opt/workspace/incubator-mxnet/cpp-package/example/inception_inference.cpp:377: The model predicts the input image to be a [ pug, pug-dog ] with Accuracy = 0.986955

root@0f0b3e022627:/opt/workspace/incubator-mxnet/build/private/cmake/cpp-package/example# LD_LIBRARY_PATH=/opt/workspace/incubator-mxnet/build/lib/:$LD_LIBRARY_PATH ./inception_inference --symbol "./model/Inception-BN-symbol.json" --params "./model/Inception-BN-0126.params" --synset "./model/synset.txt" --mean "./model/mean_224.nd" --image "./model/dog.jpg" --gpu
...
[17:54:03] /opt/workspace/incubator-mxnet/cpp-package/example/inception_inference.cpp:377: The model predicts the input image to be a [ pug, pug-dog ] with Accuracy = 0.986955
```
- [ x ] symbol.hpp: added some api, these are tested when running inception_inference
- [ x ] contrib.h: new file, added functions for binding TRT, these are tested when running inception_inference

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
  - This change is for enabling ability to use TensorRT integration through C++ API
