### PR TITLE
Fix missing args_list when defining _run_nd_operator_performance_test() function

### DIFF
--- a/benchmark/opperf/utils/benchmark_utils.py
+++ b/benchmark/opperf/utils/benchmark_utils.py
@@ -50,7 +50,7 @@ def _prepare_op_inputs(inputs, run_backward, dtype, ctx):
     return args_list, kwargs_list
 
 
-def _run_nd_operator_performance_test(op, inputs, run_backward, warmup, runs, kwargs_list, profiler):
+def _run_nd_operator_performance_test(op, inputs, run_backward, warmup, runs, args_list, kwargs_list, profiler):
     if profiler == 'native':
         if run_backward:
             benchmark_helper_func = cpp_profile(nd_forward_backward_and_profile)


### PR DESCRIPTION

## Description ##
This PR is to fix the `TypeError` issue when calling `_run_nd_operator_performance_test` function inside `run_performance_test`. I found that `args_list` parameter is missed in definition of `_run_nd_operator_performance_test` in `benchmark_utils.py` (See this [PR](https://github.com/apache/incubator-mxnet/pull/15761)). 
@pengzhao-intel @ChaiBapchya 

Before:
```
>>> from benchmark.opperf.utils.benchmark_utils import run_performance_test
>>> from mxnet import nd
>>> import mxnet as mx
>>> run_performance_test(nd.add,run_backward=True, dtype='float32', ctx=mx.cpu(),inputs=[{"lhs":(2,2),"rhs":(2,2)}],warmup=10, runs=25)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/incubator-mxnet/benchmark/opperf/utils/benchmark_utils.py", line 137, in run_performance_test
    benchmark_result = _run_nd_operator_performance_test(op, inputs, run_backward, warmup, runs, args_list, kwargs_list, profiler)
TypeError: _run_nd_operator_performance_test() takes 7 positional arguments but 8 were given
>>>

```
After:
```
>>> from benchmark.opperf.utils.benchmark_utils import run_performance_test
>>> from mxnet import nd
>>> import mxnet as mx
>>> run_performance_test(nd.add,run_backward=True, dtype='float32', ctx=mx.cpu(),inputs=[{"lhs":(2,2),"rhs":(2,2)}],warmup=10, runs=25)
INFO:root:Begin Benchmark - add
INFO:root:Complete Benchmark - add
[{'add': [{'max_storage_mem_alloc_cpu/0': 0.008, 'avg_time_forward_add': 0.006, 'avg_time_backward_add': 0.0045, 'inputs': {'lhs': (2, 2), 'rhs': (2, 2)}}]}]

```


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
