### PR TITLE
fix R docs

### DIFF
--- a/docs/python_docs/python/api/ndarray/index.rst
+++ b/docs/python_docs/python/api/ndarray/index.rst
@@ -65,7 +65,7 @@ Tutorials
 
    .. card::
       :title: NDArray Guide
-      :link: ../../guide/packages/ndarray/
+      :link: ../../tutorials/packages/ndarray/
 
       The NDArray guide. Start here!
 

--- a/docs/static_site/src/pages/api/api.html
+++ b/docs/static_site/src/pages/api/api.html
@@ -58,7 +58,7 @@ docs:
   tag: julia
 - title: R
   guide_link: /api/r
-  api_link: https://s3.amazonaws.com/mxnet-prod/docs/R/mxnet-r-reference-manual.pdf
+  api_link: /api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf
   tutorial_link: /api/r/docs/tutorials
   description:
   icon: /assets/img/R_logo.svg

--- a/docs/static_site/src/pages/api/r/index.md
+++ b/docs/static_site/src/pages/api/r/index.md
@@ -26,7 +26,7 @@ tag: r
 
 # MXNet - R API
 
-See the [MXNet R Reference Manual](https://s3.amazonaws.com/mxnet-prod/docs/R/mxnet-r-reference-manual.pdf).
+See the [MXNet R Reference Manual](/api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf).
 
 MXNet supports the R programming language. The MXNet R package brings flexible and efficient GPU
 computing and state-of-art deep learning to R. It enables you to write seamless tensor/matrix computation with multiple GPUs in R. It also lets you construct and customize the state-of-art deep learning models in R,
@@ -49,4 +49,4 @@ You can perform tensor or matrix computation in R:
 ```
 ## Resources
 
-* [MXNet R Reference Manual](https://s3.amazonaws.com/mxnet-prod/docs/R/mxnet-r-reference-manual.pdf)
+* [MXNet R Reference Manual](/api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf)


### PR DESCRIPTION
Add the link to the latest R docs rather than the old one
This is the old pdf: https://s3.amazonaws.com/mxnet-prod/docs/R/mxnet-r-reference-manual.pdf
This is the new pdf: https://mxnet.apache.org/api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf