### PR TITLE
[DOC] fix autodoc for spurrious toggles

### DIFF
--- a/docs/python_docs/_static/autodoc.js
+++ b/docs/python_docs/_static/autodoc.js
@@ -20,30 +20,32 @@
 /* Customizations to the Sphinx auto module plugin output */
 function auto_index() {
     var targets = $("dl.class>dt,dl.function>dt");
-
     var li_node = $("li.current>span>a.current.reference.internal").parent().parent();
     var html = "<ul id='autodoc'>";
     if (li_node.length > 0) {
-        for (var i = 0; i < targets.length; ++i) {
-            var id = $(targets[i]).attr('id');
-            if (id) {
-                var paths = id.split('.')
-                if (paths.length >= 2) {
-                    var id_simple = paths.pop();
-                    id_simple = paths.pop() + "." + id_simple;
-                } else {
-                    var id_simple = id;
+        if (targets.length > 0) {
+            for (var i = 0; i < targets.length; ++i) {
+                var id = $(targets[i]).attr('id');
+                if (id) {
+                    var paths = id.split('.')
+                    if (paths.length >= 2) {
+                        var id_simple = paths.pop();
+                        id_simple = paths.pop() + "." + id_simple;
+                    } else {
+                        var id_simple = id;
+                    }
+                    html += "<li><span class='link-wrapper'><a class='reference internal' href='#";
+                    html += id;
+                    html += "'>" + id_simple + "</a></span</li>";
                 }
-                html += "<li><span class='link-wrapper'><a class='reference internal' href='#";
-                html += id;
-                html += "'>" + id_simple + "</a></span</li>";
             }
+            html += "</ul>";
+            li_node.append(html);
+            li_node.prepend("<a><span id='autodoc_toggle' onclick='$(\"#autodoc\").toggle()'>[toggle]</span></a>")
         }
-        html += "</ul>";
-        li_node.append(html);
-        li_node.prepend("<a><span id='autodoc_toggle' onclick='$(\"#autodoc\").toggle()'>[toggle]</span></a>")
     } else {
         setTimeout(auto_index, 500);
     }
+
 }
 $(document).ready(auto_index);


### PR DESCRIPTION
Right now toggles appears everywhere, it should only appear in sections that have classes and functions. This does that.

Can be tested for a while here: http://54.211.76.74/api/python/docs/api/gluon/index.html

@sojiadeshina @aaronmarkham 