### PR TITLE
cuda/cuDNN lib version checking.  Force cuDNN v7 usage.

### DIFF
--- a/docs/faq/env_var.md
+++ b/docs/faq/env_var.md
@@ -242,6 +242,16 @@ If ctypes is used, it must be `mxnet._ctypes.ndarray.NDArrayBase`.
 	- If set to '0', disallows implicit type conversions to Float16 to use Tensor Cores
 	- If set to '1', allows CUDA ops like RNN and Convolution to use TensorCores even with Float32 input data by using implicit type casting to Float16. Only has an effect if `MXNET_CUDA_ALLOW_TENSOR_CORE` is `1`.
 
+* MXNET_CUDA_VERSION_CHECKING
+  - 0(false) or 1(true) ```(default=1)```
+  - If set to '0', disallows various runtime checks of the cuda library version and associated warning messages.
+  - If set to '1', permits these checks (e.g. compile vs. link mismatch, old version no longer CI-tested)
+
+* MXNET_CUDNN_VERSION_CHECKING
+  - 0(false) or 1(true) ```(default=1)```
+  - If set to '0', disallows various runtime checks of the cuDNN library version and associated warning messages.
+  - If set to '1', permits these checks (e.g. compile vs. link mismatch, old version no longer CI-tested)
+
 * MXNET_GLUON_REPO
   - Values: String ```(default='https://apache-mxnet.s3-accelerate.dualstack.amazonaws.com/'```
   - The repository url to be used for Gluon datasets and pre-trained models.

--- a/include/mxnet/resource.h
+++ b/include/mxnet/resource.h
@@ -44,11 +44,11 @@ struct ResourceRequest {
     kTempSpace,
     /*! \brief common::RandGenerator<xpu> object, which can be used in GPU kernel functions */
     kParallelRandom
-#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 7
+#if MXNET_USE_CUDNN == 1
     ,
     /*! \brief cudnnDropoutDescriptor_t object for GPU dropout kernel functions */
     kCuDNNDropoutDesc
-#endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 7
+#endif  // MXNET_USE_CUDNN == 1
   };
   /*! \brief type of resources */
   Type type;
@@ -162,7 +162,7 @@ struct Resource {
         reinterpret_cast<DType*>(get_space_internal(shape.Size() * sizeof(DType))),
         shape, shape[ndim - 1], stream);
   }
