### PR TITLE
[Dataset] add flatten API to dataset

### DIFF
--- a/python/mxnet/gluon/data/dataset.py
+++ b/python/mxnet/gluon/data/dataset.py
@@ -184,6 +184,19 @@ class Dataset(object):
             The transformed dataset.
         """
         return self.transform(_TransformFirstClosure(fn), lazy)
+    
+    def flatten(self):
+    """Returns a new dataset with samples flattened.
+
+    It is usefull to call after transform() when your transformer function 'fn' transform
+    each sample into multipul samples.
+
+    Returns
+    -------
+    Dataset
+        The result dataset.
+    """
+    return SimpleDataset(list(itertools.chain.from_iterable(self)))
 
 
 class SimpleDataset(Dataset):

--- a/python/mxnet/gluon/data/dataset.py
+++ b/python/mxnet/gluon/data/dataset.py
@@ -190,6 +190,7 @@ class Dataset(object):
 
     It is usefull to call after transform() when your transformer function 'fn' transform
     each sample into multipul samples.
+    Note that the items in dataset should be iterable, e.g., list.
 
     Returns
     -------

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -360,6 +360,14 @@ def test_dataset_take():
         total += sample
     assert total == expected_total
 
+def test_dataset_flatten():
+    length = 100
+    a = mx.gluon.data.SimpleDataset([i for i in range(length)])
+    b = mx.gluon.data.SimpleDataset([[4 * i + j for j in range(4)] for i in range(length // 4)])
+    b = b.flatten()
+    assert len(a) == length
+    assert a == b
+    
 def test_dataloader_scope():
     """
     Bug: Gluon DataLoader terminates the process pool early while

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -364,9 +364,17 @@ def test_dataset_flatten():
     length = 100
     a = mx.gluon.data.SimpleDataset([i for i in range(length)])
     b = mx.gluon.data.SimpleDataset([[4 * i + j for j in range(4)] for i in range(length // 4)])
-    b = b.flatten()
+    c = b.flatten()
     assert len(a) == length
-    assert a == b
+    for (i, tmp) in enumerate(zip(a, c)):
+        assert tmp[0] == tmp[1]
+
+    fn = lambda a : [a + i for i in range(4)]
+    d = mx.gluon.data.SimpleDataset([4 * i for i in range(length // 4)])
+    d = d.transform(fn, lazy=True)
+    d = d.flatten()
+    for (i, tmp) in enumerate(zip(a, d)):
+        assert tmp[0] == tmp[1]
     
 def test_dataloader_scope():
     """


### PR DESCRIPTION
## Description ##
add flatten API to dataset. It can be useful when one transforms a single sample into multiple samples.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
