### PR TITLE
Remove redundant branch name

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -135,7 +135,7 @@ def collect_test_results_unix(original_file_name, new_file_name) {
         sh 'cp ' + original_file_name + ' ' + new_file_name
         archiveArtifacts artifacts: new_file_name
         try {
-          s3Upload(file:new_file_name, bucket:env.MXNET_CI_UNITTEST_ARTIFACT_BUCKET, path:env.JOB_NAME+"/"+env.BRANCH_NAME+"/"+env.BUILD_NUMBER+"/"+new_file_name)
+          s3Upload(file:new_file_name, bucket:env.MXNET_CI_UNITTEST_ARTIFACT_BUCKET, path:env.JOB_NAME+"/"+env.BUILD_NUMBER+"/"+new_file_name)
         } catch (Exception e) {
           echo "S3 Upload failed ${e}"
           throw new Exception("S3 upload failed", e)
@@ -150,7 +150,7 @@ def collect_test_results_windows(original_file_name, new_file_name) {
         bat 'xcopy ' + original_file_name + ' ' + new_file_name + '*'
         archiveArtifacts artifacts: new_file_name
         try {
-          s3Upload(file:new_file_name, bucket:env.MXNET_CI_UNITTEST_ARTIFACT_BUCKET, path:env.JOB_NAME+"/"+env.BRANCH_NAME+"/"+env.BUILD_NUMBER+"/"+new_file_name)
+          s3Upload(file:new_file_name, bucket:env.MXNET_CI_UNITTEST_ARTIFACT_BUCKET, path:env.JOB_NAME+"/"+env.BUILD_NUMBER+"/"+new_file_name)
         } catch (Exception e) {
           echo "S3 Upload failed ${e}"
           throw new Exception("S3 upload failed", e)


### PR DESCRIPTION
## Description ##
Previous PR #16336 unnecessarily added branch-name to the job-name resulting in
mxnet-validation/unix-cpu/master/master/build

Job-name consists of branch itself - hence not needed to add branch name.
Fixing it here.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Remove branch name
