### PR TITLE
Fix the bug of `MXEnginePushAsyncND` and `MXEnginePushSyncND`

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -2921,12 +2921,12 @@ MXNET_DLL int MXEnginePushSync(EngineSyncFunc sync_func, void* func_param,
   * \param wait Whether this is a WaitForVar operation.
   */
 MXNET_DLL int MXEnginePushAsyncND(EngineAsyncFunc async_func, void* func_param,
-                                EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
-                                NDArrayHandle* const_nds_handle, int num_const_nds,
-                                NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
-                                EngineFnPropertyHandle prop_handle DEFAULT(NULL),
-                                int priority DEFAULT(0), const char* opr_name DEFAULT(NULL),
-                                bool wait DEFAULT(false));
+                                  EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
+                                  NDArrayHandle* const_nds_handle, int num_const_nds,
+                                  NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
+                                  EngineFnPropertyHandle prop_handle DEFAULT(NULL),
+                                  int priority DEFAULT(0), const char* opr_name DEFAULT(NULL),
+                                  bool wait DEFAULT(false));
 
 /*!
   * \brief Push a synchronous operation to the engine.
@@ -2944,11 +2944,11 @@ MXNET_DLL int MXEnginePushAsyncND(EngineAsyncFunc async_func, void* func_param,
   * \param opr_name The operation name.
   */
 MXNET_DLL int MXEnginePushSyncND(EngineSyncFunc sync_func, void* func_param,
-                               EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
-                               NDArrayHandle* const_nds_handle, int num_const_nds,
-                               NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
-                               EngineFnPropertyHandle prop_handle DEFAULT(NULL),
-                               int priority DEFAULT(0), const char* opr_name DEFAULT(NULL));
+                                 EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
+                                 NDArrayHandle* const_nds_handle, int num_const_nds,
+                                 NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
+                                 EngineFnPropertyHandle prop_handle DEFAULT(NULL),
+                                 int priority DEFAULT(0), const char* opr_name DEFAULT(NULL));
 
 #ifdef __cplusplus
 }

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -2922,8 +2922,8 @@ MXNET_DLL int MXEnginePushSync(EngineSyncFunc sync_func, void* func_param,
   */
 MXNET_DLL int MXEnginePushAsyncND(EngineAsyncFunc async_func, void* func_param,
                                 EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
-                                NDArrayHandle const_nds_handle, int num_const_nds,
-                                NDArrayHandle mutable_nds_handle, int num_mutable_nds,
+                                NDArrayHandle* const_nds_handle, int num_const_nds,
+                                NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
                                 EngineFnPropertyHandle prop_handle DEFAULT(NULL),
                                 int priority DEFAULT(0), const char* opr_name DEFAULT(NULL),
                                 bool wait DEFAULT(false));
@@ -2945,8 +2945,8 @@ MXNET_DLL int MXEnginePushAsyncND(EngineAsyncFunc async_func, void* func_param,
   */
 MXNET_DLL int MXEnginePushSyncND(EngineSyncFunc sync_func, void* func_param,
                                EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
-                               NDArrayHandle const_nds_handle, int num_const_nds,
-                               NDArrayHandle mutable_nds_handle, int num_mutable_nds,
+                               NDArrayHandle* const_nds_handle, int num_const_nds,
+                               NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
                                EngineFnPropertyHandle prop_handle DEFAULT(NULL),
                                int priority DEFAULT(0), const char* opr_name DEFAULT(NULL));
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1544,11 +1544,11 @@ int MXEnginePushSync(EngineSyncFunc sync_func, void* func_param,
 }
 
 int MXEnginePushAsyncND(EngineAsyncFunc async_func, void* func_param,
-                      EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
-                      NDArrayHandle* const_nds_handle, int num_const_nds,
-                      NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
-                      EngineFnPropertyHandle prop_handle, int priority,
-                      const char* opr_name, bool wait) {
+                        EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
+                        NDArrayHandle* const_nds_handle, int num_const_nds,
+                        NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
+                        EngineFnPropertyHandle prop_handle, int priority,
+                        const char* opr_name, bool wait) {
   API_BEGIN();
   NDArray** const_nds = reinterpret_cast<NDArray**>(const_nds_handle);
   NDArray** mutable_nds = reinterpret_cast<NDArray**>(mutable_nds_handle);
@@ -1564,11 +1564,11 @@ int MXEnginePushAsyncND(EngineAsyncFunc async_func, void* func_param,
 }
 
 int MXEnginePushSyncND(EngineSyncFunc sync_func, void* func_param,
-                     EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
-                     NDArrayHandle* const_nds_handle, int num_const_nds,
-                     NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
-                     EngineFnPropertyHandle prop_handle, int priority,
-                     const char* opr_name) {
+                       EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
+                       NDArrayHandle* const_nds_handle, int num_const_nds,
+                       NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
+                       EngineFnPropertyHandle prop_handle, int priority,
+                       const char* opr_name) {
   API_BEGIN();
   NDArray** const_nds = reinterpret_cast<NDArray**>(const_nds_handle);
   NDArray** mutable_nds = reinterpret_cast<NDArray**>(mutable_nds_handle);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1545,17 +1545,17 @@ int MXEnginePushSync(EngineSyncFunc sync_func, void* func_param,
 
 int MXEnginePushAsyncND(EngineAsyncFunc async_func, void* func_param,
                       EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
-                      NDArrayHandle const_nds_handle, int num_const_nds,
-                      NDArrayHandle mutable_nds_handle, int num_mutable_nds,
+                      NDArrayHandle* const_nds_handle, int num_const_nds,
+                      NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
                       EngineFnPropertyHandle prop_handle, int priority,
                       const char* opr_name, bool wait) {
   API_BEGIN();
-  NDArray* const_nds = static_cast<NDArray*>(const_nds_handle);
-  NDArray* mutable_nds = static_cast<NDArray*>(mutable_nds_handle);
+  NDArray** const_nds = reinterpret_cast<NDArray**>(const_nds_handle);
+  NDArray** mutable_nds = reinterpret_cast<NDArray**>(mutable_nds_handle);
   std::vector<VarHandle> const_var_vec(num_const_nds);
-  for (int i = 0; i < num_const_nds; ++i) const_var_vec[i] = (const_nds+i)->var();
+  for (int i = 0; i < num_const_nds; ++i) const_var_vec[i] = const_nds[i]->var();
   std::vector<VarHandle> mutable_var_vec(num_mutable_nds);
-  for (int i = 0; i < num_mutable_nds; ++i) mutable_var_vec[i] = (mutable_nds+i)->var();
+  for (int i = 0; i < num_mutable_nds; ++i) mutable_var_vec[i] = mutable_nds[i]->var();
   return MXEnginePushAsync(async_func, func_param, deleter, ctx_handle,
                            const_var_vec.data(), num_const_nds,
                            mutable_var_vec.data(), num_mutable_nds,
@@ -1565,17 +1565,17 @@ int MXEnginePushAsyncND(EngineAsyncFunc async_func, void* func_param,
 
 int MXEnginePushSyncND(EngineSyncFunc sync_func, void* func_param,
                      EngineFuncParamDeleter deleter, ContextHandle ctx_handle,
-                     NDArrayHandle const_nds_handle, int num_const_nds,
-                     NDArrayHandle mutable_nds_handle, int num_mutable_nds,
+                     NDArrayHandle* const_nds_handle, int num_const_nds,
+                     NDArrayHandle* mutable_nds_handle, int num_mutable_nds,
                      EngineFnPropertyHandle prop_handle, int priority,
                      const char* opr_name) {
   API_BEGIN();
-  NDArray* const_nds = static_cast<NDArray*>(const_nds_handle);
-  NDArray* mutable_nds = static_cast<NDArray*>(mutable_nds_handle);
+  NDArray** const_nds = reinterpret_cast<NDArray**>(const_nds_handle);
+  NDArray** mutable_nds = reinterpret_cast<NDArray**>(mutable_nds_handle);
   std::vector<VarHandle> const_var_vec(num_const_nds);
-  for (int i = 0; i < num_const_nds; ++i) const_var_vec[i] = (const_nds+i)->var();
+  for (int i = 0; i < num_const_nds; ++i) const_var_vec[i] = const_nds[i]->var();
   std::vector<VarHandle> mutable_var_vec(num_mutable_nds);
-  for (int i = 0; i < num_mutable_nds; ++i) mutable_var_vec[i] = (mutable_nds+i)->var();
+  for (int i = 0; i < num_mutable_nds; ++i) mutable_var_vec[i] = mutable_nds[i]->var();
   return MXEnginePushSync(sync_func, func_param, deleter, ctx_handle,
                           const_var_vec.data(), num_const_nds,
                           mutable_var_vec.data(), num_mutable_nds,

--- a/tests/cpp/engine/threaded_engine_test.cc
+++ b/tests/cpp/engine/threaded_engine_test.cc
@@ -258,47 +258,50 @@ TEST(Engine, PushFunc) {
 TEST(Engine, PushFuncND) {
   auto ctx = mxnet::Context{};
   mxnet::NDArray nd(ctx);
+  std::vector<mxnet::NDArray*> nds;
+  nds.push_back(&nd);
+  mxnet::NDArray **pnds = nds.data();
 
   // Test #1
   LOG(INFO) << "===== Test #1: PushAsyncND param and deleter =====";
   int* a = new int(100);
-  int res = MXEnginePushAsyncND(FooAsyncFunc, a, FooFuncDeleter, &ctx, &nd, 1, nullptr, 0);
+  int res = MXEnginePushAsyncND(FooAsyncFunc, a, FooFuncDeleter, &ctx, pnds, 1, nullptr, 0);
   EXPECT_EQ(res, 0);
 
   // Test #2
   LOG(INFO) << "===== Test #2: PushAsyncND NULL param and NULL deleter =====";
-  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, 0);
+  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, nullptr, 0, pnds, 0);
   EXPECT_EQ(res, 0);
 
   // Test #3
   LOG(INFO) << "===== Test #3: PushAsyncND invalid number of const nds =====";
-  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, &nd, -1, nullptr, 0);
+  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, pnds, -1, nullptr, 0);
   EXPECT_EQ(res, -1);
 
   // Test #4
   LOG(INFO) << "===== Test #4: PushAsyncND invalid number of mutable nds =====";
-  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, -1);
+  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, nullptr, 0, pnds, -1);
   EXPECT_EQ(res, -1);
 
   // Test #5
   LOG(INFO) << "===== Test #5: PushSyncND param and deleter =====";
   int* b = new int(101);
-  res = MXEnginePushSyncND(FooSyncFunc, b, FooFuncDeleter, &ctx, &nd, 1, nullptr, 0);
+  res = MXEnginePushSyncND(FooSyncFunc, b, FooFuncDeleter, &ctx, pnds, 1, nullptr, 0);
   EXPECT_EQ(res, 0);
 
   // Test #6
   LOG(INFO) << "===== Test #6: PushSyncND NULL param and NULL deleter =====";
-  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, 1);
+  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, nullptr, 0, pnds, 1);
   EXPECT_EQ(res, 0);
 
   // Test #7
   LOG(INFO) << "===== Test #7: PushSyncND invalid number of const nds =====";
-  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, &nd, -1, nullptr, 0);
+  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, pnds, -1, nullptr, 0);
   EXPECT_EQ(res, -1);
 
   // Test #8
   LOG(INFO) << "===== Test #8: PushSyncND invalid number of mutable nds =====";
-  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, nullptr, 0, &nd, -1);
+  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, nullptr, 0, pnds, -1);
   EXPECT_EQ(res, -1);
 }
 

