### PR TITLE
Numpy take operator implementation & bug fix in ndarray.take

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -25,7 +25,7 @@ from ...util import set_module
 from ...context import current_context
 from . import _internal as _npi
 
-__all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power']
+__all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'take']
 
 
 @set_module('mxnet.ndarray.numpy')
@@ -144,6 +144,89 @@ def _ufunc_helper(lhs, rhs, fn_array, fn_scalar, lfn_scalar, rfn_scalar=None, ou
     else:
         raise TypeError('type {} not supported'.format(str(type(rhs))))
 #pylint: enable= too-many-arguments, no-member, protected-access
+
+
+@set_module('mxnet.ndarray.numpy')
+def take(a, indices, axis=None, mode='clip', out=None):
+    r"""
+    Take elements from an array along an axis.
+
+    When axis is not None, this function does the same thing as "fancy"
+    indexing (indexing arrays using arrays); however, it can be easier to use
+    if you need elements along a given axis. A call such as
+    ``np.take(arr, indices, axis=3)`` is equivalent to
+    ``arr[:,:,:,indices,...]``.
+
+    Explained without fancy indexing, this is equivalent to the following use
+    of `ndindex`, which sets each of ``ii``, ``jj``, and ``kk`` to a tuple of
+    indices::
+
+        Ni, Nk = a.shape[:axis], a.shape[axis+1:]
+        Nj = indices.shape
+        for ii in ndindex(Ni):
+            for jj in ndindex(Nj):
+                for kk in ndindex(Nk):
+                    out[ii + jj + kk] = a[ii + (indices[jj],) + kk]
+
+    Parameters
+    ----------
+    a : ndarray
+        The source array.
+    indices : ndarray
+        The indices of the values to extract. Also allow scalars for indices.
+    axis : int, optional
+        The axis over which to select values. By default, the flattened
+        input array is used.
+    out : ndarray, optional
+        If provided, the result will be placed in this array. It should
+        be of the appropriate shape and dtype.
+    mode : {'clip', 'wrap'}, optional
+        Specifies how out-of-bounds indices will behave.
+
+        * 'clip' -- clip to the range (default)
+        * 'wrap' -- wrap around
+
+        'clip' mode means that all indices that are too large are replaced
+        by the index that addresses the last element along that axis. Note
+        that this disables indexing with negative numbers.
+
+    Returns
+    -------
+    out : ndarray
+        The returned array has the same type as `a`.
+
+    Notes
+    -----
+
+    This function differs from the original `numpy.take
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.take.html>`_ in
+    the following way(s):
+
+    - Only ndarray or scalar ndarray is accepted as valid input.
+    - 'raise' mode is not supported.
+
+    Examples
+    --------
+    >>> a = np.array([4, 3, 5, 7, 6, 8])
+    >>> indices = np.array([0, 1, 4])
+    >>> np.take(a, indices)
+    array([4., 3., 6.])
+
+    In this example for `a` is an ndarray, "fancy" indexing can be used.
+
+    >>> a[indices]
+    array([4., 3., 6.])
+
+    If `indices` is not one dimensional, the output also has these dimensions.
+
+    >>> np.take(a, np.array([[0, 1], [2, 3]]))
+    array([[4., 3.],
+           [5., 7.]])
+    """
+    if mode not in ('wrap', 'clip'):
+        raise NotImplementedError(
+            "function take does not support mode '{}'".format(mode))
+    return _npi.take(a, indices, axis, mode, out)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -44,7 +44,7 @@ from ..ndarray import numpy as _mx_nd_np
 from ..ndarray.numpy import _internal as _npi
 
 __all__ = ['ndarray', 'empty', 'array', 'zeros', 'ones', 'add', 'subtract', 'multiply', 'divide',
-           'mod', 'power']
+           'mod', 'power', 'take']
 
 
 # This function is copied from ndarray.py since pylint
