### PR TITLE
Remove mhard-float option when building Amalgamation for Android.

### DIFF
--- a/amalgamation/Makefile
+++ b/amalgamation/Makefile
@@ -114,8 +114,8 @@ jni_libmxnet_predict.so: jni_libmxnet_predict.o
 ifneq ($(ANDROID), 1)
         android:
 else
-        CFLAGS+=  -mhard-float -D_NDK_MATH_NO_SOFTFP=1 -O3
-        LDFLAGS+=  -Wl,--no-warn-mismatch -lm_hard
+        CFLAGS+= -O3
+        LDFLAGS+= -Wl,--no-warn-mismatch -lm_hard
         android: jni_libmxnet_predict.so
 endif
 


### PR DESCRIPTION
mhard-float option has been deprecated by Google. Removing this from the amalgamation Makefile for Android.

Please refer to [Google depreciation announcement](https://android.googlesource.com/platform/ndk/+/353e653824b79c43b948429870d0abeedebde386/docs/HardFloatAbi.md)

If this is not removed, you will get this error when merging with other C/Cpp libraries.

```
mxnet uses VFP register arguments, output does not
```