### PR TITLE
[BUGFIX] Fix race condition in kvstore.pushpull

### DIFF
--- a/src/kvstore/kvstore_dist_server.h
+++ b/src/kvstore/kvstore_dist_server.h
@@ -371,7 +371,7 @@ class KVStoreDistServer {
        */
       bool has_pull = false;
       for (const auto& req : update_buf->request) {
-        has_pull = has_pull || update_buf->request[0].pull;
+        has_pull = has_pull || req.pull;
       }
       if (has_pull) {
         // if there is a pull request, perform WaitToRead() once before DefaultStorageResponse

--- a/tests/nightly/dist_device_sync_kvstore.py
+++ b/tests/nightly/dist_device_sync_kvstore.py
@@ -44,7 +44,10 @@ kv = mx.kv.create('dist_device_sync')
 def init_kv():
     # init kv dns keys
     kv.init(keys, [mx.nd.ones(shape)] * len(keys))
+    kv.init('9', mx.nd.ones(shape))
+    kv.init('10', mx.nd.ones(shape))
     kv.init('99', mx.nd.ones(big_shape))
+    kv.init('100', mx.nd.ones(big_shape))
     # worker info
     my_rank = kv.rank
     nworker = kv.num_workers
@@ -55,33 +58,30 @@ def init_kv():
 def test_sync_push_pull():
     kv, my_rank, nworker = init_kv()
     num_gpus = 2
-    def check_default_keys(kv, my_rank, nworker, nrepeat=3, offset=0, use_pushpull=False):
+    def check_default_keys(kv, my_rank, nworker, nrepeat=3):
         # checks pull after push in loop, because behavior during
         # consecutive pushes doesn't offer any guarantees
-        for i in range(offset, nrepeat):
+        for i in range(nrepeat):
             scale = my_rank + 1
             num = (nworker + 1) * nworker * rate * num_gpus / 2 * (i + 1) + 1
 
-            arr = [mx.nd.ones(shape, ctx=mx.gpu(j)) * scale for j in range(num_gpus)]
+            arr = [mx.nd.ones(shape, ctx=mx.cpu(j)) * scale for j in range(num_gpus)]
             val = mx.nd.zeros(shape)
-            if use_pushpull:
-                kv.pushpull('3', arr, out=val)
-            else:
-                kv.push('3', arr)
-                kv.pull('3', out=val)
+            kv.push('9', arr)
+            kv.pull('9', out=val)
+            check_diff_to_scalar(val, num)
+            kv.pushpull('10', arr, out=val)
             check_diff_to_scalar(val, num)
 
-            big_arr = [mx.nd.ones(big_shape, ctx=mx.gpu(j)) * scale for j in range(num_gpus)]
+            big_arr = [mx.nd.ones(big_shape, ctx=mx.cpu(j)) * scale for j in range(num_gpus)]
             big_val = mx.nd.zeros(big_shape)
-            if use_pushpull:
-                kv.pushpull('99', big_arr, out=big_val)
-            else:
-                kv.push('99', big_arr)
-                kv.pull('99', out=big_val)
+            kv.push('99', big_arr)
+            kv.pull('99', out=big_val)
+            check_diff_to_scalar(big_val, num)
+            kv.pushpull('100', big_arr, out=big_val)
             check_diff_to_scalar(big_val, num)
 
-    check_default_keys(kv, my_rank, nworker, nrepeat=3, offset=0, use_pushpull=False)
-    check_default_keys(kv, my_rank, nworker, nrepeat=3, offset=3, use_pushpull=True)
+    check_default_keys(kv, my_rank, nworker, nrepeat=3)
     print('worker ' + str(my_rank) + ' is done')
 
 def test_sync_init():
@@ -106,10 +106,12 @@ def test_gluon_trainer_type():
         x = params.get('x', shape=(10,1), lr_mult=1.0)
         params.initialize(ctx=[mx.cpu(0), mx.cpu(1)], init='zeros')
         try:
-            trainer = mx.gluon.Trainer(params, 'sgd', {'learning_rate': 0.1}, kvstore=kv, update_on_kvstore=update_on_kv)
+            trainer = mx.gluon.Trainer(params, 'sgd', {'learning_rate': 0.1},
+                                       kvstore=kv, update_on_kvstore=update_on_kv)
             trainer._init_kvstore()
             assert trainer._kv_initialized
-            assert trainer._update_on_kvstore is True
+            if trainer._update_on_kvstore is not None:
+                assert trainer._update_on_kvstore is update_on_kv
         except ValueError:
             assert update_on_kv is False
 
@@ -122,3 +124,4 @@ def test_gluon_trainer_type():
 if __name__ == "__main__":
     test_sync_init()
     test_sync_push_pull()
+    test_gluon_trainer_type()

--- a/tests/nightly/dist_device_sync_kvstore.py
+++ b/tests/nightly/dist_device_sync_kvstore.py
@@ -110,7 +110,7 @@ def test_gluon_trainer_type():
                                        kvstore=kv, update_on_kvstore=update_on_kv)
             trainer._init_kvstore()
             assert trainer._kv_initialized
-            if trainer._update_on_kvstore is not None:
+            if update_on_kv is not None:
                 assert trainer._update_on_kvstore is update_on_kv
         except ValueError:
             assert update_on_kv is False

--- a/tests/nightly/dist_device_sync_kvstore.py
+++ b/tests/nightly/dist_device_sync_kvstore.py
@@ -65,7 +65,7 @@ def test_sync_push_pull():
             scale = my_rank + 1
             num = (nworker + 1) * nworker * rate * num_gpus / 2 * (i + 1) + 1
 
-            arr = [mx.nd.ones(shape, ctx=mx.cpu(j)) * scale for j in range(num_gpus)]
+            arr = [mx.nd.ones(shape, ctx=mx.gpu(j)) * scale for j in range(num_gpus)]
             val = mx.nd.zeros(shape)
             kv.push('9', arr)
             kv.pull('9', out=val)
@@ -73,7 +73,7 @@ def test_sync_push_pull():
             kv.pushpull('10', arr, out=val)
             check_diff_to_scalar(val, num)
 
-            big_arr = [mx.nd.ones(big_shape, ctx=mx.cpu(j)) * scale for j in range(num_gpus)]
+            big_arr = [mx.nd.ones(big_shape, ctx=mx.gpu(j)) * scale for j in range(num_gpus)]
             big_val = mx.nd.zeros(big_shape)
             kv.push('99', big_arr)
             kv.pull('99', out=big_val)


### PR DESCRIPTION
## Description ##
There was a race condition in the previous implementation for the `pushpull` API. We have to add `stored.WaitToRead()` before sending it back to workers. 
@anandj91 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ x To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
