### PR TITLE
Add disable attr to subgraph property

### DIFF
--- a/docs/tutorials/c++/subgraphAPI.md
+++ b/docs/tutorials/c++/subgraphAPI.md
@@ -105,9 +105,11 @@ class SgProperty : public SubgraphProperty {
 };
 ```
 `SetAttr` is optional and developer can define their own attributes to control property behavior.
-There're 2 built-in attributes that used by MXNet executor.
+There're some built-in attributes that used by MXNet executor.
 
-`property_name`  : std::string, name of this property.
+`property_name`  : std::string, name of this property, used for diagnose.
+
+`disable` : bool, whther to disable this property.
 
 `inference_only` : bool, apply this property only for inference. Property will be skiped when need_grad=True. Default `false` if this attribute isn't defined.
 

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -1044,6 +1044,14 @@ int MXGenBackendSubgraph(SymbolHandle sym_handle, const char *backend_name,
   auto backend = mxnet::op::SubgraphBackendRegistry::Get()->GetSubgraphBackend(backend_name);
   const auto& subgraph_prop_list = backend->GetSubgraphProperties();
   for (auto property : subgraph_prop_list) {
+    if (property->HasAttr("disable") && property->GetAttr<bool>("disable") == true) {
+      auto full_name = property->HasAttr("property_name")
+                           ? property->GetAttr<std::string>("property_name")
+                           : std::string();
+      LOG(INFO) << "subgraph property " << full_name << " from backend " << backend_name
+                << " is disabled.";
+      continue;
+    }
     nnvm::Graph g = Symbol2Graph(*s);
     property->SetAttr("graph", g);
     g.attrs["subgraph_property"] = std::make_shared<nnvm::any>(property);

--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -1659,10 +1659,15 @@ static bool SubgraphBackendCheck(const op::SubgraphBackendPtr& backend,
 static bool SubgraphPropertyCheck(const std::string& backend_name,
                                   const op::SubgraphPropertyPtr& prop, bool need_grad,
                                   bool verbose = false) {
+  auto full_name =
+      prop->HasAttr("property_name") ? prop->GetAttr<std::string>("property_name") : std::string();
+  if (prop->HasAttr("disable") && prop->GetAttr<bool>("disable") == true) {
+    LOG(INFO) << "subgraph property " << full_name << " from backend " << backend_name
+              << " is disabled.";
+    return false;
+  }
   if (prop->HasAttr("inference_only") && prop->GetAttr<bool>("inference_only") == true) {
     if (need_grad) {
-      auto full_name = prop->HasAttr("property_name") ? prop->GetAttr<std::string>("property_name")
-                                                      : std::string();
       if (verbose) {
         LOG(INFO) << "skip partitioning graph with subgraph property " << full_name
                   << " from backend " << backend_name << " as it requires `grad_req=null`.";

--- a/src/operator/subgraph/mkldnn/mkldnn_conv_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv_property.h
@@ -177,13 +177,12 @@ class SgMKLDNNConvProperty : public SubgraphProperty {
   }
   static SubgraphPropertyPtr Create() {
     static const std::string &name = "MKLDNN convolution optimization pass";
-    if (dmlc::GetEnv("MXNET_DISABLE_MKLDNN_CONV_OPT", 0)) {
-      LOG(INFO) << name << " is disabled.";
-      return nullptr;
-    }
     auto property = std::make_shared<SgMKLDNNConvProperty>();
     property->SetAttr<std::string>("property_name", name);
     property->SetAttr<bool>("inference_only", true);
+    if (dmlc::GetEnv("MXNET_DISABLE_MKLDNN_CONV_OPT", 0)) {
+      property->SetAttr<bool>("disable", true);
+    }
     return property;
   }
   nnvm::NodePtr CreateSubgraphNode(const nnvm::Symbol &sym,

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
@@ -132,13 +132,12 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
 
   static SubgraphPropertyPtr Create() {
     static const std::string &name = "MKLDNN FullyConnected optimization pass";
-    if (dmlc::GetEnv("MXNET_DISABLE_MKLDNN_FC_OPT", 0)) {
-      LOG(INFO) << name << " is disabled.";
-      return nullptr;
-    }
     auto property = std::make_shared<SgMKLDNNFCProperty>();
     property->SetAttr<std::string>("property_name", name);
     property->SetAttr<bool>("inference_only", true);
+    if (dmlc::GetEnv("MXNET_DISABLE_MKLDNN_FC_OPT", 0)) {
+      property->SetAttr<bool>("disable", true);
+    }
     return property;
   }
 

--- a/src/operator/subgraph/subgraph_property.h
+++ b/src/operator/subgraph/subgraph_property.h
@@ -357,7 +357,7 @@ class SubgraphPropertyEntry {
 
   template<typename T>
   SubgraphPropertyEntry set_attr(const std::string& name, const T value) const {
-    entry_->SetAttr<T>(name, value);
+    if (entry_) entry_->SetAttr<T>(name, value);
     return *this;
   }
 
@@ -403,9 +403,12 @@ class SubgraphBackend {
     }
   }
 
-  SubgraphPropertyPtr& RegisterSubgraphProperty(const SubgraphPropertyPtr prop) {
-    prop_ptr_.push_back(prop);
-    return prop_ptr_.back();
+  SubgraphPropertyPtr RegisterSubgraphProperty(SubgraphPropertyPtr prop) {
+    if (prop) {
+      prop_ptr_.push_back(prop);
+      return prop_ptr_.back();
+    }
+    return prop;
   }
 
   const std::string& GetName() const { return name_; }


### PR DESCRIPTION
## Description ##
Can fix the crash after `export MXNET_DISABLE_MKLDNN_CONV_OPT=1`

@pengzhao-intel @TaoLv @wuxun-zhang 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
