### PR TITLE
[MKLDNN] use dim_t instead of int in slice/transpose operators

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_pooling.cc
+++ b/src/operator/nn/mkldnn/mkldnn_pooling.cc
@@ -127,7 +127,7 @@ mkldnn::algorithm GetMKLDNNPoolAlgo(const PoolingParam &param) {
   }
 }
 
-static inline int GetPaddingSizeFull(int x, int padl, int padr, int k, int s) {
+static inline int GetPaddingSizeFull(dim_t x, int padl, int padr, int k, int s) {
   if ((x + padl + padr - k) % s != 0) {
     return (padr + s - ((x + padl + padr - k) % s));
   } else {

--- a/src/operator/nn/mkldnn/mkldnn_slice.cc
+++ b/src/operator/nn/mkldnn/mkldnn_slice.cc
@@ -41,7 +41,7 @@ MKLDNNSliceFwd::MKLDNNSliceFwd(const SliceParam &param,
   mkldnn::memory::dims dims(N);
   mkldnn::memory::dims offsets(N);
   for (int i = 0; i < N; ++i) {
-    int s = 0;
+    dim_t s = 0;
     if (i < param.begin.ndim() &&  param.begin[i]) {
       s = *param.begin[i];
       if (s < 0) s += ishape[i];

--- a/src/operator/nn/mkldnn/mkldnn_transpose.cc
+++ b/src/operator/nn/mkldnn/mkldnn_transpose.cc
@@ -73,7 +73,7 @@ class MKLDNNTransposeForward {
 
     mkldnn_dims_t strides;
     mkldnn_dims_t sh;
-    unsigned int total_stride = 1;
+    dim_t total_stride = 1;
     for (int i = data_ndim - 1; i >= 0; i--) {
       sh[i] = shape[i];
       strides[axes[i]] = total_stride;


### PR DESCRIPTION
## Description ##
When mxnet is built with large tensor support, `int` or `unsigned int` cannot properly handle some large value which is exceed 2^32. So just change to use `dim_t` to avoid overflow issue.

@pengzhao-intel @TaoLv @rongzha1 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
