### PR TITLE
Numpy Identity operator

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -179,7 +179,7 @@ def ones(shape, dtype=None, **kwargs):
 
 
 @set_module('mxnet.ndarray.numpy')
-def identity(n, dtype=None, **kwargs):
+def identity(n, dtype=None, ctx=None):
     """
     Return the identity array.
 
@@ -213,11 +213,10 @@ def identity(n, dtype=None, **kwargs):
         raise TypeError("Input 'n' should be an integer")
     if n < 0:
         raise ValueError("Input 'n' cannot be negative")
-    ctx = kwargs.pop('ctx', current_context())
     if ctx is None:
         ctx = current_context()
     dtype = _np.float32 if dtype is None else dtype
-    return _npi.identity(shape=(n, n), ctx=ctx, dtype=dtype, **kwargs)
+    return _npi.identity(shape=(n, n), ctx=ctx, dtype=dtype)
 
 
 #pylint: disable= too-many-arguments, no-member, protected-access

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -33,7 +33,7 @@ __all__ = ['zeros', 'ones', 'maximum', 'minimum', 'stack', 'arange', 'argmax',
            'clip', 'split', 'swapaxes', 'expand_dims', 'tile', 'linspace', 'eye',
            'sin', 'cos', 'sinh', 'cosh', 'log10', 'sqrt', 'abs', 'exp', 'arctan', 'sign', 'log',
            'degrees', 'log2', 'rint', 'radians', 'mean', 'reciprocal', 'square', 'arcsin',
-           'argsort', 'hstack', 'tensordot']
+           'argsort', 'hstack', 'tensordot', 'identity']
 
 
 @set_module('mxnet.ndarray.numpy')
@@ -128,7 +128,7 @@ def zeros(shape, dtype=_np.float32, **kwargs):
         The shape of the empty array.
     dtype : str or numpy.dtype, optional
         An optional value type. Default is `numpy.float32`. Note that this
-        behavior is different from NumPy's `ones` function where `float64`
+        behavior is different from NumPy's `zeros` function where `float64`
         is the default value, because `float32` is considered as the default
         data type in deep learning.
     ctx : Context, optional
@@ -170,12 +170,54 @@ def ones(shape, dtype=None, **kwargs):
     out : ndarray
         Array of zeros with the given shape, dtype, and ctx.
     """
-    _sanity_check_params('zeros', ['order'], kwargs)
+    _sanity_check_params('ones', ['order'], kwargs)
     ctx = kwargs.pop('ctx', current_context())
     if ctx is None:
         ctx = current_context()
     dtype = _np.float32 if dtype is None else dtype
     return _npi.ones(shape=shape, ctx=ctx, dtype=dtype, **kwargs)
+
+
+@set_module('mxnet.ndarray.numpy')
+def identity(n, dtype=None, **kwargs):
+    """
+    Return the identity array.
+
+    The identity array is a square array with ones on
+    the main diagonal.
+
+    Parameters
+    ----------
+    n : int
+        Number of rows (and columns) in `n` x `n` output.
+    dtype : data-type, optional
+        Data-type of the output.  Defaults to ``numpy.float32``.
+    ctx : Context, optional
+        An optional device context (default is the current default context).
+
+    Returns
+    -------
+    out : ndarray
+        `n` x `n` array with its main diagonal set to one,
+        and all other elements 0.
+
+    Examples
+    --------
+    >>> np.identity(3)
+    >>> np.identity(3)
+    array([[1., 0., 0.],
+           [0., 1., 0.],
+           [0., 0., 1.]])
+    """
+    if not isinstance(n, int):
+        raise TypeError("Input 'n' should be an integer")
+    if n < 0:
+        raise ValueError("Input 'n' cannot be negative")
+    ctx = kwargs.pop('ctx', current_context())
+    if ctx is None:
+        ctx = current_context()
+    dtype = _np.float32 if dtype is None else dtype
+    return _npi.identity(shape=(n, n), ctx=ctx, dtype=dtype, **kwargs)
 
 
 #pylint: disable= too-many-arguments, no-member, protected-access

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -1498,7 +1498,7 @@ def ones(shape, dtype=None, **kwargs):
 
 
 @set_module('mxnet.numpy')
