### PR TITLE
[numpy] array ufunc and array function protocols

### DIFF
--- a/python/mxnet/__init__.py
+++ b/python/mxnet/__init__.py
@@ -96,3 +96,7 @@ __version__ = base.__version__
 # checks the __version__ attr of MXNet, which is not set on kvstore server due to the
 # fact that kvstore-server module is imported before the __version__ attr is set.
 from . import kvstore_server
+
+from .numpy_dispatch_protocol import _register_array_function, _register_array_ufunc
+_register_array_function()
+_register_array_ufunc()

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -108,6 +108,10 @@ def _get_index(idx):
         return idx
 
 
+_NUMPY_ARRAY_FUNCTION_DICT = {}
+_NUMPY_ARRAY_UFUNC_DICT = {}
+
+
 @set_module('mxnet.numpy')  # pylint: disable=invalid-name
 class ndarray(NDArray):
     """
@@ -117,6 +121,54 @@ class ndarray(NDArray):
     floating point number, or something else, etc.). Arrays should be constructed using
     `array`, `zeros` or `empty`. Currently, only c-contiguous arrays are supported.
     """
+
+    @staticmethod
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):  # pylint: disable=bad-staticmethod-argument
+        """
+        Dispatch official NumPy unary/binary operator calls on mxnet.numpy.ndarray
+        to this function. The operators must comply with the ufunc definition in NumPy.
+        The following code is adapted from CuPy.
+        """
+        if 'out' in kwargs:
+            # need to unfold tuple argument in kwargs
+            out = kwargs['out']
+            if len(out) != 1:
+                raise ValueError('The `out` parameter must have exactly one ndarray')
+            kwargs['out'] = out[0]
+
+        if method == '__call__':
+            if ufunc.signature is not None:
+                # we don't support generalised-ufuncs (gufuncs)
+                return NotImplemented
+            name = ufunc.__name__
+            mx_ufunc = _NUMPY_ARRAY_UFUNC_DICT.get(name, None)
+            if mx_ufunc is None:
+                raise ValueError('mxnet.numpy operator `{}` has not been registered in '
+                                 'the _NUMPY_ARRAY_UFUNC_LIST. Please make sure the implementation'
+                                 ' is compatible with NumPy and then add it to the list.'
+                                 .format(name))
+            return mx_ufunc(*inputs, **kwargs)
+        else:
+            return NotImplemented
+
+    @staticmethod
+    def __array_function__(self, func, types, args, kwargs):  # pylint: disable=bad-staticmethod-argument
+        """
+        Dispatch official NumPy operators that comply with the array function protocol to
+        this function.
+        """
+        mx_np_func = _NUMPY_ARRAY_FUNCTION_DICT.get(func, None)
+        if mx_np_func is None:
+            raise ValueError('mxnet.numpy operator `{}` has not been registered in '
+                             'the _NUMPY_ARRAY_FUNCTION_LIST. Please make sure the '
+                             'implementation is compatible with NumPy and then add '
+                             'it to the list.'.format(func))
+        # Note: this allows subclasses that don't override
+        # __array_function__ to handle mxnet.numpy.ndarray objects
+        if not all(issubclass(t, ndarray) for t in types):
+            return NotImplemented
+        return mx_np_func(*args, **kwargs)
+
     def _get_np_basic_indexing(self, key):
         """
         This function indexes ``self`` with a tuple of `slice` objects only.
@@ -1238,7 +1290,7 @@ class ndarray(NDArray):
         """Returns the standard deviation of the array elements along given axis."""
         return std(self, axis=axis, dtype=dtype, ddof=ddof, keepdims=keepdims, out=out)
 
-    def var(self, axis=None, dtype=None, out=None, ddof=0, keepdims=None):  # pylint: disable=arguments-differ
+    def var(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):  # pylint: disable=arguments-differ
         """Returns the variance of the array elements, along given axis."""
         return var(self, axis=axis, dtype=dtype, out=out, ddof=ddof, keepdims=keepdims)
 
@@ -3739,7 +3791,7 @@ def mean(a, axis=None, dtype=None, out=None, keepdims=False):  # pylint: disable
 
 
 @set_module('mxnet.numpy')
-def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=None):
+def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     """
     Compute the standard deviation along the specified axis.
     Returns the standard deviation, a measure of the spread of a distribution,
