### PR TITLE
Move mrcnn_mask_target op to contrib

### DIFF
--- a/src/operator/contrib/mrcnn_mask_target-inl.h
+++ b/src/operator/contrib/mrcnn_mask_target-inl.h
@@ -19,14 +19,14 @@
 
 /*!
  *  Copyright (c) 2019 by Contributors
- * \file mrcnn_target-inl.h
+ * \file mrcnn_mask_target-inl.h
  * \brief Mask-RCNN target generator
  * \author Serge Panev
  */
 
 
-#ifndef MXNET_OPERATOR_CONTRIB_MRCNN_TARGET_INL_H_
-#define MXNET_OPERATOR_CONTRIB_MRCNN_TARGET_INL_H_
+#ifndef MXNET_OPERATOR_CONTRIB_MRCNN_MASK_TARGET_INL_H_
+#define MXNET_OPERATOR_CONTRIB_MRCNN_MASK_TARGET_INL_H_
 
 #include <mxnet/operator.h>
 #include <vector>
@@ -42,13 +42,13 @@ namespace mrcnn_index {
   enum ROIAlignOpOutputs {kMask, kMaskClasses};
 }  // namespace mrcnn_index
 
-struct MRCNNTargetParam : public dmlc::Parameter<MRCNNTargetParam> {
+struct MRCNNMaskTargetParam : public dmlc::Parameter<MRCNNMaskTargetParam> {
   int num_rois;
   int num_classes;
   int mask_size;
   int sample_ratio;
 
-  DMLC_DECLARE_PARAMETER(MRCNNTargetParam) {
+  DMLC_DECLARE_PARAMETER(MRCNNMaskTargetParam) {
     DMLC_DECLARE_FIELD(num_rois)
     .describe("Number of sampled RoIs.");
     DMLC_DECLARE_FIELD(num_classes)
@@ -60,11 +60,11 @@ struct MRCNNTargetParam : public dmlc::Parameter<MRCNNTargetParam> {
   }
 };
 
-inline bool MRCNNTargetShape(const NodeAttrs& attrs,
-                            std::vector<mxnet::TShape>* in_shape,
-                            std::vector<mxnet::TShape>* out_shape) {
+inline bool MRCNNMaskTargetShape(const NodeAttrs& attrs,
+                                 std::vector<mxnet::TShape>* in_shape,
+                                 std::vector<mxnet::TShape>* out_shape) {
   using namespace mshadow;
-  const MRCNNTargetParam& param = nnvm::get<MRCNNTargetParam>(attrs.parsed);
+  const MRCNNMaskTargetParam& param = nnvm::get<MRCNNMaskTargetParam>(attrs.parsed);
 
   CHECK_EQ(in_shape->size(), 4) << "Input:[rois, gt_masks, matches, cls_targets]";
 
@@ -98,9 +98,9 @@ inline bool MRCNNTargetShape(const NodeAttrs& attrs,
   return true;
 }
 
-inline bool MRCNNTargetType(const NodeAttrs& attrs,
-                           std::vector<int>* in_type,
-                           std::vector<int>* out_type) {
+inline bool MRCNNMaskTargetType(const NodeAttrs& attrs,
+                                std::vector<int>* in_type,
+                                std::vector<int>* out_type) {
   CHECK_EQ(in_type->size(), 4);
   int dtype = (*in_type)[1];
   CHECK_NE(dtype, -1) << "Input must have specified type";
@@ -112,21 +112,21 @@ inline bool MRCNNTargetType(const NodeAttrs& attrs,
 }
 
 template<typename xpu>
-void MRCNNTargetRun(const MRCNNTargetParam& param, const std::vector<TBlob> &inputs,
-                    const std::vector<TBlob> &outputs, mshadow::Stream<xpu> *s);
+void MRCNNMaskTargetRun(const MRCNNMaskTargetParam& param, const std::vector<TBlob> &inputs,
+                        const std::vector<TBlob> &outputs, mshadow::Stream<xpu> *s);
 
 template<typename xpu>
-void MRCNNTargetCompute(const nnvm::NodeAttrs& attrs,
-                const OpContext &ctx,
-                const std::vector<TBlob> &inputs,
-                const std::vector<OpReqType> &req,
-                const std::vector<TBlob> &outputs) {
+void MRCNNMaskTargetCompute(const nnvm::NodeAttrs& attrs,
+                            const OpContext &ctx,
+                            const std::vector<TBlob> &inputs,
+                            const std::vector<OpReqType> &req,
+                            const std::vector<TBlob> &outputs) {
   auto s = ctx.get_stream<xpu>();
-  const auto& p = dmlc::get<MRCNNTargetParam>(attrs.parsed);
-  MRCNNTargetRun<xpu>(p, inputs, outputs, s);
+  const auto& p = dmlc::get<MRCNNMaskTargetParam>(attrs.parsed);
+  MRCNNMaskTargetRun<xpu>(p, inputs, outputs, s);
 }
 
 }  // namespace op
 }  // namespace mxnet
 
-#endif  // MXNET_OPERATOR_CONTRIB_MRCNN_TARGET_INL_H_
+#endif  // MXNET_OPERATOR_CONTRIB_MRCNN_MASK_TARGET_INL_H_

--- a/tests/python/unittest/test_contrib_operator.py
+++ b/tests/python/unittest/test_contrib_operator.py
@@ -23,6 +23,7 @@ import random
 import itertools
 from numpy.testing import assert_allclose, assert_array_equal
 from mxnet.test_utils import *
+from common import with_seed
 import unittest
 
 def test_box_nms_op():
@@ -350,6 +351,63 @@ def test_box_decode_op():
     Y = mx.nd.contrib.box_decode(data, anchors, .1, .1, .2, .2)
     assert_allclose(Y.asnumpy(), np.array([[[-0.0562755, -0.00865743, 0.26227552, 0.42465743], \
         [0.13240421, 0.17859563, 0.93759584, 1.1174043 ]]]), atol=1e-5, rtol=1e-5)
+
+@with_seed()
+def test_op_mrcnn_mask_target():
+    if default_context().device_type != 'gpu':
+        return
+
+    num_rois = 2
+    num_classes = 4
+    mask_size = 3
+    ctx = mx.gpu(0)
+    # (B, N, 4)
+    rois = mx.nd.array([[[2.3, 4.3, 2.2, 3.3],
+                        [3.5, 5.5, 0.9, 2.4]]], ctx=ctx)
+    gt_masks = mx.nd.arange(0, 4*32*32, ctx=ctx).reshape(1, 4, 32, 32)
+
+    # (B, N)
+    matches = mx.nd.array([[2, 0]], ctx=ctx)
+    # (B, N)
+    cls_targets = mx.nd.array([[2, 1]], ctx=ctx)
+
+    mask_targets, mask_cls = mx.nd.contrib.mrcnn_mask_target(rois, gt_masks, matches, cls_targets,
+                                                             num_rois=num_rois,
+                                                             num_classes=num_classes,
+                                                             mask_size=mask_size)
+
+    # Ground truth outputs were generated with GluonCV's target generator
+    # gluoncv.model_zoo.mask_rcnn.MaskTargetGenerator(1, num_rois, num_classes, mask_size)
+    gt_mask_targets = mx.nd.array([[[[[2193.4    , 2193.7332 , 2194.0667 ],
+                                      [2204.0667 , 2204.4    , 2204.7334 ],
+                                      [2214.7334 , 2215.0667 , 2215.4    ]],
+                                     [[2193.4    , 2193.7332 , 2194.0667 ],
+                                      [2204.0667 , 2204.4    , 2204.7334 ],
+                                      [2214.7334 , 2215.0667 , 2215.4    ]],
+                                     [[2193.4    , 2193.7332 , 2194.0667 ],
+                                      [2204.0667 , 2204.4    , 2204.7334 ],
+                                      [2214.7334 , 2215.0667 , 2215.4    ]],
+                                     [[2193.4    , 2193.7332 , 2194.0667 ],
+                                      [2204.0667 , 2204.4    , 2204.7334 ],
+                                      [2214.7334 , 2215.0667 , 2215.4    ]]],
+                                    [[[ 185.     ,  185.33334,  185.66667],
+                                      [ 195.66667,  196.00002,  196.33334],
+                                      [ 206.33333,  206.66666,  207.     ]],
+                                     [[ 185.     ,  185.33334,  185.66667],
+                                      [ 195.66667,  196.00002,  196.33334],
+                                      [ 206.33333,  206.66666,  207.     ]],
+                                     [[ 185.     ,  185.33334,  185.66667],
+                                      [ 195.66667,  196.00002,  196.33334],
+                                      [ 206.33333,  206.66666,  207.     ]],
+                                     [[ 185.     ,  185.33334,  185.66667],
+                                      [ 195.66667,  196.00002,  196.33334],
+                                      [  206.33333,  206.66666,  207.     ]]]]])
+
+    gt_mask_cls = mx.nd.array([[0,0,1,0], [0,1,0,0]])
+    gt_mask_cls = gt_mask_cls.reshape(1,2,4,1,1).broadcast_axes(axis=(3,4), size=(3,3))
+
+    assert_almost_equal(mask_targets.asnumpy(), gt_mask_targets.asnumpy())
+    assert_almost_equal(mask_cls.asnumpy(), gt_mask_cls.asnumpy())
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -8687,63 +8687,6 @@ def test_op_rroi_align():
     test_rroi_align_value(sampling_ratio=2)
 
 @with_seed()
-def test_op_mrcnn_target():
-    if default_context().device_type != 'gpu':
-        return
-
-    num_rois = 2
-    num_classes = 4
-    mask_size = 3
-    ctx = mx.gpu(0)
-    # (B, N, 4)
-    rois = mx.nd.array([[[2.3, 4.3, 2.2, 3.3],
-                        [3.5, 5.5, 0.9, 2.4]]], ctx=ctx)
-    gt_masks = mx.nd.arange(0, 4*32*32, ctx=ctx).reshape(1, 4, 32, 32)
-
-    # (B, N)
-    matches = mx.nd.array([[2, 0]], ctx=ctx)
-    # (B, N)
-    cls_targets = mx.nd.array([[2, 1]], ctx=ctx)
-
-    mask_targets, mask_cls = mx.nd.mrcnn_target(rois, gt_masks, matches, cls_targets,
-                                                num_rois=num_rois,
-                                                num_classes=num_classes,
-                                                mask_size=mask_size)
-
-    # Ground truth outputs were generated with GluonCV's target generator
-    # gluoncv.model_zoo.mask_rcnn.MaskTargetGenerator(1, num_rois, num_classes, mask_size)
-    gt_mask_targets = mx.nd.array([[[[[2193.4    , 2193.7332 , 2194.0667 ],
-                                      [2204.0667 , 2204.4    , 2204.7334 ],
-                                      [2214.7334 , 2215.0667 , 2215.4    ]],
-                                     [[2193.4    , 2193.7332 , 2194.0667 ],
-                                      [2204.0667 , 2204.4    , 2204.7334 ],
-                                      [2214.7334 , 2215.0667 , 2215.4    ]],
-                                     [[2193.4    , 2193.7332 , 2194.0667 ],
-                                      [2204.0667 , 2204.4    , 2204.7334 ],
-                                      [2214.7334 , 2215.0667 , 2215.4    ]],
-                                     [[2193.4    , 2193.7332 , 2194.0667 ],
-                                      [2204.0667 , 2204.4    , 2204.7334 ],
-                                      [2214.7334 , 2215.0667 , 2215.4    ]]],
-                                    [[[ 185.     ,  185.33334,  185.66667],
-                                      [ 195.66667,  196.00002,  196.33334],
-                                      [ 206.33333,  206.66666,  207.     ]],
-                                     [[ 185.     ,  185.33334,  185.66667],
-                                      [ 195.66667,  196.00002,  196.33334],
-                                      [ 206.33333,  206.66666,  207.     ]],
-                                     [[ 185.     ,  185.33334,  185.66667],
-                                      [ 195.66667,  196.00002,  196.33334],
-                                      [ 206.33333,  206.66666,  207.     ]],
-                                     [[ 185.     ,  185.33334,  185.66667],
-                                      [ 195.66667,  196.00002,  196.33334],
-                                      [  206.33333,  206.66666,  207.     ]]]]])
-
-    gt_mask_cls = mx.nd.array([[0,0,1,0], [0,1,0,0]])
-    gt_mask_cls = gt_mask_cls.reshape(1,2,4,1,1).broadcast_axes(axis=(3,4), size=(3,3))
-
-    assert_almost_equal(mask_targets.asnumpy(), gt_mask_targets.asnumpy())
-    assert_almost_equal(mask_cls.asnumpy(), gt_mask_cls.asnumpy())
-
-@with_seed()
 def test_diag():
 
     # Test 2d input


### PR DESCRIPTION
## Description ##
- Rename mrcnn_target op to mrcnn_mask_target and move to contrib.
- Move the test to `test_contrib_operator.py`.
## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

@zhreshold @Jerryzcn 