### PR TITLE
Fix a typo in BilinearSampler's docstring example

### DIFF
--- a/src/operator/bilinear_sampler.cc
+++ b/src/operator/bilinear_sampler.cc
@@ -236,14 +236,14 @@ Example 2::
                   [0, 4, 1, 5],
                   [1, 0, 1, 3]]]])
 
-  warp_maxtrix = array([[[[1, 1, 1, 1],
-                          [1, 1, 1, 1],
-                          [1, 1, 1, 1],
-                          [1, 1, 1, 1]],
-                         [[0, 0, 0, 0],
-                          [0, 0, 0, 0],
-                          [0, 0, 0, 0],
-                          [0, 0, 0, 0]]]])
+  warp_matrix = array([[[[1, 1, 1, 1],
+                         [1, 1, 1, 1],
+                         [1, 1, 1, 1],
+                         [1, 1, 1, 1]],
+                        [[0, 0, 0, 0],
+                         [0, 0, 0, 0],
+                         [0, 0, 0, 0],
+                         [0, 0, 0, 0]]]])
 
   grid = GridGenerator(data=warp_matrix, transform_type='warp')
   out = BilinearSampler(data, grid)


### PR DESCRIPTION
## Description ##
BilinearSampler had a typo in its docstring example.
warp_ma**x**trix was initialized but warp_matrix was used later on.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Renamed warp_maxtrix to warp_matrix
