### PR TITLE
Adding CMake work-around for Ubuntu 18.04 and CUDA > 9.2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,16 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src)
 if(USE_CUDA)
   find_package(CUDA REQUIRED)
   add_definitions(-DMSHADOW_USE_CUDA=1)
+  # This fixes an incompatability between the CMake version provided with Ubuntu 18.04
+  # and CUDA > 9.1. CUDA 9.2 deprecated the cublas_device variable but applications
+  # built using CMake 3.12.3 and below still look for this variable. Since the
+  # cublas_device_LIBRARY and cublas_LIBRARY are usually identical, this replaces
+  # the deprecated variable with the value of the supported variable.
+  if(${CUDA_VERSION} VERSION_GREATER "9.1" AND ${CMAKE_VERSION} VERSION_LESS "3.12.3")
+    unset(CUDA_cublas_device_LIBRARY CACHE)
+    set(CUDA_cublas_device_LIBRARY ${CUDA_cublas_LIBRARY})
+    set(CUDA_CUBLAS_LIBRARIES ${CUDA_cublas_LIBRARY})
+  endif()
   if(FIRST_CUDA AND (NOT USE_OLDCMAKECUDA))
     if(NOT CUDA_TOOLSET)
       set(CUDA_TOOLSET "${CUDA_VERSION_STRING}")


### PR DESCRIPTION
## Description ##
Avoids users of CUDA 10/10.1 on Ubuntu 18.04 from having to upgrade their system CMake just to build MXNET. CMake change to fix this issue was made in 3.12.3 here: https://gitlab.kitware.com/cmake/cmake/commit/81e73b7240e3b11b454f01f21bab85b4aa95d6af.

## Checklist ##
### Essentials ###
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes) - I would consider this a "tiny change".
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
No additional tests added as many CI and unit tests run with this flag both enabled and disabled.
- [x] Code is well-documented
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Adds conditional work-around to CMakeLists.txt to fix incompatibility between CUDA > 9.1 and CMake < 3.12.3.
- [x] Tested in Docker with Ubuntu 16.04/CUDA 9.0/CuDNN 7.6.2 and Ubuntu 18.04/CUDA 10.0/CuDNN 7.6.2.