### PR TITLE
Multi Precision Lamb Update operator

### DIFF
--- a/python/mxnet/optimizer/optimizer.py
+++ b/python/mxnet/optimizer/optimizer.py
@@ -34,7 +34,8 @@ from ..ndarray import (sgd_update, sgd_mom_update, adam_update, rmsprop_update, 
                        multi_sgd_update, multi_sgd_mom_update, multi_mp_sgd_update,
                        multi_mp_sgd_mom_update, preloaded_multi_sgd_update,
                        preloaded_multi_sgd_mom_update, preloaded_multi_mp_sgd_update,
-                       preloaded_multi_mp_sgd_mom_update, lamb_update_phase1, lamb_update_phase2)
+                       preloaded_multi_mp_sgd_mom_update, lamb_update_phase1, lamb_update_phase2,
+                       mp_lamb_update_phase1, mp_lamb_update_phase2)
 from ..ndarray import sparse
 from ..random import normal
 from ..util import is_np_array
@@ -1262,34 +1263,73 @@ class LAMB(Optimizer):
 
     def create_state(self, index, weight):
         stype = weight.stype
-        dtype = weight.dtype
-        return (zeros(weight.shape, weight.context, dtype=dtype, stype=stype),
-                zeros(weight.shape, weight.context, dtype=dtype, stype=stype))
+        return (zeros(weight.shape, weight.context, dtype=numpy.float32, stype=stype),
+                zeros(weight.shape, weight.context, dtype=numpy.float32, stype=stype))
+
+    def _update_impl(self, indices, weights, grads, states, multi_precision=False):
+        aggregate = True
+        if not isinstance(indices, (tuple, list)):
+            indices = [indices]
+            weights = [weights]
+            grads = [grads]
+            states = [states]
+        for weight, grad in zip(weights, grads):
+            assert(isinstance(weight, NDArray))
+            assert(isinstance(grad, NDArray))
+            aggregate = (aggregate and
+                         weight.stype == 'default' and
+                         grad.stype == 'default')
+        self._update_count(indices)
+        lrs = self._get_lrs(indices)
+        wds = self._get_wds(indices)
+        for idx in indices:
+            t = self._index_update_count[idx]
+
+            kwargs = {'beta1': self.beta1, 'beta2': self.beta2, 'epsilon': self.epsilon,
+                      'bias_correction': self.bias_correction, 't': t,
+                      'rescale_grad': self.rescale_grad}
+
+            if self.clip_gradient:
+                kwargs['clip_gradient'] = self.clip_gradient
+
+            if multi_precision:
+                for weight, grad, state, lr, wd in zip(weights, grads, states, lrs, wds):
+                    mean, var = state[1]
+                    weight32 = state[0]
+                    g = mp_lamb_update_phase1(weight, grad, mean, var, weight32, wd=wd, **kwargs)
+
+                    kwargs = {}
+                    if self.lower_bound:
+                        kwargs['lower_bound'] = self.lower_bound
+                    if self.upper_bound:
+                        kwargs['upper_bound'] = self.upper_bound
+                    r_1 = weight32.norm()
+                    r_2 = g.norm()
+                    mp_lamb_update_phase2(weight, g, r_1, r_2, weight32, lr=lr, out=weight, **kwargs)
+            else:
+                for weight, grad, state, lr, wd in zip(weights, grads, states, lrs, wds):
+                    mean, var = state
+                    g = lamb_update_phase1(weight, grad, mean, var, wd=wd, **kwargs)
+
+                    kwargs = {}
+                    if self.lower_bound:
+                        kwargs['lower_bound'] = self.lower_bound
+                    if self.upper_bound:
+                        kwargs['upper_bound'] = self.upper_bound
+                    r_1 = weight.norm()
+                    r_2 = g.norm()
+                    lamb_update_phase2(weight, g, r_1, r_2, lr=lr, out=weight, **kwargs)
 
     def update(self, index, weight, grad, state):
