### PR TITLE
[NumPy][Operator] NumPy operator `may_share_memory` and `shares_memory`

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -4913,9 +4913,73 @@ def nonzero(a):
 
 @set_module('mxnet.ndarray.numpy')
 def shares_memory(a, b, max_work=None):
+    """
+    Determine if two arrays share memory
+
+    Parameters
+    ----------
+    a, b : ndarray
+        Input arrays
+
+    Returns
+    -------
+    out : bool
+
+    See Also
+    --------
+    may_share_memory
+
+    Examples
+    --------
+    >>> np.may_share_memory(np.array([1,2]), np.array([5,8,9]))
+    False
+
+    This function differs from the original `numpy.shares_memory
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.shares_memory.html>`_ in
+    the following way(s):
+
+    - Does not support `max_work`, it is a dummy argument
+    - Actually it is same as `may_share_memory` in MXNet DeepNumPy
+    """
     return _npi.share_memory(a, b).item()
 
 
 @set_module('mxnet.ndarray.numpy')
 def may_share_memory(a, b, max_work=None):
+    """
+    Determine if two arrays might share memory
+
+    A return of True does not necessarily mean that the two arrays
+    share any element.  It just means that they *might*.
+
+    Only the memory bounds of a and b are checked by default.
+
+    Parameters
+    ----------
+    a, b : ndarray
+        Input arrays
+
+    Returns
+    -------
+    out : bool
+
+    See Also
+    --------
+    shares_memory
+
+    Examples
+    --------
+    >>> np.may_share_memory(np.array([1,2]), np.array([5,8,9]))
+    False
+    >>> x = np.zeros([3, 4])
+    >>> np.may_share_memory(x[:,0], x[:,1])
+    True
+
+    This function differs from the original `numpy.may_share_memory
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.may_share_memory.html>`_ in
+    the following way(s):
+
+    - Does not support `max_work`, it is a dummy argument
+    - Actually it is same as `shares_memory` in MXNet DeepNumPy
+    """
     return _npi.share_memory(a, b).item()

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -38,7 +38,7 @@ __all__ = ['zeros', 'ones', 'full', 'add', 'subtract', 'multiply', 'divide', 'mo
            'std', 'var', 'indices', 'copysign', 'ravel', 'hanning', 'hamming', 'blackman', 'flip',
            'around', 'hypot', 'rad2deg', 'deg2rad', 'unique', 'lcm', 'tril', 'identity', 'take',
            'ldexp', 'vdot', 'inner', 'outer', 'equal', 'not_equal', 'greater', 'less', 'greater_equal', 'less_equal',
-           'hsplit', 'rot90', 'einsum', 'true_divide', 'nonzero']
+           'hsplit', 'rot90', 'einsum', 'true_divide', 'nonzero', 'shares_memory', 'may_share_memory']
 
 
 @set_module('mxnet.ndarray.numpy')
@@ -4909,3 +4909,13 @@ def nonzero(a):
     """
     out = _npi.nonzero(a).transpose()
     return tuple([out[i] for i in range(len(out))])
+
+
+@set_module('mxnet.ndarray.numpy')
+def shares_memory(a, b, max_work=None):
+    return _npi.share_memory(a, b).item()
+
+
+@set_module('mxnet.ndarray.numpy')
+def may_share_memory(a, b, max_work=None):
+    return _npi.share_memory(a, b).item()

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -55,7 +55,8 @@ __all__ = ['ndarray', 'empty', 'array', 'zeros', 'ones', 'full', 'add', 'subtrac
            'swapaxes', 'clip', 'argmax', 'argmin', 'std', 'var', 'indices', 'copysign', 'ravel', 'hanning', 'hamming',
            'blackman', 'flip', 'around', 'arctan2', 'hypot', 'rad2deg', 'deg2rad', 'unique', 'lcm', 'tril',
            'identity', 'take', 'ldexp', 'vdot', 'inner', 'outer', 'equal', 'not_equal', 'greater', 'less',
-           'greater_equal', 'less_equal', 'hsplit', 'rot90', 'einsum', 'true_divide', 'nonzero']
+           'greater_equal', 'less_equal', 'hsplit', 'rot90', 'einsum', 'true_divide', 'nonzero', 'shares_memory',
+           'may_share_memory']
 
 # Return code for dispatching indexing function call
 _NDARRAY_UNSUPPORTED_INDEXING = -1
@@ -6900,3 +6901,13 @@ def nonzero(a):
     (array([1, 1, 1, 2, 2, 2], dtype=int64), array([0, 1, 2, 0, 1, 2], dtype=int64))
     """
     return _mx_nd_np.nonzero(a)
