### PR TITLE
Move imagenet inference to nightly

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1394,6 +1394,7 @@ nightly_test_installation() {
 # Runs Imagenet inference
 nightly_test_imagenet_inference() {
     set -ex
+    echo $PWD
     cp /work/mxnet/build/cpp-package/example/imagenet_inference .
     ./unit_test_imagenet_inference.sh
 }

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1396,8 +1396,7 @@ nightly_test_imagenet_inference() {
     set -ex
     echo $PWD
     cp /work/mxnet/build/cpp-package/example/imagenet_inference .
-    cd /work/mxnet/build/cpp-package/example/inference
-    ./unit_test_imagenet_inference.sh
+    /work/mxnet/cpp-package/example/inference/unit_test_imagenet_inference.sh
 }
 
 #Runs a simple MNIST training example

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1394,7 +1394,7 @@ nightly_test_installation() {
 # Runs Imagenet inference
 nightly_test_imagenet_inference() {
     set -ex
-    cp /work/build/cpp-package/example/imagenet_inference .
+    cp /work/mxnet/build/cpp-package/example/imagenet_inference .
     ./unit_test_imagenet_inference.sh
 }
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1391,6 +1391,14 @@ nightly_test_installation() {
     source ./tests/jenkins/run_test_installation_docs.sh docs/install/index.md 1 1686; ${1}
 }
 
+# Runs Imagenet inference
+nightly_test_imagenet_inference() {
+    set -ex
+    cp ../../build/cpp-package/example/imagenet_inference .
+    ./unit_test_imagenet_inference.sh
+}
+
+
 #Runs a simple MNIST training example
 nightly_test_image_classification() {
     set -ex

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1396,9 +1396,9 @@ nightly_test_imagenet_inference() {
     set -ex
     echo $PWD
     cp /work/mxnet/build/cpp-package/example/imagenet_inference .
+    cd /work/mxnet/build/cpp-package/example/inference
     ./unit_test_imagenet_inference.sh
 }
-
 
 #Runs a simple MNIST training example
 nightly_test_image_classification() {

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1394,7 +1394,7 @@ nightly_test_installation() {
 # Runs Imagenet inference
 nightly_test_imagenet_inference() {
     set -ex
-    cp ../../build/cpp-package/example/imagenet_inference .
+    cp ./build/cpp-package/example/imagenet_inference .
     ./unit_test_imagenet_inference.sh
 }
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1394,7 +1394,7 @@ nightly_test_installation() {
 # Runs Imagenet inference
 nightly_test_imagenet_inference() {
     set -ex
-    cp ./build/cpp-package/example/imagenet_inference .
+    cp /work/build/cpp-package/example/imagenet_inference .
     ./unit_test_imagenet_inference.sh
 }
 

--- a/cpp-package/tests/ci_test.sh
+++ b/cpp-package/tests/ci_test.sh
@@ -66,8 +66,6 @@ cp ../../build/cpp-package/example/test_regress_label .
 sh unittests/unit_test_mlp_csv.sh
 
 cd inference
-cp ../../../build/cpp-package/example/imagenet_inference .
-./unit_test_imagenet_inference.sh
 
 cp ../../../build/cpp-package/example/sentiment_analysis_rnn .
 ./unit_test_sentiment_analysis_rnn.sh

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -69,6 +69,13 @@ core_logic: {
         }
       }
     },
+    'ImageNet Inference: GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/nt-ImageInferenceTest') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_imagenet_inference', true)
+        }
+    },
     'KVStore_SingleNode: GPU': {
       node('mxnetlinux-gpu-p3-8xlarge') {
         ws('workspace/nt-KVStoreTest') {

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -75,6 +75,7 @@ core_logic: {
           utils.unpack_and_init('gpu', mx_lib)
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_imagenet_inference', true)
         }
+      }
     },
     'KVStore_SingleNode: GPU': {
       node('mxnetlinux-gpu-p3-8xlarge') {

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -20,7 +20,7 @@
 
 mx_lib = 'lib/libmxnet.so, lib/libmxnet.a, lib/libtvm_runtime.so, lib/libtvmop.so, 3rdparty/dmlc-core/libdmlc.a, 3rdparty/tvm/nnvm/lib/libnnvm.a'
 mx_cmake_lib = 'build/libmxnet.so, build/libmxnet.a, build/3rdparty/tvm/libtvm_runtime.so, build/libtvmop.so, build/3rdparty/dmlc-core/libdmlc.a, build/tests/mxnet_unit_tests, build/3rdparty/openmp/runtime/src/libomp.so'
-mx_lib_cpp_examples = 'lib/libmxnet.so, lib/libmxnet.a, lib/libtvm_runtime.so, lib/libtvmop.so, libsample_lib.so, 3rdparty/dmlc-core/libdmlc.a, 3rdparty/tvm/nnvm/lib/libnnvm.a, 3rdparty/ps-lite/build/libps.a, deps/lib/libprotobuf-lite.a, deps/lib/libzmq.a, build/cpp-package/example/*, python/mxnet/_cy2/*.so, python/mxnet/_cy3/*.so'
+mx_lib_cpp_example = 'lib/libmxnet.so, lib/libmxnet.a, lib/libtvm_runtime.so, lib/libtvmop.so, 3rdparty/dmlc-core/libdmlc.a, 3rdparty/tvm/nnvm/lib/libnnvm.a, build/cpp-package/example/imagenet_inference'
 
 node('utility') {
   // Loading the utilities requires a node context unfortunately

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -61,14 +61,14 @@ core_logic: {
   }
 
   stage('NightlyTests'){
-    parallel 'ImageClassification: GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/nt-ImageClassificationTest') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_image_classification', true)
-        }
-      }
-    },
+    // parallel 'ImageClassification: GPU': {
+    //   node(NODE_LINUX_GPU) {
+    //     ws('workspace/nt-ImageClassificationTest') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_image_classification', true)
+    //     }
+    //   }
+    // },
     'ImageNet Inference: GPU': {
       node(NODE_LINUX_GPU) {
         ws('workspace/nt-ImageInferenceTest') {
@@ -77,14 +77,14 @@ core_logic: {
         }
       }
     },
-    'KVStore_SingleNode: GPU': {
-      node('mxnetlinux-gpu-p3-8xlarge') {
-        ws('workspace/nt-KVStoreTest') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
-        }
-      }
-    },
+    // 'KVStore_SingleNode: GPU': {
+    //   node('mxnetlinux-gpu-p3-8xlarge') {
+    //     ws('workspace/nt-KVStoreTest') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
+    //     }
+    //   }
+    // },
     // https://github.com/apache/incubator-mxnet/issues/14980
     /*'Test Large Tensor Size: CPU': {
       node(NODE_LINUX_CPU) {
@@ -103,46 +103,46 @@ core_logic: {
         }
       }
     },*/
-    'StraightDope: Python2 Single-GPU': {
-      node(NODE_LINUX_GPU_P3) {
-        ws('workspace/straight_dope-single_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
-        }
-      }
-    },
-    'StraightDope: Python2 Multi-GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/straight_dope-multi_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
-        }
-      }
-    },
-    'StraightDope: Python3 Single-GPU': {
-      node(NODE_LINUX_GPU_P3) {
-        ws('workspace/straight_dope-single_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
-        }
-      }
-    },
-    'StraightDope: Python3 Multi-GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/straight_dope-multi_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
-        }
-      }
-    },
-    'Gluon estimator: GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/estimator-test-gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
-        }
-      }
-    }
+    // 'StraightDope: Python2 Single-GPU': {
+    //   node(NODE_LINUX_GPU_P3) {
+    //     ws('workspace/straight_dope-single_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'StraightDope: Python2 Multi-GPU': {
+    //   node(NODE_LINUX_GPU) {
+    //     ws('workspace/straight_dope-multi_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'StraightDope: Python3 Single-GPU': {
+    //   node(NODE_LINUX_GPU_P3) {
+    //     ws('workspace/straight_dope-single_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'StraightDope: Python3 Multi-GPU': {
+    //   node(NODE_LINUX_GPU) {
+    //     ws('workspace/straight_dope-multi_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'Gluon estimator: GPU': {
+    //   node(NODE_LINUX_GPU) {
+    //     ws('workspace/estimator-test-gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
+    //     }
+    //   }
+    // }
   }
 }
 ,

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -37,7 +37,7 @@ core_logic: {
         ws('workspace/build-gpu') {
           utils.init_git()
           utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_cuda101_cudnn7', false)
-          utils.pack_lib('gpu', mx_lib)
+          utils.pack_lib('gpu', mx_lib_cpp_examples)
         }
       }
     }/*,
@@ -77,15 +77,15 @@ core_logic: {
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_imagenet_inference', true)
         }
       }
-    },
-    'KVStore_SingleNode: GPU': {
-      node('mxnetlinux-gpu-p3-8xlarge') {
-        ws('workspace/nt-KVStoreTest') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
-        }
-      }
-    },
+    }//,
+    // 'KVStore_SingleNode: GPU': {
+    //   node('mxnetlinux-gpu-p3-8xlarge') {
+    //     ws('workspace/nt-KVStoreTest') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
+    //     }
+    //   }
+    // },
     // https://github.com/apache/incubator-mxnet/issues/14980
     /*'Test Large Tensor Size: CPU': {
       node(NODE_LINUX_CPU) {
@@ -104,46 +104,46 @@ core_logic: {
         }
       }
     },*/
