### PR TITLE
[Numpy] Random.randn() implemented.

### DIFF
--- a/python/mxnet/numpy/random.py
+++ b/python/mxnet/numpy/random.py
@@ -24,7 +24,7 @@ __all__ = ['uniform', 'normal', 'randn']
 
 
 def randn(*size, **kwargs):
-    """Return a sample (or samples) from the "standard normal" distribution.
+    r"""Return a sample (or samples) from the "standard normal" distribution.
 
     If positive, int_like or int-convertible arguments are provided,
     `randn` generates an array of shape ``(d0, d1, ..., dn)``, filled

--- a/python/mxnet/numpy/random.py
+++ b/python/mxnet/numpy/random.py
@@ -20,7 +20,57 @@
 from __future__ import absolute_import
 from ..ndarray import numpy as _mx_nd_np
 
-__all__ = ['uniform', 'normal']
+__all__ = ['uniform', 'normal', 'randn']
+
+
+def randn(*size, **kwargs):
+    """Return a sample (or samples) from the "standard normal" distribution.
+
+    If positive, int_like or int-convertible arguments are provided,
+    `randn` generates an array of shape ``(d0, d1, ..., dn)``, filled
+    with random floats sampled from a univariate "normal" (Gaussian)
+    distribution of mean 0 and variance 1 (if any of the :math:`d_i` are
+    floats, they are first converted to integers by truncation). A single
+    float randomly sampled from the distribution is returned if no
+    argument is provided.
+
+    This is a convenience function.  If you want an interface that takes a
+    tuple as the first argument, use `numpy.random.standard_normal` instead.
+
+    Parameters
+    ----------
+    d0, d1, ..., dn : int, optional
+        The dimensions of the returned array, should be all positive.
+        If no argument is given a single Python float is returned.
+
+    Returns
+    -------
+    Z : ndarray
+        A ``(d0, d1, ..., dn)``-shaped array of floating-point samples from
+        the standard normal distribution, or a single such float if
+        no parameters were supplied.
+
+    Notes
+    -----
+    For random samples from :math:`N(\mu, \sigma^2)`, use:
+
+    ``sigma * np.random.randn(...) + mu``
+
+    Examples
+    --------
+    >>> np.random.randn()
+    2.1923875335537315 #random
+
+    Two-by-four array of samples from N(3, 6.25):
+
+    >>> 2.5 * np.random.randn(2, 4) + 3
+    array([[-4.49401501,  4.00950034, -1.81814867,  7.29718677],  #random
+        [ 0.39924804,  4.68456316,  4.99394529,  4.84057254]]) #random
+    """
+    output_shape = ()
+    for s in size:
+        output_shape += (s,)
+    return _mx_nd_np.random.normal(0, 1, size=output_shape, **kwargs)
 
 
 def uniform(low=0.0, high=1.0, size=None, **kwargs):

--- a/python/mxnet/symbol/numpy/random.py
+++ b/python/mxnet/symbol/numpy/random.py
@@ -139,7 +139,7 @@ def normal(loc=0.0, scale=1.0, size=None, **kwargs):
 
 
 def randn(*size, **kwargs):
-    """Return a sample (or samples) from the "standard normal" distribution.
+    r"""Return a sample (or samples) from the "standard normal" distribution.
 
     If positive, int_like or int-convertible arguments are provided,
     `randn` generates an array of shape ``(d0, d1, ..., dn)``, filled
