### PR TITLE
[DOC] Change mailing list url in footer to point to instructions about how to subscribe

### DIFF
--- a/docs/static_site/src/_includes/footer.html
+++ b/docs/static_site/src/_includes/footer.html
@@ -4,8 +4,7 @@
             <div class="col-4">
                 <h4 class="footer-category-title">Resources</h4>
                 <ul class="contact-list">
-                    <li><a class="u-email" href="mailto:dev@mxnet.apache.org">Dev list</a></li>
-                    <li><a class="u-email" href="mailto:user@mxnet.apache.org">User mailing list</a></li>
+                    <li><a href="{{'community/contribute#mxnet-dev-communications'|relative_url}}">Mailing lists</a></li>
                     <li><a href="https://cwiki.apache.org/confluence/display/MXNET/Apache+MXNet+Home">Developer Wiki</a></li>
                     <li><a href="https://issues.apache.org/jira/projects/MXNET/issues">Jira Tracker</a></li>
                     <li><a href="https://github.com/apache/incubator-mxnet/labels/Roadmap">Github Roadmap</a></li>


### PR DESCRIPTION
If users just send an email to the email list without being subscribed, it will just be swallowed.