### PR TITLE
[Perl] - simplify aliasing strategy

### DIFF
--- a/perl-package/AI-MXNet/lib/AI/MXNet/AutoGrad.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/AutoGrad.pm
@@ -18,28 +18,11 @@
 package AI::MXNet::AutoGrad;
 use strict;
 use warnings;
+use AI::MXNet::NS 'global';
 use AI::MXNet::Base;
 use AI::MXNet::Function::Parameters;
 use Scalar::Util qw(blessed);
 use Carp qw(confess);
-
-sub import
-{
-    my ($class, $short_name) = @_;
-    if($short_name)
-    {
-        $short_name =~ s/[^\w:]//g;
-        if(length $short_name)
-        {
-            my $short_name_package =<<"EOP";
-            package $short_name;
-            use parent 'AI::MXNet::AutoGrad';
-            1;
-EOP
-            eval $short_name_package;
-        }
-    }
-}
 
 =head1 NAME
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Base.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Base.pm
@@ -32,14 +32,14 @@ use base qw(Exporter);
 use List::Util qw(shuffle);
 use Data::Dumper;
 
-@AI::MXNet::Base::EXPORT = qw(product enumerate assert zip check_call build_param_doc
-                              pdl cat dog svd bisect_left pdl_shuffle as_array ascsr rand_sparse
-                              DTYPE_STR_TO_MX DTYPE_MX_TO_STR DTYPE_MX_TO_PDL
-                              DTYPE_PDL_TO_MX DTYPE_MX_TO_PERL GRAD_REQ_MAP
-                              STORAGE_TYPE_UNDEFINED STORAGE_TYPE_DEFAULT
-                              STORAGE_TYPE_ROW_SPARSE STORAGE_TYPE_CSR
-                              STORAGE_TYPE_STR_TO_ID STORAGE_TYPE_ID_TO_STR STORAGE_AUX_TYPES);
-@AI::MXNet::Base::EXPORT_OK = qw(pzeros pceil pones digitize hash array_index range);
+our @EXPORT = qw(product enumerate assert zip check_call build_param_doc
+                 pdl cat dog svd bisect_left pdl_shuffle as_array ascsr rand_sparse
+                 DTYPE_STR_TO_MX DTYPE_MX_TO_STR DTYPE_MX_TO_PDL
+                 DTYPE_PDL_TO_MX DTYPE_MX_TO_PERL GRAD_REQ_MAP
+                 STORAGE_TYPE_UNDEFINED STORAGE_TYPE_DEFAULT
+                 STORAGE_TYPE_ROW_SPARSE STORAGE_TYPE_CSR
+                 STORAGE_TYPE_STR_TO_ID STORAGE_TYPE_ID_TO_STR STORAGE_AUX_TYPES);
+our @EXPORT_OK = qw(pzeros pceil pones digitize hash array_index range);
 
 use constant DTYPE_STR_TO_MX => {
     float32 => 0,

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Callback.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Callback.pm
@@ -19,6 +19,7 @@ package AI::MXNet::Callback;
 use strict;
 use warnings;
 use List::Util qw/max/;
+use AI::MXNet::NS;
 use AI::MXNet::Function::Parameters;
 use Mouse;
 use overload "&{}" => sub { my $self = shift; sub { $self->call(@_) } };

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Context.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Context.pm
@@ -19,6 +19,7 @@ package AI::MXNet::Context;
 use strict;
 use warnings;
 use Mouse;
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use AI::MXNet::Types;
 use AI::MXNet::Function::Parameters;
@@ -216,12 +217,12 @@ method gpu_memory_info($device_id=0)
 
 method current_ctx()
 {
-    return $AI::MXNet::current_ctx;
+    return $AI::MXNet::Context;
 }
 
 method set_current(AI::MXNet::Context $current)
 {
-    $AI::MXNet::current_ctx = $current;
+    $AI::MXNet::Context = $current;
 }
 
 *current_context = \&current_ctx;
@@ -234,5 +235,6 @@ method deepcopy()
     );
 }
 
-$AI::MXNet::current_ctx = __PACKAGE__->new(device_type => 'cpu', device_id => 0);
+__PACKAGE__->AI::MXNet::NS::register('AI::MXNet');
 
