### PR TITLE
[Numpy] Implement numpy operator 'quantile'

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -34,12 +34,13 @@ __all__ = ['shape', 'zeros', 'ones', 'full', 'add', 'subtract', 'multiply', 'div
            'log1p', 'rint', 'radians', 'reciprocal', 'square', 'negative', 'fix', 'ceil', 'floor',
            'trunc', 'logical_not', 'arcsinh', 'arccosh', 'arctanh', 'tensordot', 'histogram', 'eye',
            'linspace', 'logspace', 'expand_dims', 'tile', 'arange', 'split', 'vsplit', 'concatenate', 'append',
-           'stack', 'vstack', 'column_stack', 'dstack', 'mean', 'maximum', 'minimum', 'swapaxes', 'clip', 'argmax',
-           'argmin', 'std', 'var', 'indices', 'copysign', 'ravel', 'unravel_index', 'hanning', 'hamming', 'blackman',
-           'flip', 'around', 'hypot', 'bitwise_xor', 'bitwise_or', 'rad2deg', 'deg2rad', 'unique', 'lcm', 'tril',
-           'identity', 'take', 'ldexp', 'vdot', 'inner', 'outer', 'equal', 'not_equal', 'greater', 'less',
+           'stack', 'vstack', 'column_stack', 'dstack', 'mean', 'maximum', 'minimum', 'quantile', 'swapaxes', 'clip',
+           'argmax', 'argmin', 'std', 'var', 'indices', 'copysign', 'ravel', 'unravel_index', 'hanning', 'hamming',
+           'blackman', 'flip', 'around', 'hypot', 'bitwise_xor', 'bitwise_or', 'rad2deg', 'deg2rad', 'unique', 'lcm',
+           'tril', 'identity', 'take', 'ldexp', 'vdot', 'inner', 'outer', 'equal', 'not_equal', 'greater', 'less',
            'greater_equal', 'less_equal', 'hsplit', 'rot90', 'einsum', 'true_divide', 'nonzero', 'shares_memory',
            'may_share_memory', 'diff', 'resize', 'nan_to_num', 'where']
+
 
 @set_module('mxnet.ndarray.numpy')
 def shape(a):
