### PR TITLE
[Numpy] basic slicing in symbolic interface

### DIFF
--- a/python/mxnet/__init__.py
+++ b/python/mxnet/__init__.py
@@ -37,6 +37,7 @@ from . import numpy_extension as npx
 from . import name
 # use mx.sym as short for symbol
 from . import symbol as sym
+from .symbol.numpy import _symbol as np_symbol
 from . import symbol
 from . import symbol_doc
 from . import io

--- a/python/mxnet/_ctypes/ndarray.py
+++ b/python/mxnet/_ctypes/ndarray.py
@@ -70,7 +70,7 @@ def _set_np_ndarray_class(cls):
     _np_ndarray_cls = cls
 
 
-def _imperative_invoke(handle, ndargs, keys, vals, out, is_np_op):
+def _imperative_invoke(handle, ndargs, keys, vals, out, is_np_op, output_is_list):
     """ctypes implementation of imperative invoke wrapper"""
     if out is not None:
         original_output = out
@@ -102,7 +102,7 @@ def _imperative_invoke(handle, ndargs, keys, vals, out, is_np_op):
     create_ndarray_fn = _np_ndarray_cls if is_np_op else _ndarray_cls
     if original_output is not None:
         return original_output
-    if num_output.value == 1:
+    if num_output.value == 1 and not output_is_list:
         return create_ndarray_fn(ctypes.cast(output_vars[0], NDArrayHandle),
                                  stype=out_stypes[0])
     else:

--- a/python/mxnet/_ctypes/symbol.py
+++ b/python/mxnet/_ctypes/symbol.py
@@ -122,7 +122,7 @@ def _set_np_symbol_class(cls):
     _np_symbol_cls = cls
 
 
-def _symbol_creator(handle, args, kwargs, keys, vals, name, is_np_op):
+def _symbol_creator(handle, args, kwargs, keys, vals, name, is_np_op, output_is_list):
     sym_handle = SymbolHandle()
     check_call(_LIB.MXSymbolCreateAtomicSymbol(
         ctypes.c_void_p(handle),
@@ -137,6 +137,11 @@ def _symbol_creator(handle, args, kwargs, keys, vals, name, is_np_op):
             'Symbols either as positional or keyword arguments, not both')
     create_symbol_fn = _np_symbol_cls if is_np_op else _symbol_cls
     s = create_symbol_fn(sym_handle)
+    if is_np_op:
+        if output_is_list:
+            s._output_is_list = True
+        else:
+            s._output_is_list = False
     if args:
         s._compose(*args, name=name)
     elif kwargs:

--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -761,11 +761,18 @@ _NP_EXT_OP_SUBMODULE_LIST = ['_image_']
 
 _NP_INTERNAL_OP_PREFIX = '_npi_'
 
+_NP_OUTPUT_IS_LIST_OPERATORS = ['npi_split']
 
 def _is_np_op(op_name):
     return op_name.startswith(_NP_OP_PREFIX) or op_name.startswith(_NP_EXT_OP_PREFIX)\
            or op_name.startswith(_NP_INTERNAL_OP_PREFIX)
 
+def _output_is_list(op_name):
+    if _is_np_op(op_name):
+        for target_operator_name in _NP_OUTPUT_IS_LIST_OPERATORS:
+            if target_operator_name in op_name:
+                return True
+    return False
 
 def _get_op_submodule_name(op_name, op_name_prefix, submodule_name_list):
     assert op_name.startswith(op_name_prefix)

--- a/python/mxnet/cython/ndarray.pyx
+++ b/python/mxnet/cython/ndarray.pyx
@@ -170,7 +170,7 @@ cdef class CachedOp:
             return [NewArray(p_output_vars[i], p_output_stypes[i], self.is_np_sym) for i in range(num_output)]
 
 
-def _imperative_invoke(handle, ndargs, keys, vals, out, is_np_op=0):
+def _imperative_invoke(handle, ndargs, keys, vals, out, is_np_op=0, output_is_list=0):
     """cython implementation of imperative invoke wrapper"""
     cdef unsigned long long ihandle = handle
     cdef OpHandle chandle = <OpHandle>ihandle
@@ -221,7 +221,7 @@ def _imperative_invoke(handle, ndargs, keys, vals, out, is_np_op=0):
 
     if original_output is not None:
         return original_output
-    if num_output == 1:
+    if num_output == 1 and not output_is_list:
         return NewArray(p_output_vars[0], p_output_stypes[0], is_np_op)
     else:
         return [NewArray(p_output_vars[i], p_output_stypes[i], is_np_op) for i in range(num_output)]

--- a/python/mxnet/cython/symbol.pyx
+++ b/python/mxnet/cython/symbol.pyx
@@ -96,15 +96,20 @@ def _set_np_symbol_class(cls):
     _np_symbol_cls = cls
 
 
-cdef NewSymbol(SymbolHandle handle, int is_np_sym=0):
+cdef NewSymbol(SymbolHandle handle, int is_np_sym=0, int output_is_list=0):
     """Create a new symbol given handle"""
     create_symbol_fn = _np_symbol_cls if is_np_sym else _symbol_cls
     sym = create_symbol_fn(None)
+    if is_np_sym:
+        if output_is_list:
+            sym._output_is_list = True
+        else:
+            sym._output_is_list = False
     (<SymbolBase>sym).chandle = handle
     return sym
 
 
-def _symbol_creator(handle, args, kwargs, keys, vals, name, is_np_op=0):
+def _symbol_creator(handle, args, kwargs, keys, vals, name, is_np_op=0, output_is_list=0):
     cdef unsigned long long ihandle = handle
     cdef OpHandle chandle = <OpHandle>ihandle
     cdef vector[string] ckeys
@@ -151,4 +156,4 @@ def _symbol_creator(handle, args, kwargs, keys, vals, name, is_np_op=0):
         &csym_keys[0] if csym_keys.size() != 0 else NULL,
         &sym_args[0] if sym_args.size() != 0 else NULL))
 
-    return NewSymbol(ret_handle, is_np_op)
+    return NewSymbol(ret_handle, is_np_op, output_is_list)

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -27,7 +27,7 @@ import re
 from collections import OrderedDict
 
 from ..base import mx_real_t, MXNetError
