### PR TITLE
cpp-package: Expose partial shape inference

### DIFF
--- a/cpp-package/include/mxnet-cpp/symbol.h
+++ b/cpp-package/include/mxnet-cpp/symbol.h
@@ -166,6 +166,19 @@ class Symbol {
       std::vector<std::vector<mx_uint> > *aux_shape,
       std::vector<std::vector<mx_uint> > *out_shape) const;
   /*!
+  * \brief infer the shapes partially by providing shapes of known argument shapes.
+  * \param arg_shapes map of argument name to shape of arguments with known
+  * shapes.
+  * \param in_shapes used to store infered shapes of input arguments.
+  * \param out_shapes used to store infered shapes of outputs.
+  * \param aux_shapes use to store the infered shapes of auxiliary states
+  */
+  void InferShapePartial(
+      const std::map<std::string, std::vector<mx_uint>> &arg_shapes,
+      std::vector<std::vector<mx_uint> >                *in_shape,
+      std::vector<std::vector<mx_uint> >                *aux_shape,
+      std::vector<std::vector<mx_uint> >                *out_shape) const;
+  /*!
   * \brief List the arguments names.
   *
   * The position of the returned list also corresponds to calling position in

--- a/cpp-package/include/mxnet-cpp/symbol.hpp
+++ b/cpp-package/include/mxnet-cpp/symbol.hpp
@@ -275,6 +275,66 @@ inline void Symbol::InferShape(
   }
 }
 
+inline void Symbol::InferShapePartial(
+  const std::map<std::string, std::vector<mx_uint>>& arg_shapes,
+  std::vector<std::vector<mx_uint>>*                 in_shape,
+  std::vector<std::vector<mx_uint>>*                 aux_shape,
+  std::vector<std::vector<mx_uint>>*                 out_shape) const {
+
+  std::vector<const char*> keys;
+  std::vector<mx_uint>     arg_ind_ptr;
+  std::vector<mx_uint>     arg_shape_data;
+
+  for (const auto& arg : arg_shapes) {
+    keys.push_back(arg.first.c_str());
+    arg_ind_ptr.push_back(arg_shape_data.size());
+    for (auto i : arg.second) {
+      arg_shape_data.push_back(i);
+    }
+  }
+  arg_ind_ptr.push_back(arg_shape_data.size());
+
+  mx_uint         in_shape_size;
+  const mx_uint*  in_shape_ndim;
+  const mx_uint** in_shape_data;
+  mx_uint         out_shape_size;
+  const mx_uint*  out_shape_ndim;
+  const mx_uint** out_shape_data;
+  mx_uint         aux_shape_size;
+  const mx_uint*  aux_shape_ndim;
+  const mx_uint** aux_shape_data;
+  int             complete;
+
+  CHECK_EQ(MXSymbolInferShapePartial(GetHandle(), keys.size(), keys.data(),
+                                     arg_ind_ptr.data(), arg_shape_data.data(),
+                                     &in_shape_size, &in_shape_ndim, &in_shape_data,
+                                     &out_shape_size, &out_shape_ndim, &out_shape_data,
+                                     &aux_shape_size, &aux_shape_ndim, &aux_shape_data,
+                                     &complete),
+          0);
+
+  if (complete) {
+    for (mx_uint i = 0; i < in_shape_size; ++i) {
+      in_shape->push_back(std::vector<mx_uint>());
+      for (mx_uint j = 0; j < in_shape_ndim[i]; ++j) {
+        (*in_shape)[i].push_back(in_shape_data[i][j]);
+      }
+    }
+    for (mx_uint i = 0; i < aux_shape_size; ++i) {
+      aux_shape->push_back(std::vector<mx_uint>());
+      for (mx_uint j = 0; j < aux_shape_ndim[i]; ++j) {
+        (*aux_shape)[i].push_back(aux_shape_data[i][j]);
+      }
+    }
+    for (mx_uint i = 0; i < out_shape_size; ++i) {
+      out_shape->push_back(std::vector<mx_uint>());
+      for (mx_uint j = 0; j < out_shape_ndim[i]; ++j) {
+        (*out_shape)[i].push_back(out_shape_data[i][j]);
+      }
+    }
+  }
+}
+
 inline void Symbol::InferExecutorArrays(
     const Context &context, std::vector<NDArray> *arg_arrays,
     std::vector<NDArray> *grad_arrays, std::vector<OpReqType> *grad_reqs,


### PR DESCRIPTION
## Description ##

Expose the ability to infer shapes partially via the cpp-package

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add `mxnet::cpp::Symbol::InferShapePartial`

