### PR TITLE
[Numpy] Added operator logaddexp; added support for zero-size tensor in BinaryBroadcastBackwardUseIn 

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -25,7 +25,7 @@ from ...util import set_module
 from ...context import current_context
 from . import _internal as _npi
 
-__all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power']
+__all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'logaddexp']
 
 
 @set_module('mxnet.ndarray.numpy')
@@ -293,3 +293,51 @@ def power(x1, x2, out=None):
         This is a scalar if both x1 and x2 are scalars.
     """
     return _ufunc_helper(x1, x2, _npi.power, _np.power, _npi.power_scalar, _npi.rpower_scalar, out)
+
+
+@set_module('mxnet.ndarray.numpy')
+def logaddexp(x1, x2, out=None):
+    """Logarithm of the sum of exponentiations of the inputs.
+    logaddexp(x1, x2, out=None)
+     Calculates ``log(exp(x1) + exp(x2))``. This function is useful in
+    statistics where the calculated probabilities of events may be so small
+    as to exceed the range of normal floating point numbers.  In such cases
+    the logarithm of the calculated probability is stored. This function
+    allows adding probabilities stored in such a fashion.
+     Parameters
+    ----------
+    x1, x2 : ndarray or scalar
+        Input values.
+    out : ndarray, None, or tuple of ndarray and None, optional
+        A location into which the result is stored. If provided, it must have
+        a shape and dtype as the expected output. If not provided or `None`,
+        a freshly-allocated array is returned.
+     Returns
+    -------
+    result : ndarray or scalar
+        Logarithm of ``exp(x1) + exp(x2)``.
+        This is a scalar if both `x1` and `x2` are scalars.
+     See Also
+    --------
+    logaddexp2: Logarithm of the sum of exponentiations of inputs in base 2.
+     Notes
+    -----
+    This function differs from the original `numpy.logaddexp2
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.logaddexp2.html>`_ in
+    the following aspects:
+     - Input type does not support Python native iterables(list, tuple, ...). Only ndarray is supported.
+    - ``out`` param: cannot perform auto broadcasting. ``out`` ndarray's shape must be the same as the expected output.
+    - ``out`` param: cannot perform auto type cast. ``out`` ndarray's dtype must be the same as the expected output.
+    - ``out`` param does not support scalar input case.
+     Examples
+    --------
+    >>> prob1 = np.log(1e-50)
+    >>> prob2 = np.log(2.5e-50)
+    >>> prob12 = np.logaddexp(prob1, prob2)
+    >>> prob12
+    -113.87649168120691
+    >>> np.exp(prob12)
+    3.5000000000000057e-50
+    """
+    return _ufunc_helper(x1, x2, _npi.logaddexp, _np.logaddexp, _npi.logaddexp_scalar,
+                         _npi.logaddexp_scalar, out)

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -44,7 +44,7 @@ from ..ndarray import numpy as _mx_nd_np
 from ..ndarray.numpy import _internal as _npi
 
 __all__ = ['ndarray', 'empty', 'array', 'zeros', 'ones', 'add', 'subtract', 'multiply', 'divide',
-           'mod', 'power']
+           'mod', 'power', 'logaddexp']
 
 
 # This function is copied from ndarray.py since pylint
@@ -1549,3 +1549,50 @@ def power(x1, x2, out=None):
         This is a scalar if both x1 and x2 are scalars.
     """
     return _mx_nd_np.power(x1, x2, out=out)
+
+
+@set_module('mxnet.numpy')
+def logaddexp(x1, x2, out=None):
+    """Logarithm of the sum of exponentiations of the inputs.
+    logaddexp(x1, x2, out=None)
+     Calculates ``log(exp(x1) + exp(x2))``. This function is useful in
+    statistics where the calculated probabilities of events may be so small
+    as to exceed the range of normal floating point numbers.  In such cases
+    the logarithm of the calculated probability is stored. This function
+    allows adding probabilities stored in such a fashion.
+     Parameters
+    ----------
+    x1, x2 : ndarray or scalar
+        Input values.
+    out : ndarray, None, or tuple of ndarray and None, optional
+        A location into which the result is stored. If provided, it must have
+        a shape and dtype as the expected output. If not provided or `None`,
+        a freshly-allocated array is returned.
+     Returns
+    -------
+    result : ndarray or scalar
+        Logarithm of ``exp(x1) + exp(x2)``.
+        This is a scalar if both `x1` and `x2` are scalars.
+     See Also
+    --------
+    logaddexp2: Logarithm of the sum of exponentiations of inputs in base 2.
+     Notes
+    -----
+    This function differs from the original `numpy.logaddexp2
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.logaddexp2.html>`_ in
+    the following aspects:
+     - Input type does not support Python native iterables(list, tuple, ...). Only ndarray is supported.
+    - ``out`` param: cannot perform auto broadcasting. ``out`` ndarray's shape must be the same as the expected output.
+    - ``out`` param: cannot perform auto type cast. ``out`` ndarray's dtype must be the same as the expected output.
+    - ``out`` param does not support scalar input case.
+     Examples
+    --------
+    >>> prob1 = np.log(1e-50)
+    >>> prob2 = np.log(2.5e-50)
+    >>> prob12 = np.logaddexp(prob1, prob2)
+    >>> prob12
+    -113.87649168120691
+    >>> np.exp(prob12)
+    3.5000000000000057e-50
+    """
+    return _mx_nd_np.logaddexp(x1, x2, out)

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -28,7 +28,7 @@ from ..symbol import Symbol
 from .._internal import _set_np_symbol_class
 from . import _internal as _npi
 
-__all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power']
+__all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'logaddexp']
 
 
 def _num_outputs(sym):
@@ -1008,6 +1008,54 @@ def mod(x1, x2, out=None):
 @set_module('mxnet.symbol.numpy')
 def power(x1, x2, out=None):
     return _ufunc_helper(x1, x2, _npi.power, _np.power, _npi.power_scalar, _npi.rpower_scalar, out)
+
+
+@set_module('mxnet.symbol.numpy')
+def logaddexp(x1, x2, out=None):
+    """Logarithm of the sum of exponentiations of the inputs.
+    logaddexp(x1, x2, out=None)
+     Calculates ``log(exp(x1) + exp(x2))``. This function is useful in
+    statistics where the calculated probabilities of events may be so small
+    as to exceed the range of normal floating point numbers.  In such cases
+    the logarithm of the calculated probability is stored. This function
+    allows adding probabilities stored in such a fashion.
+     Parameters
+    ----------
+    x1, x2 : _Symbol or scalar
+        Input values.
+    out : ndarray, None, or tuple of ndarray and None, optional
+        A location into which the result is stored. If provided, it must have
+        a shape and dtype as the expected output. If not provided or `None`,
+        a freshly-allocated array is returned.
+     Returns
+    -------
+    result : _Symbol
+        Logarithm of ``exp(x1) + exp(x2)``.
+        This is a scalar if both `x1` and `x2` are scalars.
+     See Also
+    --------
+    logaddexp2: Logarithm of the sum of exponentiations of inputs in base 2.
+     Notes
+    -----
+    This function differs from the original `numpy.logaddexp2
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.logaddexp2.html>`_ in
+    the following aspects:
+     - Input type does not support Python native iterables(list, tuple, ...). Only ndarray is supported.
+    - ``out`` param: cannot perform auto broadcasting. ``out`` ndarray's shape must be the same as the expected output.
+    - ``out`` param: cannot perform auto type cast. ``out`` ndarray's dtype must be the same as the expected output.
+    - ``out`` param does not support scalar input case.
+     Examples
+    --------
+    >>> prob1 = np.log(1e-50)
+    >>> prob2 = np.log(2.5e-50)
+    >>> prob12 = np.logaddexp(prob1, prob2)
+    >>> prob12
+    -113.87649168120691
+    >>> np.exp(prob12)
+    3.5000000000000057e-50
+    """
+    return _ufunc_helper(x1, x2, _npi.logaddexp, _np.logaddexp, _npi.logaddexp_scalar,
+                         _npi.logaddexp_scalar, out)
 
 
 _set_np_symbol_class(_Symbol)

