### PR TITLE
Add check if scipy is imported in sparse.py

### DIFF
--- a/python/mxnet/ndarray/sparse.py
+++ b/python/mxnet/ndarray/sparse.py
@@ -553,8 +553,8 @@ class CSRNDArray(BaseSparseNDArray):
         indices = self.indices.asnumpy()
         indptr = self.indptr.asnumpy()
         if not spsp:
-            raise ImportError("scipy is not available. \
-                               Please check if the scipy python bindings are installed.")
+            raise ImportError("scipy could not be imported. "
+                              "Please make sure that the scipy is installed.")
         return spsp.csr_matrix((data, indices, indptr), shape=self.shape, dtype=self.dtype)
 
 # pylint: disable=abstract-method
@@ -940,6 +940,9 @@ def csr_matrix(arg1, shape=None, ctx=None, dtype=None):
                     row = row.asnumpy()
                 if isinstance(col, NDArray):
                     col = col.asnumpy()
+                if not spsp:
+                    raise ImportError("scipy could not be imported. "
+                                      "Please make sure that the scipy is installed.")
                 coo = spsp.coo_matrix((data, (row, col)), shape=shape)
                 _check_shape(coo.shape, shape)
                 csr = coo.tocsr()


### PR DESCRIPTION
## Description ##
Add check if scipy is imported in sparse.py

Without this check, users can be confused due to error `AttributeError: 'NoneType' object has no attribute 'coo_matrix'`

