### PR TITLE
[Fix] Add ctx to the original ndarray and revise the usage of context to ctx

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -117,7 +117,7 @@ def _gather_type_ctx_info(args):
         Context of the first appeared NDArray (for backward-compatibility)
     """
     if isinstance(args, NDArray):
-        return False, True, {args.context}, args.context
+        return False, True, {args.ctx}, args.ctx
     elif isinstance(args, Symbol):
         return True, False, set(), None
     elif isinstance(args, (list, tuple)):
@@ -1141,7 +1141,7 @@ class HybridBlock(Block):
                 if len(ctx_set) > 1:
                     raise ValueError('Find multiple contexts in the input, '
                                      'After hybridized, the HybridBlock only supports one input '
-                                     'context. You can print the ele.context in the '
+                                     'context. You can print the ele.ctx in the '
                                      'input arguments to inspect their contexts. '
                                      'Find all contexts = {}'.format(ctx_set))
                 with ctx:
@@ -1324,7 +1324,7 @@ class SymbolBlock(HybridBlock):
 
     def forward(self, x, *args):
         if isinstance(x, NDArray):
-            with x.context:
+            with x.ctx:
                 return self._call_cached_op(x, *args)
 
         assert isinstance(x, Symbol), \

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -369,10 +369,10 @@ class Parameter(object):
             if self._grad_stype != 'default':
                 raise ValueError("mxnet.numpy.zeros does not support stype = {}"
                                  .format(self._grad_stype))
-            self._grad = [_mx_np.zeros(shape=i.shape, dtype=i.dtype, ctx=i.context)
+            self._grad = [_mx_np.zeros(shape=i.shape, dtype=i.dtype, ctx=i.ctx)
                           for i in self._data]
         else:
-            self._grad = [ndarray.zeros(shape=i.shape, dtype=i.dtype, ctx=i.context,
+            self._grad = [ndarray.zeros(shape=i.shape, dtype=i.dtype, ctx=i.ctx,
                                         stype=self._grad_stype) for i in self._data]
 
         autograd.mark_variables(self._check_and_get(self._data, list),
@@ -522,7 +522,7 @@ class Parameter(object):
             raise RuntimeError("Cannot return a copy of Parameter %s via row_sparse_data() " \
                                "because its storage type is %s. Please use data() instead." \
                                %(self.name, self._stype))
-        return self._get_row_sparse(self._data, row_id.context, row_id)
+        return self._get_row_sparse(self._data, row_id.ctx, row_id)
 
     def list_row_sparse_data(self, row_id):
         """Returns copies of the 'row_sparse' parameter on all contexts, in the same order
@@ -897,7 +897,7 @@ class ParameterDict(object):
                 if g.stype == 'row_sparse':
                     ndarray.zeros_like(g, out=g)
                 else:
-                    arrays[g.context].append(g)
+                    arrays[g.ctx].append(g)
 
         if len(arrays) == 0:
             return

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -245,7 +245,7 @@ fixed-size items.
         shape_info = 'x'.join(['%d' % x for x in self.shape])
         return '\n%s\n<%s %s @%s>' % (str(self.asnumpy()),
                                       self.__class__.__name__,
-                                      shape_info, self.context)
+                                      shape_info, self.ctx)
 
     def __reduce__(self):
         return NDArray, (None,), self.__getstate__()
@@ -729,14 +729,14 @@ fixed-size items.
         `squeeze_axes`: a sequence of axes to squeeze in the value array.
         """
         if isinstance(value, numeric_types):
-            value_nd = full(bcast_shape, value, ctx=self.context, dtype=self.dtype)
+            value_nd = full(bcast_shape, value, ctx=self.ctx, dtype=self.dtype)
         elif type(value) == self.__class__:  # pylint: disable=unidiomatic-typecheck
-            value_nd = value.as_in_context(self.context)
+            value_nd = value.as_in_context(self.ctx)
             if value_nd.dtype != self.dtype:
                 value_nd = value_nd.astype(self.dtype)
         else:
             try:
-                value_nd = array(value, ctx=self.context, dtype=self.dtype)
+                value_nd = array(value, ctx=self.ctx, dtype=self.dtype)
             except:
                 raise TypeError('{} does not support assignment with non-array-like '
                                 'object {} of type {}'.format(self.__class__, value, type(value)))
@@ -1220,7 +1220,7 @@ fixed-size items.
 
         shape_nd_permut = tuple(self.shape[ax] for ax in axs_nd_permut)
         converted_idcs_short = [
-            self._advanced_index_to_array(idx, ax_len, self.context)
+            self._advanced_index_to_array(idx, ax_len, self.ctx)
             for idx, ax_len in zip(idcs_permut_short, shape_nd_permut)
         ]
         bcast_idcs_permut_short = self._broadcast_advanced_indices(
@@ -1229,7 +1229,7 @@ fixed-size items.
 
         # Get the ndim of advanced indexing subspace
         converted_advanced_idcs = [
-            self._advanced_index_to_array(idx, ax_len, self.context)
+            self._advanced_index_to_array(idx, ax_len, self.ctx)
             for idx, ax_len in zip(adv_idcs_nd, [self.shape[ax] for ax in adv_axs_nd])
         ]
         bcast_advanced_shape = _broadcast_shapes(converted_advanced_idcs)
@@ -2434,6 +2434,23 @@ fixed-size items.
         return Context(Context.devtype2str[dev_typeid.value], dev_id.value)
 
     @property
+    def ctx(self):
+        """Device context of the array. Has the same meaning as context.
+
+        Examples
+        --------
+        >>> x = mx.nd.array([1, 2, 3, 4])
+        >>> x.ctx
+        cpu(0)
+        >>> type(x.ctx)
+        <class 'mxnet.context.Context'>
+        >>> y = mx.nd.zeros((2,3), mx.gpu(0))
+        >>> y.ctx
+        gpu(0)
+        """
+        return self.context
+
+    @property
     def dtype(self):
         """Data-type of the array's elements.
 
