### PR TITLE
Implement Initializer.__eq__

### DIFF
--- a/python/mxnet/initializer.py
+++ b/python/mxnet/initializer.py
@@ -268,6 +268,11 @@ class Initializer(object):
             '"weight", "bias", "gamma" (1.0), and "beta" (0.0).' \
             'Please use mx.sym.Variable(init=mx.init.*) to set initialization pattern' % name)
 
+    def __eq__(self, other):
+        if not isinstance(other, Initializer):
+            return NotImplemented
+        # pylint: disable=unidiomatic-typecheck
+        return type(self) is type(other) and self._kwargs == other._kwargs
 
 # pylint: disable=invalid-name
 _register = registry.get_register_func(Initializer, 'initializer')

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -3119,6 +3119,21 @@ def test_squeeze_consistency():
         shape = (np.random.randint(1, 10), np.random.randint(1, 10), 1)
         block(mx.nd.ones(shape))
 
+def test_shared_parameters_with_non_default_initializer():
+    class MyBlock(gluon.HybridBlock):
+        def __init__(self, **kwargs):
+            super(MyBlock, self).__init__(**kwargs)
+
+            with self.name_scope():
+                self.param = self.params.get("param", shape=(1, ), init=mx.init.Constant(-10.0))
+
+    bl = MyBlock()
+    bl2 = MyBlock(params=bl.collect_params())
+    assert bl.param is bl2.param
+    bl3 = MyBlock()
+    assert bl.param is not bl3.param
+    assert bl.param.init == bl3.param.init
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
When sharing parameters between Blocks, gluon checks that all attributes of to-be-shared parameters match. However, as mxnet initializers don't implement `__eq__`, the check will always fail. Thus it is currently impossible to share parameters between Blocks with custom initializers.

See https://github.com/apache/incubator-mxnet/issues/16049

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Support sharing parameters between blocks with custom initializers

## Comments ##
@szha @sxjscience 