### PR TITLE
[MXNET-978] [WIP] Higher Order Gradient Support `elemwise_mul`, `elemwise_div`.

### DIFF
--- a/src/operator/tensor/elemwise_binary_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_op_basic.cc
@@ -233,47 +233,16 @@ The storage type of ``elemwise_mul`` output depends on storage types of inputs
                                 return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
                               })
 .add_alias("_mul").add_alias("_Mul")
-.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_mul"});
-
-NNVM_REGISTER_OP(_backward_mul)
-.set_num_inputs(3)
-.set_num_outputs(2)
-.set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_attr<nnvm::FInplaceOption>("FInplaceOption",
-                                [](const NodeAttrs &attrs) {
-                                  return std::vector<std::pair<int, int> >{{0, 1}};
-                                })
-.set_attr<FInferStorageType>("FInferStorageType", ElemwiseBinaryOp::BackwardUseInStorageType)
-.set_attr<FResourceRequest>("FResourceRequest",  /* For Sparse CSR */
-                              [](const NodeAttrs& attrs) {
-                                return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-                              })
-.set_attr<FCompute>("FCompute<cpu>", ElemwiseBinaryOp::BackwardUseIn<
-  cpu, mshadow_op::right, mshadow_op::left>)
-.set_attr<FComputeEx>("FComputeEx<cpu>", ElemwiseBinaryOp::BackwardUseInEx<
-  cpu, mshadow_op::right, mshadow_op::left>)
 .set_attr<nnvm::FGradient>("FGradient",
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
     // z = x * y
-    // NodeEntry{n, 0, 0} : z_grad * y
-    // NodeEntry{n, 1, 0} : z_grad * x
-    // n->inputs[0] : z_grad
-    // n->inputs[1] : x
-    // n->inputs[1] : y
-    // ograds[0] : head_grads
     // f(x, y) = x * y
     // dx = z_grad * y, dy = z_grad * x
-    // d2x = 0, d2y = 0, dz_grad = dx + dy = y + x
-    auto dz_grad = MakeNode("elemwise_add", n->attrs.name + "_y_add_x",
-                            {n->inputs[2], n->inputs[1]}, nullptr, &n);
-
     std::vector<nnvm::NodeEntry> ret;
-    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad",
-                              {ograds[0], nnvm::NodeEntry{dz_grad}}, nullptr, &n));
-    ret.emplace_back(MakeNode("zeros_like", n->attrs.name + "_backward_grad_grad_x",
-                              {n->inputs[1]}, nullptr, &n));
-    ret.emplace_back(MakeNode("zeros_like", n->attrs.name + "_backward_grad_grad_y",
-                              {n->inputs[2]}, nullptr, &n));
+    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_x",
+                              {ograds[0], n->inputs[1]}, nullptr, &n));
+    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_y",
+                              {ograds[0], n->inputs[0]}, nullptr, &n));
     return ret;
 });
 
@@ -285,56 +254,25 @@ The storage type of ``elemwise_div`` output is always dense
 
 )code")
 .add_alias("_div").add_alias("_Div")
-.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_div"});
-
-NNVM_REGISTER_OP(_backward_div)
-.set_num_inputs(3)
-.set_num_outputs(2)
-.set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_attr<nnvm::FInplaceOption>("FInplaceOption",
-                                [](const NodeAttrs &attrs) {
-                                  return std::vector<std::pair<int, int> >{{0, 1}};
-                                })
-.set_attr<FCompute>("FCompute<cpu>", ElemwiseBinaryOp::BackwardUseIn<
-  cpu, mshadow_op::div_grad, mshadow_op::div_rgrad>)
-.set_attr<FComputeEx>("FComputeEx<cpu>", ElemwiseBinaryOp::BackwardUseInEx<
-  cpu, mshadow_op::div_grad, mshadow_op::div_rgrad>)
 .set_attr<nnvm::FGradient>("FGradient",
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
     // z = x / y
-    // NodeEntry{n, 0, 0} : z_grad * (1/y)
-    // NodeEntry{n, 1, 0} : z_grad * (-x/y^2)
-    // n->inputs[0] : z_grad
-    // n->inputs[1] : x
-    // n->inputs[1] : y
-    // ograds[0] : head_grads
     // f(x, y) = x / y
-    // dx = z_grad * (1/y), dy = z_grad * (-x/y^2)
-    // d2x = 0, d2y = dy * (-2/x) = (2x/y^3), dz_grad = (dx + dy) / (z_grad)
-    auto dx = nnvm::NodeEntry{n, 0, 0};
-    auto dy = nnvm::NodeEntry{n, 1, 0};
-    auto dx_add_dy = MakeNode("elemwise_add", n->attrs.name + "_x_add_y",
-                              {dx, dy}, nullptr, &n);
-    auto dz_grad = MakeNode("elemwise_div", n->attrs.name + "_x_add_y",
-                                         {nnvm::NodeEntry{dx_add_dy}, n->inputs[0]}, nullptr, &n);
+    // dx = z_grad / y, dy = z_grad * x * -1/y^2
+    auto r_y = MakeNode("reciprocal", n->attrs.name + "_reciprocal_y",
+                        {n->inputs[1]}, nullptr, &n);
 
-    const std::unordered_map<std::string, std::string> two = {{"scalar", "-2.0"}};
-    auto y = n->inputs[2];
-    auto r_y = MakeNode("reciprocal", n->attrs.name + "_r_y", {y}, nullptr, &n);
-    auto neg_two_r_y = MakeNode("_mul_scalar", n->attrs.name + "_neg_two_r_y",
-                            {nnvm::NodeEntry{r_y}}, &two, &n);
-    auto d2y = MakeNode("elemwise_mul", n->attrs.name + "_d2y",
-                            {nnvm::NodeEntry{neg_two_r_y}, dy}, &two, &n);
+    // Order Matters : First should be z_grad followed by y.
+    auto grad_r_y = MakeNode("_backward_reciprocal", n->attrs.name + "_backward_reciprocal_y",
+                        {ograds[0], n->inputs[1]}, nullptr, &n);
 
     std::vector<nnvm::NodeEntry> ret;
-    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad",
-                              {ograds[0], nnvm::NodeEntry{dz_grad}}, nullptr, &n));
-    ret.emplace_back(MakeNode("zeros_like", n->attrs.name + "_backward_grad_grad_x",
-                              {n->inputs[1]}, nullptr, &n));
-    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad_y",
-                              {ograds[0], nnvm::NodeEntry{d2y}}, nullptr, &n));
+    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_x",
+                              {ograds[0], nnvm::NodeEntry{r_y}}, nullptr, &n));
+    ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_y",
+                              {n->inputs[0], nnvm::NodeEntry{grad_r_y}}, nullptr, &n));
     return ret;