@@ -3806,7 +3858,7 @@ def std(a, axis=None, dtype=None, out=None, ddof=0, keepdims=None):
 
 
 @set_module('mxnet.numpy')
-def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=None):
+def var(a, axis=None, dtype=None, out=None, ddof=0, keepdims=False):
     """
     Compute the variance along the specified axis.
     Returns the variance of the array elements, a measure of the spread of a

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -144,8 +144,10 @@ class ndarray(NDArray):
             mx_ufunc = _NUMPY_ARRAY_UFUNC_DICT.get(name, None)
             if mx_ufunc is None:
                 raise ValueError('mxnet.numpy operator `{}` has not been registered in '
-                                 'the _NUMPY_ARRAY_UFUNC_LIST. Please make sure the implementation'
-                                 ' is compatible with NumPy and then add it to the list.'
+                                 'the _NUMPY_ARRAY_UFUNC_LIST. Please make sure you are '
+                                 'using NumPy >= 1.15.0 and the operator implementation '
+                                 'is compatible with NumPy. Then add the operator name '
+                                 'to the list.'
                                  .format(name))
             return mx_ufunc(*inputs, **kwargs)
         else:
@@ -160,9 +162,10 @@ class ndarray(NDArray):
         mx_np_func = _NUMPY_ARRAY_FUNCTION_DICT.get(func, None)
         if mx_np_func is None:
             raise ValueError('mxnet.numpy operator `{}` has not been registered in '
-                             'the _NUMPY_ARRAY_FUNCTION_LIST. Please make sure the '
-                             'implementation is compatible with NumPy and then add '
-                             'it to the list.'.format(func))
+                             'the _NUMPY_ARRAY_FUNCTION_LIST. Please make sure you are '
+                             'using NumPy >= 1.17.0 and the operator '
+                             'implementation is compatible with NumPy. Then add '
+                             'the operator name to the list.'.format(func))
         # Note: this allows subclasses that don't override
         # __array_function__ to handle mxnet.numpy.ndarray objects
         if not all(issubclass(t, ndarray) for t in types):

--- a/python/mxnet/numpy_dispatch_protocol.py
+++ b/python/mxnet/numpy_dispatch_protocol.py
@@ -1,0 +1,214 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Utils for registering NumPy array function protocol for mxnet.numpy ops."""
+
+from __future__ import absolute_import
+import functools
+import numpy as _np
+from . import numpy as mx_np  # pylint: disable=reimported
+from .numpy.multiarray import _NUMPY_ARRAY_FUNCTION_DICT, _NUMPY_ARRAY_UFUNC_DICT
+
+
+def _find_duplicate(strs):
+    str_set = set()
+    for s in strs:
+        if s in str_set:
+            return s
+        else:
+            str_set.add(s)
+    return None
+
+
+def _implements(numpy_function):
+    """Register an __array_function__ implementation for MyArray objects."""
+    def decorator(func):
+        _NUMPY_ARRAY_FUNCTION_DICT[numpy_function] = func
+        return func
+    return decorator
+
+
+def with_array_function_protocol(func):
+    """A decorator for functions that expect array function protocol.
+    The decorated function only runs when NumPy version >= 1.17."""
+    from distutils.version import LooseVersion
+    cur_np_ver = LooseVersion(_np.__version__)
+    np_1_17_ver = LooseVersion('1.17')
+
+    @functools.wraps(func)
+    def _run_with_array_func_proto(*args, **kwargs):
+        if cur_np_ver >= np_1_17_ver:
+            try:
+                func(*args, **kwargs)
+            except:
+                raise RuntimeError('Running function {} with NumPy array function protocol failed'
+                                   .format(func.__name__))
+
+    return _run_with_array_func_proto
+
+
+def with_array_ufunc_protocol(func):
+    """A decorator for functions that expect array ufunc protocol.
+    The decorated function only runs when NumPy version >= 1.15."""
+    from distutils.version import LooseVersion
+    cur_np_ver = LooseVersion(_np.__version__)
+    np_1_15_ver = LooseVersion('1.15')
+
+    @functools.wraps(func)
+    def _run_with_array_ufunc_proto(*args, **kwargs):
+        if cur_np_ver >= np_1_15_ver:
+            try:
+                func(*args, **kwargs)
+            except:
+                raise RuntimeError('Running function {} with NumPy array ufunc protocol failed'
+                                   .format(func.__name__))
+
+    return _run_with_array_ufunc_proto
+
+
+_NUMPY_ARRAY_FUNCTION_LIST = [
+    'argmax',
+    'broadcast_arrays',
+    'broadcast_to',
+    'clip',
+    'concatenate',
+    'copy',
+    'cumsum',
+    'dot',
+    'expand_dims',
+    'fix',
+    'max',
+    'mean',
+    'min',
+    'ones_like',
+    'prod',
+    'repeat',
+    'reshape',
+    'split',
+    'squeeze',
+    'stack',
+    'std',
+    'sum',
+    'swapaxes',
+    'tensordot',
+    'tile',
+    'transpose',
+    'var',
+    'zeros_like',
+]
+
+
+@with_array_function_protocol
+def _register_array_function():
+    """Register __array_function__ protocol for mxnet.numpy operators so that
+    ``mxnet.numpy.ndarray`` can be fed into the official NumPy operators and
+    dispatched to MXNet implementation.
+
+    Notes
+    -----
+    According the __array_function__ protocol (see the following reference),
+    there are three kinds of operators that cannot be dispatched using this
+    protocol:
+    1. Universal functions, which already have their own protocol in the official
+    NumPy package.
+    2. Array creation functions.
+    3. Dispatch for methods of any kind, e.g., methods on np.random.RandomState objects.
+
+    References
+    ----------
+    https://numpy.org/neps/nep-0018-array-function-protocol.html
+    """
+    dup = _find_duplicate(_NUMPY_ARRAY_FUNCTION_LIST)
+    if dup is not None:
+        raise ValueError('Duplicate operator name {} in _NUMPY_ARRAY_FUNCTION_LIST'.format(dup))
+    for op_name in _NUMPY_ARRAY_FUNCTION_LIST:
+        strs = op_name.split('.')
+        if len(strs) == 1:
+            mx_np_op = getattr(mx_np, op_name)
+            onp_op = getattr(_np, op_name)
+            setattr(mx_np, op_name, _implements(onp_op)(mx_np_op))
+        elif len(strs) == 2:
+            mx_np_submodule = getattr(mx_np, strs[0])
+            mx_np_op = getattr(mx_np_submodule, strs[1])
+            onp_submodule = getattr(_np, strs[0])
+            onp_op = getattr(onp_submodule, strs[1])
+            setattr(mx_np_submodule, strs[1], _implements(onp_op)(mx_np_op))
+        else:
+            raise ValueError('Does not support registering __array_function__ protocol '
+                             'for operator {}'.format(op_name))
+
+
+# https://docs.scipy.org/doc/numpy/reference/ufuncs.html#available-ufuncs
+_NUMPY_ARRAY_UFUNC_LIST = [
+    'add',
+    'subtract',
+    'multiply',
+    # Uncomment divide when mxnet.numpy.true_divide is added
+    # 'divide',
+    'negative',
+    'power',
+    'mod',
+    'absolute',
+    'rint',
+    'sign',
+    'exp',
+    'log',
+    'log2',
+    'log10',
+    'expm1',
+    'sqrt',
+    'square',
+    'cbrt',
+    'reciprocal',
+    'remainder',
+    'sin',
+    'cos',
+    'tan',
+    'sinh',
+    'cosh',
+    'tanh',
+    'arcsin',
+    'arccos',
+    'arctan',
+    'arcsinh',
+    'arccosh',
+    'arctanh',
+    'maximum',
+    'minimum',
+    'ceil',
+    'trunc',
+    'floor',
+]
+
+
+@with_array_ufunc_protocol
+def _register_array_ufunc():
+    """Register NumPy array ufunc protocol.
+
+    References
+    ----------
+    https://numpy.org/neps/nep-0013-ufunc-overrides.html
+    """
+    dup = _find_duplicate(_NUMPY_ARRAY_UFUNC_LIST)
+    if dup is not None:
+        raise ValueError('Duplicate operator name {} in _NUMPY_ARRAY_UFUNC_LIST'.format(dup))
+    for op_name in _NUMPY_ARRAY_UFUNC_LIST:
+        try:
+            mx_np_op = getattr(mx_np, op_name)
+            _NUMPY_ARRAY_UFUNC_DICT[op_name] = mx_np_op
+        except AttributeError:
+            raise AttributeError('mxnet.numpy does not have operator named {}'.format(op_name))