@@ -2580,7 +2597,7 @@ fixed-size items.
         if not copy and np.dtype(dtype) == self.dtype:
             return self
 
-        res = empty(self.shape, ctx=self.context, dtype=dtype)
+        res = empty(self.shape, ctx=self.ctx, dtype=dtype)
         self.copyto(res)
         return res
 
@@ -2646,7 +2663,7 @@ fixed-size items.
         array([[ 1.,  1.,  1.],
                [ 1.,  1.,  1.]], dtype=float32)
         """
-        return self.copyto(self.context)
+        return self.copyto(self.ctx)
 
     def slice_assign_scalar(self, value, begin, end, step):
         """
@@ -2904,7 +2921,7 @@ fixed-size items.
         """
         This is added as an NDArray class method in order to support polymorphism in NDArray and numpy.ndarray indexing
         """
-        return _internal._full(self.shape, value=value, ctx=self.context, dtype=self.dtype, out=self)
+        return _internal._full(self.shape, value=value, ctx=self.ctx, dtype=self.dtype, out=self)
 
     def _scatter_set_nd(self, value_nd, indices):
         """
@@ -4542,7 +4559,7 @@ def concatenate(arrays, axis=0, always_copy=True):
         assert shape_rest2 == arr.shape[axis+1:]
         assert dtype == arr.dtype
     ret_shape = shape_rest1 + (shape_axis,) + shape_rest2
-    ret = empty(ret_shape, ctx=arrays[0].context, dtype=dtype)
+    ret = empty(ret_shape, ctx=arrays[0].ctx, dtype=dtype)
 
     idx = 0
     begin = [0 for _ in ret_shape]

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -1864,7 +1864,7 @@ class ndarray(NDArray):
         Currently for internal use only. Implemented for __setitem__.
         Assign to self an array of self's same shape and type, filled with value.
         """
-        return _mx_nd_np.full(self.shape, value, ctx=self.context, dtype=self.dtype, out=self)
+        return _mx_nd_np.full(self.shape, value, ctx=self.ctx, dtype=self.dtype, out=self)
 
     # pylint: disable=redefined-outer-name
     def _scatter_set_nd(self, value_nd, indices):

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -921,7 +921,7 @@ class ndarray(NDArray):
         elif dtype not in (_np.float32, _np.bool_):
             array_str = array_str[:-1] + ', dtype={})'.format(dtype)
 
-        context = self.context
+        context = self.ctx
         if context.device_type == 'cpu':
             return array_str
         return array_str[:-1] + ', ctx={})'.format(str(context))
@@ -929,7 +929,7 @@ class ndarray(NDArray):
     def __str__(self):
         """Returns a string representation of the array."""
         array_str = self.asnumpy().__str__()
-        context = self.context
+        context = self.ctx
         if context.device_type == 'cpu' or self.ndim == 0:
             return array_str
         return '{array} @{ctx}'.format(array=array_str, ctx=context)
@@ -994,7 +994,7 @@ class ndarray(NDArray):
         if not copy and _np.dtype(dtype) == self.dtype:
             return self
 
-        res = empty(self.shape, dtype=dtype, ctx=self.context)
+        res = empty(self.shape, dtype=dtype, ctx=self.ctx)
         self.copyto(res)
         return res
 
@@ -1051,7 +1051,8 @@ class ndarray(NDArray):
 
     def as_in_context(self, context):
         """This function has been deprecated. Please refer to ``ndarray.as_in_ctx``."""
-        warnings.warn('ndarray.context has been renamed to ndarray.ctx', DeprecationWarning)
+        warnings.warn('ndarray.as_in_context has been renamed to'
+                      ' ndarray.as_in_ctx', DeprecationWarning)
         return self.as_nd_ndarray().as_in_context(context).as_np_ndarray()
 
     def as_in_ctx(self, ctx):


### PR DESCRIPTION
In the numpy interface, `context` has been renamed to be `ctx`. I've added the `ctx` back to the original ndarray and also revised the `.context` calls.
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
