### PR TITLE
Numpy Unique operator

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -34,7 +34,8 @@ __all__ = ['zeros', 'ones', 'full', 'add', 'subtract', 'multiply', 'divide', 'mo
            'trunc', 'logical_not', 'arcsinh', 'arccosh', 'arctanh', 'tensordot',
            'linspace', 'expand_dims', 'tile', 'arange', 'split', 'concatenate', 'stack', 'vstack', 'mean',
            'maximum', 'minimum', 'swapaxes', 'clip', 'argmax', 'std', 'var', 'indices', 'copysign',
-           'ravel', 'hanning', 'hamming', 'blackman', 'flip', 'around', 'hypot', 'rad2deg', 'deg2rad']
+           'ravel', 'hanning', 'hamming', 'blackman', 'flip', 'around', 'hypot', 'rad2deg', 'deg2rad',
+           'unique']
 
 
 @set_module('mxnet.ndarray.numpy')
@@ -260,6 +261,110 @@ def _ufunc_helper(lhs, rhs, fn_array, fn_scalar, lfn_scalar, rfn_scalar=None, ou
     else:
         raise TypeError('type {} not supported'.format(str(type(rhs))))
 #pylint: enable= too-many-arguments, no-member, protected-access
+
+
+@set_module('mxnet.ndarray.numpy')
+def unique(ar, return_index=False, return_inverse=False, return_counts=False, axis=None):
+    """
+    Find the unique elements of an array.
+
+    Returns the sorted unique elements of an array. There are three optional
+    outputs in addition to the unique elements:
+
+    * the indices of the input array that give the unique values
+    * the indices of the unique array that reconstruct the input array
+    * the number of times each unique value comes up in the input array
+
+    Parameters
+    ----------
+    ar : ndarray
+        Input array. Unless `axis` is specified, this will be flattened if it
+        is not already 1-D.
+    return_index : bool, optional
+        If True, also return the indices of `ar` (along the specified axis,
+        if provided, or in the flattened array) that result in the unique array.
+    return_inverse : bool, optional
+        If True, also return the indices of the unique array (for the specified
+        axis, if provided) that can be used to reconstruct `ar`.
+    return_counts : bool, optional
+        If True, also return the number of times each unique item appears
+        in `ar`.
+    axis : int or None, optional
+        The axis to operate on. If None, `ar` will be flattened. If an integer,
+        the subarrays indexed by the given axis will be flattened and treated
+        as the elements of a 1-D array with the dimension of the given axis,
+        see the notes for more details. The default is None.
+
+    Returns
+    -------
+    unique : ndarray
+        The sorted unique values.
+    unique_indices : ndarray, optional
+        The indices of the first occurrences of the unique values in the
+        original array. Only provided if `return_index` is True.
+    unique_inverse : ndarray, optional
+        The indices to reconstruct the original array from the
+        unique array. Only provided if `return_inverse` is True.
+    unique_counts : ndarray, optional
+        The number of times each of the unique values comes up in the
+        original array. Only provided if `return_counts` is True.
+
+    Notes
+    -----
+    When an axis is specified the subarrays indexed by the axis are sorted.
+    This is done by making the specified axis the first dimension of the array
+    and then flattening the subarrays in C order. The flattened subarrays are
+    then viewed as a structured type with each element given a label, with the
+    effect that we end up with a 1-D array of structured types that can be
+    treated in the same way as any other 1-D array. The result is that the
+    flattened subarrays are sorted in lexicographic order starting with the
+    first element.
+
+    This function differs from the original `numpy.unique
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.unique.html>`_ in
+    the following aspects:
+
+    - Only support ndarray as input.
+    - Object arrays or structured arrays are not supported.
+
+    Examples
+    --------
+    >>> np.unique(np.array([1, 1, 2, 2, 3, 3]))
+    array([1., 2., 3.])
+    >>> a = np.array([[1, 1], [2, 3]])
+    >>> np.unique(a)
+    array([1., 2., 3.])
+
+    Return the unique rows of a 2D array
+
+    >>> a = np.array([[1, 0, 0], [1, 0, 0], [2, 3, 4]])
+    >>> np.unique(a, axis=0)
+    array([[1., 0., 0.],
+           [2., 3., 4.]])
+
+    Return the indices of the original array that give the unique values:
+
+    >>> a = np.array([1, 2, 6, 4, 2, 3, 2])
+    >>> u, indices = np.unique(a, return_index=True)
+    >>> u
+    array([1., 2., 3., 4., 6.])
+    >>> indices
+    array([0, 1, 5, 3, 2], dtype=int64)
+    >>> a[indices]
+    array([1., 2., 3., 4., 6.])
+
+    Reconstruct the input array from the unique values:
+
+    >>> a = np.array([1, 2, 6, 4, 2, 3, 2])
+    >>> u, indices = np.unique(a, return_inverse=True)
+    >>> u
+    array([1., 2., 3., 4., 6.])
+    >>> indices
+    array([0, 1, 4, 3, 1, 2, 1], dtype=int64)
+    >>> u[indices]
+    array([1., 2., 6., 4., 2., 3., 2.])
+    """
+    return _npi.unique(ar, return_index, return_inverse, return_counts, axis)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -54,7 +54,7 @@ __all__ = ['ndarray', 'empty', 'array', 'zeros', 'ones', 'full', 'add', 'subtrac
            'tensordot', 'linspace', 'expand_dims', 'tile', 'arange', 'split', 'concatenate',
            'stack', 'vstack', 'mean', 'maximum', 'minimum', 'swapaxes', 'clip', 'argmax', 'std', 'var', 'indices',
            'copysign', 'ravel', 'hanning', 'hamming', 'blackman', 'flip', 'around', 'arctan2', 'hypot',
-           'rad2deg', 'deg2rad']
+           'rad2deg', 'deg2rad', 'unique']
 
 # Return code for dispatching indexing function call
 _NDARRAY_UNSUPPORTED_INDEXING = -1
@@ -1854,6 +1854,110 @@ def full(shape, fill_value, dtype=None, order='C', ctx=None, out=None):  # pylin
            [2, 2]], dtype=int32)
     """
     return _mx_nd_np.full(shape, fill_value, order=order, ctx=ctx, dtype=dtype, out=out)
+
+
+@set_module('mxnet.numpy')
+def unique(ar, return_index=False, return_inverse=False, return_counts=False, axis=None):
+    """
+    Find the unique elements of an array.
+
+    Returns the sorted unique elements of an array. There are three optional
+    outputs in addition to the unique elements:
+
+    * the indices of the input array that give the unique values
+    * the indices of the unique array that reconstruct the input array
+    * the number of times each unique value comes up in the input array
+
+    Parameters
+    ----------
+    ar : ndarray
+        Input array. Unless `axis` is specified, this will be flattened if it
+        is not already 1-D.
+    return_index : bool, optional
+        If True, also return the indices of `ar` (along the specified axis,
+        if provided, or in the flattened array) that result in the unique array.
+    return_inverse : bool, optional
+        If True, also return the indices of the unique array (for the specified
+        axis, if provided) that can be used to reconstruct `ar`.
+    return_counts : bool, optional
+        If True, also return the number of times each unique item appears
+        in `ar`.
+    axis : int or None, optional
+        The axis to operate on. If None, `ar` will be flattened. If an integer,
+        the subarrays indexed by the given axis will be flattened and treated
+        as the elements of a 1-D array with the dimension of the given axis,
+        see the notes for more details. The default is None.
+
+    Returns
+    -------
+    unique : ndarray
+        The sorted unique values.
+    unique_indices : ndarray, optional
+        The indices of the first occurrences of the unique values in the
+        original array. Only provided if `return_index` is True.
+    unique_inverse : ndarray, optional
+        The indices to reconstruct the original array from the
+        unique array. Only provided if `return_inverse` is True.
+    unique_counts : ndarray, optional
+        The number of times each of the unique values comes up in the
+        original array. Only provided if `return_counts` is True.
+
+    Notes
+    -----
+    When an axis is specified the subarrays indexed by the axis are sorted.
+    This is done by making the specified axis the first dimension of the array
+    and then flattening the subarrays in C order. The flattened subarrays are
+    then viewed as a structured type with each element given a label, with the
+    effect that we end up with a 1-D array of structured types that can be
+    treated in the same way as any other 1-D array. The result is that the
+    flattened subarrays are sorted in lexicographic order starting with the
+    first element.
+
+    This function differs from the original `numpy.unique
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.unique.html>`_ in
+    the following aspects:
+
+    - Only support ndarray as input.
+    - Object arrays or structured arrays are not supported.
+
+    Examples
+    --------
+    >>> np.unique(np.array([1, 1, 2, 2, 3, 3]))
+    array([1., 2., 3.])
+    >>> a = np.array([[1, 1], [2, 3]])
+    >>> np.unique(a)
+    array([1., 2., 3.])
+
+    Return the unique rows of a 2D array
+
+    >>> a = np.array([[1, 0, 0], [1, 0, 0], [2, 3, 4]])
+    >>> np.unique(a, axis=0)
+    array([[1., 0., 0.],
+           [2., 3., 4.]])
+
+    Return the indices of the original array that give the unique values:
+
+    >>> a = np.array([1, 2, 6, 4, 2, 3, 2])
+    >>> u, indices = np.unique(a, return_index=True)
+    >>> u
+    array([1., 2., 3., 4., 6.])
+    >>> indices
+    array([0, 1, 5, 3, 2], dtype=int64)
+    >>> a[indices]
+    array([1., 2., 3., 4., 6.])
+
+    Reconstruct the input array from the unique values:
+
+    >>> a = np.array([1, 2, 6, 4, 2, 3, 2])
+    >>> u, indices = np.unique(a, return_inverse=True)
+    >>> u
+    array([1., 2., 3., 4., 6.])
+    >>> indices
+    array([0, 1, 4, 3, 1, 2, 1], dtype=int64)
+    >>> u[indices]
+    array([1., 2., 6., 4., 2., 3., 2.])
+    """
+    return _mx_nd_np.unique(ar, return_index, return_inverse, return_counts, axis)
 
 
 @set_module('mxnet.numpy')

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -36,7 +36,8 @@ __all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'rem
            'trunc', 'logical_not', 'arcsinh', 'arccosh', 'arctanh', 'tensordot',
            'linspace', 'expand_dims', 'tile', 'arange', 'split', 'concatenate', 'stack', 'vstack', 'mean',
            'maximum', 'minimum', 'swapaxes', 'clip', 'argmax', 'std', 'var', 'indices', 'copysign',
-           'ravel', 'hanning', 'hamming', 'blackman', 'flip', 'around', 'hypot', 'rad2deg', 'deg2rad']
+           'ravel', 'hanning', 'hamming', 'blackman', 'flip', 'around', 'hypot', 'rad2deg', 'deg2rad',
+           'unique']
 
 
 def _num_outputs(sym):
@@ -3331,6 +3332,66 @@ def hypot(x1, x2, out=None):
         - Only support float16, float32 and float64.
     """
     return _ufunc_helper(x1, x2, _npi.hypot, _np.hypot, _npi.hypot_scalar, None, out)
