### PR TITLE
[Numpy] Numpy compatible argsort

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -32,7 +32,8 @@ __all__ = ['zeros', 'ones', 'maximum', 'minimum', 'stack', 'arange', 'argmax',
            'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'concatenate',
            'clip', 'split', 'swapaxes', 'expand_dims', 'tile', 'linspace',
            'sin', 'cos', 'sinh', 'cosh', 'log10', 'sqrt', 'abs', 'exp', 'arctan', 'sign', 'log',
-           'degrees', 'log2', 'rint', 'radians', 'mean', 'reciprocal', 'square', 'arcsin']
+           'degrees', 'log2', 'rint', 'radians', 'mean', 'reciprocal', 'square', 'arcsin',
+           'argsort']
 
 
 @set_module('mxnet.ndarray.numpy')
@@ -423,6 +424,60 @@ def argmax(a, axis=None, out=None):
     array([2., 2.])
     """
     return _npi.argmax(a, axis=axis, keepdims=False, out=out)
+
+
+@set_module('mxnet.ndarray.numpy')
+def argsort(a, axis=-1, kind='quicksort', order=None):
+    """
+    Returns the indices that would sort an input array along the given axis.
+    This function performs sorting along the given axis and returns an array
+    of indices having same shape as an input array that index data in sorted order.
+    Parameters
+    ----------
+    a : ndarray
+        Input array
+    axis : int, optional
+        The axis along which to sort teh input tensor.
+        If not given, the last, dimension -1 will be used by default.
+        If None, the flattened array is used.
+    kind: {'quicksort'}
+        Currently not supported.
+    order: None
+        Currently not supported.
+    Returns
+    -------
+    output : ndarray
+        Array of indices that sort a along the specified axis.
+        If a is one-dimensional, a[index_array] yields a sorted a.
+        More generally, np.take_along_axis(a, index_array, axis=a) always yields the sorted a,
+        irrespective of dimensionality.
+    Examples
+    --------
+    >>> x = np.array([3, 1, 2])
+    >>> np.argsort(x)
+    array([1., 2., 0.])
+    >>> x = np.array([[0, 3], [2, 2]])
+    >>> x
+    array([[0., 3.],
+           [2., 2.]])
+    >>> np.argsort(x, axis=0)  # sorts along first axis (down)
+    array([[0., 1.],
+           [1., 0.]])
+    >>> np.argsort(x, axis=1)  # sorts along last axis (across)
+    array([[0., 1.],
+           [0., 1.]])
+    Notes
+    -----
+    This function differs from the original `numpy.argsort
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.argsort.html>`_ in
+    the following way(s):
+    - kind and order is currently not supported
+    """
+    if kind != 'quicksort':
+        raise AttributeError('mxnet.numpy.argsort does not support other sorting methods')
+    if order is not None:
+        raise AttributeError('mxnet.numpy.argsort does not support sorting with fields ordering')
+    return _npi.argsort(a, axis)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -432,6 +432,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     Returns the indices that would sort an input array along the given axis.
     This function performs sorting along the given axis and returns an array
     of indices having same shape as an input array that index data in sorted order.
+
     Parameters
     ----------
     a : ndarray
@@ -444,6 +445,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
         Currently not supported.
     order: None
         Currently not supported.
+
     Returns
     -------
     output : ndarray
@@ -451,6 +453,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
         If a is one-dimensional, a[index_array] yields a sorted a.
         More generally, np.take_along_axis(a, index_array, axis=a) always yields the sorted a,
         irrespective of dimensionality.
+
     Examples
     --------
     >>> x = np.array([3, 1, 2])
@@ -466,12 +469,14 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     >>> np.argsort(x, axis=1)  # sorts along last axis (across)
     array([[0., 1.],
            [0., 1.]])
+
     Notes
     -----
     This function differs from the original `numpy.argsort
     <https://docs.scipy.org/doc/numpy/reference/generated/numpy.argsort.html>`_ in
     the following way(s):
-    - kind and order is currently not supported
+
+    - kind and order are currently not supported
     """
     if kind != 'quicksort':
         raise AttributeError('mxnet.numpy.argsort does not support other sorting methods')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -1681,6 +1681,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     Returns the indices that would sort an input array along the given axis.
     This function performs sorting along the given axis and returns an array
     of indices having same shape as an input array that index data in sorted order.
