### PR TITLE
[Numpy] numpy compatible invert

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -33,7 +33,7 @@ __all__ = ['zeros', 'ones', 'maximum', 'minimum', 'stack', 'arange', 'argmax',
            'clip', 'split', 'swapaxes', 'expand_dims', 'tile', 'linspace', 'eye',
            'sin', 'cos', 'sinh', 'cosh', 'log10', 'sqrt', 'abs', 'exp', 'arctan', 'sign', 'log',
            'degrees', 'log2', 'rint', 'radians', 'mean', 'reciprocal', 'square', 'arcsin',
-           'argsort', 'hstack', 'tensordot']
+           'argsort', 'hstack', 'tensordot', 'invert']
 
 
 @set_module('mxnet.ndarray.numpy')
@@ -1638,7 +1638,6 @@ def rint(x, out=None, **kwargs):
     out : ndarray or None
         A location into which the result is stored.
         If provided, it must have the same shape and type as the input.
-        If not provided or None, a freshly-allocated array is returned.
 
     Returns
     -------
@@ -1662,6 +1661,50 @@ def rint(x, out=None, **kwargs):
     array([-2., -2., -0.,  0.,  1.,  2.,  2.])
     """
     return _unary_func_helper(x, _npi.rint, _np.rint, out=out, **kwargs)
+
+
+def invert(x, out=None, **kwargs):
+    """
+    Compute bit-wise inversion, or bit-wise NOT, element-wise.
+    Computes the bit-wise NOT of the underlying binary representation of
+    the integers in the input arrays. This ufunc implements the C/Python operator ~.
+    For signed integer inputs, the two’s complement is returned.
+    In a two’s-complement system negative numbers are represented
+    by the two’s complement of the absolute value.
+    This is the most common method of representing signed integers on computers [1].
+    A N-bit two’s-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
+
+    Parameters
+    ----------
+    x : ndarray
+        Only integer and boolean types are handled.
+    out : ndarray or None
+        A location into which the result is stored.
+        If provided, it must have the same shape as the input.
+        If not provided or None, a freshly-allocated array is returned.
+
+    Returns
+    -------
+    out : ndarray
+        Bitwisely inverted elements of the original array.
+
+    Examples
+    --------
+    >>> np.invert(np.array([13], dtype=np.uint8))
+    array([242], dtype=uint8)
+
+    Notes
+    -----
+    This function differs from the original `numpy.invert
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.invert.html>`_ in
+    the following way(s):
+
+    - only ndarray or scalar is accpted as valid input, tuple of ndarray is not supported
+    - broadcasting to `out` of different shape is currently not supported
+    - when input is plain python numerics, the result will not be stored in the `out` param
+
+    """
+    return _unary_func_helper(x, _npi.invert, _np.invert, out=out, **kwargs)
 
 
 @set_module('mxnet.ndarray.numpy')
@@ -1688,11 +1731,8 @@ def log2(x, out=None, **kwargs):
     -----
     This function differs from the original `numpy.log2
     <https://www.google.com/search?q=numpy+log2>`_ in
-    the following way(s):
+        Result. This is a scalar if x is a scalar.
 
-    - only ndarray or scalar is accpted as valid input, tuple of ndarray is not supported
-    - broadcasting to `out` of different shape is currently not supported
-    - when input is plain python numerics, the result will not be stored in the `out` param
 
     Examples
     --------

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -48,7 +48,7 @@ __all__ = ['ndarray', 'empty', 'array', 'zeros', 'ones', 'maximum', 'minimum', '
            'clip', 'split', 'swapaxes', 'expand_dims', 'tile', 'linspace', 'eye', 'sin', 'cos',
            'sin', 'cos', 'sinh', 'cosh', 'log10', 'sqrt', 'abs', 'exp', 'arctan', 'sign', 'log',
            'degrees', 'log2', 'rint', 'radians', 'mean', 'reciprocal', 'square', 'arcsin',
-           'argsort', 'hstack', 'tensordot']
+           'argsort', 'hstack', 'tensordot', 'invert']
 
 
 @set_module('mxnet.numpy')
@@ -2766,7 +2766,6 @@ def rint(x, out=None, **kwargs):
     out : ndarray or None
         A location into which the result is stored.
         If provided, it must have the same shape and type as the input.
-        If not provided or None, a freshly-allocated array is returned.
 
     Returns
     -------
@@ -2791,6 +2790,48 @@ def rint(x, out=None, **kwargs):
     """
     return _mx_nd_np.rint(x, out=out, **kwargs)
 
