### PR TITLE
Python Docstring Convetion

### DIFF
--- a/python/mxnet/kvstore.py
+++ b/python/mxnet/kvstore.py
@@ -31,8 +31,7 @@ from . import optimizer as opt
 from .profiler import set_kvstore_handle
 
 def _ctype_key_value(keys, vals):
-    """
-    Returns ctype arrays for the key-value args, and the whether string keys are used.
+    """Returns ctype arrays for the key-value args, and the whether string keys are used.
     For internal use only.
     """
     if isinstance(keys, (tuple, list)):
@@ -66,9 +65,7 @@ def _ctype_key_value(keys, vals):
         return (c_keys, c_handle_array(vals), use_str_keys)
 
 def _ctype_dict(param_dict):
-    """
-    Returns ctype arrays for keys and values(converted to strings) in a dictionary
-    """
+    """Returns ctype arrays for keys and values(converted to strings) in a dictionary"""
     assert(isinstance(param_dict, dict)), \
         "unexpected type for param_dict: " + str(type(param_dict))
     c_keys = c_array(ctypes.c_char_p, [c_str(k) for k in param_dict.keys()])

--- a/python/mxnet/log.py
+++ b/python/mxnet/log.py
@@ -81,7 +81,7 @@ def getLogger(name=None, filename=None, filemode=None, level=WARNING):
     """Gets a customized logger.
 
     .. note:: `getLogger` is deprecated. Use `get_logger` instead.
-    
+
     """
     warnings.warn("getLogger is deprecated, Use get_logger instead.",
                   DeprecationWarning, stacklevel=2)

--- a/python/mxnet/log.py
+++ b/python/mxnet/log.py
@@ -81,6 +81,7 @@ def getLogger(name=None, filename=None, filemode=None, level=WARNING):
     """Gets a customized logger.
 
     .. note:: `getLogger` is deprecated. Use `get_logger` instead.
+    
     """
     warnings.warn("getLogger is deprecated, Use get_logger instead.",
                   DeprecationWarning, stacklevel=2)

--- a/python/mxnet/log.py
+++ b/python/mxnet/log.py
@@ -81,7 +81,6 @@ def getLogger(name=None, filename=None, filemode=None, level=WARNING):
     """Gets a customized logger.
 
     .. note:: `getLogger` is deprecated. Use `get_logger` instead.
-
     """
     warnings.warn("getLogger is deprecated, Use get_logger instead.",
                   DeprecationWarning, stacklevel=2)

--- a/python/mxnet/metric.py
+++ b/python/mxnet/metric.py
@@ -153,8 +153,7 @@ class EvalMetric(object):
         self.global_sum_metric = 0.0
 
     def reset_local(self):
-        """Resets the local portion of the internal evaluation results
-        to initial state."""
+        """Resets the local portion of the internal evaluation results to initial state."""
         self.num_inst = 0
         self.sum_metric = 0.0
 
@@ -372,8 +371,7 @@ class CompositeEvalMetric(EvalMetric):
             pass
 
     def reset_local(self):
-        """Resets the local portion of the internal evaluation results
-        to initial state."""
+        """Resets the local portion of the internal evaluation results to initial state."""
         try:
             for metric in self.metrics:
                 metric.reset_local()
@@ -592,8 +590,7 @@ class TopKAccuracy(EvalMetric):
 
 
 class _BinaryClassificationMetrics(object):
-    """
-    Private container class for classification metric statistics. True/false positive and
+    """Private container class for classification metric statistics. True/false positive and
      true/false negative counts are sufficient statistics for various classification metrics.
     This class provides the machinery to track those statistics across mini-batches of
     (label, prediction) pairs.
@@ -610,9 +607,7 @@ class _BinaryClassificationMetrics(object):
         self.global_true_negatives = 0
 
     def update_binary_stats(self, label, pred):
-        """
-        Update various binary classification counts for a single (label, pred)
-        pair.
+        """Update various binary classification counts for a single (label, pred) pair.
 
         Parameters
         ----------
@@ -691,9 +686,7 @@ class _BinaryClassificationMetrics(object):
             return 0.
 
     def matthewscc(self, use_global=False):
-        """
-        Calculate the Matthew's Correlation Coefficent
-        """
+        """Calculate the Matthew's Correlation Coefficent"""
         if use_global:
             if not self.global_total_examples:
                 return 0.
@@ -1604,8 +1597,7 @@ class PCC(EvalMetric):
         self.reset_local()
 
     def reset_local(self):
-        """Resets the local portion of the internal evaluation results
-        to initial state."""
+        """Resets the local portion of the internal evaluation results to initial state."""
         self.num_inst = 0.
         self.lcm = numpy.zeros((self.k, self.k))
 

--- a/python/mxnet/profiler.py
+++ b/python/mxnet/profiler.py
@@ -207,8 +207,7 @@ def pause(profile_process='worker'):
 
 
 def resume(profile_process='worker'):
-    """
-    Resume paused profiling.
+    """Resume paused profiling.
 
     Parameters
     ----------

