### PR TITLE
Add Sparse NDArray support for Scala

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/Executor.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Executor.scala
@@ -159,7 +159,14 @@ class Executor private[mxnet](private[mxnet] val handle: ExecutorHandle,
   private def getOutputs: Array[NDArray] = {
     val ndHandles = ArrayBuffer[NDArrayHandle]()
     checkCall(_LIB.mxExecutorOutputs(handle, ndHandles))
-    ndHandles.toArray.map(new NDArray(_, addToCollector = false))
+    ndHandles.toArray.map(ele => {
+        val nd = new NDArray(ele, addToCollector = false)
+        if (nd.isSparse) {
+          nd.asInstanceOf[SparseNDArray]
+        }
+        nd
+      }
+    )
   }
 
   /**

--- a/scala-package/core/src/main/scala/org/apache/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/LibInfo.scala
@@ -31,13 +31,14 @@ private[mxnet] class LibInfo {
   @native def mxListAllOpNames(names: ListBuffer[String]): Int
   @native def nnGetOpHandle(opName: String, opHandle: RefLong): Int
   // NDArray
-  @native def mxImperativeInvoke(creator: FunctionHandle,
+  @native def mxImperativeInvokeEx(creator: FunctionHandle,
                                  inputs: Array[NDArrayHandle],
                                  outputsGiven: Array[NDArrayHandle],
                                  outputs: ArrayBuffer[NDArrayHandle],
                                  numParams: Int,
                                  paramKeys: Array[String],
-                                 paramVals: Array[String]): Int
+                                 paramVals: Array[String],
+                                 outStype: ArrayBuffer[Int]): Int
   @native def mxNDArrayFree(handle: NDArrayHandle): Int
   @native def mxNDArrayCreateNone(out: NDArrayHandleRef): Int
   @native def mxNDArrayCreateEx(shape: Array[Int],
@@ -120,6 +121,9 @@ private[mxnet] class LibInfo {
   @native def mxNDArraySave(fname: String,
                             handles: Array[NDArrayHandle],
                             keys: Array[String]): Int
+  @native def mxNDArrayGetAuxNDArray(handle: NDArrayHandle,
+                                     location: Int,
+                                     out: NDArrayHandleRef): Int
   @native def mxNDArrayGetContext(handle: NDArrayHandle, devTypeId: RefInt, devId: RefInt): Int
   @native def mxNDArraySaveRawBytes(handle: NDArrayHandle, buf: ArrayBuffer[Byte]): Int
   @native def mxNDArrayLoadFromRawBytes(bytes: Array[Byte], handle: NDArrayHandleRef): Int

--- a/scala-package/core/src/main/scala/org/apache/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/LibInfo.scala
@@ -47,6 +47,18 @@ private[mxnet] class LibInfo {
                                 delayAlloc: Int,
                                 dtype: Int,
                                 out: NDArrayHandleRef): Int
+  @native def mxNDArrayCreateSparseEx(storageType: Int,
+                                      shape: Array[Int],
+                                      ndim: Int,
+                                      devType: Int,
+                                      devId: Int,
+                                      delayAlloc: Int,
+                                      dtype: Int,
+                                      numAux: Int,
+                                      auxTypes: Array[Int],
+                                      auxNdims: Array[Int],
+                                      auxShapes: Array[Int],
+                                      out: NDArrayHandleRef): Int
   @native def mxNDArrayWaitAll(): Int
   @native def mxNDArrayWaitToRead(handle: NDArrayHandle): Int
   @native def mxListFunctions(functions: ListBuffer[FunctionHandle]): Int
@@ -76,6 +88,9 @@ private[mxnet] class LibInfo {
   @native def mxNDArrayGetShape(handle: NDArrayHandle,
                                 ndim: MXUintRef,
                                 data: ArrayBuffer[Int]): Int
+  @native def mxNDArraySyncCopyFromNDArray(handleDst: NDArrayHandle,
+                                           handleSrc: NDArrayHandle,
+                                           locator: Int): Int
   @native def mxNDArraySyncCopyToCPU(handle: NDArrayHandle,
                                      data: Array[Byte],
                                      size: Int): Int
@@ -109,6 +124,7 @@ private[mxnet] class LibInfo {
   @native def mxNDArraySaveRawBytes(handle: NDArrayHandle, buf: ArrayBuffer[Byte]): Int
   @native def mxNDArrayLoadFromRawBytes(bytes: Array[Byte], handle: NDArrayHandleRef): Int
   @native def mxNDArrayGetDType(handle: NDArrayHandle, dtype: RefInt): Int
+  @native def mxNDArrayGetStorageType(handle: NDArrayHandle, stype: RefInt): Int
 
   // KVStore Server
   @native def mxInitPSEnv(keys: Array[String], values: Array[String]): Int

--- a/scala-package/core/src/main/scala/org/apache/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/LibInfo.scala
@@ -48,6 +48,7 @@ private[mxnet] class LibInfo {
                                 delayAlloc: Int,
                                 dtype: Int,
                                 out: NDArrayHandleRef): Int
+  // scalastyle:off parameterNum
   @native def mxNDArrayCreateSparseEx(storageType: Int,
                                       shape: Array[Int],
                                       ndim: Int,
@@ -60,6 +61,7 @@ private[mxnet] class LibInfo {
                                       auxNdims: Array[Int],
                                       auxShapes: Array[Int],
                                       out: NDArrayHandleRef): Int
+  // scalastyle:on parameterNum
   @native def mxNDArrayWaitAll(): Int
   @native def mxNDArrayWaitToRead(handle: NDArrayHandle): Int
   @native def mxListFunctions(functions: ListBuffer[FunctionHandle]): Int

--- a/scala-package/core/src/main/scala/org/apache/mxnet/LibInfo.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/LibInfo.scala
@@ -123,6 +123,7 @@ private[mxnet] class LibInfo {
   @native def mxNDArraySave(fname: String,
                             handles: Array[NDArrayHandle],
                             keys: Array[String]): Int
+  @native def mxNDArrayGetDataNDArray(handle: NDArrayHandle, out: NDArrayHandleRef): Int
   @native def mxNDArrayGetAuxNDArray(handle: NDArrayHandle,
                                      location: Int,
                                      out: NDArrayHandleRef): Int

--- a/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
@@ -1328,14 +1328,24 @@ class NDArray private[mxnet](private[mxnet] val handle: NDArrayHandle,
     if (this.context == context) this else this.copyTo(context)
   }
 
+  /**
+    * check if NDArray is SparseNDArray
+    * @return Boolean
+    */
   def isSparse: Boolean = {
-    this.sparseFormat.id != 0
+      this.sparseFormat.id != 0
   }
 
+  /**
+    * Convert a NDArray to SparseNDArray
+    *
+    * @param sfOption the target sparse type
+    * @return SparseNDArray
+    */
   def toSparse(sfOption : Option[SparseFormat] = None): SparseNDArray = {
     val sf = sfOption.getOrElse(SparseFormat.ROW_SPARSE)
     if (sf.id == 0) throw new IllegalArgumentException("Require Sparse")
-    if (this.sparseFormat.id != 0 && sfOption.isEmpty) {
+    if (isSparse && sfOption.isEmpty) {
         this.asInstanceOf[SparseNDArray]
     } else {
       NDArray.api.cast_storage(this, sf.toString).head.asInstanceOf[SparseNDArray]

--- a/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/NDArray.scala
@@ -114,10 +114,22 @@ object NDArray extends NDArrayBase {
       }
 
     val outputs = ArrayBuffer.empty[NDArrayHandle]
-    checkCall(_LIB.mxImperativeInvoke(function.handle, ndArgs.map(_.handle).toArray, outputVars,
-      outputs, updatedKwargs.size, updatedKwargs.keys.toArray, updatedKwargs.values.toArray))
+    val outStypes = ArrayBuffer.empty[Int]
+    checkCall(_LIB.mxImperativeInvokeEx(function.handle,
+      ndArgs.map(_.handle).toArray,
+      outputVars,
+      outputs,
+      updatedKwargs.size,
+      updatedKwargs.keys.toArray,
+      updatedKwargs.values.toArray,
+      outStypes))
     new NDArrayFuncReturn(Option(oriOutputs).getOrElse {
-      val outputArrs = outputs.map(new NDArray(_)).toArray
+      val outputArrs = (outputs zip outStypes).map(
+        ele => ele._2 match {
+          case 0 => new NDArray(ele._1)
+          case _ => new SparseNDArray(ele._1)
+        }
+        ).toArray
       addDependency(ndArgs.toArray, outputArrs)
       outputArrs
     })
@@ -1316,6 +1328,10 @@ class NDArray private[mxnet](private[mxnet] val handle: NDArrayHandle,
     if (this.context == context) this else this.copyTo(context)
   }
 
+  def isSparse: Boolean = {
+    this.sparseFormat.id != 0
+  }
+
   def toSparse(sfOption : Option[SparseFormat] = None): SparseNDArray = {
     val sf = sfOption.getOrElse(SparseFormat.ROW_SPARSE)
     if (sf.id == 0) throw new IllegalArgumentException("Require Sparse")
@@ -1496,6 +1512,7 @@ private[mxnet] class NDArrayInternal (private val internal: Array[Byte], private
       case DType.Float32 => units.map(wrapBytes(_).getFloat.toDouble)
       case DType.Float64 => units.map(wrapBytes(_).getDouble)
       case DType.Int32 => units.map(wrapBytes(_).getInt.toDouble)
+      case DType.Int64 => units.map(wrapBytes(_).getLong.toDouble)
       case DType.UInt8 => internal.map(_.toDouble)
     }
   }
@@ -1505,6 +1522,7 @@ private[mxnet] class NDArrayInternal (private val internal: Array[Byte], private
       case DType.Float32 => units.map(wrapBytes(_).getFloat)
       case DType.Float64 => units.map(wrapBytes(_).getDouble.toFloat)
       case DType.Int32 => units.map(wrapBytes(_).getInt.toFloat)
+      case DType.Int64 => units.map(wrapBytes(_).getLong.toFloat)
       case DType.UInt8 => internal.map(_.toFloat)
     }
   }
@@ -1514,7 +1532,18 @@ private[mxnet] class NDArrayInternal (private val internal: Array[Byte], private
       case DType.Float32 => units.map(wrapBytes(_).getFloat.toInt)
       case DType.Float64 => units.map(wrapBytes(_).getDouble.toInt)
       case DType.Int32 => units.map(wrapBytes(_).getInt)
+      case DType.Int64 => units.map(wrapBytes(_).getLong.toInt)
       case DType.UInt8 => internal.map(_.toInt)
+    }
+  }
+  def toLongArray: Array[Long] = {
+    require(dtype != DType.Float16, "Currently cannot convert float16 to native numerical types")
+    dtype match {
+      case DType.Float32 => units.map(wrapBytes(_).getFloat.toLong)
+      case DType.Float64 => units.map(wrapBytes(_).getDouble.toLong)
+      case DType.Int32 => units.map(wrapBytes(_).getInt.toLong)
+      case DType.Int64 => units.map(wrapBytes(_).getLong)
+      case DType.UInt8 => internal.map(_.toLong)
     }
   }
   def toByteArray: Array[Byte] = {
@@ -1523,6 +1552,7 @@ private[mxnet] class NDArrayInternal (private val internal: Array[Byte], private
       case DType.Float16 | DType.Float32 => units.map(wrapBytes(_).getFloat.toByte)
       case DType.Float64 => units.map(wrapBytes(_).getDouble.toByte)
       case DType.Int32 => units.map(wrapBytes(_).getInt.toByte)
+      case DType.Int64 => units.map(wrapBytes(_).getLong.toByte)
       case DType.UInt8 => internal.clone()
     }
   }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/SparseFormat.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/SparseFormat.scala
@@ -17,24 +17,9 @@
 
 package org.apache.mxnet
 
-object DType extends Enumeration {
-  type DType = Value
-  val Float32 = Value(0, "float32")
-  val Float64 = Value(1, "float64")
-  val Float16 = Value(2, "float16")
-  val UInt8 = Value(3, "uint8")
-  val Int32 = Value(4, "int32")
-  val Int8 = Value(5, "int8")
-  val Int64 = Value(6, "int64")
-  val Unknown = Value(-1, "unknown")
-  private[mxnet] def numOfBytes(dtype: DType): Int = {
-    dtype match {
-      case DType.UInt8 | DType.Int8 => 1
-      case DType.Int32 => 4
-      case DType.Float16 => 2
-      case DType.Float32 => 4
-      case DType.Float64 | DType.Int64 => 8
-      case DType.Unknown => 0
-    }
-  }
+object SparseFormat extends Enumeration {
+  type SparseFormat = Value
+  val DEFAULT = Value(0, "default")
+  val ROW_SPARSE = Value(1, "row_sparse")
+  val CSR = Value(2, "csr")
 }

--- a/scala-package/core/src/main/scala/org/apache/mxnet/SparseNDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/SparseNDArray.scala
@@ -152,6 +152,19 @@ class SparseNDArray private[mxnet] (override private[mxnet] val handle: NDArrayH
   }
 
   /**
+    * Get the Data portion from the row Sparse NDArray
+    * @return NDArray
+    */
+  def getData: NDArray = {
+    val handle = new NDArrayHandleRef
+    if (this.sparseFormat == SparseFormat.CSR) {
+      throw new UnsupportedOperationException("Not Supported for CSR")
+    }
+    _LIB.mxNDArrayGetDataNDArray(this.handle, handle)
+    new NDArray(handle.value, false)
+  }
+
+  /**
     * Get the indptr Array
     * @return NDArray
     */

--- a/scala-package/core/src/main/scala/org/apache/mxnet/SparseNDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/SparseNDArray.scala
@@ -151,6 +151,11 @@ class SparseNDArray private[mxnet] (override private[mxnet] val handle: NDArrayH
     dense.at(idx)
   }
 
+  override def slice(start: Int, end: Int): NDArray = {
+    printf(s"\n\nSlice being called!!\n\nstart:$start end:$end")
+    NDArray.api.slice(this, Shape(start), Shape(end))
+  }
+
   /**
     * Get the Data portion from the row Sparse NDArray
     * @return NDArray

--- a/scala-package/core/src/main/scala/org/apache/mxnet/SparseNDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/SparseNDArray.scala
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.mxnet
+
+import org.apache.mxnet.Base.{NDArrayHandle, NDArrayHandleRef, checkCall, _LIB}
+import org.apache.mxnet.DType.DType
+import org.apache.mxnet.SparseFormat.SparseFormat
+
+object SparseNDArray {
+  def csrMatrix(data: Array[Float], indices: Array[Float],
+                indptr: Array[Float], shape: Shape, ctx: Context): SparseNDArray = {
+    val fmt = SparseFormat.CSR
+    val dataND = NDArray.array(data, Shape(data.length), ctx)
+    val indicesND = NDArray.array(indices, Shape(indices.length), ctx).asType(DType.Int64)
+    val indptrND = NDArray.array(indptr, Shape(indptr.length), ctx).asType(DType.Int64)
+    val dTypes = Array(indptrND.dtype, indicesND.dtype)
+    val shapes = Array(indptrND.shape, indicesND.shape)
+    val handle =
+      newAllocHandle(fmt, shape, ctx, false, DType.Float32, dTypes, shapes)
+    checkCall(_LIB.mxNDArraySyncCopyFromNDArray(handle, dataND.handle, -1))
+    checkCall(_LIB.mxNDArraySyncCopyFromNDArray(handle, indptrND.handle, 0))
+    checkCall(_LIB.mxNDArraySyncCopyFromNDArray(handle, indicesND.handle, 1))
+    new SparseNDArray(handle, false)
+  }
+
+  def rowSparseArray(data: Array[_], indices: Array[Float],
+                     shape: Shape, ctx: Context): SparseNDArray = {
+    val dataND = NDArray.toNDArray(data)
+    val indicesND = NDArray.array(indices, Shape(indices.length), ctx).asType(DType.Int64)
+    rowSparseArray(dataND, indicesND, shape, ctx)
+  }
+
+  def rowSparseArray(data: NDArray, indices: NDArray,
+                     shape: Shape, ctx: Context): SparseNDArray = {
+    val fmt = SparseFormat.ROW_SPARSE
+    val handle = newAllocHandle(fmt, shape, ctx, false,
+      DType.Float32, Array(indices.dtype), Array(indices.shape))
+    checkCall(_LIB.mxNDArraySyncCopyFromNDArray(handle, data.handle, -1))
+    checkCall(_LIB.mxNDArraySyncCopyFromNDArray(handle, indices.handle, 0))
+    new SparseNDArray(handle, false)
+  }
+
+  private def newAllocHandle(stype : SparseFormat,
+                             shape: Shape,
+                             ctx: Context,
+                             delayAlloc: Boolean,
+                             dtype: DType = DType.Float32,
+                             auxDTypes: Array[DType],
+                             auxShapes: Array[Shape]) : NDArrayHandle = {
+    val hdl = new NDArrayHandleRef
+    checkCall(_LIB.mxNDArrayCreateSparseEx(
+      stype.id,
+      shape.toArray,
+      shape.length,
+      ctx.deviceTypeid,
+      ctx.deviceId,
+      if (delayAlloc) 1 else 0,
+      dtype.id,
+      auxDTypes.length,
+      auxDTypes.map(_.id),
+      auxShapes.map(_.length),
+      auxShapes.map(_.get(0)),
+      hdl)
+    )
+    hdl.value
+  }
+}
+
+class SparseNDArray private[mxnet] (override private[mxnet] val handle: NDArrayHandle,
+                                    override val writable: Boolean)
+  extends NDArray(handle, writable) {
+
+  private lazy val dense: NDArray = toDense
+
+  override def toString: String = {
+    dense.toString
+  }
+
+  def toDense: NDArray = {
+      NDArray.api.cast_storage(this, SparseFormat.DEFAULT.toString).head
+  }
+
+  override def toArray: Array[Float] = {
+    dense.toArray
+  }
+
+  override def at(idx: Int): NDArray = {
+    dense.at(idx)
+  }
+}

--- a/scala-package/core/src/main/scala/org/apache/mxnet/SparseNDArray.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/SparseNDArray.scala
@@ -152,31 +152,26 @@ class SparseNDArray private[mxnet] (override private[mxnet] val handle: NDArrayH
   }
 
   override def slice(start: Int, end: Int): NDArray = {
-    printf(s"\n\nSlice being called!!\n\nstart:$start end:$end")
     NDArray.api.slice(this, Shape(start), Shape(end))
   }
 
   /**
-    * Get the Data portion from the row Sparse NDArray
+    * Get the Data portion from a Row Sparse NDArray
     * @return NDArray
     */
   def getData: NDArray = {
+    require(this.sparseFormat == SparseFormat.ROW_SPARSE, "Not Supported for CSR")
     val handle = new NDArrayHandleRef
-    if (this.sparseFormat == SparseFormat.CSR) {
-      throw new UnsupportedOperationException("Not Supported for CSR")
-    }
     _LIB.mxNDArrayGetDataNDArray(this.handle, handle)
     new NDArray(handle.value, false)
   }
 
   /**
-    * Get the indptr Array
+    * Get the indptr Array from a CSR NDArray
     * @return NDArray
     */
   def getIndptr: NDArray = {
-    if (this.sparseFormat == SparseFormat.ROW_SPARSE) {
-      throw new UnsupportedOperationException("Not Supported for row sparse")
-    }
+    require(this.sparseFormat == SparseFormat.CSR, "Not Supported for row sparse")
     getAuxNDArray(0)
   }
 

--- a/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/NDArraySuite.scala
@@ -45,6 +45,22 @@ class NDArraySuite extends FunSuite with BeforeAndAfterAll with Matchers {
     assert(ndones.toScalar === 1f)
   }
 
+  test("to sparse") {
+    val arr = Array(
+      Array(1f, 0f, 0f),
+      Array(0f, 3f, 0f),
+      Array(0f, 0f, 1f)
+    )
+    val nd = NDArray.toNDArray(arr)
+    assert(!nd.isSparse)
+    // row sparse
+    var ndSparse = nd.toSparse()
+    assert(ndSparse.getIndices.toArray sameElements Array(0f, 1f, 2f))
+    // csr
+    ndSparse = nd.toSparse(Some(SparseFormat.CSR))
+    assert(ndSparse.getIndptr.toArray sameElements Array(0f, 1f, 2f, 3f))
+  }
+
   test("to float 64 scalar") {
     val ndzeros = NDArray.zeros(Shape(1), dtype = DType.Float64)
     assert(ndzeros.toFloat64Scalar === 0d)

--- a/scala-package/core/src/test/scala/org/apache/mxnet/SparseNDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/SparseNDArraySuite.scala
@@ -65,7 +65,7 @@ class SparseNDArraySuite  extends FunSuite {
     printf(rspIn.toString)
     val toRetain = Array(0f, 3f)
     val rspOut = SparseNDArray.retain(rspIn, toRetain)
-    assert(rspOut.at(0).toArray sameElements Array(1f, 2f))
+    assert(rspOut.getData.toArray sameElements Array(1f, 2f, 5f, 6f))
     assert(rspOut.getIndices.toArray sameElements Array(0f, 3f))
   }
 

--- a/scala-package/core/src/test/scala/org/apache/mxnet/SparseNDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/SparseNDArraySuite.scala
@@ -54,5 +54,27 @@ class SparseNDArraySuite  extends FunSuite {
     assert(sparseND.getIndices.toArray sameElements indices)
   }
 
+  test("Test retain") {
+    val arr = Array(
+      Array(1f, 2f),
+      Array(3f, 4f),
+      Array(5f, 6f)
+    )
+    val indices = Array(0f, 1f, 3f)
+    val rspIn = SparseNDArray.rowSparseArray(arr, indices, Shape(4, 2), Context.cpu())
+    printf(rspIn.toString)
+    val toRetain = Array(0f, 3f)
+    val rspOut = SparseNDArray.retain(rspIn, toRetain)
+    assert(rspOut.at(0).toArray sameElements Array(1f, 2f))
+    assert(rspOut.getIndices.toArray sameElements Array(0f, 3f))
+  }
+
+  test("Test add") {
+    val nd = NDArray.array(Array(1f, 2f, 3f), Shape(3)).toSparse(Some(SparseFormat.ROW_SPARSE))
+    val nd2 = nd + nd
+    assert(nd2.isInstanceOf[SparseNDArray])
+    assert(nd2.toArray sameElements Array(2f, 4f, 6f))
+  }
+
 
 }

--- a/scala-package/core/src/test/scala/org/apache/mxnet/SparseNDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/SparseNDArraySuite.scala
@@ -17,6 +17,7 @@
 
 package org.apache.mxnet
 
+import org.apache.mxnet.io.NDArrayIter
 import org.scalatest.FunSuite
 import org.slf4j.LoggerFactory
 
@@ -62,7 +63,6 @@ class SparseNDArraySuite  extends FunSuite {
     )
     val indices = Array(0f, 1f, 3f)
     val rspIn = SparseNDArray.rowSparseArray(arr, indices, Shape(4, 2), Context.cpu())
-    printf(rspIn.toString)
     val toRetain = Array(0f, 3f)
     val rspOut = SparseNDArray.retain(rspIn, toRetain)
     assert(rspOut.getData.toArray sameElements Array(1f, 2f, 5f, 6f))
@@ -74,6 +74,19 @@ class SparseNDArraySuite  extends FunSuite {
     val nd2 = nd + nd
     assert(nd2.isInstanceOf[SparseNDArray])
     assert(nd2.toArray sameElements Array(2f, 4f, 6f))
+  }
+
+  test("Test DataIter") {
+    val nd = NDArray.array(Array(1f, 2f, 3f), Shape(1, 3)).toSparse(Some(SparseFormat.CSR))
+    val arr = IndexedSeq(nd, nd, nd, nd)
+    val iter = new NDArrayIter(arr)
+    while (iter.hasNext) {
+      val tempArr = iter.next().data
+      tempArr.foreach(ele => {
+        assert(ele.sparseFormat == SparseFormat.CSR)
+        assert(ele.shape == Shape(1, 3))
+      })
+    }
   }
 
 

--- a/scala-package/core/src/test/scala/org/apache/mxnet/SparseNDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/SparseNDArraySuite.scala
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.mxnet
+
+import org.scalatest.FunSuite
+import org.slf4j.LoggerFactory
+
+class SparseNDArraySuite  extends FunSuite {
+
+  private val logger = LoggerFactory.getLogger(classOf[SparseNDArraySuite])
+
+  test("create CSR NDArray") {
+    val data = Array(7f, 8f, 9f)
+    val indices = Array(0f, 2f, 1f)
+    val indptr = Array(0f, 2f, 2f, 3f)
+    val shape = Shape(3, 4)
+    val sparseND = SparseNDArray.csrMatrix(data, indices, indptr, shape, Context.cpu())
+    assert(sparseND.shape == Shape(3, 4))
+    assert(sparseND.toArray
+      sameElements Array(7.0f, 0.0f, 8.0f, 0.0f,
+                         0.0f, 0.0f, 0.0f, 0.0f,
+                         0.0f, 9.0f, 0.0f, 0.0f))
+    assert(sparseND.sparseFormat == SparseFormat.CSR)
+  }
+
+  test("create Row Sparse NDArray") {
+    val data = Array(
+      Array(1f, 2f),
+      Array(3f, 4f)
+    )
+    val indices = Array(1f, 4f)
+    val shape = Shape(6, 2)
+    val sparseND = SparseNDArray.rowSparseArray(data, indices, shape, Context.cpu())
+    assert(sparseND.sparseFormat == SparseFormat.ROW_SPARSE)
+    assert(sparseND.shape == Shape(6, 2))
+    assert(sparseND.at(1).toArray sameElements Array(1f, 2f))
+  }
+
+
+}

--- a/scala-package/core/src/test/scala/org/apache/mxnet/SparseNDArraySuite.scala
+++ b/scala-package/core/src/test/scala/org/apache/mxnet/SparseNDArraySuite.scala
@@ -36,6 +36,8 @@ class SparseNDArraySuite  extends FunSuite {
                          0.0f, 0.0f, 0.0f, 0.0f,
                          0.0f, 9.0f, 0.0f, 0.0f))
     assert(sparseND.sparseFormat == SparseFormat.CSR)
+    assert(sparseND.getIndptr.toArray sameElements indptr)
+    assert(sparseND.getIndices.toArray sameElements indices)
   }
 
   test("create Row Sparse NDArray") {
@@ -49,6 +51,7 @@ class SparseNDArraySuite  extends FunSuite {
     assert(sparseND.sparseFormat == SparseFormat.ROW_SPARSE)
     assert(sparseND.shape == Shape(6, 2))
     assert(sparseND.at(1).toArray sameElements Array(1f, 2f))
+    assert(sparseND.getIndices.toArray sameElements indices)
   }
 
 

--- a/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
@@ -474,6 +474,15 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxFloat64NDArraySyncCopyFro
   return ret;
 }
 
+JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetDataNDArray
+  (JNIEnv *env, jobject obj, jlong arrayPtr, jobject ndArrayHandle) {
+  NDArrayHandle out;
+  int ret = MXNDArrayGetDataNDArray(reinterpret_cast<NDArrayHandle>(arrayPtr),
+                                     &out);
+  SetLongField(env, ndArrayHandle, reinterpret_cast<jlong>(out));
+  return ret;
+}
+
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetAuxNDArray
   (JNIEnv *env, jobject obj, jlong arrayPtr, jint location, jobject ndArrayHandle) {
   NDArrayHandle out;

--- a/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
@@ -93,6 +93,31 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayCreateEx
   return ret;
 }
 
+JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayCreateSparseEx
+  (JNIEnv *env, jobject obj, jint storageType, jintArray shape, jint ndim, jint devType,
+    jint devId, jint delayAlloc, jint dtype, jint numAux, jintArray auxTypes,
+    jintArray auxNdims, jintArray auxShapes, jobject ndArrayHandle) {
+    jint *shapeArr = env->GetIntArrayElements(shape, NULL);
+    jint *auxTypesArr = env->GetIntArrayElements(auxTypes, NULL);
+    jint *auxNdimsArr = env->GetIntArrayElements(auxNdims, NULL);
+    jint *auxShapesArr = env->GetIntArrayElements(auxShapes, NULL);
+    NDArrayHandle out;
+    int ret = MXNDArrayCreateSparseEx(storageType,
+     reinterpret_cast<const mx_uint *>(shapeArr),
+     static_cast<mx_uint>(ndim),
+     devType, devId, delayAlloc, dtype,
+     static_cast<mx_uint>(numAux),
+     reinterpret_cast<int *>(auxTypesArr),
+     reinterpret_cast<mx_uint *>(auxNdimsArr),
+     reinterpret_cast<const mx_uint *>(auxShapesArr),  &out);
+    env->ReleaseIntArrayElements(shape, shapeArr, 0);
+    env->ReleaseIntArrayElements(auxTypes, auxTypesArr, 0);
+    env->ReleaseIntArrayElements(auxNdims, auxNdimsArr, 0);
+    env->ReleaseIntArrayElements(auxShapes, auxShapesArr, 0);
+    SetLongField(env, ndArrayHandle, reinterpret_cast<jlong>(out));
+    return ret;
+}
+
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayWaitAll(JNIEnv *env, jobject obj) {
   return MXNDArrayWaitAll();
 }
@@ -379,6 +404,14 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetShape
   return ret;
 }
 
+JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArraySyncCopyFromNDArray
+  (JNIEnv *env, jobject obj, jlong dstPtr, jlong srcPtr, jint locator) {
+  int ret = MXNDArraySyncCopyFromNDArray(reinterpret_cast<NDArrayHandle>(dstPtr),
+                                   reinterpret_cast<NDArrayHandle>(srcPtr),
+                                   locator);
+  return ret;
+}
+
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArraySyncCopyToCPU
   (JNIEnv *env, jobject obj, jlong ndArrayPtr, jbyteArray data, jint size) {
   jbyte *pdata = env->GetByteArrayElements(data, NULL);
@@ -537,6 +570,14 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetDType
   int dtype;
   int ret = MXNDArrayGetDType(reinterpret_cast<NDArrayHandle>(jhandle), &dtype);
   SetIntField(env, jdtype, dtype);
+  return ret;
+}
+
+JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetStorageType
+  (JNIEnv * env, jobject obj, jlong jhandle, jobject jstype) {
+  int stype;
+  int ret = MXNDArrayGetStorageType(reinterpret_cast<NDArrayHandle>(jhandle), &stype);
+  SetIntField(env, jstype, stype);
   return ret;
 }
 

--- a/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.h
+++ b/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.h
@@ -66,10 +66,18 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayCreateNone
 /*
  * Class:     org_apache_mxnet_LibInfo
  * Method:    mxNDArrayCreateEx
- * Signature: ([IIIIIILorg/apache/mxnet/Base/RefLong;)I
+ * Signature: ([Lorg/apache/mxnet/Base/RefLong;)I
  */
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayCreateEx
   (JNIEnv *, jobject, jintArray, jint, jint, jint, jint, jint, jobject);
