### PR TITLE
[Numpy] numpy compatible invert

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -713,7 +713,7 @@ def invert(x, out=None, **kwargs):
     Computes the bit-wise NOT of the underlying binary representation of
     the integers in the input arrays. This ufunc implements the C/Python operator ~.
     For signed integer inputs, the two’s complement is returned.
-    In a two’s-complement system negative numbers are represented
+    In a two's-complement system negative numbers are represented
     by the two’s complement of the absolute value.
     This is the most common method of representing signed integers on computers [1].
     A N-bit two’s-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -27,7 +27,7 @@ from . import _internal as _npi
 from ..ndarray import NDArray
 
 __all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'tensordot',
-           'linspace', 'expand_dims', 'tile', 'arange', 'split', 'concatenate']
+           'linspace', 'expand_dims', 'tile', 'arange', 'split', 'concatenate', 'invert']
 
 
 @set_module('mxnet.ndarray.numpy')
@@ -553,7 +553,6 @@ def _unary_func_helper(x, fn_array, fn_scalar, out=None, **kwargs):
         Function to be called if x is a Python scalar.
     out : ndarray
         The buffer ndarray for storing the result of the unary function.
-
     Returns
     -------
     out : mxnet.numpy.ndarray or scalar
@@ -705,3 +704,42 @@ def concatenate(seq, axis=0, out=None):
         The concatenated array.
     """
     return _npi.concatenate(*seq, dim=axis, out=out)
+
+
+@set_module('mxnet.ndarray.numpy')
+def invert(x, out=None, **kwargs):
+    """
+    Compute bit-wise inversion, or bit-wise NOT, element-wise.
+    Computes the bit-wise NOT of the underlying binary representation of
+    the integers in the input arrays. This ufunc implements the C/Python operator ~.
+    For signed integer inputs, the two’s complement is returned.
+    In a two’s-complement system negative numbers are represented
+    by the two’s complement of the absolute value.
+    This is the most common method of representing signed integers on computers [1].
+    A N-bit two’s-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
+    Parameters
+    ----------
+    x : ndarray
+        Only integer and boolean types are handled.
+    out : ndarray or None
+        A location into which the result is stored.
+        If provided, it must have the same shape as the input.
+        If not provided or None, a freshly-allocated array is returned.
+    Returns
+    -------
+    out : ndarray
+        Bitwisely inverted elements of the original array.
+    Examples
+    --------
+    >>> np.invert(np.array([13], dtype=np.uint8))
+    array([242], dtype=uint8)
+    Notes
+    -----
+    This function differs from the original `numpy.invert
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.invert.html>`_ in
+    the following way(s):
+    - only ndarray or scalar is accpted as valid input, tuple of ndarray is not supported
+    - broadcasting to `out` of different shape is currently not supported
+    - when input is plain python numerics, the result will not be stored in the `out` param
+    """
+    return _unary_func_helper(x, _npi.invert, _np.invert, out=out, **kwargs)

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -712,11 +712,11 @@ def invert(x, out=None, **kwargs):
     Compute bit-wise inversion, or bit-wise NOT, element-wise.
     Computes the bit-wise NOT of the underlying binary representation of
     the integers in the input arrays. This ufunc implements the C/Python operator ~.
-    For signed integer inputs, the two’s complement is returned.
+    For signed integer inputs, the two's complement is returned.
     In a two's-complement system negative numbers are represented
-    by the two’s complement of the absolute value.
+    by the two's complement of the absolute value.
     This is the most common method of representing signed integers on computers [1].
-    A N-bit two’s-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
+    A N-bit two's-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
     Parameters
     ----------
     x : ndarray

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -1885,11 +1885,11 @@ def invert(x, out=None, **kwargs):
     Compute bit-wise inversion, or bit-wise NOT, element-wise.
     Computes the bit-wise NOT of the underlying binary representation of
     the integers in the input arrays. This ufunc implements the C/Python operator ~.
-    For signed integer inputs, the two’s complement is returned.
-    In a two’s-complement system negative numbers are represented
-    by the two’s complement of the absolute value.
+    For signed integer inputs, the two's complement is returned.
+    In a two's-complement system negative numbers are represented
+    by the two's complement of the absolute value.
     This is the most common method of representing signed integers on computers [1].
-    A N-bit two’s-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
+    A N-bit two's-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
     Parameters
     ----------
     x : array_like

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -45,7 +45,7 @@ from ..ndarray.numpy import _internal as _npi
 
 __all__ = ['ndarray', 'empty', 'array', 'zeros', 'ones', 'add', 'subtract', 'multiply', 'divide',
            'mod', 'power', 'tensordot', 'linspace', 'expand_dims', 'tile', 'arange', 'split',
-           'concatenate']
+           'concatenate', 'invert']
 
 
 # This function is copied from ndarray.py since pylint
@@ -1877,3 +1877,42 @@ def concatenate(seq, axis=0, out=None):
         The concatenated array.
     """
     return _mx_nd_np.concatenate(seq, axis=axis, out=out)
