### PR TITLE
Fix building of container ubuntu_build_cuda, installing driver inside…

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu_build_cuda
+++ b/ci/docker/Dockerfile.build.ubuntu_build_cuda
@@ -63,3 +63,7 @@ RUN /work/ubuntu_adduser.sh
 COPY runtime_functions.sh /work/
 
 WORKDIR /work/mxnet
+
+# fix the missing libcuda.so.1
+RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/cuda/lib64/stubs

--- a/ci/docker/Dockerfile.build.ubuntu_build_cuda
+++ b/ci/docker/Dockerfile.build.ubuntu_build_cuda
@@ -51,8 +51,8 @@ RUN /work/ubuntu_cudnn.sh
 
 # Special case because the CPP-Package requires the CUDA runtime libs
 # and not only stubs (which are provided by the base image)
-COPY install/ubuntu_nvidia.sh /work/
-RUN /work/ubuntu_nvidia.sh
+#COPY install/ubuntu_nvidia.sh /work/
+#RUN /work/ubuntu_nvidia.sh
 
 # Keep this at the end since this command is not cachable
 ARG USER_ID=0

--- a/ci/docker/Dockerfile.build.ubuntu_build_cuda
+++ b/ci/docker/Dockerfile.build.ubuntu_build_cuda
@@ -51,8 +51,8 @@ RUN /work/ubuntu_cudnn.sh
 
 # Special case because the CPP-Package requires the CUDA runtime libs
 # and not only stubs (which are provided by the base image)
-#COPY install/ubuntu_nvidia.sh /work/
-#RUN /work/ubuntu_nvidia.sh
+COPY install/ubuntu_nvidia.sh /work/
+RUN /work/ubuntu_nvidia.sh
 
 # Keep this at the end since this command is not cachable
 ARG USER_ID=0

--- a/ci/docker/Dockerfile.publish.ubuntu1604_gpu
+++ b/ci/docker/Dockerfile.publish.ubuntu1604_gpu
@@ -40,5 +40,8 @@ RUN /work/ubuntu_adduser.sh
 
 COPY runtime_functions.sh /work/
 
+# fix the missing libcuda.so.1
+RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
+
 WORKDIR /work/mxnet
-ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib:/usr/local/cuda/lib64/stubs

--- a/ci/docker/install/ubuntu_nvidia.sh
+++ b/ci/docker/install/ubuntu_nvidia.sh
@@ -22,4 +22,4 @@ set -ex
 # Retrieve ppa:graphics-drivers and install nvidia-drivers.
 # Note: DEBIAN_FRONTEND required to skip the interactive setup steps
 apt update
-DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends cuda-10-1
+DEBIAN_FRONTEND=noninteractive apt install -y --no-install-recommends cuda-cudart-dev-10-1


### PR DESCRIPTION
… container causes nvidia docker errors.

## Description ##

The build.ubuntu_build_cuda docker container is installing cuda-10-1 which is a meta-package which depends on all the available CUDA packages. This is installing cuda drivers in the container which causes problems with nvidia-docker .

This fix only install the cuda runtime libraries.

Fixes #16950
