### PR TITLE
[Numpy] support boolean indexing

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -110,6 +110,8 @@ _GRAD_REQ_MAP = {
 _NDARRAY_UNSUPPORTED_INDEXING = -1
 _NDARRAY_BASIC_INDEXING = 0
 _NDARRAY_ADVANCED_INDEXING = 1
+_NDARRAY_EMPTY_TUPLE_INDEXING = 2
+_NDARRAY_BOOLEAN_INDEXING = 3
 
 # Caching whether MXNet was built with INT64 support or not
 _INT64_TENSOR_SIZE_ENABLED = None
@@ -2951,7 +2953,6 @@ def indexing_key_expand_implicit_axes(key, shape):
     """
     if not isinstance(key, tuple):
         key = (key,)
-
     # We need to loop explicitly since tuple functions like `index()` or
     # `count()` use `==` internally, which doesn't play well with fancy
     # indexing.
@@ -2968,7 +2969,12 @@ def indexing_key_expand_implicit_axes(key, shape):
         else:
             if idx is None:
                 num_none += 1
-            nonell_key.append(idx)
+            if isinstance(idx, NDArrayBase) and idx.ndim == 0 and idx.dtype != np.bool_:
+                # This handles ndarray of zero dim. e.g array(1)
+                # while advoid converting zero dim boolean array
+                nonell_key.append(idx.item())
+            else:
+                nonell_key.append(idx)
 
     nonell_key = tuple(nonell_key)
 
@@ -3040,23 +3046,32 @@ def _is_advanced_index(idx):
 def get_indexing_dispatch_code(key):
     """Returns a dispatch code for calling basic or advanced indexing functions."""
     assert isinstance(key, tuple)
+    num_bools = 0
+    basic_indexing = True
 
     for idx in key:
         if isinstance(idx, (NDArray, np.ndarray, list, tuple)):
+            if isinstance(idx, tuple) and len(idx) == 0:
+                return _NDARRAY_EMPTY_TUPLE_INDEXING
             if getattr(idx, 'dtype', None) == np.bool_:
-                raise TypeError('ndarray indexing does not support boolean ndarray'
-                                ' in a tuple of indices. Only single boolean ndarray'
-                                ' as an index is supported.')
-            return _NDARRAY_ADVANCED_INDEXING
+                num_bools += 1
+            basic_indexing = False
         elif sys.version_info[0] > 2 and isinstance(idx, range):
-            return _NDARRAY_ADVANCED_INDEXING
+            basic_indexing = False
         elif not (isinstance(idx, (py_slice, integer_types)) or idx is None):
             raise ValueError(
                 'NDArray does not support slicing with key {} of type {}.'
                 ''.format(idx, type(idx))
             )
-
-    return _NDARRAY_BASIC_INDEXING
+    if basic_indexing and num_bools == 0:
+        return _NDARRAY_BASIC_INDEXING
+    elif not basic_indexing and num_bools == 0:
+        return _NDARRAY_ADVANCED_INDEXING
+    elif num_bools == 1:
+        return _NDARRAY_BOOLEAN_INDEXING
+    else:
+        raise TypeError('ndarray indexing does not more than one boolean ndarray'
+                        ' in a tuple of complex indices.')
 
 
 def _get_index_range(start, stop, length, step=1):

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -65,6 +65,10 @@ __all__ = ['ndarray', 'empty', 'array', 'shape', 'zeros', 'zeros_like', 'ones', 
 _NDARRAY_UNSUPPORTED_INDEXING = -1
 _NDARRAY_BASIC_INDEXING = 0
 _NDARRAY_ADVANCED_INDEXING = 1
+_NDARRAY_EMPTY_TUPLE_INDEXING = 2
+_NDARRAY_BOOLEAN_INDEXING = 3
+_NDARRAY_INT_BOOLEAN_INDEXING = 4
+_NDARRAY_SLICE_BOOLEAN_INDEXING = 5
 
 
 # This function is copied from ndarray.py since pylint
@@ -299,6 +303,19 @@ class ndarray(NDArray):
         else:
             return sliced.reshape_view(tuple(final_shape))
 
+    def _get_np_empty_tuple_indexing(self, key):
+        new_shape = []
+        num_none = 0
+        for i, idx in enumerate(key):
+            if idx is None:
+                new_shape.append(1) # expand dimension
+                num_none += 1
+            elif idx == ():
+                new_shape.append(0) # 0 shape
+            elif idx == slice(None, None, None):
+                new_shape.append(self.shape[i - num_none])
+        return empty(new_shape, dtype=self.dtype)
+
     def _get_np_advanced_indexing(self, key):
         idcs, new_axes = self._get_index_nd(key)
         if type(idcs) == NDArray:  # pylint: disable=unidiomatic-typecheck
@@ -325,6 +342,123 @@ class ndarray(NDArray):
         vshape = get_oshape_of_gather_nd_op(self.shape, idcs.shape)
         value_nd = self._prepare_value_nd(value, bcast_shape=vshape, squeeze_axes=new_axes)
         self._scatter_set_nd(value_nd, idcs)
+
+    def _check_boolean_indexing_type(self, key):
+        """Check boolean indexing type arr[bool, :, :], arr[1, bool, 4], or arr[:, bool, :]
+           return bool_type, bool_position"""
+
+        dim = len(key)
+        rest_int = True
+        rest_full_slice = True
+        pos = None
+        for idx in range(dim):
+            if isinstance(key[idx], _np.ndarray) and key[idx].dtype == _np.bool_:
+                key[idx] = array(key[idx], dtype='bool', ctx=self.ctx)
+            if isinstance(key[idx], ndarray) and key[idx].dtype == _np.bool_:
+                pos = idx
+            elif isinstance(key[idx], integer_types):
+                rest_full_slice = False
+            elif isinstance(key[idx], py_slice) and key[idx] == slice(None, None, None):
+                rest_int = False
+            # not arr[:, bool, :] format slicing or not arr[3,bool,4]
+            else:
+                raise TypeError('ndarray boolean indexing does not support slicing '
+                                'with key {} of type {}'.format(idx, type(idx))
+                                )
+
+        if rest_int:
+            return _NDARRAY_INT_BOOLEAN_INDEXING, pos
+        elif rest_full_slice:
+            return _NDARRAY_SLICE_BOOLEAN_INDEXING, pos
+        raise NotImplementedError("Do not support {} as key for boolean indexing".format(key))
+
+    @staticmethod
+    def _calculate_new_idx(key, shape, mask_pos, mask_ndim): # pylint: disable=redefined-outer-name
+        new_idx = 0
+        step = 1
+        for idx in range(len(key)-1, mask_pos, -1):
+            new_idx += key[idx]*step
+            step *= shape[idx+mask_ndim-1]
+        return new_idx
+
+    def _get_np_boolean_indexing(self, key):
+        if not isinstance(key, tuple):
+            key = (key,)
+        bool_type, pos = self._check_boolean_indexing_type(key)
+
+        from functools import reduce
+        mask_shape = key[pos].shape
+        mask_ndim = len(mask_shape)
+        ndim = len(self.shape)
+        for i in range(mask_ndim):
+            if key[pos].shape[i] != self.shape[pos + i]:
+                raise IndexError('boolean index did not match indexed array along axis {};'
+                                 ' size is {} but corresponding boolean size is {}'
+                                 .format(pos + i, self.shape[pos + i], key[pos].shape[i]))
+        remaining_idces = pos + mask_ndim
+        remaining_shapes = self.shape[remaining_idces:]
+        mask = _reshape_view(key[pos], -1)
+
+        if bool_type == _NDARRAY_SLICE_BOOLEAN_INDEXING:
+            data = _reshape_view(self, -1, *remaining_shapes)
+            # if mask is at the begining, then the scale is one
+            scale = reduce(lambda x, y: x * y, self.shape[:pos], 1)
+            keys = mask if scale == 1 else _reshape_view(_npi.stack(*[mask for i in range(scale)]), -1)
+            all_shapes = self.shape[:pos] + remaining_shapes
+            return _reshape_view(_npi.boolean_mask(data, keys), -1, *all_shapes)
+
+        elif bool_type == _NDARRAY_INT_BOOLEAN_INDEXING:
+            out = self
+            for idx in range(pos):
+                out = out[key[idx]]
+            data = _reshape_view(out, -1, *remaining_shapes)
+            after_mask = _reshape_view(_npi.boolean_mask(data, mask), -1, *remaining_shapes)
+            if pos == len(key) - 1:
+                return after_mask
+            # check boundary
+            for idx in range(pos+1, len(key)):
+                if key[idx] >= self.shape[idx+mask_ndim-1]:
+                    raise IndexError('index {} on a dimension of' # pylint: disable=too-many-format-args
+                                     .format(key[idx], self.shape[idx+mask_ndim-1]))
+            implicit_idces = len(key)+mask_ndim-1 # idces not explictly shown in the key
+            implicit_shape = self.shape[implicit_idces:]
+            new_dim = reduce(lambda x, y: x * y, self.shape[pos+mask_ndim:implicit_idces], 1)
+            new_idx = self._calculate_new_idx(key, self.shape, pos, mask_ndim)
+            after_reshape = _reshape_view(after_mask, -1, new_dim, *implicit_shape)
+            return _reshape_view(_npi.take(after_reshape, array([new_idx]), axis=1), -1, *implicit_shape)
+
+        raise NotImplementedError("This boolean indexing type is not supported.")
+
+    def _set_np_boolean_indexing(self, key, value):
+        if not isinstance(key, tuple):
+            key = (key,)
+        bool_type, pos = self._check_boolean_indexing_type(key)
+
+        mask = key[pos]
+        mask_shape = mask.shape
+        mask_ndim = len(mask_shape)
+        for i in range(mask_ndim):
+            if mask_shape[i] != self.shape[pos + i]:
+                raise IndexError('boolean index did not match indexed array along axis {};'
+                                 ' size is {} but corresponding boolean size is {}'
+                                 .format(pos + i, self.shape[pos + i], mask_shape[i]))
+
+        data = self # when bool_type == _NDARRAY_SLICE_BOOLEAN_INDEXING
+        if bool_type == _NDARRAY_INT_BOOLEAN_INDEXING:
+            if pos != len(key) - 1:
+                raise NotImplementedError('only support boolean array at the end of the idces '
+                                          'when it is mixed with integers')
+            for idx in range(pos):
+                data = data[key[idx]]
+                pos -= 1
+
+        if isinstance(value, numeric_types):
+            _npi.boolean_mask_assign_scalar(data=data, mask=mask, value=value, start_axis=pos, out=data)
+        elif isinstance(value, ndarray):
+            _npi.boolean_mask_assign_tensor(data=data, mask=mask, value=value, start_axis=pos, out=data)
+        else:
+            raise NotImplementedError('type %s is not supported.'%(type(value)))
+
 
     # pylint: disable=too-many-return-statements
     def __getitem__(self, key):
@@ -475,21 +609,6 @@ class ndarray(NDArray):
                 raise TypeError('{}'.format(str(err)))
         if isinstance(key, _np.ndarray) and key.dtype == _np.bool_:
             key = array(key, dtype='bool', ctx=self.ctx)
-        if isinstance(key, ndarray) and key.dtype == _np.bool_:  # boolean indexing
-            key_shape = key.shape
-            key_ndim = len(key_shape)
-            if ndim < key_ndim:
-                raise IndexError('too many indices, whose ndim = {}, for array with ndim = {}'
-                                 .format(key_ndim, ndim))
-            for i in range(key_ndim):
-                if key_shape[i] != shape[i]:
-                    raise IndexError('boolean index did not match indexed array along dimension {};'
-                                     ' dimension is {} but corresponding boolean dimension is {}'
-                                     .format(i, shape[i], key_shape[i]))
-            remaining_dims = shape[key_ndim:]
-            data = _reshape_view(self, -1, *remaining_dims)
-            key = _reshape_view(key, -1)
-            return _reshape_view(_npi.boolean_mask(data, key), -1, *remaining_dims)
 
         if ndim == 0:
             if key != ():
@@ -518,15 +637,21 @@ class ndarray(NDArray):
             elif key.step == 0:
                 raise ValueError("slice step cannot be zero")
 
+        key_before_expaned = key
         key = indexing_key_expand_implicit_axes(key, self.shape)
         indexing_dispatch_code = get_indexing_dispatch_code(key)
         if indexing_dispatch_code == _NDARRAY_BASIC_INDEXING:
             return self._get_np_basic_indexing(key)
+        elif indexing_dispatch_code == _NDARRAY_EMPTY_TUPLE_INDEXING:
+            return self._get_np_empty_tuple_indexing(key)
         elif indexing_dispatch_code == _NDARRAY_ADVANCED_INDEXING:
             return self._get_np_advanced_indexing(key)
+        elif indexing_dispatch_code == _NDARRAY_BOOLEAN_INDEXING:
+            return self._get_np_boolean_indexing(key_before_expaned)
         else:
             raise RuntimeError
 
+    # pylint: disable=inconsistent-return-statements
     def __setitem__(self, key, value):
         """Sets ``self[key]`` to ``value``.
 
@@ -576,7 +701,6 @@ class ndarray(NDArray):
         """
         if isinstance(value, NDArray) and not isinstance(value, ndarray):
             raise TypeError('Cannot assign mx.nd.NDArray to mxnet.numpy.ndarray')
-
         # handle basic and advanced indexing
         if self.ndim == 0:
             if not isinstance(key, tuple) or len(key) != 0:
@@ -594,6 +718,7 @@ class ndarray(NDArray):
             else:
                 raise ValueError('setting an array element with a sequence.')
         else:
+            key_before_expaned = key
             key = indexing_key_expand_implicit_axes(key, self.shape)
             slc_key = tuple(idx for idx in key if idx is not None)
             if len(slc_key) < self.ndim:
@@ -610,8 +735,12 @@ class ndarray(NDArray):
             indexing_dispatch_code = get_indexing_dispatch_code(slc_key)
             if indexing_dispatch_code == _NDARRAY_BASIC_INDEXING:
                 self._set_nd_basic_indexing(key, value)  # function is inheritated from NDArray class
+            elif indexing_dispatch_code == _NDARRAY_EMPTY_TUPLE_INDEXING:
+                pass # no action needed
             elif indexing_dispatch_code == _NDARRAY_ADVANCED_INDEXING:
                 self._set_np_advanced_indexing(key, value)
+            elif indexing_dispatch_code == _NDARRAY_BOOLEAN_INDEXING:
+                return self._set_np_boolean_indexing(key_before_expaned, value)
             else:
                 raise ValueError(
                     'Indexing NDArray with index {} of type {} is not supported'
@@ -935,6 +1064,15 @@ class ndarray(NDArray):
         if context.device_type == 'cpu' or self.ndim == 0:
             return array_str
         return '{array} @{ctx}'.format(array=array_str, ctx=context)
+
+    def __format__(self, fmt):
+        """Return value.__format__(format_spec). Overwrite to include 0-d array"""
+        if self.ndim == 0:
+            return self.item().__format__(fmt)
+        elif len(fmt) == 0:
+            return self.__str__().__format__(fmt)
+        else:
+            raise TypeError("Cannot format mxnet.numpy.ndarray with format_spec")
 
     def attach_grad(self, grad_req='write'):  # pylint: disable=arguments-differ
         """Attach a gradient buffer to this ndarray, so that `backward`

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -968,7 +968,7 @@ void SliceOpForward(const nnvm::NodeAttrs& attrs,
   MXNET_NDIM_SWITCH(data.ndim(), ndim, {
     common::StaticArray<index_t, ndim> begin, end, step;
     GetIndexRange(data.shape_, param.begin, param.end, param.step, &begin, &end, &step);
-    MSHADOW_TYPE_SWITCH(out.type_flag_, DType, {
+    MSHADOW_TYPE_SWITCH_WITH_BOOL(out.type_flag_, DType, {
       MXNET_ASSIGN_REQ_SWITCH(req[0], Req, {
         size_t num_threads = out.shape_.FlatTo2D()[0];
         if (std::is_same<xpu, gpu>::value) {
@@ -2252,7 +2252,7 @@ void StackOpForward(const nnvm::NodeAttrs& attrs,
   int axis = CheckAxis(param.axis, outputs[0].ndim());
 
   Stream<xpu> *s = ctx.get_stream<xpu>();
-  MSHADOW_TYPE_SWITCH(outputs[0].type_flag_, DType, {
+  MSHADOW_TYPE_SWITCH_WITH_BOOL(outputs[0].type_flag_, DType, {
     std::vector<Tensor<xpu, 3, DType> > data(inputs.size());
     Tensor<xpu, 3, DType> out;
     size_t leading = 1, trailing = 1;
@@ -2286,7 +2286,7 @@ void StackOpBackward(const nnvm::NodeAttrs& attrs,
   int axis = CheckAxis(param.axis, inputs[0].ndim());
 
   Stream<xpu> *s = ctx.get_stream<xpu>();
-  MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, DType, {
+  MSHADOW_TYPE_SWITCH_WITH_BOOL(inputs[0].type_flag_, DType, {
     std::vector<Tensor<xpu, 3, DType> > grad_in(outputs.size());
     Tensor<xpu, 3, DType> grad;
     size_t leading = 1, trailing = 1;


### PR DESCRIPTION
## Description ##
1. Support simple boolean indexing in __getitem__ and __setitem__

2. Use the returned value after indexing one array to index another array
```
# after 
>>> array = np.array([1,2,3,4,5], dtype = np.int32)
>>> array
array([1, 2, 3, 4, 5], dtype=int32)
>>> idxed = array[0]
>>> idxed
array(1, dtype=int32)
>>> array[idxed]
array(2, dtype=int32)
```

3. ~Enable to index 0-d array with 0~ (cancel this change)
```
>>> idxed
array(1, dtype=int32)
>>> idxed[0]
array(1, dtype=int32)
>>> idxed[()]
array(1, dtype=int32)
```

4. Enable index with empty tuple 
```
# before
>>> b.shape # (3,3,3)
>>> b[1,(),:] # get item
Traceback (most recent call last):
# after
>>> b = np.arange(81).reshape(3,3,3,3)
>>> b[:,()]
array([], shape=(3, 0, 3, 3))
>>> b[:,(),0]
array([], shape=(3, 0, 3))
>>> b[0,(),0]
array([], shape=(0, 3))
>>> b[0,(),0] = 1000 # no change
```

5.  fix: slice does not support boolean type
```
# before
>>> b
array([[False, False, False, False, False, False, False],
       [False, False, False, False, False, False, False],
       [False, False, False, False, False, False, False],
       [ True,  True,  True,  True,  True,  True,  True],
       [ True,  True,  True,  True,  True,  True,  True]])
>>> b[:,1]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/luoting/Desktop/mxnet/python/mxnet/numpy/multiarray.py", line 1056, in __repr__
    array_str = self.asnumpy().__repr__()
  File "/Users/luoting/Desktop/mxnet/python/mxnet/ndarray/ndarray.py", line 2552, in asnumpy
    ctypes.c_size_t(data.size)))
  File "/Users/luoting/Desktop/mxnet/python/mxnet/base.py", line 278, in check_call
    raise MXNetError(py_str(_LIB.MXGetLastError()))
# after
>>> b[:,1]
array([False, False,  False, True,  True])
```

6. fix: cannot print the mx.numpy scalar with format string [issue](https://github.com/apache/incubator-mxnet/issues/16745)