+
     Parameters
     ----------
     a : ndarray
@@ -1693,6 +1694,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
         Currently not supported.
     order: None
         Currently not supported.
+
     Returns
     -------
     output : ndarray
@@ -1700,6 +1702,7 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
         If a is one-dimensional, a[index_array] yields a sorted a.
         More generally, np.take_along_axis(a, index_array, axis=a) always yields the sorted a,
         irrespective of dimensionality.
+
     Examples
     --------
     >>> x = np.array([3, 1, 2])
@@ -1715,12 +1718,14 @@ def argsort(a, axis=-1, kind='quicksort', order=None):
     >>> np.argsort(x, axis=1)  # sorts along last axis (across)
     array([[0., 1.],
            [0., 1.]])
+
     Notes
     -----
     This function differs from the original `numpy.argsort
     <https://docs.scipy.org/doc/numpy/reference/generated/numpy.argsort.html>`_ in
     the following way(s):
-    - kind and order is currently not supported
+
+    - kind and order are currently not supported
     """
     if kind != 'quicksort':
         raise AttributeError('mxnet.numpy.argsort does not support other sorting methods')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -47,7 +47,8 @@ __all__ = ['ndarray', 'empty', 'array', 'zeros', 'ones', 'maximum', 'minimum', '
            'argmax', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'concatenate',
            'clip', 'split', 'swapaxes', 'expand_dims', 'tile', 'linspace', 'sin', 'cos',
            'sin', 'cos', 'sinh', 'cosh', 'log10', 'sqrt', 'abs', 'exp', 'arctan', 'sign', 'log',
-           'degrees', 'log2', 'rint', 'radians', 'mean', 'reciprocal', 'square', 'arcsin']
+           'degrees', 'log2', 'rint', 'radians', 'mean', 'reciprocal', 'square', 'arcsin',
+           'argsort']
 
 
 # This function is copied from ndarray.py since pylint
@@ -779,13 +780,17 @@ class ndarray(NDArray):
         """
         raise AttributeError('mxnet.numpy.ndarray object has no attribute topk')
 
-    def argsort(self, *args, **kwargs):
+    def argsort(self, axis=-1, kind='quicksort', order=None):   # pylint: disable=arguments-differ
         """Convenience fluent method for :py:func:`argsort`.
 
         The arguments are the same as for :py:func:`argsort`, with
         this array as data.
         """
-        raise NotImplementedError
+        if kind != 'quicksort':
+            raise AttributeError('mxnet.numpy.argsort does not support other sorting methods')
+        if order is not None:
+            raise AttributeError('mxnet.numpy.argsort does not support sorting with fields ordering')
+        return _npi.argsort(self, axis)
 
     def argmax_channel(self, *args, **kwargs):
         """Convenience fluent method for :py:func:`argmax_channel`.
@@ -1668,6 +1673,60 @@ def argmax(a, axis=None, out=None):
     array([2., 2.])
     """
     return _mx_nd_np.argmax(a, axis, out)
+
+
+@set_module('mxnet.numpy')
+def argsort(a, axis=-1, kind='quicksort', order=None):
+    """
+    Returns the indices that would sort an input array along the given axis.
+    This function performs sorting along the given axis and returns an array
+    of indices having same shape as an input array that index data in sorted order.
+    Parameters
+    ----------
+    a : ndarray
+        Input array
+    axis : int, optional
+        The axis along which to sort teh input tensor.
+        If not given, the last, dimension -1 will be used by default.
+        If None, the flattened array is used.
+    kind: {'quicksort'}
+        Currently not supported.
+    order: None
+        Currently not supported.
+    Returns
+    -------
+    output : ndarray
+        Array of indices that sort a along the specified axis.
+        If a is one-dimensional, a[index_array] yields a sorted a.
+        More generally, np.take_along_axis(a, index_array, axis=a) always yields the sorted a,
+        irrespective of dimensionality.
+    Examples
+    --------
+    >>> x = np.array([3, 1, 2])
+    >>> np.argsort(x)
+    array([1., 2., 0.])
+    >>> x = np.array([[0, 3], [2, 2]])
+    >>> x
+    array([[0., 3.],
+           [2., 2.]])
+    >>> np.argsort(x, axis=0)  # sorts along first axis (down)
+    array([[0., 1.],
+           [1., 0.]])
+    >>> np.argsort(x, axis=1)  # sorts along last axis (across)
+    array([[0., 1.],
+           [0., 1.]])
+    Notes
+    -----
+    This function differs from the original `numpy.argsort
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.argsort.html>`_ in
+    the following way(s):
+    - kind and order is currently not supported
+    """
+    if kind != 'quicksort':
+        raise AttributeError('mxnet.numpy.argsort does not support other sorting methods')
+    if order is not None:
+        raise AttributeError('mxnet.numpy.argsort does not support sorting with fields ordering')
+    return _npi.argsort(a, axis)
 
 
 @set_module('mxnet.numpy')

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -384,6 +384,7 @@ class _Symbol(Symbol):
         Returns the indices that would sort an input array along the given axis.
         This function performs sorting along the given axis and returns an array
         of indices having same shape as an input array that index data in sorted order.
