### PR TITLE
update default windows Visual Studio from 2015 to 2017

### DIFF
--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -221,7 +221,7 @@ def main():
 
     parser.add_argument("--vcvars",
         help="vcvars batch file location, typically inside vs studio install dir",
-        default=KNOWN_VCVARS['VS 2015'],
+        default=KNOWN_VCVARS['VS 2017'],
         type=str)
 
     parser.add_argument("--arch",


### PR DESCRIPTION
## Description ##
Currently on CI, windows instances contained both VS2015 and 2017.
However, the default is 2015 and that's the one used for CI Builds
Aim is to update the VSCode build to latest (ideally 2019) but for now transitioning to 2017 (and then to 2019)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