-        assert(isinstance(weight, NDArray))
-        assert(isinstance(grad, NDArray))
-        self._update_count(index)
-        lr = self._get_lr(index)
-        wd = self._get_wd(index)
-        t = self._index_update_count[index]
+        self._update_impl(index, weight, grad, state, multi_precision=False)
 
-        kwargs = {'beta1': self.beta1, 'beta2': self.beta2, 'epsilon': self.epsilon,
-                  'bias_correction': self.bias_correction, 't': t,
-                  'rescale_grad': self.rescale_grad}
-        mean, var = state
-        if self.clip_gradient:
-            kwargs['clip_gradient'] = self.clip_gradient
-        g = lamb_update_phase1(weight, grad, mean, var, wd=wd, **kwargs)
-
-        kwargs = {}
-        if self.lower_bound:
-            kwargs['lower_bound'] = self.lower_bound
-        if self.upper_bound:
-            kwargs['upper_bound'] = self.upper_bound
-        r_1 = weight.norm()
-        r_2 = g.norm()
-        lamb_update_phase2(weight, g, r_1, r_2, lr=lr, out=weight, **kwargs)
+    def update_multi_precision(self, index, weight, grad, state):
+        if not isinstance(index, (tuple, list)):
+            use_multi_precision = self.multi_precision and weight.dtype == numpy.float16
+        else:
+            use_multi_precision = self.multi_precision and weight[0].dtype == numpy.float16
+        self._update_impl(index, weight, grad, state,
+                          multi_precision=use_multi_precision)
 
 
 # pylint: enable=line-too-long

--- a/src/operator/optimizer_op-inl.h
+++ b/src/operator/optimizer_op-inl.h
@@ -1751,6 +1751,161 @@ inline void LambUpdatePhaseTwo(const nnvm::NodeAttrs& attrs,
   });
 }
 
