### PR TITLE
[Numpy] Fix numerical error in multinomial's pvalue check

### DIFF
--- a/src/operator/numpy/random/np_multinomial_op.cu
+++ b/src/operator/numpy/random/np_multinomial_op.cu
@@ -35,7 +35,7 @@ void CheckPvalGPU(DType* input, int prob_length) {
   DType sum = DType(0.0);
   for (int i = 0; i < prob_length; ++i) {
     sum += pvals_[i];
-    CHECK(sum <= DType(1.0))
+    CHECK(sum <= DType(1.0 + 1e-12))
       << "sum(pvals[:-1]) > 1.0";
   }
 }

--- a/src/operator/numpy/random/np_multinomial_op.h
+++ b/src/operator/numpy/random/np_multinomial_op.h
@@ -107,7 +107,7 @@ void CheckPval(DType* input, int prob_length) {
   DType sum = DType(0.0);
   for (int i = 0; i < prob_length; ++i) {
     sum += input[i];
-    CHECK_LE(sum, 1.0)
+    CHECK_LE(sum, 1.0 + 1e-12)
       << "sum(pvals[:-1]) > 1.0";
   }
 }
@@ -178,7 +178,7 @@ void NumpyMultinomialForward(const nnvm::NodeAttrs& attrs,
         sum += param.pvals.value()[i];
         // copy the tuple to data for later kernel usage
         pvals_[i] = param.pvals.value()[i];
-        CHECK_LE(sum, 1.0)
+        CHECK_LE(sum, 1.0 + 1e-12)
           << "sum(pvals[:-1]) > 1.0";
     }
     Kernel<multinomial_kernel, xpu>::Launch(


### PR DESCRIPTION
## Description ##
Currently, the command `np.random.multinomial(20, pvals=[1/20]*20)` would result in error as followed:
```
mxnet.base.MXNetError: [09:21:59] ../src/operator/numpy/random/./np_multinomial_op.h:168: Check failed: sum <= 1.0 (1 vs. 1) : sum(pvals[:-1]) > 1.0
```
This is due to the floating number errors cumulated during the check of `pvals` legality.
By adding a tiny epsilon the `1.0` could resolve the problem in my case.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
