### PR TITLE
adding "total" (total time) to profiler aggregate stats sorting criteria

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -345,7 +345,7 @@ MXNET_DLL int MXAggregateProfileStatsPrint(const char **out_str, int reset);
  * \param out_str will receive a pointer to the output string
  * \param reset clear the aggregate stats after printing
  * \param format whether to return in tabular or json format
- * \param sort_by sort by avg, min, max, or count
+ * \param sort_by sort by total, avg, min, max, or count
  * \param ascending whether to sort ascendingly
  * \return 0 when success, -1 when failure happens.
  * \note

--- a/python/mxnet/profiler.py
+++ b/python/mxnet/profiler.py
@@ -148,7 +148,7 @@ def dump_profile():
     dump(True)
 
 
-def dumps(reset=False, format='table', sort_by='avg', ascending=False):
+def dumps(reset=False, format='table', sort_by='total', ascending=False):
     """Return a printable string of aggregate profile stats.
 
     Parameters
@@ -160,9 +160,9 @@ def dumps(reset=False, format='table', sort_by='avg', ascending=False):
         can take 'table' or 'json'
         defaults to 'table'
     sort_by: string
-        can take 'avg', 'min', 'max', or 'count'
+        can take 'total', 'avg', 'min', 'max', or 'count'
         by which stat to sort the entries in each category
-        defaults to 'avg'
+        defaults to 'total'
     ascending: boolean
         whether to sort ascendingly
         defaults to False
@@ -170,12 +170,13 @@ def dumps(reset=False, format='table', sort_by='avg', ascending=False):
     debug_str = ctypes.c_char_p()
     reset_to_int = {False: 0, True: 1}
     format_to_int = {'table': 0, 'json': 1}
-    sort_by_to_int = {'avg': 0, 'min': 1, 'max': 2, 'count': 3}
+    sort_by_to_int = {'total': 0, 'avg': 1, 'min': 2, 'max': 3, 'count': 4}
     asc_to_int = {False: 0, True: 1}
     assert format in format_to_int.keys(),\
             "Invalid value provided for format: {0}. Support: 'table', 'json'".format(format)
     assert sort_by in sort_by_to_int.keys(),\
-            "Invalid value provided for sort_by: {0}. Support: 'avg', 'min', 'max', 'count'"\
+            "Invalid value provided for sort_by: {0}.\
+             Support: 'total', 'avg', 'min', 'max', 'count'"\
             .format(sort_by)
     assert  ascending in asc_to_int.keys(),\
             "Invalid value provided for ascending: {0}. Support: False, True".format(ascending)

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -56,6 +56,9 @@ inline std::priority_queue<pi>
     const AggregateStats::StatData& data = iter.second;
     double value = 0;
     switch (static_cast<AggregateStats::SortBy>(sort_by)) {
+      case AggregateStats::SortBy::Total:
+        value = data.total_aggregate_;
+        break;
       case AggregateStats::SortBy::Avg:
         if (data.type_ == AggregateStats::StatData::kCounter)
           value = (data.max_aggregate_ - data.min_aggregate_) / 2;

--- a/src/profiler/aggregate_stats.h
+++ b/src/profiler/aggregate_stats.h
@@ -74,7 +74,7 @@ class AggregateStats {
   void clear();
   /* !\brief by which stat to sort */
   enum class SortBy {
-    Avg, Min, Max, Count
+    Total, Avg, Min, Max, Count
   };
 
  private:

--- a/tests/python/unittest/test_profiler.py
+++ b/tests/python/unittest/test_profiler.py
@@ -243,11 +243,12 @@ def test_aggregate_stats_valid_json_return():
     debug_str = profiler.dumps(format = 'json')
     assert(len(debug_str) > 0)
     target_dict = json.loads(debug_str)
-    assert "Memory" in target_dict and "Time" in target_dict and "Unit" in target_dict
+    assert 'Memory' in target_dict and 'Time' in target_dict and 'Unit' in target_dict
     profiler.set_state('stop')
 
 def test_aggregate_stats_sorting():
-    sort_by_options = {'avg': "Avg", 'min': "Min", 'max': "Max", 'count': "Count"}
+    sort_by_options = {'total': 'Total', 'avg': 'Avg', 'min': 'Min',\
+        'max': 'Max', 'count': 'Count'}
     ascending_options = [False, True]
     def check_ascending(lst, asc):
         assert(lst == sorted(lst, reverse = not asc))
@@ -258,9 +259,11 @@ def test_aggregate_stats_sorting():
         for domain_name, domain in target_dict['Time'].items():
             lst = [item[sort_by_options[sort_by]] for item_name, item in domain.items()]
             check_ascending(lst, ascending)
-        for domain_name, domain in target_dict['Memory'].items():
-            lst = [item[sort_by_options[sort_by]] for item_name, item in domain.items()]
-            check_ascending(lst, ascending)
+        # Memory items do not have stat 'Total' 
+        if sort_by != 'total':
+            for domain_name, domain in target_dict['Memory'].items():
+                lst = [item[sort_by_options[sort_by]] for item_name, item in domain.items()]
+                check_ascending(lst, ascending)
 
     file_name = 'test_aggregate_stats_sorting.json'
     enable_profiler(file_name, True, True, True)


### PR DESCRIPTION
## Description ##
Refer to the discussion in this PR.https://github.com/apache/incubator-mxnet/pull/15132
This pr is to allow users to sort the aggregate stats by "total" which is the total time spend on the operator
Also, the default sorting criterion is revised: 'avg' -> 'total'

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here