### PR TITLE
Refactor test_random.test_shuffle to improve the timings.

### DIFF
--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -896,11 +896,16 @@ def test_shuffle():
         column0 = arr.reshape((arr.size,))[::stride].sort()
         seq = mx.nd.arange(0, arr.size - stride + 1, stride, ctx=arr.context)
         assert (column0 == seq).prod() == 1
+
+        arrays = []
         for i in range(arr.shape[0]):
             subarr = arr[i].reshape((arr[i].size,))
-            start = subarr[0].asscalar()
-            seq = mx.nd.arange(start, start + stride, ctx=arr.context)
-            assert (subarr == seq).prod() == 1
+            start = int(subarr[0].asscalar())
+            arrays.append(range(start, start + stride))
+
+        seq_array = mx.nd.array(arrays, ctx=arr.context)
+        reshaped_array = arr.reshape((arr.shape[0], -1))
+        assert (seq_array == reshaped_array).prod() == 1
 
     # This tests that the shuffling is along the first axis with `repeat1` number of shufflings
     # and the outcomes are uniformly distributed with `repeat2` number of shufflings.


### PR DESCRIPTION
## Description ##
Inspired by @larroy thread CI and PRs,
Cut down time on test_random.test_shuffle which almost always takes most time in the unix-CPU from what I have seen.
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/PR-15865/3/pipeline/282
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/PR-15865/3/pipeline/279
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/PR-15865/3/pipeline/280
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/PR-15865/3/pipeline/281

Before the changes, takes 495s on my laptop.
After the changes, takes 117s on my laptop.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
