### PR TITLE
Tvm broadcast backward

### DIFF
--- a/contrib/tvmop/__init__.py
+++ b/contrib/tvmop/__init__.py
@@ -18,5 +18,6 @@
 # coding: utf-8
 from .opdef import defop
 from .utils import AllTypes, RealTypes
+from .utils import assign_by_req, reduce_axes
 
 from . import basic

--- a/contrib/tvmop/utils.py
+++ b/contrib/tvmop/utils.py
@@ -16,5 +16,34 @@
 # under the License.
 
 # coding: utf-8
+import tvm
+
 AllTypes = ["float32", "float64", "float16", "uint8", "int8", "int32", "int64"]
 RealTypes = ["float32", "float64", "float16"]
+
+def assign_by_req(a, req):
+    b = tvm.placeholder(a.shape, name='assign_by_req_b', dtype=a.dtype)
+    if (req == "kAddTo"):
+        c = tvm.compute(a.shape, lambda *idx: a[idx] + b[idx])
+    else:
+        c = tvm.compute(a.shape, lambda *idx: a[idx])
+    return b, c
+
+
+def reduce_axes(X, axes, reducer):
+    def get_index(idx, ridx):
+        j = 0
+        k = 0
+        ret = []
+        for val in axes:
+            ret.append(idx[j] if val == 0 else ridx[k])
+            j += (val == 0)
+            k += (val != 0)
+        return tuple(ret)
+    
+    ishape = X.shape
+    odim = (len(ishape) + 1 - axes[0]) // 2
+    oshape = [tvm.var() for _ in range(odim)]
+    ridx = [tvm.reduce_axis((0, ishape[i])) for (i, val) in enumerate(axes) if val == 1]
+    ret = tvm.compute(oshape, lambda *idx: reducer(X[get_index(idx, ridx)], axis=ridx), name='ret')
+    return ret

--- a/src/operator/contrib/tvmop/ufunc.cc
+++ b/src/operator/contrib/tvmop/ufunc.cc
@@ -28,6 +28,7 @@
 #include <tvm/runtime/registry.h>
 #include <tvm/runtime/c_runtime_api.h>
 #include <mxnet/base.h>
+#include <string>
 #include "../../tensor/elemwise_binary_broadcast_op.h"
 #include "../../tvmop/op_module.h"
 #include "../../tensor/elemwise_binary_op.h"
