### PR TITLE
add operator `cast_like`.

### DIFF
--- a/src/operator/tensor/elemwise_unary_op_basic.cc
+++ b/src/operator/tensor/elemwise_unary_op_basic.cc
@@ -678,6 +678,43 @@ Example::
 .add_argument("data", "NDArray-or-Symbol", "The input.")
 .add_arguments(CastParam::__FIELDS__());
 
+NNVM_REGISTER_OP(cast_like)
+.describe(R"code(Cast elements of `lhs` to have the same dtype as elements of `rhs`.
+
+Example::
+
+  cast_like([0.9, 1.3], [1, 1]) = [0, 1]
+  cast_like([1, 2], [1.0, 1]) = [1.0, 2.0]
+
+)code" ADD_FILELINE)
+.add_alias("_npx_cast_like")
+.set_num_inputs(2)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) { return std::vector<std::string>{"lhs", "rhs"}; })
+.set_attr<mxnet::FInferShape>("FInferShape", [](const nnvm::NodeAttrs& attrs,
+                                                mxnet::ShapeVector *in_attrs,
+                                                mxnet::ShapeVector *out_attrs) {
+    // Always the shape of LHS.
+    const mxnet::TShape &lshape = (*in_attrs)[0];
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, lshape);
+    return shape_is_known(lshape);
+  })
+.set_attr<nnvm::FInferType>("FInferType", [](const nnvm::NodeAttrs& attrs,
+                                             std::vector<int> *in_attrs,
+                                             std::vector<int> *out_attrs) {
+    // Always the type of RHS.
+    CHECK_EQ(in_attrs->size(), 2) << " in operator " << attrs.name;
+    std::vector<int> checked_in_attrs = { (*in_attrs)[1] };
+    bool ret = !type_is_none((*in_attrs)[1]) &&
+               ElemwiseType<1, 1>(attrs, &checked_in_attrs, out_attrs);
+    (*in_attrs)[1] = checked_in_attrs[1];
+    return ret;
+  })
+.set_attr<FCompute>("FCompute<cpu>", CastCompute<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_cast"})
+.add_argument("lhs", "NDArray-or-Symbol", "First input.")
+.add_argument("rhs", "NDArray-or-Symbol", "Second input.");
+
 NNVM_REGISTER_OP(_backward_cast)
 .set_attr<nnvm::TIsBackward>("TIsBackward", true)
 .set_attr<nnvm::FInplaceOption>("FInplaceOption",


### PR DESCRIPTION
## Description ##
Add Operator `cast_like`.
References: #15966

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add `cast_like`.
- [ ] Relevant test.

