### PR TITLE
Fix encode write error with windows.

### DIFF
--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -672,7 +672,7 @@ def _generate_op_module_signature(root_namespace, module_name, op_code_gen_func)
         module_path = module_name.split('.')
         module_path[-1] = 'gen_' + module_path[-1]
         file_name = os.path.join(path, '..', *module_path) + '.py'
-        module_file = open(file_name, 'w')
+        module_file = open(file_name, 'w', encoding="utf-8")
         dependencies = {'symbol': ['from ._internal import SymbolBase',
                                    'from ..base import _Null'],
                         'ndarray': ['from ._internal import NDArrayBase',


### PR DESCRIPTION
change _generate_op_module_signature get_module_file open with encoding="utf-8",it fix some encode error in Chinese windows system.