-    'StraightDope: Python2 Single-GPU': {
-      node(NODE_LINUX_GPU_P3) {
-        ws('workspace/straight_dope-single_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
-        }
-      }
-    },
-    'StraightDope: Python2 Multi-GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/straight_dope-multi_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
-        }
-      }
-    },
-    'StraightDope: Python3 Single-GPU': {
-      node(NODE_LINUX_GPU_P3) {
-        ws('workspace/straight_dope-single_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
-        }
-      }
-    },
-    'StraightDope: Python3 Multi-GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/straight_dope-multi_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
-        }
-      }
-    },
-    'Gluon estimator: GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/estimator-test-gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
-        }
-      }
-    }
+    // 'StraightDope: Python2 Single-GPU': {
+    //   node(NODE_LINUX_GPU_P3) {
+    //     ws('workspace/straight_dope-single_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'StraightDope: Python2 Multi-GPU': {
+    //   node(NODE_LINUX_GPU) {
+    //     ws('workspace/straight_dope-multi_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'StraightDope: Python3 Single-GPU': {
+    //   node(NODE_LINUX_GPU_P3) {
+    //     ws('workspace/straight_dope-single_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'StraightDope: Python3 Multi-GPU': {
+    //   node(NODE_LINUX_GPU) {
+    //     ws('workspace/straight_dope-multi_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'Gluon estimator: GPU': {
+    //   node(NODE_LINUX_GPU) {
+    //     ws('workspace/estimator-test-gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
+    //     }
+    //   }
+    // }
   }
 }
 ,

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -62,30 +62,30 @@ core_logic: {
   }
 
   stage('NightlyTests'){
-    // parallel 'ImageClassification: GPU': {
-    //   node(NODE_LINUX_GPU) {
-    //     ws('workspace/nt-ImageClassificationTest') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_image_classification', true)
-    //     }
-    //   }
-    // },
-    parallel 'ImageNet Inference: GPU': {
+    parallel 'ImageClassification: GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/nt-ImageClassificationTest') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_image_classification', true)
+        }
+      }
+    },
+    'ImageNet Inference: GPU': {
       node(NODE_LINUX_GPU) {
         ws('workspace/nt-ImageInferenceTest') {
           utils.unpack_and_init('gpu', mx_lib_cpp_examples)
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_imagenet_inference', true)
         }
       }
-    }
-    // 'KVStore_SingleNode: GPU': {
-    //   node('mxnetlinux-gpu-p3-8xlarge') {
-    //     ws('workspace/nt-KVStoreTest') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
-    //     }
-    //   }
-    // },
+    },
+    'KVStore_SingleNode: GPU': {
+      node('mxnetlinux-gpu-p3-8xlarge') {
+        ws('workspace/nt-KVStoreTest') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
+        }
+      }
+    },
     // https://github.com/apache/incubator-mxnet/issues/14980
     /*'Test Large Tensor Size: CPU': {
       node(NODE_LINUX_CPU) {
@@ -104,46 +104,46 @@ core_logic: {
         }
       }
     },*/
-    // 'StraightDope: Python2 Single-GPU': {
-    //   node(NODE_LINUX_GPU_P3) {
-    //     ws('workspace/straight_dope-single_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'StraightDope: Python2 Multi-GPU': {
-    //   node(NODE_LINUX_GPU) {
-    //     ws('workspace/straight_dope-multi_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'StraightDope: Python3 Single-GPU': {
-    //   node(NODE_LINUX_GPU_P3) {
-    //     ws('workspace/straight_dope-single_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'StraightDope: Python3 Multi-GPU': {
-    //   node(NODE_LINUX_GPU) {
-    //     ws('workspace/straight_dope-multi_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'Gluon estimator: GPU': {
-    //   node(NODE_LINUX_GPU) {
-    //     ws('workspace/estimator-test-gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
-    //     }
-    //   }
-    // }
+    'StraightDope: Python2 Single-GPU': {
+      node(NODE_LINUX_GPU_P3) {
+        ws('workspace/straight_dope-single_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
+        }
+      }
+    },
+    'StraightDope: Python2 Multi-GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/straight_dope-multi_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
+        }
+      }
+    },
+    'StraightDope: Python3 Single-GPU': {
+      node(NODE_LINUX_GPU_P3) {
+        ws('workspace/straight_dope-single_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
+        }
+      }
+    },
+    'StraightDope: Python3 Multi-GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/straight_dope-multi_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
+        }
+      }
+    },
+    'Gluon estimator: GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/estimator-test-gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
+        }
+      }
+    }
   }
 }
 ,

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -69,14 +69,14 @@ core_logic: {
     //     }
     //   }
     // },
-    'ImageNet Inference: GPU': {
+    parallel 'ImageNet Inference: GPU': {
       node(NODE_LINUX_GPU) {
         ws('workspace/nt-ImageInferenceTest') {
           utils.unpack_and_init('gpu', mx_lib)
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_imagenet_inference', true)
         }
       }
-    },
+    }
     // 'KVStore_SingleNode: GPU': {
     //   node('mxnetlinux-gpu-p3-8xlarge') {
     //     ws('workspace/nt-KVStoreTest') {

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -73,19 +73,19 @@ core_logic: {
     'ImageNet Inference: GPU': {
       node(NODE_LINUX_GPU) {
         ws('workspace/nt-ImageInferenceTest') {
-          utils.unpack_and_init('gpu', mx_lib_cpp_examples)
+          utils.unpack_and_init('gpu', mx_lib_cpp_example)
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_imagenet_inference', true)
         }
       }
-    }//,
-    // 'KVStore_SingleNode: GPU': {
-    //   node('mxnetlinux-gpu-p3-8xlarge') {
-    //     ws('workspace/nt-KVStoreTest') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
-    //     }
-    //   }
-    // },
+    },
+    'KVStore_SingleNode: GPU': {
+      node('mxnetlinux-gpu-p3-8xlarge') {
+        ws('workspace/nt-KVStoreTest') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
+        }
+      }
+    },
     // https://github.com/apache/incubator-mxnet/issues/14980
     /*'Test Large Tensor Size: CPU': {
       node(NODE_LINUX_CPU) {
@@ -104,46 +104,46 @@ core_logic: {
         }
       }
     },*/