+1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Contrib.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Contrib.pm
@@ -18,8 +18,9 @@
 package AI::MXNet::Contrib;
 use strict;
 use warnings;
-use AI::MXNet::Contrib::Symbol;
-use AI::MXNet::Contrib::NDArray;
+use AI::MXNet::NS;
+use AI::MXNet::Contrib::Symbol qw(sym symbol);
+use AI::MXNet::Contrib::NDArray qw(nd ndarray);
 
 =head1 NAME
 
@@ -46,10 +47,5 @@ use AI::MXNet::Contrib::NDArray;
         );
     }
 =cut
-
-sub sym    { 'AI::MXNet::Contrib::Symbol'  }
-sub symbol { 'AI::MXNet::Contrib::Symbol'  }
-sub nd     { 'AI::MXNet::Contrib::NDArray' }
-sub ndarray { 'AI::MXNet::Contrib::NDArray' }
 
 1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Contrib/NDArray.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Contrib/NDArray.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::Contrib::NDArray;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use parent 'AI::MXNet::AutoLoad';
 sub config { ('contrib', 'AI::MXNet::NDArray') }
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Contrib/Symbol.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Contrib/Symbol.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::Contrib::Symbol;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use parent 'AI::MXNet::AutoLoad';
 sub config { ('contrib', 'AI::MXNet::Symbol') }
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/CudaModule.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/CudaModule.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::CudaModule;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use Mouse;
 use AI::MXNet::Function::Parameters;
@@ -194,6 +195,8 @@ method get_kernel(Str $name, Str $signature)
     );
     return AI::MXNet::CudaKernel->new($handle, $name, \@is_ndarray, \@dtypes);
 }
+
+__PACKAGE__->AI::MXNet::NS::register('AI::MXNet');
 
 package AI::MXNet::CudaKernel;
 use Mouse;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Engine.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Engine.pm
@@ -20,6 +20,7 @@ use strict;
 use warnings;
 use AI::MXNet::Function::Parameters;
 use AI::MXNet::Base;
+use AI::MXNet::NS;
 
 =head1 NAME
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon.pm
@@ -18,42 +18,14 @@
 package AI::MXNet::Gluon;
 use strict;
 use warnings;
-use AI::MXNet::Gluon::Loss;
+use AI::MXNet::NS 'global';
+use AI::MXNet::Gluon::Loss 'loss';
 use AI::MXNet::Gluon::Trainer;
 use AI::MXNet::Gluon::Utils;
-use AI::MXNet::Gluon::Data;
-use AI::MXNet::Gluon::NN;
-use AI::MXNet::Gluon::RNN;
+use AI::MXNet::Gluon::Data 'data';
+use AI::MXNet::Gluon::NN 'nn';
+use AI::MXNet::Gluon::RNN 'rnn';
 
-sub import
-{
-    my ($class, $short_name) = @_;
-    if($short_name)
-    {
-        $short_name =~ s/[^\w:]//g;
-        if(length $short_name)
-        {
-            my $short_name_package =<<"EOP";
-            package $short_name;
-            no warnings 'redefine';
-            sub data { 'AI::MXNet::Gluon::Data' }
-            sub nn { 'AI::MXNet::Gluon::NN_' }
-            sub rnn { 'AI::MXNet::Gluon::RNN_' }
-            sub loss { 'AI::MXNet::Gluon::Loss_' }
-            sub utils { 'AI::MXNet::Gluon::Utils' }
-            sub model_zoo { require AI::MXNet::Gluon::ModelZoo; 'AI::MXNet::Gluon::ModelZoo' }
-            sub Trainer { shift; AI::MXNet::Gluon::Trainer->new(\@_); }
-            sub Parameter { shift; AI::MXNet::Gluon::Parameter->new(\@_); }
-            sub ParameterDict { shift; AI::MXNet::Gluon::ParameterDict->new(\@_); }
-            \@${short_name}::ISA = ('AI::MXNet::Gluon_');
-            1;
-EOP
-            eval $short_name_package;
-        }
-    }
-}
-
-sub data { 'AI::MXNet::Gluon::Data' }
 sub utils { 'AI::MXNet::Gluon::Utils' }
 sub model_zoo { require AI::MXNet::Gluon::ModelZoo; 'AI::MXNet::Gluon::ModelZoo' }
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Block.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Block.pm
@@ -731,8 +731,13 @@ method forward(@args)
 method register(Str $container)
 {
     my $sub_name = $self->_class_name;
+    my $dest = $self->can('new');
+    my $func = sub {
+        splice @_, 0, 1, $self;
+        goto $dest;
+    };
     no strict 'refs';
-    *{$container.'_::'.$sub_name} = sub { shift; $self->new(@_) };
+    *{"$container\::$sub_name"} = $func;
 }
 
 =head2 summary

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Data.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Data.pm
@@ -18,11 +18,11 @@
 package AI::MXNet::Gluon::Data;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::Gluon::Data::Set;
 use AI::MXNet::Gluon::Data::Sampler;
 use AI::MXNet::Gluon::Data::Loader;