+
+
+@set_module('mxnet.numpy')
+def shares_memory(a, b, max_work=None):
+    return _mx_nd_np.shares_memory(a, b, max_work)
+
+
+@set_module('mxnet.numpy')
+def may_share_memory(a, b, max_work=None):
+    return _mx_nd_np.may_share_memory(a, b, max_work)

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -1331,7 +1331,7 @@ class ndarray(NDArray):
         The arguments are the same as for :py:func:`take`, with
         this array as data.
         """
-        take(self, indices, axis, mode=mode)
+        return take(self, indices, axis, mode=mode)
 
     def one_hot(self, *args, **kwargs):
         """Convenience fluent method for :py:func:`one_hot`.
@@ -6905,9 +6905,73 @@ def nonzero(a):
 
 @set_module('mxnet.numpy')
 def shares_memory(a, b, max_work=None):
+    """
+    Determine if two arrays share memory
+
+    Parameters
+    ----------
+    a, b : ndarray
+        Input arrays
+
+    Returns
+    -------
+    out : bool
+
+    See Also
+    --------
+    may_share_memory
+
+    Examples
+    --------
+    >>> np.may_share_memory(np.array([1,2]), np.array([5,8,9]))
+    False
+
+    This function differs from the original `numpy.shares_memory
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.shares_memory.html>`_ in
+    the following way(s):
+
+    - Does not support `max_work`, it is a dummy argument
+    - Actually it is same as `may_share_memory` in MXNet DeepNumPy
+    """
     return _mx_nd_np.shares_memory(a, b, max_work)
 
 
 @set_module('mxnet.numpy')
 def may_share_memory(a, b, max_work=None):
+    """
+    Determine if two arrays might share memory
+
+    A return of True does not necessarily mean that the two arrays
+    share any element.  It just means that they *might*.
+
+    Only the memory bounds of a and b are checked by default.
+
+    Parameters
+    ----------
+    a, b : ndarray
+        Input arrays
+
+    Returns
+    -------
+    out : bool
+
+    See Also
+    --------
+    shares_memory
+
+    Examples
+    --------
+    >>> np.may_share_memory(np.array([1,2]), np.array([5,8,9]))
+    False
+    >>> x = np.zeros([3, 4])
+    >>> np.may_share_memory(x[:,0], x[:,1])
+    True
+
+    This function differs from the original `numpy.may_share_memory
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.may_share_memory.html>`_ in
+    the following way(s):
+
+    - Does not support `max_work`, it is a dummy argument
+    - Actually it is same as `shares_memory` in MXNet DeepNumPy
+    """
     return _mx_nd_np.may_share_memory(a, b, max_work)

--- a/python/mxnet/numpy_dispatch_protocol.py
+++ b/python/mxnet/numpy_dispatch_protocol.py
@@ -127,7 +127,9 @@ _NUMPY_ARRAY_FUNCTION_LIST = [
     'tril',
     'meshgrid',
     'outer',
-    'einsum'
+    'einsum',
+    'shares_memory',
+    'may_share_memory',
 ]
 
 

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -40,7 +40,7 @@ __all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'rem
            'std', 'var', 'indices', 'copysign', 'ravel', 'hanning', 'hamming', 'blackman', 'flip',
            'around', 'hypot', 'rad2deg', 'deg2rad', 'unique', 'lcm', 'tril', 'identity', 'take',
            'ldexp', 'vdot', 'inner', 'outer', 'equal', 'not_equal', 'greater', 'less', 'greater_equal',
-           'less_equal', 'hsplit', 'rot90', 'einsum', 'true_divide']
+           'less_equal', 'hsplit', 'rot90', 'einsum', 'true_divide', 'shares_memory', 'may_share_memory']
 
 
 def _num_outputs(sym):
@@ -4588,6 +4588,45 @@ def einsum(*operands, **kwargs):
     subscripts = operands[0]
     operands = operands[1:]
     return _npi.einsum(*operands, subscripts=subscripts, out=out, optimize=int(optimize_arg))
