### PR TITLE
Workaround problem with fusion in CUDA 9

### DIFF
--- a/src/operator/fusion/fused_op.cu
+++ b/src/operator/fusion/fused_op.cu
@@ -594,13 +594,12 @@ CUfunction FusedOp::CompileCode(const std::string &code,
 
     std::string gpu_arch_arg = "--gpu-architecture=compute_" + std::to_string(sm_arch);
     const char *opts[] = {gpu_arch_arg.c_str(),
-                          "--std=c++11",
-                          "-default-device"};
+                          "--std=c++11"};
     const std::string kernel_name_demangled = "FusedKernel_" + kernel_name;
     NVRTC_CALL(nvrtcAddNameExpression(program, (kernel_name_demangled).c_str()));
 
     nvrtcResult compileResult = nvrtcCompileProgram(program,  // prog
-                                                    3,        // num options
+                                                    2,        // num options
                                                     opts);    // options
     CHECK_EQ(compileResult, NVRTC_SUCCESS)
         << "NVRTC Compilation failed. Please set environment variable MXNET_USE_FUSION to 0.\n"


### PR DESCRIPTION
## Description ##
Fixes #17020 

The problem comes from the bug in how NVRTC in CUDA 9 handles the `default-device` flag. That flag is supposed to mark all the functions in the file as `__device__` functions, but it should leave the functions decorated differently (like kernels decorated with `__global__`) alone. This is the behavior in CUDA 10+. In CUDA 9, however, this `__device__` attribute is applied to every function (including kernels), which is incompatible with `__launch_bounds__()` attribute that we use for kernels.

This PR removes the usage of `default-device` flag for NVRTC compilation and instead manually decorates all the required functions as `__device__`