### PR TITLE
Add omp parallel optimization for _contrib_BilinearReisze2D

### DIFF
--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -1144,6 +1144,22 @@ def test_flatten_slice_after_conv():
 
 
 @with_seed()
+def test_bilinear_resize_op():
+    ctx_list = [{'ctx': mx.cpu(0), 'data': (2, 2, 20, 20), 'type_dict': {'data': np.float32}},
+                {'ctx': mx.gpu(0), 'data': (2, 2, 20, 20), 'type_dict': {'data': np.float32}}]
+
+    data = mx.sym.Variable('data')
+    sym = mx.sym.contrib.BilinearResize2D(data, height=10, width=5)
+    check_consistency(sym, ctx_list)
+
+    sym = mx.sym.contrib.BilinearResize2D(data, None, scale_height=2, scale_width=0.5, mode='odd_scale')
+    check_consistency(sym, ctx_list)
+
+    sym = mx.sym.contrib.BilinearResize2D(data, None, scale_height=0.5, scale_width=2, mode='to_even_up')
+    check_consistency(sym, ctx_list)
+
+
+@with_seed()
 def test_global_pooling():
     def test_1d_pooling(pool_type, p_value=2):
         data = (2, 3, 20)

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -7525,7 +7525,7 @@ def test_bilinear_resize_op():
                 w1r = 1.0 * w2 * rwidth
                 w1 = int(np.floor(w1r))
                 w1lambda = w1r - w1
-                w1p = 1 if w1 < (inputHeight - 1) else 0
+                w1p = 1 if w1 < (inputWidth - 1) else 0
                 for b in range(batch):
                     for c in range(channel):
                         y[b][c][h2][w2] = (1-h1lambda)*((1-w1lambda)*x[b][c][h1][w1] + \


### PR DESCRIPTION
## Description ##
This PR aims to improve the performance of `_contrib_BilinearReisze2D` via omp parallel optimization. 
This will be a great help to deploy Fully Convolutional Network model on CPU. @pengzhao-intel @ZhennanQin @TaoLv @zhanghang1989 

The below table shows the speedup between w/ OMP and w/o OMP.

Before   resize | After resize | w/o OMP  (ms) | w/ OMP 28 cores   (ms) | Speedup
-- | -- | -- | -- | --
shape: (1, 32,   32, 32) | shape: (1, 32, 480,   480) | 25.643921 | 5.877519 | **4.36**
shape: (2, 64,   32, 32) | shape: (2, 64, 480,   480) | 134.311175 | 32.115507 | **4.18**
shape: (1,   128, 64, 64) | shape: (1, 128, 480,   480) | 126.516438 | 34.05602 | **3.71**
shape: (32,   32, 32, 32) | shape: (32, 32, 480,   480) | 2262.586236 | 341.702771 | **6.62**
shape: (32,   32, 64, 64) | shape: (32, 32, 480,   480) | 2201.238561 | 339.254451 | **6.49**



## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