--- a/tests/cpp/engine/threaded_engine_test.cc
+++ b/tests/cpp/engine/threaded_engine_test.cc
@@ -327,7 +327,6 @@ TEST(Engine, PushFuncND) {
               const_nds_handle, num_const_nds,
               mutable_nds_handle, -1);
       EXPECT_EQ(res, -1);
-
   }
   for (mxnet::NDArray* pnd : nds) {
       delete pnd;

--- a/tests/cpp/engine/threaded_engine_test.cc
+++ b/tests/cpp/engine/threaded_engine_test.cc
@@ -274,50 +274,58 @@ TEST(Engine, PushFuncND) {
       LOG(INFO) << "===== Test #1: PushAsyncND param and deleter =====";
       int* a = new int(100);
       int res = MXEnginePushAsyncND(FooAsyncFunc, a, FooFuncDeleter, &ctx,
-              const_nds_handle, num_const_nds, mutable_nds_handle, num_mutable_nds);
+              const_nds_handle, num_const_nds,
+              mutable_nds_handle, num_mutable_nds);
       EXPECT_EQ(res, 0);
 
       // Test #2
       LOG(INFO) << "===== Test #2: PushAsyncND NULL param and NULL deleter =====";
       res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx,
-              const_nds_handle, num_const_nds, mutable_nds_handle, num_mutable_nds);
+              const_nds_handle, num_const_nds,
+              mutable_nds_handle, num_mutable_nds);
       EXPECT_EQ(res, 0);
 
       // Test #3
       LOG(INFO) << "===== Test #3: PushAsyncND invalid number of const nds =====";
       res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx,
