### PR TITLE
Update instructions for Clojure bindings

### DIFF
--- a/contrib/clojure-package/README.md
+++ b/contrib/clojure-package/README.md
@@ -133,7 +133,7 @@ After making this change and running `lein deps`, you should be able to run exam
 
 ### Option 2: Clojure package from Source, Scala Package from Jar
 
-With this option, you will install a Git revision of the Clojure package source and a [Scala package jar from Maven](https://search.maven.org/search?q=g:org.apache.mxnet) with native dependencies baked in.
+With this option, you will install a Git revision of the Clojure package source and a [Scala package jar from Maven](https://search.maven.org/search?q=g:org.apache.mxnet) with native dependencies baked in. Pick this if you want to make changes to the Clojure bindings but don't want to build the shared library or the Scala package jar yourself.
 
 - Install additional dependencies as described in [the corresponding section for Option 1](#installing-additional-dependencies),
 
@@ -172,7 +172,7 @@ In that case, however, breakage can happen at any point, for instance when the S
 
 ### Option 3: Everything from Source
 
-With this option, you will compile the core MXNet C++ package and jars for both Scala and Clojure language bindings from source. If you intend to make changes to the code in any of the parts, or if you simply want the latest and greatest features, this choice is for you.
+With this option, you will compile the core MXNet C++ package and jars for both Scala and Clojure language bindings from source. If you intend to make changes to the C++ or Scala code, or if you simply want the latest and greatest features, this choice is for you.
 
 The first step is to recursively clone the MXNet repository and checkout the desired version, (example 1.4.1). You should use the latest [version](https://search.maven.org/search?q=clojure-mxnet)), and clone into the `~/mxnet` directory:
 
@@ -207,8 +207,8 @@ The outcome of this step will be a shared library `lib/libmxnet.so` that is used
   ```
 
 #### Building the Clojure jar
- 
-- Enter the `contrib/clojure` directory and edit the `project.clj` file. Add the Scala jar that was just created and installed, e.g., `[org.apache.mxnet/mxnet-full_2.11-osx-x86_64-cpu "latest-version-SNAPSHOT"]`, to the `:dependencies`.
+
+- Enter the `contrib/clojure` directory.
 - Run `lein test`. All the tests should run without an error.
 - Run `lein install` to build and install the Clojure jar locally.
 

--- a/contrib/clojure-package/project.clj
+++ b/contrib/clojure-package/project.clj
@@ -28,7 +28,7 @@
                  ;[org.apache.mxnet/mxnet-full_2.11-linux-x86_64-cpu "<insert-snapshot-version>"]
                  ;[org.apache.mxnet/mxnet-full_2.11-linux-x86_64-gpu "<insert-snapshot-version"]
 
-                 ;;; CI
+                 ;;; CI / Local Build
                  [org.apache.mxnet/mxnet-full_2.11 "INTERNAL"]
 
                  [org.clojure/tools.logging "0.4.0"]
@@ -44,4 +44,4 @@
   :repositories [["staging" {:url "https://repository.apache.org/content/repositories/staging"                  :snapshots true
                              :update :always}]
                  ["snapshots" {:url "https://repository.apache.org/content/repositories/snapshots"               :snapshots true
-                              :update :always}]])
+                               :update :always}]])


### PR DESCRIPTION
## Description ##
While setting up the repository on my local machine, I came across some instructions that were out of date:

- Building everything from source was recommended if you want to make changes to any of the code, but I understand from the `mxnet` Slack channel that using the nightly snapshots of the Scala package jar is adequate for making changes to the Clojure code.
- Updating the `project.clj` file was part of the instructions for building everything from source, but this is no longer necessary.
- Similarly the `project.clj` file lists `[org.apache.mxnet/mxnet-full_2.11 "INTERNAL"]` as used for `CI` builds, when it is also used for local builds of the Scala package jar.

This PR updates those instructions.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Update the Clojure package's `README.md`.
- [x] Update a comment in the Clojure package's `project.clj`.