--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -115,6 +115,12 @@ MXNET_BINARY_MATH_OP_NC(plus, a + b);
 
 MXNET_BINARY_MATH_OP_NC(minus, a - b);
 
+MXNET_BINARY_MATH_OP_NC(logaddexp, math::id(a) + math::log1p(math::exp(b - a)));
+
+MXNET_BINARY_MATH_OP_NC(logadd_left, math::exp(a) / (math::exp(a) + math::exp(b)));
+
+MXNET_BINARY_MATH_OP_NC(logadd_right, math::exp(b) / (math::exp(a) + math::exp(b)));
+
 MXNET_UNARY_MATH_OP(negation, -a);
 
 MXNET_UNARY_MATH_OP(reciprocal, 1.0f / math::id(a));

--- a/src/operator/numpy/np_elemwise_broadcast_op.cu
+++ b/src/operator/numpy/np_elemwise_broadcast_op.cu
@@ -36,6 +36,14 @@ NNVM_REGISTER_OP(_npi_subtract)
 NNVM_REGISTER_OP(_npi_multiply)
 .set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastCompute<gpu, op::mshadow_op::mul>);
 
+NNVM_REGISTER_OP(_npi_logaddexp)
+.set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastCompute<gpu, op::mshadow_op::logaddexp>);
+
+NNVM_REGISTER_OP(_backward_broadcast_logaddexp)
+.set_attr<FCompute>("FCompute<gpu>",
+                    BinaryBroadcastBackwardUseIn<gpu, mshadow_op::logadd_left,
+                                                      mshadow_op::logadd_right>);
+
 NNVM_REGISTER_OP(_npi_mod)
 .set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastCompute<gpu, mshadow_op::mod>);
 
@@ -77,6 +85,13 @@ NNVM_REGISTER_OP(_npi_maximum_scalar)
 
 NNVM_REGISTER_OP(_npi_minimum_scalar)
 .set_attr<FCompute>("FCompute<gpu>", BinaryScalarOp::Compute<gpu, mshadow_op::minimum>);
+
+NNVM_REGISTER_OP(_npi_logaddexp_scalar)
+.set_attr<FCompute>("FCompute<gpu>", BinaryScalarOp::Compute<gpu, op::mshadow_op::logaddexp>);
+
+NNVM_REGISTER_OP(_backward_logaddexp_scalar)
+.set_attr<FCompute>("FCompute<gpu>",
+                    BinaryScalarOp::Backward<gpu, mshadow_op::logadd_left>);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/operator_tune.cc
+++ b/src/operator/operator_tune.cc
@@ -362,6 +362,9 @@ IMPLEMENT_BINARY_WORKLOAD_BWD(mxnet::op::mshadow_op::smooth_l1_gradient);  // NO
 IMPLEMENT_BLANK_WORKLOAD_FWD(mxnet::op::mxnet_op::set_to_int<0>);  // NOLINT()
 IMPLEMENT_BLANK_WORKLOAD_FWD(mxnet::op::mxnet_op::set_to_int<1>);  // NOLINT()
 IMPLEMENT_BLANK_WORKLOAD_FWD(mxnet::op::PopulateFullIdxRspKernel);  // NOLINT()
+IMPLEMENT_BINARY_WORKLOAD_FWD(mxnet::op::mshadow_op::logaddexp);  // NOLINT()
+IMPLEMENT_BINARY_WORKLOAD_BWD(mxnet::op::mshadow_op::logadd_left);  // NOLINT()
+IMPLEMENT_BINARY_WORKLOAD_BWD(mxnet::op::mshadow_op::logadd_right);  // NOLINT()
 /*!
  * \brief Tuner objects, *not* automatically generated
  */

