### PR TITLE
add uint8 bn mkldnn implementation

### DIFF
--- a/example/quantization/imagenet_gen_qsym_mkldnn.py
+++ b/example/quantization/imagenet_gen_qsym_mkldnn.py
@@ -216,7 +216,7 @@ if __name__ == '__main__':
             if exclude_first_conv:
                 excluded_sym_names += ['resnetv10_conv0_fwd']
         elif args.model.find('resnet') != -1 and args.model.find('v2') != -1:
-            excluded_sym_names += ['resnetv20_flatten0_flatten0']
+            excluded_sym_names += ['resnetv20_flatten0_flatten0', 'resnetv20_stage1_batchnorm0_fwd']
             if exclude_first_conv:
                 excluded_sym_names += ['resnetv20_conv0_fwd']
         elif args.model.find('vgg') != -1:

--- a/example/quantization/imagenet_gen_qsym_mkldnn.py
+++ b/example/quantization/imagenet_gen_qsym_mkldnn.py
@@ -216,6 +216,7 @@ if __name__ == '__main__':
             if exclude_first_conv:
                 excluded_sym_names += ['resnetv10_conv0_fwd']
         elif args.model.find('resnet') != -1 and args.model.find('v2') != -1:
+            # resnetv20_stage1_batchnorm0_fwd is excluded for the sake of accuracy
             excluded_sym_names += ['resnetv20_flatten0_flatten0', 'resnetv20_stage1_batchnorm0_fwd']
             if exclude_first_conv:
                 excluded_sym_names += ['resnetv20_conv0_fwd']

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -132,14 +132,13 @@ class MKLDNNBNForward {
     return *var_m;
   }
 
