### PR TITLE
Minor fix in ToTensor documentation.

### DIFF
--- a/python/mxnet/gluon/data/vision/transforms.py
+++ b/python/mxnet/gluon/data/vision/transforms.py
@@ -112,7 +112,7 @@ class ToTensor(HybridBlock):
         - **data**: input tensor with (H x W x C) or (N x H x W x C) shape and uint8 type.
 
     Outputs:
-        - **out**: output tensor with (C x H x W) or (N x H x W x C) shape and float32 type.
+        - **out**: output tensor with (C x H x W) or (N x C x H x W) shape and float32 type.
 
     Examples
     --------


### PR DESCRIPTION
## Description ##

Fix minor typo, the output shape should read (N x C x H x W), not (N x H x W x C).

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

