### PR TITLE
fix memory overwrite bug in numpy multinomial

### DIFF
--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -712,6 +712,16 @@ def test_np_multinomial():
         for size in sizes:
             freq = mx.np.random.multinomial(experiements, pvals, size=size).asnumpy()
             assert freq.size == 0
+    # test small experiment for github issue
+    # https://github.com/apache/incubator-mxnet/issues/15383
+    small_exp, total_exp = 20, 10000
+    for pvals in pvals_list:
+        x = np.random.multinomial(small_exp, pvals)
+        for i in range(total_exp // small_exp):
+            x = x + np.random.multinomial(20, pvals)
+    freq = (x.asnumpy() / _np.float32(total_exp)).reshape((-1, len(pvals)))
+    for i in range(freq.shape[0]):
+        mx.test_utils.assert_almost_equal(freq[i, :], pvals, rtol=0.20, atol=1e-1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
fix memory override bug in multinomial
fixes #15383

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###



## Comments ##
@reminisce @haojin2 