--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -580,17 +580,19 @@ inline void BinaryBroadcastBackwardUseInImpl(const OpContext& ctx,
   const TBlob ograd = inputs[0].reshape(new_oshape);
   const TBlob lhs = inputs[1].reshape(new_lshape);
   const TBlob rhs = inputs[2].reshape(new_rshape);
-  size_t workspace_size_l = ReduceWorkspaceSize<ndim, DType>(
-      s, lgrad.shape_, req[0], ograd.shape_, lhs.shape_, rhs.shape_);
-  size_t workspace_size_r = ReduceWorkspaceSize<ndim, DType>(
-      s, rgrad.shape_, req[1], ograd.shape_, lhs.shape_, rhs.shape_);
-  size_t workspace_size = std::max(workspace_size_l, workspace_size_r);
-  Tensor<xpu, 1, char> workspace =
-      ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size), s);
-  Reduce<red::sum, ndim, DType, op::mshadow_op::mul, LOP>(s, lgrad, req[0], workspace,
-    ograd, lhs, rhs);
-  Reduce<red::sum, ndim, DType, op::mshadow_op::mul, ROP>(s, rgrad, req[1], workspace,
-    ograd, lhs, rhs);
+  if (inputs[0].shape_.Size() != 0) {
+    size_t workspace_size_l = ReduceWorkspaceSize<ndim, DType>(
+        s, lgrad.shape_, req[0], ograd.shape_, lhs.shape_, rhs.shape_);
+    size_t workspace_size_r = ReduceWorkspaceSize<ndim, DType>(
+        s, rgrad.shape_, req[1], ograd.shape_, lhs.shape_, rhs.shape_);
+    size_t workspace_size = std::max(workspace_size_l, workspace_size_r);
+    Tensor<xpu, 1, char> workspace =
+        ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size), s);
+    Reduce<red::sum, ndim, DType, op::mshadow_op::mul, LOP>(s, lgrad, req[0], workspace,
+      ograd, lhs, rhs);
+    Reduce<red::sum, ndim, DType, op::mshadow_op::mul, ROP>(s, rgrad, req[1], workspace,
+      ograd, lhs, rhs);
+  }
 }
 
 template<typename xpu, typename LOP, typename ROP>

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -149,6 +149,96 @@ def test_npx_slice():
             assert same(a.grad.asnumpy(), expected_grad)
 
 
