### PR TITLE
[R package] Make R package compilation support opencv 4.0

### DIFF
--- a/R-package/src/im2rec.h
+++ b/R-package/src/im2rec.h
@@ -23,6 +23,14 @@
  * \brief Export module that takes charge of code generation and document
  *  Generation for functions exported from R-side
  */
+#include <opencv2/core/version.hpp>
+#if CV_VERSION_MAJOR >= 4
+
+#define CV_IMWRITE_PNG_COMPRESSION cv::IMWRITE_PNG_COMPRESSION
+#define CV_IMWRITE_JPEG_QUALITY cv::IMWRITE_JPEG_QUALITY
+
+#endif  // CV_VERSION_MAJOR >= 4
+
 
 #ifndef MXNET_RCPP_IM2REC_H_
 #define MXNET_RCPP_IM2REC_H_

--- a/R-package/src/im2rec.h
+++ b/R-package/src/im2rec.h
@@ -23,6 +23,7 @@
  * \brief Export module that takes charge of code generation and document
  *  Generation for functions exported from R-side
  */
+
 #ifndef MXNET_RCPP_IM2REC_H_
 #define MXNET_RCPP_IM2REC_H_
 

--- a/R-package/src/im2rec.h
+++ b/R-package/src/im2rec.h
@@ -23,20 +23,17 @@
  * \brief Export module that takes charge of code generation and document
  *  Generation for functions exported from R-side
  */
-#include <opencv2/core/version.hpp>
-#if CV_VERSION_MAJOR >= 4
-
-#define CV_IMWRITE_PNG_COMPRESSION cv::IMWRITE_PNG_COMPRESSION
-#define CV_IMWRITE_JPEG_QUALITY cv::IMWRITE_JPEG_QUALITY
-
-#endif  // CV_VERSION_MAJOR >= 4
-
-
 #ifndef MXNET_RCPP_IM2REC_H_
 #define MXNET_RCPP_IM2REC_H_
 
 #include <Rcpp.h>
 #include <string>
+#include <opencv2/core/version.hpp>
+#if CV_VERSION_MAJOR >= 4
+#include <opencv2/opencv.hpp>
+#define CV_IMWRITE_PNG_COMPRESSION cv::IMWRITE_PNG_COMPRESSION
+#define CV_IMWRITE_JPEG_QUALITY cv::IMWRITE_JPEG_QUALITY
+#endif  // CV_VERSION_MAJOR >= 4
 
 namespace mxnet {
 namespace R {


### PR DESCRIPTION
Make R package compilation support opencv 4.0

## Description ##
Make R package compilation support opencv 4.0.
The build test under debian 10 was successful, The R package loaded successfully in R 3.5.

### Changes ###
- Make R package compilation support opencv 4.0

## Comments ##
- Make R package support  opencv 4.0. And thanks for WKCN's guidance.
