### PR TITLE
Making Features as a singleton for improved caching

### DIFF
--- a/python/mxnet/runtime.py
+++ b/python/mxnet/runtime.py
@@ -73,6 +73,12 @@ class Features(collections.OrderedDict):
     """
     OrderedDict of name to Feature
     """
+    instance = None
+    def __new__(cls):
+        if cls.instance is None:
+            cls.instance = super(Features, cls).__new__(cls)
+        return cls.instance
+
     def __init__(self):
         super(Features, self).__init__([(f.name, f) for f in feature_list()])
 

--- a/tests/python/unittest/test_runtime.py
+++ b/tests/python/unittest/test_runtime.py
@@ -21,11 +21,19 @@ from mxnet.runtime import *
 from mxnet.base import MXNetError
 from nose.tools import *
 
+
 def test_features():
     features = Features()
     print(features)
     ok_('CUDA' in features)
     ok_(len(features) >= 30)
+
+
+def test_is_singleton():
+    x = Features()
+    y = Features()
+    assert x is y
+
 
 def test_is_enabled():
     features = Features()
@@ -34,6 +42,7 @@ def test_is_enabled():
             ok_(features.is_enabled(f))
         else:
             ok_(not features.is_enabled(f))
+
 
 @raises(RuntimeError)
 def test_is_enabled_not_existing():


### PR DESCRIPTION
## Description ##
Caches Features by making it singleton.
Used Approach mentioned here: https://medium.com/@mrfksiv/python-design-patterns-2-the-singleton-f995c3198c8

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Testing ##
ubuntu@ip-172-31-82-110 ~/incubator-mxnet (singleton_feature) $ MXNET_TEST_COUNT=1 nosetests --logging-level=DEBUG --verbose -s tests/python/unittest/test_runtime.py
1
/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters
test_runtime.test_features ... 2
[✖ CUDA, ✖ CUDNN, ✖ NCCL, ✖ CUDA_RTC, ✖ TENSORRT, ✔ CPU_SSE, ✔ CPU_SSE2, ✔ CPU_SSE3, ✔ CPU_SSE4_1, ✔ CPU_SSE4_2, ✖ CPU_SSE4A, ✔ CPU_AVX, ✖ CPU_AVX2, ✖ OPENMP, ✖ SSE, ✔ F16C, ✖ JEMALLOC, ✔ BLAS_OPEN, ✖ BLAS_ATLAS, ✖ BLAS_MKL, ✖ BLAS_APPLE, ✖ LAPACK, ✖ MKLDNN, ✖ OPENCV, ✖ CAFFE, ✖ PROFILER, ✖ DIST_KVSTORE, ✖ CXX14, ✔ INT64_TENSOR_SIZE, ✖ SIGNAL_HANDLER, ✔ DEBUG, ✖ TVM_OP]
ok
test_runtime.test_is_singleton ... 2
2
ok
test_runtime.test_is_enabled ... 2
ok
test_runtime.test_is_enabled_not_existing ... 2
ok

----------------------------------------------------------------------
Ran 4 tests in 0.001s
