### PR TITLE
Fix inconsistent interpolation method values

### DIFF
--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -309,11 +309,11 @@ def _get_interp_method(interp, sizes=()):
         Possible values:
         0: Nearest Neighbors Interpolation.
         1: Bilinear interpolation.
-        2: Area-based (resampling using pixel area relation). It may be a
+        2: Bicubic interpolation over 4x4 pixel neighborhood.
+        3: Area-based (resampling using pixel area relation). It may be a
         preferred method for image decimation, as it gives moire-free
         results. But when the image is zoomed, it is similar to the Nearest
         Neighbors method. (used by default).
-        3: Bicubic interpolation over 4x4 pixel neighborhood.
         4: Lanczos interpolation over 8x8 pixel neighborhood.
         9: Cubic for enlarge, area for shrink, bilinear for others
         10: Random select from interpolation method metioned above.
@@ -372,11 +372,11 @@ def resize_short(src, size, interp=2):
         Possible values:
         0: Nearest Neighbors Interpolation.
         1: Bilinear interpolation.
-        2: Area-based (resampling using pixel area relation). It may be a
+        2: Bicubic interpolation over 4x4 pixel neighborhood.
+        3: Area-based (resampling using pixel area relation). It may be a
         preferred method for image decimation, as it gives moire-free
         results. But when the image is zoomed, it is similar to the Nearest
         Neighbors method. (used by default).
-        3: Bicubic interpolation over 4x4 pixel neighborhood.
         4: Lanczos interpolation over 8x8 pixel neighborhood.
         9: Cubic for enlarge, area for shrink, bilinear for others
         10: Random select from interpolation method metioned above.
@@ -1062,11 +1062,11 @@ def CreateAugmenter(data_shape, resize=0, rand_crop=False, rand_resize=False, ra
         Possible values:
         0: Nearest Neighbors Interpolation.
         1: Bilinear interpolation.
-        2: Area-based (resampling using pixel area relation). It may be a
+        2: Bicubic interpolation over 4x4 pixel neighborhood.
+        3: Area-based (resampling using pixel area relation). It may be a
         preferred method for image decimation, as it gives moire-free
         results. But when the image is zoomed, it is similar to the Nearest
         Neighbors method. (used by default).
-        3: Bicubic interpolation over 4x4 pixel neighborhood.
         4: Lanczos interpolation over 8x8 pixel neighborhood.
         9: Cubic for enlarge, area for shrink, bilinear for others
         10: Random select from interpolation method metioned above.


### PR DESCRIPTION
In cv2, bicubic interpolation should be represented by 2, and area-based interpolation should be 3. This is correct in the docstring of `imresize` method, but wrong in the docstring of several other methods, which can be quite confusing when following the documentation.

