### PR TITLE
[Scala][Clojure] change confusing native jar loading message

### DIFF
--- a/scala-package/core/src/main/scala/org/apache/mxnet/Base.scala
+++ b/scala-package/core/src/main/scala/org/apache/mxnet/Base.scala
@@ -62,18 +62,17 @@ private[mxnet] object Base {
   // The primitives currently supported for NDArray operations
   val MX_PRIMITIVES = new Group ((Double, Float))
 
+
+  /* Find the native libray either on the path or copy it from
+   * the jar in the dependency
+   * jar into a temp directory and load it
+   */
   try {
     try {
       tryLoadLibraryOS("mxnet-scala")
     } catch {
       case e: UnsatisfiedLinkError =>
-        logger.warn("MXNet Scala native library not found in path. " +
-          "Copying native library from the archive. " +
-          "Consider installing the library somewhere in the path " +
-          "(for Windows: PATH, for Linux: LD_LIBRARY_PATH), " +
-          "or specifying by Java cmd option -Djava.library.path=[lib path].")
-        logger.warn("LD_LIBRARY_PATH=" + System.getenv("LD_LIBRARY_PATH"))
-        logger.warn("java.library.path=" + System.getProperty("java.library.path"))
+        logger.info("Copying and loading native library from the jar archive")
         NativeLibraryLoader.loadLibrary("mxnet-scala")
     }
   } catch {


### PR DESCRIPTION
## Description ##
This PR address feedback in the issue https://github.com/apache/incubator-mxnet/issues/13108

This warning is confusing and alarming to new users of the Clojure package. This PR changes the log level to info and the messaging to better reflect that the normal action is to extract, copy, and load the native dependencies from the jar.

New output will be :

```
INFO  MXNetJVM: Try loading mxnet-scala from native path.
INFO  MXNetJVM: Copying and loading native library from the jar archive
INFO  org.apache.mxnet.util.NativeLibraryLoader: Replaced .dylib with .jnilib
```
as opposed to the old output of 

```
INFO  MXNetJVM: Try loading mxnet-scala from native path.
INFO  MXNetJVM: Try loading mxnet-scala-linux-x86_64-gpu from native path.
INFO  MXNetJVM: Try loading mxnet-scala-linux-x86_64-cpu from native path.
WARN  MXNetJVM: MXNet Scala native library not found in path. Copying native library from the archive. Consider installing the library somewhere in the path (for Windows: PATH, for Linux: LD_LIBRARY_PATH), or specifying by Java cmd option -Djava.library.path=[lib path].
INFO  org.apache.mxnet.util.NativeLibraryLoader: Loading libmxnet-scala.so from /lib/native/ copying to mxnet-scala
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

