### PR TITLE
[Numpy] Numpy behavior random.uniform()

### DIFF
--- a/python/mxnet/ndarray/numpy/random.py
+++ b/python/mxnet/ndarray/numpy/random.py
@@ -17,5 +17,65 @@
 
 """Namespace for operators used in Gluon dispatched by F=ndarray."""
 from __future__ import absolute_import
+from ...context import current_context
+from . import _internal as _npi
 
-__all__ = []
+__all__ = ['uniform']
+
+
+def uniform(low=0.0, high=1.0, size=None, ctx=None, dtype=None, out=None):
+    """Draw samples from a uniform distribution.
+
+    Samples are uniformly distributed over the half-open interval
+    ``[low, high)`` (includes low, but excludes high).  In other words,
+    any value within the given interval is equally likely to be drawn
+    by `uniform`.
+
+    Parameters
+    ----------
+    low : float, ndarray, optional
+        Lower boundary of the output interval.  All values generated will be
+        greater than or equal to low.  The default value is 0.
+    high : float, ndarray, optional
+        Upper boundary of the output interval.  All values generated will be
+        less than high.  The default value is 1.0.
+    size : int or tuple of ints, optional
+        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+        ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+        a scalar tensor containing a single value is returned if
+        ``low`` and ``high`` are both scalars.
+    dtype : {'float16', 'float32', 'float64'}, optional
+        Data type of output samples. Default is 'float32'
+    ctx : Context, optional
+        Device context of output. Default is current context.
+
+    Returns
+    -------
+    out : ndarray
+        Drawn samples from the parameterized uniform distribution.
+    """
+    from ...numpy import ndarray as np_ndarray
+    input_type = (isinstance(low, np_ndarray), isinstance(high, np_ndarray))
+    if dtype is None:
+        dtype = 'float32'
+    if ctx is None:
+        ctx = current_context()
+    if out is not None:
+        size = out.shape
+    if size == ():
+        size = None
+    if input_type == (True, True):
+        return _npi.uniform(low, high, low=None, high=None, size=size,
+                            ctx=ctx, dtype=dtype, out=out)
+    elif input_type == (False, True):
+        return _npi.uniform(high, low=low, high=None, size=size,
+                            ctx=ctx, dtype=dtype, out=out)
+    elif input_type == (True, False):
+        return _npi.uniform(low, low=None, high=high, size=size,
+                            ctx=ctx, dtype=dtype, out=out)
+    else:
+        return _npi.uniform(low=low, high=high, size=size,
+                            ctx=ctx, dtype=dtype, out=out)
+
+    raise ValueError(
+        "Distribution parameters must be either mxnet.numpy.ndarray or numbers")

--- a/python/mxnet/ndarray/numpy/random.py
+++ b/python/mxnet/ndarray/numpy/random.py
@@ -23,7 +23,7 @@ from . import _internal as _npi
 __all__ = ['uniform']
 
 
-def uniform(low=0.0, high=1.0, size=None, ctx=None, dtype=None, out=None):
+def uniform(low=0.0, high=1.0, size=None, dtype=None, ctx=None, out=None):
     """Draw samples from a uniform distribution.
 
     Samples are uniformly distributed over the half-open interval

--- a/python/mxnet/numpy/random.py
+++ b/python/mxnet/numpy/random.py
@@ -18,5 +18,40 @@
 """Namespace for ops used in imperative programming."""
 
 from __future__ import absolute_import
+from ..ndarray import numpy as _mx_nd_np
 
-__all__ = []
+__all__ = ['uniform']
+
+
+def uniform(low=0.0, high=1.0, size=None, ctx=None, dtype=None, out=None):
+    """Draw samples from a uniform distribution.
+
+    Samples are uniformly distributed over the half-open interval
+    ``[low, high)`` (includes low, but excludes high).  In other words,
+    any value within the given interval is equally likely to be drawn
+    by `uniform`.
+
+    Parameters
+    ----------
+    low : float, ndarray, optional
+        Lower boundary of the output interval.  All values generated will be
+        greater than or equal to low.  The default value is 0.
+    high : float, ndarray, optional
+        Upper boundary of the output interval.  All values generated will be
+        less than high.  The default value is 1.0.
+    size : int or tuple of ints, optional
+        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+        ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+        a scalar tensor containing a single value is returned if
+        ``low`` and ``high`` are both scalars.
+    dtype : {'float16', 'float32', 'float64'}, optional
+        Data type of output samples. Default is 'float32'
+    ctx : Context, optional
+        Device context of output. Default is current context.
+
+    Returns
+    -------
+    out : ndarray
+        Drawn samples from the parameterized uniform distribution.
+    """
+    return _mx_nd_np.random.uniform(low, high, size=size, ctx=ctx, dtype=dtype, out=out)

--- a/python/mxnet/numpy/random.py
+++ b/python/mxnet/numpy/random.py
@@ -23,7 +23,7 @@ from ..ndarray import numpy as _mx_nd_np
 __all__ = ['uniform']
 
 
-def uniform(low=0.0, high=1.0, size=None, ctx=None, dtype=None, out=None):
+def uniform(low=0.0, high=1.0, size=None, dtype=None, ctx=None, out=None):
     """Draw samples from a uniform distribution.
 
     Samples are uniformly distributed over the half-open interval

--- a/python/mxnet/symbol/numpy/random.py
+++ b/python/mxnet/symbol/numpy/random.py
@@ -18,5 +18,65 @@
 """Namespace for operators used in Gluon dispatched by F=symbol."""
 
 from __future__ import absolute_import
+from ...context import current_context
+from . import _internal as _npi
 
