### PR TITLE
[MKLDNN]Support fullyconnected and element-wise ops fusion

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -620,9 +620,6 @@ bool MKLDNNStorageType(const nnvm::NodeAttrs &attrs,
 #define MKLDNN_OPCHECK_COPY_RESULT(outputs, indice) \
     if (debug) check.CopyResult(outputs, indice);
 
-}  // namespace mxnet
-#endif
-
 struct MKLDNNPostEltwiseParam {
   mkldnn::algorithm alg = mkldnn::algorithm::algorithm_undef;
   float scale = 1.f;
@@ -630,4 +627,6 @@ struct MKLDNNPostEltwiseParam {
   float beta = 1.f;
 };
 
+}  // namespace mxnet
+#endif
 #endif  // MXNET_OPERATOR_NN_MKLDNN_MKLDNN_BASE_INL_H_

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -622,4 +622,12 @@ bool MKLDNNStorageType(const nnvm::NodeAttrs &attrs,
 
 }  // namespace mxnet
 #endif
+
+struct MKLDNNPostEltwiseParam {
+  mkldnn::algorithm alg = mkldnn::algorithm::algorithm_undef;
+  float scale = 1.f;
+  float alpha = 0.f;
+  float beta = 1.f;
+};
+
 #endif  // MXNET_OPERATOR_NN_MKLDNN_MKLDNN_BASE_INL_H_

--- a/src/operator/nn/mkldnn/mkldnn_convolution-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_convolution-inl.h
@@ -70,20 +70,13 @@ struct MKLDNNConvParam : public dmlc::Parameter<MKLDNNConvParam> {
   }
 };
 
-struct MKLDNNPostActParam {
-  mkldnn::algorithm alg = mkldnn::algorithm::algorithm_undef;
-  float scale = 1.f;
-  float alpha = 0.f;
-  float beta = 1.f;
-};
-
 struct MKLDNNConvFullParam {
   ConvolutionParam conv_param;
   MKLDNNConvParam mkldnn_param;
   float sum_scale = 1.f;
   std::vector<float> requantize_scales;
-  MKLDNNPostActParam act_param;
-  MKLDNNPostActParam postsum_act_param;
+  MKLDNNPostEltwiseParam act_param;
+  MKLDNNPostEltwiseParam postsum_act_param;
 };
 
 mkldnn::convolution_forward::primitive_desc GetConvFwdImpl(const MKLDNNConvFullParam &param,

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
@@ -87,8 +87,6 @@ class MKLDNNFullyConnectedForward {
                               const mkldnn::memory::desc &out_md)
       : fwd_pd(GetFCFwdImpl(full_param, is_train, data, weight, bias, out_md)) {}
 
-  void SetNewMem(const mkldnn::memory &data, const mkldnn::memory &output);
-
   void SetNewMem(const mkldnn::memory &data, const mkldnn::memory &weight,
                  const mkldnn::memory *bias, const mkldnn::memory &output);
 

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected-inl.h
@@ -70,7 +70,6 @@ struct MKLDNNFCFullParam {
   MKLDNNPostEltwiseParam eltwise_param;
   std::vector<float> output_scales = {0.0};
   std::vector<float> requantize_scales = {0.0};
-
 };
 
 mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -44,11 +44,11 @@ mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(
 
   mkldnn::primitive_attr attr;
   mkldnn::post_ops ops;
-  if (full_param.mkldnn_param.with_relu) {
-    const float scale = 1.0f;
-    const float alpha = 0.0f;
-    const float beta = 1.0f;
-    ops.append_eltwise(scale, eltwise_relu, alpha, beta);
+  if (full_param.mkldnn_param.with_eltwise) {
+    ops.append_eltwise(full_param.eltwise_param.scale,
+                       full_param.eltwise_param.alg,
+                       full_param.eltwise_param.alpha,
+                       full_param.eltwise_param.beta);
   }
   attr.set_post_ops(ops);
 

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -263,7 +263,6 @@ void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam &full_param,
       CHECK(weight_mem->get_primitive_desc() == fwd->fwd_pd.weights_primitive_desc());
     }
   }
-
   auto out_mem = CreateMKLDNNMem(out_data[fullc::kOut],
       fwd->fwd_pd.dst_primitive_desc(), req[fullc::kOut], &data);
   if (!full_param.default_param.no_bias) {
@@ -273,7 +272,6 @@ void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam &full_param,
   } else {
     fwd->SetNewMem(*data_mem, *weight_mem, nullptr, *out_mem.second);
   }
-
   MKLDNNStream::Get()->RegisterPrim(fwd->GetFwd());
   CommitOutput(out_data[fullc::kOut], out_mem);
   MKLDNNStream::Get()->Submit();

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -263,6 +263,7 @@ void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam &full_param,
       CHECK(weight_mem->get_primitive_desc() == fwd->fwd_pd.weights_primitive_desc());
     }
   }