+
         Parameters
         ----------
         a : _Symbol
@@ -396,6 +397,7 @@ class _Symbol(Symbol):
             Currently not supported.
         order: None
             Currently not supported.
+
         Returns
         -------
         output : ndarray
@@ -403,6 +405,7 @@ class _Symbol(Symbol):
         If a is one-dimensional, a[index_array] yields a sorted a.
         More generally, np.take_along_axis(a, index_array, axis=a) always yields the sorted a,
         irrespective of dimensionality.
+
         Examples
         --------
         >>> x = np.array([3, 1, 2])
@@ -418,13 +421,14 @@ class _Symbol(Symbol):
         >>> np.argsort(x, axis=1)  # sorts along last axis (across)
         array([[0., 1.],
             [0., 1.]])
+
         Notes
         -----
         This function differs from the original `numpy.mean
         <https://docs.scipy.org/doc/numpy/reference/generated/numpy.argsort.html>`_ in
         the following way(s):
 
-        - kind and order is currently not supported
+        - kind and order are currently not supported
         """
         if kind != 'quicksort':
             raise AttributeError('mxnet.numpy.argsort does not support other sorting methods')

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -33,7 +33,7 @@ __all__ = ['zeros', 'ones', 'maximum', 'minimum', 'stack', 'concatenate', 'arang
            'clip', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'split', 'swapaxes',
            'expand_dims', 'tile', 'linspace', 'sin', 'cos', 'sinh', 'cosh', 'log10', 'sqrt',
            'abs', 'exp', 'arctan', 'sign', 'log', 'degrees', 'log2', 'rint', 'radians', 'mean',
-           'reciprocal', 'square', 'arcsin']
+           'reciprocal', 'square', 'arcsin', 'argsort']
 
 
 def _num_outputs(sym):
@@ -379,13 +379,58 @@ class _Symbol(Symbol):
         """
         raise AttributeError('_Symbol object has no attribute topk')
 
-    def argsort(self, *args, **kwargs):
-        """Convenience fluent method for :py:func:`argsort`.
-
-        The arguments are the same as for :py:func:`argsort`, with
-        this array as data.
+    def argsort(self, axis=-1, kind='quicksort', order=None):   # pylint: disable=arguments-differ
         """
