### PR TITLE
Utility to help developers debug operators: Tensor Inspector

### DIFF
--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -114,7 +114,7 @@ class TensorInspector {
     int dimension = tb_.ndim();
     *os << "<" << typeid(tb_.dptr<DType>()[0]).name() << " Tensor ";
     *os << tb_.shape_[0];
-    for (int i = 1; i < dimension; i++) {
+    for (int i = 1; i < dimension; ++i) {
       *os << 'x' << tb_.shape_[i];
     }
     *os << ">" << std::endl;
@@ -132,7 +132,7 @@ class TensorInspector {
     int dimension = shape.size();
     *os << "<" << typeid(tb_.dptr<DType>()[0]).name() << " Tensor ";
     *os << shape[0];
-    for (int i = 1; i < dimension; i++) {
+    for (int i = 1; i < dimension; ++i) {
       *os << 'x' << shape[i];
     }
     *os << ">" << std::endl;
@@ -154,15 +154,15 @@ class TensorInspector {
     }
 #endif  // MXNET_USE_CUDA
     int dimension = tb_.ndim();
-    std::vector<unsigned int> multiples;
-    int multiple = 1;
-    for (int i = dimension-1; i >= 0; i--) {
+    std::vector<size_t> multiples;
+    size_t multiple = 1;
+    for (int i = dimension-1; i >= 0; --i) {
       multiple *= tb_.shape_[i];
       multiples.push_back(multiple);
     }
     *os << std::string(dimension, '[');
     *os << tb_.dptr<DType>()[0];
-    for (size_t i = 1; i < tb_.shape_.Size(); i++) {
+    for (size_t i = 1; i < tb_.shape_.Size(); ++i) {
       int n = 0;
       for (auto divisor : multiples) {
         n += (i % divisor == 0);
@@ -221,16 +221,16 @@ class TensorInspector {
       return;
     }
     int dimension = sub_shape.size();
-    std::vector<int> multiples;
+    std::vector<size_t> multiples;
     size_t multiple = 1;
-    for (int i = dimension-1; i >= 0; i--) {
+    for (int i = dimension-1; i >= 0; --i) {
       multiple *= sub_shape[i];
       multiples.push_back(multiple);
     }
     std::stringstream ss;
     *os << std::string(dimension, '[');
     *os << dptr[0];
-    for (size_t i = 1; i < multiple; i++) {
+    for (size_t i = 1; i < multiple; ++i) {
       int n = 0;
       for (auto divisor : multiples) {
         n += (i % divisor == 0);
@@ -258,14 +258,14 @@ class TensorInspector {
     int dimension = tb_.ndim();
     int sub_dim = dimension - pos.size();
     sub_shape->resize(sub_dim);
-    int multiple = 1;
-    for (int i = pos.size(), j = 0; i < dimension; i++, j++) {
+    size_t multiple = 1;
+    for (int i = pos.size(), j = 0; i < dimension; ++i, ++j) {
       (*sub_shape)[j] = tb_.shape_[i];
       multiple *= tb_.shape_[i];
     }
-    int sum = 0;
-    int m = 1;
-    for (int i = pos.size()-1; i >= 0; i--) {
+    size_t sum = 0;
+    size_t m = 1;
+    for (int i = pos.size()-1; i >= 0; --i) {
       sum += pos[i] * m;
       m *= tb_.shape_[i];
     }
@@ -291,7 +291,7 @@ class TensorInspector {
     if (pos->size() > dimension) {
       return false;
     }
-    for (unsigned i = 0; i < pos->size(); i++) {
+    for (unsigned i = 0; i < pos->size(); ++i) {
       if ((*pos)[i] > (tb_.shape_[i]-1)) {
         return false;
       }
@@ -474,7 +474,7 @@ class TensorInspector {
   inline std::vector<int> index_to_coordinates(size_t idx) {
     int dimension = tb_.ndim();
     std::vector<int> ret;
-    for (int i = dimension-1; i >= 0; i--) {
+    for (int i = dimension-1; i >= 0; --i) {
       ret.push_back(idx % tb_.shape_[i]);
       idx /= tb_.shape_[i];
     }
@@ -500,11 +500,11 @@ class TensorInspector {
           .check_value_helper<DType>(ret, checker, interactive, tag);
     }
 #endif  // MXNET_USE_CUDA
-    int count = 0;
+    size_t count = 0;
     std::stringstream ss;
     ss << "[";
     bool first_pass = true;
-    for (size_t i = 0; i < tb_.shape_.Size(); i++) {
+    for (size_t i = 0; i < tb_.shape_.Size(); ++i) {
       if (checker(tb_.dptr<DType>()[i])) {
         count += 1;
         if (!first_pass) {
@@ -513,7 +513,7 @@ class TensorInspector {
         first_pass = false;
         std::vector<int> coords = index_to_coordinates(i);
         ss << "(" << coords[0];
-        for (size_t i = 1; i < coords.size(); i++) {
+        for (unsigned int i = 1; i < coords.size(); ++i) {
           ss << ", " << coords[i];
         }
         ss << ")";
@@ -590,7 +590,7 @@ class TensorInspector {
     dict += std::to_string(sizeof(DType));
     dict += "','fortran_order':False,'shape':(";
     dict += std::to_string(tb_.shape_[0]);
-    for (int i = 1; i < tb_.ndim(); i++) {
+    for (int i = 1; i < tb_.ndim(); ++i) {
       dict += ',';
       dict += std::to_string(tb_.shape_[i]);
     }

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -451,7 +451,7 @@ class TensorInspector {
         if (std::is_same<DType, float>::value || std::is_same<DType, double>::value ||
             std::is_same<DType, mshadow::half::half_t>::value) {
           return [] (DType x) {
-                return x += (DType)1.0 / (DType)0.0 || x == -(DType)1.0 / (DType)0.0 &&
+                return x == (DType)1.0 / (DType)0.0 || x == -(DType)1.0 / (DType)0.0 ||
                     x != x;
               };
         } else {

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -81,7 +81,7 @@ enum CheckerType {
                        // will always return false if DType is not a float type
   FiniteChecker,  // check if is finite, will always return false if DType is not a float type
   NormalChecker,  // check if is neither infinity nor NaN
-  AbnormalChecker, // chekc if is infinity or nan
+  AbnormalChecker,  // chekck if is infinity or nan
 };
 
 /**
@@ -484,7 +484,7 @@ class TensorInspector {
 
   /*!
    * \brief check/validate the values within the tensor, find the coordinates
-   * where the lambda evaluates to true
+   * where the value checker evaluates to true
    * \tparam DType the data type
    * \param ret a vector of coordinates which itself is a vector of int; calculated here
    * \param checker the lambda function to check each value of within the tensor
@@ -569,7 +569,8 @@ class TensorInspector {
   }
 
   /*!
-   * \brief dump the value of the tensor to a file with name "tag_[visit count].npy" in npy format
+   * \brief dump the value of the tensor to a file with name "[tag]_[visit count].npy" in npy format
+   * the dump file follows npy 1.0 stantand
    * \tparam DType the data type
    * \param tag the name given to this call
    */
@@ -615,6 +616,8 @@ class TensorInspector {
     file.write(header.c_str(), header.size());
     file.write(reinterpret_cast<char*>(tb_.dptr<DType>()), sizeof(DType) * tb_.shape_.Size());
     file.close();
+    std::cout << "Tensor dumped to file: " <<
+        tag + "_" + std::to_string(visit) + ".npy" << std::endl;
   }
 
   /* !\brief the tensor blob */
@@ -682,7 +685,7 @@ class TensorInspector {
 
   /*!
    * \brief check/validate the values within the tensor, return the coordinates
-   * where the lambda evaluates to true
+   * where the value checker evaluates to true
    * \tparam ValueChecker the type of the lambda
    * \param checker the lambda function to check each value of within the tensor
    * \param interactive wherether to allow the user to interactively check the coordinates

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -63,7 +63,7 @@ struct InspectorManager {
   /* !\brief visit count for check value tags */
   std::unordered_map<std::string, int> check_value_tag_counter_;
   /* !\brief visit count for dump value tags */
-  std::unordered_map<std::string, int> dump_value_tag_counter_;
+  std::unordered_map<std::string, int> dump_to_file_tag_counter_;
 };
 
 /*!
@@ -109,9 +109,9 @@ class TensorInspector {
    * \tparam StreamType the type of the stream object
    * \param os stream object to output to
    */
-  template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
+  template<typename DType, typename StreamType>
   inline void tensor_info_to_string(StreamType* os) {
-    int dimension = tb_.ndim();
+    const int dimension = tb_.ndim();
     *os << "<" << typeid(tb_.dptr<DType>()[0]).name() << " Tensor ";
     *os << tb_.shape_[0];
     for (int i = 1; i < dimension; ++i) {
@@ -127,9 +127,9 @@ class TensorInspector {
    * \param os stream object to output to
    * \param shape the shape of the tensor
    */
-  template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
+  template<typename DType, typename StreamType>
   inline void tensor_info_to_string(StreamType* os, const std::vector<int>& shape) {
-    int dimension = shape.size();
+    const int dimension = shape.size();
     *os << "<" << typeid(tb_.dptr<DType>()[0]).name() << " Tensor ";
     *os << shape[0];
     for (int i = 1; i < dimension; ++i) {
@@ -144,7 +144,7 @@ class TensorInspector {
    * \tparam StreamType the type of the stream object
    * \param os stream object to output to
    */
-  template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
+  template<typename DType, typename StreamType>
   inline void to_string_helper(StreamType* os) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
@@ -153,7 +153,7 @@ class TensorInspector {
       return;
     }
 #endif  // MXNET_USE_CUDA
-    int dimension = tb_.ndim();
+    const int dimension = tb_.ndim();
     std::vector<size_t> multiples;
     size_t multiple = 1;
     for (int i = dimension-1; i >= 0; --i) {
@@ -175,7 +175,7 @@ class TensorInspector {
       *os << tb_.dptr<DType>()[i];
     }
     *os << std::string(dimension, ']') << std::endl;
-    tensor_info_to_string(os);
+    tensor_info_to_string<DType>(os);
   }
 
   /*!
@@ -185,7 +185,7 @@ class TensorInspector {
    * \param os stream object to output to
    * \param dptr the data pointer
    */
-  template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
+  template<typename DType, typename StreamType>
   inline void to_string_helper(StreamType* os, const DType* dptr) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
@@ -206,7 +206,7 @@ class TensorInspector {
    * \param sub_shape the sub-shape of the desired part of the tensor
    * \param offset the position of the first value of the desired part of the tensor
    */
-  template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
+  template<typename DType, typename StreamType>
   inline void to_string_helper(StreamType* os, const std::vector<int>& sub_shape, size_t offset) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
@@ -220,7 +220,7 @@ class TensorInspector {
       to_string_helper<DType>(os, dptr);
       return;
     }
-    int dimension = sub_shape.size();
+    const int dimension = sub_shape.size();
     std::vector<size_t> multiples;
     size_t multiple = 1;
     for (int i = dimension-1; i >= 0; --i) {
@@ -243,7 +243,7 @@ class TensorInspector {
       *os << dptr[i];
     }
     *os << std::string(dimension, ']') << std::endl;
-    tensor_info_to_string(os, sub_shape);
+    tensor_info_to_string<DType>(os, sub_shape);
   }
 
   /*!
@@ -255,7 +255,7 @@ class TensorInspector {
    */
   inline void print_locator(const std::vector<int>& pos, std::vector<int>* sub_shape,
       size_t* offset) {
-    int dimension = tb_.ndim();
+    const int dimension = tb_.ndim();
     int sub_dim = dimension - pos.size();
     sub_shape->resize(sub_dim);
     size_t multiple = 1;
@@ -279,7 +279,7 @@ class TensorInspector {
    * \param str the string that represents the coordinate
    */
   inline bool parse_position(std::vector<int>* pos, const std::string& str) {
-    int dimension = tb_.ndim();
+    const int dimension = tb_.ndim();
     std::stringstream ss(str);
     int i;
     while (ss >> i) {
@@ -304,7 +304,7 @@ class TensorInspector {
    * \tparam DType the data type
    * \param tag the name given to this call
    */
-  template<typename DType MSHADOW_DEFAULT_DTYPE>
+  template<typename DType>
   inline void interactive_print_helper(std::string tag) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
@@ -321,10 +321,12 @@ class TensorInspector {
         std::cout << "Tag: " << tag << "  Visit: " <<
             InspectorManager::get()->interactive_print_tag_counter_[tag] <<  std::endl;
       }
-      tensor_info_to_string(&std::cout);
+      tensor_info_to_string<DType>(&std::cout);
       std::cout << "Please specify the position, seperated by \",\"" << std::endl;
-      std::cout << "\"e\" for the entire tensor, \"d\" to dump value to file," <<
-          " \"b\" to break, \"s\" to skip all: ";
+      std::cout << "\"e\" for the entire tensor, " <<
+          "\"d\" to dump value to file, " <<
+          "\"b\" to break, " <<
+          "\"s\" to skip all: ";
       std::string str;
       std::cin >> str;
       if (str == "b") {
@@ -343,7 +345,7 @@ class TensorInspector {
             std::cout << "Invalid input. ";
             continue;
           }
-          dump_value_helper(str);
+          dump_to_file_helper<DType>(str);
           break;
         }
         continue;
@@ -365,8 +367,8 @@ class TensorInspector {
    * \tparam DType the data type
    * \param ct the type of the checker
    */
-  template<typename DType MSHADOW_DEFAULT_DTYPE>
-  inline std::function<bool(DType)> build_checker(CheckerType ct) {
+  template<typename DType>
+  inline std::function<bool(DType)> get_checker(CheckerType ct) {
     switch (ct) {
       case NegativeChecker:
         return [] (DType x) {
@@ -472,7 +474,7 @@ class TensorInspector {
    * \param idx the index of the value in the tensor
    */
   inline std::vector<int> index_to_coordinates(size_t idx) {
-    int dimension = tb_.ndim();
+    const int dimension = tb_.ndim();
     std::vector<int> ret;
     for (int i = dimension-1; i >= 0; --i) {
       ret.push_back(idx % tb_.shape_[i]);
@@ -491,7 +493,7 @@ class TensorInspector {
    * \param interactive wherether to allow the user to interactively check the coordinates
    * \param tag the name given to this call
    */
-  template<typename DType MSHADOW_DEFAULT_DTYPE>
+  template<typename DType>
   inline void check_value_helper(std::vector<std::vector<int>>* ret,
       const std::function<bool(DType)>& checker, bool interactive, std::string tag) {
 #if MXNET_USE_CUDA
@@ -531,7 +533,9 @@ class TensorInspector {
               InspectorManager::get()->check_value_tag_counter_[tag] <<  std::endl;
         }
         std::cout << count << " value(s) found." << std::endl;
-        std::cout << "\"p\" to print the coordinates, \"b\" to break, \"s\" to skip all: ";
+        std::cout << "\"p\" to print the coordinates, " <<
+            "\"b\" to break, " <<
+            "\"s\" to skip all: ";
         std::string str;
         std::cin >> str;
         if (str == "b") {
@@ -569,20 +573,12 @@ class TensorInspector {
   }
 
   /*!
-   * \brief dump the value of the tensor to a file with name "[tag]_[visit count].npy" in npy format
-   * the dump file follows npy 1.0 stantand
+   * \brief generate the header following npy 1.0 format
    * \tparam DType the data type
-   * \param tag the name given to this call
    */
-  template<typename DType MSHADOW_DEFAULT_DTYPE>
-  inline void dump_value_helper(const std::string& tag) {
-#if MXNET_USE_CUDA
-    if (tb_.dev_mask() == gpu::kDevMask) {
-      TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
-          .dump_value_helper<DType>(tag);
-      return;
-    }
-#endif  // MXNET_USE_CUDA
+  template<typename DType>
+  inline std::string get_header() {
+    const int dimension = tb_.ndim();
     std::string dict;
     dict += "{'descr':'";
     dict += endian_test();
@@ -590,17 +586,17 @@ class TensorInspector {
     dict += std::to_string(sizeof(DType));
     dict += "','fortran_order':False,'shape':(";
     dict += std::to_string(tb_.shape_[0]);
-    for (int i = 1; i < tb_.ndim(); ++i) {
+    for (int i = 1; i < dimension; ++i) {
       dict += ',';
       dict += std::to_string(tb_.shape_[i]);
     }
-    if (tb_.ndim() == 1) {
+    if (dimension == 1) {
        dict += ",";
     }
     dict += ")} ";
     int padding_size = 64 - ((10 + dict.size()) % 64);
     dict += std::string(padding_size, ' ');
-    dict[dict.size()-1] = '\n';
+    dict.back() = '\n';
     std::string header;
     header += static_cast<char>(0x93);
     header += "NUMPY";
@@ -609,15 +605,50 @@ class TensorInspector {
     header += static_cast<char>((uint16_t)dict.size() & 0x00ff);
     header += static_cast<char>(((uint16_t)dict.size() >> 8) & 0x00ff);
     header += dict;
-    InspectorManager::get()->dump_value_tag_counter_[tag] += 1;
-    int visit = InspectorManager::get()->dump_value_tag_counter_[tag];
-    std::ofstream file(tag + "_" + std::to_string(visit) + ".npy",
-        std::ios::out | std::ios::binary);
-    file.write(header.c_str(), header.size());
-    file.write(reinterpret_cast<char*>(tb_.dptr<DType>()), sizeof(DType) * tb_.shape_.Size());
-    file.close();
-    std::cout << "Tensor dumped to file: " <<
-        tag + "_" + std::to_string(visit) + ".npy" << std::endl;
+    return header;
+  }
+
+  /*!
+   * \brief write the header and the date to an npy file
+   * \tparam DType the data type
+   * \param header the header of the file
+   * \param filename the file name
+   */
+  template<typename DType>
+  void write_npy(const std::string& header, const std::string& filename) {
+    std::ofstream file;
+    file.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+    try {
+      file.open(filename, std::ios::out | std::ios::binary);
+      file.write(header.c_str(), header.size());
+      file.write(reinterpret_cast<char*>(tb_.dptr<DType>()), sizeof(DType) * tb_.shape_.Size());
+      file.close();
+      std::cout << "Tensor dumped to file: " << filename << std::endl;
+    } catch (std::ofstream::failure e) {
+      std::cerr << "Exception opening/writing/closing file " << filename << std::endl;
+    }    
+  }
+
+  /*!
+   * \brief dump the value of the tensor to a file with name "[tag]_[visit count].npy" in npy format
+   * the dump file follows npy 1.0 stantand
+   * \tparam DType the data type
+   * \param tag the name given to this call
+   */
+  template<typename DType>
+  inline void dump_to_file_helper(const std::string& tag) {
+#if MXNET_USE_CUDA
+    if (tb_.dev_mask() == gpu::kDevMask) {
+      TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
+          .dump_to_file_helper<DType>(tag);
+      return;
+    }
+#endif  // MXNET_USE_CUDA
+    std::string header = get_header<DType>();
+    InspectorManager::get()->dump_to_file_tag_counter_[tag] += 1;
+    const int visit = InspectorManager::get()->dump_to_file_tag_counter_[tag];
+    std::string filename = tag + "_" + std::to_string(visit) + ".npy";
+    write_npy<DType>(header, filename);
   }
 
   /* !\brief the tensor blob */
@@ -634,8 +665,7 @@ class TensorInspector {
    * \param ts the source tensor object
    * \param ctx the run context of the tensor
    */
-  template<typename Device, int dimension,
-      typename DType MSHADOW_DEFAULT_DTYPE>
+  template<typename Device, int dimension, typename DType>
   TensorInspector(const mshadow::Tensor<Device, dimension, DType>& ts, const RunContext& ctx):
       tb_(ts), ctx_(ctx) {}
 
@@ -712,7 +742,7 @@ class TensorInspector {
       std::string tag = "") {
     std::vector<std::vector<int>> ret;
     MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
-      check_value_helper<DType>(&ret, build_checker<DType>(ct), interactive, tag);
+      check_value_helper<DType>(&ret, get_checker<DType>(ct), interactive, tag);
     });
     return ret;
   }
@@ -721,9 +751,9 @@ class TensorInspector {
    * \brief dump the value of the tensor to a file with name "tag_[visit count].npy" in npy format
    * \param tag the name given to this call
    */
-  inline void dump_value(std::string tag) {
+  inline void dump_to_file(std::string tag) {
     MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
-      dump_value_helper<DType>(tag);
+      dump_to_file_helper<DType>(tag);
     });
   }
 };

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -259,13 +259,13 @@ class TensorInspector {
     const int sub_dim = dimension - pos.size();
     sub_shape->resize(sub_dim);
     index_t multiple = 1;
-    for (int i = pos.size(), j = 0; i < dimension; ++i, ++j) {
+    for (size_t i = pos.size(), j = 0; i < static_cast<size_t>(dimension); ++i, ++j) {
       (*sub_shape)[j] = tb_.shape_[i];
       multiple *= tb_.shape_[i];
     }
     index_t sum = 0;
     index_t m = 1;
-    for (int i = pos.size() - 1; i >= 0; --i) {
+    for (index_t i = pos.size() - 1; i >= 0; --i) {
       sum += pos[i] * m;
       m *= tb_.shape_[i];
     }
@@ -291,7 +291,7 @@ class TensorInspector {
     if (pos->size() > static_cast<size_t>(dimension)) {
       return false;
     }
-    for (unsigned i = 0; i < pos->size(); ++i) {
+    for (size_t i = 0; i < pos->size(); ++i) {
       if ((*pos)[i] > (tb_.shape_[i] - 1) || (*pos)[i] < 0) {
         return false;
       }

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -81,6 +81,7 @@ enum CheckerType {
                        // will always return false if DType is not a float type
   FiniteChecker,  // check if is finite, will always return false if DType is not a float type
   NormalChecker,  // check if is neither infinity nor NaN
+  AbnormalChecker, // chekc if is infinity or nan
 };
 
 /**
@@ -443,6 +444,18 @@ class TensorInspector {
               };
         } else {
           LOG(WARNING) << "NormalChecker only applies to float types. " <<
+              "Lambda will always return false.";
+        }
+        break;
+      case AbnormalChecker:
+        if (std::is_same<DType, float>::value || std::is_same<DType, double>::value ||
+            std::is_same<DType, mshadow::half::half_t>::value) {
+          return [] (DType x) {
+                return x += (DType)1.0 / (DType)0.0 || x == -(DType)1.0 / (DType)0.0 &&
+                    x != x;
+              };
+        } else {
+          LOG(WARNING) << "AbnormalChecker only applies to float types. " <<
               "Lambda will always return false.";
         }
         break;

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -110,7 +110,7 @@ class TensorInspector {
    * \param os stream object to output to
    */
   template<typename DType, typename StreamType>
-  inline void tensor_info_to_string(StreamType* os) {
+  void tensor_info_to_string(StreamType* os) {
     const int dimension = tb_.ndim();
     *os << "<" << typeid(tb_.dptr<DType>()[0]).name() << " Tensor ";
     *os << tb_.shape_[0];
@@ -128,7 +128,7 @@ class TensorInspector {
    * \param shape the shape of the tensor
    */
   template<typename DType, typename StreamType>
-  inline void tensor_info_to_string(StreamType* os, const std::vector<int>& shape) {
+  void tensor_info_to_string(StreamType* os, const std::vector<int>& shape) {
     const int dimension = shape.size();
     *os << "<" << typeid(tb_.dptr<DType>()[0]).name() << " Tensor ";
     *os << shape[0];
@@ -145,7 +145,7 @@ class TensorInspector {
    * \param os stream object to output to
    */
   template<typename DType, typename StreamType>
-  inline void to_string_helper(StreamType* os) {
+  void to_string_helper(StreamType* os) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
       TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
@@ -186,7 +186,7 @@ class TensorInspector {
    * \param dptr the data pointer
    */
   template<typename DType, typename StreamType>
-  inline void to_string_helper(StreamType* os, const DType* dptr) {
+  void to_string_helper(StreamType* os, const DType* dptr) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
       TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
@@ -207,7 +207,7 @@ class TensorInspector {
    * \param offset the position of the first value of the desired part of the tensor
    */
   template<typename DType, typename StreamType>
-  inline void to_string_helper(StreamType* os, const std::vector<int>& sub_shape, size_t offset) {
+  void to_string_helper(StreamType* os, const std::vector<int>& sub_shape, size_t offset) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
       TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
@@ -253,7 +253,7 @@ class TensorInspector {
    * \param sub_shape the sub-shape of the desired part of the tensor; calculated here
    * \param offset the position of the first value of the desired part of the tensor; calculated here
    */
-  inline void print_locator(const std::vector<int>& pos, std::vector<int>* sub_shape,
+  void print_locator(const std::vector<int>& pos, std::vector<int>* sub_shape,
       size_t* offset) {
     const int dimension = tb_.ndim();
     int sub_dim = dimension - pos.size();
@@ -278,7 +278,7 @@ class TensorInspector {
    * \param pos the coordinates of the desired part of the tensor, calculated here
    * \param str the string that represents the coordinate
    */
-  inline bool parse_position(std::vector<int>* pos, const std::string& str) {
+  bool parse_position(std::vector<int>* pos, const std::string& str) {
     const int dimension = tb_.ndim();
     std::stringstream ss(str);
     int i;
@@ -305,7 +305,7 @@ class TensorInspector {
    * \param tag the name given to this call
    */
   template<typename DType>
-  inline void interactive_print_helper(std::string tag) {
+  void interactive_print_helper(std::string tag) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
       TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
@@ -368,7 +368,7 @@ class TensorInspector {
    * \param ct the type of the checker
    */
   template<typename DType>
-  inline std::function<bool(DType)> get_checker(CheckerType ct) {
+  std::function<bool(DType)> get_checker(CheckerType ct) {
     switch (ct) {
       case NegativeChecker:
         return [] (DType x) {
@@ -473,7 +473,7 @@ class TensorInspector {
    * \brief calculate the coordinate of a value in the tensor, given its index
    * \param idx the index of the value in the tensor
    */
-  inline std::vector<int> index_to_coordinates(size_t idx) {
+  std::vector<int> index_to_coordinates(size_t idx) {
     const int dimension = tb_.ndim();
     std::vector<int> ret;
     for (int i = dimension-1; i >= 0; --i) {
@@ -494,7 +494,7 @@ class TensorInspector {
    * \param tag the name given to this call
    */
   template<typename DType>
-  inline void check_value_helper(std::vector<std::vector<int>>* ret,
+  void check_value_helper(std::vector<std::vector<int>>* ret,
       const std::function<bool(DType)>& checker, bool interactive, std::string tag) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
@@ -577,7 +577,7 @@ class TensorInspector {
    * \tparam DType the data type
    */
   template<typename DType>
-  inline std::string get_header() {
+  std::string get_header() {
     const int dimension = tb_.ndim();
     std::string dict;
     dict += "{'descr':'";
@@ -636,7 +636,7 @@ class TensorInspector {
    * \param tag the name given to this call
    */
   template<typename DType>
-  inline void dump_to_file_helper(const std::string& tag) {
+  void dump_to_file_helper(const std::string& tag) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
       TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
@@ -688,14 +688,14 @@ class TensorInspector {
   /*!
    * \brief print the tensor to std::cout
    */
-  inline void print_string() {
+  void print_string() {
     std::cout << to_string() << std::endl;
   }
 
   /*!
    * \brief return a string which contains the values and other info of the tensor
    */
-  inline std::string to_string() {
+  std::string to_string() {
     std::stringstream ss;
     MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
       to_string_helper<DType>(&ss);
@@ -707,7 +707,7 @@ class TensorInspector {
    * \brief interactively print the tensor value
    * \param tag the name given to this call
    */
-  inline void interactive_print(std::string tag = "") {
+  void interactive_print(std::string tag = "") {
     MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
       interactive_print_helper<DType>(tag);
     });
@@ -722,7 +722,7 @@ class TensorInspector {
    * \param tag the name given to this call
    */
   template<typename ValueChecker>
-  inline std::vector<std::vector<int>> check_value(const ValueChecker& checker,
+  std::vector<std::vector<int>> check_value(const ValueChecker& checker,
       bool interactive = false, std::string tag = "") {
     std::vector<std::vector<int>> ret;
     MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
@@ -738,7 +738,7 @@ class TensorInspector {
    * \param interactive wherether to allow the user to interactively check the coordinates
    * \param tag the name given to this call
    */
-  inline std::vector<std::vector<int>> check_value(CheckerType ct, bool interactive = false,
+  std::vector<std::vector<int>> check_value(CheckerType ct, bool interactive = false,
       std::string tag = "") {
     std::vector<std::vector<int>> ret;
     MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
@@ -751,7 +751,7 @@ class TensorInspector {
    * \brief dump the value of the tensor to a file with name "tag_[visit count].npy" in npy format
    * \param tag the name given to this call
    */
-  inline void dump_to_file(std::string tag) {
+  void dump_to_file(std::string tag) {
     MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
       dump_to_file_helper<DType>(tag);
     });

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -162,7 +162,7 @@ class TensorInspector {
     }
     *os << std::string(dimension, '[');
     *os << tb_.dptr<DType>()[0];
-    for (index_t i = 1; i < tb_.shape_.Size(); ++i) {
+    for (index_t i = 1; static_cast<size_t>(i) < tb_.shape_.Size(); ++i) {
       int n = 0;
       for (auto divisor : multiples) {
         n += (i % divisor == 0);
@@ -256,7 +256,7 @@ class TensorInspector {
   void print_locator(const std::vector<index_t>& pos, std::vector<index_t>* sub_shape,
     index_t* offset) {
     const int dimension = tb_.ndim();
-    int sub_dim = dimension - pos.size();
+    const int sub_dim = dimension - pos.size();
     sub_shape->resize(sub_dim);
     index_t multiple = 1;
     for (int i = pos.size(), j = 0; i < dimension; ++i, ++j) {
@@ -288,7 +288,7 @@ class TensorInspector {
         ss.ignore();
       }
     }
-    if (pos->size() > dimension) {
+    if (pos->size() > static_cast<unsigned long>(dimension)) {
       return false;
     }
     for (unsigned i = 0; i < pos->size(); ++i) {
@@ -322,7 +322,8 @@ class TensorInspector {
             InspectorManager::get()->interactive_print_tag_counter_[tag] <<  std::endl;
       }
       tensor_info_to_string<DType>(&std::cout);
-      std::cout << "Please specify the position, seperated by \",\"" << std::endl;
+      std::cout << "To print a part of the tensor," <<
+	        " please specify a position, seperated by \",\"" << std::endl;
       std::cout << "\"e\" for the entire tensor, " <<
           "\"d\" to dump value to file, " <<
           "\"b\" to break, " <<
@@ -397,7 +398,7 @@ class TensorInspector {
         if (std::is_same<DType, float>::value || std::is_same<DType, double>::value ||
             std::is_same<DType, mshadow::half::half_t>::value) {
           return [] (DType x) {
-                return x == (DType)1.0 / (DType)0.0 || x == -(DType)1.0 / (DType)0.0;
+                return x == (DType)1.0 / 0.0f || x == -(DType)1.0 / 0.0f;
               };
         } else {
           LOG(WARNING) << "InfChecker only applies to float types. " <<
@@ -408,7 +409,7 @@ class TensorInspector {
         if (std::is_same<DType, float>::value || std::is_same<DType, double>::value ||
             std::is_same<DType, mshadow::half::half_t>::value) {
           return [] (DType x) {
-                return x == (DType)1.0 / (DType)0.0;
+                return x == (DType)1.0 /  0.0f;
               };
         } else {
           LOG(WARNING) << "PositiveInfChecker only applies to float types. " <<
@@ -419,7 +420,7 @@ class TensorInspector {
         if (std::is_same<DType, float>::value || std::is_same<DType, double>::value ||
             std::is_same<DType, mshadow::half::half_t>::value) {
           return [] (DType x) {
-                return x == -(DType)1.0 / (DType)0.0;
+                return x == -(DType)1.0 /  0.0f;
               };
         } else {
           LOG(WARNING) << "NegativeInfChecker only applies to float types. " <<
@@ -430,7 +431,7 @@ class TensorInspector {
         if (std::is_same<DType, float>::value || std::is_same<DType, double>::value ||
             std::is_same<DType, mshadow::half::half_t>::value) {
           return [] (DType x) {
-                return x != (DType)1.0 / (DType)0.0 && x != -(DType)1.0 / (DType)0.0;
+                return x != (DType)1.0 /  0.0f && x != -(DType)1.0 /  0.0f;
               };
         } else {
           LOG(WARNING) << "FiniteChecker only applies to float types. " <<
@@ -441,7 +442,7 @@ class TensorInspector {
         if (std::is_same<DType, float>::value || std::is_same<DType, double>::value ||
             std::is_same<DType, mshadow::half::half_t>::value) {
           return [] (DType x) {
-                return x != (DType)1.0 / (DType)0.0 && x != -(DType)1.0 / (DType)0.0 &&
+                return x != (DType)1.0 /  0.0f && x != -(DType)1.0 /  0.0f &&
                     x == x;
               };
         } else {
@@ -453,7 +454,7 @@ class TensorInspector {
         if (std::is_same<DType, float>::value || std::is_same<DType, double>::value ||
             std::is_same<DType, mshadow::half::half_t>::value) {
           return [] (DType x) {
-                return x == (DType)1.0 / (DType)0.0 || x == -(DType)1.0 / (DType)0.0 ||
+                return x == (DType)1.0 /  0.0f || x == -(DType)1.0 /  0.0f ||
                     x != x;
               };
         } else {
@@ -506,7 +507,7 @@ class TensorInspector {
     std::stringstream ss;
     ss << "[";
     bool first_pass = true;
-    for (index_t i = 0; i < tb_.shape_.Size(); ++i) {
+    for (index_t i = 0; static_cast<size_t>(i) < tb_.shape_.Size(); ++i) {
       if (checker(tb_.dptr<DType>()[i])) {
         count += 1;
         if (!first_pass) {
@@ -674,7 +675,7 @@ class TensorInspector {
    */
   inline void validate_shape() {
     const int dimension = tb_.ndim();
-    CHECK(dimension > 0) << "Tensor Inspector does not support empty tensors " << 
+    CHECK(dimension > 0) << "Tensor Inspector does not support empty tensors " <<
         "or tensors of unknow shape.";
     for (int i = 0; i < dimension; ++i) {
       CHECK(tb_.shape_[i] != 0) << "Invalid tensor shape: shape_[" << i << "] is 0";

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -139,7 +139,7 @@ class TensorInspector {
   }
 
   /*!
-   * \brief output the tensor in a structed format 
+   * \brief output the tensor in a structured format 
    * \tparam DType the data type
    * \tparam StreamType the type of the stream object
    * \param os stream object to output to
@@ -154,15 +154,15 @@ class TensorInspector {
     }
 #endif  // MXNET_USE_CUDA
     const int dimension = tb_.ndim();
-    std::vector<size_t> multiples;
-    size_t multiple = 1;
+    std::vector<index_t> multiples;
+    index_t multiple = 1;
     for (int i = dimension-1; i >= 0; --i) {
       multiple *= tb_.shape_[i];
       multiples.push_back(multiple);
     }
     *os << std::string(dimension, '[');
     *os << tb_.dptr<DType>()[0];
-    for (size_t i = 1; i < tb_.shape_.Size(); ++i) {
+    for (index_t i = 1; i < tb_.shape_.Size(); ++i) {
       int n = 0;
       for (auto divisor : multiples) {
         n += (i % divisor == 0);
@@ -179,7 +179,7 @@ class TensorInspector {
   }
 
   /*!
-   * \brief output the tensor in a structed format 
+   * \brief output the tensor in a structured format 
    * \tparam DType the data type
    * \tparam StreamType the type of the stream object
    * \param os stream object to output to
@@ -207,7 +207,7 @@ class TensorInspector {
    * \param offset the position of the first value of the desired part of the tensor
    */
   template<typename DType, typename StreamType>
-  void to_string_helper(StreamType* os, const std::vector<int>& sub_shape, size_t offset) {
+  void to_string_helper(StreamType* os, const std::vector<int>& sub_shape, index_t offset) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
       TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
@@ -221,8 +221,8 @@ class TensorInspector {
       return;
     }
     const int dimension = sub_shape.size();
-    std::vector<size_t> multiples;
-    size_t multiple = 1;
+    std::vector<index_t> multiples;
+    index_t multiple = 1;
     for (int i = dimension-1; i >= 0; --i) {
       multiple *= sub_shape[i];
       multiples.push_back(multiple);
@@ -230,7 +230,7 @@ class TensorInspector {
     std::stringstream ss;
     *os << std::string(dimension, '[');
     *os << dptr[0];
-    for (size_t i = 1; i < multiple; ++i) {
+    for (index_t i = 1; i < multiple; ++i) {
       int n = 0;
       for (auto divisor : multiples) {
         n += (i % divisor == 0);
@@ -253,18 +253,17 @@ class TensorInspector {
    * \param sub_shape the sub-shape of the desired part of the tensor; calculated here
    * \param offset the position of the first value of the desired part of the tensor; calculated here
    */
-  void print_locator(const std::vector<int>& pos, std::vector<int>* sub_shape,
-      size_t* offset) {
+  void print_locator(const std::vector<int>& pos, std::vector<int>* sub_shape, index_t* offset) {
     const int dimension = tb_.ndim();
     int sub_dim = dimension - pos.size();
     sub_shape->resize(sub_dim);
-    size_t multiple = 1;
+    index_t multiple = 1;
     for (int i = pos.size(), j = 0; i < dimension; ++i, ++j) {
       (*sub_shape)[j] = tb_.shape_[i];
       multiple *= tb_.shape_[i];
     }
-    size_t sum = 0;
-    size_t m = 1;
+    index_t sum = 0;
+    index_t m = 1;
     for (int i = pos.size()-1; i >= 0; --i) {
       sum += pos[i] * m;
       m *= tb_.shape_[i];
@@ -353,7 +352,7 @@ class TensorInspector {
       std::vector<int> pos;
       if (parse_position(&pos, str)) {
         std::vector<int> sub_shape;
-        size_t offset;
+        index_t offset;
         print_locator(pos, &sub_shape, &offset);
         to_string_helper<DType>(&std::cout, sub_shape, offset);
       } else {
@@ -473,7 +472,7 @@ class TensorInspector {
    * \brief calculate the coordinate of a value in the tensor, given its index
    * \param idx the index of the value in the tensor
    */
-  std::vector<int> index_to_coordinates(size_t idx) {
+  std::vector<int> index_to_coordinates(index_t idx) {
     const int dimension = tb_.ndim();
     std::vector<int> ret;
     for (int i = dimension-1; i >= 0; --i) {
@@ -502,11 +501,11 @@ class TensorInspector {
           .check_value_helper<DType>(ret, checker, interactive, tag);
     }
 #endif  // MXNET_USE_CUDA
-    size_t count = 0;
+    index_t count = 0;
     std::stringstream ss;
     ss << "[";
     bool first_pass = true;
-    for (size_t i = 0; i < tb_.shape_.Size(); ++i) {
+    for (index_t i = 0; i < tb_.shape_.Size(); ++i) {
       if (checker(tb_.dptr<DType>()[i])) {
         count += 1;
         if (!first_pass) {

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -38,7 +38,7 @@
 namespace mxnet {
 
 /*!
- * \brief This singleton struct mediates individual TensorInspector objects
+ * \brief this singleton struct mediates individual TensorInspector objects
  * so that we can control the global behavior from each of them
  */
 struct InspectorManager {
@@ -611,7 +611,7 @@ class TensorInspector {
 
  public:
    /*!
-   * \brief Construct from Tensor object
+   * \brief construct from Tensor object
    * \tparam Device the device the tensor resides in
    * \tparam dimension the dimension of the tensor
    * \tparam DType the data type
@@ -620,11 +620,11 @@ class TensorInspector {
    */
   template<typename Device, int dimension,
       typename DType MSHADOW_DEFAULT_DTYPE>
-  TensorInspector(const Tensor<Device, dimension, DType>& ts, const RunContext& ctx):
+  TensorInspector(const mshadow::Tensor<Device, dimension, DType>& ts, const RunContext& ctx):
       tb_(ts), ctx_(ctx) {}
 
   /*!
-   * \brief Construct from TBlob object
+   * \brief construct from TBlob object
    * \param tb the source tblob object
    * \param ctx the run context of the tensor
    */
@@ -632,7 +632,7 @@ class TensorInspector {
       tb_(tb), ctx_(ctx) {}
 
   /*!
-   * \brief Construct from NDArray object. Currently this only works with kDefaultStorage
+   * \brief construct from NDArray object. Currently this only works with kDefaultStorage
    * \param arr the source ndarray object
    * \param ctx the run context of the tensor
    */
@@ -658,7 +658,7 @@ class TensorInspector {
   }
 
   /*!
-   * \brief interactive print the tensor value
+   * \brief interactively print the tensor value
    * \param tag the name given to this call
    */
   inline void interactive_print(std::string tag = "") {

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -626,7 +626,7 @@ class TensorInspector {
       std::cout << "Tensor dumped to file: " << filename << std::endl;
     } catch (std::ofstream::failure e) {
       std::cerr << "Exception opening/writing/closing file " << filename << std::endl;
-    }    
+    }
   }
 
   /*!

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -321,8 +321,9 @@ class TensorInspector {
             InspectorManager::get()->interactive_print_tag_counter_[tag] <<  std::endl;
       }
       tensor_info_to_string(&std::cout);
-      std::cout << "Please specify the position, seperated by \",\"" << std::endl
-          << "\"e\" for the entire tensor, \"d\" to dump value to file, \"b\" to break, \"s\" to skip all: ";
+      std::cout << "Please specify the position, seperated by \",\"" << std::endl;
+      std::cout << "\"e\" for the entire tensor, \"d\" to dump value to file," <<
+          " \"b\" to break, \"s\" to skip all: ";
       std::string str;
       std::cin >> str;
       if (str == "b") {

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -530,7 +530,7 @@ class TensorInspector {
     else if (ti == typeid(uint8_t)) return 'u';
     else if (ti == typeid(int32_t)) return 'i';
     else if (ti == typeid(int64_t)) return 'i';
-    else 
+    else
       return '?';
   }
 

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -175,7 +175,8 @@ class TensorInspector {
   inline void to_string_helper(StreamType* os, const DType* dptr) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
-      explicit TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)()).to_string_helper<DType>(os, dptr);
+      explicit TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)())
+          .to_string_helper<DType>(os, dptr);
       return;
     }
 #endif  // MXNET_USE_CUDA
@@ -195,8 +196,8 @@ class TensorInspector {
   inline void to_string_helper(StreamType* os, const std::vector<int>& sub_shape, size_t offset) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
-      explicit TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)()).to_string_helper<DType>(os,
-          sub_shape, offset);
+      explicit TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)())
+          .to_string_helper<DType>(os, sub_shape, offset);
       return;
     }
 #endif  // MXNET_USE_CUDA
@@ -263,25 +264,25 @@ class TensorInspector {
    * \param pos the coordinates of the desired part of the tensor, calculated here
    * \param str the string that represents the coordinate
    */
-  inline bool parse_position(std::vector<int>& pos, const std::string& str) {
+  inline bool parse_position(std::vector<int>* pos, const std::string& str) {
     int dimension = tb_.ndim();
     std::stringstream ss(str);
     int i;
     while (ss >> i) {
-      pos.push_back(i);
+      pos->push_back(i);
       if (ss.peek() == ',') {
         ss.ignore();
       }
     }
-    if (pos.size() > dimension) {
+    if (pos->size() > dimension) {
       return false;
     }
-    for (unsigned i = 0; i < pos.size(); i++) {
-      if (pos[i] > (tb_.shape_[i]-1)) {
+    for (unsigned i = 0; i < pos->size(); i++) {
+      if ((*pos)[i] > (tb_.shape_[i]-1)) {
         return false;
       }
     }
-    return !pos.empty();
+    return !pos->empty();
   }
 
   /*!
@@ -293,7 +294,8 @@ class TensorInspector {
   inline void interactive_print_helper(std::string tag) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
-      explicit TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)()).interactive_print_helper<DType>(tag);
+      explicit TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)())
+          .interactive_print_helper<DType>(tag);
       return;
     }
 #endif  // MXNET_USE_CUDA
@@ -320,7 +322,7 @@ class TensorInspector {
         break;
       }
       std::vector<int> pos;
-      if (parse_position(pos, str)) {
+      if (parse_position(&pos, str)) {
         std::vector<int> sub_shape;
         size_t offset;
         print_locator(pos, &sub_shape, &offset);

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -322,7 +322,7 @@ class TensorInspector {
       }
       tensor_info_to_string(&std::cout);
       std::cout << "Please specify the position, seperated by \",\"" << std::endl
-          << "\"e\" for the entire tensor, \"b\" to break, \"s\" to skip all: ";
+          << "\"e\" for the entire tensor, \"d\" to dump value to file, \"b\" to break, \"s\" to skip all: ";
       std::string str;
       std::cin >> str;
       if (str == "b") {
@@ -333,6 +333,18 @@ class TensorInspector {
       } else if (str == "s") {
         InspectorManager::get()->interactive_print_skip_all_ = true;
         break;
+      } else if (str == "d") {
+        while (true) {
+          std::cout << "Please enter a tag: ";
+          std::cin >> str;
+          if (str.find(' ') != std::string::npos) {
+            std::cout << "Invalid input. ";
+            continue;
+          }
+          dump_value_helper(str);
+          break;
+        }
+        continue;
       }
       std::vector<int> pos;
       if (parse_position(&pos, str)) {
@@ -504,8 +516,8 @@ class TensorInspector {
           std::cout << "Tag: " << tag << "  Visit: " <<
               InspectorManager::get()->check_value_tag_counter_[tag] <<  std::endl;
         }
-        std::cout << count << " value(s) found. \"p\" to print the coordinates," <<
-            " \"b\" to break, \"s\" to skip all: ";
+        std::cout << count << " value(s) found." << std::endl;
+        std::cout << "\"p\" to print the coordinates, \"b\" to break, \"s\" to skip all: ";
         std::string str;
         std::cin >> str;
         if (str == "b") {

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -1,0 +1,521 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file tensor_inspector.h
+ * \brief utility to inspector tensor objects
+ * \author Zhaoqi Zhu
+*/
+
+#ifndef MXNET_COMMON_TENSOR_INSPECTOR_H_
+#define MXNET_COMMON_TENSOR_INSPECTOR_H_
+
+#include <algorithm> 
+#include<cmath>
+#include "../../3rdparty/mshadow/mshadow/base.h"
+#include "../../tests/cpp/include/test_util.h"
+
+namespace mxnet{
+
+/*!
+ * \brief This singleton struct mediates individual TensorInspector objects
+ * so that we can control the global behavior from each of them
+ */
+struct InspectorManager {
+  static InspectorManager* get() {
+    static std::mutex mtx;
+    static std::unique_ptr<InspectorManager> im = nullptr;
+    if (!im) {
+      std::unique_lock<std::mutex> lk(mtx);
+      if (!im)
+        im = std::make_unique<InspectorManager>();
+    }
+    return im.get();
+  }
+   /* !\brief mutex used to lock interactive_print() and check_value() */
+  std::mutex mutex_;
+   /* !\brief skip all interactive prints */
+  bool interactive_print_skip_all_ = false;
+   /* !\brief skip all value checks */
+  bool check_value_skip_all_ = false;
+   /* !\brief visit count for interactive print tags */
+  std::unordered_map<std::string, int> interactive_print_tag_counter_;
+   /* !\brief visit count for check value tags */
+  std::unordered_map<std::string, int> check_value_tag_counter_;
+};
+
+/*!
+ * \brief Enum for building value checkers for TensorInspector::check_value()
+ */
+enum CheckerType {
+  NegativeChecker, // check if is negative
+  PositiveChecker, // check if is positive
+  NanChecker // check if is Nan, will always return false if DType is not a float type
+};
+
+/**
+ *  _______                      _____                           _             
+ * |__   __|                    |_   _|                         | |            
+ *    | | ___ _ __  ___  ___  _ __| |  _ __  ___ _ __   ___  ___| |_ ___  _ __ 
+ *    | |/ _ \ '_ \/ __|/ _ \| '__| | | '_ \/ __| '_ \ / _ \/ __| __/ _ \| '__|
+ *    | |  __/ | | \__ \ (_) | | _| |_| | | \__ \ |_) |  __/ (__| || (_) | |   
+ *    |_|\___|_| |_|___/\___/|_||_____|_| |_|___/ .__/ \___|\___|\__\___/|_|   
+ *                                              | |                            
+ *                                              |_|   
+ */
+
+/*!
+ * \brief This class provides a unified interface to inspect the value of all data types
+ * including Tensor, TBlob, and NDArray. If the tensor resides on GPU, then it will be
+ * copied from GPU memory back to CPU memory to be operated on. Internally, all data types
+ * are stored as a TBlob object tb_.
+ */
+class TensorInspector {
+  /*!
+   * \brief generate the tensor info, including data type and shape 
+   * \tparam DType the data type
+   * \tparam StreamType the type of the stream object
+   * \param os stream object to output to
+   */
+  template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
+  inline void tensor_info_to_string(StreamType& os) {
+    int dimension = tb_.ndim();
+    os << "<" << typeid(tb_.dptr<DType>()[0]).name() << " Tensor ";
+    os << tb_.shape_[0]; 
+    for (int i = 1; i < dimension; i++) {
+      os << 'x' << tb_.shape_[i];
+    }
+    os << ">" << std::endl;
+  }
+
+  /*!
+   * \brief output the tensor info, including data type and shape 
+   * \tparam DType the data type
+   * \tparam StreamType the type of the stream object
+   * \param os stream object to output to
+   * \param shape the shape of the tensor
+   */
+  template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
+  inline void tensor_info_to_string(StreamType& os, const std::vector<int>& shape) {
+    int dimension = shape.size();
+    os << "<" << typeid(tb_.dptr<DType>()[0]).name() << " Tensor ";
+    os << shape[0];
+    for (int i = 1; i < dimension; i++) {
+      os << 'x' << shape[i];
+    }
+    os << ">" << std::endl;
+  }
+
+  /*!
+   * \brief output the tensor in a structed format 
+   * \tparam DType the data type
+   * \tparam StreamType the type of the stream object
+   * \param ctx the run context of the tensor
+   * \param os stream object to output to
+   */
+  template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
+  inline void to_string_helper(const RunContext& ctx, StreamType& os) { 
+    int dimension = tb_.ndim();
+    std::vector<unsigned int> multiples;
+    int multiple = 1;
+    for (int i = dimension-1; i >= 0; i--) {
+      multiple *= tb_.shape_[i];
+      multiples.push_back(multiple);
+    }
+    os << std::string(dimension, '[');
+    os << tb_.dptr<DType>()[0];
+    for (size_t i = 1; i < tb_.shape_.Size(); i++) {
+      int n = 0;
+      for (auto divisor : multiples) {
+        n += (i % divisor == 0);
+      }
+      if (n) {
+        os << std::string(n, ']') << ", " <<  std::string(n, '[');
+      } else  {
+        os << ", ";
+      }
+      os << tb_.dptr<DType>()[i];
+    }
+    os << std::string(dimension, ']') << std::endl;
+    tensor_info_to_string(os);
+  }
+
+  /*!
+   * \brief output the tensor in a structed format 
+   * \tparam DType the data type
+   * \tparam StreamType the type of the stream object
+   * \param ctx the run context of the tensor
+   * \param os stream object to output to
+   * \param dptr the data pointer
+   */
+  template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
+  inline void to_string_helper(const RunContext& ctx, StreamType& os, const DType* dptr) {
+    os << *dptr << std::endl;
+    os << "<" << typeid(*dptr).name() << ">" << std::endl;
+  }
+
+  /*!
+   * \brief output a part of the tensor in a structed format 
+   * \tparam DType the data type
+   * \tparam StreamType the type of the stream object
+   * \param ctx the run context of the tensor
+   * \param os stream object to output to
+   * \param sub_shape the sub-shape of the desired part of the tensor
+   * \param offset the position of the first value of the desired part of the tensor
+   */
+  template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
+  inline void to_string_helper(const RunContext& ctx, StreamType& os, const std::vector<int>& sub_shape, size_t offset) {
+    DType* dptr = tb_.dptr<DType>() + offset;
+    if (sub_shape.size() == 0) {
+      to_string_helper<DType>(ctx, os, dptr);
+      return;
+    }
+    int dimension = sub_shape.size();
+    std::vector<int> multiples;
+    size_t multiple = 1;
+    for (int i = dimension-1; i >= 0; i--) {
+      multiple *= sub_shape[i];
+      multiples.push_back(multiple);
+    }
+    std::stringstream ss;
+    os << std::string(dimension, '[');
+    os << dptr[0];
+    for (size_t i = 1; i < multiple; i++) {
+      int n = 0;
+      for (auto divisor : multiples) {
+        n += (i % divisor == 0);
+      }
+      if (n) {
+        os << std::string(n, ']') << ", " <<  std::string(n, '[');
+      } else  {
+        os << ", ";
+      }
+      os << dptr[i];
+    }
+    os << std::string(dimension, ']') << std::endl;
+    tensor_info_to_string(os, sub_shape);
+  }
+
+  /*!
+   * \brief helper functino to calculate the sub_shape and offset for the desired part of the tensor,
+   * given its coordinates in the original tensor
+   * \param pos the coordinates of the desired part of the tensor
+   * \param sub_shape the sub-shape of the desired part of the tensor; calculated here
+   * \param offset the position of the first value of the desired part of the tensor; calculated here
+   */
+  inline void print_locator(const std::vector<int>& pos, std::vector<int>& sub_shape, size_t& offset) {
+    int dimension = tb_.ndim();
+    int sub_dim = dimension - pos.size();
+    sub_shape.resize(sub_dim);
+    int multiple = 1;
+    for (int i = pos.size(), j = 0; i < dimension; i++, j++) {
+      sub_shape[j] = tb_.shape_[i];
+      multiple *= tb_.shape_[i];
+    }
+    int sum = 0;
+    int m = 1;
+    for (int i = pos.size()-1; i >= 0; i--) {
+      sum += pos[i] * m;
+      m *= tb_.shape_[i];
+    }
+    offset = sum * multiple;
+  }
+
+  /*!
+   * \brief parse the coordinate of the desired part of the tensor, given a string that represents that
+   * coordinate
+   * \param pos the coordinates of the desired part of the tensor, calculated here
+   * \param str the string that represents the coordinate
+   */
+  inline bool parse_position(std::vector<int>& pos, const std::string& str) {
+    int dimension = tb_.ndim();
+    std::stringstream ss(str);
+    int i;
+    while (ss >> i) {
+      pos.push_back(i);
+      if (ss.peek() == ',') {
+        ss.ignore();
+      }
+    }
+    if (pos.size() > dimension) {
+      return false;
+    }
+    for (unsigned i = 0; i < pos.size(); i++) {
+      if (pos[i] > (tb_.shape_[i]-1)) {
+        return false;
+      }
+    }
+    return !pos.empty();
+  }
+
+  /*!
+   * \brief interactive print the tensor value
+   * \tparam DType the data type
+   * \param ctx the run context of the tensor
+   * \param tag the name given to this call
+   */
+  template<typename DType MSHADOW_DEFAULT_DTYPE>
+  inline void interactive_print_helper(const RunContext& ctx, std::string tag) {
+    std::lock_guard<std::mutex> lock(InspectorManager::get()->mutex_);
+    InspectorManager::get()->interactive_print_tag_counter_[tag] += 1;
+    while (!InspectorManager::get()->interactive_print_skip_all_) {
+      std::cout << "----------Interactive Print----------" << std::endl;
+      if (tag != "") {
+        std::cout << "Tag: " << tag << "  Visit: " <<
+            InspectorManager::get()->interactive_print_tag_counter_[tag] <<  std::endl;
+      }
+      tensor_info_to_string(std::cout);
+      std::cout << "Please specify the position, seperated by \",\"" << std::endl
+          << "\"e\" for the entire tensor, \"b\" to break, \"s\" to skip all: " << std::endl;
+      std::string str;
+      std::cin >> str;
+      if (str == "b") {
+        break;
+      } else if (str == "e") {
+        to_string_helper<DType>(ctx, std::cout);
+        continue;
+      } else if (str == "s") {
+        InspectorManager::get()->interactive_print_skip_all_ = true;
+        break;
+      }
+      std::vector<int> pos;
+      if (parse_position(pos, str)) {
+        std::vector<int> sub_shape;
+        size_t offset;
+        print_locator(pos, sub_shape, offset);
+        to_string_helper<DType>(ctx, std::cout, sub_shape, offset);
+      } else {
+        std::cout << "invalid input" << std::endl;
+      }
+    }
+  }
+
+  /*!
+   * \brief calculate the coordinate of a value in the tensor, given its index
+   * \param idx the index of the value in the tensor
+   */
+  inline std::vector<int> index_to_coordinates(size_t idx){
+    int dimension = tb_.ndim();
+    std::vector<int> ret;
+    for (int i = dimension-1; i >= 0; i--) {
+      ret.push_back(idx % tb_.shape_[i]);
+      idx /= tb_.shape_[i];
+    }
+    std::reverse(ret.begin(), ret.end());
+    return ret;
+  }
+
+  /*!
+   * \brief check/validate the values within the tensor, return the coordinates
+   * where the lambda evaluates to true
+   * \tparam DType the data type
+   * \param ctx the run context of the tensor
+   * \param checker the lambda function to check each value of within the tensor
+   * \param interactive wherether to allow the user to interactively check the coordinates
+   * \param tag the name given to this call
+   */
+  template<typename DType MSHADOW_DEFAULT_DTYPE>
+  inline std::vector<std::vector<int>> check_value_helper(const RunContext& ctx,
+      const std::function<bool(DType)>& checker, bool interactive, std::string tag) {
+    std::vector<std::vector<int>> ret;
+    int count = 0;
+    std::stringstream ss;
+    ss << "[";
+    bool first_pass = true;
+    for (size_t i = 0; i < tb_.shape_.Size(); i++) {
+      if (checker(tb_.dptr<DType>()[i])) {
+        count += 1;
+        if (!first_pass) {
+          ss  << ", ";
+        }
+        first_pass = false;
+        std::vector<int> coords = index_to_coordinates(i);
+        ss << "(" << coords[0];
+        for (size_t i = 1; i < coords.size(); i++) {
+          ss << ", " << coords[i];
+        }
+        ss << ")";
+        ret.push_back(coords);
+      }
+    }
+    ss << "]" << std::endl;
+    if (interactive) {
+      std::lock_guard<std::mutex> lock(InspectorManager::get()->mutex_);
+       InspectorManager::get()->check_value_tag_counter_[tag] += 1;
+      while (!InspectorManager::get()->check_value_skip_all_) {
+        std::cout << "----------Value Check----------" << std::endl;
+        if (tag != "") {
+          std::cout << "Tag: " << tag << "  Visit: " << InspectorManager::get()->check_value_tag_counter_[tag] <<  std::endl;
+        }
+        std::cout << count << " value(s) found. \"p\" to print the coordinates, \"b\" to break, \"s\" to skip all: ";
+        std::string str;
+        std::cin >> str;
+        if (str == "b") {
+          break;
+        } else if (str == "p") {
+          std::cout << ss.str() << std::endl;
+        } else if (str == "s") {
+          InspectorManager::get()->check_value_skip_all_ = true;
+        }
+      }
+    }
+   
+    return ret;
+  }
+  
+  /*!
+   * \brief build the lambda function, aka the checker, given its type
+   * \tparam DType the data type
+   * \param ct the type of the checker
+   */
+  template<typename DType MSHADOW_DEFAULT_DTYPE>
+  inline std::function<bool(DType)> build_checker(CheckerType ct){
+    switch (ct) {
+      case NegativeChecker:
+        return [] (DType x) {
+              return x < 0;
+            };
+      case PositiveChecker:
+        return [] (DType x) {
+              return x < 0;
+            };
+      case NanChecker:
+        if (std::is_same<DType, float>::value || std::is_same<DType, double>::value ||
+            std::is_same<DType, long double>::value) {
+          return [] (DType x) {
+                return x != x;
+              };
+        } else {
+          LOG(WARNING) << "NanChecker only applies to float types. " <<
+              "Lambda will always return false.";
+        }
+        break;
+      default:
+        return [] (DType x) {
+              return false;
+            };
+    }
+    return [] (DType x) {return false;};
+  }
+
+ public:
+   /*!
+   * \brief Construct from Tensor object
+   * \tparam Device the device the tensor resides in
+   * \tparam dimension the dimension of the tensor
+   * \tparam DType the data type
+   * \param ts the source tensor obeject
+   */
+  template<typename Device, int dimension,
+      typename DType MSHADOW_DEFAULT_DTYPE>
+  TensorInspector(const Tensor<Device, dimension, DType>& ts) : tb_(ts) {}
+
+  /*!
+   * \brief Construct from TBlob object
+   * \tparam Device the device the tensor resides in
+   * \tparam dimension the dimension of the tensor
+   * \tparam DType the data type
+   * \param ts the source tensor obeject
+   */
+  TensorInspector(const TBlob& tb) : tb_(tb) {}
+
+  /*!
+   * \brief Construct from NDArray object. Currently this only works with kDefaultStorage
+   * \tparam Device the device the tensor resides in
+   * \tparam dimension the dimension of the tensor
+   * \tparam DType the data type
+   * \param ts the source tensor obeject
+   */
+  TensorInspector(const NDArray& arr) : tb_(arr.data()){}
+
+  /*!
+   * \brief print the tensor to std::cout
+   * \param ctx the run context of the tensor
+   */
+  inline void print_string(const RunContext& ctx) {
+    std::cout << to_string(ctx) << std::endl;
+  }
+
+  /*!
+   * \brief return a string which contains the values and other info of the tensor
+   * \param ctx the run context of the tensor
+   */
+  inline std::string to_string(const RunContext& ctx) {
+    std::stringstream ss;
+    MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
+      to_string_helper<DType>(ctx, ss);
+    });
+    return ss.str();
+  }
+
+  /*!
+   * \brief interactive print the tensor value
+   * \param ctx the run context of the tensor
+   * \param tag the name given to this call
+   */
+  inline void interactive_print(const RunContext& ctx, std::string tag = "") {
+    MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
+      interactive_print_helper<DType>(ctx, tag);
+    });
+  }
+
+  /*!
+   * \brief check/validate the values within the tensor, return the coordinates
+   * where the lambda evaluates to true
+   * \tparam ValueChecker the type of the lambda
+   * \param ctx the run context of the tensor
+   * \param checker the lambda function to check each value of within the tensor
+   * \param interactive wherether to allow the user to interactively check the coordinates
+   * \param tag the name given to this call
+   */
+  template<typename ValueChecker>
+  std::vector<std::vector<int>> check_value(const RunContext& ctx, const ValueChecker& checker,
+      bool interactive = false, std::string tag = "") {
+    MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
+      return check_value_helper<DType>(ctx, checker, interactive, tag);
+    });
+    return std::vector<std::vector<int>>();
+  }
+
+  /*!
+   * \brief check/validate the values within the tensor, return the coordinates
+   * where the lambda evaluates to true
+   * \param ctx the run context of the tensor
+   * \param ct the type of the checker
+   * \param interactive wherether to allow the user to interactively check the coordinates
+   * \param tag the name given to this call
+   */
+  std::vector<std::vector<int>> check_value(const RunContext& ctx, CheckerType ct,
+      bool interactive = false, std::string tag = "") {
+    MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
+      return check_value_helper<DType>(ctx, build_checker<DType>(ct), interactive, tag);
+    });
+    return std::vector<std::vector<int>>();
+  }
+
+ private:
+  /* !\brief the tensor blob */
+  const TBlob tb_;
+};
+
+
+} // namespace mxnet
+
+#endif  // MXNET_COMMON_TENSOR_INSPECTOR_H_

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -22,7 +22,7 @@
  * \file tensor_inspector.h
  * \brief utility to inspector tensor objects
  * \author Zhaoqi Zhu
-*/
+ */
 
 #ifndef MXNET_COMMON_TENSOR_INSPECTOR_H_
 #define MXNET_COMMON_TENSOR_INSPECTOR_H_
@@ -69,6 +69,7 @@ struct InspectorManager {
 enum CheckerType {
   NegativeChecker,  // check if is negative
   PositiveChecker,  // check if is positive
+  ZeroChecker,  // check if is zero
   NanChecker  // check if is Nan, will always return false if DType is not a float type
 };
 
@@ -90,6 +91,7 @@ enum CheckerType {
  * are stored as a TBlob object tb_.
  */
 class TensorInspector {
+ private:
   /*!
    * \brief generate the tensor info, including data type and shape 
    * \tparam DType the data type
@@ -427,7 +429,11 @@ class TensorInspector {
             };
       case PositiveChecker:
         return [] (DType x) {
-              return x < 0;
+              return x > 0;
+            };
+      case ZeroChecker:
+        return [] (DType x) {
+              return x == 0;
             };
       case NanChecker:
         if (std::is_same<DType, float>::value || std::is_same<DType, double>::value ||
@@ -447,6 +453,11 @@ class TensorInspector {
     }
     return [] (DType x) {return false;};
   }
+
+  /* !\brief the tensor blob */
+  const TBlob tb_;
+  /* !\brief the run context of the tensor */
+  const RunContext& ctx_;
 
  public:
    /*!
@@ -540,12 +551,6 @@ class TensorInspector {
     });
     return std::vector<std::vector<int>>();
   }
-
- private:
-  /* !\brief the tensor blob */
-  const TBlob tb_;
-  /* !\brief the run context of the tensor */
-  const RunContext& ctx_;
 };
 
 

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -144,7 +144,8 @@ class TensorInspector {
   inline void to_string_helper(StreamType* os) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
-      explicit TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)()).to_string_helper<DType>(os);
+      TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
+          .to_string_helper<DType>(os);
       return;
     }
 #endif  // MXNET_USE_CUDA
@@ -184,7 +185,7 @@ class TensorInspector {
   inline void to_string_helper(StreamType* os, const DType* dptr) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
-      explicit TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)())
+      TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
           .to_string_helper<DType>(os, dptr);
       return;
     }
@@ -205,7 +206,7 @@ class TensorInspector {
   inline void to_string_helper(StreamType* os, const std::vector<int>& sub_shape, size_t offset) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
-      explicit TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)())
+      TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
           .to_string_helper<DType>(os, sub_shape, offset);
       return;
     }
@@ -303,7 +304,7 @@ class TensorInspector {
   inline void interactive_print_helper(std::string tag) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
-      explicit TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)())
+      TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
           .interactive_print_helper<DType>(tag);
       return;
     }
@@ -318,7 +319,7 @@ class TensorInspector {
       }
       tensor_info_to_string(&std::cout);
       std::cout << "Please specify the position, seperated by \",\"" << std::endl
-          << "\"e\" for the entire tensor, \"b\" to break, \"s\" to skip all: " << std::endl;
+          << "\"e\" for the entire tensor, \"b\" to break, \"s\" to skip all: ";
       std::string str;
       std::cin >> str;
       if (str == "b") {
@@ -358,24 +359,23 @@ class TensorInspector {
   }
 
   /*!
-   * \brief check/validate the values within the tensor, return the coordinates
+   * \brief check/validate the values within the tensor, find the coordinates
    * where the lambda evaluates to true
    * \tparam DType the data type
+   * \param ret a vector of coordinates which itself is a vector of int; calculated here
    * \param checker the lambda function to check each value of within the tensor
    * \param interactive wherether to allow the user to interactively check the coordinates
    * \param tag the name given to this call
    */
   template<typename DType MSHADOW_DEFAULT_DTYPE>
-  inline std::vector<std::vector<int>>
-      check_value_helper(const std::function<bool(DType)>& checker,
-      bool interactive, std::string tag) {
+  inline void check_value_helper(std::vector<std::vector<int>>* ret,
+      const std::function<bool(DType)>& checker,bool interactive, std::string tag) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
-      return TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)())
-          .check_value_helper<DType>(checker, interactive, tag);
+      return TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
+          .check_value_helper<DType>(ret, checker, interactive, tag);
     }
 #endif  // MXNET_USE_CUDA
-    std::vector<std::vector<int>> ret;
     int count = 0;
     std::stringstream ss;
     ss << "[";
@@ -393,7 +393,7 @@ class TensorInspector {
           ss << ", " << coords[i];
         }
         ss << ")";
-        ret.push_back(coords);
+        ret->push_back(coords);
       }
     }
     ss << "]" << std::endl;
@@ -419,7 +419,6 @@ class TensorInspector {
         }
       }
     }
-    return ret;
   }
 
   /*!
@@ -595,12 +594,13 @@ class TensorInspector {
    * \param tag the name given to this call
    */
   template<typename ValueChecker>
-  std::vector<std::vector<int>> check_value(const ValueChecker& checker, bool interactive = false,
+  inline std::vector<std::vector<int>> check_value(const ValueChecker& checker, bool interactive = false,
       std::string tag = "") {
+    std::vector<std::vector<int>> ret;
     MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
-      return check_value_helper<DType>(checker, interactive, tag);
+      check_value_helper<DType>(&ret, checker, ret, interactive, tag);
     });
-    return std::vector<std::vector<int>>();
+    return ret;
   }
 
   /*!
@@ -610,12 +610,13 @@ class TensorInspector {
    * \param interactive wherether to allow the user to interactively check the coordinates
    * \param tag the name given to this call
    */
-  std::vector<std::vector<int>> check_value(CheckerType ct, bool interactive = false,
+  inline std::vector<std::vector<int>> check_value(CheckerType ct, bool interactive = false,
       std::string tag = "") {
+    std::vector<std::vector<int>> ret;
     MSHADOW_TYPE_SWITCH(tb_.type_flag_, DType, {
-      return check_value_helper<DType>(build_checker<DType>(ct), interactive, tag);
+      check_value_helper<DType>(&ret, build_checker<DType>(ct), interactive, tag);
     });
-    return std::vector<std::vector<int>>();
+    return ret;
   }
 };
 

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -132,6 +132,12 @@ class TensorInspector {
    */
   template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
   inline void to_string_helper(const RunContext& ctx, StreamType& os) { 
+#if MXNET_USE_CUDA
+    if (tb_.dev_mask() == gpu::kDevMask) {
+      TensorInspector(test::CAccessAsCPU(ctx, tb_, false)()).to_string_helper<DType>(ctx, os);
+      return;
+    }
+#endif // MXNET_USE_CUDA
     int dimension = tb_.ndim();
     std::vector<unsigned int> multiples;
     int multiple = 1;
@@ -167,6 +173,12 @@ class TensorInspector {
    */
   template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
   inline void to_string_helper(const RunContext& ctx, StreamType& os, const DType* dptr) {
+#if MXNET_USE_CUDA
+    if (tb_.dev_mask() == gpu::kDevMask) {
+      TensorInspector(test::CAccessAsCPU(ctx, tb_, false)()).to_string_helper<DType>(ctx, os, dptr);
+      return;
+    }
+#endif // MXNET_USE_CUDA
     os << *dptr << std::endl;
     os << "<" << typeid(*dptr).name() << ">" << std::endl;
   }
@@ -182,6 +194,12 @@ class TensorInspector {
    */
   template<typename DType MSHADOW_DEFAULT_DTYPE, typename StreamType>
   inline void to_string_helper(const RunContext& ctx, StreamType& os, const std::vector<int>& sub_shape, size_t offset) {
+#if MXNET_USE_CUDA
+    if (tb_.dev_mask() == gpu::kDevMask) {
+      TensorInspector(test::CAccessAsCPU(ctx, tb_, false)()).to_string_helper<DType>(ctx, os, sub_shape, offset);
+      return;
+    }
+#endif // MXNET_USE_CUDA
     DType* dptr = tb_.dptr<DType>() + offset;
     if (sub_shape.size() == 0) {
       to_string_helper<DType>(ctx, os, dptr);
@@ -273,6 +291,12 @@ class TensorInspector {
    */
   template<typename DType MSHADOW_DEFAULT_DTYPE>
   inline void interactive_print_helper(const RunContext& ctx, std::string tag) {
+#if MXNET_USE_CUDA
+    if (tb_.dev_mask() == gpu::kDevMask) {
+      TensorInspector(test::CAccessAsCPU(ctx, tb_, false)()).interactive_print_helper<DType>(ctx, tag);
+      return;
+    }
+#endif // MXNET_USE_CUDA
     std::lock_guard<std::mutex> lock(InspectorManager::get()->mutex_);
     InspectorManager::get()->interactive_print_tag_counter_[tag] += 1;
     while (!InspectorManager::get()->interactive_print_skip_all_) {
@@ -334,6 +358,12 @@ class TensorInspector {
   template<typename DType MSHADOW_DEFAULT_DTYPE>
   inline std::vector<std::vector<int>> check_value_helper(const RunContext& ctx,
       const std::function<bool(DType)>& checker, bool interactive, std::string tag) {
+#if MXNET_USE_CUDA
+    if (tb_.dev_mask() == gpu::kDevMask) {
+      return TensorInspector(test::CAccessAsCPU(ctx, tb_, false)()).check_value_helper<DType>(ctx,
+          checker, interactive, tag);
+    }
+#endif // MXNET_USE_CUDA
     std::vector<std::vector<int>> ret;
     int count = 0;
     std::stringstream ss;

--- a/src/common/tensor_inspector.h
+++ b/src/common/tensor_inspector.h
@@ -20,7 +20,7 @@
 /*!
  * Copyright (c) 2019 by Contributors
  * \file tensor_inspector.h
- * \brief utility to inspector tensor objects
+ * \brief utility to inspect tensor objects
  * \author Zhaoqi Zhu
  */
 
@@ -467,7 +467,7 @@ class TensorInspector {
    */
   template<typename DType MSHADOW_DEFAULT_DTYPE>
   inline void check_value_helper(std::vector<std::vector<int>>* ret,
-      const std::function<bool(DType)>& checker,bool interactive, std::string tag) {
+      const std::function<bool(DType)>& checker, bool interactive, std::string tag) {
 #if MXNET_USE_CUDA
     if (tb_.dev_mask() == gpu::kDevMask) {
       return TensorInspector(test::CAccessAsCPU(ctx_, tb_, false)(), ctx_)
@@ -524,13 +524,14 @@ class TensorInspector {
    * \tparam ti the type info 
    */
   inline char infer_type(const std::type_info& ti) {
-    if(ti == typeid(float)) return 'f';
-    else if(ti == typeid(double)) return 'f';
-    else if(ti == typeid(mshadow::half::half_t) ) return 'f';
-    else if(ti == typeid(uint8_t)) return 'u';
-    else if(ti == typeid(int32_t)) return 'i';
-    else if(ti == typeid(int64_t)) return 'i';
-    else return '?';
+    if (ti == typeid(float)) return 'f';
+    else if (ti == typeid(double)) return 'f';
+    else if (ti == typeid(mshadow::half::half_t) ) return 'f';
+    else if (ti == typeid(uint8_t)) return 'u';
+    else if (ti == typeid(int32_t)) return 'i';
+    else if (ti == typeid(int64_t)) return 'i';
+    else 
+      return '?';
   }
 
   /*!
@@ -538,7 +539,7 @@ class TensorInspector {
    */
   inline char endian_test() {
     int x = 1;
-    return (((char*)&x)[0]) ? '<' : '>';
+    return (reinterpret_cast<char*>(&x)[0]) ? '<' : '>';
   }
 
   /*!
@@ -574,19 +575,19 @@ class TensorInspector {
     dict += std::string(padding_size, ' ');
     dict[dict.size()-1] = '\n';
     std::string header;
-    header += (char)0x93;
+    header += static_cast<char>(0x93);
     header += "NUMPY";
-    header += (char)0x01;
-    header += (char)0x00;
-    header += (char)((uint16_t)dict.size() & 0x00ff);
-    header += (char)(((uint16_t)dict.size() >> 8) & 0x00ff);
+    header += static_cast<char>(0x01);
+    header += static_cast<char>(0x00);
+    header += static_cast<char>((uint16_t)dict.size() & 0x00ff);
+    header += static_cast<char>(((uint16_t)dict.size() >> 8) & 0x00ff);
     header += dict;
     InspectorManager::get()->dump_value_tag_counter_[tag] += 1;
     int visit = InspectorManager::get()->dump_value_tag_counter_[tag];
-    std::ofstream file (tag + "_" + std::to_string(visit) + ".npy",
+    std::ofstream file(tag + "_" + std::to_string(visit) + ".npy",
         std::ios::out | std::ios::binary);
     file.write(header.c_str(), header.size());
-    file.write((char*)tb_.dptr<DType>(), sizeof(DType) * tb_.shape_.Size());
+    file.write(reinterpret_cast<char*>(tb_.dptr<DType>()), sizeof(DType) * tb_.shape_.Size());
     file.close();
   }
 
@@ -696,7 +697,6 @@ class TensorInspector {
       dump_value_helper<DType>(tag);
     });
   }
-
 };
 
 }  // namespace mxnet


### PR DESCRIPTION
Created a separate PR for a new tutorial on usage.
https://github.com/apache/incubator-mxnet/pull/15517








## Background ##

When developing new operators, developers need to deal with Tensors, TBlobs, and NDArrays extensively (for simplicity, we will simply refer them as “tensors”). However, there is no existing tool that helps developers inspect the value of the tensors within an operator, so it’s hard to locate the spot where the computation goes wrong. With that said, we can create a new utility that supports inspecting, dumping and verifying tensor values to alleviate the developer’s need to use hacky prints every time. This new utility will support all the three data types (Tensor, TBlob, NDArray), as well as both CPU and GPU tensors.

Some related GitHub issues: https://github.com/apache/incubator-mxnet/issues/15198

## Methodology ##

First off, to support all three data types, we will need to first convert them to TBlob, so that we can base our new functionalists on one single class and avoid code repetition. To access the value of a tensor/TBlob object, the easiest way is to add some function, such as to_string(), to the TBlob class. Then, we could use shape_ to dereference dptr and extract the actual data from the tensor in a structured format. However, to preserve the integrity of the TBlob class, we would want to avoid making direct changes to tensor_blob.h. Instead, considering that all the member variables of TBlob are all public, we could create a wrapper around TensorBlob, which we would call TensorInspector, and we could then add our new functions to this new wrapper class. We could put this new file tensor_inspector.h in src/common along with a bunch of other utilities. 

```
class TensorInspector {
  private:
    const TBlob tb_;
  public:
    // our new functions
}
```

Besides tensor inspectors which are one-to-one with tensors, I also propose to have a singleton class called InspectorManage which is responsible for data sharing and maintaining locking between the individual TensorInspector objects. This way, we could control some global behaviors within each of the objects.

## The Value of Creating a New Utility ##

It’s important to point out that there is an existing utility that helps print out the value of a tensor, tests/cpp/include/test_util.h, (https://github.com/apache/incubator-mxnet/blob/master/tests/cpp/include/test_util.h#L472). However, this new utility under discussion aims to start from the use cases of the users, who in our case are developers, and has more functionalities than the existing utility. Note: this new utility will use CAccessAsCPU from test_util.h for data copying from GPU memory to CPU memory.

## Proposed Funtionalities/APIs ##

### Create a TensorInspector Object from Tensor, TBlob, and NDarray Objects ###

We can create a TensorInspector object by passing in a Tensor, TBlob, or NDArray object.

```
// Convolution-inl.h, Forward()
Tensor<xpu, 3, DType> weight_3d = in_data[conv::kWeight].get_with_shape<xpu, 3, DType>(
        Shape3(group_, M, K), s);
TensorInspector ti(weight_3d, ctx.run_ctx);

// Similarly, we could do:
TensorInspector ti(/*TBlob obj*/, ctx.run_ctx);
// OR:
TensorInspector ti(/*NDArray obj*/, ctx.run_ctx);
```

### Print Tensor Value (static) ###

We could use `std::string TensorInspector::to_string()` or `void TensorInspector::print_string()` to get a formatted string representation of the entire tensor. We could see the tensor value in a structured way, the data type, as well as the tensor shape. 

```
TensorInspector ti(/*Tensor, Tblob, or Ndarray obj*/, /*RunContext obj*/);
ti.to_string(); // print tensor
```

![Screen Shot 2019-07-08 at 4 07 16 PM](https://user-images.githubusercontent.com/16669457/60848554-d8c06100-a19b-11e9-9fe0-23e79a7a371a.png)

### Interactively Print Tensor Value (dynamic) ###

During debugging, situations might occur that ahead of time (at compilation time), we do not know which part of a tensor we need to inspect. Also, sometimes we might want to pause the operator control flow to “zoom into” an erroneous part of a tensor multiple times until we are satisfied to move on. In this regard, we could use void `TensorInspector::interactive_print(std::string tag = "")` like a break point to dynamically specify the part of the tensor to inspect and whether we want to skip the break point. tag is an optional parameter where we can give the break points names so that we can distinguish them. A “Visit” counter would tell us how many times have we stepped into a break point with this tag name.

```
    TensorInspector ti(weight_3d);
    ti.interactive_print("My Convolution");
```

![Screen Shot 2019-07-10 at 5 29 07 PM](https://user-images.githubusercontent.com/16669457/61013632-5325e800-a338-11e9-90e6-607f17d81495.png)

As we can see from the screenshot, we would be in a loop that asks us for command. We would be prompted with the Tensor info, <f Tensor 20x1x5x5>, and we could enter coordinates such as “0,0” to print only a part of the tensor. We could also type “e” for the entire tensor, “b” to break from this loop, and “s” to break from this loop and skip all the future break points. 

### Check Tensor Value ###

Sometimes, developers might want to check if the tensor contains unexpected values which could be negative values, Nans, or others. We could have a templated api `std::vector<std::vector<int>>TensorInspector::validate_value(const ValueChecker& vc, bool interactive = false, std::string tag = "")` where vc is a bool value checker function that users can define, interactive is whether you want to check the values on the go (similar to interactive print, refer to the first screenshot below), and tag is the name you want to give to the call to identify it. The return is a vector of coordinates (represented with vector) at which checker evaluates to true. 

![Screen Shot 2019-07-10 at 5 34 20 PM](https://user-images.githubusercontent.com/16669457/61013773-fe36a180-a338-11e9-9a2b-5f11ccc7afa7.png)

To the developer's convenience, we would also pre-define a bunch of value checkers. Refer to the Enum below:

![Screen Shot 2019-07-10 at 5 24 41 PM](https://user-images.githubusercontent.com/16669457/61013509-c549fd00-a337-11e9-85aa-82b3947f6be7.png)

Developers could skip wiring their own checker by using this API: `std::vector<std::vector<int>>TensorInspector::validate_value(ValueChecker vc, bool interactive = false, std::string tag = "")`

This API can also be used creatively to find coordinates where the values equal to some required value or fall in some range. 

### Dump Tensor Value  ###

Sometimes, we would want to dump the tensor to a file in binary mode, so that we could use, for example, a python script to further analyze the numbers. We could use void TensorInspector::dump_value(std::string tag) to achieve this. We would want to use .npy format for its compatibility with Numpy and its great load efficiency. A benchmark can be found here: https://github.com/mverleg/array_storage_benchmark.

![Screen Shot 2019-07-10 at 5 45 44 PM](https://user-images.githubusercontent.com/16669457/61014145-e19b6900-a33a-11e9-986f-4ce8d7e1ca16.png)

In this screenshot, we can compare side by side the regular print (left) and the value dump (right). Even without formatting the dumped value, we can see it has a better accuracy.

![Screen Shot 2019-07-10 at 5 14 09 PM](https://user-images.githubusercontent.com/16669457/61013144-561fd900-a336-11e9-8f88-b7de4a4927e9.png)

<img width="793" alt="Screen Shot 2019-07-10 at 5 14 43 PM" src="https://user-images.githubusercontent.com/16669457/61013155-5d46e700-a336-11e9-8d8a-ec114a0e355f.png">

As we can see in the screenshot, the output files are named "{tag}_{visit}.npy", where tag is the name that we give to the call, and visit is the visit count. 

To load the file, we could just do:

```
import numpy as np
a = np.load('abc_1.npy')
print(a)
```

![Screen Shot 2019-07-10 at 5 17 29 PM](https://user-images.githubusercontent.com/16669457/61013259-cc244000-a336-11e9-8564-a018041634f6.png)

Notice: in interactive print, we could also do value dump with command "d":

![Screen Shot 2019-07-10 at 5 29 07 PM](https://user-images.githubusercontent.com/16669457/61013612-40131800-a338-11e9-9838-58808e7170f5.png)

## Usage ##
To test or use this new utility in your operator, just include the .h file and construct a TensorInspector object, say "ti", as described above. Then, you can use all functionalities listed above by writing, for example, "ti.print_string()" or "ti.interactive_print()". Finally, just run any python script that uses the operator that you modified.

![Screen Shot 2019-07-11 at 4 57 41 PM](https://user-images.githubusercontent.com/16669457/61092906-0f48e680-a3fd-11e9-8251-c4371cdd00ad.png)


## TODOs ##
1. Support sparse NDArrays if necessary
2. Check corner cases e.g. if Tblob's shape is unknown








## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here