### PR TITLE
[v1.5.x] prevent TRT_Logger to be destroyed before TRT engine (#14898)

### DIFF
--- a/src/operator/subgraph/tensorrt/onnx_to_tensorrt.h
+++ b/src/operator/subgraph/tensorrt/onnx_to_tensorrt.h
@@ -32,6 +32,7 @@
 #include <NvInfer.h>
 
 #include <fstream>
+#include <memory>
 #include <iostream>
 #include <sstream>
 #include <string>
@@ -40,33 +41,51 @@
 
 namespace onnx_to_tensorrt {
 
-class TRT_Logger : public nvinfer1::ILogger {
-        nvinfer1::ILogger::Severity _verbosity;
-        std::ostream* _ostream;
- public:
-        TRT_Logger(Severity verbosity = Severity::kWARNING,
-                   std::ostream& ostream = std::cout)
-                : _verbosity(verbosity), _ostream(&ostream) {}
-        void log(Severity severity, const char* msg) override {
-                if ( severity <= _verbosity ) {
-                        time_t rawtime = std::time(0);
-                        char buf[256];
-                        strftime(&buf[0], 256,
-                                 "%Y-%m-%d %H:%M:%S",
-                                 std::gmtime(&rawtime));
-                        const char* sevstr = (severity == Severity::kINTERNAL_ERROR ? "    BUG" :
-                                              severity == Severity::kERROR          ? "  ERROR" :
-                                              severity == Severity::kWARNING        ? "WARNING" :
-                                              severity == Severity::kINFO           ? "   INFO" :
-                                              "UNKNOWN");
-                        (*_ostream) << "[" << buf << " " << sevstr << "] "
-                                    << msg
-                                    << std::endl;
-                }
-        }
+struct InferDeleter {
+  template<typename T>
+    void operator()(T* obj) const {
+      if ( obj ) {
+        obj->destroy();
+      }
+    }
 };
 
-std::tuple<nvinfer1::ICudaEngine*, nvonnxparser::IParser*> onnxToTrtCtx(
+template<typename T>
+using unique_ptr = std::unique_ptr<T, InferDeleter>;
+
+template<typename T>
+inline unique_ptr<T> InferObject(T* obj) {
+  if ( !obj ) {
+    throw std::runtime_error("Failed to create object");
+  }
+  return unique_ptr<T>(obj, InferDeleter());
+}
+
+class TRT_Logger : public nvinfer1::ILogger {
+  nvinfer1::ILogger::Severity _verbosity;
+  std::ostream* _ostream;
+ public:
+  TRT_Logger(Severity verbosity = Severity::kWARNING,
+             std::ostream& ostream = std::cout) :
+               _verbosity(verbosity), _ostream(&ostream) {}
+  void log(Severity severity, const char* msg) override {
+    if (severity <= _verbosity) {
+      time_t rawtime = std::time(0);
+      char buf[256];
+      strftime(&buf[0], 256, "%Y-%m-%d %H:%M:%S", std::gmtime(&rawtime));
+      const char* sevstr = (severity == Severity::kINTERNAL_ERROR ? "    BUG" :
+                            severity == Severity::kERROR          ? "  ERROR" :
+                            severity == Severity::kWARNING        ? "WARNING" :
+                            severity == Severity::kINFO           ? "   INFO" :
+                            "UNKNOWN");
+      (*_ostream) << "[" << buf << " " << sevstr << "] " << msg << std::endl;
+    }
+  }
+};
+
+std::tuple<unique_ptr<nvinfer1::ICudaEngine>,
+           unique_ptr<nvonnxparser::IParser>,
+           std::unique_ptr<TRT_Logger> > onnxToTrtCtx(
         const std::string& onnx_model,
         int32_t max_batch_size = 32,
         size_t max_workspace_size = 1L << 30,
@@ -75,5 +94,4 @@ std::tuple<nvinfer1::ICudaEngine*, nvonnxparser::IParser*> onnxToTrtCtx(
 }  // namespace onnx_to_tensorrt
 
 #endif  // MXNET_USE_TENSORRT
-
 #endif  // MXNET_OPERATOR_SUBGRAPH_TENSORRT_ONNX_TO_TENSORRT_H_

--- a/src/operator/subgraph/tensorrt/tensorrt-inl.h
+++ b/src/operator/subgraph/tensorrt/tensorrt-inl.h
@@ -51,10 +51,14 @@ struct TRTParam {
 };
 
 struct TRTEngineParam {
-  TRTEngineParam(nvinfer1::ICudaEngine* trt_engine,
-                 nvonnxparser::IParser* _parser,
-                 const std::unordered_map<std::string, uint32_t> input_map,
-                 const std::unordered_map<std::string, uint32_t> output_map) {
+  TRTEngineParam(onnx_to_tensorrt::unique_ptr<nvinfer1::ICudaEngine> _trt_engine,
+                 onnx_to_tensorrt::unique_ptr<nvonnxparser::IParser> _trt_parser,
+                 std::unique_ptr<onnx_to_tensorrt::TRT_Logger> _trt_logger,
+                 const std::unordered_map<std::string, uint32_t>& input_map,
+                 const std::unordered_map<std::string, uint32_t>& output_map) {
+    trt_engine = std::move(_trt_engine);
+    trt_logger = std::move(_trt_logger);
+    trt_parser = std::move(_trt_parser);
     binding_order = std::make_shared<std::vector<std::pair<uint32_t, bool> > >();
     bindings = std::make_shared<std::vector<void*> >();
     binding_order->reserve(trt_engine->getNbBindings());
@@ -67,16 +71,13 @@ struct TRTEngineParam {
         binding_order->emplace_back(output_map.at(binding_name), false);
       }
     }
-    trt_executor = trt_engine->createExecutionContext();
-    trt_parser = _parser;
+    trt_executor = onnx_to_tensorrt::InferObject(trt_engine->createExecutionContext());
   }
 
-  ~TRTEngineParam() {
-    trt_parser->destroy();
-    trt_executor->destroy();
-  }
-  nvinfer1::IExecutionContext* trt_executor;
-  nvonnxparser::IParser* trt_parser;
+  onnx_to_tensorrt::unique_ptr<nvinfer1::ICudaEngine> trt_engine;
+  onnx_to_tensorrt::unique_ptr<nvinfer1::IExecutionContext> trt_executor;
+  onnx_to_tensorrt::unique_ptr<nvonnxparser::IParser> trt_parser;
+  std::unique_ptr<onnx_to_tensorrt::TRT_Logger> trt_logger;
   std::shared_ptr<std::vector<std::pair<uint32_t, bool> > > binding_order;
   std::shared_ptr<std::vector<void*> > bindings;
 };

--- a/src/operator/subgraph/tensorrt/tensorrt.cc
+++ b/src/operator/subgraph/tensorrt/tensorrt.cc
@@ -312,7 +312,9 @@ OpStatePtr TRTCreateState(const nnvm::NodeAttrs& attrs, Context ctx,
   graph.attrs["shape"]        = std::make_shared<nnvm::any>(std::move(shapes));
   auto onnx_graph = op::nnvm_to_onnx::ConvertNnvmGraphToOnnx(graph, &params_map);
   auto trt_tuple = ::onnx_to_tensorrt::onnxToTrtCtx(onnx_graph, max_batch_size, 1 << 30);
-  return OpStatePtr::Create<TRTEngineParam>(std::get<0>(trt_tuple), std::get<1>(trt_tuple),
+  return OpStatePtr::Create<TRTEngineParam>(std::move(std::get<0>(trt_tuple)),
+                                            std::move(std::get<1>(trt_tuple)),
+                                            std::move(std::get<2>(trt_tuple)),
                                             inputs_to_idx, outputs_to_idx);
 }
 


### PR DESCRIPTION
## Description ##
prevent TRT_Logger to be destroyed before TRT engine

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:

### Changes ###
- add TRT_Logger in TRTEngineParam
- delete TRT_Logger when TRTEngineParam

## Comments ##
- Correct a bug that is exposed when using CUDA 10.1
