### PR TITLE
Fix scala publish & nvidia-docker cublas issue

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu_build_cuda
+++ b/ci/docker/Dockerfile.build.ubuntu_build_cuda
@@ -54,6 +54,10 @@ RUN /work/ubuntu_cudnn.sh
 COPY install/ubuntu_nvidia.sh /work/
 RUN /work/ubuntu_nvidia.sh
 
+# hotfix nvidia-docker image come with wrong version of libcublas
+COPY install/ubuntu_cublas.sh /work/
+RUN /work/ubuntu_cublas.sh
+
 # Keep this at the end since this command is not cachable
 ARG USER_ID=0
 ARG GROUP_ID=0

--- a/ci/docker/Dockerfile.build.ubuntu_gpu_cu101
+++ b/ci/docker/Dockerfile.build.ubuntu_gpu_cu101
@@ -69,6 +69,10 @@ ENV CUDNN_VERSION=7.5.1.10
 COPY install/ubuntu_cudnn.sh /work/
 RUN /work/ubuntu_cudnn.sh
 
+# hotfix nvidia-docker image come with wrong version of libcublas
+COPY install/ubuntu_cublas.sh /work/
+RUN /work/ubuntu_cublas.sh
+
 # Always last
 ARG USER_ID=0
 ARG GROUP_ID=0

--- a/ci/docker/install/centos7_cublas.sh
+++ b/ci/docker/install/centos7_cublas.sh
@@ -1,4 +1,5 @@
-# -*- mode: dockerfile -*-
+#!/usr/bin/env bash
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,33 +16,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-# Dockerfile to build and run MXNet on CentOS 7 for GPU
 
-FROM nvidia/cuda:10.1-devel-centos7
+# build and install are separated so changes to build don't invalidate
+# the whole docker cache for the image
 
-WORKDIR /work/deps
+set -ex
 
-COPY install/centos7_core.sh /work/
-RUN /work/centos7_core.sh
-COPY install/centos7_ccache.sh /work/
-RUN /work/centos7_ccache.sh
-COPY install/centos7_python.sh /work/
-RUN /work/centos7_python.sh
-
-ENV CUDNN_VERSION=7.6.0.64
-COPY install/centos7_cudnn.sh /work/
-RUN /work/centos7_cudnn.sh
-
-# hotfix nvidia-docker image come with wrong version of libcublas
-COPY install/centos7_cublas.sh /work/
-RUN /work/centos7_cublas.sh
-
-ARG USER_ID=0
-COPY install/centos7_adduser.sh /work/
-RUN /work/centos7_adduser.sh
-
-ENV PYTHONPATH=./python/
-WORKDIR /work/mxnet
-
-COPY runtime_functions.sh /work/
+# fix nvidia docker image come with wrong version of libcublas
+yum -y downgrade libcublas-devel-10.2.1.243-1.x86_64
+yum -y downgrade libcublas10-10.2.1.243-1.x86_64

--- a/ci/docker/install/ubuntu_cublas.sh
+++ b/ci/docker/install/ubuntu_cublas.sh
@@ -1,4 +1,5 @@
-# -*- mode: dockerfile -*-
+#!/usr/bin/env bash
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -15,33 +16,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-# Dockerfile to build and run MXNet on CentOS 7 for GPU
 
-FROM nvidia/cuda:10.1-devel-centos7
+# build and install are separated so changes to build don't invalidate
+# the whole docker cache for the image
 
-WORKDIR /work/deps
-
-COPY install/centos7_core.sh /work/
-RUN /work/centos7_core.sh
-COPY install/centos7_ccache.sh /work/
-RUN /work/centos7_ccache.sh
-COPY install/centos7_python.sh /work/
-RUN /work/centos7_python.sh
-
-ENV CUDNN_VERSION=7.6.0.64
-COPY install/centos7_cudnn.sh /work/
-RUN /work/centos7_cudnn.sh
-
-# hotfix nvidia-docker image come with wrong version of libcublas
-COPY install/centos7_cublas.sh /work/
-RUN /work/centos7_cublas.sh
-
-ARG USER_ID=0
-COPY install/centos7_adduser.sh /work/
-RUN /work/centos7_adduser.sh
-
-ENV PYTHONPATH=./python/
-WORKDIR /work/mxnet
-
-COPY runtime_functions.sh /work/
+apt update
+# fix nvidia docker image come with wrong version of libcublas
+apt install -y --allow-downgrades libcublas-dev=10.2.1.243-1
+apt install -y --allow-downgrades  libcublas10=10.2.1.243-1

--- a/ci/publish/Jenkinsfile
+++ b/ci/publish/Jenkinsfile
@@ -84,7 +84,7 @@ for (x in labels) {
   toDeploy["Scala Deploy ${label}"] = wrapStep(nodeMap['cpu'], "deploy-scala-${label}") {
     withEnv(["MAVEN_PUBLISH_OS_TYPE=${scalaOSMap[label]}", "mxnet_variant=${scalaVariantMap[label]}"]) {
       utils.unpack_and_init("scala_${label}", mx_scala_pub, false)
-      utils.docker_run("publish.ubuntu1604_${label}", 'publish_scala_deploy', false, '500m', 'MAVEN_PUBLISH_OS_TYPE MAVEN_PUBLISH_SECRET_ENDPOINT_URL MAVEN_PUBLISH_SECRET_NAME_CREDENTIALS MAVEN_PUBLISH_SECRET_NAME_GPG DOCKERHUB_SECRET_ENDPOINT_REGION mxnet_variant')
+      utils.docker_run("publish.ubuntu1604_${label}", 'publish_scala_deploy', label == 'gpu' ? true : false, '500m', 'MAVEN_PUBLISH_OS_TYPE MAVEN_PUBLISH_SECRET_ENDPOINT_URL MAVEN_PUBLISH_SECRET_NAME_CREDENTIALS MAVEN_PUBLISH_SECRET_NAME_GPG DOCKERHUB_SECRET_ENDPOINT_REGION mxnet_variant')
     }
   }
 }


### PR DESCRIPTION
## Description ##
Fixes two things
1. libcuda.so.1 shoule be able to mapped by nvidia-docker, so we need to add --nvidiadocker when we publish scala package
2. temporily downgrade the libcublas version as current nvidia-docker comes with wrong version of libcublas

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