-              pnds, -1, mutable_nds_handle, num_mutable_nds);
+              const_nds_handle, -1,
+              mutable_nds_handle, num_mutable_nds);
       EXPECT_EQ(res, -1);
 
       // Test #4
       LOG(INFO) << "===== Test #4: PushAsyncND invalid number of mutable nds =====";
       res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx,
-              const_nds_handle, num_const_nds, pnds, -1);
+              const_nds_handle, num_const_nds,
+              mutable_nds_handle, -1);
       EXPECT_EQ(res, -1);
 
       // Test #5
       LOG(INFO) << "===== Test #5: PushSyncND param and deleter =====";
       int* b = new int(101);
       res = MXEnginePushSyncND(FooSyncFunc, b, FooFuncDeleter, &ctx,
-              const_nds_handle, num_const_nds, mutable_nds_handle, num_mutable_nds);
+              const_nds_handle, num_const_nds,
+              mutable_nds_handle, num_mutable_nds);
       EXPECT_EQ(res, 0);
 
       // Test #6
       LOG(INFO) << "===== Test #6: PushSyncND NULL param and NULL deleter =====";
       res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx,
-              const_nds_handle, num_const_nds, mutable_nds_handle, num_mutable_nds);
+              const_nds_handle, num_const_nds,
+              mutable_nds_handle, num_mutable_nds);
       EXPECT_EQ(res, 0);
 
       // Test #7
       LOG(INFO) << "===== Test #7: PushSyncND invalid number of const nds =====";
