### PR TITLE
Sequence last fix

### DIFF
--- a/src/operator/mxnet_op.h
+++ b/src/operator/mxnet_op.h
@@ -499,7 +499,7 @@ MSHADOW_XINLINE Shape<ndim> unravel(const index_t idx, const Shape<ndim>& shape)
   Shape<ndim> ret;
   #pragma unroll
   for (index_t i = ndim-1, j = idx; i >=0; --i) {
-    auto tmp = j / shape[i];
+    index_t tmp = j / shape[i];
     ret[i] = j - tmp*shape[i];
     j = tmp;
   }

--- a/src/operator/mxnet_op.h
+++ b/src/operator/mxnet_op.h
@@ -499,7 +499,7 @@ MSHADOW_XINLINE Shape<ndim> unravel(const index_t idx, const Shape<ndim>& shape)
   Shape<ndim> ret;
   #pragma unroll
   for (index_t i = ndim-1, j = idx; i >=0; --i) {
-    index_t tmp = j / shape[i];
+    auto tmp = j / shape[i];
     ret[i] = j - tmp*shape[i];
     j = tmp;
   }

--- a/src/operator/sequence_last-inl.h
+++ b/src/operator/sequence_last-inl.h
@@ -121,11 +121,11 @@ class SequenceLastOp : public Operator {
     using namespace mshadow::expr;
 
     auto axis = param_.axis;
-    int batch = out_grad.size(0);
-    int rest = out_grad.size(1);
-    int out_size = batch * rest;
+    index_t batch = out_grad.size(0);
+    index_t rest = out_grad.size(1);
+    index_t out_size = batch * rest;
 
-    int max_seq_len = in_grad.size(axis);
+    index_t max_seq_len = in_grad.size(axis);
     index_t offset1 = axis ? rest : out_size;
     index_t offset2 = axis ? (max_seq_len * rest) : rest;
 

--- a/src/operator/sequence_last-inl.h
+++ b/src/operator/sequence_last-inl.h
@@ -101,8 +101,8 @@ class SequenceLastOp : public Operator {
     using namespace mshadow::expr;
 
     int axis = param_.axis;
-    int out_size = out.size(0) * out.size(1);
-    int max_seq_len = data.size(axis);
+    index_t out_size = out.size(0) * out.size(1);
+    index_t max_seq_len = data.size(axis);
     index_t offset1 = axis ? out.size(1) : out_size;
     index_t offset2 = axis ? (max_seq_len * out.size(1)) : out.size(1);
 

--- a/src/operator/sequence_last.cc
+++ b/src/operator/sequence_last.cc
@@ -31,9 +31,9 @@ template <>
 Operator *CreateOp<cpu>(SequenceLastParam param, int dtype, int itype) {
   Operator *op = nullptr;
   MSHADOW_TYPE_SWITCH(dtype, DType, {
-//      MSHADOW_TYPE_SWITCH(itype, IType, {
-          op = new SequenceLastOp<cpu, DType, int64_t>(param);
-  //      });
+     MSHADOW_TYPE_SWITCH(itype, IType, {
+          op = new SequenceLastOp<cpu, DType, IType>(param);
+       });
     });
   return op;
 }

--- a/src/operator/sequence_last.cc
+++ b/src/operator/sequence_last.cc
@@ -54,7 +54,6 @@ Operator *SequenceLastProp::CreateOperatorEx(Context ctx,
   #else
       DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0], mshadow::kInt32);
   #endif
-  
 }
 
 DMLC_REGISTER_PARAMETER(SequenceLastParam);

--- a/src/operator/sequence_last.cc
+++ b/src/operator/sequence_last.cc
@@ -31,9 +31,9 @@ template <>
 Operator *CreateOp<cpu>(SequenceLastParam param, int dtype, int itype) {
   Operator *op = nullptr;
   MSHADOW_TYPE_SWITCH(dtype, DType, {
-      MSHADOW_TYPE_SWITCH(itype, IType, {
-          op = new SequenceLastOp<cpu, DType, IType>(param);
-        });
+//      MSHADOW_TYPE_SWITCH(itype, IType, {
+          op = new SequenceLastOp<cpu, DType, int64_t>(param);
+  //      });
     });
   return op;
 }

