### PR TITLE
Clojure: Support MKLDNN subgraph backend in tests

### DIFF
--- a/contrib/clojure-package/test/org/apache/clojure_mxnet/operator_test.clj
+++ b/contrib/clojure-package/test/org/apache/clojure_mxnet/operator_test.clj
@@ -407,8 +407,8 @@
                  (-> (executor/forward exec-test) (executor/outputs) (first))))))
 
 (deftest test-maximum
-  (let [data1 (sym/variable "data")
-        data2 (sym/variable "data")
+  (let [data1 (sym/variable "data1")
+        data2 (sym/variable "data2")
         shape-vec [3 4]
         data-tmp1 (random/uniform 0 100 shape-vec)
         data-tmp2 (random/uniform 0 100 shape-vec)
@@ -424,8 +424,8 @@
                  out))))
 
 (deftest test-minimun
-  (let [data1 (sym/variable "data")
-        data2 (sym/variable "data")
+  (let [data1 (sym/variable "data1")
+        data2 (sym/variable "data2")
         shape-vec [3 4]
         data-tmp1 (random/uniform 0 100 shape-vec)
         data-tmp2 (random/uniform 0 100 shape-vec)


### PR DESCRIPTION
## Description ##
When the MKLDNN subgraph backend is enabled, subgraph assumes that any input variables have unique names. To avoid failing tests in this scenario, this PR replaces such non-unique variable names with unique ones in the Clojure test suite.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change.

### Changes ###
- [x] Remove non-unique variable names from test suite.

## Comments ##
Example error message when unique variable names are not used:
```
actual: org.apache.mxnet.MXNetError: [01:57:41] src/executor/graph_executor.cc:1847: Check failed: arg_names.size() == in_args_map.size() (2 vs. 1) :
Stack trace:
  [bt] (0) /tmp/mxnet4687853178926540653/libmxnet.so(+0x2ac5eb) [0x7fb8f7f495eb]
  [bt] (1) /tmp/mxnet4687853178926540653/libmxnet.so(+0x2be36e8) [0x7fb8fa8806e8]
  [bt] (2) /tmp/mxnet4687853178926540653/libmxnet.so(mxnet::Executor::Bind(nnvm::Symbol, mxnet::Context const&, std::map<std::string, mxnet::Context, std::less<std::string>, std::allocator<std::pair<std::string const, mxnet::Context> > > const&, std::vector<mxnet::NDArray, std::allocator<mxnet::NDArray> > const&, std::vector<mxnet::NDArray, std::allocator<mxnet::NDArray> > const&, std::vector<mxnet::OpReqType, std::allocator<mxnet::OpReqType> > const&, std::vector<mxnet::NDArray, std::allocator<mxnet::NDArray> > const&, mxnet::Executor*)+0x7ad) [0x7fb8fa894c3d]
  [bt] (3) /tmp/mxnet4687853178926540653/libmxnet.so(MXExecutorBindEX+0x97b) [0x7fb8fa7cf52b]
  [bt] (4) /tmp/mxnet4687853178926540653/mxnet-scala(Java_org_apache_mxnet_LibInfo_mxExecutorBindEX+0x220) [0x7fb9297a0f00]
  [bt] (5) [0x7fb939018427]
```

Related to https://github.com/apache/incubator-mxnet/issues/16106.