### PR TITLE
Remove Scala package test on build

### DIFF
--- a/ci/publish/scala/build.sh
+++ b/ci/publish/scala/build.sh
@@ -28,4 +28,4 @@ set -ex
 
 # Compile tests for discovery later
 cd scala-package
-mvn -B deploy
+mvn -B deploy -DskipTests=true

--- a/make/maven/maven_darwin_mkl.mk
+++ b/make/maven/maven_darwin_mkl.mk
@@ -77,7 +77,7 @@ USE_CUDNN = 0
 # CUDA_ARCH :=
 
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
-USE_NVRTC = 0
+ENABLE_CUDA_RTC = 0
 
 # use openmp for parallelization
 USE_OPENMP = 0

--- a/make/maven/maven_linux_cu90mkl.mk
+++ b/make/maven/maven_linux_cu90mkl.mk
@@ -79,7 +79,9 @@ USE_NCCL = 1
 # CUDA_ARCH :=
 
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
-USE_NVRTC = 1
+ENABLE_CUDA_RTC = 1
+
+USE_NVTX=1
 
 # use openmp for parallelization
 USE_OPENMP = 1

--- a/make/maven/maven_linux_cu92mkl.mk
+++ b/make/maven/maven_linux_cu92mkl.mk
@@ -79,7 +79,9 @@ USE_NCCL = 1
 # CUDA_ARCH :=
 
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
-USE_NVRTC = 1
+ENABLE_CUDA_RTC = 1
+
+USE_NVTX=1
 
 # use openmp for parallelization
 USE_OPENMP = 1

--- a/make/maven/maven_linux_mkl.mk
+++ b/make/maven/maven_linux_mkl.mk
@@ -76,7 +76,7 @@ USE_CUDNN = 0
 # CUDA_ARCH :=
 
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
-USE_NVRTC = 0
+ENABLE_CUDA_RTC = 0
 
 # use openmp for parallelization
 USE_OPENMP = 1

--- a/make/pip/pip_linux_cu100.mk
+++ b/make/pip/pip_linux_cu100.mk
@@ -81,6 +81,8 @@ USE_NCCL = 1
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
 ENABLE_CUDA_RTC = 1
 
+USE_NVTX=1
+
 # use openmp for parallelization
 USE_OPENMP = 1
 USE_OPERATOR_TUNING = 1

--- a/make/pip/pip_linux_cu100mkl.mk
+++ b/make/pip/pip_linux_cu100mkl.mk
@@ -81,6 +81,8 @@ USE_NCCL = 1
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
 ENABLE_CUDA_RTC = 1
 
+USE_NVTX=1
+
 # use openmp for parallelization
 USE_OPENMP = 1
 USE_OPERATOR_TUNING = 1

--- a/make/pip/pip_linux_cu101.mk
+++ b/make/pip/pip_linux_cu101.mk
@@ -81,6 +81,8 @@ USE_NCCL = 1
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
 ENABLE_CUDA_RTC = 1
 
+USE_NVTX=1
+
 # use openmp for parallelization
 USE_OPENMP = 1
 USE_OPERATOR_TUNING = 1

--- a/make/pip/pip_linux_cu101mkl.mk
+++ b/make/pip/pip_linux_cu101mkl.mk
@@ -81,6 +81,8 @@ USE_NCCL = 1
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
 ENABLE_CUDA_RTC = 1
 
+USE_NVTX=1
+
 # use openmp for parallelization
 USE_OPENMP = 1
 USE_OPERATOR_TUNING = 1

--- a/make/pip/pip_linux_cu91.mk
+++ b/make/pip/pip_linux_cu91.mk
@@ -81,6 +81,8 @@ USE_NCCL = 1
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
 ENABLE_CUDA_RTC = 1
 
+USE_NVTX=1
+
 # use openmp for parallelization
 USE_OPENMP = 1
 USE_OPERATOR_TUNING = 1

--- a/make/pip/pip_linux_cu91mkl.mk
+++ b/make/pip/pip_linux_cu91mkl.mk
@@ -81,6 +81,8 @@ USE_NCCL = 1
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
 ENABLE_CUDA_RTC = 1
 
+USE_NVTX=1
+
 # use openmp for parallelization
 USE_OPENMP = 1
 USE_OPERATOR_TUNING = 1

--- a/make/pip/pip_linux_cu92.mk
+++ b/make/pip/pip_linux_cu92.mk
@@ -81,6 +81,8 @@ USE_NCCL = 1
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
 ENABLE_CUDA_RTC = 1
 
+USE_NVTX=1
+
 # use openmp for parallelization
 USE_OPENMP = 1
 USE_OPERATOR_TUNING = 1

--- a/make/pip/pip_linux_cu92mkl.mk
+++ b/make/pip/pip_linux_cu92mkl.mk
@@ -81,6 +81,8 @@ USE_NCCL = 1
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
 ENABLE_CUDA_RTC = 1
 
+USE_NVTX=1
+
 # use openmp for parallelization
 USE_OPENMP = 1
 USE_OPERATOR_TUNING = 1

--- a/tools/dependencies/openblas.sh
+++ b/tools/dependencies/openblas.sh
@@ -20,7 +20,7 @@
 # This script builds the static library of openblas that can be used as dependency of mxnet.
 set +e # This script throws an error but otherwise works
 set -x
