### PR TITLE
Re-enable flaky test_prelu

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -794,7 +794,6 @@ def test_leaky_relu():
 # NOTE(haojin2): Skipping the numeric check tests for float16 data type due to precision issues,
 # the analytical checks are still performed on each and every data type to verify the correctness.
 @with_seed()
-@unittest.skip("Flaky test tracked by https://github.com/apache/incubator-mxnet/issues/12885")
 def test_prelu():
     def fprelu(x, gamma):
         pos_indices = x > 0


### PR DESCRIPTION
## Description ##

Re-enables disabled flaky test_prelu

Fixes #12885

run flakyness checker without issue:

```
python tools/flakiness_checker.py -v 10 tests/python/unittest/test_operator.py:test_prelu
```

