### PR TITLE
Imagenet inference to nightly fix

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1467,7 +1467,8 @@ nightly_test_imagenet_inference() {
     set -ex
     echo $PWD
     cp /work/mxnet/build/cpp-package/example/imagenet_inference .
-    /work/mxnet/cpp-package/example/inference/unit_test_imagenet_inference.sh
+    cd /work/mxnet/cpp-package/example/inference/
+    ./unit_test_imagenet_inference.sh
 }
 
 #Runs a simple MNIST training example

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1466,7 +1466,7 @@ nightly_test_installation() {
 nightly_test_imagenet_inference() {
     set -ex
     echo $PWD
-    cp /work/mxnet/build/cpp-package/example/imagenet_inference .
+    cp /work/mxnet/build/cpp-package/example/imagenet_inference /work/mxnet/cpp-package/example/inference/
     cd /work/mxnet/cpp-package/example/inference/
     ./unit_test_imagenet_inference.sh
 }

--- a/cpp-package/example/inference/unit_test_imagenet_inference.sh
+++ b/cpp-package/example/inference/unit_test_imagenet_inference.sh
@@ -38,7 +38,11 @@ wget -nc https://raw.githubusercontent.com/dmlc/gluon-cv/master/gluoncv/model_zo
 cd ../data
 wget -nc http://data.mxnet.io/data/val_256_q90.rec
 cd ..
-
+echo $PWD
+echo "lib path"
+ls -al ../../../lib
+echo "current file"
+ls -al .
 # Running inference on imagenet.
 if [ "$(uname)" == "Darwin" ]; then
     echo ">>> INFO: FP32 real data"

--- a/cpp-package/example/inference/unit_test_imagenet_inference.sh
+++ b/cpp-package/example/inference/unit_test_imagenet_inference.sh
@@ -38,11 +38,7 @@ wget -nc https://raw.githubusercontent.com/dmlc/gluon-cv/master/gluoncv/model_zo
 cd ../data
 wget -nc http://data.mxnet.io/data/val_256_q90.rec
 cd ..
-echo $PWD
-echo "lib path"
-ls -al ../../../lib
-echo "current file"
-ls -al .
+
 # Running inference on imagenet.
 if [ "$(uname)" == "Darwin" ]; then
     echo ">>> INFO: FP32 real data"

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -34,9 +34,9 @@ core_logic: {
   stage('Build') {
     parallel 'GPU: CUDA10.1+cuDNN7': {
       node(NODE_LINUX_CPU) {
-        ws('workspace/build-gpu') {
+        ws('workspace/build-mkldnn-gpu') {
           utils.init_git()
-          utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_cuda101_cudnn7', false)
+          utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_mkldnn', false)
           utils.pack_lib('gpu', mx_lib_cpp_example_mkl)
         }
       }

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -62,30 +62,30 @@ core_logic: {
   }
 
   stage('NightlyTests'){
-    parallel 'ImageClassification: GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/nt-ImageClassificationTest') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_image_classification', true)
-        }
-      }
-    },
-    'ImageNet Inference: GPU': {
+    // parallel 'ImageClassification: GPU': {
+    //   node(NODE_LINUX_GPU) {
+    //     ws('workspace/nt-ImageClassificationTest') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_image_classification', true)
+    //     }
+    //   }
+    // },
+    parallel 'ImageNet Inference: GPU': {
       node(NODE_LINUX_GPU) {
         ws('workspace/nt-ImageInferenceTest') {
           utils.unpack_and_init('gpu', mx_lib_cpp_example)
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_imagenet_inference', true)
         }
       }
-    },
-    'KVStore_SingleNode: GPU': {
-      node('mxnetlinux-gpu-p3-8xlarge') {
-        ws('workspace/nt-KVStoreTest') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
-        }
-      }
-    },
+    }//,
+    // 'KVStore_SingleNode: GPU': {
+    //   node('mxnetlinux-gpu-p3-8xlarge') {
+    //     ws('workspace/nt-KVStoreTest') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
+    //     }
+    //   }
+    // },
     // https://github.com/apache/incubator-mxnet/issues/14980
     /*'Test Large Tensor Size: CPU': {
       node(NODE_LINUX_CPU) {
@@ -104,46 +104,46 @@ core_logic: {
         }
       }
     },*/
-    'StraightDope: Python2 Single-GPU': {
-      node(NODE_LINUX_GPU_P3) {
-        ws('workspace/straight_dope-single_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
-        }
-      }
-    },
-    'StraightDope: Python2 Multi-GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/straight_dope-multi_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
-        }
-      }
-    },
-    'StraightDope: Python3 Single-GPU': {
-      node(NODE_LINUX_GPU_P3) {
-        ws('workspace/straight_dope-single_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
-        }
-      }
-    },
-    'StraightDope: Python3 Multi-GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/straight_dope-multi_gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
-        }
-      }
-    },
-    'Gluon estimator: GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/estimator-test-gpu') {
-          utils.unpack_and_init('gpu', mx_lib)
-          utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
-        }
-      }
-    }
+    // 'StraightDope: Python2 Single-GPU': {
+    //   node(NODE_LINUX_GPU_P3) {
+    //     ws('workspace/straight_dope-single_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'StraightDope: Python2 Multi-GPU': {
+    //   node(NODE_LINUX_GPU) {
+    //     ws('workspace/straight_dope-multi_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'StraightDope: Python3 Single-GPU': {
+    //   node(NODE_LINUX_GPU_P3) {
+    //     ws('workspace/straight_dope-single_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'StraightDope: Python3 Multi-GPU': {
+    //   node(NODE_LINUX_GPU) {
+    //     ws('workspace/straight_dope-multi_gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
+    //     }
+    //   }
+    // },
+    // 'Gluon estimator: GPU': {
+    //   node(NODE_LINUX_GPU) {
+    //     ws('workspace/estimator-test-gpu') {
+    //       utils.unpack_and_init('gpu', mx_lib)
+    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
+    //     }
+    //   }
+    // }
   }
 }
 ,

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -36,7 +36,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/build-mkldnn-gpu') {
           utils.init_git()
