### PR TITLE
migrate cudaMemcpy to cudaMemcpyAsync+cudaStreamSynchronize

### DIFF
--- a/src/ndarray/ndarray_function.cu
+++ b/src/ndarray/ndarray_function.cu
@@ -129,12 +129,13 @@ void ElementwiseSumRspImpl(mshadow::Stream<gpu>* s,
       IType* row_flg = NULL;
       void* d_temp_storage = NULL;
       size_t temp_storage_bytes = 0;
+      cudaStream_t stream = mshadow::Stream<gpu>::GetStream(s);
       cub::DeviceScan::InclusiveSum(d_temp_storage,
                                     temp_storage_bytes,
                                     row_flg,
                                     row_flg,
                                     num_rows,
-                                    mshadow::Stream<gpu>::GetStream(s));
+                                    stream);
       mshadow::Tensor<gpu, 1, char> workspace = rsc
           .get_space_typed<gpu, 1, char>(mshadow::Shape1(num_rows * sizeof(IType) +
                                                          temp_storage_bytes), s);
@@ -158,11 +159,12 @@ void ElementwiseSumRspImpl(mshadow::Stream<gpu>* s,
                                     row_flg,
                                     row_flg,
                                     num_rows,
-                                    mshadow::Stream<gpu>::GetStream(s));
+                                    stream);
       // Get total number of output non-zero rows from GPU and allocate out data and row_idx
       dim_t nnr_out = 0;
-      CUDA_CALL(cudaMemcpy(&nnr_out, &row_flg[num_rows-1], sizeof(dim_t),
-                           cudaMemcpyDeviceToHost));
+      CUDA_CALL(cudaMemcpyAsync(&nnr_out, &row_flg[num_rows-1], sizeof(dim_t),
+                                cudaMemcpyDeviceToHost, stream));
+      CUDA_CALL(cudaStreamSynchronize(stream));
       out->CheckAndAlloc({mshadow::Shape1(nnr_out)});
       IType* out_row_idx = out->aux_data(kIdx).dptr<IType>();
       DType* out_data = out->data().dptr<DType>();

--- a/src/operator/contrib/adamw-inl.h
+++ b/src/operator/contrib/adamw-inl.h
@@ -442,14 +442,15 @@ static inline void MultiAdamWUpdate(const nnvm::NodeAttrs& attrs,
 }
 
 template<typename xpu>
-void GetScaleFloat(const TBlob &scale_blob, float *pScalef);
+void GetScaleFloat(mshadow::Stream<xpu> *s, const TBlob &scale_blob, float *pScalef);
 
 template<typename xpu>
