### PR TITLE
[MKL-DNN] Enable and Optimization for s8 eltwise_add

### DIFF
--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -607,6 +607,11 @@ class OpSignature {
     eles.push_back(val);
   }
 
+  void AddSign(float val) {
+    hash = dmlc::HashCombine(hash, val);
+    eles.push_back(val);
+  }
+
   bool operator==(const OpSignature &sign) const {
     if (hash != sign.hash)
       return false;

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
@@ -217,7 +217,8 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs, cons
   auto output_desc = mkldnn::memory::desc(i_dims,
                                           output_data_type,
                                           mkldnn::memory::format_tag::any);
-  MKLDNNQuantizedElemwiseAddFwd &fwd = GetQuantizedElemwiseAddForward(output_desc, scales, in_data, out_data, in_desc);
+  MKLDNNQuantizedElemwiseAddFwd &fwd = GetQuantizedElemwiseAddForward(output_desc, scales,
+                                                                      in_data, out_data, in_desc);
   auto mem = CreateMKLDNNMem(out_data[quantized_elemwise_add_enum::kOut],
                              fwd.fwd_pd.dst_desc(),
                              req[0],

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
@@ -39,6 +39,55 @@ static inline float GetScale(const NDArray& data, float min, float max) {
   return data_range / MaxAbs(min, max);
 }
 
+class MKLDNNQuantizedElemwiseAddFwd {
+ public:
+  mkldnn::sum::primitive_desc fwd_pd;
+
+  MKLDNNQuantizedElemwiseAddFwd(
+               const mkldnn::memory::desc &output_desc,
+               const std::vector<float> &scales,
+               const std::vector<mkldnn::memory::desc> &data_md)
+      : fwd_pd(output_desc, scales, data_md, CpuEngine::Get()->get_engine()) {
+    fwd_ = std::make_shared<mkldnn::sum>(fwd_pd);
+    data_.resize(data_md.size());
+  }
+
+  const mkldnn::sum &GetFwd() const { return *fwd_; }
+
+ private:
+  std::shared_ptr<mkldnn::sum> fwd_;
+  std::vector<std::shared_ptr<mkldnn::memory>> data_;
+  std::shared_ptr<mkldnn::memory> out_;
+};
+
+static MKLDNNQuantizedElemwiseAddFwd &GetQuantizedElemwiseAddForward(
+    const mkldnn::memory::desc &output_desc, const std::vector<float> &scales,
+    const std::vector<NDArray> &in_data, const std::vector<NDArray> &out_data,
+    const std::vector<mkldnn::memory::desc> &data_md) {
+#if DMLC_CXX11_THREAD_LOCAL
+  static thread_local std::unordered_map<OpSignature, MKLDNNQuantizedElemwiseAddFwd, OpHash> fwds;
+#else
+  static MX_THREAD_LOCAL std::unordered_map<OpSignature, MKLDNNQuantizedElemwiseAddFwd, OpHash> fwds;
+#endif
+  OpSignature key;
+  key.AddSign(in_data);
+  key.AddSign(in_data[quantized_elemwise_add_enum::kAMin].data().dptr<float>()[0]);
+  key.AddSign(in_data[quantized_elemwise_add_enum::kAMax].data().dptr<float>()[0]);
+  key.AddSign(in_data[quantized_elemwise_add_enum::kBMin].data().dptr<float>()[0]);
+  key.AddSign(in_data[quantized_elemwise_add_enum::kBMax].data().dptr<float>()[0]);
+  key.AddSign(out_data);
+  key.AddSign(out_data[quantized_elemwise_add_enum::kMin].data().dptr<float>()[0]);
+  key.AddSign(out_data[quantized_elemwise_add_enum::kMax].data().dptr<float>()[0]);
+
+  auto it = fwds.find(key);
+  if (it == fwds.end()) {
+    MKLDNNQuantizedElemwiseAddFwd fwd(output_desc, scales, data_md);
+    it = AddToCache(&fwds, key, fwd);
+  }
+  return it->second;
+}
+
+
 static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs, const OpContext& ctx,
                                               const std::vector<NDArray>& in_data,
                                               const std::vector<OpReqType>& req,
@@ -166,16 +215,16 @@ static void MKLDNNQuantizedElemwiseAddForward(const nnvm::NodeAttrs& attrs, cons
   auto output_desc = mkldnn::memory::desc(i_dims,
                                           output_data_type,
                                           mkldnn::memory::format_tag::any);
-  mkldnn::sum::primitive_desc pdesc(output_desc, scales, in_desc, engine);
+  MKLDNNQuantizedElemwiseAddFwd &fwd = GetQuantizedElemwiseAddForward(output_desc, scales, in_data, out_data, in_desc);
   auto mem = CreateMKLDNNMem(out_data[quantized_elemwise_add_enum::kOut],
-                             pdesc.dst_desc(),
+                             fwd.fwd_pd.dst_desc(),
                              req[0],
                              &in_data[0]);
   mkldnn_args_map_t args({{MKLDNN_ARG_MULTIPLE_SRC,  *dataA_mem},
                           {MKLDNN_ARG_MULTIPLE_SRC + 1,  *dataB_mem},
                           {MKLDNN_ARG_DST, *mem.second}});
   MKLDNNStream *stream = MKLDNNStream::Get();
-  stream->RegisterPrimArgs(mkldnn::sum(pdesc), args);
+  stream->RegisterPrimArgs(fwd.GetFwd(), args);
   CommitOutput(out_data[quantized_elemwise_add_enum::kOut], mem);
   stream->Submit();
 

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_elemwise_add.cc
@@ -65,9 +65,11 @@ static MKLDNNQuantizedElemwiseAddFwd &GetQuantizedElemwiseAddForward(
     const std::vector<NDArray> &in_data, const std::vector<NDArray> &out_data,
     const std::vector<mkldnn::memory::desc> &data_md) {
 #if DMLC_CXX11_THREAD_LOCAL
-  static thread_local std::unordered_map<OpSignature, MKLDNNQuantizedElemwiseAddFwd, OpHash> fwds;
+  static thread_local std::unordered_map<OpSignature,
+              MKLDNNQuantizedElemwiseAddFwd, OpHash> fwds;
 #else
-  static MX_THREAD_LOCAL std::unordered_map<OpSignature, MKLDNNQuantizedElemwiseAddFwd, OpHash> fwds;
+  static MX_THREAD_LOCAL std::unordered_map<OpSignature,
+              MKLDNNQuantizedElemwiseAddFwd, OpHash> fwds;
 #endif
   OpSignature key;
   key.AddSign(in_data);

--- a/src/operator/quantization/quantized_elemwise_add.cc
+++ b/src/operator/quantization/quantized_elemwise_add.cc
@@ -125,8 +125,6 @@ and max thresholds representing the threholds for quantizing the float32 output 
 .add_argument("rhs_max", "NDArray-or-Symbol", "6th input");
 
 
-// TODO(zhangrong): need extra condition check if there's benefited if it's switched on
-// Since it's not compute-intensive.
 NNVM_REGISTER_OP(elemwise_add)
 .set_attr<FQuantizedOp>("FQuantizedOp", [](const NodeAttrs& attrs) {
   nnvm::NodePtr node = nnvm::Node::Create();

--- a/src/operator/quantization/quantized_elemwise_add.cc
+++ b/src/operator/quantization/quantized_elemwise_add.cc
@@ -127,7 +127,6 @@ and max thresholds representing the threholds for quantizing the float32 output 
 
 // TODO(zhangrong): need extra condition check if there's benefited if it's switched on
 // Since it's not compute-intensive.
-#if 0
 NNVM_REGISTER_OP(elemwise_add)
 .set_attr<FQuantizedOp>("FQuantizedOp", [](const NodeAttrs& attrs) {
   nnvm::NodePtr node = nnvm::Node::Create();
@@ -139,7 +138,6 @@ NNVM_REGISTER_OP(elemwise_add)
   }
   return node;
 });
-#endif
 
 }  // namespace op
 }  // namespace mxnet

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -872,7 +872,6 @@ def test_quantize_model_with_forward():
         def check_qsym_forward(qsym, qarg_params, qaux_params, data_shape, label_shape=None):
             if label_shape is None:
                 mod = mx.mod.Module(symbol=qsym, label_names=None, context=mx.current_context())
-                qsym.save('debug.json')
                 mod.bind(for_training=False,
                          data_shapes=[('data', data_shape)])
             else:

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -872,6 +872,7 @@ def test_quantize_model_with_forward():
         def check_qsym_forward(qsym, qarg_params, qaux_params, data_shape, label_shape=None):
             if label_shape is None:
                 mod = mx.mod.Module(symbol=qsym, label_names=None, context=mx.current_context())
+                qsym.save('debug.json')
                 mod.bind(for_training=False,
                          data_shapes=[('data', data_shape)])
             else:
@@ -957,6 +958,8 @@ def test_quantize_model_with_forward():
                         excluded_sym_names = excluded_names
                     else:
                         excluded_sym_names = excluded_names + optional_names
+            if name == 'sym4':
+                excluded_op_names += ['elemwise_add']
 
             qsym, qarg_params, qaux_params = mx.contrib.quant.quantize_model(sym=s,
                                                                              arg_params=arg_params,


### PR DESCRIPTION
## Description ##
cache primitive for int8 eltwise_add operator with dnnl 1.0
@pengzhao-intel @TaoLv @rongzha1 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