+def invert(x, out=None, **kwargs):
+    """
+    Compute bit-wise inversion, or bit-wise NOT, element-wise.
+    Computes the bit-wise NOT of the underlying binary representation of
+    the integers in the input arrays. This ufunc implements the C/Python operator ~.
+    For signed integer inputs, the two’s complement is returned.
+    In a two’s-complement system negative numbers are represented
+    by the two’s complement of the absolute value.
+    This is the most common method of representing signed integers on computers [1].
+    A N-bit two’s-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
+
+    Parameters
+    ----------
+    x : array_like
+        Only integer and boolean types are handled.
+    out : ndarray, None, or tuple of ndarray and None, optional
+        A location into which the result is stored.
+        If provided, it must have the same shape as the input.
+        If not provided or None, a freshly-allocated array is returned.
+
+    Returns
+    -------
+    out : ndarray
+        Bitwisely inverted elements of the original array.
+
+    Examples
+    --------
+    >>> np.invert(np.array([13], dtype=np.uint8))
+    array([242], dtype=uint8)
+
+    Notes
+    -----
+    This function differs from the original `numpy.invert
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.invert.html>`_ in
+    the following way(s):
+
+    - only ndarray or scalar is accpted as valid input, tuple of ndarray is not supported
+    - broadcasting to `out` of different shape is currently not supported
+    - when input is plain python numerics, the result will not be stored in the `out` param
+
+    """
+    return _mx_nd_np.invert(x, out=out, **kwargs)
 
 @set_module('mxnet.numpy')
 def log2(x, out=None, **kwargs):
@@ -2905,16 +2946,6 @@ def radians(x, out=None, **kwargs):
     y : ndarray
         The corresponding radian values. This is a scalar if x is a scalar.
 
-    Notes
-    -----
-    This function differs from the original `numpy.radians
-    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.radians.html>`_ in
-    the following way(s):
-
-    - only ndarray or scalar is accpted as valid input, tuple of ndarray is not supported
-    - broadcasting to `out` of different shape is currently not supported
-    - when input is plain python numerics, the result will not be stored in the `out` param
-
     Examples
     --------
     >>> deg = np.arange(12.) * 30.
@@ -2922,6 +2953,12 @@ def radians(x, out=None, **kwargs):
     array([0.       , 0.5235988, 1.0471976, 1.5707964, 2.0943952, 2.6179938,
            3.1415927, 3.6651914, 4.1887903, 4.712389 , 5.2359877, 5.7595863],
            dtype=float32)
+
+    Notes
+    -----
+    This function differs from the original `numpy.radians
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.radians.html>`_ in
+        Result. This is a scalar if x is a scalar.
 
     """
     return _mx_nd_np.radians(x, out=out, **kwargs)

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -33,7 +33,7 @@ __all__ = ['zeros', 'ones', 'maximum', 'minimum', 'stack', 'concatenate', 'arang
            'clip', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'split', 'swapaxes',
            'expand_dims', 'tile', 'linspace', 'eye', 'sin', 'cos', 'sinh', 'cosh', 'log10', 'sqrt',
            'abs', 'exp', 'arctan', 'sign', 'log', 'degrees', 'log2', 'rint', 'radians', 'mean',
-           'reciprocal', 'square', 'arcsin', 'argsort', 'hstack', 'tensordot']
+           'reciprocal', 'square', 'arcsin', 'argsort', 'hstack', 'tensordot', 'invert']
 
 
 def _num_outputs(sym):
@@ -2066,6 +2066,48 @@ def degrees(x, out=None, **kwargs):
     return _unary_func_helper(x, _npi.degrees, _np.degrees, out=out, **kwargs)
 
 
+def invert(x, out=None, **kwargs):
+    """
+    Compute bit-wise inversion, or bit-wise NOT, element-wise.
+    Computes the bit-wise NOT of the underlying binary representation of
+    the integers in the input arrays. This ufunc implements the C/Python operator ~.
+    For signed integer inputs, the two’s complement is returned.
+    In a two’s-complement system negative numbers are represented
+    by the two’s complement of the absolute value.
+    This is the most common method of representing signed integers on computers [1].
+    A N-bit two’s-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
+
+    Parameters
+    ----------
+    x : _Symbol
+        Input value. Elements must be of real value.
+    out : _Symbol or None, optional
+        Dummy parameter to keep the consistency with the ndarray counterpart.
+
+    Returns
+    -------
+    out : _Symbol
+        Dummy parameter to keep the consistency with the ndarray counterpart.
+
+    Examples
+    --------
+    >>> np.invert(np.array([13], dtype=np.uint8))
+    array([242], dtype=uint8)
+
+    Notes
+    -----
+    This function differs from the original `numpy.invert
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.invert.html>`_ in
+    the following way(s):
+
+    - only ndarray or scalar is accpted as valid input, tuple of ndarray is not supported
+    - broadcasting to `out` of different shape is currently not supported
+    - when input is plain python numerics, the result will not be stored in the `out` param
+
+    """
+    return _unary_func_helper(x, _npi.invert, _np.invert, out=out, **kwargs)
+
+
 def rint(x, out=None, **kwargs):
     """
     Round elements of the array to the nearest integer.
