### PR TITLE
[mkldnn-v1.0] Must reorder and emplace weights for rnn inference primitives

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_rnn.cc
+++ b/src/operator/nn/mkldnn/mkldnn_rnn.cc
@@ -533,8 +533,7 @@ void MKLDNNRnnForward::SetWeightsMem(MKLDNNRnnMemMgr* mgr, void *w_ptr, void *b_
   // their gradients. Then, forward training primitives could fetch them from the scope
   // of forward inference. And from there, we don't need to reorder the plain memory to
   // the optimal rnn-packed memory for forward inference.
-  if (!is_train)
-    ReorderWeights();
+  ReorderWeights();
 
   // Process bias
   MSHADOW_REAL_TYPE_SWITCH(dtype, DType, {
@@ -550,11 +549,10 @@ void MKLDNNRnnForward::SetWeightsMem(MKLDNNRnnMemMgr* mgr, void *w_ptr, void *b_
   });
 
   // insert weights into net_args
-  if (!is_train) {
-    EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WEIGHTS_LAYER, this->weights_layer_);
-    EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WEIGHTS_ITER,  this->weights_iter_);
-    EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_BIAS,          this->bias_);
-  }
+  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WEIGHTS_LAYER, this->weights_layer_);
+  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_WEIGHTS_ITER,  this->weights_iter_);
+  EmplaceNetArgs(&this->net_args_, MKLDNN_ARG_BIAS,          this->bias_);
+
   initialized_ = true;
 }
 


### PR DESCRIPTION
## Description ##
Some problems that the primitives cannot be executed  or give wrong results will appear in the case below,
https://github.com/apache/incubator-mxnet/blob/b5d07e30321da47d604b99048c1b57c03ec819b0/tests/python/unittest/test_operator.py#L103-L108

For better performance of `forward(is_train=True)`, `ReorderWeights` is no longer used as forward training only uses plain memory. When we then invoke `forward(is_train=False)`, the required `ReorderWeights` may not be executed as the operator has been already initialized. As a consequence, the forward primitives may give wrong results. The same thing will happen with `EmplaceNetArgs`, which results in the unable executing of primitives. Currently, we use `ctx.is_train || ctx.need_grad` to check if the operator requires preparing data for forward training. Things become more complicated with the usage above, especially with `grad_req` specified. It needs a further design for the stateful RNN operator. 

## Checklist ##
### Changes ###
- [x] Must reorder and emplace weights in initailization.

## Comments ##
- Actually, reorder and emplace must be executed over the previous commit before b38d6a9ab415bba8c6c0d0cddf0f2ffcaff53a27. But it has a mistake in the code, which was fixed by b38d6a9ab415bba8c6c0d0cddf0f2ffcaff53a27. This PR just fixes the problem above based on that commit. We left a never used variable `is_train` in `SetWeightsMem(...)` for some potential uses of further design.
- We prefer to have #16555 merged due to the limited time to 1.6 release.
@TaoLv @pengzhao-intel  @ZhennanQin 