### PR TITLE
Fix memory leaks caused by multi-calls to Extract().

### DIFF
--- a/cpp-package/example/feature_extract/feature_extract.cpp
+++ b/cpp-package/example/feature_extract/feature_extract.cpp
@@ -99,9 +99,17 @@ class FeatureExtractor {
     data.Slice(0, 1) -= mean_img;
     data.Slice(1, 2) -= mean_img;
     args_map["data"] = data;
-    /*bind the executor*/
-    executor = net.SimpleBind(global_ctx, args_map, map<string, NDArray>(),
-                              map<string, OpReqType>(), aux_map);
+    /*Singleton Pattern*/
+    if(!executor){
+        args_map["data"] = data;
+        /*bind the executor*/
+        executor = net.SimpleBind(global_ctx, args_map, map<string, NDArray>(),
+                                  map<string, OpReqType>(), aux_map);
+    }else{
+        /*update data*/
+        data.CopyTo(&(executor->arg_dict()["data"]));
+        NDArray::WaitAll();
+    }
     executor->Forward(false);
     /*print out the features*/
     auto array = executor->outputs[0].Copy(Context(kCPU, 0));


### PR DESCRIPTION
Fix memory leaks caused by multiple calls to Extract functions.

## Description ##
Multiple calls to the Extract function can cause **memory leaks**, so we need to use the singleton pattern to create only one instance of executor.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Feature1, tests, (and when applicable, API doc)
- [x] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