-  });
+});
 
 MXNET_OPERATOR_REGISTER_BINARY(_mod)
 .add_alias("_Mod")

--- a/tests/python/unittest/test_higher_order_grad.py
+++ b/tests/python/unittest/test_higher_order_grad.py
@@ -134,6 +134,7 @@ def test_abs():
         check_second_order_unary(array, abs, grad_grad_op)
 
 
+@with_seed()
 def test_sigmoid():
     def sigmoid(x):
         return nd.sigmoid(x)
@@ -167,6 +168,21 @@ def test_elemwise_mul():
 
 
 @with_seed()
+def test_elemwise_mul_same_var():
+    def fourth_power(x):
+        y = nd.elemwise_mul(x, x)
+        return nd.elemwise_mul(y, y)
+
+    def grad_grad_op(x):
+        return 12 * (x**2)
+
+    for dim in range(1, 5):
+        shape = rand_shape_nd(dim)
+        array_x = random_arrays(shape)
+        check_second_order_unary(array_x, fourth_power, grad_grad_op)
+
+
+@with_seed()
 def test_elemwise_div():
     def elemwise_div(x, y):
         return nd.elemwise_div(x, y)
@@ -183,6 +199,25 @@ def test_elemwise_div():
         inputs = (array_x, array_y)
         grad_grad_ops = (grad_grad_op_x, grad_grad_op_y)
         check_second_order_binary(inputs, elemwise_div, grad_grad_ops)
+
+
+@with_seed()
+def test_elemwise_div_same_var():
+    def f(x):
+        # f = x / (x^2 + 1)
+        return nd.elemwise_div(x, nd.elemwise_mul(x, x) + 1)
+
+    def grad_grad_op(x):
+        # d^2f    -2*x*(-x^2 + 3)
+        # ---- = ----------------
+        # dx^2     (x^2 + 1)^3
+        return (-2*x*(-x**2 + 3))/((x**2+1)**3)
+
+    for dim in range(1, 5):
+        shape = rand_shape_nd(dim)
+        x = random_arrays(shape)
+        x += 10
+        check_second_order_unary(x, f, grad_grad_op)
 
 
 def check_second_order_unary(x, op, grad_grad_op):
@@ -228,12 +263,6 @@ def check_second_order_binary(inputs, binary_op, grad_grad_ops):
                                        head_grads=z_grad,
                                        create_graph=True, retain_graph=True)
 
-    x_grad.backward(head_grad_grads, retain_graph=True)
-
-    # The line below follower by above
-    # line leads to (y.grad == zeros_like(y))
-    # y_grad.backward(head_grad_grads)
-
     # Compute expected values.
     expected_grad_grad_x = grad_grad_x.asnumpy() * head_grad_grads.asnumpy() *\
         z_grad.asnumpy()
@@ -241,7 +270,17 @@ def check_second_order_binary(inputs, binary_op, grad_grad_ops):
         z_grad.asnumpy()
 
     # Validate the gradients.
+    x_grad.backward(head_grad_grads, retain_graph=True)
     assert_almost_equal(expected_grad_grad_x, x.grad.asnumpy())
+
+    # TODO Figure what is happening.
+    # Somehow gradients of y are affected with this backward.
+    # Only in case of `test_elemwise_mul`
+    # As y.grad == head_grad_grads * z_grad
+    # Temporary Hack: Reset them.
+    nd.zeros_like(y.grad, out=y.grad)
+
+    y_grad.backward(head_grad_grads)
     assert_almost_equal(expected_grad_grad_y, y.grad.asnumpy())
 
 


### PR DESCRIPTION
## Description ##
PR intends to add support for higher order gradient for `elemwise_mul`, `elemwise_div`.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA-978 issue](https://issues.apache.org/jira/browse/MXNET-978) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] higher order gradient for a `elemwise_mul`, `elemwise_div`.
- [x] unit test for the same.
