### PR TITLE
[WIP]add inference mode for op perf benchmark

### DIFF
--- a/benchmark/opperf/nd_operations/binary_operators.py
+++ b/benchmark/opperf/nd_operations/binary_operators.py
@@ -38,7 +38,7 @@ from benchmark.opperf.utils.op_registry_utils import get_all_broadcast_binary_op
     get_all_elemen_wise_binary_operators
 
 
-def run_mx_binary_broadcast_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100):
+def run_mx_binary_broadcast_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100, inference_mode=False):
     """Runs benchmarks with the given context and precision (dtype)for all the binary
     broadcast operators in MXNet.
 
@@ -59,13 +59,13 @@ def run_mx_binary_broadcast_operators_benchmarks(ctx=mx.cpu(), dtype='float32', 
 
     """
     # Fetch all Binary Broadcast Operators
-    mx_binary_broadcast_ops = get_all_broadcast_binary_operators()
+    mx_binary_broadcast_ops = get_all_broadcast_binary_operators(inference_mode=inference_mode)
     # Run benchmarks
     mx_binary_op_results = run_op_benchmarks(mx_binary_broadcast_ops, dtype, ctx, warmup, runs)
     return mx_binary_op_results
 
 
-def run_mx_binary_element_wise_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100):
+def run_mx_binary_element_wise_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100, inference_mode=False):
     """Runs benchmarks with the given context and precision (dtype)for all the binary
     element_wise operators in MXNet.
 
@@ -86,7 +86,7 @@ def run_mx_binary_element_wise_operators_benchmarks(ctx=mx.cpu(), dtype='float32
 
     """
     # Fetch all Binary Element_wise Operators
-    mx_binary_element_wise_ops = get_all_elemen_wise_binary_operators()
+    mx_binary_element_wise_ops = get_all_elemen_wise_binary_operators(inference_mode)
     # Run benchmarks
     mx_binary_op_results = run_op_benchmarks(mx_binary_element_wise_ops, dtype, ctx, warmup, runs)
     return mx_binary_op_results

--- a/benchmark/opperf/nd_operations/gemm_operators.py
+++ b/benchmark/opperf/nd_operations/gemm_operators.py
@@ -34,7 +34,7 @@ TODO
 """
 
 
-def run_gemm_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100):
+def run_gemm_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100, inference_mode=False):
     """Runs benchmarks with the given context and precision (dtype)for all the GEMM
     operators (dot, batch_dot) in MXNet.
 
@@ -56,7 +56,7 @@ def run_gemm_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs
     """
     # Benchmark tests for dot and batch_dot operators
     dot_benchmark_res = run_performance_test(
-        [getattr(MX_OP_MODULE, "dot")], run_backward=True,
+        [getattr(MX_OP_MODULE, "dot")], run_backward=False if inference_mode else True,
         dtype=dtype, ctx=ctx,
         inputs=[{"lhs": (1024, 1024),
                  "rhs": (1024, 1024)},
@@ -70,7 +70,7 @@ def run_gemm_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs
         warmup=warmup, runs=runs)
 
     batch_dot_benchmark_res = run_performance_test(
-        [getattr(MX_OP_MODULE, "batch_dot")], run_backward=True,
+        [getattr(MX_OP_MODULE, "batch_dot")], run_backward=False if inference_mode else True,
         dtype=dtype, ctx=ctx,
         inputs=[{"lhs": (32, 1024, 1024),
                  "rhs": (32, 1024, 1024)},

--- a/benchmark/opperf/nd_operations/nn_activation_operators.py
+++ b/benchmark/opperf/nd_operations/nn_activation_operators.py
@@ -35,7 +35,7 @@ from benchmark.opperf.rules.default_params import MX_OP_MODULE
 """
 
 