@@ -37,16 +38,49 @@ namespace op {
 
 static constexpr char func_vadd_cpu[] = "vadd";
 static constexpr char func_vadd_gpu[] = "cuda_vadd";
+static constexpr char func_bakcward_vadd_cpu[] = "backward_vadd";
+static constexpr char func_bakcward_vadd_gpu[] = "cuda_backward_vadd";
 
 template<const char* func>
-void TVMBroadcastCompute(const nnvm::NodeAttrs& attrs,
-                         const mxnet::OpContext& ctx,
-                         const std::vector<TBlob>& inputs,
-                         const std::vector<OpReqType>& req,
-                         const std::vector<TBlob>& outputs) {
+void TVMBinaryCompute(const nnvm::NodeAttrs& attrs,
+                      const mxnet::OpContext& ctx,
+                      const std::vector<TBlob>& inputs,
+                      const std::vector<OpReqType>& req,
+                      const std::vector<TBlob>& outputs) {
   CHECK_EQ(inputs.size(), 2U);
   CHECK_EQ(outputs.size(), 1U);
   tvm::runtime::TVMOpModule::Get()->Call(func, ctx, {inputs[0], inputs[1], outputs[0]});
+}
+
+template<const char* func>
+void TVMBinaryBackwardComputeUseNone(const nnvm::NodeAttrs& attrs,
+                                     const mxnet::OpContext& ctx,
+                                     const std::vector<TBlob>& inputs,
+                                     const std::vector<OpReqType>& req,
+                                     const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK_EQ(outputs.size(), 2U);
+  int ndim = inputs[0].shape_.ndim();
+  for (int k = 0; k < 2; ++k) {
+    std::vector<int> ov, iv;
+    const TBlob& ograd = inputs[0], igrad = outputs[k];
+    bool flag = ograd.size(0) != igrad.size(0);
+    for (int i = 0; i < ndim; ++i) {
+      if (i == 0 || (ograd.size(i) != igrad.size(i)) != (ograd.size(i - 1) != igrad.size(i - 1))) {
+        ov.push_back(ograd.size(i));
+      } else {
+        ov.back() *= ograd.size(i);
+      }
+    }
+    for (int i = flag; i < ov.size(); i += 2) {
+      iv.push_back(ov[i]);
+    }
+    TShape oshape(ov.begin(), ov.end()), ishape(iv.begin(), iv.end());
+    TBlob ograd_tvm(ograd.reshape(oshape).dltensor());
+    TBlob igrad_tvm(igrad.reshape(ishape).dltensor());
+    std::string funcname = std::string(func) + "reduce1st_" + std::to_string(flag);
+    tvm::runtime::TVMOpModule::Get()->Call(funcname, ctx, {ograd_tvm, igrad_tvm});
+  }
 }
 
 NNVM_REGISTER_OP(_contrib_tvm_vadd)
@@ -54,12 +88,28 @@ NNVM_REGISTER_OP(_contrib_tvm_vadd)
     .set_num_outputs(1)
     .add_argument("a", "NDArray-or-Symbol", "first input")
     .add_argument("b", "NDArray-or-Symbol", "second input")
+    .set_attr<nnvm::FListInputNames>("FListInputNames",
+      [](const NodeAttrs& attrs) {
+        return std::vector<std::string>{"a", "b"};
+      })
     .set_attr<mxnet::FInferShape>("FInferShape", BinaryBroadcastShape)
     .set_attr<nnvm::FInferType>("FInferType", mxnet::op::ElemwiseType<2, 1>)
 #if MXNET_USE_CUDA
-    .set_attr<mxnet::FCompute>("FCompute<gpu>", mxnet::op::TVMBroadcastCompute<func_vadd_gpu>)
+    .set_attr<mxnet::FCompute>("FCompute<gpu>", mxnet::op::TVMBinaryCompute<func_vadd_gpu>)
 #endif  // MXNET_USE_CUDA
-    .set_attr<mxnet::FCompute>("FCompute<cpu>", mxnet::op::TVMBroadcastCompute<func_vadd_cpu>);
+    .set_attr<mxnet::FCompute>("FCompute<cpu>", mxnet::op::TVMBinaryCompute<func_vadd_cpu>)
+    .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_contrib_tvm_vadd"});
+
+NNVM_REGISTER_OP(_backward_contrib_tvm_vadd)
+    .set_num_inputs(1)
+    .set_num_outputs(2)
+    .set_attr<nnvm::TIsBackward>("TIsBackward", true)
+#if MXNET_USE_CUDA
+    .set_attr<mxnet::FCompute>("FCompute<gpu>",
+                               mxnet::op::TVMBinaryBackwardComputeUseNone<func_bakcward_vadd_gpu>)
+#endif  // MXNET_USE_CUDA
+    .set_attr<mxnet::FCompute>("FCompute<cpu>",
+                               mxnet::op::TVMBinaryBackwardComputeUseNone<func_bakcward_vadd_cpu>);
 
 }  // namespace op
 }  // namespace mxnet

--- a/tests/python/unittest/test_tvm_op.py
+++ b/tests/python/unittest/test_tvm_op.py
@@ -26,35 +26,46 @@ _features = Features()
 @with_seed()
 def test_tvm_broadcast_add():
     if _features.is_enabled("TVM_OP"):
