### PR TITLE
[CD] dynamic libmxet pipeline fix + small fixes

### DIFF
--- a/cd/mxnet_lib/dynamic/Jenkins_pipeline.groovy
+++ b/cd/mxnet_lib/dynamic/Jenkins_pipeline.groovy
@@ -22,6 +22,7 @@
 
 // NOTE: ci_utils is loaded by the originating Jenkins job, e.g. jenkins/Jenkinsfile_release_job
 
+// NOTE: the following variables are referenced in the mxnet_lib_pipeline jenkins file imported bellow
 // libmxnet location
 libmxnet = 'lib/libmxnet.so'
 
@@ -30,6 +31,7 @@ licenses = 'licenses/*'
 
 // libmxnet dependencies
 mx_deps = ''
+mx_mkldnn_deps = ''
 
 // library type
 // either static or dynamic - depending on how it links to its dependencies

--- a/cd/mxnet_lib/static/Jenkins_pipeline.groovy
+++ b/cd/mxnet_lib/static/Jenkins_pipeline.groovy
@@ -23,6 +23,8 @@
 // To avoid confusion, please note:
 // ci_utils is loaded by the originating Jenkins job, e.g. jenkins/Jenkinsfile_release_job
 
+// NOTE: the following variables are referenced in the mxnet_lib_pipeline jenkins file imported bellow
+
 // libmxnet location
 libmxnet = 'lib/libmxnet.so'
 

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu101
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu101
@@ -65,7 +65,7 @@ RUN /work/ubuntu_docs.sh
 COPY install/ubuntu_tutorials.sh /work/
 RUN /work/ubuntu_tutorials.sh
 
-ENV CUDNN_VERSION=7.5.1.10
+ENV CUDNN_VERSION=7.6.0.64
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1002,7 +1002,7 @@ sanity_check() {
 cd_unittest_ubuntu() {
     set -ex
     export PYTHONPATH=./python/
-    export MXNET_MKLDNN_DEBUG=1  # Ignored if not present
+    export MXNET_MKLDNN_DEBUG=0  # Ignored if not present
     export MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
     export MXNET_SUBGRAPH_VERBOSE=0
     export MXNET_ENABLE_CYTHON=0

--- a/make/staticbuild/linux_cu90.mk
+++ b/make/staticbuild/linux_cu90.mk
@@ -81,6 +81,8 @@ USE_NCCL = 1
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
 ENABLE_CUDA_RTC = 1
 
+USE_NVTX=1
+
 # use openmp for parallelization
 USE_OPENMP = 1
 USE_OPERATOR_TUNING = 1

--- a/make/staticbuild/linux_cu90mkl.mk
+++ b/make/staticbuild/linux_cu90mkl.mk
@@ -81,6 +81,8 @@ USE_NCCL = 1
 # whether use cuda runtime compiling for writing kernels in native language (i.e. Python)
 ENABLE_CUDA_RTC = 1
 
+USE_NVTX=1
+
 # use openmp for parallelization
 USE_OPENMP = 1
 USE_OPERATOR_TUNING = 1


### PR DESCRIPTION
## Description ##
MKL builds for the dynamic libmxet are failing because because of a previous PR's change. It deleted `mx_mkldnn_deps` from the Jenkins file, however, this is needed by an underlying import.

I also noticed a couple of inconsistencies: 
1. USE_NVTX=1 was not set for the cuda 9.0 make configuration
2. ubuntu_gpu_cu101 was using an older cudnn version

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