--- a/python/mxnet/numpy_dispatch_protocol.py
+++ b/python/mxnet/numpy_dispatch_protocol.py
@@ -54,9 +54,10 @@ def with_array_function_protocol(func):
         if cur_np_ver >= np_1_17_ver:
             try:
                 func(*args, **kwargs)
-            except:
+            except Exception as e:
                 raise RuntimeError('Running function {} with NumPy array function protocol failed'
-                                   .format(func.__name__))
+                                   ' with exception {}'
+                                   .format(func.__name__, str(e)))
 
     return _run_with_array_func_proto
 
@@ -73,9 +74,10 @@ def with_array_ufunc_protocol(func):
         if cur_np_ver >= np_1_15_ver:
             try:
                 func(*args, **kwargs)
-            except:
+            except Exception as e:
                 raise RuntimeError('Running function {} with NumPy array ufunc protocol failed'
-                                   .format(func.__name__))
+                                   ' with exception {}'
+                                   .format(func.__name__, str(e)))
 
     return _run_with_array_ufunc_proto
 

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -538,7 +538,7 @@ class _Symbol(Symbol):
         """Returns the standard deviation of the array elements along given axis."""
         return std(self, axis=axis, dtype=dtype, ddof=ddof, keepdims=keepdims, out=out)
 
