### PR TITLE
Use omp threads for cpu data loader

### DIFF
--- a/src/io/iter_image_recordio_2.cc
+++ b/src/io/iter_image_recordio_2.cc
@@ -828,7 +828,8 @@ class ImageRecordIter2Wrapper : public IIterator<DataBatch> {
       dtype = prefetch_param.dtype.value();
     }
     if (prefetch_param.ctx == PrefetcherParam::CtxType::kCPU) {
-      LOG(INFO) << "Create ImageRecordIter2 optimized for CPU backend. Use omp threads instead of preprocess_threads.";
+      LOG(INFO) << "Create ImageRecordIter2 optimized for CPU backend."
+                << "Use omp threads instead of preprocess_threads.";
       switch (dtype) {
         case mshadow::kFloat32:
           record_iter_ = new ImageRecordIter2CPU<float>();

--- a/src/io/iter_image_recordio_2.cc
+++ b/src/io/iter_image_recordio_2.cc
@@ -134,19 +134,25 @@ inline void ImageRecordIOParser2<DType>::Init(
   record_param_.InitAllowUnknown(kwargs);
   batch_param_.InitAllowUnknown(kwargs);
   normalize_param_.InitAllowUnknown(kwargs);
+  PrefetcherParam prefetch_param;
+  prefetch_param.InitAllowUnknown(kwargs);
   n_parsed_ = 0;
   overflow = false;
   rnd_.seed(kRandMagic + record_param_.seed);
   int maxthread, threadget;
-  #pragma omp parallel
-  {
-    // be conservative, set number of real cores
-    maxthread = std::max(omp_get_num_procs(), 1);
-  }
-  param_.preprocess_threads = std::min(maxthread, param_.preprocess_threads);
-  #pragma omp parallel num_threads(param_.preprocess_threads)
-  {
-    threadget = omp_get_num_threads();
+  if (prefetch_param.ctx == PrefetcherParam::CtxType::kCPU) {
+    threadget = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
+  } else {
+    #pragma omp parallel
+    {
+      // be conservative, set number of real cores
+      maxthread = std::max(omp_get_num_procs() / 2, 1);
+    }
+    param_.preprocess_threads = std::min(maxthread, param_.preprocess_threads);
+    #pragma omp parallel num_threads(param_.preprocess_threads)
+    {
+      threadget = omp_get_num_threads();
+    }
   }
   param_.preprocess_threads = threadget;
 
@@ -822,7 +828,7 @@ class ImageRecordIter2Wrapper : public IIterator<DataBatch> {
       dtype = prefetch_param.dtype.value();
     }
     if (prefetch_param.ctx == PrefetcherParam::CtxType::kCPU) {
-      LOG(INFO) << "Create ImageRecordIter2 optimized for CPU backend.";
+      LOG(INFO) << "Create ImageRecordIter2 optimized for CPU backend. Use omp threads instead of preprocess_threads.";
       switch (dtype) {
         case mshadow::kFloat32:
           record_iter_ = new ImageRecordIter2CPU<float>();


### PR DESCRIPTION
## Description ##
CPU data loader works as a normal op, so it's naturally to use omp threads number. This change can help to improve data loader performance for non-core-binding usage. 

@pengzhao-intel @anirudh2290 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
