### PR TITLE
added -DCMAKE_BUILD_TYPE=Release to docs for building from source

### DIFF
--- a/docs/install/build_from_source.md
+++ b/docs/install/build_from_source.md
@@ -182,6 +182,8 @@ There is a configuration file for make,
 
 **NOTE:** When certain set of build flags are set, MXNet archive increases to more than 4 GB. Since MXNet uses archive internally archive runs into a bug ("File Truncated": [bugreport](https://sourceware.org/bugzilla/show_bug.cgi?id=14625)) for archives greater than 4 GB. Please use ar version 2.27 or greater to overcome this bug. Please see https://github.com/apache/incubator-mxnet/issues/15084 for more details.
 
+You can specify different cmake compiler configurations with the option `CMAKE_BUILD_TYPE`. In most cases you should set this to option to `Release` for a smaller and faster binary compared to `Debug`. Alternatively, if you are interested in building the smallest binary you can set the option to `MinSizeRel`. In the case you are developing MXNet you might choose `Debug` instead.
+
 <hr>
 
 ## Build MXNet
@@ -233,7 +235,7 @@ For example, you can specify using all cores on Linux as follows:
 
 ```bash
 mkdir build && cd build
-cmake -GNinja ..
+cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..
 ninja -v
 ```
 
@@ -243,7 +245,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -DUSE_MKLDNN=1 -GNinja ..
+cmake -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -DUSE_MKLDNN=1 -GNinja ..
 ninja -v
 ```
 
@@ -252,7 +254,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DBLAS=open -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -GNinja ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBLAS=open -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -GNinja ..
 ninja -v
 ```
 
@@ -261,7 +263,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DUSE_CUDA=0 -DUSE_MKLDNN=1 -GNinja ..
+cmake -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA=0 -DUSE_MKLDNN=1 -GNinja ..
 ninja -v
 ```
 
@@ -270,7 +272,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DUSE_CUDA=0 -DBLAS=open -GNinja ..
+cmake -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA=0 -DBLAS=open -GNinja ..
 ninja -v
 ```
 
@@ -280,7 +282,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DUSE_OPENCV=0 -GNinja ..
+cmake -DCMAKE_BUILD_TYPE=Release -DUSE_OPENCV=0 -GNinja ..
 ninja -v
 ```
 
@@ -288,7 +290,7 @@ ninja -v
 
 ```bash
 mkdir build && cd build
-cmake -DBLAS=apple -DUSE_OPENCV=0 -DUSE_OPENMP=0 -GNinja ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBLAS=apple -DUSE_OPENCV=0 -DUSE_OPENMP=0 -GNinja ..
 ninja -v
 ```
 
@@ -297,7 +299,7 @@ ninja -v
 ```bash
 brew install llvm
 mkdir build && cd build
-cmake -DBLAS=apple -DUSE_OPENMP=1 -GNinja ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBLAS=apple -DUSE_OPENMP=1 -GNinja ..
 ninja -v
 ```
 

--- a/docs/install/build_from_source.md
+++ b/docs/install/build_from_source.md
@@ -182,7 +182,7 @@ There is a configuration file for make,
 
 **NOTE:** When certain set of build flags are set, MXNet archive increases to more than 4 GB. Since MXNet uses archive internally archive runs into a bug ("File Truncated": [bugreport](https://sourceware.org/bugzilla/show_bug.cgi?id=14625)) for archives greater than 4 GB. Please use ar version 2.27 or greater to overcome this bug. Please see https://github.com/apache/incubator-mxnet/issues/15084 for more details.
 
-You can specify different cmake compiler configurations with the option `CMAKE_BUILD_TYPE`. In most cases you should set this to option to `Release` for a smaller and faster binary compared to `Debug`. Alternatively, if you are interested in building the smallest binary you can set the option to `MinSizeRel`. In the case you are developing MXNet you might choose `Debug` instead.
+You can specify different cmake compiler configurations with the option `CMAKE_BUILD_TYPE`. In most cases you should set this to option to `Release` for a smaller and faster binary compared to `Debug`. Alternatively, if you are interested in building the smallest binary you can set the option to `MinSizeRel`. In the case you are developing MXNet you might choose `Debug` or `RelWithDebInfo` instead.
 
 <hr>
 

--- a/docs/install/c_plus_plus.md
+++ b/docs/install/c_plus_plus.md
@@ -23,7 +23,7 @@ To enable C++ package, just add `USE_CPP_PACKAGE=1` in the [build from source](b
 For example to build MXNet with GPU support and the C++ package, OpenCV, and OpenBLAS, from the project root you would run:
 
 ```bash
-cmake -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -DUSE_MKLDNN=1 -DUSE_CPP_PACKAGE=1 -GNinja ..
+cmake -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA=1 -DUSE_CUDA_PATH=/usr/local/cuda -DUSE_CUDNN=1 -DUSE_MKLDNN=1 -DUSE_CPP_PACKAGE=1 -GNinja ..
 ninja -v
 ```
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -1484,6 +1484,7 @@ Build:
 ```
     mkdir -p build && cd build
     cmake \
+        -DCMAKE_BUILD_TYPE=Release \
         -DUSE_SSE=OFF \
         -DUSE_CUDA=OFF \
         -DUSE_OPENCV=ON \

--- a/docs/install/ubuntu_setup.md
+++ b/docs/install/ubuntu_setup.md
@@ -201,6 +201,7 @@ Build with CMake and ninja, without GPU and without MKL.
     rm -rf build
     mkdir -p build && cd build
     cmake -GNinja \
+        -DCMAKE_BUILD_TYPE=Release \
         -DUSE_CUDA=OFF \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
@@ -216,6 +217,7 @@ If building on CPU and using MKL and MKL-DNN (make sure MKL is installed accordi
     rm -rf build
     mkdir -p build && cd build
     cmake -GNinja \
+        -DCMAKE_BUILD_TYPE=Release \
         -DUSE_CUDA=OFF \
         -DUSE_MKL_IF_AVAILABLE=ON \
         -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
@@ -232,6 +234,7 @@ Cuda 10.1 in Ubuntu 18.04 builds fine but is not currently tested in CI.
     rm -rf build
     mkdir -p build && cd build
     cmake -GNinja \
+        -DCMAKE_BUILD_TYPE=Release \
         -DUSE_CUDA=ON \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \

--- a/docs/install/windows_setup.md
+++ b/docs/install/windows_setup.md
@@ -180,7 +180,7 @@ cd C:\incubator-mxnet\build
 ```
 5. Compile the MXNet source code with `cmake` by using following command:
 ```
-cmake -G "Visual Studio 15 2017 Win64" -T cuda=9.2,host=x64 -DUSE_CUDA=1 -DUSE_CUDNN=1 -DUSE_NVRTC=1 -DUSE_OPENCV=1 -DUSE_OPENMP=1 -DUSE_BLAS=open -DUSE_LAPACK=1 -DUSE_DIST_KVSTORE=0 -DCUDA_ARCH_LIST=Common -DCUDA_TOOLSET=9.2 -DCUDNN_INCLUDE=C:\cuda\include -DCUDNN_LIBRARY=C:\cuda\lib\x64\cudnn.lib "C:\incubator-mxnet"
+cmake -G "Visual Studio 15 2017 Win64" -T cuda=9.2,host=x64 -DCMAKE_BUILD_TYPE=Release -DUSE_CUDA=1 -DUSE_CUDNN=1 -DUSE_NVRTC=1 -DUSE_OPENCV=1 -DUSE_OPENMP=1 -DUSE_BLAS=open -DUSE_LAPACK=1 -DUSE_DIST_KVSTORE=0 -DCUDA_ARCH_LIST=Common -DCUDA_TOOLSET=9.2 -DCUDNN_INCLUDE=C:\cuda\include -DCUDNN_LIBRARY=C:\cuda\lib\x64\cudnn.lib "C:\incubator-mxnet"
 ```
 * Make sure you set the environment variables correctly (OpenBLAS_HOME, OpenCV_DIR) and change the version of the Visual studio 2017 to v14.11 before enter above command.
 6. After the CMake successfully completed, compile the MXNet source code by using following command:


### PR DESCRIPTION
## Description ##
The `CMAKE_BUILD_TYPE` is not set in most cases for the build instructions from source.
If the `CMAKE_BUILD_TYPE` is empty no optimization flags are used by default. This results not only in a higher memory footprint but also in a much slower binary compared to the official python MXNet pip packages. This PR adds the option `-DCMAKE_BUILD_TYPE=Release` in the documentation as the default option. @zachgk @aaronmarkham

## Checklist ##
### Essentials ###

- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- This PR introduces no functional change and only affects markdown documentation files.