-    def var(self, axis=None, dtype=None, out=None, ddof=0, keepdims=None):  # pylint: disable=arguments-differ,too-many-arguments
+    def var(self, axis=None, dtype=None, out=None, ddof=0, keepdims=False):  # pylint: disable=arguments-differ,too-many-arguments
         """Returns the variance of the array elements, along given axis."""
         return var(self, axis=axis, dtype=dtype, out=out, ddof=ddof, keepdims=keepdims)
 

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -37,6 +37,7 @@ from common import run_in_spawned_process
 from test_operator import *
 from test_numpy_ndarray import *
 from test_numpy_op import *
+from test_numpy_interoperability import *
 from test_optimizer import *
 from test_random import *
 from test_exc_handling import *

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -1,0 +1,211 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: skip-file
+from __future__ import absolute_import
+import numpy as _np
+from mxnet import np
+from mxnet.test_utils import assert_almost_equal
+from mxnet.test_utils import use_np
+from common import assertRaises, with_seed
+from mxnet.numpy_dispatch_protocol import with_array_function_protocol, with_array_ufunc_protocol
+from mxnet.numpy_dispatch_protocol import _NUMPY_ARRAY_FUNCTION_LIST, _NUMPY_ARRAY_UFUNC_LIST
+
+
+class OpArgMngr(object):
+    """Operator argument manager for storing operator workloads."""
+    _args = {}
+
+    @staticmethod
+    def add_workload(name, *args, **kwargs):
+        if name not in OpArgMngr._args:
+            OpArgMngr._args[name] = []
+        OpArgMngr._args[name].append({'args': args, 'kwargs': kwargs})
+
+    @staticmethod
+    def get_workloads(name):
+        return OpArgMngr._args.get(name, None)
+
+
+@use_np
+def _prepare_workloads():
+    array_pool = {
+        '4x1': np.random.uniform(size=(4, 1)) + 2,
+        '1x2': np.random.uniform(size=(1, 2)) + 2,
+        '1x1x0': np.array([[[]]])
+    }
+
+    # workloads for array function protocol
+    OpArgMngr.add_workload('argmax', array_pool['4x1'])
+    OpArgMngr.add_workload('broadcast_arrays', array_pool['4x1'], array_pool['1x2'])
+    OpArgMngr.add_workload('broadcast_to', array_pool['4x1'], (4, 2))
+    OpArgMngr.add_workload('clip', array_pool['4x1'], 0.2, 0.8)
+    OpArgMngr.add_workload('concatenate', [array_pool['4x1'], array_pool['4x1']])
+    OpArgMngr.add_workload('concatenate', [array_pool['4x1'], array_pool['4x1']], axis=1)
+    OpArgMngr.add_workload('copy', array_pool['4x1'])
+    OpArgMngr.add_workload('cumsum', array_pool['4x1'])
+    OpArgMngr.add_workload('cumsum', array_pool['4x1'], axis=1)
+    OpArgMngr.add_workload('dot', array_pool['4x1'], array_pool['4x1'].T)
+    OpArgMngr.add_workload('expand_dims', array_pool['4x1'], -1)
+    OpArgMngr.add_workload('fix', array_pool['4x1'])
+    OpArgMngr.add_workload('max', array_pool['4x1'])
+    OpArgMngr.add_workload('min', array_pool['4x1'])
+    OpArgMngr.add_workload('mean', array_pool['4x1'])
+    OpArgMngr.add_workload('mean', array_pool['4x1'], axis=0, keepdims=True)
+    OpArgMngr.add_workload('ones_like', array_pool['4x1'])
+    OpArgMngr.add_workload('prod', array_pool['4x1'])
+    OpArgMngr.add_workload('repeat', array_pool['4x1'], 3)
+    OpArgMngr.add_workload('reshape', array_pool['4x1'], -1)
+    OpArgMngr.add_workload('split', array_pool['4x1'], 2)
+    OpArgMngr.add_workload('squeeze', array_pool['4x1'])
+    OpArgMngr.add_workload('stack', [array_pool['4x1']] * 2)
+    OpArgMngr.add_workload('std', array_pool['4x1'])
+    OpArgMngr.add_workload('sum', array_pool['4x1'])
+    OpArgMngr.add_workload('swapaxes', array_pool['4x1'], 0, 1)
+    OpArgMngr.add_workload('tensordot', array_pool['4x1'], array_pool['4x1'])
+    OpArgMngr.add_workload('tile', array_pool['4x1'], 2)
+    OpArgMngr.add_workload('tile', np.array([[[]]]), (3, 2, 5))
+    OpArgMngr.add_workload('transpose', array_pool['4x1'])
+    OpArgMngr.add_workload('var', array_pool['4x1'])
+    OpArgMngr.add_workload('zeros_like', array_pool['4x1'])
+
+    # workloads for array ufunc protocol
+    OpArgMngr.add_workload('add', array_pool['4x1'], array_pool['1x2'])
+    OpArgMngr.add_workload('add', array_pool['4x1'], 2)
+    OpArgMngr.add_workload('add', 2, array_pool['4x1'])
+    OpArgMngr.add_workload('add', array_pool['4x1'], array_pool['1x1x0'])
+    OpArgMngr.add_workload('subtract', array_pool['4x1'], array_pool['1x2'])
+    OpArgMngr.add_workload('subtract', array_pool['4x1'], 2)
+    OpArgMngr.add_workload('subtract', 2, array_pool['4x1'])
+    OpArgMngr.add_workload('subtract', array_pool['4x1'], array_pool['1x1x0'])
+    OpArgMngr.add_workload('multiply', array_pool['4x1'], array_pool['1x2'])
+    OpArgMngr.add_workload('multiply', array_pool['4x1'], 2)
+    OpArgMngr.add_workload('multiply', 2, array_pool['4x1'])
+    OpArgMngr.add_workload('multiply', array_pool['4x1'], array_pool['1x1x0'])
+    OpArgMngr.add_workload('power', array_pool['4x1'], array_pool['1x2'])
+    OpArgMngr.add_workload('power', array_pool['4x1'], 2)
+    OpArgMngr.add_workload('power', 2, array_pool['4x1'])
+    OpArgMngr.add_workload('power', array_pool['4x1'], array_pool['1x1x0'])
+    OpArgMngr.add_workload('mod', array_pool['4x1'], array_pool['1x2'])
+    OpArgMngr.add_workload('mod', array_pool['4x1'], 2)
+    OpArgMngr.add_workload('mod', 2, array_pool['4x1'])
+    OpArgMngr.add_workload('mod', array_pool['4x1'], array_pool['1x1x0'])
+    OpArgMngr.add_workload('remainder', array_pool['4x1'], array_pool['1x2'])
+    OpArgMngr.add_workload('remainder', array_pool['4x1'], 2)
+    OpArgMngr.add_workload('remainder', 2, array_pool['4x1'])
+    OpArgMngr.add_workload('remainder', array_pool['4x1'], array_pool['1x1x0'])
+    OpArgMngr.add_workload('maximum', array_pool['4x1'], array_pool['1x2'])
+    OpArgMngr.add_workload('maximum', array_pool['4x1'], 2)
+    OpArgMngr.add_workload('maximum', 2, array_pool['4x1'])
+    OpArgMngr.add_workload('maximum', array_pool['4x1'], array_pool['1x1x0'])
+    OpArgMngr.add_workload('minimum', array_pool['4x1'], array_pool['1x2'])
+    OpArgMngr.add_workload('minimum', array_pool['4x1'], 2)
+    OpArgMngr.add_workload('minimum', 2, array_pool['4x1'])
+    OpArgMngr.add_workload('minimum', array_pool['4x1'], array_pool['1x1x0'])
+    OpArgMngr.add_workload('negative', array_pool['4x1'])
+    OpArgMngr.add_workload('absolute', array_pool['4x1'])
+    OpArgMngr.add_workload('rint', array_pool['4x1'])
+    OpArgMngr.add_workload('sign', array_pool['4x1'])
+    OpArgMngr.add_workload('exp', array_pool['4x1'])
+    OpArgMngr.add_workload('log', array_pool['4x1'])
+    OpArgMngr.add_workload('log2', array_pool['4x1'])
+    OpArgMngr.add_workload('log10', array_pool['4x1'])
+    OpArgMngr.add_workload('expm1', array_pool['4x1'])
+    OpArgMngr.add_workload('sqrt', array_pool['4x1'])
+    OpArgMngr.add_workload('square', array_pool['4x1'])
+    OpArgMngr.add_workload('cbrt', array_pool['4x1'])
+    OpArgMngr.add_workload('reciprocal', array_pool['4x1'])
+    OpArgMngr.add_workload('sin', array_pool['4x1'])
+    OpArgMngr.add_workload('cos', array_pool['4x1'])
+    OpArgMngr.add_workload('tan', array_pool['4x1'])
+    OpArgMngr.add_workload('sinh', array_pool['4x1'])
+    OpArgMngr.add_workload('cosh', array_pool['4x1'])
+    OpArgMngr.add_workload('tanh', array_pool['4x1'])
+    OpArgMngr.add_workload('arcsin', array_pool['4x1'] - 2)
+    OpArgMngr.add_workload('arccos', array_pool['4x1'] - 2)
+    OpArgMngr.add_workload('arctan', array_pool['4x1'])
+    OpArgMngr.add_workload('arcsinh', array_pool['4x1'])
+    OpArgMngr.add_workload('arccosh', array_pool['4x1'])
+    OpArgMngr.add_workload('arctanh', array_pool['4x1'] - 2)
+    OpArgMngr.add_workload('ceil', array_pool['4x1'])
+    OpArgMngr.add_workload('trunc', array_pool['4x1'])
+    OpArgMngr.add_workload('floor', array_pool['4x1'])
+
+
+_prepare_workloads()
+
+
+def _get_numpy_op_output(onp_op, *args, **kwargs):
+    onp_args = [arg.asnumpy() if isinstance(arg, np.ndarray) else arg for arg in args]
+    onp_kwargs = {k: v.asnumpy() if isinstance(v, np.ndarray) else v for k, v in kwargs.items()}
+    for i, v in enumerate(onp_args):
+        if isinstance(v, (list, tuple)):
+            new_arrs = [a.asnumpy() if isinstance(a, np.ndarray) else a for a in v]
+            onp_args[i] = new_arrs
+
+    return onp_op(*onp_args, **onp_kwargs)
+
+
+def _check_interoperability_helper(op_name, *args, **kwargs):
+    strs = op_name.split('.')
+    if len(strs) == 1:
+        onp_op = getattr(_np, op_name)
+    elif len(strs) == 2:
+        onp_op = getattr(getattr(_np, strs[0]), strs[1])
+    else:
+        assert False
+    out = onp_op(*args, **kwargs)
+    expected_out = _get_numpy_op_output(onp_op, *args, **kwargs)
+    if isinstance(out, (tuple, list)):
+        assert type(out) == type(expected_out)
+        for arr in out:
+            assert isinstance(arr, np.ndarray)
+        for arr, expected_arr in zip(out, expected_out):
+            assert isinstance(arr, np.ndarray)
+            assert_almost_equal(arr.asnumpy(), expected_arr, rtol=1e-3, atol=1e-4, use_broadcast=False)
+    else:
+        assert isinstance(out, np.ndarray)
+        assert_almost_equal(out.asnumpy(), expected_out, rtol=1e-3, atol=1e-4, use_broadcast=False)
+
+
+def check_interoperability(op_list):
+    for name in op_list:
+        workloads = OpArgMngr.get_workloads(name)
+        assert workloads is not None, 'Workloads for operator `{}` has not been ' \
+                                      'added for checking interoperability with ' \
+                                      'the official NumPy.'.format(name)
+        for workload in workloads:
+            _check_interoperability_helper(name, *workload['args'], **workload['kwargs'])
+
+
+@with_seed()
+@use_np
+@with_array_function_protocol
+def test_np_array_function_protocol():
+    check_interoperability(_NUMPY_ARRAY_FUNCTION_LIST)
+
+
+@with_seed()
+@use_np
+@with_array_ufunc_protocol
+def test_np_array_ufunc_protocol():
+    check_interoperability(_NUMPY_ARRAY_UFUNC_LIST)
+
+
+if __name__ == '__main__':
+    import nose
+    nose.runmodule()