-__all__ = []
+__all__ = ['uniform']
+
+
+def uniform(low=0.0, high=1.0, size=None, ctx=None, dtype=None, out=None):
+    """Draw samples from a uniform distribution.
+
+    Samples are uniformly distributed over the half-open interval
+    ``[low, high)`` (includes low, but excludes high).  In other words,
+    any value within the given interval is equally likely to be drawn
+    by `uniform`.
+
+    Parameters
+    ----------
+    low : float, ndarray, optional
+        Lower boundary of the output interval.  All values generated will be
+        greater than or equal to low.  The default value is 0.
+    high : float, ndarray, optional
+        Upper boundary of the output interval.  All values generated will be
+        less than high.  The default value is 1.0.
+    size : int or tuple of ints, optional
+        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+        ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+        a scalar tensor containing a single value is returned if
+        ``low`` and ``high`` are both scalars.
+    dtype : {'float16', 'float32', 'float64'}, optional
+        Data type of output samples. Default is 'float32'
+    ctx : Context, optional
+        Device context of output. Default is current context.
+
+    Returns
+    -------
+    out : ndarray
+        Drawn samples from the parameterized uniform distribution.
+    """
+    from ._symbol import _Symbol as np_symbol
+    input_type = (isinstance(low, np_symbol), isinstance(high, np_symbol))
+    if dtype is None:
+        dtype = 'float32'
+    if ctx is None:
+        ctx = current_context()
+    if out is not None:
+        size = out.shape
+    if size == ():
+        size = None
+    if input_type == (True, True):
+        return _npi.uniform(low, high, low=None, high=None, size=size,
+                            ctx=ctx, dtype=dtype, out=out)
+    elif input_type == (False, True):
+        return _npi.uniform(high, low=low, high=None, size=size,
+                            ctx=ctx, dtype=dtype, out=out)
+    elif input_type == (True, False):
+        return _npi.uniform(low, low=None, high=high, size=size,
+                            ctx=ctx, dtype=dtype, out=out)
+    else:
+        return _npi.uniform(low=low, high=high, size=size,
+                            ctx=ctx, dtype=dtype, out=out)
+
+    raise ValueError(
+        "Distribution parameters must be either mxnet.numpy.ndarray or numbers")

--- a/python/mxnet/symbol/numpy/random.py
+++ b/python/mxnet/symbol/numpy/random.py
@@ -24,7 +24,7 @@ from . import _internal as _npi
 __all__ = ['uniform']
 
 
