### PR TITLE
MKLDNN FC : Add error info when mkldnn fc bias dimension is wrong

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -87,7 +87,7 @@ mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(
 
   if (bias) {
     if ((*bias).shape().ndim() != 1)
-      LOG(FATAL) << "Unexpected shape for bias "<<(*bias).shape();
+      LOG(FATAL) << "Unexpected shape for bias " << (*bias).shape();
     auto bias_md = GetMemDesc(*bias);
     mkldnn::inner_product_forward::desc desc(propagation,
         data_md, weight_md, bias_md, out_md);

--- a/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
+++ b/src/operator/nn/mkldnn/mkldnn_fully_connected.cc
@@ -86,6 +86,8 @@ mkldnn::inner_product_forward::primitive_desc GetFCFwdImpl(
   };
 
   if (bias) {
+    if ((*bias).shape().ndim() != 1)
+      LOG(FATAL) << "Unexpected shape for bias "<<(*bias).shape();
     auto bias_md = GetMemDesc(*bias);
     mkldnn::inner_product_forward::desc desc(propagation,
         data_md, weight_md, bias_md, out_md);


### PR DESCRIPTION
## Description ##
add error info when fc bias shape is not 1D [issue 15032](https://github.com/apache/incubator-mxnet/issues/15032)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here

@PatricZhao @TaoLv @anirudh2290 