-use AI::MXNet::Gluon::Data::Vision;
-sub vision { 'AI::MXNet::Gluon::Data::Vision' }
+use AI::MXNet::Gluon::Data::Vision 'vision';
 
 1;
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Data/Vision.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Data/Vision.pm
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+package AI::MXNet::Gluon::Data::Vision;
+use AI::MXNet::NS;
+
 package AI::MXNet::Gluon::Data::Vision::DownloadedDataSet;
 use strict;
 use warnings;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Loss.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Loss.pm
@@ -18,6 +18,7 @@
 use strict;
 use warnings;
 package AI::MXNet::Gluon::Loss;
+use AI::MXNet::NS;
 use AI::MXNet::Gluon::Block;
 use AI::MXNet::Function::Parameters;
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN.pm
@@ -18,27 +18,10 @@
 package AI::MXNet::Gluon::NN;
 use strict;
 use warnings;
+use AI::MXNet::NS 'global';
 use AI::MXNet::Gluon::Block;
 use AI::MXNet::Gluon::NN::Activation;
 use AI::MXNet::Gluon::NN::BasicLayers;
 use AI::MXNet::Gluon::NN::ConvLayers;
-
-sub import
-{
-    my ($class, $short_name) = @_;
-    if($short_name)
-    {
-        $short_name =~ s/[^\w:]//g;
-        if(length $short_name)
-        {
-            my $short_name_package =<<"EOP";
-            package $short_name;
-            \@${short_name}::ISA = ('AI::MXNet::Gluon::NN_');
-            1;
-EOP
-            eval $short_name_package;
-        }
-    }
-}
 
 1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/Activation.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/Activation.pm
@@ -240,3 +240,5 @@ method hybrid_forward(GluonClass $F, GluonInput $x)
 }
 
 __PACKAGE__->register('AI::MXNet::Gluon::NN');
