### PR TITLE
Add -R option to ci/build.py to avoid rebuilding containers

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -416,6 +416,10 @@ def main() -> int:
                         help="Only build the container, don't build the project",
                         action='store_true')
 
+    parser.add_argument("-R", "--run-only",
+                        help="Only run the container, don't rebuild the container",
+                        action='store_true')
+
     parser.add_argument("-a", "--all",
                         help="build for all platforms",
                         action='store_true')
@@ -492,8 +496,12 @@ def main() -> int:
         tag = get_docker_tag(platform=platform, registry=args.docker_registry)
         if args.docker_registry:
             load_docker_cache(tag=tag, docker_registry=args.docker_registry)
-        build_docker(platform=platform, docker_binary=docker_binary, registry=args.docker_registry,
+        if not args.run_only:
+            build_docker(platform=platform, docker_binary=docker_binary, registry=args.docker_registry,
                      num_retries=args.docker_build_retries, no_cache=args.no_cache)
+        else:
+            logging.info("Skipping docker build step.")
+
         if args.build_only:
             logging.warning("Container was just built. Exiting due to build-only.")
             return 0


### PR DESCRIPTION
There are a couple of problems which trigger continuous rebuild of the containers which have difficult solutions, this option enables a workaround.
https://github.com/docker/docker.github.io/issues/8886

@marcoabreu 


In one ec2 machine:

```
Sending build context to Docker daemon  264.2kB                                                                                                                                     [73/1937]
Step 1/41 : FROM ubuntu:16.04
 ---> 13c9f1285025                  
Step 2/41 : WORKDIR /work/deps
 ---> Using cache 
 ---> fd89693ec7d8                              
Step 3/41 : COPY install/ubuntu_core.sh /work/
 ---> Using cache 
 ---> acc84b2e4ad2                    
Step 4/41 : RUN /work/ubuntu_core.sh
 ---> Using cache 
 ---> 97d47815b79e                              
Step 5/41 : COPY install/deb_ubuntu_ccache.sh /work/
 ---> Using cache 
 ---> 458bcdc2b9e2                    
```


Different machine:

```
build.py: 2019-07-02 01:05:05,098Z INFO Running command: 'docker build -f docker/Dockerfile.build.ubuntu_cpu --build-arg USER_ID=624416249 --build-arg GROUP_ID=600260513 --cache-from mxnetci/build.ubuntu_cpu -t mxnetci/build.ubuntu_cpu docker'
Sending build context to Docker daemon  264.2kB
Step 1/41 : FROM ubuntu:16.04
 ---> 13c9f1285025
Step 2/41 : WORKDIR /work/deps
 ---> Using cache
 ---> 44a97319ecd8
Step 3/41 : COPY install/ubuntu_core.sh /work/
 ---> d0284928a471
Step 4/41 : RUN /work/ubuntu_core.sh
 ---> Running in cc6d4d02a210
+ apt-get update
Get:1 http://archive.ubuntu.com/ubuntu xenial InRelease [247 kB]
Get:2 http://security.ubuntu.com/ubuntu xenial-security InRelease [109 kB]
Get:3 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
Get:5 http://archive.ubuntu.com/ubuntu xenial/main amd64 Packages [1558 kB]
```

I haven't found a solution for this and I think is related to different user id's and problems with docker caching.