### PR TITLE
Fix learning rate scheduler being unexpectedly overwritten by optimizer's default value

### DIFF
--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -103,8 +103,6 @@ class Optimizer(object):
         self.rescale_grad = rescale_grad
         self.lr = learning_rate
         self.lr_scheduler = lr_scheduler
-        if lr_scheduler is not None:
-            self.lr_scheduler.base_lr = learning_rate
 
         self.wd = wd
         self.lr_mult = {}

--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -66,7 +66,8 @@ class Optimizer(object):
     learning_rate : float, optional, default None
         The initial learning rate. If None, the optimization will use the
         learning rate from ``lr_scheduler``. If not None, it will overwrite
-        the learning rate in ``lr_scheduler``.
+        the learning rate in ``lr_scheduler``. If None and ``lr_scheduler``
+        is also None, then it will be set to 0.01 by default.
 
     lr_scheduler : LRScheduler, optional, default None
         The learning rate scheduler.

--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -109,8 +109,8 @@ class Optimizer(object):
         self.lr = learning_rate
         if self.lr_scheduler is not None and learning_rate is not None:
             if self.lr_scheduler.base_lr != learning_rate:
-                raise UserWarning("learning rate from ``lr_scheduler`` has been
-                                   overwritten by ``learning_rate`` in optimizer.")
+                raise UserWarning("learning rate from ``lr_scheduler`` has been "
+                                   "overwritten by ``learning_rate`` in optimizer.")
                 self.lr_scheduler.base_lr = learning_rate
 
         self.wd = wd

--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -109,8 +109,8 @@ class Optimizer(object):
         self.lr = learning_rate
         if self.lr_scheduler is not None and learning_rate is not None:
             if self.lr_scheduler.base_lr != learning_rate:
-                raise UserWarning("learning rate from ``lr_scheduler`` has been "
-                                   "overwritten by ``learning_rate`` in optimizer.")
+                print(UserWarning("learning rate from ``lr_scheduler`` has been "
+                                  "overwritten by ``learning_rate`` in optimizer."))
                 self.lr_scheduler.base_lr = learning_rate
 
         self.wd = wd

--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -63,8 +63,10 @@ class Optimizer(object):
     clip_gradient : float, optional, default None
         Clip the gradient by projecting onto the box ``[-clip_gradient, clip_gradient]``.
 
-    learning_rate : float, optional, default 0.01
-        The initial learning rate.
+    learning_rate : float, optional, default None
+        The initial learning rate. If None, the optimization will use the
+        learning rate from ``lr_scheduler``. If not None, it will overwrite
+        the learning rate in ``lr_scheduler``.
 
     lr_scheduler : LRScheduler, optional, default None
         The learning rate scheduler.
@@ -97,12 +99,19 @@ class Optimizer(object):
         optimizer, its learning rate can be accessed as optimizer.learning_rate.
     """
     def __init__(self, rescale_grad=1., param_idx2name=None, wd=0.,
-                 clip_gradient=None, learning_rate=0.01,
+                 clip_gradient=None, learning_rate=None,
                  lr_scheduler=None, sym=None, begin_num_update=0,
                  multi_precision=False, param_dict=None):
         self.rescale_grad = rescale_grad
-        self.lr = learning_rate
         self.lr_scheduler = lr_scheduler
+        if self.lr_scheduler is None and learning_rate is None:
+            learning_rate = 0.01
+        self.lr = learning_rate
+        if self.lr_scheduler is not None and learning_rate is not None:
+            if self.lr_scheduler.base_lr != learning_rate:
+                raise UserWarning("learning rate from ``lr_scheduler`` has been
+                                   overwritten by ``learning_rate`` in optimizer.")
+                self.lr_scheduler.base_lr = learning_rate
 
         self.wd = wd
         self.lr_mult = {}

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -39,7 +39,7 @@ def test_learning_rate():
     o2.lr_scheduler.base_lr = 0.4
     assert o2.learning_rate == 0.4
 
-    lr_s = lr_scheduler.FactorScheduler(base_lr=1024)
+    lr_s = lr_scheduler.FactorScheduler(step=1, base_lr=1024)
     o3 = mx.optimizer.Optimizer(lr_scheduler=lr_s)
     assert o3.learning_rate == 1024
 

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -39,6 +39,10 @@ def test_learning_rate():
     o2.lr_scheduler.base_lr = 0.4
     assert o2.learning_rate == 0.4
 
+    lr_s = lr_scheduler.FactorScheduler(base_lr=1024)
+    o3 = mx.optimizer.Optimizer(lr_scheduler=lr_s)
+    assert o3.learning_rate == 1024
+
 
 @raises(UserWarning)
 @with_seed()


### PR DESCRIPTION
## Description ##

Right now the following example (similar as from https://github.com/dmlc/gluon-cv/issues/750) yields surprising and unexpected output:

```python
import mxnet as mx 
lr_scheduler = mx.lr_scheduler.FactorScheduler(1000, base_lr=10) 
optim = mx.optimizer.create('sgd', lr_scheduler=lr_scheduler)

print(optim.learning_rate) # 0.01
```

In the current implementation of optimizer, mxnet overwrite the learning rate scheduler's learning rate with the optimizer's learning rate by 

```python
if lr_scheduler is not None:	
    self.lr_scheduler.base_lr = learning_rate
```

Therefore, when users define a learning rate scheduler, and use it as the parameter of the optimizer, they are going to surprisingly find that the learning rate has been overwritten by the default value, `0.01`.

My patch set default `learning_rate` to `None`, and assign the original `0.01` to it only in the absence of `lr_scheduler`. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

