### PR TITLE
Speed fused_op compilation by caching ptx and jit-compiled device functions

### DIFF
--- a/src/operator/fusion/fused_op-inl.h
+++ b/src/operator/fusion/fused_op-inl.h
@@ -982,11 +982,9 @@ const char kernel_begin[] = R"code(
 const int tid = threadIdx.x + blockIdx.x * blockDim.x;
 for (int i = tid; i < N; i+= gridDim.x * blockDim.x) {
     int offset = i*nvec;
-
 )code";
 
-const char kernel_end[] = R"code(
-}
+const char kernel_end[] = R"code(}
 }
 )code";
 

--- a/src/operator/fusion/fused_op.cu
+++ b/src/operator/fusion/fused_op.cu
@@ -163,9 +163,33 @@ void AddPointerAndShape(const TBlob& data,
   });
 }
 
+// Obtain compilation log from the program.
+std::string GetCompileLog(nvrtcProgram program) {
+  size_t log_size_including_null;
+  NVRTC_CALL(nvrtcGetProgramLogSize(program, &log_size_including_null));
+  // For most std::string implementations, this is probably 1 char bigger than needed.  OK though.
+  std::string log(log_size_including_null, '\0');
+  NVRTC_CALL(nvrtcGetProgramLog(program, &log[0]));
+  // Make sure the string reflects the true size (so minus the null terminator).
+  log.resize(log_size_including_null - 1);
+  return log;
+}
+
+// Obtain compilation result (ptx assembly) from the program.
+std::string GetPtx(nvrtcProgram program) {
+  size_t ptx_size_including_null;
+  NVRTC_CALL(nvrtcGetPTXSize(program, &ptx_size_including_null));
+  // For most std::string implementations, this is probably 1 char bigger than needed.  OK though.
+  std::string ptx(ptx_size_including_null, '\0');
+  NVRTC_CALL(nvrtcGetPTX(program, &ptx[0]));
+  // Make sure the string reflects the true size (so minus the null terminator).
+  ptx.resize(ptx_size_including_null - 1);
+  return ptx;
+}
+
 }  // namespace
 
