### PR TITLE
removing unnecessary int64 C apis

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -1020,9 +1020,6 @@ MXNET_DLL int MXNDArrayGetGradState(NDArrayHandle handle, int *out);
 MXNET_DLL int MXListFunctions(mx_uint *out_size,
                               FunctionHandle **out_array);
 
-MXNET_DLL int MXListFunctions64(mx_int64 *out_size,
-                                FunctionHandle **out_array);
-
 /*!
  * \brief get the function handle by name
  * \param name the name of the function
@@ -1291,9 +1288,6 @@ MXNET_DLL int MXInvokeCachedOpEx(CachedOpHandle handle,
 MXNET_DLL int MXListAllOpNames(mx_uint *out_size,
                                const char ***out_array);
 
-MXNET_DLL int MXListAllOpNames64(mx_int64 *out_size,
-                                 const char ***out_array);
-
 /*!
  * \brief list all the available AtomicSymbolEntry
  * \param out_size the size of returned array
@@ -1302,9 +1296,6 @@ MXNET_DLL int MXListAllOpNames64(mx_int64 *out_size,
  */
 MXNET_DLL int MXSymbolListAtomicSymbolCreators(mx_uint *out_size,
                                                AtomicSymbolCreator **out_array);
-
-MXNET_DLL int MXSymbolListAtomicSymbolCreators64(mx_int64 *out_size,
-                                                 AtomicSymbolCreator **out_array);
 
 /*!
  * \brief Get the name of an atomic symbol.
@@ -1519,10 +1510,6 @@ MXNET_DLL int MXSymbolListArguments(SymbolHandle symbol,
                                     mx_uint *out_size,
                                     const char ***out_str_array);
 
-MXNET_DLL int MXSymbolListArguments64(SymbolHandle symbol,
-                                      size_t *out_size,
-                                      const char ***out_str_array);
-
 /*!
  * \brief List returns in the symbol.
  * \param symbol the symbol
@@ -1533,10 +1520,6 @@ MXNET_DLL int MXSymbolListArguments64(SymbolHandle symbol,
 MXNET_DLL int MXSymbolListOutputs(SymbolHandle symbol,
                                   mx_uint *out_size,
                                   const char ***out_str_array);
-
-MXNET_DLL int MXSymbolListOutputs64(SymbolHandle symbol,
-                                    size_t *out_size,
-                                    const char ***out_str_array);
 
 /*!
  * \brief Get number of outputs of the symbol.
@@ -1584,10 +1567,6 @@ MXNET_DLL int MXSymbolGetOutput(SymbolHandle symbol,
 MXNET_DLL int MXSymbolListAuxiliaryStates(SymbolHandle symbol,
                                           mx_uint *out_size,
                                           const char ***out_str_array);
-
-MXNET_DLL int MXSymbolListAuxiliaryStates64(SymbolHandle symbol,
-                                            size_t *out_size,
-                                            const char ***out_str_array);
 
 /*!
  * \brief Compose the symbol on other symbols.


### PR DESCRIPTION

## Description ##
Removing C apis that were added to support Large Tensors and Vectors but not required. They don't have any implementation and no calls from any language bindings

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
