### PR TITLE
fixing problem with existing Singleton Caching

### DIFF
--- a/python/mxnet/runtime.py
+++ b/python/mxnet/runtime.py
@@ -77,10 +77,8 @@ class Features(collections.OrderedDict):
     def __new__(cls):
         if cls.instance is None:
             cls.instance = super(Features, cls).__new__(cls)
+            super(Features, cls.instance).__init__([(f.name, f) for f in feature_list()])
         return cls.instance
-
-    def __init__(self):
-        super(Features, self).__init__([(f.name, f) for f in feature_list()])
 
     def __repr__(self):
         return str(list(self.values()))


### PR DESCRIPTION
## Description ##
Populating static variable in `__init__()` overwrites the cache every time thus defeating the purpose of the cache. Therefore populating cache in `__new__()` where it is checked whether instance is populated or not. This ensures instance is not repopulated everytime a `Feature()` constructor is called.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