+
+
+@set_module('mxnet.symbol.numpy')
+def shares_memory(a, b, max_work=None):
+    """
+    Determine if two arrays share memory
+
+    Parameters
+    ----------
+    a, b : _Symbol
+        Input arrays
+
+    Returns
+    -------
+    out : _Symbol
+    """
+    return _npi.share_memory(a, b)
+
+
+@set_module('mxnet.symbol.numpy')
+def may_share_memory(a, b, max_work=None):
+    """
+    Determine if two arrays might share memory
+
+    A return of True does not necessarily mean that the two arrays
+    share any element.  It just means that they *might*.
+
+    Only the memory bounds of a and b are checked by default.
+
+    Parameters
+    ----------
+    a, b : _Symbol
+        Input arrays
+
+    Returns
+    -------
+    out : _Symbol
+    """
+    return _npi.share_memory(a, b)
 
 
 _set_np_symbol_class(_Symbol)

--- a/src/operator/numpy/np_memory_op.cc
+++ b/src/operator/numpy/np_memory_op.cc
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_memory_op.cc
+ */
+
+#include "./np_memory_op.h"
+
+namespace mxnet {
+namespace op {
+
+inline bool NumpyShareMemoryType(const nnvm::NodeAttrs& attrs,
+                                 std::vector<int> *in_attrs,
+                                 std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 2U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  TYPE_ASSIGN_CHECK(*out_attrs, 0, mshadow::kBool);
+  return out_attrs->at(0) != -1;
+}
+
+inline bool NumpyShareMemoryShape(const nnvm::NodeAttrs& attrs,
+                                  mxnet::ShapeVector *in_attrs,
+                                  mxnet::ShapeVector *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 2U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  SHAPE_ASSIGN_CHECK(*out_attrs, 0, mxnet::TShape(0, -1));
+  return true;
+}
+
+NNVM_REGISTER_OP(_npi_share_memory)
+.set_num_inputs(2)
+.set_num_outputs(1)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"a", "b"};
+  })
+.set_attr<mxnet::FInferShape>("FInferShape", NumpyShareMemoryShape)
+.set_attr<nnvm::FInferType>("FInferType", NumpyShareMemoryType)
+.set_attr<FCompute>("FCompute<cpu>", NumpyShareMemoryCompute<cpu>)
+.add_argument("a", "NDArray-or-Symbol", "First input")
+.add_argument("b", "NDArray-or-Symbol", "Second input");
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/np_memory_op.cu
+++ b/src/operator/numpy/np_memory_op.cu
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_memory_op.cu
+ */
+
+ #include "./np_memory_op.h"
+
+ namespace mxnet {
+ namespace op {
+
+ NNVM_REGISTER_OP(_npi_share_memory)
+ .set_attr<FCompute>("FCompute<gpu>", NumpyShareMemoryCompute<gpu>);
+
+ }  // namespace op
+ }  // namespace mxnet

--- a/src/operator/numpy/np_memory_op.cu
+++ b/src/operator/numpy/np_memory_op.cu
@@ -22,13 +22,13 @@
  * \file np_memory_op.cu
  */
 
- #include "./np_memory_op.h"
+#include "./np_memory_op.h"
 
