### PR TITLE
[Numpy] Fix axis=-1 bug in max

### DIFF
--- a/src/operator/numpy/np_broadcast_reduce_op.h
+++ b/src/operator/numpy/np_broadcast_reduce_op.h
@@ -187,7 +187,7 @@ inline bool NumpyReduceAxesNoDTypeShape(const nnvm::NodeAttrs& attrs,
   if (param.axis.has_value()) {
     const mxnet::Tuple<int>& axes = param.axis.value();
     for (int i = 0; i < axes.ndim(); ++i) {
-      if (ishape[axes[i]] == 0) {
+      if ((axes[i] >= 0) && (ishape[axes[i]] == 0)) {
         is_all_reducded_axes_not_zero = false;
         break;
       }

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -531,7 +531,7 @@ def test_np_max_min():
             elif axis == 2:
                 temp[:,:,index,:] = 1
                 return temp
-            elif axis == 3:
+            elif (axis == 3 or axis == -1):
                 temp[:,:,:,index] = 1
                 return temp
             elif not axis:
@@ -549,7 +549,7 @@ def test_np_max_min():
     for func in ['max', 'min']:
         for hybridize in [False, True]:
             for keepdims in [True, False]:
-                for axis in ([i for i in range(in_data_dim)] + [(), None]):
+                for axis in ([i for i in range(in_data_dim)] + [(), None] + [-1]):
                     for itype in ['float16', 'float32', 'float64', 'int']:
                         # test gluon
                         if func == 'max':


### PR DESCRIPTION
## Description ##
Fix
https://github.com/apache/incubator-mxnet/issues/17011

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