+template<int n_in, int n_out, int total_in>
+inline bool MPLambPhaseOneType(const nnvm::NodeAttrs& attrs,
+                             std::vector<int> *in_attrs,
+                             std::vector<int> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), static_cast<size_t>(total_in)) << " in operator " << attrs.name;
+  CHECK_EQ(out_attrs->size(), static_cast<size_t>(n_out)) << " in operator " << attrs.name;
+  for (int i = 0; i < n_in; ++i) {
+    TYPE_ASSIGN_CHECK(*in_attrs, i, mshadow::kFloat16);
+  }
+  for (int i = n_in; i < total_in; ++i) {
+    TYPE_ASSIGN_CHECK(*in_attrs, i, mshadow::kFloat32);
+  }
+  for (int i = 0; i < n_out; ++i) {
+    TYPE_ASSIGN_CHECK(*out_attrs, i, mshadow::kFloat32);
+  }
+  return true;
+}
+
+struct MPLambUpdatePhaseOneKernel {
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, float* out_data,
+    float* mean_data, float* var_data, const DType* weight_data,
+    const DType* grad_data, const float* weight32_data,
+    const float clip_gradient, const float rescale_grad,
+    const float beta1, const float beta2, const float wd,
+    const float epsilon, const float t,
+    bool bias_correction, const OpReqType req) {
+    using namespace mshadow_op;
+
+    float grad_rescaled = grad_data[i] * rescale_grad;
+    if (clip_gradient >= 0.f) {
+      grad_rescaled = clip::Map(grad_rescaled, clip_gradient);
+    }
+
+    mean_data[i] = beta1 * mean_data[i] + (1.f - beta1) * grad_rescaled;
+    var_data[i] = beta2 * var_data[i] + (1.f - beta2) * grad_rescaled * grad_rescaled;
+
+    float g = mean_data[i] / (square_root::Map(var_data[i]) + epsilon) + wd * weight32_data[i];
+
+    if (bias_correction) {
+      float mean_hat = mean_data[i] / (1. - power::Map(beta1, t));
+      float var_hat = var_data[i] / (1 - power::Map(beta2, t));
+      g = mean_hat / (square_root::Map(var_hat) + epsilon) + wd * weight32_data[i];
+    }
+    KERNEL_ASSIGN(out_data[i], req, g);
+  }
+};
+
+template<typename xpu>
+inline void MPLambUpdatePhaseOne(const nnvm::NodeAttrs& attrs,
+                       const OpContext &ctx,
+                       const std::vector<TBlob> &inputs,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &outputs) {
+  using namespace mxnet_op;
+  const LambUpdatePhaseOneParam& param = nnvm::get<LambUpdatePhaseOneParam>(attrs.parsed);
+  Stream<xpu>* s = ctx.get_stream<xpu>();
+  MSHADOW_REAL_TYPE_SWITCH(inputs[0].type_flag_, DType, {
+    Tensor<xpu, 2, DType> weight = inputs[0].FlatTo2D<xpu, DType>(s);
+    Tensor<xpu, 2, DType> grad = inputs[1].FlatTo2D<xpu, DType>(s);
+    Tensor<xpu, 2, float> mean = inputs[2].FlatTo2D<xpu, float>(s);
+    Tensor<xpu, 2, float> var = inputs[3].FlatTo2D<xpu, float>(s);
+    Tensor<xpu, 2, float> weight32 = inputs[4].FlatTo2D<xpu, float>(s);
+    Tensor<xpu, 2, float> out = outputs[0].FlatTo2D<xpu, float>(s);
+
+  Kernel<MPLambUpdatePhaseOneKernel, xpu>::Launch(s, weight.shape_.Size(),
+    out.dptr_, mean.dptr_, var.dptr_, weight.dptr_, grad.dptr_, weight32.dptr_,
+    param.clip_gradient, param.rescale_grad, param.beta1, param.beta2,
+    param.wd, param.epsilon, param.t, param.bias_correction, req[0]);
+  });
+}
+
+inline bool MPLambUpdatePhaseTwoShape(const nnvm::NodeAttrs& attrs,
+                            mxnet::ShapeVector* in_attrs,
+                            mxnet::ShapeVector* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 5U);
+  CHECK_EQ(out_attrs->size(), 1U);
+
+  mxnet::TShape expected_out(in_attrs->at(0).ndim(), -1);
+
+  mxnet::TShape& weight_shape = in_attrs->at(0);
+  mxnet::TShape& g_shape = in_attrs->at(1);
+  mxnet::TShape& weight32_shape = in_attrs->at(4);
+  CHECK_EQ(weight_shape.ndim(), g_shape.ndim())
+           << "total no. of dimensions for weights and g must match";
+  CHECK_EQ(weight_shape.ndim(), weight32_shape.ndim())
+           << "total no. of dimensions for weights and g must match";
+  for (int i=0; i < weight_shape.ndim(); ++i) {
+    CHECK_EQ(weight_shape[i], g_shape[i])
+           << "weight and g dimension size mismatch at " << i << "-th index";
+    CHECK_EQ(weight_shape[i], weight32_shape[i])
+           << "weight and g dimension size mismatch at " << i << "-th index";
+  }
+  mxnet::TShape& r1_shape = in_attrs->at(2);
+  mxnet::TShape& r2_shape = in_attrs->at(3);
+  CHECK_EQ(r1_shape[0], 1U) << "r1 shape incorrect";
+  CHECK_EQ(r2_shape[0], 1U) << "r2 shape incorrect";
+  for (int i=0; i < expected_out.ndim(); ++i) {
+    expected_out[i] = weight_shape[i];
+  }
+
+  SHAPE_ASSIGN_CHECK(*out_attrs, 0, expected_out);
+  return shape_is_known(expected_out);
+}
+
+struct MPLambUpdatePhaseTwoKernel {
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, DType* out_data,
+    const DType* weight_data, const float* g,
+    const float* r1, const float* r2, const float* weight32_data,
+    float lr, const float lower_bound,
+    const float upper_bound, const OpReqType req) {
+    using namespace mshadow_op;
+
+    float new_r1 = r1[0];
+    if (lower_bound >= 0) {
+      new_r1 = maximum::Map(new_r1, lower_bound);
+    }
+    if (upper_bound >= 0) {
+      new_r1 = minimum::Map(new_r1, upper_bound);
+    }
+    if (new_r1 == 0.0f || r2[0] == 0.0f) {
+      lr = lr * 1.0f;
+    } else {
+      lr = lr * new_r1 / r2[0];
+    }
+
+    KERNEL_ASSIGN(out_data[i], req, weight32_data[i] - lr * g[i]);
+  }
+};
+
+template<typename xpu>
+inline void MPLambUpdatePhaseTwo(const nnvm::NodeAttrs& attrs,
+                       const OpContext &ctx,
+                       const std::vector<TBlob> &inputs,
+                       const std::vector<OpReqType> &req,
+                       const std::vector<TBlob> &outputs) {
+  using namespace mxnet_op;
+  const LambUpdatePhaseTwoParam& param = nnvm::get<LambUpdatePhaseTwoParam>(attrs.parsed);
+  Stream<xpu>* s = ctx.get_stream<xpu>();
+  MSHADOW_REAL_TYPE_SWITCH(inputs[0].type_flag_, DType, {
+    Tensor<xpu, 2, DType> weight = inputs[0].FlatTo2D<xpu, DType>(s);
+    Tensor<xpu, 2, float> g = inputs[1].FlatTo2D<xpu, float>(s);
+    Tensor<xpu, 2, float> r1 = inputs[2].FlatTo2D<xpu, float>(s);
+    Tensor<xpu, 2, float> r2 = inputs[3].FlatTo2D<xpu, float>(s);
+    Tensor<xpu, 2, float> weight32 = inputs[4].FlatTo2D<xpu, float>(s);
+    Tensor<xpu, 2, DType> out = outputs[0].FlatTo2D<xpu, DType>(s);
+
+  Kernel<MPLambUpdatePhaseTwoKernel, xpu>::Launch(s, weight.shape_.Size(),
+    out.dptr_, weight.dptr_, g.dptr_, r1.dptr_, r2.dptr_, weight32.dptr_,
+    param.lr, param.lower_bound,
+    param.upper_bound, req[0]);
+  });
+}
+
 // This RMSProp code follows the version in
 // http://arxiv.org/pdf/1308.0850v5.pdf Eq(38) - Eq(45)
 // by Alex Graves, 2013.
