### PR TITLE
Include eval_net the validation model in the estimator api

### DIFF
--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -441,4 +441,4 @@ def test_eval_net():
     est.fit(train_data=dataloader,
             val_data=dataloader,
             epochs=num_epochs)
->>>>>>> Include eval_net the validation model in the estimator api
+


### PR DESCRIPTION
## Description ##
We add validation model eval_net to the base estimator API. Users may use different models during training and validation. In this PR, we make the following contribution:

-  We add the implementation of eval_net in the estimator class
-  We add unit test for the introduced feature to ensure that parameter sharing works correctly for self.eval_net and self.net

Fixes issue #16942.