--- a/src/operator/sequence_last.cc
+++ b/src/operator/sequence_last.cc
@@ -46,9 +46,15 @@ Operator *SequenceLastProp::CreateOperatorEx(Context ctx,
     DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0], (*in_type)[1]);
   }
 
-  // sequence_length not passed in, so fall back to using int64 dtype for second argument
+  // sequence_length not passed in, so fall back to using int32/int64 dtype for second argument
   // second argument is the dtype of the sequence_length NDArray
-  DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0], 6);
+  // use int32 or int64 as index dtype based on build flag
+  #if MXNET_USE_INT64_TENSOR_SIZE == 1
+      DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0], mshadow::kInt64);
+  #else
+      DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0], mshadow::kInt32);
+  #endif
+  
 }
 
 DMLC_REGISTER_PARAMETER(SequenceLastParam);

--- a/src/operator/sequence_last.cc
+++ b/src/operator/sequence_last.cc
@@ -46,8 +46,9 @@ Operator *SequenceLastProp::CreateOperatorEx(Context ctx,
     DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0], (*in_type)[1]);
   }
 
-  // sequence_length not passed in, so fall back to using input array dtype for second argument
-  DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0], (*in_type)[0]);
+  // sequence_length not passed in, so fall back to using int64 dtype for second argument
+  // second argument is the dtype of the sequence_length NDArray
+  DO_BIND_DISPATCH(CreateOp, param_, (*in_type)[0], 6);
 }
 
 DMLC_REGISTER_PARAMETER(SequenceLastParam);

--- a/src/operator/sequence_last.cc
+++ b/src/operator/sequence_last.cc
@@ -31,9 +31,9 @@ template <>
 Operator *CreateOp<cpu>(SequenceLastParam param, int dtype, int itype) {
   Operator *op = nullptr;
   MSHADOW_TYPE_SWITCH(dtype, DType, {
-     MSHADOW_TYPE_SWITCH(itype, IType, {
+      MSHADOW_TYPE_SWITCH(itype, IType, {
           op = new SequenceLastOp<cpu, DType, IType>(param);
-       });
+        });
     });
   return op;
 }

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -346,7 +346,7 @@ def test_sequence_reverse():
 
 
 def test_sequence_last():
-    a = nd.arange(0, LARGE_X * 2, dtype="int64").reshape(LARGE_X, 2)
+    a = nd.arange(0, LARGE_X * 2).reshape(LARGE_X, 2)
 
     # test if returns last sequence
     b = nd.SequenceLast(a)
@@ -356,6 +356,8 @@ def test_sequence_last():
     # test with sequence length
     # parameter sequence_length - NDArray with shape (batch_size)
     # (2,3) indicates 2nd sequence from batch 1 and 3rd sequence from batch 2
+    # need to mention dtype = int64 for sequence_length ndarray to support large indices
+    # else it defaults to float32 and errors
     b = nd.SequenceLast(a, sequence_length=mx.nd.array([2, 3], dtype="int64"),
                         use_sequence_length=True)
     # check if it takes 2nd sequence from the first batch

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -346,7 +346,7 @@ def test_sequence_reverse():
 
 
 def test_sequence_last():
-    a = nd.arange(0, LARGE_X * 2).reshape(LARGE_X, 2)
+    a = nd.arange(0, LARGE_X * 2, dtype="int64").reshape(LARGE_X, 2)
 
     # test if returns last sequence
     b = nd.SequenceLast(a)
@@ -356,7 +356,7 @@ def test_sequence_last():
     # test with sequence length
     # parameter sequence_length - NDArray with shape (batch_size)
     # (2,3) indicates 2nd sequence from batch 1 and 3rd sequence from batch 2
-    b = nd.SequenceLast(a, sequence_length=mx.nd.array([2, 3]),
+    b = nd.SequenceLast(a, sequence_length=mx.nd.array([2, 3], dtype="int64"),
                         use_sequence_length=True)
     # check if it takes 2nd sequence from the first batch
     assert b[0] == a[1][0]


### PR DESCRIPTION
## Description ##
Pass dtype to sequence_last operator.

Why?
Unless explicitly specified, default MXNet implementation turns NDArray into dtype=Float32
However, indices need to support int64 (>2**32)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Fix dtypes

## Comments ##
Hopefully, for v2.0 of MXNet, we introduce API breaking change of ensuring NDArray for indices are either int32 or int64