### PR TITLE
Speed up group executor

### DIFF
--- a/python/mxnet/module/executor_group.py
+++ b/python/mxnet/module/executor_group.py
@@ -273,9 +273,10 @@ class DataParallelExecutorGroup(object):
         self.data_layouts = None
         self.label_layouts = None
         self.output_names = self.symbol.list_outputs()
-        self.output_layouts = [DataDesc.get_batch_axis(self.symbol[name].attr('__layout__'))
-                               for name in self.output_names]
-        self.num_outputs = len(self.symbol.list_outputs())
+        self.num_outputs = len(self.output_names)
+        self.output_layouts = [i for i in range(self.num_outputs)]
+        for index, name in enumerate(self.output_names):
+            self.output_layouts[index] = DataDesc.get_batch_axis(self.symbol[index].attr('__layout__'))
 
         self.bind_exec(data_shapes, label_shapes, shared_group)
 

--- a/python/mxnet/module/executor_group.py
+++ b/python/mxnet/module/executor_group.py
@@ -274,9 +274,8 @@ class DataParallelExecutorGroup(object):
         self.label_layouts = None
         self.output_names = self.symbol.list_outputs()
         self.num_outputs = len(self.output_names)
-        self.output_layouts = [i for i in range(self.num_outputs)]
-        for index, name in enumerate(self.output_names):
-            self.output_layouts[index] = DataDesc.get_batch_axis(self.symbol[index].attr('__layout__'))
+        self.output_layouts = [DataDesc.get_batch_axis(self.symbol[index].attr('__layout__'))
+                               for index in range(self.num_outputs)]
 
         self.bind_exec(data_shapes, label_shapes, shared_group)
 


### PR DESCRIPTION
## Description ##
We ran into an issue where mxnet took over 15 minutes of real-time to process large symbols, this change was the root cause. The square-brackets implementation of symbol looks up the symbol using a loop, so the implementation was O(n^2) where it should have been O(n)
