### PR TITLE
[Python] Remove requests_failed_to_import handling

### DIFF
--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -28,12 +28,7 @@ import uuid
 import warnings
 import collections
 import weakref
-try:
-    import requests
-except ImportError:
-    class requests_failed_to_import(object):
-        pass
-    requests = requests_failed_to_import
+import requests
 
 import numpy as np
 


### PR DESCRIPTION
We already required requests package. If a user is missing it nevertheless, fail
with a standard error message instead of some hard to understand error that
requests_failed_to_import object does not have a get method..

The current implementation has a bad user experience.

Example https://github.com/dmlc/gluon-nlp/issues/892