### PR TITLE
Reducing memory footprint of one_hot for Large Array Testing

### DIFF
--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -25,6 +25,7 @@ from tests.python.unittest.common import with_seed, teardown
 
 # dimension constants
 MEDIUM_X = 10000
+VLARGE_X = 4300000000
 LARGE_X = 100000000
 SMALL_X = 100
 SMALL_Y = 50
@@ -1197,12 +1198,11 @@ def test_slice_axis():
 
 
 def test_one_hot():
-    a = nd.array(np.zeros(SMALL_Y))
-    a[0] = 1
-    a[-1] = 1
-    b = nd.one_hot(a, LARGE_X)
+    #default dtype of ndarray is float32 which cannot index elements over 2^32
+    a = nd.array([1, (VLARGE_X - 1)], dtype=np.int64)
+    b = nd.one_hot(a, VLARGE_X)
     b[0][1] == 1
-    b[-1][1] == 1
+    b[1][-1] == 1
 
 
 def test_full():

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -715,12 +715,13 @@ def test_full():
 
 
 def test_one_hot():
-    a = nd.zeros(10)
-    a[0] = 1
-    a[-1] = 1
+    #default dtype of ndarray is float32 which cannot index elements over 2^32
+    a = nd.array([1], dtype=np.int64)
     b = nd.one_hot(a, LARGE_X)
     assert b[0][1] == 1
-    assert b[-1][1] == 1
+    a = nd.array([LARGE_X-1], dtype=np.int64)
+    b = nd.one_hot(a, LARGE_X)
+    assert b[0][-1] == 1
 
 
 if __name__ == '__main__':

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -714,16 +714,6 @@ def test_full():
     assert a[-1] == 3
 
 
-def test_one_hot():
-    #default dtype of ndarray is float32 which cannot index elements over 2^32
-    a = nd.array([1], dtype=np.int64)
-    b = nd.one_hot(a, LARGE_X)
-    assert b[0][1] == 1
-    a = nd.array([LARGE_X-1], dtype=np.int64)
-    b = nd.one_hot(a, LARGE_X)
-    assert b[0][-1] == 1
-
-
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
Using 2 element one hot location NDarray to ensure `one_hot` operator is not using too much memory.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Testing ##
```
$ MXNET_TEST_COUNT=1 nosetests --logging-level=DEBUG --verbose -s tests/nightly/test_large_array.py:test_one_hot
/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters
test_large_array.test_one_hot ... ok

----------------------------------------------------------------------
Ran 1 test in 9.245s

OK
```

Currently running full suite of all tests in test_large_array.py