### PR TITLE
Adding tests and C APIs for Large Tensors

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -734,6 +734,7 @@ MXNET_DLL int MXNDArraySyncCopyFromCPU(NDArrayHandle handle,
 MXNET_DLL int MXNDArraySyncCopyToCPU(NDArrayHandle handle,
                                      void *data,
                                      size_t size);
+
 /*!
  * \brief Copy src.data() to dst.data() if i = -1, else dst.aux_data(i) if i >= 0
  * This function blocks. Do not use it in performance critical code.
@@ -790,6 +791,11 @@ MXNET_DLL int MXNDArraySlice(NDArrayHandle handle,
                              mx_uint slice_end,
                              NDArrayHandle *out);
 
+MXNET_DLL int MXNDArraySlice64(NDArrayHandle handle,
+                               int64_t slice_begin,
+                               int64_t slice_end,
+                               NDArrayHandle *out);
+
 /*!
  * \brief Index the NDArray along axis 0.
  * \param handle the handle to the NDArray
@@ -800,6 +806,10 @@ MXNET_DLL int MXNDArraySlice(NDArrayHandle handle,
 MXNET_DLL int MXNDArrayAt(NDArrayHandle handle,
                           mx_uint idx,
                           NDArrayHandle *out);
+
+MXNET_DLL int MXNDArrayAt64(NDArrayHandle handle,
+                            int64_t idx,
+                            NDArrayHandle *out);
 
 /*!
  * \brief get the storage type of the array

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -451,21 +451,46 @@ int MXNDArrayFree(NDArrayHandle handle) {
   API_END();
 }
 
+template<typename dtype>
+void SliceArray(NDArrayHandle handle, dtype slice_begin, dtype slice_end, NDArray* ptr,
+                NDArrayHandle* out) {
+  *ptr = static_cast<NDArray*>(handle)->SliceWithRecord(slice_begin, slice_end);
+  *out = ptr;
+}
+
 int MXNDArraySlice(NDArrayHandle handle,
                    mx_uint slice_begin,
                    mx_uint slice_end,
                    NDArrayHandle *out) {
   NDArray *ptr = new NDArray();
   API_BEGIN();
-  *ptr = static_cast<NDArray*>(handle)->SliceWithRecord(
-      slice_begin, slice_end);
-  *out = ptr;
+  SliceArray<uint32_t>(handle, slice_begin, slice_end, ptr, out);
+  API_END_HANDLE_ERROR(delete ptr);
+}
+
+int MXNDArraySlice64(NDArrayHandle handle,
+                     int64_t slice_begin,
+                     int64_t slice_end,
+                     NDArrayHandle *out) {
+  NDArray *ptr = new NDArray();
+  API_BEGIN();
+  SliceArray<int64_t>(handle, slice_begin, slice_end, ptr, out);
   API_END_HANDLE_ERROR(delete ptr);
 }
 
 int MXNDArrayAt(NDArrayHandle handle,
-                mx_uint idx,
+                uint32_t idx,
                 NDArrayHandle *out) {
+  NDArray *ptr = new NDArray();
+  API_BEGIN();
+  *ptr = static_cast<NDArray*>(handle)->AtWithRecord(idx);
+  *out = ptr;
+  API_END_HANDLE_ERROR(delete ptr);
+}
+
+int MXNDArrayAt64(NDArrayHandle handle,
+                  int64_t idx,
+                  NDArrayHandle *out) {
   NDArray *ptr = new NDArray();
   API_BEGIN();
   *ptr = static_cast<NDArray*>(handle)->AtWithRecord(idx);

--- a/src/operator/tensor/dot-inl.h
+++ b/src/operator/tensor/dot-inl.h
@@ -91,7 +91,7 @@ void DotForward_(const nnvm::NodeAttrs& attrs,
                 inputs[0].get<xpu, 1, DType>(s),
                 inputs[1].get<xpu, 1, DType>(s));
     } else {
-      int ma, na, mb, nb, m, n;
+      index_t ma, na, mb, nb, m, n;
       if (param.transpose_a) {
         ma = inputs[0].size(0);
         na = inputs[0].Size()/ma;

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -19,7 +19,7 @@ import math
 import numpy as np
 import mxnet as mx
 
-from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, default_context
+from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, default_context, check_symbolic_forward
 from mxnet import gluon, nd
 from tests.python.unittest.common import with_seed
 
@@ -889,6 +889,320 @@ def test_rpow():
     c = c.__rpow__(a)
     assert c[0][-1] == 8
     assert c.shape == a.shape
+
+
+def test_shape():
+    b = create_2d_tensor(rows=SMALL_Y, columns=LARGE_X)
+    mx.nd.waitall()
+    assert b.shape == (SMALL_Y, LARGE_X)
+
+
+def test_size():
+    b = create_2d_tensor(rows=SMALL_Y, columns=LARGE_X)
+    mx.nd.waitall()
+    assert b.size == LARGE_SIZE
+
+
+def test_copy():
+    a = nd.ones((SMALL_Y, LARGE_X))
+    b = a.copy()
+    nd.waitall()
+    assert b.shape == a.shape
+    assert b.size == LARGE_SIZE
+
+
+def test_copy_to():
+    a = create_2d_tensor(rows=SMALL_Y, columns=LARGE_X)
+    b = nd.array(np.zeros((SMALL_Y, LARGE_X)))
+    c = a.copyto(b)
+    assert c is b
+    print(b)
+    assert b[0][-1] == LARGE_X-1
+
+
+def test_zeros_like():
+    a = nd.array(np.ones((SMALL_Y, LARGE_X)))
+    b = nd.zeros_like(a)
+    assert b[-1][-1] == 0
+    assert b.shape == a.shape
+
+
+def test_ones_like():
+    a = nd.array(np.zeros((SMALL_Y, LARGE_X)))
+    b = nd.ones_like(a)
+    assert b[-1][-1] == 1
+    assert b.shape == a.shape
+
+
+def test_reshape_like():
+    a = nd.array(np.zeros((SMALL_Y, LARGE_X)))
+    b = nd.array(np.zeros((SMALL_Y//2, LARGE_X*2)))
+    c = nd.reshape_like(a, b)
+    assert c.shape == (SMALL_Y//2, LARGE_X*2)
+
+
+def test_flatten():
+    a = create_2d_tensor(rows=LARGE_X, columns=SMALL_Y).reshape((LARGE_X//2, 2, SMALL_Y))
+    b = nd.flatten(a)
+    assert b[-1][-1] == (LARGE_X-1)
+    assert b[-1][0] == (LARGE_X-2)
+    assert b.shape == (LARGE_X//2, SMALL_Y*2)
+
+
+def test_expand_dims():
+    a = nd.array(np.ones((SMALL_Y, LARGE_X)))
+    b = nd.expand_dims(a, axis=1)
+    nd.waitall()
+    assert b.shape == (SMALL_Y, 1, LARGE_X)
+
+
+def test_concat():
+    a = nd.array(np.ones((SMALL_Y, LARGE_X)))
+    b = nd.array(np.zeros((SMALL_Y, LARGE_X)))
+    c = nd.concat(a,b, dim=0)
+    assert c.shape == (b.shape[0]*2, LARGE_X)
+
+
+def test_stack():
+    a = nd.array(np.ones((SMALL_Y, LARGE_X)))
+    b = nd.array(np.zeros((SMALL_Y, LARGE_X)))
+    c = nd.stack(a,b, axis=1)
+    assert c.shape == (b.shape[0], 2, LARGE_X)
+
+
+def test_broadcast_axes():
+    a = create_2d_tensor(rows=1, columns=LARGE_X)
+    b = nd.broadcast_axis(a, axis=[0], size=2)
+    assert b.shape == (a.shape[0]*2, a.shape[1])
+
+
+def test_sum():
+    a = nd.array(np.ones((SMALL_Y, LARGE_X)))
+    b = nd.sum(a, axis=1)
+    assert b.shape[0] == SMALL_Y
+
+
+def test_prod():
+    a = nd.array(np.ones((SMALL_Y, LARGE_X)))
+    b = nd.prod(a, axis=1)
+    assert b.shape[0] == SMALL_Y
+
+
+def test_mean():
+    a = create_2d_tensor(rows=SMALL_Y, columns=LARGE_X)
+    b = nd.mean(a, axis=0)
+    assert b[0] == (SMALL_Y/2-1)
+
+
+def test_min():
+    a = create_2d_tensor(rows=SMALL_Y, columns=LARGE_X)
+    b = nd.min(a, axis=0)
+    assert b[0] == 0
+    assert b[-1] == 0
+
+
+def test_max():
+    a = create_2d_tensor(rows=SMALL_Y, columns=LARGE_X)
+    b = nd.max(a, axis=0)
+    assert b[0] == (SMALL_Y-1)
+    assert b[-1] == (SMALL_Y-1)
+
+
+def test_norm():
+    a = np.array(np.full((1, LARGE_X), 3))
+    b = np.array(np.full((1, LARGE_X), 4))
+    c = nd.array(np.concatenate((a,b), axis=0))
+    d = nd.norm(c, ord=2, axis=0)
+    e = nd.norm(c, ord=1, axis=0)
+    assert d.shape[0] == LARGE_X
+    assert e.shape[0] == LARGE_X
+    assert d[-1] == 5
+    assert e[-1] == 7
+
+
+def test_argmax():
+    a = np.ones((SMALL_Y, LARGE_X))
+    b = np.zeros((SMALL_Y, LARGE_X))
+    c = nd.array(np.concatenate((a,b), axis=0))
+    d = nd.argmax(c, axis=0)
+    assert d.shape[0] == LARGE_X
+    assert d[-1] == d[0] == 0
+
+
+def test_relu():
+    def frelu(x):
+        return np.maximum(x, 0.0)
+    def frelu_grad(x):
+        return 1.0 * (x > 0.0)
+    shape = (SMALL_Y, LARGE_X)
+    x = mx.symbol.Variable("x")
+    y = mx.sym.relu(x)
+    xa = np.random.uniform(low=-1.0,high=1.0,size=shape)
+    eps = 1e-4
+    xa[abs(xa) < eps] = 1.0
+    ya = frelu(xa)
+    ga = frelu_grad(xa)
+    check_symbolic_forward(y, [xa], [ya])
+
+
+def test_sigmoid():
+    def fsigmoid(a):
+        return np.divide(1.0, (1.0 + np.exp(-a)))
+    shape = (SMALL_Y, LARGE_X)
+    x = mx.symbol.Variable("x")
+    y = mx.sym.sigmoid(x)
+    xa = np.random.uniform(low=-1.0,high=1.0,size=shape)
+    ya = fsigmoid(xa)
+    check_symbolic_forward(y, [xa], [ya])
+
+
+def np_softmax(x, axis=-1, temperature=1.0):
+    x = x - np.max(x, axis=axis, keepdims=True)
+    x = np.exp(x/temperature)
+    x /= np.sum(x, axis=axis, keepdims=True)
+    return x
+
+
+def test_log_softmax():
+    ndim = 2
+    shape = (SMALL_Y, LARGE_X)
+    axis = np.random.randint(0, ndim)
+    data = np.random.uniform(-2, 2, size=shape)
+    sym = mx.sym.log_softmax(axis=axis-ndim)
+    check_symbolic_forward(sym, [data], [np.log(np_softmax(data, axis=axis)+1e-20)])
+
+
+def test_iadd():
+    a = nd.array(np.ones((SMALL_Y, LARGE_X)))
+    b = nd.array(np.ones((SMALL_Y, LARGE_X)))
+    c = b
+    c += a
+    assert c.shape == a.shape
+    assert c[0][-1] == 2
+
+
+def test_isub():
+    a = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 3)))
+    b = nd.array(np.ones((SMALL_Y, LARGE_X)))
+    c = a
+    c -= b
+    assert c.shape == a.shape
+    assert c[0][-1] == 2
+
+
+def test_imul():
+    a = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 3)))
+    b = nd.array(np.ones((SMALL_Y, LARGE_X)))
+    c = b
+    c *= a
+    assert c.shape == a.shape
+    assert c[0][-1] == 3
+
+
+def test_idiv():
+    a = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 4)))
+    b = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 2)))
+    c = a
+    c /= b
+    assert c.shape == a.shape
+    assert c[0][-1] == 2
+
+
+def test_imod():
+    a = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 3)))
+    b = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 2)))
+    c = a
+    c %= b
+    assert c.shape == a.shape
+    assert c[0][-1] == 1
+
+
+def test_eq():
+    a = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 3)))
+    b = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 3)))
+    c = (a == b)
+    assert np.sum(c[0].asnumpy() == 1).all()
+
+
+def test_neq():
+    a = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 2)))
+    b = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 3)))
+    c = (a != b)
+    assert np.sum(c[0].asnumpy() == 1).all()
+
+
+def test_lt():
+    a = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 2)))
+    b = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 3)))
+    d = (a <= b)
+    assert np.sum(d[0].asnumpy() == 1).all()
+
+
+def test_lte():
+    a = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 2)))
+    b = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 3)))
+    c = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 2)))
+    d = (a <= b)
+    e = (a <= c)
+    assert np.sum(d[0].asnumpy() == 1).all()
+    assert np.sum(e[0].asnumpy() == 1).all()
+
+
+def test_gt():
+    a = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 3)))
+    b = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 2)))
+    d = (a >= b)
+    assert np.sum(d[0].asnumpy() == 1).all()
+
+
+def test_gte():
+    a = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 3)))
+    b = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 2)))
+    c = nd.array(np.array(np.full((SMALL_Y, LARGE_X), 3)))
+    d = (a >= b)
+    e = (a >= c)
+    assert np.sum(d[0].asnumpy() == 1).all()
+    assert np.sum(e[0].asnumpy() == 1).all()
+
+
+def test_slice_like():
+    a = create_2d_tensor(rows=SMALL_Y, columns=LARGE_X)
+    b = nd.array(np.ones((SMALL_Y//2, LARGE_X//2)))
+    c = nd.slice_like(a, b)
+    d = nd.slice_like(a, b, axes=(0))
+    e = nd.slice_like(a, b, axes=(-1))
+    assert c.shape == b.shape
+    assert d.shape[0] == b.shape[0]
+    assert e.shape[-1] == b.shape[-1]
+    assert c[0][-1] == 0
+    assert d[-1][0] == (SMALL_Y//2-1)
+    assert e[-1][-1] == (SMALL_Y-1)
+
+
+def test_slice_axis():
+    a = create_2d_tensor(rows=SMALL_Y, columns=LARGE_X)
+    c = nd.slice_axis(a, axis=0, begin=0, end=SMALL_Y//2)
+    d = nd.slice_axis(a, axis=1, begin=0, end=LARGE_X//2)
+    assert c.shape[0] == a.shape[0]//2
+    assert d.shape[1] == a.shape[1]//2
+    assert c[-1][0] == (SMALL_Y//2-1)
+    assert d[-1][-1] == (SMALL_Y-1)
+
+
+def test_one_hot():
+    a = nd.array(np.zeros(SMALL_Y))
+    a[0] = 1
+    a[-1] = 1
+    b = nd.one_hot(a, LARGE_X)
+    b[0][1] == 1
+    b[-1][1] == 1
+
+
+def test_full():
+    a = nd.full((SMALL_Y, LARGE_X), 3)
+    assert a.shape == (SMALL_Y, LARGE_X)
+    assert a[SMALL_Y//2][LARGE_X//2] == 3
+    assert a[-1][-1] == 3
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
Added new tests to verify support for Large Tensors and new C_Apis to support 64bit indexing 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
