### PR TITLE
add option to remove indexes

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -1,3 +1,4 @@
+Options -Indexes
 DirectorySlash off
 RewriteEngine on
 RewriteOptions AllowNoSlash


### PR DESCRIPTION
## Description ##
This feature was removed due to inconsistency in server configs between prod and staging. Adding it back. It'll fix the issues happening on prod with trailing slashes and directories w/o index pages show a dir listing.

Refer to https://issues.apache.org/jira/browse/INFRA-19187 for more context.