-from .. import symbol, ndarray, initializer
+from .. import symbol, ndarray, initializer, np_symbol
 from ..symbol import Symbol
 from ..ndarray import NDArray
 from .. import name as _name
@@ -1055,7 +1055,10 @@ class SymbolBlock(HybridBlock):
         ...     'net1-symbol.json', ['data'], 'net1-0001.params')
         >>> out2 = net2(x)
         """
-        sym = symbol.load(symbol_file)
+        if is_np_array():
+            sym = np_symbol.load(symbol_file)
+        else:
+            sym = symbol.load(symbol_file)
         if isinstance(input_names, str):
             input_names = [input_names]
         if param_file is None:
@@ -1063,7 +1066,7 @@ class SymbolBlock(HybridBlock):
             inputs = [symbol.var(i, dtype=mx_real_t) for i in input_names]
         else:
             # Do not specify type, rely on saved params type instead
-            inputs = [symbol.var(i) for i in input_names]
+            inputs = [symbol.var(i).as_np_ndarray() if is_np_array() else symbol.var(i) for i in input_names]
         ret = SymbolBlock(sym, inputs)
         if param_file is not None:
             ret.collect_params().load(param_file, ctx=ctx, cast_dtype=True, dtype_source='saved')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -946,7 +946,7 @@ def split(ary, indices_or_sections, axis=0):
         raise ValueError('indices_or_sections must either int or tuple of ints')
     ret = _npi.split(ary, indices, axis, False)
     if not isinstance(ret, list):
-        raise NotImplementedError('single output from split is not supported yet...')
+        raise NotImplementedError('Output of split should be list, get a return type %s'%(str(type(ret))))
     return ret
 # pylint: enable=line-too-long
 

--- a/python/mxnet/ndarray/register.py
+++ b/python/mxnet/ndarray/register.py
@@ -24,7 +24,7 @@ import numpy as _np  # pylint: disable=unused-import
 from ._internal import NDArrayBase, _imperative_invoke # pylint: disable=unused-import
 from ..ndarray_doc import _build_doc
 
-from ..base import mx_uint, check_call, _LIB, py_str, _init_op_module, _Null, _is_np_op  # pylint: disable=unused-import
+from ..base import mx_uint, check_call, _LIB, py_str, _init_op_module, _Null, _is_np_op, _output_is_list  # pylint: disable=unused-import
 from ..util import use_np_shape  # pylint: disable=unused-import
 
 
@@ -176,6 +176,7 @@ def _generate_ndarray_function_code(handle, op_name, func_name, signature_only=F
 
     code = []
     is_np_op = _is_np_op(op_name)
+    output_is_list = _output_is_list(op_name)
     doc_str_idx = 1
     if is_np_op:
         doc_str_idx = 2
@@ -241,8 +242,8 @@ def %s(%s):"""%(func_name, ', '.join(signature)))
     {verify_fn}("{op_name}", "{func_name}", ndargs, out)
         """.format(verify_fn=verify_ndarrays_fn, op_name=op_name, func_name=func_name))
         code.append("""
-    return _imperative_invoke(%d, ndargs, keys, vals, out, %s)"""%(
-        handle.value, str(is_np_op)))
+    return _imperative_invoke(%d, ndargs, keys, vals, out, %s, %s)"""%(
+        handle.value, str(is_np_op), str(output_is_list)))
     else:
         code.append("""
     return (0,)""")

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -20,14 +20,21 @@
 
 from __future__ import absolute_import
 import ctypes
+import json
 import numpy as _np
 from . import _op as _mx_np_op
-from ...base import _LIB, SymbolHandle, numeric_types, mx_uint
+from ...base import _LIB, SymbolHandle, numeric_types, mx_uint, integer_types, string_types
+from ...base import c_str, c_handle_array
+from ...base import py_str
 from ...util import _sanity_check_params, check_call, set_module
 from ...context import current_context
 from ..symbol import Symbol
 from .._internal import _set_np_symbol_class
 from . import _internal as _npi
