### PR TITLE
Typedef cleanup

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -55,11 +55,9 @@ extern "C" {
 #endif
 
 /*! \brief manually define unsigned int */
-typedef uint32_t uint32_t;
-/*! \brief manually define 64-bit int */
-typedef int64_t int64_t;
+typedef uint32_t mx_uint;
 /*! \brief manually define float */
-typedef float float;
+typedef float mx_float;
 /*! \brief data type to store dim size */
 typedef int64_t dim_t;
 // all the handles are simply void *

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -57,7 +57,7 @@ extern "C" {
 /*! \brief manually define unsigned int */
 typedef uint32_t uint32_t;
 /*! \brief manually define 64-bit int */
-typedef int64_t mx_int64;
+typedef int64_t int64_t;
 /*! \brief manually define float */
 typedef float mx_float;
 /*! \brief data type to store dim size */
@@ -574,7 +574,7 @@ MXNET_DLL int MXNDArrayCreateEx(const uint32_t *shape,
                               int dtype,
                               NDArrayHandle *out);
 
-MXNET_DLL int MXNDArrayCreateEx64(const mx_int64 *shape,
+MXNET_DLL int MXNDArrayCreateEx64(const int64_t *shape,
                                   int ndim,
                                   int dev_type,
                                   int dev_id,
@@ -613,7 +613,7 @@ MXNET_DLL int MXNDArrayCreateSparseEx(int storage_type,
                                       NDArrayHandle *out);
 
 MXNET_DLL int MXNDArrayCreateSparseEx64(int storage_type,
-                                        const mx_int64 *shape,
+                                        const int64_t *shape,
                                         int ndim,
                                         int dev_type,
                                         int dev_id,
@@ -622,7 +622,7 @@ MXNET_DLL int MXNDArrayCreateSparseEx64(int storage_type,
                                         uint32_t num_aux,
                                         int *aux_type,
                                         int *aux_ndims,
-                                        const mx_int64 *aux_shape,
+                                        const int64_t *aux_shape,
                                         NDArrayHandle *out);
 
 /*!
@@ -673,9 +673,9 @@ MXNET_DLL int MXNDArrayLoad(const char* fname,
                             const char*** out_names);
 
 MXNET_DLL int MXNDArrayLoad64(const char* fname,
-                              mx_int64 *out_size,
+                              int64_t *out_size,
                               NDArrayHandle** out_arr,
-                              mx_int64 *out_name_size,
+                              int64_t *out_name_size,
                               const char*** out_names);
 
 /*!
@@ -701,9 +701,9 @@ MXNET_DLL int MXNDArrayLoadFromBuffer(const void *ndarray_buffer,
 
 MXNET_DLL int MXNDArrayLoadFromBuffer64(const void *ndarray_buffer,
                                         size_t size,
-                                        mx_int64 *out_size,
+                                        int64_t *out_size,
                                         NDArrayHandle** out_arr,
-                                        mx_int64 *out_name_size,
+                                        int64_t *out_name_size,
                                         const char*** out_names);
 
 /*!
@@ -872,7 +872,7 @@ MXNET_DLL int MXNDArrayGetShapeEx(NDArrayHandle handle,
 
 MXNET_DLL int MXNDArrayGetShapeEx64(NDArrayHandle handle,
                                     int *out_dim,
-                                    const mx_int64 **out_pdata);
+                                    const int64_t **out_pdata);
 
 /*!
  * \brief get the content of the data in NDArray
@@ -958,7 +958,7 @@ MXNET_DLL int MXNDArrayGetAuxType(NDArrayHandle handle,
                                   int *out_type);
 
 MXNET_DLL int MXNDArrayGetAuxType64(NDArrayHandle handle,
-                                    mx_int64 i,
+                                    int64_t i,
                                     int *out_type);
 
 /*!
@@ -971,7 +971,7 @@ MXNET_DLL int MXNDArrayGetAuxNDArray(NDArrayHandle handle,
                                      NDArrayHandle *out);
 
 MXNET_DLL int MXNDArrayGetAuxNDArray64(NDArrayHandle handle,
-                                       mx_int64 i,
+                                       int64_t i,
                                        NDArrayHandle *out);
 
 /*!
@@ -1652,17 +1652,17 @@ MXNET_DLL int MXSymbolInferShape(SymbolHandle sym,
 MXNET_DLL int MXSymbolInferShape64(SymbolHandle sym,
                                    uint32_t num_args,
                                    const char** keys,
-                                   const mx_int64 *arg_ind_ptr,
-                                   const mx_int64 *arg_shape_data,
+                                   const int64_t *arg_ind_ptr,
+                                   const int64_t *arg_shape_data,
                                    size_t *in_shape_size,
                                    const int **in_shape_ndim,
-                                   const mx_int64 ***in_shape_data,
+                                   const int64_t ***in_shape_data,
                                    size_t *out_shape_size,
                                    const int **out_shape_ndim,
-                                   const mx_int64 ***out_shape_data,
+                                   const int64_t ***out_shape_data,
                                    size_t *aux_shape_size,
                                    const int **aux_shape_ndim,
-                                   const mx_int64 ***aux_shape_data,
+                                   const int64_t ***aux_shape_data,
                                    int *complete);
 
 /*!
@@ -1706,17 +1706,17 @@ MXNET_DLL int MXSymbolInferShapeEx(SymbolHandle sym,
 MXNET_DLL int MXSymbolInferShapeEx64(SymbolHandle sym,
                                      uint32_t num_args,
                                      const char** keys,
-                                     const mx_int64 *arg_ind_ptr,
-                                     const mx_int64 *arg_shape_data,
+                                     const int64_t *arg_ind_ptr,
+                                     const int64_t *arg_shape_data,
                                      size_t *in_shape_size,
                                      const int **in_shape_ndim,
-                                     const mx_int64 ***in_shape_data,
+                                     const int64_t ***in_shape_data,
                                      size_t *out_shape_size,
                                      const int **out_shape_ndim,
-                                     const mx_int64 ***out_shape_data,
+                                     const int64_t ***out_shape_data,
                                      size_t *aux_shape_size,
                                      const int **aux_shape_ndim,
-                                     const mx_int64 ***aux_shape_data,
+                                     const int64_t ***aux_shape_data,
                                      int *complete);
 
 /*!
@@ -1763,17 +1763,17 @@ MXNET_DLL int MXSymbolInferShapePartial(SymbolHandle sym,
 MXNET_DLL int MXSymbolInferShapePartial64(SymbolHandle sym,
                                           uint32_t num_args,
                                           const char** keys,
-                                          const mx_int64 *arg_ind_ptr,
-                                          const mx_int64 *arg_shape_data,
+                                          const int64_t *arg_ind_ptr,
+                                          const int64_t *arg_shape_data,
                                           size_t *in_shape_size,
                                           const int **in_shape_ndim,
-                                          const mx_int64 ***in_shape_data,
+                                          const int64_t ***in_shape_data,
                                           size_t *out_shape_size,
                                           const int **out_shape_ndim,
-                                          const mx_int64 ***out_shape_data,
+                                          const int64_t ***out_shape_data,
                                           size_t *aux_shape_size,
                                           const int **aux_shape_ndim,
-                                          const mx_int64 ***aux_shape_data,
+                                          const int64_t ***aux_shape_data,
                                           int *complete);
 
 /*!
@@ -1819,17 +1819,17 @@ MXNET_DLL int MXSymbolInferShapePartialEx(SymbolHandle sym,
 MXNET_DLL int MXSymbolInferShapePartialEx64(SymbolHandle sym,
                                             uint32_t num_args,
                                             const char** keys,
-                                            const mx_int64 *arg_ind_ptr,
-                                            const mx_int64 *arg_shape_data,
+                                            const int64_t *arg_ind_ptr,
+                                            const int64_t *arg_shape_data,
                                             size_t *in_shape_size,
                                             const int **in_shape_ndim,
-                                            const mx_int64 ***in_shape_data,
+                                            const int64_t ***in_shape_data,
                                             size_t *out_shape_size,
                                             const int **out_shape_ndim,
-                                            const mx_int64 ***out_shape_data,
+                                            const int64_t ***out_shape_data,
                                             size_t *aux_shape_size,
                                             const int **aux_shape_ndim,
-                                            const mx_int64 ***aux_shape_data,
+                                            const int64_t ***aux_shape_data,
                                             int *complete);
 
 /*!

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -55,7 +55,7 @@ extern "C" {
 #endif
 
 /*! \brief manually define unsigned int */
-typedef uint32_t mx_uint;
+typedef uint32_t uint32_t;
 /*! \brief manually define 64-bit int */
 typedef int64_t mx_int64;
 /*! \brief manually define float */
@@ -547,8 +547,8 @@ MXNET_DLL int MXNDArrayCreateNone(NDArrayHandle *out);
  * \param out the returning handle
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXNDArrayCreate(const mx_uint *shape,
-                              mx_uint ndim,
+MXNET_DLL int MXNDArrayCreate(const uint32_t *shape,
+                              uint32_t ndim,
                               int dev_type,
                               int dev_id,
                               int delay_alloc,
@@ -566,8 +566,8 @@ MXNET_DLL int MXNDArrayCreate(const mx_uint *shape,
  * \param out the returning handle
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXNDArrayCreateEx(const mx_uint *shape,
-                              mx_uint ndim,
+MXNET_DLL int MXNDArrayCreateEx(const uint32_t *shape,
+                              uint32_t ndim,
                               int dev_type,
                               int dev_id,
                               int delay_alloc,
@@ -600,16 +600,16 @@ MXNET_DLL int MXNDArrayCreateEx64(const mx_int64 *shape,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArrayCreateSparseEx(int storage_type,
-                                      const mx_uint *shape,
-                                      mx_uint ndim,
+                                      const uint32_t *shape,
+                                      uint32_t ndim,
                                       int dev_type,
                                       int dev_id,
                                       int delay_alloc,
                                       int dtype,
-                                      mx_uint num_aux,
+                                      uint32_t num_aux,
                                       int *aux_type,
-                                      mx_uint *aux_ndims,
-                                      const mx_uint *aux_shape,
+                                      uint32_t *aux_ndims,
+                                      const uint32_t *aux_shape,
                                       NDArrayHandle *out);
 
 MXNET_DLL int MXNDArrayCreateSparseEx64(int storage_type,
@@ -619,7 +619,7 @@ MXNET_DLL int MXNDArrayCreateSparseEx64(int storage_type,
                                         int dev_id,
                                         int delay_alloc,
                                         int dtype,
-                                        mx_uint num_aux,
+                                        uint32_t num_aux,
                                         int *aux_type,
                                         int *aux_ndims,
                                         const mx_int64 *aux_shape,
@@ -654,7 +654,7 @@ MXNET_DLL int MXNDArraySaveRawBytes(NDArrayHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArraySave(const char* fname,
-                            mx_uint num_args,
+                            uint32_t num_args,
                             NDArrayHandle* args,
                             const char** keys);
 /*!
@@ -667,9 +667,9 @@ MXNET_DLL int MXNDArraySave(const char* fname,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArrayLoad(const char* fname,
-                            mx_uint *out_size,
+                            uint32_t *out_size,
                             NDArrayHandle** out_arr,
-                            mx_uint *out_name_size,
+                            uint32_t *out_name_size,
                             const char*** out_names);
 
 MXNET_DLL int MXNDArrayLoad64(const char* fname,
@@ -694,9 +694,9 @@ MXNET_DLL int MXNDArrayLoad64(const char* fname,
  */
 MXNET_DLL int MXNDArrayLoadFromBuffer(const void *ndarray_buffer,
                                       size_t size,
-                                      mx_uint *out_size,
+                                      uint32_t *out_size,
                                       NDArrayHandle** out_arr,
-                                      mx_uint *out_name_size,
+                                      uint32_t *out_name_size,
                                       const char*** out_names);
 
 MXNET_DLL int MXNDArrayLoadFromBuffer64(const void *ndarray_buffer,
@@ -787,8 +787,8 @@ MXNET_DLL int MXNDArrayFree(NDArrayHandle handle);
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArraySlice(NDArrayHandle handle,
-                             mx_uint slice_begin,
-                             mx_uint slice_end,
+                             uint32_t slice_begin,
+                             uint32_t slice_end,
                              NDArrayHandle *out);
 
 MXNET_DLL int MXNDArraySlice64(NDArrayHandle handle,
@@ -804,7 +804,7 @@ MXNET_DLL int MXNDArraySlice64(NDArrayHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArrayAt(NDArrayHandle handle,
-                          mx_uint idx,
+                          uint32_t idx,
                           NDArrayHandle *out);
 
 MXNET_DLL int MXNDArrayAt64(NDArrayHandle handle,
@@ -852,8 +852,8 @@ MXNET_DLL int MXNDArrayReshape64(NDArrayHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArrayGetShape(NDArrayHandle handle,
-                                mx_uint *out_dim,
-                                const mx_uint **out_pdata);
+                                uint32_t *out_dim,
+                                const uint32_t **out_pdata);
 
 MXNET_DLL int MXNDArrayGetShape64(NDArrayHandle handle,
                                   int *out_dim,
@@ -954,7 +954,7 @@ MXNET_DLL int MXNDArrayGetDType(NDArrayHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArrayGetAuxType(NDArrayHandle handle,
-                                  mx_uint i,
+                                  uint32_t i,
                                   int *out_type);
 
 MXNET_DLL int MXNDArrayGetAuxType64(NDArrayHandle handle,
@@ -967,7 +967,7 @@ MXNET_DLL int MXNDArrayGetAuxType64(NDArrayHandle handle,
  * This function blocks. Do not use it in performance critical code.
  */
 MXNET_DLL int MXNDArrayGetAuxNDArray(NDArrayHandle handle,
-                                     mx_uint i,
+                                     uint32_t i,
                                      NDArrayHandle *out);
 
 MXNET_DLL int MXNDArrayGetAuxNDArray64(NDArrayHandle handle,
@@ -1027,7 +1027,7 @@ MXNET_DLL int MXNDArrayGetGradState(NDArrayHandle handle, int *out);
  * \param out_array the output function array
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXListFunctions(mx_uint *out_size,
+MXNET_DLL int MXListFunctions(uint32_t *out_size,
                               FunctionHandle **out_array);
 
 /*!
@@ -1053,7 +1053,7 @@ MXNET_DLL int MXGetFunction(const char *name,
 MXNET_DLL int MXFuncGetInfo(FunctionHandle fun,
                             const char **name,
                             const char **description,
-                            mx_uint *num_args,
+                            uint32_t *num_args,
                             const char ***arg_names,
                             const char ***arg_type_infos,
                             const char ***arg_descriptions,
@@ -1069,9 +1069,9 @@ MXNET_DLL int MXFuncGetInfo(FunctionHandle fun,
  * \sa MXFuncInvoke
  */
 MXNET_DLL int MXFuncDescribe(FunctionHandle fun,
-                             mx_uint *num_use_vars,
-                             mx_uint *num_scalars,
-                             mx_uint *num_mutate_vars,
+                             uint32_t *num_use_vars,
+                             uint32_t *num_scalars,
+                             uint32_t *num_mutate_vars,
                              int *type_mask);
 /*!
  * \brief invoke a function, the array size of passed in arguments
@@ -1194,9 +1194,9 @@ MXNET_DLL int MXSetIsNumpyShape(int is_np_shape, int* prev);
  * \param var_handles variable NDArrays
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXAutogradMarkVariables(mx_uint num_var,
+MXNET_DLL int MXAutogradMarkVariables(uint32_t num_var,
                                       NDArrayHandle *var_handles,
-                                      mx_uint *reqs_array,
+                                      uint32_t *reqs_array,
                                       NDArrayHandle *grad_handles);
 /*!
  * \brief compute the gradient of outputs w.r.t variabels
@@ -1204,7 +1204,7 @@ MXNET_DLL int MXAutogradMarkVariables(mx_uint num_var,
  * \param output_handles output NDArrays
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXAutogradComputeGradient(mx_uint num_output,
+MXNET_DLL int MXAutogradComputeGradient(uint32_t num_output,
                                         NDArrayHandle* output_handles);
 /*!
  * \brief compute the gradient of outputs w.r.t variabels
@@ -1214,7 +1214,7 @@ MXNET_DLL int MXAutogradComputeGradient(mx_uint num_output,
  * \param retain_graph whether to keep the graph after backward
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXAutogradBackward(mx_uint num_output,
+MXNET_DLL int MXAutogradBackward(uint32_t num_output,
                                  NDArrayHandle* output_handles,
                                  NDArrayHandle* ograd_handles,
                                  int retain_graph);
@@ -1229,10 +1229,10 @@ MXNET_DLL int MXAutogradBackward(mx_uint num_output,
  * \param is_train whether to do backward for training or inference
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXAutogradBackwardEx(mx_uint num_output,
+MXNET_DLL int MXAutogradBackwardEx(uint32_t num_output,
                                    NDArrayHandle *output_handles,
                                    NDArrayHandle *ograd_handles,
-                                   mx_uint num_variables,
+                                   uint32_t num_variables,
                                    NDArrayHandle *var_handles,
                                    int retain_graph,
                                    int create_graph,
@@ -1295,7 +1295,7 @@ MXNET_DLL int MXInvokeCachedOpEx(CachedOpHandle handle,
  * \param out_array the output operator name array.
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXListAllOpNames(mx_uint *out_size,
+MXNET_DLL int MXListAllOpNames(uint32_t *out_size,
                                const char ***out_array);
 
 /*!
@@ -1304,7 +1304,7 @@ MXNET_DLL int MXListAllOpNames(mx_uint *out_size,
  * \param out_array the output AtomicSymbolCreator array
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXSymbolListAtomicSymbolCreators(mx_uint *out_size,
+MXNET_DLL int MXSymbolListAtomicSymbolCreators(uint32_t *out_size,
                                                AtomicSymbolCreator **out_array);
 
 /*!
@@ -1356,7 +1356,7 @@ MXNET_DLL int MXSymbolCutSubgraph(SymbolHandle sym, SymbolHandle **inputs,
 MXNET_DLL int MXSymbolGetAtomicSymbolInfo(AtomicSymbolCreator creator,
                                           const char **name,
                                           const char **description,
-                                          mx_uint *num_args,
+                                          uint32_t *num_args,
                                           const char ***arg_names,
                                           const char ***arg_type_infos,
                                           const char ***arg_descriptions,
@@ -1372,7 +1372,7 @@ MXNET_DLL int MXSymbolGetAtomicSymbolInfo(AtomicSymbolCreator creator,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolCreateAtomicSymbol(AtomicSymbolCreator creator,
-                                         mx_uint num_param,
+                                         uint32_t num_param,
                                          const char **keys,
                                          const char **vals,
                                          SymbolHandle *out);
@@ -1390,7 +1390,7 @@ MXNET_DLL int MXSymbolCreateVariable(const char *name, SymbolHandle *out);
  * \param out pointer to the created symbol handle
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXSymbolCreateGroup(mx_uint num_symbols,
+MXNET_DLL int MXSymbolCreateGroup(uint32_t num_symbols,
                                   SymbolHandle *symbols,
                                   SymbolHandle *out);
 /*!
@@ -1497,7 +1497,7 @@ MXNET_DLL int MXSymbolSetAttr(SymbolHandle symbol,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolListAttr(SymbolHandle symbol,
-                               mx_uint *out_size,
+                               uint32_t *out_size,
                                const char*** out);
 /*!
  * \brief Get all attributes from symbol, excluding descendents.
@@ -1507,7 +1507,7 @@ MXNET_DLL int MXSymbolListAttr(SymbolHandle symbol,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolListAttrShallow(SymbolHandle symbol,
-                                      mx_uint *out_size,
+                                      uint32_t *out_size,
                                       const char*** out);
 /*!
  * \brief List arguments in the symbol.
@@ -1517,7 +1517,7 @@ MXNET_DLL int MXSymbolListAttrShallow(SymbolHandle symbol,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolListArguments(SymbolHandle symbol,
-                                    mx_uint *out_size,
+                                    uint32_t *out_size,
                                     const char ***out_str_array);
 
 /*!
@@ -1528,7 +1528,7 @@ MXNET_DLL int MXSymbolListArguments(SymbolHandle symbol,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolListOutputs(SymbolHandle symbol,
-                                  mx_uint *out_size,
+                                  uint32_t *out_size,
                                   const char ***out_str_array);
 
 /*!
@@ -1538,7 +1538,7 @@ MXNET_DLL int MXSymbolListOutputs(SymbolHandle symbol,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolGetNumOutputs(SymbolHandle symbol,
-                                    mx_uint *output_count);
+                                    uint32_t *output_count);
 
 /*!
  * \brief Get a symbol that contains all the internals.
@@ -1564,7 +1564,7 @@ MXNET_DLL int MXSymbolGetChildren(SymbolHandle symbol,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolGetOutput(SymbolHandle symbol,
-                                mx_uint index,
+                                uint32_t index,
                                 SymbolHandle *out);
 
 /*!
@@ -1575,7 +1575,7 @@ MXNET_DLL int MXSymbolGetOutput(SymbolHandle symbol,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolListAuxiliaryStates(SymbolHandle symbol,
-                                          mx_uint *out_size,
+                                          uint32_t *out_size,
                                           const char ***out_str_array);
 
 /*!
@@ -1594,7 +1594,7 @@ MXNET_DLL int MXSymbolListAuxiliaryStates(SymbolHandle symbol,
  */
 MXNET_DLL int MXSymbolCompose(SymbolHandle sym,
                               const char *name,
-                              mx_uint num_args,
+                              uint32_t num_args,
                               const char** keys,
                               SymbolHandle* args);
 /*!
@@ -1607,7 +1607,7 @@ MXNET_DLL int MXSymbolCompose(SymbolHandle sym,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolGrad(SymbolHandle sym,
-                           mx_uint num_wrt,
+                           uint32_t num_wrt,
                            const char** wrt,
                            SymbolHandle* out);
 /*!
@@ -1634,23 +1634,23 @@ MXNET_DLL int MXSymbolGrad(SymbolHandle sym,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolInferShape(SymbolHandle sym,
-                                 mx_uint num_args,
+                                 uint32_t num_args,
                                  const char** keys,
-                                 const mx_uint *arg_ind_ptr,
-                                 const mx_uint *arg_shape_data,
-                                 mx_uint *in_shape_size,
-                                 const mx_uint **in_shape_ndim,
-                                 const mx_uint ***in_shape_data,
-                                 mx_uint *out_shape_size,
-                                 const mx_uint **out_shape_ndim,
-                                 const mx_uint ***out_shape_data,
-                                 mx_uint *aux_shape_size,
-                                 const mx_uint **aux_shape_ndim,
-                                 const mx_uint ***aux_shape_data,
+                                 const uint32_t *arg_ind_ptr,
+                                 const uint32_t *arg_shape_data,
+                                 uint32_t *in_shape_size,
+                                 const uint32_t **in_shape_ndim,
+                                 const uint32_t ***in_shape_data,
+                                 uint32_t *out_shape_size,
+                                 const uint32_t **out_shape_ndim,
+                                 const uint32_t ***out_shape_data,
+                                 uint32_t *aux_shape_size,
+                                 const uint32_t **aux_shape_ndim,
+                                 const uint32_t ***aux_shape_data,
                                  int *complete);
 
 MXNET_DLL int MXSymbolInferShape64(SymbolHandle sym,
-                                   mx_uint num_args,
+                                   uint32_t num_args,
                                    const char** keys,
                                    const mx_int64 *arg_ind_ptr,
                                    const mx_int64 *arg_shape_data,
@@ -1688,23 +1688,23 @@ MXNET_DLL int MXSymbolInferShape64(SymbolHandle sym,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolInferShapeEx(SymbolHandle sym,
-                                   mx_uint num_args,
+                                   uint32_t num_args,
                                    const char** keys,
-                                   const mx_uint *arg_ind_ptr,
+                                   const uint32_t *arg_ind_ptr,
                                    const int *arg_shape_data,
-                                   mx_uint *in_shape_size,
+                                   uint32_t *in_shape_size,
                                    const int **in_shape_ndim,
                                    const int ***in_shape_data,
-                                   mx_uint *out_shape_size,
+                                   uint32_t *out_shape_size,
                                    const int **out_shape_ndim,
                                    const int ***out_shape_data,
-                                   mx_uint *aux_shape_size,
+                                   uint32_t *aux_shape_size,
                                    const int **aux_shape_ndim,
                                    const int ***aux_shape_data,
                                    int *complete);
 
 MXNET_DLL int MXSymbolInferShapeEx64(SymbolHandle sym,
-                                     mx_uint num_args,
+                                     uint32_t num_args,
                                      const char** keys,
                                      const mx_int64 *arg_ind_ptr,
                                      const mx_int64 *arg_shape_data,
@@ -1745,23 +1745,23 @@ MXNET_DLL int MXSymbolInferShapeEx64(SymbolHandle sym,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolInferShapePartial(SymbolHandle sym,
-                                        mx_uint num_args,
+                                        uint32_t num_args,
                                         const char** keys,
-                                        const mx_uint *arg_ind_ptr,
-                                        const mx_uint *arg_shape_data,
-                                        mx_uint *in_shape_size,
-                                        const mx_uint **in_shape_ndim,
-                                        const mx_uint ***in_shape_data,
-                                        mx_uint *out_shape_size,
-                                        const mx_uint **out_shape_ndim,
-                                        const mx_uint ***out_shape_data,
-                                        mx_uint *aux_shape_size,
-                                        const mx_uint **aux_shape_ndim,
-                                        const mx_uint ***aux_shape_data,
+                                        const uint32_t *arg_ind_ptr,
+                                        const uint32_t *arg_shape_data,
+                                        uint32_t *in_shape_size,
+                                        const uint32_t **in_shape_ndim,
+                                        const uint32_t ***in_shape_data,
+                                        uint32_t *out_shape_size,
+                                        const uint32_t **out_shape_ndim,
+                                        const uint32_t ***out_shape_data,
+                                        uint32_t *aux_shape_size,
+                                        const uint32_t **aux_shape_ndim,
+                                        const uint32_t ***aux_shape_data,
                                         int *complete);
 
 MXNET_DLL int MXSymbolInferShapePartial64(SymbolHandle sym,
-                                          mx_uint num_args,
+                                          uint32_t num_args,
                                           const char** keys,
                                           const mx_int64 *arg_ind_ptr,
                                           const mx_int64 *arg_shape_data,
@@ -1801,23 +1801,23 @@ MXNET_DLL int MXSymbolInferShapePartial64(SymbolHandle sym,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolInferShapePartialEx(SymbolHandle sym,
-                                          mx_uint num_args,
+                                          uint32_t num_args,
                                           const char** keys,
-                                          const mx_uint *arg_ind_ptr,
+                                          const uint32_t *arg_ind_ptr,
                                           const int *arg_shape_data,
-                                          mx_uint *in_shape_size,
+                                          uint32_t *in_shape_size,
                                           const int **in_shape_ndim,
                                           const int ***in_shape_data,
-                                          mx_uint *out_shape_size,
+                                          uint32_t *out_shape_size,
                                           const int **out_shape_ndim,
                                           const int ***out_shape_data,
-                                          mx_uint *aux_shape_size,
+                                          uint32_t *aux_shape_size,
                                           const int **aux_shape_ndim,
                                           const int ***aux_shape_data,
                                           int *complete);
 
 MXNET_DLL int MXSymbolInferShapePartialEx64(SymbolHandle sym,
-                                            mx_uint num_args,
+                                            uint32_t num_args,
                                             const char** keys,
                                             const mx_int64 *arg_ind_ptr,
                                             const mx_int64 *arg_shape_data,
@@ -1851,14 +1851,14 @@ MXNET_DLL int MXSymbolInferShapePartialEx64(SymbolHandle sym,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolInferType(SymbolHandle sym,
-                                mx_uint num_args,
+                                uint32_t num_args,
                                 const char** keys,
                                 const int *arg_type_data,
-                                mx_uint *in_type_size,
+                                uint32_t *in_type_size,
                                 const int **in_type_data,
-                                mx_uint *out_type_size,
+                                uint32_t *out_type_size,
                                 const int **out_type_data,
-                                mx_uint *aux_type_size,
+                                uint32_t *aux_type_size,
                                 const int **aux_type_data,
                                 int *complete);
 
@@ -1883,14 +1883,14 @@ MXNET_DLL int MXSymbolInferType(SymbolHandle sym,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXSymbolInferTypePartial(SymbolHandle sym,
-                                       mx_uint num_args,
+                                       uint32_t num_args,
                                        const char** keys,
                                        const int *arg_type_data,
-                                       mx_uint *in_type_size,
+                                       uint32_t *in_type_size,
                                        const int **in_type_data,
-                                       mx_uint *out_type_size,
+                                       uint32_t *out_type_size,
                                        const int **out_type_data,
-                                       mx_uint *aux_type_size,
+                                       uint32_t *aux_type_size,
                                        const int **aux_type_data,
                                        int *complete);
 
@@ -1911,15 +1911,16 @@ MXNET_DLL int MXSymbolInferTypePartial(SymbolHandle sym,
  * \param out_num_calib_names return the number of nodes to be calibrated
  * \param out_calib_names return the node names to be calibrated
  */
-MXNET_DLL int MXQuantizeSymbol(SymbolHandle sym_handle, SymbolHandle *ret_sym_handle,
+MXNET_DLL int MXQuantizeSymbol(SymbolHandle sym_handle,
+                               SymbolHandle *ret_sym_handle,
                                const int* dev_type,
-                               const mx_uint num_excluded_sym_names,
+                               const uint32_t num_excluded_sym_names,
                                const char **excluded_sym_names,
-                               const mx_uint num_excluded_op_names,
+                               const uint32_t num_excluded_op_names,
                                const char **excluded_op_names,
-                               const mx_uint num_offline, const char **offline_params,
+                               const uint32_t num_offline, const char **offline_params,
                                const char *quantized_dtype, const bool calib_quantize,
-                               const char *quantize_mode, mx_uint* out_num_calib_names,
+                               const char *quantize_mode, uint32_t* out_num_calib_names,
                                const char ***out_calib_names);
 
 /*!
@@ -1950,18 +1951,18 @@ MXNET_DLL int MXQuantizeSymbol(SymbolHandle sym_handle, SymbolHandle *ret_sym_ha
  */
 MXNET_DLL int MXReducePrecisionSymbol(SymbolHandle sym_handle,
                                       SymbolHandle *ret_sym_handle,
-                                      mx_uint num_args,
+                                      uint32_t num_args,
                                       const int* arg_type_data,
-                                      mx_uint num_ind_ptr,
+                                      uint32_t num_ind_ptr,
                                       const int* ind_ptr,
                                       const int* target_dtype,
                                       const int cast_optional_params,
-                                      const mx_uint num_target_dtype_op_names,
-                                      const mx_uint num_fp32_op_names,
-                                      const mx_uint num_widest_dtype_op_names,
-                                      const mx_uint num_conditional_fp32_op_names,
-                                      const mx_uint num_excluded_symbols,
-                                      const mx_uint num_model_params,
+                                      const uint32_t num_target_dtype_op_names,
+                                      const uint32_t num_fp32_op_names,
+                                      const uint32_t num_widest_dtype_op_names,
+                                      const uint32_t num_conditional_fp32_op_names,
+                                      const uint32_t num_excluded_symbols,
+                                      const uint32_t num_model_params,
                                       const char **target_dtype_op_names,
                                       const char **fp32_op_names,
                                       const char **widest_dtype_op_names,
@@ -1981,7 +1982,7 @@ MXNET_DLL int MXReducePrecisionSymbol(SymbolHandle sym_handle,
  * \param ret_sym_handle returned symbol
  */
 MXNET_DLL int MXSetCalibTableToQuantizedSymbol(SymbolHandle qsym_handle,
-                                               const mx_uint num_layers,
+                                               const uint32_t num_layers,
                                                const char** layer_names,
                                                const float* low_quantiles,
                                                const float* high_quantiles,
@@ -2038,7 +2039,7 @@ MXNET_DLL int MXExecutorForward(ExecutorHandle handle, int is_train);
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXExecutorBackward(ExecutorHandle handle,
-                                 mx_uint len,
+                                 uint32_t len,
                                  NDArrayHandle *head_grads);
 /*!
  * \brief Excecutor run backward
@@ -2051,7 +2052,7 @@ MXNET_DLL int MXExecutorBackward(ExecutorHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXExecutorBackwardEx(ExecutorHandle handle,
-                                   mx_uint len,
+                                   uint32_t len,
                                    NDArrayHandle *head_grads,
                                    int is_train);
 /*!
@@ -2063,7 +2064,7 @@ MXNET_DLL int MXExecutorBackwardEx(ExecutorHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXExecutorOutputs(ExecutorHandle handle,
-                                mx_uint *out_size,
+                                uint32_t *out_size,
                                 NDArrayHandle **out);
 
 /*!
@@ -2084,11 +2085,11 @@ MXNET_DLL int MXExecutorOutputs(ExecutorHandle handle,
 MXNET_DLL int MXExecutorBind(SymbolHandle symbol_handle,
                              int dev_type,
                              int dev_id,
-                             mx_uint len,
+                             uint32_t len,
                              NDArrayHandle *in_args,
                              NDArrayHandle *arg_grad_store,
-                             mx_uint *grad_req_type,
-                             mx_uint aux_states_len,
+                             uint32_t *grad_req_type,
+                             uint32_t aux_states_len,
                              NDArrayHandle *aux_states,
                              ExecutorHandle *out);
 /*!
@@ -2115,15 +2116,15 @@ MXNET_DLL int MXExecutorBind(SymbolHandle symbol_handle,
 MXNET_DLL int MXExecutorBindX(SymbolHandle symbol_handle,
                               int dev_type,
                               int dev_id,
-                              mx_uint num_map_keys,
+                              uint32_t num_map_keys,
                               const char** map_keys,
                               const int* map_dev_types,
                               const int* map_dev_ids,
-                              mx_uint len,
+                              uint32_t len,
                               NDArrayHandle *in_args,
                               NDArrayHandle *arg_grad_store,
-                              mx_uint *grad_req_type,
-                              mx_uint aux_states_len,
+                              uint32_t *grad_req_type,
+                              uint32_t aux_states_len,
                               NDArrayHandle *aux_states,
                               ExecutorHandle *out);
 /*!
@@ -2151,15 +2152,15 @@ MXNET_DLL int MXExecutorBindX(SymbolHandle symbol_handle,
 MXNET_DLL int MXExecutorBindEX(SymbolHandle symbol_handle,
                                int dev_type,
                                int dev_id,
-                               mx_uint num_map_keys,
+                               uint32_t num_map_keys,
                                const char** map_keys,
                                const int* map_dev_types,
                                const int* map_dev_ids,
-                               mx_uint len,
+                               uint32_t len,
                                NDArrayHandle *in_args,
                                NDArrayHandle *arg_grad_store,
-                               mx_uint *grad_req_type,
-                               mx_uint aux_states_len,
+                               uint32_t *grad_req_type,
+                               uint32_t aux_states_len,
                                NDArrayHandle *aux_states,
                                ExecutorHandle shared_exec,
                                ExecutorHandle *out);
@@ -2168,34 +2169,34 @@ MXNET_DLL int MXExecutorBindEX(SymbolHandle symbol_handle,
 MXNET_DLL int MXExecutorSimpleBind(SymbolHandle symbol_handle,
                                    int dev_type,
                                    int dev_id,
-                                   const mx_uint num_g2c_keys,
+                                   const uint32_t num_g2c_keys,
                                    const char** g2c_keys,
                                    const int* g2c_dev_types,
                                    const int* g2c_dev_ids,
-                                   const mx_uint provided_grad_req_list_len,
+                                   const uint32_t provided_grad_req_list_len,
                                    const char** provided_grad_req_names,
                                    const char** provided_grad_req_types,
-                                   const mx_uint num_provided_arg_shapes,
+                                   const uint32_t num_provided_arg_shapes,
                                    const char** provided_arg_shape_names,
-                                   const mx_uint* provided_arg_shape_data,
-                                   const mx_uint* provided_arg_shape_idx,
-                                   const mx_uint num_provided_arg_dtypes,
+                                   const uint32_t* provided_arg_shape_data,
+                                   const uint32_t* provided_arg_shape_idx,
+                                   const uint32_t num_provided_arg_dtypes,
                                    const char** provided_arg_dtype_names,
                                    const int* provided_arg_dtypes,
-                                   const mx_uint num_provided_arg_stypes,
+                                   const uint32_t num_provided_arg_stypes,
                                    const char** provided_arg_stype_names,
                                    const int* provided_arg_stypes,
-                                   const mx_uint num_shared_arg_names,
+                                   const uint32_t num_shared_arg_names,
                                    const char** shared_arg_name_list,
                                    int* shared_buffer_len,
                                    const char** shared_buffer_name_list,
                                    NDArrayHandle* shared_buffer_handle_list,
                                    const char*** updated_shared_buffer_name_list,
                                    NDArrayHandle** updated_shared_buffer_handle_list,
-                                   mx_uint* num_in_args,
+                                   uint32_t* num_in_args,
                                    NDArrayHandle** in_args,
                                    NDArrayHandle** arg_grads,
-                                   mx_uint* num_aux_states,
+                                   uint32_t* num_aux_states,
                                    NDArrayHandle** aux_states,
                                    ExecutorHandle shared_exec_handle,
                                    ExecutorHandle* out);
@@ -2204,34 +2205,34 @@ MXNET_DLL int MXExecutorSimpleBind(SymbolHandle symbol_handle,
 MXNET_DLL int MXExecutorSimpleBindEx(SymbolHandle symbol_handle,
                                      int dev_type,
                                      int dev_id,
-                                     const mx_uint num_g2c_keys,
+                                     const uint32_t num_g2c_keys,
                                      const char** g2c_keys,
                                      const int* g2c_dev_types,
                                      const int* g2c_dev_ids,
-                                     const mx_uint provided_grad_req_list_len,
+                                     const uint32_t provided_grad_req_list_len,
                                      const char** provided_grad_req_names,
                                      const char** provided_grad_req_types,
-                                     const mx_uint num_provided_arg_shapes,
+                                     const uint32_t num_provided_arg_shapes,
                                      const char** provided_arg_shape_names,
                                      const int* provided_arg_shape_data,
-                                     const mx_uint* provided_arg_shape_idx,
-                                     const mx_uint num_provided_arg_dtypes,
+                                     const uint32_t* provided_arg_shape_idx,
+                                     const uint32_t num_provided_arg_dtypes,
                                      const char** provided_arg_dtype_names,
                                      const int* provided_arg_dtypes,
-                                     const mx_uint num_provided_arg_stypes,
+                                     const uint32_t num_provided_arg_stypes,
                                      const char** provided_arg_stype_names,
                                      const int* provided_arg_stypes,
-                                     const mx_uint num_shared_arg_names,
+                                     const uint32_t num_shared_arg_names,
                                      const char** shared_arg_name_list,
                                      int* shared_buffer_len,
                                      const char** shared_buffer_name_list,
                                      NDArrayHandle* shared_buffer_handle_list,
                                      const char*** updated_shared_buffer_name_list,
                                      NDArrayHandle** updated_shared_buffer_handle_list,
-                                     mx_uint* num_in_args,
+                                     uint32_t* num_in_args,
                                      NDArrayHandle** in_args,
                                      NDArrayHandle** arg_grads,
-                                     mx_uint* num_aux_states,
+                                     uint32_t* num_aux_states,
                                      NDArrayHandle** aux_states,
                                      ExecutorHandle shared_exec_handle,
                                      ExecutorHandle* out);
@@ -2261,18 +2262,18 @@ MXNET_DLL int MXExecutorReshape(int partial_shaping,
                                 int allow_up_sizing,
                                 int dev_type,
                                 int dev_id,
-                                mx_uint num_map_keys,
+                                uint32_t num_map_keys,
                                 const char** map_keys,
                                 const int* map_dev_types,
                                 const int* map_dev_ids,
-                                const mx_uint num_provided_arg_shapes,
+                                const uint32_t num_provided_arg_shapes,
                                 const char** provided_arg_shape_names,
-                                const mx_uint* provided_arg_shape_data,
-                                const mx_uint* provided_arg_shape_idx,
-                                mx_uint* num_in_args,
+                                const uint32_t* provided_arg_shape_data,
+                                const uint32_t* provided_arg_shape_idx,
+                                uint32_t* num_in_args,
                                 NDArrayHandle** in_args,
                                 NDArrayHandle** arg_grads,
-                                mx_uint* num_aux_states,
+                                uint32_t* num_aux_states,
                                 NDArrayHandle** aux_states,
                                 ExecutorHandle shared_exec,
                                 ExecutorHandle *out);
@@ -2301,18 +2302,18 @@ MXNET_DLL int MXExecutorReshapeEx(int partial_shaping,
                                   int allow_up_sizing,
                                   int dev_type,
                                   int dev_id,
-                                  mx_uint num_map_keys,
+                                  uint32_t num_map_keys,
                                   const char** map_keys,
                                   const int* map_dev_types,
                                   const int* map_dev_ids,
-                                  const mx_uint num_provided_arg_shapes,
+                                  const uint32_t num_provided_arg_shapes,
                                   const char** provided_arg_shape_names,
                                   const int* provided_arg_shape_data,
-                                  const mx_uint* provided_arg_shape_idx,
-                                  mx_uint* num_in_args,
+                                  const uint32_t* provided_arg_shape_idx,
+                                  uint32_t* num_in_args,
                                   NDArrayHandle** in_args,
                                   NDArrayHandle** arg_grads,
-                                  mx_uint* num_aux_states,
+                                  uint32_t* num_aux_states,
                                   NDArrayHandle** aux_states,
                                   ExecutorHandle shared_exec,
                                   ExecutorHandle *out);
@@ -2345,7 +2346,7 @@ MXNET_DLL int MXExecutorSetMonitorCallbackEX(ExecutorHandle handle,
  * \param out_array the output iteratos entries
  * \return 0 when success, -1 when failure happens
  */
-MXNET_DLL int MXListDataIters(mx_uint *out_size,
+MXNET_DLL int MXListDataIters(uint32_t *out_size,
                               DataIterCreator **out_array);
 /*!
  * \brief Init an iterator, init with parameters
@@ -2358,7 +2359,7 @@ MXNET_DLL int MXListDataIters(mx_uint *out_size,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXDataIterCreateIter(DataIterCreator handle,
-                                   mx_uint num_param,
+                                   uint32_t num_param,
                                    const char **keys,
                                    const char **vals,
                                    DataIterHandle *out);
@@ -2376,7 +2377,7 @@ MXNET_DLL int MXDataIterCreateIter(DataIterCreator handle,
 MXNET_DLL int MXDataIterGetIterInfo(DataIterCreator creator,
                                     const char **name,
                                     const char **description,
-                                    mx_uint *num_args,
+                                    uint32_t *num_args,
                                     const char ***arg_names,
                                     const char ***arg_type_infos,
                                     const char ***arg_descriptions);
@@ -2445,7 +2446,7 @@ MXNET_DLL int MXDataIterGetLabel(DataIterHandle handle,
  * \param keys environment keys
  * \param vals environment values
  */
-MXNET_DLL int MXInitPSEnv(mx_uint num_vars,
+MXNET_DLL int MXInitPSEnv(uint32_t num_vars,
                           const char **keys,
                           const char **vals);
 
@@ -2467,7 +2468,7 @@ MXNET_DLL int MXKVStoreCreate(const char *type,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStoreSetGradientCompression(KVStoreHandle handle,
-                                              mx_uint num_params,
+                                              uint32_t num_params,
                                               const char** keys,
                                               const char** vals);
 
@@ -2486,7 +2487,7 @@ MXNET_DLL int MXKVStoreFree(KVStoreHandle handle);
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStoreInit(KVStoreHandle handle,
-                            mx_uint num,
+                            uint32_t num,
                             const int* keys,
                             NDArrayHandle* vals);
 
@@ -2499,7 +2500,7 @@ MXNET_DLL int MXKVStoreInit(KVStoreHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStoreInitEx(KVStoreHandle handle,
-                              mx_uint num,
+                              uint32_t num,
                               const char** keys,
                               NDArrayHandle* vals);
 
@@ -2513,7 +2514,7 @@ MXNET_DLL int MXKVStoreInitEx(KVStoreHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStorePush(KVStoreHandle handle,
-                            mx_uint num,
+                            uint32_t num,
                             const int* keys,
                             NDArrayHandle* vals,
                             int priority);
@@ -2527,7 +2528,7 @@ MXNET_DLL int MXKVStorePush(KVStoreHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStorePushEx(KVStoreHandle handle,
-                              mx_uint num,
+                              uint32_t num,
                               const char** keys,
                               NDArrayHandle* vals,
                               int priority);
@@ -2542,7 +2543,7 @@ MXNET_DLL int MXKVStorePushEx(KVStoreHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStorePullWithSparse(KVStoreHandle handle,
-                                      mx_uint num,
+                                      uint32_t num,
                                       const int* keys,
                                       NDArrayHandle* vals,
                                       int priority,
@@ -2558,7 +2559,7 @@ MXNET_DLL int MXKVStorePullWithSparse(KVStoreHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStorePullWithSparseEx(KVStoreHandle handle,
-                                        mx_uint num,
+                                        uint32_t num,
                                         const char** keys,
                                         NDArrayHandle* vals,
                                         int priority,
@@ -2573,7 +2574,7 @@ MXNET_DLL int MXKVStorePullWithSparseEx(KVStoreHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStorePull(KVStoreHandle handle,
-                            mx_uint num,
+                            uint32_t num,
                             const int* keys,
                             NDArrayHandle* vals,
                             int priority);
@@ -2587,7 +2588,7 @@ MXNET_DLL int MXKVStorePull(KVStoreHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStorePullEx(KVStoreHandle handle,
-                              mx_uint num,
+                              uint32_t num,
                               const char** keys,
                               NDArrayHandle* vals,
                               int priority);
@@ -2605,7 +2606,7 @@ MXNET_DLL int MXKVStorePullEx(KVStoreHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStorePullRowSparse(KVStoreHandle handle,
-                                     mx_uint num,
+                                     uint32_t num,
                                      const int* keys,
                                      NDArrayHandle* vals,
                                      const NDArrayHandle* row_ids,
@@ -2623,7 +2624,7 @@ MXNET_DLL int MXKVStorePullRowSparse(KVStoreHandle handle,
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXKVStorePullRowSparseEx(KVStoreHandle handle,
-                                       mx_uint num,
+                                       uint32_t num,
                                        const char** keys,
                                        NDArrayHandle* vals,
                                        const NDArrayHandle* row_ids,
@@ -2874,7 +2875,7 @@ MXNET_DLL int MXRecordIOReaderTell(RecordIOHandle handle, size_t *pos);
 /**
  * \brief Create a MXRtc object
 */
-MXNET_DLL int MXRtcCreate(char* name, mx_uint num_input, mx_uint num_output,
+MXNET_DLL int MXRtcCreate(char* name, uint32_t num_input, uint32_t num_output,
                           char** input_names, char** output_names,
                           NDArrayHandle* inputs, NDArrayHandle* outputs,
                           char* kernel, RtcHandle *out);
@@ -2882,14 +2883,14 @@ MXNET_DLL int MXRtcCreate(char* name, mx_uint num_input, mx_uint num_output,
 /**
  * \brief Run cuda kernel
 */
-MXNET_DLL int MXRtcPush(RtcHandle handle, mx_uint num_input, mx_uint num_output,
+MXNET_DLL int MXRtcPush(RtcHandle handle, uint32_t num_input, uint32_t num_output,
                         NDArrayHandle* inputs, NDArrayHandle* outputs,
-                        mx_uint gridDimX,
-                        mx_uint gridDimY,
-                        mx_uint gridDimZ,
-                        mx_uint blockDimX,
-                        mx_uint blockDimY,
-                        mx_uint blockDimZ);
+                        uint32_t gridDimX,
+                        uint32_t gridDimY,
+                        uint32_t gridDimZ,
+                        uint32_t blockDimX,
+                        uint32_t blockDimY,
+                        uint32_t blockDimZ);
 
 /**
  * \brief Delete a MXRtc object
@@ -2961,10 +2962,10 @@ MXNET_DLL int MXRtcCudaKernelFree(CudaKernelHandle handle);
  * \param shared_mem size of dynamically allocated shared memory
  */
 MXNET_DLL int MXRtcCudaKernelCall(CudaKernelHandle handle, int dev_id, void** args,
-                                  mx_uint grid_dim_x, mx_uint grid_dim_y,
-                                  mx_uint grid_dim_z, mx_uint block_dim_x,
-                                  mx_uint block_dim_y, mx_uint block_dim_z,
-                                  mx_uint shared_mem);
+                                  uint32_t grid_dim_x, uint32_t grid_dim_y,
+                                  uint32_t grid_dim_z, uint32_t block_dim_x,
+                                  uint32_t block_dim_y, uint32_t block_dim_z,
+                                  uint32_t shared_mem);
 /*!
  * \brief Get shared memory handle from NDArray
  * \param handle NDArray handle.
@@ -2983,8 +2984,8 @@ MXNET_DLL int MXNDArrayGetSharedMemHandle(NDArrayHandle handle, int* shared_pid,
  * \param dtype data type of NDArray
  * \param out constructed NDArray
  */
-MXNET_DLL int MXNDArrayCreateFromSharedMem(int shared_pid, int shared_id, const mx_uint *shape,
-                                           mx_uint ndim, int dtype, NDArrayHandle *out);
+MXNET_DLL int MXNDArrayCreateFromSharedMem(int shared_pid, int shared_id, const uint32_t *shape,
+                                           uint32_t ndim, int dtype, NDArrayHandle *out);
 
 /*!
  * \brief Release all unreferenced memory from the devices storage managers memory pool

--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -59,7 +59,7 @@ typedef uint32_t uint32_t;
 /*! \brief manually define 64-bit int */
 typedef int64_t int64_t;
 /*! \brief manually define float */
-typedef float mx_float;
+typedef float float;
 /*! \brief data type to store dim size */
 typedef int64_t dim_t;
 // all the handles are simply void *
@@ -1085,7 +1085,7 @@ MXNET_DLL int MXFuncDescribe(FunctionHandle fun,
  */
 MXNET_DLL int MXFuncInvoke(FunctionHandle fun,
                            NDArrayHandle *use_vars,
-                           mx_float *scalar_args,
+                           float *scalar_args,
                            NDArrayHandle *mutate_vars);
 /*!
  * \brief invoke a function, the array size of passed in arguments
@@ -1102,7 +1102,7 @@ MXNET_DLL int MXFuncInvoke(FunctionHandle fun,
  */
 MXNET_DLL int MXFuncInvokeEx(FunctionHandle fun,
                              NDArrayHandle *use_vars,
-                             mx_float *scalar_args,
+                             float *scalar_args,
                              NDArrayHandle *mutate_vars,
                              int num_params,
                              char **param_keys,

--- a/include/mxnet/c_api_test.h
+++ b/include/mxnet/c_api_test.h
@@ -40,7 +40,7 @@ extern "C" {
  */
 MXNET_DLL int MXBuildSubgraphByOpNames(SymbolHandle sym_handle,
                                         const char* prop_name,
-                                        const mx_uint num_ops,
+                                        const uint32_t num_ops,
                                         const char** op_names,
                                         SymbolHandle* ret_sym_handle);
 
@@ -50,7 +50,7 @@ MXNET_DLL int MXBuildSubgraphByOpNames(SymbolHandle sym_handle,
  * the predefined one. This is only for the purpose of testing.
  */
 MXNET_DLL int MXSetSubgraphPropertyOpNames(const char* prop_name,
-                                           const mx_uint num_ops,
+                                           const uint32_t num_ops,
                                            const char** op_names);
 
 /*!

--- a/include/mxnet/c_predict_api.h
+++ b/include/mxnet/c_predict_api.h
@@ -42,7 +42,7 @@ extern "C" {
 #endif
 
 /*! \brief manually define unsigned int */
-typedef uint32_t mx_uint;
+typedef uint32_t uint32_t;
 /*! \brief manually define 64-bit int */
 typedef int64_t mx_int64;
 /*! \brief manually define float */
@@ -87,10 +87,10 @@ MXNET_DLL int MXPredCreate(const char* symbol_json_str,
                            const void* param_bytes,
                            int param_size,
                            int dev_type, int dev_id,
-                           mx_uint num_input_nodes,
+                           uint32_t num_input_nodes,
                            const char** input_keys,
-                           const mx_uint* input_shape_indptr,
-                           const mx_uint* input_shape_data,
+                           const uint32_t* input_shape_indptr,
+                           const uint32_t* input_shape_data,
                            PredictorHandle* out);
 
 /*!
@@ -122,11 +122,11 @@ MXNET_DLL int MXPredCreateEx(const char* symbol_json_str,
                              const void* param_bytes,
                              int param_size,
                              int dev_type, int dev_id,
-                             const mx_uint num_input_nodes,
+                             const uint32_t num_input_nodes,
                              const char** input_keys,
-                             const mx_uint* input_shape_indptr,
-                             const mx_uint* input_shape_data,
-                             const mx_uint num_provided_arg_dtypes,
+                             const uint32_t* input_shape_indptr,
+                             const uint32_t* input_shape_data,
+                             const uint32_t num_provided_arg_dtypes,
                              const char** provided_arg_dtype_names,
                              const int* provided_arg_dtypes,
                              PredictorHandle* out);
@@ -158,11 +158,11 @@ MXNET_DLL int MXPredCreatePartialOut(const char* symbol_json_str,
                                      const void* param_bytes,
                                      int param_size,
                                      int dev_type, int dev_id,
-                                     mx_uint num_input_nodes,
+                                     uint32_t num_input_nodes,
                                      const char** input_keys,
-                                     const mx_uint* input_shape_indptr,
-                                     const mx_uint* input_shape_data,
-                                     mx_uint num_output_nodes,
+                                     const uint32_t* input_shape_indptr,
+                                     const uint32_t* input_shape_data,
+                                     uint32_t num_output_nodes,
                                      const char** output_keys,
                                      PredictorHandle* out);
 
@@ -191,10 +191,10 @@ MXNET_DLL int MXPredCreateMultiThread(const char* symbol_json_str,
                                       const void* param_bytes,
                                       int param_size,
                                       int dev_type, int dev_id,
-                                      mx_uint num_input_nodes,
+                                      uint32_t num_input_nodes,
                                       const char** input_keys,
-                                      const mx_uint* input_shape_indptr,
-                                      const mx_uint* input_shape_data,
+                                      const uint32_t* input_shape_indptr,
+                                      const uint32_t* input_shape_data,
                                       int num_threads,
                                       PredictorHandle* out);
 
@@ -213,10 +213,10 @@ MXNET_DLL int MXPredCreateMultiThread(const char* symbol_json_str,
  * \param out The reshaped predictor handle.
  * \return 0 when success, -1 when failure.
  */
-MXNET_DLL int MXPredReshape(mx_uint num_input_nodes,
+MXNET_DLL int MXPredReshape(uint32_t num_input_nodes,
                   const char** input_keys,
-                  const mx_uint* input_shape_indptr,
-                  const mx_uint* input_shape_data,
+                  const uint32_t* input_shape_indptr,
+                  const uint32_t* input_shape_data,
                   PredictorHandle handle,
                   PredictorHandle* out);
 /*!
@@ -229,9 +229,9 @@ MXNET_DLL int MXPredReshape(mx_uint num_input_nodes,
  * \return 0 when success, -1 when failure.
  */
 MXNET_DLL int MXPredGetOutputShape(PredictorHandle handle,
-                                   mx_uint index,
-                                   mx_uint** shape_data,
-                                   mx_uint* shape_ndim);
+                                   uint32_t index,
+                                   uint32_t** shape_data,
+                                   uint32_t* shape_ndim);
 
 /*!
  * \brief Get the dtype of output node.
@@ -241,7 +241,7 @@ MXNET_DLL int MXPredGetOutputShape(PredictorHandle handle,
  * \param out_dtype The dtype of the output node
  */
 MXNET_DLL int MXPredGetOutputType(PredictorHandle handle,
-                                  mx_uint out_index,
+                                  uint32_t out_index,
                                   int* out_dtype);
 
 /*!
@@ -256,7 +256,7 @@ MXNET_DLL int MXPredGetOutputType(PredictorHandle handle,
 MXNET_DLL int MXPredSetInput(PredictorHandle handle,
                              const char* key,
                              const mx_float* data,
-                             mx_uint size);
+                             uint32_t size);
 /*!
  * \brief Run a forward pass to get the output.
  * \param handle The handle of the predictor.
@@ -289,9 +289,9 @@ MXNET_DLL int MXPredPartialForward(PredictorHandle handle, int step, int* step_l
  * \return 0 when success, -1 when failure.
  */
 MXNET_DLL int MXPredGetOutput(PredictorHandle handle,
-                              mx_uint index,
+                              uint32_t index,
                               mx_float* data,
-                              mx_uint size);
+                              uint32_t size);
 /*!
  * \brief Free a predictor handle.
  * \param handle The handle of the predictor.
@@ -310,7 +310,7 @@ MXNET_DLL int MXPredFree(PredictorHandle handle);
 MXNET_DLL int MXNDListCreate(const char* nd_file_bytes,
                              int nd_file_size,
                              NDListHandle *out,
-                             mx_uint* out_length);
+                             uint32_t* out_length);
 /*!
  * \brief Get an element from list
  * \param handle The handle to the NDArray
@@ -322,11 +322,11 @@ MXNET_DLL int MXNDListCreate(const char* nd_file_bytes,
  * \return 0 when success, -1 when failure.
  */
 MXNET_DLL int MXNDListGet(NDListHandle handle,
-                          mx_uint index,
+                          uint32_t index,
                           const char** out_key,
                           const mx_float** out_data,
-                          const mx_uint** out_shape,
-                          mx_uint* out_ndim);
+                          const uint32_t** out_shape,
+                          uint32_t* out_ndim);
 
 /*!
  * \brief set a call back to notify the completion of operation and allow for

--- a/include/mxnet/c_predict_api.h
+++ b/include/mxnet/c_predict_api.h
@@ -46,7 +46,7 @@ typedef uint32_t uint32_t;
 /*! \brief manually define 64-bit int */
 typedef int64_t int64_t;
 /*! \brief manually define float */
-typedef float mx_float;
+typedef float float;
 /*! \brief handle to Predictor */
 typedef void *PredictorHandle;
 /*! \brief handle to NDArray list */
@@ -255,7 +255,7 @@ MXNET_DLL int MXPredGetOutputType(PredictorHandle handle,
  */
 MXNET_DLL int MXPredSetInput(PredictorHandle handle,
                              const char* key,
-                             const mx_float* data,
+                             const float* data,
                              uint32_t size);
 /*!
  * \brief Run a forward pass to get the output.
@@ -290,7 +290,7 @@ MXNET_DLL int MXPredPartialForward(PredictorHandle handle, int step, int* step_l
  */
 MXNET_DLL int MXPredGetOutput(PredictorHandle handle,
                               uint32_t index,
-                              mx_float* data,
+                              float* data,
                               uint32_t size);
 /*!
  * \brief Free a predictor handle.
@@ -324,7 +324,7 @@ MXNET_DLL int MXNDListCreate(const char* nd_file_bytes,
 MXNET_DLL int MXNDListGet(NDListHandle handle,
                           uint32_t index,
                           const char** out_key,
-                          const mx_float** out_data,
+                          const float** out_data,
                           const uint32_t** out_shape,
                           uint32_t* out_ndim);
 

--- a/include/mxnet/c_predict_api.h
+++ b/include/mxnet/c_predict_api.h
@@ -44,7 +44,7 @@ extern "C" {
 /*! \brief manually define unsigned int */
 typedef uint32_t uint32_t;
 /*! \brief manually define 64-bit int */
-typedef int64_t mx_int64;
+typedef int64_t int64_t;
 /*! \brief manually define float */
 typedef float mx_float;
 /*! \brief handle to Predictor */

--- a/include/mxnet/c_predict_api.h
+++ b/include/mxnet/c_predict_api.h
@@ -42,11 +42,9 @@ extern "C" {
 #endif
 
 /*! \brief manually define unsigned int */
-typedef uint32_t uint32_t;
-/*! \brief manually define 64-bit int */
-typedef int64_t int64_t;
+typedef uint32_t mx_uint;
 /*! \brief manually define float */
-typedef float float;
+typedef float mx_float;
 /*! \brief handle to Predictor */
 typedef void *PredictorHandle;
 /*! \brief handle to NDArray list */

--- a/include/mxnet/imperative.h
+++ b/include/mxnet/imperative.h
@@ -129,7 +129,7 @@ class Imperative {
                       OpStatePtr state = OpStatePtr());
   /*! \brief mark variables for computing gradients. */
   void MarkVariables(const std::vector<NDArray*>& variables,
-                     const std::vector<mx_uint>& grad_reqs,
+                     const std::vector<uint32_t>& grad_reqs,
                      const std::vector<NDArray*>& gradients);
   /*! \brief compute the gradient of outputs w.r.t variables. */
   std::vector<NDArray*> Backward(const std::vector<NDArray*>& outputs,

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -62,7 +62,7 @@ template<typename FunRegType>
 inline int MXAPIGetFunctionRegInfo(const FunRegType *e,
                                    const char **name,
                                    const char **description,
-                                   mx_uint *num_args,
+                                   uint32_t *num_args,
                                    const char ***arg_names,
                                    const char ***arg_type_infos,
                                    const char ***arg_descriptions,
@@ -72,7 +72,7 @@ inline int MXAPIGetFunctionRegInfo(const FunRegType *e,
   API_BEGIN();
   *name = e->name.c_str();
   *description = e->description.c_str();
-  *num_args = static_cast<mx_uint>(e->arguments.size());
+  *num_args = static_cast<uint32_t>(e->arguments.size());
   if (return_type) *return_type = e->return_type.c_str();
   ret->ret_vec_charp.clear();
   for (size_t i = 0; i < e->arguments.size(); ++i) {
@@ -202,8 +202,8 @@ void CreateNDArray(const DataType* shape,
                      delay_alloc != 0, dtype);
 }
 
-int MXNDArrayCreate(const mx_uint *shape,
-                    mx_uint ndim,
+int MXNDArrayCreate(const uint32_t *shape,
+                    uint32_t ndim,
                     int dev_type,
                     int dev_id,
                     int delay_alloc,
@@ -227,29 +227,29 @@ int MXNDArrayCreateEx64(const mx_int64 *shape,
   API_END();
 }
 
-int MXNDArrayCreateEx(const mx_uint *shape,
-                      mx_uint ndim,
+int MXNDArrayCreateEx(const uint32_t *shape,
+                      uint32_t ndim,
                       int dev_type,
                       int dev_id,
                       int delay_alloc,
                       int dtype,
                       NDArrayHandle *out) {
   API_BEGIN();
-  CreateNDArray<mx_uint, mx_uint>(shape, ndim, dev_type, dev_id, delay_alloc, dtype, out);
+  CreateNDArray<uint32_t, uint32_t>(shape, ndim, dev_type, dev_id, delay_alloc, dtype, out);
   API_END();
 }
 
 int MXNDArrayCreateSparseEx(int storage_type,
-                            const mx_uint *shape,
-                            mx_uint ndim,
+                            const uint32_t *shape,
+                            uint32_t ndim,
                             int dev_type,
                             int dev_id,
                             int delay_alloc,
                             int dtype,
-                            mx_uint num_aux,
+                            uint32_t num_aux,
                             int *aux_type,
-                            mx_uint *aux_ndims,
-                            const mx_uint *aux_shape,
+                            uint32_t *aux_ndims,
+                            const uint32_t *aux_shape,
                             NDArrayHandle *out) {
   API_BEGIN();
   std::vector<int> aux_types;
@@ -358,18 +358,18 @@ int MXNDArrayWaitAll() {
 }
 
 int MXNDArraySave(const char* fname,
-                  mx_uint num_args,
+                  uint32_t num_args,
                   NDArrayHandle* args,
                   const char** keys) {
   API_BEGIN();
   std::vector<NDArray> data(num_args);
   std::vector<std::string> names;
-  for (mx_uint i = 0; i < num_args; ++i) {
+  for (uint32_t i = 0; i < num_args; ++i) {
     data[i] = *static_cast<NDArray*>(args[i]);
   }
   if (keys != nullptr) {
     names.resize(num_args);
-    for (mx_uint i = 0; i < num_args; ++i) {
+    for (uint32_t i = 0; i < num_args; ++i) {
       names[i] = keys[i];
     }
   }
@@ -381,9 +381,9 @@ int MXNDArraySave(const char* fname,
 }
 
 int MXNDArrayLoad(const char* fname,
-                  mx_uint *out_size,
+                  uint32_t *out_size,
                   NDArrayHandle** out_arr,
-                  mx_uint *out_name_size,
+                  uint32_t *out_name_size,
                   const char*** out_names) {
   MXAPIThreadLocalEntry<> *ret = MXAPIThreadLocalStore<>::Get();
   ret->ret_vec_str.clear();
@@ -404,18 +404,18 @@ int MXNDArrayLoad(const char* fname,
   for (size_t i = 0; i < names.size(); ++i) {
     ret->ret_vec_charp[i] = names[i].c_str();
   }
-  *out_size = static_cast<mx_uint>(data.size());
+  *out_size = static_cast<uint32_t>(data.size());
   *out_arr = dmlc::BeginPtr(ret->ret_handles);
-  *out_name_size = static_cast<mx_uint>(names.size());
+  *out_name_size = static_cast<uint32_t>(names.size());
   *out_names = dmlc::BeginPtr(ret->ret_vec_charp);
   API_END();
 }
 
 int MXNDArrayLoadFromBuffer(const void *ndarray_buffer,
                             size_t size,
-                            mx_uint *out_size,
+                            uint32_t *out_size,
                             NDArrayHandle** out_arr,
-                            mx_uint *out_name_size,
+                            uint32_t *out_name_size,
                             const char*** out_names) {
   MXAPIThreadLocalEntry<> *ret = MXAPIThreadLocalStore<>::Get();
   ret->ret_vec_str.clear();
@@ -438,9 +438,9 @@ int MXNDArrayLoadFromBuffer(const void *ndarray_buffer,
   for (size_t i = 0; i < names.size(); ++i) {
     ret->ret_vec_charp[i] = names[i].c_str();
   }
-  *out_size = static_cast<mx_uint>(data.size());
+  *out_size = static_cast<uint32_t>(data.size());
   *out_arr = dmlc::BeginPtr(ret->ret_handles);
-  *out_name_size = static_cast<mx_uint>(names.size());
+  *out_name_size = static_cast<uint32_t>(names.size());
   *out_names = dmlc::BeginPtr(ret->ret_vec_charp);
   API_END();
 }
@@ -459,8 +459,8 @@ void SliceArray(NDArrayHandle handle, dtype slice_begin, dtype slice_end, NDArra
 }
 
 int MXNDArraySlice(NDArrayHandle handle,
-                   mx_uint slice_begin,
-                   mx_uint slice_end,
+                   uint32_t slice_begin,
+                   uint32_t slice_end,
                    NDArrayHandle *out) {
   NDArray *ptr = new NDArray();
   API_BEGIN();
@@ -562,8 +562,8 @@ int MXNDArrayGetStorageType(NDArrayHandle handle,
 }
 
 int MXNDArrayGetShape(NDArrayHandle handle,
-                      mx_uint *out_dim,
-                      const mx_uint **out_pdata) {
+                      uint32_t *out_dim,
+                      const uint32_t **out_pdata) {
   MXAPIThreadLocalEntry<> *ret = MXAPIThreadLocalStore<>::Get();
   API_BEGIN();
   NDArray *arr = static_cast<NDArray*>(handle);
@@ -680,7 +680,7 @@ int MXNDArrayGetDType(NDArrayHandle handle,
 }
 
 int MXNDArrayGetAuxType(NDArrayHandle handle,
-                        mx_uint i,
+                        uint32_t i,
                         int *out_type) {
   API_BEGIN();
   NDArray *arr = static_cast<NDArray*>(handle);
@@ -694,7 +694,7 @@ int MXNDArrayGetAuxType(NDArrayHandle handle,
  * This function blocks. Do not use it in performance critical code.
  */
 int MXNDArrayGetAuxNDArray(NDArrayHandle handle,
-                           mx_uint i,
+                           uint32_t i,
                            NDArrayHandle *out) {
   API_BEGIN();
   NDArray *arr = static_cast<NDArray*>(handle);
@@ -765,11 +765,11 @@ int MXNDArrayGetGradState(NDArrayHandle handle, int *out) {
   API_END();
 }
 
-int MXListFunctions(mx_uint *out_size,
+int MXListFunctions(uint32_t *out_size,
                     FunctionHandle **out_array) {
   API_BEGIN();
   auto &vec = dmlc::Registry<NDArrayFunctionReg>::List();
-  *out_size = static_cast<mx_uint>(vec.size());
+  *out_size = static_cast<uint32_t>(vec.size());
   *out_array = (FunctionHandle*)(dmlc::BeginPtr(vec));  //  NOLINT(*)
   API_END();
 }
@@ -784,7 +784,7 @@ int MXGetFunction(const char *name,
 int MXFuncGetInfo(FunctionHandle fun,
                   const char **name,
                   const char **description,
-                  mx_uint *num_args,
+                  uint32_t *num_args,
                   const char ***arg_names,
                   const char ***arg_type_infos,
                   const char ***arg_descriptions,
@@ -796,9 +796,9 @@ int MXFuncGetInfo(FunctionHandle fun,
 }
 
 int MXFuncDescribe(FunctionHandle fun,
-                   mx_uint *num_use_vars,
-                   mx_uint *num_scalars,
-                   mx_uint *num_mutate_vars,
+                   uint32_t *num_use_vars,
+                   uint32_t *num_scalars,
+                   uint32_t *num_mutate_vars,
                    int *type_mask) {
   API_BEGIN();
   auto *f = static_cast<const NDArrayFunctionReg*>(fun);
@@ -845,11 +845,11 @@ int MXFuncInvokeEx(FunctionHandle fun,
 //--------------------------------------------
 // Part 5: IO Interface
 //--------------------------------------------
-int MXListDataIters(mx_uint *out_size,
+int MXListDataIters(uint32_t *out_size,
                     DataIterCreator **out_array) {
   API_BEGIN();
   auto &vec = dmlc::Registry<DataIteratorReg>::List();
-  *out_size = static_cast<mx_uint>(vec.size());
+  *out_size = static_cast<uint32_t>(vec.size());
   *out_array = (DataIterCreator*)(dmlc::BeginPtr(vec));  //  NOLINT(*)
   API_END();
 }
@@ -857,7 +857,7 @@ int MXListDataIters(mx_uint *out_size,
 int MXDataIterGetIterInfo(DataIterCreator creator,
                           const char **name,
                           const char **description,
-                          mx_uint *num_args,
+                          uint32_t *num_args,
                           const char ***arg_names,
                           const char ***arg_type_infos,
                           const char ***arg_descriptions) {
@@ -868,7 +868,7 @@ int MXDataIterGetIterInfo(DataIterCreator creator,
 }
 
 int MXDataIterCreateIter(DataIterCreator creator,
-                         mx_uint num_param,
+                         uint32_t num_param,
                          const char **keys,
                          const char **vals,
                          DataIterHandle *out) {
@@ -877,7 +877,7 @@ int MXDataIterCreateIter(DataIterCreator creator,
   DataIteratorReg *e = static_cast<DataIteratorReg *>(creator);
   iter = e->body();
   std::vector<std::pair<std::string, std::string> > kwargs;
-  for (mx_uint i = 0; i < num_param; ++i) {
+  for (uint32_t i = 0; i < num_param; ++i) {
     kwargs.push_back({std::string(keys[i]), std::string(vals[i])});
   }
   iter->Init(kwargs);
@@ -950,11 +950,11 @@ int MXKVStoreCreate(const char *type,
   API_END();
 }
 
-int MXKVStoreSetGradientCompression(KVStoreHandle handle, mx_uint num_params,
+int MXKVStoreSetGradientCompression(KVStoreHandle handle, uint32_t num_params,
                                     const char** keys, const char** vals) {
   API_BEGIN();
   std::vector<std::pair<std::string, std::string> > params;
-  for (mx_uint i = 0; i < num_params; ++i) {
+  for (uint32_t i = 0; i < num_params; ++i) {
     std::pair<std::string, std::string> p;
     p.first = keys[i];
     p.second = vals[i];
@@ -971,13 +971,13 @@ int MXKVStoreFree(KVStoreHandle handle) {
 }
 
 int MXKVStoreInit(KVStoreHandle handle,
-                  mx_uint num,
+                  uint32_t num,
                   const int* keys,
                   NDArrayHandle* vals) {
   API_BEGIN();
   std::vector<int> v_keys(num);
   std::vector<NDArray> v_vals(num);
-  for (mx_uint i = 0; i < num; ++i) {
+  for (uint32_t i = 0; i < num; ++i) {
     v_keys[i] = keys[i];
     v_vals[i] = *static_cast<NDArray*>(vals[i]);
   }
@@ -986,13 +986,13 @@ int MXKVStoreInit(KVStoreHandle handle,
 }
 
 int MXKVStoreInitEx(KVStoreHandle handle,
-                  mx_uint num,
+                  uint32_t num,
                   const char** keys,
                   NDArrayHandle* vals) {
   API_BEGIN();
   std::vector<std::string> v_keys(num);
   std::vector<NDArray> v_vals(num);
-  for (mx_uint i = 0; i < num; ++i) {
+  for (uint32_t i = 0; i < num; ++i) {
     v_keys[i] = keys[i];
     v_vals[i] = *static_cast<NDArray*>(vals[i]);
   }
@@ -1001,14 +1001,14 @@ int MXKVStoreInitEx(KVStoreHandle handle,
 }
 
 int MXKVStorePush(KVStoreHandle handle,
-                  mx_uint num,
+                  uint32_t num,
                   const int* keys,
                   NDArrayHandle* vals,
                   int priority) {
   API_BEGIN();
   std::vector<int> v_keys(num);
   std::vector<NDArray> v_vals(num);
-  for (mx_uint i = 0; i < num; ++i) {
+  for (uint32_t i = 0; i < num; ++i) {
     v_keys[i] = keys[i];
     v_vals[i] = *static_cast<NDArray*>(vals[i]);
   }
@@ -1017,14 +1017,14 @@ int MXKVStorePush(KVStoreHandle handle,
 }
 
 int MXKVStorePushEx(KVStoreHandle handle,
-                  mx_uint num,
+                  uint32_t num,
                   const char** keys,
                   NDArrayHandle* vals,
                   int priority) {
   API_BEGIN();
   std::vector<std::string> v_keys(num);
   std::vector<NDArray> v_vals(num);
-  for (mx_uint i = 0; i < num; ++i) {
+  for (uint32_t i = 0; i < num; ++i) {
     v_keys[i] = keys[i];
     v_vals[i] = *static_cast<NDArray*>(vals[i]);
   }
@@ -1033,14 +1033,14 @@ int MXKVStorePushEx(KVStoreHandle handle,
 }
 
 int MXKVStorePull(KVStoreHandle handle,
-                  mx_uint num,
+                  uint32_t num,
                   const int* keys,
                   NDArrayHandle* vals,
                   int priority) {
   API_BEGIN();
   std::vector<int> v_keys(num);
   std::vector<NDArray*> v_vals(num);
-  for (mx_uint i = 0; i < num; ++i) {
+  for (uint32_t i = 0; i < num; ++i) {
     v_keys[i] = keys[i];
     v_vals[i] = static_cast<NDArray*>(vals[i]);
   }
@@ -1049,14 +1049,14 @@ int MXKVStorePull(KVStoreHandle handle,
 }
 
 int MXKVStorePullEx(KVStoreHandle handle,
-                    mx_uint num,
+                    uint32_t num,
                     const char** keys,
                     NDArrayHandle* vals,
                     int priority) {
   API_BEGIN();
   std::vector<std::string> v_keys(num);
   std::vector<NDArray*> v_vals(num);
-  for (mx_uint i = 0; i < num; ++i) {
+  for (uint32_t i = 0; i < num; ++i) {
     v_keys[i] = keys[i];
     v_vals[i] = static_cast<NDArray*>(vals[i]);
   }
@@ -1065,7 +1065,7 @@ int MXKVStorePullEx(KVStoreHandle handle,
 }
 
 int MXKVStorePullWithSparse(KVStoreHandle handle,
-                            mx_uint num,
+                            uint32_t num,
                             const int* keys,
                             NDArrayHandle* vals,
                             int priority,
@@ -1073,7 +1073,7 @@ int MXKVStorePullWithSparse(KVStoreHandle handle,
   API_BEGIN();
   std::vector<int> v_keys(num);
   std::vector<NDArray*> v_vals(num);
-  for (mx_uint i = 0; i < num; ++i) {
+  for (uint32_t i = 0; i < num; ++i) {
     v_keys[i] = keys[i];
     v_vals[i] = static_cast<NDArray*>(vals[i]);
   }
@@ -1082,7 +1082,7 @@ int MXKVStorePullWithSparse(KVStoreHandle handle,
 }
 
 int MXKVStorePullWithSparseEx(KVStoreHandle handle,
-                              mx_uint num,
+                              uint32_t num,
                               const char** keys,
                               NDArrayHandle* vals,
                               int priority,
@@ -1090,7 +1090,7 @@ int MXKVStorePullWithSparseEx(KVStoreHandle handle,
   API_BEGIN();
   std::vector<std::string> v_keys(num);
   std::vector<NDArray*> v_vals(num);
-  for (mx_uint i = 0; i < num; ++i) {
+  for (uint32_t i = 0; i < num; ++i) {
     v_keys[i] = keys[i];
     v_vals[i] = static_cast<NDArray*>(vals[i]);
   }
@@ -1099,7 +1099,7 @@ int MXKVStorePullWithSparseEx(KVStoreHandle handle,
 }
 
 int MXKVStorePullRowSparse(KVStoreHandle handle,
-                           mx_uint num,
+                           uint32_t num,
                            const int* keys,
                            NDArrayHandle* vals,
                            const NDArrayHandle* row_ids,
@@ -1107,7 +1107,7 @@ int MXKVStorePullRowSparse(KVStoreHandle handle,
   API_BEGIN();
   std::vector<int> v_keys(num);
   std::vector<std::pair<NDArray*, NDArray>> v_val_rowids(num);
-  for (mx_uint i = 0; i < num; ++i) {
+  for (uint32_t i = 0; i < num; ++i) {
     v_keys[i] = keys[i];
     v_val_rowids[i] = std::make_pair(static_cast<NDArray*>(vals[i]),
                                      *static_cast<NDArray*>(row_ids[i]));
@@ -1117,7 +1117,7 @@ int MXKVStorePullRowSparse(KVStoreHandle handle,
 }
 
 int MXKVStorePullRowSparseEx(KVStoreHandle handle,
-                             mx_uint num,
+                             uint32_t num,
                              const char** keys,
                              NDArrayHandle* vals,
                              const NDArrayHandle* row_ids,
@@ -1125,7 +1125,7 @@ int MXKVStorePullRowSparseEx(KVStoreHandle handle,
   API_BEGIN();
   std::vector<std::string> v_keys(num);
   std::vector<std::pair<NDArray*, NDArray>> v_val_rowids(num);
-  for (mx_uint i = 0; i < num; ++i) {
+  for (uint32_t i = 0; i < num; ++i) {
     v_keys[i] = keys[i];
     v_val_rowids[i] = std::make_pair(static_cast<NDArray*>(vals[i]),
                                      *static_cast<NDArray*>(row_ids[i]));
@@ -1206,12 +1206,12 @@ int MXKVStoreSetBarrierBeforeExit(KVStoreHandle handle,
   API_END();
 }
 
-int MXInitPSEnv(mx_uint num_vars,
+int MXInitPSEnv(uint32_t num_vars,
                 const char **keys,
                 const char **vals) {
   API_BEGIN();
   std::unordered_map<std::string, std::string> kwargs;
-  for (mx_uint i = 0; i < num_vars; ++i) {
+  for (uint32_t i = 0; i < num_vars; ++i) {
     kwargs[std::string(keys[i])] = std::string(vals[i]);
   }
   KVStore::InitPSEnv(kwargs);
@@ -1376,7 +1376,7 @@ int MXRecordIOReaderTell(RecordIOHandle handle, size_t *pos) {
   API_END();
 }
 
-int MXRtcCreate(char* name, mx_uint num_input, mx_uint num_output,
+int MXRtcCreate(char* name, uint32_t num_input, uint32_t num_output,
                 char** input_names, char** output_names,
                 NDArrayHandle* inputs, NDArrayHandle* outputs,
                 char* kernel, RtcHandle *out) {
@@ -1385,14 +1385,14 @@ int MXRtcCreate(char* name, mx_uint num_input, mx_uint num_output,
   API_END();
 }
 
-int MXRtcPush(RtcHandle handle, mx_uint num_input, mx_uint num_output,
+int MXRtcPush(RtcHandle handle, uint32_t num_input, uint32_t num_output,
               NDArrayHandle* inputs, NDArrayHandle* outputs,
-              mx_uint gridDimX,
-              mx_uint gridDimY,
-              mx_uint gridDimZ,
-              mx_uint blockDimX,
-              mx_uint blockDimY,
-              mx_uint blockDimZ) {
+              uint32_t gridDimX,
+              uint32_t gridDimY,
+              uint32_t gridDimZ,
+              uint32_t blockDimX,
+              uint32_t blockDimY,
+              uint32_t blockDimZ) {
   API_BEGIN();
   LOG(FATAL) << "Old rtc API is deprecated. Please use CudaModule";
   API_END();
@@ -1468,10 +1468,10 @@ int MXRtcCudaKernelFree(CudaKernelHandle handle) {
 }
 
 int MXRtcCudaKernelCall(CudaKernelHandle handle, int dev_id, void** args,
-                        mx_uint grid_dim_x, mx_uint grid_dim_y,
-                        mx_uint grid_dim_z, mx_uint block_dim_x,
-                        mx_uint block_dim_y, mx_uint block_dim_z,
-                        mx_uint shared_mem) {
+                        uint32_t grid_dim_x, uint32_t grid_dim_y,
+                        uint32_t grid_dim_z, uint32_t block_dim_x,
+                        uint32_t block_dim_y, uint32_t block_dim_z,
+                        uint32_t shared_mem) {
   API_BEGIN();
 #if MXNET_USE_CUDA && MXNET_ENABLE_CUDA_RTC
   auto kernel = reinterpret_cast<std::shared_ptr<rtc::CudaModule::Kernel>*>(handle);
@@ -1514,8 +1514,8 @@ int MXNDArrayGetSharedMemHandle(NDArrayHandle handle, int* shared_pid, int* shar
   API_END();
 }
 
-int MXNDArrayCreateFromSharedMem(int shared_pid, int shared_id, const mx_uint *shape,
-                                 mx_uint ndim, int dtype, NDArrayHandle *out) {
+int MXNDArrayCreateFromSharedMem(int shared_pid, int shared_id, const uint32_t *shape,
+                                 uint32_t ndim, int dtype, NDArrayHandle *out) {
   API_BEGIN();
   *out = new NDArray(shared_pid, shared_id, mxnet::TShape(shape, shape + ndim), dtype);
   API_END();

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -215,7 +215,7 @@ int MXNDArrayCreate(const uint32_t *shape,
   API_END();
 }
 
-int MXNDArrayCreateEx64(const mx_int64 *shape,
+int MXNDArrayCreateEx64(const int64_t *shape,
                         int ndim,
                         int dev_type,
                         int dev_id,
@@ -223,7 +223,7 @@ int MXNDArrayCreateEx64(const mx_int64 *shape,
                         int dtype,
                         NDArrayHandle *out) {
   API_BEGIN();
-  CreateNDArray<mx_int64, int>(shape, ndim, dev_type, dev_id, delay_alloc, dtype, out);
+  CreateNDArray<int64_t, int>(shape, ndim, dev_type, dev_id, delay_alloc, dtype, out);
   API_END();
 }
 
@@ -616,10 +616,10 @@ int MXNDArrayGetShapeEx(NDArrayHandle handle,
 
 int MXNDArrayGetShapeEx64(NDArrayHandle handle,
                           int *out_dim,
-                          const mx_int64 **out_pdata) {
+                          const int64_t **out_pdata) {
   MXAPIThreadLocalEntry<int64_t> *ret = MXAPIThreadLocalStore<int64_t>::Get();
   API_BEGIN();
-  GetShape<mx_int64>(handle, out_pdata, out_dim, ret);
+  GetShape<int64_t>(handle, out_pdata, out_dim, ret);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -811,7 +811,7 @@ int MXFuncDescribe(FunctionHandle fun,
 
 int MXFuncInvoke(FunctionHandle fun,
                  NDArrayHandle *use_vars,
-                 mx_float *scalar_args,
+                 float *scalar_args,
                  NDArrayHandle *mutate_vars) {
   API_BEGIN();
   auto *f = static_cast<const NDArrayFunctionReg*>(fun);
@@ -826,7 +826,7 @@ int MXFuncInvoke(FunctionHandle fun,
 
 int MXFuncInvokeEx(FunctionHandle fun,
                  NDArrayHandle *use_vars,
-                 mx_float *scalar_args,
+                 float *scalar_args,
                  NDArrayHandle *mutate_vars,
                  int num_params,
                  char **param_keys,

--- a/src/c_api/c_api_common.h
+++ b/src/c_api/c_api_common.h
@@ -76,11 +76,11 @@ struct MXAPIThreadLocalEntry {
   /*! \brief result holder for returning storage types */
   std::vector<int> arg_storage_types, out_storage_types, aux_storage_types;
   /*! \brief result holder for returning shape dimensions */
-  std::vector<mx_uint> arg_shape_ndim, out_shape_ndim, aux_shape_ndim;
+  std::vector<uint32_t> arg_shape_ndim, out_shape_ndim, aux_shape_ndim;
   /*! \brief result holder for returning shape dimensions */
   std::vector<int> arg_shape_ndim_ex, out_shape_ndim_ex, aux_shape_ndim_ex;
   /*! \brief result holder for returning shape pointer */
-  std::vector<const mx_uint*> arg_shape_data, out_shape_data, aux_shape_data;
+  std::vector<const uint32_t*> arg_shape_data, out_shape_data, aux_shape_data;
   /*! \brief result holder for returning shape pointer */
   std::vector<const dtype*> arg_shape_data_ex, out_shape_data_ex, aux_shape_data_ex;
   /*! \brief uint32_t buffer for returning shape pointer */
@@ -93,8 +93,8 @@ struct MXAPIThreadLocalEntry {
   // helper function to setup return value of shape array
   inline static void SetupShapeArrayReturnWithBuffer(
       const mxnet::ShapeVector &shapes,
-      std::vector<mx_uint> *ndim,
-      std::vector<const mx_uint*> *data,
+      std::vector<uint32_t> *ndim,
+      std::vector<const uint32_t*> *data,
       std::vector<uint32_t> *buffer) {
     ndim->resize(shapes.size());
     data->resize(shapes.size());

--- a/src/c_api/c_api_executor.cc
+++ b/src/c_api/c_api_executor.cc
@@ -55,20 +55,20 @@ int MXExecutorForward(ExecutorHandle handle, int is_train) {
 }
 
 int MXExecutorBackward(ExecutorHandle handle,
-                       mx_uint len,
+                       uint32_t len,
                        NDArrayHandle *head_grads) {
   return MXExecutorBackwardEx(handle, len, head_grads, true);
 }
 
 int MXExecutorBackwardEx(ExecutorHandle handle,
-                         mx_uint len,
+                         uint32_t len,
                          NDArrayHandle *head_grads,
                          int is_train) {
   API_BEGIN();
   Executor *exec = static_cast<Executor*>(handle);
   std::vector<NDArray> ndarrays;
   NDArray **args_ptr = reinterpret_cast<NDArray**>(head_grads);
-  for (mx_uint i = 0; i < len; ++i) {
+  for (uint32_t i = 0; i < len; ++i) {
     ndarrays.push_back(*args_ptr[i]);
   }
   exec->Backward(ndarrays, is_train);
@@ -76,7 +76,7 @@ int MXExecutorBackwardEx(ExecutorHandle handle,
 }
 
 int MXExecutorOutputs(ExecutorHandle handle,
-                      mx_uint *out_size,
+                      uint32_t *out_size,
                       NDArrayHandle **out) {
   MXAPIThreadLocalEntry<> *ret = MXAPIThreadLocalStore<>::Get();
   API_BEGIN();
@@ -96,11 +96,11 @@ int MXExecutorOutputs(ExecutorHandle handle,
 int MXExecutorBind(SymbolHandle symbol_handle,
                    int dev_type,
                    int dev_id,
-                   mx_uint len,
+                   uint32_t len,
                    NDArrayHandle *in_args,
                    NDArrayHandle *arg_grad_store,
-                   mx_uint *grad_req_type,
-                   mx_uint aux_states_len,
+                   uint32_t *grad_req_type,
+                   uint32_t aux_states_len,
                    NDArrayHandle *aux_states,
                    ExecutorHandle *out) {
   return MXExecutorBindX(symbol_handle,
@@ -113,15 +113,15 @@ int MXExecutorBind(SymbolHandle symbol_handle,
 int MXExecutorBindX(SymbolHandle symbol_handle,
                     int dev_type,
                     int dev_id,
-                    mx_uint num_map_keys,
+                    uint32_t num_map_keys,
                     const char** map_keys,
                     const int* map_dev_types,
                     const int* map_dev_ids,
-                    mx_uint len,
+                    uint32_t len,
                     NDArrayHandle *in_args,
                     NDArrayHandle *arg_grad_store,
-                    mx_uint *grad_req_type,
-                    mx_uint aux_states_len,
+                    uint32_t *grad_req_type,
+                    uint32_t aux_states_len,
                     NDArrayHandle *aux_states,
                     ExecutorHandle *out) {
   return MXExecutorBindEX(symbol_handle,
@@ -135,15 +135,15 @@ int MXExecutorBindX(SymbolHandle symbol_handle,
 int MXExecutorBindEX(SymbolHandle symbol_handle,
                      int dev_type,
                      int dev_id,
-                     mx_uint num_map_keys,
+                     uint32_t num_map_keys,
                      const char** map_keys,
                      const int* map_dev_types,
                      const int* map_dev_ids,
-                     mx_uint len,
+                     uint32_t len,
                      NDArrayHandle *in_args,
                      NDArrayHandle *arg_grad_store,
-                     mx_uint *grad_req_type,
-                     mx_uint aux_states_len,
+                     uint32_t *grad_req_type,
+                     uint32_t aux_states_len,
                      NDArrayHandle *aux_states,
                      ExecutorHandle shared_exec,
                      ExecutorHandle *out) {
@@ -151,7 +151,7 @@ int MXExecutorBindEX(SymbolHandle symbol_handle,
   nnvm::Symbol *symb = static_cast<nnvm::Symbol*>(symbol_handle);
   Context ctx = Context::Create(static_cast<Context::DeviceType>(dev_type), dev_id);
   std::map<std::string, Context> ctx_map;
-  for (mx_uint i = 0; i < num_map_keys; ++i) {
+  for (uint32_t i = 0; i < num_map_keys; ++i) {
     ctx_map[std::string(map_keys[i])] = Context::Create(
         static_cast<Context::DeviceType>(map_dev_types[i]), map_dev_ids[i]);
   }
@@ -162,7 +162,7 @@ int MXExecutorBindEX(SymbolHandle symbol_handle,
   std::vector<NDArray> arg_grad_vec;
   std::vector<OpReqType> grad_req_vec;
   std::vector<NDArray> aux_states_vec;
-  for (mx_uint i = 0; i < len; ++i) {
+  for (uint32_t i = 0; i < len; ++i) {
     in_args_vec.push_back(*(in_args_ptr[i]));
     if (arg_grad_ptr[i] == nullptr) {
       arg_grad_vec.emplace_back();
@@ -172,7 +172,7 @@ int MXExecutorBindEX(SymbolHandle symbol_handle,
       grad_req_vec.push_back(static_cast<OpReqType>(grad_req_type[i]));
     }
   }
-  for (mx_uint i = 0; i < aux_states_len; ++i) {
+  for (uint32_t i = 0; i < aux_states_len; ++i) {
     aux_states_vec.push_back(*(aux_states_ptr[i]));
   }
   *out = Executor::Bind(*symb, ctx, ctx_map, in_args_vec,
@@ -221,34 +221,34 @@ int MXExecutorBindEX(SymbolHandle symbol_handle,
 int MXExecutorSimpleBind(SymbolHandle symbol_handle,
                          int dev_type,
                          int dev_id,
-                         const mx_uint num_g2c_keys,
+                         const uint32_t num_g2c_keys,
                          const char** g2c_keys,
                          const int* g2c_dev_types,
                          const int* g2c_dev_ids,
-                         const mx_uint provided_grad_req_list_len,
+                         const uint32_t provided_grad_req_list_len,
                          const char** provided_grad_req_names,
                          const char** provided_grad_req_types,
-                         const mx_uint num_provided_arg_shapes,
+                         const uint32_t num_provided_arg_shapes,
                          const char** provided_arg_shape_names,
-                         const mx_uint* provided_arg_shape_data,
-                         const mx_uint* provided_arg_shape_idx,
-                         const mx_uint num_provided_arg_dtypes,
+                         const uint32_t* provided_arg_shape_data,
+                         const uint32_t* provided_arg_shape_idx,
+                         const uint32_t num_provided_arg_dtypes,
                          const char** provided_arg_dtype_names,
                          const int* provided_arg_dtypes,
-                         const mx_uint num_provided_arg_stypes,
+                         const uint32_t num_provided_arg_stypes,
                          const char** provided_arg_stype_names,
                          const int* provided_arg_stypes,
-                         const mx_uint num_shared_arg_names,
+                         const uint32_t num_shared_arg_names,
                          const char** shared_arg_name_list,
                          int* shared_buffer_len,
                          const char** shared_buffer_name_list,
                          NDArrayHandle* shared_buffer_handle_list,
                          const char*** updated_shared_buffer_name_list,
                          NDArrayHandle** updated_shared_buffer_handle_list,
-                         mx_uint* num_in_args,
+                         uint32_t* num_in_args,
                          NDArrayHandle** in_args,
                          NDArrayHandle** arg_grads,
-                         mx_uint* num_aux_states,
+                         uint32_t* num_aux_states,
                          NDArrayHandle** aux_states,
                          ExecutorHandle shared_exec_handle,
                          ExecutorHandle* out) {
@@ -283,7 +283,7 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
   } else {  // use user input type_dict
     // create dtype map for in_args and aux_states
     arg_dtype_map.reserve(num_provided_arg_dtypes);
-    for (mx_uint i = 0; i < num_provided_arg_dtypes; ++i) {
+    for (uint32_t i = 0; i < num_provided_arg_dtypes; ++i) {
       arg_dtype_map[provided_arg_dtype_names[i]] = provided_arg_dtypes[i];
     }
   }
@@ -300,7 +300,7 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
   } else {  // use user input type_dict
     // create stype map for in_args and aux_states
     arg_stype_map.reserve(num_provided_arg_stypes);
-    for (mx_uint i = 0; i < num_provided_arg_stypes; ++i) {
+    for (uint32_t i = 0; i < num_provided_arg_stypes; ++i) {
       arg_stype_map[provided_arg_stype_names[i]] = provided_arg_stypes[i];
     }
   }
@@ -312,7 +312,7 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
   std::vector<Context> in_arg_ctx_vec(in_arg_names.size(), ctx);
   std::vector<Context> aux_state_ctx_vec(aux_state_names.size(), ctx);
   if (nullptr != g2c_keys) {  // use user input group2ctx dict
-    for (mx_uint i = 0; i < num_g2c_keys; ++i) {
+    for (uint32_t i = 0; i < num_g2c_keys; ++i) {
       ctx_map[g2c_keys[i]] = Context::Create(
           static_cast<Context::DeviceType>(g2c_dev_types[i]), g2c_dev_ids[i]);
     }
@@ -370,7 +370,7 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
       && nullptr != provided_grad_req_types) {  // dict, grad_req=['lhs': 'null', 'rhs': 'write']
     grad_req_type = "dict";
     provided_grad_req_map.reserve(provided_grad_req_list_len);
-    for (mx_uint i = 0; i < provided_grad_req_list_len; ++i) {
+    for (uint32_t i = 0; i < provided_grad_req_list_len; ++i) {
       CHECK_EQ(req_map.count(provided_grad_req_types[i]), 1U)
         << "grad_req=" << provided_grad_req_types[i] << " is not a valid input in simple_bind; "
         "only \'null\', \'write\', and \'add\' are supported";
@@ -408,7 +408,7 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
 
   // create shape map for in_args and aux_states
   std::unordered_map<std::string, mxnet::TShape> arg_shape_map(num_provided_arg_shapes);
-  for (mx_uint i = 0; i < num_provided_arg_shapes; ++i) {
+  for (uint32_t i = 0; i < num_provided_arg_shapes; ++i) {
     auto p = arg_shape_map.emplace(provided_arg_shape_names[i],
         mxnet::TShape(provided_arg_shape_data+provided_arg_shape_idx[i],
           provided_arg_shape_data+provided_arg_shape_idx[i+1]));
@@ -423,7 +423,7 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
 
   // create para name set for sharing data array memory
   std::unordered_set<std::string> shared_arg_name_set(num_shared_arg_names);
-  for (mx_uint i = 0; i < num_shared_arg_names; ++i) {
+  for (uint32_t i = 0; i < num_shared_arg_names; ++i) {
     shared_arg_name_set.insert(shared_arg_name_list[i]);
   }
 
@@ -555,34 +555,34 @@ int MXExecutorSimpleBind(SymbolHandle symbol_handle,
 int MXExecutorSimpleBindEx(SymbolHandle symbol_handle,
                            int dev_type,
                            int dev_id,
-                           const mx_uint num_g2c_keys,
+                           const uint32_t num_g2c_keys,
                            const char** g2c_keys,
                            const int* g2c_dev_types,
                            const int* g2c_dev_ids,
-                           const mx_uint provided_grad_req_list_len,
+                           const uint32_t provided_grad_req_list_len,
                            const char** provided_grad_req_names,
                            const char** provided_grad_req_types,
-                           const mx_uint num_provided_arg_shapes,
+                           const uint32_t num_provided_arg_shapes,
                            const char** provided_arg_shape_names,
                            const int* provided_arg_shape_data,
-                           const mx_uint* provided_arg_shape_idx,
-                           const mx_uint num_provided_arg_dtypes,
+                           const uint32_t* provided_arg_shape_idx,
+                           const uint32_t num_provided_arg_dtypes,
                            const char** provided_arg_dtype_names,
                            const int* provided_arg_dtypes,
-                           const mx_uint num_provided_arg_stypes,
+                           const uint32_t num_provided_arg_stypes,
                            const char** provided_arg_stype_names,
                            const int* provided_arg_stypes,
-                           const mx_uint num_shared_arg_names,
+                           const uint32_t num_shared_arg_names,
                            const char** shared_arg_name_list,
                            int* shared_buffer_len,
                            const char** shared_buffer_name_list,
                            NDArrayHandle* shared_buffer_handle_list,
                            const char*** updated_shared_buffer_name_list,
                            NDArrayHandle** updated_shared_buffer_handle_list,
-                           mx_uint* num_in_args,
+                           uint32_t* num_in_args,
                            NDArrayHandle** in_args,
                            NDArrayHandle** arg_grads,
-                           mx_uint* num_aux_states,
+                           uint32_t* num_aux_states,
                            NDArrayHandle** aux_states,
                            ExecutorHandle shared_exec_handle,
                            ExecutorHandle* out) {
@@ -617,7 +617,7 @@ int MXExecutorSimpleBindEx(SymbolHandle symbol_handle,
   } else {  // use user input type_dict
     // create dtype map for in_args and aux_states
     arg_dtype_map.reserve(num_provided_arg_dtypes);
-    for (mx_uint i = 0; i < num_provided_arg_dtypes; ++i) {
+    for (uint32_t i = 0; i < num_provided_arg_dtypes; ++i) {
       arg_dtype_map[provided_arg_dtype_names[i]] = provided_arg_dtypes[i];
     }
   }
@@ -634,7 +634,7 @@ int MXExecutorSimpleBindEx(SymbolHandle symbol_handle,
   } else {  // use user input type_dict
     // create stype map for in_args and aux_states
     arg_stype_map.reserve(num_provided_arg_stypes);
-    for (mx_uint i = 0; i < num_provided_arg_stypes; ++i) {
+    for (uint32_t i = 0; i < num_provided_arg_stypes; ++i) {
       arg_stype_map[provided_arg_stype_names[i]] = provided_arg_stypes[i];
     }
   }
@@ -646,7 +646,7 @@ int MXExecutorSimpleBindEx(SymbolHandle symbol_handle,
   std::vector<Context> in_arg_ctx_vec(in_arg_names.size(), ctx);
   std::vector<Context> aux_state_ctx_vec(aux_state_names.size(), ctx);
   if (nullptr != g2c_keys) {  // use user input group2ctx dict
-    for (mx_uint i = 0; i < num_g2c_keys; ++i) {
+    for (uint32_t i = 0; i < num_g2c_keys; ++i) {
       ctx_map[g2c_keys[i]] = Context::Create(
           static_cast<Context::DeviceType>(g2c_dev_types[i]), g2c_dev_ids[i]);
     }
@@ -704,7 +704,7 @@ int MXExecutorSimpleBindEx(SymbolHandle symbol_handle,
       && nullptr != provided_grad_req_types) {  // dict, grad_req=['lhs': 'null', 'rhs': 'write']
     grad_req_type = "dict";
     provided_grad_req_map.reserve(provided_grad_req_list_len);
-    for (mx_uint i = 0; i < provided_grad_req_list_len; ++i) {
+    for (uint32_t i = 0; i < provided_grad_req_list_len; ++i) {
       CHECK_EQ(req_map.count(provided_grad_req_types[i]), 1U)
         << "grad_req=" << provided_grad_req_types[i] << " is not a valid input in simple_bind; "
         "only \'null\', \'write\', and \'add\' are supported";
@@ -742,7 +742,7 @@ int MXExecutorSimpleBindEx(SymbolHandle symbol_handle,
 
   // create shape map for in_args and aux_states
   std::unordered_map<std::string, mxnet::TShape> arg_shape_map(num_provided_arg_shapes);
-  for (mx_uint i = 0; i < num_provided_arg_shapes; ++i) {
+  for (uint32_t i = 0; i < num_provided_arg_shapes; ++i) {
     auto p = arg_shape_map.emplace(provided_arg_shape_names[i],
         mxnet::TShape(provided_arg_shape_data+provided_arg_shape_idx[i],
           provided_arg_shape_data+provided_arg_shape_idx[i+1]));
@@ -757,7 +757,7 @@ int MXExecutorSimpleBindEx(SymbolHandle symbol_handle,
 
   // create para name set for sharing data array memory
   std::unordered_set<std::string> shared_arg_name_set(num_shared_arg_names);
-  for (mx_uint i = 0; i < num_shared_arg_names; ++i) {
+  for (uint32_t i = 0; i < num_shared_arg_names; ++i) {
     shared_arg_name_set.insert(shared_arg_name_list[i]);
   }
 
@@ -853,18 +853,18 @@ int MXExecutorReshape(int partial_shaping,
                       int allow_up_sizing,
                       int dev_type,
                       int dev_id,
-                      mx_uint num_map_keys,
+                      uint32_t num_map_keys,
                       const char** map_keys,
                       const int* map_dev_types,
                       const int* map_dev_ids,
-                      const mx_uint num_provided_arg_shapes,
+                      const uint32_t num_provided_arg_shapes,
                       const char** provided_arg_shape_names,
-                      const mx_uint* provided_arg_shape_data,
-                      const mx_uint* provided_arg_shape_idx,
-                      mx_uint* num_in_args,
+                      const uint32_t* provided_arg_shape_data,
+                      const uint32_t* provided_arg_shape_idx,
+                      uint32_t* num_in_args,
                       NDArrayHandle** in_args,
                       NDArrayHandle** arg_grads,
-                      mx_uint* num_aux_states,
+                      uint32_t* num_aux_states,
                       NDArrayHandle** aux_states,
                       ExecutorHandle shared_exec,
                       ExecutorHandle *out) {
@@ -875,7 +875,7 @@ int MXExecutorReshape(int partial_shaping,
   *out = nullptr;  // ensure we can know whether to free executor on early abort
   // create shape map for in_args and aux_states
   std::unordered_map<std::string, mxnet::TShape> kwargs(num_provided_arg_shapes);
-  for (mx_uint i = 0; i < num_provided_arg_shapes; ++i) {
+  for (uint32_t i = 0; i < num_provided_arg_shapes; ++i) {
     auto p = kwargs.emplace(provided_arg_shape_names[i],
         mxnet::TShape(provided_arg_shape_data+provided_arg_shape_idx[i],
           provided_arg_shape_data+provided_arg_shape_idx[i+1]));
@@ -885,7 +885,7 @@ int MXExecutorReshape(int partial_shaping,
 
   Context ctx = Context::Create(static_cast<Context::DeviceType>(dev_type), dev_id);
   std::map<std::string, Context> ctx_map;
-  for (mx_uint i = 0; i < num_map_keys; ++i) {
+  for (uint32_t i = 0; i < num_map_keys; ++i) {
     ctx_map[std::string(map_keys[i])] = Context::Create(
         static_cast<Context::DeviceType>(map_dev_types[i]), map_dev_ids[i]);
   }
@@ -944,18 +944,18 @@ int MXExecutorReshapeEx(int partial_shaping,
                         int allow_up_sizing,
                         int dev_type,
                         int dev_id,
-                        mx_uint num_map_keys,
+                        uint32_t num_map_keys,
                         const char** map_keys,
                         const int* map_dev_types,
                         const int* map_dev_ids,
-                        const mx_uint num_provided_arg_shapes,
+                        const uint32_t num_provided_arg_shapes,
                         const char** provided_arg_shape_names,
                         const int* provided_arg_shape_data,
-                        const mx_uint* provided_arg_shape_idx,
-                        mx_uint* num_in_args,
+                        const uint32_t* provided_arg_shape_idx,
+                        uint32_t* num_in_args,
                         NDArrayHandle** in_args,
                         NDArrayHandle** arg_grads,
-                        mx_uint* num_aux_states,
+                        uint32_t* num_aux_states,
                         NDArrayHandle** aux_states,
                         ExecutorHandle shared_exec,
                         ExecutorHandle *out) {
@@ -966,7 +966,7 @@ int MXExecutorReshapeEx(int partial_shaping,
   *out = nullptr;  // ensure we can know whether to free executor on early abort
   // create shape map for in_args and aux_states
   std::unordered_map<std::string, mxnet::TShape> kwargs(num_provided_arg_shapes);
-  for (mx_uint i = 0; i < num_provided_arg_shapes; ++i) {
+  for (uint32_t i = 0; i < num_provided_arg_shapes; ++i) {
     auto p = kwargs.emplace(provided_arg_shape_names[i],
         mxnet::TShape(provided_arg_shape_data+provided_arg_shape_idx[i],
           provided_arg_shape_data+provided_arg_shape_idx[i+1]));
@@ -976,7 +976,7 @@ int MXExecutorReshapeEx(int partial_shaping,
 
   Context ctx = Context::Create(static_cast<Context::DeviceType>(dev_type), dev_id);
   std::map<std::string, Context> ctx_map;
-  for (mx_uint i = 0; i < num_map_keys; ++i) {
+  for (uint32_t i = 0; i < num_map_keys; ++i) {
     ctx_map[std::string(map_keys[i])] = Context::Create(
         static_cast<Context::DeviceType>(map_dev_types[i]), map_dev_ids[i]);
   }

--- a/src/c_api/c_api_ndarray.cc
+++ b/src/c_api/c_api_ndarray.cc
@@ -288,17 +288,17 @@ int MXSetIsNumpyShape(int is_np_shape, int* prev) {
   API_END();
 }
 
-int MXAutogradMarkVariables(mx_uint num_var,
+int MXAutogradMarkVariables(uint32_t num_var,
                             NDArrayHandle *var_handles,
-                            mx_uint *reqs_array,
+                            uint32_t *reqs_array,
                             NDArrayHandle *grad_handles) {
   API_BEGIN();
   std::vector<NDArray*> variables, gradients;
-  std::vector<mx_uint> grad_reqs;
+  std::vector<uint32_t> grad_reqs;
   variables.reserve(num_var);
   gradients.reserve(num_var);
   grad_reqs.reserve(num_var);
-  for (mx_uint i = 0; i < num_var; ++i) {
+  for (uint32_t i = 0; i < num_var; ++i) {
     variables.emplace_back(static_cast<NDArray*>(var_handles[i]));
     gradients.emplace_back(static_cast<NDArray*>(grad_handles[i]));
     grad_reqs.emplace_back(reqs_array[i]);
@@ -307,12 +307,12 @@ int MXAutogradMarkVariables(mx_uint num_var,
   API_END();
 }
 
-int MXAutogradComputeGradient(mx_uint num_output,
+int MXAutogradComputeGradient(uint32_t num_output,
                               NDArrayHandle *output_handles) {
   return MXAutogradBackward(num_output, output_handles, nullptr, 0);
 }
 
-int MXAutogradBackward(mx_uint num_output,
+int MXAutogradBackward(uint32_t num_output,
                        NDArrayHandle *output_handles,
                        NDArrayHandle *ograd_handles,
                        int retain_graph) {
@@ -321,10 +321,10 @@ int MXAutogradBackward(mx_uint num_output,
                               nullptr, nullptr);
 }
 
-int MXAutogradBackwardEx(mx_uint num_output,
+int MXAutogradBackwardEx(uint32_t num_output,
                          NDArrayHandle *output_handles,
                          NDArrayHandle *ograd_handles,
-                         mx_uint num_variables,
+                         uint32_t num_variables,
                          NDArrayHandle *var_handles,
                          int retain_graph,
                          int create_graph,
@@ -336,12 +336,12 @@ int MXAutogradBackwardEx(mx_uint num_output,
 
   std::vector<NDArray*> outputs, ograds, variables;
   outputs.reserve(num_output);
-  for (mx_uint i = 0; i < num_output; ++i) {
+  for (uint32_t i = 0; i < num_output; ++i) {
     outputs.emplace_back(reinterpret_cast<NDArray*>(output_handles[i]));
   }
 
   ograds.reserve(num_output);
-  for (mx_uint i = 0; i < num_output; ++i) {
+  for (uint32_t i = 0; i < num_output; ++i) {
     if (ograd_handles != nullptr) {
       ograds.emplace_back(reinterpret_cast<NDArray*>(ograd_handles[i]));
     } else {
@@ -350,7 +350,7 @@ int MXAutogradBackwardEx(mx_uint num_output,
   }
 
   variables.reserve(num_variables);
-  for (mx_uint i = 0; i < num_variables; ++i) {
+  for (uint32_t i = 0; i < num_variables; ++i) {
     variables.emplace_back(reinterpret_cast<NDArray*>(var_handles[i]));
   }
 

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -80,7 +80,7 @@ int MXListAllOpNames(nn_uint *out_size,
   return NNListAllOpNames(out_size, out_array);
 }
 
-int MXSymbolListAtomicSymbolCreators(mx_uint *out_size,
+int MXSymbolListAtomicSymbolCreators(uint32_t *out_size,
                                      AtomicSymbolCreator **out_array) {
   mxnet::op::RegisterLegacyOpProp();
   mxnet::op::RegisterLegacyNDFunc();
@@ -90,7 +90,7 @@ int MXSymbolListAtomicSymbolCreators(mx_uint *out_size,
 int MXSymbolGetAtomicSymbolInfo(AtomicSymbolCreator creator,
                                 const char **name,
                                 const char **description,
-                                mx_uint *num_args,
+                                uint32_t *num_args,
                                 const char ***arg_names,
                                 const char ***arg_type_infos,
                                 const char ***arg_descriptions,
@@ -113,7 +113,7 @@ int MXSymbolGetAtomicSymbolInfo(AtomicSymbolCreator creator,
 }
 
 int MXSymbolCreateAtomicSymbol(AtomicSymbolCreator creator,
-                               mx_uint num_param,
+                               uint32_t num_param,
                                const char **keys,
                                const char **vals,
                                SymbolHandle *out) {
@@ -150,14 +150,14 @@ int MXSymbolCreateVariable(const char *name, SymbolHandle *out) {
   return NNSymbolCreateVariable(name, out);
 }
 
-int MXSymbolCreateGroup(mx_uint num_symbols,
+int MXSymbolCreateGroup(uint32_t num_symbols,
                         SymbolHandle *symbols,
                         SymbolHandle *out) {
   return NNSymbolCreateGroup(num_symbols, symbols, out);
 }
 
 int MXSymbolGetOutput(SymbolHandle symbol,
-                      mx_uint index,
+                      uint32_t index,
                       SymbolHandle *out) {
   return NNSymbolGetOutput(symbol, index, out);
 }
@@ -248,7 +248,7 @@ int MXSymbolSetAttr(SymbolHandle symbol,
 }
 
 int MXSymbolListAttr(SymbolHandle symbol,
-                     mx_uint *out_size,
+                     uint32_t *out_size,
                      const char*** out) {
   nnvm::Symbol *s = static_cast<nnvm::Symbol*>(symbol);
   MXAPIThreadLocalEntry<> *ret = MXAPIThreadLocalStore<>::Get();
@@ -278,7 +278,7 @@ int MXSymbolListAttr(SymbolHandle symbol,
 }
 
 int MXSymbolListAttrShallow(SymbolHandle symbol,
-                            mx_uint *out_size,
+                            uint32_t *out_size,
                             const char*** out) {
   nnvm::Symbol *s = static_cast<nnvm::Symbol*>(symbol);
   MXAPIThreadLocalEntry<> *ret = MXAPIThreadLocalStore<>::Get();
@@ -307,19 +307,19 @@ int MXSymbolListAttrShallow(SymbolHandle symbol,
 }
 
 int MXSymbolListOutputs(SymbolHandle symbol,
-                        mx_uint *out_size,
+                        uint32_t *out_size,
                         const char ***out_str_array) {
   return NNSymbolListOutputNames(symbol, out_size, out_str_array);
 }
 
 int MXSymbolGetNumOutputs(SymbolHandle symbol,
-                           mx_uint *output_count) {
+                           uint32_t *output_count) {
   return NNSymbolGetNumOutputs(symbol, output_count);
 }
 
 int MXSymbolCompose(SymbolHandle sym,
                     const char *name,
-                    mx_uint num_args,
+                    uint32_t num_args,
                     const char** keys,
                     SymbolHandle* args) {
   return NNSymbolCompose(sym, name, num_args, keys, args);
@@ -327,13 +327,13 @@ int MXSymbolCompose(SymbolHandle sym,
 
 // adapter functions that re-implements the functions.
 int MXSymbolListArguments(SymbolHandle symbol,
-                          mx_uint *out_size,
+                          uint32_t *out_size,
                           const char ***out_str_array) {
   return NNSymbolListInputNames(symbol, 1, out_size, out_str_array);
 }
 
 int MXSymbolListAuxiliaryStates(SymbolHandle symbol,
-                                mx_uint *out_size,
+                                uint32_t *out_size,
                                 const char ***out_str_array) {
   return NNSymbolListInputNames(symbol, 2, out_size, out_str_array);
 }
@@ -513,19 +513,19 @@ void MatchArguments(
 }  // namespace mxnet
 
 int MXSymbolInferShape(SymbolHandle sym,
-                       mx_uint num_args,
+                       uint32_t num_args,
                        const char** keys,
-                       const mx_uint *arg_ind_ptr,
-                       const mx_uint *arg_shape_data,
-                       mx_uint *in_shape_size,
-                       const mx_uint **in_shape_ndim,
-                       const mx_uint ***in_shape_data,
-                       mx_uint *out_shape_size,
-                       const mx_uint **out_shape_ndim,
-                       const mx_uint ***out_shape_data,
-                       mx_uint *aux_shape_size,
-                       const mx_uint **aux_shape_ndim,
-                       const mx_uint ***aux_shape_data,
+                       const uint32_t *arg_ind_ptr,
+                       const uint32_t *arg_shape_data,
+                       uint32_t *in_shape_size,
+                       const uint32_t **in_shape_ndim,
+                       const uint32_t ***in_shape_data,
+                       uint32_t *out_shape_size,
+                       const uint32_t **out_shape_ndim,
+                       const uint32_t ***out_shape_data,
+                       uint32_t *aux_shape_size,
+                       const uint32_t **aux_shape_ndim,
+                       const uint32_t ***aux_shape_data,
                        int *complete) {
   nnvm::Symbol *s = static_cast<nnvm::Symbol*>(sym);
   MXAPIThreadLocalEntry<> *ret = MXAPIThreadLocalStore<>::Get();
@@ -535,13 +535,13 @@ int MXSymbolInferShape(SymbolHandle sym,
   if (keys == nullptr && num_args != 0) {
     std::vector<uint32_t> read_only_args = mxnet::ReadOnlyArgIndices(g.indexed_graph());
     CHECK_LE(num_args, read_only_args.size());
-    for (mx_uint i = 0; i < num_args; ++i) {
+    for (uint32_t i = 0; i < num_args; ++i) {
       arg_shapes[read_only_args[i]] = mxnet::ShapeTypeCast(
           arg_shape_data + arg_ind_ptr[i], arg_shape_data + arg_ind_ptr[i+1]);
     }
   } else {
     std::unordered_map<std::string, mxnet::TShape> kwargs;
-    for (mx_uint i = 0; i < num_args; ++i) {
+    for (uint32_t i = 0; i < num_args; ++i) {
       kwargs[keys[i]] = mxnet::ShapeTypeCast(
           arg_shape_data + arg_ind_ptr[i], arg_shape_data + arg_ind_ptr[i+1]);
     }
@@ -571,13 +571,13 @@ int MXSymbolInferShape(SymbolHandle sym,
       &(ret->out_shape_ndim), &(ret->out_shape_data), &(ret->out_shape_buffer));
   MXAPIThreadLocalEntry<>::SetupShapeArrayReturnWithBuffer(ret->aux_shapes,
       &(ret->aux_shape_ndim), &(ret->aux_shape_data), &(ret->aux_shape_buffer));
-  *in_shape_size = static_cast<mx_uint>(ret->arg_shapes.size());
+  *in_shape_size = static_cast<uint32_t>(ret->arg_shapes.size());
   *in_shape_ndim = dmlc::BeginPtr(ret->arg_shape_ndim);
   *in_shape_data = dmlc::BeginPtr(ret->arg_shape_data);
-  *out_shape_size = static_cast<mx_uint>(ret->out_shapes.size());
+  *out_shape_size = static_cast<uint32_t>(ret->out_shapes.size());
   *out_shape_ndim = dmlc::BeginPtr(ret->out_shape_ndim);
   *out_shape_data = dmlc::BeginPtr(ret->out_shape_data);
-  *aux_shape_size = static_cast<mx_uint>(ret->aux_shapes.size());
+  *aux_shape_size = static_cast<uint32_t>(ret->aux_shapes.size());
   *aux_shape_ndim = dmlc::BeginPtr(ret->aux_shape_ndim);
   *aux_shape_data = dmlc::BeginPtr(ret->aux_shape_data);
   // mark complete
@@ -587,7 +587,7 @@ int MXSymbolInferShape(SymbolHandle sym,
 
 template<typename dtype, typename stype, typename itype>
 inline void SymbolInferShape(const char** keys,
-                             mx_uint num_args,
+                             uint32_t num_args,
                              const dtype* arg_shape_data,
                              const itype* arg_ind_ptr,
                              const int** in_shape_ndim,
@@ -607,13 +607,13 @@ inline void SymbolInferShape(const char** keys,
   if (keys == nullptr && num_args != 0) {
     std::vector < uint32_t > read_only_args = mxnet::ReadOnlyArgIndices(g.indexed_graph());
     CHECK_LE(num_args, read_only_args.size());
-    for (mx_uint i = 0; i < num_args; ++i) {
+    for (uint32_t i = 0; i < num_args; ++i) {
       arg_shapes[read_only_args[i]] = mxnet::ShapeTypeCast(arg_shape_data + arg_ind_ptr[i],
                                                            arg_shape_data + arg_ind_ptr[i + 1]);
     }
   } else {
     std::unordered_map<std::string, mxnet::TShape> kwargs;
-    for (mx_uint i = 0; i < num_args; ++i) {
+    for (uint32_t i = 0; i < num_args; ++i) {
       kwargs[keys[i]] = mxnet::ShapeTypeCast(arg_shape_data + arg_ind_ptr[i],
                                              arg_shape_data + arg_ind_ptr[i + 1]);
     }
@@ -658,24 +658,24 @@ inline void SymbolInferShape(const char** keys,
 }
 
 int MXSymbolInferShapeEx(SymbolHandle sym,
-                         mx_uint num_args,
+                         uint32_t num_args,
                          const char** keys,
-                         const mx_uint *arg_ind_ptr,
+                         const uint32_t *arg_ind_ptr,
                          const int *arg_shape_data,
-                         mx_uint *in_shape_size,
+                         uint32_t *in_shape_size,
                          const int **in_shape_ndim,
                          const int ***in_shape_data,
-                         mx_uint *out_shape_size,
+                         uint32_t *out_shape_size,
                          const int **out_shape_ndim,
                          const int ***out_shape_data,
-                         mx_uint *aux_shape_size,
+                         uint32_t *aux_shape_size,
                          const int **aux_shape_ndim,
                          const int ***aux_shape_data,
                          int *complete) {
   nnvm::Symbol *s = static_cast<nnvm::Symbol*>(sym);
   MXAPIThreadLocalEntry<> *ret = MXAPIThreadLocalStore<>::Get();
   API_BEGIN();
-  SymbolInferShape<int, mx_uint, mx_uint>(keys,
+  SymbolInferShape<int, uint32_t, uint32_t>(keys,
                                               num_args,
                                               arg_shape_data,
                                               arg_ind_ptr,
@@ -695,7 +695,7 @@ int MXSymbolInferShapeEx(SymbolHandle sym,
 }
 
 int MXSymbolInferShapeEx64(SymbolHandle sym,
-                           mx_uint num_args,
+                           uint32_t num_args,
                            const char** keys,
                            const int64_t *arg_ind_ptr,
                            const int64_t *arg_shape_data,
@@ -732,19 +732,19 @@ int MXSymbolInferShapeEx64(SymbolHandle sym,
 }
 
 int MXSymbolInferShapePartial(SymbolHandle sym,
-                              mx_uint num_args,
+                              uint32_t num_args,
                               const char** keys,
-                              const mx_uint *arg_ind_ptr,
-                              const mx_uint *arg_shape_data,
-                              mx_uint *in_shape_size,
-                              const mx_uint **in_shape_ndim,
-                              const mx_uint ***in_shape_data,
-                              mx_uint *out_shape_size,
-                              const mx_uint **out_shape_ndim,
-                              const mx_uint ***out_shape_data,
-                              mx_uint *aux_shape_size,
-                              const mx_uint **aux_shape_ndim,
-                              const mx_uint ***aux_shape_data,
+                              const uint32_t *arg_ind_ptr,
+                              const uint32_t *arg_shape_data,
+                              uint32_t *in_shape_size,
+                              const uint32_t **in_shape_ndim,
+                              const uint32_t ***in_shape_data,
+                              uint32_t *out_shape_size,
+                              const uint32_t **out_shape_ndim,
+                              const uint32_t ***out_shape_data,
+                              uint32_t *aux_shape_size,
+                              const uint32_t **aux_shape_ndim,
+                              const uint32_t ***aux_shape_data,
                               int *complete) {
   int succ = 0;
   *complete = 1;
@@ -757,17 +757,17 @@ int MXSymbolInferShapePartial(SymbolHandle sym,
 }
 
 int MXSymbolInferShapePartialEx(SymbolHandle sym,
-                                mx_uint num_args,
+                                uint32_t num_args,
                                 const char** keys,
-                                const mx_uint *arg_ind_ptr,
+                                const uint32_t *arg_ind_ptr,
                                 const int *arg_shape_data,
-                                mx_uint *in_shape_size,
+                                uint32_t *in_shape_size,
                                 const int **in_shape_ndim,
                                 const int ***in_shape_data,
-                                mx_uint *out_shape_size,
+                                uint32_t *out_shape_size,
                                 const int **out_shape_ndim,
                                 const int ***out_shape_data,
-                                mx_uint *aux_shape_size,
+                                uint32_t *aux_shape_size,
                                 const int **aux_shape_ndim,
                                 const int ***aux_shape_data,
                                 int *complete) {
@@ -782,7 +782,7 @@ int MXSymbolInferShapePartialEx(SymbolHandle sym,
 }
 
 int MXSymbolInferShapePartialEx64(SymbolHandle sym,
-                                  mx_uint num_args,
+                                  uint32_t num_args,
                                   const char** keys,
                                   const int64_t *arg_ind_ptr,
                                   const int64_t *arg_shape_data,
@@ -807,14 +807,14 @@ int MXSymbolInferShapePartialEx64(SymbolHandle sym,
 }
 
 int MXSymbolInferType(SymbolHandle sym,
-                      mx_uint num_args,
+                      uint32_t num_args,
                       const char** keys,
                       const int *arg_type_data,
-                      mx_uint *in_type_size,
+                      uint32_t *in_type_size,
                       const int **in_type_data,
-                      mx_uint *out_type_size,
+                      uint32_t *out_type_size,
                       const int **out_type_data,
-                      mx_uint *aux_type_size,
+                      uint32_t *aux_type_size,
                       const int **aux_type_data,
                       int *complete) {
   nnvm::Symbol *s = static_cast<nnvm::Symbol*>(sym);
@@ -825,12 +825,12 @@ int MXSymbolInferType(SymbolHandle sym,
   if (keys == nullptr && num_args != 0) {
     std::vector<uint32_t> read_only_args = mxnet::ReadOnlyArgIndices(g.indexed_graph());
     CHECK_LE(num_args, read_only_args.size());
-    for (mx_uint i = 0; i < num_args; ++i) {
+    for (uint32_t i = 0; i < num_args; ++i) {
       arg_types[read_only_args[i]] = arg_type_data[i];
     }
   } else {
     std::unordered_map<std::string, int> kwargs;
-    for (mx_uint i = 0; i < num_args; ++i) {
+    for (uint32_t i = 0; i < num_args; ++i) {
       kwargs[keys[i]] = arg_type_data[i];
     }
     mxnet::MatchArguments(g.indexed_graph(), kwargs, &arg_types, "InferType");
@@ -841,25 +841,25 @@ int MXSymbolInferType(SymbolHandle sym,
   CopyAttr(g.indexed_graph(), g.GetAttr<nnvm::DTypeVector>("dtype"),
            &(ret->arg_types), &(ret->out_types), &(ret->aux_types));
 
-  *in_type_size = static_cast<mx_uint>(ret->arg_types.size());
+  *in_type_size = static_cast<uint32_t>(ret->arg_types.size());
   *in_type_data = dmlc::BeginPtr(ret->arg_types);
-  *out_type_size = static_cast<mx_uint>(ret->out_types.size());
+  *out_type_size = static_cast<uint32_t>(ret->out_types.size());
   *out_type_data = dmlc::BeginPtr(ret->out_types);
-  *aux_type_size = static_cast<mx_uint>(ret->aux_types.size());
+  *aux_type_size = static_cast<uint32_t>(ret->aux_types.size());
   *aux_type_data = dmlc::BeginPtr(ret->aux_types);
   *complete = (g.GetAttr<size_t>("dtype_num_unknown_nodes") == 0);
   API_END();
 }
 
 int MXSymbolInferTypePartial(SymbolHandle sym,
-                             mx_uint num_args,
+                             uint32_t num_args,
                              const char** keys,
                              const int *arg_type_data,
-                             mx_uint *in_type_size,
+                             uint32_t *in_type_size,
                              const int **in_type_data,
-                             mx_uint *out_type_size,
+                             uint32_t *out_type_size,
                              const int **out_type_data,
-                             mx_uint *aux_type_size,
+                             uint32_t *aux_type_size,
                              const int **aux_type_data,
                              int *complete) {
   int succ = 0;
@@ -872,7 +872,7 @@ int MXSymbolInferTypePartial(SymbolHandle sym,
                             &succ);
 }
 
-int MXSymbolGrad(SymbolHandle sym, mx_uint num_wrt, const char** wrt, SymbolHandle* out) {
+int MXSymbolGrad(SymbolHandle sym, uint32_t num_wrt, const char** wrt, SymbolHandle* out) {
   API_BEGIN();
   LOG(FATAL) << "not implemented";
   API_END();
@@ -881,11 +881,11 @@ int MXSymbolGrad(SymbolHandle sym, mx_uint num_wrt, const char** wrt, SymbolHand
 int MXQuantizeSymbol(SymbolHandle sym_handle,
                      SymbolHandle *ret_sym_handle,
                      const int* dev_type,
-                     const mx_uint num_excluded_sym_names,
+                     const uint32_t num_excluded_sym_names,
                      const char **excluded_sym_names,
-                     const mx_uint num_excluded_op_names,
+                     const uint32_t num_excluded_op_names,
                      const char **excluded_op_names,
-                     const mx_uint num_offline,
+                     const uint32_t num_offline,
                      const char **offline_params,
                      const char *quantized_dtype,
                      const bool calib_quantize,
@@ -1020,18 +1020,18 @@ static void _UpdateSymDTypeAttrs(
 
 int MXReducePrecisionSymbol(SymbolHandle sym_handle,
                             SymbolHandle *ret_sym_handle,
-                            mx_uint num_args,
+                            uint32_t num_args,
                             const int *arg_type_data,
-                            mx_uint num_ind_ptr,
+                            uint32_t num_ind_ptr,
                             const int* ind_ptr,
                             const int* target_dtype,
                             const int cast_optional_params,
-                            const mx_uint num_target_dtype_op_names,
-                            const mx_uint num_fp32_op_names,
-                            const mx_uint num_widest_dtype_op_names,
-                            const mx_uint num_conditional_fp32_op_names,
-                            const mx_uint num_excluded_symbols,
-                            const mx_uint num_model_params,
+                            const uint32_t num_target_dtype_op_names,
+                            const uint32_t num_fp32_op_names,
+                            const uint32_t num_widest_dtype_op_names,
+                            const uint32_t num_conditional_fp32_op_names,
+                            const uint32_t num_excluded_symbols,
+                            const uint32_t num_model_params,
                             const char **target_dtype_op_names,
                             const char **fp32_op_names,
                             const char **widest_dtype_op_names,
@@ -1084,7 +1084,7 @@ int MXReducePrecisionSymbol(SymbolHandle sym_handle,
   std::unordered_map<std::string, int> kwargs;
   std::unordered_map<std::string, int> node_name_dtype_map, node_without_dtype_map;
   nnvm::DTypeVector arg_types(g.indexed_graph().input_nodes().size(), -1);
-  for (mx_uint i = 0; i < num_args; ++i) {
+  for (uint32_t i = 0; i < num_args; ++i) {
     kwargs[arg_names[i]] = arg_type_data[i];
     node_name_dtype_map[arg_names[i]] = arg_type_data[i];
   }
@@ -1138,7 +1138,7 @@ int MXReducePrecisionSymbol(SymbolHandle sym_handle,
 }
 
 int MXSetCalibTableToQuantizedSymbol(SymbolHandle qsym_handle,
-                                     const mx_uint num_layers,
+                                     const uint32_t num_layers,
                                      const char** layer_names,
                                      const float* min_ranges,
                                      const float* max_ranges,

--- a/src/c_api/c_api_test.cc
+++ b/src/c_api/c_api_test.cc
@@ -29,7 +29,7 @@
 
 int MXBuildSubgraphByOpNames(SymbolHandle sym_handle,
                               const char* prop_name,
-                              const mx_uint num_ops,
+                              const uint32_t num_ops,
                               const char** op_names,
                               SymbolHandle* ret_sym_handle) {
   nnvm::Symbol* s = new nnvm::Symbol();
@@ -62,7 +62,7 @@ int MXBuildSubgraphByOpNames(SymbolHandle sym_handle,
 }
 
 int MXSetSubgraphPropertyOpNames(const char* prop_name,
-                                 const mx_uint num_ops,
+                                 const uint32_t num_ops,
                                  const char** op_names) {
   API_BEGIN();
   std::unordered_set<std::string> op_name_set;

--- a/src/c_api/c_predict_api.cc
+++ b/src/c_api/c_predict_api.cc
@@ -91,16 +91,16 @@ int _CreatePartialOut(const char* symbol_json_str,
                       const void* param_bytes,
                       int param_size,
                       int dev_type, int dev_id,
-                      const mx_uint num_input_nodes,
+                      const uint32_t num_input_nodes,
                       const char** input_keys,
-                      const mx_uint* input_shape_indptr,
-                      const mx_uint* input_shape_data,
-                      mx_uint num_output_nodes,
+                      const uint32_t* input_shape_indptr,
+                      const uint32_t* input_shape_data,
+                      uint32_t num_output_nodes,
                       const char** output_keys,
                       // This is used for parallel inference.
                       int num_threads,
                       bool lazy,
-                      const mx_uint num_provided_arg_dtypes,
+                      const uint32_t num_provided_arg_dtypes,
                       const char** provided_arg_dtype_names,
                       const int* provided_arg_dtypes,
                       PredictorHandle* out) {
@@ -110,7 +110,7 @@ int _CreatePartialOut(const char* symbol_json_str,
   Symbol sym;
   // make sure symbols are registered
   {
-  mx_uint outSize;
+  uint32_t outSize;
   const char **outArray;
   MXListAllOpNames(&outSize, &outArray);
   }
@@ -125,7 +125,7 @@ int _CreatePartialOut(const char* symbol_json_str,
     Symbol internal = sym.GetInternals();
     std::vector<std::string> all_out = internal.ListOutputNames();
     std::vector<Symbol> out_syms(num_output_nodes);
-    for (mx_uint i = 0; i < num_output_nodes; ++i) {
+    for (uint32_t i = 0; i < num_output_nodes; ++i) {
       std::string out_key(output_keys[i]);
       out_key += "_output";
       for (size_t j = 0; j < all_out.size(); ++j) {
@@ -176,7 +176,7 @@ int _CreatePartialOut(const char* symbol_json_str,
     }
 
     if (num_provided_arg_dtypes > 0) {
-      for (mx_uint i = 0; i < num_provided_arg_dtypes; ++i) {
+      for (uint32_t i = 0; i < num_provided_arg_dtypes; ++i) {
         if (aux_types.count(provided_arg_dtype_names[i]) == 0 &&
             arg_types.count(provided_arg_dtype_names[i]) == 0) {
           arg_types[provided_arg_dtype_names[i]] = provided_arg_dtypes[i];
@@ -187,7 +187,7 @@ int _CreatePartialOut(const char* symbol_json_str,
 
   // shape inference and bind
   std::unordered_map<std::string, mxnet::TShape> known_shape;
-  for (mx_uint i = 0; i < num_input_nodes; ++i) {
+  for (uint32_t i = 0; i < num_input_nodes; ++i) {
     known_shape[std::string(input_keys[i])] =
         mxnet::TShape(input_shape_data + input_shape_indptr[i],
                input_shape_data + input_shape_indptr[i + 1]);
@@ -309,11 +309,11 @@ int MXPredCreatePartialOut(const char* symbol_json_str,
                            const void* param_bytes,
                            int param_size,
                            int dev_type, int dev_id,
-                           mx_uint num_input_nodes,
+                           uint32_t num_input_nodes,
                            const char** input_keys,
-                           const mx_uint* input_shape_indptr,
-                           const mx_uint* input_shape_data,
-                           mx_uint num_output_nodes,
+                           const uint32_t* input_shape_indptr,
+                           const uint32_t* input_shape_data,
+                           uint32_t num_output_nodes,
                            const char** output_keys,
                            PredictorHandle* out) {
   return _CreatePartialOut(
@@ -339,10 +339,10 @@ int MXPredCreate(const char* symbol_json_str,
                  const void* param_bytes,
                  int param_size,
                  int dev_type, int dev_id,
-                 mx_uint num_input_nodes,
+                 uint32_t num_input_nodes,
                  const char** input_keys,
-                 const mx_uint* input_shape_indptr,
-                 const mx_uint* input_shape_data,
+                 const uint32_t* input_shape_indptr,
+                 const uint32_t* input_shape_data,
                  PredictorHandle* out) {
   return _CreatePartialOut(
       symbol_json_str,
@@ -368,11 +368,11 @@ int MXPredCreateEx(const char* symbol_json_str,
                    const void* param_bytes,
                    int param_size,
                    int dev_type, int dev_id,
-                   mx_uint num_input_nodes,
+                   uint32_t num_input_nodes,
                    const char** input_keys,
-                   const mx_uint* input_shape_indptr,
-                   const mx_uint* input_shape_data,
-                   const mx_uint num_provided_arg_dtypes,
+                   const uint32_t* input_shape_indptr,
+                   const uint32_t* input_shape_data,
+                   const uint32_t num_provided_arg_dtypes,
                    const char** provided_arg_dtype_names,
                    const int* provided_arg_dtypes,
                    PredictorHandle* out) {
@@ -400,10 +400,10 @@ int MXPredCreateMultiThread(const char* symbol_json_str,
                             const void* param_bytes,
                             int param_size,
                             int dev_type, int dev_id,
-                            mx_uint num_input_nodes,
+                            uint32_t num_input_nodes,
                             const char** input_keys,
-                            const mx_uint* input_shape_indptr,
-                            const mx_uint* input_shape_data,
+                            const uint32_t* input_shape_indptr,
+                            const uint32_t* input_shape_data,
                             // This is used for paralle inference.
                             int num_threads,
                             PredictorHandle* out) {
@@ -434,10 +434,10 @@ int MXPredCreateMultiThread(const char* symbol_json_str,
       out);
 }
 
-int MXPredReshape(mx_uint num_input_nodes,
+int MXPredReshape(uint32_t num_input_nodes,
                   const char** input_keys,
-                  const mx_uint* input_shape_indptr,
-                  const mx_uint* input_shape_data,
+                  const uint32_t* input_shape_indptr,
+                  const uint32_t* input_shape_data,
                   PredictorHandle handle,
                   PredictorHandle* out) {
   _CreateExecutor(handle);
@@ -447,7 +447,7 @@ int MXPredReshape(mx_uint num_input_nodes,
   API_BEGIN();
   // shape inference
   std::unordered_map<std::string, mxnet::TShape> new_shape;
-  for (mx_uint i = 0; i < num_input_nodes; ++i) {
+  for (uint32_t i = 0; i < num_input_nodes; ++i) {
     new_shape[std::string(input_keys[i])] =
         mxnet::TShape(input_shape_data + input_shape_indptr[i],
             input_shape_data + input_shape_indptr[i + 1]);
@@ -526,9 +526,9 @@ int MXPredReshape(mx_uint num_input_nodes,
 }
 
 int MXPredGetOutputShape(PredictorHandle handle,
-                         mx_uint out_index,
-                         mx_uint** shape_data,
-                         mx_uint* shape_ndim) {
+                         uint32_t out_index,
+                         uint32_t** shape_data,
+                         uint32_t* shape_ndim) {
   MXAPIPredictor* p = static_cast<MXAPIPredictor*>(handle);
   API_BEGIN();
   CHECK_LT(out_index, p->out_arrays.size())
@@ -544,7 +544,7 @@ int MXPredGetOutputShape(PredictorHandle handle,
 }
 
 int MXPredGetOutputType(PredictorHandle handle,
-                        mx_uint out_index,
+                        uint32_t out_index,
                         int* out_dtype) {
   MXAPIPredictor* p = static_cast<MXAPIPredictor*>(handle);
   API_BEGIN();
@@ -561,7 +561,7 @@ int MXPredGetOutputType(PredictorHandle handle,
 int MXPredSetInput(PredictorHandle handle,
                    const char* key,
                    const mx_float* data,
-                   mx_uint size) {
+                   uint32_t size) {
   MXAPIPredictor* p = static_cast<MXAPIPredictor*>(handle);
   API_BEGIN();
   auto it = p->key2arg.find(key);
@@ -590,9 +590,9 @@ int MXPredPartialForward(PredictorHandle handle, int step, int* step_left) {
 }
 
 int MXPredGetOutput(PredictorHandle handle,
-                    mx_uint index,
+                    uint32_t index,
                     mx_float* data,
-                    mx_uint size) {
+                    uint32_t size) {
   MXAPIPredictor* p = static_cast<MXAPIPredictor*>(handle);
   API_BEGIN();
   CHECK_LT(index, p->out_arrays.size())
@@ -611,7 +611,7 @@ int MXPredFree(PredictorHandle handle) {
 int MXNDListCreate(const char* nd_file_bytes,
                    int nd_file_size,
                    NDListHandle *out,
-                   mx_uint* out_length) {
+                   uint32_t* out_length) {
   MXAPINDList* ret = new MXAPINDList();
   API_BEGIN();
   std::vector<NDArray> arrays;
@@ -633,16 +633,16 @@ int MXNDListCreate(const char* nd_file_bytes,
     ret->indptr.push_back(begin + size);
   }
   *out = ret;
-  *out_length = static_cast<mx_uint>(arrays.size());
+  *out_length = static_cast<uint32_t>(arrays.size());
   API_END();
 }
 
 int MXNDListGet(NDListHandle handle,
-                mx_uint index,
+                uint32_t index,
                 const char** out_key,
                 const mx_float** out_data,
-                const mx_uint** out_shape,
-                mx_uint* out_ndim) {
+                const uint32_t** out_shape,
+                uint32_t* out_ndim) {
   MXAPINDList* p = static_cast<MXAPINDList*>(handle);
   API_BEGIN();
   CHECK_LT(index, p->shapes.size())

--- a/src/c_api/c_predict_api.cc
+++ b/src/c_api/c_predict_api.cc
@@ -67,7 +67,7 @@ struct MXAPINDList {
   mxnet::ShapeVector shapes;
   std::vector<uint32_t> shapes_buffer;
   std::vector<size_t> indptr;
-  std::vector<mx_float> data;
+  std::vector<float> data;
 };
 
 inline void _CreateExecutor(PredictorHandle pred_hnd) {
@@ -560,7 +560,7 @@ int MXPredGetOutputType(PredictorHandle handle,
 
 int MXPredSetInput(PredictorHandle handle,
                    const char* key,
-                   const mx_float* data,
+                   const float* data,
                    uint32_t size) {
   MXAPIPredictor* p = static_cast<MXAPIPredictor*>(handle);
   API_BEGIN();
@@ -591,7 +591,7 @@ int MXPredPartialForward(PredictorHandle handle, int step, int* step_left) {
 
 int MXPredGetOutput(PredictorHandle handle,
                     uint32_t index,
-                    mx_float* data,
+                    float* data,
                     uint32_t size) {
   MXAPIPredictor* p = static_cast<MXAPIPredictor*>(handle);
   API_BEGIN();
@@ -640,7 +640,7 @@ int MXNDListCreate(const char* nd_file_bytes,
 int MXNDListGet(NDListHandle handle,
                 uint32_t index,
                 const char** out_key,
-                const mx_float** out_data,
+                const float** out_data,
                 const uint32_t** out_shape,
                 uint32_t* out_ndim) {
   MXAPINDList* p = static_cast<MXAPINDList*>(handle);

--- a/src/imperative/imperative.cc
+++ b/src/imperative/imperative.cc
@@ -122,7 +122,7 @@ OpStatePtr Imperative::Invoke(
 
 void Imperative::MarkVariables(
     const std::vector<NDArray*>& variables,
-    const std::vector<mx_uint>& grad_reqs,
+    const std::vector<uint32_t>& grad_reqs,
     const std::vector<NDArray*>& gradients) {
   for (uint32_t i = 0; i < variables.size(); ++i) {
     std::string str_c(std::to_string(variable_count_++));


### PR DESCRIPTION
## Description ##
changes  
- mx_uint -> uint32_t
- mx_float -> float

removes 
- mx_int64 (Since introduced only by large tensor support so not present in other language bindings)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change