+
+
+@set_module('mxnet.numpy')
+def invert(x, out=None, **kwargs):
+    """
+    Compute bit-wise inversion, or bit-wise NOT, element-wise.
+    Computes the bit-wise NOT of the underlying binary representation of
+    the integers in the input arrays. This ufunc implements the C/Python operator ~.
+    For signed integer inputs, the two’s complement is returned.
+    In a two’s-complement system negative numbers are represented
+    by the two’s complement of the absolute value.
+    This is the most common method of representing signed integers on computers [1].
+    A N-bit two’s-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
+    Parameters
+    ----------
+    x : array_like
+        Only integer and boolean types are handled.
+    out : ndarray, None, or tuple of ndarray and None, optional
+        A location into which the result is stored.
+        If provided, it must have the same shape as the input.
+        If not provided or None, a freshly-allocated array is returned.
+    Returns
+    -------
+    out : ndarray
+        Bitwisely inverted elements of the original array.
+    Examples
+    --------
+    >>> np.invert(np.array([13], dtype=np.uint8))
+    array([242], dtype=uint8)
+    Notes
+    -----
+    This function differs from the original `numpy.invert
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.invert.html>`_ in
+    the following way(s):
+    - only ndarray or scalar is accpted as valid input, tuple of ndarray is not supported
+    - broadcasting to `out` of different shape is currently not supported
+    - when input is plain python numerics, the result will not be stored in the `out` param
+    """
+    return _mx_nd_np.invert(x, out=out, **kwargs)

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -30,7 +30,7 @@ from .._internal import _set_np_symbol_class
 from . import _internal as _npi
 
 __all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'power', 'tensordot',
-           'linspace', 'expand_dims', 'tile', 'arange', 'split', 'concatenate']
+           'linspace', 'expand_dims', 'tile', 'arange', 'split', 'concatenate', 'invert']
 
 
 def _num_outputs(sym):
@@ -1135,6 +1135,66 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis
     else:
         return _npi.linspace(start=start, stop=stop, num=num, endpoint=endpoint, ctx=ctx, dtype=dtype)
 
