### PR TITLE
Add missing imports in python/mxnet/contrib/__init__.py 

### DIFF
--- a/python/mxnet/contrib/__init__.py
+++ b/python/mxnet/contrib/__init__.py
@@ -30,6 +30,7 @@ from . import tensorboard
 from . import amp
 from . import text
 from . import onnx
+from . import svrg_optimization
 from . import io
 from . import quantization
 from . import quantization as quant

--- a/python/mxnet/contrib/__init__.py
+++ b/python/mxnet/contrib/__init__.py
@@ -27,6 +27,7 @@ from . import ndarray as nd
 from . import autograd
 from . import tensorboard
 
+from . import amp
 from . import text
 from . import onnx
 from . import io


### PR DESCRIPTION
## Description ##
Add missing imports in python/mxnet/contrib/__init__.py 

## Comments ##
Without this change, users need to `import mxnet; import mxnet.contrib.amp; print(mxnet.contrib.amp)` before they can use amp.
With this change, users can `import mxnet; print(mxnet.contrib.amp)`