-      res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, pnds, -1,
+      res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx,
+              const_nds_handle, -1,
               mutable_nds_handle, num_mutable_nds);
       EXPECT_EQ(res, -1);
 
       // Test #8
       LOG(INFO) << "===== Test #8: PushSyncND invalid number of mutable nds =====";
       res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx,
-              const_nds_handle, num_const_nds, pnds, -1);
+              const_nds_handle, num_const_nds,
+              mutable_nds_handle, -1);
       EXPECT_EQ(res, -1);
 
   }

--- a/tests/cpp/engine/threaded_engine_test.cc
+++ b/tests/cpp/engine/threaded_engine_test.cc
@@ -259,50 +259,72 @@ TEST(Engine, PushFuncND) {
   auto ctx = mxnet::Context{};
   mxnet::NDArray nd(ctx);
   std::vector<mxnet::NDArray*> nds;
-  nds.push_back(&nd);
-  void** pnds = reinterpret_cast<void**>(nds.data());
+  const int num_nds = 5;
+  for (int i = 0; i < num_nds; ++i) {
+      mxnet::NDArray *pnd = new mxnet::NDArray(ctx);
+      nds.push_back(pnd);
+  }
+  for (int num_const_nds = 0; num_const_nds <= num_nds; ++num_const_nds) {
+      int num_mutable_nds = num_nds - num_const_nds;
+      void** const_nds_handle = num_const_nds > 0 ?
+          reinterpret_cast<void**>(nds.data()) : nullptr;
+      void** mutable_nds_handle = num_mutable_nds > 0 ?
+          reinterpret_cast<void**>(nds.data() + num_const_nds);
 
-  // Test #1
-  LOG(INFO) << "===== Test #1: PushAsyncND param and deleter =====";
-  int* a = new int(100);
-  int res = MXEnginePushAsyncND(FooAsyncFunc, a, FooFuncDeleter, &ctx, pnds, 1, nullptr, 0);
-  EXPECT_EQ(res, 0);
+      // Test #1
+      LOG(INFO) << "===== Test #1: PushAsyncND param and deleter =====";
+      int* a = new int(100);
+      int res = MXEnginePushAsyncND(FooAsyncFunc, a, FooFuncDeleter, &ctx,
+              const_nds_handle, num_const_nds, mutable_nds_handle, num_mutable_nds);
+      EXPECT_EQ(res, 0);
 
-  // Test #2
-  LOG(INFO) << "===== Test #2: PushAsyncND NULL param and NULL deleter =====";
-  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, nullptr, 0, pnds, 0);
-  EXPECT_EQ(res, 0);
+      // Test #2
+      LOG(INFO) << "===== Test #2: PushAsyncND NULL param and NULL deleter =====";
+      res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx,
+              const_nds_handle, num_const_nds, mutable_nds_handle, num_mutable_nds);
+      EXPECT_EQ(res, 0);
 
