### PR TITLE
Fix InferType logic - add backward inference for some ops

### DIFF
--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1003,7 +1003,8 @@ class Symbol(SymbolBase):
         else:
             str_keys = []
             for k, v in kwargs.items():
-                v = _numpy.dtype(v).type
+                # if v is None just use that to search in _DTYPE_NP_TO_MX
+                v = _numpy.dtype(v).type if v else None
                 if v in _DTYPE_NP_TO_MX:
                     str_keys.append(k)
                     sdata.append(_DTYPE_NP_TO_MX[v])

--- a/src/operator/contrib/deformable_convolution-inl.h
+++ b/src/operator/contrib/deformable_convolution-inl.h
@@ -44,6 +44,7 @@
 #include "../operator_common.h"
 #include "../nn/im2col.h"
 #include "./nn/deformable_im2col.h"
+#include "../elemwise_op_common.h"
 #include "../linalg.h"
 
 
@@ -453,18 +454,10 @@ class DeformableConvolutionProp : public OperatorProperty {
                  std::vector<int> *out_type,
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1U);
-    int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
-    for (size_t i = 0; i < in_type->size(); ++i) {
-      if ((*in_type)[i] == -1) {
-        (*in_type)[i] = dtype;
-      } else {
-        UNIFORM_TYPE_CHECK((*in_type)[i], dtype, ListArguments()[i]);
-      }
-    }
-    out_type->clear();
-    out_type->push_back(dtype);
-    return true;
+    std::string node_name = "deformable_convolution_node";
+    return ElemwiseAttrHelper<int, type_is_none,
+                              type_assign, true,
+                              type_string>(node_name, in_type, out_type, -1);
   }
 
   OperatorProperty* Copy() const override {

--- a/src/operator/contrib/fft-inl.h
+++ b/src/operator/contrib/fft-inl.h
@@ -33,6 +33,7 @@
 #include <utility>
 #include <iostream>
 #include "../operator_common.h"
+#include "../elemwise_op_common.h"
 #include "../mshadow_op.h"
 
 #if MXNET_USE_CUDA
@@ -256,24 +257,10 @@ class FFTProp : public OperatorProperty {
                  std::vector<int> *out_type,
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1);
-    /*
-    int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
-    for (size_t i = 0; i < in_type->size(); ++i) {
-      if ((*in_type)[i] == -1) {
-        (*in_type)[i] = dtype;
-      } else {
-        UNIFORM_TYPE_CHECK((*in_type)[i], dtype, ListArguments()[i]);
-      }
-    }
-    out_type->clear();
-    out_type->push_back(dtype);
-    return true;
-    */
     std::string node_name = "fft_node";
     return ElemwiseAttrHelper<int, type_is_none,
                               type_assign, true,
-                              type_string, 1>(node_name, in_type, out_type, -1);
+                              type_string>(node_name, in_type, out_type, -1);
   }
 
   OperatorProperty* Copy() const override {

--- a/src/operator/contrib/fft-inl.h
+++ b/src/operator/contrib/fft-inl.h
@@ -256,6 +256,7 @@ class FFTProp : public OperatorProperty {
                  std::vector<int> *out_type,
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1);
+    /*
     int dtype = (*in_type)[0];
     CHECK_NE(dtype, -1) << "First input must have specified type";
     for (size_t i = 0; i < in_type->size(); ++i) {
@@ -268,6 +269,11 @@ class FFTProp : public OperatorProperty {
     out_type->clear();
     out_type->push_back(dtype);
     return true;
+    */
+    std::string node_name = "fft_node";
+    return ElemwiseAttrHelper<int, type_is_none,
+                              type_assign, true,
+                              type_string, 1>(node_name, in_type, out_type, -1);
   }
 
   OperatorProperty* Copy() const override {

--- a/src/operator/contrib/ifft-inl.h
+++ b/src/operator/contrib/ifft-inl.h
@@ -34,6 +34,7 @@
 #include <utility>
 #include "../operator_common.h"
 #include "../mshadow_op.h"
+#include "../elemwise_op_common.h"
 
 #if MXNET_USE_CUDA
 #include <cufft.h>
@@ -248,18 +249,10 @@ class IFFTProp : public OperatorProperty {
                  std::vector<int> *out_type,
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1);
-    int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
-    for (size_t i=0; i < in_type->size(); ++i) {
-      if ((*in_type)[i] == -1) {
-        (*in_type)[i] = dtype;
-      } else {
-        UNIFORM_TYPE_CHECK((*in_type)[i], dtype, ListArguments()[i]);
-      }
-    }
-    out_type->clear();
-    out_type->push_back(dtype);
-    return true;
+    std::string node_name = "fft_node";
+    return ElemwiseAttrHelper<int, type_is_none,
+                              type_assign, true,
+                              type_string>(node_name, in_type, out_type, -1);
   }
 
   OperatorProperty* Copy() const override {

--- a/src/operator/contrib/multi_sum_sq-inl.h
+++ b/src/operator/contrib/multi_sum_sq-inl.h
@@ -31,6 +31,7 @@
 #include <mxnet/operator.h>
 #include <vector>
 #include "../operator_common.h"
+#include "../elemwise_op_common.h"
 
 namespace mxnet {
 namespace op {
@@ -64,18 +65,9 @@ inline bool MultiSumSqType(const NodeAttrs& attrs,
                            std::vector<int>* out_type) {
   const auto& p = dmlc::get<MultiSumSqParam>(attrs.parsed);
   CHECK_EQ(in_type->size(), p.num_arrays);
-  int dtype = (*in_type)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
-  for (size_t i = 0; i < in_type->size(); ++i) {
-    if ((*in_type)[i] == -1) {
-      (*in_type)[i] = dtype;
-    } else {
-      UNIFORM_TYPE_CHECK((*in_type)[i], dtype, "array_" + std::to_string(i));
-    }
-  }
-  out_type->clear();
-  out_type->push_back(mshadow::kFloat32);
-  return true;
+  return ElemwiseAttr<int, type_is_none,
+                      type_assign, true,
+                      type_string>(attrs, in_type, out_type, -1);
 }
 
 template<typename xpu>

--- a/src/operator/convolution_v1-inl.h
+++ b/src/operator/convolution_v1-inl.h
@@ -38,6 +38,7 @@
 #include <string>
 #include <utility>
 #include "./operator_common.h"
+#include "./elemwise_op_common.h"
 #include "./linalg.h"
 
 namespace mxnet {
@@ -498,18 +499,10 @@ class ConvolutionV1Prop : public OperatorProperty {
                  std::vector<int> *out_type,
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1);
-    int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
-    for (size_t i = 0; i < in_type->size(); ++i) {
-      if ((*in_type)[i] == -1) {
-        (*in_type)[i] = dtype;
-      } else {
-        UNIFORM_TYPE_CHECK((*in_type)[i], dtype, ListArguments()[i]);
-      }
-    }
-    out_type->clear();
-    out_type->push_back(dtype);
-    return true;
+    std::string node_name = "convolution_v1_node";
+    return ElemwiseAttrHelper<int, type_is_none,
+                              type_assign, true,
+                              type_string>(node_name, in_type, out_type, -1);
   }
 
   OperatorProperty* Copy() const override {

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -27,6 +27,7 @@
 #include "./upsampling-inl.h"
 #include <nnvm/op_attr_types.h>
 #include "./deconvolution-inl.h"
+#include "../elemwise_op_common.h"
 
 namespace mxnet {
 namespace op {
@@ -90,18 +91,9 @@ static bool UpSamplingType(const nnvm::NodeAttrs& attrs,
                            std::vector<int> *in_type, std::vector<int> *out_type) {
   const UpSamplingParam& param = nnvm::get<UpSamplingParam>(attrs.parsed);
   CHECK_GE(in_type->size(), 1U);
-  int dtype = (*in_type)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
-  for (size_t i = 0; i < in_type->size(); ++i) {
-    if ((*in_type)[i] == -1) {
-      (*in_type)[i] = dtype;
-    } else {
-      UNIFORM_TYPE_CHECK((*in_type)[i], dtype, ListArguments(param)[i]);
-    }
-  }
-  out_type->clear();
-  out_type->push_back(dtype);
-  return true;
+  return ElemwiseAttr<int, type_is_none,
+                      type_assign, true,
+                      type_string>(attrs, in_type, out_type, -1);
 }
 
 struct UpSamplingGrad {

--- a/src/operator/sequence_reverse-inl.h
+++ b/src/operator/sequence_reverse-inl.h
@@ -40,6 +40,7 @@
 #include "./mxnet_op.h"
 #include "./operator_common.h"
 #include "./sequence_op_common.h"
+#include "./elemwise_op_common.h"
 
 namespace mxnet {
 namespace op {
@@ -243,16 +244,10 @@ class SequenceReverseProp : public OperatorProperty {
   bool InferType(std::vector<int> *in_type, std::vector<int> *out_type,
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), param_.use_sequence_length ? 2U : 1U);
-    int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
-    for (size_t i = 0; i < in_type->size(); ++i) {
-      if ((*in_type)[i] == -1) {
-        (*in_type)[i] = dtype;
-      }
-    }
-    out_type->clear();
-    out_type->push_back(dtype);
-    return true;
+    std::string node_name = "sequence_reverse_node";
+    return ElemwiseAttrHelper<int, type_is_none,
+                              type_assign, true,
+                              type_string>(node_name, in_type, out_type, -1);
   }
 
   OperatorProperty *Copy() const override {


### PR DESCRIPTION
## Description ##
- Fixes partially https://github.com/apache/incubator-mxnet/issues/16757
- Also fixes: https://github.com/apache/incubator-mxnet/issues/16816

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
