### PR TITLE
Numpy custom array interface

### DIFF
--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -192,6 +192,9 @@ class ndarray(NDArray):
         return mx_np_func(*args, **kwargs)
 
     def __array__(self, dtype=None):
+        """
+        Interface to make DeepNumPy compatible to some libraries that use official NumPy.
+        """
         if dtype is None or self.dtype == dtype:
             return self
         else:
@@ -199,6 +202,11 @@ class ndarray(NDArray):
 
     @property
     def __array_interface__(self):
+        """
+        Interface to have another way to convert DeepNumPy ndarray to official NumPy ndarray.
+
+        It makes that `arr.asnumpy()` equals to `onp.array(arr)`.
+        """
         return self.asnumpy().__array_interface__
 
     def _get_np_basic_indexing(self, key):

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -1797,54 +1797,6 @@ def array(object, dtype=None, copy=True, order='C', ctx=None, **kwargs):
 
 @set_module('mxnet.numpy')
 def asarray(a, dtype=None, order='C'):
-    """Convert the input to an ndarray, but pass ndarray subclasses through.
-
-    Parameters
-    ----------
-    a : array_like
-        Input data, in any form that can be converted to an array.  This
-        includes scalars, lists, lists of tuples, tuples, tuples of tuples,
-        tuples of lists, and ndarrays.
-    dtype : data-type, optional
-        By default, the data-type is inferred from the input data.
-    order : {'C', 'F'}, optional
-        Whether to use row-major (C-style) or column-major
-        (Fortran-style) memory representation.  Defaults to 'C'.
-
-    Returns
-    -------
-    out : ndarray or an ndarray subclass
-        Array interpretation of `a`.  If `a` is an ndarray or a subclass
-        of ndarray, it is returned as-is and no copy is performed.
-
-    See Also
-    --------
-    asarray : Similar function which always returns ndarrays.
-    ascontiguousarray : Convert input to a contiguous array.
-    asfarray : Convert input to a floating point ndarray.
-    asfortranarray : Convert input to an ndarray with column-major
-                     memory order.
-    asarray_chkfinite : Similar function which checks input for NaNs and
-                        Infs.
-    fromiter : Create an array from an iterator.
-    fromfunction : Construct an array by executing a function on grid
-                   positions.
-
-    Examples
-    --------
-    Convert a list into an array:
-
-    >>> a = [1, 2]
-    >>> np.asanyarray(a)
-    array([1, 2])
-
-    Instances of `ndarray` subclasses are passed through as-is:
-
-    >>> a = np.array([(1.0, 2), (3.0, 4)], dtype='f4,i4').view(np.recarray)
-    >>> np.asanyarray(a) is a
-    True
-
-    """
     if order != 'C':
         raise NotImplementedError('`asarray` only supports order equal to `C`, while received {}'
                                   .format(str(order)))

--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -94,11 +94,11 @@ def test_np_array_creation():
         for src in objects:
             mx_arr = np.array(src, dtype=dtype)
             assert mx_arr.ctx == mx.current_context()
-            if isinstance(src, mx.nd.NDArray):
-                np_arr = _np.array(src.asnumpy(), dtype=dtype if dtype is not None else _np.float32)
+            np_arr = _np.array(src, dtype=dtype)
+            if dtype is None and not isinstance(src, _np.ndarray):
+                assert mx_arr.dtype == np.float32
             else:
-                np_arr = _np.array(src, dtype=dtype if dtype is not None else _np.float32)
-            assert mx_arr.dtype == np_arr.dtype
+                assert mx_arr.dtype == np_arr.dtype
             assert same(mx_arr.asnumpy(), np_arr)
 
 

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -2322,7 +2322,7 @@ def test_np_choice():
             if hybridize:
                 test_choice.hybridize()
                 test_choice_weighted.hybridize()
-            weight = np.array(_np.random.dirichlet([1.0] * num_classes))
+            weight = np.array(_np.random.dirichlet([1.0] * num_classes), dtype=np.float32)
             test_indexing_mode(test_choice, num_classes, num_classes // 2, replace, None)
             test_indexing_mode(test_choice_weighted, num_classes, num_classes // 2, replace, weight)
 


### PR DESCRIPTION
- Add more arguments to `np.array`
- Add function `np.asarray`
- Change the behavior of `np.array`, now if input is a numpy ndarray and `dtype` is `None`, the output has the same `dtype` as input.
- Add `__array__` and `__array_interface__`, it makes that `arr.asnumpy()` equals to `onp.array(arr)`