### PR TITLE
fix broken links in README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Apache MXNet (incubating) for Deep Learning
 ![banner](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/image/banner.png)
 
 Apache MXNet (incubating) is a deep learning framework designed for both *efficiency* and *flexibility*.
-It allows you to ***mix*** [symbolic and imperative programming](https://mxnet.incubator.apache.org/architecture/index.html#deep-learning-system-design-concepts)
+It allows you to ***mix*** [symbolic and imperative programming](https://mxnet.incubator.apache.org/api/architecture/program_model)
 to ***maximize*** efficiency and productivity.
 At its core, MXNet contains a dynamic dependency scheduler that automatically parallelizes both symbolic and imperative operations on the fly.
 A graph optimization layer on top of that makes symbolic execution fast and memory efficient.
 MXNet is portable and lightweight, scaling effectively to multiple GPUs and multiple machines.
 
 MXNet is more than a deep learning project. It is a collection of
-[blue prints and guidelines](https://mxnet.incubator.apache.org/architecture/index.html#deep-learning-system-design-concepts) for building
+[blue prints and guidelines](https://mxnet.incubator.apache.org/api/architecture/overview) for building
 deep learning systems, and interesting insights of DL systems for hackers.
 
 Ask Questions
@@ -71,24 +71,21 @@ What's New
 * [MKLDNN for Faster CPU Performance](./docs/tutorials/mkldnn/MKLDNN_README.md)
 * [MXNet Memory Monger, Training Deeper Nets with Sublinear Memory Cost](https://github.com/dmlc/mxnet-memonger)
 * [Tutorial for NVidia GTC 2016](https://github.com/dmlc/mxnet-gtc-tutorial)
-* [Embedding Torch layers and functions in MXNet](https://mxnet.incubator.apache.org/faq/torch.html)
-* [MXNet.js: Javascript Package for Deep Learning in Browser (without server)
-](https://github.com/dmlc/mxnet.js/)
-* [Design Note: Design Efficient Deep Learning Data Loading Module](https://mxnet.incubator.apache.org/architecture/note_data_loading.html)
-* [MXNet on Mobile Device](https://mxnet.incubator.apache.org/faq/smart_device.html)
-* [Distributed Training](https://mxnet.incubator.apache.org/faq/multi_devices.html)
-* [Guide to Creating New Operators (Layers)](https://mxnet.incubator.apache.org/faq/new_op.html)
+* [MXNet.js: Javascript Package for Deep Learning in Browser (without server)](https://github.com/dmlc/mxnet.js/)
+* [Guide to Creating New Operators (Layers)](https://mxnet.incubator.apache.org/api/faq/new_op)
 * [Go binding for inference](https://github.com/songtianyi/go-mxnet-predictor)
 * [Amalgamation and Go Binding for Predictors](https://github.com/jdeng/gomxnet/) - Outdated
 * [Large Scale Image Classification](https://github.com/apache/incubator-mxnet/tree/master/example/image-classification)
 
 Contents
 --------
-* [Documentation](https://mxnet.incubator.apache.org/) and  [Tutorials](https://mxnet.incubator.apache.org/tutorials/)
-* [Design Notes](https://mxnet.incubator.apache.org/architecture/index.html)
+* [Website](https://mxnet.incubator.apache.org)
+* [Documentation](https://mxnet.incubator.apache.org/api)
+* [Blog](https://mxnet.incubator.apache.org/blog)
 * [Code Examples](https://github.com/apache/incubator-mxnet/tree/master/example)
-* [Installation](https://mxnet.incubator.apache.org/install/index.html)
-* [Pretrained Models](http://mxnet.incubator.apache.org/api/python/gluon/model_zoo.html)
+* [Installation](https://mxnet.incubator.apache.org/get_started)
+* [Features](https://mxnet.incubator.apache.org/features)
+* [Ecosystem](https://mxnet.incubator.apache.org/ecosystem)
 
 Features
 --------
@@ -97,8 +94,8 @@ Features
 * Mix and match imperative and symbolic programming to maximize flexibility and efficiency
 * Lightweight, memory efficient and portable to smart devices
 * Scales up to multi GPUs and distributed setting with auto parallelism
-* Support for [Python](https://github.com/apache/incubator-mxnet/tree/master/python), [Scala](https://github.com/apache/incubator-mxnet/tree/master/scala-package), [C++](https://github.com/apache/incubator-mxnet/tree/master/cpp-package), [Java](https://github.com/apache/incubator-mxnet/tree/master/scala-package), [Clojure](https://github.com/apache/incubator-mxnet/tree/master/contrib/clojure-package), [R](https://github.com/apache/incubator-mxnet/tree/master/R-package), [Go](https://github.com/jdeng/gomxnet/), [Javascript](https://github.com/dmlc/mxnet.js/), [Perl](https://github.com/apache/incubator-mxnet/tree/master/perl-package), [Matlab](https://github.com/apache/incubator-mxnet/tree/master/matlab), and [Julia](https://github.com/apache/incubator-mxnet/tree/master/julia)
-* Cloud-friendly and directly compatible with S3, HDFS, and Azure
+* Support for [Python](https://mxnet.incubator.apache.org/api/python), [Scala](https://mxnet.incubator.apache.org/api/scala), [C++](https://mxnet.incubator.apache.org/api/cpp), [Java](https://mxnet.incubator.apache.org/api/java), [Clojure](https://mxnet.incubator.apache.org/api/clojure), [R](https://mxnet.incubator.apache.org/api/r), [Go](https://github.com/jdeng/gomxnet/), [Javascript](https://github.com/dmlc/mxnet.js/), [Perl](https://mxnet.incubator.apache.org/api/perl), [Matlab](https://github.com/apache/incubator-mxnet/tree/master/matlab), and [Julia](https://mxnet.incubator.apache.org/api/julia)
+* Cloud-friendly and directly compatible with AWS S3, AWS Deep Learning AMI, AWS SageMaker, HDFS, and Azure
 
 License
 -------

--- a/docs/static_site/src/_includes/get_started/get_started.html
+++ b/docs/static_site/src/_includes/get_started/get_started.html
@@ -256,8 +256,8 @@
             </div> <!-- END - C++-->
 
             <br>
-            For more installation options, refer to the <a href="ubuntu_setup.html">Ubuntu installation guide</a> and
-            <a href="centos_setup.html">CentOS installation guide</a>.
+            For more installation options, refer to the <a href="get_started/ubuntu_setup.html">Ubuntu installation guide</a> and
+            <a href="get_started/centos_setup.html">CentOS installation guide</a>.
         </div> <!-- END - Linux -->
 
 
@@ -354,7 +354,7 @@
                 </div> <!-- End of cpu gpu -->
             </div>
             <br>
-            For more installation options, refer to the <a href="osx_setup.html">MXNet macOS installation guide</a>.
+            For more installation options, refer to the <a href="get_started/osx_setup.html">MXNet macOS installation guide</a>.
         </div> <!-- END - Mac OS -->
 
 
@@ -440,7 +440,7 @@
                 </div> <!-- End of cpu gpu -->
             </div> <!-- End of C++ -->
 
-            For more installation options, refer to the <a href="windows_setup.html">MXNet Windows installation guide</a>.
+            For more installation options, refer to the <a href="get_started/windows_setup.html">MXNet Windows installation guide</a>.
         </div> <!-- End of Windows -->
 
 

--- a/docs/static_site/src/_includes/get_started/pip_snippet.md
+++ b/docs/static_site/src/_includes/get_started/pip_snippet.md
@@ -1,6 +1,6 @@
 MXNet offers MKL pip packages that will be much faster when running on Intel hardware.
 Check the chart below for other options, refer to <a href="https://pypi.org/project/mxnet/">PyPI for
-other MXNet pip packages</a>, or <a href="validate_mxnet.html">validate your MXNet installation</a>.
+other MXNet pip packages</a>, or <a href="get_started/validate_mxnet.html">validate your MXNet installation</a>.
 
 <div style="text-align: center">
     <img src="https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/install/pip-packages.png"

--- a/docs/static_site/src/pages/api/cpp/index.md
+++ b/docs/static_site/src/pages/api/cpp/index.md
@@ -40,9 +40,9 @@ The cpp-package directory contains the implementation of C++ API. As mentioned a
 	git clone --recursive https://github.com/apache/incubator-mxnet mxnet
 	```
 
-3.  Install the [prerequisites](<https://mxnet.incubator.apache.org/install/build_from_source#prerequisites>), desired [BLAS libraries](<https://mxnet.incubator.apache.org/install/build_from_source#blas-library>) and optional [OpenCV, CUDA, and cuDNN](<https://mxnet.incubator.apache.org/install/build_from_source#optional>) for building MXNet from source.
+3.  Install the [prerequisites](<https://mxnet.incubator.apache.org/get_started/build_from_source#prerequisites>), desired [BLAS libraries](<https://mxnet.incubator.apache.org/get_started/build_from_source#blas-library>) and optional [OpenCV, CUDA, and cuDNN](<https://mxnet.incubator.apache.org/get_started/build_from_source#optional>) for building MXNet from source.
 4.  There is a configuration file for make, [make/config.mk](<https://github.com/apache/incubator-mxnet/blob/master/make/config.mk>) that contains all the compilation options. You can edit this file and set the appropriate options prior to running the **make** command.
-5.  Please refer to  [platform specific build instructions](<https://mxnet.incubator.apache.org/install/build_from_source#build-instructions-by-operating-system>) and available [build configurations](https://mxnet.incubator.apache.org/install/build_from_source#build-configurations) for more details.
+5.  Please refer to  [platform specific build instructions](<https://mxnet.incubator.apache.org/get_started/build_from_source#build-instructions-by-operating-system>) and available [build configurations](https://mxnet.incubator.apache.org/get_started/build_from_source#build-configurations) for more details.
 5.  For enabling the build of C++ Package, set the **USE\_CPP\_PACKAGE = 1** in [make/config.mk](<https://github.com/apache/incubator-mxnet/blob/master/make/config.mk>). Optionally, the compilation flag can also be specified on **make** command line as follows.
 	```
 	make -j USE_CPP_PACKAGE=1

--- a/docs/static_site/src/pages/get_started/index.html
+++ b/docs/static_site/src/pages/get_started/index.html
@@ -28,6 +28,6 @@ permalink: /get_started/index.html
 <div class="get-started-from-source">
 <div class="wrapper">
     <h2>Download from source</h2>
-    <p>The signed source code for Apache MXNet (incubating) is available for download <a href="download">here</a></p>
+    <p>The signed source code for Apache MXNet (incubating) is available for download <a href="get_started/download">here</a></p>
 </div>
 </div>

--- a/docs/static_site/src/pages/get_started/windows_setup.md
+++ b/docs/static_site/src/pages/get_started/windows_setup.md
@@ -74,7 +74,7 @@ Install MXNet with CPU support with Python:
 pip install mxnet
 ```
 
-Now [validate your MXNet installation with Python](validate_mxnet).
+Now [validate your MXNet installation with Python](get_started/validate_mxnet).
 
 ### Install with Intel CPUs
 


### PR DESCRIPTION
## Description ##
Fixes #16240 

@ThomasDelteil there's some issue with the includes... I've had to put in `getting_started` in front of a bunch of references to installation docs. Hopefully this fixes things, but let me know if there's something else that should be done to make sure the links resolve.

Preview:
http://54.211.76.74/get_started