+
+
+@set_module('mxnet.symbol.numpy')
+def unique(ar, return_index=False, return_inverse=False, return_counts=False, axis=None):
+    """
+    Find the unique elements of an array.
+
+    Returns the sorted unique elements of an array. There are three optional
+    outputs in addition to the unique elements:
+
+    * the indices of the input array that give the unique values
+    * the indices of the unique array that reconstruct the input array
+    * the number of times each unique value comes up in the input array
+
+    Parameters
+    ----------
+    ar : _Symbol
+        Input array. Unless `axis` is specified, this will be flattened if it
+        is not already 1-D.
+    return_index : bool, optional
+        If True, also return the indices of `ar` (along the specified axis,
+        if provided, or in the flattened array) that result in the unique array.
+    return_inverse : bool, optional
+        If True, also return the indices of the unique array (for the specified
+        axis, if provided) that can be used to reconstruct `ar`.
+    return_counts : bool, optional
+        If True, also return the number of times each unique item appears
+        in `ar`.
+    axis : int or None, optional
+        The axis to operate on. If None, `ar` will be flattened. If an integer,
+        the subarrays indexed by the given axis will be flattened and treated
+        as the elements of a 1-D array with the dimension of the given axis,
+        see the notes for more details. The default is None.
+
+    Returns
+    -------
+    unique : _Symbol
+        The sorted unique values.
+    unique_indices : _Symbol, optional
+        The indices of the first occurrences of the unique values in the
+        original array. Only provided if `return_index` is True.
+    unique_inverse : _Symbol, optional
+        The indices to reconstruct the original array from the
+        unique array. Only provided if `return_inverse` is True.
+    unique_counts : _Symbol, optional
+        The number of times each of the unique values comes up in the
+        original array. Only provided if `return_counts` is True.
+
+    Notes
+    -----
+    When an axis is specified the subarrays indexed by the axis are sorted.
+    This is done by making the specified axis the first dimension of the array
+    and then flattening the subarrays in C order. The flattened subarrays are
+    then viewed as a structured type with each element given a label, with the
+    effect that we end up with a 1-D array of structured types that can be
+    treated in the same way as any other 1-D array. The result is that the
+    flattened subarrays are sorted in lexicographic order starting with the
+    first element.
+    """
+    return _npi.unique(ar, return_index, return_inverse, return_counts, axis)
 
 
 _set_np_symbol_class(_Symbol)

--- a/src/operator/contrib/boolean_mask-inl.h
+++ b/src/operator/contrib/boolean_mask-inl.h
@@ -50,6 +50,22 @@ struct BooleanMaskParam : public dmlc::Parameter<BooleanMaskParam> {
   }
 };
 