-        raise NotImplementedError
+        Returns the indices that would sort an input array along the given axis.
+        This function performs sorting along the given axis and returns an array
+        of indices having same shape as an input array that index data in sorted order.
+        Parameters
+        ----------
+        a : _Symbol
+            Input array
+        axis : int, optional
+            The axis along which to sort teh input tensor.
+            If not given, the last, dimension -1 will be used by default.
+            If None, the flattened array is used.
+        kind: {'quicksort'}
+            Currently not supported.
+        order: None
+            Currently not supported.
+        Returns
+        -------
+        output : ndarray
+        Array of indices that sort a along the specified axis.
+        If a is one-dimensional, a[index_array] yields a sorted a.
+        More generally, np.take_along_axis(a, index_array, axis=a) always yields the sorted a,
+        irrespective of dimensionality.
+        Examples
+        --------
+        >>> x = np.array([3, 1, 2])
+        >>> np.argsort(x)
+        array([1., 2., 0.])
+        >>> x = np.array([[0, 3], [2, 2]])
+        >>> x
+        array([[0., 3.],
+            [2., 2.]])
+        >>> np.argsort(x, axis=0)  # sorts along first axis (down)
+        array([[0., 1.],
+            [1., 0.]])
+        >>> np.argsort(x, axis=1)  # sorts along last axis (across)
+        array([[0., 1.],
+            [0., 1.]])
+        Notes
+        -----
+        This function differs from the original `numpy.mean
+        <https://docs.scipy.org/doc/numpy/reference/generated/numpy.argsort.html>`_ in
+        the following way(s):
+
+        - kind and order is currently not supported
+        """
+        if kind != 'quicksort':
+            raise AttributeError('mxnet.numpy.argsort does not support other sorting methods')
+        if order is not None:
+            raise AttributeError('mxnet.numpy.argsort does not support sorting with fields ordering')
+        return _npi.argsort(self, axis)
 
     def argmax_channel(self, *args, **kwargs):
         """Convenience fluent method for :py:func:`argmax_channel`.