-def identity(n, dtype=None, **kwargs):
+def identity(n, dtype=None, ctx=None):
     """
     Return the identity array.
 
@@ -1528,7 +1528,7 @@ def identity(n, dtype=None, **kwargs):
            [0., 1., 0.],
            [0., 0., 1.]])
     """
-    return _mx_nd_np.identity(n, dtype, **kwargs)
+    return _mx_nd_np.identity(n, dtype, ctx)
 
 
 @set_module('mxnet.numpy')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -48,7 +48,7 @@ __all__ = ['ndarray', 'empty', 'array', 'zeros', 'ones', 'maximum', 'minimum', '
            'clip', 'split', 'swapaxes', 'expand_dims', 'tile', 'linspace', 'eye', 'sin', 'cos',
            'sin', 'cos', 'sinh', 'cosh', 'log10', 'sqrt', 'abs', 'exp', 'arctan', 'sign', 'log',
            'degrees', 'log2', 'rint', 'radians', 'mean', 'reciprocal', 'square', 'arcsin',
-           'argsort', 'hstack', 'tensordot']
+           'argsort', 'hstack', 'tensordot', 'identity']
 
 
 @set_module('mxnet.numpy')
@@ -1457,7 +1457,7 @@ def zeros(shape, dtype=_np.float32, **kwargs):
         The shape of the empty array.
     dtype : str or numpy.dtype, optional
         An optional value type (default is `numpy.float32`). Note that this
-        behavior is different from NumPy's `ones` function where `float64`
+        behavior is different from NumPy's `zeros` function where `float64`
         is the default value, because `float32` is considered as the default
         data type in deep learning.
     ctx : Context, optional
@@ -1495,6 +1495,40 @@ def ones(shape, dtype=None, **kwargs):
         Array of zeros with the given shape, dtype, and ctx.
     """
     return _mx_nd_np.ones(shape, dtype, **kwargs)
+
+
+@set_module('mxnet.numpy')
+def identity(n, dtype=None, **kwargs):
+    """
+    Return the identity array.
+
+    The identity array is a square array with ones on
+    the main diagonal.
+
+    Parameters
+    ----------
+    n : int
+        Number of rows (and columns) in `n` x `n` output.
+    dtype : data-type, optional
+        Data-type of the output.  Defaults to ``numpy.float32``.
+    ctx : Context, optional
+        An optional device context (default is the current default context).
+
+    Returns
+    -------
+    out : ndarray
+        `n` x `n` array with its main diagonal set to one,
+        and all other elements 0.
+
+    Examples
+    --------
+    >>> np.identity(3)
+    >>> np.identity(3)
+    array([[1., 0., 0.],
+           [0., 1., 0.],
+           [0., 0., 1.]])
+    """
+    return _mx_nd_np.identity(n, dtype, **kwargs)
 
 
 @set_module('mxnet.numpy')

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -981,7 +981,7 @@ def ones(shape, dtype=None, **kwargs):
 
 
 @set_module('mxnet.symbol.numpy')
-def identity(n, dtype=None, **kwargs):
+def identity(n, dtype=None, ctx=None):
     """
     Return the identity array.
 
@@ -1007,11 +1007,10 @@ def identity(n, dtype=None, **kwargs):
         raise TypeError("Input 'n' should be an integer")
     if n < 0:
         raise ValueError("Input 'n' cannot be negative")
-    ctx = kwargs.pop('ctx', current_context())
     if ctx is None:
         ctx = current_context()
     dtype = _np.float32 if dtype is None else dtype
