### PR TITLE
Fix crashing on Windows in ObjectPool ~ctor

### DIFF
--- a/src/common/object_pool.h
+++ b/src/common/object_pool.h
@@ -133,7 +133,11 @@ struct ObjectPoolAllocatable {
 template <typename T>
 ObjectPool<T>::~ObjectPool() {
   for (auto i : allocated_) {
+#ifdef _MSC_VER
+	  _aligned_free(i);
+#else
     free(i);
+#endif
   }
 }
 

--- a/src/common/object_pool.h
+++ b/src/common/object_pool.h
@@ -134,7 +134,7 @@ template <typename T>
 ObjectPool<T>::~ObjectPool() {
   for (auto i : allocated_) {
 #ifdef _MSC_VER
-	  _aligned_free(i);
+    _aligned_free(i);
 #else
     free(i);
 #endif


### PR DESCRIPTION
## Description ##
On Windows in ObjectPool ~ctor _aligned_free should be used instead free
https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-malloc?view=vs-2019
