### PR TITLE
Opperf: Support Python<3.6

### DIFF
--- a/benchmark/opperf/opperf.py
+++ b/benchmark/opperf/opperf.py
@@ -141,7 +141,7 @@ def main():
     # 4. Generate list of MXNet operators not covered in benchmarks
     ops_not_covered = get_operators_with_no_benchmark(final_benchmark_results.keys())
     for idx, op in enumerate(ops_not_covered):
-        print("{idx}. {op}".format(idx, op))
+        print("{idx}. {op}".format(idx=idx, op=op))
 
     return 0
 

--- a/benchmark/opperf/opperf.py
+++ b/benchmark/opperf/opperf.py
@@ -125,8 +125,9 @@ def main():
                              'output file.')
 
     args = parser.parse_args()
-    logging.info(f"Running MXNet operator benchmarks with the following options: {args}")
-    assert not os.path.isfile(args.output_file), f"Output file {args.output_file} already exists."
+    logging.info("Running MXNet operator benchmarks with the following options: {args}".format(args=args))
+    assert not os.path.isfile(args.output_file),\
+        "Output file {output_file} already exists.".format(output_file=args.output_file)
 
     # 2. RUN BENCHMARKS
     ctx = _parse_mxnet_context(args.ctx)
@@ -140,7 +141,7 @@ def main():
     # 4. Generate list of MXNet operators not covered in benchmarks
     ops_not_covered = get_operators_with_no_benchmark(final_benchmark_results.keys())
     for idx, op in enumerate(ops_not_covered):
-        print(f"{idx}. {op}")
+        print("{idx}. {op}".format(idx, op))
 
     return 0
 

--- a/benchmark/opperf/utils/benchmark_utils.py
+++ b/benchmark/opperf/utils/benchmark_utils.py
@@ -55,14 +55,14 @@ def _run_nd_operator_performance_test(op, inputs, run_backward, warmup, runs, kw
 
     # Run Benchmarks
     op_benchmark_result = {op.__name__: []}
-    logging.info(f"Begin Benchmark - {op.__name__}")
+    logging.info("Begin Benchmark - {name}".format(name=op.__name__))
     for idx, kwargs in enumerate(kwargs_list):
         _, profiler_output = benchmark_helper_func(op, runs, **kwargs)
 
         # Add inputs used for profiling this operator into result
         profiler_output["inputs"] = inputs[idx]
         op_benchmark_result[op.__name__].append(profiler_output)
-    logging.info(f"Complete Benchmark - {op.__name__}")
+    logging.info("Complete Benchmark - {name}".format(name=op.__name__))
     return op_benchmark_result
 
 


### PR DESCRIPTION
f-Strings are supported only from Python 3.6 onwards.
Have replaced their occurrences with str.format which is supported from Python 2.6.