-    return _npi.identity(shape=(n, n), ctx=ctx, dtype=dtype, **kwargs)
+    return _npi.identity(shape=(n, n), ctx=ctx, dtype=dtype)
 
 
 #pylint: disable= too-many-arguments, no-member, protected-access

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -33,7 +33,7 @@ __all__ = ['zeros', 'ones', 'maximum', 'minimum', 'stack', 'concatenate', 'arang
            'clip', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'split', 'swapaxes',
            'expand_dims', 'tile', 'linspace', 'eye', 'sin', 'cos', 'sinh', 'cosh', 'log10', 'sqrt',
            'abs', 'exp', 'arctan', 'sign', 'log', 'degrees', 'log2', 'rint', 'radians', 'mean',
-           'reciprocal', 'square', 'arcsin', 'argsort', 'hstack', 'tensordot']
+           'reciprocal', 'square', 'arcsin', 'argsort', 'hstack', 'tensordot', 'identity']
 
 
 def _num_outputs(sym):
@@ -972,12 +972,46 @@ def ones(shape, dtype=None, **kwargs):
     out : ndarray
         Array of zeros with the given shape, dtype, and ctx.
     """
-    _sanity_check_params('zeros', ['order'], kwargs)
+    _sanity_check_params('ones', ['order'], kwargs)
     ctx = kwargs.get('ctx', current_context())
     if ctx is None:
         ctx = current_context()
     dtype = _np.float32 if dtype is None else dtype
     return _npi.ones(shape=shape, ctx=ctx, dtype=dtype, **kwargs)
+
+
+@set_module('mxnet.symbol.numpy')
+def identity(n, dtype=None, **kwargs):
+    """
+    Return the identity array.
+
+    The identity array is a square array with ones on
+    the main diagonal.
+
+    Parameters
+    ----------
+    n : int
+        Number of rows (and columns) in `n` x `n` output.
+    dtype : data-type, optional
+        Data-type of the output.  Defaults to ``numpy.float32``.
+    ctx : Context, optional
+        An optional device context (default is the current default context).
+
+    Returns
+    -------
+    out : _Symbol
+        `n` x `n` array with its main diagonal set to one,
+        and all other elements 0.
+    """
+    if not isinstance(n, int):
+        raise TypeError("Input 'n' should be an integer")
+    if n < 0:
+        raise ValueError("Input 'n' cannot be negative")
+    ctx = kwargs.pop('ctx', current_context())
+    if ctx is None:
+        ctx = current_context()
+    dtype = _np.float32 if dtype is None else dtype
+    return _npi.identity(shape=(n, n), ctx=ctx, dtype=dtype, **kwargs)
 
 
 #pylint: disable= too-many-arguments, no-member, protected-access

--- a/src/operator/numpy/np_init_op.cc
+++ b/src/operator/numpy/np_init_op.cc
@@ -50,6 +50,16 @@ NNVM_REGISTER_OP(_npi_ones)
 .set_attr<FCompute>("FCompute<cpu>", FillCompute<cpu, 1>)
 .add_arguments(InitOpParam::__FIELDS__());
 
+NNVM_REGISTER_OP(_npi_identity)
+.describe("Return a new identity array of given shape, type, and context.")
+.set_num_inputs(0)
+.set_num_outputs(1)
+.set_attr_parser(ParamParser<InitOpParam>)
+.set_attr<mxnet::FInferShape>("FInferShape", InitShape<InitOpParam>)
+.set_attr<nnvm::FInferType>("FInferType", InitType<InitOpParam>)
+.set_attr<FCompute>("FCompute<cpu>", IdentityCompute<cpu>)
+.add_arguments(InitOpParam::__FIELDS__());
+
 NNVM_REGISTER_OP(_np_zeros_like)
 .describe(R"code(Return an array of zeros with the same shape and type as a given array.
 

--- a/src/operator/numpy/np_init_op.cu
+++ b/src/operator/numpy/np_init_op.cu
@@ -34,6 +34,9 @@ NNVM_REGISTER_OP(_npi_zeros)
 NNVM_REGISTER_OP(_npi_ones)
 .set_attr<FCompute>("FCompute<gpu>", FillCompute<gpu, 1>);
 
+NNVM_REGISTER_OP(_npi_identity)
+.set_attr<FCompute>("FCompute<gpu>", IdentityCompute<gpu>);
+
 NNVM_REGISTER_OP(_np_zeros_like)
 .set_attr<FCompute>("FCompute<gpu>", FillCompute<gpu, 0>);
 

--- a/src/operator/numpy/np_init_op.h
+++ b/src/operator/numpy/np_init_op.h
@@ -114,8 +114,9 @@ struct identity {
   MSHADOW_XINLINE static void Map(index_t i, DType* out_data, const int n) {
     using namespace mxnet_op;
 
-    auto j = unravel(i, mshadow::Shape2(n, n));
-    if (j[0] == j[1]) {
+    const index_t row_id = i / n;
+    const index_t col_id = i % n;
+    if (row_id == col_id) {
       KERNEL_ASSIGN(out_data[i], req, static_cast<DType>(1));
     } else {
       KERNEL_ASSIGN(out_data[i], req, static_cast<DType>(0));

--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -157,11 +157,11 @@ def test_identity():
             self._n = n
             self._dtype = dtype
 
-        def hybrid_forward(self, F, x, *args, **kwargs):
-            return x * F.np.identity(n, dtype)
+        def hybrid_forward(self, F, x):
+            return x * F.np.identity(self._n, self._dtype)
 
     class TestIdentityOutputType(HybridBlock):
-        def hybrid_forward(self, F, x, *args, **kwargs):
+        def hybrid_forward(self, F, x):
             return x, F.np.identity(0)
 
     def check_identity_array_creation(shape, dtype):

--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -149,7 +149,7 @@ def test_ones():
 
 
 @with_seed()
-@npx.use_np_shape
+@use_np
 def test_identity():
     class TestIdentity(HybridBlock):
         def __init__(self, shape, dtype=None):

--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -149,6 +149,51 @@ def test_ones():
 
 
 @with_seed()
+@npx.use_np_shape
+def test_identity():
+    class TestIdentity(HybridBlock):
+        def __init__(self, shape, dtype=None):
+            super(TestIdentity, self).__init__()
+            self._n = n
+            self._dtype = dtype
+
+        def hybrid_forward(self, F, x, *args, **kwargs):
+            return x * F.np.identity(n, dtype)
+
+    class TestIdentityOutputType(HybridBlock):
+        def hybrid_forward(self, F, x, *args, **kwargs):
+            return x, F.np.identity(0)
+
+    def check_identity_array_creation(shape, dtype):
+        np_out = _np.identity(n=n, dtype=dtype)
+        mx_out = np.identity(n=n, dtype=dtype)
+        assert same(mx_out.asnumpy(), np_out)
+        if dtype is None:
+            assert mx_out.dtype == _np.float32
+            assert np_out.dtype == _np.float64
+
+    ns = [0, 1, 2, 3, 5, 15, 30, 200]
+    dtypes = [_np.int8, _np.int32, _np.float16, _np.float32, _np.float64, None]
+    for n in ns:
+        for dtype in dtypes:
+            check_identity_array_creation(n, dtype)
+            x = mx.nd.array(_np.random.uniform(size=(n, n)), dtype=dtype).as_np_ndarray()
+            if dtype is None:
+                x = x.astype('float32')
+            for hybridize in [True, False]:
+                test_identity = TestIdentity(n, dtype)
+                test_identity_output_type = TestIdentityOutputType()
+                if hybridize:
+                    test_identity.hybridize()
+                    test_identity_output_type.hybridize()
+                y = test_identity(x)
+                assert type(y) == np.ndarray
+                assert same(x.asnumpy() * _np.identity(n, dtype), y.asnumpy())
+                y = test_identity_output_type(x)
+                assert type(y[1]) == np.ndarray
+
+
+@with_seed()
 def test_ndarray_binary_element_wise_ops():
     np_op_map = {
         '+': _np.add,


### PR DESCRIPTION
## Description ##
Implementation of numpy `identity` operator in mxnet.
The version that cherry-pick on new numpy branch, old pr -> #15511.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- add op `identity`
- fix some typos/mistakes in doc of `zeros` and `ones`

## Comments ##
Welcome @reminisce, @haojin2, and others for reviewing.