+
   auto out_mem = CreateMKLDNNMem(out_data[fullc::kOut],
       fwd->fwd_pd.dst_primitive_desc(), req[fullc::kOut], &data);
   if (!full_param.default_param.no_bias) {
@@ -272,6 +273,7 @@ void MKLDNNFCForwardFullFeature(const MKLDNNFCFullParam &full_param,
   } else {
     fwd->SetNewMem(*data_mem, *weight_mem, nullptr, *out_mem.second);
   }
+
   MKLDNNStream::Get()->RegisterPrim(fwd->GetFwd());
   CommitOutput(out_data[fullc::kOut], out_mem);
   MKLDNNStream::Get()->Submit();

--- a/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_FC_INL_H_
+#define MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_FC_INL_H_
+#if MXNET_USE_MKLDNN == 1
+
+#include <string>
+#include <utility>
+#include <vector>
+#include "mkldnn.hpp"
+#include "../../nn/activation-inl.h"
+
+namespace mxnet {
+namespace op {
+
+namespace sg_mkldnn_fc_fusion {
+  std::set<std::string> eltwise_name_list = {
+    "Activation",
+    "square",
+    "square_root",
+    "exp",
+    "abs",
+    "clip"
+  };
+}
+
+static inline bool SupportMKLDNNFCEltwiseFusion(const std::string op_name) {
+  auto res = sg_mkldnn_fc_fusion::eltwise_name_list.find(op_name);
+  if (res != sg_mkldnn_fc_fusion::eltwise_name_list.end())
+    return true;
+  else
+    return false;
+}
+
+static inline mkldnn::algorithm GetMKLDNNEltwiseAlgo(const std::string op_name) {
+  switch (op_name) {
+    case "square":
+      return mkldnn::algorithm::eltwise_square;
+    case "square_root":
+      return mkldnn::algorithm::eltwise_sqrt;
+    case "exp:
+      return mkldnn::algorithm::exp;
+    case "abs":
+      return mkldnn::algorithm::abs;
+    default:
+      LOG(FATAL) << "Unsupported eltwise fusion op: " << op_name; 
+  }
+}
+
+static inline bool IsOutputUInt8(const MKLDNNConvFusionParam& param) {
+  bool result = false;
+  const auto& mkldnn_param = param.full_conv_param.mkldnn_param;
+  auto IsOutputUInt8Helper = [](const mkldnn::algorithm& act_alg) {
+    return (act_alg == mkldnn::algorithm::eltwise_relu ||
+            act_alg == mkldnn::algorithm::eltwise_logistic ||
+            act_alg == mkldnn::algorithm::eltwise_soft_relu ||
+            act_alg == mkldnn::algorithm::eltwise_bounded_relu);
+  };
+  if ((!mkldnn_param.with_sum) && mkldnn_param.with_act) {
+    CHECK(param.full_conv_param.act_param.alg != mkldnn::algorithm::algorithm_undef);
+    result = IsOutputUInt8Helper(param.full_conv_param.act_param.alg);
+  } else if (mkldnn_param.with_postsum_act) {
+    CHECK(param.full_conv_param.postsum_act_param.alg != mkldnn::algorithm::algorithm_undef);
+    result = IsOutputUInt8Helper(param.full_conv_param.postsum_act_param.alg);
+  }
+  return result;
+}
+
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_USE_MKLDNN == 1
+#endif  // MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_FC_INL_H_

--- a/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
@@ -33,7 +33,7 @@ namespace op {
 static inline bool SupportMKLDNNFCEltwiseFusion(const std::string op_name) {
   if (op_name == "Activation" ||
       op_name == "square" ||
-      op_name == "square_root" ||
+      op_name == "sqrt" ||
       op_name == "exp" ||
       op_name == "abs" ||
       op_name == "clip") {
@@ -46,7 +46,7 @@ static inline bool SupportMKLDNNFCEltwiseFusion(const std::string op_name) {
 static inline mkldnn::algorithm GetMKLDNNEltwiseAlgo(const std::string op_name) {
   if (op_name == "square")
     return mkldnn::algorithm::eltwise_square;
-  else if (op_name == "square_root")
+  else if (op_name == "sqrt")
     return mkldnn::algorithm::eltwise_sqrt;
   else if (op_name == "exp")
     return mkldnn::algorithm::eltwise_exp;

--- a/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc-inl.h
@@ -76,7 +76,6 @@ static inline bool IsOutputUint8(const MKLDNNFCFullParam& full_param) {
   return false;
 }
 
-
 }  // namespace op
 }  // namespace mxnet
 

--- a/src/operator/subgraph/mkldnn/mkldnn_fc.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc.cc
@@ -146,7 +146,7 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
       auto data_range = (data.dtype() == mshadow::kInt8) ? kInt8Range : kUint8Range;
       float data_scale  = data_range / MaxAbs(cached_min_data_, cached_max_data_);
       float weight_scale = kInt8Range / MaxAbs(cached_min_weight_, cached_max_weight_);
-      float quantized_out_range = mkldnn_param.with_eltwise? kUint8Range : kInt8Range;
+      float quantized_out_range = IsOutputUint8(full_param_)? kUint8Range : kInt8Range;
 
       if (has_bias) {
         NDArray bias = in_data[fullc::kBias];

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
@@ -116,7 +116,7 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
         }
         if (new_node.op() == Op::Get("clip")) {
           const ClipParam &param = nnvm::get<ClipParam>(new_node.attrs.parsed);
-          if (param.a_min == 0.f && param.a_max == 1.0f) {
+          if (param.a_min == 0.f) {
             matched_list_.push_back(&new_node);
             status_ = kSuccess;
             return true;

--- a/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc_property.h
@@ -31,6 +31,8 @@
 #include <string>
 #include <vector>
 #include "../common.h"
+#include "../../tensor/matrix_op-inl.h"
+#include "mkldnn_fc-inl.h"
 #include "../subgraph_property.h"
 
 namespace mxnet {
@@ -46,18 +48,21 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
   };
 
  private:
-  bool disable_fc_relu;
-  SelectStatus status;
-  std::vector<const nnvm::Node *> matched_list;
+  bool disable_fc_eltwise_;
+  bool quantized_;
+  SelectStatus status_;
+  std::vector<const nnvm::Node *> matched_list_;
 
  public:
-  explicit SgMKLDNNFCSelector(const bool dis_fc_relu) : disable_fc_relu(dis_fc_relu) {}
+  explicit SgMKLDNNFCSelector(const bool dis_fc_eltwise, bool quantized) :
+      disable_fc_eltwise_(dis_fc_eltwise),
+      quantized_(quantized) {}
 
   bool Select(const nnvm::Node &n) override {
     if (n.op() == Op::Get("FullyConnected")) {
-      status = disable_fc_relu ? kSuccess : kStart;
-      matched_list.clear();
-      matched_list.push_back(&n);
+      status_ = disable_fc_eltwise_ ? kSuccess : kStart;
+      matched_list_.clear();
+      matched_list_.push_back(&n);
       return true;
     }
     return false;
@@ -68,44 +73,69 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
   }
 
   bool SelectOutput(const nnvm::Node &n, const nnvm::Node &new_node) override {
-    if (status == kFail || status == kSuccess || new_node.is_variable())
+    if (status_ == kFail || status_ == kSuccess || new_node.is_variable())
       return false;
 
     // If n isn't the last matched node, then we encoutered a internal
     // branch, we should pop out the node behind n and stop fusion.
-    if (matched_list.back() != &n) {
-      if (std::find(matched_list.begin(), matched_list.end(), &n) !=
-        matched_list.end()) {
-        while (matched_list.back() != &n) {
-          matched_list.pop_back();
+    if (matched_list_.back() != &n) {
+      if (std::find(matched_list_.begin(), matched_list_.end(), &n) !=
+        matched_list_.end()) {
+        while (matched_list_.back() != &n) {
+          matched_list_.pop_back();
         }
       }
 
-      status = kSuccess;
+      status_ = kSuccess;
       return false;
     }
 
-    switch (status) {
+    switch (status_) {
       case kStart:
-        if (new_node.op() == Op::Get("Activation") &&
-            new_node.attrs.dict.at("act_type") == "relu") {
-          matched_list.push_back(&new_node);
-          status = kSuccess;
+        // Currently, For INT8 FC fusion, only supports relu/bounded_relu(clip)/abs.
+        if (new_node.op() == Op::Get("Activation")) {
+          const ActivationParam &param = nnvm::get<ActivationParam>(new_node.attrs.parsed);
+          if ((quantized_ && SupportQuantizedMKLDNNAct(param)) ||
+              (!quantized_ && SupportMKLDNNAct(param))) {
+          matched_list_.push_back(&new_node);
+          status_ = kSuccess;
           return true;
         }
+        if (!quantized_ && (new_node.op() == Op::Get("square") ||
+          new_node.op() == Op::Get("square_root") ||
+          new_node.op() == Op::Get("exp"))) {
+          matched_list_.push_back(&new_node);
+          status_ = kSuccess;
+          return true;
+        }
+        if (new_node.op() == Op::Get("abs")) {
+          matched_list_.push_back(&new_node);
+          status_ = kSuccess;
+          return true;
+        }
+        if (new_node.op() == Op::Get("clip")) {
+          const ClipParam &param == nnvm::get<ClipParam>(new_node.attrs.parsed);
+          if (param.a_min == 0.f && param.a_max == 1.0f) {
+            matched_list_.push_back(&new_node);
+            status_ = kSuccess;
+            return true;
+          }
+          status_ = kSuccess;
+          return false;
+        }
       default:
-        status = kSuccess;
+        status_ = kSuccess;
         return false;
     }
   }
 
   std::vector<nnvm::Node *> Filter(
       const std::vector<nnvm::Node *> &candidates) override {
-    if (status == kFail) {
+    if (status_ == kFail) {
       return std::vector<nnvm::Node *>(0);
     } else {
       std::vector<nnvm::Node *> ret;
-      for (auto i : matched_list) {
+      for (auto i : matched_list_) {
         auto non_const_i = const_cast<nnvm::Node *>(i);
         if (std::find(candidates.begin(), candidates.end(), non_const_i) !=
             candidates.end()) {
@@ -117,9 +147,9 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
   }
 
   void Reset() override {
-    CHECK_GE(matched_list.size(), 1);
-    auto new_selector = SgMKLDNNFCSelector(disable_fc_relu);
-    new_selector.Select(*matched_list[0]);
+    CHECK_GE(matched_list_.size(), 1);
+    auto new_selector = SgMKLDNNFCSelector(disable_fc_eltwise_, quantized_);
+    new_selector.Select(*matched_list_[0]);
     *this = new_selector;
   }
 };
@@ -127,7 +157,8 @@ class SgMKLDNNFCSelector : public SubgraphSelector {
 class SgMKLDNNFCProperty : public SubgraphProperty {
  public:
   SgMKLDNNFCProperty() {
-    disable_fc_relu = dmlc::GetEnv("MXNET_DISABLE_MKLDNN_FUSE_FC_RELU", false);
+    quantized_ = HasAttr("quantize") ? GetAttr<bool>("quantize") : false;
+    disable_fc_eltwise_ = dmlc::GetEnv("MXNET_DISABLE_MKLDNN_FUSE_FC_ELTWISE", false);
   }
 
   static SubgraphPropertyPtr Create() {
@@ -149,16 +180,15 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
     nnvm::Symbol new_sym;
     new_sym.outputs.emplace_back(last_node);
     std::ostringstream node_name;
-    node_name << "sg_mkldnn_";
+    node_name << quantized_ ? "sg_quantized_mkldnn_" : "sg_mkldnn_";
     DFSVisit(new_sym.outputs, [&](const nnvm::NodePtr &node) {
       if (node->is_variable()) return;
       auto &sub_name = node->op()->name;
       if (sub_name == "FullyConnected") {
         node_name << "fully_connected_";
-      } else if ((sub_name == "Activation") &&
-                 (node->attrs.dict.at("act_type") == "relu")) {
-          node_name << "relu_";
-          n->attrs.dict["with_relu"] = "True";
+      } else if (SupportMKLDNNFCEltwiseFusion(sub_name)) {
+          node_name << "eltwise_";
+          n->attrs.dict["with_eltwise"] = "True";
       }
     });
     node_name << std::to_string(subgraph_id);
@@ -171,7 +201,7 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
   }
 
   SubgraphSelectorPtr CreateSubgraphSelector() const override {
-    auto selector = std::make_shared<SgMKLDNNFCSelector>(disable_fc_relu);
+    auto selector = std::make_shared<SgMKLDNNFCSelector>(disable_fc_eltwise_, quantized_);
     return selector;
   }
 
@@ -186,7 +216,8 @@ class SgMKLDNNFCProperty : public SubgraphProperty {
   }
 
  private:
-  bool disable_fc_relu;
+  bool disable_fc_eltwise_;
+  bool quantized_;
 };
 
 }  // namespace op

--- a/tests/python/mkl/test_subgraph.py
+++ b/tests/python/mkl/test_subgraph.py
@@ -49,6 +49,8 @@ config =  {
 }
 
 DATA_SHAPE=[(64, 4, 10, 10), (4, 3, 24, 24), (1, 16, 32, 32)]
+fc_post_ops_list=['relu', 'sigmoid', 'tanh', 'softrelu',
+                  'square', 'square_root', 'abs', 'exp', 'bounded_relu']
 
 def check_qsym_calibrated(qsym, out_type, name='conv'):
   quantized_op_name = 'quantized_' + name
@@ -236,6 +238,12 @@ def check_quantize_whole_model_with_forward():
 @with_seed()
 def check_fusion(sym, data_shape, attrs_dict, check_fp32_fusion=True, check_quantization=True, out_types=['uint8', 'int8', 'auto']):
   if check_fp32_fusion:
+    data_min = -1.0
+    data_max = 1.0
+    if ''.join(sym.get_internals().list_outputs()).find('sqrt'):
+      check_quantization = False
+      data_min = 0
+
     sym_sg = sym.get_backend_symbol(SG_PASS_NAME)
     for name, attrs in attrs_dict.items():
       if name in config:
@@ -251,9 +259,8 @@ def check_fusion(sym, data_shape, attrs_dict, check_fp32_fusion=True, check_quan
               for attr_name, attr_value in attrs.items():
                 assert v[attr_name].lower() == attr_value.lower()
           assert found
-
     arg_shapes, _, aux_shapes = sym.infer_shape()
-    arg_array = [mx.nd.random.uniform(-1.0, 1.0, shape=shape) for shape in arg_shapes]
+    arg_array = [mx.nd.random.uniform(data_min, data_max, shape=shape) for shape in arg_shapes]
     aux_array = [mx.nd.random.uniform(shape=shape) for shape in aux_shapes]
     exe = sym.bind(ctx=mx.current_context(), args=arg_array, aux_states=aux_array, grad_req='null')
     exe.forward()
@@ -625,13 +632,28 @@ def single_fc(no_bias, data_shape, flatten=True):
                                 no_bias=no_bias, flatten=flatten)
   return fc, attr
 
-def fc_relu(no_bias, data_shape, flatten=True):
-  attr = {'fc': {'with_relu': 'true'}}
+# fc + eltwise fusion case
+def fc_eltwise(no_bias, data_shape, flatten=True, alg='relu'):
+  assert alg in fc_post_ops_list
+
+  attr = {'fc': {'with_eltwise': 'true'}}
   data, weight = head_symbol(data_shape)
   fc = mx.symbol.FullyConnected(name='fc', data=data, weight=weight, num_hidden=64,
                                 no_bias=no_bias, flatten=flatten)
-  relu = mx.symbol.Activation(data=fc, name='relu', act_type="relu")
-  return relu, attr
+  if alg in ['relu', 'sigmoid', 'tanh', 'softrelu']:
+    sym = mx.symbol.Activation(data=fc, name='act', act_type=alg)
+  elif alg == 'square':
+    sym = mx.symbol.square(data=fc, name='square')
+  elif alg == 'square_root':
+    sym = mx.symbol.sqrt(data=fc, name='sqrt')
+  elif alg == 'abs':
+    sym = mx.symbol.abs(data=fc, name='abs')
+  elif alg == 'exp':
+    sym = mx.symbol.exp(data=fc, name='exp')
+  else:
+    sym = mx.symbol.clip(data=fc, name='bounded_relu', a_min=0, a_max=1.0)
+
+  return sym, attr
 
 # fc + relu can't be fusion case
 # eg.1
@@ -805,9 +827,13 @@ def test_single_fc():
 
 
 @with_seed()
-def test_fc_relu():
-  for dshape, no_bias, flatten in itertools.product(DATA_SHAPE, [True, False], [True, False]):
-    syms, attrs = fc_relu(no_bias, dshape, flatten)
+def test_fc_eltwise():
+  for dshape, no_bias, flatten, alg in itertools.product(DATA_SHAPE,
+                                                        [True, False],
+                                                        [True, False],
+                                                        fc_post_ops_list):
+    syms, attrs = fc_eltwise(no_bias, dshape, flatten, alg)
+    print ('alg={0}, no_bias={1}, flatten={2}, dshape={3}'.format(alg, no_bias, flatten, dshape))
     if flatten is True:
       check_fusion(syms, dshape, attrs, check_quantization=True)
     else:

--- a/tests/python/mkl/test_subgraph.py
+++ b/tests/python/mkl/test_subgraph.py
@@ -833,7 +833,6 @@ def test_fc_eltwise():
                                                         [True, False],
                                                         fc_post_ops_list):
     syms, attrs = fc_eltwise(no_bias, dshape, flatten, alg)
-    print ('alg={0}, no_bias={1}, flatten={2}, dshape={3}'.format(alg, no_bias, flatten, dshape))
     if flatten is True:
       check_fusion(syms, dshape, attrs, check_quantization=True)
     else:


### PR DESCRIPTION
## Description ##
This PR is to add the support for fullyconnected and some element-wise (including activation/square/sqrt/exp/abs/clip) ops fusion.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
@pengzhao-intel @TaoLv @ZhennanQin 