@@ -2105,9 +2147,10 @@ def log2(x, out=None, **kwargs):
     ----------
     x : _Symbol
         Input values.
-    out : ndarray or None
-        A location into which the result is stored.
-        If provided, it must have the same shape and type as the input.
+
+    out : _Symbol or None
+        A location into which the result is stored. If provided,
+        it must have the same shape as the input.
         If not provided or None, a freshly-allocated array is returned.
 
     Returns

--- a/src/operator/elemwise_op_common.h
+++ b/src/operator/elemwise_op_common.h
@@ -186,6 +186,28 @@ inline bool ElemwiseType(const nnvm::NodeAttrs& attrs,
     attrs, in_attrs, out_attrs, -1);
 }
 
+template<index_t n_in, index_t n_out>
+inline bool ElemwiseIntType(const nnvm::NodeAttrs& attrs,
+                         std::vector<int> *in_attrs,
+                         std::vector<int> *out_attrs) {
+  if (n_in != -1) {
+    CHECK_EQ(in_attrs->size(), static_cast<size_t>(n_in)) << " in operator " << attrs.name;
+  }
+  if (n_out != -1) {
+    CHECK_EQ(out_attrs->size(), static_cast<size_t>(n_out)) << " in operator " << attrs.name;
+  }
+  for (size_t i = 0; i < in_attrs->size(); ++i) {
+    CHECK(type_is_none(in_attrs->at(i)) || type_is_int(in_attrs->at(i)))
+      <<"only integer input type is accepted, received type " << type_string(in_attrs->at(i));
+  }
+  for (size_t i = 0; i < out_attrs->size(); ++i) {
+    CHECK(type_is_none(out_attrs->at(i)) || type_is_int(out_attrs->at(i)))
+      <<"only integer output type is accepted, received type " << type_string(out_attrs->at(i));
+  }
+  return ElemwiseAttr<int, type_is_none, type_assign, true, type_string>(
+    attrs, in_attrs, out_attrs, -1);
+}
+
 // Transfer gradient and input to FGradient function
 struct ElemwiseGradUseIn {
   const char *op_name;

--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -117,6 +117,8 @@ MXNET_BINARY_MATH_OP_NC(minus, a - b);
 
 MXNET_UNARY_MATH_OP(negation, -a);
 
+MXNET_UNARY_MATH_OP(invert, DType(~static_cast<int64_t>(a)));
+
 MXNET_UNARY_MATH_OP(reciprocal, 1.0f / math::id(a));
 
 MXNET_UNARY_MATH_OP(reciprocal_grad, -1.0f / math::sqr(a));

--- a/src/operator/numpy/np_elemwise_unary_op_basic.cc
+++ b/src/operator/numpy/np_elemwise_unary_op_basic.cc
@@ -69,6 +69,27 @@ NNVM_REGISTER_OP(_np_copy)
   })
 .add_argument("a", "NDArray-or-Symbol", "The input");
 
+NNVM_REGISTER_OP(_npi_invert)
+.describe(R"code(Compute the truth value of NOT x element-wise.
+Example::
+  invert([13]) = array([242])
+)code")
+.set_num_inputs(1)
+.set_num_outputs(1)
+.set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseIntType<1, 1>)
+.set_attr<nnvm::FInplaceOption>("FInplaceOption",
+  [](const NodeAttrs& attrs){
+    return std::vector<std::pair<int, int> >{{0, 0}};
+  })
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"x"};
+  })
+.set_attr<FCompute>("FCompute<cpu>", UnaryOp::Compute<cpu, mshadow_op::invert>)
+.add_argument("x", "NDArray-or-Symbol", "The input array.")
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
+
 #define MXNET_OPERATOR_REGISTER_NUMPY_UNARY(__name$, __input_name$, __kernel$)          \
 NNVM_REGISTER_OP(__name$)                                                               \
 .set_num_inputs(1)                                                                      \

--- a/src/operator/numpy/np_elemwise_unary_op_basic.cu
+++ b/src/operator/numpy/np_elemwise_unary_op_basic.cu
@@ -61,6 +61,8 @@ MXNET_OPERATOR_REGISTER_NUMPY_UNARY_GPU(_npi_square, mshadow_op::square);
 
 MXNET_OPERATOR_REGISTER_NUMPY_UNARY_GPU(_npi_sqrt, mshadow_op::square_root);
 
