### PR TITLE
Added more tests for Large Indices

### DIFF
--- a/src/ndarray/ndarray_function.cc
+++ b/src/ndarray/ndarray_function.cc
@@ -38,7 +38,7 @@ void Copy<cpu, cpu>(const TBlob &from, TBlob *to,
                     RunContext ctx) {
   MSHADOW_TYPE_SWITCH(to->type_flag_, DType, {
     if (to->type_flag_ == from.type_flag_) {
-      const index_t size = from.Size();
+      const index_t size = static_cast<index_t>(from.Size());
       CHECK_EQ(size, to->Size()) << "copying size mismatch, from: " << size * sizeof(DType)
                << " bytes, to: " << to->Size() * sizeof(DType) << " bytes.";
       common::ParallelCopy(to->dptr<DType>(), from.dptr<DType>(), size);

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -1133,7 +1133,7 @@ void BatchTakeOpForward(const nnvm::NodeAttrs& attrs,
  * \brief The parameters of the one_hot operator.
  */
 struct OneHotParam : public dmlc::Parameter<OneHotParam> {
-  int depth;
+  index_t depth;
   double on_value;
   double off_value;
   int axis;
@@ -1153,7 +1153,7 @@ struct OneHotParam : public dmlc::Parameter<OneHotParam> {
   }
 };
 
-inline void GetOneHotParams(const OneHotParam& param, int* depth, double* on_value,
+inline void GetOneHotParams(const OneHotParam& param, index_t* depth, double* on_value,
                             double* off_value, int* dtype) {
   *depth = param.depth;
   CHECK_GE(*depth, 0) << "Dimension size, depth, must be a non-negative integer";
@@ -1172,7 +1172,7 @@ inline bool OneHotOpShape(const nnvm::NodeAttrs& attrs,
   const mxnet::TShape& ishape = (*in_attrs)[0];
   if (!shape_is_known(ishape)) return false;
 
-  int depth = 0;
+  index_t depth = 0;
   double on_value = 1.0;
   double off_value = 0.0;
   int dtype = mshadow::kFloat32;
@@ -1193,7 +1193,7 @@ inline bool OneHotOpType(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(in_attrs->size(), 1U);
   CHECK_EQ(out_attrs->size(), 1U);
   CHECK_NE((*in_attrs)[0], -1) << "Index type must be set for one_hot operator";
-  int depth = 0;
+  index_t depth = 0;
   double on_value = 1.0;
   double off_value = 0.0;
   int dtype = -1;
@@ -1207,10 +1207,10 @@ inline bool OneHotOpType(const nnvm::NodeAttrs& attrs,
 template<int req>
 struct one_hot {
   template<typename DType, typename IType>
-  MSHADOW_XINLINE static void Map(int i, DType* out, const IType* indices,
-                                  int depth, DType on_value) {
-    int offset = i * depth;
-    int j = static_cast<int>(indices[i]);
+  MSHADOW_XINLINE static void Map(index_t i, DType* out, const IType* indices,
+                                  index_t depth, DType on_value) {
+    index_t offset = i * depth;
+    index_t j = static_cast<index_t>(indices[i]);
     if (j >= 0 && j < depth) {
       KERNEL_ASSIGN(out[offset+j], req, on_value);
     }
@@ -1229,7 +1229,7 @@ void OneHotOpForward(const nnvm::NodeAttrs& attrs,
   // The following line is needed to guard the situation when
   // an output array is empty on GPU. In that case, out.dptr() = 0x0
   if (outputs[0].Size() == 0) return;
-  int depth = 0;
+  index_t depth = 0;
   double on_value = 1.0;
   double off_value = 0.0;
   int dtype = mshadow::kFloat32;

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -1148,8 +1148,8 @@ void SliceAssignScalarOpForward(const nnvm::NodeAttrs& attrs,
 
 struct SliceAxisParam : public dmlc::Parameter<SliceAxisParam> {
   int axis;
-  int begin;
-  dmlc::optional<int> end;
+  index_t begin;
+  dmlc::optional<index_t> end;
   DMLC_DECLARE_PARAMETER(SliceAxisParam) {
     DMLC_DECLARE_FIELD(axis)
       .describe("Axis along which to be sliced, supports negative indexes.");

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -25,6 +25,7 @@ from tests.python.unittest.common import with_seed
 # dimension constants
 LARGE_X = 5000000000
 MEDIUM_X = 1000000000
+LARGE_Y = 100000
 SMALL_Y = 1
 
 

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -25,6 +25,7 @@ from tests.python.unittest.common import with_seed
 # dimension constants
 LARGE_X = 5000000000
 MEDIUM_X = 1000000000
+SMALL_Y = 1
 
 
 def test_slice():

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -25,8 +25,6 @@ from tests.python.unittest.common import with_seed
 # dimension constants
 LARGE_X = 5000000000
 MEDIUM_X = 1000000000
-LARGE_Y = 100000
-SMALL_Y = 1
 
 
 def test_slice():


### PR DESCRIPTION
## Description ##
Remainder of Ops that are required to support DGL on MXNet. Changes to support Large Indices in one_hot and slice_axis operators.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Testing ##
`~/incubator-mxnet (new_ops_large_vector) $ MXNET_TEST_COUNT=1 nosetests --logging-level=DEBUG --verbose -s tests/nightly/test_large_vector.py`

/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np
.dtype(float).type`.
  from ._conv import register_converters as _register_converters
test_large_vector.test_slice ... ok
test_large_vector.test_ndarray_zeros ... ok
test_large_vector.test_ndarray_ones ... ok
test_large_vector.test_ndarray_random_uniform ... [DEBUG] Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1631832474 to reproduce.
ok
test_large_vector.test_ndarray_random_randint ... [DEBUG] Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1887298151 to reproduce.
ok
test_large_vector.test_ndarray_empty ... ok
test_large_vector.test_elementwise ... ok
test_large_vector.test_reduce ... ok
test_large_vector.test_clip ... ok
test_large_vector.test_argmin ... ok
test_large_vector.test_take ... ok
test_large_vector.test_slice_assign ... ok
test_large_vector.test_expand_dims ... ok
test_large_vector.test_squeeze ... ok
test_large_vector.test_broadcast_div ... ok
test_large_vector.test_Dense ... ok
test_large_vector.test_argsort ... ok
test_large_vector.test_sort ... ok
test_large_vector.test_topk ... ok
test_large_vector.test_shape ... ok
test_large_vector.test_size ... ok
test_large_vector.test_copy ... ok
test_large_vector.test_copy_to ... ok
test_large_vector.test_zeros_like ... ok
test_large_vector.test_ones_like ... ok
test_large_vector.test_concat ... ok
test_large_vector.test_sum ... ok
test_large_vector.test_prod ... ok
test_large_vector.test_min ... ok
test_large_vector.test_max ... ok
test_large_vector.test_argmax ... ok
test_large_vector.test_iadd ... ok
test_large_vector.test_isub ... ok
test_large_vector.test_imul ... ok
test_large_vector.test_idiv ... ok
test_large_vector.test_imod ... ok
test_large_vector.test_eq ... ok
test_large_vector.test_neq ... ok
test_large_vector.test_lt ... ok
test_large_vector.test_lte ... ok
test_large_vector.test_gt ... ok
test_large_vector.test_gte ... ok
test_large_vector.test_slice_like ... ok
test_large_vector.test_slice_axis ... ok
test_large_vector.test_full ... ok
test_large_vector.test_one_hot ... ok

----------------------------------------------------------------------
Ran 46 tests in 16078.103s

OK