+try:
+    from __builtin__ import slice as py_slice
+except ImportError:
+    from builtins import slice as py_slice
 
 __all__ = ['zeros', 'ones', 'maximum', 'minimum', 'stack', 'concatenate', 'arange', 'argmax',
            'clip', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'split', 'swapaxes',
@@ -42,25 +49,88 @@ def _num_outputs(sym):
 
 @set_module('mxnet.symbol.numpy')
 class _Symbol(Symbol):
-    def __getitem__(self, key):
-        num_outputs = _num_outputs(self)
-        if num_outputs == 1:
-            raise NotImplementedError
-        if not isinstance(key, int):
-            raise NotImplementedError
-        if key >= num_outputs:
-            # Important, python determines the end by this exception
-            raise IndexError
-        handle = SymbolHandle()
-        check_call(_LIB.MXSymbolGetOutput(
-            self.handle, mx_uint(key), ctypes.byref(handle)))
-        return _Symbol(handle=handle)
+    def __init__(self, handle):
+        super(_Symbol, self).__init__(handle)
+        self._output_is_list = False
 
-    def __setitem__(self, key, value):
-        raise NotImplementedError
+    def __getitem__(self, key): # pylint: disable = too-many-return-statements, inconsistent-return-statements
+        num_outputs = len(self)
+        # print("Num of outputs is ", num_outputs)
+        if num_outputs == 1: # pylint: disable = too-many-nested-blocks
+            # If number of output is one and is not a list, perform ndarray basic slicing
+            if not self._output_is_list:
+                if isinstance(key, integer_types):
+                    sliced = _npi.slice(self, key, key+1)
+                    return _npi.reshape(sliced, (-3, -4))
+                elif isinstance(key, py_slice):
+                    if key.step is None or key.step != 0:
+                        start = [None] if key.start is None else key.start
+                        stop = [None] if key.stop is None else key.stop
+                        return _npi.slice(self, start, stop, key.step)
+                    else:
+                        raise ValueError("slice step cannot be zero")
+                elif isinstance(key, list):
+                    raise NotImplementedError
+                elif isinstance(key, tuple):
+                    begin = []
+                    end = []
+                    step = []
+                    new_shape = ()
+                    for index in key:
+                        if isinstance(index, py_slice):
+                            if index.step is not None and index.step == 0:
+                                raise ValueError("slice step cannot be zero")
+                            begin.append(index.start)
+                            end.append(index.stop)
+                            step.append(index.step)
+                            new_shape += (-2,)
+                        elif isinstance(index, integer_types):
+                            begin.append(index)
+                            end.append(index+1)
+                            step.append(1)
+                            new_shape += (-3,)
+                    new_shape += (-4,)
+                    sliced = _npi.slice(self, begin, end, step)
+                    return _npi.reshape(sliced, new_shape)
+            # perform trivial list slicing on length one list represented by flag
+            else:
+                if isinstance(key, integer_types):
+                    if key in [-1, 0]:
+                        self._output_is_list = False
+                        return self
+                    else:
+                        raise IndexError
+                elif isinstance(key, py_slice):
+                    if (key.start is None or key.start <= 0) and (key.stop is None or key.stop > 0):
+                        return self
+                    else:
+                        raise ValueError
+                else:
+                    raise IndexError
+        # list slicing on several nodes of outputs
+        elif num_outputs > 1:
+            if isinstance(key, py_slice):
+                start = 0 if key.start is None else key.start
+                stop = num_outputs if key.stop is None else key.stop
+                step = 1 if key.step is None else key.step
+                return Group([self[i] for i in range(start, stop, step)], _Symbol)
+            elif isinstance(key, integer_types):
+                if key >= num_outputs:
+                # Important, python determines the end by this exception
+                    raise IndexError
+                handle = SymbolHandle()
+                check_call(_LIB.MXSymbolGetOutput(
+                    self.handle, mx_uint(key), ctypes.byref(handle)))
+                return _Symbol(handle=handle)
+            else:
+                raise NotImplementedError
+        else:
+            raise NotImplementedError
+
 
     def __iter__(self):
-        raise AttributeError('_Symbol object has no attribute __iter__')
+        return (self[i] for i in range(len(self)))
+        # raise AttributeError('_Symbol object has no attribute __iter__')
 
     def __add__(self, other):
         """x.__add__(y) <=> x + y"""
@@ -193,7 +263,10 @@ class _Symbol(Symbol):
             raise TypeError("_Symbol does not support type {} as operand".format(str(type(other))))
 
     def __len__(self):
-        raise NotImplementedError
+        # raise NotImplementedError
+        output_count = mx_uint()
+        check_call(_LIB.MXSymbolGetNumOutputs(self.handle, ctypes.byref(output_count)))
+        return output_count.value
 
     def as_nd_ndarray(self):
         """Convert _Symbol to mxnet.symbol.Symbol to use its convenience fluent methods."""
@@ -917,6 +990,57 @@ class _Symbol(Symbol):
     def broadcast_like(self, *args, **kwargs):
         raise AttributeError('_Symbol object has no attribute broadcast_like')
 
+    def save(self, fname, remove_amp_cast=True):
+        """Saves symbol to a file.
+
+        You can also use pickle to do the job if you only work on python.
+        The advantage of `load`/`save` functions is that the file contents are language agnostic.
+        This means the model saved by one language binding can be loaded by a different
+        language binding of `MXNet`.
+        You also get the benefit of being able to directly load/save from cloud storage(S3, HDFS).
+
+        Parameters
+        ----------
+        fname : str
+            The name of the file.
+
+            - "s3://my-bucket/path/my-s3-symbol"
+            - "hdfs://my-bucket/path/my-hdfs-symbol"
+            - "/path-to/my-local-symbol"
+        remove_amp_cast : bool, optional
+            Whether to remove the amp_cast and amp_multicast operators, before saving the model.
+
+        See Also
+        --------
+        symbol.load : Used to load symbol from file.
+        """
+        if not isinstance(fname, string_types):
+            raise TypeError('fname need to be string')
+
+        handle = self.handle
+        if remove_amp_cast:
+            handle = SymbolHandle()
+            check_call(_LIB.MXSymbolRemoveAmpCast(self.handle, ctypes.byref(handle)))
+
+        processed_symbol = _Symbol(handle)
+        json_str = processed_symbol.save_json_string()
+        json_data = json.loads(json_str)
+        with open(fname, 'w') as file_out:
+            json.dump(json_data, file_out, indent=2, sort_keys=True)
+
+    def save_json_string(self):
+        """Saves symbol to a JSON string.
+
+        See Also
+        --------
+        symbol.load_json : Used to load symbol from JSON string.
+        """
+        json_str = ctypes.c_char_p()
+        check_call(_LIB.MXSymbolSaveToJSON(self.handle, ctypes.byref(json_str)))
+        json_data = json.loads(py_str(json_str.value))
+        json_data["output_is_list"] = self._output_is_list
+        return json.dumps(json_data)
+
 
 @set_module('mxnet.symbol.numpy')
 def zeros(shape, dtype=_np.float32, **kwargs):
@@ -1252,6 +1376,8 @@ def concatenate(seq, axis=0, out=None):
     res : ndarray
         The concatenated array.
     """
+    if len(seq) > 1:
+        return _npi.concatenate(*[seq[i] for i in range(len(seq))], dim=axis, out=out)
     return _npi.concatenate(*seq, dim=axis, out=out)
 
 
@@ -2357,5 +2483,106 @@ def tensordot(a, b, axes=2):
 
     return _npi.tensordot(a, b, a_axes_summed, b_axes_summed)
 
+
+def Group(symbols, create_fn=_Symbol):
+    """Creates a symbol that contains a collection of other symbols, grouped together.
+    A classic symbol (`mx.sym.Symbol`) will be returned if all the symbols in the list
+    are of that type; a numpy symbol (`mx.sym.np._Symbol`) will be returned if all the
+    symbols in the list are of that type. A type error will be raised if a list of mixed
+    classic and numpy symbols are provided.
+
+    Example
+    -------
+    >>> a = mx.sym.Variable('a')
+    >>> b = mx.sym.Variable('b')
+    >>> mx.sym.Group([a,b])
+    <Symbol Grouped>
+
+    Parameters
+    ----------
+    symbols : list
+        List of symbols to be grouped.
+
+    create_fn : mx.sym.Symbol or mx.sym.np._Symbol
+        Symbol class for creating the grouped symbol.
+
+    Returns
+    -------
+    sym : Symbol
+        A group symbol.
+     """
+    if not symbols or any(not isinstance(sym, Symbol) for sym in symbols):
+        raise TypeError('Expected a list of symbols as input')
+    handle = SymbolHandle()
+    check_call(_LIB.MXSymbolCreateGroup(
+        mx_uint(len(symbols)),
+        c_handle_array(symbols), ctypes.byref(handle)))
+    self = create_fn(handle)
+    self._output_is_list = True #pylint: disable = protected-access
+    return self
+
+
+def load_json_string(json_str):
+    """
+    Loads symbol from json string.
+
+    Parameters
+    ----------
+    json_str : str
+        A JSON string.
+
+    Returns
+    -------
+    sym : Symbol
+        The loaded symbol.
+
+    See Also
+    --------
+    Symbol.tojson : Used to save symbol into json string.
+    """
+    if not isinstance(json_str, string_types):
+        raise TypeError('fname required to be string')
+    handle = SymbolHandle()
+    json_data = json.loads(json_str)
+    output_is_list = json_data["output_is_list"]
+    del json_data["output_is_list"]
+    check_call(_LIB.MXSymbolCreateFromJSON(c_str(json.dumps(json_data)), ctypes.byref(handle)))
+    s = _Symbol(handle)
+    s._output_is_list = output_is_list #pylint: disable = protected-access
+    return s
+
+
+def load(fname):
+    """Loads symbol from a JSON file.
+
+    You can also use pickle to do the job if you only work on python.
+    The advantage of load/save is the file is language agnostic.
+    This means the file saved using save can be loaded by other language binding of mxnet.
+    You also get the benefit being able to directly load/save from cloud storage(S3, HDFS).
+
+    Parameters
+    ----------
+    fname : str
+        The name of the file, examples:
+
+        - `s3://my-bucket/path/my-s3-symbol`
+        - `hdfs://my-bucket/path/my-hdfs-symbol`
+        - `/path-to/my-local-symbol`
+
+    Returns
+    -------
+    sym : Symbol
+        The loaded symbol.
+
+    See Also
+    --------
+    Symbol.save : Used to save symbol into file.
+    """
+    if not isinstance(fname, string_types):
+        raise TypeError('fname need to be string')
+    with open(fname, 'r') as file_input:
+        json_data = json.load(file_input)
+
+    return load_json_string(json.dumps(json_data))
 
 _set_np_symbol_class(_Symbol)

--- a/python/mxnet/symbol/register.py
+++ b/python/mxnet/symbol/register.py
@@ -27,7 +27,7 @@ from ._internal import SymbolBase, _symbol_creator
 from ..attribute import AttrScope
 from ..base import mx_uint, check_call, _LIB, py_str
 from ..symbol_doc import _build_doc
-from ..base import _Null, _init_op_module, _is_np_op
+from ..base import _Null, _init_op_module, _is_np_op, _output_is_list
 from ..name import NameManager
 # pylint: enable=unused-import
 
@@ -144,6 +144,7 @@ def _generate_symbol_function_code(handle, op_name, func_name, signature_only=Fa
     signature = ndsignature + signature
 
     is_np_op = _is_np_op(op_name)
+    output_is_list = _output_is_list(op_name)
     verify_symbol_fn = _verify_np_symbol.__name__ if is_np_op else _verify_legacy_symbol.__name__
     code = []
     if arr_name:
@@ -191,8 +192,8 @@ def %s(*%s, **kwargs):"""%(func_name, arr_name))
             key_var_num_args, key_var_num_args))
 
             code.append("""
-    return _symbol_creator(%d, sym_args, sym_kwargs, keys, vals, name, %s)"""%(
-        handle.value, str(is_np_op)))
+    return _symbol_creator(%d, sym_args, sym_kwargs, keys, vals, name, %s, %s)"""%(
+        handle.value, str(is_np_op), str(output_is_list)))
     else:
         code.append("""
 def %s(%s):"""%(func_name, ', '.join(signature)))
@@ -244,8 +245,8 @@ def %s(%s):"""%(func_name, ', '.join(signature)))
     if not hasattr(NameManager._current, "value"):
         NameManager._current.value = NameManager()
     name = NameManager._current.value.get(name, '%s')