+
+1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/BasicLayers.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/BasicLayers.pm
@@ -272,7 +272,7 @@ sub BUILD
         if(defined $self->activation)
         {
             $self->act(
-                AI::MXNet::Gluon::NN::Activation->new(
+                AI::MXNet::Gluon::NN->Activation(
                     activation => $self->activation,
                     prefix => $self->activation.'_'
                 )

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/ConvLayers.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/NN/ConvLayers.pm
@@ -156,7 +156,7 @@ sub BUILD
         if(defined $self->activation)
         {
             $self->act(
-                AI::MXNet::Gluon::NN::Activation->new(
+                AI::MXNet::Gluon::NN->Activation(
                     activation => $self->activation,
                     prefix     => $self->activation.'_'
                 )

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Parameter.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Parameter.pm
@@ -19,6 +19,7 @@ use strict;
 use warnings;
 use Hash::Ordered;
 package AI::MXNet::Gluon::Parameter;
+use AI::MXNet::NS;
 use AI::MXNet::Function::Parameters;
 
 =head1 NAME 
@@ -799,6 +800,8 @@ method cast(Dtype $dtype)
     });
 }
 
+__PACKAGE__->AI::MXNet::NS::register('AI::MXNet::Gluon');
+
 package AI::MXNet::Gluon::Constant;
 use strict;
 use warnings;
@@ -1322,5 +1325,7 @@ method load(
         $self->_params->get($name)->_load_init($arg_dict{$name}, $ctx);
     }
 }
+
+__PACKAGE__->AI::MXNet::NS::register('AI::MXNet::Gluon');
 
 1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/RNN.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/RNN.pm
@@ -18,25 +18,8 @@
 package AI::MXNet::Gluon::RNN;
 use strict;
 use warnings;
+use AI::MXNet::NS 'global';
 use AI::MXNet::Gluon::RNN::Layer;
 use AI::MXNet::Gluon::RNN::Cell;
-
-sub import
-{
-    my ($class, $short_name) = @_;
-    if($short_name)
-    {
-        $short_name =~ s/[^\w:]//g;
-        if(length $short_name)
-        {
-            my $short_name_package =<<"EOP";
-            package $short_name;
-            \@${short_name}::ISA = ('AI::MXNet::Gluon::RNN_');
-            1;
-EOP
-            eval $short_name_package;
-        }
-    }
-}
 
 1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Trainer.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Trainer.pm
@@ -18,6 +18,7 @@
 use strict;
 use warnings;
 package AI::MXNet::Gluon::Trainer;
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use AI::MXNet::Function::Parameters;
 use IO::File;
@@ -553,5 +554,7 @@ method load_states(Str $fname)
         $self->_optimizer($self->_updaters->[0]->optimizer);
     }
 }
+
+__PACKAGE__->AI::MXNet::NS::register('AI::MXNet::Gluon');
 
 1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Utils.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Utils.pm
@@ -25,7 +25,7 @@ use File::Path qw(make_path);
 use HTTP::Tiny;
 use Exporter;
 use base qw(Exporter);
-@AI::MXNet::Gluon::Utils::EXPORT_OK = qw(download check_sha1);
+our @EXPORT_OK = qw(download check_sha1);
 
 =head1 NAME
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/IO.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/IO.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::IO;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use AI::MXNet::Function::Parameters;
 use Scalar::Util qw/blessed/;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Image.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Image.pm
@@ -19,6 +19,7 @@ package AI::MXNet::Image;
 use strict;
 use warnings;
 use Scalar::Util qw(blessed);
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use AI::MXNet::Function::Parameters;
 use AI::MXNet::Image::NDArray;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Initializer.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Initializer.pm
