### PR TITLE
Make Clojure API Generator Tests Less Brittle

### DIFF
--- a/contrib/clojure-package/test/dev/generator_test.clj
+++ b/contrib/clojure-package/test/dev/generator_test.clj
@@ -17,7 +17,14 @@
 
 (ns dev.generator-test
   (:require [clojure.test :refer :all]
-            [dev.generator :as gen]))
+            [dev.generator :as gen]
+            [clojure.string :as string]))
+
+(defn file-function-name [f]
+  (->> (string/split (slurp f) #"\n")
+       (take 33)
+       last
+       (string/trim)))
 
 (deftest test-clojure-case
   (is (= "foo-bar" (gen/clojure-case "FooBar")))
@@ -334,20 +341,20 @@
           fns (gen/all-symbol-api-functions gen/op-names)
           _ (gen/write-to-file [(first fns) (second fns)]
                                (gen/symbol-api-gen-ns false)
-                               fname)
-          good-contents (slurp "test/good-test-symbol-api.clj")
-          contents (slurp fname)]
-      (is (= good-contents contents))))
+                               fname)]
+      (is (= "activation"
+             (file-function-name "test/good-test-symbol-api.clj")
+             (file-function-name fname)))))
 
   (testing "symbol-random-api"
     (let [fname "test/test-symbol-random-api.clj"
           fns (gen/all-symbol-random-api-functions gen/op-names)
           _ (gen/write-to-file [(first fns) (second fns)]
                                (gen/symbol-api-gen-ns true)
-                               fname)
-          good-contents (slurp "test/good-test-symbol-random-api.clj")
-          contents (slurp fname)]
-      (is (= good-contents contents))))
+                               fname)]
+      (is (= "exponential"
+             (file-function-name "test/good-test-symbol-random-api.clj")
+             (file-function-name fname)))))
 
 
  (testing "symbol"
@@ -364,20 +371,20 @@
           fns (gen/all-ndarray-api-functions gen/op-names)
           _ (gen/write-to-file [(first fns) (second fns)]
                                (gen/ndarray-api-gen-ns false)
-                               fname)
-          good-contents (slurp "test/good-test-ndarray-api.clj")
-          contents (slurp fname)]
-      (is (= good-contents contents))))
+                               fname)]
+      (is (= "activation"
+             (file-function-name "test/good-test-ndarray-api.clj")
+             (file-function-name fname)))))
 
   (testing "ndarray-random-api"
     (let [fname "test/test-ndarray-random-api.clj"
           fns (gen/all-ndarray-random-api-functions gen/op-names)
           _ (gen/write-to-file [(first fns) (second fns)]
                                (gen/ndarray-api-gen-ns true)
-                               fname)
-          good-contents (slurp "test/good-test-ndarray-random-api.clj")
-          contents (slurp fname)]
-      (is (= good-contents contents))))
+                               fname)]
+      (is (= "exponential"
+             (file-function-name "test/good-test-ndarray-random-api.clj")
+             (file-function-name fname)))))
 
   (testing "ndarray"
     (let [fname "test/test-ndarray.clj"


### PR DESCRIPTION
## Description ##
Address https://github.com/apache/incubator-mxnet/issues/15571

This makes the api generator tests less brittle. The generated apis contain documentation with the source line numbers from the c code. The tests broke whenever the underlying code changed. 
This PR makes it so it just compares the generated function name and not the full generated code.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

