### PR TITLE
Fix ConcatType backward type inference

### DIFF
--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -173,7 +173,7 @@ bool ConcatType(const nnvm::NodeAttrs& attrs,
   // if both out_types and in_types are known, and different
   } else if ((*out_type)[0] != -1 && dtype != -1 && ((*out_type)[0] != dtype)) {
     std::ostringstream os;
-    os << "Type inconsistent, Provided = "
+    os << "Type inconsistent, Provided output type = "
        << mxnet::op::type_string((*out_type)[0]) << ','
        << " inferred type = " << mxnet::op::type_string(dtype);
     throw mxnet::op::InferTypeError(os.str(), 0);

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -177,7 +177,6 @@ bool ConcatType(const nnvm::NodeAttrs& attrs,
        << mxnet::op::type_string((*out_type)[0]) << ','
        << " inferred type = " << mxnet::op::type_string(dtype);
     throw mxnet::op::InferTypeError(os.str(), 0);
-    return false;
   }
   return true;
 }

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -144,6 +144,7 @@ bool ConcatType(const nnvm::NodeAttrs& attrs,
   const ConcatParam& param_ = nnvm::get<ConcatParam>(attrs.parsed);
   int dtype = -1;
 
+  // checks uniformity of input
   for (int i : *in_type) {
     if (dtype == -1) {
       dtype = i;
@@ -154,18 +155,30 @@ bool ConcatType(const nnvm::NodeAttrs& attrs,
     }
   }
 
-  if (dtype == -1) {
-    LOG(FATAL) << "Not enough information to infer type in Concat.";
+  size_t nin = param_.num_args;
+
+  // if in types are known out types are unknown
+  if (dtype != -1 && (*out_type)[0] == -1) {
+    (*out_type)[0] = dtype;
+    in_type->clear();
+    for (size_t i = 0; i < nin; ++i) {
+      in_type->push_back(dtype);
+    }
+  // if out types are known in types are unknown
+  } else if ((*out_type)[0] != -1 && dtype == -1) {
+    in_type->clear();
+    for (size_t i = 0; i < nin; ++i) {
+      in_type->push_back((*out_type)[0]);
+    }
+  // if both out_types and in_types are known, and different
+  } else if ((*out_type)[0] != -1 && dtype != -1 && ((*out_type)[0] != dtype)) {
+    std::ostringstream os;
+    os << "Type inconsistent, Provided = "
+       << mxnet::op::type_string((*out_type)[0]) << ','
+       << " inferred type = " << mxnet::op::type_string(dtype);
+    throw mxnet::op::InferTypeError(os.str(), 0);
     return false;
   }
-
-  size_t nin = param_.num_args;
-  in_type->clear();
-  for (size_t i = 0; i < nin; ++i) in_type->push_back(dtype);
-
-  out_type->clear();
-  out_type->push_back(dtype);
-
   return true;
 }
 

--- a/tests/python/gpu/test_contrib_amp.py
+++ b/tests/python/gpu/test_contrib_amp.py
@@ -31,6 +31,7 @@ from mxnet.contrib.amp import amp
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../unittest'))
 from common import with_seed, teardown, assert_raises_cudnn_not_satisfied
+set_default_context(mx.gpu(0))
 
 def test_amp_coverage():
     conditional = [item[0] for item in amp.lists.symbol.CONDITIONAL_FP32_FUNCS]


### PR DESCRIPTION
## Description ##

Added backward type inference support for _rnn_param_concat.
fixes: https://github.com/apache/incubator-mxnet/issues/15716

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
