### PR TITLE
Tests of interoperability of numpy dispatch

### DIFF
--- a/python/mxnet/numpy_dispatch_protocol.py
+++ b/python/mxnet/numpy_dispatch_protocol.py
@@ -118,6 +118,9 @@ _NUMPY_ARRAY_FUNCTION_LIST = [
     'unique',
     'var',
     'zeros_like',
+    'linalg.norm',
+    'trace',
+    'tril',
     'meshgrid',
     'outer',
     'einsum'


### PR DESCRIPTION
## Description ##
Tests of interoperability of numpy dispatch, this PR covers these OPs:
- concatenate
- copy
- expand_dims
- expm1
- norm
- svd
- split
- squeeze
- std
- swapaxes
- tensorfot
- tile
- trace
- transpose
- tril
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
Known common issues:
- data type coverage
- some module (like masked array, np.matrix, etc) not supported
- python native scalar and list objects are not dispatchable

@reminisce Thanks for your effort to review the test codes, please feedback me any problems.