### PR TITLE
introduce  gradient update handler to the  base estimator

### DIFF
--- a/python/mxnet/gluon/contrib/estimator/estimator.py
+++ b/python/mxnet/gluon/contrib/estimator/estimator.py
@@ -302,7 +302,7 @@ class Estimator(object):
 
         with autograd.record():
             pred = [self.net(x) for x in data]
-            loss = [self.loss(y_hat, y) / batch_size for y_hat, y in zip(pred, label)]
+            loss = [self.loss(y_hat, y) for y_hat, y in zip(pred, label)]
 
         for l in loss:
             l.backward()
@@ -358,6 +358,7 @@ class Estimator(object):
 
         self.max_epoch = epochs
         self.max_batch = batches
+        self.batch_axis = batch_axis
 
         # provide default handlers
         event_handlers = self._prepare_default_handlers(val_data, event_handlers)

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -28,7 +28,6 @@ import numpy as np
 from ....metric import CompositeEvalMetric, EvalMetric
 from ....metric import Loss as metric_loss
 from .utils import _check_metrics
-from .... import ndarray
 
 __all__ = ['TrainBegin', 'TrainEnd', 'EpochBegin', 'EpochEnd', 'BatchBegin', 'BatchEnd',
            'StoppingHandler', 'MetricHandler', 'ValidationHandler',
@@ -732,7 +731,7 @@ class GradientUpdateHandler(BatchEnd):
     def batch_end(self, estimator, *args, **kwargs):
         loss = kwargs['loss']
         batch_size = 0
-        if isinstance(loss, ndarray.ndarray.NDArray):
+        if not isinstance(loss, list):
             loss = [loss]
         if isinstance(loss, list) and len(loss) > 0:
             for l in loss:

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -731,9 +731,11 @@ class GradientUpdateHandler(BatchEnd):
 
     def batch_end(self, estimator, *args, **kwargs):
         loss = kwargs['loss']
-        batch_size = 1
-        if isinstance(loss, list) and len(loss) > 0:
-            loss = loss[0]
+        batch_size = 0
         if isinstance(loss, ndarray.ndarray.NDArray):
-            batch_size = loss.shape[estimator.batch_axis]
+            loss = [loss]
+        if isinstance(loss, list) and len(loss) > 0:
+            for l in loss:
+                batch_size += l.shape[estimator.batch_axis]
+                
         estimator.trainer.step(batch_size)

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -724,7 +724,7 @@ class GradientUpdateHandler(BatchEnd):
 
     Parameters
     ----------
-    priority : scalar, default -np.Inf
+    priority : scalar, default -2000
         priority level of the gradient update handler. Priority level is sorted in ascending
         order. The lower the number is, the higher priority level it is.
     ----------

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -739,7 +739,7 @@ class GradientUpdateHandler(BatchEnd):
         batch_size = 0
         if not isinstance(loss, list):
             loss = [loss]
-        if isinstance(loss, list) and len(loss) > 0:
+        if isinstance(loss, list):
             for l in loss:
                 batch_size += l.shape[estimator.batch_axis]
 

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -28,6 +28,7 @@ import numpy as np
 from ....metric import CompositeEvalMetric, EvalMetric
 from ....metric import Loss as metric_loss
 from .utils import _check_metrics
+from .... import ndarray
 
 __all__ = ['TrainBegin', 'TrainEnd', 'EpochBegin', 'EpochEnd', 'BatchBegin', 'BatchEnd',
            'StoppingHandler', 'MetricHandler', 'ValidationHandler',
@@ -729,4 +730,10 @@ class GradientUpdateHandler(BatchEnd):
         self.priority = priority
 
     def batch_end(self, estimator, *args, **kwargs):
-        estimator.trainer.step(1)
+        loss = kwargs['loss']
+        batch_size = 1
+        if isinstance(loss, list) and len(loss) > 0:
+            loss = loss[0]
+        if isinstance(loss, ndarray.ndarray.NDArray):
+            batch_size = loss.shape[estimator.batch_axis]
+        estimator.trainer.step(batch_size)

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -31,7 +31,7 @@ from .utils import _check_metrics
 
 __all__ = ['TrainBegin', 'TrainEnd', 'EpochBegin', 'EpochEnd', 'BatchBegin', 'BatchEnd',
            'StoppingHandler', 'MetricHandler', 'ValidationHandler',
-           'LoggingHandler', 'CheckpointHandler', 'EarlyStoppingHandler']
+           'LoggingHandler', 'CheckpointHandler', 'EarlyStoppingHandler', 'GradientUpdateHandler']
 
 
 class EventHandler(object):
@@ -130,13 +130,15 @@ class MetricHandler(EpochBegin, BatchEnd):
     ----------
     train_metrics : List of EvalMetrics
         Training metrics to be updated at batch end.
+    priority : scalar
+        Priority level of the MetricHandler
     """
 
-    def __init__(self, train_metrics):
+    def __init__(self, train_metrics, priority=-1000):
         self.train_metrics = _check_metrics(train_metrics)
         # order to be called among all callbacks
         # metrics need to be calculated before other callbacks can access them
-        self.priority = -np.Inf
+        self.priority = priority
 
     def epoch_begin(self, estimator, *args, **kwargs):
         for metric in self.train_metrics:
@@ -176,6 +178,8 @@ class ValidationHandler(TrainBegin, BatchEnd, EpochEnd):
     batch_period : int, default None
         How often to run validation at batch end, by default
         :py:class:`ValidationHandler` does not validate at batch end.
+    priority: scalar, default -1000
+        Priority level of the ValidataionHandler
     """
 
     def __init__(self,
@@ -183,7 +187,8 @@ class ValidationHandler(TrainBegin, BatchEnd, EpochEnd):
                  eval_fn,
                  val_metrics=None,
                  epoch_period=1,
-                 batch_period=None):
+                 batch_period=None,
+                 priority=-1000):
         self.val_data = val_data
         self.eval_fn = eval_fn
         self.epoch_period = epoch_period
