### PR TITLE
Decouple dtype from shape for Random multinomial

### DIFF
--- a/src/operator/random/sample_multinomial_op.h
+++ b/src/operator/random/sample_multinomial_op.h
@@ -70,11 +70,6 @@ inline bool SampleMultinomialOpShape(const nnvm::NodeAttrs& attrs,
   const mxnet::TShape& ishape = (*in_attrs)[0];
   if (!ndim_is_known(ishape)) return false;
 
-  MSHADOW_TYPE_SWITCH(param.dtype, DType, {
-    // CHECK_LE(ishape[ishape.ndim() - 1], mxnet::common::MaxIntegerValue<DType>())
-    // << "'dtype' does not have a sufficient precision to represent the indices of the input array.";
-  });
-
   if (ishape.ndim() == 1) {
     if (param.shape.ndim() > 0) {
       SHAPE_ASSIGN_CHECK(*out_attrs, 0, param.shape);

--- a/src/operator/random/sample_multinomial_op.h
+++ b/src/operator/random/sample_multinomial_op.h
@@ -71,8 +71,8 @@ inline bool SampleMultinomialOpShape(const nnvm::NodeAttrs& attrs,
   if (!ndim_is_known(ishape)) return false;
 
   MSHADOW_TYPE_SWITCH(param.dtype, DType, {
-    CHECK_LE(ishape[ishape.ndim() - 1], mxnet::common::MaxIntegerValue<DType>())
-    << "'dtype' does not have a sufficient precision to represent the indices of the input array.";
+    // CHECK_LE(ishape[ishape.ndim() - 1], mxnet::common::MaxIntegerValue<DType>())
+    // << "'dtype' does not have a sufficient precision to represent the indices of the input array.";
   });
 
   if (ishape.ndim() == 1) {
@@ -121,7 +121,7 @@ inline bool SampleMultinomialOpType(const nnvm::NodeAttrs& attrs,
 
 struct SampleMultinomialKernel {
   template<typename DType, typename IType>
-  MSHADOW_XINLINE static void Map(int i, index_t K, index_t M,
+  MSHADOW_XINLINE static void Map(index_t i, index_t K, index_t M,
                                   DType* dist, float* uniform, float* cum_table,
                                   IType* out, DType* prob) {
     double acc = 0.0;


### PR DESCRIPTION
## Description ##
Currently, if we pass shape >2**32 to random multinomial
It fails with this error
`dtype' does not have a sufficient precision to represent the indices
of the input array.`

It's wrong for an operator to expect the shape to fall within the limits of dtype. Reason - they are not related.

even if default dtype is float32, it shouldn't be restrict the shape space to 2**32.

```
======================================================================
ERROR: test_large_vector.test_ndarray_random_multinomial
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ubuntu/anaconda3/lib/python3.6/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/ubuntu/workspace/lts/vector/incubator-mxnet/tests/python/unittest/common.py", line 177, in test_new
    orig_test(*args, **kwargs)
  File "/home/ubuntu/workspace/lts/vector/incubator-mxnet/tests/nightly/test_large_vector.py", line 67, in test_ndarray_random_multino$
ial
    a = nd.random.multinomial(nd.random.uniform(shape=(LARGE_X)))
  File "/home/ubuntu/workspace/lts/vector/incubator-mxnet/python/mxnet/ndarray/random.py", line 562, in multinomial
    return _internal._sample_multinomial(data, shape, get_prob, out=out, dtype=dtype, **kwargs)
  File "<string>", line 70, in _sample_multinomial
  File "/home/ubuntu/workspace/lts/vector/incubator-mxnet/python/mxnet/_ctypes/ndarray.py", line 100, in _imperative_invoke
    ctypes.byref(out_stypes)))
  File "/home/ubuntu/workspace/lts/vector/incubator-mxnet/python/mxnet/base.py", line 254, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError: [20:02:50] ../src/operator/random/./sample_multinomial_op.h:76: Check failed: ishape[ishape.ndim() - 1] <= mxne$
::common::MaxIntegerValue<DType>() (5000000000 vs. 2147483647) : 'dtype' does not have a sufficient precision to represent the indices
of the input array.
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Removed the check for shape to be within the MAX INT limit

## Comments ##
Must be made to ensure shape and dtype are decoupled.