### PR TITLE
Fix NDArrayIter iteration bug when last_batch_handle='pad'

### DIFF
--- a/python/mxnet/io/io.py
+++ b/python/mxnet/io/io.py
@@ -748,7 +748,15 @@ class NDArrayIter(DataIter):
             self.cursor + self.batch_size > self.num_data:
             pad = self.batch_size - self.num_data + self.cursor
             first_data = self._getdata(data_source, start=self.cursor)
-            second_data = self._getdata(data_source, end=pad)
+            if pad > self.num_data:
+                while True:
+                    if pad <= self.num_data:
+                        break
+                    second_data = self._getdata(data_source, end=self.num_data)
+                    pad -= self.num_data
+                second_data = self._concat(second_data, self._getdata(data_source, end=pad))
+            else:
+                second_data = self._getdata(data_source, end=pad)
             return self._concat(first_data, second_data)
         # normal case
         else:

--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -198,6 +198,13 @@ def _test_shuffle(data, labels=None):
         assert np.array_equal(batch.data[0].asnumpy(), batch_list[idx_list[i]])
         i += 1
 
+# fixes the issue https://github.com/apache/incubator-mxnet/issues/15535
+def _test_corner_case():
+    data = np.arange(10)
+    data_iter = mx.io.NDArrayIter(data=data, batch_size=25, shuffle=False, last_batch_handle='pad')
+    expect = np.concatenate((np.tile(data, 2), np.arange(5)))
+    assert np.array_equal(data_iter.next().data[0].asnumpy(), expect)
+
 
 def test_NDArrayIter():
     dtype_list = ['NDArray', 'ndarray']
@@ -220,6 +227,7 @@ def test_NDArrayIter():
             _test_shuffle({'data1': data, 'data2': data})
             _test_shuffle(data, [])
             _test_shuffle(data)
+    _test_corner_case()
 
 
 def test_NDArrayIter_h5py():


### PR DESCRIPTION
## Description ##
Fixes #15535
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###

## Comments ##
@zhreshold