+
+/*
+ * Class:     org_apache_mxnet_LibInfo
+ * Method:    mxNDArrayCreateSparseEx
+ * Signature: ([Lorg/apache/mxnet/Base/RefLong;)I
+ */
+JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayCreateSparseEx
+  (JNIEnv *, jobject, jint, jintArray, jint, jint, jint, jint, jint, jint, jintArray, jintArray, jintArray, jobject);
 
 /*
  * Class:     org_apache_mxnet_LibInfo
@@ -134,6 +142,14 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxFuncInvokeEx
  */
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetShape
   (JNIEnv *, jobject, jlong, jobject, jobject);
+
+/*
+ * Class:     org_apache_mxnet_LibInfo
+ * Method:    mxNDArraySyncCopyFromNDArray
+ * Signature: (J[BI)I
+ */
+JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArraySyncCopyFromNDArray
+  (JNIEnv *, jobject, jlong, jlong, jint);
 
 /*
  * Class:     org_apache_mxnet_LibInfo
@@ -229,6 +245,14 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayLoadFromRawBytes
  * Signature: (JLorg/apache/mxnet/Base/RefInt;)I
  */
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetDType
+  (JNIEnv *, jobject, jlong, jobject);
+
+/*
+ * Class:     org_apache_mxnet_LibInfo
+ * Method:    mxNDArrayGetStorageType
+ * Signature: (JLorg/apache/mxnet/Base/RefInt;)I
+ */
+JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetStorageType
   (JNIEnv *, jobject, jlong, jobject);
 
 /*

--- a/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.h
+++ b/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.h
@@ -41,11 +41,12 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_nnGetOpHandle
 
 /*
  * Class:     org_apache_mxnet_LibInfo
- * Method:    mxImperativeInvoke
+ * Method:    mxImperativeInvokeEx
  * Signature: (J[J[JLscala/collection/mutable/ArrayBuffer;I[Ljava/lang/String;[Ljava/lang/String;)I
  */
-JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxImperativeInvoke
-  (JNIEnv *, jobject, jlong, jlongArray, jlongArray, jobject, jint, jobjectArray, jobjectArray);
+JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxImperativeInvokeEx
+  (JNIEnv *, jobject, jlong, jlongArray, jlongArray, jobject,
+   jint, jobjectArray, jobjectArray, jobject);
 
 /*
  * Class:     org_apache_mxnet_LibInfo
@@ -214,6 +215,15 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayLoad
  */
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArraySave
   (JNIEnv *, jobject, jstring, jlongArray, jobjectArray);
+
+
+/*
+ * Class:     org_apache_mxnet_LibInfo
+ * Method:    mxNDArrayGetAuxNDArray
+ * Signature: (JLorg/apache/mxnet/Base/RefInt;Lorg/apache/mxnet/Base/RefInt;)I
+ */
+JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetAuxNDArray
+  (JNIEnv *, jobject, jlong, jint, jobject);
 
 /*
  * Class:     org_apache_mxnet_LibInfo

--- a/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.h
+++ b/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.h
@@ -42,11 +42,10 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_nnGetOpHandle
 /*
  * Class:     org_apache_mxnet_LibInfo
  * Method:    mxImperativeInvokeEx
- * Signature: (J[J[JLscala/collection/mutable/ArrayBuffer;I[Ljava/lang/String;[Ljava/lang/String;)I
+ * Signature: (J[J[JLscala/collection/mutable/ArrayBuffer;I[Ljava/lang/String;[Ljava/lang/String;Lscala/collection/mutable/ArrayBuffer;)I
  */
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxImperativeInvokeEx
-  (JNIEnv *, jobject, jlong, jlongArray, jlongArray, jobject,
-   jint, jobjectArray, jobjectArray, jobject);
+  (JNIEnv *, jobject, jlong, jlongArray, jlongArray, jobject, jint, jobjectArray, jobjectArray, jobject);
 
 /*
  * Class:     org_apache_mxnet_LibInfo
@@ -67,7 +66,7 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayCreateNone
 /*
  * Class:     org_apache_mxnet_LibInfo
  * Method:    mxNDArrayCreateEx
- * Signature: ([Lorg/apache/mxnet/Base/RefLong;)I
+ * Signature: ([IIIIIILorg/apache/mxnet/Base/RefLong;)I
  */
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayCreateEx
   (JNIEnv *, jobject, jintArray, jint, jint, jint, jint, jint, jobject);