@@ -1258,6 +1303,60 @@ def argmax(a, axis=None, out=None):
 
     """
     return _npi.argmax(a, axis=axis, keepdims=False, out=out)
+
+
+@set_module('mxnet.symbol.numpy')
+def argsort(a, axis=-1, kind='quicksort', order=None):
+    """
+    Returns the indices that would sort an input array along the given axis.
+    This function performs sorting along the given axis and returns an array
+    of indices having same shape as an input array that index data in sorted order.
+    Parameters
+    ----------
+    a : _Symbol
+        Input array
+    axis : int, optional
+        The axis along which to sort teh input tensor.
+        If not given, the last, dimension -1 will be used by default.
+        If None, the flattened array is used.
+    kind: {'quicksort'}
+        Currently not supported.
+    order: None
+        Currently not supported.
+    Returns
+    -------
+    output : _Symbol
+        Array of indices that sort a along the specified axis.
+        If a is one-dimensional, a[index_array] yields a sorted a.
+        More generally, np.take_along_axis(a, index_array, axis=a) always yields the sorted a,
+        irrespective of dimensionality.
+    Examples
+    --------
+    >>> x = np.array([3, 1, 2])
+    >>> np.argsort(x)
+    array([1., 2., 0.])
+    >>> x = np.array([[0, 3], [2, 2]])
+    >>> x
+    array([[0., 3.],
+           [2., 2.]])
+    >>> np.argsort(x, axis=0)  # sorts along first axis (down)
+    array([[0., 1.],
+           [1., 0.]])
+    >>> np.argsort(x, axis=1)  # sorts along last axis (across)
+    array([[0., 1.],
+           [0., 1.]])
+    Notes
+    -----
+    This function differs from the original `numpy.argsort
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.argsort.html>`_ in
+    the following way(s):
+    - kind and order is currently not supported
+    """
+    if kind != 'quicksort':
+        raise AttributeError('mxnet.numpy.argsort does not support other sorting methods')
+    if order is not None:
+        raise AttributeError('mxnet.numpy.argsort does not support sorting with fields ordering')
+    return _npi.argsort(a, axis)
 
 
 @set_module('mxnet.symbol.numpy')

--- a/src/operator/tensor/ordering_op-inl.h
+++ b/src/operator/tensor/ordering_op-inl.h
@@ -580,18 +580,38 @@ void ArgSort(const nnvm::NodeAttrs& attrs,
              const std::vector<OpReqType>& req,
              const std::vector<TBlob>& outputs) {
   const ArgSortParam& param = nnvm::get<ArgSortParam>(attrs.parsed);
-  TopKParam topk_param;
-  topk_param.axis = param.axis;
-  topk_param.is_ascend = param.is_ascend;
-  topk_param.k = 0;
-  topk_param.dtype = param.dtype;
-  topk_param.ret_typ = topk_enum::kReturnIndices;
-  MXNET_NO_FLOAT16_TYPE_SWITCH(inputs[0].type_flag_, DType, {
-    MSHADOW_TYPE_SWITCH(param.dtype, IDType, {
-      TopKImpl<xpu, DType, IDType>(ctx.run_ctx,
-                                   ctx.requested[0], req, inputs[0], outputs, topk_param);
+
+  if (inputs[0].shape_.ndim() == 0) {
+  // Scalar tensor only accept axis of value 0, -1 or None
+    CHECK(!static_cast<bool>(param.axis) || param.axis.value() == -1 || param.axis.value() == 0)
+      << "Axis can only be -1 or 0 for scalor tensor";
+    MSHADOW_TYPE_SWITCH(param.dtype, DType, {
+      Stream<xpu> *s = ctx.get_stream<xpu>();
+      Tensor<xpu, 1, DType> outdata = outputs[0].get_with_shape<xpu, 1, DType>(Shape1(1), s);
+      ASSIGN_DISPATCH(outdata, OpReqType::kWriteTo, 0);
     });
-  });
+  } else if (inputs[0].shape_.Size() == 0) {
+    // If the input tensor is zero size, only a check on axis is needed
+    if (static_cast<bool>(param.axis)) {
+      int axis = param.axis.value();
+      if (axis < 0) axis += inputs[0].shape_.ndim();
+      CHECK(axis >= 0 && axis < inputs[0].shape_.ndim())
+        << "Axis must be within the range of input tensor's dimension";
+    }
+  } else {
+    TopKParam topk_param;
+    topk_param.axis = param.axis;
+    topk_param.is_ascend = param.is_ascend;
+    topk_param.k = 0;
+    topk_param.dtype = param.dtype;
+    topk_param.ret_typ = topk_enum::kReturnIndices;
+    MXNET_NO_FLOAT16_TYPE_SWITCH(inputs[0].type_flag_, DType, {
+      MSHADOW_TYPE_SWITCH(param.dtype, IDType, {
+        TopKImpl<xpu, DType, IDType>(ctx.run_ctx,
+                                     ctx.requested[0], req, inputs[0], outputs, topk_param);
+      });
+    });
+  }
 }
 
 template<typename xpu, typename DType, typename IDType>
@@ -824,12 +844,21 @@ inline bool ArgSortShape(const nnvm::NodeAttrs& attrs,
                          mxnet::ShapeVector *in_attrs,
                          mxnet::ShapeVector *out_attrs) {
   const ArgSortParam& param = nnvm::get<ArgSortParam>(attrs.parsed);
-  TopKParam topk_param;
-  topk_param.axis = param.axis;
-  topk_param.is_ascend = param.is_ascend;
-  topk_param.k = 0;
-  topk_param.ret_typ = topk_enum::kReturnIndices;
-  return TopKShapeImpl(topk_param, in_attrs, out_attrs);
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  mxnet::TShape& in_shape = (*in_attrs)[0];
+
+  if (in_shape.ndim() == 0) {
+    mxnet::TShape target_shape({1});
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, target_shape);
+  } else if (!static_cast<bool>(param.axis)) {
+    mxnet::TShape target_shape(Shape1(in_shape.Size()));
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, target_shape);
+  } else {
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, in_shape);
+  }
+
+  return true;
 }
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/ordering_op.cc
+++ b/src/operator/tensor/ordering_op.cc
@@ -176,6 +176,7 @@ Examples::
   // flatten and then sort
   argsort(x) = [ 3.,  1.,  5.,  0.,  4.,  2.]
 )code" ADD_FILELINE)
+.add_alias("_npi_argsort")
 .set_num_inputs(1)
 .set_num_outputs(1)
 .set_attr_parser(ParamParser<ArgSortParam>)


### PR DESCRIPTION
## Description ##
Numpy compatible argsort with existing kernals.
[Numpy argsort API](https://docs.scipy.org/doc/numpy/reference/generated/numpy.argsort.html)
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Modify the `ArgSortShape` and `ArgSort` function in src/operator/tensor/ordering_op-inl.h to accommodate the following cases:
#### Tensor types
- [x] Scalor tensor 
- [x] Zero-size tensor
- [x] Other tensor
#### Axis types
- [x] Default: -1, last axis is used
- [x] None: flattened array is used
- [x] Other integer in range `[0, input.ndim()-1]` or `[-input.ndim(), -1]`
## Comments ##
This is new PR dedicated to replace my last PR on argsort, which has messed up commits.
Thank @reminisce and @haojin2 for reviewing
