### PR TITLE
Fix desired precision for test_ndarray.py:test_reduce

### DIFF
--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -601,7 +601,7 @@ def test_reduce():
     def test_reduce_inner(numpy_reduce_func, nd_reduce_func, multi_axes,
                           allow_almost_equal=False, check_dtype=True):
         dtypes = [(np.float16, 1),
-                  (np.float32, 5),
+                  (np.float32, 4),
                   (np.double, 6)]
         for i in range(sample_num):
             dtype, decimal = random.choice(dtypes)


### PR DESCRIPTION
## Description ##
Hi, there.
I change the testing precision for test_ndarray.py:test_reduce, to make the CI happy.
I have tested it for more than 900 times.

Related Test: http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/master/1349/pipeline

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] tiny change. The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Change the testing precision for test_ndarray.py:test_reduce

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
