### PR TITLE
Fix crashing on Windows in ObjectPool ~ctor

### DIFF
--- a/src/common/object_pool.h
+++ b/src/common/object_pool.h
@@ -133,7 +133,11 @@ struct ObjectPoolAllocatable {
 template <typename T>
 ObjectPool<T>::~ObjectPool() {
   for (auto i : allocated_) {
+#ifdef _MSC_VER
+    _aligned_free(i);
+#else
     free(i);
+#endif
   }
 }
 


### PR DESCRIPTION
## Description ##
Hi, there.
With unknown reason, @dmitry-markeshov may delete his Github account. The PR #16941 disapears.

I recover his PR and keep his name in the commit.
In the PR, the bug of memory-free has been addressed. `_aligned_free` should be matched with `_aligned_alloc`, which is called in https://github.com/apache/incubator-mxnet/blob/5823ce64bfec97cdfa0a781253795a6945d469f3/src/common/object_pool.h#L189-L191

_aligned_free: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/aligned-free?view=vs-2019

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Feature1, tests, (and when applicable, API doc)
- [x] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
