### PR TITLE
[OpPerf] PDF Random ops fix

### DIFF
--- a/benchmark/opperf/README.md
+++ b/benchmark/opperf/README.md
@@ -75,7 +75,7 @@ For example, you want to run benchmarks for all NDArray Broadcast Binary Operato
 
 ```
 #!/usr/bin/python
-from benchmark.opperf.tensor_operations.binary_broadcast_operators import run_mx_binary_broadcast_operators_benchmarks
+from benchmark.opperf.nd_operations.binary_broadcast_operators import run_mx_binary_broadcast_operators_benchmarks
 
 # Run all Binary Broadcast operations benchmarks with default input values
 print(run_mx_binary_broadcast_operators_benchmarks())

--- a/benchmark/opperf/rules/default_params.py
+++ b/benchmark/opperf/rules/default_params.py
@@ -34,7 +34,7 @@ DEFAULT_RHS = [[(1024, 1024), (10000, 10), (10000, 1)]]
 
 # For operators like - random_uniform, random_normal etc..
 DEFAULT_SHAPE = [(1024, 1024), (10000, 1), (10000, 100)]
-DEFAULT_SAMPLE = [(1, 2), (1, 10000, 2), (1, 10, 100, 2)]
+DEFAULT_SAMPLE = [(2,)]
 DEFAULT_LOW = [0]
 DEFAULT_HIGH = [5]
 DEFAULT_K = [1]

--- a/benchmark/opperf/rules/default_params.py
+++ b/benchmark/opperf/rules/default_params.py
@@ -34,6 +34,7 @@ DEFAULT_RHS = [[(1024, 1024), (10000, 10), (10000, 1)]]
 
 # For operators like - random_uniform, random_normal etc..
 DEFAULT_SHAPE = [(1024, 1024), (10000, 1), (10000, 100)]
+DEFAULT_SAMPLE = [(1, 2), (1, 10000, 2), (1, 10, 100, 2)]
 DEFAULT_LOW = [0]
 DEFAULT_HIGH = [5]
 DEFAULT_K = [1]
@@ -64,6 +65,7 @@ DEFAULT_AXIS = [0]
 
 # Default Inputs. MXNet Op Param Name to Default Input mapping
 DEFAULTS_INPUTS = {"data": DEFAULT_DATA,
+                   "sample": DEFAULT_SAMPLE,
                    "lhs": DEFAULT_LHS,
                    "rhs": DEFAULT_RHS,
                    "shape": DEFAULT_SHAPE,
@@ -88,6 +90,6 @@ DEFAULTS_INPUTS = {"data": DEFAULT_DATA,
 # given as NDArray and translate users inputs such as a shape tuple, Numpy Array or
 # a list to MXNet NDArray. This is just a convenience added so benchmark utility users
 # can just say shape of the tensor, and we automatically create Tensors.
-PARAMS_OF_TYPE_NDARRAY = ["lhs", "rhs", "data", "base", "exp",
+PARAMS_OF_TYPE_NDARRAY = ["lhs", "rhs", "data", "base", "exp", "sample",
                           "mu", "sigma", "lam", "alpha", "beta", "gamma", "k", "p",
                           "low", "high", "weight", "bias", "moving_mean", "moving_var"]


### PR DESCRIPTION
## Description ##
Fixes #15636 
Newly add PDF Random ops - https://github.com/apache/incubator-mxnet/pull/14617
Caused the opperf.py to error out due to parameter issues.
Hence added new param `sample` to handle that

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] added param
Had to add a param Sample (of type NDArray) so as to cater to all the random_pdf_* functions.
Moreover, I tried playing with different shapes and dimensions. Based of various functions and their definitions, it turns out (2,) is the one-size-fits-all solution. Different functions have different requirement and hence its tough to come up with larger shapes that won't give error on any of these functions.
 
## Comments ##
Ran `python benchmark/opperf/opperf.py` successfully without error on CPU & GPU

## Error resolved ##
If you checkout master and run `python benchmark/opperf/opperf.py`
Will give you following error
```
Traceback (most recent call last):
  File "benchmark/opperf/opperf.py", line 157, in <module>
    sys.exit(main())
  File "benchmark/opperf/opperf.py", line 142, in main
    final_benchmark_results = run_all_mxnet_operator_benchmarks(ctx=ctx, dtype=dtype)
  File "benchmark/opperf/opperf.py", line 73, in run_all_mxnet_operator_benchmarks
    mxnet_operator_benchmark_results.append(run_mx_random_sampling_operators_benchmarks(ctx=ctx, dtype=dtype))
  File "/home/ubuntu/workspace/incubator-mxnet/benchmark/opperf/nd_operations/random_sampling_operators.py", line 60, in ru
