### PR TITLE
Allow loading from model files with empty weights.

### DIFF
--- a/python/mxnet/model.py
+++ b/python/mxnet/model.py
@@ -431,6 +431,7 @@ def load_params(prefix, epoch):
     aux_params = {}
     if not save_dict:
         logging.warning("Params file '%s' is empty", '%s-%04d.params' % (prefix, epoch))
+        return (arg_params, aux_params)
     for k, v in save_dict.items():
         tp, name = k.split(":", 1)
         if tp == "arg":


### PR DESCRIPTION
This patch extends mxnet.model.load_checkpoint to support loading from saved graphs with empty weights. Weightless graphs can arise from several scenarios; e.g., graphs that only contain mxnet.ndarray ops such as repeat, reshape etc. The feature is quite useful in testing each individual component of a large neural network. Many thanks to Joshua Z. Zhang for suggesting the fix.