### PR TITLE
Fix memory leak reported by ASAN in NNVM to ONNX conversion

### DIFF
--- a/src/operator/subgraph/tensorrt/nnvm_to_onnx.cc
+++ b/src/operator/subgraph/tensorrt/nnvm_to_onnx.cc
@@ -519,21 +519,18 @@ void ConvertConstant(
   auto size = shape.Size();
 
   if (dtype == TensorProto_DataType_FLOAT) {
-    std::shared_ptr<float> shared_data_ptr(new float[size]);
-    float* const data_ptr = shared_data_ptr.get();
-    nd.SyncCopyToCPU(static_cast<void*>(data_ptr), size);
-
-    for (size_t blob_idx = 0; blob_idx < size; ++blob_idx) {
-      initializer_proto->add_float_data(data_ptr[blob_idx]);
-    }
+      std::vector<float> constants(size);
+      nd.SyncCopyToCPU(constants.data(), size);
+      for (const auto& constant : constants) {
+          initializer_proto->add_float_data(constant);
+      }
   } else if (dtype == TensorProto_DataType_FLOAT16) {
-    std::shared_ptr<uint16_t> shared_data_ptr(new uint16_t[size]);
-    uint16_t* const data_ptr = shared_data_ptr.get();
-    nd.SyncCopyToCPU(static_cast<void*>(data_ptr), size);
-    for (size_t blob_idx = 0; blob_idx < size; ++blob_idx) {
-      initializer_proto->add_int32_data(
-          reinterpret_cast<int32_t*>(data_ptr)[blob_idx]);
-    }
+      std::vector<uint16_t> constants(size);
+      nd.SyncCopyToCPU(constants.data(), size);
+      for (const auto& constant : constants) {
+          initializer_proto->add_int32_data(
+                  reinterpret_cast<int32_t&>(constant));
+      }
   } else {
     LOG(FATAL) << "dtype not supported for variables: " << node_name;
   }


### PR DESCRIPTION
## Description ##
Fix memory leak reported by ASAN in NNVM to ONNX conversion of a constant.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fixed a memory leak in NNVM to ONNX constants conversion code. The `shared_ptr`, as written, does not call `delete[]` on a dynamically allocated array.

## Comments ##