### PR TITLE
[MKLDNN] Fix int8 convolution/fc bias overflow

### DIFF
--- a/src/operator/subgraph/mkldnn/mkldnn_conv.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv.cc
@@ -107,11 +107,8 @@ static std::vector<float> GetWeightScales(const NDArray &weight, const NDArray *
     weight_scales.resize(channel);
 #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
     for (int c = 0; c < static_cast<int>(channel); ++c) {
-      float weight_range = MaxAbs(weight_c_min[c], weight_c_max[c]);
-      float scale = kInt8Range / weight_range;
-      if (weight_range == 0) {
-        scale = 1.0f;
-      } else if (bias_ptr) {
+      float scale = GetQuantizeScale(mshadow::kInt8, weight_c_min[c], weight_c_max[c]);
+      if (bias_ptr) {
         // avoid overflow on bias
         // TODO(zhennan): mkldnn has bug to handle INT_MAX in bias, so set the maximum value of bias
         // to INT_MAX / 2.
@@ -130,8 +127,7 @@ static std::vector<float> GetWeightScales(const NDArray &weight, const NDArray *
       if (total_max < weight_c_max[c]) total_max = weight_c_max[c];
     }
     weight_scales.resize(3);
-    DType weight_range = MaxAbs(total_min, total_max);
-    weight_scales[0] = kInt8Range / weight_range;
+    weight_scales[0] = GetQuantizeScale(mshadow::kInt8, total_min, total_max);
     weight_scales[1] = total_min;
     weight_scales[2] = total_max;
   }
@@ -346,8 +342,7 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
         post_requantize_ = true;
         weight_channelwise_scale = true;
       }
-      auto data_range = (data.dtype() == mshadow::kInt8) ? kInt8Range : kUint8Range;
-      data_scale_ = data_range / MaxAbs(cached_data_min_, cached_data_max_);
+      data_scale_ = GetQuantizeScale(data.dtype(), cached_data_min_, cached_data_max_);
       MSHADOW_REAL_TYPE_SWITCH(cached_weight_.dtype(), DType, {
         weight_scales_ = GetWeightScales<DType>(cached_weight_, has_bias ? &cached_bias_ : nullptr,
                                                 data_scale_, weight_channelwise_scale);
@@ -361,7 +356,7 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
       if (mkldnn_param.with_sum) {
         auto quantized_sum_range =
             (inputs[in_sum].dtype() == mshadow::kInt8) ? kInt8Range : kUint8Range;
-        sum_in_scale = quantized_sum_range / MaxAbs(cached_sum_min_, cached_sum_max_);
+        sum_in_scale = GetQuantizeScale(inputs[in_sum].dtype(), cached_sum_min_, cached_sum_max_);
       }
       if (post_requantize_) {
         quantized_out_range = IsOutputUInt8(param_) ? kUint8Range : kInt8Range;

--- a/src/operator/subgraph/mkldnn/mkldnn_conv.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv.cc
@@ -350,16 +350,13 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
       // Collect scale.
       size_t channel = cached_weight_.shape()[0];
       float sum_in_scale = 1.0;
-      float out_range;
-      float quantized_out_range;
       float output_scale;
       if (mkldnn_param.with_sum) {
         sum_in_scale = GetQuantizeScale(inputs[in_sum].dtype(), cached_sum_min_, cached_sum_max_);
       }
       if (post_requantize_) {
-        quantized_out_range = IsOutputUInt8(param_) ? kUint8Range : kInt8Range;
-        out_range = MaxAbs(cached_output_min_, cached_output_max_);
-        output_scale = quantized_out_range / out_range;
+        output_scale = GetQuantizeScale(IsOutputUInt8(param_) ? mshadow::kUint8 : mshadow::kInt8,
+                                        cached_output_min_, cached_output_max_);
         full_conv_param.requantize_scales.resize(weight_channelwise_scale ? channel : 1);
         for (size_t c = 0; c < full_conv_param.requantize_scales.size(); c++) {
           full_conv_param.requantize_scales[c] = output_scale / data_scale_ / weight_scales_[c];

--- a/src/operator/subgraph/mkldnn/mkldnn_conv.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv.cc
@@ -354,8 +354,6 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
       float quantized_out_range;
       float output_scale;
       if (mkldnn_param.with_sum) {
-        auto quantized_sum_range =
-            (inputs[in_sum].dtype() == mshadow::kInt8) ? kInt8Range : kUint8Range;
         sum_in_scale = GetQuantizeScale(inputs[in_sum].dtype(), cached_sum_min_, cached_sum_max_);
       }
       if (post_requantize_) {

--- a/src/operator/subgraph/mkldnn/mkldnn_conv.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_conv.cc
@@ -82,9 +82,11 @@ static inline size_t GetInSumIndex(const MKLDNNConvFusionParam &param) {
 }
 
 template <typename DType>
-static std::vector<float> GetWeightScales(const NDArray &weight, bool weight_channelwise_scale) {
+static std::vector<float> GetWeightScales(const NDArray &weight, const NDArray *bias,
+                                          const float data_scale, bool weight_channelwise_scale) {
   std::vector<float> weight_scales;
   const DType *weight_ptr = weight.data().dptr<DType>();
+  const DType *bias_ptr = bias? bias->data().dptr<DType>() : nullptr;
   size_t channel = weight.shape()[0];
 
   // TODO(Zhennan): Handle the case weight is not in dims 4.
@@ -103,9 +105,22 @@ static std::vector<float> GetWeightScales(const NDArray &weight, bool weight_cha
 
   if (weight_channelwise_scale) {
     weight_scales.resize(channel);
+#pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
     for (int c = 0; c < static_cast<int>(channel); ++c) {
-      DType weight_range = MaxAbs(weight_c_min[c], weight_c_max[c]);
-      weight_scales[c] = kInt8Range / weight_range;
+      float weight_range = MaxAbs(weight_c_min[c], weight_c_max[c]);
+      float scale = kInt8Range / weight_range;
+      if (weight_range == 0) {
+        scale = 1.0f;
+      } else if (bias_ptr) {
+        // avoid overflow on bias
+        // TODO(zhennan): mkldnn has bug to handle INT_MAX in bias, so set the maximum value of bias
+        // to INT_MAX / 2.
+        float scale_max =
+            static_cast<float>(bias_ptr[c] > 0 ? MaxValue<int32_t>() : MinValue<int32_t>()) / 2 /
+            bias_ptr[c] / data_scale;
+        scale = Min(scale, scale_max);
+      }
+      weight_scales[c] = scale;
     }
   } else {
     DType total_min = weight_c_min[0];
@@ -334,8 +349,8 @@ void SgMKLDNNConvOperator::Forward(const OpContext &ctx,
       auto data_range = (data.dtype() == mshadow::kInt8) ? kInt8Range : kUint8Range;
       data_scale_ = data_range / MaxAbs(cached_data_min_, cached_data_max_);
       MSHADOW_REAL_TYPE_SWITCH(cached_weight_.dtype(), DType, {
-        weight_scales_ =
-            GetWeightScales<DType>(cached_weight_, weight_channelwise_scale);
+        weight_scales_ = GetWeightScales<DType>(cached_weight_, has_bias ? &cached_bias_ : nullptr,
+                                                data_scale_, weight_channelwise_scale);
       });
       // Collect scale.
       size_t channel = cached_weight_.shape()[0];

--- a/src/operator/subgraph/mkldnn/mkldnn_fc.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc.cc
@@ -165,7 +165,7 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
           size_t weight_size = weight.shape().Size();
 #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
           for (index_t i = 0; i < static_cast<index_t>(weight_size); ++i) {
-            quantized_weight_ptr[i] = weight_ptr[i] * weight_rescale;
+            quantized_weight_ptr[i] = std::round(weight_ptr[i] * weight_rescale);
           }
           weight_scale *= weight_rescale;
           weight = *cached_weight_;
@@ -177,7 +177,7 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
         size_t bias_size = bias.shape().Size();
         #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
         for (index_t i = 0; i < static_cast<index_t>(bias_size); ++i) {
-          quantized_bias_ptr[i] = bias_ptr[i] * bias_int32_rescale;
+          quantized_bias_ptr[i] = std::round(bias_ptr[i] * bias_int32_rescale);
         }
       }
 

--- a/src/operator/subgraph/mkldnn/mkldnn_fc.cc
+++ b/src/operator/subgraph/mkldnn/mkldnn_fc.cc
@@ -66,6 +66,7 @@ class SgMKLDNNFCOp {
   nnvm::Symbol subgraph_sym_;
   MKLDNNFCFullParam full_param_;
   std::shared_ptr<MKLDNNFullyConnectedForward> fwd_;
+  std::shared_ptr<NDArray> cached_weight_;
   NDArray cached_bias_;
   float cached_min_data_;
   float cached_max_data_;
@@ -114,7 +115,7 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
   CHECK_EQ(out_data.size(), total_num_outputs);
 
   NDArray data = in_data[fullc::kData];
-  NDArray weight = in_data[fullc::kWeight];
+  NDArray weight = cached_weight_ ? *cached_weight_ : in_data[fullc::kWeight];
   NDArray output = out_data[fullc::kOut];
 
   mkldnn::memory::desc out_md = GetMemDesc(output);
@@ -143,18 +144,34 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
 
     if (mkldnn_param.quantized) {
       CHECK(data.dtype() == mshadow::kInt8 || data.dtype() == mshadow::kUint8);
-      auto data_range = (data.dtype() == mshadow::kInt8) ? kInt8Range : kUint8Range;
-      float data_scale  = data_range / MaxAbs(cached_min_data_, cached_max_data_);
-      float weight_scale = kInt8Range / MaxAbs(cached_min_weight_, cached_max_weight_);
-      float quantized_out_range = IsOutputUint8(full_param_)? kUint8Range : kInt8Range;
-
+      float data_scale  = GetQuantizeScale(data.dtype(), cached_min_data_, cached_max_data_);
+      float weight_scale = GetQuantizeScale(mshadow::kInt8, cached_min_weight_, cached_max_weight_);
       if (has_bias) {
         NDArray bias = in_data[fullc::kBias];
-        float bias_int32_rescale = data_scale * weight_scale *
-            MaxAbs(cached_min_bias_, cached_max_bias_) / kInt8Range;
-
-        cached_bias_ = NDArray(bias.storage_type(), bias.shape(),
-                               bias.ctx(), true, mshadow::kInt32);
+        float bias_scale = GetQuantizeScale(mshadow::kInt8, cached_min_bias_, cached_max_bias_);
+        float bias_int32_rescale = data_scale * weight_scale / bias_scale;
+        // TODO(zhennan): mkldnn has bug to handle INT_MAX in bias, so set the maximum value of bias
+        // to INT_MAX / 2.
+        float bias_max_rescale =
+            MaxValue<int32_t>() / 2 / MaxAbs(cached_min_bias_, cached_max_bias_) / bias_scale;
+        if (bias_int32_rescale > bias_max_rescale) {
+          // avoid overflow on bias
+          bias_int32_rescale = bias_max_rescale;
+          float weight_rescale = bias_int32_rescale * bias_scale / data_scale / weight_scale;
+          cached_weight_.reset(new NDArray(weight.storage_type(), weight.shape(), weight.ctx(),
+                                           true, mshadow::kInt8));
+          int8_t *weight_ptr = weight.data().dptr<int8_t>();
+          int8_t *quantized_weight_ptr = cached_weight_->data().dptr<int8_t>();
+          size_t weight_size = weight.shape().Size();
+#pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+          for (index_t i = 0; i < static_cast<index_t>(weight_size); ++i) {
+            quantized_weight_ptr[i] = weight_ptr[i] * weight_rescale;
+          }
+          weight_scale *= weight_rescale;
+          weight = *cached_weight_;
+        }
+        cached_bias_ =
+            NDArray(bias.storage_type(), bias.shape(), bias.ctx(), true, mshadow::kInt32);
         int8_t *bias_ptr = bias.data().dptr<int8_t>();
         int32_t *quantized_bias_ptr = cached_bias_.data().dptr<int32_t>();
         size_t bias_size = bias.shape().Size();
@@ -172,9 +189,10 @@ void SgMKLDNNFCOp::Forward(const OpContext &ctx,
         full_param_.output_scales.resize(0);
         cached_min_output_ = mkldnn_param.min_calib_range.value();
         cached_max_output_ = mkldnn_param.max_calib_range.value();
-
-        full_param_.requantize_scales[0] = quantized_out_range /
-          MaxAbs(cached_min_output_, cached_max_output_) / data_scale / weight_scale;
+        float out_scale =
+            GetQuantizeScale(IsOutputUint8(full_param_) ? mshadow::kUint8 : mshadow::kInt8,
+                             cached_min_output_, cached_max_output_);
+        full_param_.requantize_scales[0] = out_scale / data_scale / weight_scale;
       } else {
         Stream<cpu> *s = ctx.get_stream<cpu>();
         if (data.dtype() == mshadow::kInt8) {

--- a/tests/python/mkl/test_subgraph.py
+++ b/tests/python/mkl/test_subgraph.py
@@ -877,14 +877,14 @@ def test_float64_fallback():
     ex.outputs[0].wait_to_read()
 
 
-def helper_test_quantized_conv_bias_overflow(weight_min, weight_max):
+def helper_test_quantized_conv_bias_overflow(data_min, data_max, weight_min, weight_max):
   data_shape = (1, 32, 2, 2)
   data = mx.symbol.Variable('data', shape=data_shape, dtype='float32')
   weight = mx.symbol.Variable('weight', dtype='float32')
   bias = mx.symbol.Variable('bias', dtype='float32')
   sym = mx.symbol.Convolution(data=data, weight=weight, bias=bias, name='conv', num_filter=64,
                                kernel=(1, 1), stride=(1, 1))
-  data_nd = mx.random.uniform(-1, +1, shape=data_shape, ctx=mx.cpu())
+  data_nd = mx.random.uniform(data_min, data_max, shape=data_shape, ctx=mx.cpu())
   weight_nd = mx.random.uniform(weight_min, weight_max, shape=[64, 32, 1, 1], ctx=mx.cpu())
   bias_nd = mx.random.uniform(-1, +1, shape=[64], ctx=mx.cpu())
   arg_params = {
@@ -923,8 +923,13 @@ def helper_test_quantized_conv_bias_overflow(weight_min, weight_max):
 
 @with_seed()
 def test_quantized_conv_bias_overflow():
-    helper_test_quantized_conv_bias_overflow(0, 0)
-    helper_test_quantized_conv_bias_overflow(-1e-6, +1e-6)
+    helper_test_quantized_conv_bias_overflow(-1, 1, 0, 0)
+    helper_test_quantized_conv_bias_overflow(-1, 1, -1e-6, +1e-6)
+    helper_test_quantized_conv_bias_overflow(0, 0, 1, 1)
+    helper_test_quantized_conv_bias_overflow(-1e-6, +1e-6, -1, 1)
+    helper_test_quantized_conv_bias_overflow(-1e-6, +1e-6, -1e-6, +1e-6)
+    helper_test_quantized_conv_bias_overflow(0, 0, 0, 0)
+
 
 if __name__ == "__main__":
   import nose

--- a/tests/python/mkl/test_subgraph.py
+++ b/tests/python/mkl/test_subgraph.py
@@ -877,7 +877,7 @@ def test_float64_fallback():
     ex.outputs[0].wait_to_read()
 
 
-def helper_test_quantized_conv_bias_overflow(data_min, data_max, weight_min, weight_max):
+def helper_quantized_conv_bias_overflow(data_min, data_max, weight_min, weight_max):
   data_shape = (1, 32, 2, 2)
   data = mx.symbol.Variable('data', shape=data_shape, dtype='float32')
   weight = mx.symbol.Variable('weight', dtype='float32')
@@ -915,7 +915,52 @@ def helper_test_quantized_conv_bias_overflow(data_min, data_max, weight_min, wei
                                                                    num_calib_examples=1,
                                                                    quantize_mode='full')
   qsym = qsym.get_backend_symbol(QUANTIZE_SG_PASS_NAME)
-  qex = qsym.bind(mx.cpu(), arg_params, args_grad=None)
+  qarg_params['data'] = data_nd
+  qex = qsym.bind(mx.cpu(), qarg_params, args_grad=None)
+  qex.forward()
+  qex.outputs[0].wait_to_read()
+  assert_almost_equal_with_err(ex.outputs[0].asnumpy(), qex.outputs[0].asnumpy(),
+                               rtol=1e-2, atol=1e-2, etol=0.01)
+
+def helper_quantized_fc_bias_overflow(data_min, data_max, weight_min, weight_max):
+  data_shape = (1, 32)
+  data = mx.symbol.Variable('data', shape=data_shape, dtype='float32')
+  weight = mx.symbol.Variable('weight', dtype='float32')
+  bias = mx.symbol.Variable('bias', dtype='float32')
+  sym = mx.symbol.FullyConnected(data=data, weight=weight, bias=bias, name='fc', num_hidden=64)
+  data_nd = mx.random.uniform(data_min, data_max, shape=data_shape, ctx=mx.cpu())
+  weight_nd = mx.random.uniform(weight_min, weight_max, shape=[64, 32], ctx=mx.cpu())
+  bias_nd = mx.random.uniform(-1, +1, shape=[64], ctx=mx.cpu())
+  arg_params = {
+      'data': data_nd,
+      'weight': weight_nd,
+      'bias': bias_nd
+  }
+
+  ex = sym.bind(mx.cpu(), arg_params, args_grad=None)
+  ex.forward()
+  ex.outputs[0].wait_to_read()
+  sym_sg = sym.get_backend_symbol(QUANTIZE_SG_PASS_NAME)
+  batch = mx.io.DataBatch([data_nd], [])
+  calib_data = CalibIter(batch, data_shape, 1)
+  qsym, qarg_params, qaux_params = mx.contrib.quant.quantize_model(sym=sym_sg,
+                                                                   arg_params={
+                                                                       'weight': weight_nd,
+                                                                       'bias': bias_nd
+                                                                   },
+                                                                   aux_params={},
+                                                                   ctx=mx.cpu(),
+                                                                   excluded_sym_names=None,
+                                                                   excluded_op_names=None,
+                                                                   quantized_dtype='int8',
+                                                                   calib_mode='naive',
+                                                                   calib_data=calib_data,
+                                                                   label_names=None,
+                                                                   num_calib_examples=1,
+                                                                   quantize_mode='full')
+  qarg_params['data'] = data_nd
+  qsym = qsym.get_backend_symbol(QUANTIZE_SG_PASS_NAME)
+  qex = qsym.bind(mx.cpu(), qarg_params, args_grad=None)
   qex.forward()
   qex.outputs[0].wait_to_read()
   assert_almost_equal_with_err(ex.outputs[0].asnumpy(), qex.outputs[0].asnumpy(),
@@ -923,12 +968,20 @@ def helper_test_quantized_conv_bias_overflow(data_min, data_max, weight_min, wei
 
 @with_seed()
 def test_quantized_conv_bias_overflow():
-    helper_test_quantized_conv_bias_overflow(-1, 1, 0, 0)
-    helper_test_quantized_conv_bias_overflow(-1, 1, -1e-6, +1e-6)
-    helper_test_quantized_conv_bias_overflow(0, 0, 1, 1)
-    helper_test_quantized_conv_bias_overflow(-1e-6, +1e-6, -1, 1)
-    helper_test_quantized_conv_bias_overflow(-1e-6, +1e-6, -1e-6, +1e-6)
-    helper_test_quantized_conv_bias_overflow(0, 0, 0, 0)
+    helper_quantized_conv_bias_overflow(-1, 1, 0, 0)
+    helper_quantized_conv_bias_overflow(-1, 1, -1e-6, +1e-6)
+    helper_quantized_conv_bias_overflow(0, 0, 1, 1)
+    helper_quantized_conv_bias_overflow(-1e-6, +1e-6, -1, 1)
+    helper_quantized_conv_bias_overflow(-1e-6, +1e-6, -1e-6, +1e-6)
+    helper_quantized_conv_bias_overflow(0, 0, 0, 0)
+
+def test_quantized_fc_bias_overflow():
+    helper_quantized_fc_bias_overflow(-1, 1, 0, 0)
+    helper_quantized_fc_bias_overflow(-1, 1, -1e-6, +1e-6)
+    helper_quantized_fc_bias_overflow(0, 0, 1, 1)
+    helper_quantized_fc_bias_overflow(-1e-6, +1e-6, -1, 1)
+    helper_quantized_fc_bias_overflow(-1e-6, +1e-6, -1e-6, +1e-6)
+    helper_quantized_fc_bias_overflow(0, 0, 0, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description ##
When weights or data are too small(~1e-6), bias may get overflow in int32. This is to handle this case, and can provide correct result.

@pengzhao-intel @TaoLv @ciyongch 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