-    // 'StraightDope: Python2 Single-GPU': {
-    //   node(NODE_LINUX_GPU_P3) {
-    //     ws('workspace/straight_dope-single_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'StraightDope: Python2 Multi-GPU': {
-    //   node(NODE_LINUX_GPU) {
-    //     ws('workspace/straight_dope-multi_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'StraightDope: Python3 Single-GPU': {
-    //   node(NODE_LINUX_GPU_P3) {
-    //     ws('workspace/straight_dope-single_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'StraightDope: Python3 Multi-GPU': {
-    //   node(NODE_LINUX_GPU) {
-    //     ws('workspace/straight_dope-multi_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'Gluon estimator: GPU': {
-    //   node(NODE_LINUX_GPU) {
-    //     ws('workspace/estimator-test-gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
-    //     }
-    //   }
-    // }
+    'StraightDope: Python2 Single-GPU': {
+      node(NODE_LINUX_GPU_P3) {
+        ws('workspace/straight_dope-single_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
+        }
+      }
+    },
+    'StraightDope: Python2 Multi-GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/straight_dope-multi_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
+        }
+      }
+    },
+    'StraightDope: Python3 Single-GPU': {
+      node(NODE_LINUX_GPU_P3) {
+        ws('workspace/straight_dope-single_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
+        }
+      }
+    },
+    'StraightDope: Python3 Multi-GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/straight_dope-multi_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
+        }
+      }
+    },
+    'Gluon estimator: GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/estimator-test-gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
+        }
+      }
+    }
   }
 }
 ,

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -37,7 +37,7 @@ core_logic: {
         ws('workspace/build-gpu') {
           utils.init_git()
           utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_cuda101_cudnn7', false)
-          utils.pack_lib('gpu', mx_lib_cpp_examples)
+          utils.pack_lib('gpu', mx_lib_cpp_example)
         }
       }
     }/*,

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -20,6 +20,7 @@
 
 mx_lib = 'lib/libmxnet.so, lib/libmxnet.a, lib/libtvm_runtime.so, lib/libtvmop.so, 3rdparty/dmlc-core/libdmlc.a, 3rdparty/tvm/nnvm/lib/libnnvm.a'
 mx_cmake_lib = 'build/libmxnet.so, build/libmxnet.a, build/3rdparty/tvm/libtvm_runtime.so, build/libtvmop.so, build/3rdparty/dmlc-core/libdmlc.a, build/tests/mxnet_unit_tests, build/3rdparty/openmp/runtime/src/libomp.so'
+mx_lib_cpp_examples = 'lib/libmxnet.so, lib/libmxnet.a, lib/libtvm_runtime.so, lib/libtvmop.so, libsample_lib.so, 3rdparty/dmlc-core/libdmlc.a, 3rdparty/tvm/nnvm/lib/libnnvm.a, 3rdparty/ps-lite/build/libps.a, deps/lib/libprotobuf-lite.a, deps/lib/libzmq.a, build/cpp-package/example/*, python/mxnet/_cy2/*.so, python/mxnet/_cy3/*.so'
 
 node('utility') {
   // Loading the utilities requires a node context unfortunately
@@ -72,7 +73,7 @@ core_logic: {
     parallel 'ImageNet Inference: GPU': {
       node(NODE_LINUX_GPU) {
         ws('workspace/nt-ImageInferenceTest') {
-          utils.unpack_and_init('gpu', mx_lib)
+          utils.unpack_and_init('gpu', mx_lib_cpp_examples)
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_imagenet_inference', true)
         }
       }


### PR DESCRIPTION
## Description ##
Reduces the timeout issue for UNIX GPU by moving the imagenet inference

Pointed out by @aaronmarkham 
Imagenet inference test (along with few others) involve downloading 1.5G of 

## Checklist ##
### Essentials ###

- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Remove test from unix GPU cpp examples
- [x] Add test to nightly

## Comments ##
- Tested it on MXNet CI Dev Jenkins
http://jenkins.mxnet-ci-dev.amazon-ml.com/blue/organizations/jenkins/NightlyTestsForBinaries/detail/move_imagenet_inference_nightly/18/pipeline
