### PR TITLE
Julia: add API docs back

### DIFF
--- a/julia/docs/src/api/ndarray.md
+++ b/julia/docs/src/api/ndarray.md
@@ -70,5 +70,21 @@ In the following example `y` can be a `Real` value or another `NDArray`
 
 ```@autodocs
 Modules = [MXNet.mx]
-Pages = ["ndarray.jl"]
+Pages = [
+  "ndarray.jl",
+  "ndarray/activation.jl",
+  "ndarray/arithmetic.jl",
+  "ndarray/array.jl",
+  "ndarray/autoimport.jl",
+  "ndarray/comparison.jl",
+  "ndarray/context.jl",
+  "ndarray/io.jl",
+  "ndarray/linalg.jl",
+  "ndarray/reduction.jl",
+  "ndarray/remap.jl",
+  "ndarray/show.jl",
+  "ndarray/statistic.jl",
+  "ndarray/trig.jl",
+  "ndarray/type.jl",
+]
 ```

--- a/julia/docs/src/api/symbolic-node.md
+++ b/julia/docs/src/api/symbolic-node.md
@@ -19,5 +19,14 @@
 
 ```@autodocs
 Modules = [MXNet.mx]
-Pages = ["symbolic-node.jl"]
+Pages = [
+  "symbolic-node.jl",
+  "symbolic-node/arithmetic.jl",
+  "symbolic-node/array.jl",
+  "symbolic-node/autodiff.jl",
+  "symbolic-node/io.jl",
+  "symbolic-node/op.jl",
+  "symbolic-node/show.jl",
+  "symbolic-node/type.jl",
+]
 ```


### PR DESCRIPTION
## Description ##
`ndarray` and `symbolic-node` have been refactored by splitting into a
few files in commits ed8307121 and 36a3cb828, but the corresponding
document setting for MXNet.jl is not updated yet.

List all split source files into the `at_autodoc` setting.

Also refer to the `at_autodoc` setting in `julia/docs/src/api/optimizer.md`

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)

### Changes ###
- [x] Julia docs

## Comments ##
- has been backported by @iblis17 in PR 16348