@@ -3240,6 +3241,92 @@ def minimum(x1, x2, out=None, **kwargs):
     out : mxnet.numpy.ndarray or scalar
         The minimum of x1 and x2, element-wise. This is a scalar if both x1 and x2 are scalars."""
     return _ufunc_helper(x1, x2, _npi.minimum, _np.minimum, _npi.minimum_scalar, None, out)
+
+
+@set_module('mxnet.ndarray.numpy')
+def quantile(a, q, axis=None, out=None, interpolation='linear', keepdims=False): # pylint: disable=too-many-arguments
+    """
+    Compute the q-th quantile of the data along the specified axis.
+
+    New in version 1.15.0.
+
+    Parameters
+    ----------
+    a : ndarray
+        Input array or object that can be converted to an array.
+    q : ndarray
+        Quantile or sequence of quantiles to compute, which must be between 0 and 1 inclusive.
+    axis : {int, tuple of int, None}, optional
+        Axis or axes along which the quantiles are computed.
+        The default is to compute the quantile(s) along a flattened version of the array.
+    out : ndarray, optional
+        Alternative output array in which to place the result.
+        It must have the same shape and buffer length as the expected output,
+        but the type (of the output) will be cast if necessary.
+    interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
+        This optional parameter specifies the interpolation method to use
+        when the desired quantile lies between two data points i < j:
+            linear: i + (j - i) * fraction, where fraction is the fractional part of the index surrounded by i and j.
+            lower: i.
+            higher: j.
+            nearest: i or j, whichever is nearest.
+            midpoint: (i + j) / 2.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left in the result as dimensions with size one.
+        With this option, the result will broadcast correctly against the original array a.
+
+    Returns
+    -------
+    quantile : ndarray
+        If q is a single quantile and axis=None, then the result is a scalar.
+        If multiple quantiles are given, first axis of the result corresponds to the quantiles.
+        The other axes are the axes that remain after the reduction of a.
+        If out is specified, that array is returned instead.
+
+    See also
+    --------
+    mean
+
+    Notes
+    -----
+    Given a vector V of length N, the q-th quantile of V is the value q of the way from the minimum
+    to the maximum in a sorted copy of V. The values and distances of the two nearest neighbors
+    as well as the interpolation parameter will determine the quantile if the normalized ranking
+    does not match the location of q exactly. This function is the same as the median if q=0.5,
+    the same as the minimum if q=0.0 and the same as the maximum if q=1.0.
+
+    This function differs from the original `numpy.quantile
+    <https://numpy.org/devdocs/reference/generated/numpy.quantile.html>`_ in
+    the following aspects:
+    - q must be ndarray type even if it is a scalar
+    - do not support overwrite_input
+
+    Examples
+    --------
+    >>> a = np.array([[10, 7, 4], [3, 2, 1]])
+    >>> a
+    array([[10., 7., 4.],
+           [3., 2., 1.]])
+    >>> q = np.array(0.5)
+    >>> q
+    array(0.5)
+    >>> np.quantile(a, q)
+    array(3.5)
+    >>> np.quantile(a, q, axis=0)
+    array([6.5, 4.5, 2.5])
+    >>> np.quantile(a, q, axis=1)
+    array([7., 2.])
+    >>> np.quantile(a, q, axis=1, keepdims=True)
+    array([[7.],
+           [2.]])
+    >>> m = np.quantile(a, q, axis=0)
+    >>> out = np.zeros_like(m)
+    >>> np.quantile(a, q, axis=0, out=out)
+    array([6.5, 4.5, 2.5])
+    >>> out
+    array([6.5, 4.5, 2.5])
+    """
+    return _npi.quantile(a, q, axis=axis, interpolation=interpolation, keepdims=keepdims, out=out)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -53,11 +53,13 @@ __all__ = ['ndarray', 'empty', 'array', 'shape', 'zeros', 'ones', 'full', 'add',
            'fix', 'ceil', 'floor', 'trunc', 'logical_not', 'arcsinh', 'arccosh', 'arctanh', 'append',
            'tensordot', 'histogram', 'eye', 'linspace', 'logspace', 'expand_dims', 'tile', 'arange',
            'split', 'vsplit', 'concatenate', 'stack', 'vstack', 'column_stack', 'dstack', 'mean', 'maximum', 'minimum',
-           'swapaxes', 'clip', 'argmax', 'argmin', 'std', 'var', 'indices', 'copysign', 'ravel', 'unravel_index',
-           'hanning', 'hamming', 'blackman', 'flip', 'around', 'arctan2', 'hypot', 'bitwise_xor', 'bitwise_or',
-           'rad2deg', 'deg2rad', 'unique', 'lcm', 'tril', 'identity', 'take', 'ldexp', 'vdot', 'inner', 'outer',
-           'equal', 'not_equal', 'greater', 'less', 'greater_equal', 'less_equal', 'hsplit', 'rot90', 'einsum',
-           'true_divide', 'nonzero', 'shares_memory', 'may_share_memory', 'diff', 'resize', 'nan_to_num', 'where']
+           'quantile', 'swapaxes', 'clip', 'argmax', 'argmin', 'std', 'var', 'indices', 'copysign', 'ravel',
+           'unravel_index', 'hanning', 'hamming', 'blackman', 'flip', 'around', 'arctan2', 'hypot', 'bitwise_xor',
+           'bitwise_or', 'rad2deg', 'deg2rad', 'unique', 'lcm', 'tril', 'identity', 'take', 'ldexp', 'vdot', 'inner',
+           'outer', 'equal', 'not_equal', 'greater', 'less', 'greater_equal', 'less_equal', 'hsplit', 'rot90',
+           'einsum', 'true_divide', 'nonzero', 'shares_memory', 'may_share_memory', 'diff', 'resize', 'nan_to_num',
+           'where']
+
 
 # Return code for dispatching indexing function call
 _NDARRAY_UNSUPPORTED_INDEXING = -1
@@ -5167,6 +5169,92 @@ def minimum(x1, x2, out=None, **kwargs):
            [0. , 1. ]])
     """
     return _mx_nd_np.minimum(x1, x2, out=out)
