### PR TITLE
Enabling large tensor support for binary broadcast operators

### DIFF
--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -55,10 +55,10 @@ inline bool BinaryBroadcastShape(const nnvm::NodeAttrs& attrs,
     return shape_is_known(lhs);
   }
   mxnet::TShape out(std::max(lhs.ndim(), rhs.ndim()), -1);
-  const int bl = out.ndim() - lhs.ndim();
-  const int br = out.ndim() - rhs.ndim();
-  for (int i = 0; i < out.ndim(); ++i) {
-    int l = 1, r = 1;
+  const dim_t bl = out.ndim() - lhs.ndim();
+  const dim_t br = out.ndim() - rhs.ndim();
+  for (dim_t i = 0; i < out.ndim(); ++i) {
+    dim_t l = 1, r = 1;
     if (i >= bl) l = lhs[i-bl];
     if (i >= br) r = rhs[i-br];
     if (!mxnet::dim_size_is_known(l) || !mxnet::dim_size_is_known(r)) continue;

--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -55,10 +55,10 @@ inline bool BinaryBroadcastShape(const nnvm::NodeAttrs& attrs,
     return shape_is_known(lhs);
   }
   mxnet::TShape out(std::max(lhs.ndim(), rhs.ndim()), -1);
-  const dim_t bl = out.ndim() - lhs.ndim();
-  const dim_t br = out.ndim() - rhs.ndim();
-  for (dim_t i = 0; i < out.ndim(); ++i) {
-    dim_t l = 1, r = 1;
+  const int bl = out.ndim() - lhs.ndim();
+  const int br = out.ndim() - rhs.ndim();
+  for (int i = 0; i < out.ndim(); ++i) {
+    int l = 1, r = 1;
     if (i >= bl) l = lhs[i-bl];
     if (i >= br) r = rhs[i-br];
     if (!mxnet::dim_size_is_known(l) || !mxnet::dim_size_is_known(r)) continue;

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1678,6 +1678,17 @@ def test_gather():
     assert np.sum(arr[idx[0]] == 2) == SMALL_Y
 
 
+def test_binary_broadcast():
+    def check_correctness(mxnet_op, numpy_op, atol=1e-3):
+        a = mx.nd.ones((LARGE_X, SMALL_Y)).as_np_ndarray()
+        b = 2*mx.nd.ones((LARGE_X, SMALL_Y)).as_np_ndarray()
+        res = mxnet_op(a, b)
+        np_res = numpy_op(1, 2)
+        assert np.abs(res[-1][-1] - np_res) < atol
+    check_correctness(mx.np.arctan2, np.arctan2)
+    check_correctness(mx.np.hypot, np.hypot)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -1065,6 +1065,17 @@ def test_infer_shape():
     assert out_shapes == [(LARGE_X,)]
 
 
+def test_binary_broadcast():
+    def check_correctness(mxnet_op, numpy_op, atol=1e-3):
+        a = mx.nd.ones(LARGE_X).as_np_ndarray()
+        b = 2*mx.nd.ones(LARGE_X).as_np_ndarray()
+        res = mxnet_op(a, b)
+        np_res = numpy_op(1, 2)
+        assert np.abs(res[-1] - np_res) < atol
+    check_correctness(mx.np.arctan2, np.arctan2)
+    check_correctness(mx.np.hypot, np.hypot)
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
## Description ##
In continuation of #16714 
Add tests
- arctan2
- hypot

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] tests/nightly/test_large_array.py
- [x] src/operator/tensor/elemwise_binary_broadcast_op.h

