### PR TITLE
Expose get_all_registered_operators and get_operator_arguments in the…

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8667,11 +8667,9 @@ def test_get_operator_arguments():
     operator_arguments = get_operator_arguments('Activation')
     ok_(isinstance(operator_arguments, OperatorArguments))
     ok_(operator_arguments.names == ['data', 'act_type'])
-    print(operator_arguments.types)
     ok_(operator_arguments.types
         == ['NDArray-or-Symbol', "{'relu', 'sigmoid', 'softrelu', 'softsign', 'tanh'}, required"])
     ok_(operator_arguments.narg == 2)
-
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -27,10 +27,11 @@ import itertools
 from distutils.version import LooseVersion
 from numpy.testing import assert_allclose, assert_array_equal
 from mxnet.test_utils import *
+from mxnet.operator import *
 from mxnet.base import py_str, MXNetError, _as_list
 from common import setup_module, with_seed, teardown, assert_raises_cudnn_not_satisfied, assertRaises
 from common import run_in_spawned_process
-from nose.tools import assert_raises
+from nose.tools import assert_raises, ok_
 import unittest
 import os
 
@@ -8653,6 +8654,17 @@ def test_add_n():
         rslt += data[i]
     add_n_rslt = mx.nd.add_n(*data, out=data[0])
     assert_almost_equal(rslt.asnumpy(), add_n_rslt.asnumpy(), atol=1e-5)
+
+
+def test_get_all_registered_operators():
+    ops = get_all_registered_operators()
+    ok_(isinstance(ops, list))
+    ok_(len(ops) > 0)
+
+
+def test_get_operator_arguments():
+    operator_arguments = get_operator_arguments(mx.operator.get_all_registered_operators()[0])
+    ok_(isinstance(operator_arguments, OperatorArguments))
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8660,11 +8660,18 @@ def test_get_all_registered_operators():
     ops = get_all_registered_operators()
     ok_(isinstance(ops, list))
     ok_(len(ops) > 0)
+    ok_('Activation' in ops)
 
 
 def test_get_operator_arguments():
-    operator_arguments = get_operator_arguments(mx.operator.get_all_registered_operators()[0])
+    operator_arguments = get_operator_arguments('Activation')
     ok_(isinstance(operator_arguments, OperatorArguments))
+    ok_(operator_arguments.names == ['data', 'act_type'])
+    print(operator_arguments.types)
+    ok_(operator_arguments.types
+        == ['NDArray-or-Symbol', "{'relu', 'sigmoid', 'softrelu', 'softsign', 'tanh'}, required"])
+    ok_(operator_arguments.narg == 2)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
… Python API.

Resolves #15367 

@sandeep-krishnamurthy 

## Checklist ##
I checked that opperf.py runs with the changes provided.

### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
