### PR TITLE
Faster Scala NDArray to BufferedImage function

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/Image.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Image.scala
@@ -174,16 +174,18 @@ object Image {
   def toImage(src: NDArray): BufferedImage = {
     require(src.dtype == DType.UInt8, "The input NDArray must be bytes")
     require(src.shape.length == 3, "The input should contains height, width and channel")
+    require(src.shape(2) == 3, "There should be three channels: RGB")
     val height = src.shape.get(0)
     val width = src.shape.get(1)
     val img = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+    val arr = src.toArray
     (0 until height).par.foreach(r => {
       (0 until width).par.foreach(c => {
-        val arr = src.at(r).at(c).toArray
         // NDArray in RGB
-        val red = arr(0).toByte & 0xFF
-        val green = arr(1).toByte & 0xFF
-        val blue = arr(2).toByte & 0xFF
+        val cellIndex = r * width * 3 + c * 3
+        val red = arr(cellIndex).toByte & 0xFF
+        val green = arr(cellIndex + 1).toByte & 0xFF
+        val blue = arr(cellIndex + 2).toByte & 0xFF
         val rgb = (red << 16) | (green << 8) | blue
         img.setRGB(c, r, rgb)
       })


### PR DESCRIPTION
## Description ##
Fixes #15123
The toImage function now runs ~85x faster on the 1024x576px Pug_cookie.jpg image.
@Chouffe 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
