### PR TITLE
no such method => modified function args

### DIFF
--- a/julia/deps/build.jl
+++ b/julia/deps/build.jl
@@ -54,7 +54,7 @@ if Sys.isunix()
   nvcc_path = Sys.which("nvcc")
   if nvcc_path ≢ nothing
     @info "Found nvcc: $nvcc_path"
-    push!(CUDAPATHS, replace(nvcc_path, "bin/nvcc", "lib64"))
+    push!(CUDAPATHS, replace(nvcc_path, "bin/nvcc" => "lib64"))
   end
 end
 

--- a/julia/src/metric.jl
+++ b/julia/src/metric.jl
@@ -260,7 +260,7 @@ end
 
 function get(metric::MSE)
   # Delay copy until last possible moment
-  mse_sum = mapreduce(nda->copy(nda)[1], +, metric.mse_sum)
+  mse_sum = mapreduce(nda->copy(nda)[1], +, metric.mse_sum; init = zero(MX_float))
   [(:MSE, mse_sum / metric.n_sample)]
 end
 

--- a/julia/src/metric.jl
+++ b/julia/src/metric.jl
@@ -260,7 +260,7 @@ end
 
 function get(metric::MSE)
   # Delay copy until last possible moment
-  mse_sum = mapreduce(nda->copy(nda)[1], +, 0.0, metric.mse_sum)
+  mse_sum = mapreduce(nda->copy(nda)[1], +, metric.mse_sum)
   [(:MSE, mse_sum / metric.n_sample)]
 end
 


### PR DESCRIPTION
```
ERROR: MethodError: no method matching mapreduce(::getfield(MXNet.mx, Symbol("##8072#8073")), ::typeof(+), ::Float64, ::Array{NDArray{Float32,1},1})
```
## Description ##
The Julia [regression example](https://github.com/apache/incubator-mxnet/blob/9f8425b2774630f5442da257b306f4fa9afa8124/julia/examples/regression-example.jl) did not run due to an inappropriate call of the `mapreduce` function when usen MSE() loss.


### Changes ###
- Changed the use of the `mapreduce` function to remove the error 
