### PR TITLE
[numpy] add op matmul

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -31,7 +31,7 @@ from ..ndarray import NDArray
 __all__ = ['shape', 'zeros', 'zeros_like', 'ones', 'ones_like', 'full', 'full_like', 'empty_like', 'invert', 'delete',
            'add', 'broadcast_to', 'subtract', 'multiply', 'divide', 'mod', 'remainder', 'power', 'bitwise_not',
            'arctan2', 'sin', 'cos', 'tan', 'sinh', 'cosh', 'tanh', 'log10', 'sqrt', 'cbrt', 'abs',
-           'absolute', 'exp', 'expm1', 'arcsin', 'arccos', 'arctan', 'sign', 'log', 'degrees', 'log2',
+           'absolute', 'exp', 'expm1', 'arcsin', 'arccos', 'arctan', 'sign', 'log', 'degrees', 'log2', 'matmul',
            'log1p', 'rint', 'radians', 'reciprocal', 'square', 'negative', 'fix', 'ceil', 'floor', 'histogram',
            'trunc', 'logical_not', 'arcsinh', 'arccosh', 'arctanh', 'argsort', 'sort',
            'tensordot', 'eye', 'linspace',
@@ -1092,6 +1092,106 @@ def delete(arr, obj, axis=None):
         return _npi.delete(arr, obj, axis=axis)
     else:
         raise TypeError("'obj' can not support type {}".format(str(type(obj))))
+
+
+@set_module('mxnet.ndarray.numpy')
+@wrap_np_binary_func
+def matmul(a, b, out=None):
+    """
+    Matrix product of two arrays.
+
+    Parameters
+    ----------
+    a, b : ndarray
+        Input arrays, scalars not allowed.
+    out : ndarray, optional
+        A location into which the result is stored.
+        If provided, it must have a shape that matches the signature (n,k),(k,m)->(n,m).
+        If not provided or None, a freshly-allocated array is returned.
+
+    Returns
+    -------
+    y : ndarray
+        The matrix product of the inputs.
+        This is a scalar only when both x1, x2 are 1-d vectors.
+
+    Raises
+    ------
+    MXNetError
+        If the last dimension of a is not the same size as the second-to-last dimension of b.
+        If a scalar value is passed in.
+
+    See Also
+    --------
+    tensordot :
+        Sum products over arbitrary axes.
+    dot :
+        alternative matrix product with different broadcasting rules.
+    einsum :
+        Einstein summation convention.
+
+    Notes
+    -----
+    The behavior depends on the arguments in the following way.
+
+    - If both arguments are 2-D they are multiplied like conventional matrices.
+    - If either argument is N-D, N > 2, it is treated as a stack of matrices
+      residing in the last two indexes and broadcast accordingly.
+    - If the first argument is 1-D, it is promoted to a matrix by prepending
+      a 1 to its dimensions. After matrix multiplication the prepended 1 is removed.
+    - If the second argument is 1-D, it is promoted to a matrix by appending a 1
+      to its dimensions. After matrix multiplication the appended 1 is removed.
+
+    matmul differs from dot in two important ways:
+
+    - Multiplication by scalars is not allowed, use multiply instead.
+    - Stacks of matrices are broadcast together as if the matrices were elements,
+    respecting the signature (n,k),(k,m)->(n,m):
+    >>> a = np.ones([9, 5, 7, 4])
+    >>> c = np.ones([9, 5, 4, 3])
+    >>> np.dot(a, c).shape
+    (9, 5, 7, 9, 5, 3)
+    >>> np.matmul(a, c).shape
+    (9, 5, 7, 3)
+    >>> # n is 7, k is 4, m is 3
+
+    Examples
+    --------
+    For 2-D arrays it is the matrix product:
+    >>> a = np.array([[1, 0],
+    ...               [0, 1]])
+    >>> b = np.array([[4, 1],
+    ...               [2, 2]])
+    >>> np.matmul(a, b)
+    array([[4., 1.],
+           [2., 2.]])
+
+    For 2-D mixed with 1-D, the result is the usual.
+    >>> a = np.array([[1, 0],
+    ...               [0, 1]])
+    >>> b = np.array([1, 2])
+    >>> np.matmul(a, b)
+    array([1., 2.])
+    >>> np.matmul(b, a)
+    array([1., 2.])
+
+    Broadcasting is conventional for stacks of arrays
+    >>> a = np.arange(2 * 2 * 4).reshape((2, 2, 4))
+    >>> b = np.arange(2 * 2 * 4).reshape((2, 4, 2))
+    >>> np.matmul(a, b).shape
+    (2, 2, 2)
+    >>> np.matmul(a, b)[0, 1, 1]
+    array(98.)
+    >>> sum(a[0, 1, :] * b[0, :, 1])
+    array(98.)
+
+    Scalar multiplication raises an error.
+    >>> np.matmul([1, 2], 3)
+    Traceback (most recent call last):
+    ...
+    mxnet.base.MXNetError: ... : Multiplication by scalars is not allowed.
+    """
+    return _npi.matmul(a, b, out=out)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -224,9 +224,6 @@ class ndarray(NDArray):
             kwargs['out'] = out[0]
 
         if method == '__call__':
-            #if ufunc.signature is not None:
-                # we don't support generalised-ufuncs (gufuncs)
-                #return NotImplemented
             name = ufunc.__name__
             mx_ufunc = _NUMPY_ARRAY_UFUNC_DICT.get(name, None)
             if mx_ufunc is None:
@@ -3033,6 +3030,7 @@ def matmul(a, b, out=None, **kwargs):
     mxnet.base.MXNetError: ... : Multiplication by scalars is not allowed.
     """
     return _mx_nd_np.matmul(a, b, out=out)
+
 
 @set_module('mxnet.numpy')
 @wrap_np_binary_func

--- a/python/mxnet/numpy_dispatch_protocol.py
+++ b/python/mxnet/numpy_dispatch_protocol.py
@@ -234,6 +234,7 @@ _NUMPY_ARRAY_UFUNC_LIST = [
     'negative',
     'power',
     'mod',
+    'matmul',
     'absolute',
     'rint',
     'sign',

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -1563,15 +1563,15 @@ def matmul(a, b, out=None, **kwargs):
 
     Parameters
     ----------
-    a, b : Symbol.
-    out : Symbol, optional
+    a, b : _Symbol.
+    out : _Symbol, optional
         A location into which the result is stored.
         If provided, it must have a shape that matches the signature (n,k),(k,m)->(n,m).
         If not provided or None, a freshly-allocated array is returned.
 
     Returns
     -------
-    y : Symbol
+    y : _Symbol
         The matrix product of the inputs.
         This is a scalar only when both x1, x2 are 1-d vectors.
 

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -39,7 +39,7 @@ except ImportError:
 __all__ = ['zeros', 'zeros_like', 'ones', 'ones_like', 'full', 'full_like', 'empty_like', 'bitwise_not', 'invert',
            'delete', 'add', 'broadcast_to', 'subtract', 'multiply', 'divide', 'mod', 'remainder', 'power', 'arctan2',
            'sin', 'cos', 'tan', 'sinh', 'cosh', 'tanh', 'log10', 'sqrt', 'cbrt', 'abs', 'absolute', 'exp',
-           'expm1', 'arcsin', 'arccos', 'arctan', 'sign', 'log', 'degrees', 'log2', 'log1p',
+           'expm1', 'arcsin', 'arccos', 'arctan', 'sign', 'log', 'degrees', 'log2', 'log1p', 'matmul',
            'rint', 'radians', 'reciprocal', 'square', 'negative', 'fix', 'ceil', 'floor', 'histogram',
            'trunc', 'logical_not', 'arcsinh', 'arccosh', 'arctanh', 'argsort', 'sort', 'tensordot', 'eye', 'linspace',
            'logspace', 'expand_dims', 'tile', 'arange', 'array_split', 'split', 'vsplit', 'concatenate', 'append',
@@ -1553,6 +1553,62 @@ def remainder(x1, x2, out=None, **kwargs):
 @wrap_np_binary_func
 def power(x1, x2, out=None, **kwargs):
     return _ufunc_helper(x1, x2, _npi.power, _np.power, _npi.power_scalar, _npi.rpower_scalar, out)
+
+
+@set_module('mxnet.symbol.numpy')
+@wrap_np_binary_func
+def matmul(a, b, out=None, **kwargs):
+    """
+    Matrix product of two arrays.
+
+    Parameters
+    ----------
+    a, b : Symbol.
+    out : Symbol, optional
+        A location into which the result is stored.
+        If provided, it must have a shape that matches the signature (n,k),(k,m)->(n,m).
+        If not provided or None, a freshly-allocated array is returned.
+
+    Returns
+    -------
+    y : Symbol
+        The matrix product of the inputs.
+        This is a scalar only when both x1, x2 are 1-d vectors.
+
+    Raises
+    ------
+    MXNetError
+        If the last dimension of a is not the same size as the second-to-last dimension of b.
+        If a scalar value is passed in.
+
+    See Also
+    --------
+    tensordot :
+        Sum products over arbitrary axes.
+    dot :
+        alternative matrix product with different broadcasting rules.
+    einsum :
+        Einstein summation convention.
+
+    Notes
+    -----
+    The behavior depends on the arguments in the following way.
+
+    - If both arguments are 2-D they are multiplied like conventional matrices.
+    - If either argument is N-D, N > 2, it is treated as a stack of matrices
+      residing in the last two indexes and broadcast accordingly.
+    - If the first argument is 1-D, it is promoted to a matrix by prepending
+      a 1 to its dimensions. After matrix multiplication the prepended 1 is removed.
+    - If the second argument is 1-D, it is promoted to a matrix by appending a 1
+      to its dimensions. After matrix multiplication the appended 1 is removed.
+
+    matmul differs from dot in two important ways:
+
+    - Multiplication by scalars is not allowed, use multiply instead.
+    - Stacks of matrices are broadcast together as if the matrices were elements,
+      respecting the signature (n,k),(k,m)->(n,m).
+    """
+    return _npi.matmul(a, b, out=out)
 
 
 @set_module('mxnet.symbol.numpy')

--- a/src/operator/numpy/np_matmul_op-inl.h
+++ b/src/operator/numpy/np_matmul_op-inl.h
@@ -85,7 +85,7 @@ mshadow::Shape<ndim> BroadcastKernelShape(mshadow::Shape<ndim> in_shape,
    */
   mshadow::Shape<ndim>out_shape(in_shape);
   *size = 1;
-  for (int i = 0; i < N - 2; ++i) {
+  for (size_t i = 0; i < N - 2; ++i) {
     out_shape[i] = std::max(in_shape[i], broadcast_shape[i]);
     *size *= out_shape[i];
   }
@@ -115,21 +115,21 @@ struct NDMatmul {
                                   const size_t ndim){
     // i is the global flatten index in the output
     mshadow::Shape<10> out_idx;  // position in output's shape
-    for (int j = 0; j < ndim; ++j) {
+    for (size_t j = 0; j < ndim; ++j) {
       const int64_t head = i / out_stride[j];
       const int64_t mid = head % out_shape[j];
       out_idx[j] = mid;
     }
     mshadow::Shape<10> a_idx(out_idx);  // data block position in a's shape
     size_t a_pos = 0;
-    for (int j = 0; j < ndim - 2; ++j) {
+    for (size_t j = 0; j < ndim - 2; ++j) {
       a_idx[j] = (a_shape[j] == 1) ? 0 : a_idx[j];  // broadcast
       a_pos += a_idx[j] * a_stride[j];
     }
     a_pos += out_idx[ndim - 2] * a_stride[ndim - 2];
     mshadow::Shape<10> b_idx(out_idx);  // data block position in b's shape
     size_t b_pos = 0;
-    for (int j = 0; j < ndim - 2; ++j) {
+    for (size_t j = 0; j < ndim - 2; ++j) {
       b_idx[j] = (b_shape[j] == 1) ? 0 : b_idx[j];  // broadcast
       b_pos += b_idx[j] * b_stride[j];
     }
@@ -153,7 +153,6 @@ struct TransposeLastTwoAxes {
   MSHADOW_XINLINE static void Map(int i, DType* out, const DType* in,
                                   const size_t in_row, const size_t in_col) {
     // i is the global position in flattened output
-    const size_t out_row = in_col;
     const size_t out_col = in_row;
     const size_t last = i % (in_row * in_col);
     const size_t base = i - last;
@@ -224,7 +223,7 @@ void NumpyMatmulForward(const nnvm::NodeAttrs& attrs,
       if (a_shape.ndim() == 1) {
         ndim += 1;
         std::vector<size_t> newshape(ndim);
-        for (int i = 0; i < ndim - 2; ++i) {
+        for (size_t i = 0; i < ndim - 2; ++i) {
           newshape[i] = out_shape[i];
         }
         newshape[ndim - 2] = 1;
@@ -285,7 +284,7 @@ void NumpyMatmulBackward(const nnvm::NodeAttrs& attrs,
         a_shape.assign(temp_shape.begin(), temp_shape.end());
         ndim += 1;
         std::vector<size_t> newshape(ndim);
-        for (int i = 0; i < ndim - 2; ++i) {
+        for (size_t i = 0; i < ndim - 2; ++i) {
           newshape[i] = out_shape[i];
         }
         newshape[ndim - 2] = 1;

--- a/src/operator/numpy/np_matmul_op-inl.h
+++ b/src/operator/numpy/np_matmul_op-inl.h
@@ -270,7 +270,7 @@ void NumpyMatmulForward(const nnvm::NodeAttrs& attrs,
     size_t bc_size_a = batch_size * a_shape[a_shape.ndim() - 2] * a_shape[a_shape.ndim() - 1];
     size_t bc_size_b = batch_size * b_shape[b_shape.ndim() - 2] * b_shape[b_shape.ndim() - 1];
     size_t temp_mem_size = (bc_size_a + bc_size_b) * sizeof(DType) +
-                            3 * batch_size * sizeof(DType*);
+                           3 * batch_size * sizeof(DType*);
     Tensor<xpu, 1, char> temp_mem =
       ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(temp_mem_size), s);
     MatmulImpl<xpu, DType>(ctx, inputs[0], inputs[1], req[0], outputs[0], temp_mem,
@@ -395,7 +395,7 @@ void NumpyMatmulBackward(const nnvm::NodeAttrs& attrs,
     Tensor<xpu, 1, char> temp_mem =
       ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(temp_mem_size), s);
     Tensor<xpu, 1, char> workspace_grada(temp_mem.dptr_, Shape1(temp_mem_size_grada), s);
-    Tensor<xpu, 1, char> workspace_gradb(workspace_grada.dptr_ + temp_mem_size_grada ,
+    Tensor<xpu, 1, char> workspace_gradb(workspace_grada.dptr_ + temp_mem_size_grada,
                                          Shape1(temp_mem_size_gradb), s);
     Tensor<xpu, 1, DType> temp_grada(
       reinterpret_cast<DType*>(workspace_gradb.dptr_ + temp_mem_size_gradb),

--- a/src/operator/numpy/np_matmul_op-inl.h
+++ b/src/operator/numpy/np_matmul_op-inl.h
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file np_matmul_op-inl.h
+ * \brief Function definition of matrix numpy-compatible matmul operator
+ */
+
+#ifndef MXNET_OPERATOR_NUMPY_NP_MATMUL_OP_INL_H_
+#define MXNET_OPERATOR_NUMPY_NP_MATMUL_OP_INL_H_
+
+#include <mxnet/operator_util.h>
+#include <vector>
+#include <algorithm>
+#include <memory>
+#include "np_tensordot_op-inl.h"
+#include "np_dot-inl.h"
+
+namespace mxnet {
+namespace op {
+
+template<int ndim>
+mshadow::Shape<ndim> GetStride(mshadow::Shape<ndim> shape, size_t N) {
+  /*!
+   * \brief Calculate stride of each dim from shape 
+   */
+  mshadow::Shape<ndim>stride;
+  size_t tmp = 1;
+  for (int i = N - 1; i >= 0; --i) {
+    stride[i] = tmp;
+    tmp *= shape[i];
+  }
+  return stride;
+}
+
+template<int ndim>
+mshadow::Shape<ndim> GetKernelShape(const mxnet::TShape& shape,
+                                    size_t N, bool T = false) {
+  /*!
+   * \brief Get mshadow::Shape from mxnet::TShape. Extra dims is filled with 1.
+   * \param N - ndim of mshape::Shape shape.
+   * \param T - If T is True, transpose the last two axis, otherwise not.
+   */
+  mshadow::Shape<ndim>k_shape;
+  for (int i = shape.ndim() - 1, j = N - 1; i >= 0 || j >= 0 ; --i, --j) {
+    if (i >= 0) {
+      k_shape[j] = shape[i];
+    } else {
+      k_shape[j] = 1;
+    }
+  }
+  if (T) {  // transpose the latest two axes
+    size_t t = k_shape[N - 1];
+    k_shape[N - 1] = k_shape[N - 2];
+    k_shape[N - 2] = t;
+  }
+  return k_shape;
+}
+
+template<int ndim>
+mshadow::Shape<ndim> BroadcastKernelShape(mshadow::Shape<ndim> in_shape,
+                                          mshadow::Shape<ndim> broadcast_shape,
+                                          size_t N, size_t* size) {
+  /*!
+   * \brief Broadcast in_shape(ndim = N) to broadcast_shape(ndim = N) expect the last two axes.
+            Make sure that: If i < N - 2 and in_shape[i] != broadcast_shape[i], in_shape[i] == 1.
+   * \param N - ndim of both in_shape and broadcast_shape.
+   * \param size - The size of the broadcast_shape.
+   */
+  mshadow::Shape<ndim>out_shape(in_shape);
+  *size = 1;
+  for (int i = 0; i < N - 2; ++i) {
+    out_shape[i] = std::max(in_shape[i], broadcast_shape[i]);
+    *size *= out_shape[i];
+  }
+  *size *= (out_shape[N - 2] * out_shape[N - 1]);
+  return out_shape;
+}
+
+template<int req>
+struct NDMatmul {
+  /*!
+   * \brief matmul(a, b) in both N-D(N >= 2) case.
+            It is treated as a stack of matrices residing in the last two indexes and broadcast accordingly.
+   * \param out - output: insert 'value' to 'arr' according to 'index'.
+   * \param a - input: the first argument.
+   * \param b - input: the second argument.
+   * \param ndim - ndim of a, b and output. Because of broadcast, regard their ndim as equal.  
+   */
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, DType* out,
+                                  const DType* a, const DType* b,
+                                  const mshadow::Shape<10> a_stride,
+                                  const mshadow::Shape<10> b_stride,
+                                  const mshadow::Shape<10> out_stride,
+                                  const mshadow::Shape<10> a_shape,
+                                  const mshadow::Shape<10> b_shape,
+                                  const mshadow::Shape<10> out_shape,
+                                  const size_t ndim){
+    // i is the global flatten index in the output
+    mshadow::Shape<10> out_idx;  // position in output's shape
+    for (int j = 0; j < ndim; ++j) {
+      const int64_t head = i / out_stride[j];
+      const int64_t mid = head % out_shape[j];
+      out_idx[j] = mid;
+    }
+    mshadow::Shape<10> a_idx(out_idx);  // data block position in a's shape
+    size_t a_pos = 0;
+    for (int j = 0; j < ndim - 2; ++j) {
+      a_idx[j] = (a_shape[j] == 1) ? 0 : a_idx[j];  // broadcast
+      a_pos += a_idx[j] * a_stride[j];
+    }
+    a_pos += out_idx[ndim - 2] * a_stride[ndim - 2];
+    mshadow::Shape<10> b_idx(out_idx);  // data block position in b's shape
+    size_t b_pos = 0;
+    for (int j = 0; j < ndim - 2; ++j) {
+      b_idx[j] = (b_shape[j] == 1) ? 0 : b_idx[j];  // broadcast
+      b_pos += b_idx[j] * b_stride[j];
+    }
+    b_pos += out_idx[ndim - 1];
+    DType res = 0;
+    for (int j = 0; j < a_shape[ndim - 1]; ++j) {
+      res += a[a_pos + j] * b[b_pos + j * b_stride[ndim - 2]];
+    }
+    KERNEL_ASSIGN(out[i], req, res);
+  }
+};
+
+struct TransposeLastTwoAxes {
+  /*!
+  * \brief transpose the last two axes
+  * \example (a, b, c, d) -> (a, b, d, c)
+  * \param in_row - the second-to-last dim size of in's shape
+  * \param in_col - the last dim size of in's shape
+  */
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, DType* out, const DType* in,
+                                  const size_t in_row, const size_t in_col) {
+    // i is the global position in flattened output
+    const size_t out_row = in_col;
+    const size_t out_col = in_row;
+    const size_t last = i % (in_row * in_col);
+    const size_t base = i - last;
+    const size_t row = last / out_col;
+    const size_t col = last % out_col;
+    const size_t dest = base + col * in_col + row;
+    out[i] = in[dest];
+  }
+};
+
+template<int req>
+struct SumByShape {
+  /*!
+  * \brief 
+  * \param out - output: insert 'value' to 'arr' according to 'index'.
+  * \param a - input: the first argument.
+  * \param b - input: the second argument.
+  * \param ndim - ndim of a, b and output. Because of broadcast, regard their ndim as equal.  
+  */
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, DType* output, DType* input,
+                                  size_t in_size, size_t out_size){
+    // i is the global position in flattened output
+    size_t pos = static_cast<size_t>(i);
+    DType temp = 0;
+    while (pos < in_size) {
+      temp += input[pos];
+      pos += out_size;
+    }
+    KERNEL_ASSIGN(output[i], req, temp);
+  }
+};
+
+template<typename xpu>
+void NumpyMatmulForward(const nnvm::NodeAttrs& attrs,
+                        const OpContext& ctx,
+                        const std::vector<TBlob>& inputs,
+                        const std::vector<OpReqType>& req,
+                        const std::vector<TBlob>& outputs) {
+  using namespace mshadow;
+  using namespace mxnet_op;
+
+  CHECK_EQ(inputs.size(), 2U);
+  CHECK_EQ(outputs.size(), 1U);
+
+  const TBlob& a = inputs[0];
+  const TBlob& b = inputs[1];
+  const TBlob& out = outputs[0];
+  mxnet::TShape a_shape = a.shape_;
+  mxnet::TShape b_shape = b.shape_;
+  mxnet::TShape out_shape = out.shape_;
+  size_t ndim = out_shape.ndim();
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+
+  CHECK_NE(a_shape.ndim(), 0)
+    << "Multiplication by scalars is not allowed.\n";
+  CHECK_NE(b_shape.ndim(), 0)
+    << "Multiplication by scalars is not allowed.\n";
+  MSHADOW_REAL_TYPE_SWITCH(out.type_flag_, DType, {
+    if (b_shape.ndim() <= 2) {
+      // case 1: both 1-D arrays, inner product of vectors
+      // case 2: both 2-D arrays, matrix multiplication
+      // case 3: If the second argument is 1-D.
+      // case 5(1): If the first argument is N-D(N > 2), the second argument is 2-D.
+      TensordotIntAxesImpl<xpu>(1, ctx, a, b, out, req[0]);
+    } else {
+      // Case 4: If the first argument is 1-D.
+      if (a_shape.ndim() == 1) {
+        ndim += 1;
+        std::vector<size_t> newshape(ndim);
+        for (int i = 0; i < ndim - 2; ++i) {
+          newshape[i] = out_shape[i];
+        }
+        newshape[ndim - 2] = 1;
+        newshape[ndim - 1] = out_shape[ndim - 2];
+        out_shape.assign(newshape.begin(), newshape.end());
+      }
+      // case 5(2): If the first argument is N-D(N > 2), the second argument is N-D(N > 2).
+      const mshadow::Shape<10> k_a_shape = GetKernelShape<10>(a_shape, ndim);
+      const mshadow::Shape<10> k_b_shape = GetKernelShape<10>(b_shape, ndim);
+      const mshadow::Shape<10> k_out_shape = GetKernelShape<10>(out_shape, ndim);
+      const mshadow::Shape<10> a_stride = GetStride<10>(k_a_shape, ndim);
+      const mshadow::Shape<10> b_stride = GetStride<10>(k_b_shape, ndim);
+      const mshadow::Shape<10> out_stride = GetStride<10>(k_out_shape, ndim);
+      MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+        Kernel<NDMatmul<req_type>, xpu>::Launch(
+          s, out_shape.Size(), out.dptr<DType>(), a.dptr<DType>(),
+          b.dptr<DType>(), a_stride, b_stride, out_stride,
+          k_a_shape, k_b_shape, k_out_shape, ndim);
+      });
+    }
+  });
+}
+
+template<typename xpu>
+void NumpyMatmulBackward(const nnvm::NodeAttrs& attrs,
+                        const OpContext& ctx,
+                        const std::vector<TBlob>& inputs,
+                        const std::vector<OpReqType>& req,
+                        const std::vector<TBlob>& outputs) {
+  using namespace mshadow;
+  using namespace mxnet_op;
+
+  CHECK_EQ(inputs.size(), 3U);
+  CHECK_EQ(outputs.size(), 2U);
+
+  const TBlob& ograd = inputs[0];
+  const TBlob& a = inputs[1];
+  const TBlob& b = inputs[2];
+  const TBlob& grad_a = outputs[0];
+  const TBlob& grad_b = outputs[1];
+  mxnet::TShape a_shape = a.shape_;
+  mxnet::TShape b_shape = b.shape_;
+  mxnet::TShape out_shape = ograd.shape_;
+  size_t ndim = out_shape.ndim();
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+
+  MSHADOW_REAL_TYPE_SWITCH(ograd.type_flag_, DType, {
+    if (b_shape.ndim() <= 2) {
+      // case 1: both 1-D arrays, inner product of vectors
+      // case 2: both 2-D arrays, matrix multiplication
+      // case 3: If the second argument is 1-D.
+      // case 5(1): If the first argument is N-D(N > 2), the second argument is 2-D.
+      TensordotIntAxesBackwardImpl<xpu>(1, ctx, ograd, a, b, grad_a, grad_b, req);
+    } else {
+      // Case 4: If the first argument is 1-D.
+      if (a_shape.ndim() == 1) {
+        std::vector<size_t>temp_shape({1, a_shape.Size()});
+        a_shape.assign(temp_shape.begin(), temp_shape.end());
+        ndim += 1;
+        std::vector<size_t> newshape(ndim);
+        for (int i = 0; i < ndim - 2; ++i) {
+          newshape[i] = out_shape[i];
+        }
+        newshape[ndim - 2] = 1;
+        newshape[ndim - 1] = out_shape[ndim - 2];
+        out_shape.assign(newshape.begin(), newshape.end());
+      }
+      // case 5(2): If the first argument is N-D(N > 2), the second argument is N-D(N > 2).
+      const mshadow::Shape<10> k_a_shape = GetKernelShape<10>(a_shape, ndim);
+      const mshadow::Shape<10> k_a_shape_T = GetKernelShape<10>(a_shape, ndim, true);
+      const mshadow::Shape<10> k_b_shape = GetKernelShape<10>(b_shape, ndim);
+      const mshadow::Shape<10> k_b_shape_T = GetKernelShape<10>(b_shape, ndim, true);
+      const mshadow::Shape<10> k_out_shape = GetKernelShape<10>(out_shape, ndim);
+      size_t bc_size_a = 1, bc_size_b = 1;
+      const mshadow::Shape<10> k_a_shape_bc =
+        BroadcastKernelShape<10>(k_a_shape, k_out_shape, ndim, &bc_size_a);
+      const mshadow::Shape<10> k_b_shape_bc =
+        BroadcastKernelShape<10>(k_b_shape, k_out_shape, ndim, &bc_size_b);
+      const mshadow::Shape<10> a_stride_T = GetStride<10>(k_a_shape_T, ndim);
+      const mshadow::Shape<10> a_stride_bc = GetStride<10>(k_a_shape_bc, ndim);
+      const mshadow::Shape<10> b_stride_T = GetStride<10>(k_b_shape_T, ndim);
+      const mshadow::Shape<10> b_stride_bc = GetStride<10>(k_b_shape_bc, ndim);
+      const mshadow::Shape<10> out_stride = GetStride<10>(k_out_shape, ndim);
+
+      size_t temp_mem_size = (a_shape.Size() + b_shape.Size() +
+                              bc_size_a + bc_size_b) * sizeof(DType);
+      Tensor<xpu, 1, char> temp_mem =
+        ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(temp_mem_size), s);
+      DType* a_T_ptr = reinterpret_cast<DType*>(temp_mem.dptr_);
+      DType* b_T_ptr = reinterpret_cast<DType*>(
+        temp_mem.dptr_ + a_shape.Size() * sizeof(DType));
+      DType* grad_a_temp = reinterpret_cast<DType*>(
+        temp_mem.dptr_ + (a_shape.Size() + b_shape.Size()) * sizeof(DType));
+      DType* grad_b_temp = reinterpret_cast<DType*>(
+        temp_mem.dptr_ + (a_shape.Size() + b_shape.Size() + bc_size_a) * sizeof(DType));
+
+      Kernel<TransposeLastTwoAxes, xpu>::Launch(
+        s, a_shape.Size(), a_T_ptr, a.dptr<DType>(),
+        static_cast<size_t>(k_a_shape[ndim - 2]),
+        static_cast<size_t>(k_a_shape[ndim - 1]));
+      Kernel<TransposeLastTwoAxes, xpu>::Launch(
+        s, b_shape.Size(), b_T_ptr, b.dptr<DType>(),
+        static_cast<size_t>(k_b_shape[ndim - 2]),
+        static_cast<size_t>(k_b_shape[ndim - 1]));
+
+      Kernel<NDMatmul<OpReqType::kWriteTo>, xpu>::Launch(
+        s, bc_size_a, grad_a_temp, ograd.dptr<DType>(),
+        b_T_ptr, out_stride, b_stride_T, a_stride_bc,
+        k_out_shape, k_b_shape_T, k_a_shape_bc, ndim);
+      Kernel<NDMatmul<OpReqType::kWriteTo>, xpu>::Launch(
+        s, bc_size_b, grad_b_temp, a_T_ptr,
+        ograd.dptr<DType>(), a_stride_T, out_stride, b_stride_bc,
+        k_a_shape_T, k_out_shape, k_b_shape_bc, ndim);
+
+      MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+        Kernel<SumByShape<req_type>, xpu>::Launch(
+          s, a_shape.Size(), grad_a.dptr<DType>(), grad_a_temp,
+          bc_size_a, a_shape.Size());
+        Kernel<SumByShape<req_type>, xpu>::Launch(
+          s, b_shape.Size(), grad_b.dptr<DType>(), grad_b_temp,
+          bc_size_b, b_shape.Size());
+      });
+    }
+  });
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NUMPY_NP_MATMUL_OP_INL_H_

--- a/src/operator/numpy/np_matmul_op.cc
+++ b/src/operator/numpy/np_matmul_op.cc
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file np_matmul_op.cc
+ * \brief CPU Implementation of numpy-compatible matmul
+ */
+
+#include <string>
+#include "np_matmul_op-inl.h"
+
+namespace mxnet {
+namespace op {
+
+inline bool NumpyMatmulShape(const nnvm::NodeAttrs& attrs,
+                             mxnet::ShapeVector *in_attrs,
+                             mxnet::ShapeVector *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 2U);
+  CHECK_EQ(out_attrs->size(), 1U);
+
+  const mxnet::TShape& a_shape = in_attrs->at(0);
+  const mxnet::TShape& b_shape = in_attrs->at(1);
+  const size_t a_ndim = a_shape.ndim();
+  const size_t b_ndim = b_shape.ndim();
+  if (!ndim_is_known(a_shape) || !ndim_is_known(b_shape)) {
+    return false;
+  }
+
+  CHECK_NE(a_ndim, 0)
+    << "Multiplication by scalars is not allowed.\n";
+  CHECK_NE(b_ndim, 0)
+    << "Multiplication by scalars is not allowed.\n";
+
+  if (a_ndim == 1 && b_ndim == 1) {
+    // case 1: both 1-D arrays, inner product of vectors
+    SHAPE_ASSIGN_CHECK(*in_attrs, 0, in_attrs->at(1));
+    SHAPE_ASSIGN_CHECK(*in_attrs, 1, in_attrs->at(0));
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, mxnet::TShape(0, 0));
+  } else if (a_ndim == 2 && b_ndim == 2) {
+    // case 2: both 2-D arrays, matrix multiplication
+    mxnet::TShape tmp_shape(2, -1);
+    tmp_shape[1] = b_shape[0];
+    SHAPE_ASSIGN_CHECK(*in_attrs, 0, tmp_shape);
+
+    tmp_shape[0] = a_shape[1];
+    tmp_shape[1] = -1;
+    SHAPE_ASSIGN_CHECK(*in_attrs, 1, tmp_shape);
+
+    tmp_shape[0] = a_shape[0];
+    tmp_shape[1] = b_shape[1];
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, tmp_shape);
+  } else if (b_ndim == 1) {
+    // case 3: If the second argument is 1-D, it is promoted to a matrix
+    //          by appending a 1 to its dimensions.
+    //         After matrix multiplication the appended 1 is removed.
+    TShape tmp_shape(a_ndim, -1);
+    tmp_shape[a_ndim - 1] = b_shape[0];
+    SHAPE_ASSIGN_CHECK(*in_attrs, 0, tmp_shape);
+
+    tmp_shape = TShape(1, -1);
+    tmp_shape[0] = a_shape[a_ndim - 1];
+    SHAPE_ASSIGN_CHECK(*in_attrs, 1, tmp_shape);
+
+    mxnet::TShape out_shape(a_ndim - 1, -1);
+    for (int i = 0; i < a_ndim - 1; ++i) {
+      out_shape[i] = a_shape[i];
+    }
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, out_shape);
+  } else if (a_ndim == 1) {
+    // Case 4: If the first argument is 1-D, it is promoted to a matrix
+    //         by prepending a 1 to its dimensions.
+    //         After matrix multiplication the prepended 1 is removed.
+    TShape tmp_shape(b_ndim, -1);
+    tmp_shape[b_ndim - 2] = a_shape[0];
+    SHAPE_ASSIGN_CHECK(*in_attrs, 1, tmp_shape);
+
+    tmp_shape = TShape(1, -1);
+    tmp_shape[0] = b_shape[b_ndim - 2];
+    SHAPE_ASSIGN_CHECK(*in_attrs, 0, tmp_shape);
+
+    mxnet::TShape out_shape(b_ndim - 1, -1);
+    for (int i = 0; i < b_ndim - 2; ++i) {
+      out_shape[i] = b_shape[i];
+    }
+    out_shape[b_ndim - 2] = b_shape[b_ndim - 1];
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, out_shape);
+  } else {
+    // case 5: If either argument is N-D, N > 2, it is treated as a stack of matrices
+    //         residing in the last two indexes and broadcast accordingly.
+    TShape tmp_shape(a_ndim, -1);
+    tmp_shape[a_ndim - 1] = b_shape[b_ndim - 2];
+    SHAPE_ASSIGN_CHECK(*in_attrs, 0, tmp_shape);
+    tmp_shape = TShape(b_ndim, -1);
+    tmp_shape[b_ndim - 2] = a_shape[a_ndim - 1];
+    SHAPE_ASSIGN_CHECK(*in_attrs, 1, tmp_shape);
+    size_t ndim = std::max(a_ndim, b_ndim);
+    mxnet::TShape out_shape(ndim, -1);
+    out_shape[ndim - 1] = b_shape[b_ndim - 1];
+    out_shape[ndim - 2] = a_shape[a_ndim - 2];
+    for (int p = ndim - 3, pa = a_ndim - 3, pb = b_ndim - 3;
+         p >= 0; --p, --pa, --pb) {
+      if (pa >= 0 && pb >= 0) {
+        if (a_shape[pa] == 1) {
+          out_shape[p] = b_shape[pb];
+        } else if (b_shape[pb] == 1) {
+          out_shape[p] = a_shape[pa];
+        } else {
+          CHECK_EQ(a_shape[pa], b_shape[pb])
+            << "Could not be broadcast.\n";
+          out_shape[p] = b_shape[pb];
+        }
+      } else if (pa >= 0) {
+        out_shape[p] = a_shape[pa];
+      } else if (pb >= 0) {
+        out_shape[p] = b_shape[pb];
+      }
+    }
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, out_shape);
+  }
+  return shape_is_known(*in_attrs) && shape_is_known(*out_attrs);
+}
+
+NNVM_REGISTER_OP(_npi_matmul)
+.describe(R"doc(Matrix product of two arrays.
+The behavior depends on the arguments in the following way.
+- If both arguments are 2-D they are multiplied like conventional matrices.
+- If either argument is N-D, N > 2, it is treated as a stack of matrices residing
+ in the last two indexes and broadcast accordingly.
+- If the first argument is 1-D, it is promoted to a matrix by prepending a 1 to its
+ dimensions. After matrix multiplication the prepended 1 is removed.
+- If the second argument is 1-D, it is promoted to a matrix by appending a 1 to its
+ dimensions. After matrix multiplication the appended 1 is removed.
+
+'matmul' differs from 'dot' in two important ways:
+- Multiplication by scalars is not allowed, use * instead.
+- Stacks of matrices are broadcast together as if the matrices were elements,
+ respecting the signature (n,k),(k,m)->(n,m).
+)doc" ADD_FILELINE)
+.set_num_inputs(2U)
+.set_num_outputs(1U)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"a", "b"};
+})
+.set_attr<nnvm::FListOutputNames>("FListOutputNames",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"out"};
+})
+.set_attr<mxnet::FInferShape>("FInferShape", NumpyMatmulShape)
+.set_attr<nnvm::FInferType>("FInferType", ElemwiseType<2, 1>)
+.set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
+.set_attr<FCompute>("FCompute<cpu>", NumpyMatmulForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_np_matmul"})
+.add_argument("a", "NDArray-or-Symbol", "First input")
+.add_argument("b", "NDArray-or-Symbol", "Second input");
+
+NNVM_REGISTER_OP(_backward_np_matmul)
+.set_num_inputs(3U)
+.set_num_outputs(2U)
+.set_attr<nnvm::TIsBackward>("TIsBackward", true)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const NodeAttrs& attrs) {
+    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+  })
+.set_attr<FCompute>("FCompute<cpu>", NumpyMatmulBackward<cpu>);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/np_matmul_op.cc
+++ b/src/operator/numpy/np_matmul_op.cc
@@ -67,7 +67,7 @@ inline bool NumpyMatmulShape(const nnvm::NodeAttrs& attrs,
     SHAPE_ASSIGN_CHECK(*out_attrs, 0, tmp_shape);
   } else if (b_ndim == 1) {
     // case 3: If the second argument is 1-D, it is promoted to a matrix
-    //          by appending a 1 to its dimensions.
+    //         by appending a 1 to its dimensions.
     //         After matrix multiplication the appended 1 is removed.
     TShape tmp_shape(a_ndim, -1);
     tmp_shape[a_ndim - 1] = b_shape[0];
@@ -167,6 +167,10 @@ The behavior depends on the arguments in the following way.
 .set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
 .set_attr<FCompute>("FCompute<cpu>", NumpyMatmulForward<cpu>)
 .set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_np_matmul"})
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const NodeAttrs& attrs) {
+    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+  })
 .add_argument("a", "NDArray-or-Symbol", "First input")
 .add_argument("b", "NDArray-or-Symbol", "Second input");
 

--- a/src/operator/numpy/np_matmul_op.cc
+++ b/src/operator/numpy/np_matmul_op.cc
@@ -78,7 +78,7 @@ inline bool NumpyMatmulShape(const nnvm::NodeAttrs& attrs,
     SHAPE_ASSIGN_CHECK(*in_attrs, 1, tmp_shape);
 
     mxnet::TShape out_shape(a_ndim - 1, -1);
-    for (int i = 0; i < a_ndim - 1; ++i) {
+    for (size_t i = 0; i < a_ndim - 1; ++i) {
       out_shape[i] = a_shape[i];
     }
     SHAPE_ASSIGN_CHECK(*out_attrs, 0, out_shape);
@@ -95,7 +95,7 @@ inline bool NumpyMatmulShape(const nnvm::NodeAttrs& attrs,
     SHAPE_ASSIGN_CHECK(*in_attrs, 0, tmp_shape);
 
     mxnet::TShape out_shape(b_ndim - 1, -1);
-    for (int i = 0; i < b_ndim - 2; ++i) {
+    for (size_t i = 0; i < b_ndim - 2; ++i) {
       out_shape[i] = b_shape[i];
     }
     out_shape[b_ndim - 2] = b_shape[b_ndim - 1];

--- a/src/operator/numpy/np_matmul_op.cc
+++ b/src/operator/numpy/np_matmul_op.cc
@@ -137,21 +137,7 @@ inline bool NumpyMatmulShape(const nnvm::NodeAttrs& attrs,
 }
 
 NNVM_REGISTER_OP(_npi_matmul)
-.describe(R"doc(Matrix product of two arrays.
-The behavior depends on the arguments in the following way.
-- If both arguments are 2-D they are multiplied like conventional matrices.
-- If either argument is N-D, N > 2, it is treated as a stack of matrices residing
- in the last two indexes and broadcast accordingly.
-- If the first argument is 1-D, it is promoted to a matrix by prepending a 1 to its
- dimensions. After matrix multiplication the prepended 1 is removed.
-- If the second argument is 1-D, it is promoted to a matrix by appending a 1 to its
- dimensions. After matrix multiplication the appended 1 is removed.
-
-'matmul' differs from 'dot' in two important ways:
-- Multiplication by scalars is not allowed, use * instead.
-- Stacks of matrices are broadcast together as if the matrices were elements,
- respecting the signature (n,k),(k,m)->(n,m).
-)doc" ADD_FILELINE)
+.describe(R"doc()doc" ADD_FILELINE)
 .set_num_inputs(2U)
 .set_num_outputs(1U)
 .set_attr<nnvm::FListInputNames>("FListInputNames",

--- a/src/operator/numpy/np_matmul_op.cu
+++ b/src/operator/numpy/np_matmul_op.cu
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.ø
+ */
+
+/*!
+ * \file np_matmul_op.cu
+ * \brief GPU Implementation of numpy-compatible matmul
+ */
+
+#include "np_matmul_op-inl.h"
+namespace mxnet {
+namespace op {
+
+NNVM_REGISTER_OP(_npi_matmul)
+.set_attr<FCompute>("FCompute<gpu>", NumpyMatmulForward<gpu>);
+
+NNVM_REGISTER_OP(_backward_np_matmul)
+.set_attr<FCompute>("FCompute<gpu>", NumpyMatmulBackward<gpu>);
+
+}  // namespace op
+}  // namespace mxnet

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -1572,6 +1572,103 @@ def _add_workload_vdot():
     OpArgMngr.add_workload('vdot', np.random.normal(size=(2, 4)).astype(np.float64), np.random.normal(size=(2, 4)).astype(np.float64))
 
 
+def _add_workload_matmul():
+    OpArgMngr.add_workload('matmul', np.random.normal(size=(2, 4)), np.random.normal(size=(4, 2)))
+    dtype = [np.float32, np.float64]
+    def test_shapes():
+        dims = [((1, 1), (2, 1, 1)),     # broadcast first argument
+                ((2, 1, 1), (1, 1)),     # broadcast second argument
+                ((2, 1, 1), (2, 1, 1)),  # matrix stack sizes match
+                ]
+        for dt, (dm1, dm2) in itertools.product(dtype, dims):
+            a = np.ones(dm1, dtype=dt)
+            b = np.ones(dm2, dtype=dt)
+            OpArgMngr.add_workload('matmul', a, b)
+        # vector vector returns scalars.
+        for dt in dtype:
+            a = np.ones((2,), dtype=dt)
+            b = np.ones((2,), dtype=dt)
+            OpArgMngr.add_workload('matmul', a, b)
+    
+    def test_result_types():
+        mat = np.ones((1,1))
+        vec = np.ones((1,))
+        for dt in dtype:
+            m = mat.astype(dt)
+            v = vec.astype(dt)
+            for arg in [(m, v), (v, m), (m, m)]:
+                OpArgMngr.add_workload('matmul', *arg)
+    
+    def test_scalar_output():
+        vec1 = np.array([2])
+        vec2 = np.array([3, 4]).reshape(1, -1)
+        for dt in dtype:
+            v1 = vec1.astype(dt)
+            v2 = vec2.astype(dt)
+            OpArgMngr.add_workload('matmul', v1, v2)
+            OpArgMngr.add_workload('matmul', v2.T, v1)
+    
+    def test_vector_vector_values():
+        vec1 = np.array([1, 2])
+        vec2 = np.array([3, 4]).reshape(-1, 1)
+        for dt in dtype:
+            v1 = vec1.astype(dt)
+            v2 = vec2.astype(dt)
+            OpArgMngr.add_workload('matmul', v1, v2)
+            # no broadcast, we must make v1 into a 2d ndarray
+            OpArgMngr.add_workload('matmul', v2, v1.reshape(1, -1))
+
+    def test_vector_matrix_values():
+        vec = np.array([1, 2])
+        mat1 = np.array([[1, 2], [3, 4]])
+        mat2 = np.stack([mat1]*2, axis=0)
+        for dt in dtype:
+            v = vec.astype(dt)
+            m1 = mat1.astype(dt)
+            m2 = mat2.astype(dt)
+            OpArgMngr.add_workload('matmul', v, m1)
+            OpArgMngr.add_workload('matmul', v, m2)
+
+    def test_matrix_vector_values():
+        vec = np.array([1, 2])
+        mat1 = np.array([[1, 2], [3, 4]])
+        mat2 = np.stack([mat1]*2, axis=0)
+        for dt in dtype:
+            v = vec.astype(dt)
+            m1 = mat1.astype(dt)
+            m2 = mat2.astype(dt)
+            OpArgMngr.add_workload('matmul', m1, v)
+            OpArgMngr.add_workload('matmul', m2, v)
+    
+    def test_matrix_matrix_values():
+        mat1 = np.array([[1, 2], [3, 4]])
+        mat2 = np.array([[1, 0], [1, 1]])
+        mat12 = np.stack([mat1, mat2], axis=0)
+        mat21 = np.stack([mat2, mat1], axis=0)
+        for dt in dtype:
+            m1 = mat1.astype(dt)
+            m2 = mat2.astype(dt)
+            m12 = mat12.astype(dt)
+            m21 = mat21.astype(dt)
+            # matrix @ matrix
+            OpArgMngr.add_workload('matmul', m1, m2)
+            OpArgMngr.add_workload('matmul', m2, m1)
+            # stacked @ matrix
+            OpArgMngr.add_workload('matmul', m12, m1)
+            # matrix @ stacked
+            OpArgMngr.add_workload('matmul', m1, m12)
+            # stacked @ stacked
+            OpArgMngr.add_workload('matmul', m12, m21)
+
+    test_shapes()
+    test_result_types()
+    test_scalar_output()
+    test_vector_vector_values()
+    test_vector_matrix_values()
+    test_matrix_vector_values()
+    test_matrix_matrix_values()
+
+
 def _add_workload_vstack(array_pool):
     OpArgMngr.add_workload('vstack', (array_pool['4x1'], np.random.uniform(size=(5, 1))))
     OpArgMngr.add_workload('vstack', array_pool['4x1'])
@@ -1846,6 +1943,7 @@ def _prepare_workloads():
     _add_workload_diagonal()
     _add_workload_diagflat()
     _add_workload_dot()
+    _add_workload_matmul()
     _add_workload_expand_dims()
     _add_workload_fix()
     _add_workload_flip()

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -431,9 +431,6 @@ def test_np_matmul():
             return F.np.matmul(a, b)
 
     def matmul_backward(a, b):
-        if (a.ndim < 1) or (b.ndim < 1):
-            raise ValueError('An input is zero-dim')
-
         def ShapeInfer(mat_a, mat_b):
             if mat_a.ndim == 1:
                 mat_a = mat_a.reshape((1, mat_a.size))

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -422,6 +422,143 @@ def test_np_outer():
 
 @with_seed()
 @use_np
+def test_np_matmul():
+    class TestMatmul(HybridBlock):
+        def __init__(self):
+            super(TestMatmul, self).__init__()
+
+        def hybrid_forward(self, F, a, b):
+            return F.np.matmul(a, b)
+
+    def matmul_backward(a, b):
+        if (a.ndim < 1) or (b.ndim < 1):
+            raise ValueError('An input is zero-dim')
+
+        def ShapeInfer(mat_a, mat_b):
+            if mat_a.ndim == 1:
+                mat_a = mat_a.reshape((1, mat_a.size))
+            if mat_b.ndim == 1:
+                mat_b = mat_b.reshape((mat_b.size, 1))
+            ndim = max(mat_a.ndim, mat_b.ndim)
+            newshape_a = list(_np.array(mat_a, ndmin=ndim).shape)
+            newshape_b = list(_np.array(mat_b, ndmin=ndim).shape)
+            if ndim >= 3:
+                pre_shape = _np.fmax(newshape_a[ndim - 3::-1], newshape_b[ndim - 3::-1])
+                newshape_a[ndim - 3::-1] = pre_shape
+                newshape_b[ndim - 3::-1] = pre_shape
+            else:
+                pre_shape = _np.array([])
+            out_shape = _np.append(pre_shape[::-1].astype(_np.int64), [newshape_a[ndim - 2], newshape_b[ndim - 1]])
+            return [ndim, newshape_a, newshape_b, out_shape]
+
+        def ShapeReduce(mat, shape, is_b=False):
+            ndim = mat.ndim
+            if is_b and len(shape) == 1:
+                rng = _np.arange(ndim - 2)
+            else:
+                pre_len = ndim - len(shape)
+                in_pre = _np.array(mat.shape[pre_len : ndim - 2])
+                out_pre = _np.array(shape[:len(shape) - 2])
+                diff = _np.nonzero(in_pre != out_pre)[0] + pre_len
+                rng = _np.append(_np.arange(ndim - len(shape)), diff)
+            mat = _np.sum(mat, axis=tuple(rng))
+            return mat.reshape(shape)
+
+        a_shape = a.shape
+        b_shape = b.shape
+        [ndim, newshape_a, newshape_b, out_shape] = ShapeInfer(a, b)
+        new_a = _np.broadcast_to(a, newshape_a)
+        if len(b_shape) == 1:
+            new_b = _np.broadcast_to(b.reshape((b.size, 1)), newshape_b)
+        else:
+            new_b = _np.broadcast_to(b, newshape_b)
+        
+        ad1 = new_a.shape[ndim - 2]
+        ad2 = new_a.shape[ndim - 1]
+        bd1 = new_b.shape[ndim - 2]
+        bd2 = new_b.shape[ndim - 1]
+        a_T = _np.moveaxis(new_a, [ndim - 2, ndim - 1], [ndim - 1, ndim - 2])
+        b_T = _np.moveaxis(new_b, [ndim - 2, ndim - 1], [ndim - 1, ndim - 2])
+        out_grad = _np.ones(out_shape)
+        grad_b = _np.matmul(a_T, out_grad)
+        grad_b = ShapeReduce(grad_b, b_shape, is_b=True)
+        grad_a = _np.matmul(out_grad, b_T)
+        grad_a = ShapeReduce(grad_a, a_shape)
+        return [grad_a, grad_b]
+
+    shapes = [
+        ((3,), (3,)),               # Case 1
+        ((3, 4), (4, 5)),           # Case 2
+        ((3, 0), (0, 4)),           # Case 2
+        ((4, 5), (5,)),             # Case 3
+        ((3, 4, 5), (5,)),          # Case 3
+        ((5,), (5, 2)),             # Case 4
+        ((2,), (4, 2, 3)),          # Case 4
+        ((2, 1, 3, 4, 5), (5, 2)),  # Case 5
+        ((1, 3, 5, 4), (1, 4, 3)),  # Case 5
+        ((3, 5, 4), (2, 1, 4, 3)),  # Case 5
+        ((3, 4), (1, 5, 4, 3)),        # Case 5
+    ]
+
+    dtypes = ['float32', 'float64']
+    eps = 1E-4
+    for dtype in dtypes:
+        for hybridize in [True, False]:
+            for shape_a, shape_b in shapes:
+                for grad_req_a in ['write', 'add']:
+                    for grad_req_b in ['write', 'add']:
+                        test_matmul = TestMatmul()
+                        if hybridize:
+                            test_matmul.hybridize()
+
+                        np_a = _np.random.uniform(-1.0, 1.0, shape_a).astype(dtype)
+                        np_a[abs(np_a) < eps] = 2 * eps
+                        np_b = _np.random.uniform(-1.0, 1.0, shape_b).astype(dtype)
+                        np_b[abs(np_b) < eps] = 2 * eps
+                        a = mx.np.array(np_a, dtype=dtype)
+                        a.attach_grad(grad_req=grad_req_a)
+                        b = mx.np.array(np_b, dtype=dtype)
+                        b.attach_grad(grad_req=grad_req_b)
+
+                        np_out = _np.matmul(np_a, np_b)
+                        with mx.autograd.record():
+                            mx_out = test_matmul(a, b)
+                        assert mx_out.shape == np_out.shape
+                        assert_almost_equal(np_out, mx_out.asnumpy(), rtol=eps, atol=eps)
+                        mx_out.backward()
+                        np_backward = matmul_backward(np_a, np_b)
+                        assert_almost_equal(b.grad.asnumpy(), np_backward[1], rtol = eps, atol=eps)
+                        assert_almost_equal(a.grad.asnumpy(), np_backward[0], rtol = eps, atol=eps)
+                        
+                        # Test imperative once again
+                        mx_out = np.matmul(a, b)
+                        np_out = _np.matmul(np_a, np_b)
+                        assert_almost_equal(mx_out.asnumpy(), np_out, rtol=eps, atol=eps)
+
+    bad_shapes = [
+                ((1,), (2,)),            # mismatched vector vector
+                ((2, 1,), (2,)),         # mismatched matrix vector
+                ((2,), (1, 2)),          # mismatched vector matrix
+                ((1, 2), (3, 1)),        # mismatched matrix matrix
+                ((1,), ()),              # vector scalar
+                ((), (1,)),              # scalar vector
+                ((1, 1), ()),            # matrix scalar
+                ((), (1, 1)),            # scalar matrix
+                ((2, 2, 1), (3, 1, 2)),  # cannot broadcast
+                ]
+
+    for shape_a, shape_b in bad_shapes:
+        a = mx.nd.array(random.random()) if len(shape_a) == 0 else rand_ndarray(shape_a)
+        b = mx.nd.array(random.random()) if len(shape_b) == 0 else rand_ndarray(shape_b)
+        try:
+            mx_res = np.matmul(a.as_np_ndarray(), b.as_np_ndarray())
+        except mx.base.MXNetError:
+            continue
+        assert False
+
+
+@with_seed()
+@use_np
 def test_np_sum():
     class TestSum(HybridBlock):
         def __init__(self, axis=None, dtype=None, keepdims=False):

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -510,7 +510,6 @@ def test_np_matmul():
                         test_matmul = TestMatmul()
                         if hybridize:
                             test_matmul.hybridize()
-
                         np_a = _np.random.uniform(-1.0, 1.0, shape_a).astype(dtype)
                         np_a[abs(np_a) < eps] = 2 * eps
                         np_b = _np.random.uniform(-1.0, 1.0, shape_b).astype(dtype)
@@ -527,8 +526,8 @@ def test_np_matmul():
                         assert_almost_equal(np_out, mx_out.asnumpy(), rtol=eps, atol=eps)
                         mx_out.backward()
                         np_backward = matmul_backward(np_a, np_b)
-                        assert_almost_equal(b.grad.asnumpy(), np_backward[1], rtol = eps, atol=eps)
                         assert_almost_equal(a.grad.asnumpy(), np_backward[0], rtol = eps, atol=eps)
+                        assert_almost_equal(b.grad.asnumpy(), np_backward[1], rtol = eps, atol=eps)
                         
                         # Test imperative once again
                         mx_out = np.matmul(a, b)


### PR DESCRIPTION
## Description ##
unary op: matmul
Because matmul has a special signature (i.e. (n?,k),(k,m?)->(n?,m?)) in official numpy, I comment out the following  code segment in python/mxnet/numpy/multiarray.py :
if ufunc.signature is not None:
                # we don't support generalised-ufuncs (gufuncs)
                return NotImplemented

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