n_mx_random_sampling_operators_benchmarks
    mx_random_sample_op_results = run_op_benchmarks(mx_random_sample_ops, dtype, ctx, warmup, runs)
  File "/home/ubuntu/workspace/incubator-mxnet/benchmark/opperf/utils/benchmark_utils.py", line 127, in run_op_benchmarks
  warmup=warmup, runs=runs)
  File "/home/ubuntu/workspace/incubator-mxnet/benchmark/opperf/utils/benchmark_utils.py", line 109, in run_performance_tes
t
    benchmark_result = _run_nd_operator_performance_test(op, inputs, run_backward, warmup, runs, kwargs_list)
  File "/home/ubuntu/workspace/incubator-mxnet/benchmark/opperf/utils/benchmark_utils.py", line 54, in _run_nd_operator_performance_test
    _, _ = benchmark_helper_func(op, warmup, **kwargs_list[0])
  File "/home/ubuntu/workspace/incubator-mxnet/benchmark/opperf/utils/profiler_utils.py", line 169, in profile_it
    res = func(*args, **kwargs)
  File "/home/ubuntu/workspace/incubator-mxnet/benchmark/opperf/utils/ndarray_utils.py", line 79, in nd_forward_and_profile
    res = op(*args, **kwargs)
  File "<string>", line 59, in random_pdf_dirichlet
  File "/home/ubuntu/workspace/incubator-mxnet/python/mxnet/_ctypes/ndarray.py", line 92, in _imperative_invoke
    ctypes.byref(out_stypes)))
  File "/home/ubuntu/workspace/incubator-mxnet/python/mxnet/base.py", line 253, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError: [22:17:53] src/c_api/../imperative/imperative_utils.h:369: Check failed: num_inputs == infered_num_i
nputs (1 vs. 2) : Operator _random_pdf_dirichlet expects 2 inputs, but got 1 instead.

Stack trace:                                                                                                       [0/1922]
  [bt] (0) /home/ubuntu/workspace/incubator-mxnet/python/mxnet/../../lib/libmxnet.so(dmlc::LogMessageFatal::~LogMessageFata
l()+0x32) [0x7fdf8a36f1b2]
  [bt] (1) /home/ubuntu/workspace/incubator-mxnet/python/mxnet/../../lib/libmxnet.so(mxnet::imperative::SetNumOutputs(nnvm:
:Op const*, nnvm::NodeAttrs const&, int const&, int*, int*)+0x437) [0x7fdf8d1a4f07]
  [bt] (2) /home/ubuntu/workspace/incubator-mxnet/python/mxnet/../../lib/libmxnet.so(MXImperativeInvokeImpl(void*, int, voi
d**, int*, void***, int, char const**, char const**)+0xa50) [0x7fdf8d1a25a0]
  [bt] (3) /home/ubuntu/workspace/incubator-mxnet/python/mxnet/../../lib/libmxnet.so(MXImperativeInvokeEx+0x534) [0x7fdf8d1
a4234]
  [bt] (4) /home/ubuntu/anaconda3/lib/python3.6/lib-dynload/../../libffi.so.6(ffi_call_unix64+0x4c) [0x7fdfa3a9aec0]
  [bt] (5) /home/ubuntu/anaconda3/lib/python3.6/lib-dynload/../../libffi.so.6(ffi_call+0x22d) [0x7fdfa3a9a87d]
  [bt] (6) /home/ubuntu/anaconda3/lib/python3.6/lib-dynload/_ctypes.cpython-36m-x86_64-linux-gnu.so(_ctypes_callproc+0x2ce)
 [0x7fdfa3cafe2e]
  [bt] (7) /home/ubuntu/anaconda3/lib/python3.6/lib-dynload/_ctypes.cpython-36m-x86_64-linux-gnu.so(+0x12865) [0x7fdfa3cb08
65]
  [bt] (8) python(_PyObject_FastCallDict+0x8b) [0x563b009b2d7b]

```