@@ -75,7 +74,7 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayCreateEx
 /*
  * Class:     org_apache_mxnet_LibInfo
  * Method:    mxNDArrayCreateSparseEx
- * Signature: ([Lorg/apache/mxnet/Base/RefLong;)I
+ * Signature: (I[IIIIIII[I[I[ILorg/apache/mxnet/Base/RefLong;)I
  */
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayCreateSparseEx
   (JNIEnv *, jobject, jint, jintArray, jint, jint, jint, jint, jint, jint, jintArray, jintArray, jintArray, jobject);
@@ -147,7 +146,7 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetShape
 /*
  * Class:     org_apache_mxnet_LibInfo
  * Method:    mxNDArraySyncCopyFromNDArray
- * Signature: (J[BI)I
+ * Signature: (JJI)I
  */
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArraySyncCopyFromNDArray
   (JNIEnv *, jobject, jlong, jlong, jint);
@@ -216,11 +215,18 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayLoad
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArraySave
   (JNIEnv *, jobject, jstring, jlongArray, jobjectArray);
 
+/*
+ * Class:     org_apache_mxnet_LibInfo
+ * Method:    mxNDArrayGetDataNDArray
+ * Signature: (JLorg/apache/mxnet/Base/RefLong;)I
+ */
+JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetDataNDArray
+  (JNIEnv *, jobject, jlong, jobject);
 
 /*
  * Class:     org_apache_mxnet_LibInfo
  * Method:    mxNDArrayGetAuxNDArray
- * Signature: (JLorg/apache/mxnet/Base/RefInt;Lorg/apache/mxnet/Base/RefInt;)I
+ * Signature: (JILorg/apache/mxnet/Base/RefLong;)I
  */
 JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxNDArrayGetAuxNDArray
   (JNIEnv *, jobject, jlong, jint, jobject);


### PR DESCRIPTION
## Description ##
This is the initial PR to start supporting Sparse `NDArray` for the Scala package. 

`SparseNDArray` is a child class of MXNet NDArray. It supports the following types:
- row sparse
- CSR

Currently, users can call `toSparse` method to convert a `NDArray` from dense to sparse or cast a `NDArray` to `SparseNDArray`. User can also call the following two methods to create Sparse NDArray from scratch
- `SparseNDArray.csrMatrix`
- `SparseNDArray.rowSparseArray`

@gigasquid @zachgk @yzhliu @nswamy @eric-haibin-lin @frankfliu 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
