### PR TITLE
fix missing docs due to git add issues

### DIFF
--- a/docs/python_docs/python/api/gluon/data/index.rst
+++ b/docs/python_docs/python/api/gluon/data/index.rst
@@ -1,0 +1,63 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+gluon.data
+==========
+
+.. automodule:: mxnet.gluon.data
+
+Datasets
+--------
+
+.. autosummary::
+
+   Dataset
+   ArrayDataset
+   RecordFileDataset
+   SimpleDataset
+
+Sampling
+--------
+
+.. autosummary::
+
+   Sampler
+   SequentialSampler
+   RandomSampler
+   BatchSampler
+
+DataLoader
+----------
+
+.. autosummary::
+
+   DataLoader
+
+
+API Reference
+-------------
+.. automodule:: mxnet.gluon.data
+    :members:
+    :imported-members:
+    :autosummary:
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :glob:
+
+   */index

--- a/docs/python_docs/python/api/gluon/data/vision/datasets/index.rst
+++ b/docs/python_docs/python/api/gluon/data/vision/datasets/index.rst
@@ -1,0 +1,26 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+vision.datasets
+===============
+
+Gluon provides pre-defined vision datasets functions in the :py:mod:`mxnet.gluon.data.vision.datasets`
+module.
+
+.. automodule:: mxnet.gluon.data.vision.datasets
+    :members:
+    :autosummary:

--- a/docs/python_docs/python/api/gluon/data/vision/index.rst
+++ b/docs/python_docs/python/api/gluon/data/vision/index.rst
@@ -1,0 +1,53 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+data.vision
+============
+
+.. automodule:: mxnet.gluon.data.vision
+
+Datasets
+^^^^^^^^
+
+.. autosummary::
+    :nosignatures:
+
+    mxnet.gluon.data.vision.datasets
+
+
+Data transformations
+^^^^^^^^^^^^^^^^^^^^
+
+
+.. autosummary::
+    :nosignatures:
+
+    mxnet.gluon.data.vision.transforms
+
+
+API Reference
+-------------
+.. automodule:: mxnet.gluon.data.vision
+    :members:
+    :autosummary:
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+   :glob:
+
+   */index

--- a/docs/python_docs/python/api/gluon/data/vision/transforms/index.rst
+++ b/docs/python_docs/python/api/gluon/data/vision/transforms/index.rst
@@ -1,0 +1,48 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+vision.transforms
+=================
+
+Gluon provides pre-defined vision transformation and data augmentation functions in the :py:mod:`mxnet.gluon.data.vision.transforms`
+module.
+
+.. currentmodule:: mxnet.gluon.data.vision
+
+.. autosummary::
+   :nosignatures:
+
+   transforms.Compose
+   transforms.Cast
+   transforms.ToTensor
+   transforms.Normalize
+   transforms.RandomResizedCrop
+   transforms.CenterCrop
+   transforms.Resize
+   transforms.RandomFlipLeftRight
+   transforms.RandomFlipTopBottom
+   transforms.RandomBrightness
+   transforms.RandomContrast
+   transforms.RandomSaturation
+   transforms.RandomHue
+   transforms.RandomColorJitter
+   transforms.RandomLighting
+
+API Reference
+-------------
+.. automodule:: mxnet.gluon.data.vision.transforms
+    :members:

--- a/docs/python_docs/python/api/mxnet/log/index.rst
+++ b/docs/python_docs/python/api/mxnet/log/index.rst
@@ -1,0 +1,23 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+mxnet.log
+=========
+
+.. automodule:: mxnet.log
+    :members:
+    :autosummary:

--- a/docs/python_docs/python/api/mxnet/model/index.rst
+++ b/docs/python_docs/python/api/mxnet/model/index.rst
@@ -1,0 +1,23 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+
+mxnet.model
+===========
+
+.. automodule:: mxnet.model
+    :members:
+    :autosummary:


### PR DESCRIPTION
## Description ##
Some files were missing from the #16392 pr due to gitignore issue. They are now included here. 

This should allow the pages for gluon.data to be rendered properly.

Fixes https://github.com/apache/incubator-mxnet/issues/16495