### PR TITLE
[Numpy] Fix inv test flakiness

### DIFF
--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3155,14 +3155,22 @@ def test_np_linalg_inv():
         test_inv = TestInverse()
         if hybridize:
             test_inv.hybridize()
-        # use LU decomposition to generate invertible matrices
+        # generate well-conditioned matrices with small eigenvalues
         if 0 in shape:
             data_np = _np.ones(shape)
         else:
-            n = shape[-1]
-            L = _np.tril(_np.random.uniform(-10., 10., shape))
-            U = _np.triu(_np.random.uniform(-10., 10., shape))
-            data_np = _np.matmul(L, U)
+            n = int(np.prod(np.array(shape[:-2]))) if len(shape) > 2 else 1
+            # eigenvalues
+            D = _np.array([_np.diag(_np.random.uniform(-10., 10., shape[-1])) \
+                             for i in range(n)]).reshape(shape)
+            # orthogonal matrix through householder transformation
+            I = _np.array([_np.eye(shape[-1]) for i in range(n)]).reshape(shape)
+            v = _np.random.uniform(-10, 10,
+                    int(np.prod(np.array(shape[:-1])))).reshape(shape[:-1] + (1,))
+            v = v / _np.linalg.norm(v, axis=-2, keepdims=True)
+            v_T = _np.swapaxes(v, -1, -2)
+            U = I - 2 * _np.matmul(v, v_T)
+            data_np = _np.matmul(_np.matmul(U, D), _np.swapaxes(U, -1, -2))
         data = np.array(data_np, dtype=dtype)
         data.attach_grad()
         with mx.autograd.record():


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)
Fix inv test flakiness using random matrices generated by SVD
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
