### PR TITLE
[Gluon] Don't serialize shared parameters twice

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -527,7 +527,7 @@ class Block(object):
 
         if not allow_missing:
             # Shared parameters are stored only a single time as of MXNet 1.6.
-            # We thus retrieve all prefixes (à la _collect_params_with_prefix)
+            # We thus retrieve all prefixes (through _collect_params_with_prefix)
             # that a shared parameter is used with. Check that there are no
             # missing parameters that were not yet already loaded from the
             # shared version.

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -524,7 +524,9 @@ class Block(object):
 
         if not any('.' in i for i in loaded.keys()):
             # legacy loading
-            del loaded
+            loaded = None
+            # We cannot `del loaded` as it is used in a generator expression
+            # below. `del loaded` would be a SyntaxError in Python 2.
             self.collect_params().load(
                 filename, ctx, allow_missing, ignore_extra, self.prefix,
                 cast_dtype=cast_dtype, dtype_source=dtype_source)

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -524,9 +524,7 @@ class Block(object):
 
         if not any('.' in i for i in loaded.keys()):
             # legacy loading
-            loaded = None
-            # We cannot `del loaded` as it is used in a generator expression
-            # below. `del loaded` would be a SyntaxError in Python 2.
+            loaded = None  # This should be changed to `del loaded` when dropping Python 2
             self.collect_params().load(
                 filename, ctx, allow_missing, ignore_extra, self.prefix,
                 cast_dtype=cast_dtype, dtype_source=dtype_source)

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1540,6 +1540,17 @@ def test_save_load_deduplicate_with_shared_params():
     c = C(b1, b2)
     c.load_parameters('tmp.params')
 
+    # Test default behavior
+    c.save_parameters('tmp2.params', deduplicate=False)
+
+    params = mx.nd.load('tmp2.params')
+    assert len(params) == 2  # Only a single copy of the shared parameter is saved
+
+    b1 = B()
+    b2 = B(b1.collect_params())
+    c = C(b1, b2)
+    c.load_parameters('tmp2.params')
+
 @with_seed()
 def test_symbol_block_save_load():
     class Net(gluon.HybridBlock):

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1512,17 +1512,17 @@ def test_save_load():
     net2.load_parameters('tmp.params')
 
 @with_seed()
-def test_save_load_with_shared_params():
+def test_save_load_deduplicate_with_shared_params():
     class B(mx.gluon.Block):
         def __init__(self, params=None):
-            super().__init__(params=params)
+            super(B, self).__init__(params=params)
 
             with self.name_scope():
                 self.weight = self.params.get('weight', shape=(10, 10))
 
     class C(mx.gluon.Block):
         def __init__(self, b1, b2):
-            super().__init__()
+            super(C, self).__init__()
             self.b1 = b1
             self.b2 = b2
 
@@ -1530,7 +1530,7 @@ def test_save_load_with_shared_params():
     b2 = B(b1.collect_params())
     c = C(b1, b2)
     c.initialize()
-    c.save_parameters('tmp.params')
+    c.save_parameters('tmp.params', deduplicate=True)
 
     params = mx.nd.load('tmp.params')
     assert len(params) == 1  # Only a single copy of the shared parameter is saved

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1512,6 +1512,35 @@ def test_save_load():
     net2.load_parameters('tmp.params')
 
 @with_seed()
+def test_save_load_with_shared_params():
+    class B(mx.gluon.Block):
+        def __init__(self, params=None):
+            super().__init__(params=params)
+
+            with self.name_scope():
+                self.weight = self.params.get('weight', shape=(10, 10))
+
+    class C(mx.gluon.Block):
+        def __init__(self, b1, b2):
+            super().__init__()
+            self.b1 = b1
+            self.b2 = b2
+
+    b1 = B()
+    b2 = B(b1.collect_params())
+    c = C(b1, b2)
+    c.initialize()
+    c.save_parameters('tmp.params')
+
+    params = mx.nd.load('tmp.params')
+    assert len(params) == 1  # Only a single copy of the shared parameter is saved
+
+    b1 = B()
+    b2 = B(b1.collect_params())
+    c = C(b1, b2)
+    c.load_parameters('tmp.params')
+
+@with_seed()
 def test_symbol_block_save_load():
     class Net(gluon.HybridBlock):
         def __init__(self):


### PR DESCRIPTION
## Description ##
`Block.save_parameters` currently stores a separate copy of shared parameters for sub-block which uses the shared parameter. This is wasteful. Instead only store a single copy.
This change is backwards compatible; all existing valid serialized files continue to work. However, newly serialized files will be smaller in case they contain shared parameters.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Don't serialize shared parameters twice in Gluon `Block.save_parameters`

## Comments ##
@szha @eric-haibin-lin 