### PR TITLE
[Numpy] Numpy compatible slicing

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -700,42 +700,13 @@ inline void GetIndexRange(const mxnet::TShape& dshape,
       b = param_begin[i].has_value() ? param_begin[i].value() : (s < 0 ? len - 1 : 0);
       e = param_end[i].has_value() ? param_end[i].value() : (s < 0 ? -1 : len);
 
-      // checking upper and lower bounds for begin
       if (b < 0) {
         b += len;
-        if (!Imperative::Get()->is_np_shape()) {
-          CHECK_GE(b, 0) << "slicing with begin[" << i << "]=" << b - len
-                         << " exceeds limit of input dimension[" << i << "]=" << len;
-        }
       }
-      if (!Imperative::Get()->is_np_shape()) {
-        CHECK_LT(b, len) << "slicing with begin[" << i << "]=" << b
-                         << " exceeds limit of input dimension[" << i << "]=" << len;
-      }
-      // checking upper and lower bounds for end
       if (e < 0 && param_end[i].has_value()) {
         e += len;
-        if (!Imperative::Get()->is_np_shape()) {
-          CHECK_GE(e, 0) << "slicing with end[" << i << "]=" << e - len
-                         << " exceeds limit of input dimension[" << i << "]=" << len;
-        }
-      }
-      if (!Imperative::Get()->is_np_shape()) {
-        CHECK_LE(e, len) << "slicing with end[" << i << "]=" << e
-                         << " exceeds limit of input dimension[" << i << "]=" << len;
       }
 
-      // checking begin==end case which is not supported
-      if (!Imperative::Get()->is_np_shape()) {
-        CHECK_NE(b, e) << "slicing with begin[" << i << "]=end[" << i << "]="
-                       << e << " results in an empty tensor and is not supported";
-      }
-    } else if (len == 0) {
-      b = 0;
-      e = 0;
-    }
-
-    if (Imperative::Get()->is_np_shape() && len > 0) {
       // move the begin and end to correct position for calculating dim size
       b = b < 0 && s > 0 ? 0 : b;
       b = b > len - 1 && s < 0 ? len-1 : b;
@@ -743,7 +714,11 @@ inline void GetIndexRange(const mxnet::TShape& dshape,
       b = b < 0 || b > len - 1 ? -1 : b;
       e = e > -1 ? e : -1;
       e = e > len ? len : e;
+    } else if (len == 0) {
+      b = 0;
+      e = 0;
     }
+
     (*begin)[i] = b;
     (*end)[i] = e;
     (*step)[i] = s;

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -756,7 +756,7 @@ inline void GetIndexRange(const mxnet::TShape& dshape,
 inline void SetSliceOpOutputDimSize(const index_t i, const int b,
                                     const int e, const int s,
                                     mxnet::TShape* oshape) {
-  if (!Imperative::Get()->is_np_shape()) { //handle as ndarray
+  if (!Imperative::Get()->is_np_shape()) {  // handle as ndarray
     if (e != b) {
       if (s > 0) {
         CHECK_LT(b, e) << "slicing with begin=[" << i << "]=" << b << ", end[" << i << "]="
@@ -768,7 +768,7 @@ inline void SetSliceOpOutputDimSize(const index_t i, const int b,
         (*oshape)[i] = (b - e - 1) / (-s) + 1;
       }
     }  // else leave oshape[i] as 0 for partial infer
-  } else { //handle as numpy compatible array
+  } else {  // handle as numpy compatible array
     if (e != b && b >= 0) {
       if (s > 0) {
         (*oshape)[i] = e > b ? (e - b - 1) / s + 1 : 0;

--- a/src/operator/tensor/matrix_op.cc
+++ b/src/operator/tensor/matrix_op.cc
@@ -506,6 +506,7 @@ Example::
                                                             [5.,  7.],
                                                             [1.,  3.]]
 )code" ADD_FILELINE)
+.add_alias("_npx_slice")
 .set_attr_parser(ParamParser<SliceParam>)
 .set_attr<mxnet::FInferShape>("FInferShape", SliceOpShape)
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -7519,15 +7519,6 @@ def test_slice():
     for index in index_list:
         test_slice_forward_backward(arr, index)
 
-    def test_begin_equals_end(shape, begin, end, step):
-        in_arr = mx.nd.arange(np.prod(shape)).reshape(shape=shape)
-        out_arr = mx.nd.slice(in_arr, begin=begin, end=end, step=step)
-
-    assertRaises(MXNetError, test_begin_equals_end, (4,), (2,), (2,), (1,))
-    assertRaises(MXNetError, test_begin_equals_end, (1, 5), (None, 3), (None, 3), (-1, 1))
-    assertRaises(MXNetError, test_begin_equals_end, (3, 4, 5), (1, 3, 1), (3, 3, 1), (1, -3, 2))
-    assertRaises(MXNetError, test_begin_equals_end, (2, 4), (None, 2), (None, 2), (1, -1))
-
     # check numeric gradient
     in_data = np.arange(36).reshape(2, 2, 3, 3)
     data = mx.sym.Variable('data')


### PR DESCRIPTION
## Description ##
Add numpy compatible slicing operator under npx namespace

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- generally similar behavior as ndarray.slice
- like numpy slicing, we allow the starting index to be greater than ending index, in which case a zero size tensor is generated 

## Comments ##
Thank @haojin2 and @reminisce for reviewing