-#if MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 7
+#if MXNET_USE_CUDNN == 1
   /*!
    * \brief Get cudnn dropout descriptor from shared state space.
    *
@@ -175,7 +175,7 @@ struct Resource {
       mshadow::Stream<gpu> *stream,
       const float dropout,
       uint64_t seed) const;
-#endif  // MXNET_USE_CUDNN == 1 && CUDNN_MAJOR >= 7
+#endif  // MXNET_USE_CUDNN == 1
 
   /*!
    * \brief Get CPU space as mshadow Tensor in specified type.

--- a/src/common/cuda_utils.cc
+++ b/src/common/cuda_utils.cc
@@ -46,12 +46,9 @@ namespace cuda {
 bool cuda_version_check_performed = []() {
   // Don't bother with checks if there are no GPUs visible (e.g. with CUDA_VISIBLE_DEVICES="")
   if (dmlc::GetEnv("MXNET_CUDA_VERSION_CHECKING", true) && Context::GetGPUCount() > 0) {
-    int linkedAgainstCudaVersion = 0;
-    CUDA_CALL(cudaRuntimeGetVersion(&linkedAgainstCudaVersion));
-    if (linkedAgainstCudaVersion != CUDA_VERSION)
-      LOG(WARNING) << "cuda library mismatch: linked-against version " << linkedAgainstCudaVersion
-                   << " != compiled-against version " << CUDA_VERSION << "."
-                   << "Set MXNET_CUDA_VERSION_CHECKING=0 to quiet this warning.";
+    // Not currently performing a runtime check of linked-against vs. compiled-against
+    // cuda runtime library, as major.minor must match for libmxnet.so to even load, per:
+    // https://docs.nvidia.com/deploy/cuda-compatibility/#binary-compatibility
     if (CUDA_VERSION < MXNET_CI_OLDEST_CUDA_VERSION)
       LOG(WARNING) << "Upgrade advisory: this mxnet has been built against cuda library version "
                    << CUDA_VERSION << ", which is older than the oldest version tested by CI ("

--- a/src/common/cuda_utils.cc
+++ b/src/common/cuda_utils.cc
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file cuda_utils.cc
+ * \brief CUDA debugging utilities.
+ */
+
+#include <mxnet/base.h>
+#include "cuda_utils.h"
+
+#if MXNET_USE_CUDA == 1
+
+namespace mxnet {
+namespace common {
+namespace cuda {
+
+// The oldest version of cuda used in upstream MXNet CI testing, both for unix and windows.
+// Users that have rebuilt MXNet against older versions will we advised with a warning to upgrade
+// their systems to match the CI level.  Minimally, users should rerun the CI locally.
+#if defined(_MSC_VER)
+#define MXNET_CI_OLDEST_CUDA_VERSION  9020
+#else
+#define MXNET_CI_OLDEST_CUDA_VERSION 10000
+#endif
+
+
+// Start-up check that the version of cuda compiled-against matches the linked-against version.
+bool CudaVersionChecks() {
+  if (dmlc::GetEnv("MXNET_CUDA_VERSION_CHECKING", true)) {
+    int linkedAgainstCudaVersion = 0;
+    CUDA_CALL(cudaRuntimeGetVersion(&linkedAgainstCudaVersion));
+    if (linkedAgainstCudaVersion != CUDA_VERSION)
+      LOG(WARNING) << "cuda library mismatch: linked-against version " << linkedAgainstCudaVersion
+                   << " != compiled-against version " << CUDA_VERSION << "."
+                   << "Set MXNET_CUDA_VERSION_CHECKING=0 to quiet this warning.";
+    if (CUDA_VERSION < MXNET_CI_OLDEST_CUDA_VERSION)
+      LOG(WARNING) << "Upgrade advisory: this mxnet has been built against cuda library version "
+                   << CUDA_VERSION << ", which is older than the oldest version tested by CI ("
+                   << MXNET_CI_OLDEST_CUDA_VERSION << ").  "
+                   << "Set MXNET_CUDA_VERSION_CHECKING=0 to quiet this warning.";
+  }
+  return true;
+}
+
+// Dynamic initialization here will emit a warning if runtime and compile-time versions mismatch.
+// Also if the user has recompiled their source to a version no longer tested by upstream CI.
+bool cuda_version_ok = CudaVersionChecks();
+
+}  // namespace cuda
+}  // namespace common
+}  // namespace mxnet
+
+#endif  // MXNET_USE_CUDA
+
+#if MXNET_USE_CUDNN == 1
+
+namespace mxnet {
+namespace common {
+namespace cudnn {
+
+// The oldest version of CUDNN used in upstream MXNet CI testing, both for unix and windows.
+// Users that have rebuilt MXNet against older versions will we advised with a warning to upgrade
+// their systems to match the CI level.  Minimally, users should rerun the CI locally.
+#if defined(_MSC_VER)
+#define MXNET_CI_OLDEST_CUDNN_VERSION 7600
+#else
+#define MXNET_CI_OLDEST_CUDNN_VERSION 7600
+#endif
+
+// Start-up check that the version of cudnn compiled-against matches the linked-against version.
+// Also if the user has recompiled their source to a version no longer tested by upstream CI.
+bool CuDNNVersionChecks() {
+  if (dmlc::GetEnv("MXNET_CUDNN_VERSION_CHECKING", true)) {
+    size_t linkedAgainstCudnnVersion = cudnnGetVersion();
+    if (linkedAgainstCudnnVersion != CUDNN_VERSION)
+      LOG(WARNING) << "cuDNN library mismatch: linked-against version " << linkedAgainstCudnnVersion
+                   << " != compiled-against version " << CUDNN_VERSION << ".  "
+                   << "Set MXNET_CUDNN_VERSION_CHECKING=0 to quiet this warning.";
+    if (CUDNN_VERSION < MXNET_CI_OLDEST_CUDNN_VERSION)
+      LOG(WARNING) << "Upgrade advisory: this mxnet has been built against cuDNN library version "
+                   <<  CUDNN_VERSION << ", which is older than the oldest version tested by CI ("
+                   << MXNET_CI_OLDEST_CUDNN_VERSION << ").  "
+                   << "Set MXNET_CUDNN_VERSION_CHECKING=0 to quiet this warning.";
+  }
+  return true;
+}
+
+// Dynamic initialization here will emit a warning if runtime and compile-time versions mismatch.
+// Also if the user has recompiled their source to a version no longer tested by upstream CI.
+bool cudnn_version_ok = CuDNNVersionChecks();
+
+}  // namespace cudnn
+}  // namespace common
+}  // namespace mxnet
+
+#endif  // MXNET_USE_CUDNN

