### PR TITLE
make TransposeShape infer shape form both sides

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -354,17 +354,12 @@ inline bool TransposeShape(const nnvm::NodeAttrs& attrs,
     CHECK_EQ(out_shp.ndim(), shp.ndim());
   mxnet::TShape get(std::max(shp.ndim(), out_shp.ndim()), -1);
   mxnet::TShape ret(std::max(shp.ndim(), out_shp.ndim()), -1);
-  auto ifUnknownAssignElseCheck = [](mxnet::TShape& arr, int i, int val) {
-                                     if (arr[i] == -1) { arr[i] = val;
-                                     } else { CHECK_EQ(arr[i], val); } };
   if (param.axes.ndim() == 0) {
     for (int i = 0; i < shp.ndim(); ++i) {
-      get[i] = shp[i];
       ret[i] = shp[shp.ndim()-1-i];
     }
     for (int i = 0; i < out_shp.ndim(); ++i) {
-      ifUnknownAssignElseCheck(ret, i, out_shp[i]);
-      ifUnknownAssignElseCheck(get, shp.ndim()-1-i, out_shp[i]);
+      get[shp.ndim()-1-i] = out_shp[i];
     }
   } else {
     CHECK_EQ(std::max(shp.ndim(), out_shp.ndim()), param.axes.ndim());
@@ -373,8 +368,7 @@ inline bool TransposeShape(const nnvm::NodeAttrs& attrs,
       ret[i] = shp[param.axes[i]];
     }
     for (int i = 0; i < out_shp.ndim(); ++i) {
-      ifUnknownAssignElseCheck(ret, i, out_shp[i]);
-      ifUnknownAssignElseCheck(get, param.axes[i], out_shp[i]);
+      get[param.axes[i]] = out_shp[i];
     }
   }
   SHAPE_ASSIGN_CHECK(*in_attrs, 0, get);

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -348,15 +348,15 @@ inline bool TransposeShape(const nnvm::NodeAttrs& attrs,
   CHECK_LE(shp.ndim(), 6) << "Transpose support at most 6 dimensions";
   CHECK_NE(shp.ndim(), 0) << "Number of dimensions cannot be 0";
   CHECK_NE(out_shp.ndim(), 0) << "Number of dimensions cannot be 0";
-  if (shp.ndim() == -1 and out_shp.ndim() == -1)
-    return false; // none of the shapes is known
-  if (out_shp.ndim() > 0 and shp.ndim() > 0)
+  if (shp.ndim() == -1 && out_shp.ndim() == -1)
+    return false;  // none of the shapes is known
+  if (out_shp.ndim() > 0 && shp.ndim() > 0)
     CHECK_EQ(out_shp.ndim(), shp.ndim());
   mxnet::TShape get(std::max(shp.ndim(), out_shp.ndim()), -1);
   mxnet::TShape ret(std::max(shp.ndim(), out_shp.ndim()), -1);
   auto ifUnknownAssignElseCheck = [](mxnet::TShape& arr, int i, int val) {
-                                     if (arr[i] == -1) arr[i] = val;
-                                     else CHECK_EQ(arr[i], val); };
+                                     if (arr[i] == -1) { arr[i] = val;
+                                     } else { CHECK_EQ(arr[i], val); } };
   if (param.axes.ndim() == 0) {
     for (int i = 0; i < shp.ndim(); ++i) {
       get[i] = shp[i];

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8970,6 +8970,26 @@ def test_get_operator_arguments():
     ok_(operator_arguments.narg == 2)
 
 
+def test_transpose_infer_shape_back():
+    o1 = mx.sym.ones(shape=[2,3])
+    o2 = mx.sym.ones(shape=[-1,-1])
+    t = mx.sym.transpose(o2)
+    b = o1 + t
+    x = b.bind(mx.cpu(), args={})
+    y = x.forward()
+    assert(y[0].shape == (2,3))
+
+
+def test_transpose_infer_shape_mixed():
+    o1 = mx.sym.ones(shape=[2,-1])
+    o2 = mx.sym.ones(shape=[3,-1])
+    t = mx.sym.transpose(o2)
+    b = o1 + t
+    x = b.bind(mx.cpu(), args={})
+    y = x.forward()
+    assert(y[0].shape == (2,3))
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
Make the function TransposeShape use both input and output data. Base on this it completes all unknown dimension sizes. If any of them is know on both sides the function checks if they match.