### PR TITLE
Reduce time cost of test_operator.test_norm, test_operator. test_laop_5 and test_sparse_operator.test_elemwise_binary_ops

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -3704,7 +3704,7 @@ def test_norm():
 
     ctx = default_context()
     data = mx.symbol.Variable('data')
-    in_data_dim = random_sample([4,5,6], 1)[0]
+    in_data_dim = random_sample([2,3,4], 1)[0]
     in_shape = rand_shape_nd(in_data_dim, dim=5)
     epsilon = 1e-3
     acc_type = {np.float16: np.float32, np.float32: np.float32, np.float64: np.float64,
@@ -6808,7 +6808,7 @@ def test_laop_5():
     # tests for diagonal and triangular matrix extraction and generation
     data = mx.symbol.Variable('data')
     # test complete range of small matrices to cover corner cases
-    for n in range(1, 10):
+    for n in range(1, 5):
         # test batched and non-batched processing
         for b in range(3):
             shape = (n, n) if b == 0 else (b, n, n)

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -494,10 +494,10 @@ def test_elemwise_binary_ops():
 
         for ii in range(1):
             # Run defaults
-            check_elemwise_binary_ops('default', 'default', rand_shape_2d())
+            check_elemwise_binary_ops('default', 'default', rand_shape_2d(5, 5))
 
             # Try different densities
-            shape = rand_shape_2d()
+            shape = rand_shape_2d(5, 5)
             for lhs_density in [0.0, random.uniform(0, 1), 1.0]:
                 for rhs_density in [0.0, random.uniform(0, 1), 1.0]:
                     for ograd_density in [0.0, random.uniform(0, 1), 1.0]:


### PR DESCRIPTION
because test_norm and  test_elemwise_binary_ops use  rand_shape_2d()。 by default, rand_shape_2d generate shape(0,0) to (10, 10), so it will generate too large shape. for some operator, it will consume much time. so i  limit it .

for test_laop_5, i modify for loop from (1, 10) to (1, 5), beacuse i it's ok!  so the test time from 71.902s to 16.569s. 