### PR TITLE
website build for julia: fix path to be static

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1210,6 +1210,16 @@ test_ubuntu_cpu_python3() {
 build_docs() {
     set -ex
     pushd .
+
+    # Setup environment for Julia docs
+    export PATH="/work/julia10/bin:$PATH"
+    export MXNET_HOME='/work/mxnet'
+    export JULIA_DEPOT_PATH='/work/julia-depot'
+
+    julia -e 'using InteractiveUtils; versioninfo()'
+    export LD_PRELOAD='/usr/lib/x86_64-linux-gnu/libjemalloc.so'
+    export LD_LIBRARY_PATH=/work/mxnet/lib:$LD_LIBRARY_PATH
+
     cd /work/mxnet/docs/build_version_doc
     # Parameters are set in the Jenkins pipeline: restricted-website-build
     # $1: the list of branches/tags to build

--- a/docs/build_version_doc/build_all_version.sh
+++ b/docs/build_version_doc/build_all_version.sh
@@ -46,17 +46,6 @@ set -x
 # Set OPTS to any Sphinx build options, like -W for "warnings as errors"
 OPTS=
 
-# Setup environment for Julia docs
-export PATH="$1/bin:$PATH"
-export MXNET_HOME='/work/mxnet'
-export JULIA_DEPOT_PATH='/work/julia-depot'
-export INTEGRATION_TEST=1
-
-julia -e 'using InteractiveUtils; versioninfo()'
-export LD_PRELOAD='/usr/lib/x86_64-linux-gnu/libjemalloc.so'
-export LD_LIBRARY_PATH=/work/mxnet/lib:$LD_LIBRARY_PATH
-
-
 # $1 is the list of branches/tags to build
 if [ -z "$1" ]
   then


### PR DESCRIPTION
## Description ##
This patch fixes the bug in my previous PR for Julia on the website. Third time's a charm. I now have a way to test this all the way through and closer to CI. I moved the logic back to `runtime_functions.sh` because having it in the `build_all_version.sh` script will break regular local testing.

This command uses this branch as a source, gets the new config with updated `PATH` and in my tests, it now finds Julia in the Docker container.

```
ci/build.py --platform ubuntu_cpu /work/runtime_functions.sh build_docs "julia_path_patch" "master" https://github.com/aaronmarkham/incubator-mxnet.git

```