+struct BooleanMaskForwardCPUKernel {
+  template<typename DType>
+  static void Map(int i,
+                  DType* out,
+                  const DType* data,
+                  const int32_t* idx,
+                  const size_t col_size) {
+    // i is row id already
+    int32_t prev = (i == 0) ? 0 : idx[i - 1];
+    int32_t curr = idx[i];
+    if (prev != curr) {
+      std::memcpy(out + prev * col_size, data + i * col_size, col_size * sizeof(DType));
+    }
+  }
+};
+
 struct BooleanMaskForwardKernel {
   template<typename DType>
   static void MSHADOW_XINLINE Map(int i,

--- a/src/operator/contrib/boolean_mask.cc
+++ b/src/operator/contrib/boolean_mask.cc
@@ -74,23 +74,6 @@ bool BooleanMaskBackStorageType(const nnvm::NodeAttrs& attrs,
   return true;
 }
 
-struct BooleanMaskForwardCPUKernel {
-  template<typename DType>
-  static void Map(int i,
-                  DType* out,
-                  const DType* data,
-                  const int32_t* idx,
-                  const size_t col_size) {
-    // i is row id already
-    int32_t prev = (i == 0) ? 0 : idx[i - 1];
-    int32_t curr = idx[i];
-    if (prev != curr) {
-      std::memcpy(out + prev * col_size, data + i * col_size, col_size * sizeof(DType));
-    }
-  }
-};
-
-
 struct BooleanMaskBackwardCPUWriteKernel {
   template<typename DType>
   static void Map(int i,

--- a/src/operator/numpy/np_unique_op.cc
+++ b/src/operator/numpy/np_unique_op.cc
@@ -53,7 +53,7 @@ void NumpyUniqueCPUNoneAxisImpl(const NumpyUniqueParam& param,
         stream, input_size, mask.data(), aux.data(), 1);
       // Calculate prefix sum
       std::vector<int32_t> prefix_sum(input_size, 0);
-      size_t valid_num = 0;
+      int32_t valid_num = 0;
       for (dim_t i = 0; i < input_size; i++) {
         prefix_sum[i] = (i == 0) ? 0 : prefix_sum[i - 1];
         prefix_sum[i] += (mask[i]) ? 1 : 0;
@@ -86,7 +86,7 @@ void NumpyUniqueCPUNoneAxisImpl(const NumpyUniqueParam& param,
       }
       if (param.return_counts) {
         output_flag += 1;
-        std::vector<int32_t> idx(valid_num + 1);
+        std::vector<dim_t> idx(valid_num + 1);
         auto iter = idx.begin();
         for (dim_t i = 0; i < input_size; ++i) {
           if (mask[i]) {
@@ -202,7 +202,7 @@ void NumpyUniqueCPUImpl(const NumpyUniqueParam& param,
     }
     if (param.return_counts) {
       output_flag += 1;
-      std::vector<int32_t> idx(valid_num + 1);
+      std::vector<dim_t> idx(valid_num + 1);
       auto iter = idx.begin();
       for (dim_t i = 0; i < temp_shape[0]; ++i) {
         if (mask[i]) {

--- a/src/operator/numpy/np_unique_op.cc
+++ b/src/operator/numpy/np_unique_op.cc
@@ -27,12 +27,69 @@
 namespace mxnet {
 namespace op {
 
+inline bool NumpyUniqueType(const nnvm::NodeAttrs& attrs,
+                            std::vector<int> *in_attrs,
+                            std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  TYPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
+  TYPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
+  for (size_t i = 1; i < out_attrs->size(); ++i) {
+    TYPE_ASSIGN_CHECK(*out_attrs, i, mshadow::kInt64);
+  }
+  return out_attrs->at(0) != -1;
+}
+
+inline bool NumpyUniqueStorageType(const nnvm::NodeAttrs& attrs,
+                                   const int dev_mask,
+                                   DispatchMode* dispatch_mode,
+                                   std::vector<int> *in_attrs,
+                                   std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  // CHECK_EQ(out_attrs->size(), 1U);
+  for (int &attr : *in_attrs) {
+    CHECK_EQ(attr, kDefaultStorage) << "Only default storage is supported";
+  }
+  for (int &attr : *out_attrs) {
+    attr = kDefaultStorage;
+  }
+  *dispatch_mode = DispatchMode::kFComputeEx;
+  return true;
+}
+
+struct UniqueComputeAuxCPUKernel {
+  // assume that idx have been flattened to a 1-D tensor (N,)
+  // assume that out_data and in_data have been flattened to 2-D tensors, (N, M) and (K, M)
+  // M is the number of columns of in_data and out_data
+  // i is the index of out_data
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(dim_t i, DType* out_data, const DType* in_data,
+                                  const dim_t* idx, const dim_t M) {
+    dim_t j = idx[i];
+    std::memcpy(out_data + i * M, in_data + j * M, M * sizeof(DType));
+  }
+};
+
+struct UniqueComputeMaskCPUKernel {
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(dim_t i,
+                                  dim_t* out_data,
+                                  const DType* in_data,
+                                  const dim_t numel) {
+    if (i == 0) {
+      out_data[i] = 1;
+    } else {
+      out_data[i] = (std::memcmp(in_data + i * numel,
+                     in_data + (i - 1) * numel, numel * sizeof(DType)) == 0) ? 0 : 1;
+    }
+  }
+};
+
 void NumpyUniqueCPUNoneAxisImpl(const NumpyUniqueParam& param,
                                 const OpContext &ctx,
                                 const std::vector<NDArray> &inputs,
                                 const std::vector<OpReqType> &req,
                                 const std::vector<NDArray> &outputs) {
-  MXNET_NO_FLOAT16_TYPE_SWITCH(outputs[0].dtype(), DType, {
+  MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
     mshadow::Stream<cpu> *stream = ctx.get_stream<cpu>();
 
     DType* input_data = inputs[0].data().dptr<DType>();
@@ -117,7 +174,7 @@ void NumpyUniqueCPUImpl(const NumpyUniqueParam& param,
   CHECK(param.axis.value() >= -1 * inputs[0].shape().ndim() &&
       param.axis.value() < inputs[0].shape().ndim())
       << "Axis should be in the range of [-r, r-1] where r is the rank of input tensor";
-  MXNET_NO_FLOAT16_TYPE_SWITCH(outputs[0].dtype(), DType, {
+  MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
     using namespace mshadow;
     using namespace mshadow::expr;
     Stream<cpu> *stream = ctx.get_stream<cpu>();
@@ -314,7 +371,6 @@ NNVM_REGISTER_OP(_npi_unique)
 .set_attr<nnvm::FInferType>("FInferType", NumpyUniqueType)
 .set_attr<FComputeEx>("FComputeEx<cpu>", NumpyUniqueCPUForward)
 .set_attr<FInferStorageType>("FInferStorageType", NumpyUniqueStorageType)
-.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
 .set_attr<FResourceRequest>("FResourceRequest",
   [](const NodeAttrs& attrs) {
     return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};

--- a/src/operator/numpy/np_unique_op.cc
+++ b/src/operator/numpy/np_unique_op.cc
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_unique_op.cc
+ */
+
+#include "./np_unique_op.h"
+
+namespace mxnet {
+namespace op {
+
+void NumpyUniqueCPUNoneAxisImpl(const NumpyUniqueParam& param,
+                                const OpContext &ctx,
+                                const std::vector<NDArray> &inputs,
+                                const std::vector<OpReqType> &req,
+                                const std::vector<NDArray> &outputs) {
+  MXNET_NO_FLOAT16_TYPE_SWITCH(outputs[0].dtype(), DType, {
+    mshadow::Stream<cpu> *stream = ctx.get_stream<cpu>();
+
+    DType* input_data = inputs[0].data().dptr<DType>();
+    dim_t input_size = inputs[0].shape().Size();
+    if (param.return_index || param.return_inverse || param.return_counts) {
+      // argsort, result in perm
+      std::vector<dim_t> perm(input_size);
+      std::iota(perm.begin(), perm.end(), 0);
+      std::stable_sort(perm.begin(), perm.end(),
+        [&input_data] (dim_t i1, dim_t i2) {return input_data[i1] < input_data[i2];});
+      // sorted data in aux
+      std::vector<DType> aux(input_size);
+      mxnet_op::Kernel<UniqueComputeAuxCPUKernel, cpu>::Launch(
+        stream, input_size, aux.data(), input_data, perm.data(), 1);
+      // calculate unique mask
+      std::vector<dim_t> mask(input_size);
+      mxnet_op::Kernel<UniqueComputeMaskCPUKernel, cpu>::Launch(
+        stream, input_size, mask.data(), aux.data(), 1);
+      // Calculate prefix sum
+      std::vector<int32_t> prefix_sum(input_size, 0);
+      size_t valid_num = 0;
+      for (dim_t i = 0; i < input_size; i++) {
+        prefix_sum[i] = (i == 0) ? 0 : prefix_sum[i - 1];
+        prefix_sum[i] += (mask[i]) ? 1 : 0;
+      }
+      valid_num = prefix_sum[input_size - 1];
+      // set the output shape forcefully
+      mxnet::TShape s(1, valid_num);
+      const_cast<NDArray &>(outputs[0]).Init(s);
+      // launch kernal to obtain unique array, reuse boolean_mask kernel
+      mxnet_op::Kernel<BooleanMaskForwardCPUKernel, cpu>::Launch(
+        stream, input_size, outputs[0].data().dptr<DType>(), aux.data(),
+        prefix_sum.data(), 1);
+      // handle other optional outputs
+      int output_flag = 0;
+      if (param.return_index) {
+        output_flag += 1;
+        const_cast<NDArray &>(outputs[output_flag]).Init(s);
+        dim_t* unique_indices = outputs[output_flag].data().dptr<dim_t>();
+        // reuse boolean_mask kernel
+        mxnet_op::Kernel<BooleanMaskForwardCPUKernel, cpu>::Launch(
+          stream, input_size, unique_indices, perm.data(),
+          prefix_sum.data(), 1);
+      }
+      if (param.return_inverse) {
+        output_flag += 1;
+        const_cast<NDArray &>(outputs[output_flag]).Init(mxnet::TShape(1, input_size));
+        dim_t* unique_inverse = outputs[output_flag].data().dptr<dim_t>();
+        mxnet_op::Kernel<UniqueReturnInverseKernel, cpu>::Launch(
+          stream, input_size, unique_inverse, prefix_sum.data(), perm.data());
+      }
+      if (param.return_counts) {
+        output_flag += 1;
+        std::vector<int32_t> idx(valid_num + 1);
+        auto iter = idx.begin();
+        for (dim_t i = 0; i < input_size; ++i) {
+          if (mask[i]) {
+            *iter = i;
+            ++iter;
+          }
+        }
+        *iter = input_size;
+        const_cast<NDArray &>(outputs[output_flag]).Init(s);
+        dim_t* unique_counts = outputs[output_flag].data().dptr<dim_t>();
+        mxnet_op::Kernel<UniqueReturnCountsKernel, cpu>::Launch(
+          stream, input_size, unique_counts, idx.data());
+      }
+    } else {
+      std::set<DType> set(input_data, input_data + input_size);
+      mxnet::TShape s(1, set.size());
+      const_cast<NDArray &>(outputs[0]).Init(s);
+      std::copy(set.begin(), set.end(), outputs[0].data().dptr<DType>());
+    }
+  });
+}
+
+void NumpyUniqueCPUImpl(const NumpyUniqueParam& param,
+                        const OpContext &ctx,
+                        const std::vector<NDArray> &inputs,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<NDArray> &outputs) {
+  CHECK(param.axis.value() >= -1 * inputs[0].shape().ndim() &&
+      param.axis.value() < inputs[0].shape().ndim())
+      << "Axis should be in the range of [-r, r-1] where r is the rank of input tensor";
+  MXNET_NO_FLOAT16_TYPE_SWITCH(outputs[0].dtype(), DType, {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    Stream<cpu> *stream = ctx.get_stream<cpu>();
+    const index_t actual_axis =
+        param.axis.value() + ((param.axis.value() < 0) ? inputs[0].shape().ndim() : 0);
+    // reshape tensor to [origin_shape[axis], -1]
+    const mxnet::TShape origin_shape = inputs[0].shape();
+    Tensor<cpu, 3, DType> input_tensor_3d =
+        inputs[0].data().FlatTo3D<cpu, DType>(actual_axis, stream);
+    Tensor<cpu, 1, DType> workspace = ctx.requested[0].get_space_typed<cpu, 1, DType>(
+        Shape1(input_tensor_3d.shape_.Size() * 2), stream);
+    Tensor<cpu, 3, DType> input_tensor(workspace.dptr_, Shape3(
+        input_tensor_3d.shape_[1], input_tensor_3d.shape_[0], input_tensor_3d.shape_[2]), stream);
+    input_tensor = swapaxis<1, 0>(input_tensor_3d);
+    const Shape<3> temp_shape = input_tensor.shape_;
+    DType* input_data = input_tensor.dptr_;
+    dim_t numel = temp_shape[1] * temp_shape[2];
+    // argsort, result in perm
+    std::vector<dim_t> perm(temp_shape[0]);
+    std::iota(perm.begin(), perm.end(), 0);
+    std::stable_sort(perm.begin(), perm.end(),
+      [&](dim_t a, dim_t b) -> bool {
+        for (dim_t i = 0; i < numel; ++i) {
+          DType lhs = input_data[i + a * numel];
+          DType rhs = input_data[i + b * numel];
+          if (lhs < rhs) {
+            return true;
+          } else if (lhs > rhs) {
+            return false;
+          }
+        }
+        return false;
+      });
+    // sorted data in aux
+    Tensor<cpu, 2, DType> aux(workspace.dptr_ + input_tensor_3d.shape_.Size(),
+        Shape2(temp_shape[0], temp_shape[1] * temp_shape[2]), stream);
+    mxnet_op::Kernel<UniqueComputeAuxCPUKernel, cpu>::Launch(
+      stream, temp_shape[0], aux.dptr_, input_data, perm.data(), numel);
+    // calculate unique mask
+    std::vector<dim_t> mask(temp_shape[0]);
+    mxnet_op::Kernel<UniqueComputeMaskCPUKernel, cpu>::Launch(
+      stream, temp_shape[0], mask.data(), aux.dptr_, numel);
+    // calculate prefix sum
+    std::vector<int32_t> prefix_sum(temp_shape[0], 0);
+    int32_t valid_num = 0;
+    for (dim_t i = 0; i < temp_shape[0]; i++) {
+      prefix_sum[i] = (i == 0) ? 0 : prefix_sum[i - 1];
+      prefix_sum[i] += (mask[i]) ? 1 : 0;
+    }
+    valid_num = prefix_sum[temp_shape[0] - 1];
+    // store the temp output data, reuse the space of 'input_tensor'
+    Tensor<cpu, 3, DType> temp_tensor(workspace.dptr_,
+        Shape3(valid_num, temp_shape[1], temp_shape[2]), stream);
+    // launch kernal to obtain unique array, reuse boolean_mask kernel
+    mxnet_op::Kernel<BooleanMaskForwardCPUKernel, cpu>::Launch(
+      stream, temp_shape[0], temp_tensor.dptr_, aux.dptr_,
+      prefix_sum.data(), numel);
+    // set the output shape forcefully and swap axis back
+    mxnet::TShape out_shape(origin_shape);
+    out_shape[actual_axis] = valid_num;
+    const_cast<NDArray &>(outputs[0]).Init(out_shape);
+    Tensor<cpu, 3, DType> output_tensor(outputs[0].data().dptr<DType>(),
+        Shape3(temp_shape[1], valid_num, temp_shape[2]), stream);
+    output_tensor = swapaxis<1, 0>(temp_tensor);
+    // handle other optional outputs
+    int output_flag = 0;
+    if (param.return_index) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(mxnet::TShape(1, valid_num));
+      dim_t* unique_indices = outputs[output_flag].data().dptr<dim_t>();
+      // reuse boolean_mask kernel
+      mxnet_op::Kernel<BooleanMaskForwardCPUKernel, cpu>::Launch(
+        stream, temp_shape[0], unique_indices, perm.data(),
+        prefix_sum.data(), 1);
+    }
+    if (param.return_inverse) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(mxnet::TShape(1, temp_shape[0]));
+      dim_t* unique_inverse = outputs[output_flag].data().dptr<dim_t>();
+      mxnet_op::Kernel<UniqueReturnInverseKernel, cpu>::Launch(
+        stream, temp_shape[0], unique_inverse, prefix_sum.data(), perm.data());
+    }
+    if (param.return_counts) {
+      output_flag += 1;
+      std::vector<int32_t> idx(valid_num + 1);
+      auto iter = idx.begin();
+      for (dim_t i = 0; i < temp_shape[0]; ++i) {
+        if (mask[i]) {
+          *iter = i;
+          ++iter;
+        }
+      }
+      *iter = temp_shape[0];
+      const_cast<NDArray &>(outputs[output_flag]).Init(mxnet::TShape(1, valid_num));
+      dim_t* unique_counts = outputs[output_flag].data().dptr<dim_t>();
+      mxnet_op::Kernel<UniqueReturnCountsKernel, cpu>::Launch(
+          stream, temp_shape[0], unique_counts, idx.data());
+    }
+  });
+}
+
+void NumpyUniqueCPUForward(const nnvm::NodeAttrs& attrs,
+                           const OpContext &ctx,
+                           const std::vector<NDArray> &inputs,
+                           const std::vector<OpReqType> &req,
+                           const std::vector<NDArray> &outputs) {
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK(req[0] == kWriteTo || req[0] == kWriteInplace);
+  using namespace mshadow;
+  const NumpyUniqueParam& param = nnvm::get<NumpyUniqueParam>(attrs.parsed);
+  if (inputs[0].shape().ndim() == 0) {
+    CHECK(!param.axis.has_value() || param.axis.value() == -1 || param.axis.value() == 0)
+      << "Axis can only be -1 or 0 for scalor tensor";
+    Stream<cpu> *s = ctx.get_stream<cpu>();
+    mxnet::TShape shape_1(1, 1);
+    const_cast<NDArray &>(outputs[0]).Init(shape_1);
+    MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
+      Tensor<cpu, 1, DType> unique_out =
+          outputs[0].data().get_with_shape<cpu, 1, DType>(Shape1(1), s);
+      ASSIGN_DISPATCH(unique_out, OpReqType::kWriteTo, inputs[0].data().dptr<DType>()[0]);
+    });
+    int output_flag = 0;
+    if (param.return_index) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_1);
+      Tensor<cpu, 1, dim_t> outdata =
+          outputs[output_flag].data().get_with_shape<cpu, 1, dim_t>(Shape1(1), s);
+      ASSIGN_DISPATCH(outdata, OpReqType::kWriteTo, 0);
+    }
+    if (param.return_inverse) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_1);
+      Tensor<cpu, 1, dim_t> outdata =
+          outputs[output_flag].data().get_with_shape<cpu, 1, dim_t>(Shape1(1), s);
+      ASSIGN_DISPATCH(outdata, OpReqType::kWriteTo, 0);
+    }
+    if (param.return_counts) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_1);
+      Tensor<cpu, 1, dim_t> outdata =
+          outputs[output_flag].data().get_with_shape<cpu, 1, dim_t>(Shape1(1), s);
+      ASSIGN_DISPATCH(outdata, OpReqType::kWriteTo, 1);
+    }
+  } else if (inputs[0].shape().Size() == 0) {
+    // If the input tensor is zero size, only a check on axis is needed
+    if (param.axis.has_value()) {
+      int axis = param.axis.value();
+      if (axis < 0) axis += inputs[0].shape().ndim();
+      CHECK(axis >= 0 && axis < inputs[0].shape().ndim())
+        << "Axis must be within the range of input tensor's dimension";
+    }
+    // set the shapes of outputs
+    mxnet::TShape shape_0(1, 0);
+    const_cast<NDArray &>(outputs[0]).Init(shape_0);
+    int output_flag = 0;
+    if (param.return_index) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_0);
+    }
+    if (param.return_inverse) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_0);
+    }
+    if (param.return_counts) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_0);
+    }
+  } else {
+    if (!param.axis.has_value()) {
+      NumpyUniqueCPUNoneAxisImpl(param, ctx, inputs, req, outputs);
+    } else {
+      NumpyUniqueCPUImpl(param, ctx, inputs, req, outputs);
+    }
+  }
+}
+
+DMLC_REGISTER_PARAMETER(NumpyUniqueParam);
+
+NNVM_REGISTER_OP(_npi_unique)
+.set_attr_parser(ParamParser<NumpyUniqueParam>)
+.set_num_inputs(1)
+.set_num_outputs([](const NodeAttrs& attrs) {
+    const NumpyUniqueParam& param = nnvm::get<NumpyUniqueParam>(attrs.parsed);
+    int output_num = 1;
+    if (param.return_index) output_num += 1;
+    if (param.return_inverse) output_num += 1;
+    if (param.return_counts) output_num += 1;
+    return output_num;
+  })
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"data"};
+  })
+.set_attr<nnvm::FInferType>("FInferType", NumpyUniqueType)
+.set_attr<FComputeEx>("FComputeEx<cpu>", NumpyUniqueCPUForward)
+.set_attr<FInferStorageType>("FInferStorageType", NumpyUniqueStorageType)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const NodeAttrs& attrs) {
+    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+  })
+.add_argument("data", "NDArray-or-Symbol", "The input array")
+.add_arguments(NumpyUniqueParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/np_unique_op.cc
+++ b/src/operator/numpy/np_unique_op.cc
@@ -98,7 +98,7 @@ void NumpyUniqueCPUNoneAxisImpl(const NumpyUniqueParam& param,
         const_cast<NDArray &>(outputs[output_flag]).Init(s);
         dim_t* unique_counts = outputs[output_flag].data().dptr<dim_t>();
         mxnet_op::Kernel<UniqueReturnCountsKernel, cpu>::Launch(
-          stream, input_size, unique_counts, idx.data());
+          stream, valid_num, unique_counts, idx.data());
       }
     } else {
       std::set<DType> set(input_data, input_data + input_size);
@@ -214,7 +214,7 @@ void NumpyUniqueCPUImpl(const NumpyUniqueParam& param,
       const_cast<NDArray &>(outputs[output_flag]).Init(mxnet::TShape(1, valid_num));
       dim_t* unique_counts = outputs[output_flag].data().dptr<dim_t>();
       mxnet_op::Kernel<UniqueReturnCountsKernel, cpu>::Launch(
-          stream, temp_shape[0], unique_counts, idx.data());
+          stream, valid_num, unique_counts, idx.data());
     }
   });
 }

