### PR TITLE
Skip coverage files find for nightly tests

### DIFF
--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -45,7 +45,7 @@ core_logic: {
         ws('workspace/build-cpu-int64') {
           utils.init_git()
           utils.docker_run('ubuntu_nightly_cpu', 'build_ubuntu_cpu_large_tensor', false)
-          utils.pack_lib('cpu_int64', mx_cmake_lib, true)
+          utils.pack_lib('cpu_int64', mx_cmake_lib)
         }
       }
     },
@@ -54,7 +54,7 @@ core_logic: {
         ws('workspace/build-gpu-int64') {
           utils.init_git()
           utils.docker_run('ubuntu_nightly_gpu', 'build_ubuntu_gpu_large_tensor', true)
-          utils.pack_lib('gpu_int64', mx_cmake_lib, true)
+          utils.pack_lib('gpu_int64', mx_cmake_lib)
         }
       }
     }


### PR DESCRIPTION
## Description ##
Skip coverage files find for nightly tests. Certain stages were assuming ENABLE_TESTCOVERAGE was on, but it has been turned off here : https://github.com/apache/incubator-mxnet/pull/15981/files#diff-1335fbaf3930b1438d9be18edb07a1a6L784


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
