### PR TITLE
fix for enable model parallelism for non-fp32 data and symbolic interface

### DIFF
--- a/src/operator/cross_device_copy.cc
+++ b/src/operator/cross_device_copy.cc
@@ -60,6 +60,16 @@ class CrossDeviceCopyProp : public OperatorProperty {
     return true;
   }
 
+  bool InferType(std::vector<int> *in_type,
+                 std::vector<int> *out_type,
+                 std::vector<int> *aux_type) const {
+    CHECK_EQ(in_type->size(), 1) << "Input:[data]";
+    if (in_type->at(0) == -1) return false;
+    out_type->clear();
+    out_type->push_back(in_type->at(0));
+    return true;
+  }
+
   OperatorProperty* Copy() const override {
     return new CrossDeviceCopyProp();
   }


### PR DESCRIPTION
## Description ##
In symbolic model parallel computation where different nodes of the same compute graph are assigned to different physical devices, MXNet automatically inserts appropriate cross-device-copy operations whenever necessary. Though the internally generated copy does not work for any data type other than float32. Reason is that the properties of the CrossDeviceCopy are missing an explicit function for type inference (though they surprisingly have one for shape inference). So type inference falls back to the default implementation associated with the base operator class, which is an old dummy routine that just accepts fp32 data as input and output (defined in include/mxnet/operator.h, method OperatorProperty.InferType)

This fixes that problem by providing an appropriate type inference method for cross-device copy.

Note that this is only an issue for the symbolic interface, not for imperative nd.array interface (this is apparently based on a different implementation). 

This bug is currently blocking development of a concrete application based on mxnet as this application uses symbolic API for good reasons and also needs to work with fp64 data.  

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x ] All changes have test coverage
- [x] Code is well-documented: 
- [x ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
