### PR TITLE
[CD] PyPI pipeline fix

### DIFF
--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -89,7 +89,9 @@ class _Py2CompatibleUnicodeFileWriter(object):
             self.unicode = str
         else:
             from functools import partial
+            # pylint: disable=undefined-variable
             self.unicode = partial(unicode, encoding="utf-8")
+            # pylint: enable=undefined-variable
 
     def write(self, value):
         self._file_handle.write(self.unicode(value))


### PR DESCRIPTION
## Description ##
PyPI CD pipeline is [failing](http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job/detail/mxnet-cd-release-job/145/pipeline) - it seems base.py should be made python2 compatible. The call to open with encoding is breaking compatibility. This PR makes that update. A successful run on dev can be seen [here](http://jenkins.mxnet-ci-dev.amazon-ml.com/job/restricted-mxnet-cd/job/mxnet-cd-release-job/394/console).

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
