### PR TITLE
Added blas and int64 to cmake options

### DIFF
--- a/cmake/cmake_options.yml
+++ b/cmake/cmake_options.yml
@@ -40,6 +40,8 @@ USE_MXNET_LIB_NAMING: "ON" # Use MXNet library naming conventions.
 USE_GPROF: "OFF" # Compile with gprof (profiling) flag
 USE_CXX14_IF_AVAILABLE: "OFF" # Build with C++14 if the compiler supports it
 USE_VTUNE: "OFF" # Enable use of Intel Amplifier XE (VTune)) # one could set VTUNE_ROOT for search path
+USE_BLAS: "openblas" # Build with BLAS version "openblas" # choose from : mkl, blas, atlas (linux default), openblas, apple (osx default)
+USE_INT64_TENSOR_SIZE: "OFF" # Build with int64 (large tensor) support
 ENABLE_CUDA_RTC: "ON" # Build with CUDA runtime compilation support
 BUILD_CPP_EXAMPLES: "ON" # Build cpp examples
 INSTALL_EXAMPLES: "OFF" # Install the example source files.


### PR DESCRIPTION
## Description ##
For building MXNet, while using
```
./dev_menu.py build
```
It picks up config for cmake from cmake/cmake_options.yml
It doesn't have 2 build flags for BLAS and INT64_TENSOR

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
