### PR TITLE
Reduce memory footprint in Large array nightly tests

### DIFF
--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -31,6 +31,12 @@ SMALL_Y = 50
 LARGE_SIZE = LARGE_X * SMALL_Y
 
 
+def create_2d_tensor(rows, columns, dtype=np.int64):
+    a = nd.arange(0, rows, dtype=dtype).reshape(rows, 1)
+    b = nd.broadcast_to(a, shape=(a.shape[0], columns))
+    return nd.array(b, dtype=dtype)
+
+
 def test_gluon_embedding():
     m = gluon.nn.Embedding(SMALL_Y, MEDIUM_X)
     m.initialize()
@@ -381,12 +387,6 @@ def test_unravel_index():
     indices_2d = mx.nd.unravel_index(mx.nd.array(idx_numpy, dtype=np.int64),
                                      shape=(LARGE_X, SMALL_Y))
     assert (indices_2d.asnumpy() == np.array(original_2d_indices)).all()
-
-
-def create_2d_tensor(rows, columns, dtype=np.int64):
-    a = np.arange(0, rows).reshape(rows, 1)
-    b = np.broadcast_to(a, shape=(a.shape[0], columns))
-    return nd.array(b, dtype=dtype)
 
 
 def test_transpose():


### PR DESCRIPTION
## Description ##
Using NDArray primitives instead of using numpy to create an array and calling NDArray constructor on that.

Memory usage of following Ops have significantly been reduced:
topk
sort
argsort

from around 400GB -> under 100GB 
                     (before)               (after)
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change