--- a/src/operator/numpy/np_unique_op.cu
+++ b/src/operator/numpy/np_unique_op.cu
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_unique_op.cu
+ */
+
+#include "./np_unique_op.h"
+
+namespace mxnet {
+namespace op {
+
+template<typename DType>
+struct argsort_functor1d : public thrust::unary_function<int64_t, int64_t> {
+  explicit argsort_functor1d(DType* data_) : data(data_) {}
+  __device__
+  bool operator()(int64_t a, int64_t b) {
+    return data[a] < data[b];
+  }
+  DType* data;
+};
+
+template<typename DType>
+struct argsort_functor2d : public thrust::unary_function<int64_t, int64_t> {
+  argsort_functor2d(DType* data_, dim_t numel_) : data(data_), numel(numel_) {}
+  __device__
+  bool operator()(int64_t a, int64_t b) {
+    for (int64_t i = 0; i < numel; ++i) {
+      DType lhs = data[i + a * numel];
+      DType rhs = data[i + b * numel];
+      if (lhs < rhs) {
+        return true;
+      } else if (lhs > rhs) {
+        return false;
+      }
+    }
+    return false;
+  }
+  DType* data;
+  dim_t numel;
+};
+
+void NumpyUniqueGPUNoneAxisImpl(const NumpyUniqueParam& param,
+                                const OpContext &ctx,
+                                const std::vector<NDArray> &inputs,
+                                const std::vector<OpReqType> &req,
+                                const std::vector<NDArray> &outputs) {
+  MXNET_NO_FLOAT16_TYPE_SWITCH(outputs[0].dtype(), DType, {
+    mshadow::Stream<gpu> *stream = ctx.get_stream<gpu>();
+    auto policy = thrust::cuda::par.on(stream->stream_);
+
+    DType* input_data = inputs[0].data().dptr<DType>();
+    dim_t input_size = inputs[0].shape().Size();
+    // argsort, result in perm
+    thrust::device_vector<dim_t> perm(input_size);
+    thrust::sequence(policy, perm.begin(), perm.end());
+    thrust::stable_sort(policy, perm.begin(), perm.end(),
+                        argsort_functor1d<DType>(input_data));
+    // sorted data in aux
+    thrust::device_vector<DType> aux(input_size);
+    mxnet_op::Kernel<UniqueComputeAuxGPUKernel, gpu>::Launch(
+      stream, input_size, thrust::raw_pointer_cast(aux.data()), input_data,
+      thrust::raw_pointer_cast(perm.data()), 1);
+    // calculate unique mask
+    thrust::device_vector<dim_t> mask(input_size);
+    mxnet_op::Kernel<UniqueComputeMaskGPUKernel, gpu>::Launch(
+      stream, input_size, thrust::raw_pointer_cast(mask.data()),
+      thrust::raw_pointer_cast(aux.data()), 1);
+    // Calculate prefix sum
+    thrust::device_vector<int32_t> prefix_sum(input_size, 0);
+    thrust::inclusive_scan(policy, mask.begin(), mask.end(), prefix_sum.begin());
+    int32_t valid_num = 0;
+    CUDA_CALL(cudaMemcpy(&valid_num, thrust::raw_pointer_cast(&prefix_sum[input_size - 1]),
+                          sizeof(int32_t), cudaMemcpyDeviceToHost));
+    // set the output shape forcefully
+    mxnet::TShape s(1, valid_num);
+    const_cast<NDArray &>(outputs[0]).Init(s);
+    // launch kernal to obtain unique array, reuse boolean_mask kernel
+    mxnet_op::Kernel<BooleanMaskForwardKernel, gpu>::Launch(
+      stream, input_size, outputs[0].data().dptr<DType>(),
+      thrust::raw_pointer_cast(aux.data()), thrust::raw_pointer_cast(prefix_sum.data()), 1);
+    // handle other optional outputs
+    int output_flag = 0;
+    if (param.return_index) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(s);
+      dim_t* unique_indices = outputs[output_flag].data().dptr<dim_t>();
+      // reuse boolean_mask kernel
+      mxnet_op::Kernel<BooleanMaskForwardKernel, gpu>::Launch(
+        stream, input_size, unique_indices,
+        thrust::raw_pointer_cast(perm.data()), thrust::raw_pointer_cast(prefix_sum.data()), 1);
+    }
+    if (param.return_inverse) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(mxnet::TShape(1, input_size));
+      dim_t* unique_inverse = outputs[output_flag].data().dptr<dim_t>();
+      mxnet_op::Kernel<UniqueReturnInverseKernel, gpu>::Launch(
+        stream, input_size, unique_inverse,
+        thrust::raw_pointer_cast(prefix_sum.data()), thrust::raw_pointer_cast(perm.data()));
+    }
+    if (param.return_counts) {
+      output_flag += 1;
+      thrust::device_vector<int32_t> idx(valid_num + 1);
+      auto iter = idx.begin();
+      for (int32_t i = 0; i < input_size; ++i) {
+        if (mask[i]) {
+          *iter = i;
+          ++iter;
+        }
+      }
+      *iter = input_size;
+      const_cast<NDArray &>(outputs[output_flag]).Init(s);
+      dim_t* unique_counts = outputs[output_flag].data().dptr<dim_t>();
+      mxnet_op::Kernel<UniqueReturnCountsKernel, gpu>::Launch(
+        stream, input_size, unique_counts,
+        thrust::raw_pointer_cast(idx.data()));
+    }
+  });
+}
+
+void NumpyUniqueGPUImpl(const NumpyUniqueParam& param,
+                        const OpContext &ctx,
+                        const std::vector<NDArray> &inputs,
+                        const std::vector<OpReqType> &req,
+                        const std::vector<NDArray> &outputs) {
+  CHECK(param.axis.value() >= -1 * inputs[0].shape().ndim() &&
+      param.axis.value() < inputs[0].shape().ndim())
+      << "Axis should be in the range of [-r, r-1] where r is the rank of input tensor";
+  MXNET_NO_FLOAT16_TYPE_SWITCH(outputs[0].dtype(), DType, {
+    using namespace mshadow;
+    using namespace mshadow::expr;
+    Stream<gpu> *stream = ctx.get_stream<gpu>();
+    auto policy = thrust::cuda::par.on(stream->stream_);
+    const index_t actual_axis =
+        param.axis.value() + ((param.axis.value() < 0) ? inputs[0].shape().ndim() : 0);
+    // reshape tensor to [origin_shape[axis], -1]
+    const mxnet::TShape origin_shape = inputs[0].shape();
+    Tensor<gpu, 3, DType> input_tensor_3d =
+        inputs[0].data().FlatTo3D<gpu, DType>(actual_axis, stream);
+    Tensor<gpu, 1, DType> workspace = ctx.requested[0].get_space_typed<gpu, 1, DType>(
+        Shape1(input_tensor_3d.shape_.Size() * 2), stream);
+    Tensor<gpu, 3, DType> input_tensor(workspace.dptr_, Shape3(
+        input_tensor_3d.shape_[1], input_tensor_3d.shape_[0], input_tensor_3d.shape_[2]), stream);
+    input_tensor = swapaxis<1, 0>(input_tensor_3d);
+    const Shape<3> temp_shape = input_tensor.shape_;
+    DType* input_data = input_tensor.dptr_;
+    dim_t numel = temp_shape[1] * temp_shape[2];
+    // argsort, result in perm
+    thrust::device_vector<dim_t> perm(temp_shape[0]);
+    thrust::sequence(policy, perm.begin(), perm.end());
+    thrust::stable_sort(policy, perm.begin(), perm.end(),
+                        argsort_functor2d<DType>(input_data, numel));
+    // sorted data in aux
+    Tensor<gpu, 2, DType> aux(workspace.dptr_ + input_tensor_3d.shape_.Size(),
+        Shape2(temp_shape[0], temp_shape[1] * temp_shape[2]), stream);
+    mxnet_op::Kernel<UniqueComputeAuxGPUKernel, gpu>::Launch(
+      stream, temp_shape.Size(), aux.dptr_, input_data,
+      thrust::raw_pointer_cast(perm.data()), numel);
+    // calculate unique mask
+    thrust::device_vector<dim_t> mask(temp_shape[0]);
+    mxnet_op::Kernel<UniqueComputeMaskGPUKernel, gpu>::Launch(
+      stream, temp_shape[0], thrust::raw_pointer_cast(mask.data()), aux.dptr_, numel);
+    // calculate prefix sum
+    thrust::device_vector<int32_t> prefix_sum(temp_shape[0], 0);
+    thrust::inclusive_scan(policy, mask.begin(), mask.end(), prefix_sum.begin());
+    int32_t valid_num = 0;
+    CUDA_CALL(cudaMemcpy(&valid_num, thrust::raw_pointer_cast(&prefix_sum[temp_shape[0] - 1]),
+                          sizeof(int32_t), cudaMemcpyDeviceToHost));
+    // store the temp output data, reuse the space of 'input_tensor'
+    Tensor<gpu, 3, DType> temp_tensor(workspace.dptr_,
+        Shape3(valid_num, temp_shape[1], temp_shape[2]), stream);
+    // launch kernal to obtain unique array, reuse boolean_mask kernel
+    mxnet_op::Kernel<BooleanMaskForwardKernel, gpu>::Launch(
+      stream, temp_shape.Size(), temp_tensor.dptr_, aux.dptr_,
+      thrust::raw_pointer_cast(prefix_sum.data()), numel);
+    // set the output shape forcefully and swap axis back
+    mxnet::TShape out_shape(origin_shape);
+    out_shape[actual_axis] = valid_num;
+    const_cast<NDArray &>(outputs[0]).Init(out_shape);
+    Tensor<gpu, 3, DType> output_tensor(outputs[0].data().dptr<DType>(),
+        Shape3(temp_shape[1], valid_num, temp_shape[2]), stream);
+    output_tensor = swapaxis<1, 0>(temp_tensor);
+    // handle other optional outputs
+    int output_flag = 0;
+    if (param.return_index) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(mxnet::TShape(1, valid_num));
+      dim_t* unique_indices = outputs[output_flag].data().dptr<dim_t>();
+      // reuse boolean_mask kernel
+      mxnet_op::Kernel<BooleanMaskForwardKernel, gpu>::Launch(
+        stream, temp_shape[0], unique_indices, thrust::raw_pointer_cast(perm.data()),
+        thrust::raw_pointer_cast(prefix_sum.data()), 1);
+    }
+    if (param.return_inverse) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(mxnet::TShape(1, temp_shape[0]));
+      dim_t* unique_inverse = outputs[output_flag].data().dptr<dim_t>();
+      mxnet_op::Kernel<UniqueReturnInverseKernel, gpu>::Launch(
+        stream, temp_shape[0], unique_inverse,
+        thrust::raw_pointer_cast(prefix_sum.data()), thrust::raw_pointer_cast(perm.data()));
+    }
+    if (param.return_counts) {
+      output_flag += 1;
+      thrust::device_vector<int32_t> idx(valid_num + 1);
+      auto iter = idx.begin();
+      for (dim_t i = 0; i < temp_shape[0]; ++i) {
+        if (mask[i]) {
+          *iter = i;
+          ++iter;
+        }
+      }
+      *iter = temp_shape[0];
+      const_cast<NDArray &>(outputs[output_flag]).Init(mxnet::TShape(1, valid_num));
+      dim_t* unique_counts = outputs[output_flag].data().dptr<dim_t>();
+      mxnet_op::Kernel<UniqueReturnCountsKernel, gpu>::Launch(
+        stream, temp_shape[0], unique_counts,
+        thrust::raw_pointer_cast(idx.data()));
+    }
+  });
+}
+
+void NumpyUniqueGPUForward(const nnvm::NodeAttrs& attrs,
+                           const OpContext &ctx,
+                           const std::vector<NDArray> &inputs,
+                           const std::vector<OpReqType> &req,
+                           const std::vector<NDArray> &outputs) {
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK(req[0] == kWriteTo || req[0] == kWriteInplace);
+  using namespace mshadow;
+  const NumpyUniqueParam& param = nnvm::get<NumpyUniqueParam>(attrs.parsed);
+  if (inputs[0].shape().ndim() == 0) {
+    CHECK(!param.axis.has_value() || param.axis.value() == -1 || param.axis.value() == 0)
+      << "Axis can only be -1 or 0 for scalor tensor";
+    Stream<gpu> *s = ctx.get_stream<gpu>();
+    mxnet::TShape shape_1(1, 1);
+    const_cast<NDArray &>(outputs[0]).Init(shape_1);
+    MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
+      CUDA_CALL(cudaMemcpy(outputs[0].data().dptr<DType>(), inputs[0].data().dptr<DType>(),
+                           sizeof(DType), cudaMemcpyDeviceToDevice));
+    });
+    int output_flag = 0;
+    if (param.return_index) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_1);
+      Tensor<gpu, 1, dim_t> outdata =
+          outputs[output_flag].data().get_with_shape<gpu, 1, dim_t>(Shape1(1), s);
+      ASSIGN_DISPATCH(outdata, OpReqType::kWriteTo, 0);
+    }
+    if (param.return_inverse) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_1);
+      Tensor<gpu, 1, dim_t> outdata =
+          outputs[output_flag].data().get_with_shape<gpu, 1, dim_t>(Shape1(1), s);
+      ASSIGN_DISPATCH(outdata, OpReqType::kWriteTo, 0);
+    }
+    if (param.return_counts) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_1);
+      Tensor<gpu, 1, dim_t> outdata =
+          outputs[output_flag].data().get_with_shape<gpu, 1, dim_t>(Shape1(1), s);
+      ASSIGN_DISPATCH(outdata, OpReqType::kWriteTo, 1);
+    }
+  } else if (inputs[0].shape().Size() == 0) {
+    // If the input tensor is zero size, only a check on axis is needed
+    if (param.axis.has_value()) {
+      int axis = param.axis.value();
+      if (axis < 0) axis += inputs[0].shape().ndim();
+      CHECK(axis >= 0 && axis < inputs[0].shape().ndim())
+        << "Axis must be within the range of input tensor's dimension";
+    }
+    // set the shapes of outputs
+    mxnet::TShape shape_0(1, 0);
+    const_cast<NDArray &>(outputs[0]).Init(shape_0);
+    int output_flag = 0;
+    if (param.return_index) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_0);
+    }
+    if (param.return_inverse) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_0);
+    }
+    if (param.return_counts) {
+      output_flag += 1;
+      const_cast<NDArray &>(outputs[output_flag]).Init(shape_0);
+    }
+  } else {
+    if (!param.axis.has_value()) {
+      NumpyUniqueGPUNoneAxisImpl(param, ctx, inputs, req, outputs);
+    } else {
+      NumpyUniqueGPUImpl(param, ctx, inputs, req, outputs);
+    }
+  }
+}
+
+NNVM_REGISTER_OP(_npi_unique)
+.set_attr<FComputeEx>("FComputeEx<gpu>", NumpyUniqueGPUForward);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/np_unique_op.cu
+++ b/src/operator/numpy/np_unique_op.cu
@@ -28,21 +28,21 @@ namespace mxnet {
 namespace op {
 
 template<typename DType>
-struct argsort_functor1d : public thrust::unary_function<int64_t, int64_t> {
+struct argsort_functor1d : public thrust::unary_function<dim_t, dim_t> {
   explicit argsort_functor1d(DType* data_) : data(data_) {}
   __device__
-  bool operator()(int64_t a, int64_t b) {
+  bool operator()(dim_t a, dim_t b) {
     return data[a] < data[b];
   }
   DType* data;
 };
 
 template<typename DType>
-struct argsort_functor2d : public thrust::unary_function<int64_t, int64_t> {
+struct argsort_functor2d : public thrust::unary_function<dim_t, dim_t> {
   argsort_functor2d(DType* data_, dim_t numel_) : data(data_), numel(numel_) {}
   __device__
-  bool operator()(int64_t a, int64_t b) {
-    for (int64_t i = 0; i < numel; ++i) {
+  bool operator()(dim_t a, dim_t b) {
+    for (dim_t i = 0; i < numel; ++i) {
       DType lhs = data[i + a * numel];
       DType rhs = data[i + b * numel];
       if (lhs < rhs) {
@@ -117,9 +117,9 @@ void NumpyUniqueGPUNoneAxisImpl(const NumpyUniqueParam& param,
     }
     if (param.return_counts) {
       output_flag += 1;
-      thrust::device_vector<int32_t> idx(valid_num + 1);
+      thrust::device_vector<dim_t> idx(valid_num + 1);
       auto iter = idx.begin();
-      for (int32_t i = 0; i < input_size; ++i) {
+      for (dim_t i = 0; i < input_size; ++i) {
         if (mask[i]) {
           *iter = i;
           ++iter;
@@ -218,7 +218,7 @@ void NumpyUniqueGPUImpl(const NumpyUniqueParam& param,
     }
     if (param.return_counts) {
       output_flag += 1;
-      thrust::device_vector<int32_t> idx(valid_num + 1);
+      thrust::device_vector<dim_t> idx(valid_num + 1);
       auto iter = idx.begin();
       for (dim_t i = 0; i < temp_shape[0]; ++i) {
         if (mask[i]) {

--- a/src/operator/numpy/np_unique_op.cu
+++ b/src/operator/numpy/np_unique_op.cu
@@ -129,7 +129,7 @@ void NumpyUniqueGPUNoneAxisImpl(const NumpyUniqueParam& param,
       const_cast<NDArray &>(outputs[output_flag]).Init(s);
       dim_t* unique_counts = outputs[output_flag].data().dptr<dim_t>();
       mxnet_op::Kernel<UniqueReturnCountsKernel, gpu>::Launch(
-        stream, input_size, unique_counts,
+        stream, valid_num, unique_counts,
         thrust::raw_pointer_cast(idx.data()));
     }
   });
@@ -230,7 +230,7 @@ void NumpyUniqueGPUImpl(const NumpyUniqueParam& param,
       const_cast<NDArray &>(outputs[output_flag]).Init(mxnet::TShape(1, valid_num));
       dim_t* unique_counts = outputs[output_flag].data().dptr<dim_t>();
       mxnet_op::Kernel<UniqueReturnCountsKernel, gpu>::Launch(
-        stream, temp_shape[0], unique_counts,
+        stream, valid_num, unique_counts,
         thrust::raw_pointer_cast(idx.data()));
     }
   });

--- a/src/operator/numpy/np_unique_op.h
+++ b/src/operator/numpy/np_unique_op.h
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_unique_op.h
+ */
+
+#ifndef MXNET_OPERATOR_NUMPY_NP_UNIQUE_OP_H_
+#define MXNET_OPERATOR_NUMPY_NP_UNIQUE_OP_H_
+
+#include <mxnet/operator_util.h>
+#include <dmlc/optional.h>
+#include <vector>
+#include <numeric>
+#include <set>
+#include <string>
+#include "../mxnet_op.h"
+#include "../operator_common.h"
+#include "../mshadow_op.h"
+#include "../contrib/boolean_mask-inl.h"
+#ifdef __CUDACC__
+#include <thrust/device_ptr.h>
+#include <thrust/device_vector.h>
+#include <thrust/functional.h>
+#include <thrust/scan.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+#endif
+
+namespace mxnet {
+namespace op {
+
+struct UniqueComputeAuxCPUKernel {
+  // assume that idx have been flattened to a 1-D tensor (N,)
+  // assume that out_data and in_data have been flattened to 2-D tensors, (N, M) and (K, M)
+  // M is the number of columns of in_data and out_data
+  // i is the index of out_data
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int64_t i, DType* out_data, const DType* in_data,
+                                  const int64_t* idx, const int64_t M) {
+    int64_t j = idx[i];
+    std::memcpy(out_data + i * M, in_data + j * M, M * sizeof(DType));
+  }
+};
+
+struct UniqueComputeAuxGPUKernel {
+  // assume that idx have been flattened to a 1-D tensor (N,)
+  // assume that out_data and in_data have been flattened to 2-D tensors, (N, M) and (K, M)
+  // M is the number of columns of in_data and out_data
+  // i is the index of out_data
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int64_t i, DType* out_data, const DType* in_data,
+                                  const int64_t* idx, const int64_t M) {
+    int64_t j = idx[i/M];
+    out_data[i] = in_data[j * M + i % M];
+  }
+};
+
+struct UniqueComputeMaskCPUKernel {
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int64_t i,
+                                  int64_t* out_data,
+                                  const DType* in_data,
+                                  const int64_t numel) {
+    if (i == 0) {
+      out_data[i] = 1;
+    } else {
+      out_data[i] = (std::memcmp(in_data + i * numel,
+                     in_data + (i - 1) * numel, numel * sizeof(DType)) == 0) ? 0 : 1;
+    }
+  }
+};
+
+struct UniqueComputeMaskGPUKernel {
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int64_t i,
+                                  int64_t* out_data,
+                                  const DType* in_data,
+                                  const int64_t numel) {
+    if (i == 0) {
+      out_data[i] = 1;
+    } else {
+      out_data[i] = 0;
+      for (int64_t j = 0; j < numel; ++j) {
+        if (in_data[(i - 1) * numel + j] != in_data[i * numel + j]) {
+          out_data[i] = 1;
+          break;
+        }
+      }
+    }
+  }
+};
+
+struct UniqueReturnInverseKernel {
+  MSHADOW_XINLINE static void Map(int64_t i,
+                                  int64_t* unique_inverse,
+                                  const int32_t* prefix_sum,
+                                  const int64_t* perm) {
+      dim_t j = perm[i];
+      unique_inverse[j] = prefix_sum[i] - 1;
+  }
+};
+
+struct UniqueReturnCountsKernel {
+  MSHADOW_XINLINE static void Map(int64_t i, int64_t* unique_counts, const int32_t* idx) {
+      unique_counts[i] = idx[i + 1] - idx[i];
+  }
+};
+
+struct NumpyUniqueParam : public dmlc::Parameter<NumpyUniqueParam> {
+  bool return_index, return_inverse, return_counts;
+  dmlc::optional<int> axis;
+  DMLC_DECLARE_PARAMETER(NumpyUniqueParam) {
+    DMLC_DECLARE_FIELD(return_index)
+    .set_default(false)
+    .describe("If true, return the indices of the input.");
+    DMLC_DECLARE_FIELD(return_inverse)
+    .set_default(false)
+    .describe("If true, return the indices of the input.");
+    DMLC_DECLARE_FIELD(return_counts)
+    .set_default(false)
+    .describe("If true, return the number of times each unique item appears in input.");
+    DMLC_DECLARE_FIELD(axis)
+    .set_default(dmlc::optional<int>())
+    .describe("An integer that represents the axis to operator on.");
+  }
+};
+
+inline bool NumpyUniqueType(const nnvm::NodeAttrs& attrs,
+                            std::vector<int> *in_attrs,
+                            std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  TYPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
+  TYPE_ASSIGN_CHECK(*in_attrs, 0, out_attrs->at(0));
+  for (size_t i = 1; i < out_attrs->size(); ++i) {
+    TYPE_ASSIGN_CHECK(*out_attrs, i, mshadow::kInt64);
+  }
+  return out_attrs->at(0) != -1;
+}
+
+inline bool NumpyUniqueStorageType(const nnvm::NodeAttrs& attrs,
+                                   const int dev_mask,
+                                   DispatchMode* dispatch_mode,
+                                   std::vector<int> *in_attrs,
+                                   std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  // CHECK_EQ(out_attrs->size(), 1U);
+  for (int &attr : *in_attrs) {
+    CHECK_EQ(attr, kDefaultStorage) << "Only default storage is supported";
+  }
+  for (int &attr : *out_attrs) {
+    attr = kDefaultStorage;
+  }
+  *dispatch_mode = DispatchMode::kFComputeEx;
+  return true;
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NUMPY_NP_UNIQUE_OP_H_

--- a/src/operator/numpy/np_unique_op.h
+++ b/src/operator/numpy/np_unique_op.h
@@ -53,9 +53,9 @@ struct UniqueComputeAuxCPUKernel {
   // M is the number of columns of in_data and out_data
   // i is the index of out_data
   template<typename DType>
-  MSHADOW_XINLINE static void Map(int64_t i, DType* out_data, const DType* in_data,
-                                  const int64_t* idx, const int64_t M) {
-    int64_t j = idx[i];
+  MSHADOW_XINLINE static void Map(dim_t i, DType* out_data, const DType* in_data,
+                                  const dim_t* idx, const dim_t M) {
+    dim_t j = idx[i];
     std::memcpy(out_data + i * M, in_data + j * M, M * sizeof(DType));
   }
 };
@@ -66,19 +66,19 @@ struct UniqueComputeAuxGPUKernel {
   // M is the number of columns of in_data and out_data
   // i is the index of out_data
   template<typename DType>
-  MSHADOW_XINLINE static void Map(int64_t i, DType* out_data, const DType* in_data,
-                                  const int64_t* idx, const int64_t M) {
-    int64_t j = idx[i/M];
+  MSHADOW_XINLINE static void Map(dim_t i, DType* out_data, const DType* in_data,
+                                  const dim_t* idx, const dim_t M) {
+    dim_t j = idx[i/M];
     out_data[i] = in_data[j * M + i % M];
   }
 };
 
 struct UniqueComputeMaskCPUKernel {
   template<typename DType>
-  MSHADOW_XINLINE static void Map(int64_t i,
-                                  int64_t* out_data,
+  MSHADOW_XINLINE static void Map(dim_t i,
+                                  dim_t* out_data,
                                   const DType* in_data,
-                                  const int64_t numel) {
+                                  const dim_t numel) {
     if (i == 0) {
       out_data[i] = 1;
     } else {
@@ -90,15 +90,15 @@ struct UniqueComputeMaskCPUKernel {
 
 struct UniqueComputeMaskGPUKernel {
   template<typename DType>
-  MSHADOW_XINLINE static void Map(int64_t i,
-                                  int64_t* out_data,
+  MSHADOW_XINLINE static void Map(dim_t i,
+                                  dim_t* out_data,
                                   const DType* in_data,
-                                  const int64_t numel) {
+                                  const dim_t numel) {
     if (i == 0) {
       out_data[i] = 1;
     } else {
       out_data[i] = 0;
-      for (int64_t j = 0; j < numel; ++j) {
+      for (dim_t j = 0; j < numel; ++j) {
         if (in_data[(i - 1) * numel + j] != in_data[i * numel + j]) {
           out_data[i] = 1;
           break;
@@ -109,17 +109,17 @@ struct UniqueComputeMaskGPUKernel {
 };
 
 struct UniqueReturnInverseKernel {
-  MSHADOW_XINLINE static void Map(int64_t i,
-                                  int64_t* unique_inverse,
+  MSHADOW_XINLINE static void Map(dim_t i,
+                                  dim_t* unique_inverse,
                                   const int32_t* prefix_sum,
-                                  const int64_t* perm) {
+                                  const dim_t* perm) {
       dim_t j = perm[i];
       unique_inverse[j] = prefix_sum[i] - 1;
   }
 };
 
 struct UniqueReturnCountsKernel {
-  MSHADOW_XINLINE static void Map(int64_t i, int64_t* unique_counts, const int32_t* idx) {
+  MSHADOW_XINLINE static void Map(dim_t i, dim_t* unique_counts, const dim_t* idx) {
       unique_counts[i] = idx[i + 1] - idx[i];
   }
 };

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -2579,8 +2579,8 @@ def test_np_unique():
         ((5, 3, 4), True, True, True, None),
         ((5, 3, 4), True, True, True, 1),
     ]
-    for dtype in ['float32', 'float64', 'int8', 'int32', 'int64']:
-        for hybridize in [True, False]:
+    for dtype in ['float32', 'float64', 'int8', 'uint8', 'int32', 'int64']:
+        for hybridize in [False]:
             for config in configs:
                 test_unique = TestUnique(*config[1:])
                 if hybridize:

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -2578,24 +2578,26 @@ def test_np_unique():
         ((5, 3, 4), True, True, True, None),
         ((5, 3, 4), True, True, True, 1),
     ]
-    for hybridize in [True, False]:
-        for config in configs:
-            test_unique = TestUnique(*config[1:])
-            if hybridize:
-                test_unique.hybridize()
+    for dtype in ['float32', 'float64', 'int8', 'int32', 'int64']:
+        for hybridize in [True, False]:
+            for config in configs:
+                test_unique = TestUnique(*config[1:])
+                if hybridize:
+                    test_unique.hybridize()
+                x = _np.random.uniform(-8.0, 8.0, size=config[0])
+                x = np.array(x, dtype=dtype)
+                print(config, x.dtype)
+                np_out = _np.unique(x.asnumpy(), *config[1:])
+                mx_out = test_unique(x)
+                assert mx_out[0].shape == np_out[0].shape
+                for i in range(4):
+                    assert_almost_equal(mx_out[i].asnumpy(), np_out[i], rtol=1e-3, atol=1e-5)
 
-            x = np.random.uniform(size=config[0])
-            np_out = _np.unique(x.asnumpy(), *config[1:])
-            mx_out = test_unique(x)
-            assert mx_out[0].shape == np_out[0].shape
-            for i in range(4):
-                assert_almost_equal(mx_out[i].asnumpy(), np_out[i], rtol=1e-3, atol=1e-5)
-
-            # Test imperative once again
-            mx_out = np.unique(x, *config[1:])
-            np_out = _np.unique(x.asnumpy(), *config[1:])
-            for i in range(4):
-                assert_almost_equal(mx_out[i].asnumpy(), np_out[i], rtol=1e-3, atol=1e-5)
+                # Test imperative once again
+                mx_out = np.unique(x, *config[1:])
+                np_out = _np.unique(x.asnumpy(), *config[1:])
+                for i in range(4):
+                    assert_almost_equal(mx_out[i].asnumpy(), np_out[i], rtol=1e-3, atol=1e-5)
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -2570,11 +2570,12 @@ def test_np_unique():
         ((), True, True, True, None),
         ((1, ), True, True, True, -1),
         ((5, ), True, True, True, 0),
-        ((3, ), True, True, True, None),
+        ((5, ), True, True, True, None),
+        ((5, 4), True, True, True, None),
         ((5, 4), True, True, True, -1),
         ((5, 0, 4), True, True, True, None),
         ((0, 0, 0), True, True, True, None),
-        ((5, 3, 4), True, True, True, -1),
+        # ((5, 3, 4), True, True, True, -1), # waiting for numpy 1.18, details in pr 14255
         ((5, 3, 4), True, True, True, None),
         ((5, 3, 4), True, True, True, 1),
     ]
@@ -2586,7 +2587,6 @@ def test_np_unique():
                     test_unique.hybridize()
                 x = _np.random.uniform(-8.0, 8.0, size=config[0])
                 x = np.array(x, dtype=dtype)
-                print(config, x.dtype)
                 np_out = _np.unique(x.asnumpy(), *config[1:])
                 mx_out = test_unique(x)
                 assert mx_out[0].shape == np_out[0].shape


### PR DESCRIPTION
## Description ##
Implementation of numpy `unique` operator in mxnet.
Old pr on numpy branch -> #15733.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- add op `unique`

## Comments ##
Welcome @reminisce, @haojin2, and others for reviewing.