### PR TITLE
Julia path patch

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1210,6 +1210,16 @@ test_ubuntu_cpu_python3() {
 build_docs() {
     set -ex
     pushd .
+
+    # Setup environment for Julia docs
+    export PATH="/work/julia10/bin:$PATH"
+    export MXNET_HOME='/work/mxnet'
+    export JULIA_DEPOT_PATH='/work/julia-depot'
+
+    julia -e 'using InteractiveUtils; versioninfo()'
+    export LD_PRELOAD='/usr/lib/x86_64-linux-gnu/libjemalloc.so'
+    export LD_LIBRARY_PATH=/work/mxnet/lib:$LD_LIBRARY_PATH
+
     cd /work/mxnet/docs/build_version_doc
     # Parameters are set in the Jenkins pipeline: restricted-website-build
     # $1: the list of branches/tags to build

--- a/docs/build_version_doc/build_all_version.sh
+++ b/docs/build_version_doc/build_all_version.sh
@@ -46,17 +46,6 @@ set -x
 # Set OPTS to any Sphinx build options, like -W for "warnings as errors"
 OPTS=
 
-# Setup environment for Julia docs
-export PATH="$1/bin:$PATH"
-export MXNET_HOME='/work/mxnet'
-export JULIA_DEPOT_PATH='/work/julia-depot'
-export INTEGRATION_TEST=1
-
-julia -e 'using InteractiveUtils; versioninfo()'
-export LD_PRELOAD='/usr/lib/x86_64-linux-gnu/libjemalloc.so'
-export LD_LIBRARY_PATH=/work/mxnet/lib:$LD_LIBRARY_PATH
-
-
 # $1 is the list of branches/tags to build
 if [ -z "$1" ]
   then

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -98,7 +98,7 @@ def build_mxnet(app):
 
 def build_julia_docs(app):
     """build Julia docs"""
-    os.environ['MXNET_HOME'] = str(os.path.abspath('{}/..'.format(app.builder.srcdir)))
+    os.environ['MXNET_HOME'] = os.path.abspath(os.path.join(app.builder.srcdir, '..'))
     print("Julia will check for MXNet in {}/lib".format(os.environ.get('MXNET_HOME')))
     dest_path = app.builder.outdir + '/api/julia/site'
     _run_cmd('cd {}/.. && make -C julia/docs'.format(app.builder.srcdir))

--- a/docs/mxdoc.py
+++ b/docs/mxdoc.py
@@ -98,6 +98,8 @@ def build_mxnet(app):
 
 def build_julia_docs(app):
     """build Julia docs"""
+    os.environ['MXNET_HOME'] = str(os.path.abspath('{}/..'.format(app.builder.srcdir)))
+    print("Julia will check for MXNet in {}/lib".format(os.environ.get('MXNET_HOME')))
     dest_path = app.builder.outdir + '/api/julia/site'
     _run_cmd('cd {}/.. && make -C julia/docs'.format(app.builder.srcdir))
     _run_cmd('mkdir -p {}'.format(dest_path))


### PR DESCRIPTION
## Description ##
Another followup PR to fix the Julia site build and unblock website publishing...
Since the website builds so many versions, it does so in their own folders inside `/mxnet/docs/build_version_doc/apache-mxnet/...` and this makes it difficult for Julia to find when it's expecting the binaries in `/work/mxnet/lib`. After digging through the Julia source and testing a bunch of things I found that `$LD_LIBRARY_PATH` doesn't seem to do anything, but `$MXNET_HOME` is what Julia is looking for. It then manually appends `lib`. 
Unfortunately, according to the [MXNet environment variables](https://mxnet.incubator.apache.org/versions/master/faq/env_var.html) page, this same env var is used elsewhere to store models in `.mxnet`, not a typical `$HOME/incubator-mxnet` or what is often called `$MXNET_ROOT` in tutorials.

Unblocking website publishing is my primary goal, not dealing with conflicting environment variables, so I'm patching this for now, but I think the Julia package should updated to use `$MXNET_LIBRARY_PATH` or `$LD_LIBRARY_PATH` instead. 

My test run used a test CI pipeline that points to my fork:
http://jenkins.mxnet-ci.amazon-ml.com/job/test-website-build/

The "successful" run was here. It fails because there's no place to publish, which is fine. Everything else worked: http://jenkins.mxnet-ci.amazon-ml.com/job/test-website-build/3/console
We might want to keep this test pipeline around... it took me awhile to remember how to create one for testing, and I definitely should have done this thorough test in the first place.

It was able to find Julia, and it used the locally compiled binary based off of the target branch: this one.

I'm hoping this is the last surprise that the CI environment is going to give me for getting Julia to publish.

Previous PRs for the Julia docs publishing:
https://github.com/apache/incubator-mxnet/pull/15554
https://github.com/apache/incubator-mxnet/pull/15523
https://github.com/apache/incubator-mxnet/pull/15454