+
+
+@set_module('mxnet.numpy')
+def quantile(a, q, axis=None, out=None, interpolation='linear', keepdims=False): # pylint: disable=too-many-arguments
+    """
+    Compute the q-th quantile of the data along the specified axis.
+
+    New in version 1.15.0.
+
+    Parameters
+    ----------
+    a : ndarray
+        Input array or object that can be converted to an array.
+    q : ndarray
+        Quantile or sequence of quantiles to compute, which must be between 0 and 1 inclusive.
+    axis : {int, tuple of int, None}, optional
+        Axis or axes along which the quantiles are computed.
+        The default is to compute the quantile(s) along a flattened version of the array.
+    out : ndarray, optional
+        Alternative output array in which to place the result.
+        It must have the same shape and buffer length as the expected output,
+        but the type (of the output) will be cast if necessary.
+    interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
+        This optional parameter specifies the interpolation method to use
+        when the desired quantile lies between two data points i < j:
+            linear: i + (j - i) * fraction, where fraction is the fractional part of the index surrounded by i and j.
+            lower: i.
+            higher: j.
+            nearest: i or j, whichever is nearest.
+            midpoint: (i + j) / 2.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left in the result as dimensions with size one.
+        With this option, the result will broadcast correctly against the original array a.
+
+    Returns
+    -------
+    quantile : ndarray
+        If q is a single quantile and axis=None, then the result is a scalar.
+        If multiple quantiles are given, first axis of the result corresponds to the quantiles.
+        The other axes are the axes that remain after the reduction of a.
+        If out is specified, that array is returned instead.
+
+    See also
+    --------
+    mean
+
+    Notes
+    -----
+    Given a vector V of length N, the q-th quantile of V is the value q of the way from the minimum
+    to the maximum in a sorted copy of V. The values and distances of the two nearest neighbors
+    as well as the interpolation parameter will determine the quantile if the normalized ranking
+    does not match the location of q exactly. This function is the same as the median if q=0.5,
+    the same as the minimum if q=0.0 and the same as the maximum if q=1.0.
+
+    This function differs from the original `numpy.quantile
+    <https://numpy.org/devdocs/reference/generated/numpy.quantile.html>`_ in
+    the following aspects:
+    - q must be ndarray type even if it is a scalar
+    - do not support overwrite_input
+
+    Examples
+    --------
+    >>> a = np.array([[10, 7, 4], [3, 2, 1]])
+    >>> a
+    array([[10., 7., 4.],
+           [3., 2., 1.]])
+    >>> q = np.array(0.5)
+    >>> q
+    array(0.5)
+    >>> np.quantile(a, q)
+    array(3.5)
+    >>> np.quantile(a, q, axis=0)
+    array([6.5, 4.5, 2.5])
+    >>> np.quantile(a, q, axis=1)
+    array([7., 2.])
+    >>> np.quantile(a, q, axis=1, keepdims=True)
+    array([[7.],
+           [2.]])
+    >>> m = np.quantile(a, q, axis=0)
+    >>> out = np.zeros_like(m)
+    >>> np.quantile(a, q, axis=0, out=out)
+    array([6.5, 4.5, 2.5])
+    >>> out
+    array([6.5, 4.5, 2.5])
+    """
+    return _mx_nd_np.quantile(a, q, axis=axis, interpolation=interpolation, keepdims=keepdims, out=out)
 
 
 @set_module('mxnet.numpy')

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -42,10 +42,10 @@ __all__ = ['zeros', 'ones', 'add', 'subtract', 'multiply', 'divide', 'mod', 'rem
            'rint', 'radians', 'reciprocal', 'square', 'negative', 'fix', 'ceil', 'floor',
            'trunc', 'logical_not', 'arcsinh', 'arccosh', 'arctanh', 'tensordot', 'histogram', 'eye',
            'linspace', 'logspace', 'expand_dims', 'tile', 'arange', 'split', 'vsplit', 'concatenate', 'append',
-           'stack', 'vstack', 'column_stack', 'dstack', 'mean', 'maximum', 'minimum', 'swapaxes', 'clip', 'argmax',
-           'argmin', 'std', 'var', 'indices', 'copysign', 'ravel', 'unravel_index', 'hanning', 'hamming', 'blackman',
-           'flip', 'around', 'hypot', 'bitwise_xor', 'bitwise_or', 'rad2deg', 'deg2rad', 'unique', 'lcm', 'tril',
-           'identity', 'take', 'ldexp', 'vdot', 'inner', 'outer', 'equal', 'not_equal', 'greater', 'less',
+           'stack', 'vstack', 'column_stack', 'dstack', 'mean', 'maximum', 'minimum', 'quantile', 'swapaxes', 'clip',
+           'argmax', 'argmin', 'std', 'var', 'indices', 'copysign', 'ravel', 'unravel_index', 'hanning', 'hamming',
+           'blackman', 'flip', 'around', 'hypot', 'bitwise_xor', 'bitwise_or', 'rad2deg', 'deg2rad', 'unique', 'lcm',
+           'tril', 'identity', 'take', 'ldexp', 'vdot', 'inner', 'outer', 'equal', 'not_equal', 'greater', 'less',
            'greater_equal', 'less_equal', 'hsplit', 'rot90', 'einsum', 'true_divide', 'shares_memory',
            'may_share_memory', 'diff', 'resize', 'nan_to_num', 'where']
 
