### PR TITLE
[MXNET-1422] Fix wrong results of min([inf, inf]) and max([-inf,-inf])

### DIFF
--- a/3rdparty/mshadow/mshadow/base.h
+++ b/3rdparty/mshadow/mshadow/base.h
@@ -656,12 +656,12 @@ MSHADOW_XINLINE DType NegInfValue(void) {
 /*! \brief negative infinity value of float */
 template<>
 MSHADOW_XINLINE float NegInfValue<float>(void) {
-  return -std::numeric_limits<float>::infinity();
+  return -HUGE_VALF;
 }
 /*! \brief negative infinity value of double */
 template<>
 MSHADOW_XINLINE double NegInfValue<double>(void) {
-  return -std::numeric_limits<double>::infinity();
+  return -HUGE_VAL;
 }
 
 /*!
@@ -717,12 +717,12 @@ MSHADOW_XINLINE DType PosInfValue(void) {
 /*! \brief positive infinity value of float */
 template<>
 MSHADOW_XINLINE float PosInfValue<float>(void) {
-  return std::numeric_limits<float>::infinity();
+  return HUGE_VALF;
 }
 /*! \brief positive infinity value of double */
 template<>
 MSHADOW_XINLINE double PosInfValue<double>(void) {
-  return std::numeric_limits<double>::infinity();
+  return HUGE_VAL;
 }
 
 }  // namespace limits

--- a/3rdparty/mshadow/mshadow/base.h
+++ b/3rdparty/mshadow/mshadow/base.h
@@ -646,6 +646,25 @@ MSHADOW_XINLINE int64_t MinValue<int64_t>(void) {
 }
 
 /*!
+ * \brief negative infinity of certain types
+ * \tparam DType data type
+ */
+template<typename DType>
+MSHADOW_XINLINE DType NegInfValue(void) {
+  return MinValue<DType>();
+}
+/*! \brief negative infinity value of float */
+template<>
+MSHADOW_XINLINE float NegInfValue<float>(void) {
+  return -std::numeric_limits<float>::infinity();
+}
+/*! \brief negative infinity value of double */
+template<>
+MSHADOW_XINLINE double NegInfValue<double>(void) {
+  return -std::numeric_limits<double>::infinity();
+}
+
+/*!
  * \brief maximum value of certain types
  * \tparam DType data type
  */
@@ -686,6 +705,26 @@ template<>
 MSHADOW_XINLINE int64_t MaxValue<int64_t>(void) {
   return LLONG_MAX;
 }
+
+/*!
+ * \brief positive infinity of certain types
+ * \tparam DType data type
+ */
+template<typename DType>
+MSHADOW_XINLINE DType PosInfValue(void) {
+  return MaxValue<DType>();
+}
+/*! \brief positive infinity value of float */
+template<>
+MSHADOW_XINLINE float PosInfValue<float>(void) {
+  return std::numeric_limits<float>::infinity();
+}
+/*! \brief positive infinity value of double */
+template<>
+MSHADOW_XINLINE double PosInfValue<double>(void) {
+  return std::numeric_limits<double>::infinity();
+}
+
 }  // namespace limits
 
 /*! \brief sum reducer */
@@ -793,7 +832,7 @@ struct maximum {
    */
   template<typename DType>
   MSHADOW_XINLINE static void SetInitValue(DType &initv) { // NOLINT(*)
-    initv = limits::MinValue<DType>();
+    initv = limits::NegInfValue<DType>();
   }
   /*!
    *\brief set the initial value during reduction
@@ -849,7 +888,7 @@ struct minimum {
    */
   template<typename DType>
   MSHADOW_XINLINE static void SetInitValue(DType &initv) { // NOLINT(*)
-    initv = limits::MaxValue<DType>();
+    initv = limits::PosInfValue<DType>();
   }
   /*!
    *\brief set the initial value during reduction

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -9266,6 +9266,7 @@ def test_min_max_inf():
                 min_data_mx, max_data_mx = data_mx.min(), data_mx.max()
 
                 assert_array_equal(min_data_np, min_data_mx.asnumpy())
+                assert_array_equal(max_data_np, max_data_mx.asnumpy())
 
 
 if __name__ == '__main__':

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -9252,6 +9252,22 @@ def test_sample_normal_default_shape():
     assert s.shape == (1, 1)
 
 
+def test_min_max_inf():
+    dtypes = [np.float32, np.double]
+    elem_list = [-1, 1, 0, np.inf, -np.inf]
+
+    for dtype in dtypes:
+        for a in elem_list:
+            for b in elem_list:
+                data_np = np.array([a, b], dtype=dtype)
+                data_mx = mx.nd.array(data_np, dtype=dtype)
+
+                min_data_np, max_data_np = data_np.min(), data_np.max()
+                min_data_mx, max_data_mx = data_mx.min(), data_mx.max()
+
+                assert_array_equal(min_data_np, min_data_mx.asnumpy())
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
Hi, there.
In the latest version of MXNet, the results of min([inf, inf]) and max([-inf, -inf]) are wrong. #16206 .
The reason is that the initial values of minimum or maximum reducer are the MaxValue and the MinValue. They should be the +InfValue and the -InfValue.

In this PR, I add `PosInfValue` and `NegInfValue` in mshadow. Then I fixed the bug.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add `PosInfValue` and `NegInfValue` in mshadow
- [x] Modify the initial value of minimum and maximum reducer.
- [x] Add the relative unittest.