--- a/src/common/cuda_utils.cc
+++ b/src/common/cuda_utils.cc
@@ -41,9 +41,9 @@ namespace cuda {
 #define MXNET_CI_OLDEST_CUDA_VERSION 10000
 #endif
 
-
-// Start-up check that the version of cuda compiled-against matches the linked-against version.
-bool CudaVersionChecks() {
+// Dynamic init here will emit a warning if runtime and compile-time cuda lib versions mismatch.
+// Also if the user has recompiled their source to a version no longer tested by upstream CI.
+bool cuda_version_check_performed = []() {
   // Don't bother with checks if there are no GPUs visible (e.g. with CUDA_VISIBLE_DEVICES="")
   if (dmlc::GetEnv("MXNET_CUDA_VERSION_CHECKING", true) && Context::GetGPUCount() > 0) {
     int linkedAgainstCudaVersion = 0;
@@ -59,11 +59,7 @@ bool CudaVersionChecks() {
                    << "Set MXNET_CUDA_VERSION_CHECKING=0 to quiet this warning.";
   }
   return true;
-}
-
-// Dynamic initialization here will emit a warning if runtime and compile-time versions mismatch.
-// Also if the user has recompiled their source to a version no longer tested by upstream CI.
-bool cuda_version_ok = CudaVersionChecks();
+}();
 
 }  // namespace cuda
 }  // namespace common
@@ -86,9 +82,9 @@ namespace cudnn {
 #define MXNET_CI_OLDEST_CUDNN_VERSION 7600
 #endif
 
-// Start-up check that the version of cudnn compiled-against matches the linked-against version.
+// Dynamic init here will emit a warning if runtime and compile-time cudnn lib versions mismatch.
 // Also if the user has recompiled their source to a version no longer tested by upstream CI.
-bool CuDNNVersionChecks() {
+bool cudnn_version_check_performed = []() {
   // Don't bother with checks if there are no GPUs visible (e.g. with CUDA_VISIBLE_DEVICES="")
   if (dmlc::GetEnv("MXNET_CUDNN_VERSION_CHECKING", true) && Context::GetGPUCount() > 0) {
     size_t linkedAgainstCudnnVersion = cudnnGetVersion();
@@ -103,11 +99,7 @@ bool CuDNNVersionChecks() {
                    << "Set MXNET_CUDNN_VERSION_CHECKING=0 to quiet this warning.";
   }
   return true;
-}
-
-// Dynamic initialization here will emit a warning if runtime and compile-time versions mismatch.
-// Also if the user has recompiled their source to a version no longer tested by upstream CI.
-bool cudnn_version_ok = CuDNNVersionChecks();
+}();
 
 }  // namespace cudnn
 }  // namespace common