-def run_activation_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100):
+def run_activation_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100, inference_mode=False):
     """Runs benchmarks with the given context and precision (dtype)for all the activation
     operators (relu, sigmoid, softmax) in MXNet.
 
@@ -57,7 +57,7 @@ def run_activation_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25
     """
     # Relu and its variation
     relu_benchmark_res = run_performance_test([getattr(MX_OP_MODULE, "LeakyReLU")],
-                                              run_backward=True,
+                                              run_backward=False if inference_mode else True,
                                               dtype=dtype,
                                               ctx=ctx,
                                               inputs=[{"data": (1024, 1024), "act_type": "leaky", "slope": 0.1},
@@ -79,7 +79,7 @@ def run_activation_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25
     # Sigmoid => Covered as part of Unary ops
     # Hard_Sigmoid
     hard_sigmoid_benchmark_res = run_performance_test([getattr(MX_OP_MODULE, "hard_sigmoid")],
-                                                      run_backward=True,
+                                                      run_backward=False if inference_mode else True,
                                                       dtype=dtype,
                                                       ctx=ctx,
                                                       inputs=[{"data": (1024, 1024), "alpha": 0.25, "beta": 0.5},
@@ -92,7 +92,7 @@ def run_activation_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25
     # Softmax, LogSoftmax
     softmax_benchmark_res = run_performance_test([getattr(MX_OP_MODULE, "softmax"),
                                                   getattr(MX_OP_MODULE, "log_softmax")],
-                                                 run_backward=True,
+                                                 run_backward=False if inference_mode else True,
                                                  dtype=dtype,
                                                  ctx=ctx,
                                                  inputs=[{"data": (1024, 1024), "axis": -1, "temperature": 0.5},

--- a/benchmark/opperf/nd_operations/nn_basic_operators.py
+++ b/benchmark/opperf/nd_operations/nn_basic_operators.py
@@ -29,10 +29,10 @@ from benchmark.opperf.rules.default_params import MX_OP_MODULE
 """
 
 
-def run_nn_basic_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100):
+def run_nn_basic_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100, inference_mode=False):
     # FullyConnnected operator benchmarks
     fc_benchmark_res = run_performance_test([getattr(MX_OP_MODULE, "FullyConnected")],
-                                            run_backward=True,
+                                            run_backward=False if inference_mode else True,
                                             dtype=dtype,
                                             ctx=ctx,
                                             inputs=[{"data": (32, 3, 256, 256),
@@ -50,7 +50,7 @@ def run_nn_basic_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, 
 
     # Dropout benchmarks
     dropout_benchmark_res = run_performance_test([getattr(MX_OP_MODULE, "Dropout")],
-                                                 run_backward=True,
+                                                 run_backward=False if inference_mode else True,
                                                  dtype=dtype,
                                                  ctx=ctx,
                                                  inputs=[{"data": (32, 3, 256, 256),
@@ -63,7 +63,7 @@ def run_nn_basic_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, 
                                                  runs=runs)
     # BatchNorm benchmarks
     batchnorm_benchmark_res = run_performance_test([getattr(MX_OP_MODULE, "BatchNorm")],
-                                                   run_backward=True,
+                                                   run_backward=False if inference_mode else True,
                                                    dtype=dtype,
                                                    ctx=ctx,
                                                    inputs=[{"data": (32, 3, 256, 256),

--- a/benchmark/opperf/nd_operations/nn_conv_operators.py
+++ b/benchmark/opperf/nd_operations/nn_conv_operators.py
@@ -51,7 +51,7 @@ MXNet NDArray NN Convolution Operators
 """
 
 
-def run_pooling_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100):
+def run_pooling_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100, inference_mode=False):
     pool_types = ['avg', 'max', 'sum']
     global_pool_types = [0, 1]
 
@@ -62,7 +62,7 @@ def run_pooling_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, r
         for global_pool in global_pool_types:
             for pool1d_data in [(32, 3, 256), (32, 3, 64)]:
                 pool1d_benchmark_res += run_performance_test([getattr(MX_OP_MODULE, "Pooling")],
-                                                             run_backward=True,
+                                                             run_backward=False if inference_mode else True,
                                                              dtype=dtype,
                                                              ctx=ctx,
                                                              inputs=[{"data": pool1d_data,
@@ -76,7 +76,7 @@ def run_pooling_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, r
                                                              runs=runs)
             for pool2d_data in [(32, 3, 256, 256), (32, 3, 64, 64)]:
                 pool2d_benchmark_res += run_performance_test([getattr(MX_OP_MODULE, "Pooling")],
-                                                             run_backward=True,
+                                                             run_backward=False if inference_mode else True,
                                                              dtype=dtype,
                                                              ctx=ctx,
                                                              inputs=[{"data": pool2d_data,
@@ -93,12 +93,12 @@ def run_pooling_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, r
     return mx_pooling_op_results
 
 
-def run_convolution_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100):
+def run_convolution_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100, inference_mode=False):
     # Conv1D Benchmarks
     conv1d_benchmark_res = []
     for conv_data in [(32, 3, 256), (32, 3, 64)]:
         conv1d_benchmark_res += run_performance_test([getattr(MX_OP_MODULE, "Convolution")],
-                                                     run_backward=True,
+                                                     run_backward=False if inference_mode else True,
                                                      dtype=dtype,
                                                      ctx=ctx,
                                                      inputs=[{"data": conv_data,
@@ -117,7 +117,7 @@ def run_convolution_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=2
     conv2d_benchmark_res = []
     for conv_data in [(32, 3, 256, 256), (32, 3, 64, 64)]:
         conv2d_benchmark_res += run_performance_test([getattr(MX_OP_MODULE, "Convolution")],
-                                                     run_backward=True,
+                                                     run_backward=False if inference_mode else True,
                                                      dtype=dtype,
                                                      ctx=ctx,
                                                      inputs=[{"data": conv_data,

--- a/benchmark/opperf/nd_operations/random_sampling_operators.py
+++ b/benchmark/opperf/nd_operations/random_sampling_operators.py
@@ -34,7 +34,7 @@ from benchmark.opperf.utils.benchmark_utils import run_op_benchmarks
 from benchmark.opperf.utils.op_registry_utils import get_all_random_sampling_operators
 
 
-def run_mx_random_sampling_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100):
+def run_mx_random_sampling_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100, inference_mode=False):
     """Runs benchmarks with the given context and precision (dtype)for all the random sampling
     operators in MXNet.
 
@@ -55,7 +55,7 @@ def run_mx_random_sampling_operators_benchmarks(ctx=mx.cpu(), dtype='float32', w
 
     """
     # Fetch all Random Sampling Operators
-    mx_random_sample_ops = get_all_random_sampling_operators()
+    mx_random_sample_ops = get_all_random_sampling_operators(inference_mode)
     # Run benchmarks
     mx_random_sample_op_results = run_op_benchmarks(mx_random_sample_ops, dtype, ctx, warmup, runs)
     return mx_random_sample_op_results

--- a/benchmark/opperf/nd_operations/reduction_operators.py
+++ b/benchmark/opperf/nd_operations/reduction_operators.py
@@ -31,7 +31,7 @@ from benchmark.opperf.utils.op_registry_utils import get_all_reduction_operators
 from benchmark.opperf.utils.benchmark_utils import run_op_benchmarks
 
 
-def run_mx_reduction_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100):
+def run_mx_reduction_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100, inference_mode=False):
     """Runs benchmarks with the given context and precision (dtype)for all the reduction
     operators in MXNet.
 
@@ -52,7 +52,7 @@ def run_mx_reduction_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=
 
     """
     # Fetch all Reduction Operators
-    mx_reduction_broadcast_ops = get_all_reduction_operators()
+    mx_reduction_broadcast_ops = get_all_reduction_operators(inference_mode)
     # Run benchmarks
     mx_reduction_op_results = run_op_benchmarks(mx_reduction_broadcast_ops, dtype, ctx, warmup, runs)
     return mx_reduction_op_results

--- a/benchmark/opperf/nd_operations/unary_operators.py
+++ b/benchmark/opperf/nd_operations/unary_operators.py
@@ -35,7 +35,7 @@ from benchmark.opperf.utils.op_registry_utils import get_all_unary_operators
 from benchmark.opperf.utils.benchmark_utils import run_op_benchmarks
 
 
-def run_mx_unary_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100):
+def run_mx_unary_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, runs=100, inference_mode=False):
     """Runs benchmarks with the given context and precision (dtype)for all the unary
     operators in MXNet.
 
@@ -56,7 +56,7 @@ def run_mx_unary_operators_benchmarks(ctx=mx.cpu(), dtype='float32', warmup=25, 
 
     """
     # Fetch all Unary Operators
-    mx_unary_broadcast_ops = get_all_unary_operators()
+    mx_unary_broadcast_ops = get_all_unary_operators(inference_mode=inference_mode)
     # Run benchmarks
     mx_unary_op_results = run_op_benchmarks(mx_unary_broadcast_ops, dtype, ctx, warmup, runs)
     return mx_unary_op_results

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -28,7 +28,7 @@ from benchmark.opperf.rules.default_params import DEFAULTS_INPUTS, MX_OP_MODULE
 unique_ops = ("sample_multinomial",)
 
 
-def _select_ops(operator_names, filters=("_contrib", "_"), merge_op_forward_backward=True):
+def _select_ops(operator_names, filters=("_contrib", "_"), merge_op_forward_backward=True, inference_mode=False):
     """From a given list of operators, filter out all operator names starting with given filters and prepares
     a dictionary of operator with attributes - 'has_backward' and 'nd_op_handle = mxnet.ndarray.op'
 
@@ -70,7 +70,7 @@ def _select_ops(operator_names, filters=("_contrib", "_"), merge_op_forward_back
         for op_with_backward in operators_with_backward:
             op_name = op_with_backward.split("_backward_")[1]
             if op_name in mx_operators:
-                mx_operators[op_name]["has_backward"] = True
+                mx_operators[op_name]["has_backward"] = True if not inference_mode else False
 
     return mx_operators
 
@@ -155,10 +155,10 @@ def _set_op_arguments(mx_operators):
                                            "arg_types": arg_types}
 
 
-def _get_all_mxnet_operators():
+def _get_all_mxnet_operators(inference_mode=False):
     # Step 1 - Get all registered op names and filter it
     operator_names = _get_all_registered_ops()
-    mx_operators = _select_ops(operator_names)
+    mx_operators = _select_ops(operator_names, inference_mode=inference_mode)
 
     # Step 2 - Get all parameters for the operators
     _set_op_arguments(mx_operators)
@@ -212,7 +212,7 @@ def prepare_op_inputs(arg_params):
     return inputs
 
 
-def get_all_unary_operators():
+def get_all_unary_operators(inference_mode=False):
     """Gets all Unary operators registered with MXNet.
 
     Returns
@@ -220,7 +220,7 @@ def get_all_unary_operators():
     {"operator_name": {"has_backward", "nd_op_handle", "params"}}
     """
     # Get all mxnet operators
-    mx_operators = _get_all_mxnet_operators()
+    mx_operators = _get_all_mxnet_operators(inference_mode)
 
     # Filter for unary broadcast operators
     unary_broadcast_mx_operators = {}
@@ -231,7 +231,7 @@ def get_all_unary_operators():
     return unary_broadcast_mx_operators
 
 
-def get_all_broadcast_binary_operators():
+def get_all_broadcast_binary_operators(inference_mode=False):
     """Gets all binary broadcast operators registered with MXNet.
 
     Returns
@@ -239,7 +239,7 @@ def get_all_broadcast_binary_operators():
     {"operator_name": {"has_backward", "nd_op_handle", "params"}}
     """
     # Get all mxnet operators
-    mx_operators = _get_all_mxnet_operators()
+    mx_operators = _get_all_mxnet_operators(inference_mode)
 
     # Filter for binary broadcast operators
     binary_broadcast_mx_operators = {}
@@ -251,7 +251,7 @@ def get_all_broadcast_binary_operators():
     return binary_broadcast_mx_operators
 
 
-def get_all_elemen_wise_binary_operators():
+def get_all_elemen_wise_binary_operators(inference_mode=False):
     """Gets all binary elemen_wise operators registered with MXNet.
 
     Returns
@@ -259,7 +259,7 @@ def get_all_elemen_wise_binary_operators():
     {"operator_name": {"has_backward", "nd_op_handle", "params"}}
     """
     # Get all mxnet operators
-    mx_operators = _get_all_mxnet_operators()
+    mx_operators = _get_all_mxnet_operators(inference_mode)
 
     # Filter for binary elemen_wise operators
     binary_elemen_wise_mx_operators = {}
@@ -271,7 +271,7 @@ def get_all_elemen_wise_binary_operators():
     return binary_elemen_wise_mx_operators
 
 
-def get_all_random_sampling_operators():
+def get_all_random_sampling_operators(inference_mode=False):
     """Gets all Random Sampling operators registered with MXNet.
 
     Returns
@@ -279,7 +279,7 @@ def get_all_random_sampling_operators():
     {"operator_name": {"has_backward", "nd_op_handle", "params"}}
     """
     # Get all mxnet operators
-    mx_operators = _get_all_mxnet_operators()
+    mx_operators = _get_all_mxnet_operators(inference_mode)
 
     # Filter for Random Sampling operators
     random_sampling_mx_operators = {}
@@ -289,7 +289,7 @@ def get_all_random_sampling_operators():
     return random_sampling_mx_operators
 
 
-def get_all_reduction_operators():
+def get_all_reduction_operators(inference_mode=False):
     """Gets all Reduction operators registered with MXNet.
 
     Returns
@@ -297,7 +297,7 @@ def get_all_reduction_operators():
     {"operator_name": {"has_backward", "nd_op_handle", "params"}}
     """
     # Get all mxnet operators
-    mx_operators = _get_all_mxnet_operators()
+    mx_operators = _get_all_mxnet_operators(inference_mode)
 
     # Filter for Reduction operators
     reduction_mx_operators = {}

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -18,7 +18,10 @@
 """Utilities to interact with MXNet operator registry."""
 import ctypes
 from operator import itemgetter
-from mxnet import runtime
+try:
+    from mxnet import runtime
+except ImportError:
+    print("No runtime module available in MXNet. Please use MXNet 1.5.0 or above!")
 from mxnet.base import _LIB, check_call, py_str, OpHandle, c_str, mx_uint
 
 from benchmark.opperf.rules.default_params import DEFAULTS_INPUTS, MX_OP_MODULE


### PR DESCRIPTION
As one of the efforts to address https://github.com/apache/incubator-mxnet/issues/15429

We need to run op perf in inference mode as well as in 1.4.1 where runtime_feature is not available.