### PR TITLE
Fixes openblas static build

### DIFF
--- a/tools/dependencies/openblas.sh
+++ b/tools/dependencies/openblas.sh
@@ -18,9 +18,8 @@
 # under the License.
 
 # This script builds the static library of openblas that can be used as dependency of mxnet.
-set +e # This script throws an error but otherwise works
-set -x
-OPENBLAS_VERSION=0.3.5
+set -ex
+OPENBLAS_VERSION=0.3.7
 if [[ ! -e $DEPS_PATH/lib/libopenblas.a ]]; then
     # download and build openblas
     >&2 echo "Building openblas..."
@@ -32,8 +31,13 @@ if [[ ! -e $DEPS_PATH/lib/libopenblas.a ]]; then
     pushd .
     cd $DEPS_PATH/OpenBLAS-$OPENBLAS_VERSION
 
-    $MAKE DYNAMIC_ARCH=1 NO_SHARED=1 USE_OPENMP=1
+    # Adding NO_DYNAMIC=1 flag causes make install to fail
+    $MAKE DYNAMIC_ARCH=1 USE_OPENMP=1
     $MAKE PREFIX=$DEPS_PATH install
+
+    # Manually removing .so to avoid linking against it
+    rm $DEPS_PATH/lib/libopenblasp-r${OPENBLAS_VERSION}.so
+
     popd
     ln -s libopenblas.a $DEPS_PATH/lib/libcblas.a
     ln -s libopenblas.a $DEPS_PATH/lib/liblapack.a


### PR DESCRIPTION
## Description ##
Fixes #16021. The static build fails with openblas v0.3.5, this PR bumps it to v0.3.7, which seems to work. Also, fixes error checking in the openblas installation to ensure errors will make CI fail.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
