### PR TITLE
[v1.5.x] fix LinearRegressionOutput with empty label (#15620)

### DIFF
--- a/cpp-package/example/CMakeLists.txt
+++ b/cpp-package/example/CMakeLists.txt
@@ -27,6 +27,10 @@ endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
+add_executable(test_regress_label test_regress_label.cpp ${CPP_PACKAGE_HAEDERS})
+target_link_libraries(test_regress_label ${CPP_EXAMPLE_LIBS})
+add_dependencies(test_regress_label ${CPPEX_DEPS})
+
 add_executable(lenet lenet.cpp ${CPP_PACKAGE_HEADERS})
 target_link_libraries(lenet ${CPP_EXAMPLE_LIBS})
 add_dependencies(lenet ${CPPEX_DEPS})

--- a/cpp-package/example/test_regress_label.cpp
+++ b/cpp-package/example/test_regress_label.cpp
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * 
+ * This file is used for testing LinearRegressionOutput can
+ *   still bind if label is not provided
+ */
+
+#include <iostream>
+#include <vector>
+#include <string>
+#include "dmlc/logging.h"
+#include "mxnet-cpp/MxNetCpp.h"
+
+using namespace mxnet::cpp;
+
+int main() {
+    LOG(INFO) << "Running LinearRegressionOutput symbol testing, "
+                 "executor should be able to bind without label.";
+    Symbol data = Symbol::Variable("data");
+    Symbol label = Symbol::Variable("regress_label");
+    Symbol symbol = LinearRegressionOutput(data, label);
+    std::map<std::string, mxnet::cpp::OpReqType> opReqMap;
+    for (const auto& iter : symbol.ListArguments()) {
+        opReqMap[iter] = mxnet::cpp::OpReqType::kNullOp;
+    }
+    std::map<std::string, mxnet::cpp::NDArray> argMap({
+        {"data", NDArray(Shape{1, 3}, Context::cpu(), true)}
+    });
+
+    try {
+        symbol.SimpleBind(Context::cpu(),
+                argMap,
+                std::map<std::string, mxnet::cpp::NDArray>(),
+                opReqMap,
+                std::map<std::string, mxnet::cpp::NDArray>());
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Error binding the symbol: " << MXGetLastError() << " " << e.what();
+        throw;
+    }
+    return 0;
+}

--- a/cpp-package/tests/ci_test.sh
+++ b/cpp-package/tests/ci_test.sh
@@ -60,6 +60,9 @@ cp ../../build/cpp-package/example/test_score .
 cp ../../build/cpp-package/example/test_ndarray_copy .
 ./test_ndarray_copy
 
+cp ../../build/cpp-package/example/test_regress_label .
+./test_regress_label
+
 sh unittests/unit_test_mlp_csv.sh
 
 cd inference

--- a/src/operator/regression_output-inl.h
+++ b/src/operator/regression_output-inl.h
@@ -59,7 +59,8 @@ inline bool RegressionOpShape(const nnvm::NodeAttrs& attrs,
   const mxnet::TShape &dshape = in_attrs->at(0);
   if (!shape_is_known(dshape)) return false;
   auto &lshape = (*in_attrs)[1];
-  if (lshape.ndim() == 0) {
+  // if label is not defined, manually build the shape based on dshape
+  if (lshape.ndim() == -1) {
     // special treatment for 1D output, to allow 1D label by default.
     // Think about change convention later
     if (dshape.ndim() == 2 && dshape[1] == 1) {


### PR DESCRIPTION
## Description ##
This PR intends to cherry pick #15620 from the master branch to v1.5.x branch to fix issue https://github.com/apache/incubator-mxnet/issues/15784

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
