### PR TITLE
[v1.5.x]Add MKLDNN 4c layout to fix gluoncv se_resnext101_64x4d (#15692)

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_base.cc
+++ b/src/operator/nn/mkldnn/mkldnn_base.cc
@@ -329,6 +329,7 @@ mkldnn_memory_format_t GetDefaultFormat(const mkldnn::memory::desc &desc) {
       case mkldnn_nchw:
       case mkldnn_nhwc:
       case mkldnn_chwn:
+      case mkldnn_nChw4c:
       case mkldnn_nChw8c:
       case mkldnn_nChw16c:
         return mkldnn_nchw;
@@ -338,6 +339,7 @@ mkldnn_memory_format_t GetDefaultFormat(const mkldnn::memory::desc &desc) {
       case mkldnn_iohw:
       case mkldnn_oIhw8i:
       case mkldnn_oIhw16i:
+      case mkldnn_OIhw4i4o:
       case mkldnn_OIhw8i8o:
       case mkldnn_hwio_s8s8:
       case mkldnn_OIhw16i16o:
@@ -376,6 +378,7 @@ mkldnn_memory_format_t GetDefaultFormat(const mkldnn::memory::desc &desc) {
       case mkldnn_giohw:
       case mkldnn_hwigo:
       case mkldnn_hwigo_s8s8:
+      case mkldnn_gOIhw4i4o:
       case mkldnn_gOIhw8i8o:
       case mkldnn_gOIhw16i16o:
       case mkldnn_gOIhw4i16o4i:
@@ -383,6 +386,7 @@ mkldnn_memory_format_t GetDefaultFormat(const mkldnn::memory::desc &desc) {
       case mkldnn_gOIhw8i16o2i:
       case mkldnn_gOIhw8o16i2o:
       case mkldnn_gOIhw8o8i:
+      case mkldnn_gOIhw4o4i:
       case mkldnn_gOIhw16o16i:
       case mkldnn_gIOhw16o16i:
       case mkldnn_gOihw8o:


### PR DESCRIPTION
* add 4c type

* trigger

## Description ##
cherry-picking PR#15692

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
