### PR TITLE
Add -DMXNET_USE_OPENMP to Makefiles so runtime info gets updated accordingly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,7 @@ endif
 
 ifeq ($(USE_OPENMP), 1)
 	CFLAGS += -fopenmp
+	CFLAGS += -DMXNET_USE_OPENMP=1
 endif
 
 ifeq ($(USE_NNPACK), 1)


### PR DESCRIPTION
## Description ##

Fixes OPENMP info in runtime features.

https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/runtime.py

This would be also needed to fix BLAS flags.
https://github.com/apache/incubator-mxnet/pull/15424

