### PR TITLE
julia: bump Windows prebult binary version to v1.5.0

### DIFF
--- a/julia/REQUIRE
+++ b/julia/REQUIRE
@@ -1,6 +1,0 @@
-julia 0.7
-Formatting
-BinDeps
-JSON
-MacroTools
-Reexport


### PR DESCRIPTION
- remove file REQUIRE, it's stale for Pkg3.jl
- this patch has been included in the Julia package v1.5.x branch (https://github.com/dmlc/MXNet.jl/commit/73e0fba911539bf074ee9de71d09541ec5368480)