### PR TITLE
[MKLDNN]Fix reorder2default

### DIFF
--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -1635,11 +1635,13 @@ void NDArray::Save(dmlc::Stream *strm) const {
     nd_cpu.WaitToRead();
     save_data = nd_cpu.data();
   } else {
-    nd_cpu = *this;
 #if MXNET_USE_MKLDNN == 1
     // For mkldnn, a copy of *this can ensure no write access pending on *this.
     nd_cpu = this->Copy(Context::CPU());
     nd_cpu.WaitToRead();
+#else
+    this->WaitToRead();
+    nd_cpu = *this;
 #endif
     save_data = nd_cpu.data();
   }

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -1635,7 +1635,6 @@ void NDArray::Save(dmlc::Stream *strm) const {
     nd_cpu.WaitToRead();
     save_data = nd_cpu.data();
   } else {
-    this->WaitToRead();
     nd_cpu = *this;
 #if MXNET_USE_MKLDNN == 1
     // For mkldnn, a copy of *this can ensure no write access pending on *this.

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -2025,14 +2025,15 @@ void NDArray::SyncCopyToCPU(void *data, size_t size) const {
   if (this->ctx().dev_mask() == cpu::kDevMask) {
     Engine::Get()->PushAsync(
         [&](RunContext rctx, Engine::CallbackOnComplete on_complete) {
+          RunContext ctx{this->ctx(), nullptr, nullptr, false};
           NDArray src = *this;
 #if MXNET_USE_MKLDNN == 1
           src = this->Reorder2Default();
 #endif
-          ndarray::Copy<cpu, cpu>(src.data(), &dst, Context::CPU(), Context::CPU(), rctx);
+          ndarray::Copy<cpu, cpu>(src.data(), &dst, Context::CPU(), Context::CPU(), ctx);
           on_complete();
         },
-        this->ctx(), {this->var()}, {}, FnProperty::kNormal, 0, "Reorder2Default");
+        this->ctx(), {this->var()}, {}, FnProperty::kNormal, 0, "SyncCopyCPU2CPU");
     this->WaitToWrite();
   } else {
 #if MXNET_USE_CUDA


### PR DESCRIPTION
convolution and fc weights may get updated during inference, thus we need to handle reorder2default within engine to ensure no write access during this.

@PatricZhao @TaoLv 

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