@@ -193,7 +198,7 @@ class ValidationHandler(TrainBegin, BatchEnd, EpochEnd):
         self.current_epoch = 0
         # order to be called among all callbacks
         # validation metrics need to be calculated before other callbacks can access them
-        self.priority = -np.Inf
+        self.priority = priority
 
     def train_begin(self, estimator, *args, **kwargs):
         # reset epoch and batch counter
@@ -235,11 +240,14 @@ class LoggingHandler(TrainBegin, TrainEnd, EpochBegin, EpochEnd, BatchBegin, Bat
         Training metrics to be logged, logged at batch end, epoch end, train end.
     val_metrics : list of EvalMetrics
         Validation metrics to be logged, logged at epoch end, train end.
+    priority : scalar, default np.Inf
+        Priority level of the LoggingHandler
     """
 
     def __init__(self, log_interval='epoch',
                  train_metrics=None,
-                 val_metrics=None):
+                 val_metrics=None,
+                 priority=np.Inf):
         super(LoggingHandler, self).__init__()
         if not isinstance(log_interval, int) and log_interval != 'epoch':
             raise ValueError("log_interval must be either an integer or string 'epoch'")
@@ -250,7 +258,7 @@ class LoggingHandler(TrainBegin, TrainEnd, EpochBegin, EpochEnd, BatchBegin, Bat
         self.processed_samples = 0
         # logging handler need to be called at last to make sure all states are updated
         # it will also shut down logging at train end
-        self.priority = np.Inf
+        self.priority = priority
         self.log_interval = log_interval
 
     def train_begin(self, estimator, *args, **kwargs):
@@ -704,3 +712,21 @@ class EarlyStoppingHandler(TrainBegin, EpochEnd, TrainEnd):
             estimator.logger.info('[Epoch %d] EarlyStoppingHanlder: '
                                   'early stopping due to %s not improving',
                                   self.stopped_epoch, self.monitor.get()[0])
+
+class GradientUpdateHandler(BatchEnd):
+    """Gradient Update Handler that apply gradients on network weights
+
+    :py:class:`GradientUpdateHandler` takes the priority level. It updates weight parameters
+    at the end of each batch
+
+    Parameters
+    ----------
+    priority : scalar, default -np.Inf
+        priority level of the gradient update handler. It should be executed before all other handlers.
+    ----------
+    """
+    def __init__(self, priority=-np.Inf):
+        self.priority = priority
+
+    def batch_end(self, estimator, *args, **kwargs):
+        estimator.trainer.step(1)

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -737,5 +737,5 @@ class GradientUpdateHandler(BatchEnd):
         if isinstance(loss, list) and len(loss) > 0:
             for l in loss:
                 batch_size += l.shape[estimator.batch_axis]
-                
+
         estimator.trainer.step(batch_size)

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -132,7 +132,7 @@ class MetricHandler(EpochBegin, BatchEnd):
         Training metrics to be updated at batch end.
     priority : scalar
         Priority level of the MetricHandler. Priority level is sorted in ascending
-        order. The lower the number is, the higher priority level it is.
+        order. The lower the number is, the higher priority level the handler is.
     """
 
     def __init__(self, train_metrics, priority=-1000):
@@ -181,7 +181,8 @@ class ValidationHandler(TrainBegin, BatchEnd, EpochEnd):
         :py:class:`ValidationHandler` does not validate at batch end.
     priority: scalar, default -1000
         Priority level of the ValidationHandler. Priority level is sorted in
-        ascending order. The lower the number is, the higher priority level it is.
+        ascending order. The lower the number is, the higher priority level the
+        handler is.
     """
 
     def __init__(self,
@@ -244,7 +245,8 @@ class LoggingHandler(TrainBegin, TrainEnd, EpochBegin, EpochEnd, BatchBegin, Bat
         Validation metrics to be logged, logged at epoch end, train end.
     priority : scalar, default np.Inf
         Priority level of the LoggingHandler. Priority level is sorted in
-        ascending order. The lower the number is, the higher priority level it is.
+        ascending order. The lower the number is, the higher priority level the
+        handler is.
     """
 
     def __init__(self, log_interval='epoch',
@@ -726,7 +728,7 @@ class GradientUpdateHandler(BatchEnd):
     ----------
     priority : scalar, default -2000
         priority level of the gradient update handler. Priority level is sorted in ascending
-        order. The lower the number is, the higher priority level it is.
+        order. The lower the number is, the higher priority level the handler is.
     ----------
     """
     def __init__(self, priority=-2000):

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -131,7 +131,8 @@ class MetricHandler(EpochBegin, BatchEnd):
     train_metrics : List of EvalMetrics
         Training metrics to be updated at batch end.
     priority : scalar
-        Priority level of the MetricHandler
+        Priority level of the MetricHandler. Priority level is sorted in ascending
+        order. The lower the number is, the higher priority level it is.
     """
 
     def __init__(self, train_metrics, priority=-1000):
@@ -179,7 +180,8 @@ class ValidationHandler(TrainBegin, BatchEnd, EpochEnd):
         How often to run validation at batch end, by default
         :py:class:`ValidationHandler` does not validate at batch end.
     priority: scalar, default -1000
-        Priority level of the ValidataionHandler
+        Priority level of the ValidationHandler. Priority level is sorted in
+        ascending order. The lower the number is, the higher priority level it is.
     """
 
     def __init__(self,
@@ -241,7 +243,8 @@ class LoggingHandler(TrainBegin, TrainEnd, EpochBegin, EpochEnd, BatchBegin, Bat
     val_metrics : list of EvalMetrics
         Validation metrics to be logged, logged at epoch end, train end.
     priority : scalar, default np.Inf
-        Priority level of the LoggingHandler
+        Priority level of the LoggingHandler. Priority level is sorted in
+        ascending order. The lower the number is, the higher priority level it is.
     """
 
     def __init__(self, log_interval='epoch',
@@ -722,10 +725,11 @@ class GradientUpdateHandler(BatchEnd):
     Parameters
     ----------
     priority : scalar, default -np.Inf
-        priority level of the gradient update handler. It should be executed before all other handlers.
+        priority level of the gradient update handler. Priority level is sorted in ascending
+        order. The lower the number is, the higher priority level it is.
     ----------
     """
-    def __init__(self, priority=-np.Inf):
+    def __init__(self, priority=-2000):
         self.priority = priority
 
     def batch_end(self, estimator, *args, **kwargs):

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -334,36 +334,36 @@ def test_default_handlers():
     train_acc = mx.metric.RMSE()
     loss = gluon.loss.L2Loss()
 
-    gradient_update = GradientUpdateHandler()
     est = Estimator(net=net,
                     loss=loss,
                     metrics=train_acc,
                     trainer=trainer,
                     context=ctx)
-    # no handler except gradient update handler (all default handlers), no warning
+    # no handler(all default handlers), no warning
     with warnings.catch_warnings(record=True) as w:
-        est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[gradient_update])
+        est.fit(train_data=train_data, epochs=num_epochs)
 
     # handler with prepared loss and metrics
     # use mix of default and user defined handlers
     train_metrics = est.train_metrics
     val_metrics = est.val_metrics
     logging = LoggingHandler(train_metrics=train_metrics, val_metrics=val_metrics)
-    est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[logging, gradient_update])
+    est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[logging])
 
     # handler with all user defined metrics
     # use mix of default and user defined handlers
     metric = MetricHandler(train_metrics=[train_acc])
     logging = LoggingHandler(train_metrics=[train_acc])
-    est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[metric, logging, gradient_update])
+    est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[metric, logging])
 
     # handler with mixed metrics, some handler use metrics prepared by estimator
     # some handler use metrics user prepared
     logging = LoggingHandler(train_metrics=train_metrics, val_metrics=[mx.metric.RMSE("val acc")])
     with assert_raises(ValueError):
-        est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[logging, gradient_update])
+        est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[logging])
 
     # test handler order
+    gradient_update = GradientUpdateHandler()
     train_metrics = est.train_metrics
     val_metrics = est.val_metrics
     early_stopping = EarlyStoppingHandler(monitor=val_metrics[0])

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -363,7 +363,6 @@ def test_default_handlers():
         est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[logging])
 
     # test handler order
-    gradient_update = GradientUpdateHandler()
     train_metrics = est.train_metrics
     val_metrics = est.val_metrics
     early_stopping = EarlyStoppingHandler(monitor=val_metrics[0])


### PR DESCRIPTION
## Description ##
This change add default gradient update handler to the base estimator class. The purpose of this change is to decouple the forward/backward computation with the gradient apply process. In some use cases such as gradient accumulation, gradient updates are not executed during each training batch.  See issue description #16869.