--- a/python/mxnet/rtc.py
+++ b/python/mxnet/rtc.py
@@ -172,7 +172,8 @@ class CudaModule(object):
 
 class CudaKernel(object):
     """Constructs CUDA kernel. Should be created by `CudaModule.get_kernel`,
-    not intended to be used by users."""
+    not intended to be used by users.
+    """
     def __init__(self, handle, name, is_ndarray, dtypes):
         self.handle = handle
         self._name = name

--- a/python/mxnet/runtime.py
+++ b/python/mxnet/runtime.py
@@ -26,9 +26,7 @@ import collections
 from .base import _LIB, check_call
 
 class Feature(ctypes.Structure):
-    """
-    Compile time feature description, member fields: `name` and `enabled`.
-    """
+    """Compile time feature description, member fields: `name` and `enabled`."""
     _fields_ = [
         ("_name", ctypes.c_char_p),
         ("_enabled", ctypes.c_bool)
@@ -36,16 +34,12 @@ class Feature(ctypes.Structure):
 
     @property
     def name(self):
-        """
-        Feature name.
-        """
+        """Feature name."""
         return self._name.decode()
 
     @property
     def enabled(self):
-        """
-        True if MXNet was compiled with the given compile-time feature.
-        """
+        """True if MXNet was compiled with the given compile-time feature."""
         return self._enabled
 
     def __repr__(self):
@@ -55,8 +49,7 @@ class Feature(ctypes.Structure):
             return "✖ {}".format(self.name)
 
 def feature_list():
-    """
-    Check the library for compile-time features. The list of features are maintained in libinfo.h and libinfo.cc
+    """Check the library for compile-time features. The list of features are maintained in libinfo.h and libinfo.cc
 
     Returns
     -------
@@ -70,9 +63,7 @@ def feature_list():
     return features
 
 class Features(collections.OrderedDict):
-    """
-    OrderedDict of name to Feature
-    """
+    """OrderedDict of name to Feature"""
     instance = None
     def __new__(cls):
         if cls.instance is None:
@@ -84,8 +75,7 @@ class Features(collections.OrderedDict):
         return str(list(self.values()))
 
     def is_enabled(self, feature_name):
-        """
-        Check for a particular feature by name
+        """Check for a particular feature by name
 
         Parameters
         ----------

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1932,8 +1932,7 @@ def same_array(array1, array2):
 
 @contextmanager
 def discard_stderr():
-    """
-    Discards error output of a routine if invoked as:
+    """Discards error output of a routine if invoked as:
 
     with discard_stderr():
         ...
@@ -2321,7 +2320,8 @@ class EnvManager(object):
 
 def collapse_sum_like(a, shape):
     """Given `a` as a numpy ndarray, perform reduce_sum on `a` over the axes that do not
-    exist in `shape`. Note that an ndarray with `shape` must be broadcastable to `a`."""
+    exist in `shape`. Note that an ndarray with `shape` must be broadcastable to `a`.
+    """
     assert len(a.shape) >= len(shape)
     if np.prod(shape) == 0 or a.size == 0:
         return np.zeros(shape, dtype=a.dtype)
@@ -2346,7 +2346,8 @@ _features = Features()
 
 def has_tvm_ops():
     """Returns True if MXNet is compiled with TVM generated operators. If current ctx
-    is GPU, it only returns True for CUDA compute capability > 52 where FP16 is supported."""
+    is GPU, it only returns True for CUDA compute capability > 52 where FP16 is supported.
+    """
     built_with_tvm_op = _features.is_enabled("TVM_OP")
     ctx = current_context()
     if ctx.device_type == 'gpu':
@@ -2364,7 +2365,8 @@ def has_tvm_ops():
 def is_op_runnable():
     """Returns True for all CPU tests. Returns True for GPU tests that are either of the following.
     1. Built with USE_TVM_OP=0.
-    2. Built with USE_TVM_OP=1, but with compute capability >= 53."""
+    2. Built with USE_TVM_OP=1, but with compute capability >= 53.
+    """
     ctx = current_context()
     if ctx.device_type == 'gpu':
         if not _features.is_enabled("TVM_OP"):

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -60,8 +60,7 @@ def get_gpu_memory(gpu_dev_id):
 
 
 def set_np_shape(active):
-    """
-    Turns on/off NumPy shape semantics, in which `()` represents the shape of scalar tensors,
+    """Turns on/off NumPy shape semantics, in which `()` represents the shape of scalar tensors,
     and tuples with `0` elements, for example, `(0,)`, `(1, 0, 2)`, represent the shapes
     of zero-size tensors. This is turned off by default for keeping backward compatibility.
 
@@ -568,8 +567,7 @@ def use_np(func):
 
 
 def np_ufunc_legal_option(key, value):
-    """
-    Checking if ufunc arguments are legal inputs
+    """Checking if ufunc arguments are legal inputs
 
     Parameters
     ----------


### PR DESCRIPTION
## Description ##
Python docstring convention is not consistent through out codes. This PR changes some files to respect [PEP docstring convention](https://www.python.org/dev/peps/pep-0257/). Do you guys think this can be enforced with a linter?

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


## Comments ##
- Just changes comments. 