-bool PrepareInputBlobs(const std::vector<TBlob> &inputs,
+bool PrepareInputBlobs(const OpContext &ctx,
+                       const std::vector<TBlob> &inputs,
                        std::vector<TBlob> *inputs_wo_scale,
                        float *pScalef) {
   const size_t num_in = inputs.size() - 1;
-  GetScaleFloat<xpu>(inputs[num_in], pScalef);
+  GetScaleFloat<xpu>(ctx.get_stream<xpu>(), inputs[num_in], pScalef);
   if (!std::isfinite(*pScalef) || *pScalef == 0)
     return false;
 
@@ -468,7 +469,7 @@ inline void MPUpdate(const nnvm::NodeAttrs& attrs,
                      const std::vector<TBlob> &outputs) {
   std::vector<TBlob> inputs_wo_scale;
   float scalef;
-  if (!PrepareInputBlobs<xpu>(inputs, &inputs_wo_scale, &scalef))
+  if (!PrepareInputBlobs<xpu>(ctx, inputs, &inputs_wo_scale, &scalef))
     return;
 
   F::Forward(attrs, ctx, inputs_wo_scale, req, outputs, scalef);
@@ -482,7 +483,7 @@ inline void multiMPUpdate(const nnvm::NodeAttrs& attrs,
                           const std::vector<TBlob> &outputs) {
   std::vector<TBlob> inputs_wo_scale;
   float scalef;
-  if (!PrepareInputBlobs<xpu>(inputs, &inputs_wo_scale, &scalef))
+  if (!PrepareInputBlobs<xpu>(ctx, inputs, &inputs_wo_scale, &scalef))
     return;
 
   if (!MP)

--- a/src/operator/contrib/adamw.cc
+++ b/src/operator/contrib/adamw.cc
@@ -119,7 +119,7 @@ the update is skipped.
 .add_arguments(AdamWParam::__FIELDS__());
 
 template<>
-void GetScaleFloat<cpu>(const TBlob &scale_blob, float *pScalef) {
+void GetScaleFloat<cpu>(mshadow::Stream<cpu> *s, const TBlob &scale_blob, float *pScalef) {
   MSHADOW_REAL_TYPE_SWITCH(scale_blob.type_flag_, DType,
     *pScalef = static_cast<float>(*scale_blob.dptr<DType>());
   )

--- a/src/operator/contrib/adamw.cu
+++ b/src/operator/contrib/adamw.cu
@@ -29,11 +29,13 @@ namespace mxnet {
 namespace op {
 
 template<>
-void GetScaleFloat<gpu>(const TBlob &scale_blob, float *pScalef) {
+void GetScaleFloat<gpu>(mshadow::Stream<gpu> *s, const TBlob &scale_blob, float *pScalef) {
   MSHADOW_REAL_TYPE_SWITCH(scale_blob.type_flag_, DType, {
     DType scale = 0;
-    CUDA_CALL(cudaMemcpy(&scale, scale_blob.dptr<DType>(), sizeof(DType),
-                         cudaMemcpyDeviceToHost));
+    cudaStream_t stream = mshadow::Stream<gpu>::GetStream(s);
+    CUDA_CALL(cudaMemcpyAsync(&scale, scale_blob.dptr<DType>(), sizeof(DType),
+                              cudaMemcpyDeviceToHost, stream));
+    CUDA_CALL(cudaStreamSynchronize(stream));
     *pScalef = static_cast<float>(scale);
   })
 }

--- a/src/operator/contrib/boolean_mask.cu
+++ b/src/operator/contrib/boolean_mask.cu
@@ -46,6 +46,7 @@ inline void BooleanMaskForward<gpu>(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(data.shape()[axis], idx.shape()[0]);
   CHECK_EQ(idx.shape().ndim(), 1U);
   Stream<gpu>* s = ctx.get_stream<gpu>();
+  cudaStream_t stream = Stream<gpu>::GetStream(s);
   // count the number of 1s in `idx`, so that we could know the output dimension
   size_t idx_size = idx.shape()[0];
   int32_t valid_num = 0;
@@ -58,7 +59,7 @@ inline void BooleanMaskForward<gpu>(const nnvm::NodeAttrs& attrs,
                                 prefix_sum,
                                 prefix_sum,
                                 idx_size,
-                                Stream<gpu>::GetStream(s));
+                                stream);
   size_t buffer_size = idx_size * sizeof(int32_t);
   temp_storage_bytes += buffer_size;
   // Allocate memory on GPU and allocate pointer
@@ -76,9 +77,11 @@ inline void BooleanMaskForward<gpu>(const nnvm::NodeAttrs& attrs,
                                 prefix_sum,
                                 prefix_sum,
                                 idx_size,
-                                Stream<gpu>::GetStream(s));
-  CUDA_CALL(cudaMemcpy(&valid_num, &prefix_sum[idx_size - 1], sizeof(int32_t),
-                       cudaMemcpyDeviceToHost));
+                                stream);
+  CUDA_CALL(cudaMemcpyAsync(&valid_num, &prefix_sum[idx_size - 1], sizeof(int32_t),
+                            cudaMemcpyDeviceToHost, stream));
+  CUDA_CALL(cudaStreamSynchronize(stream));
+
   // Set the output shape forcefully
   mxnet::TShape data_shape = data.shape();
   data_shape[axis] = valid_num;
@@ -110,6 +113,7 @@ inline void BooleanMaskBackward<gpu>(const nnvm::NodeAttrs& attrs,
   const NDArray& idx = inputs[2];
   const NDArray& igrad_data = outputs[0];
   Stream<gpu>* s = ctx.get_stream<gpu>();
+  cudaStream_t stream = Stream<gpu>::GetStream(s);
   // Count the number of 1s in `idx`, so that we could know the output dimension
   size_t idx_size = idx.shape()[0];
   int32_t* prefix_sum = nullptr;
@@ -121,7 +125,7 @@ inline void BooleanMaskBackward<gpu>(const nnvm::NodeAttrs& attrs,
                                 prefix_sum,
                                 prefix_sum,
                                 idx_size,
-                                Stream<gpu>::GetStream(s));
+                                stream);
   size_t buffer_size = idx_size * sizeof(int32_t);
   temp_storage_bytes += buffer_size;
   // Allocate memory on GPU and allocate pointer
@@ -139,7 +143,7 @@ inline void BooleanMaskBackward<gpu>(const nnvm::NodeAttrs& attrs,
                                 prefix_sum,
                                 prefix_sum,
                                 idx_size,
-                                Stream<gpu>::GetStream(s));
+                                stream);
   size_t input_size = igrad_data.shape().Size();
   size_t col_size = input_size / idx_size;
   // Backward pass

--- a/src/operator/contrib/proposal.cu
+++ b/src/operator/contrib/proposal.cu
@@ -305,7 +305,8 @@ __global__ void nms_kernel(const int n_boxes, const float nms_overlap_thresh,
   }
 }
 
-void _nms(const mshadow::Tensor<gpu, 2>& boxes,
+void _nms(mshadow::Stream<gpu> *s,
+          const mshadow::Tensor<gpu, 2>& boxes,
           const float nms_overlap_thresh,
           const int rpn_post_nms_top_n,
           int *keep,
@@ -330,10 +331,12 @@ void _nms(const mshadow::Tensor<gpu, 2>& boxes,
                                   mask_dev);
   FRCNN_CUDA_CHECK(cudaPeekAtLastError());
   std::vector<uint64_t> mask_host(boxes_num * col_blocks);
-  FRCNN_CUDA_CHECK(cudaMemcpy(&mask_host[0],
-                              mask_dev,
-                              sizeof(uint64_t) * boxes_num * col_blocks,
-                              cudaMemcpyDeviceToHost));
+  cudaStream_t stream = mshadow::Stream<gpu>::GetStream(s);
+  FRCNN_CUDA_CHECK(cudaMemcpyAsync(&mask_host[0],
+                                   mask_dev,
+                                   sizeof(uint64_t) * boxes_num * col_blocks,
+                                   cudaMemcpyDeviceToHost, stream));
+  FRCNN_CUDA_CHECK(cudaStreamSynchronize(stream));
 
   std::vector<uint64_t> remv(col_blocks);
   memset(&remv[0], 0, sizeof(uint64_t) * col_blocks);
@@ -456,9 +459,10 @@ class ProposalGPUOp : public Operator{
     float* workspace_proposals_ptr = NULL;
     FRCNN_CUDA_CHECK(cudaMalloc(&workspace_proposals_ptr, sizeof(float) * count * 5));
     Tensor<xpu, 2> workspace_proposals(workspace_proposals_ptr, Shape2(count, 5));
-    FRCNN_CUDA_CHECK(cudaMemcpy(workspace_proposals.dptr_,
-                                &anchors[0], sizeof(float) * anchors.size(),
-      cudaMemcpyHostToDevice));
+    cudaStream_t stream = mshadow::Stream<gpu>::GetStream(s);
+    FRCNN_CUDA_CHECK(cudaMemcpyAsync(workspace_proposals.dptr_,
+                                     &anchors[0], sizeof(float) * anchors.size(),
+                                     cudaMemcpyHostToDevice, stream));
 
     // Copy proposals to a mesh grid
     dim3 dimGrid((count + kMaxThreadsPerBlock - 1) / kMaxThreadsPerBlock);
@@ -471,9 +475,10 @@ class ProposalGPUOp : public Operator{
 
     // im_info is small, we want to copy them to cpu
     std::vector<float> cpu_im_info(3);
-    FRCNN_CUDA_CHECK(cudaMemcpy(&cpu_im_info[0], im_info.dptr_,
-                                sizeof(float) * cpu_im_info.size(),
-                                cudaMemcpyDeviceToHost));
+    FRCNN_CUDA_CHECK(cudaMemcpyAsync(&cpu_im_info[0], im_info.dptr_,
+                                     sizeof(float) * cpu_im_info.size(),
+                                     cudaMemcpyDeviceToHost, stream));
+    FRCNN_CUDA_CHECK(cudaStreamSynchronize(stream));
 
     // prevent padded predictions
     int real_height = static_cast<int>(cpu_im_info[0] / param_.feature_stride);
@@ -543,7 +548,7 @@ class ProposalGPUOp : public Operator{
     // perform nms
     std::vector<int> _keep(workspace_ordered_proposals.size(0));
     int out_size = 0;
-    _nms(workspace_ordered_proposals,
+    _nms(s, workspace_ordered_proposals,
          param_.threshold,
          rpn_post_nms_top_n,
          &_keep[0],
@@ -552,8 +557,8 @@ class ProposalGPUOp : public Operator{
     // copy nms result to gpu
     int* keep;
     FRCNN_CUDA_CHECK(cudaMalloc(&keep, sizeof(int) * _keep.size()));
-    FRCNN_CUDA_CHECK(cudaMemcpy(keep, &_keep[0], sizeof(int) * _keep.size(),
-                                cudaMemcpyHostToDevice));
+    FRCNN_CUDA_CHECK(cudaMemcpyAsync(keep, &_keep[0], sizeof(int) * _keep.size(),
+                                     cudaMemcpyHostToDevice, stream));
 
     // copy results after nms
     dimGrid.x = (param_.rpn_post_nms_top_n + kMaxThreadsPerBlock - 1) / kMaxThreadsPerBlock;

--- a/src/operator/numpy/np_nonzero_op.cu
+++ b/src/operator/numpy/np_nonzero_op.cu
@@ -63,6 +63,7 @@ void NonzeroForwardGPU(const nnvm::NodeAttrs& attrs,
   }
   int32_t valid_num = 0;
   Stream<gpu>* stream = ctx.get_stream<gpu>();
+  cudaStream_t cuda_stream = Stream<gpu>::GetStream(stream);
   int32_t* prefix_sum = nullptr;
   void* d_temp_storage = nullptr;
   size_t temp_storage_bytes = 0;
@@ -72,7 +73,7 @@ void NonzeroForwardGPU(const nnvm::NodeAttrs& attrs,
                                 prefix_sum,
                                 prefix_sum,
                                 in_size,
-                                Stream<gpu>::GetStream(stream));
+                                cuda_stream);
   size_t buffer_size = in_size * sizeof(int32_t);
   temp_storage_bytes += buffer_size;
   // Allocate memory on GPU and allocate pointer
@@ -90,17 +91,18 @@ void NonzeroForwardGPU(const nnvm::NodeAttrs& attrs,
                                 prefix_sum,
                                 prefix_sum,
                                 in_size,
-                                Stream<gpu>::GetStream(stream));
-  CUDA_CALL(cudaMemcpy(&valid_num, &prefix_sum[in_size - 1], sizeof(int32_t),
-                       cudaMemcpyDeviceToHost));
+                                cuda_stream);
+  CUDA_CALL(cudaMemcpyAsync(&valid_num, &prefix_sum[in_size - 1], sizeof(int32_t),
+                            cudaMemcpyDeviceToHost, cuda_stream));
+  CUDA_CALL(cudaStreamSynchronize(cuda_stream));
   // 0-dim
   if (0 == in.shape().ndim()) {
     mxnet::TShape s(2, 1);
     if (valid_num) {
       const_cast<NDArray &>(out).Init(s);
       int64_t temp = 0;
-      CUDA_CALL(cudaMemcpy(out.data().dptr<int64_t>(), &temp, sizeof(int64_t),
-                           cudaMemcpyHostToDevice));
+      CUDA_CALL(cudaMemcpyAsync(out.data().dptr<int64_t>(), &temp, sizeof(int64_t),
+                                cudaMemcpyHostToDevice, cuda_stream));
     } else {
       s[0] = 0;
       const_cast<NDArray &>(out).Init(s);

--- a/src/operator/numpy/np_unique_op.cu
+++ b/src/operator/numpy/np_unique_op.cu
@@ -97,6 +97,7 @@ void NumpyUniqueGPUNoneAxisImpl(const NumpyUniqueParam& param,
                                 const std::vector<NDArray> &outputs) {
   MXNET_NO_FLOAT16_TYPE_SWITCH(outputs[0].dtype(), DType, {
     mshadow::Stream<gpu> *stream = ctx.get_stream<gpu>();
+    cudaStream_t cuda_stream = mshadow::Stream<gpu>::GetStream(stream);
     auto policy = thrust::cuda::par.on(stream->stream_);
 
     DType* input_data = inputs[0].data().dptr<DType>();
@@ -120,8 +121,9 @@ void NumpyUniqueGPUNoneAxisImpl(const NumpyUniqueParam& param,
     thrust::device_vector<int32_t> prefix_sum(input_size, 0);
     thrust::inclusive_scan(policy, mask.begin(), mask.end(), prefix_sum.begin());
     int32_t valid_num = 0;
-    CUDA_CALL(cudaMemcpy(&valid_num, thrust::raw_pointer_cast(&prefix_sum[input_size - 1]),
-                          sizeof(int32_t), cudaMemcpyDeviceToHost));
+    CUDA_CALL(cudaMemcpyAsync(&valid_num, thrust::raw_pointer_cast(&prefix_sum[input_size - 1]),
+                              sizeof(int32_t), cudaMemcpyDeviceToHost, cuda_stream));
+    CUDA_CALL(cudaStreamSynchronize(cuda_stream));
     // set the output shape forcefully
     mxnet::TShape s(1, valid_num);
     const_cast<NDArray &>(outputs[0]).Init(s);
@@ -180,6 +182,7 @@ void NumpyUniqueGPUImpl(const NumpyUniqueParam& param,
     using namespace mshadow;
     using namespace mshadow::expr;
     Stream<gpu> *stream = ctx.get_stream<gpu>();
+    cudaStream_t cuda_stream = Stream<gpu>::GetStream(stream);
     auto policy = thrust::cuda::par.on(stream->stream_);
     const index_t actual_axis =
         param.axis.value() + ((param.axis.value() < 0) ? inputs[0].shape().ndim() : 0);
@@ -214,8 +217,9 @@ void NumpyUniqueGPUImpl(const NumpyUniqueParam& param,
     thrust::device_vector<int32_t> prefix_sum(temp_shape[0], 0);
     thrust::inclusive_scan(policy, mask.begin(), mask.end(), prefix_sum.begin());
     int32_t valid_num = 0;
-    CUDA_CALL(cudaMemcpy(&valid_num, thrust::raw_pointer_cast(&prefix_sum[temp_shape[0] - 1]),
-                          sizeof(int32_t), cudaMemcpyDeviceToHost));
+    CUDA_CALL(cudaMemcpyAsync(&valid_num, thrust::raw_pointer_cast(&prefix_sum[temp_shape[0] - 1]),
+                              sizeof(int32_t), cudaMemcpyDeviceToHost, cuda_stream));
+    CUDA_CALL(cudaStreamSynchronize(cuda_stream));
     // store the temp output data, reuse the space of 'input_tensor'
     Tensor<gpu, 3, DType> temp_tensor(workspace.dptr_,
         Shape3(valid_num, temp_shape[1], temp_shape[2]), stream);
@@ -282,11 +286,12 @@ void NumpyUniqueGPUForward(const nnvm::NodeAttrs& attrs,
     CHECK(!param.axis.has_value() || param.axis.value() == -1 || param.axis.value() == 0)
       << "Axis can only be -1 or 0 for scalor tensor";
     Stream<gpu> *s = ctx.get_stream<gpu>();
+    cudaStream_t stream = Stream<gpu>::GetStream(s);
     mxnet::TShape shape_1(1, 1);
     const_cast<NDArray &>(outputs[0]).Init(shape_1);
     MSHADOW_TYPE_SWITCH(outputs[0].dtype(), DType, {
-      CUDA_CALL(cudaMemcpy(outputs[0].data().dptr<DType>(), inputs[0].data().dptr<DType>(),
-                           sizeof(DType), cudaMemcpyDeviceToDevice));
+      CUDA_CALL(cudaMemcpyAsync(outputs[0].data().dptr<DType>(), inputs[0].data().dptr<DType>(),
+                                sizeof(DType), cudaMemcpyDeviceToDevice, stream));
     });
     int output_flag = 0;
     if (param.return_index) {

--- a/src/operator/numpy/random/dist_common.cc
+++ b/src/operator/numpy/random/dist_common.cc
@@ -30,12 +30,12 @@ namespace mxnet {
 namespace op {
 
 template <>
-void _copy<cpu>(float *dst, float *src) {
+void _copy<cpu>(mshadow::Stream<cpu> *s, float *dst, float *src) {
   *dst = *src;
 }
 
 template <>
-void _copy<cpu>(double *dst, double *src) {
+void _copy<cpu>(mshadow::Stream<cpu> *s, double *dst, double *src) {
   *dst = *src;
 }
 

--- a/src/operator/numpy/random/dist_common.cu
+++ b/src/operator/numpy/random/dist_common.cu
@@ -30,13 +30,19 @@ namespace mxnet {
 namespace op {
 
 template <>
-void _copy<gpu>(float *dst, float *src) {
-CUDA_CALL(cudaMemcpy(dst, src, sizeof(float), cudaMemcpyDeviceToHost));
+void _copy<gpu>(mshadow::Stream<gpu> *s, float *dst, float *src) {
+  cudaStream_t stream = mshadow::Stream<gpu>::GetStream(s);
+  CUDA_CALL(cudaMemcpyAsync(dst, src, sizeof(float), cudaMemcpyDeviceToHost,
+                            stream));
+  CUDA_CALL(cudaStreamSynchronize(stream));
 }
 
 template <>
-void _copy<gpu>(double *dst, double *src) {
-CUDA_CALL(cudaMemcpy(dst, src, sizeof(double), cudaMemcpyDeviceToHost));
+void _copy<gpu>(mshadow::Stream<gpu> *s, double *dst, double *src) {
+  cudaStream_t stream = mshadow::Stream<gpu>::GetStream(s);
+  CUDA_CALL(cudaMemcpyAsync(dst, src, sizeof(double), cudaMemcpyDeviceToHost,
+                            stream));
+  CUDA_CALL(cudaStreamSynchronize(stream));
 }
 
 }  // namespace op

--- a/src/operator/numpy/random/dist_common.h
+++ b/src/operator/numpy/random/dist_common.h
@@ -41,10 +41,10 @@ namespace mxnet {
 namespace op {
 
 template <typename xpu>
-void _copy(float *dst, float*src);
+void _copy(mshadow::Stream<xpu> *s, float *dst, float*src);
 
 template <typename xpu>
-void _copy(double *dst, double*src);
+void _copy(mshadow::Stream<xpu> *s, double *dst, double*src);
 
 
 inline int FillShape(const mxnet::TShape &lshape, const mxnet::TShape &rshape,

--- a/src/operator/numpy/random/np_bernoulli_op.h
+++ b/src/operator/numpy/random/np_bernoulli_op.h
@@ -173,7 +173,7 @@ void NumpyBernoulliForward(const nnvm::NodeAttrs &attrs,
         Kernel<check_legal_prob_kernel<IType>, xpu>::Launch(
             s, inputs[0].Size(), inputs[0].dptr<IType>(), indicator_device_ptr);
       });
-      _copy<xpu>(&indicator_host, indicator_device_ptr);
+      _copy<xpu>(s, &indicator_host, indicator_device_ptr);
       CHECK_GE(indicator_host, 0.0)
           << "ValueError: expect probs >= 0 && probs <= 1";
     }

--- a/src/operator/numpy/random/np_multinomial_op.cu
+++ b/src/operator/numpy/random/np_multinomial_op.cu
@@ -28,10 +28,12 @@ namespace mxnet {
 namespace op {
 
 template<typename DType>
-void CheckPvalGPU(DType* input, int prob_length) {
+void CheckPvalGPU(const OpContext& ctx, DType* input, int prob_length) {
   std::vector<DType> pvals_(prob_length);
-  CUDA_CALL(cudaMemcpy(&pvals_[0], input, sizeof(DType) * prob_length,
-    cudaMemcpyDeviceToHost));
+  cudaStream_t stream = mshadow::Stream<gpu>::GetStream(ctx.get_stream<gpu>());
+  CUDA_CALL(cudaMemcpyAsync(&pvals_[0], input, sizeof(DType) * prob_length,
+                            cudaMemcpyDeviceToHost, stream));
+  CUDA_CALL(cudaStreamSynchronize(stream));
   DType sum = DType(0.0);
   for (int i = 0; i < prob_length; ++i) {
     sum += pvals_[i];

--- a/src/operator/numpy/random/np_multinomial_op.h
+++ b/src/operator/numpy/random/np_multinomial_op.h
@@ -100,7 +100,7 @@ inline bool NumpyMultinomialOpType(const nnvm::NodeAttrs& attrs,
 }
 
 template<typename DType>
-void CheckPvalGPU(DType* input, int prob_length);
+void CheckPvalGPU(const OpContext& ctx, DType* input, int prob_length);
 
 template<typename DType>
 void CheckPval(DType* input, int prob_length) {
@@ -188,7 +188,7 @@ void NumpyMultinomialForward(const nnvm::NodeAttrs& attrs,
        if (std::is_same<xpu, cpu>::value) {
          CheckPval<DType>(inputs[0].dptr<DType>(), prob_length);
        } else {
-         CheckPvalGPU<DType>(inputs[0].dptr<DType>(), prob_length);
+         CheckPvalGPU<DType>(ctx, inputs[0].dptr<DType>(), prob_length);
        }
       Kernel<multinomial_kernel, xpu>::Launch(
         s, num_output, num_exp, prob_length,

--- a/src/operator/numpy/random/np_normal_op.h
+++ b/src/operator/numpy/random/np_normal_op.h
@@ -183,7 +183,7 @@ void NumpyNormalForward(const nnvm::NodeAttrs &attrs,
         Kernel<check_legal_scale_kernel<IType>, xpu>::Launch(
             s, inputs[0].Size(), inputs[0].dptr<IType>(), indicator_device_ptr);
       });
-      _copy<xpu>(&indicator_host, indicator_device_ptr);
+      _copy<xpu>(s, &indicator_host, indicator_device_ptr);
       CHECK_GE(indicator_host, 0.0) << "ValueError: scale < 0";
     } else {
       scalar_pos = 1;
@@ -208,7 +208,7 @@ void NumpyNormalForward(const nnvm::NodeAttrs &attrs,
       Kernel<check_legal_scale_kernel<IType>, xpu>::Launch(
           s, inputs[1].Size(), inputs[1].dptr<IType>(), indicator_device_ptr);
     });
-    _copy<xpu>(&indicator_host, indicator_device_ptr);
+    _copy<xpu>(s, &indicator_host, indicator_device_ptr);
     CHECK_GE(indicator_host, 0.0) << "ValueError: scale < 0";
     int ndim = FillShape(inputs[0].shape_, inputs[1].shape_, outputs[0].shape_,
                          &new_lshape, &new_hshape, &new_oshape);

--- a/src/operator/tensor/cast_storage-inl.cuh
+++ b/src/operator/tensor/cast_storage-inl.cuh
@@ -162,7 +162,9 @@ void CastStorageDnsRspGPUImpl_(const OpContext& ctx,
 
   // Get total number of non-zero rows from device
   dim_t nnr = 0;
-  CUDA_CALL(cudaMemcpy(&nnr, &row_flg[num_rows - 1], sizeof(dim_t), cudaMemcpyDeviceToHost));
+  CUDA_CALL(cudaMemcpyAsync(&nnr, &row_flg[num_rows - 1], sizeof(dim_t),
+                            cudaMemcpyDeviceToHost, mshadow::Stream<gpu>::GetStream(s)));
+  CUDA_CALL(cudaStreamSynchronize(mshadow::Stream<gpu>::GetStream(s)));
 
   // Allocate rsp tensor row index array and fill
   rsp->CheckAndAllocAuxData(rowsparse::kIdx, Shape1(nnr));
@@ -555,7 +557,9 @@ inline void CastStorageDnsCsrImpl(const OpContext& ctx,
 
         // Receive total number of nnz values from device
         IType nnz = 0;
-        CUDA_CALL(cudaMemcpy(&nnz, &(indptr[num_rows]), sizeof(IType), cudaMemcpyDeviceToHost));
+        CUDA_CALL(cudaMemcpyAsync(&nnz, &(indptr[num_rows]), sizeof(IType), cudaMemcpyDeviceToHost,
+                                  mshadow::Stream<gpu>::GetStream(s)));
+        CUDA_CALL(cudaStreamSynchronize(mshadow::Stream<gpu>::GetStream(s)));
 
         // Allocate column index array and data array of the csr matrix
         csr->CheckAndAllocAuxData(csr::kIdx, Shape1(static_cast<dim_t>(nnz)));

--- a/src/operator/tensor/elemwise_binary_op_basic.cu
+++ b/src/operator/tensor/elemwise_binary_op_basic.cu
@@ -115,8 +115,9 @@ void ElemwiseBinaryOp::RspRspOp(mshadow::Stream<gpu> *s,
                                       num_rows,
                                       mshadow::Stream<gpu>::GetStream(s));
         nnvm::dim_t nnr_out = 0;
-        CUDA_CALL(cudaMemcpy(&nnr_out, &common_row_table[num_rows-1], sizeof(nnvm::dim_t),
-                              cudaMemcpyDeviceToHost));
+        CUDA_CALL(cudaMemcpyAsync(&nnr_out, &common_row_table[num_rows-1], sizeof(nnvm::dim_t),
+                                  cudaMemcpyDeviceToHost, mshadow::Stream<gpu>::GetStream(s)));
+        CUDA_CALL(cudaStreamSynchronize(mshadow::Stream<gpu>::GetStream(s)))
         output.CheckAndAlloc({mshadow::Shape1(nnr_out)});
         Kernel<FillRspRowIdxKernel, gpu>::Launch(
           s, num_rows, output.aux_data(kIdx).dptr<IType>(), common_row_table, num_rows);

--- a/src/operator/tensor/indexing_op.cu
+++ b/src/operator/tensor/indexing_op.cu
@@ -154,8 +154,9 @@ bool CheckIndexOutOfBound(mshadow::Stream<gpu> *s, const DType* data_ptr, size_t
   int32_t is_valid = 0;
   Kernel<set_zero, gpu>::Launch(s, 1, is_valid_ptr);
   Kernel<is_valid_check, gpu>::Launch(s, data_size, is_valid_ptr, data_ptr, min, max);
-  CUDA_CALL(cudaMemcpy(&is_valid, is_valid_ptr, sizeof(char),
-            cudaMemcpyDeviceToHost));
+  CUDA_CALL(cudaMemcpyAsync(&is_valid, is_valid_ptr, sizeof(char),
+                            cudaMemcpyDeviceToHost, mshadow::Stream<gpu>::GetStream(s)));
+  CUDA_CALL(cudaStreamSynchronize(mshadow::Stream<gpu>::GetStream(s)));
   return is_valid == 0;
 }
 
@@ -307,8 +308,9 @@ void SparseEmbeddingDeterministicKernelLaunch(const OpContext& ctx,
       grad_row_idx, grad_row_idx + data_size, data_size, Stream<gpu>::GetStream(s));
 
   dim_t nnr = 0;
-  CUDA_CALL(cudaMemcpy(&nnr, grad_row_idx + data_size, sizeof(RType),
-      cudaMemcpyDeviceToHost));
+  CUDA_CALL(cudaMemcpyAsync(&nnr, grad_row_idx + data_size, sizeof(RType),
+                            cudaMemcpyDeviceToHost, mshadow::Stream<gpu>::GetStream(s)));
+  CUDA_CALL(cudaStreamSynchronize(mshadow::Stream<gpu>::GetStream(s)));
   CHECK_EQ(output.shape().ndim(), 2) << "Unexcepted ndim";
   output.CheckAndAllocData(Shape2(nnr, output.shape()[1]));
   output.set_aux_shape(kIdx, Shape1(nnr));
@@ -410,8 +412,9 @@ inline void SparseEmbeddingOpBackwardRspImpl<gpu>(const bool deterministic,
                                       num_rows,
                                       mshadow::Stream<gpu>::GetStream(s));
         dim_t nnr = 0;
-        CUDA_CALL(cudaMemcpy(&nnr, &prefix_sum[num_rows-1], sizeof(dim_t),
-            cudaMemcpyDeviceToHost));
+        CUDA_CALL(cudaMemcpyAsync(&nnr, &prefix_sum[num_rows-1], sizeof(dim_t),
+                                  cudaMemcpyDeviceToHost, mshadow::Stream<gpu>::GetStream(s)));
+        CUDA_CALL(cudaStreamSynchronize(mshadow::Stream<gpu>::GetStream(s)));
         if (nnr == 0) {
           FillZerosRspImpl(s, output);
           return;

--- a/src/operator/tensor/matrix_op.cu
+++ b/src/operator/tensor/matrix_op.cu
@@ -114,8 +114,9 @@ void SliceDimTwoCsrImpl<gpu>(const mxnet::TShape &begin, const mxnet::TShape &en
                                       Stream<gpu>::GetStream(s));
         // retrieve nnr
         RType nnr = 0;
-        CUDA_CALL(cudaMemcpy(&nnr, &out_indptr[indptr_len-1], sizeof(RType),
-            cudaMemcpyDeviceToHost));
+        CUDA_CALL(cudaMemcpyAsync(&nnr, &out_indptr[indptr_len-1], sizeof(RType),
+                                  cudaMemcpyDeviceToHost, mshadow::Stream<gpu>::GetStream(s)));
+        CUDA_CALL(cudaStreamSynchronize(mshadow::Stream<gpu>::GetStream(s)));
 
         // returns zeros in csr format if nnr = 0
         if (nnr == 0) {

--- a/src/operator/tensor/square_sum.cu
+++ b/src/operator/tensor/square_sum.cu
@@ -42,7 +42,9 @@ void CheckSameIdx<gpu>(const OpContext& ctx,
     mxnet_op::Kernel<mxnet_op::set_zero, gpu>::Launch(s, 1, is_diff_ptr);
     mxnet_op::Kernel<CheckSameIdxKernel, gpu>::Launch(s, idx_size,
       ograd_idx, in_idx, is_diff_ptr);
-    CUDA_CALL(cudaMemcpy(&is_diff, is_diff_ptr, sizeof(int32_t), cudaMemcpyDeviceToHost));
+    CUDA_CALL(cudaMemcpyAsync(&is_diff, is_diff_ptr, sizeof(int32_t),
+                              cudaMemcpyDeviceToHost, mshadow::Stream<gpu>::GetStream(s)));
+    CUDA_CALL(cudaStreamSynchronize(mshadow::Stream<gpu>::GetStream(s)));
     CHECK_EQ(is_diff, 0) << "SquareSumRspGradImpl only supports"
                             " equal ograd_row_idx and input_row_idx"
                             " when ograd and input are both"


### PR DESCRIPTION
## Description ##
As title.
Plus some refactors to reduce calls to `mshadow::Stream<gpu>::GetStream()`.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] API Migration from `cudaMemcpy` to `cudaStreamSynchronize`

## Comments ##
address #16583