@@ -182,10 +182,6 @@ def randn(*size, **kwargs):
     array([[-4.49401501,  4.00950034, -1.81814867,  7.29718677],  #random
         [ 0.39924804,  4.68456316,  4.99394529,  4.84057254]]) #random
     """
-    output_shape = ()
-    for s in size:
-        output_shape += (s,)
-    return _mx_nd_np.random.normal(0, 1, size=output_shape, **kwargs)
     output_shape = ()
     for s in size:
         output_shape += (s,)

--- a/python/mxnet/symbol/numpy/random.py
+++ b/python/mxnet/symbol/numpy/random.py
@@ -22,7 +22,7 @@ from ...base import numeric_types
 from ...context import current_context
 from . import _internal as _npi
 
-__all__ = ['uniform', 'normal']
+__all__ = ['uniform', 'normal', 'randn']
 
 
 def _random_helper(random, sampler, params, shape, dtype, ctx, out, kwargs):
@@ -136,3 +136,57 @@ def normal(loc=0.0, scale=1.0, size=None, **kwargs):
     out = kwargs.pop('out', None)
     return _random_helper(_npi.random_normal, None,
                           [loc, scale], size, dtype, ctx, out, kwargs)
+
+
+def randn(*size, **kwargs):
+    """Return a sample (or samples) from the "standard normal" distribution.
+
+    If positive, int_like or int-convertible arguments are provided,
+    `randn` generates an array of shape ``(d0, d1, ..., dn)``, filled
+    with random floats sampled from a univariate "normal" (Gaussian)
+    distribution of mean 0 and variance 1 (if any of the :math:`d_i` are
+    floats, they are first converted to integers by truncation). A single
+    float randomly sampled from the distribution is returned if no
+    argument is provided.
+
+    This is a convenience function.  If you want an interface that takes a
+    tuple as the first argument, use `numpy.random.standard_normal` instead.
+
+    Parameters
+    ----------
+    d0, d1, ..., dn : int, optional
+        The dimensions of the returned array, should be all positive.
+        If no argument is given a single Python float is returned.
+
+    Returns
+    -------
+    Z : Symbol
+        A ``(d0, d1, ..., dn)``-shaped array of floating-point samples from
+        the standard normal distribution, or a single such float if
+        no parameters were supplied.
+
+    Notes
+    -----
+    For random samples from :math:`N(\mu, \sigma^2)`, use:
+
+    ``sigma * np.random.randn(...) + mu``
+
+    Examples
+    --------
+    >>> np.random.randn()
+    2.1923875335537315 #random
+
+    Two-by-four array of samples from N(3, 6.25):
+
+    >>> 2.5 * np.random.randn(2, 4) + 3
+    array([[-4.49401501,  4.00950034, -1.81814867,  7.29718677],  #random
+        [ 0.39924804,  4.68456316,  4.99394529,  4.84057254]]) #random
+    """
+    output_shape = ()
+    for s in size:
+        output_shape += (s,)
+    return _mx_nd_np.random.normal(0, 1, size=output_shape, **kwargs)
+    output_shape = ()
+    for s in size:
+        output_shape += (s,)
+    return normal(0, 1, size=output_shape, **kwargs)

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -1566,6 +1566,27 @@ def test_np_trace():
         assert False
 
 
+@with_seed()
+@use_np
+def test_np_randn():
+    shapes = [
+        (3, 3),
+        (3, 4),
+        (0, 0),
+        (3, 3, 3),
+        (0, 0, 0),
+        (2, 2, 4, 3),
+        (2, 2, 4, 3),
+        (2, 0, 3, 0),
+        (2, 0, 2, 3)
+    ]
+    dtypes = ['float16', 'float32', 'float64']
+    for dtype in dtypes:
+        for shape in shapes:
+            data_mx = np.random.randn(*shape, dtype=dtype)
+            assert data_mx.shape == shape
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -25,6 +25,8 @@ from mxnet.gluon import HybridBlock
 from mxnet.base import MXNetError
 from mxnet.test_utils import same, assert_almost_equal, rand_shape_nd, rand_ndarray
 from mxnet.test_utils import check_numeric_gradient, use_np
+from mxnet.test_utils import verify_generator, gen_buckets_probs_with_ppf, retry
+import scipy.stats as ss
 from common import assertRaises, with_seed
 import random
 import collections
@@ -1569,6 +1571,7 @@ def test_np_trace():
 @with_seed()
 @use_np
 def test_np_randn():
+    # Test shapes.
     shapes = [
         (3, 3),
         (3, 4),
@@ -1585,6 +1588,29 @@ def test_np_randn():
         for shape in shapes:
             data_mx = np.random.randn(*shape, dtype=dtype)
             assert data_mx.shape == shape
+
+    # Test random generator.
+    ctx = mx.context.current_context()
+    samples = 1000000
+    trials = 8
+    num_buckets = 5
+    mu = 0.0
+    sigma = 1.0
+    for dtype in ['float16', 'float32', 'float64']:
+        buckets, probs = gen_buckets_probs_with_ppf(lambda x: ss.norm.ppf(x, mu, sigma), num_buckets)
+        # Quantize bucket boundaries to reflect the actual dtype and adjust probs accordingly
+        buckets = np.array(buckets, dtype=dtype).tolist()
+        probs = [(ss.norm.cdf(buckets[i][1], mu, sigma) -
+                    ss.norm.cdf(buckets[i][0], mu, sigma)) for i in range(num_buckets)]
+        generator_mx = lambda x: np.random.randn(samples, ctx=ctx, dtype=dtype).asnumpy()
+        verify_generator(generator=generator_mx, buckets=buckets, probs=probs,
+                            nsamples=samples, nrepeat=trials)
+        generator_mx_same_seed =\
+            lambda x: _np.concatenate(
+                [np.random.randn(x // 10, ctx=ctx, dtype=dtype).asnumpy()
+                    for _ in range(10)])
+        verify_generator(generator=generator_mx_same_seed, buckets=buckets, probs=probs,
+                            nsamples=samples, nrepeat=trials)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
`numpy.random.randn(d0, d1, ..., dn)` implemented. 
This operator enables users to sample from Normal(0, 1) with shape (d0, d1,..., dn).

https://docs.scipy.org/doc/numpy-1.16.0/reference/generated/numpy.random.randn.html#numpy.random.randn

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Wrappers in random.py 
- [x] Unit tests in test_numpy_op.py

## Comments ##