-  // Test #3
-  LOG(INFO) << "===== Test #3: PushAsyncND invalid number of const nds =====";
-  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, pnds, -1, nullptr, 0);
-  EXPECT_EQ(res, -1);
+      // Test #3
+      LOG(INFO) << "===== Test #3: PushAsyncND invalid number of const nds =====";
+      res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx,
+              pnds, -1, mutable_nds_handle, num_mutable_nds);
+      EXPECT_EQ(res, -1);
 
-  // Test #4
-  LOG(INFO) << "===== Test #4: PushAsyncND invalid number of mutable nds =====";
-  res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx, nullptr, 0, pnds, -1);
-  EXPECT_EQ(res, -1);
+      // Test #4
+      LOG(INFO) << "===== Test #4: PushAsyncND invalid number of mutable nds =====";
+      res = MXEnginePushAsyncND(FooAsyncFunc, nullptr, nullptr, &ctx,
+              const_nds_handle, num_const_nds, pnds, -1);
+      EXPECT_EQ(res, -1);
 
-  // Test #5
-  LOG(INFO) << "===== Test #5: PushSyncND param and deleter =====";
-  int* b = new int(101);
-  res = MXEnginePushSyncND(FooSyncFunc, b, FooFuncDeleter, &ctx, pnds, 1, nullptr, 0);
-  EXPECT_EQ(res, 0);
+      // Test #5
+      LOG(INFO) << "===== Test #5: PushSyncND param and deleter =====";
+      int* b = new int(101);
+      res = MXEnginePushSyncND(FooSyncFunc, b, FooFuncDeleter, &ctx,
+              const_nds_handle, num_const_nds, mutable_nds_handle, num_mutable_nds);
+      EXPECT_EQ(res, 0);
 