-    return _symbol_creator(%d, None, sym_kwargs, _keys, _vals, name, %s)"""%(
-        func_name.lower(), handle.value, str(is_np_op)))
+    return _symbol_creator(%d, None, sym_kwargs, _keys, _vals, name, %s, %s)"""%(
+        func_name.lower(), handle.value, str(is_np_op), str(output_is_list)))
 
     if signature_only:
         code.append("""

--- a/src/operator/numpy/np_matrix_op-inl.h
+++ b/src/operator/numpy/np_matrix_op-inl.h
@@ -26,7 +26,9 @@
 #define MXNET_OPERATOR_NUMPY_NP_MATRIX_OP_INL_H_
 
 #include <vector>
+#include <string>
 #include "../tensor/matrix_op-inl.h"
+#include "np_broadcast_reduce_op.h"
 
 namespace mxnet {
 namespace op {
@@ -37,6 +39,72 @@ struct NumpyTransposeParam : public dmlc::Parameter<NumpyTransposeParam> {
     DMLC_DECLARE_FIELD(axes).set_default(mxnet::TShape(-1, 0))
     .describe("By default, reverse the dimensions, otherwise permute "
               "the axes according to the values given.");
+  }
+};
+
+struct NumpyReshapeParam : public dmlc::Parameter<NumpyReshapeParam> {
+  mxnet::TShape newshape;
+  std::string order;
+  DMLC_DECLARE_PARAMETER(NumpyReshapeParam) {
+      DMLC_DECLARE_FIELD(newshape)
+          .describe("The new shape should be compatible with the original shape."
+                    " If an integer, then the result will be a 1-D array of that length."
+                    " One shape dimension can be -1. In this case, the value is inferred"
+                    " from the length of the array and remaining dimensions.");
+      DMLC_DECLARE_FIELD(order)
+      .set_default("C")
+      .describe("Read the elements of a using this index order, and place the elements into"
+                " the reshaped array using this index order. 'C' means to read/write the elements"
+                " using C-like index order, with the last axis index changing fastest, back to the"
+                " first axis index changing slowest. Note that currently only C-like order is"
+                " supported");
+  }
+};
+
+struct NumpyXSliceParam : public dmlc::Parameter<NumpyXSliceParam> {
+  mxnet::Tuple<dmlc::optional<int>> begin, end;
+  mxnet::Tuple<dmlc::optional<int>> step;
+  DMLC_DECLARE_PARAMETER(NumpyXSliceParam) {
+    DMLC_DECLARE_FIELD(begin)
+    .describe("starting indices for the slice operation, supports negative indices.");
+    DMLC_DECLARE_FIELD(end)
+    .describe("ending indices for the slice operation, supports negative indices.");
+    DMLC_DECLARE_FIELD(step)
+    .set_default(mxnet::Tuple<dmlc::optional<int>>())
+    .describe("step for the slice operation, supports negative values.");
+  }
+  bool operator==(const NumpyXSliceParam& other) const {
+    return this->begin == other.begin &&
+           this->end == other.end &&
+           this->step == other.step;
+  }
+};
+
+struct NumpyXReshapeParam : public dmlc::Parameter<NumpyXReshapeParam> {
+  mxnet::Tuple<int> newshape;
+  std::string order;
+  DMLC_DECLARE_PARAMETER(NumpyXReshapeParam) {
+      DMLC_DECLARE_FIELD(newshape)
+          .set_default(mxnet::Tuple<int>())
+          .describe("The new shape should be compatible with the original shape."
+                    " If an integer, then the result will be a 1-D array of that length."
+                    " One shape dimension can be -1. In this case, the value is inferred"
+                    " from the length of the array and remaining dimensions."
+                    " -2 to -6 are used for data manipulation"
+                    " -2 copy this dimension from the input to the output shape"
+                    " -3 will skip current dimension if and only if the current dim size is one"
+                    " -4 copy all remain of the input dimensions to the output shape"
+                    " -5 use the product of two consecutive dimensions of the input"
+                    " shape as the output"
+                    " -6 split one dimension of the input into two dimensions passed"
+                    " subsequent to -6 in the new shape");
+      DMLC_DECLARE_FIELD(order)
+      .set_default("C")
+      .describe("Read the elements of a using this index order, and place the elements into"
+                " the reshaped array using this index order. 'C' means to read/write the elements"
+                " using C-like index order, with the last axis index changing fastest, back to the"
+                " first axis index changing slowest. Note that currently only C-like order is"
+                " supported");
   }
 };
 
@@ -59,7 +127,171 @@ void NumpyTranspose(const nnvm::NodeAttrs& attrs,
   }
 }
 
+template<int ndim>
+inline void NumpyXGetIndexRange(const mxnet::TShape& dshape,
+                          const mxnet::Tuple<dmlc::optional<int>>& param_begin,
+                          const mxnet::Tuple<dmlc::optional<int>>& param_end,
+                          const mxnet::Tuple<dmlc::optional<int>>& param_step,
+                          common::StaticArray<index_t, ndim>* begin,
+                          common::StaticArray<index_t, ndim>* end,
+                          common::StaticArray<index_t, ndim>* step) {
+  CHECK_NE(dshape.ndim(), 0U);
+  CHECK_LE(param_begin.ndim(), dshape.ndim())
+    << "Slicing axis exceeds data dimensions";
+  CHECK_LE(param_end.ndim(), dshape.ndim())
+    << "Slicing axis exceeds data dimensions";
+  CHECK_EQ(param_begin.ndim(), param_end.ndim())
+    << "begin and end must have the same length";
+  CHECK_EQ(ndim, dshape.ndim())
+    << "Static array size=" << ndim
+    << " is not equal to data shape ndim=" << dshape.ndim();
+
+  if (param_step.ndim() > 0) {
+    CHECK_EQ(param_step.ndim(), param_begin.ndim())
+      << "step and begin must have the same length";
+  }
+
+  for (int i = 0; i < param_begin.ndim(); ++i) {
+    index_t s = param_step.ndim() > 0 && param_step[i].has_value()?
+                param_step[i].value() : 1;
+    CHECK_NE(s, 0) << "slice op step[" << i << "] cannot be 0";
+
+    index_t b = 0, e = 0;
+    const index_t len = dshape[i];
+    if (len > 0) {
+      b = param_begin[i].has_value() ? param_begin[i].value() : (s < 0 ? len - 1 : 0);
+      e = param_end[i].has_value() ? param_end[i].value() : (s < 0 ? -1 : len);
+
+      if (b < 0) {
+        b += len;
+      }
+
+      if (e < 0 && param_end[i].has_value()) {
+        e += len;
+      }
+    }
+
+    // move the begin and end to correct position for calculating dim size
+    b = b < 0 && s > 0 ? 0 : b;
+    b = b > len-1 && s < 0 ? len-1 : b;
+    // if the start value lead to empty tensor under step s, use -1 for indication
+    b = b < 0 || b > len-1 ? -1 : b;
+    e = e > -1 ? e : -1;
+    e = e > len ? len : e;
+    (*begin)[i] = b;
+    (*end)[i] = e;
+    (*step)[i] = s;
+  }
+
+  for (index_t i = param_begin.ndim(); i < dshape.ndim(); ++i) {
+    (*begin)[i] = 0;
+    (*end)[i] = dshape[i];
+    (*step)[i] = 1;
+  }
+}
+
+inline void NumpyXSetSliceOpOutputDimSize(const index_t i, const int b,
+                                    const int e, const int s,
+                                    mxnet::TShape* oshape) {
+  if (e != b && b >= 0) {
+    if (s > 0) {
+      (*oshape)[i] = e > b ? (e - b - 1) / s + 1 : 0;
+    } else {
+      (*oshape)[i] = e < b ? (b - e - 1) / (-s) + 1 : 0;
+    }
+  } else {
+      (*oshape)[i] = 0;
+  }
+}
+
+template<typename xpu>
+void NumpyXSliceOpForward(const nnvm::NodeAttrs& attrs,
+                    const OpContext& ctx,
+                    const std::vector<TBlob>& inputs,
+                    const std::vector<OpReqType>& req,
+                    const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+  if (req[0] == kNullOp) return;
+  using namespace mshadow;
+  Stream<xpu>* s = ctx.get_stream<xpu>();
+  const TBlob& data = inputs[0];
+  const TBlob& out = outputs[0];
+  if (out.Size() == 0) {
+    return;
+  }
+  const NumpyXSliceParam& param = nnvm::get<NumpyXSliceParam>(attrs.parsed);
+  MXNET_NDIM_SWITCH(data.ndim(), ndim, {
+    common::StaticArray<index_t, ndim> begin, end, step;
+    NumpyXGetIndexRange(data.shape_, param.begin, param.end, param.step, &begin, &end, &step);
+    MSHADOW_TYPE_SWITCH(out.type_flag_, DType, {
+      MXNET_ASSIGN_REQ_SWITCH(req[0], Req, {
+        size_t num_threads = out.shape_.FlatTo2D()[0];
+        if (std::is_same<xpu, gpu>::value) {
+          num_threads *= out.shape_.get<ndim>()[ndim - 1];
+        }
+        mxnet_op::Kernel<slice_forward<ndim, Req, xpu>, xpu>::Launch(s, num_threads,
+            out.dptr<DType>(), data.dptr<DType>(),
+            data.shape_.get<ndim>(), out.shape_.get<ndim>(), begin, step);
+      })
+    })
+  })
+}
+
+template<typename xpu>
+void NumpyXSliceOpBackward(const nnvm::NodeAttrs& attrs,
+                     const OpContext& ctx,
+                     const std::vector<TBlob>& inputs,
+                     const std::vector<OpReqType>& req,
+                     const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+  if (req[0] == kNullOp) return;
+  using namespace mshadow;
+  Stream<xpu>* s = ctx.get_stream<xpu>();
+  const TBlob& ograd = inputs[0];
+  const TBlob& igrad = outputs[0];
+  const NumpyXSliceParam& param = nnvm::get<NumpyXSliceParam>(attrs.parsed);
+  if (req[0] == kWriteTo) {
+    Fill(s, igrad, req[0], 0);
+  } else if (req[0] == kWriteInplace) {
+    LOG(FATAL) << "_slice_backward does not support kWriteInplace";
+  }
+  if (ograd.Size() == 0) return;
+  MXNET_NDIM_SWITCH(ograd.ndim(), ndim, {
+    common::StaticArray<index_t, ndim> begin, end, step;
+    NumpyXGetIndexRange(igrad.shape_, param.begin, param.end, param.step, &begin, &end, &step);
+    MSHADOW_TYPE_SWITCH(ograd.type_flag_, DType, {
+      MXNET_ASSIGN_REQ_SWITCH(req[0], Req, {
+      int num_threads = ograd.shape_.FlatTo2D()[0];
+      if (std::is_same<xpu, gpu>::value) {
+        num_threads *= ograd.shape_.get<ndim>()[ndim - 1];
+      }
+      mxnet_op::Kernel<slice_assign<ndim, Req, xpu>, xpu>::Launch(s, num_threads,
+          igrad.dptr<DType>(), ograd.dptr<DType>(),
+          igrad.shape_.get<ndim>(), ograd.shape_.get<ndim>(), begin, step);
+      })
+    })
+  })
+}
+
+
 }  // namespace op
 }  // namespace mxnet
+
+namespace std {
+template<>
+struct hash<mxnet::op::NumpyXSliceParam> {
+  size_t operator()(const mxnet::op::NumpyXSliceParam& val) {
+    size_t ret = 0;
+    ret = dmlc::HashCombine(ret, val.begin);
+    ret = dmlc::HashCombine(ret, val.end);
+    ret = dmlc::HashCombine(ret, val.step);
+    return ret;
+  }
+};
+}  // namespace std
 
 #endif  // MXNET_OPERATOR_NUMPY_NP_MATRIX_OP_INL_H_

--- a/src/operator/numpy/np_matrix_op.cu
+++ b/src/operator/numpy/np_matrix_op.cu
@@ -34,6 +34,9 @@ NNVM_REGISTER_OP(_np_transpose)
 NNVM_REGISTER_OP(_np_reshape)
 .set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
 
+NNVM_REGISTER_OP(_npx_reshape)
+.set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
+
 NNVM_REGISTER_OP(_npi_stack)
 .set_attr<FCompute>("FCompute<gpu>", StackOpForward<gpu>);
 
@@ -51,6 +54,13 @@ NNVM_REGISTER_OP(_backward_np_hstack)
 
 NNVM_REGISTER_OP(_np_squeeze)
 .set_attr<FCompute>("FCompute<gpu>", UnaryOp::IdentityCompute<gpu>);
+
+NNVM_REGISTER_OP(_npx_slice)
+.add_alias("_npi_slice")
+.set_attr<FCompute>("FCompute<gpu>", NumpyXSliceOpForward<gpu>);
+
+NNVM_REGISTER_OP(_backward_npx_slice)
+.set_attr<FCompute>("FCompute<gpu>", NumpyXSliceOpBackward<gpu>);
 
 }  // namespace op
 }  // namespace mxnet

--- a/tests/python/unittest/test_numpy_gluon.py
+++ b/tests/python/unittest/test_numpy_gluon.py
@@ -20,8 +20,10 @@ from __future__ import absolute_import
 from __future__ import division
 
 import mxnet as mx
-from mxnet import gluon, autograd, np
-from mxnet.test_utils import use_np
+from mxnet import gluon, autograd, np, npx
+from mxnet.test_utils import use_np, assert_almost_equal
+from common import with_seed
+import random
 
 
 def test_create_np_param():
@@ -106,6 +108,140 @@ def test_optimizer_with_np_ndarrays():
             loss = total_loss(output, y)  # loss is a scalar np.ndarray
         loss.backward()
         trainer.step(1)
+
+
+@with_seed()
+@use_np
+def test_symbolic_basic_slicing():
+    def get_slice_index(shape):
+        index = []
+        step_switch = random.randint(0,1)
+        step = None if step_switch == 0 else []
+        for i in range(len(shape)):
+            if shape[i] == 0:
+                index.append(slice(0,1))
+                continue
+            if random.randint(0, 5) > 4:
+                index.append(random.randint(0, shape[i]-1))
+                continue
+            s = random.randint(0, shape[i]-1)
+            e = random.randint(s+1, shape[i])
+            if step_switch == 1:
+                index.append(slice(s, e, 1))
+            elif step_switch == -1:
+                if e == shape[i]:
+                    e -= 1
+                    s -= 1
+                    if s == -1:
+                        s = None
+                index.append(slice(e, s, -1))
+            else:
+                index.append(slice(s, e))
+        return tuple(index)
+
+    shapes = [
+        (4, 6, 8, 9),
+        (1, 1, 1, 6),
+        (10, 20, 30),
+    ]
+    for shape in shapes:
+        for i in range(10):
+            index = get_slice_index(shape)
+            # Test basic slicing on single symbol
+            class TestSlicingSingleSymbol(gluon.HybridBlock):
+                def __init__(self, **kwargs):
+                    super(TestSlicingSingleSymbol, self).__init__(**kwargs)
+
+                def hybrid_forward(self, F, x):
+                    x = x[:]
+                    x = x[index]
+                    return x
+
+            net = TestSlicingSingleSymbol()
+            x = mx.nd.random.normal(shape=shape).as_np_ndarray()
+            x.attach_grad()
+            with autograd.record():
+                imperative_out = net(x)
+            imperative_out.backward()
+            imperative_grad = x.grad.asnumpy()
+
+            y = x
+            y.attach_grad()
+            net2 = TestSlicingSingleSymbol()
+            net2.hybridize()
+            with autograd.record():
+                symbolic_out = net2(y)
+            symbolic_out.backward()
+            symbolic_grad = y.grad.asnumpy()
+            assert_almost_equal(imperative_out.asnumpy(), symbolic_out.asnumpy(), rtol=1e-3, atol=1e-5)
+            assert_almost_equal(imperative_grad, symbolic_grad, rtol=1e-3, atol=1e-5)
+            
+            # Test save and load
+            net2.export('gluon')
+            net2_imported = gluon.SymbolBlock.imports('gluon-symbol.json', 'data', 'gluon-0000.params')
+            assert_almost_equal(net2(x).asnumpy(), net2_imported(x).asnumpy())
+
+            #Test slicing on symbol with list of outputs
+            slice_on_first_dim = index[0] if isinstance(index[0], slice) else slice(index[0], index[0] + 1)
+            class TestSlicingListOutputs(gluon.HybridBlock):
+                def __init__(self, **kwargs):
+                    super(TestSlicingListOutputs, self).__init__(**kwargs)
+
+                def hybrid_forward(self, F, x):
+                    x = F.np.split(x, shape[0])
+                    x = x[slice_on_first_dim]
+                    x = F.np.concatenate(x)
+                    return F.np.sum(x)
+
+            net = TestSlicingListOutputs()
+            x = mx.nd.random.normal(shape=shape).as_np_ndarray()
+            x.attach_grad()
+            with autograd.record():
+                imperative_out = net(x)
+            imperative_out.backward()
+            imperative_grad = x.grad.asnumpy()
+
+            y = x
+            y.attach_grad()
+            net2 = TestSlicingListOutputs()
+            net2.hybridize()
+            with autograd.record():
+                symbolic_out = net2(y)
+            symbolic_out.backward()
+            symbolic_grad = y.grad.asnumpy()
+            assert_almost_equal(imperative_out.asnumpy(), symbolic_out.asnumpy(), rtol=1e-3, atol=1e-5)
+            assert_almost_equal(imperative_grad, symbolic_grad, rtol=1e-3, atol=1e-5)
+
+            # Test slicing on length one list of symbol (flag enabled list)
+            class TestSlicingSingletonList(gluon.HybridBlock):
+                def __init__(self, **kwargs):
+                    super(TestSlicingSingletonList, self).__init__(**kwargs)
+
+                def hybrid_forward(self, F, x):
+                    x = F.np.split(x, 1)
+                    x = x[0]
+                    x = x[index]
+                    return F.np.sum(x)
+            
+            net = TestSlicingSingletonList()
+            x = mx.nd.random.normal(shape=shape).as_np_ndarray()
+            x.attach_grad()
+            with autograd.record():
+                imperative_out = net(x)
+            imperative_out.backward()
+            imperative_grad = x.grad.asnumpy()
+
+            y = x
+            y.attach_grad()
+            net2 = TestSlicingSingletonList()
+            net2.hybridize()
+            with autograd.record():
+                symbolic_out = net2(y)
+            symbolic_out.backward()
+            symbolic_grad = y.grad.asnumpy()
+            assert_almost_equal(imperative_out.asnumpy(), symbolic_out.asnumpy(), rtol=1e-3, atol=1e-5)
+            assert_almost_equal(imperative_grad, symbolic_grad, rtol=1e-3, atol=1e-5)
+
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -1250,6 +1250,132 @@ def test_np_squeeze():
 
 @with_seed()
 @use_np
+def test_npx_slice():
+    class TestSlice(HybridBlock):
+        def __init__(self, begin, end, step):
+            super(TestSlice, self).__init__()
+            self._begin = begin
+            self._end = end
+            self._step = step
+
+        def hybrid_forward(self, F, a, *args, **kwargs):
+            return F.npx.slice(a, begin=self._begin, end=self._end, step=self._step)
+
+    def get_start_end_step(shape):
+        start = []
+        end = []
+        step_switch = random.randint(-1,1)
+        step = None if step_switch == 0 else []
+        for i in range(len(shape)):
+            s = random.randint(0, shape[i]-1)
+            e = random.randint(s+1, shape[i])
+            if step_switch == 1:
+                step.append(1)
+                start.append(s)
+                end.append(e)
+            elif step_switch == -1:
+                step.append(-1)
+                if e == shape[i]:
+                    e -= 1
+                    s -= 1
+                    if s == -1:
+                        s = None
+                start.append(e)
+                end.append(s)
+            else:
+                start.append(s)
+                end.append(e)
+        return start, end, step
+
+    for hybridize in [True, False]:
+        for i in range(10):
+            dim = random.randint(1,4)
+            shape = [random.randint(1,5) for i in range(dim)]
+
+            # test gluon
+            start, end, step = get_start_end_step(shape)
+            test_slice = TestSlice(begin=start, end=end, step=step)
+            if hybridize:
+                test_slice.hybridize()
+
+            a = mx.nd.random.uniform(shape=shape).as_np_ndarray()
+            a.attach_grad()
+            if step is not None:
+                expected_ret = a.as_nd_ndarray().slice(start, end, step)
+            else:
+                expected_ret = a.as_nd_ndarray().slice(start, end)
+            with mx.autograd.record():
+                y = test_slice(a)
+
+            assert_almost_equal(y.asnumpy(), expected_ret.asnumpy(), rtol=1e-3, atol=1e-5)
+
+            # test backward
+            mx.autograd.backward(y)
+            expected_grad = _np.zeros(shape)
+            basic_index = tuple([ 
+                slice(start[i], end[i], step[i]) if step is not None else slice(start[i], end[i])
+                for i in range(len(start))
+                ])
+            expected_grad[basic_index] = 1
+            assert_almost_equal(a.grad.asnumpy(), expected_grad, rtol=1e-3, atol=1e-5)
+
+@with_seed()
+@use_np
+def test_npx_reshape():
+    class TestNumpyXReshape(HybridBlock):
+        def __init__(self, newshape):
+            super(TestNumpyXReshape, self).__init__()
+            self._newshape = newshape
+
+        def hybrid_forward(self, F, a, *args, **kwargs):
+            return F.npx.reshape(a, self._newshape)
+
+    test_cases = [
+        [(2, 3, 5, 5),  (-2, -1),         (2, 75)],
+        [(2, 3, 5, 5),  (-2, -2, -1),     (2, 3, 25)],
+        [(5, 3, 4, 5),  (-2, -1, -2),     (5, 15, 4)],
+        [(2, 3, 5, 4),  (-1, -2, -2),     (8, 3, 5)],
+        [(2, 3, 5, 5),  (-2, -2, -2, -2), (2, 3, 5, 5)],
+        [(2, 1, 4, 5),  (-2, -3, -2, -2), (2, 4, 5)],
+        [(1, 1, 4, 1),  (-3, -3, -2, -2), (4, 1)],
+        [(1, 1, 1, 1),  (-3, -3, -3, -3), ()],
+        [(2, 4, 5, 3),  (-1, 2, 2, 1),    (30, 2, 2, 1)],
+        [(2, 3, 5, 6),  (-4,),            (2, 3, 5, 6)],
+        [(2, 3, 5, 6),  (6, 1, -4),       (6, 1, 5, 6)],
+        [(2, 3, 5, 6),  (-5, -5),         (6, 30)],
+        [(2, 3, 5, 6),  (-5, -1),         (6, 30)],
+        [(64,),         (-6, 16, 4),      (16, 4)],
+        [(64,),         (-6, 16, -1),     (16, 4)],
+        [(64, 1, 2, 3), (-6, 16, -1, -4), (16, 4, 1, 2, 3)]
+    ]
+    for hybridize in [True, False]:
+        for shape, newshape, expected_ret_shape in test_cases:
+            # test gluon
+            test_reshape = TestNumpyXReshape(newshape=newshape)
+            if hybridize:
+                test_reshape.hybridize()
+
+            a = np.random.uniform(size=shape)
+            a.attach_grad()
+            with mx.autograd.record():
+                y = test_reshape(a)
+
+            assert y.shape == expected_ret_shape
+            assert_almost_equal(y.asnumpy(), a.asnumpy().reshape(expected_ret_shape), rtol=1e-3, atol=1e-5)
+
+            # test backward
+            mx.autograd.backward(y)
+            expected_grad = _np.ones(shape)
+            assert_almost_equal(a.grad.asnumpy(), expected_grad, rtol=1e-3, atol=1e-5)
+
+            # test imperative
+            npx_out = npx.reshape(a, newshape)
+            expected_out = _np.reshape(a.asnumpy(), expected_ret_shape)
+            assert_almost_equal(npx_out.asnumpy(), expected_out, rtol=1e-3, atol=1e-5)
+
+
+@with_seed()
+@use_np
 def test_np_split():
     class TestSplit(HybridBlock):
         def __init__(self, indices_or_sections, axis=None):


### PR DESCRIPTION
## Description ##
Implement basic slicing in symbolic interface

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Add **npx_slice** to support the same kind of slicing in ndarray
- Add **npx_reshape** to support reshape with special flags  
    - -1 to infer this dimension from the other given dimensions
    - -2 copy the current dimension from the input to the output
    - -3 skip the current dimension if and only if the current dimension is of size 1, report an error otherwise
    - -4 copy all remaining dimensions from the input to the output
    - -5 use the product of the next two consecutive dimensions in the output
    - -6 split current dimension in the output into the next two  dimensions in the input

- Implement basic slicing in __symbol.py_ : \_\_getitem\_\_, basic slicing means slicing with 
    - an integer 
    - a pyslice
    - a tuple of integers and pyslices

A flag `_output_is_list` is added to symbol class in the frontend to differentiate the cases in which a symbol with only one output Node is conceptually a list, eg: `split(x, 1)`

- Overload the `Group` function in Symbol
- Overload the `save`, `save_json_string`, `load`, `load_json_string` to specially take care of the newly added flag

## Comments 
Based on the current implementation, any operator that generates a list-like output should register their name in the list `python/mxnet/base.py:_NP_OUTPUT_IS_LIST_OPERATORS`

Thank @reminisce and @haojin2 for reviewing