### PR TITLE
Fix transform call in ImageFolderDataset

### DIFF
--- a/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Data/Vision.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/Gluon/Data/Vision.pm
@@ -367,7 +367,7 @@ extends 'AI::MXNet::Gluon::Data::Set';
 =cut
 has 'root'      => (is => 'rw', isa => 'Str');
 has 'flag'      => (is => 'rw', isa => 'Bool', default => 1);
-has 'transform' => (is => 'rw', isa => 'Maybe[CodeRef]');
+has 'transform' => (is => 'ro', isa => 'Maybe[CodeRef]');
 has [qw/exts
     synsets
     items/]     => (is => 'rw', init_arg => undef);
@@ -421,7 +421,7 @@ method at(Int $idx)
     my $label = $self->items->[$idx][1];
     if(defined $self->transform)
     {
-        return [$self->transform($img, $label)];
+        return [$self->transform->($img, $label)];
     }
     return [$img, $label];
 }


### PR DESCRIPTION
## Description ##
Without this change I get the following (partial) error:

Expected exactly one or two argument for an accessor of transform at
              /home/user/perl5/lib/perl5/AI/MXNet/Gluon/Data/Vision.pm line 422, <DATA> line 207.

This change addresses that error.

## Checklist ##
### Essentials ###
I will take a look at how to add unit test to this change.

### Changes ###
There are no new features.   From my perspective the change addresses a typo as other packages in the same file call the transform sub the same way this change does.

## Comments ##
I could not get original code to work so cannot confirm if change is backwards compatible.
