### PR TITLE
[MXNET-1431] Multiple channel support in Gluon PReLU

### DIFF
--- a/python/mxnet/gluon/nn/activations.py
+++ b/python/mxnet/gluon/nn/activations.py
@@ -120,7 +120,7 @@ class PReLU(HybridBlock):
     ----------
     alpha_initializer : Initializer
         Initializer for the `embeddings` matrix.
-    in_channels : int
+    in_channels : int, default 1
         Number of channels (alpha parameters) to learn. Can either be 1
         or `n` where `n` is the size of the second dimension of the input
         tensor.

--- a/python/mxnet/gluon/nn/activations.py
+++ b/python/mxnet/gluon/nn/activations.py
@@ -120,7 +120,10 @@ class PReLU(HybridBlock):
     ----------
     alpha_initializer : Initializer
         Initializer for the `embeddings` matrix.
-
+    in_channels : int
+        Number of channels (alpha parameters) to learn. Can either be 1
+        or `n` where `n` is the size of the second dimension of the input
+        tensor.
 
     Inputs:
         - **data**: input tensor with arbitrary shape.
@@ -128,10 +131,12 @@ class PReLU(HybridBlock):
     Outputs:
         - **out**: output tensor with the same shape as `data`.
     """
-    def __init__(self, alpha_initializer=initializer.Constant(0.25), **kwargs):
+    def __init__(self, alpha_initializer=initializer.Constant(0.25),
+                 in_channels=1, **kwargs):
         super(PReLU, self).__init__(**kwargs)
         with self.name_scope():
-            self.alpha = self.params.get('alpha', shape=(1,), init=alpha_initializer)
+            self.alpha = self.params.get('alpha', shape=(in_channels,),
+                                         init=alpha_initializer)
 
     def hybrid_forward(self, F, x, alpha):
         return F.LeakyReLU(x, gamma=alpha, act_type='prelu', name='fwd')

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1240,6 +1240,11 @@ def test_activations():
     x = point_to_validate.reshape((1, 3, 2))
     assert_almost_equal(prelu(x).asnumpy(), mx.nd.where(x >= 0, x, 0.25 * x).asnumpy())
 
+    multichannel_init = mx.initializer.Constant(mx.nd.array([0.1, 0.25, 0.5]))
+    prelu_multichannel = mx.gluon.nn.PReLU(alpha_initializer=multichannel_init, in_channels=3)
+    prelu_multichannel.initialize()
+    assert_almost_equal(prelu_multichannel(x).asnumpy(), np.array([[-0.01, 0.1], [-0.025, 0.1], [-0.05, 0.1]]))
+
     gelu = mx.gluon.nn.GELU()
     def gelu_test(x):
         CUBE_CONSTANT = 0.044715


### PR DESCRIPTION
## Description ##
Add support for multiple parameters in Gluon PReLU block.

This was already proposed in https://github.com/apache/incubator-mxnet/issues/10972 to resolve performance issues. I think this change is helpful for usability.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Adding `in_channels` input to `PReLU`