@@ -3320,6 +3320,67 @@ def maximum(x1, x2, out=None, **kwargs):
 @wrap_np_binary_func
 def minimum(x1, x2, out=None, **kwargs):
     return _ufunc_helper(x1, x2, _npi.minimum, _np.minimum, _npi.minimum_scalar, None, out)
+
+
+@set_module('mxnet.symbol.numpy')
+def quantile(a, q, axis=None, out=None, interpolation='linear', keepdims=False): # pylint: disable=too-many-arguments
+    """
+    Compute the q-th quantile of the data along the specified axis.
+
+    New in version 1.15.0.
+
+    Parameters
+    ----------
+    a : _Symbol
+        Input array or object that can be converted to an array.
+    q : _Symbol
+        Quantile or sequence of quantiles to compute, which must be between 0 and 1 inclusive.
+    axis : {int, tuple of int, None}, optional
+        Axis or axes along which the quantiles are computed.
+        The default is to compute the quantile(s) along a flattened version of the array.
+    out : ndarray, optional
+        Alternative output array in which to place the result.
+        It must have the same shape and buffer length as the expected output,
+        but the type (of the output) will be cast if necessary.
+    interpolation : {'linear', 'lower', 'higher', 'midpoint', 'nearest'}
+        This optional parameter specifies the interpolation method to use
+        when the desired quantile lies between two data points i < j:
+            linear: i + (j - i) * fraction, where fraction is the fractional part of the index surrounded by i and j.
+            lower: i.
+            higher: j.
+            nearest: i or j, whichever is nearest.
+            midpoint: (i + j) / 2.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left in the result as dimensions with size one.
+        With this option, the result will broadcast correctly against the original array a.
+
+    Returns
+    -------
+    quantile : _Symbol
+        If q is a single quantile and axis=None, then the result is a scalar.
+        If multiple quantiles are given, first axis of the result corresponds to the quantiles.
+        The other axes are the axes that remain after the reduction of a.
+        If out is specified, that array is returned instead.
+
+    See also
+    --------
+    mean
+
+    Notes
+    -----
+    Given a vector V of length N, the q-th quantile of V is the value q of the way from the minimum
+    to the maximum in a sorted copy of V. The values and distances of the two nearest neighbors
+    as well as the interpolation parameter will determine the quantile if the normalized ranking
+    does not match the location of q exactly. This function is the same as the median if q=0.5,
+    the same as the minimum if q=0.0 and the same as the maximum if q=1.0.
+
+    This function differs from the original `numpy.quantile
+    <https://numpy.org/devdocs/reference/generated/numpy.quantile.html>`_ in
+    the following aspects:
+    - q must be _Symbol type even if it is a scalar
+    - do not support overwrite_input
+    """
+    return _npi.quantile(a, q, axis=axis, interpolation=interpolation, keepdims=keepdims, out=out)
 
 
 @set_module('mxnet.symbol.numpy')

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -274,7 +274,7 @@ inline void SetDependency(const nnvm::NodeAttrs& attrs,
         LOG(FATAL) << "resource type not yet supported";
       }
     }
