### PR TITLE
Fix omp fork race conditions and assert issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ if(USE_TENSORRT)
 endif()
 
 # please note that when you enable this, you might run into an linker not being able to work properly due to large code injection.
-# you can find more information here https://github.com/apache/incubator-mxnet/issues/15971 
+# you can find more information here https://github.com/apache/incubator-mxnet/issues/15971
 if(ENABLE_TESTCOVERAGE)
   message(STATUS "Compiling with test coverage support enabled. This will result in additional files being written to your source directory!")
   find_program( GCOV_PATH gcov )
@@ -445,6 +445,15 @@ endif()
 
 # ---[ OpenMP
 if(USE_OPENMP)
+
+  function(load_omp)
+    # Intel/llvm OpenMP: https://github.com/llvm-mirror/openmp
+    set(OPENMP_STANDALONE_BUILD TRUE)
+    set(LIBOMP_ENABLE_SHARED TRUE)
+    set(CMAKE_BUILD_TYPE Release)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/openmp)
+  endfunction()
+
   find_package(OpenMP REQUIRED)
   # This should build on Windows, but there's some problem and I don't have a Windows box, so
   # could a Windows user please fix?
@@ -452,11 +461,7 @@ if(USE_OPENMP)
      AND SYSTEM_ARCHITECTURE STREQUAL "x86_64"
      AND NOT MSVC
      AND NOT CMAKE_CROSSCOMPILING)
-
-    # Intel/llvm OpenMP: https://github.com/llvm-mirror/openmp
-    set(OPENMP_STANDALONE_BUILD TRUE)
-    set(LIBOMP_ENABLE_SHARED TRUE)
-    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/openmp)
+    load_omp()
     list(REMOVE_ITEM mxnet_LINKER_LIBS iomp5)
     list(APPEND mxnet_LINKER_LIBS omp)
     if(UNIX)

--- a/src/engine/openmp.cc
+++ b/src/engine/openmp.cc
@@ -41,6 +41,7 @@ OpenMP *OpenMP::Get() {
 OpenMP::OpenMP()
   : omp_num_threads_set_in_environment_(is_env_set("OMP_NUM_THREADS")) {
 #ifdef _OPENMP
+  initialize_process();
   const int max = dmlc::GetEnv("MXNET_OMP_MAX_THREADS", INT_MIN);
   if (max != INT_MIN) {
     omp_thread_max_ = max;
@@ -58,6 +59,12 @@ OpenMP::OpenMP()
 #else
   enabled_ = false;
   omp_thread_max_ = 1;
+#endif
+}
+
+void OpenMP:: initialize_process() {
+#ifdef _OPENMP
+  omp_get_num_procs();  // will force OpenMP to be initialized
 #endif
 }
 

--- a/src/engine/openmp.h
+++ b/src/engine/openmp.h
@@ -75,6 +75,13 @@ class OpenMP {
   void on_start_worker_thread(bool use_omp);
 
   /*!
+   * \brief Initialize a new process to use omp (after a fork,
+   *        in case you're starting threads in the atfork() that may interfere
+   *        with the initialization. Can serialize the init with this first.
+   */
+  void initialize_process();
+
+  /*!
    * \brief Get the OpenMP object's singleton pointer
    * \return Singleton OpenMP object pointer
    */

--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -209,6 +209,7 @@ void LibraryInitializer::atfork_child() {
 #if MXNET_USE_OPENCV && !__APPLE__
   cv::setNumThreads(mp_cv_num_threads_);
 #endif  // MXNET_USE_OPENCV
+  engine::OpenMP::Get()->initialize_process();
   engine::OpenMP::Get()->set_thread_max(1);
   engine::OpenMP::Get()->set_enabled(false);
   Engine::Get()->Start();
@@ -218,6 +219,7 @@ void LibraryInitializer::atfork_child() {
 
 void LibraryInitializer::install_pthread_atfork_handlers() {
 #ifndef _WIN32
+  engine::OpenMP::Get()->initialize_process();  // force omp to set its atfork handler first
   pthread_atfork(pthread_atfork_prepare, pthread_atfork_parent, pthread_atfork_child);
 #endif
 }


### PR DESCRIPTION
## Description ##
Fix for: https://github.com/apache/incubator-mxnet/issues/14979

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ X] Changes are complete (i.e. I finished coding on this PR)
- [X ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##

* When forking, sometimes mxnet can hook its fork handler before openmp's, depending upon static startup order as well as variables such as whether OMP_NUM_THREADS is set.  This is mitigated by forcing an OMP call before mxnet hooks a fork handler as well as first-thing after forking as the child.  This avoids two scenarios:
  1) An OMP API call by mxnet before openmp's child fork handler has run, reinitializing its state to the new process
  2) Starting a thread which may call an OpenMP API call (or open a parallel region) before or **during** OMP library's child fork handler.

* A considerable amount of multithreading is done by mxnext both during static init as ell as in atfork() handlers, and we may wish to change this over time.  Due to the non-deterministic startup order of static init (and thus sometimes fork handling), it can cause unpredictable results.

* Build omp in release mode to stop harmless assert.  Comment notes that assert is harmless and represents a variable that fails to get set to null in their atfork_child handler (they set other similar variables to to null). The variable is set to NULL in the next line of code.