+def _unary_func_helper(x, fn_array, fn_scalar, out=None, **kwargs):
+    """Helper function for unary operators.
+    Parameters
+    ----------
+    x : _Symbol or scalar
+        Input of the unary operator.
+    fn_array : function
+        Function to be called if x is of ``_Symbol`` type.
+    fn_scalar : function
+        Function to be called if x is a Python scalar.
+    out : _Symbol
+        Dummy parameter to keep the consistency with the ndarray counterpart.
+    Returns
+    -------
+    out : _Symbol or scalar
+        Result _Symbol or scalar.
+    """
+    if isinstance(x, numeric_types):
+        return fn_scalar(x, **kwargs)
+    elif isinstance(x, _Symbol):
+        return fn_array(x, out=out, **kwargs)
+    else:
+        raise TypeError('type {} not supported'.format(str(type(x))))
+
+
+@set_module('mxnet.symbol.numpy')
+def invert(x, out=None, **kwargs):
+    """
+    Compute bit-wise inversion, or bit-wise NOT, element-wise.
+    Computes the bit-wise NOT of the underlying binary representation of
+    the integers in the input arrays. This ufunc implements the C/Python operator ~.
+    For signed integer inputs, the two’s complement is returned.
+    In a two’s-complement system negative numbers are represented
+    by the two’s complement of the absolute value.
+    This is the most common method of representing signed integers on computers [1].
+    A N-bit two’s-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
+    Parameters
+    ----------
+    x : _Symbol
+        Input value. Elements must be of real value.
+    out : _Symbol or None, optional
+        Dummy parameter to keep the consistency with the ndarray counterpart.
+    Returns
+    -------
+    out : _Symbol
+        Dummy parameter to keep the consistency with the ndarray counterpart.
+    Examples
+    --------
+    >>> np.invert(np.array([13], dtype=np.uint8))
+    array([242], dtype=uint8)
+    Notes
+    -----
+    This function differs from the original `numpy.invert
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.invert.html>`_ in
+    the following way(s):
+    - only ndarray or scalar is accpted as valid input, tuple of ndarray is not supported
+    - broadcasting to `out` of different shape is currently not supported
+    - when input is plain python numerics, the result will not be stored in the `out` param
+    """
+    return _unary_func_helper(x, _npi.invert, _np.invert, out=out, **kwargs)
 
 @set_module('mxnet.symbol.numpy')
 def expand_dims(a, axis):

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -1196,6 +1196,7 @@ def invert(x, out=None, **kwargs):
     """
     return _unary_func_helper(x, _npi.invert, _np.invert, out=out, **kwargs)
 
+
 @set_module('mxnet.symbol.numpy')
 def expand_dims(a, axis):
     """Expand the shape of an array.
@@ -1216,33 +1217,6 @@ def expand_dims(a, axis):
         the input array.
     """
     return _npi.expand_dims(a, axis)
-
-
-def _unary_func_helper(x, fn_array, fn_scalar, out=None, **kwargs):
-    """Helper function for unary operators.
-
-    Parameters
-    ----------
-    x : _Symbol or scalar
-        Input of the unary operator.
-    fn_array : function
-        Function to be called if x is of ``_Symbol`` type.
-    fn_scalar : function
-        Function to be called if x is a Python scalar.
-    out : _Symbol
-        Dummy parameter to keep the consistency with the ndarray counterpart.
-
-    Returns
-    -------
-    out : _Symbol or scalar
-        Result _Symbol or scalar.
-    """
-    if isinstance(x, numeric_types):
-        return fn_scalar(x, **kwargs)
-    elif isinstance(x, _Symbol):
-        return fn_array(x, out=out, **kwargs)
-    else:
-        raise TypeError('type {} not supported'.format(str(type(x))))
 
 
 @set_module('mxnet.symbol.numpy')

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -1135,6 +1135,29 @@ def linspace(start, stop, num=50, endpoint=True, retstep=False, dtype=None, axis
     else:
         return _npi.linspace(start=start, stop=stop, num=num, endpoint=endpoint, ctx=ctx, dtype=dtype)
 
+
+@set_module('mxnet.symbol.numpy')
+def expand_dims(a, axis):
+    """Expand the shape of an array.
+
+    Insert a new axis that will appear at the `axis` position in the expanded
+
+    Parameters
+    ----------
+    a : _Symbol
+        Input array.
+    axis : int
+        Position in the expanded axes where the new axis is placed.
+
+    Returns
+    -------
+    res : _Symbol
+        Output array. The number of dimensions is one greater than that of
+        the input array.
+    """
+    return _npi.expand_dims(a, axis)
+
+
 def _unary_func_helper(x, fn_array, fn_scalar, out=None, **kwargs):
     """Helper function for unary operators.
     Parameters
