### PR TITLE
Unfold operator

### DIFF
--- a/src/operator/tensor/fold-inl.h
+++ b/src/operator/tensor/fold-inl.h
@@ -34,16 +34,16 @@ namespace mxnet {
 namespace op {
 
 struct UnfoldParam : public dmlc::Parameter<UnfoldParam> {
-  int kernel_size;
   int dim;
+  int kernel_size;
   uint32_t stride;
   DMLC_DECLARE_PARAMETER(UnfoldParam) {
-    DMLC_DECLARE_FIELD(kernel_size)
-      .set_lower_bound(1)
-      .describe("Size of each unfolded block");
     DMLC_DECLARE_FIELD(dim)
       .set_default(-1)
       .describe("Dimension to unfold");
+    DMLC_DECLARE_FIELD(kernel_size)
+      .set_lower_bound(1)
+      .describe("Size of each unfolded block");
     DMLC_DECLARE_FIELD(stride)
       .set_lower_bound(1)
       .set_default(1)
@@ -57,7 +57,7 @@ inline mxnet::TShape UnfoldShapeImpl(const mxnet::TShape& ishape, const int k,
 
   auto elems_target_dim = ishape[axis];
 
-  CHECK_LE(k, elems_target_dim) << "kernel size " << k << "must be less than or equal"
+  CHECK_LE(k, elems_target_dim) << "kernel size " << k << " must be less than or equal"
                              " to the number of elements in the target dimension";
 
   int num_windows = (elems_target_dim - k) / stride + 1;

--- a/src/operator/tensor/fold-inl.h
+++ b/src/operator/tensor/fold-inl.h
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file fold-inl.h
+ * \brief CPU implementation of unfold operator
+ * \author Istvan Fehervari
+*/
+#ifndef MXNET_OPERATOR_NN_FOLD_INL_H_
+#define MXNET_OPERATOR_NN_FOLD_INL_H_
+#include <dmlc/parameter.h>
+#include <mxnet/operator.h>
+#include "../operator_common.h"
+#include "./broadcast_reduce_op.h"
+
+namespace mxnet {
+namespace op {
+
+struct UnfoldParam : public dmlc::Parameter<UnfoldParam> {
+  int kernel_size;
+  int dim;
+  int stride;
+  DMLC_DECLARE_PARAMETER(UnfoldParam) {
+    DMLC_DECLARE_FIELD(kernel_size)
+      .set_lower_bound(1)
+      .describe("Size of each unfolded block");
+    DMLC_DECLARE_FIELD(dim)
+      .set_default(-1)
+      .describe("Dimension to unfold");
+    DMLC_DECLARE_FIELD(stride)
+      .set_lower_bound(1)
+      .set_default(1)
+      .describe("Stride of the sliding window");
+  }
+};  // struct UnfoldParam
+
+inline mxnet::TShape UnfoldShapeImpl(const mxnet::TShape& ishape, const int k,
+                            const int32_t dim, const int32_t stride) {
+  int32_t axis = CheckAxis(dim, ishape.ndim());
+
+  auto num_target_dim = ishape[axis];
+
+  CHECK_LE(k, num_target_dim) << "kernel size " << k << "must be less than or equal"
+                             " to the number of elements in the target dimension";
+
+  int num_windows = num_target_dim / k;
+
+  auto o_ndim = ishape.ndim() + 1;
+  mxnet::TShape oshape(o_ndim, -1);
+
+  for (auto i = 0; i < ishape.ndim(); i++) {
+    oshape[i] = ishape[i];
+  }
+
+  oshape[o_ndim - 1] = k;
+  oshape[axis] = num_windows;
+  return oshape;
+}
+
+inline bool UnfoldOpShape(const nnvm::NodeAttrs& attrs,
+                          mxnet::ShapeVector* in_attrs,
+                          mxnet::ShapeVector* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+
+  const mxnet::TShape& ishape = (*in_attrs)[0];
+  if (!mxnet::ndim_is_known(ishape)) {
+    return false;
+  }
+
+  const UnfoldParam& param = nnvm::get<UnfoldParam>(attrs.parsed);
+
+  mxnet::TShape oshape = UnfoldShapeImpl(ishape,
+                                  param.kernel_size,
+                                  param.dim,
+                                  param.stride);
+  if (shape_is_none(oshape)) {
+    LOG(FATAL) << "Failed to infer shape for unfold.";
+  }
+  SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);
+
+  return shape_is_known(out_attrs->at(0));
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NN_FOLD_INL_H_

--- a/src/operator/tensor/fold.cc
+++ b/src/operator/tensor/fold.cc
@@ -49,25 +49,17 @@ This operation flattens each sliding kernel_size-sized block within the spatial 
 .set_attr<mxnet::FInferShape>("FInferShape", UnfoldOpShape)
 .set_attr<nnvm::FInferType>("FInferType", UnfoldOpType)
 .set_attr<FCompute>("FCompute<cpu>", UnfoldOpForward<cpu>)
-/*.set_attr<nnvm::FGradient>("FGradient",
-  [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
-    auto p = nnvm::Node::Create();
-    p->attrs.op = nnvm::Op::Get("_backward_gather_nd");
-    p->attrs.name = n->attrs.name + "_backward";
-    p->inputs.push_back(ograds[0]);
-    p->inputs.push_back(n->inputs[1]);
-    p->control_deps.emplace_back(n);
-    auto zero = MakeNode("zeros_like", n->attrs.name + "_backward_indices",
-                         {n->inputs[1]}, nullptr, &n);
-
-    std::vector<nnvm::NodeEntry> ret;
-    ret.emplace_back(p);
-    ret.emplace_back(zero);
-    return ret;
-  })
-.set_attr<nnvm::TIsBackward>("TIsBackward", true)*/
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_unfold"})
 .add_argument("data", "NDArray-or-Symbol", "data")
 .add_arguments(UnfoldParam::__FIELDS__());
+
+
+NNVM_REGISTER_OP(_backward_unfold)
+.set_attr_parser(ParamParser<UnfoldParam>)
+.set_num_inputs(1)
+.set_num_outputs(1)
+.set_attr<nnvm::TIsBackward>("TIsBackward", true)
+.set_attr<FCompute>("FCompute<cpu>", UnfoldOpBackward<cpu>);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/fold.cc
+++ b/src/operator/tensor/fold.cc
@@ -47,8 +47,8 @@ This operation flattens each sliding kernel_size-sized block within the spatial 
   return std::vector<std::string>{"data"};
 })
 .set_attr<mxnet::FInferShape>("FInferShape", UnfoldOpShape)
-//.set_attr<nnvm::FInferType>("FInferType", GatherNDType)
-//.set_attr<FCompute>("FCompute<cpu>", GatherNDForward<cpu>)
+.set_attr<nnvm::FInferType>("FInferType", UnfoldOpType)
+.set_attr<FCompute>("FCompute<cpu>", UnfoldOpForward<cpu>)
 /*.set_attr<nnvm::FGradient>("FGradient",
   [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
     auto p = nnvm::Node::Create();

--- a/src/operator/tensor/fold.cc
+++ b/src/operator/tensor/fold.cc
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file fold.cc
+ * \brief CPU implementation of unfold operator
+ * \author Istvan Fehervari
+*/
+
+#include "./fold-inl.h"
+namespace mxnet {
+namespace op {
+
+DMLC_REGISTER_PARAMETER(UnfoldParam);
+
+NNVM_REGISTER_OP(unfold)
+.describe(R"code(Extracts sliding local blocks from a batched input tensor.
+
+Consider an batched input tensor of shape (N, C, *), where N is the batch dimension, C is the channel dimension, and * represent arbitrary spatial dimensions.
+This operation flattens each sliding kernel_size-sized block within the spatial dimensions of input into a column (i.e., last dimension) of a 3-D output tensor of shape (N, C \times \prod(\text{kernel\_size}), L)(N,C×∏(kernel_size),L) , where C \times \prod(\text{kernel\_size})C×∏(kernel_size) is the total number of values within each block (a block has \prod(\text{kernel\_size})∏(kernel_size) spatial locations each containing a CC -channeled vector), and LL is the total number of such blocks:
+
+(text copied from https://pytorch.org/docs/stable/nn.html?highlight=unfold#torch.nn.functional.unfold)
+
+)code")
+.set_num_outputs(1)
+.set_num_inputs(1)
+.set_attr_parser(ParamParser<UnfoldParam>)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+    [](const NodeAttrs& attrs) {
+  return std::vector<std::string>{"data"};
+})
+.set_attr<mxnet::FInferShape>("FInferShape", UnfoldOpShape)
+//.set_attr<nnvm::FInferType>("FInferType", GatherNDType)
+//.set_attr<FCompute>("FCompute<cpu>", GatherNDForward<cpu>)
+/*.set_attr<nnvm::FGradient>("FGradient",
+  [](const nnvm::NodePtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
+    auto p = nnvm::Node::Create();
+    p->attrs.op = nnvm::Op::Get("_backward_gather_nd");
+    p->attrs.name = n->attrs.name + "_backward";
+    p->inputs.push_back(ograds[0]);
+    p->inputs.push_back(n->inputs[1]);
+    p->control_deps.emplace_back(n);
+    auto zero = MakeNode("zeros_like", n->attrs.name + "_backward_indices",
+                         {n->inputs[1]}, nullptr, &n);
+
+    std::vector<nnvm::NodeEntry> ret;
+    ret.emplace_back(p);
+    ret.emplace_back(zero);
+    return ret;
+  })
+.set_attr<nnvm::TIsBackward>("TIsBackward", true)*/
+.add_argument("data", "NDArray-or-Symbol", "data")
+.add_arguments(UnfoldParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/tensor/fold.cc
+++ b/src/operator/tensor/fold.cc
@@ -31,12 +31,11 @@ namespace op {
 DMLC_REGISTER_PARAMETER(UnfoldParam);
 
 NNVM_REGISTER_OP(unfold)
-.describe(R"code(Extracts sliding local blocks from a batched input tensor.
+.describe(R"code(Returns a new tensor with ``kernel_size``-sized slices from the input along dimension ``dim``. Step between the slices is given by ``stride``.
 
-Consider an batched input tensor of shape (N, C, *), where N is the batch dimension, C is the channel dimension, and * represent arbitrary spatial dimensions.
-This operation flattens each sliding kernel_size-sized block within the spatial dimensions of input into a column (i.e., last dimension) of a 3-D output tensor of shape (N, C \times \prod(\text{kernel\_size}), L)(N,C×∏(kernel_size),L) , where C \times \prod(\text{kernel\_size})C×∏(kernel_size) is the total number of values within each block (a block has \prod(\text{kernel\_size})∏(kernel_size) spatial locations each containing a CC -channeled vector), and LL is the total number of such blocks:
+The size of dimension ``dim`` in the output will be ``(input.shape[dim] - kernel_size) / stride + 1``. 
 
-(text copied from https://pytorch.org/docs/stable/nn.html?highlight=unfold#torch.nn.functional.unfold)
+Rest of the dimensions will be copied and an additional dimension with size ``kernel_size`` will be appended in the returned tensor.
 
 )code")
 .set_num_outputs(1)

--- a/src/operator/tensor/fold.cu
+++ b/src/operator/tensor/fold.cu
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file fold.cu
+ * \brief GPU implementation of unfold operator
+ * \author Istvan Fehervari
+*/
+
+#include "./fold-inl.h"
+
+namespace mxnet {
+namespace op {
+
+NNVM_REGISTER_OP(unfold)
+.set_attr<FCompute>("FCompute<gpu>", UnfoldOpForward<gpu>);
+
+NNVM_REGISTER_OP(_backward_unfold)
+.set_attr<FCompute>("FCompute<gpu>", UnfoldOpBackward<gpu>);
+
+}  // namespace op
+}  // namespace mxnet

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -7134,6 +7134,50 @@ def test_dropout():
         check_dropout_axes(0.25, nshape, axes = (1, 2, 3), cudnn_off=False)
 
 
+@with_seed()
+def test_unfold():
+    def np_unfold(x, dim, size, step):
+        new_size = [0] * (x.ndim + 1)
+        new_stride = [0] * (x.ndim + 1)
+
+        new_size[x.ndim] = size
+        new_stride[x.ndim] = 1 if x.ndim == 0 else x.strides[dim]
+
+        for d in range(x.ndim):
+            self_size = x.shape[d]
+            self_stride = x.strides[d]
+            if d == dim:
+                new_size[d] = (self_size - size) / step + 1
+                new_stride[d] = step * self_stride
+            else:
+                new_size[d] = self_size
+                new_stride[d] = self_stride
+
+        return np.lib.stride_tricks.as_strided(x, new_size, new_stride)
+
+    for dtype in ['int32', 'int64', 'float16', 'float32', 'float64']:
+        for _ in range(100):
+            data_shape = tuple(np.random.randint(1, 6, np.random.randint(1, 6, 1)))
+
+            data = mx.nd.random.randint(0, 100, data_shape).astype(dtype)
+            data_np = data.asnumpy()
+
+            vaild_dims = [x for x in range(len(data_shape)) if data_shape[x] > 1]
+            if len(vaild_dims) == 0:
+                continue
+            dim = np.random.choice(vaild_dims)
+            kernel = np.random.randint(2, data_shape[dim] + 1)
+            stride = np.random.randint(1, data_shape[dim] - kernel + 2)
+
+            output = mx.nd.unfold(data, dim, kernel, stride)
+            output_np = np_unfold(data_np, dim, kernel, stride)
+
+            assert assert_almost_equal(output, output_np)
+
+            # Check gradient
+            unfold_sym = mx.sym.diag(data=mx.sym.Variable('data'), dim=dim, kernel_size=kernel, stride=stride)
+            check_numeric_gradient(unfold_sym, [data_np])
+
 
 @unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/11290")
 @with_seed()


### PR DESCRIPTION
## Description ##
This change adds the unfold tensor operator equivalent to the same operator in pytorch[1]. This operator helps in implementing new local attention-based neural network layers.

Unfold returns a tensor which contains all slices of a given kernel size from the input tensor in the given dimension. Step between two slices is given by stride.

If sizedim is the size of target dimension for the input, the size of the same dimension in the returned tensor will be (sizedim - kernel_size) / stride + 1.

An additional dimension of size size is appended in the returned tensor.

[1] https://pytorch.org/docs/stable/tensors.html#torch.Tensor.unfold

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
