### PR TITLE
[Perl] - ndarray operator overloading enhancements

### DIFF
--- a/perl-package/AI-MXNet/lib/AI/MXNet/NDArray.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/NDArray.pm
@@ -65,7 +65,7 @@ use AI::MXNet::NDArray::Slice;
 use AI::MXNet::Context;
 use Mouse;
 use AI::MXNet::Function::Parameters;
-use overload
+use overload (
     '""' => \&stringify,
     '+'  => \&add,
     '+=' => \&iadd,
@@ -86,7 +86,16 @@ use overload
     '<=' => \&lesser_equal,
     '.=' => \&set,
     '@{}'=> \&split_array,
-    '='  => sub { $_[0] };
+    '='  => sub { $_[0] },
+
+    'sqrt' => sub { $_[0]->sqrt() },
+    'abs' => sub { $_[0]->abs() },
+    'sin' => sub { $_[0]->sin() },
+    'cos' => sub { $_[0]->cos() },
+    'atan2' => \&atan2,
+    'log' => sub { $_[0]->log() },
+    'exp' => sub { $_[0]->exp() },
+);
 
 extends 'AI::MXNet::NDArray::Base';
 has 'writable' => (is => 'rw', isa => 'Int', default => 1, lazy => 1);
@@ -761,6 +770,12 @@ sub  _ufunc_helper
 method stringify($other=, $reverse=)
 {
     sprintf("<%s %s @%s>", ref($self), join('x', @{ $self->shape }), $self->context);
+}
+
+method atan2($other=, $reverse=)
+{
+    my $val = $reverse ? $other / $self : $self / $other;
+    return __PACKAGE__->arctan($val);
 }
 
 method iadd(AI::MXNet::NDArray|Num $other, $reverse=)

--- a/perl-package/AI-MXNet/lib/AI/MXNet/TestUtils.pm
+++ b/perl-package/AI-MXNet/lib/AI/MXNet/TestUtils.pm
@@ -46,9 +46,16 @@ use constant default_numerical_threshold => 1e-6;
     b : pdl
 =cut
 
+func isNaN(PDL $a)
+{
+    # Only NaN is not greater, equal to, or less than zero.
+    return !(($a > 0) + ($a <= 0));
+}
+
 func same(PDL $a, PDL $b)
 {
-    return ($a != $b)->sum == 0;
+    my $rv = ($a != $b) - isNaN($a) * isNaN($b);
+    return $rv->sum == 0;
 }
 
 =head2 allclose

--- a/perl-package/AI-MXNet/t/test_ndarray.t
+++ b/perl-package/AI-MXNet/t/test_ndarray.t
@@ -19,7 +19,7 @@ use strict;
 use warnings;
 use AI::MXNet qw(mx);
 use AI::MXNet::TestUtils qw(almost_equal same rand_ndarray randint zip);
-use Test::More tests => 261;
+use Test::More tests => 280;
 use PDL;
 use File::Temp qw(tempdir);
 use IO::File;
@@ -217,6 +217,35 @@ sub test_histogram
     ok(same($bins->aspdl, pdl([10, 20, 30, 60])));
 }
 
+sub test_overload
+{
+    # much of this depends on PDL being sane as well.
+    my $px = PDL->new([ 2, -5, 11, 17 ]) / 2;
+    my $nx = mx->nd->array($px, dtype => 'float64');
+    my $py = PDL->new([ -3, 7, 13, 19 ]) / 4;
+    my $ny = mx->nd->array($py, dtype => 'float64');
+
+    ok(same(($nx + $ny)->aspdl(), $px + $py), 'overloaded add');
+    ok(same(($nx - $ny)->aspdl(), $px - $py), 'overloaded sub');
+    ok(same(($nx * $ny)->aspdl(), $px * $py), 'overloaded mul');
+    ok(same(($nx / $ny)->aspdl(), $px / $py), 'overloaded div');
+    ok(same(($nx % $ny)->aspdl(), $px % $py), 'overloaded mod');
+    ok(same(($nx ** $ny)->aspdl(), $px ** $py), 'overloaded pow');
+    ok(same(($nx->copy() += $ny)->aspdl(), $px + $py), 'inplace add');
+    ok(same(($nx->copy() -= $ny)->aspdl(), $px - $py), 'inplace sub');
+    ok(same(($nx->copy() *= $ny)->aspdl(), $px * $py), 'inplace mul');
+    ok(same(($nx->copy() /= $ny)->aspdl(), $px / $py), 'inplace div');
+    ok(same(($nx->copy() %= $ny)->aspdl(), $px % $py), 'inplace mod');
+    ok(same(($nx->copy() **= $ny)->aspdl(), $px ** $py), 'inplace pow');
+    ok(same(cos($nx)->aspdl(), cos($px)), 'overloaded cos');
+    ok(same(sin($nx)->aspdl(), sin($px)), 'overloaded sin');
+    ok(same(exp($nx)->aspdl(), exp($px)), 'overloaded exp');
+    ok(same(abs($nx)->aspdl(), abs($px)), 'overloaded abs');
+    ok(same(log($nx)->aspdl(), log($px)), 'overloaded log');
+    ok(same(sqrt($nx)->aspdl(), sqrt($px)), 'overloaded sqrt');
+    ok(same(atan2($nx, 1.0)->aspdl(), atan2($px, 1.0)), 'overloaded atan2');
+}
+
 sub test_array_overload
 {
     # array conversions are largely calls to mx->nd->split(), but have
@@ -242,4 +271,5 @@ test_linalg_gemm2();
 test_image_to_tensor();
 test_buffer_load();
 test_histogram();
+test_overload();
 test_array_overload();


### PR DESCRIPTION
## Description ##
I noticed a bug with `abs()` on NDArray objects.  Perl understood enough to treat them as numbers, but not well enough to correctly calculate absolute values of them properly.  Distinct from Python, Perl has a set of overloadable core math functions, and I think it's prudent to handle them similar to PDL.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
