### PR TITLE
Extend estimator.evaluate() to support event handlers

### DIFF
--- a/python/mxnet/gluon/contrib/estimator/estimator.py
+++ b/python/mxnet/gluon/contrib/estimator/estimator.py
@@ -230,6 +230,8 @@ class Estimator(object):
             self._train_metrics.append(metric_loss(loss_name))
 
         for metric in self._train_metrics:
+            # add training prefix to the metric name
+            # it is useful for event handlers to distinguish them from validation metrics
             metric.name = 'training ' + metric.name
 
     def _add_validation_metrics(self):
@@ -237,6 +239,8 @@ class Estimator(object):
             self._val_metrics = [copy.deepcopy(metric) for metric in self._train_metrics]
 
         for metric in self._val_metrics:
+            # add validation prefix to the metric name
+            # it is useful for event handlers to distinguish them from training metrics
             if 'training' in metric.name:
                 metric.name = metric.name.replace('training', 'validation')
             else:

--- a/python/mxnet/gluon/contrib/estimator/estimator.py
+++ b/python/mxnet/gluon/contrib/estimator/estimator.py
@@ -256,7 +256,6 @@ class Estimator(object):
 
     def evaluate_batch(self,
                        val_batch,
-                       val_metrics,
                        batch_axis=0):
         """Evaluate model on a batch of validation data.
 
@@ -264,8 +263,6 @@ class Estimator(object):
         ----------
         val_batch : tuple
             Data and label of a batch from the validation data loader.
-        val_metrics : EvalMetric or list of EvalMetrics
-            Metrics to update validation result.
         batch_axis : int, default 0
             Batch axis to split the validation data into devices.
         """
@@ -318,7 +315,7 @@ class Estimator(object):
             for handler in batch_begin:
                 handler.batch_begin(estimator_ref, batch=batch)
 
-            _, label, pred, loss = self.evaluate_batch(batch, self.val_metrics, batch_axis)
+            _, label, pred, loss = self.evaluate_batch(batch, batch_axis)
 
             for handler in batch_end:
                 handler.batch_end(estimator_ref, batch=batch, pred=pred, label=label, loss=loss)
@@ -475,14 +472,9 @@ class Estimator(object):
         if not any(isinstance(handler, ValidationHandler) for handler in event_handlers):
             # no validation handler
             if val_data:
-                val_metrics = self.val_metrics
                 # add default validation handler if validation data found
                 added_default_handlers.append(ValidationHandler(val_data=val_data,
-                                                                eval_fn=self.evaluate,
-                                                                val_metrics=val_metrics))
-            else:
-                # set validation metrics to None if no validation data and no validation handler
-                val_metrics = []
+                                                                eval_fn=self.evaluate))
 
         if not any(isinstance(handler, LoggingHandler) for handler in event_handlers):
             added_default_handlers.append(LoggingHandler(metrics=self.train_metrics))

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -305,6 +305,7 @@ class LoggingHandler(TrainBegin, TrainEnd, EpochBegin, EpochEnd, BatchBegin, Bat
     def epoch_begin(self, estimator, *args, **kwargs):
         if isinstance(self.log_interval, int) or self.log_interval == 'epoch':
             is_training = False
+            # use the name hack defined in __init__() of estimator class
             for metric in self.metrics:
                 if 'training' in metric.name:
                     is_training = True

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -135,7 +135,7 @@ class MetricHandler(EpochBegin, BatchEnd):
         order. The lower the number is, the higher priority level the handler is.
     """
 
-    def __init__(self, metrics):
+    def __init__(self, metrics, priority=-1000):
         self.metrics = _check_metrics(metrics)
         # order to be called among all callbacks
         # metrics need to be calculated before other callbacks can access them

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -249,6 +249,7 @@ class LoggingHandler(TrainBegin, TrainEnd, EpochBegin, EpochEnd, BatchBegin, Bat
         # it will also shut down logging at train end
         self.priority = priority
         self.log_interval = log_interval
+        self.log_interval_time = 0
 
     def train_begin(self, estimator, *args, **kwargs):
         self.train_start = time.time()

--- a/python/mxnet/gluon/contrib/estimator/event_handler.py
+++ b/python/mxnet/gluon/contrib/estimator/event_handler.py
@@ -171,8 +171,6 @@ class ValidationHandler(TrainBegin, BatchEnd, EpochEnd):
     eval_fn : function
         A function defines how to run evaluation and
         calculate loss and metrics.
-    val_metrics : List of EvalMetrics
-        Validation metrics to be updated.
     epoch_period : int, default 1
         How often to run validation at epoch end, by default
         :py:class:`ValidationHandler` validate every epoch.
@@ -188,7 +186,6 @@ class ValidationHandler(TrainBegin, BatchEnd, EpochEnd):
     def __init__(self,
                  val_data,
                  eval_fn,
-                 val_metrics=None,
                  epoch_period=1,
                  batch_period=None,
                  priority=-1000):
@@ -196,7 +193,6 @@ class ValidationHandler(TrainBegin, BatchEnd, EpochEnd):
         self.eval_fn = eval_fn
         self.epoch_period = epoch_period
         self.batch_period = batch_period
-        self.val_metrics = _check_metrics(val_metrics)
         self.current_batch = 0
         self.current_epoch = 0
         # order to be called among all callbacks

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -464,6 +464,6 @@ def test_val_handlers():
         est.fit(train_data=train_data, epochs=num_epochs)
         est.evaluate(val_data=val_data)
 
-    logging = LoggingHandler(verbose=LoggingHandler.LOG_PER_BATCH, metrics=est.val_metrics)
+    logging = LoggingHandler(log_interval=1, metrics=est.val_metrics)
     est.evaluate(val_data=val_data, event_handlers=[logging])
 

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -105,8 +105,7 @@ def test_validation():
     # using validation handler
     train_metrics = est.train_metrics
     val_metrics = est.val_metrics
-    validation_handler = ValidationHandler(val_data=dataloader, eval_fn=est.evaluate,
-                                           val_metrics=val_metrics)
+    validation_handler = ValidationHandler(val_data=dataloader, eval_fn=est.evaluate)
 
     with assert_raises(ValueError):
         est.fit(train_data=dataiter,

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -63,7 +63,7 @@ def test_fit():
     trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
     est = Estimator(net=net,
                     loss=loss,
-                    metrics=acc,
+                    train_metrics=acc,
                     trainer=trainer,
                     context=ctx)
 
@@ -93,7 +93,7 @@ def test_validation():
     trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
     est = Estimator(net=net,
                     loss=loss,
-                    metrics=acc,
+                    train_metrics=acc,
                     trainer=trainer,
                     context=ctx,
                     evaluation_loss=evaluation_loss)
@@ -132,7 +132,7 @@ def test_initializer():
     # no initializer
     est = Estimator(net=net,
                     loss=loss,
-                    metrics=acc,
+                    train_metrics=acc,
                     context=ctx)
     est.fit(train_data=train_data,
             epochs=num_epochs)
@@ -145,7 +145,7 @@ def test_initializer():
     with warnings.catch_warnings(record=True) as w:
         est = Estimator(net=net,
                         loss=loss,
-                        metrics=acc,
+                        train_metrics=acc,
                         initializer=mx.init.MSRAPrelu(),
                         trainer=trainer,
                         context=ctx)
@@ -153,7 +153,7 @@ def test_initializer():
     # net partially initialized, fine tuning use case
     net = gluon.model_zoo.vision.resnet18_v1(pretrained=True, ctx=ctx)
     net.output = gluon.nn.Dense(10) #last layer not initialized
-    est = Estimator(net, loss=loss, metrics=acc, context=ctx)
+    est = Estimator(net, loss=loss, train_metrics=acc, context=ctx)
     dataset =  gluon.data.ArrayDataset(mx.nd.zeros((10, 3, 224, 224)), mx.nd.zeros((10, 10)))
     train_data = gluon.data.DataLoader(dataset=dataset, batch_size=5)
     est.fit(train_data=train_data,
@@ -175,7 +175,7 @@ def test_trainer():
     with warnings.catch_warnings(record=True) as w:
         est = Estimator(net=net,
                         loss=loss,
-                        metrics=acc,
+                        train_metrics=acc,
                         context=ctx)
         assert 'No trainer specified' in str(w[-1].message)
     est.fit(train_data=train_data,
@@ -186,7 +186,7 @@ def test_trainer():
     with assert_raises(ValueError):
         est = Estimator(net=net,
                         loss=loss,
-                        metrics=acc,
+                        train_metrics=acc,
                         trainer=trainer,
                         context=ctx)
 
@@ -212,7 +212,7 @@ def test_metric():
     metrics = [mx.metric.Accuracy(), mx.metric.Accuracy()]
     est = Estimator(net=net,
                     loss=loss,
-                    metrics=metrics,
+                    train_metrics=metrics,
                     trainer=trainer,
                     context=ctx)
     est.fit(train_data=train_data,
@@ -221,7 +221,7 @@ def test_metric():
     with assert_raises(ValueError):
         est = Estimator(net=net,
                         loss=loss,
-                        metrics='acc',
+                        train_metrics='acc',
                         trainer=trainer,
                         context=ctx)
     # test default metric
@@ -244,7 +244,7 @@ def test_loss():
     with assert_raises(ValueError):
         est = Estimator(net=net,
                         loss='mse',
-                        metrics=acc,
+                        train_metrics=acc,
                         trainer=trainer,
                         context=ctx)
 
@@ -257,26 +257,26 @@ def test_context():
     # input no context
     est = Estimator(net=net,
                     loss=loss,
-                    metrics=metrics)
+                    train_metrics=metrics)
     # input list of context
     gpus = mx.context.num_gpus()
     ctx = [mx.gpu(i) for i in range(gpus)] if gpus > 0 else [mx.cpu()]
     net = _get_test_network()
     est = Estimator(net=net,
                     loss=loss,
-                    metrics=metrics,
+                    train_metrics=metrics,
                     context=ctx)
     # input invalid context
     with assert_raises(ValueError):
         est = Estimator(net=net,
                         loss=loss,
-                        metrics=metrics,
+                        train_metrics=metrics,
                         context='cpu')
 
     with assert_raises(AssertionError):
         est = Estimator(net=net,
                         loss=loss,
-                        metrics=metrics,
+                        train_metrics=metrics,
                         context=[mx.gpu(0), mx.gpu(100)])
 
 
@@ -341,7 +341,7 @@ def test_default_handlers():
 
     est = Estimator(net=net,
                     loss=loss,
-                    metrics=train_acc,
+                    train_metrics=train_acc,
                     trainer=trainer,
                     context=ctx)
     # no handler(all default handlers), no warning
@@ -352,18 +352,18 @@ def test_default_handlers():
     # use mix of default and user defined handlers
     train_metrics = est.train_metrics
     val_metrics = est.val_metrics
-    logging = LoggingHandler(train_metrics=train_metrics, val_metrics=val_metrics)
+    logging = LoggingHandler(metrics=train_metrics)
     est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[logging])
 
     # handler with all user defined metrics
     # use mix of default and user defined handlers
-    metric = MetricHandler(train_metrics=[train_acc])
-    logging = LoggingHandler(train_metrics=[train_acc])
+    metric = MetricHandler(metrics=[train_acc])
+    logging = LoggingHandler(metrics=[train_acc])
     est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[metric, logging])
 
     # handler with mixed metrics, some handler use metrics prepared by estimator
     # some handler use metrics user prepared
-    logging = LoggingHandler(train_metrics=train_metrics, val_metrics=[mx.metric.RMSE("val acc")])
+    logging = LoggingHandler(metrics=[mx.metric.RMSE("val acc")])
     with assert_raises(ValueError):
         est.fit(train_data=train_data, epochs=num_epochs, event_handlers=[logging])
 
@@ -441,4 +441,30 @@ def test_eval_net():
     est.fit(train_data=dataloader,
             val_data=dataloader,
             epochs=num_epochs)
+
+def test_val_handlers():
+    net = _get_test_network()
+    train_data, _ = _get_test_data()
+    val_data, _ = _get_test_data()
+
+    num_epochs = 1
+    ctx = mx.cpu()
+    net.initialize(ctx=ctx)
+    trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
+
+    train_acc = mx.metric.RMSE()
+    loss = gluon.loss.L2Loss()
+
+    est = Estimator(net=net,
+                    loss=loss,
+                    train_metrics=train_acc,
+                    trainer=trainer,
+                    context=ctx)
+
+    with warnings.catch_warnings(record=True) as w:
+        est.fit(train_data=train_data, epochs=num_epochs)
+        est.evaluate(val_data=val_data)
+
+    logging = LoggingHandler(verbose=LoggingHandler.LOG_PER_BATCH, metrics=est.val_metrics)
+    est.evaluate(val_data=val_data, event_handlers=[logging])
 

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -391,7 +391,7 @@ def test_eval_net():
     trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
     est = Estimator(net=net,
                     loss=loss,
-                    metrics=acc,
+                    train_metrics=acc,
                     trainer=trainer,
                     context=ctx,
                     evaluation_loss=evaluation_loss,
@@ -409,7 +409,7 @@ def test_eval_net():
     trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
     est = Estimator(net=net,
                     loss=loss,
-                    metrics=acc,
+                    train_metrics=acc,
                     trainer=trainer,
                     context=ctx,
                     evaluation_loss=evaluation_loss,
@@ -431,7 +431,7 @@ def test_eval_net():
     trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
     est = Estimator(net=net,
                     loss=loss,
-                    metrics=acc,
+                    train_metrics=acc,
                     trainer=trainer,
                     context=ctx,
                     evaluation_loss=evaluation_loss,

--- a/tests/python/unittest/test_gluon_event_handler.py
+++ b/tests/python/unittest/test_gluon_event_handler.py
@@ -219,10 +219,10 @@ def test_logging_interval():
     num_epochs = 1
     ce_loss = loss.SoftmaxCrossEntropyLoss()
     acc = mx.metric.Accuracy()
-    logging = LoggingHandler(train_metrics=[acc], log_interval=log_interval)
+    logging = LoggingHandler(metrics=[acc], log_interval=log_interval)
     est = estimator.Estimator(net=net,
                               loss=ce_loss,
-                              metrics=acc)
+                              train_metrics=acc)
 
     est.fit(train_data=dataloader,
             epochs=num_epochs,
@@ -244,10 +244,10 @@ def test_logging_interval():
     sys.stdout = mystdout = StringIO()
     acc = mx.metric.Accuracy()
     log_interval = 5
-    logging = LoggingHandler(train_metrics=[acc], log_interval=log_interval)
+    logging = LoggingHandler(metrics=[acc], log_interval=log_interval)
     est = estimator.Estimator(net=net,
                               loss=ce_loss,
-                              metrics=acc)
+                              train_metrics=acc)
     est.fit(train_data=dataloader,
             epochs=num_epochs,
             event_handlers=[logging])

--- a/tests/python/unittest/test_gluon_event_handler.py
+++ b/tests/python/unittest/test_gluon_event_handler.py
@@ -54,7 +54,7 @@ def test_checkpoint_handler():
         net = _get_test_network()
         ce_loss = loss.SoftmaxCrossEntropyLoss()
         acc = mx.metric.Accuracy()
-        est = estimator.Estimator(net, loss=ce_loss, metrics=acc)
+        est = estimator.Estimator(net, loss=ce_loss, train_metrics=acc)
         checkpoint_handler = event_handler.CheckpointHandler(model_dir=tmpdir,
                                                              model_prefix=model_prefix,
                                                              monitor=acc,
@@ -72,7 +72,7 @@ def test_checkpoint_handler():
         file_path = os.path.join(tmpdir, model_prefix)
         net = _get_test_network(nn.HybridSequential())
         net.hybridize()
-        est = estimator.Estimator(net, loss=ce_loss, metrics=acc)
+        est = estimator.Estimator(net, loss=ce_loss, train_metrics=acc)
         checkpoint_handler = event_handler.CheckpointHandler(model_dir=tmpdir,
                                                              model_prefix=model_prefix,
                                                              epoch_period=None,
@@ -100,7 +100,7 @@ def test_resume_checkpoint():
         net = _get_test_network()
         ce_loss = loss.SoftmaxCrossEntropyLoss()
         acc = mx.metric.Accuracy()
-        est = estimator.Estimator(net, loss=ce_loss, metrics=acc)
+        est = estimator.Estimator(net, loss=ce_loss, train_metrics=acc)
         checkpoint_handler = event_handler.CheckpointHandler(model_dir=tmpdir,
                                                              model_prefix=model_prefix,
                                                              monitor=acc,
@@ -125,7 +125,7 @@ def test_early_stopping():
     net = _get_test_network()
     ce_loss = loss.SoftmaxCrossEntropyLoss()
     acc = mx.metric.Accuracy()
-    est = estimator.Estimator(net, loss=ce_loss, metrics=acc)
+    est = estimator.Estimator(net, loss=ce_loss, train_metrics=acc)
     early_stopping = event_handler.EarlyStoppingHandler(monitor=acc,
                                                         patience=0,
                                                         mode='min')
@@ -149,14 +149,13 @@ def test_logging():
         net = _get_test_network()
         ce_loss = loss.SoftmaxCrossEntropyLoss()
         acc = mx.metric.Accuracy()
-        est = estimator.Estimator(net, loss=ce_loss, metrics=acc)
+        est = estimator.Estimator(net, loss=ce_loss, train_metrics=acc)
 
         est.logger.addHandler(logging.FileHandler(output_dir))
 
         train_metrics = est.train_metrics
         val_metrics = est.val_metrics
-        logging_handler = event_handler.LoggingHandler(train_metrics=train_metrics,
-                                                       val_metrics=val_metrics)
+        logging_handler = event_handler.LoggingHandler(metrics=train_metrics)
         est.fit(test_data, event_handlers=[logging_handler], epochs=3)
         assert logging_handler.batch_index == 0
         assert logging_handler.current_epoch == 3
@@ -197,7 +196,7 @@ def test_custom_handler():
     net = _get_test_network()
     ce_loss = loss.SoftmaxCrossEntropyLoss()
     acc = mx.metric.Accuracy()
-    est = estimator.Estimator(net, loss=ce_loss, metrics=acc)
+    est = estimator.Estimator(net, loss=ce_loss, train_metrics=acc)
     custom_handler = CustomStopHandler(3, 2)
     est.fit(test_data, event_handlers=[custom_handler], epochs=3)
     assert custom_handler.num_batch == 3


### PR DESCRIPTION
## Description ##
Motivated by the issue #16959, we find that we could use existing `LoggingHandler` and `MetricHandler` for validation purpose. We extend `estimator.evaluate()` to support default and customized handlers. Our contributions can be summarized below:

- We extend estimator.evaluate() to support event_handlers
- We replace the metrics in estimator constructor with train_metrics and val_metrics
- We decouple the dependence of default event handlers on training or validation metrics 
- We add test script to verify the correctness of evaluate function 

Fix #16959.