--- a/src/common/cuda_utils.cc
+++ b/src/common/cuda_utils.cc
@@ -44,7 +44,8 @@ namespace cuda {
 
 // Start-up check that the version of cuda compiled-against matches the linked-against version.
 bool CudaVersionChecks() {
-  if (dmlc::GetEnv("MXNET_CUDA_VERSION_CHECKING", true)) {
+  // Don't bother with checks if there are no GPUs visible (e.g. with CUDA_VISIBLE_DEVICES="")
+  if (dmlc::GetEnv("MXNET_CUDA_VERSION_CHECKING", true) && Context::GetGPUCount() > 0) {
     int linkedAgainstCudaVersion = 0;
     CUDA_CALL(cudaRuntimeGetVersion(&linkedAgainstCudaVersion));
     if (linkedAgainstCudaVersion != CUDA_VERSION)
@@ -88,7 +89,8 @@ namespace cudnn {
 // Start-up check that the version of cudnn compiled-against matches the linked-against version.
 // Also if the user has recompiled their source to a version no longer tested by upstream CI.
 bool CuDNNVersionChecks() {
-  if (dmlc::GetEnv("MXNET_CUDNN_VERSION_CHECKING", true)) {
+  // Don't bother with checks if there are no GPUs visible (e.g. with CUDA_VISIBLE_DEVICES="")
+  if (dmlc::GetEnv("MXNET_CUDNN_VERSION_CHECKING", true) && Context::GetGPUCount() > 0) {
     size_t linkedAgainstCudnnVersion = cudnnGetVersion();
     if (linkedAgainstCudnnVersion != CUDNN_VERSION)
       LOG(WARNING) << "cuDNN library mismatch: linked-against version " << linkedAgainstCudnnVersion

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -172,7 +172,6 @@ static std::vector<ResourceRequest> RNNResourceEx(const NodeAttrs& attrs, const 
   std::vector<ResourceRequest> request;
   if (dev_mask == kGPU) {
 #if MXNET_USE_CUDNN_RNN
-    STATIC_ASSERT_CUDNN_VERSION_GE(7000);
     request.emplace_back(ResourceRequest::kTempSpace);
 
     const RNNParam& param = nnvm::get<RNNParam>(attrs.parsed);

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -172,6 +172,7 @@ static std::vector<ResourceRequest> RNNResourceEx(const NodeAttrs& attrs, const 
   std::vector<ResourceRequest> request;
   if (dev_mask == kGPU) {
 #if MXNET_USE_CUDNN_RNN
+    STATIC_ASSERT_CUDNN_VERSION_GE(7000);
     request.emplace_back(ResourceRequest::kTempSpace);
 
     const RNNParam& param = nnvm::get<RNNParam>(attrs.parsed);


### PR DESCRIPTION
This PR addresses two issues:
    - rnn.cc of mxnet v1.5 does not compile against cudnn v6.  This PR enforces systems that rebuild mxnet to have cudnn v7, and improves the error message for compiling against v6.
    - We are accumulating stale code that references no-longer-supported cuda/cudnn versions.  This PR provides a means for cleaning out this code.

This PR introduces both runtime and compile-time cuda and cuDNN version checking.  The compile time checks are based on new macros: STATIC_ASSERT_CUDNN_VERSION_GE(min_version) and STATIC_ASSERT_CUDA_VERSION_GE(min_version).  Example usage:
Before PR:
```
#if MXNET_USE_CUDNN
#if CUDNN_VERSION >= 7000
    <impl 1>
#elif CUDNN_VERSION >= 6000
    <impl 2>
#else
    LOG(FATAL) << "cuDNN too old.";
#endif
#endif  // MXNET_USE_CUDNN
```
After PR (given the assumption that we're now requiring cuDNN v7):
```
#if MXNET_USE_CUDNN
STATIC_ASSERT_CUDNN_VERSION_GE(7000);
<impl 1>
#endif  // MXNET_USE_CUDNN
```
Discussion continues in the comments section.
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
This PR improves the compile-time message to a user trying to build MXNet 1.5 against cuDNN v6.
Before PR, only the missing library entrypoint is mentioned:
```
g++ ... -c src/operator/operator.cc -o build/src/operator/operator.o
src/operator/rnn.cc: In function 'std::vector<mxnet::ResourceRequest> mxnet::op::RNNResourceEx(const nnvm::NodeAttrs&, int, mxnet::DispatchMode)':    src/operator/rnn.cc:179:28: error: 'kCuDNNDropoutDesc' is not a member of 'mxnet::ResourceRequest'                                                           request.emplace_back(ResourceRequest::kCuDNNDropoutDesc);
```
After the PR, the error mentions the library version issue directly:
```
g++ ... -c src/operator/optimizer_op.cc -o build/src/operator/optimizer_op.o
In file included from src/operator/././operator_common.h:42:0,
                 from src/operator/./rnn-inl.h:45,
                 from src/operator/rnn.cc:29:
src/operator/rnn.cc: In function 'std::vector<mxnet::ResourceRequest> mxnet::op::RNNResourceEx(const nnvm::NodeAttrs&, int, mxnet::DispatchMode)':
src/operator/././../common/cuda_utils.h:467:3: error: static assertion failed: Compiled-against cuDNN version 6021 is too old, please upgrade system to version 7000 or later.
   static_assert(CUDNN_VERSION >= min_version, "Compiled-against cuDNN version " \
   ^
src/operator/rnn.cc:175:5: note: in expansion of macro 'STATIC_ASSERT_CUDNN_VERSION_GE'
     STATIC_ASSERT_CUDNN_VERSION_GE(7000);
     ^
src/operator/rnn.cc:180:28: error: 'kCuDNNDropoutDesc' is not a member of 'mxnet::ResourceRequest'
       request.emplace_back(ResourceRequest::kCuDNNDropoutDesc);
                            ^
```
This PR provides 2 runtime checks and issues a warning:
    - when the compiled-against cuda or cuDNN library version does not match the linked-against version, and
    - when the library versions are old w.r.t. the versions tested against by the MXNet CI.

I built the PR against cuda 9 and cuDNN v7.1.4.  Running any model will emit the warning:
```
[01:05:03] src/common/cuda_utils.cc:50: Upgrade advisory: this mxnet has been built against cuda library version 9000, which is older than the oldest version tested by CI (10000).  Set MXNET_CUDA_VERSION_CHECKING=0 to quiet this warning.
[01:05:03] src/common/cuda_utils.cc:89: Upgrade advisory: this mxnet has been built against cuDNN library version 7104, which is older than the oldest version tested by CI (7600).  Set MXNET_CUDNN_VERSION_CHECKING=0 to quiet this warning.
```
I then upgraded cuDNN to v7.2.1 without recompiling.  The following additional message now appears when running models:
```
[01:11:11] src/common/cuda_utils.cc:85: cuDNN library mismatch: linked-against version 7201 != compiled-against version 7104.  Set MXNET_CUDNN_VERSION_CHECKING=0 to quiet this warning.
```
As stated, the user can choose to kill the warning messages with environment variables settings.