--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -729,8 +729,8 @@ def test_np_ndarray_indexing():
                         ((3, 0), [2, (slice(None, None, None)), (slice(None, None, None), None)]),
     ]
     for shape, indices in shapes_indices:
+        np_array = _np.zeros(shape)
         for index in indices:
-            np_array = np.zeros(shape)
             test_getitem(np_array, index)
             test_setitem(np_array, index)
             test_getitem_autograd(np_array, index)

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -20,16 +20,14 @@ from __future__ import absolute_import
 import numpy as _np
 import mxnet as mx
 from mxnet import np, npx
-from mxnet.base import MXNetError
 from mxnet.gluon import HybridBlock
 from mxnet.base import MXNetError
 from mxnet.test_utils import same, assert_almost_equal, rand_shape_nd, rand_ndarray
 from mxnet.test_utils import check_numeric_gradient, use_np, collapse_sum_like
 from common import assertRaises, with_seed
 import random
-import collections
 import scipy.stats as ss
-from mxnet.test_utils import verify_generator, gen_buckets_probs_with_ppf, retry
+from mxnet.test_utils import verify_generator, gen_buckets_probs_with_ppf
 import platform
 
 
@@ -657,7 +655,6 @@ def test_np_reshape():
     for hybridize in [True, False]:
         for shape_pair in shape_pairs:
             shape1, shape2 = shape_pair
