### PR TITLE
[fix] print `self` in warning.

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -842,9 +842,9 @@ class HybridBlock(Block):
         self._flags = list(kwargs.items())
         self._clear_cached_op()
         if active and self._forward_hooks or self._forward_pre_hooks:
-            warnings.warn('"{}" is being hybridized while still having forward hook/pre-hook. '
-                          'If "{}" is a child of HybridBlock, the hooks will not take effect.'
-                          .format(self, self))
+            warnings.warn('"%s" is being hybridized while still having forward hook/pre-hook. '
+                          'If "%s" is a child of HybridBlock, the hooks will not take effect.'
+                          %(str(self), str(self)))
         super(HybridBlock, self).hybridize(active, **kwargs)
 
     def cast(self, dtype):

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -842,9 +842,9 @@ class HybridBlock(Block):
         self._flags = list(kwargs.items())
         self._clear_cached_op()
         if active and self._forward_hooks or self._forward_pre_hooks:
-            warnings.warn('"%s" is being hybridized while still having forward hook/pre-hook. '
-                          'If "%s" is a child of HybridBlock, the hooks will not take effect.'
-                          %(str(self), str(self)))
+            warnings.warn('"{block}" is being hybridized while still having forward hook/pre-hook. '
+                          'If "{block}" is a child of HybridBlock, the hooks will not take effect.'
+                          .format(block=self))
         super(HybridBlock, self).hybridize(active, **kwargs)
 
     def cast(self, dtype):

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -843,7 +843,8 @@ class HybridBlock(Block):
         self._clear_cached_op()
         if active and self._forward_hooks or self._forward_pre_hooks:
             warnings.warn('"{}" is being hybridized while still having forward hook/pre-hook. '
-                          'If "{}" is a child of HybridBlock, the hooks will not take effect.')
+                          'If "{}" is a child of HybridBlock, the hooks will not take effect.'
+                          .format(self, self))
         super(HybridBlock, self).hybridize(active, **kwargs)
 
     def cast(self, dtype):


### PR DESCRIPTION
Before this:
```
/home/user/Desktop/Repositories/mxnet/incubator-mxnet/python/mxnet/gluon/block.py:845: UserWarning: "{}" is being hybridized while still having forward hook/pre-hook. If "{}" is a child of HybridBlock, the hooks will not take effect.
  warnings.warn('"{}" is being hybridized while still having forward hook/pre-hook. '
```

After this:
```
/home/user/Desktop/Repositories/mxnet/incubator-mxnet/python/mxnet/gluon/block.py:847: UserWarning: "Dense(120 -> 84, linear)" is being hybridized while still having forward hook/pre-hook. If "Dense(120 -> 84, linear)" is a child of HybridBlock, the hooks will not take effect.
  .format(self, self))
```