-  // Test #6
-  LOG(INFO) << "===== Test #6: PushSyncND NULL param and NULL deleter =====";
-  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, nullptr, 0, pnds, 1);
-  EXPECT_EQ(res, 0);
+      // Test #6
+      LOG(INFO) << "===== Test #6: PushSyncND NULL param and NULL deleter =====";
+      res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx,
+              const_nds_handle, num_const_nds, mutable_nds_handle, num_mutable_nds);
+      EXPECT_EQ(res, 0);
 
-  // Test #7
-  LOG(INFO) << "===== Test #7: PushSyncND invalid number of const nds =====";
-  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, pnds, -1, nullptr, 0);
-  EXPECT_EQ(res, -1);
+      // Test #7
+      LOG(INFO) << "===== Test #7: PushSyncND invalid number of const nds =====";
+      res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, pnds, -1,
+              mutable_nds_handle, num_mutable_nds);
+      EXPECT_EQ(res, -1);
 
-  // Test #8
-  LOG(INFO) << "===== Test #8: PushSyncND invalid number of mutable nds =====";
-  res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx, nullptr, 0, pnds, -1);
-  EXPECT_EQ(res, -1);
+      // Test #8
+      LOG(INFO) << "===== Test #8: PushSyncND invalid number of mutable nds =====";
+      res = MXEnginePushSyncND(FooSyncFunc, nullptr, nullptr, &ctx,
+              const_nds_handle, num_const_nds, pnds, -1);
+      EXPECT_EQ(res, -1);
+
+  }
+  for (mxnet::NDArray* pnd : nds) {
+      delete pnd;
+  }
 }
 
 TEST(Engine, basics) {

--- a/tests/cpp/engine/threaded_engine_test.cc
+++ b/tests/cpp/engine/threaded_engine_test.cc
@@ -260,7 +260,7 @@ TEST(Engine, PushFuncND) {
   mxnet::NDArray nd(ctx);
   std::vector<mxnet::NDArray*> nds;
   nds.push_back(&nd);
-  mxnet::NDArray **pnds = nds.data();
+  void** pnds = reinterpret_cast<void**>(nds.data());
 
   // Test #1
   LOG(INFO) << "===== Test #1: PushAsyncND param and deleter =====";

--- a/tests/cpp/engine/threaded_engine_test.cc
+++ b/tests/cpp/engine/threaded_engine_test.cc
@@ -269,7 +269,7 @@ TEST(Engine, PushFuncND) {
       void** const_nds_handle = num_const_nds > 0 ?
           reinterpret_cast<void**>(nds.data()) : nullptr;
       void** mutable_nds_handle = num_mutable_nds > 0 ?
-          reinterpret_cast<void**>(nds.data() + num_const_nds);
+          reinterpret_cast<void**>(nds.data() + num_const_nds) : nullptr;
 
       // Test #1
       LOG(INFO) << "===== Test #1: PushAsyncND param and deleter =====";

--- a/tests/cpp/engine/threaded_engine_test.cc
+++ b/tests/cpp/engine/threaded_engine_test.cc
@@ -257,7 +257,6 @@ TEST(Engine, PushFunc) {
 
 TEST(Engine, PushFuncND) {
   auto ctx = mxnet::Context{};
-  mxnet::NDArray nd(ctx);
   std::vector<mxnet::NDArray*> nds;
   const int num_nds = 5;
   for (int i = 0; i < num_nds; ++i) {


### PR DESCRIPTION
## Description ##
Sorry that I wrote a bug in the two APIs `MXEnginePushAsyncND` and `MXEnginePushSyncND`, whose argument should be an array pointer of NDArrayHandle.

Issue: #15774 
master branch: #15751 
v1.5.x branch: #15775 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Modify the type of arguments to 'NDArry**'
- [x] Update the unittest

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
