### PR TITLE
[Dataset] Add take, filter API to dataset

### DIFF
--- a/python/mxnet/gluon/data/dataset.py
+++ b/python/mxnet/gluon/data/dataset.py
@@ -101,7 +101,7 @@ class Dataset(object):
         from . import Sampler
         if not isinstance(sampler, Sampler):
             raise TypeError('Invalid sampler type: %s. Expected gluon.data.Sampler instead.'%
-                             type(sampler))
+                            type(sampler))
         return _SampledDataset(self, sampler)
 
     def transform(self, fn, lazy=True):

--- a/python/mxnet/gluon/data/dataset.py
+++ b/python/mxnet/gluon/data/dataset.py
@@ -175,8 +175,8 @@ class _FilteredDataset(Dataset):
     def __init__(self, dataset, fn):
         self._dataset = dataset
         self._indices = []
-        for i in range(len(dataset)):
-            if fn(dataset[i]):
+        for i, sample in enumerate(dataset):
+            if fn(sample):
                 self._indices.append(i)
 
     def __len__(self):

--- a/python/mxnet/gluon/data/dataset.py
+++ b/python/mxnet/gluon/data/dataset.py
@@ -180,7 +180,7 @@ class _FilteredDataset(Dataset):
     """Dataset with a filter applied"""
     def __init__(self, dataset, fn):
         self._dataset = dataset
-        self._indices = [i for for i, sample in enumerate(dataset) if fn(sample)]
+        self._indices = [i for i, sample in enumerate(dataset) if fn(sample)]
 
     def __len__(self):
         return len(self._indices)

--- a/python/mxnet/gluon/data/dataset.py
+++ b/python/mxnet/gluon/data/dataset.py
@@ -44,6 +44,12 @@ class Dataset(object):
         """Returns a new dataset with samples filtered by the
         filter function `fn`.
 
+        Note that if the Dataset is the result of a lazily transformed one with
+        transform(lazy=False), the filter is eagerly applied to the transformed
+        samples without materializing the transformed result. That is, the
+        transformation will be applied again whenever a sample is retrieved after
+        filter().
+
         Parameters
         ----------
         fn : callable
@@ -174,10 +180,7 @@ class _FilteredDataset(Dataset):
     """Dataset with a filter applied"""
     def __init__(self, dataset, fn):
         self._dataset = dataset
-        self._indices = []
-        for i, sample in enumerate(dataset):
-            if fn(sample):
-                self._indices.append(i)
+        self._indices = [i for for i, sample in enumerate(dataset) if fn(sample)]
 
     def __len__(self):
         return len(self._indices)

--- a/python/mxnet/gluon/data/sampler.py
+++ b/python/mxnet/gluon/data/sampler.py
@@ -18,7 +18,7 @@
 # coding: utf-8
 # pylint: disable=
 """Dataset sampler."""
-__all__ = ['Sampler', 'SequentialSampler', 'RandomSampler', 'BatchSampler']
+__all__ = ['Sampler', 'SequentialSampler', 'RandomSampler', 'FilterSampler', 'BatchSampler']
 
 import numpy as np
 
@@ -71,6 +71,27 @@ class RandomSampler(Sampler):
 
     def __len__(self):
         return self._length
+
+class FilterSampler(Sampler):
+    """Samples elements from a Dataset for which `fn` returns True.
+
+    Parameters
+    ----------
+    fn : callable
+        A callable function that takes a sample and returns a boolean
+    dataset : Dataset
+        The dataset to filter.
+    """
+    def __init__(self, fn, dataset):
+        self._fn = fn
+        self._dataset = dataset
+        self._indices = [i for i, sample in enumerate(dataset) if fn(sample)]
+
+    def __iter__(self):
+        return iter(self._indices)
+
+    def __len__(self):
+        return len(self._indices)
 
 
 class BatchSampler(Sampler):

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -283,6 +283,31 @@ def test_dataloader_context():
 def batchify(a):
     return a
 
+def test_dataset_filter():
+    length = 100
+    a = mx.gluon.data.SimpleDataset([i for i in range(length)])
+    a_filtered = a.filter(lambda x: x % 10 == 0)
+    assert(len(a_filtered) == 10)
+    for idx, sample in enumerate(gluon.data.DataLoader(a_filtered, 1)):
+        assert sample % 10 == 0
+
+def test_dataset_take():
+    length = 100
+    a = mx.gluon.data.SimpleDataset([i for i in range(length)])
+    a_take_full = a.take(1000)
+    assert len(a_take_full) == length
+    a_take_full = a.take(None)
+    assert len(a_take_full) == length
+    count = 10
+    a_take_10 = a.take(count)
+    assert len(a_take_10) == count
+    expected_total = sum([i for i in range(count)])
+    total = 0
+    for idx, sample in enumerate(a_take_10):#gluon.data.DataLoader(a_take_10, 1)):
+        assert sample < count
+        total += sample
+    assert total == expected_total
+
 def test_dataloader_scope():
     """
     Bug: Gluon DataLoader terminates the process pool early while

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -288,7 +288,12 @@ def test_dataset_filter():
     a = mx.gluon.data.SimpleDataset([i for i in range(length)])
     a_filtered = a.filter(lambda x: x % 10 == 0)
     assert(len(a_filtered) == 10)
-    for idx, sample in enumerate(gluon.data.DataLoader(a_filtered, 1)):
+    for idx, sample in enumerate(a_filtered):
+        assert sample % 10 == 0
+    a_xform_filtered = a.transform(lambda x: x + 1).filter(lambda x: x % 10 == 0)
+    assert(len(a_xform_filtered) == 10)
+    # the filtered data is already transformed
+    for idx, sample in enumerate(a_xform_filtered):
         assert sample % 10 == 0
 
 def test_dataset_take():
@@ -303,8 +308,17 @@ def test_dataset_take():
     assert len(a_take_10) == count
     expected_total = sum([i for i in range(count)])
     total = 0
-    for idx, sample in enumerate(a_take_10):#gluon.data.DataLoader(a_take_10, 1)):
+    for idx, sample in enumerate(a_take_10):
         assert sample < count
+        total += sample
+    assert total == expected_total
+
+    a_xform_take_10 = a.transform(lambda x: x * 10).take(count)
+    assert len(a_xform_take_10) == count
+    expected_total = sum([i * 10 for i in range(count)])
+    total = 0
+    for idx, sample in enumerate(a_xform_take_10):
+        assert sample < count * 10
         total += sample
     assert total == expected_total
 


### PR DESCRIPTION
## Description ##
Add dataset.filter, dataset.take APIs. @zhreshold 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