-def uniform(low=0.0, high=1.0, size=None, ctx=None, dtype=None, out=None):
+def uniform(low=0.0, high=1.0, size=None, dtype=None, ctx=None, out=None):
     """Draw samples from a uniform distribution.
 
     Samples are uniformly distributed over the half-open interval

--- a/src/operator/numpy/random/dist_common.h
+++ b/src/operator/numpy/random/dist_common.h
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ *  Copyright (c) 2015 by Contributors
+ * \file etwoparams_dist_common.h
+ * \brief Function definition of common functions for distributions
+ * \with two parameters.
+ */
+
+#ifndef MXNET_OPERATOR_NUMPY_RANDOM_DIST_COMMON_H_
+#define MXNET_OPERATOR_NUMPY_RANDOM_DIST_COMMON_H_
+
+#include <mxnet/operator_util.h>
+#include <mshadow/base.h>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include "../../elemwise_op_common.h"
+#include "../../tensor/elemwise_binary_broadcast_op.h"
+#include "../../mshadow_op.h"
+#include "../../mxnet_op.h"
+#include "../../operator_common.h"
+
+namespace mxnet {
+namespace op {
+
+inline int FillShape(const mxnet::TShape &lshape, const mxnet::TShape &rshape,
+                     const mxnet::TShape &oshape, mxnet::TShape *new_lshape,
+                     mxnet::TShape *new_rshape, mxnet::TShape *new_oshape) {
+  const int odim = std::max(oshape.ndim(), broadcast::MAX_DIM);
+  *new_lshape = mxnet::TShape(odim, 1);
+  *new_rshape = mxnet::TShape(odim, 1);
+  *new_oshape = mxnet::TShape(odim, 1);
+  int bl = oshape.ndim() - lshape.ndim();
+  int br = oshape.ndim() - rshape.ndim();
+  int j = 0, lprod = 1, rprod = 1, oprod = 1;
+  for (int i = 0; i < oshape.ndim(); ++i) {
+    int l = 1;
+    int r = 1;
+    int o = oshape[i];
+    if (i >= bl)  l = lshape[i - bl];
+    if (i >= br)  r = rshape[i - br];
+    if ((lprod != rprod || lprod != oprod || l != r || l != o) &&
+        (lprod * l > 1 || rprod * r > 1 || oprod * o > 1)) {
+      (*new_lshape)[j] = lprod;
+      (*new_rshape)[j] = rprod;
+      (*new_oshape)[j] = oprod;
+      lprod = rprod = oprod = 1; ++j;
+    }
+    lprod *= l;
+    rprod *= r;
+    oprod *= o;
+  }
+  if (lprod > 1 || rprod > 1 || oprod > 1) {
+    (*new_lshape)[j] = lprod;
+    (*new_rshape)[j] = rprod;
+    (*new_oshape)[j] = oprod;
+    ++j;
+  }
+  if (j <= broadcast::MAX_DIM) {
+    BROADCAST_NDIM_SWITCH(j, NDim, {
+      new_lshape->assign(new_lshape->begin(), new_lshape->begin() + NDim);
+      new_rshape->assign(new_rshape->begin(), new_rshape->begin() + NDim);
+      new_oshape->assign(new_oshape->begin(), new_oshape->begin() + NDim);
+    });
+  } else {
+    LOG(FATAL) << "Too many broadcast dimensions with operands " << lshape << " " << rshape;
+  }
+  return j;
+}
+
+inline void CheckBroadcastable(const mxnet::TShape &from, const mxnet::TShape &to) {
+  const int bl = to.ndim() - from.ndim();
+  const int br = 0;
+  for (int i = 0; i < to.ndim(); ++i) {
+    int l = 1, r = 1;
+    if (i >= bl)
+      l = from[i - bl];
+    if (i >= br)
+      r = to[i - br];
+    if (!mxnet::dim_size_is_known(l) || !mxnet::dim_size_is_known(r))
+      continue;
+    if (l != r) {
+      // Make it compatible with NumPy.
+      // For example, (2, 3) cannot broadcast to (2, 0, 3), but (1, 3) can
+      // broadcast to (2, 0, 3).
+      CHECK(l == 1 || r == 1)
+          << "operands could not be broadcast together with shapes " << from
+          << " " << to;
+    }
+  }
+}
+
+inline void InferBroadcastShape(const mxnet::TShape &lhs, const mxnet::TShape &rhs,
+                         mxnet::TShape* out_ptr) {
+  mxnet::TShape& out = (*out_ptr);
+  const int bl = out.ndim() - lhs.ndim();
+  const int br = out.ndim() - rhs.ndim();
+  for (int i = 0; i < out.ndim(); ++i) {
+    int l = 1, r = 1;
+    if (i >= bl)
+      l = lhs[i - bl];
+    if (i >= br)
+      r = rhs[i - br];
+    if (!mxnet::dim_size_is_known(l) || !mxnet::dim_size_is_known(r))
+      continue;
+    if (l != r) {
+      // Make it compatible with NumPy.
+      // For example, (2, 3) cannot broadcast to (2, 0, 3), but (1, 3) can
+      // broadcast to (2, 0, 3).
+      CHECK(l == 1 || r == 1)
+          << "operands could not be broadcast together with shapes " << lhs
+          << " " << rhs;
+      out[i] = (l == 1 ? r : l);
+    } else {
+      out[i] = l;
+    }
+  }
+}
+
+template<typename DistParam>
+inline bool TwoparamsDistOpShape(const nnvm::NodeAttrs &attrs,
+                                std::vector<TShape> *in_attrs,
+                                std::vector<TShape> *out_attrs) {
+  const DistParam &param = nnvm::get<DistParam>(attrs.parsed);
+  CHECK_EQ(out_attrs->size(), 1U);
+  if (param.size.has_value()) {
+    // Size declared.
+    std::vector<dim_t> oshape_vec;
+    const mxnet::Tuple<int> &size = param.size.value();
+    for (int i = 0; i < size.ndim(); ++i) {
+      oshape_vec.emplace_back(size[i]);
+    }
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, TShape(oshape_vec));
+    for (size_t input_idx = 0; input_idx < in_attrs->size(); input_idx++) {
+      CheckBroadcastable((*in_attrs)[input_idx], (*out_attrs)[0]);
+    }
+  } else {
+    // Size undeclared.
+    if (in_attrs->size() == 2U) {
+      // Both params from ndarray.
+      mxnet::TShape& low = (*in_attrs)[0];
+      mxnet::TShape& high = (*in_attrs)[1];
+      mxnet::TShape out(std::max(low.ndim(), high.ndim()), -1);
+      InferBroadcastShape(low, high, &out);
+      SHAPE_ASSIGN_CHECK(*out_attrs, 0, out);
+    } else if (in_attrs->size() == 1U) {
+      // One param from ndarray.
+      SHAPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0))
+    } else if (in_attrs->size() == 0) {
+    // Two scalar case.
+      SHAPE_ASSIGN_CHECK(*out_attrs, 0, TShape(0, -1))
+      return true;
+    }
+  }
+  return out_attrs->at(0).ndim() != 0U;
+}
+
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NUMPY_RANDOM_DIST_COMMON_H_ */

--- a/src/operator/numpy/random/dist_common.h
+++ b/src/operator/numpy/random/dist_common.h
@@ -19,7 +19,7 @@
 
 /*!
  *  Copyright (c) 2015 by Contributors
- * \file etwoparams_dist_common.h
+ * \file dist_common.h
  * \brief Function definition of common functions for distributions
  * \with two parameters.
  */
@@ -27,16 +27,16 @@
 #ifndef MXNET_OPERATOR_NUMPY_RANDOM_DIST_COMMON_H_
 #define MXNET_OPERATOR_NUMPY_RANDOM_DIST_COMMON_H_
 
-#include <mxnet/operator_util.h>
 #include <mshadow/base.h>
-#include <vector>
-#include <string>
+#include <mxnet/operator_util.h>
 #include <algorithm>
+#include <string>
+#include <vector>
 #include "../../elemwise_op_common.h"
-#include "../../tensor/elemwise_binary_broadcast_op.h"
 #include "../../mshadow_op.h"
 #include "../../mxnet_op.h"
 #include "../../operator_common.h"
+#include "../../tensor/elemwise_binary_broadcast_op.h"
 
 namespace mxnet {
 namespace op {
@@ -55,14 +55,15 @@ inline int FillShape(const mxnet::TShape &lshape, const mxnet::TShape &rshape,
     int l = 1;
     int r = 1;
     int o = oshape[i];
-    if (i >= bl)  l = lshape[i - bl];
-    if (i >= br)  r = rshape[i - br];
+    if (i >= bl) l = lshape[i - bl];
+    if (i >= br) r = rshape[i - br];
     if ((lprod != rprod || lprod != oprod || l != r || l != o) &&
         (lprod * l > 1 || rprod * r > 1 || oprod * o > 1)) {
       (*new_lshape)[j] = lprod;
       (*new_rshape)[j] = rprod;
       (*new_oshape)[j] = oprod;
-      lprod = rprod = oprod = 1; ++j;
+      lprod = rprod = oprod = 1;
+      ++j;
     }
     lprod *= l;
     rprod *= r;
@@ -81,22 +82,21 @@ inline int FillShape(const mxnet::TShape &lshape, const mxnet::TShape &rshape,
       new_oshape->assign(new_oshape->begin(), new_oshape->begin() + NDim);
     });
   } else {
-    LOG(FATAL) << "Too many broadcast dimensions with operands " << lshape << " " << rshape;
+    LOG(FATAL) << "Too many broadcast dimensions with operands " << lshape
+               << " " << rshape;
   }
   return j;
 }
 
-inline void CheckBroadcastable(const mxnet::TShape &from, const mxnet::TShape &to) {
+inline void CheckBroadcastable(const mxnet::TShape &from,
+                               const mxnet::TShape &to) {
   const int bl = to.ndim() - from.ndim();
   const int br = 0;
   for (int i = 0; i < to.ndim(); ++i) {
     int l = 1, r = 1;
-    if (i >= bl)
-      l = from[i - bl];
-    if (i >= br)
-      r = to[i - br];
-    if (!mxnet::dim_size_is_known(l) || !mxnet::dim_size_is_known(r))
-      continue;
+    if (i >= bl) l = from[i - bl];
+    if (i >= br) r = to[i - br];
+    if (!mxnet::dim_size_is_known(l) || !mxnet::dim_size_is_known(r)) continue;
     if (l != r) {
       // Make it compatible with NumPy.
       // For example, (2, 3) cannot broadcast to (2, 0, 3), but (1, 3) can
@@ -108,19 +108,17 @@ inline void CheckBroadcastable(const mxnet::TShape &from, const mxnet::TShape &t
   }
 }
 
-inline void InferBroadcastShape(const mxnet::TShape &lhs, const mxnet::TShape &rhs,
-                         mxnet::TShape* out_ptr) {
-  mxnet::TShape& out = (*out_ptr);
+inline void InferBroadcastShape(const mxnet::TShape &lhs,
+                                const mxnet::TShape &rhs,
+                                mxnet::TShape *out_ptr) {
+  mxnet::TShape &out = (*out_ptr);
   const int bl = out.ndim() - lhs.ndim();
   const int br = out.ndim() - rhs.ndim();
   for (int i = 0; i < out.ndim(); ++i) {
     int l = 1, r = 1;
-    if (i >= bl)
-      l = lhs[i - bl];
-    if (i >= br)
-      r = rhs[i - br];
-    if (!mxnet::dim_size_is_known(l) || !mxnet::dim_size_is_known(r))
-      continue;
+    if (i >= bl) l = lhs[i - bl];
+    if (i >= br) r = rhs[i - br];
+    if (!mxnet::dim_size_is_known(l) || !mxnet::dim_size_is_known(r)) continue;
     if (l != r) {
       // Make it compatible with NumPy.
       // For example, (2, 3) cannot broadcast to (2, 0, 3), but (1, 3) can
@@ -135,10 +133,10 @@ inline void InferBroadcastShape(const mxnet::TShape &lhs, const mxnet::TShape &r
   }
 }
 
-template<typename DistParam>
+template <typename DistParam>
 inline bool TwoparamsDistOpShape(const nnvm::NodeAttrs &attrs,
-                                std::vector<TShape> *in_attrs,
-                                std::vector<TShape> *out_attrs) {
+                                 std::vector<TShape> *in_attrs,
+                                 std::vector<TShape> *out_attrs) {
   const DistParam &param = nnvm::get<DistParam>(attrs.parsed);
   CHECK_EQ(out_attrs->size(), 1U);
   if (param.size.has_value()) {
@@ -156,8 +154,8 @@ inline bool TwoparamsDistOpShape(const nnvm::NodeAttrs &attrs,
     // Size undeclared.
     if (in_attrs->size() == 2U) {
       // Both params from ndarray.
-      mxnet::TShape& low = (*in_attrs)[0];
-      mxnet::TShape& high = (*in_attrs)[1];
+      mxnet::TShape &low = (*in_attrs)[0];
+      mxnet::TShape &high = (*in_attrs)[1];
       mxnet::TShape out(std::max(low.ndim(), high.ndim()), -1);
       InferBroadcastShape(low, high, &out);
       SHAPE_ASSIGN_CHECK(*out_attrs, 0, out);
@@ -165,14 +163,13 @@ inline bool TwoparamsDistOpShape(const nnvm::NodeAttrs &attrs,
       // One param from ndarray.
       SHAPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0))
     } else if (in_attrs->size() == 0) {
-    // Two scalar case.
+      // Two scalar case.
       SHAPE_ASSIGN_CHECK(*out_attrs, 0, TShape(0, -1))
       return true;
     }
   }
   return out_attrs->at(0).ndim() != 0U;
 }
-
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/numpy/random/np_uniform_op.cc
+++ b/src/operator/numpy/random/np_uniform_op.cc
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_uniform_op.h
+ * \brief Operator for numpy sampling from uniform distributions
+ */
+#include "./np_uniform_op.h"
+
+namespace mxnet {
+namespace op {
+
+DMLC_REGISTER_PARAMETER(NumpyUniformParam);
+
+NNVM_REGISTER_OP(_npi_uniform)
+.describe("numpy behavior uniform")
+.set_num_inputs(
+  [](const nnvm::NodeAttrs& attrs) {
+    const NumpyUniformParam& param = nnvm::get<NumpyUniformParam>(attrs.parsed);
+    int num_inputs = 2;
+    if (param.low.has_value()) num_inputs -= 1;
+    if (param.high.has_value()) num_inputs -= 1;
+    return num_inputs;
+  }
+)
+.set_num_outputs(1)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"input1", "input2"};
+  })
+.set_attr_parser(ParamParser<NumpyUniformParam>)
+.set_attr<mxnet::FInferShape>("FInferShape", TwoparamsDistOpShape<NumpyUniformParam>)
+.set_attr<nnvm::FInferType>("FInferType", NumpyUniformOpType)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const nnvm::NodeAttrs& attrs) {
+      return std::vector<ResourceRequest>{
+        ResourceRequest::kRandom, ResourceRequest::kTempSpace};
+  })
+.set_attr<FCompute>("FCompute<cpu>", NumpyUniformForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+.add_argument("input1", "NDArray-or-Symbol", "Source input")
+.add_argument("input2", "NDArray-or-Symbol", "Source input")
+.add_arguments(NumpyUniformParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/random/np_uniform_op.cc
+++ b/src/operator/numpy/random/np_uniform_op.cc
@@ -19,7 +19,7 @@
 
 /*!
  * Copyright (c) 2019 by Contributors
- * \file np_uniform_op.h
+ * \file np_uniform_op.cc
  * \brief Operator for numpy sampling from uniform distributions
  */
 #include "./np_uniform_op.h"

--- a/src/operator/numpy/random/np_uniform_op.cu
+++ b/src/operator/numpy/random/np_uniform_op.cu
@@ -31,5 +31,5 @@ namespace op {
 NNVM_REGISTER_OP(_npi_uniform)
 .set_attr<FCompute>("FCompute<gpu>", NumpyUniformForward<gpu>);
 
-}
-}
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/random/np_uniform_op.cu
+++ b/src/operator/numpy/random/np_uniform_op.cu
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_uniform_op.cu
+ * \brief Operator for numpy sampling from uniform distributions
+ */
+
+#include "./np_uniform_op.h"
+
+namespace mxnet {
+namespace op {
+
+NNVM_REGISTER_OP(_npi_uniform)
+.set_attr<FCompute>("FCompute<gpu>", NumpyUniformForward<gpu>);
+
+}
+}

--- a/src/operator/numpy/random/np_uniform_op.h
+++ b/src/operator/numpy/random/np_uniform_op.h
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_uniform_op.h
+ * \brief Operator for numpy sampling from uniform distributions
+ */
+#ifndef MXNET_OPERATOR_NUMPY_RANDOM_NP_UNIFORM_OP_H_
+#define MXNET_OPERATOR_NUMPY_RANDOM_NP_UNIFORM_OP_H_
+
+#include <mxnet/operator_util.h>
+#include <mshadow/base.h>
+#include <vector>
+#include <string>
+#include <algorithm>
+#include "./dist_common.h"
+#include "../../elemwise_op_common.h"
+#include "../../tensor/elemwise_binary_broadcast_op.h"
+#include "../../mshadow_op.h"
+#include "../../mxnet_op.h"
+#include "../../operator_common.h"
+
+namespace mxnet {
+namespace op {
+
+struct NumpyUniformParam : public dmlc::Parameter<NumpyUniformParam> {
+  dmlc::optional<float> low;
+  dmlc::optional<float> high;
+  std::string ctx;
+  int dtype;
+  dmlc::optional<mxnet::Tuple<int>> size;
+  DMLC_DECLARE_PARAMETER(NumpyUniformParam) {
+    DMLC_DECLARE_FIELD(low);
+    DMLC_DECLARE_FIELD(high);
+    DMLC_DECLARE_FIELD(size)
+        .set_default(dmlc::optional<mxnet::Tuple<int>>())
+        .describe("Output shape. If the given shape is, "
+                  "e.g., (m, n, k), then m * n * k samples are drawn. "
+                  "Default is None, in which case a single value is returned.");
+    DMLC_DECLARE_FIELD(ctx)
+    .set_default("cpu")
+    .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
+              " Only used for imperative calls.");
+    DMLC_DECLARE_FIELD(dtype)
+    .add_enum("float32", mshadow::kFloat32)
+    .add_enum("float64", mshadow::kFloat64)
+    .add_enum("float16", mshadow::kFloat16)
+    .set_default(mshadow::kFloat32)
+    .describe("DType of the output in case this can't be inferred. "
+              "Defaults to float32 if not defined (dtype=None).");
+  }
+};
+
+inline bool NumpyUniformOpType(const nnvm::NodeAttrs &attrs,
+                                   std::vector<int> *in_attrs,
+                                   std::vector<int> *out_attrs) {
+  const NumpyUniformParam &param = nnvm::get<NumpyUniformParam>(attrs.parsed);
+  int otype = param.dtype;
+  if (otype != -1) {
+    (*out_attrs)[0] = otype;
+  } else {
+    (*out_attrs)[0] = mshadow::kFloat32;
+  }
+  return true;
+}
+
+namespace mxnet_op {
+template <int ndim, typename IType, typename OType>
+struct uniform_kernel {
+  MSHADOW_XINLINE static void Map(index_t i,
+                                  const Shape <ndim> &lstride, const Shape <ndim> &hstride,
+                                  const Shape <ndim> &oshape,
+                                  IType *low, IType *high,
+                                  float *uniform, OType *out) {
+  Shape<ndim> coord = unravel(i, oshape);
+  auto lidx = static_cast<index_t>(dot(coord, lstride));
+  auto hidx = static_cast<index_t>(dot(coord, hstride));
+  IType low_value = low[lidx];
+  IType high_value = high[hidx];
+  out[i] = low_value + uniform[i] * (high_value - low_value);
+  }
+};
+}  // namespace mxnet_op
+
+namespace mxnet_op {
+template <int ndim, typename IType, typename OType>
+struct uniform_one_scalar_kernel {
+  MSHADOW_XINLINE static void Map(index_t i, int scalar_pos,
+                                  const Shape <ndim> &stride,
+                                  const Shape <ndim> &oshape,
+                                  IType *array, float scalar,
+                                  float *uniform, OType *out) {
+  Shape<ndim> coord = unravel(i, oshape);
+  auto idx = static_cast<index_t>(dot(coord, stride));
+  IType low_value;
+  IType high_value;
+  if (scalar_pos == 0) {
+    low_value = scalar;
+    high_value = array[idx];
+  } else {
+    low_value = array[idx];
+    high_value = scalar;
+  }
+  out[i] = low_value + uniform[i] * (high_value - low_value);
+  }
+};
+}  // namespace mxnet_op
+
+namespace mxnet_op {
+template <typename OType>
+struct uniform_two_scalar_kernel {
+  MSHADOW_XINLINE static void Map(index_t i,
+                                  float low, float high,
+                                  float *uniform, OType *out) {
+  out[i] = low + uniform[i] * (high - low);
+  }
+};
+}  // namespace mxnet_op
+
+
+
+
+template <typename xpu>
+void NumpyUniformForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
+                         const std::vector<TBlob> &inputs,
+                         const std::vector<OpReqType> &req,
+                         const std::vector<TBlob> &outputs) {
+  using namespace mshadow;
+  using namespace mxnet_op;
+  const NumpyUniformParam &param = nnvm::get<NumpyUniformParam>(attrs.parsed);
+  CHECK_EQ(outputs.size(), 1);
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+
+  // Generate base random number.
+  Random<xpu, float> *prnd = ctx.requested[0].get_random<xpu, float>(s);
+  Tensor<xpu, 1, float> uniform_tensor =
+      ctx.requested[1].get_space_typed<xpu, 1, float>(Shape1(outputs[0].Size()), s);
+  prnd->SampleUniform(&uniform_tensor, 0, 1);
+  mxnet::TShape new_lshape, new_hshape, new_oshape;
+
+  // [scalar scalar] case
+  if (inputs.size() == 0U) {
+    MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, OType, {
+      mxnet_op::Kernel<uniform_two_scalar_kernel<OType>, xpu>::Launch(
+            s, outputs[0].Size(),
+            param.low.value(), param.high.value(),
+            uniform_tensor.dptr_, outputs[0].dptr<OType>());
+    });
+  } else if (inputs.size() == 1U) {
+    // [scalar tensor], [tensor scalar] case
+    int ndim = FillShape(inputs[0].shape_, inputs[0].shape_, outputs[0].shape_,
+                         &new_lshape, &new_lshape, &new_oshape);
+    int scalar_pos;
+    float scalar_value;
+    // int type_flag = param.t;
+    if (param.low.has_value()) {
+      scalar_pos = 0;
+      scalar_value = param.low.value();
+    } else {
+      scalar_pos = 1;
+      scalar_value = param.high.value();
+    }
+    MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, IType, {
+      MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, OType, {
+        BROADCAST_NDIM_SWITCH(ndim, NDim, {
+        mshadow::Shape<NDim> oshape = new_oshape.get<NDim>();
+        mshadow::Shape<NDim> stride =
+            mxnet_op::calc_stride(new_lshape.get<NDim>());
+        mxnet_op::Kernel<uniform_one_scalar_kernel<NDim, IType, OType>, xpu>::Launch(
+            s, outputs[0].Size(), scalar_pos, stride, oshape,
+            inputs[0].dptr<IType>(), scalar_value,
+            uniform_tensor.dptr_, outputs[0].dptr<OType>());
+        });
+      });
+    });
+  } else if (inputs.size() == 2U) {
+    // [tensor tensor] case
+    int ndim = FillShape(inputs[0].shape_, inputs[1].shape_, outputs[0].shape_,
+                         &new_lshape, &new_hshape, &new_oshape);
+    MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, IType, {
+      MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, OType, {
+        BROADCAST_NDIM_SWITCH(ndim, NDim, {
+        mshadow::Shape<NDim> oshape = new_oshape.get<NDim>();
+        mshadow::Shape<NDim> lstride =
+            mxnet_op::calc_stride(new_lshape.get<NDim>());
+        mshadow::Shape<NDim> hstride =
+            mxnet_op::calc_stride(new_hshape.get<NDim>());
+        mxnet_op::Kernel<uniform_kernel<NDim, IType, OType>, xpu>::Launch(
+            s, outputs[0].Size(), lstride, hstride, oshape,
+            inputs[0].dptr<IType>(), inputs[1].dptr<IType>(),
+            uniform_tensor.dptr_, outputs[0].dptr<OType>());
+        });
+      });
+    });
+  }
+}
+
+};  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NUMPY_RANDOM_NP_UNIFORM_OP_H_

--- a/src/operator/numpy/random/np_uniform_op.h
+++ b/src/operator/numpy/random/np_uniform_op.h
@@ -25,17 +25,17 @@
 #ifndef MXNET_OPERATOR_NUMPY_RANDOM_NP_UNIFORM_OP_H_
 #define MXNET_OPERATOR_NUMPY_RANDOM_NP_UNIFORM_OP_H_
 
-#include <mxnet/operator_util.h>
 #include <mshadow/base.h>
-#include <vector>
-#include <string>
+#include <mxnet/operator_util.h>
 #include <algorithm>
-#include "./dist_common.h"
+#include <string>
+#include <vector>
 #include "../../elemwise_op_common.h"
-#include "../../tensor/elemwise_binary_broadcast_op.h"
 #include "../../mshadow_op.h"
 #include "../../mxnet_op.h"
 #include "../../operator_common.h"
+#include "../../tensor/elemwise_binary_broadcast_op.h"
+#include "./dist_common.h"
 
 namespace mxnet {
 namespace op {
@@ -51,26 +51,27 @@ struct NumpyUniformParam : public dmlc::Parameter<NumpyUniformParam> {
     DMLC_DECLARE_FIELD(high);
     DMLC_DECLARE_FIELD(size)
         .set_default(dmlc::optional<mxnet::Tuple<int>>())
-        .describe("Output shape. If the given shape is, "
-                  "e.g., (m, n, k), then m * n * k samples are drawn. "
-                  "Default is None, in which case a single value is returned.");
-    DMLC_DECLARE_FIELD(ctx)
-    .set_default("cpu")
-    .describe("Context of output, in format [cpu|gpu|cpu_pinned](n)."
-              " Only used for imperative calls.");
+        .describe(
+            "Output shape. If the given shape is, "
+            "e.g., (m, n, k), then m * n * k samples are drawn. "
+            "Default is None, in which case a single value is returned.");
+    DMLC_DECLARE_FIELD(ctx).set_default("cpu").describe(
+        "Context of output, in format [cpu|gpu|cpu_pinned](n)."
+        " Only used for imperative calls.");
     DMLC_DECLARE_FIELD(dtype)
-    .add_enum("float32", mshadow::kFloat32)
-    .add_enum("float64", mshadow::kFloat64)
-    .add_enum("float16", mshadow::kFloat16)
-    .set_default(mshadow::kFloat32)
-    .describe("DType of the output in case this can't be inferred. "
-              "Defaults to float32 if not defined (dtype=None).");
+        .add_enum("float32", mshadow::kFloat32)
+        .add_enum("float64", mshadow::kFloat64)
+        .add_enum("float16", mshadow::kFloat16)
+        .set_default(mshadow::kFloat32)
+        .describe(
+            "DType of the output in case this can't be inferred. "
+            "Defaults to float32 if not defined (dtype=None).");
   }
 };
 
 inline bool NumpyUniformOpType(const nnvm::NodeAttrs &attrs,
-                                   std::vector<int> *in_attrs,
-                                   std::vector<int> *out_attrs) {
+                               std::vector<int> *in_attrs,
+                               std::vector<int> *out_attrs) {
   const NumpyUniformParam &param = nnvm::get<NumpyUniformParam>(attrs.parsed);
   int otype = param.dtype;
   if (otype != -1) {
@@ -84,61 +85,52 @@ inline bool NumpyUniformOpType(const nnvm::NodeAttrs &attrs,
 namespace mxnet_op {
 template <int ndim, typename IType, typename OType>
 struct uniform_kernel {
-  MSHADOW_XINLINE static void Map(index_t i,
-                                  const Shape <ndim> &lstride, const Shape <ndim> &hstride,
-                                  const Shape <ndim> &oshape,
-                                  IType *low, IType *high,
-                                  float *uniform, OType *out) {
-  Shape<ndim> coord = unravel(i, oshape);
-  auto lidx = static_cast<index_t>(dot(coord, lstride));
-  auto hidx = static_cast<index_t>(dot(coord, hstride));
-  IType low_value = low[lidx];
-  IType high_value = high[hidx];
-  out[i] = low_value + uniform[i] * (high_value - low_value);
+  MSHADOW_XINLINE static void Map(index_t i, const Shape<ndim> &lstride,
+                                  const Shape<ndim> &hstride,
+                                  const Shape<ndim> &oshape, IType *low,
+                                  IType *high, float *uniform, OType *out) {
+    Shape<ndim> coord = unravel(i, oshape);
+    auto lidx = static_cast<index_t>(dot(coord, lstride));
+    auto hidx = static_cast<index_t>(dot(coord, hstride));
+    IType low_value = low[lidx];
+    IType high_value = high[hidx];
+    out[i] = low_value + uniform[i] * (high_value - low_value);
   }
 };
-}  // namespace mxnet_op
 
-namespace mxnet_op {
 template <int ndim, typename IType, typename OType>
 struct uniform_one_scalar_kernel {
   MSHADOW_XINLINE static void Map(index_t i, int scalar_pos,
-                                  const Shape <ndim> &stride,
-                                  const Shape <ndim> &oshape,
-                                  IType *array, float scalar,
-                                  float *uniform, OType *out) {
-  Shape<ndim> coord = unravel(i, oshape);
-  auto idx = static_cast<index_t>(dot(coord, stride));
-  IType low_value;
-  IType high_value;
-  if (scalar_pos == 0) {
-    low_value = scalar;
-    high_value = array[idx];
-  } else {
-    low_value = array[idx];
-    high_value = scalar;
-  }
-  out[i] = low_value + uniform[i] * (high_value - low_value);
+                                  const Shape<ndim> &stride,
+                                  const Shape<ndim> &oshape, IType *array,
+                                  float scalar, float *uniform, OType *out) {
+    Shape<ndim> coord = unravel(i, oshape);
+    auto idx = static_cast<index_t>(dot(coord, stride));
+    IType low_value;
+    IType high_value;
+    if (scalar_pos == 0) {
+      low_value = scalar;
+      high_value = array[idx];
+    } else {
+      low_value = array[idx];
+      high_value = scalar;
+    }
+    out[i] = low_value + uniform[i] * (high_value - low_value);
   }
 };
-}  // namespace mxnet_op
 
-namespace mxnet_op {
 template <typename OType>
 struct uniform_two_scalar_kernel {
-  MSHADOW_XINLINE static void Map(index_t i,
-                                  float low, float high,
+  MSHADOW_XINLINE static void Map(index_t i, float low, float high,
                                   float *uniform, OType *out) {
-  out[i] = low + uniform[i] * (high - low);
+    out[i] = low + uniform[i] * (high - low);
   }
 };
 }  // namespace mxnet_op
 
-
-
-
 template <typename xpu>
-void NumpyUniformForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
+void NumpyUniformForward(const nnvm::NodeAttrs &attrs,
+                         const OpContext &ctx,
                          const std::vector<TBlob> &inputs,
                          const std::vector<OpReqType> &req,
                          const std::vector<TBlob> &outputs) {
@@ -151,7 +143,8 @@ void NumpyUniformForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
   // Generate base random number.
   Random<xpu, float> *prnd = ctx.requested[0].get_random<xpu, float>(s);
   Tensor<xpu, 1, float> uniform_tensor =
-      ctx.requested[1].get_space_typed<xpu, 1, float>(Shape1(outputs[0].Size()), s);
+      ctx.requested[1].get_space_typed<xpu, 1, float>(Shape1(outputs[0].Size()),
+                                                      s);
   prnd->SampleUniform(&uniform_tensor, 0, 1);
   mxnet::TShape new_lshape, new_hshape, new_oshape;
 
@@ -159,9 +152,8 @@ void NumpyUniformForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
   if (inputs.size() == 0U) {
     MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, OType, {
       mxnet_op::Kernel<uniform_two_scalar_kernel<OType>, xpu>::Launch(
-            s, outputs[0].Size(),
-            param.low.value(), param.high.value(),
-            uniform_tensor.dptr_, outputs[0].dptr<OType>());
+          s, outputs[0].Size(), param.low.value(), param.high.value(),
+          uniform_tensor.dptr_, outputs[0].dptr<OType>());
     });
   } else if (inputs.size() == 1U) {
     // [scalar tensor], [tensor scalar] case
@@ -180,13 +172,14 @@ void NumpyUniformForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
     MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, IType, {
       MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, OType, {
         BROADCAST_NDIM_SWITCH(ndim, NDim, {
-        mshadow::Shape<NDim> oshape = new_oshape.get<NDim>();
-        mshadow::Shape<NDim> stride =
-            mxnet_op::calc_stride(new_lshape.get<NDim>());
-        mxnet_op::Kernel<uniform_one_scalar_kernel<NDim, IType, OType>, xpu>::Launch(
-            s, outputs[0].Size(), scalar_pos, stride, oshape,
-            inputs[0].dptr<IType>(), scalar_value,
-            uniform_tensor.dptr_, outputs[0].dptr<OType>());
+          mshadow::Shape<NDim> oshape = new_oshape.get<NDim>();
+          mshadow::Shape<NDim> stride =
+              mxnet_op::calc_stride(new_lshape.get<NDim>());
+          mxnet_op::Kernel<uniform_one_scalar_kernel<NDim, IType, OType>,
+                           xpu>::Launch(s, outputs[0].Size(), scalar_pos,
+                                        stride, oshape, inputs[0].dptr<IType>(),
+                                        scalar_value, uniform_tensor.dptr_,
+                                        outputs[0].dptr<OType>());
         });
       });
     });
@@ -197,22 +190,22 @@ void NumpyUniformForward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
     MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, IType, {
       MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, OType, {
         BROADCAST_NDIM_SWITCH(ndim, NDim, {
-        mshadow::Shape<NDim> oshape = new_oshape.get<NDim>();
-        mshadow::Shape<NDim> lstride =
-            mxnet_op::calc_stride(new_lshape.get<NDim>());
-        mshadow::Shape<NDim> hstride =
-            mxnet_op::calc_stride(new_hshape.get<NDim>());
-        mxnet_op::Kernel<uniform_kernel<NDim, IType, OType>, xpu>::Launch(
-            s, outputs[0].Size(), lstride, hstride, oshape,
-            inputs[0].dptr<IType>(), inputs[1].dptr<IType>(),
-            uniform_tensor.dptr_, outputs[0].dptr<OType>());
+          mshadow::Shape<NDim> oshape = new_oshape.get<NDim>();
+          mshadow::Shape<NDim> lstride =
+              mxnet_op::calc_stride(new_lshape.get<NDim>());
+          mshadow::Shape<NDim> hstride =
+              mxnet_op::calc_stride(new_hshape.get<NDim>());
+          mxnet_op::Kernel<uniform_kernel<NDim, IType, OType>, xpu>::Launch(
+              s, outputs[0].Size(), lstride, hstride, oshape,
+              inputs[0].dptr<IType>(), inputs[1].dptr<IType>(),
+              uniform_tensor.dptr_, outputs[0].dptr<OType>());
         });
       });
     });
   }
 }
 
-};  // namespace op
+}  // namespace op
 }  // namespace mxnet
 
 #endif  // MXNET_OPERATOR_NUMPY_RANDOM_NP_UNIFORM_OP_H_

--- a/src/operator/numpy/random/np_uniform_op.h
+++ b/src/operator/numpy/random/np_uniform_op.h
@@ -151,7 +151,7 @@ void NumpyUniformForward(const nnvm::NodeAttrs &attrs,
   // [scalar scalar] case
   if (inputs.size() == 0U) {
     MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, OType, {
-      mxnet_op::Kernel<uniform_two_scalar_kernel<OType>, xpu>::Launch(
+      Kernel<uniform_two_scalar_kernel<OType>, xpu>::Launch(
           s, outputs[0].Size(), param.low.value(), param.high.value(),
           uniform_tensor.dptr_, outputs[0].dptr<OType>());
     });
@@ -172,14 +172,12 @@ void NumpyUniformForward(const nnvm::NodeAttrs &attrs,
     MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, IType, {
       MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, OType, {
         BROADCAST_NDIM_SWITCH(ndim, NDim, {
-          mshadow::Shape<NDim> oshape = new_oshape.get<NDim>();
-          mshadow::Shape<NDim> stride =
-              mxnet_op::calc_stride(new_lshape.get<NDim>());
-          mxnet_op::Kernel<uniform_one_scalar_kernel<NDim, IType, OType>,
-                           xpu>::Launch(s, outputs[0].Size(), scalar_pos,
-                                        stride, oshape, inputs[0].dptr<IType>(),
-                                        scalar_value, uniform_tensor.dptr_,
-                                        outputs[0].dptr<OType>());
+          Shape<NDim> oshape = new_oshape.get<NDim>();
+          Shape<NDim> stride = calc_stride(new_lshape.get<NDim>());
+          Kernel<uniform_one_scalar_kernel<NDim, IType, OType>, xpu>::Launch(
+              s, outputs[0].Size(), scalar_pos, stride, oshape,
+              inputs[0].dptr<IType>(), scalar_value, uniform_tensor.dptr_,
+              outputs[0].dptr<OType>());
         });
       });
     });
@@ -190,12 +188,10 @@ void NumpyUniformForward(const nnvm::NodeAttrs &attrs,
     MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, IType, {
       MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, OType, {
         BROADCAST_NDIM_SWITCH(ndim, NDim, {
-          mshadow::Shape<NDim> oshape = new_oshape.get<NDim>();
-          mshadow::Shape<NDim> lstride =
-              mxnet_op::calc_stride(new_lshape.get<NDim>());
-          mshadow::Shape<NDim> hstride =
-              mxnet_op::calc_stride(new_hshape.get<NDim>());
-          mxnet_op::Kernel<uniform_kernel<NDim, IType, OType>, xpu>::Launch(
+          Shape<NDim> oshape = new_oshape.get<NDim>();
+          Shape<NDim> lstride = calc_stride(new_lshape.get<NDim>());
+          Shape<NDim> hstride = calc_stride(new_hshape.get<NDim>());
+          Kernel<uniform_kernel<NDim, IType, OType>, xpu>::Launch(
               s, outputs[0].Size(), lstride, hstride, oshape,
               inputs[0].dptr<IType>(), inputs[1].dptr<IType>(),
               uniform_tensor.dptr_, outputs[0].dptr<OType>());

--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -25,6 +25,8 @@ from mxnet import np, npx, autograd
 from mxnet.gluon import HybridBlock
 from mxnet.test_utils import same, assert_almost_equal, rand_shape_nd, rand_ndarray, retry, assert_exception, use_np
 from common import with_seed, TemporaryDirectory
+from mxnet.test_utils import verify_generator, gen_buckets_probs_with_ppf
+import scipy.stats as ss
 
 
 @with_seed()
@@ -665,6 +667,40 @@ def test_np_save_load_ndarrays():
         for k, v in arr_dict_loaded.items():
             assert k in arr_dict
             assert _np.array_equal(v.asnumpy(), arr_dict[k].asnumpy())
+
+
+@retry(5)
+@with_seed()
+@use_np
+def test_np_uniform():
+    types = [None, "float32", "float64"]
+    ctx = mx.context.current_context()
+    samples = 1000000
+    # Generation test
+    trials = 8
+    num_buckets = 5
+    for dtype in types:
+        for low, high in [(-100.0, -98.0), (99.0, 101.0)]:
+            scale = high - low
+            buckets, probs = gen_buckets_probs_with_ppf(lambda x: ss.uniform.ppf(x, loc=low, scale=scale), num_buckets)
+            buckets = np.array(buckets, dtype=dtype).tolist()
+            probs = [(buckets[i][1] - buckets[i][0])/scale for i in range(num_buckets)]
+            generator_mx_np = lambda x: mx.np.random.uniform(low, high, size=x, ctx=ctx, dtype=dtype).asnumpy()
+            verify_generator(generator=generator_mx_np, buckets=buckets, probs=probs, nsamples=samples, nrepeat=trials)
+
+    # Broadcasting test
+    params = [
+        (1.0, mx.np.ones((4,4)) + 2.0),
+        (mx.np.zeros((4,4)) + 1, 2.0),
+        (mx.np.zeros((1,4)), mx.np.ones((4,4)) + mx.np.array([1, 2, 3, 4])),
+        (mx.np.array([1, 2, 3, 4]), mx.np.ones((2,4,4)) * 5)
+    ]
+    for dtype in types:
+        for low, high in params:
+            expect_mean = (low + high) / 2
+            expanded_size = (samples,) + expect_mean.shape
+            uniform_samples = mx.np.random.uniform(low, high, size=expanded_size, dtype=dtype)
+            mx.test_utils.assert_almost_equal(uniform_samples.asnumpy().mean(0), expect_mean.asnumpy(), rtol=0.20, atol=1e-1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
Current `mx.np.random.uniform` does not support parameters (low and high) as `Ndarray`, as the current version is implemented by wrapping `mxnet.ndarray.random.uniform`, which behaves in a different way **when the output shape is given by the user** compared with native Numpy. 
For example: 
```
low = np.zeros((1,4))
high = np.ones((1,4))
shape = (2,4,4)
```
`mxnet.ndarray.random.uniform(low, high, shape)`  would have output tensor of shape 1x4x2x4x4, however, result from `numpy.random.uniform(low, high, shape)` would have shape 2x4x4.

Another major difference is that,  numpy allows parameters to have different shapes as long as they are broadcastable.
For example: 
```
low = np.zeros((1,4))
high = np.ones((4,4))
shape = (2,4,4)
```
This setting would cause `Operator _sample_uniform inferring shapes failed.` with `mxnet.ndarray.random.uniform`.

This pull request implements a uniform distribution generator with numpy behavior and GPU support.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] New backend for random.uniform (np_uniform_op.*) implemented.
- [x] Current np.random.uniform() in python frontend is renamed to __deprecated_uniform().

## Comments ##
- When both low and high are python scalars and `size` is not defined, a scalar tensor would be returned. This is different from native Numpy, which would return python scalar if both parameters are python scalar.
For example:
```
>>>numpy.random.uniform()
0.1234
>>>mxnet.np.random.uniform()
array(0.1234)
```