@@ -2492,6 +2647,5 @@ inline void AdagradUpdateEx(const nnvm::NodeAttrs& attrs,
 
 }  // namespace op
 }  // namespace mxnet
-
 
 #endif  // MXNET_OPERATOR_OPTIMIZER_OP_INL_H_

--- a/src/operator/optimizer_op.cc
+++ b/src/operator/optimizer_op.cc
@@ -947,7 +947,7 @@ Link to paper: https://arxiv.org/pdf/1904.00962.pdf
          var_hat = var / (1 - beta2^t);
          g = mean_hat / (var_hat^(1/2) + epsilon) + wd * weight;
     else
-         g = mean / (var_data^(1/2) + epsilon) + wd * weight_data[i];
+         g = mean / (var_data^(1/2) + epsilon) + wd * weight;
     \end{gather*}
 
 )code" ADD_FILELINE)
@@ -1000,6 +1000,94 @@ Link to paper: https://arxiv.org/pdf/1904.00962.pdf
 .add_argument("g", "NDArray-or-Symbol", "Output of lamb_update_phase 1")
 .add_argument("r1", "NDArray-or-Symbol", "r1")
 .add_argument("r2", "NDArray-or-Symbol", "r2")
+.add_arguments(LambUpdatePhaseTwoParam::__FIELDS__());
+
+NNVM_REGISTER_OP(mp_lamb_update_phase1)
+.describe(R"code(Mixed Precision version of Phase I of lamb update 
+it performs the following operations and returns g:.
+
+          Link to paper: https://arxiv.org/pdf/1904.00962.pdf
+
+          .. math::
+              \begin{gather*}
+              grad32 = grad(float16) * rescale_grad
+              if (grad < -clip_gradient)
+              then
+                   grad = -clip_gradient
+              if (grad > clip_gradient)
+              then
+                   grad = clip_gradient
+
+              mean = beta1 * mean + (1 - beta1) * grad;
+              variance = beta2 * variance + (1. - beta2) * grad ^ 2;
+
+              if (bias_correction)
+              then
+                   mean_hat = mean / (1. - beta1^t);
+                   var_hat = var / (1 - beta2^t);
+                   g = mean_hat / (var_hat^(1/2) + epsilon) + wd * weight32;
+              else
+                   g = mean / (var_data^(1/2) + epsilon) + wd * weight32;
+              \end{gather*}
+
+          )code" ADD_FILELINE)
+.set_num_inputs(5)
+.set_num_outputs(1)
+.set_attr_parser(ParamParser<LambUpdatePhaseOneParam>)
+.set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<5, 1>)
+.set_attr<nnvm::FInferType>("FInferType", MPLambPhaseOneType<2, 1, 5>)
+.set_attr<FCompute>("FCompute<cpu>", MPLambUpdatePhaseOne<cpu>)
+.set_attr<nnvm::FMutateInputs>("FMutateInputs",
+  [](const nnvm::NodeAttrs& attrs) {
+    return std::vector<uint32_t>{2, 3};
+  })
+.add_argument("weight", "NDArray-or-Symbol", "Weight")
+.add_argument("grad", "NDArray-or-Symbol", "Gradient")
+.add_argument("mean", "NDArray-or-Symbol", "Moving mean")
+.add_argument("var", "NDArray-or-Symbol", "Moving variance")
+.add_argument("weight32", "NDArray-or-Symbol", "Weight32")
+.add_arguments(LambUpdatePhaseOneParam::__FIELDS__());
+
+NNVM_REGISTER_OP(mp_lamb_update_phase2)
+.describe(R"code(Mixed Precision version Phase II of lamb update 
+it performs the following operations and updates grad.
+
+          Link to paper: https://arxiv.org/pdf/1904.00962.pdf
+
+          .. math::
+              \begin{gather*}
+              if (lower_bound >= 0)
+              then
+                   r1 = max(r1, lower_bound)
+              if (upper_bound >= 0)
+              then
+                   r1 = max(r1, upper_bound)
+
+              if (r1 == 0 or r2 == 0)
+              then
+                   lr = lr
+              else
+                   lr = lr * (r1/r2)
+              weight32 = weight32 - lr * g
+              weight(float16) = weight32
+              \end{gather*}
+
+          )code" ADD_FILELINE)
+.set_num_inputs(5)
+.set_num_outputs(1)
+.set_attr_parser(ParamParser<LambUpdatePhaseTwoParam>)
+.set_attr<mxnet::FInferShape>("FInferShape", MPLambUpdatePhaseTwoShape)
+.set_attr<nnvm::FInferType>("FInferType", MP_InferType<1, 1, 5>)
+.set_attr<FCompute>("FCompute<cpu>", MPLambUpdatePhaseTwo<cpu>)
+.set_attr<nnvm::FMutateInputs>("FMutateInputs",
+  [](const nnvm::NodeAttrs& attrs) {
+    return std::vector<uint32_t>{4};
+  })
+.add_argument("weight", "NDArray-or-Symbol", "Weight")
+.add_argument("g", "NDArray-or-Symbol", "Output of mp_lamb_update_phase 1")
+.add_argument("r1", "NDArray-or-Symbol", "r1")
+.add_argument("r2", "NDArray-or-Symbol", "r2")
+.add_argument("weight32", "NDArray-or-Symbol", "Weight32")
 .add_arguments(LambUpdatePhaseTwoParam::__FIELDS__());
 
 }  // namespace op

