### PR TITLE
[Doc] broadcast axis is alias to broadcast axes

### DIFF
--- a/src/operator/tensor/broadcast_reduce_op_value.cc
+++ b/src/operator/tensor/broadcast_reduce_op_value.cc
@@ -221,6 +221,8 @@ MXNET_OPERATOR_REGISTER_BROADCAST(broadcast_axis)
 Broadcasting is allowed on axes with size 1, such as from `(2,1,3,1)` to
 `(2,8,3,9)`. Elements will be duplicated on the broadcasted axes.
 
+`broadcast_axes` is an alias to the function `broadcast_axis`.
+
 Example::
 
    // given x of shape (1,2,1)


### PR DESCRIPTION
## Description ##
Minor doc fix - doc doesn't mention that broadcast_axis and broadcast_axes are same (one is alias of the other)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] Code is well-documented: 
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] doc fix