@@ -1195,28 +1218,6 @@ def invert(x, out=None, **kwargs):
     - when input is plain python numerics, the result will not be stored in the `out` param
     """
     return _unary_func_helper(x, _npi.invert, _np.invert, out=out, **kwargs)
-
-
-@set_module('mxnet.symbol.numpy')
-def expand_dims(a, axis):
-    """Expand the shape of an array.
-
-    Insert a new axis that will appear at the `axis` position in the expanded
-
-    Parameters
-    ----------
-    a : _Symbol
-        Input array.
-    axis : int
-        Position in the expanded axes where the new axis is placed.
-
-    Returns
-    -------
-    res : _Symbol
-        Output array. The number of dimensions is one greater than that of
-        the input array.
-    """
-    return _npi.expand_dims(a, axis)
 
 
 @set_module('mxnet.symbol.numpy')

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -1166,11 +1166,11 @@ def invert(x, out=None, **kwargs):
     Compute bit-wise inversion, or bit-wise NOT, element-wise.
     Computes the bit-wise NOT of the underlying binary representation of
     the integers in the input arrays. This ufunc implements the C/Python operator ~.
-    For signed integer inputs, the two’s complement is returned.
-    In a two’s-complement system negative numbers are represented
-    by the two’s complement of the absolute value.
+    For signed integer inputs, the two's complement is returned.
+    In a two's-complement system negative numbers are represented
+    by the two's complement of the absolute value.
     This is the most common method of representing signed integers on computers [1].
-    A N-bit two’s-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
+    A N-bit two's-complement system can represent every integer in the range -2^{N-1} to +2^{N-1}-1.
     Parameters
     ----------
     x : _Symbol

--- a/src/operator/elemwise_op_common.h
+++ b/src/operator/elemwise_op_common.h
@@ -186,6 +186,29 @@ inline bool ElemwiseType(const nnvm::NodeAttrs& attrs,
     attrs, in_attrs, out_attrs, -1);
 }
 
+template<index_t n_in, index_t n_out>
+inline bool ElemwiseIntType(const nnvm::NodeAttrs& attrs,
+                         std::vector<int> *in_attrs,
+                         std::vector<int> *out_attrs) {
+  if (n_in != -1) {
+    CHECK_EQ(in_attrs->size(), static_cast<size_t>(n_in)) << " in operator " << attrs.name;
+  }
+  if (n_out != -1) {
+    CHECK_EQ(out_attrs->size(), static_cast<size_t>(n_out)) << " in operator " << attrs.name;
+  }
+  for (size_t i = 0; i < in_attrs->size(); ++i) {
+    CHECK(type_is_none(in_attrs->at(i)) || type_is_int(in_attrs->at(i)))
+      <<"only integer input type is accepted, received type " << type_string(in_attrs->at(i));
+  }
+  for (size_t i = 0; i < out_attrs->size(); ++i) {
+    CHECK(type_is_none(out_attrs->at(i)) || type_is_int(out_attrs->at(i)))
+      <<"only integer output type is accepted, received type " << type_string(out_attrs->at(i));
+  }
+  return ElemwiseAttr<int, type_is_none, type_assign, true, type_string>(
+    attrs, in_attrs, out_attrs, -1);
+}
+
+
 // Transfer gradient and input to FGradient function
 struct ElemwiseGradUseIn {
   const char *op_name;

--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -119,6 +119,8 @@ MXNET_UNARY_MATH_OP(negation, -a);
 
 MXNET_UNARY_MATH_OP(reciprocal, 1.0f / math::id(a));
 
+MXNET_UNARY_MATH_OP(invert, DType(~static_cast<int64_t>(a)));
+
 MXNET_UNARY_MATH_OP(reciprocal_grad, -1.0f / math::sqr(a));
 
 MXNET_UNARY_MATH_OP(sigmoid, 1.0f / (1.0f + math::exp(-a)));

--- a/src/operator/numpy/np_elemwise_unary_op_basic.cc
+++ b/src/operator/numpy/np_elemwise_unary_op_basic.cc
@@ -1,26 +1,26 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 
 /*!
- * \file np_elemwise_unary_op_basic.cc
- * \brief CPU Implementation of numpy elementwise unary function.
- */
+* \file np_elemwise_unary_op_basic.cc
+* \brief CPU Implementation of numpy elementwise unary function.
+*/
 #include <mxnet/base.h>
 #include "../tensor/elemwise_unary_op.h"
 
@@ -30,20 +30,20 @@ namespace op {
 NNVM_REGISTER_OP(_npi_invert)
 .describe(R"code(Compute the truth value of NOT x element-wise.
 Example::
-  invert([13]) = array([242])
+invert([13]) = array([242])
 )code")
 .set_num_inputs(1)
 .set_num_outputs(1)
 .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseIntType<1, 1>)
 .set_attr<nnvm::FInplaceOption>("FInplaceOption",
-  [](const NodeAttrs& attrs){
-    return std::vector<std::pair<int, int> >{{0, 0}};
-  })
+[](const NodeAttrs& attrs){
+return std::vector<std::pair<int, int> >{{0, 0}};
+})
 .set_attr<nnvm::FListInputNames>("FListInputNames",
-  [](const NodeAttrs& attrs) {
-    return std::vector<std::string>{"x"};
-  })
+[](const NodeAttrs& attrs) {
+return std::vector<std::string>{"x"};
+})
 .set_attr<FCompute>("FCompute<cpu>", UnaryOp::Compute<cpu, mshadow_op::invert>)
 .add_argument("x", "NDArray-or-Symbol", "The input array.")
 .set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);

--- a/src/operator/numpy/np_elemwise_unary_op_basic.cc
+++ b/src/operator/numpy/np_elemwise_unary_op_basic.cc
@@ -38,11 +38,11 @@ invert([13]) = array([242])
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseIntType<1, 1>)
 .set_attr<nnvm::FInplaceOption>("FInplaceOption",
 [](const NodeAttrs& attrs){
-return std::vector<std::pair<int, int> >{{0, 0}};
+  return std::vector<std::pair<int, int> >{{0, 0}};
 })
 .set_attr<nnvm::FListInputNames>("FListInputNames",
 [](const NodeAttrs& attrs) {
-return std::vector<std::string>{"x"};
+  return std::vector<std::string>{"x"};
 })
 .set_attr<FCompute>("FCompute<cpu>", UnaryOp::Compute<cpu, mshadow_op::invert>)
 .add_argument("x", "NDArray-or-Symbol", "The input array.")

--- a/src/operator/numpy/np_elemwise_unary_op_basic.cc
+++ b/src/operator/numpy/np_elemwise_unary_op_basic.cc
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file np_elemwise_unary_op_basic.cc
+ * \brief CPU Implementation of numpy elementwise unary function.
+ */
+#include <mxnet/base.h>
+#include "../tensor/elemwise_unary_op.h"
+
+namespace mxnet {
+namespace op {
+
+NNVM_REGISTER_OP(_npi_invert)
+.describe(R"code(Compute the truth value of NOT x element-wise.
+Example::
+  invert([13]) = array([242])
+)code")
+.set_num_inputs(1)
+.set_num_outputs(1)
+.set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseIntType<1, 1>)
+.set_attr<nnvm::FInplaceOption>("FInplaceOption",
+  [](const NodeAttrs& attrs){
+    return std::vector<std::pair<int, int> >{{0, 0}};
+  })
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"x"};
+  })
+.set_attr<FCompute>("FCompute<cpu>", UnaryOp::Compute<cpu, mshadow_op::invert>)
+.add_argument("x", "NDArray-or-Symbol", "The input array.")
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/np_elemwise_unary_op_basic.cu
+++ b/src/operator/numpy/np_elemwise_unary_op_basic.cu
@@ -1,32 +1,32 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
 
 /*!
- * \file np_elemwise_unary_op_basic.cu
- * \brief GPU Implementation of numpy unary functions.
- */
- #include "../tensor/elemwise_binary_op.h"
+* \file np_elemwise_unary_op_basic.cu
+* \brief GPU Implementation of numpy unary functions.
+*/
+#include "../tensor/elemwise_binary_op.h"
 
- namespace mxnet {
- namespace op {
- 
- MXNET_OPERATOR_REGISTER_NUMPY_UNARY_GPU(_npi_invert, mshadow_op::invert);
- 
- }  // namespace op
- }  // namespace mxnet
+namespace mxnet {
+namespace op {
+
+MXNET_OPERATOR_REGISTER_NUMPY_UNARY_GPU(_npi_invert, mshadow_op::invert);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/np_elemwise_unary_op_basic.cu
+++ b/src/operator/numpy/np_elemwise_unary_op_basic.cu
@@ -26,6 +26,10 @@
 namespace mxnet {
 namespace op {
 
+#define MXNET_OPERATOR_REGISTER_NUMPY_UNARY_GPU(__name$, __kernel$)     \
+NNVM_REGISTER_OP(__name$)                                               \
+.set_attr<FCompute>("FCompute<gpu>", UnaryOp::Compute<gpu, __kernel$>)  \
+
 MXNET_OPERATOR_REGISTER_NUMPY_UNARY_GPU(_npi_invert, mshadow_op::invert);
 
 }  // namespace op

--- a/src/operator/numpy/np_elemwise_unary_op_basic.cu
+++ b/src/operator/numpy/np_elemwise_unary_op_basic.cu
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file np_elemwise_unary_op_basic.cu
+ * \brief GPU Implementation of numpy unary functions.
+ */
+ #include "../tensor/elemwise_binary_op.h"
+
+ namespace mxnet {
+ namespace op {
+ 
+ MXNET_OPERATOR_REGISTER_NUMPY_UNARY_GPU(_npi_invert, mshadow_op::invert);
+ 
+ }  // namespace op
+ }  // namespace mxnet

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -131,6 +131,19 @@ inline std::string shape_string(const mxnet::TShape& x) {
   return os.str();
 }
 
+/*! \brief check if type is integer */
+inline bool type_is_int(const int& x) {
+   switch (x) {
+    case mshadow::kInt8:
+    case mshadow::kUint8:
+    case mshadow::kInt32:
+    case mshadow::kInt64:
+      return true;
+    default:
+      return false;
+  }
+}
+
 /*! \brief get string representation of data type */
 inline std::string type_string(const int& x) {
   switch (x) {

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -133,7 +133,7 @@ inline std::string shape_string(const mxnet::TShape& x) {
 
 /*! \brief check if type is integer */
 inline bool type_is_int(const int& x) {
-   switch (x) {
+  switch (x) {
     case mshadow::kInt8:
     case mshadow::kUint8:
     case mshadow::kInt32:

--- a/src/operator/operator_tune.cc
+++ b/src/operator/operator_tune.cc
@@ -209,6 +209,7 @@ OperatorTuneBase::duration_t OperatorTuneBase::omp_overhead_ns_ = 5000;
 IMPLEMENT_UNARY_WORKLOAD_FWD(mxnet::op::mshadow_op::identity);  // NOLINT()
 IMPLEMENT_UNARY_WORKLOAD_BWD(mxnet::op::mshadow_op::identity_grad);  // NOLINT()
 IMPLEMENT_UNARY_WORKLOAD_FWD(mxnet::op::mshadow_op::negation);  // NOLINT()
+IMPLEMENT_UNARY_WORKLOAD_FWD(mxnet::op::mshadow_op::invert);  // NOLINT()
 IMPLEMENT_UNARY_WORKLOAD_FWD(mxnet::op::mshadow_op::reciprocal);  // NOLINT()
 IMPLEMENT_UNARY_WORKLOAD_BWD(mxnet::op::mshadow_op::reciprocal_grad);  // NOLINT()
 IMPLEMENT_UNARY_WORKLOAD_FWD(mxnet::op::mshadow_op::sigmoid);  // NOLINT()


### PR DESCRIPTION
## Description ##
- add numpy compatible [invert](https://docs.scipy.org/doc/numpy/reference/generated/numpy.invert.html) 
- add a helper function for checking if input or output is integer

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- add invert and its test
- a helper function to check for checking if input and output is of type integer at ` src/operator/operator_common.h type_is_int`

## Comments ##
- pass CPU,GPU test, pylint, cpplint
- Thank @haojin2 and @reminisce  for reviewing
