### PR TITLE
Build dmlc-core with old thread_local implementation for MXNet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,9 @@ if("$ENV{VERBOSE}" STREQUAL "1")
   set(CMAKE_VERBOSE_MAKEFILE ON)
 endif()
 
+#Switch off modern thread local for dmlc-core, please see: https://github.com/dmlc/dmlc-core/issues/571#issuecomment-543467484
+add_definitions(-DDMLC_MODERN_THREAD_LOCAL=0)
+
 
 if(MSVC)
   add_definitions(-DWIN32_LEAN_AND_MEAN)

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,8 @@ include $(DMLC_CORE)/make/dmlc.mk
 # all tge possible warning tread
 WARNFLAGS= -Wall -Wsign-compare
 CFLAGS = -DMSHADOW_FORCE_STREAM $(WARNFLAGS)
+# use old thread local implementation in DMLC-CORE
+CFLAGS += -DDMLC_MODERN_THREAD_LOCAL=0
 
 ifeq ($(DEV), 1)
 	CFLAGS += -g -Werror

--- a/tests/cpp/engine/thread_local_test.cc
+++ b/tests/cpp/engine/thread_local_test.cc
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file engine_thread_local_test.cc
+ * \brief Tests thread safety and lifetime of thread local store
+*/
+#include <gtest/gtest.h>
+#include <time.h>
+#include <dmlc/logging.h>
+#include <dmlc/thread_group.h>
+#include <dmlc/omp.h>
+#include <mxnet/c_api.h>
+#include <mxnet/engine.h>
+#include <mxnet/ndarray.h>
+#include <dmlc/timer.h>
+#include <cstdio>
+#include <thread>
+#include <chrono>
+#include <vector>
+
+struct A {
+    std::vector<int> a;
+};
+int num_threads = 10;
+int num_elements = num_threads * 10;
+
+static int ThreadSafetyTest(int num, std::vector<int>* tmp_inputs, std::vector<int*>* res) {
+    A *ret = dmlc::ThreadLocalStore<A>::Get();
+    for (size_t i = num * 10; i < num * 10 + 10; ++i) {
+        (*tmp_inputs)[i] = i;
+    }
+    ret->a.clear();
+    ret->a.reserve(10);
+    for (size_t i = num * 10; i < num * 10 + 10; ++i) {
+        ret->a.push_back((*tmp_inputs)[i]);
+    }
+    (*res)[num] = dmlc::BeginPtr(ret->a);
+    return 0;
+}
+
+TEST(ThreadLocal, verify_thread_safety) {
+    std::vector<int> tmp_inputs;
+    tmp_inputs.resize(num_elements);
+    std::vector<int*> outputs;
+    outputs.resize(num_threads);
+    auto func = [&](int num) {
+        ThreadSafetyTest(num, &tmp_inputs, &outputs);
+    };
+    std::vector<std::thread> worker_threads(num_threads);
+    int count = 0;
+    for (auto&& i : worker_threads) {
+        i = std::thread(func, count);
+        count++;
+    }
+    for (auto&& i : worker_threads) {
+        i.join();
+    }
+
+    for (size_t i = 0; i < num_elements; i++) {
+        CHECK(outputs[i/10][i%10] == i);
+    }
+}


### PR DESCRIPTION
## Description ##
MXNet depends on thread local store from dmlc-core. There are two versions of Thread Local store implementations. One where the thread local object gets destructed when the spawned thread finishes and the other where thread local object is alive for the lifetime of the program. MXNet C API code is based on this assumption that the thread local object extends beyond the lifetime of the thread in which the API is called (assuming that it is called from a different thread). Example : https://github.com/apache/incubator-mxnet/blob/master/src/c_api/c_api_ndarray.cc#L251

Thus using the old implementation.
Required PR : https://github.com/dmlc/dmlc-core/pull/573

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
