### PR TITLE
Fix python doc build issue

### DIFF
--- a/docs/python_docs/environment.yml
+++ b/docs/python_docs/environment.yml
@@ -28,12 +28,12 @@ dependencies:
 - notebook
 - pip:
   # using nbconvert master until v5.5 comes out
-  - git+https://github.com/jupyter/nbconvert@master
-  - nbsphinx>=0.4.2
-  - recommonmark
-  - notedown
-  - pypandoc
-  - breathe
-  - mock
-  - awscli
-  - autodocsumm
+  - nbconvert==5.6.1
+  - nbsphinx==0.4.3
+  - recommonmark==0.6.0
+  - notedown==1.5.1
+  - pypandoc==1.4
+  - breathe==4.13.1
+  - mock==3.0.5
+  - awscli==1.16.266
+  - autodocsumm==0.1.11

--- a/docs/python_docs/environment.yml
+++ b/docs/python_docs/environment.yml
@@ -27,7 +27,6 @@ dependencies:
 - matplotlib
 - notebook
 - pip:
-  # using nbconvert master until v5.5 comes out
   - nbconvert==5.6.1
   - nbsphinx==0.4.3
   - recommonmark==0.6.0


### PR DESCRIPTION
## Description ##
Fixes #16624 

Issue was with nbconvert (older nbconvert had issue while converting ipynb )
For now pinning the versions to latest working pip versions
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] m docs/python_docs/environment.yml

## Comments ##
Pinning the versions isn't the correct approach. But for now it is a temp fix.