### PR TITLE
Enforces NDArray type in get_symbol

### DIFF
--- a/python/mxnet/autograd.py
+++ b/python/mxnet/autograd.py
@@ -360,6 +360,8 @@ def get_symbol(x):
     Symbol
         The retrieved Symbol.
     """
+    assert isinstance(x, NDArray), \
+       "get_symbol: Invalid argument type, expecting %s, got %s"%(NDArray, type(x))
     hdl = SymbolHandle()
     check_call(_LIB.MXAutogradGetSymbol(x.handle, ctypes.byref(hdl)))
     return Symbol(hdl)


### PR DESCRIPTION
## Description ##
Giving a Python object different than NDArray to `get_symbol` causes a Segfault, we need to enforce the type.
Add an assert for type checking.

## Checklist ##
### Essentials ###

- [X] Changes are complete (i.e. I finished coding on this PR)
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Add type check
