### PR TITLE
fix naive engine for multi-threaded inference

### DIFF
--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -155,9 +155,9 @@ class NaiveEngine final : public Engine {
                  int priority = 0,
                  const char* opr_name = nullptr,
                  bool wait = false) override {
+    bool req_completed = false;
     CallbackOnComplete callback = CreateCallback(
-        NaiveEngine::OnComplete, nullptr);
-    this->req_completed_ = false;
+        NaiveEngine::OnComplete, &req_completed);
     profiler::Profiler *profiler = profiler::Profiler::Get();
     auto opr_deleter = [this](NaiveOpr* p) {
       this->DeleteOperator(p);
@@ -202,7 +202,7 @@ class NaiveEngine final : public Engine {
     for (auto var : mutable_vars) {
       ++var->version_;
     }
-    CHECK(this->req_completed_)
+    CHECK(req_completed)
         << "NaiveEngine only support synchronize Push so far";
     if (profiling) {
       opr->opr_profile->stop();
@@ -235,14 +235,9 @@ class NaiveEngine final : public Engine {
   // callback to oncomplete
   static void OnComplete(Engine *engine, void *param,
                          const dmlc::Error* error) {
-    static_cast<NaiveEngine*>(engine)->req_completed_ = true;
+    bool *req_completed = static_cast<bool*>(param);
+    *req_completed = true;
   }
-  // whether action is completed
-#if DMLC_CXX11_THREAD_LOCAL
-  static thread_local bool req_completed_;
-#else
-  static MX_THREAD_LOCAL bool req_completed_;
-#endif
   /*! \brief whether it is during shutdown phase*/
   std::atomic<bool> shutdown_phase_{false};
   // CPU stream
@@ -265,12 +260,6 @@ class NaiveEngine final : public Engine {
 Engine *CreateNaiveEngine() {
   return new NaiveEngine();
 }
-
-#if DMLC_CXX11_THREAD_LOCAL
-thread_local bool NaiveEngine::req_completed_ = false;
-#else
-MX_THREAD_LOCAL bool NaiveEngine::req_completed_ = false;
-#endif
 
 }  // namespace engine
 }  // namespace mxnet

--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -238,7 +238,11 @@ class NaiveEngine final : public Engine {
     static_cast<NaiveEngine*>(engine)->req_completed_ = true;
   }
   // whether action is completed
-  bool req_completed_;
+#if DMLC_CXX11_THREAD_LOCAL
+  static thread_local bool req_completed_;
+#else
+  static MX_THREAD_LOCAL bool req_completed_;
+#endif
   /*! \brief whether it is during shutdown phase*/
   std::atomic<bool> shutdown_phase_{false};
   // CPU stream
@@ -261,5 +265,12 @@ class NaiveEngine final : public Engine {
 Engine *CreateNaiveEngine() {
   return new NaiveEngine();
 }
+
+#if DMLC_CXX11_THREAD_LOCAL
+thread_local bool NaiveEngine::req_completed_ = false;
+#else
+MX_THREAD_LOCAL bool NaiveEngine::req_completed_ = false;
+#endif
+
 }  // namespace engine
 }  // namespace mxnet


### PR DESCRIPTION
## Description ##
In the [cpp example of image classification](https://github.com/apache/incubator-mxnet/tree/master/example/image-classification/predict-cpp), `MXPredCreateMultiThread` is used to perform multi-threaded inference with naive engine. The `req_completed_` variable in naive engine is not thread-safe, which is fixed in this PR.

The problem is reported in #8966.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