-          utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_mkldnn', false)
+          utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_mkldnn', true)
           utils.pack_lib('gpu', mx_lib_cpp_example_mkl)
         }
       }

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -20,7 +20,7 @@
 
 mx_lib = 'lib/libmxnet.so, lib/libmxnet.a, lib/libtvm_runtime.so, lib/libtvmop.so, 3rdparty/dmlc-core/libdmlc.a, 3rdparty/tvm/nnvm/lib/libnnvm.a'
 mx_cmake_lib = 'build/libmxnet.so, build/libmxnet.a, build/3rdparty/tvm/libtvm_runtime.so, build/libtvmop.so, build/3rdparty/dmlc-core/libdmlc.a, build/tests/mxnet_unit_tests, build/3rdparty/openmp/runtime/src/libomp.so'
-mx_lib_cpp_example = 'lib/libmxnet.so, lib/libmxnet.a, lib/libtvm_runtime.so, lib/libtvmop.so, 3rdparty/dmlc-core/libdmlc.a, 3rdparty/tvm/nnvm/lib/libnnvm.a, build/cpp-package/example/imagenet_inference'
+mx_lib_cpp_example_mkl = 'lib/libmxnet.so, lib/libmxnet.a, lib/libtvm_runtime.so, lib/libtvmop.so, 3rdparty/dmlc-core/libdmlc.a, 3rdparty/tvm/nnvm/lib/libnnvm.a, build/cpp-package/example/imagenet_inference, lib/libmkldnn.so.0, lib/libmklml_intel.so'
 
 node('utility') {
   // Loading the utilities requires a node context unfortunately
@@ -37,7 +37,7 @@ core_logic: {
         ws('workspace/build-gpu') {
           utils.init_git()
           utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_cuda101_cudnn7', false)
-          utils.pack_lib('gpu', mx_lib_cpp_example)
+          utils.pack_lib('gpu', mx_lib_cpp_example_mkl)
         }
       }
     }/*,
@@ -73,7 +73,7 @@ core_logic: {
     'ImageNet Inference: GPU': {
       node(NODE_LINUX_GPU) {
         ws('workspace/nt-ImageInferenceTest') {
-          utils.unpack_and_init('gpu', mx_lib_cpp_example)
+          utils.unpack_and_init('gpu', mx_lib_cpp_example_mkl)
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_imagenet_inference', true)
         }
       }

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -36,7 +36,7 @@ core_logic: {
       node(NODE_LINUX_CPU) {
         ws('workspace/build-mkldnn-gpu') {
           utils.init_git()
-          utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_mkldnn', true)
+          utils.docker_run('ubuntu_build_cuda', 'build_ubuntu_gpu_mkldnn', false)
           utils.pack_lib('gpu', mx_lib_cpp_example_mkl)
         }
       }

--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -62,30 +62,30 @@ core_logic: {
   }
 
   stage('NightlyTests'){
-    // parallel 'ImageClassification: GPU': {
-    //   node(NODE_LINUX_GPU) {
-    //     ws('workspace/nt-ImageClassificationTest') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_image_classification', true)
-    //     }
-    //   }
-    // },
-    parallel 'ImageNet Inference: GPU': {
+    parallel 'ImageClassification: GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/nt-ImageClassificationTest') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_image_classification', true)
+        }
+      }
+    },
+    'ImageNet Inference: GPU': {
       node(NODE_LINUX_GPU) {
         ws('workspace/nt-ImageInferenceTest') {
           utils.unpack_and_init('gpu', mx_lib_cpp_example)
           utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_imagenet_inference', true)
         }
       }
-    }//,
-    // 'KVStore_SingleNode: GPU': {
-    //   node('mxnetlinux-gpu-p3-8xlarge') {
-    //     ws('workspace/nt-KVStoreTest') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
-    //     }
-    //   }
-    // },
+    },
+    'KVStore_SingleNode: GPU': {
+      node('mxnetlinux-gpu-p3-8xlarge') {
+        ws('workspace/nt-KVStoreTest') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_KVStore_singleNode', true)
+        }
+      }
+    },
     // https://github.com/apache/incubator-mxnet/issues/14980
     /*'Test Large Tensor Size: CPU': {
       node(NODE_LINUX_CPU) {
@@ -104,46 +104,46 @@ core_logic: {
         }
       }
     },*/