+MXNET_OPERATOR_REGISTER_NUMPY_UNARY_GPU(_npi_invert, mshadow_op::invert);
+
 MXNET_OPERATOR_REGISTER_NUMPY_UNARY_GPU(_np_cbrt, mshadow_op::cube_root);
 
 MXNET_OPERATOR_REGISTER_NUMPY_UNARY_GPU(_npi_exp, mshadow_op::exp);

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -131,6 +131,19 @@ inline std::string shape_string(const mxnet::TShape& x) {
   return os.str();
 }
 
+/*! \brief check if type is integer */
+inline bool type_is_int(const int& x) {
+   switch (x) {
+    case mshadow::kInt8:
+    case mshadow::kUint8:
+    case mshadow::kInt32:
+    case mshadow::kInt64:
+      return true;
+    default:
+      return false;
+  }
+}
+
 /*! \brief get string representation of data type */
 inline std::string type_string(const int& x) {
   switch (x) {

--- a/src/operator/operator_tune.cc
+++ b/src/operator/operator_tune.cc
@@ -209,6 +209,7 @@ OperatorTuneBase::duration_t OperatorTuneBase::omp_overhead_ns_ = 5000;
 IMPLEMENT_UNARY_WORKLOAD_FWD(mxnet::op::mshadow_op::identity);  // NOLINT()
 IMPLEMENT_UNARY_WORKLOAD_BWD(mxnet::op::mshadow_op::identity_grad);  // NOLINT()
 IMPLEMENT_UNARY_WORKLOAD_FWD(mxnet::op::mshadow_op::negation);  // NOLINT()
+IMPLEMENT_UNARY_WORKLOAD_FWD(mxnet::op::mshadow_op::invert);  // NOLINT()
 IMPLEMENT_UNARY_WORKLOAD_FWD(mxnet::op::mshadow_op::reciprocal);  // NOLINT()
 IMPLEMENT_UNARY_WORKLOAD_BWD(mxnet::op::mshadow_op::reciprocal_grad);  // NOLINT()
 IMPLEMENT_UNARY_WORKLOAD_FWD(mxnet::op::mshadow_op::sigmoid);  // NOLINT()

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -639,6 +639,50 @@ def test_np_unary_funcs():
 
 @with_seed()
 @use_np
+def test_np_unary_funcs_int():
+    # test unary functions that require integer input type in the standard numpy
+    def check_unary_func(func, ref_grad, shape, low, high):
+        @use_np
+        class TestUnaryInt(HybridBlock):
+            def __init__(self, func):
+                super(TestUnaryInt, self).__init__()
+                self._func = func
+
+            def hybrid_forward(self, F, a, *args, **kwargs):
+                return getattr(F.np, self._func)(a)
+
+        np_func = getattr(_np, func)
+        mx_func = TestUnaryInt(func)
+        np_test_data = _np.random.uniform(low, high, shape).astype(_np.int32)
+        mx_test_data = mx.numpy.array(np_test_data, dtype=np.int32)
+        for hybridize in [True, False]:
+            if hybridize:
+                mx_func.hybridize()
+            if ref_grad:
+                mx_test_data.attach_grad()
+            np_out = np_func(np_test_data)
+            with mx.autograd.record():
+                y = mx_func(mx_test_data)
+            assert y.shape == np_out.shape
+            assert_almost_equal(y.asnumpy(), np_out, rtol=1e-3, atol=1e-5)
+
+            if ref_grad:
+                y.backward()
+                assert_almost_equal(mx_test_data.grad.asnumpy(), ref_grad(np_test_data), rtol=1e-5, atol=1e-6, equal_nan=True)
+
+    funcs = {
+        'invert' : (None, -10, 10)
+    }
+    ndim = random.choice([2, 3, 4])
+    shape = random.choice([rand_shape_nd(ndim, dim=3), (1, 0, 2)])
+    for shape in [rand_shape_nd(ndim, dim=3), (1, 0, 2)]:
+        for func, func_data in funcs.items():
+            ref_grad, low, high = func_data
+            check_unary_func(func, ref_grad, shape, low, high)
+
+
+@with_seed()
+@use_np
 def test_np_stack():
     class TestStack(HybridBlock):
         def __init__(self, axis=None):


### PR DESCRIPTION
## Description ##
- add numpy compatible [invert](https://docs.scipy.org/doc/numpy/reference/generated/numpy.invert.html) 
- add a helper function for checking if input or output is integer

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- add invert and its test
- a helper function to check for checking if input and output is of type integer at ` src/operator/operator_common.h type_is_int`

## Comments ##
- pass CPU,GPU test, pylint, cpplint
- Thank @haojin2 for reviewing
