### PR TITLE
Export symbols for checking cuda/cudnn versions

### DIFF
--- a/make/config/libmxnet.sym
+++ b/make/config/libmxnet.sym
@@ -13,3 +13,4 @@ Java_org_apache_mxnet*
 *on_enter_api*
 *on_exit_api*
 *MXAPISetLastError*
+*LibCheck*

--- a/make/config/libmxnet.ver
+++ b/make/config/libmxnet.ver
@@ -15,5 +15,6 @@
         *on_enter_api*;
         *on_exit_api*;
         *MXAPISetLastError*;
+        *LibCheck*;
     local: *;
 };


### PR DESCRIPTION
Fixes #15578 

Two functions (CudaLibChecks and CuDNNLibChecks) were added in #15551 to fix #15548. These two functions need to be exported in our pip package such that downstream projects consuming mxnet library will not encounter [undefined symbol error](https://github.com/horovod/horovod/issues/1217#issuecomment-512680079) as shown below:

```
OSError: /home/ubuntu/anaconda3/envs/mxnet_p36/lib/python3.6/site-packages/horovod/mxnet/mpi_lib.cpython-36m-x86_64-linux-gnu.so: undefined symbol: _ZN5mxnet7Context13CudaLibChecksEv
```
