### PR TITLE
Enforce adding documentation for builtin numpy operators

### DIFF
--- a/src/operator/numpy/np_elemwise_broadcast_op.cu
+++ b/src/operator/numpy/np_elemwise_broadcast_op.cu
@@ -138,8 +138,5 @@ NNVM_REGISTER_OP(_backward_npi_ldexp_scalar)
 NNVM_REGISTER_OP(_backward_npi_rldexp_scalar)
 .set_attr<FCompute>("FCompute<gpu>", BinaryScalarOp::Backward<gpu, mshadow_op::rldexp_grad>);
 
-NNVM_REGISTER_OP(_np_bitwise_xor)
-.set_attr<FCompute>("FCompute<gpu>", BinaryBroadcastCompute<gpu, mshadow_op::bitwise_xor>);
-
 }  // namespace op
 }  // namespace mxnet

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -34,6 +34,7 @@ import random
 from mxnet.test_utils import verify_generator, gen_buckets_probs_with_ppf
 from mxnet.numpy_op_signature import _get_builtin_op
 from mxnet.test_utils import is_op_runnable, has_tvm_ops
+from mxnet.operator import get_all_registered_operators
 
 
 @with_seed()
@@ -3164,10 +3165,15 @@ def test_np_take():
 def test_np_builtin_op_signature():
     import inspect
     from mxnet import _numpy_op_doc
-    for op_name in dir(_numpy_op_doc):
+    builtin_np_op_names = [name for name in get_all_registered_operators() if name.startswith('_np_')]
+    for op_name in builtin_np_op_names:
+        _op_from_doc = getattr(_numpy_op_doc, op_name, None)
+        assert _op_from_doc is not None, "Failed to find documentation for operator {}. " \
+                                         "Please add the documentation in _numpy_op_doc.py for this operator."\
+            .format(op_name)
         op = _get_builtin_op(op_name)
-        if op is not None:
-            assert str(op.__signature__) == str(inspect.signature(getattr(_numpy_op_doc, op_name)))
+        assert op is not None
+        assert str(op.__signature__) == str(inspect.signature(_op_from_doc))
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
Tweaked one unit test to enforce adding docstrings for numpy operators that are exposed directly from backend, i.e., the operators whose names have `_np_` prefix.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
