### PR TITLE
Fix the problem in printing feature in c++ API examples : feature_extract

### DIFF
--- a/cpp-package/example/feature_extract/feature_extract.cpp
+++ b/cpp-package/example/feature_extract/feature_extract.cpp
@@ -106,6 +106,7 @@ class FeatureExtractor {
     /*print out the features*/
     auto array = executor->outputs[0].Copy(Context(kCPU, 0));
     NDArray::WaitAll();
+    array = array.Reshape({2, 1024});
     for (int i = 0; i < 1024; ++i) {
       cout << array.At(0, i) << ",";
     }


### PR DESCRIPTION
Fixed a run-time error caused by mismatch of output dimensions.

## Description ##

The dimensions output with origin code and model is **(2, 1024, 1, 1)**, which may lead to the following errors:

```bash
terminate called after throwing an instance of 'dmlc::Error'
  what():  [10:34:56] /mnt/feature_extract/3rdparty/mxnet-cpp-package/include/mxnet-cpp/ndarray.hpp:379: Check failed: shape.size() == 2 (4 vs. 2) : The NDArray needs to be 2 dimensional.
```
so we should reshape the output array to **(2, 1024)**

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Feature1, tests, (and when applicable, API doc)
- [x] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