-OPENBLAS_VERSION=0.3.3
+OPENBLAS_VERSION=0.3.5
 if [[ ! -e $DEPS_PATH/lib/libopenblas.a ]]; then
     # download and build openblas
     >&2 echo "Building openblas..."

--- a/tools/setup_gpu_build_tools.sh
+++ b/tools/setup_gpu_build_tools.sh
@@ -73,6 +73,7 @@ fi
 if [[ $VARIANT == cu* ]]; then
     CUDA_MAJOR_VERSION=$(echo $CUDA_VERSION | tr '-' '.' | cut -d. -f1,2)
     CUDA_MAJOR_DASH=$(echo $CUDA_VERSION | tr '-' '.' | cut -d. -f1,2 | tr '.' '-')
+    CUDA_PATCH_MAJOR_DASH=$(echo $CUDA_PATCH_VERSION | tr '-' '.' | cut -d. -f1,2 | tr '.' '-')
     NVIDIA_MAJOR_VERSION=$(echo $LIBCUDA_VERSION | cut -d. -f1)
     LIBCUDA_MAJOR=$(echo $LIBCUDA_VERSION | cut -d. -f1)
     LIBCUDNN_MAJOR=$(echo $LIBCUDNN_VERSION | cut -d. -f1)
@@ -83,8 +84,8 @@ if [[ $VARIANT == cu* ]]; then
         os_id="ubuntu1604"
     fi
     export PATH=/usr/lib/binutils-2.26/bin/:${PATH}:$DEPS_PATH/usr/local/cuda-$CUDA_MAJOR_VERSION/bin
-    export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}:$DEPS_PATH/usr/local/cuda-$CUDA_MAJOR_VERSION/include
-    export C_INCLUDE_PATH=${C_INCLUDE_PATH}:$DEPS_PATH/usr/local/cuda-$CUDA_MAJOR_VERSION/include
+    export CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH}:$DEPS_PATH/usr/local/cuda-$CUDA_MAJOR_VERSION/include:$DEPS_PATH/usr/include
+    export C_INCLUDE_PATH=${C_INCLUDE_PATH}:$DEPS_PATH/usr/local/cuda-$CUDA_MAJOR_VERSION/include:$DEPS_PATH/usr/include
     export LIBRARY_PATH=${LIBRARY_PATH}:$DEPS_PATH/usr/local/cuda-$CUDA_MAJOR_VERSION/lib64:$DEPS_PATH/usr/lib/x86_64-linux-gnu:$DEPS_PATH/usr/lib/nvidia-$NVIDIA_MAJOR_VERSION
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$DEPS_PATH/usr/local/cuda-$CUDA_MAJOR_VERSION/lib64:$DEPS_PATH/usr/lib/x86_64-linux-gnu:$DEPS_PATH/usr/lib/nvidia-$NVIDIA_MAJOR_VERSION
     export NVCC=$DEPS_PATH/usr/local/cuda-$CUDA_MAJOR_VERSION/bin/nvcc
@@ -108,6 +109,7 @@ if [[ $VARIANT == cu101* ]]; then
       "cuda-cusolver-dev-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "cuda-misc-headers-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "cuda-nvcc-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
+      "cuda-nvtx-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "libcuda1-${LIBCUDA_MAJOR}_${LIBCUDA_VERSION}_amd64.deb" \
       "nvidia-${LIBCUDA_MAJOR}_${LIBCUDA_VERSION}_amd64.deb" \
     )
@@ -132,6 +134,7 @@ elif [[ $VARIANT == cu100* ]]; then
       "cuda-cusolver-dev-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "cuda-misc-headers-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "cuda-nvcc-${CUDA_MAJOR_DASH}_${CUDA_PATCH_VERSION}_amd64.deb" \
+      "cuda-nvtx-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "libcuda1-${LIBCUDA_MAJOR}_${LIBCUDA_VERSION}_amd64.deb" \
       "nvidia-${LIBCUDA_MAJOR}_${LIBCUDA_VERSION}_amd64.deb" \
     )
@@ -156,6 +159,7 @@ elif [[ $VARIANT == cu92* ]]; then
       "cuda-cusolver-dev-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "cuda-misc-headers-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "cuda-nvcc-${CUDA_MAJOR_DASH}_${CUDA_PATCH_VERSION}_amd64.deb" \
+      "cuda-nvtx-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "libcuda1-${LIBCUDA_MAJOR}_${LIBCUDA_VERSION}_amd64.deb" \
       "nvidia-${LIBCUDA_MAJOR}_${LIBCUDA_VERSION}_amd64.deb" \
     )
@@ -180,6 +184,7 @@ elif [[ $VARIANT == cu91* ]]; then
       "cuda-cusolver-dev-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "cuda-misc-headers-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "cuda-nvcc-${CUDA_MAJOR_DASH}_9.1.85.2-1_amd64.deb" \
+      "cuda-nvtx-${CUDA_MAJOR_DASH}_${CUDA_VERSION}_amd64.deb" \
       "libcuda1-${LIBCUDA_MAJOR}_${LIBCUDA_VERSION}_amd64.deb" \
       "nvidia-${LIBCUDA_MAJOR}_${LIBCUDA_VERSION}_amd64.deb" \
     )


### PR DESCRIPTION
Removes testing in build stage of the maven release pipeline as there is a more thorough testing stage of the pipeline
Various release build improvements to mirror pip build


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change