### PR TITLE
Julia docs

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -58,7 +58,7 @@ EOF
     else
         echo "NOTE: cython is used."
         return 0
-    fi 
+    fi
 }
 
 build_ccache_wrappers() {
@@ -1415,15 +1415,7 @@ deploy_docs() {
     set -ex
     pushd .
 
-    export CC="ccache gcc"
-    export CXX="ccache g++"
-    make docs SPHINXOPTS=-W USE_MKLDNN=0
-
-    popd
-}
-
-deploy_jl_docs() {
-    set -ex
+    # Setup for Julia docs
     export PATH="/work/julia10/bin:$PATH"
     export MXNET_HOME='/work/mxnet'
     export JULIA_DEPOT_PATH='/work/julia-depot'
@@ -1433,11 +1425,13 @@ deploy_jl_docs() {
     # FIXME
     export LD_PRELOAD='/usr/lib/x86_64-linux-gnu/libjemalloc.so'
     export LD_LIBRARY_PATH=/work/mxnet/lib:$LD_LIBRARY_PATH
+    # End Julia setup
 
-    make -C julia/docs
+    export CC="ccache gcc"
+    export CXX="ccache g++"
+    make docs SPHINXOPTS=-W USE_MKLDNN=0
 
-    # TODO: make Jenkins worker push to MXNet.jl ph-pages branch if master build
-    # ...
+    popd
 }
 
 build_static_scala_mkl() {

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 //
-// This file contains the steps that will be used in the 
+// This file contains the steps that will be used in the
 // Jenkins pipelines
 
 utils = load('ci/Jenkinsfile_utils.groovy')
@@ -1381,21 +1381,8 @@ def docs_website() {
             if ( master_url == 'jenkins.mxnet-ci.amazon-ml.com') {
                 sh "ci/other/ci_deploy_doc.sh ${env.BRANCH_NAME} ${env.BUILD_NUMBER}"
             } else {
-                print "Skipping staging documentation publishing since we are not running in prod. Host: {$master_url}" 
+                print "Skipping staging documentation publishing since we are not running in prod. Host: {$master_url}"
             }
-          }
-        }
-      }
-    }]
-}
-
-def docs_julia() {
-    return ['Julia docs': {
-      node(NODE_LINUX_CPU) {
-        ws('workspace/julia-docs') {
-          timeout(time: max_time, unit: 'MINUTES') {
-            utils.unpack_and_init('cpu', mx_lib)
-            utils.docker_run('ubuntu_cpu', 'deploy_jl_docs', false)
           }
         }
       }

--- a/ci/jenkins/Jenkinsfile_website
+++ b/ci/jenkins/Jenkinsfile_website
@@ -39,7 +39,6 @@ core_logic: {
 
   utils.parallel_stage('Deploy', [
     custom_steps.docs_website(),
-    custom_steps.docs_julia()
   ])
 }
 ,

--- a/dev_menu.py
+++ b/dev_menu.py
@@ -134,6 +134,8 @@ COMMANDS = OrderedDict([
     ),
     ('[Docker] Website and docs build outputs to "docs/_build/html/"',
         "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh deploy_docs"),
+    ('[Docker] Julia docs build outputs markdown to "julia/docs/build/"',
+        "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh deploy_jl_docs"),
     ('[Docker] sanity_check. Check for linting and code formatting and licenses.',
     [
         "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh sanity_check",

--- a/dev_menu.py
+++ b/dev_menu.py
@@ -134,8 +134,6 @@ COMMANDS = OrderedDict([
     ),
     ('[Docker] Website and docs build outputs to "docs/_build/html/"',
         "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh deploy_docs"),
-    ('[Docker] Julia docs build outputs markdown to "julia/docs/build/"',
-        "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh deploy_jl_docs"),
     ('[Docker] sanity_check. Check for linting and code formatting and licenses.',
     [
         "ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh sanity_check",

--- a/docs/api/julia/index.md
+++ b/docs/api/julia/index.md
@@ -25,3 +25,10 @@ computing and the state-of-art deep learning to Julia.
 - It enables you to write seamless tensor/matrix computation with multiple GPUs in Julia.
 - It also enables you to construct and customize the state-of-art deep learning models in Julia,
   and apply them to tasks such as image classification and data science challenges.
+
+## Installation
+* [Ubuntu installation guide](../../install/ubuntu_setup.html)
+* Mac / Windows guides are not available (contributions welcome!) 
+
+## Docs
+To build your own copy of the [MXNet Julia Site](site/index.html) using Docker, run `dev_menu.py` from the MXNet source root and choose the menu item for Julia docs.

--- a/docs/api/julia/index.md
+++ b/docs/api/julia/index.md
@@ -17,7 +17,7 @@
 
 # MXNet - Julia API
 
-See the [MXNet Julia Site](site/) for examples and API reference docs.
+See the [MXNet Julia Site](site/index.html) for examples and API reference docs.
 
 MXNet supports the Julia programming language. The MXNet Julia package brings flexible and efficient GPU
 computing and the state-of-art deep learning to Julia.

--- a/docs/api/julia/index.md
+++ b/docs/api/julia/index.md
@@ -28,7 +28,7 @@ computing and the state-of-art deep learning to Julia.
 
 ## Installation
 * [Ubuntu installation guide](../../install/ubuntu_setup.html)
-* Mac / Windows guides are not available (contributions welcome!) 
+* Mac / Windows guides are not available (contributions welcome!)
 
 ## Docs
-To build your own copy of the [MXNet Julia Site](site/index.html) using Docker, run `dev_menu.py` from the MXNet source root and choose the menu item for Julia docs.
+To build your own copy of the [MXNet Julia Site](site/index.html), run `make -C julia/docs` from the MXNet source root directory. You can also generate it with Docker by using `dev_menu.py` from the root directory and choosing to build the entire website. The Julia site will be located in `api/julia/site/`.

--- a/docs/api/julia/index.md
+++ b/docs/api/julia/index.md
@@ -17,7 +17,7 @@
 
 # MXNet - Julia API
 
-See the [MXNet Julia Reference Manual](https://media.readthedocs.org/pdf/mxnet-test/latest/mxnet-test.pdf).
+See the [MXNet Julia Site](site/) for examples and API reference docs.
 
 MXNet supports the Julia programming language. The MXNet Julia package brings flexible and efficient GPU
 computing and the state-of-art deep learning to Julia.
@@ -25,9 +25,3 @@ computing and the state-of-art deep learning to Julia.
 - It enables you to write seamless tensor/matrix computation with multiple GPUs in Julia.
 - It also enables you to construct and customize the state-of-art deep learning models in Julia,
   and apply them to tasks such as image classification and data science challenges.
-
-
-&nbsp;
-
-## Julia API Reference
-Julia documents are available at [http://dmlc.ml/MXNet.jl/latest/](http://dmlc.ml/MXNet.jl/latest/).

--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -338,7 +338,7 @@ If you're still getting the old version, remove it.
 sudo apt remove julia
 ```
 
-Update your PATH to have Julia's new location. Add this to your `.zshrc`, `.bashrc` or `.bash_profile`.
+Update your PATH to have Julia's new location. Add this to your `.zshrc`, `.bashrc`, `.profile` or `.bash_profile`.
 ```bash
 export PATH=~/julia/julia-1.0.3/bin:$PATH
 ```
@@ -355,38 +355,45 @@ julia -e 'using InteractiveUtils; versioninfo()'
 
 #### Setup Your MXNet-Julia Environment
 
-**For each of the following environment variables, add the commands to your `.zshrc` `.bashrc` or `.bash_profile` to make them persist.**
+**For each of the following environment variables, add the commands to your `.zshrc`, `.bashrc`, `.profile` or `.bash_profile` to make them persist.**
 
 Create a `julia-depot` folder and environment variable.
 ```bash
 mkdir julia-depot
-export JULIA_DEPOT_PATH='~/julia/julia-depot'
+export JULIA_DEPOT_PATH=$HOME/julia/julia-depot
 ```
 
 To use the Julia binding with an existing `libmxnet` installation, set the `MXNET_HOME` environment variable to the MXNet source root. For example:
 ```bash
-export MXNET_HOME='~/incubator-mxnet/mxnet'
+export MXNET_HOME=$HOME/incubator-mxnet
 ```
 
 Now set the `LD_LIBRARY_PATH` environment variable to where `libmxnet.so` is found. If you can't find it, you might have skipped the building MXNet step. Go back and [build MXNet](#build-the-shared-library) first. For example:
 ```bash
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:'~/incubator-mxnet/mxnet/lib'
+export LD_LIBRARY_PATH=$HOME/incubator-mxnet/lib:$LD_LIBRARY_PATH
 ```
 
 Verify the location of `libjemalloc.so` and set the `LD_PRELOAD` environment variable.
 ```bash
-export LD_PRELOAD=$LD_PRELOAD:'/usr/lib/x86_64-linux-gnu/libjemalloc.so'
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so:$LD_PRELOAD
 ```
 
-Install MXNet in the Julia console. First launch Julia:
+With all of these updates, here's an example of what you might want to have in your `.zshrc`, `.bashrc`, `.profile` or `.bash_profile`.
+
+```
+export PATH=$HOME/bin:$HOME/.local/bin:$HOME/julia/julia-1.0.3/bin:$PATH
+export JULIA_DEPOT_PATH=$HOME/julia/julia-depot
+export MXNET_HOME=$HOME/incubator-mxnet
+export LD_LIBRARY_PATH=$HOME/incubator-mxnet/lib:$LD_LIBRARY_PATH
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so:$LD_PRELOAD
+```
+
+Install MXNet with Julia:
 
 ```bash
-julia
-```
-
-At the Julia prompt use `Pkg` to install MXNet.
-```julia
-using Pkg; Pkg.build("MXNet")
+julia --color=yes --project=./ -e \
+	  'using Pkg; \
+	   Pkg.develop(PackageSpec(name="MXNet", path = joinpath(ENV["MXNET_HOME"], "julia")))'
 ```
 
 For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](../api/julia/site/).

--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -310,25 +310,86 @@ Refer to the [Clojure setup guide](https://github.com/apache/incubator-mxnet/tre
 
 ### Install the MXNet Package for Julia
 
-The MXNet package for Julia is hosted in a separate repository, MXNet.jl, which is available on [GitHub](https://github.com/dmlc/MXNet.jl). To use Julia binding it with an existing libmxnet installation, set the ```MXNET_HOME``` environment variable by running the following command:
+#### Install Julia
+The package available through `apt-get` is old and not compatible with the latest version of MXNet.
+Fetch the latest version (1.0.3 at the time of this writing).
 
 ```bash
-    export MXNET_HOME=/<path to>/libmxnet
+wget -qO julia-10.tar.gz https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.3-linux-x86_64.tar.gz
 ```
 
-The path to the existing libmxnet installation should be the root directory of libmxnet. In other words, you should be able to find the ```libmxnet.so``` file at ```$MXNET_HOME/lib```. For example, if the root directory of libmxnet is ```~```, you would run the following command:
+Place the extracted files somewhere like a julia folder in your home dir.
 
 ```bash
-    export MXNET_HOME=/~/libmxnet
+mkdir ~/julia
+mv julia-10.tar.gz ~/julia
+cd ~/julia
+tar xvf julia-10.tar.gz
 ```
 
-You might want to add this command to your ```~/.bashrc``` file. If you do, you can install the Julia package in the Julia console using the following command:
+Test Julia.
+```bash
+cd julia-1.0.3/bin
+julia -e 'using InteractiveUtils; versioninfo()'
+```
 
+If you're still getting the old version, remove it.
+```bash
+sudo apt remove julia
+```
+
+Update your PATH to have Julia's new location. Add this to your `.zshrc`, `.bashrc` or `.bash_profile`.
+```bash
+export PATH=~/julia/julia-1.0.3/bin:$PATH
+```
+
+Validate your PATH.
+```bash
+echo $PATH
+```
+
+Validate Julia works and is the expected version.
+```bash
+julia -e 'using InteractiveUtils; versioninfo()'
+```
+
+#### Setup Your MXNet-Julia Environment
+
+**For each of the following environment variables, add the commands to your `.zshrc` `.bashrc` or `.bash_profile` to make them persist.**
+
+Create a `julia-depot` folder and environment variable.
+```bash
+mkdir julia-depot
+export JULIA_DEPOT_PATH='~/julia/julia-depot'
+```
+
+To use the Julia binding with an existing `libmxnet` installation, set the `MXNET_HOME` environment variable to the MXNet source root. For example:
+```bash
+export MXNET_HOME='~/incubator-mxnet/mxnet'
+```
+
+Now set the `LD_LIBRARY_PATH` environment variable to where `libmxnet.so` is found. If you can't find it, you might have skipped the building MXNet step. Go back and [build MXNet](#build-the-shared-library) first. For example:
+```bash
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:'~/incubator-mxnet/mxnet/lib'
+```
+
+Verify the location of `libjemalloc.so` and set the `LD_PRELOAD` environment variable.
+```bash
+export LD_PRELOAD=$LD_PRELOAD:'/usr/lib/x86_64-linux-gnu/libjemalloc.so'
+```
+
+Install MXNet in the Julia console. First launch Julia:
+
+```bash
+julia
+```
+
+At the Julia prompt use `Pkg` to install MXNet.
 ```julia
-    Pkg.add("MXNet")
+using Pkg; Pkg.build("MXNet")
 ```
 
-For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](/api/julia/site/).
+For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](../api/julia/site/).
 <hr>
 
 

--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -328,7 +328,7 @@ You might want to add this command to your ```~/.bashrc``` file. If you do, you 
     Pkg.add("MXNet")
 ```
 
-For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](http://dmlc.ml/MXNet.jl/latest/user-guide/install/).
+For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](/api/julia/site/).
 <hr>
 
 

--- a/docs/install/windows_setup.md
+++ b/docs/install/windows_setup.md
@@ -494,7 +494,7 @@ You might want to add this command to your ```~/.bashrc``` file. If you do, you 
 	Pkg.add("MXNet")
 ```
 
-For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](http://dmlc.ml/MXNet.jl/latest/user-guide/install/).
+For more details about installing and using MXNet with Julia, see the [MXNet Julia documentation](/api/julia/site/).
 
 
 ## Installing the MXNet Package for Scala

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -466,7 +466,7 @@ def copy_artifacts(app):
 def setup(app):
     # If MXNET_DOCS_BUILD_MXNET is set something different than 1
     # Skip the build step
-    if _MXNET_DOCS_BUILD_MXNET:
+    if os.getenv('MXNET_DOCS_BUILD_MXNET') == '1'or _MXNET_DOCS_BUILD_MXNET:
         print("Building MXNet!")
         app.connect("builder-inited", build_mxnet)
     if _DOXYGEN_DOCS:

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -41,7 +41,7 @@ if _DOC_SET not in parser.sections():
 
 for section in [ _DOC_SET ]:
     print("Document sets to generate:")
-    for candidate in [ 'scala_docs', 'java_docs', 'clojure_docs', 'doxygen_docs', 'r_docs' ]:
+    for candidate in [ 'scala_docs', 'java_docs', 'clojure_docs', 'doxygen_docs', 'julia_docs', 'r_docs' ]:
         print('%-12s  : %s' % (candidate, parser.get(section, candidate)))
 
 _MXNET_DOCS_BUILD_MXNET = parser.getboolean('mxnet', 'build_mxnet')
@@ -98,9 +98,10 @@ def build_mxnet(app):
 
 def build_julia_docs(app):
     """build Julia docs"""
-    dest_path = app.builder.outdir + '/api/julia/'
-    _run_cmd('cd %s/.. && make -C julia/docs' % app.builder.srcdir)
-    _run_cmd('cp -a julia/docs/site/* ' + dest_path)
+    dest_path = app.builder.outdir + '/api/julia/site'
+    _run_cmd('cd {}/.. && make -C julia/docs'.format(app.builder.srcdir))
+    _run_cmd('mkdir -p {}'.format(dest_path))
+    _run_cmd('cd {}/.. && cp -a julia/docs/site/* {}'.format(app.builder.srcdir, dest_path))
 
 def build_r_docs(app):
     """build r pdf"""

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -466,7 +466,7 @@ def copy_artifacts(app):
 def setup(app):
     # If MXNET_DOCS_BUILD_MXNET is set something different than 1
     # Skip the build step
-    if os.getenv('MXNET_DOCS_BUILD_MXNET', '1') == '1' or _MXNET_DOCS_BUILD_MXNET:
+    if _MXNET_DOCS_BUILD_MXNET:
         print("Building MXNet!")
         app.connect("builder-inited", build_mxnet)
     if _DOXYGEN_DOCS:

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -50,6 +50,7 @@ _JAVA_DOCS = parser.getboolean(_DOC_SET, 'java_docs')
 _CLOJURE_DOCS = parser.getboolean(_DOC_SET, 'clojure_docs')
 _DOXYGEN_DOCS = parser.getboolean(_DOC_SET,  'doxygen_docs')
 _R_DOCS = parser.getboolean(_DOC_SET, 'r_docs')
+_JULIA_DOCS = parser.getboolean(_DOC_SET, 'julia_docs')
 _ARTIFACTS = parser.getboolean(_DOC_SET, 'artifacts')
 
 # white list to evaluate the code block output, such as ['tutorials/gluon']
@@ -94,6 +95,12 @@ def build_mxnet(app):
     else:
         _run_cmd("cd %s/.. && make -j$(nproc) USE_MKLDNN=0 USE_CPP_PACKAGE=1 " %
                 app.builder.srcdir)
+
+def build_julia_docs(app):
+    """build Julia docs"""
+    dest_path = app.builder.outdir + '/api/julia/'
+    _run_cmd('cd %s/.. && make -C julia/docs' % app.builder.srcdir)
+    _run_cmd('cp -a julia/docs/site/* ' + dest_path)
 
 def build_r_docs(app):
     """build r pdf"""
@@ -476,6 +483,9 @@ def setup(app):
     if _CLOJURE_DOCS:
         print("Building Clojure Docs!")
         app.connect("builder-inited", build_clojure_docs)
+    if _JULIA_DOCS:
+        print("Building Julia Docs!")
+        app.connect("builder-inited", build_julia_docs)
     if _R_DOCS:
         print("Building R Docs!")
         app.connect("builder-inited", build_r_docs)

--- a/docs/settings.ini
+++ b/docs/settings.ini
@@ -24,6 +24,7 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 0
 
 [document_sets_default]
@@ -32,6 +33,7 @@ clojure_docs = 1
 doxygen_docs = 1
 java_docs = 1
 r_docs = 0
+julia_docs = 1
 scala_docs = 1
 
 [document_sets_1.4.0]
@@ -40,6 +42,7 @@ clojure_docs = 1
 doxygen_docs = 1
 java_docs = 1
 r_docs = 0
+julia_docs = 0
 scala_docs = 1
 
 [document_sets_v1.4.x]
@@ -48,6 +51,7 @@ clojure_docs = 1
 doxygen_docs = 1
 java_docs = 1
 r_docs = 0
+julia_docs = 0
 scala_docs = 1
 
 [document_sets_1.3.1]
@@ -56,6 +60,7 @@ clojure_docs = 1
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 1
 
 [document_sets_1.3.0]
@@ -64,6 +69,7 @@ clojure_docs = 1
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 1
 
 [document_sets_v1.3.x]
@@ -72,6 +78,7 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 0
 
 [document_sets_1.2.0]
@@ -80,6 +87,7 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 1
 
 [document_sets_v1.2.0]
@@ -88,6 +96,7 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 1
 
 [document_sets_1.1.0]
@@ -96,6 +105,7 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 0
 
 [document_sets_v1.1.0]
@@ -104,6 +114,7 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 0
 
 [document_sets_1.0.0]
@@ -112,6 +123,7 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 0
 
 [document_sets_v1.0.0]
@@ -120,6 +132,7 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 0
 
 [document_sets_0.12.0]
@@ -128,6 +141,7 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 0
 
 [document_sets_v0.12.0]
@@ -136,6 +150,7 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 0
 
 [document_sets_0.11.0]
@@ -144,6 +159,7 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 0
 
 [document_sets_v0.11.0]
@@ -152,4 +168,5 @@ clojure_docs = 0
 doxygen_docs = 1
 java_docs = 0
 r_docs = 0
+julia_docs = 0
 scala_docs = 0

--- a/docs/settings.ini
+++ b/docs/settings.ini
@@ -16,7 +16,7 @@
 # under the License.
 
 [mxnet]
-build_mxnet = 0
+build_mxnet = 1
 
 [document_sets_tutorial]
 artifacts = 0


### PR DESCRIPTION
## Description ##
Since the dmlc.ml domain is gone we lost our Julia docs (and other things). 
This PR adds Julia docs to our regular website deployment pipeline. 💥 Links to the Julia docs will no longer go to a spam/malware website.

Fixes #15415 

**Update**: It also adds a thorough [Ubuntu setup guide for Julia](http://34.201.8.176/versions/julia/install/ubuntu_setup.html#install-the-mxnet-package-for-julia). The existing one doesn't work. However, this needs more eyes and testing. I did get it to work, but after a ton of troubleshooting, so I might have missed some env var or some setting that is required.

**Update 2**: I removed the separate Julia pipeline for docs. I needed to have its installation and config steps and it was duplicating things anyways. So since I had to fix CI, I went ahead and removed the duplication. That being said, sometime in the future it would be nice to revamp the docs build and have stages for each of the doc sets and make it so you don't have to rerun every stage of CI if one particular part of docs generation fails.

## Preview
The Julia docs site ends up in /site in the Julia API area.
http://34.201.8.176/versions/julia/api/julia/site/index.html