### PR TITLE
Fix inconsistent interpolation method values

### DIFF
--- a/python/mxnet/image/detection.py
+++ b/python/mxnet/image/detection.py
@@ -522,11 +522,11 @@ def CreateDetAugmenter(data_shape, resize=0, rand_crop=0, rand_pad=0, rand_gray=
         Possible values:
         0: Nearest Neighbors Interpolation.
         1: Bilinear interpolation.
-        2: Area-based (resampling using pixel area relation). It may be a
+        2: Bicubic interpolation over 4x4 pixel neighborhood.
+        3: Area-based (resampling using pixel area relation). It may be a
         preferred method for image decimation, as it gives moire-free
         results. But when the image is zoomed, it is similar to the Nearest
         Neighbors method. (used by default).
-        3: Bicubic interpolation over 4x4 pixel neighborhood.
         4: Lanczos interpolation over 8x8 pixel neighborhood.
         9: Cubic for enlarge, area for shrink, bilinear for others
         10: Random select from interpolation method metioned above.


### PR DESCRIPTION
Documentation of `CreateDetAugmenter`s inter_method doesn't match the one of cv2.
This has already been fixed in image.py, see the relevant PR here: https://github.com/apache/incubator-mxnet/pull/16212
