### PR TITLE
CI: upgrade Julia version from 1.0.3 to 1.0.4

### DIFF
--- a/ci/docker/install/ubuntu_julia.sh
+++ b/ci/docker/install/ubuntu_julia.sh
@@ -40,4 +40,4 @@ function install_julia() {
 }
 
 install_julia 0.7 0.7.0
-install_julia 1.0 1.0.3
+install_julia 1.0 1.0.4


### PR DESCRIPTION
This is a bugfix release. No breaking changes.
see: https://julialang.org/downloads/
