### PR TITLE
detect number of procs during sphinx build

### DIFF
--- a/docs/python_docs/python/Makefile_sphinx
+++ b/docs/python_docs/python/Makefile_sphinx
@@ -18,8 +18,25 @@
 # Makefile for Sphinx documentation
 #
 
+
+NPROCS := 1
+OS := $(shell uname)
+export NPROCS
+
+ifeq ($J,)
+
+ifeq ($(OS),Linux)
+  NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
+else ifeq ($(OS),Darwin)
+  NPROCS := $(shell system_profiler | awk '/Number of CPUs/ {print $$4}{next;}')
+endif # $(OS)
+
+else
+  NPROCS := $J
+endif # $J
+
 # You can set these variables from the command line.
-SPHINXOPTS    = -j 32 -c ../scripts
+SPHINXOPTS    = -j$(NPROCS) -c ../scripts
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/python_docs/python/Makefile_sphinx
+++ b/docs/python_docs/python/Makefile_sphinx
@@ -18,12 +18,12 @@
 # Makefile for Sphinx documentation
 #
 
-
+# Begin number of processors detection
 NPROCS := 1
 OS := $(shell uname)
 export NPROCS
 
-ifeq ($J,)
+ifeq ($(NUMJOBS),)
 
 ifeq ($(OS),Linux)
   NPROCS := $(shell grep -c ^processor /proc/cpuinfo)
@@ -32,8 +32,9 @@ else ifeq ($(OS),Darwin)
 endif # $(OS)
 
 else
-  NPROCS := $J
-endif # $J
+  NPROCS := $(NUMJOBS)
+endif # $(NUMJOBS)
+# End number of processors detection
 
 # You can set these variables from the command line.
 SPHINXOPTS    = -j$(NPROCS) -c ../scripts


### PR DESCRIPTION
## Description ##
I ran into a build issue when making the python docs on an instance with 16 processors. The makefile for sphinx was hardcoded to 32 which I guess was fine for CI.

The error was like this:

```
/work/mxnet/docs/python_docs/python/build/tutorials/packages/gluon/training/fit_api_tutorial.ipynb:395: WARNING: File not found: 'tutorials/packages/gluon/blocks/save_load_params.html#saving-model-parameters-to-file'

Sphinx parallel build error:
IndexError: list index out of range
```

I turned off parallel builds with Sphinx and it worked, then switched to this new code that detects the number of processors in the Makefile and that worked.

## Testing
1. Clone the repo.
2. [Install Docker and Docker for python and make it so docker doesn't need sudo to run](https://github.com/apache/incubator-mxnet/blob/master/ci/README.md).
3. Run the following two commands to build the mxnet binary, then build the python docs.

```
ci/build.py --docker-registry mxnetci --platform ubuntu_cpu_lite /work/runtime_functions.sh build_ubuntu_cpu_docs
ci/build.py --docker-registry mxnetci --platform ubuntu_cpu_python /work/runtime_functions.sh build_python_docs
```