-void FusedOp::GenerateCode(int kernel_index, const std::vector<OpReqType> &req,
+std::string FusedOp::GenerateCode(const std::vector<OpReqType> &req,
                            const std::vector<int> &in_dtypes,
                            const std::vector<int> &out_dtypes,
                            const std::vector<int> &in_ndims,
@@ -175,7 +199,7 @@ void FusedOp::GenerateCode(int kernel_index, const std::vector<OpReqType> &req,
                            const int nvec,
                            const std::string &kernel_name,
                            std::vector<uint32_t>* check_shapes) {
-  const auto& g = this->subgraph_.indexed_graph();
+  const auto& g = subgraph_.indexed_graph();
   std::string code = "";
   int temp_name_counter = 0;
   using NodeEntry = nnvm::IndexedGraph::NodeEntry;
@@ -459,16 +483,11 @@ void FusedOp::GenerateCode(int kernel_index, const std::vector<OpReqType> &req,
     ++counter;
   }
 
-  this->code_[kernel_index] = code;
-
   // Add boilerplate and type information
-  if (dmlc::GetEnv("MXNET_FUSION_VERBOSE", false)) {
-    LOG(INFO) << code_[kernel_index];
-  }
   std::string kernel_params = "";
   std::string tensor_params = "";
   nnvm::Symbol sym;
-  sym.outputs = this->subgraph_.outputs;
+  sym.outputs = subgraph_.outputs;
   const std::vector<std::string> input_names = sym.ListInputNames(nnvm::Symbol::kAll);
   size_t num_params = in_dtypes.size() + out_dtypes.size();
   size_t i = 0;
@@ -513,85 +532,102 @@ void FusedOp::GenerateCode(int kernel_index, const std::vector<OpReqType> &req,
   }
   kernel_params += tensor_params;
 
-  code_[kernel_index] = std::string(fusion::fp16_support_string) + "\n" +
-          fusion::type_support_string + "\n" +
-          fusion::function_definitions + "\n" +
-          fusion::backward_function_definitions + "\n" +
-          aux_code + "\n" +
-          "__launch_bounds__(" + std::to_string(FusedOp::NTHREADS) + ")\n" +
-          "__global__ void FusedKernel_" + kernel_name +
-          "(size_t N, " + kernel_params + ") {\n" +
-          fusion::kernel_begin + "\n" +
-          code_[kernel_index] + "\n" +
-          fusion::kernel_end;
+  // Create kernel source (minus the common header)
+  return aux_code + "\n" +
+         "__launch_bounds__(" + std::to_string(FusedOp::NTHREADS) + ")\n" +
+         "__global__ void FusedKernel_" + kernel_name +
+         "(size_t N, " + kernel_params + ") {\n" +
+         fusion::kernel_begin + "\n" +
+         code + "\n" +
+         fusion::kernel_end;
 }
 
-void FusedOp::CompileCode(int kernel_index, const std::string &kernel_name) {
+CUfunction FusedOp::CompileCode(const std::string &code,
+                                const std::string &kernel_name,
+                                int dev_id) {
   // Guard NVRTC calls
   std::lock_guard<std::mutex> lock_nvrtc(mutex_);
-  nvrtcProgram program;
-  NVRTC_CALL(
-      nvrtcCreateProgram(&program,                                  // prog
-                         &code_[kernel_index][0],                                 // buffer
-                         (kernel_name + "_kernel.cu").c_str(),      // name
-                         0,                                         // num headers
-                         NULL,                                      // headers
-                         NULL));                                    // include names
-  std::string gpu_arch = "--gpu-architecture=compute_" +
-                         std::to_string(this->cc_major_) +
-                         std::to_string(this->cc_minor_);
+  // Local class for value type of compile cache
+  struct KernelInfo {
+    std::string mangled_name;
+    std::string ptx;
+    std::vector<CUfunction> functions;
+  };
+  // Maps from the cuda source code (minus header) to the ptx and jit-compiled CUfunctions.
+  using KernelCache = std::map<std::string, KernelInfo>;
+  // Per-gpu-architecture compiled kernel cache with jit-compiled function for each device context
+  static std::map<int32_t, KernelCache> compiled_kernels;
+  int sm_arch = SMArch(dev_id);
+  KernelCache& compiled_kernels_this_arch = compiled_kernels[sm_arch];  // make null map as needed
+  KernelInfo& kinfo = compiled_kernels_this_arch[code];                 // make KernelInfo as needed
+  if (kinfo.ptx.size() == 0) {
+    // It's the first time we've seen this kernel, so we need to generate the ptx and mangled_name.
+    static std::string common_header =
+        std::string(fusion::fp16_support_string) + "\n" +
+        fusion::type_support_string + "\n" +
+        fusion::function_definitions + "\n" +
+        fusion::backward_function_definitions + "\n";
+    std::string code_with_header = common_header + code;
+    // If verbose mode, output kernel source, though not including the common header
+    if (dmlc::GetEnv("MXNET_FUSION_VERBOSE", false)) {
+      LOG(INFO) << "\n" << std::string(80, '-') << "\n" << code;
+    }
+    if (compiled_kernels_this_arch.size() == CACHESIZE_WARN_THRESHOLD + 1 &&
+        dmlc::GetEnv("MXNET_FUSION_SIZE_WARNING", true)) {
+      LOG(WARNING) << "The number of different fused ops exceeds " << CACHESIZE_WARN_THRESHOLD
+                   << ".  Set MXNET_FUSION_SIZE_WARNING=0 to quiet this warning.";
+    }
+    nvrtcProgram program;
+    NVRTC_CALL(nvrtcCreateProgram(&program,                                  // prog
+                                  &code_with_header[0],                      // buffer
+                                  (kernel_name + "_kernel.cu").c_str(),      // name
+                                  0,                                         // num headers
+                                  NULL,                                      // headers
+                                  NULL));                                    // include names
 
-  const char *opts[] = {gpu_arch.c_str(),
-                        "--std=c++11",
-                        "-default-device"};
-  const std::string kernel_name_demangled = "FusedKernel_" + kernel_name;
-  NVRTC_CALL(nvrtcAddNameExpression(program, (kernel_name_demangled).c_str()));
+    std::string gpu_arch_arg = "--gpu-architecture=compute_" + std::to_string(sm_arch);
+    const char *opts[] = {gpu_arch_arg.c_str(),
+                          "--std=c++11",
+                          "-default-device"};
+    const std::string kernel_name_demangled = "FusedKernel_" + kernel_name;
+    NVRTC_CALL(nvrtcAddNameExpression(program, (kernel_name_demangled).c_str()));
 
-  nvrtcResult compileResult = nvrtcCompileProgram(program,  // prog
-                                                  3,        // num options
-                                                  opts);    // options
-  // Obtain compilation log from the program.
-  size_t log_size;
-  NVRTC_CALL(nvrtcGetProgramLogSize(program, &log_size));
-  std::string log(log_size, '\0');
-  NVRTC_CALL(nvrtcGetProgramLog(program, &log[0]));
-  CHECK_EQ(compileResult, NVRTC_SUCCESS)
-    << "NVRTC Compilation failed. Please set environment variable MXNET_USE_FUSION to 0.\n" << log;
-  // Obtain PTX from the program.
-  size_t ptx_size;
-  NVRTC_CALL(nvrtcGetPTXSize(program, &ptx_size));
-  ptx_[kernel_index].reserve(ptx_size);
-  NVRTC_CALL(nvrtcGetPTX(program, &ptx_[kernel_index][0]));
-  const char *name;
-  NVRTC_CALL(nvrtcGetLoweredName(program,
-                                 kernel_name_demangled.c_str(),
-                                 &name));
-  kernel_name_[kernel_index] = name;
-  // Destroy the program.
-  NVRTC_CALL(nvrtcDestroyProgram(&program));
-  int device;
-  CUdevice cu_device;
-  CUcontext context;
-  CUmodule module;
-  CUDA_CALL(cudaGetDevice(&device));
-  CUDA_DRIVER_CALL(cuDeviceGet(&cu_device, device));
-  CUDA_DRIVER_CALL(cuDevicePrimaryCtxRetain(&context, cu_device));
-  CUDA_DRIVER_CALL(cuModuleLoadData(&module, &ptx_[kernel_index][0]));
-  CUDA_DRIVER_CALL(cuModuleGetFunction(&kernel_[kernel_index],
-                                       module,
-                                       kernel_name_[kernel_index].c_str()));
+    nvrtcResult compileResult = nvrtcCompileProgram(program,  // prog
+                                                    3,        // num options
+                                                    opts);    // options
+    CHECK_EQ(compileResult, NVRTC_SUCCESS)
+        << "NVRTC Compilation failed. Please set environment variable MXNET_USE_FUSION to 0.\n"
+        << GetCompileLog(program);
+
+    kinfo.ptx = GetPtx(program);
+    const char *mangled_name;
+    NVRTC_CALL(nvrtcGetLoweredName(program,
+                                   kernel_name_demangled.c_str(),
+                                   &mangled_name));
+    kinfo.mangled_name = mangled_name;
+    // Destroy the program.
+    NVRTC_CALL(nvrtcDestroyProgram(&program));
+  }
+  // Ensure function array is deep enough to index by dev_id
+  while (kinfo.functions.size() <= static_cast<size_t>(dev_id))
+    kinfo.functions.push_back(static_cast<CUfunction>(nullptr));
+  // Jit-compile ptx for the device as needed
+  if (kinfo.functions[dev_id] == static_cast<CUfunction>(nullptr)) {
+    // Make sure driver context is set to the proper device
+    CUdevice cu_device;
+    CUcontext context;
+    CUDA_DRIVER_CALL(cuDeviceGet(&cu_device, dev_id));
+    CUDA_DRIVER_CALL(cuDevicePrimaryCtxRetain(&context, cu_device));
+    // Jit-compile ptx for the driver's current context
+    CUmodule module;
+    CUDA_DRIVER_CALL(cuModuleLoadData(&module, kinfo.ptx.c_str()));
+    CUDA_DRIVER_CALL(cuModuleGetFunction(&kinfo.functions[dev_id],
+                                         module,
+                                         kinfo.mangled_name.c_str()));
+  }
+  return kinfo.functions[dev_id];
 }
 
-bool FusedOp::CheckComputeCapability(const OpContext &ctx) {
-  const int dev_id = ctx.run_ctx.ctx.dev_id;
-  const int cc_major = ComputeCapabilityMajor(dev_id);
-  const int cc_minor = ComputeCapabilityMinor(dev_id);
-
-  const bool ret = cc_major == this->cc_major_ && cc_minor == this->cc_minor_;
-  this->cc_major_ = cc_major;
-  this->cc_minor_ = cc_minor;
-  return ret;
-}
 
 void FusedOp::CheckShapesAndTypes(const std::vector<TBlob> &inputs,
                                   const std::vector<TBlob> &outputs,
@@ -665,23 +701,30 @@ void FusedOp::Forward<gpu>(const nnvm::NodeAttrs& attrs,
   const auto& node_shapes = intermediate_shapes_[0].internal_attr;
   const auto& node_dtypes = intermediate_dtypes_[0].internal_attr;
 
-  // Check and save compute capability of the current GPU
-  if (!CheckComputeCapability(ctx)) initialized_ = false;
+  int dev_id = ctx.run_ctx.ctx.dev_id;
 
+  // A change between training and inference modes may require different kernel functions
   initialized_ = initialized_ && (req == saved_reqs_);
   saved_reqs_ = req;
 
   if (!initialized_) {
-    this->GenerateCode(0, req, in_dtypes, out_dtypes, in_ndims, out_ndims,
+    const auto& code = GenerateCode(req, in_dtypes, out_dtypes, in_ndims, out_ndims,
                        node_shapes, node_dtypes, nvec, attrs.name, &check_shape_args_);
-    this->CompileCode(0, attrs.name);
+    kernel_functions_[fusion::kGeneral] = CompileCode(code, attrs.name, dev_id);
     if (check_shape_args_.size() > 0) {
-        this->GenerateCode(1, req, in_dtypes, out_dtypes, in_ndims, out_ndims,
+      const auto& code = GenerateCode(req, in_dtypes, out_dtypes, in_ndims, out_ndims,
                            node_shapes, node_dtypes, nvec, attrs.name, NULL);
-        this->CompileCode(1, attrs.name);
+      kernel_functions_[fusion::kShapeOptimized] = CompileCode(code, attrs.name, dev_id);
     }
     initialized_ = true;
+    kernel_function_dev_id_ = dev_id;
   }
+
+  // A change in device would force recompiling, but this is unexpected so signal as an error
+  if (dev_id != kernel_function_dev_id_)
+    LOG(FATAL) << "Fused op compiled for device " << kernel_function_dev_id_
+               <<  ", not expecting switch to device " << dev_id;
+
   Stream<gpu>* s = ctx.get_stream<gpu>();
   auto stream = Stream<gpu>::GetStream(s);
   std::vector<void*> args;
@@ -713,18 +756,18 @@ void FusedOp::Forward<gpu>(const nnvm::NodeAttrs& attrs,
   for (auto &ptr : ptrs) {
     args.push_back(reinterpret_cast<void *>(&ptr));
   }
-  int kernel_index = 0;
+  int kernel_variant = fusion::kGeneral;
   if (check_shape_args_.size() > 0) {
-      kernel_index = 1;
+    kernel_variant = fusion::kShapeOptimized;
       for (const auto &shape_id : check_shape_args_) {
           const auto& shape = node_shapes[shape_id];
           if (shape[shape.ndim()-1] % nvec != 0) {
-              kernel_index = 0;
+            kernel_variant = fusion::kGeneral;
           }
       }
   }
   CUDA_DRIVER_CALL(
-      cuLaunchKernel(kernel_[kernel_index],
+      cuLaunchKernel(kernel_functions_[kernel_variant],
         num_blocks, 1, 1,          // grid dim
         FusedOp::NTHREADS, 1, 1,   // block dim
         0, stream,                 // shared mem and stream

--- a/src/operator/fusion/fused_op.h
+++ b/src/operator/fusion/fused_op.h
@@ -34,6 +34,12 @@
 
 namespace mxnet {
 
+namespace fusion {
+  enum KernelVariants {kGeneral, kShapeOptimized,
+    kNumKernelVariants  // Not a variant- leave this at the end
+  };
+}
+
 struct FusedOpConfig : public dmlc::Parameter<FusedOpConfig> {
   int num_inputs;
   int num_outputs;
@@ -53,6 +59,7 @@ struct FusedOpEntry {
 class FusedOp {
  public:
   static const int NTHREADS = 512;
+  static const int CACHESIZE_WARN_THRESHOLD = 10000;
 
   explicit FusedOp(const nnvm::NodeAttrs* attrs, const FusedOpConfig& config);
   ~FusedOp() {}
@@ -120,20 +127,20 @@ class FusedOp {
   }
 
  private:
-  void GenerateCode(int kernel_index,
-                    const std::vector<OpReqType> &req,
-                    const std::vector<int> &in_dtypes,
-                    const std::vector<int> &out_dtypes,
-                    const std::vector<int> &in_ndims,
-                    const std::vector<int> &out_ndims,
-                    const mxnet::ShapeVector &node_shapes,
-                    const std::vector<int> &node_dtypes,
-                    const int nvec,
-                    const std::string& kernel_name,
-                    std::vector<uint32_t> *check_shapes);
-  void CompileCode(int kernel_index,
-                   const std::string &kernel_name);
-  bool CheckComputeCapability(const OpContext &ctx);
+  std::string GenerateCode(const std::vector<OpReqType> &req,
+                           const std::vector<int> &in_dtypes,
+                           const std::vector<int> &out_dtypes,
+                           const std::vector<int> &in_ndims,
+                           const std::vector<int> &out_ndims,
+                           const mxnet::ShapeVector &node_shapes,
+                           const std::vector<int> &node_dtypes,
+                           const int nvec,
+                           const std::string& kernel_name,
+                           std::vector<uint32_t> *check_shapes);
+
+  CUfunction CompileCode(const std::string &code,
+                         const std::string &kernel_name, int dev_id);
+
   void CheckShapesAndTypes(const std::vector<TBlob> &inputs,
                            const std::vector<TBlob> &outputs,
                            std::vector<int> *in_dtypes,
@@ -145,7 +152,6 @@ class FusedOp {
   std::vector<FusedOpEntry> inputs_;
   std::vector<FusedOpEntry> outputs_;
 
-  std::string code_[2];
   nnvm::Graph subgraph_;
 
   template <typename T>
@@ -173,12 +179,9 @@ class FusedOp {
   std::vector<uint32_t> extra_shape_args_;
   std::vector<uint32_t> check_shape_args_;
 
-  std::string ptx_[2];
-  std::string kernel_name_[2];
-  CUfunction kernel_[2];
+  CUfunction kernel_functions_[fusion::kNumKernelVariants];
   bool initialized_;
-  int cc_major_;
-  int cc_minor_;
+  int kernel_function_dev_id_;
 
   static std::mutex mutex_;
   std::mutex my_mutex_;


### PR DESCRIPTION
## Description ##
This PR speeds up the dynamic nvrtc-compilation of fused_ops in response to @rondogency's comment https://github.com/apache/incubator-mxnet/pull/15167#issuecomment-550008831.  As reported in the comment, the runtime of 3 mentioned unittests had grown drastically with the fusion enabled to 17.5 minutes in total.  With this PR, the runtime drops to 1 minute, with the original fusion-turned-off runtime being 30 seconds.

The process of runtime compilation of NVIDIA gpu kernels involves 2 steps:
    - compiling the cuda code to PTX assembly (performed once per GPU architecture)
    - translating the ptx assembly to binary and loading it into a GPU's set of runnable kernels (performed once per GPU device).  This latter step produces the CUfunction needed to execute the kernel on the device.

After realizing that the slowed-down unittests were creating many identical fused ops, I added a cache of the PTX and CUfunctions.  The cache comprises a mapping (for each GPU arch) from the cuda source code to the PTX and to any CUfunctions created from it.

It's worth a reminder that the fusion framework is targeting the typical scenario of creating a model's graph and executing it many times.  The CI was adversely impacted because it often executes a model's graph just once after creation.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ X] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X ] Changes are complete (i.e. I finished coding on this PR)
- [X ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