-            print(shape1, shape2)
             test_reshape = TestReshape(shape2)
             if hybridize:
                 test_reshape.hybridize()
@@ -742,7 +739,6 @@ def test_np_prod():
                             test_prod.hybridize()
                         x = np.array(_np.random.uniform(-2.0, 2.0, size=shape), dtype=itype)
                         x.attach_grad()
-                        print(x.grad.dtype)
                         expected_ret = _np.prod(x.asnumpy(), axis=axis, keepdims=keepdims)
                         expected_ret = expected_ret.astype(dtype)
                         with mx.autograd.record():
@@ -963,7 +959,6 @@ def test_np_unary_funcs():
                 self._func = func
 
             def hybrid_forward(self, F, a, *args, **kwargs):
-                print(self._func)
                 return getattr(F.np, self._func)(a)
 
         np_func = getattr(_np, func)
@@ -1588,10 +1583,6 @@ def test_np_random():
     for shape in shapes:
         for dtype in dtypes:
             for op_name in op_names:
-                print('-------------------------------')
-                print(op_name)
-                print(shape)
-                print(dtype)
                 op = getattr(np.random, op_name, None)
                 assert op is not None
                 out = op(size=shape, dtype=dtype)

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -1723,7 +1723,7 @@ def test_np_choice():
             samples = sampler(a)
         assert len(samples) == samples_size
         if not replace:
-            assert len(_np.unique(samples)) == samples_size
+            assert len(_np.unique(samples.asnumpy())) == samples_size
 
     num_classes = 10
     num_samples = 10 ** 8


### PR DESCRIPTION
## Description ##
This PR implemented NumPy's [array ufunc](https://numpy.org/neps/nep-0013-ufunc-overrides.html) and [array function](https://numpy.org/neps/nep-0018-array-function-protocol.html) protocols so that `mxnet.numpy.ndarray` can be fed into a subset of official NumPy operators and get dispatched to the corresponding MXNet operators for execution. See the following for examples.

```python
import os

import numpy as onp  # the official NumPy's version must be >= 1.17
from mxnet import np as mx_np

a = mx_np.random.uniform(size=(1, 3))
b = mx_np.random.uniform(size=(2, 1))
assert type(onp.concatenate([a, a])) == mx_np.ndarray
assert type(onp.sum(a)) == mx_np.ndarray
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