@@ -1403,6 +1403,86 @@ def ones(shape, dtype=_np.float32, order='C', ctx=None):
         Array of zeros with the given shape, dtype, and ctx.
     """
     return _mx_nd_np.ones(shape, dtype, order, ctx)
+
+
+@set_module('mxnet.numpy')
+def take(a, indices, axis=None, mode='clip', out=None):
+    r"""
+    Take elements from an array along an axis.
+
+    When axis is not None, this function does the same thing as "fancy"
+    indexing (indexing arrays using arrays); however, it can be easier to use
+    if you need elements along a given axis. A call such as
+    ``np.take(arr, indices, axis=3)`` is equivalent to
+    ``arr[:,:,:,indices,...]``.
+
+    Explained without fancy indexing, this is equivalent to the following use
+    of `ndindex`, which sets each of ``ii``, ``jj``, and ``kk`` to a tuple of
+    indices::
+
+        Ni, Nk = a.shape[:axis], a.shape[axis+1:]
+        Nj = indices.shape
+        for ii in ndindex(Ni):
+            for jj in ndindex(Nj):
+                for kk in ndindex(Nk):
+                    out[ii + jj + kk] = a[ii + (indices[jj],) + kk]
+
+    Parameters
+    ----------
+    a : ndarray
+        The source array.
+    indices : ndarray
+        The indices of the values to extract. Also allow scalars for indices.
+    axis : int, optional
+        The axis over which to select values. By default, the flattened
+        input array is used.
+    out : ndarray, optional
+        If provided, the result will be placed in this array. It should
+        be of the appropriate shape and dtype.
+    mode : {'clip', 'wrap'}, optional
+        Specifies how out-of-bounds indices will behave.
+
+        * 'clip' -- clip to the range (default)
+        * 'wrap' -- wrap around
+
+        'clip' mode means that all indices that are too large are replaced
+        by the index that addresses the last element along that axis. Note
+        that this disables indexing with negative numbers.
+
+    Returns
+    -------
+    out : ndarray
+        The returned array has the same type as `a`.
+
+    Notes
+    -----
+
+    This function differs from the original `numpy.take
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.take.html>`_ in
+    the following way(s):
+
+    - Only ndarray or scalar ndarray is accepted as valid input.
+    - 'raise' mode is not supported.
+
+    Examples
+    --------
+    >>> a = np.array([4, 3, 5, 7, 6, 8])
+    >>> indices = np.array([0, 1, 4])
+    >>> np.take(a, indices)
+    array([4., 3., 6.])
+
+    In this example for `a` is an ndarray, "fancy" indexing can be used.
+
+    >>> a[indices]
+    array([4., 3., 6.])
+
+    If `indices` is not one dimensional, the output also has these dimensions.
+
+    >>> np.take(a, np.array([[0, 1], [2, 3]]))
+    array([[4., 3.],
+           [5., 7.]])
+    """
+    return _mx_nd_np.take(a, indices, axis, mode, out)
 
 
 @set_module('mxnet.numpy')

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -28,7 +28,7 @@ from ..symbol import Symbol
 from .._internal import _set_np_symbol_class
 from . import _internal as _npi
 
-__all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power']
+__all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'take']
 
 
 def _num_outputs(sym):
@@ -1008,6 +1008,70 @@ def mod(x1, x2, out=None):
 @set_module('mxnet.symbol.numpy')
 def power(x1, x2, out=None):
     return _ufunc_helper(x1, x2, _npi.power, _np.power, _npi.power_scalar, _npi.rpower_scalar, out)
+
+
+@set_module('mxnet.symbol.numpy')
+def take(a, indices, axis=None, mode='clip', out=None):
+    r"""
+    Take elements from an array along an axis.
+
+    When axis is not None, this function does the same thing as "fancy"
+    indexing (indexing arrays using arrays); however, it can be easier to use
+    if you need elements along a given axis. A call such as
+    ``np.take(arr, indices, axis=3)`` is equivalent to
+    ``arr[:,:,:,indices,...]``.
+
+    Explained without fancy indexing, this is equivalent to the following use
+    of `ndindex`, which sets each of ``ii``, ``jj``, and ``kk`` to a tuple of
+    indices::
+
+        Ni, Nk = a.shape[:axis], a.shape[axis+1:]
+        Nj = indices.shape
+        for ii in ndindex(Ni):
+            for jj in ndindex(Nj):
+                for kk in ndindex(Nk):
+                    out[ii + jj + kk] = a[ii + (indices[jj],) + kk]
+
+    Parameters
+    ----------
+    a : _Symbol
+        The source array.
+    indices : _Symbol
+        The indices of the values to extract. Also allow scalars for indices.
+    axis : int, optional
+        The axis over which to select values. By default, the flattened
+        input array is used.
+    out : _Symbol or None, optional
+        Dummy parameter to keep the consistency with the ndarray counterpart.
+    mode : {'clip', 'wrap'}, optional
+        Specifies how out-of-bounds indices will behave.
+
+        * 'clip' -- clip to the range (default)
+        * 'wrap' -- wrap around
+
+        'clip' mode means that all indices that are too large are replaced
+        by the index that addresses the last element along that axis. Note
+        that this disables indexing with negative numbers.
+
+    Returns
+    -------
+    out : _Symbol
+        The returned array has the same type as `a`.
+
+    Notes
+    -----
+
+    This function differs from the original `numpy.take
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.take.html>`_ in
+    the following way(s):
+
+    - Only ndarray or scalar ndarray is accepted as valid input.
+    - 'raise' mode is not supported.
+    """
+    if mode not in ('wrap', 'clip'):
+        raise NotImplementedError(
+            "function take does not support mode '{}'".format(mode))
+    return _npi.take(a, indices, axis, mode, out)
 
 
 _set_np_symbol_class(_Symbol)

--- a/src/operator/numpy/indexing_op.cc
+++ b/src/operator/numpy/indexing_op.cc
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file indexing_op.cc
+ * \brief CPU implementation of numpy indexing operator
+*/
+
+#include "./indexing_op.h"
+
+namespace mxnet {
+namespace op {
+
+template<>
+void NumpyTakeOpForward<cpu>(const nnvm::NodeAttrs& attrs,
+                             const OpContext& ctx,
+                             const std::vector<TBlob>& inputs,
+                             const std::vector<OpReqType>& req,
+                             const std::vector<TBlob>& outputs) {
+  using namespace mxnet_op;
+  if (req[take_::kOut] == kNullOp) return;
+  const NumpyTakeParam& param = nnvm::get<NumpyTakeParam>(attrs.parsed);
+  CHECK_EQ(inputs.size(), 2U);
+  CHECK_EQ(outputs.size(), 1U);
+
+  const mxnet::TShape& idxshape = inputs[take_::kIdx].shape_;
+  const mxnet::TShape& arrshape = inputs[take_::kArr].shape_;
+  const mxnet::TShape& oshape = outputs[take_::kOut].shape_;
+
+  if (idxshape.Size() == 0) {
+    return;
+  }
+
+  Stream<cpu> *s = ctx.get_stream<cpu>();
+
+  if (param.axis.has_value()) {
+    const int actual_axis = param.axis.value() + ((param.axis.value() < 0) ? arrshape.ndim() : 0);
+
+    MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {  // output data type
+      MSHADOW_TYPE_SWITCH(inputs[1].type_flag_, IType, {  // index data type
+        if (actual_axis == 0) {
+          if (param.mode == take_::kClip) {
+            Kernel<TakeCPU<true>, cpu>::Launch(s, idxshape.Size(),
+                                               outputs[take_::kOut].dptr<DType>(),
+                                               inputs[take_::kArr].dptr<DType>(),
+                                               inputs[take_::kIdx].dptr<IType>(),
+                                               oshape.Size()/idxshape.Size(), arrshape[0]);
+          } else {
+            Kernel<TakeCPU<false>, cpu>::Launch(s, idxshape.Size(),
+                                                outputs[take_::kOut].dptr<DType>(),
+                                                inputs[take_::kArr].dptr<DType>(),
+                                                inputs[take_::kIdx].dptr<IType>(),
+                                                oshape.Size()/idxshape.Size(), arrshape[0]);
+          }
+        } else {
+          mshadow::Shape<10> in_strides;
+          int stride = 1;
+          for (int i = arrshape.ndim() - 1; i >= 0; stride *= arrshape[i], --i) {
+            in_strides[i] = stride;
+          }
+          mshadow::Shape<10> out_strides;
+          stride = 1;
+          for (int i = oshape.ndim() - 1; i >= 0; stride *= oshape[i], --i) {
+            out_strides[i] = stride;
+          }
+          if (param.mode == take_::kClip) {
+            Kernel<Take<true>, cpu>::Launch(s, oshape.Size(),
+                                            outputs[take_::kOut].dptr<DType>(),
+                                            inputs[take_::kArr].dptr<DType>(),
+                                            inputs[take_::kIdx].dptr<IType>(),
+                                            in_strides, out_strides, arrshape.ndim(),
+                                            oshape.ndim(), idxshape.ndim(),
+                                            arrshape[actual_axis], actual_axis);
+          } else if (param.mode == take_::kWrap) {
+            Kernel<Take<false>, cpu>::Launch(s, oshape.Size(),
+                                             outputs[take_::kOut].dptr<DType>(),
+                                             inputs[take_::kArr].dptr<DType>(),
+                                             inputs[take_::kIdx].dptr<IType>(),
+                                             in_strides, out_strides, arrshape.ndim(),
+                                             oshape.ndim(), idxshape.ndim(),
+                                             arrshape[actual_axis], actual_axis);
+          }
+        }
+      });
+    });
+  } else {
+    MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {  // output data type
+      MSHADOW_TYPE_SWITCH(inputs[1].type_flag_, IType, {  // index data type
+        if (param.mode == take_::kClip) {
+          Kernel<TakeCPU<true>, cpu>::Launch(s, idxshape.Size(),
+                                             outputs[take_::kOut].dptr<DType>(),
+                                             inputs[take_::kArr].dptr<DType>(),
+                                             inputs[take_::kIdx].dptr<IType>(),
+                                             1, arrshape.Size());
+        } else {
+          Kernel<TakeCPU<false>, cpu>::Launch(s, idxshape.Size(),
+                                              outputs[take_::kOut].dptr<DType>(),
+                                              inputs[take_::kArr].dptr<DType>(),
+                                              inputs[take_::kIdx].dptr<IType>(),
+                                              1, arrshape.Size());
+        }
+      });
+    });
+  }
+}
+
+DMLC_REGISTER_PARAMETER(NumpyTakeParam);
+
+NNVM_REGISTER_OP(_npi_take)
+.set_num_inputs(2)
+.set_num_outputs(1)
+.set_attr_parser(ParamParser<NumpyTakeParam>)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"a", "indices"};
+  })
+.set_attr<mxnet::FInferShape>("FInferShape", NumpyTakeOpShape)
+.set_attr<nnvm::FInferType>("FInferType", TakeOpType)
+.set_attr<FCompute>("FCompute<cpu>", NumpyTakeOpForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient",
+  [](const nnvm::NodePtr& n,  const std::vector<nnvm::NodeEntry>& ograds) {
+    return MakeNonlossGradNode("_backward_np_take", n, ograds,
+                               {n->inputs[1]}, n->attrs.dict);
+  })
+.add_argument("a", "NDArray-or-Symbol", "The input array.")
+.add_argument("indices", "NDArray-or-Symbol", "The indices of the values to be extracted.")
+.add_arguments(NumpyTakeParam::__FIELDS__());
+
+NNVM_REGISTER_OP(_backward_np_take)
+.set_num_inputs(2)
+.set_num_outputs(2)
+.set_attr_parser(ParamParser<NumpyTakeParam>)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const NodeAttrs& attrs) {
+    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+  })
+.set_attr<nnvm::TIsBackward>("TIsBackward", true)
+.set_attr<FCompute>("FCompute<cpu>", NumpyTakeOpBackward<cpu>);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/indexing_op.cu
+++ b/src/operator/numpy/indexing_op.cu
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file indexing_op.cu
+ * \brief GPU implementation of indexing operator
+ */
+
+#include "./indexing_op.h"
+
+namespace mxnet {
+namespace op {
+
+template<>
+void NumpyTakeOpForward<gpu>(const nnvm::NodeAttrs& attrs,
+                             const OpContext& ctx,
+                             const std::vector<TBlob>& inputs,
+                             const std::vector<OpReqType>& req,
+                             const std::vector<TBlob>& outputs) {
+  using namespace mxnet_op;
+  if (req[take_::kOut] == kNullOp) return;
+  const NumpyTakeParam& param = nnvm::get<NumpyTakeParam>(attrs.parsed);
+  CHECK_EQ(inputs.size(), 2U);
+  CHECK_EQ(outputs.size(), 1U);
+
+  const mxnet::TShape& idxshape = inputs[take_::kIdx].shape_;
+  const mxnet::TShape& arrshape = inputs[take_::kArr].shape_;
+  const mxnet::TShape& oshape = outputs[take_::kOut].shape_;
+
+  if (idxshape.Size() == 0) {
+    return;
+  }
+
+  Stream<gpu> *s = ctx.get_stream<gpu>();
+
+  if (param.axis.has_value()) {
+    const int actual_axis = param.axis.value() + ((param.axis.value() < 0) ? arrshape.ndim() : 0);
+
+    MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {  // output data type
+      MSHADOW_TYPE_SWITCH(inputs[1].type_flag_, IType, {  // index data type
+        if (actual_axis == 0) {
+          if (param.mode == take_::kClip) {
+            Kernel<TakeGPU<true>, gpu>::Launch(s, oshape.Size(),
+                                               outputs[take_::kOut].dptr<DType>(),
+                                               inputs[take_::kArr].dptr<DType>(),
+                                               inputs[take_::kIdx].dptr<IType>(),
+                                               oshape.Size()/idxshape.Size(), arrshape[0]);
+          } else {
+            Kernel<TakeGPU<false>, gpu>::Launch(s, oshape.Size(),
+                                                outputs[take_::kOut].dptr<DType>(),
+                                                inputs[take_::kArr].dptr<DType>(),
+                                                inputs[take_::kIdx].dptr<IType>(),
+                                                oshape.Size()/idxshape.Size(), arrshape[0]);
+          }
+        } else {
+          mshadow::Shape<10> in_strides;
+          int stride = 1;
+          for (int i = arrshape.ndim() - 1; i >= 0; stride *= arrshape[i], --i) {
+            in_strides[i] = stride;
+          }
+          mshadow::Shape<10> out_strides;
+          stride = 1;
+          for (int i = oshape.ndim() - 1; i >= 0; stride *= oshape[i], --i) {
+            out_strides[i] = stride;
+          }
+          if (param.mode == take_::kClip) {
+            Kernel<Take<true>, gpu>::Launch(s, oshape.Size(),
+                                            outputs[take_::kOut].dptr<DType>(),
+                                            inputs[take_::kArr].dptr<DType>(),
+                                            inputs[take_::kIdx].dptr<IType>(),
+                                            in_strides, out_strides, arrshape.ndim(), oshape.ndim(),
+                                            idxshape.ndim(), arrshape[actual_axis], actual_axis);
+          } else if (param.mode == take_::kWrap) {
+            Kernel<Take<false>, gpu>::Launch(s, oshape.Size(),
+                                             outputs[take_::kOut].dptr<DType>(),
+                                             inputs[take_::kArr].dptr<DType>(),
+                                             inputs[take_::kIdx].dptr<IType>(),
+                                             in_strides, out_strides,
+                                             arrshape.ndim(), oshape.ndim(),
+                                             idxshape.ndim(), arrshape[actual_axis], actual_axis);
+          }
+        }
+      });
+    });
+  } else {
+    MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {  // output data type
+      MSHADOW_TYPE_SWITCH(inputs[1].type_flag_, IType, {  // index data type
+        if (param.mode == take_::kClip) {
+          Kernel<TakeGPU<true>, gpu>::Launch(s, oshape.Size(),
+                                             outputs[take_::kOut].dptr<DType>(),
+                                             inputs[take_::kArr].dptr<DType>(),
+                                             inputs[take_::kIdx].dptr<IType>(),
+                                             1, arrshape.Size());
+        } else {
+          Kernel<TakeGPU<false>, gpu>::Launch(s, oshape.Size(),
+                                              outputs[take_::kOut].dptr<DType>(),
+                                              inputs[take_::kArr].dptr<DType>(),
+                                              inputs[take_::kIdx].dptr<IType>(),
+                                              1, arrshape.Size());
+        }
+      });
+    });
+  }
+}
+
+NNVM_REGISTER_OP(_npi_take)
+.set_attr<FCompute>("FCompute<gpu>", NumpyTakeOpForward<gpu>);
+
+NNVM_REGISTER_OP(_backward_np_take)
+.set_attr<FCompute>("FCompute<gpu>", NumpyTakeOpBackward<gpu>);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/indexing_op.h
+++ b/src/operator/numpy/indexing_op.h
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file indexing_op.h
+ * \brief Function definition of numpy indexing operator
+ */
+
+#ifndef MXNET_OPERATOR_NUMPY_INDEXING_OP_H_
+#define MXNET_OPERATOR_NUMPY_INDEXING_OP_H_
+
+#include <dmlc/parameter.h>
+#include <mxnet/operator_util.h>
+#include <vector>
+#include "../mxnet_op.h"
+#include "../operator_common.h"
+#include "../tensor/indexing_op.h"
+
+namespace mxnet {
+namespace op {
+
+struct NumpyTakeParam: public dmlc::Parameter<NumpyTakeParam> {
+  dmlc::optional<int> axis;
+  int mode;
+  DMLC_DECLARE_PARAMETER(NumpyTakeParam) {
+    DMLC_DECLARE_FIELD(axis)
+    .set_default(dmlc::optional<int>())
+    .describe("The axis of input array to be taken."
+              "For input tensor of rank r, it could be in the range of [-r, r-1]");
+    DMLC_DECLARE_FIELD(mode)
+    .add_enum("raise", take_::kRaise)
+    .add_enum("wrap", take_::kWrap)
+    .add_enum("clip", take_::kClip)
+    .set_default(take_::kClip)
+    .describe("Specify how out-of-bound indices bahave. Default is \"clip\"."
+              " \"clip\" means clip to the range. So, if all indices mentioned are too large,"
+              " they are replaced by the index that addresses the last element along an axis."
+              " \"wrap\" means to wrap around."
+              " \"raise\" means to raise an error, not supported yet.");
+  }
+};
+
+inline bool NumpyTakeOpShape(const nnvm::NodeAttrs& attrs,
+                             mxnet::ShapeVector *in_attrs,
+                             mxnet::ShapeVector *out_attrs) {
+  using namespace mshadow;
+  const mxnet::TShape &arrshape = (*in_attrs)[take_::kArr];
+  const mxnet::TShape &idxshape = (*in_attrs)[take_::kIdx];
+  if (!shape_is_known(idxshape)) {
+    LOG(FATAL) << "Shape of indices is unknown...";
+    return false;
+  }
+  const NumpyTakeParam& param = nnvm::get<NumpyTakeParam>(attrs.parsed);
+  out_attrs->clear();
+  if (param.axis.has_value()) {
+    CHECK(param.axis.value() >= -1 * arrshape.ndim() &&
+      param.axis.value() < arrshape.ndim())
+      << "If axis is not None, axis should be in "\
+      "the range of [-r, r-1] where r is the rank of input tensor";
+    const index_t actual_axis = param.axis.value() +
+                                ((param.axis.value() < 0) ? arrshape.ndim() : 0);
+    mxnet::TShape oshape(idxshape.ndim() + arrshape.ndim() - 1, -1);
+    for (index_t i = 0; i < idxshape.ndim(); ++i) {
+      oshape[i + actual_axis] = idxshape[i];
+    }
+    for (index_t i = 0; i < arrshape.ndim(); i++) {
+      if (i < actual_axis) {
+        oshape[i] = arrshape[i];
+      } else if (i > actual_axis) {
+        oshape[i + idxshape.ndim() - 1] = arrshape[i];
+      }
+    }
+    out_attrs->push_back(oshape);
+    return shape_is_known(oshape);
+  } else {
+    mxnet::TShape oshape = idxshape;
+    out_attrs->push_back(oshape);
+    return shape_is_known(oshape);
+  }
+}
+
+template<typename xpu>
+void NumpyTakeOpForward(const nnvm::NodeAttrs& attrs,
+                        const OpContext& ctx,
+                        const std::vector<TBlob>& inputs,
+                        const std::vector<OpReqType>& req,
+                        const std::vector<TBlob>& outputs);
+
+template<typename xpu>
+void NumpyTakeOpBackward(const nnvm::NodeAttrs& attrs,
+                         const OpContext& ctx,
+                         const std::vector<TBlob>& inputs,
+                         const std::vector<OpReqType>& req,
+                         const std::vector<TBlob>& outputs) {
+  using namespace mshadow;
+  using namespace mshadow::expr;
+  CHECK_EQ(inputs.size(), 2U);
+  CHECK_EQ(outputs.size(), 2U);
+  CHECK_NE(req[take_::kIdx], kAddTo)
+    << "take layer doesn't support gradient of req type kAddTo to index";
+
+  const NumpyTakeParam& param = nnvm::get<NumpyTakeParam>(attrs.parsed);
+
+  // grad_out is the gradient of the outputs in the feed-forward
+  // grad_in is the gradient of the inputs in the feed-forward
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+
+  MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {  // output data type
+    MSHADOW_TYPE_SWITCH(inputs[1].type_flag_, IType, {  // index data type
+      // inputs are specified in the .cc file, which are the gradients from
+      // the upper layer and the input index
+      // outputs are the gradients of inputs in the feed-forward pass
+      const mxnet::TShape& idxshape = inputs[1].shape_;
+      const mxnet::TShape& arrshape = outputs[0].shape_;
+      const mxnet::TShape& oshape = inputs[0].shape_;
+
+      if (idxshape.Size() == 0) {
+        return;
+      }
+
+      if (req[take_::kIdx] != kNullOp) {
+        mxnet_op::Kernel<mxnet_op::set_zero, xpu>::Launch(
+          s, idxshape.Size(), outputs[take_::kIdx].dptr<IType>());
+      }
+
+      bool flag = false;
+      if (!param.axis.has_value()) {
+        flag = true;
+      } else if (param.axis.value() == 0) {
+        flag = true;
+      } else if (param.axis.value() + arrshape.ndim() == 0) {
+        flag = true;
+      }
+
+      if (flag) {
+        int idxndim = idxshape.ndim();
+        Tensor<xpu, 1, IType> idx = inputs[1].get_with_shape<xpu, 1, IType>(
+            Shape1(idxshape.ProdShape(0, idxndim)), s);
+        Tensor<xpu, 2, DType> grad_in;
+        if (!param.axis.has_value()) {
+          grad_in = outputs[0].get_with_shape<xpu, 2, DType>(Shape2(arrshape.Size(), 1), s);
+        } else {
+          grad_in = outputs[0].get_with_shape<xpu, 2, DType>(
+              Shape2(arrshape[0], arrshape.ProdShape(1, arrshape.ndim())), s);
+        }
+        Tensor<xpu, 2, DType> grad_out = inputs[0].get_with_shape<xpu, 2, DType>(
+            Shape2(oshape.ProdShape(0, idxndim), oshape.ProdShape(idxndim, oshape.ndim())), s);
+
+        if (req[take_::kArr] == kWriteTo || req[take_::kArr] == kAddTo) {
+          if (req[take_::kArr] == kWriteTo) {
+            grad_in = scalar<DType>(0.0f);
+          }
+          if (param.mode == take_::kClip) {
+            TakeGradZeroDim<IType, DType, true>(grad_in, idx, grad_out);
+          } else {
+            TakeGradZeroDim<IType, DType, false>(grad_in, idx, grad_out);
+          }
+        } else {
+          LOG(FATAL) << "wrong req";
+        }
+      } else {
+        const int actual_axis = param.axis.value() +
+                                ((param.axis.value() < 0) ? arrshape.ndim() : 0);
+
+        const TBlob& idx = inputs[1];
+        const TBlob& arr = outputs[0];
+        const TBlob& ograd = inputs[0];
+
+        if (param.mode == take_::kClip) {
+          TakeOpBackwardImpl<true>(s, ctx, arr, idx, ograd, actual_axis);
+        } else {
+          TakeOpBackwardImpl<false>(s, ctx, arr, idx, ograd, actual_axis);
+        }
+      }
+    });
+  });
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NUMPY_INDEXING_OP_H_

--- a/src/operator/tensor/indexing_op.cc
+++ b/src/operator/tensor/indexing_op.cc
@@ -28,28 +28,6 @@
 namespace mxnet {
 namespace op {
 
-template<bool clip = true>
-struct TakeCPU {
-  // assume that idx have been flattened to a 1-D tensor (N,)
-  // assume that out_data and in_data have been flattened to 2-D tensors, (N, M) and (K, M)
-  // M is the number of columns of in_data and out_data
-  // K is the number of rows of in_data
-  // i is the index of out_data
-  template<typename DType, typename IType>
-  MSHADOW_XINLINE static void Map(index_t i, DType* out_data, const DType* in_data,
-                                  const IType* idx, const size_t M, const int64_t K) {
-    int64_t j = static_cast<int64_t>(idx[i]);
-    if (clip) {
-      if (j <= 0) j = 0;
-      else if (j >= K) j = K - 1;
-    } else {
-      j = j % K;
-      j += (j < 0) ? K : 0;
-    }
-    std::memcpy(out_data + i * M, in_data + j * M, M * sizeof(DType));
-  }
-};
-
 /*
  * \brief returns true if all indices are between [min, max]
  * \param data_ptr the indices to check

--- a/src/operator/tensor/indexing_op.cu
+++ b/src/operator/tensor/indexing_op.cu
@@ -116,31 +116,6 @@ struct AddTakeGradRspDeterministicKernel {
   }
 };
 
-/*! \brief name the struct Take instead of take
- * to avoid conflict with the take function in mshadow
- */
-template<bool clip = true>
-struct TakeGPU {
-  // assume that idx have been flattened to a 1-D tensor (N,)
-  // assume that out_data and in_data have been flattened to 2-D tensors, (N, M) and (K, M)
-  // M is the number of columns of in_data and out_data
-  // K is the number of rows of in_data
-  // i is the index of out_data
-  template<typename DType, typename IType>
-  MSHADOW_XINLINE static void Map(int i, DType* out_data, const DType* in_data,
-                                  const IType* idx, const int64_t M, const int64_t K) {
-    int64_t j = static_cast<int64_t>(idx[i/M]);
-    if (clip) {
-      if (j <= 0) j = 0;
-      else if (j >= K) j = K - 1;
-    } else {
-      j = j % K;
-      j += (j < 0) ? K : 0;
-    }
-    out_data[i] = in_data[j * M + i % M];
-  }
-};
-
 /*
  * \brief returns true if all indices are between [min, max]
  * \param s the stream

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -341,6 +341,53 @@ struct Take {
   }
 };
 
+template<bool clip = true>
+struct TakeCPU {
+  // assume that idx have been flattened to a 1-D tensor (N,)
+  // assume that out_data and in_data have been flattened to 2-D tensors, (N, M) and (K, M)
+  // M is the number of columns of in_data and out_data
+  // K is the number of rows of in_data
+  // i is the index of out_data
+  template<typename DType, typename IType>
+  MSHADOW_XINLINE static void Map(index_t i, DType* out_data, const DType* in_data,
+                                  const IType* idx, const size_t M, const int64_t K) {
+    int64_t j = static_cast<int64_t>(idx[i]);
+    if (clip) {
+      if (j <= 0) j = 0;
+      else if (j >= K) j = K - 1;
+    } else {
+      j = j % K;
+      j += (j < 0) ? K : 0;
+    }
+    std::memcpy(out_data + i * M, in_data + j * M, M * sizeof(DType));
+  }
+};
+
+/*! \brief name the struct Take instead of take
+ * to avoid conflict with the take function in mshadow
+ */
+template<bool clip = true>
+struct TakeGPU {
+  // assume that idx have been flattened to a 1-D tensor (N,)
+  // assume that out_data and in_data have been flattened to 2-D tensors, (N, M) and (K, M)
+  // M is the number of columns of in_data and out_data
+  // K is the number of rows of in_data
+  // i is the index of out_data
+  template<typename DType, typename IType>
+  MSHADOW_XINLINE static void Map(int i, DType* out_data, const DType* in_data,
+                                  const IType* idx, const int64_t M, const int64_t K) {
+    int64_t j = static_cast<int64_t>(idx[i/M]);
+    if (clip) {
+      if (j <= 0) j = 0;
+      else if (j >= K) j = K - 1;
+    } else {
+      j = j % K;
+      j += (j < 0) ? K : 0;
+    }
+    out_data[i] = in_data[j * M + i % M];
+  }
+};
+
 // Embedding forward implementation with dense weight
 template<typename xpu>
 void EmbeddingOpForwardDnsImpl(mshadow::Stream<xpu>* s,
@@ -792,6 +839,24 @@ void TakeOpForward(const nnvm::NodeAttrs& attrs,
                    const std::vector<OpReqType>& req,
                    const std::vector<TBlob>& outputs);
 
+template<typename IndexType, typename DType, bool clip = true>
+inline void TakeGradZeroDim(mshadow::Tensor<cpu, 2, DType> dst,
+                        const mshadow::Tensor<cpu, 1, IndexType>& index,
+                        const mshadow::Tensor<cpu, 2, DType> &src) {
+  const int K = dst.shape_[0];
+  for (index_t y = 0; y < index.size(0); ++y) {
+    int j = index[y];
+    if (clip) {
+      if (j <= 0) j = 0;
+      else if (j >= K) j = K - 1;
+    } else {
+      j = j % K;
+      j += (j < 0) ? K : 0;
+    }
+    dst[j] += src[y];
+  }
+}
+
 struct TakeGradGeneralKernel {
   /*!
    * \brief Map function for general case of take grad
@@ -1030,21 +1095,24 @@ void TakeOpBackward(const nnvm::NodeAttrs& attrs,
 
       const int actual_axis = param.axis + ((param.axis < 0) ? arrshape.ndim() : 0);
 
-      int idxndim = idxshape.ndim();
-      Tensor<xpu, 1, IType> idx = inputs[1].get_with_shape<xpu, 1, IType>(
-          Shape1(idxshape.ProdShape(0, idxndim)), s);
-      Tensor<xpu, 2, DType> grad_out = inputs[0].get_with_shape<xpu, 2, DType>(
-          Shape2(oshape.ProdShape(0, idxndim), oshape.ProdShape(idxndim, oshape.ndim())), s);
-      Tensor<xpu, 2, DType> grad_in = outputs[0].get_with_shape<xpu, 2, DType>(
-          Shape2(arrshape[0], arrshape.ProdShape(1, arrshape.ndim())), s);
-
-      // re-using the previous code for axis = 0 case
       if (actual_axis == 0) {
+        int idxndim = idxshape.ndim();
+        Tensor<xpu, 1, IType> idx = inputs[1].get_with_shape<xpu, 1, IType>(
+            Shape1(idxshape.ProdShape(0, idxndim)), s);
+        Tensor<xpu, 2, DType> grad_out = inputs[0].get_with_shape<xpu, 2, DType>(
+            Shape2(oshape.ProdShape(0, idxndim), oshape.ProdShape(idxndim, oshape.ndim())), s);
+        Tensor<xpu, 2, DType> grad_in = outputs[0].get_with_shape<xpu, 2, DType>(
+            Shape2(arrshape[0], arrshape.ProdShape(1, arrshape.ndim())), s);
+
         if (req[take_::kArr] == kWriteTo || req[take_::kArr] == kAddTo) {
           if (req[take_::kArr] == kWriteTo) {
             grad_in = scalar<DType>(0.0f);
           }
-          AddTakeGrad(grad_in, idx, grad_out);
+          if (param.mode == take_::kClip) {
+            TakeGradZeroDim<IType, DType, true>(grad_in, idx, grad_out);
+          } else {
+            TakeGradZeroDim<IType, DType, false>(grad_in, idx, grad_out);
+          }
         } else {
           LOG(FATAL) << "wrong req";
         }

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -149,6 +149,112 @@ def test_npx_slice():
             assert same(a.grad.asnumpy(), expected_grad)
 
 
+@with_seed()
+@use_np
+def test_np_take():
+    configs = [
+        ((4, 4), (4, 0), None),
+        ((4, 4), (4, 0), 0),
+        ((4, 4), (4, 0), 1),
+        ((), (4, 0), None),
+        ((), (5, ), None),
+        ((), (4, 5), None),
+        ((), (), None),
+        ((3, 4), (), None),
+        ((3, 4), (), 0),
+        ((3, 4), (), 1),
+        ((3, 4, 5), (), 2),
+        ((3, 4, 5), (), -3),
+    ]
+
+    class TestTake(HybridBlock):
+        def __init__(self, axis, mode):
+            super(TestTake, self).__init__()
+            self._axis = axis
+            self._mode = mode
+
+        def hybrid_forward(self, F, a, indices):
+            return F.np.take(a, indices, axis=self._axis, mode=self._mode)
+
+    def grad_helper(grad_in, axis, idx, mode):
+        k = grad_in.shape[axis]
+        if mode == 'clip':
+            idx = 0 if idx < 0 else idx
+            idx = k - 1 if idx >= k else idx
+        else:
+            idx = idx % k
+        if axis == None:
+            grad_in[idx] += 1.0
+        elif axis == 0:
+            if axis == len(grad_in.shape) - 1:
+                grad_in[idx] += 1.0
+            else:
+                grad_in[idx, :] += 1.0
+        elif axis == 1:
+            if axis == len(grad_in.shape) - 1:
+                grad_in[:, idx] += 1.0
+            else:
+                grad_in[:, idx, :] += 1.0
+        elif axis == 2:
+            if axis == len(grad_in.shape) - 1:
+                grad_in[:, :, idx] += 1.0
+            else:
+                grad_in[:, :, idx, :] += 1.0
+        elif axis == 3:
+            if axis == len(grad_in.shape) - 1:
+                grad_in[:, :, :, idx] += 1.0
+            else:
+                grad_in[:, :, :, idx, :] += 1.0
+        elif axis == 4:
+            grad_in[:, :, :, :, idx] += 1.0
+        else:
+            raise ValueError("axis %d is not supported..." % axis)
+
+    def check_output_n_grad(data_shape, idx_shape, axis, mode):
+        data_real = _np.random.normal(size=data_shape).astype('float32')
+        idx_real = _np.random.randint(low=-100, high=100, size=idx_shape)
+        same(np.take(np.array(data_real), np.array(idx_real), axis=axis, mode=mode).asnumpy(),
+             _np.take(data_real, idx_real, axis=axis, mode=mode))
+
+        grad_in = _np.zeros(data_shape, dtype='float32')
+
+        test_take = TestTake(axis=axis, mode=mode)
+        if hybridize:
+            test_take.hybridize()
+        x = np.array(data_real)
+        x.attach_grad()
+        with mx.autograd.record():
+            mx_out = test_take(x, np.array(idx_real))
+        same(mx_out.asnumpy(), _np.take(data_real, idx_real, axis=axis, mode=mode))
+
+        if axis and axis < 0:
+            axis += len(data_shape)
+        try:
+            for i in _np.nditer(idx_real):
+                grad_helper(grad_in, axis, i, mode)
+        except:
+            pass
+
+        mx_out.backward()
+        same(x.grad.asnumpy(), grad_in)
+
+    for hybridize in [True, False]:
+        for mode in ['clip', 'wrap']:
+            for data_ndim in range(1, 5):
+                for idx_ndim in range(1, 4):
+                    for axis in range(-data_ndim, data_ndim):
+                        data_shape = ()
+                        for _ in range(data_ndim):
+                            data_shape += (_np.random.randint(low=1, high=5), )
+                        idx_shape = ()
+                        for _ in range(idx_ndim):
+                            idx_shape += (_np.random.randint(low=1, high=5), )
+                        check_output_n_grad(data_shape, idx_shape, axis, mode)
+
+            for config in configs:
+                check_output_n_grad(config[0], config[1], config[2], mode)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
Implementation of numpy `take` operator in mxnet.
Fix a bug that backward computation of `ndarray.take` does not check argument `mode`.

The version that cherry-pick on new numpy branch, old pr -> #15699.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- add op `take`
- bug fix of `nd.take`
- auto remove some whitespaces

## Comments ##
Welcome @reminisce, @haojin2  and others for reviewing.