--- a/src/operator/optimizer_op.cu
+++ b/src/operator/optimizer_op.cu
@@ -283,6 +283,11 @@ NNVM_REGISTER_OP(lamb_update_phase1)
 NNVM_REGISTER_OP(lamb_update_phase2)
 .set_attr<FCompute>("FCompute<gpu>", LambUpdatePhaseTwo<gpu>);
 
+NNVM_REGISTER_OP(mp_lamb_update_phase1)
+.set_attr<FCompute>("FCompute<gpu>", MPLambUpdatePhaseOne<gpu>);
+
+NNVM_REGISTER_OP(mp_lamb_update_phase2)
+.set_attr<FCompute>("FCompute<gpu>", MPLambUpdatePhaseTwo<gpu>);
 
 }  // namespace op
 }  // namespace mxnet

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -423,64 +423,6 @@ def test_preloaded_multi_sgd():
                 check_preloaded_multi_sgd(dtype, shapes, momentum, use_master_weights)
 
 
-def check_multi_lamb(dtype, shapes, use_master_weights):
-    def _flatten_list(nested_list):
-        return [item for sublist in nested_list for item in sublist]
-    weights_arr = [np.random.rand(*shape).astype(dtype) * 100. for shape in shapes]
-    grads_arr = [np.random.rand(*shape).astype(dtype) * 100. for shape in shapes]
-    means_arr = [np.random.rand(*shape).astype(dtype) * 100. for shape in shapes]
-    variences_arr = [np.random.rand(*shape).astype(dtype) * 100. for shape in shapes]
-    rescale_grad = (np.random.random() + 1.0)
-    mx_w = _make_ndarrays(weights_arr)
-    mx_g = _make_ndarrays(grads_arr)
-    mx_m = _make_ndarrays(means_arr)
-    mx_v = _make_ndarrays(variences_arr)
-    mx_p_w = _make_ndarrays(weights_arr)
-    mx_p_g = _make_ndarrays(grads_arr)
-    lrs = list((np.random.random(size=len(shapes)).astype('float32') + 0.1) / 100.)
-    mx_lrs = mx.nd.array(lrs, dtype='float32', ctx=mx.gpu(0))
-    wds = list((np.random.random(size=len(shapes)).astype('float32') + 0.1) / 1000.)
-    mx_wds = mx.nd.array(wds, dtype='float32', ctx=mx.gpu(0))
-
-    if use_master_weights:
-        weights32_arr = [arr.astype('float32') for arr in weights_arr]
-        mx_w32 = _make_ndarrays(weights32_arr)
-        mx_p_w32 = _make_ndarrays(weights32_arr)
-
-    mx.nd.multi_mp_lamb_update(
-                             *_flatten_list(zip(mx_w, mx_g, mx_m, mx_v, mx_w32)),
-                             num_weights=len(shapes), lrs=lrs, wds=wds,
-                             rescale_grad=rescale_grad, out=mx_w)
-
-    def _assert_all_almost_equal(lhs_list, rhs_list, rtol, atol):
-        for i, (lhs, rhs) in enumerate(zip(lhs_list, rhs_list)):
-            assert_almost_equal(lhs.asnumpy(), rhs.asnumpy(), rtol=rtol, atol=atol)
-    if dtype == 'float16':
-        rtol = 1e-3
-        atol = 1e-2
-    else:
-        rtol = 1e-5
-        atol = 1e-6
-    _assert_all_almost_equal(mx_p_w, mx_w, rtol, atol)
-    if use_master_weights:
-        _assert_all_almost_equal(mx_p_w32, mx_w32, 1e-5, 1e-6)
-
-
-@with_seed
-def test_multi_lamb():
-    dtypes = ['float16', 'float32']
-    min_nparam = 5
-    max_nparam = 10
-    maxdim = 6
-    maxndim = 4
-    for dtype in dtypes:
-        use_master_weights_list = [False,] if dtype == 'float32' else [True, False]
-        for use_master_weights in use_master_weights_list:
-            nparam = np.random.randint(min_nparam + 1, max_nparam + 1)
-            shapes = [np.random.randint(1, maxdim + 1, size=maxndim) for i in range(nparam)]
-            check_multi_LAMB(dtype, shapes, use_master_weights)
-
-
 @with_seed()
 def test_batchnorm_with_type():
   ctx_list_v1_2D = [

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -422,6 +422,65 @@ def test_preloaded_multi_sgd():
                 shapes = [np.random.randint(1, maxdim + 1, size=maxndim) for i in range(nparam)]
                 check_preloaded_multi_sgd(dtype, shapes, momentum, use_master_weights)
 
+
+def check_multi_lamb(dtype, shapes, use_master_weights):
+    def _flatten_list(nested_list):
+        return [item for sublist in nested_list for item in sublist]
+    weights_arr = [np.random.rand(*shape).astype(dtype) * 100. for shape in shapes]
+    grads_arr = [np.random.rand(*shape).astype(dtype) * 100. for shape in shapes]
+    means_arr = [np.random.rand(*shape).astype(dtype) * 100. for shape in shapes]
+    variences_arr = [np.random.rand(*shape).astype(dtype) * 100. for shape in shapes]
+    rescale_grad = (np.random.random() + 1.0)
+    mx_w = _make_ndarrays(weights_arr)
+    mx_g = _make_ndarrays(grads_arr)
+    mx_m = _make_ndarrays(means_arr)
+    mx_v = _make_ndarrays(variences_arr)
+    mx_p_w = _make_ndarrays(weights_arr)
+    mx_p_g = _make_ndarrays(grads_arr)
+    lrs = list((np.random.random(size=len(shapes)).astype('float32') + 0.1) / 100.)
+    mx_lrs = mx.nd.array(lrs, dtype='float32', ctx=mx.gpu(0))
+    wds = list((np.random.random(size=len(shapes)).astype('float32') + 0.1) / 1000.)
+    mx_wds = mx.nd.array(wds, dtype='float32', ctx=mx.gpu(0))
+
+    if use_master_weights:
+        weights32_arr = [arr.astype('float32') for arr in weights_arr]
+        mx_w32 = _make_ndarrays(weights32_arr)
+        mx_p_w32 = _make_ndarrays(weights32_arr)
+
+    mx.nd.multi_mp_lamb_update(
+                             *_flatten_list(zip(mx_w, mx_g, mx_m, mx_v, mx_w32)),
+                             num_weights=len(shapes), lrs=lrs, wds=wds,
+                             rescale_grad=rescale_grad, out=mx_w)
+
+    def _assert_all_almost_equal(lhs_list, rhs_list, rtol, atol):
+        for i, (lhs, rhs) in enumerate(zip(lhs_list, rhs_list)):
+            assert_almost_equal(lhs.asnumpy(), rhs.asnumpy(), rtol=rtol, atol=atol)
+    if dtype == 'float16':
+        rtol = 1e-3
+        atol = 1e-2
+    else:
+        rtol = 1e-5
+        atol = 1e-6
+    _assert_all_almost_equal(mx_p_w, mx_w, rtol, atol)
+    if use_master_weights:
+        _assert_all_almost_equal(mx_p_w32, mx_w32, 1e-5, 1e-6)
+
+
+@with_seed
+def test_multi_lamb():
+    dtypes = ['float16', 'float32']
+    min_nparam = 5
+    max_nparam = 10
+    maxdim = 6
+    maxndim = 4
+    for dtype in dtypes:
+        use_master_weights_list = [False,] if dtype == 'float32' else [True, False]
+        for use_master_weights in use_master_weights_list:
+            nparam = np.random.randint(min_nparam + 1, max_nparam + 1)
+            shapes = [np.random.randint(1, maxdim + 1, size=maxndim) for i in range(nparam)]
+            check_multi_LAMB(dtype, shapes, use_master_weights)
+
+
 @with_seed()
 def test_batchnorm_with_type():
   ctx_list_v1_2D = [

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -443,20 +443,29 @@ class PyLAMB(mx.optimizer.Optimizer):
 
     def create_state(self, index, weight):
         stype = weight.stype
-        return (mx.nd.zeros(weight.shape, weight.context, dtype=weight.dtype, stype=stype),
-                mx.nd.zeros(weight.shape, weight.context, dtype=weight.dtype, stype=stype))
+        return (mx.nd.zeros(weight.shape, weight.context, dtype=np.float32, stype=stype),
+                mx.nd.zeros(weight.shape, weight.context, dtype=np.float32, stype=stype))
+
 
     def update(self, index, weight, grad, state):
         self._update_count(index)
         lr = self._get_lr(index)
         wd = self._get_wd(index)
         t = self._index_update_count[index]
+        use_multi_precision = self.multi_precision
 
+        if use_multi_precision:
+            mp_weight = weight
+            grad = array(grad, ctx=grad.context, dtype=np.float32)
+            weight = state[0]
+            mean, var = state[1]
+        else:
+            mean, var = state
         grad *= self.rescale_grad
         if self.clip_gradient is not None:
             grad = mx.nd.clip(grad, -self.clip_gradient, self.clip_gradient)
 
-        mean, var = state
+        
         mean[:] = self.beta1 * mean + (1. - self.beta1) * grad
         var[:] = self.beta2 * var + (1. - self.beta2) * mx.nd.square(grad)
 
@@ -472,15 +481,20 @@ class PyLAMB(mx.optimizer.Optimizer):
             var_hat = var / (1. - mx.nd.power(self.beta2, t))
 
         g = mean_hat / (mx.nd.sqrt(var_hat) + self.epsilon) + wd * weight
+
         r2 = g.norm()
         # calculate lamb_trust_ratio
         r = 1. if r1 == 0. or r2 == 0. else r1 / r2
         lr *= r
         # update weight
         weight[:] -= lr * g
+        if use_multi_precision:
+            tmp = weight.astype(mp_weight.dtype)
+            tmp.copyto(weight)
 
     def update_multi_precision(self, index, weight, grad, state):
         self.update(index, weight, grad, state)
+
 
 @with_seed()
 def test_lamb():
@@ -495,7 +509,10 @@ def test_lamb():
     ub_options = [{}, {'upper_bound': None}, {'upper_bound': 10}]
     for params in itertools.product(cg_options, rg_options, wd_options, bc_options, lb_options, ub_options):
         kwarg = {k: v for param in params for k, v in param.items()}
+        kwarg['multi_precision'] = False
         compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, np.float32)
+        kwarg['multi_precision'] = True
+        compare_optimizer(opt1(**kwarg), opt2(**kwarg), shape, np.float16, rtol=1e-3, atol=1e-3)
 
 
 #SGLD

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -452,20 +452,11 @@ class PyLAMB(mx.optimizer.Optimizer):
         lr = self._get_lr(index)
         wd = self._get_wd(index)
         t = self._index_update_count[index]
-        use_multi_precision = self.multi_precision
-
-        if use_multi_precision:
-            mp_weight = weight
-            grad = array(grad, ctx=grad.context, dtype=np.float32)
-            weight = state[0]
-            mean, var = state[1]
-        else:
-            mean, var = state
+        mean, var = state
         grad *= self.rescale_grad
         if self.clip_gradient is not None:
             grad = mx.nd.clip(grad, -self.clip_gradient, self.clip_gradient)
 
-        
         mean[:] = self.beta1 * mean + (1. - self.beta1) * grad
         var[:] = self.beta2 * var + (1. - self.beta2) * mx.nd.square(grad)
 
@@ -488,12 +479,6 @@ class PyLAMB(mx.optimizer.Optimizer):
         lr *= r
         # update weight
         weight[:] -= lr * g
-        if use_multi_precision:
-            tmp = weight.astype(mp_weight.dtype)
-            tmp.copyto(weight)
-
-    def update_multi_precision(self, index, weight, grad, state):
-        self.update(index, weight, grad, state)
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
adding to new operators:

  - mp_lamb_update_phase1
  - mp_lamb_update_phase1
    Link to paper: https://arxiv.org/pdf/1904.00962.pdf

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] Code is well-documented: 
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Testing ##
```
$ MXNET_TEST_COUNT=1 nosetests --logging-level=DEBUG --verbose -s tests/python/unittest/test_optimizer.py:test_lamb
/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters
[INFO] Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=1104492960 to reproduce.
test_optimizer.test_lamb ... [DEBUG] Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1864085207 to reproduce.
ok

----------------------------------------------------------------------
Ran 1 test in 9.091s

OK
```