- namespace mxnet {
- namespace op {
+namespace mxnet {
+namespace op {
 
- NNVM_REGISTER_OP(_npi_share_memory)
- .set_attr<FCompute>("FCompute<gpu>", NumpyShareMemoryCompute<gpu>);
+NNVM_REGISTER_OP(_npi_share_memory)
+.set_attr<FCompute>("FCompute<gpu>", NumpyShareMemoryCompute<gpu>);
 
- }  // namespace op
- }  // namespace mxnet
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/np_memory_op.h
+++ b/src/operator/numpy/np_memory_op.h
@@ -51,15 +51,19 @@ void NumpyShareMemoryCompute(const nnvm::NodeAttrs& attrs,
     *(outdata.dptr<bool>()) = false;
     return;
   }
-  uint64_t start1 = reinterpret_cast<uint64_t>(a.dptr_);
-  uint64_t end1 = start1 + a.Size();
-  uint64_t start2 = reinterpret_cast<uint64_t>(b.dptr_);
-  uint64_t end2 = start2 + b.Size();
-  if (!(start1 < end2 && start2 < end1 && start1 < end1 && start2 < end2)) {
-    *(outdata.dptr<bool>()) = false;
-  } else {
-    *(outdata.dptr<bool>()) = true;
-  }
+  MSHADOW_TYPE_SWITCH_WITH_BOOL(a.type_flag_, AType, {
+    MSHADOW_TYPE_SWITCH_WITH_BOOL(b.type_flag_, BType, {
+      uint64_t start1 = reinterpret_cast<uint64_t>(a.dptr_);
+      uint64_t end1 = start1 + a.Size() * sizeof(AType);
+      uint64_t start2 = reinterpret_cast<uint64_t>(b.dptr_);
+      uint64_t end2 = start2 + b.Size() * sizeof(BType);
+      if (!(start1 < end2 && start2 < end1 && start1 < end1 && start2 < end2)) {
+        *(outdata.dptr<bool>()) = false;
+      } else {
+        *(outdata.dptr<bool>()) = true;
+      }
+    });
+  });
   return;
 }
 

--- a/src/operator/numpy/np_memory_op.h
+++ b/src/operator/numpy/np_memory_op.h
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ *  Copyright (c) 2019 by Contributors
+ * \file np_memory_op.h
+ * \brief Function definition of numpy memory op
+ */
+
+#ifndef MXNET_OPERATOR_NUMPY_NP_MEMORY_OP_H_
+#define MXNET_OPERATOR_NUMPY_NP_MEMORY_OP_H_
+
+#include <vector>
+#include <string>
+#include "../operator_common.h"
+
+namespace mxnet {
+namespace op {
+
+template<typename xpu>
+void NumpyShareMemoryCompute(const nnvm::NodeAttrs& attrs,
+                             const OpContext& ctx,
+                             const std::vector<TBlob>& inputs,
+                             const std::vector<OpReqType>& req,
+                             const std::vector<TBlob>& outputs) {
+  using namespace mxnet_op;
+  using namespace mshadow;
+  CHECK_EQ(inputs.size(), 2U);
+  CHECK_EQ(outputs.size(), 1U);
+  const TBlob& a = inputs[0];
+  const TBlob& b = inputs[1];
+  const TBlob& outdata = outputs[0];
+
+  if (a.Size() == 0 || b.Size() == 0) {
+    *(outdata.dptr<bool>()) = false;
+    return;
+  }
+  uint64_t start1 = reinterpret_cast<uint64_t>(a.dptr_);
+  uint64_t end1 = start1 + a.Size();
+  uint64_t start2 = reinterpret_cast<uint64_t>(b.dptr_);
+  uint64_t end2 = start2 + b.Size();
+  if (!(start1 < end2 && start2 < end1 && start1 < end1 && start2 < end2)) {
+    *(outdata.dptr<bool>()) = false;
+  } else {
+    *(outdata.dptr<bool>()) = true;
+  }
+  return;
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NUMPY_NP_MEMORY_OP_H_

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -1234,6 +1234,8 @@ def check_interoperability(op_list):
     for name in op_list:
         if name in _TVM_OPS and not is_op_runnable():
             continue
+        if name in ['shares_memory', 'may_share_memory']:  # skip list
+            continue
         print('Dispatch test:', name)
         workloads = OpArgMngr.get_workloads(name)
         assert workloads is not None, 'Workloads for operator `{}` has not been ' \
@@ -1241,6 +1243,19 @@ def check_interoperability(op_list):
                                       'the official NumPy.'.format(name)
         for workload in workloads:
             _check_interoperability_helper(name, *workload['args'], **workload['kwargs'])
+
+
+@with_seed()
+@use_np
+@with_array_function_protocol
+def test_np_memory_array_function():
+    ops = [_np.shares_memory, _np.may_share_memory]
+    for op in ops:
+        data_mx = np.zeros([13, 21, 23, 22], dtype=np.float32)
+        data_np = _np.zeros([13, 21, 23, 22], dtype=np.float32)
+        assert op(data_mx[0,:,:,:], data_mx[1,:,:,:]) == op(data_np[0,:,:,:], data_np[1,:,:,:])
+        assert op(data_mx[0,0,0,2:5], data_mx[0,0,0,4:7]) == op(data_np[0,0,0,2:5], data_np[0,0,0,4:7])
+        assert op(data_mx, np.ones((5, 0))) == op(data_np, _np.ones((5, 0)))
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