-  void SetDataHandle(const NDArray &data, const mkldnn::memory *mean,
+  void SetDataHandle(const mkldnn::memory *data, const mkldnn::memory *mean,
                      const mkldnn::memory *var, const mkldnn::memory *out) {
-    auto _data = data.GetMKLDNNData();
     if (data_m) {
-      data_m->set_data_handle(_data->get_data_handle());
+      data_m->set_data_handle(data->get_data_handle());
     } else {
-      data_m.reset(new mkldnn::memory(_data->get_primitive_desc(),
-                                      _data->get_data_handle()));
+      data_m.reset(new mkldnn::memory(data->get_primitive_desc(),
+                                      data->get_data_handle()));
     }
     if (out_m) {
       out_m->set_data_handle(out->get_data_handle());
@@ -175,7 +174,7 @@ class MKLDNNBNForward {
 
   void SetDataHandle(const NDArray &data, const NDArray &mean,
                      const NDArray &var, const mkldnn::memory &out) {
-    SetDataHandle(data, mean.GetMKLDNNData(), var.GetMKLDNNData(), &out);
+    SetDataHandle(data.GetMKLDNNData(), mean.GetMKLDNNData(), var.GetMKLDNNData(), &out);
   }
 
   const mkldnn::batch_normalization_forward &GetFwd() const {

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
@@ -40,6 +40,27 @@ static void MKLDNNQuantizedBatchNormForward(const nnvm::NodeAttrs &attrs, const 
   TmpMemMgr::Get()->Init(ctx.requested[batchnorm::kTempSpace]);
   const BatchNormParam &param = nnvm::get<BatchNormParam>(attrs.parsed);
   const NDArray &data = in_data[quantized_batchnorm::kData];
+  auto data_mem = data.GetMKLDNNData();
+
+  // reorder if data type = uint8
+  if (in_data[quantized_batchnorm::kData].dtype() == mshadow::kUint8) {
+    auto u8_pd = data_mem->get_primitive_desc();
+    auto u8_md = u8_pd.desc();
+    mkldnn::memory::desc s8_md(
+        mkldnn::memory::dims(u8_md.data.dims, u8_md.data.dims + u8_md.data.ndims),
+        mkldnn::memory::data_type::s8, static_cast<mkldnn::memory::format>(u8_md.data.format));
+    auto s8_pd = mkldnn::memory::primitive_desc(s8_md, CpuEngine::Get()->get_engine());
+    auto data_reorder_mem = TmpMemMgr::Get()->Alloc(s8_pd);
+
+    std::vector<float> reorder_scale;
+    reorder_scale = {float(kInt8Range) / kUint8Range};
+    primitive_attr reorder_attr;
+    reorder_attr.set_int_output_round_mode(round_mode::round_nearest);
+    reorder_attr.set_output_scales(0, reorder_scale);
+    const auto reorder_pd = mkldnn::reorder::primitive_desc(u8_pd, s8_pd, reorder_attr);
+    MKLDNNStream::Get()->RegisterPrim(mkldnn::reorder(reorder_pd, *data_mem, *data_reorder_mem));
+    data_mem = data_reorder_mem;
+  }
   const size_t channelAxis = static_cast<size_t>(
       param.axis < 0 ? static_cast<int>(data.shape().ndim()) + param.axis : param.axis);
   const int channel_count = data.shape()[channelAxis];
@@ -92,7 +113,7 @@ static void MKLDNNQuantizedBatchNormForward(const nnvm::NodeAttrs &attrs, const 
 
   auto out_mem = CreateMKLDNNMem(outputs[batchnorm::kOut],
       fwd.GetPd().dst_primitive_desc(), req[batchnorm::kOut], &data);
-  fwd.SetDataHandle(data, rescaled_mean_mem, rescaled_var_mem, out_mem.second);
+  fwd.SetDataHandle(data_mem, rescaled_mean_mem, rescaled_var_mem, out_mem.second);
 
   MKLDNNStream::Get()->RegisterPrim(fwd.GetFwd());
   MKLDNNStream::Get()->Submit();

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_batch_norm.cc
@@ -53,7 +53,7 @@ static void MKLDNNQuantizedBatchNormForward(const nnvm::NodeAttrs &attrs, const 
     auto data_reorder_mem = TmpMemMgr::Get()->Alloc(s8_pd);
 
     std::vector<float> reorder_scale;
-    reorder_scale = {float(kInt8Range) / kUint8Range};
+    reorder_scale = {static_cast<float>(kInt8Range) / kUint8Range};
     primitive_attr reorder_attr;
     reorder_attr.set_int_output_round_mode(round_mode::round_nearest);
     reorder_attr.set_output_scales(0, reorder_scale);

--- a/src/operator/quantization/quantized_batch_norm.cc
+++ b/src/operator/quantization/quantized_batch_norm.cc
@@ -67,7 +67,13 @@ bool QuantizedBatchNormType(const nnvm::NodeAttrs& attrs, std::vector<int>* in_t
   CHECK_EQ(in_type->size(), 7U);
   CHECK_EQ(out_type->size(), 3U);
 
+#if MXNET_USE_MKLDNN == 1
+  CHECK(in_type->at(0) == mshadow::kInt8 || in_type->at(0) == mshadow::kUint8)
+      << "QuantizedBatchNorm with MKLDNN backend only supports int8/uint8 input, while "
+      << in_type->at(0) << " is given.";
+#else
   TYPE_ASSIGN_CHECK(*in_type, 0, mshadow::kInt8);
+#endif
   for (size_t i = 1; i < 7; ++i) {
     TYPE_ASSIGN_CHECK(*in_type, i, mshadow::kFloat32);
   }

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -919,6 +919,12 @@ def test_quantize_model_with_forward():
         lshape_list.append(None)
 
         for s, dshape, lshape, name in zip(sym_list, dshape_list, lshape_list, name_list):
+            if qdtype == 'int8' and name in ['sym1','sym2','sym3']:
+                print('mkldnn_quantized_conv op only supports uint8 as input type, skip test with int8.')
+                continue
+            if qdtype == 'uint8' and name in ['sym1']:
+                print('mkldnn_quantized_bn doesn\'t support calib_mode=None')
+                continue
             if lshape is None:
                 mod = Module(symbol=s, label_names=None)
                 mod.bind(for_training=False,

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -607,10 +607,7 @@ def test_quantized_bn():
         return mean, var
 
     def check_quantized_bn(data_shape, qdtype):
-        if qdtype == 'uint8':
-            print('skipped testing quantize_bn for uint8 since it is not supported yet')
-            return
-        elif is_test_for_native_cpu():
+        if is_test_for_native_cpu():
             print('skipped testing quantize_bn for native cpu since it is not supported yet')
             return
         elif is_test_for_gpu():
@@ -672,9 +669,10 @@ def test_quantized_bn():
 
         assert_almost_equal(output.asnumpy(), output_int8_to_fp32.asnumpy(), rtol=1e-1, atol=3)
 
-    check_quantized_bn((32, 512, 4, 4), 'int8')
-    check_quantized_bn((32, 1024, 8, 8), 'int8')
-    check_quantized_bn((32, 3, 224, 224), 'int8')
+    for qdtype in ['int8', 'uint8']:
+        check_quantized_bn((32, 512, 4, 4), qdtype)
+        check_quantized_bn((32, 1024, 8, 8), qdtype)
+        check_quantized_bn((32, 3, 224, 224), qdtype)
 
 @with_seed()
 def test_quantize_params():
@@ -918,15 +916,9 @@ def test_quantize_model_with_forward():
         lshape_list.append(None)
 
         for s, dshape, lshape, name in zip(sym_list, dshape_list, lshape_list, name_list):
-            if qdtype == 'int8' and is_test_for_mkldnn() and name in ['sym1', 'sym2', 'sym3']:
-              print('skipped testing test_quantize_model_with_forward for mkldnn cpu int8 since it is not supported yet')
-              continue
-            elif qdtype == 'uint8' and is_test_for_mkldnn() and name in ['sym1']:
-              print('skipping test_quantize_model_with_forward for mkldnn cpu uint8 since it is not supported yet')
-              continue
-            elif qdtype == 'int8' and is_test_for_gpu() and name in ['sym1']:
-              print('skipped testing test_quantize_model_with_forward for gpu int8 since it is not supported yet')
-              continue
+            if is_test_for_gpu() and name in ['sym1']:
+               print('skipped testing test_quantize_model_with_forward for gpu int8 since it is not supported yet')
+               continue
 
             if lshape is None:
                 mod = Module(symbol=s, label_names=None)

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -916,10 +916,6 @@ def test_quantize_model_with_forward():
         lshape_list.append(None)
 
         for s, dshape, lshape, name in zip(sym_list, dshape_list, lshape_list, name_list):
-            if is_test_for_gpu() and name in ['sym1']:
-               print('skipped testing test_quantize_model_with_forward for gpu int8 since it is not supported yet')
-               continue
-
             if lshape is None:
                 mod = Module(symbol=s, label_names=None)
                 mod.bind(for_training=False,


### PR DESCRIPTION
## Description ##
add uint8 batchnorm, mkldnn implementation and test
@PatricZhao @ZhennanQin 

## Details ##
### Usage ###
Check the doc in https://github.com/apache/incubator-mxnet/tree/master/example/quantization/README.md to quantize models and do inference.
Quantized bn will be used automatically when a bn operator cannot be fused.

### Performance ###
In most cases, bn can be fused, so quantized bn is not introduced. In reset50 v2, some of the bn operators are standalone, quantizing these bn give a performance as follows:

| Model | FP32 (Top-1 / Top-5) | Fusion + fp32 bn | Fusion + int8 bn |
| - | - | - | - |
Resnet50 v2 | 0.764 / 0.935 | 0.722 / 0.901 | 0.712 / 0.897
