### PR TITLE
Deprecate m_hard LDFLAGS

### DIFF
--- a/amalgamation/Makefile
+++ b/amalgamation/Makefile
@@ -115,7 +115,7 @@ ifneq ($(ANDROID), 1)
         android:
 else
         CFLAGS+= -O3
-        LDFLAGS+= -Wl,--no-warn-mismatch -lm_hard
+        LDFLAGS+= -Wl,--no-warn-mismatch
         android: jni_libmxnet_predict.so
 endif
 


### PR DESCRIPTION
Forgot to remove the flags in PR #15435. The previous PR fixes the issue but this PR makes it cleaner.

mhard-float option has been deprecated by Google. Removing this from the amalgamation Makefile for Android.

Please refer to [Google depreciation announcement](https://android.googlesource.com/platform/ndk/+/353e653824b79c43b948429870d0abeedebde386/docs/HardFloatAbi.md)

If this is not removed, you will get this error when merging with other C/Cpp libraries.

```
mxnet uses VFP register arguments, output does not
```