-    // 'StraightDope: Python2 Single-GPU': {
-    //   node(NODE_LINUX_GPU_P3) {
-    //     ws('workspace/straight_dope-single_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'StraightDope: Python2 Multi-GPU': {
-    //   node(NODE_LINUX_GPU) {
-    //     ws('workspace/straight_dope-multi_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'StraightDope: Python3 Single-GPU': {
-    //   node(NODE_LINUX_GPU_P3) {
-    //     ws('workspace/straight_dope-single_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'StraightDope: Python3 Multi-GPU': {
-    //   node(NODE_LINUX_GPU) {
-    //     ws('workspace/straight_dope-multi_gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
-    //     }
-    //   }
-    // },
-    // 'Gluon estimator: GPU': {
-    //   node(NODE_LINUX_GPU) {
-    //     ws('workspace/estimator-test-gpu') {
-    //       utils.unpack_and_init('gpu', mx_lib)
-    //       utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
-    //     }
-    //   }
-    // }
+    'StraightDope: Python2 Single-GPU': {
+      node(NODE_LINUX_GPU_P3) {
+        ws('workspace/straight_dope-single_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_single_gpu_tests', true)
+        }
+      }
+    },
+    'StraightDope: Python2 Multi-GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/straight_dope-multi_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python2_multi_gpu_tests', true)
+        }
+      }
+    },
+    'StraightDope: Python3 Single-GPU': {
+      node(NODE_LINUX_GPU_P3) {
+        ws('workspace/straight_dope-single_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_single_gpu_tests', true)
+        }
+      }
+    },
+    'StraightDope: Python3 Multi-GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/straight_dope-multi_gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_straight_dope_python3_multi_gpu_tests', true)
+        }
+      }
+    },
+    'Gluon estimator: GPU': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/estimator-test-gpu') {
+          utils.unpack_and_init('gpu', mx_lib)
+          utils.docker_run('ubuntu_nightly_gpu', 'nightly_estimator', true)
+        }
+      }
+    }
   }
 }
 ,


### PR DESCRIPTION
## Description ##
PR #16577  was introduced to move imagenet inference to nightly
However, I made the PR prematurely (without testing it completely)

As it so happened (https://github.com/apache/incubator-mxnet/pull/16577/files#r337663583)
Jenkins CI (NightlyTestForBinaries) failed coz of issue in file getting access to the imagenet_inference binary
http://jenkins.mxnet-ci-dev.amazon-ml.com/blue/organizations/jenkins/NightlyTestsForBinaries/detail/move_imagenet_inference_nightly/20/pipeline/72

