### PR TITLE
fixed gradient computation of activation softrelu

### DIFF
--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -167,7 +167,7 @@ struct softrelu : public mxnet_op::tunable {
   }
 };
 
-MXNET_UNARY_MATH_OP(softrelu_grad, -math::expm1(-a));
+MXNET_UNARY_MATH_OP(softrelu_grad, 1.0 / (1.0 + math::exp(-a)));
 
 MXNET_UNARY_MATH_OP(erfinv_grad, 0.5 * math::sqrt(PI) * math::exp(math::sqr(erfinv::Map(a))));
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8255,7 +8255,6 @@ def test_op_all_names_monitor():
         del os.environ['MXNET_SUBGRAPH_BACKEND']
 
 @with_seed()
-@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/13915")
 def test_activation():
     shapes = [(9,), (9, 10), (9, 10, 10), (1, 9, 10, 10)]
     dtype_l = [np.float64, np.float32, np.float16]


### PR DESCRIPTION
## Description ##
The code for the gradient of the activation of type "softrelu" is wrong. This most likely lead to the flaky tests referenced in #13915 which failed exactly in the gradient checking. Unfortunately these tests where then simply disabled by PR 14969 instead of root causing it. This fix adds correct gradient computation and re-enables the tests.

## Checklist ##
### Essentials ###
- [X ] Changes are complete (i.e. I finished coding on this PR)
- [X ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