+@with_seed()
+@use_np
+def test_np_logaddexp():
+    @use_np
+    class TestLogaddexp(HybridBlock):
+        def __init__(self):
+            super(TestLogaddexp, self).__init__()
+
+        def hybrid_forward(self, F, x1, x2):
+            return F.np.logaddexp(x1, x2)
+
+    shapes = [
+        ((3, 1), (3, 1)),
+        ((3, 1, 2), (3, 1, 2)),
+        ((1, ), (1, )),
+        ((3, 0), (3, 0)),  # zero-size shape
+        ((0, 1), (0, 1)),  # zero-size shape
+        ((2, 0, 2), (2, 0, 2)),  # zero-size shape
+        ((1, ), (3, )),  # broadcast
+        ((2, 3), (2, 1)),  # broadcast
+        ((1, 3), (2, 3)),  # broadcast
+        ((1, 3), (2, 0, 3)),  # broadcast to zero-dim shape
+        ((1, 0, 1), (3, 0, 1)),  # broadcast of zero-dim shape
+        ((), ()),  # zero-dim shape
+    ]
+    eps = 1e-3
+    # Legal shape test.
+    for shape_a, shape_b in shapes:
+        for hybridize in [True, False]:
+            test_logaddexp = TestLogaddexp()
+            if hybridize:
+                test_logaddexp.hybridize()
+            lhs = rand_ndarray(shape_a).as_np_ndarray()
+            rhs = rand_ndarray(shape_b).as_np_ndarray()
+            lhs.attach_grad()
+            rhs.attach_grad()
+            np_out = _np.logaddexp(lhs.asnumpy(), rhs.asnumpy())
+            np_backward_lhs = _np.exp(
+                lhs.asnumpy()) / (_np.exp(lhs.asnumpy()) + _np.exp(rhs.asnumpy()))
+            np_backward_rhs = _np.exp(
+                rhs.asnumpy()) / (_np.exp(lhs.asnumpy()) + _np.exp(rhs.asnumpy()))
+            with mx.autograd.record():
+                mx_out = test_logaddexp(lhs, rhs)
+            assert mx_out.shape == np_out.shape
+            assert_almost_equal(mx_out.asnumpy(), np_out, rtol=1e-3, atol=1e-5)
+            mx_out.backward()
+            # For broadcast backward case,
+            # reduce sum is applied on numpy result.
+            for n_dim in range(len(shape_a)):
+                if (shape_a[n_dim] != shape_b[n_dim]):
+                    if (shape_a[n_dim] > shape_b[n_dim]):
+                        np_backward_rhs = np_backward_rhs.sum(
+                            axis=n_dim, keepdims=True)
+                    else:
+                        np_backward_lhs = np_backward_lhs.sum(
+                            axis=n_dim, keepdims=True)
+            assert_almost_equal(lhs.grad.asnumpy(),
+                                np_backward_lhs, rtol=1e-3, atol=1e-5)
+            assert_almost_equal(rhs.grad.asnumpy(),
+                                np_backward_rhs, rtol=1e-3, atol=1e-5)
+            # Test imperative once again
+            mx_out = np.logaddexp(lhs, rhs)
+            np_out = _np.logaddexp(lhs.asnumpy(), rhs.asnumpy())
+            assert_almost_equal(mx_out.asnumpy(), np_out, rtol=1e-3, atol=1e-5)
+
+        # Range case.
+    x = [1000000, -1000000, 1000200, -1000200]
+    y = [1000200, -1000200, 1000000, -1000000]
+    z = [1000200, -1000000, 1000200, -1000000]
+    for dt in ['float64']:
+        logxf = np.array(x, dtype=dt)
+        logyf = np.array(y, dtype=dt)
+        logzf = np.array(z, dtype=dt)
+        assert_almost_equal(np.logaddexp(logxf, logyf).asnumpy(),
+                            logzf.asnumpy())
+
+        # Bad shape case.
+    bad_shapes = [((4, 5), (2, 3)), ((3, 4, 5), (6, ))]
+    for shape_a, shape_b in bad_shapes:
+        a = mx.nd.array(random.random()) if len(
+            shape_a) == 0 else rand_ndarray(shape_a)
+        b = mx.nd.array(random.random()) if len(
+            shape_b) == 0 else rand_ndarray(shape_b)
+        try:
+            mx_res = np.logaddexp(a.as_np_ndarray(), b.as_np_ndarray())
+        except mx.base.MXNetError:
+            continue
+        assert False
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
- Added [np.logaddexp](https://docs.scipy.org/doc/numpy/reference/generated/numpy.logaddexp.html) and its docs for future rendering. Scalar calculation is supported.

- Fixed zero-size tensor error in BinaryBroadcastBackwardUseIn (GPU version).

## Checklist ##
### Essentials ###

- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Added [np.logaddexp](https://docs.scipy.org/doc/numpy/reference/generated/numpy.logaddexp.html) and its docs for future rendering. Scalar calculation is supported.
- Fixed zero-size tensor error in BinaryBroadcastBackwardUseIn (GPU version).



## Comments ##
- The previous error case description: when one operand is non-zero-size (eg. shape of (1, 3)) and the other is zero-size (eg. shape of (2, 0, 3)), the backward calculation on GPU will raise a floating point error.
