### PR TITLE
Add Gather_nd Scatter_nd to NDArray API category doc

### DIFF
--- a/docs/api/python/ndarray/ndarray.md
+++ b/docs/api/python/ndarray/ndarray.md
@@ -462,6 +462,8 @@ The `ndarray` package provides several classes:
     where
     ravel_multi_index
     unravel_index
+    gather_nd
+    scatter_nd
 ```
 
 ## Mathematical functions


### PR DESCRIPTION
## Description ##
`gather_nd` and `scatter_nd` - present in Symbol API Indexing routine category - https://mxnet.incubator.apache.org/versions/master/api/python/symbol/symbol.html#indexing-routines

But not present in Indexing routine category in NDArray API

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- [X] Code is well-documented: 
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add to Doc
