### PR TITLE
Discard needless test cases in `test_convolution_independent_gradients`

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -2009,7 +2009,7 @@ def test_convolution_independent_gradients():
     reqs = ["null", "write", "add"]
     var_names = ["x", "w", "b"]
     dims = [1, 2]
-    num_bases = [1, 16, 64]
+    num_bases = [1, 8]
     kernel_xs = [3, 5]
     stride_xs = [1, 2]
     pad_xs = [0, 1]


### PR DESCRIPTION
## Description ##
`test_operator.test_convolution_independent_gradients` may cost too much occasionally, leading to terminated failed CIs. As it was discussed in ISSUE #15880, `test_random.test_shuffle` was also time-consuming, which has been already fixed by PR #15922. This PR aims to reduce the cost of `test_convolution_independent_gradients` by discarding some needless test cases. @pengzhao-intel @ciyongch @TaoLv 

## Checklist ##
### Changes ###
- [x] num_bases change: [1, 16, 64] -> [1, 8]

### Performance ###
| Compiled with MKL-DNN | Total test time / sec (bcbdc1c) | Total test time / sec (b75357f) |
|---                                       |---                                           |---                                           |
| N                                        |41.968                                     |16.133                                     |
| Y                                        |46.166                                     |20.354                                      |
