### PR TITLE
[MXNET-1421] Added (CuDNN)BatchNorm operator to the list of mirrored operators

### DIFF
--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -359,8 +359,6 @@ nnvm::Graph GraphExecutor::InitFullGraph(nnvm::Symbol symbol,
     if (type == "FullyConnected") return false;
     if (type == "Concat") return false;
     if (type == "SoftmaxOutput") return false;
-    if (type == "BatchNorm") return false;
-    if (type == "CuDNNBatchNorm") return false;
     return true;
   };
 

--- a/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
+++ b/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
@@ -128,7 +128,8 @@ class CuDNNBatchNormOp {
         // which further indicates that we are in the backward mirroring mode,
         // and therefore update to the auxiliary states is disabled.
         // This is done by setting the `momentum` to `1` (or `factor` to `0`).
-        float factor = internal_aux_states_lock_ ? 0 : (1 - param_.momentum);
+        float factor = (dmlc::GetEnv("MXNET_BACKWARD_DO_MIRROR", 0) && internal_aux_states_lock_) ?
+            0 : (1 - param_.momentum);
         CUDNN_CALL(cudnnBatchNormalizationForwardTraining(s->dnn_handle_,
                                                           mode,
                                                           &a,

--- a/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
+++ b/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
@@ -55,6 +55,7 @@ class CuDNNBatchNormOp {
     dtype_param_ = (dtype_ == CUDNN_DATA_HALF) ? kFloat32 : DataType<DType>::kFlag;
     CUDNN_CALL(cudnnCreateTensorDescriptor(&io_desc_));
     CUDNN_CALL(cudnnCreateTensorDescriptor(&mean_desc_));
+    internal_aux_states_lock_ = false;
   }
 
   void Init(const BatchNormParam &param) {
@@ -122,6 +123,12 @@ class CuDNNBatchNormOp {
         Tensor<gpu, 1, DTypeParam> save_inv_var =
           out_data[cudnnbatchnorm::kInvVar]
           .get_with_shape<gpu, 1, DTypeParam>(Shape1(shape_[1]), s);
+        // If the lock on the auxiliary states is set,
+        // then this implies that the preceding call is also a `Forward()` call,
+        // which further indicates that we are in the backward mirroring mode,
+        // and therefore update to the auxiliary states is disabled.
+        // This is done by setting the `momentum` to `1` (or `factor` to `0`).
+        float factor = internal_aux_states_lock_ ? 0 : (1 - param_.momentum);
         CUDNN_CALL(cudnnBatchNormalizationForwardTraining(s->dnn_handle_,
                                                           mode,
                                                           &a,
@@ -133,7 +140,7 @@ class CuDNNBatchNormOp {
                                                           mean_desc_,
                                                           gamma.dptr_,
                                                           beta.dptr_,
-                                                          1 - param_.momentum,
+                                                          factor,
                                                           moving_mean.dptr_,
                                                           moving_inv_var.dptr_,
                                                           param_.eps,
@@ -156,6 +163,10 @@ class CuDNNBatchNormOp {
                                                            param_.eps));
       }
     })
+    // Set the lock on the auxiliary states.
+    // If the next call to the operator is a `Forward()` call,
+    // then `momentum` will be set to `1` and hence auxiliary states will not be updated.
+    internal_aux_states_lock_ = true;
   }
 
   void Backward(const OpContext &ctx,
@@ -230,6 +241,9 @@ class CuDNNBatchNormOp {
         global_stats ? nullptr : save_inv_var.dptr_));
       if (param_.fix_gamma) dgamma = 0.f;
     })
+    // Release the lock on the auxiliary states, so that the next forward pass
+    // will be able to update the auxiliary states normally.
+    internal_aux_states_lock_ = false;
   }
 
  private:
@@ -262,6 +276,7 @@ class CuDNNBatchNormOp {
   cudnnTensorDescriptor_t io_desc_, mean_desc_;
   mshadow::Shape<4> shape_;
   BatchNormParam param_;
+  bool internal_aux_states_lock_;
 };
 #endif  // defined(__CUDACC__)
 


### PR DESCRIPTION
## Description ##
Added the (CuDNN)BatchNorm operator to the list of mirrored operators.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] In file `src/executor/graph_executor.cc` method `GraphExecutor::InitFullGraph`, removed the restriction on the `(CuDNN)BatchNorm` operator.
- [x] In file `src/operator/cudnn_batch_norm-inl.h` class `CuDNNBatchNormOp`, added an internal lock on auxiliary states to prevent multiple consecutive updates on the moving mean and variance.

## Comments ##

I have documented the changes [**here**](https://v2.overleaf.com/read/snhdnvhmjrcb). Any comment is welcome. Thanks.

FYI, @antinucleon 

S.A. Issue #14383 