@@ -45,6 +45,7 @@ around BUILDARGS => sub {
 # Base class for Initializers
 package AI::MXNet::Initializer;
 use Mouse;
+use AI::MXNet::NS;
 use AI::MXNet::Base qw(:DEFAULT pzeros pceil);
 use AI::MXNet::NDArray;
 use JSON::PP;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/KVStore.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/KVStore.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::KVStore;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use AI::MXNet::NDArray;
 use AI::MXNet::Optimizer;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/LinAlg.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/LinAlg.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::LinAlg;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::LinAlg::Symbol;
 use AI::MXNet::LinAlg::NDArray;
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Metric.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Metric.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::Metric;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::Function::Parameters;
 use Scalar::Util qw/blessed/;
 use JSON::PP;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Module.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Module.pm
@@ -32,6 +32,7 @@ has [qw/_param_names _fixed_param_names
 ] => (is => 'rw', init_arg => undef);
 
 package AI::MXNet::Module;
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use AI::MXNet::Function::Parameters;
 use List::Util qw(max);

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Monitor.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Monitor.pm
@@ -17,6 +17,7 @@
 
 package AI::MXNet::Monitor;
 use Mouse;
+use AI::MXNet::NS;
 use AI::MXNet::Function::Parameters;
 use AI::MXNet::Base;
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/NDArray.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/NDArray.pm
@@ -59,6 +59,7 @@ package AI::MXNet::NDArray;
 
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use AI::MXNet::NDArray::Slice;
 use AI::MXNet::Context;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/NS.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/NS.pm
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+package AI::MXNet::NS;
+# this class is similar to Exporter, in that it will add an "import"
+# method to the calling package.  It is to allow a package to emulate
+# the python "import mxnet as mx" style aliasing as "use AI::MXNet 'mx'"
+use strict;
+use warnings;
+
+sub _sym : lvalue
+{
+    my ($pkg, $name) = @_;
+    no strict 'refs';
+    *{"$pkg\::$name"};
+}
+
+sub import
+{
+    my (undef, $opt) = @_;
+    my $class = caller();
+    my $func = sub { $class };
+    _sym($class, 'import') = sub {
+        my (undef, @names) = @_;
+        @names = map { s/[^\w:]//sgr } @names;
+        my $target = caller();
+
+        _sym($names[0], '') = _sym($class, '') if
+            @names == 1 and $opt and $opt eq 'global';
+
+        _sym($target, $_) = $func for @names;
+    };
+}
+
+my $autoload_template = q(
+    sub AUTOLOAD
+    {
+        our ($AUTOLOAD, %AUTOLOAD);
+        my $name = $AUTOLOAD =~ s/.*:://sr;
+        my $func = $AUTOLOAD{$name};
+        Carp::carp(qq(Can't locate object method "$name" via package "${\ __PACKAGE__ }"))
+            unless $func;
+        goto $func;
+    }
+);
+
+# using AUTOLOAD here allows for the addition of an AI::MXNet::SomeClass
+# class to coexist with an AI::MXNet->SomeClass() shorthand constructor.
+sub register
+{
+    my ($class, $target) = @_;
+    my $name = $class =~ s/.*:://sr;
+    my $dest = $class->can('new');
+    ${_sym($target, 'AUTOLOAD')}{$name} = sub {
+        splice @_, 0, 1, $class;
+        goto $dest;
+    };
+    return if $target->can('AUTOLOAD');
+    eval sprintf 'package %s { %s }', $target, $autoload_template;
+    die if $@;
+    return;
+}
+
+1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Optimizer.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Optimizer.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::Optimizer;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use AI::MXNet::NDArray;
 use AI::MXNet::Random;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/RNN.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/RNN.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::RNN;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::Function::Parameters;
 use AI::MXNet::RNN::IO;
 use AI::MXNet::RNN::Cell;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Random.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Random.pm
@@ -19,6 +19,7 @@ package AI::MXNet::Random;
 use strict;
 use warnings;
 use Scalar::Util qw/blessed/;
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use AI::MXNet::NDArray::Base;
 use AI::MXNet::Function::Parameters;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/RecordIO.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/RecordIO.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::RecordIO;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::Function::Parameters;
 use AI::MXNet::Types;
 use AI::MXNet::Base;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Symbol.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Symbol.pm
@@ -24,6 +24,7 @@ package AI::MXNet::Symbol;
 
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use AI::MXNet::Symbol::Base;
 use AI::MXNet::Symbol::Random;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Symbol/AttrScope.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Symbol/AttrScope.pm
@@ -19,6 +19,7 @@ package AI::MXNet::Symbol::AttrScope;
 use strict;
 use warnings;
 use Mouse;
+use AI::MXNet::NS;
 use AI::MXNet::Function::Parameters;
 around BUILDARGS => sub {
     my $orig  = shift;
@@ -58,7 +59,12 @@ has 'attr' => (
 
 method current()
 {
-    $AI::MXNet::curr_attr_scope;
+    $AI::MXNet::AttrScope;
+}
+
+method set_current(AI::MXNet::Symbol::AttrScope $new)
+{
+    $AI::MXNet::AttrScope = $new;
 }
 
 =head2 get
@@ -83,4 +89,6 @@ method get(Maybe[HashRef[Str]] $attr=)
     return bless (\%ret, 'AI::MXNet::Util::Printable');
 }
 
-$AI::MXNet::curr_attr_scope = __PACKAGE__->new;
+__PACKAGE__->AI::MXNet::NS::register('AI::MXNet');
+
+1;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Symbol/NameManager.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Symbol/NameManager.pm
@@ -79,15 +79,13 @@ method get(Maybe[Str] $name, Str $hint)
 
 method current()
 {
-    $AI::MXNet::Symbol::NameManager;
+    $AI::MXNet::NameManager;
 }
 
 method set_current(AI::MXNet::Symbol::NameManager $new)
 {
-    $AI::MXNet::Symbol::NameManager = $new;
+    $AI::MXNet::NameManager = $new;
 }
-
-$AI::MXNet::Symbol::NameManager = __PACKAGE__->new;
 
 package AI::MXNet::Symbol::Prefix;
 use Mouse;

--- a/perl-package/AI-MXNet/lib/AI/MXNet/TestUtils.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/TestUtils.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::TestUtils;
 use strict;
 use warnings;
+use AI::MXNet 'mx';
 use PDL;
 use Carp qw(confess);
 use Scalar::Util qw(blessed);
@@ -26,10 +27,10 @@ use AI::MXNet::Function::Parameters;
 use AI::MXNet::Base;
 use Exporter;
 use base qw(Exporter);
-@AI::MXNet::TestUtils::EXPORT_OK = qw(same reldiff almost_equal GetMNIST_ubyte
-                                      GetCifar10 pdl_maximum pdl_minimum mlp2 conv dies_ok
-                                      check_consistency zip assert enumerate same_array dies_like allclose rand_shape_2d
-                                      rand_shape_3d rand_sparse_ndarray random_arrays rand_ndarray randint pdl);
+our @EXPORT_OK = qw(same reldiff almost_equal GetMNIST_ubyte
+                    GetCifar10 pdl_maximum pdl_minimum mlp2 conv dies_ok
+                    check_consistency zip assert enumerate same_array dies_like allclose rand_shape_2d
+                    rand_shape_3d rand_sparse_ndarray random_arrays rand_ndarray randint pdl);
 use constant default_numerical_threshold => 1e-6;
 =head1 NAME
 

--- a/perl-package/AI-MXNet/lib/AI/MXNet/Visualization.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Visualization.pm
@@ -18,6 +18,7 @@
 package AI::MXNet::Visualization;
 use strict;
 use warnings;
+use AI::MXNet::NS;
 use AI::MXNet::Base;
 use AI::MXNet::Function::Parameters;
 use JSON::PP;

--- a/perl-package/AI-MXNet/t/AI-MXNet.t
+++ b/perl-package/AI-MXNet/t/AI-MXNet.t
@@ -17,5 +17,8 @@
 
 use strict;
 use warnings;
-use Test::More tests => 1;
+use Test::More tests => 3;
 BEGIN { use_ok('AI::MXNet') };
+
+isa_ok(AI::MXNet->Context(), 'AI::MXNet::Context');
+isa_ok(AI::MXNet::Context->new(), 'AI::MXNet::Context');

--- a/perl-package/AI-MXNet/t/test_multi_device_exec.t
+++ b/perl-package/AI-MXNet/t/test_multi_device_exec.t
@@ -62,11 +62,11 @@ sub test_ctx_group
         my ($arr, $name) = @$_;
         if(exists $set_stage1{ $name })
         {
-            ok($arr->context == $group2ctx->{stage1});
+            cmp_ok($arr->context, '==', $group2ctx->{stage1});
         }
         else
         {
-            ok($arr->context == $group2ctx->{stage2});
+            cmp_ok($arr->context, '==', $group2ctx->{stage2});
         }
     }
 }


### PR DESCRIPTION
## Description ##
There is some unnecessary complexity in the shorthand aliasing scheme this work aims to correct.  We expect `mx->nd->array(...)` and `AI::MXNet::NDArray->array(...)` to be functionally equivalent and they are, but there are edge cases where the methods supported by the short and long names don't exactly align.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Responsibility of short name aliases moved from importer to imported module.
- [x] Retool constructor shorthand aliases to use `AUTOLOAD` rather than dynamic method creation to avoid namespace collisions between class and function names.  For example, `AI::MXNet::Context` the class vs. `AI::MXNet->Context()` the shorthand for `AI::MXNet::Context->new()`.
- [x] Folds the '_' suffixed shadow classes enhancements into the full name classes.
- [x] Retool of `register()` methods to not mangle stack traces.

## Comments ##
- I believe these changes are backwards compatible to the documented API, and brings the API as a whole closer to the designed intent.
- Interesting edge cases to note here, I was unable to convert `AI::MXNet::Gluon::Block->register()` to use the `AUTOLOAD` scheme even though it seems to need the same class vs. method collision avoidance as in other places.  Hopefully this can be dealt with in a future effort.