-    CHECK_LE(ntmp, 1) << "Only support 1 temp space request";
+    CHECK_LE(ntmp, 2) << "Only support 1 temp space request";
   }
 
   // append extra resource requests for storage fallback

--- a/src/operator/numpy/np_broadcast_reduce_op.h
+++ b/src/operator/numpy/np_broadcast_reduce_op.h
@@ -30,6 +30,8 @@
 #include <string>
 #include "../nn/moments-inl.h"
 #include "../tensor/broadcast_reduce_op.h"
+#include "../tensor/ordering_op-inl.h"
+#include "../tensor/matrix_op-inl.h"
 
 namespace mxnet {
 namespace op {
@@ -475,6 +477,252 @@ void NumpyMomentsForward(const nnvm::NodeAttrs& attrs,
       }
     });
   });
+}
+
+namespace quantile_enum {
+enum InterpolationType {kLinear, kLower, kHigher, kMidpoint, kNearest};
+}
+
+struct NumpyQuantileParam : public dmlc::Parameter<NumpyQuantileParam> {
+  dmlc::optional<mxnet::Tuple<int>> axis;
+  int interpolation;
+  bool keepdims;
+  DMLC_DECLARE_PARAMETER(NumpyQuantileParam) {
+    DMLC_DECLARE_FIELD(axis)
+      .set_default(dmlc::optional<mxnet::Tuple<int>>())
+      .describe("Axis or axes along which the quantiles are computed. "
+                "The default is to compute the "
+                "quantile(s) along a flattened version of the array.");
+    DMLC_DECLARE_FIELD(interpolation)
+      .set_default(quantile_enum::kLinear)
+      .add_enum("linear", quantile_enum::kLinear)
+      .add_enum("lower", quantile_enum::kLower)
+      .add_enum("higher", quantile_enum::kHigher)
+      .add_enum("midpoint", quantile_enum::kMidpoint)
+      .add_enum("nearest", quantile_enum::kNearest)
+      .describe("This optional parameter specifies the interpolation method to use when the desired"
+                " quantile lies between two data points i < j");
+    DMLC_DECLARE_FIELD(keepdims)
+      .set_default(false)
+      .describe("If this is set to `True`, the reduced axes are left "
+                "in the result as dimension with size one.");
+  }
+};
+
+inline bool NumpyQuantileShape(const nnvm::NodeAttrs& attrs,
+                               std::vector<TShape> *in_attrs,
+                               std::vector<TShape> *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 2U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  const mxnet::TShape& a_shape = in_attrs->at(0);
+  const mxnet::TShape& q_shape = in_attrs->at(1);
+  auto &param = nnvm::get<NumpyQuantileParam>(attrs.parsed);
+  CHECK_LE(q_shape.ndim(), 1);
+  auto small = NumpyReduceAxesShapeImpl(a_shape, param.axis, param.keepdims);
+  if (q_shape.ndim() == 0) {
+    // q is scalar
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, small);
+  } else {
+    CHECK_EQ(q_shape.ndim(), 1U);
+    mxnet::TShape shape(small.ndim()+1, 0);
+    shape[0] = q_shape[0];
+    for (int i = 1; i < shape.ndim(); ++i) {
+      shape[i] = small[i-1];
+    }
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, shape);
+  }
+  return shape_is_known(*in_attrs) && shape_is_known(*out_attrs);
+}
+
+template<int NDim>
+struct quantile_take {
+  template<typename DType, typename QType>
+  MSHADOW_XINLINE static void Map(int i,
+                                  DType* out,
+                                  const QType* q,
+                                  const DType* a_sort,
+                                  const int interpolation,
+                                  mshadow::Shape<NDim> t_shape,
+                                  mshadow::Shape<NDim> r_shape) {
+    using namespace mshadow;
+    using namespace mxnet_op;
+
+    auto r_coord = unravel(i, r_shape);
+    size_t q_idx = r_coord[0];
+
+    Shape<NDim> t_coord(t_shape);
+
+    for (int j = 0; j < NDim-1; ++j) {
+      t_coord[j] = r_coord[j+1];
+    }
+
+    float idx = q[q_idx] * (t_shape[NDim-1]-1);
+    int integral_idx = -1;
+    if (interpolation == quantile_enum::kLower) {
+      integral_idx = floor(idx);
+    } else if (interpolation == quantile_enum::kHigher) {
+      integral_idx = ceil(idx);
+    } else if (interpolation == quantile_enum::kMidpoint) {
+      idx = (floor(idx) + ceil(idx)) / 2;
+    } else if (interpolation == quantile_enum::kNearest) {
+      integral_idx = round(idx);
+    }
+
+    if (integral_idx >= 0) {
+      t_coord[NDim-1] = integral_idx;
+      size_t t_idx = ravel(t_coord, t_shape);
+      out[i] = a_sort[t_idx];
+    } else {
+      int idx_below = floor(idx);
+      int idx_above = idx_below + 1;
+      idx_above = idx_above > t_shape[NDim-1] - 1 ? t_shape[NDim-1] - 1 : idx_above;
+      float weight_above = idx - idx_below;
+      float weight_below = 1 - weight_above;
+      t_coord[NDim-1] = idx_below;
+      size_t t_idx1 = ravel(t_coord, t_shape);
+      size_t t_idx2 = t_idx1 + (idx_above - idx_below);
+      DType x1 = a_sort[t_idx1] * weight_below;
+      DType x2 = a_sort[t_idx2] * weight_above;
+      out[i] = x1 + x2;
+    }
+  }
+};
+
+template<typename xpu>
+void NumpyQuantileImpl(const OpContext& ctx,
+                       const std::vector<TBlob>& inputs,
+                       const std::vector<OpReqType>& req,
+                       const std::vector<TBlob>& outputs,
+                       const dmlc::optional<mxnet::Tuple<int>>& axis,
+                       const int interpolation) {
+  using namespace mxnet;
+  using namespace mxnet_op;
+  CHECK_EQ(inputs.size(), 2U);
+  CHECK_EQ(outputs.size(), 1U);
+
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+
+  const TBlob& a = inputs[0];
+  const TBlob& q = inputs[1];
+  const TBlob& r = outputs[0];
+
+  auto small = NumpyReduceAxesShapeImpl(a.shape_, axis, false);
+
+  TShape r_shape;
+  r_shape = TShape(small.ndim()+1, 1);
+  for (int i = 1; i < r_shape.ndim(); ++i) {
+    r_shape[i] = small[i-1];
+  }
+  if (q.shape_.ndim() != 0) {
+    r_shape[0] = q.shape_[0];
+  }
+
+  TShape axes;
+  if (!axis.has_value()) {
+    axes = TShape(a.shape_.ndim(), 1);
+    for (int i = 0; i < a.shape_.ndim(); ++i) {
+      axes[i] = i;
+    }
+  } else {
+    auto axis_tuple = axis.value();
+    axes = TShape(axis_tuple.ndim(), 1);
+    for (int i = 0; i < axis_tuple.ndim(); ++i) {
+      axes[i] = axis_tuple[i];
+    }
+  }
+
+  TShape t_axes(a.shape_.ndim(), 1);
+  int j = 0;
+  for (int i = 0; i < t_axes.ndim(); ++i) {
+    bool red = false;
+    for (int k = 0; k < axes.ndim(); ++k) {
+      if (axes[k] == i) {
+        red = true;
+      }
+    }
+    if (!red) {
+      t_axes[j] = i;
+      j++;
+    }
+  }
+  for (int jj = j; jj < t_axes.ndim(); ++jj) {
+    t_axes[jj] = axes[jj-j];
+  }
+
+  TShape t_shape(small.ndim()+1, 1);
+  for (int i = 0; i < small.ndim(); ++i) {
+    t_shape[i] = small[i];
+  }
+  size_t red_size = 1;
+  for (int i = 0; i < axes.ndim(); ++i) {
+    red_size *= a.shape_[axes[i]];
+  }
+  t_shape[t_shape.ndim()-1] = red_size;
+  TShape t_shape_ex(a.shape_.ndim(), 1);
+  for (int i = 0; i < small.ndim(); ++i) {
+    t_shape_ex[i] = small[i];
+  }
+  for (int i = small.ndim(); i < a.shape_.ndim(); ++i) {
+    t_shape_ex[i] = a.shape_[axes[i-small.ndim()]];
+  }
+
+  MSHADOW_TYPE_SWITCH(a.type_flag_, DType, {
+    size_t temp_data_size = a.shape_.Size() * sizeof(DType);
+    size_t idx_size = a.shape_.Size() * sizeof(index_t);
+    size_t temp_mem_size = 2 * temp_data_size + idx_size;
+    Tensor<xpu, 1, char> temp_mem =
+        ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(temp_mem_size), s);
+    DType* trans_ptr, *sort_ptr;
+    index_t* idx_ptr;
+    if (sizeof(DType) >= sizeof(index_t)) {
+      trans_ptr = reinterpret_cast<DType*>(temp_mem.dptr_);
+      sort_ptr = reinterpret_cast<DType*>(temp_mem.dptr_ + temp_data_size);
+      idx_ptr = reinterpret_cast<index_t*>(temp_mem.dptr_ + 2 * temp_data_size);
+    } else {
+      idx_ptr = reinterpret_cast<index_t*>(temp_mem.dptr_);
+      trans_ptr = reinterpret_cast<DType*>(temp_mem.dptr_ + idx_size);
+      sort_ptr = reinterpret_cast<DType*>(temp_mem.dptr_ + temp_data_size + idx_size);
+    }
+
+    TBlob a_trans = TBlob(trans_ptr, t_shape_ex, xpu::kDevMask);
+
+    TransposeImpl<xpu>(ctx.run_ctx, a, a_trans, t_axes);
+
+    TopKParam topk_param;
+    topk_param.axis = dmlc::optional<int>(-1);
+    topk_param.is_ascend = true;
+    topk_param.k = 0;
+    topk_param.ret_typ = topk_enum::kReturnValue;
+
+    TBlob a_sort = TBlob(sort_ptr, t_shape, xpu::kDevMask);
+    TBlob a_idx = TBlob(idx_ptr, t_shape, xpu::kDevMask);
+    TopKImpl<xpu, DType, index_t>(ctx.run_ctx,
+                                  ctx.requested[1], {kWriteTo, kNullOp}, a_trans.reshape(t_shape),
+                                  {a_sort, a_idx},
+                                  topk_param);
+
+    MSHADOW_TYPE_SWITCH(q.type_flag_, QType, {
+      MXNET_NDIM_SWITCH(small.ndim()+1, NDim, {
+        Kernel<quantile_take<NDim>, xpu>::Launch(
+            s, r_shape.Size(), r.dptr<DType>(), q.dptr<QType>(), a_sort.dptr<DType>(),
+            interpolation, t_shape.get<NDim>(), r_shape.get<NDim>());
+      })
+    })
+  })
+}
+
+template<typename xpu>
+void NumpyQuantileForward(const nnvm::NodeAttrs& attrs,
+                          const OpContext& ctx,
+                          const std::vector<TBlob>& inputs,
+                          const std::vector<OpReqType>& req,
+                          const std::vector<TBlob>& outputs) {
+  if (req[0] == kNullOp)
+    return;
+  auto &param = nnvm::get<NumpyQuantileParam>(attrs.parsed);
+  NumpyQuantileImpl<xpu>(
+      ctx, inputs, req, outputs,
+      param.axis, param.interpolation);
 }
 
 template<typename xpu>

--- a/src/operator/numpy/np_broadcast_reduce_op_value.cu
+++ b/src/operator/numpy/np_broadcast_reduce_op_value.cu
@@ -32,6 +32,9 @@ NNVM_REGISTER_OP(_np_sum)
 NNVM_REGISTER_OP(_backward_np_sum)
 .set_attr<FCompute>("FCompute<gpu>", NumpyReduceAxesBackwardUseNone<gpu>);
 
+NNVM_REGISTER_OP(_npi_quantile)
+.set_attr<FCompute>("FCompute<gpu>", NumpyQuantileForward<gpu>);
+
 NNVM_REGISTER_OP(_np_max)
 .set_attr<FCompute>("FCompute<gpu>", NumpyReduceAxesNoDTypeCompute<gpu, mshadow::red::maximum>);
 


### PR DESCRIPTION
## Description ##
Implement numpy operator 'quantile'

https://numpy.org/devdocs/reference/generated/numpy.quantile.html

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] quantile, tests

## Comments ##
- q must be ndarray type even if it is a scalar
- do not support overwrite_input
