### PR TITLE
fix heap-use-after-free in scala

### DIFF
--- a/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
+++ b/scala-package/native/src/main/native/org_apache_mxnet_native_c_api.cc
@@ -247,9 +247,6 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxImperativeInvokeEx
                                cParamVals,
                                &cOutStypes);
   env->ReleaseLongArrayElements(inputs, cInputs, 0);
-  if (cOutputsGiven) {
-    env->ReleaseLongArrayElements(outputsGiven, cOutputsGiven, 0);
-  }
 
   // release allocated memory
   if (numParams > 0) {
@@ -282,6 +279,10 @@ JNIEXPORT jint JNICALL Java_org_apache_mxnet_LibInfo_mxImperativeInvokeEx
                             env->NewObject(intCls, intConst,
                             cOutStypes[i]));
     }
+  }
+
+  if (cOutputsGiven) {
+    env->ReleaseLongArrayElements(outputsGiven, cOutputsGiven, 0);
   }
 
   return ret;


### PR DESCRIPTION
## Description ##
As title, detected by running java examples with ASAN build of mxnet and scala jni lib.

The `cOutputsGiven` should be released after all usages of `cOutputs`.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