-        a_shape = rand_shape_nd(4)
-        b_shape = (1,) + a_shape[1:2] + (1, 1)
-        a = mx.nd.normal(shape=a_shape)
-        b = mx.nd.normal(shape=b_shape)
-        a.attach_grad()
-        b.attach_grad()
-        with mx.autograd.record():
-            c = mx.nd.contrib.tvm_vadd(a, b)
-        c_np = a.asnumpy() + b.asnumpy()
-        assert same(c.asnumpy(), c_np)
-        # test backward
-        c.backward()
-        expected_grad_a = _np.ones_like(a.asnumpy()) * c_np.size / a.asnumpy().size
-        expected_grad_b = _np.ones_like(b.asnumpy()) * c_np.size / b.asnumpy().size
-        assert same(a.grad.asnumpy(), expected_grad_a)
-        assert same(b.grad.asnumpy(), expected_grad_b)
-        # test kAddTo request
-        a = mx.nd.normal(shape=a_shape)
-        b = mx.nd.normal(shape=b_shape)
-        a.attach_grad()
-        b.attach_grad()
-        with mx.autograd.record():
-            c = mx.nd.contrib.tvm_vadd(a, b)
-            d = mx.nd.contrib.tvm_vadd(a, b)
-        mx.autograd.backward([c, d])
-        expected_grad_a = 2 * _np.ones_like(a.asnumpy()) * c.size / a.size
-        expected_grad_b = 2 * _np.ones_like(b.asnumpy()) * c.size / b.size
-        assert same(a.grad.asnumpy(), expected_grad_a)
-        assert same(b.grad.asnumpy(), expected_grad_b)
+        configs = [
+            [[5, 6, 7, 8, 9], [1]],
+            [[6, 4, 5, 2, 1], [6, 1, 5, 1, 1]],
+            [[3, 5, 6], [1, 6]],
+            [[3, 5, 6], [5, 1]],
+            [[3, 5, 6], [5, 6]],
+            [[4, 3, 2, 1], [2, 1]],
+            [[4, 3, 2, 2], [4, 1, 1, 2]],
+            [[6, 6], [6, 6]],
+        ]
+        for config in configs:
+            a_shape = config[0]
+            b_shape = config[1]
+            a = mx.nd.normal(shape=a_shape)
+            b = mx.nd.normal(shape=b_shape)
+            a.attach_grad()
+            b.attach_grad()
+            with mx.autograd.record():
+                c = mx.nd.contrib.tvm_vadd(a, b)
+            c_np = a.asnumpy() + b.asnumpy()
+            assert same(c.asnumpy(), c_np)
+            # test backward
+            c.backward()
+            expected_grad_a = _np.ones_like(a.asnumpy()) * c_np.size / a.asnumpy().size
+            expected_grad_b = _np.ones_like(b.asnumpy()) * c_np.size / b.asnumpy().size
+            assert same(a.grad.asnumpy(), expected_grad_a)
+            assert same(b.grad.asnumpy(), expected_grad_b)
+            # test kAddTo request
+            a = mx.nd.normal(shape=a_shape)
+            b = mx.nd.normal(shape=b_shape)
+            a.attach_grad()
+            b.attach_grad()
+            with mx.autograd.record():
+                c = mx.nd.contrib.tvm_vadd(a, b)
+                d = mx.nd.contrib.tvm_vadd(a, b)
+            mx.autograd.backward([c, d])
+            expected_grad_a = 2 * _np.ones_like(a.asnumpy()) * c.size / a.size
+            expected_grad_b = 2 * _np.ones_like(b.asnumpy()) * c.size / b.size
+            assert same(a.grad.asnumpy(), expected_grad_a)
+            assert same(b.grad.asnumpy(), expected_grad_b)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
Use tvm to implement vadd backward with broadcast.

### Changes ###
- add vadd backward

## Comments ##
- As vadd is not a Numpy op, 0-dim and 0-size is not supported.
- For now, I implemented infra-level things on op-level, like
  - dispatch of different req
  - dispatch of backward

I think code for these may be further reused in the future. It'll be great if we can have a consistent interface for tvm op and hide the dispatch of things like req and backward.

Thank @yzhliu and @junrushao1994 for the brilliant "compressed bit string" idea.