### PR TITLE
Change Reshape's shape size check to EQ

### DIFF
--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -243,8 +243,9 @@ NDArray NDArray::MKLDNNDataReshape(const mxnet::TShape &shape) const {
 
 NDArray NDArray::Reshape(const mxnet::TShape &shape) const {
   CHECK(!is_none()) << "NDArray is not initialized";
-  CHECK_GE(shape_.Size(), shape.Size())
-    << "NDArray.Reshape: target shape size is larger current shape";
+  CHECK_EQ(shape_.Size(), shape.Size())
+    << "NDArray.Reshape: target shape must have the same size as "
+    << "current shape.";
   NDArray ret = this->Detach();
   // If the shape doesn't change, we can just return it now.
   if (ret.shape_ == shape)
@@ -260,9 +261,6 @@ NDArray NDArray::ReshapeWithRecord(const mxnet::TShape &shape) {
   NDArray ret = this->Reshape(shape);
   if (!Imperative::Get()->is_recording()) return ret;
 
-  CHECK_EQ(shape_.Size(), shape.Size())
-    << "NDArray.Reshape: target shape must have the same size as "
-    << "current shape when recording with autograd.";
   nnvm::NodeAttrs attrs;
   attrs.op = nnvm::Op::Get("Reshape");;
   std::ostringstream os;


### PR DESCRIPTION
## Description ##
Change non-recorded `NDArray::Reshape` to accept only shapes with the same volume, in order to match NumPy behavior.

NumPy behavior:
```
>>> a = np.ones(shape=(2,4))
>>> a
array([[1., 1., 1., 1.],
       [1., 1., 1., 1.]])
>>> a.reshape(1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: cannot reshape array of size 8 into shape (1,)
```

MXNet behavior prior to the change:
```
>>> a = mx.nd.ones(shape=(2,4))
>>> a.reshape(1)

[1.]
<NDArray 1 @cpu(0)>
```

MXNet behavior after the change:
```
>>> a = mx.nd.ones(shape=(2,4))
>>> a.reshape(1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/mxnet/python/mxnet/ndarray/ndarray.py", line 1067, in reshape
    ctypes.byref(handle)))
  File "/opt/mxnet/python/mxnet/base.py", line 252, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
mxnet.base.MXNetError: [17:03:38] src/ndarray/ndarray.cc:239: Check failed: shape_.Size() == shape.Size() (8 vs. 1) : NDArray.Reshape: target shape must have the same size as current shape.
```

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Change Reshape check
