### PR TITLE
fix parameter names in the estimator api

### DIFF
--- a/python/mxnet/gluon/contrib/estimator/batch_processor.py
+++ b/python/mxnet/gluon/contrib/estimator/batch_processor.py
@@ -61,8 +61,8 @@ class BatchProcessor(object):
             Batch axis to split the validation data into devices.
         """
         data, label = self._get_data_and_label(val_batch, estimator.context, batch_axis)
-        pred = [estimator.eval_net(x) for x in data]
-        loss = [estimator.evaluation_loss(y_hat, y) for y_hat, y in zip(pred, label)]
+        pred = [estimator.val_net(x) for x in data]
+        loss = [estimator.val_loss(y_hat, y) for y_hat, y in zip(pred, label)]
 
         return data, label, pred, loss
 

--- a/python/mxnet/gluon/contrib/estimator/estimator.py
+++ b/python/mxnet/gluon/contrib/estimator/estimator.py
@@ -61,22 +61,19 @@ class Estimator(object):
         Trainer to apply optimizer on network parameters.
     context : Context or list of Context
         Device(s) to run the training on.
-    evaluation_loss : gluon.loss.loss
-        Loss (objective) function to calculate during validation. If set evaluation_loss
-        None, it will use the same loss function as self.loss
-    eval_net : gluon.Block
+    val_net : gluon.Block
         The model used for validation. The validation model does not necessarily belong to
         the same model class as the training model. But the two models typically share the
         same architecture. Therefore the validation model can reuse parameters of the
         training model.
 
-        The code example of consruction of eval_net sharing the same network parameters as
+        The code example of consruction of val_net sharing the same network parameters as
         the training net is given below:
 
         >>> net = _get_train_network()
-        >>> eval_net = _get_test_network(params=net.collect_params())
+        >>> val_net = _get_test_network(params=net.collect_params())
         >>> net.initialize(ctx=ctx)
-        >>> est = Estimator(net, loss, eval_net=eval_net)
+        >>> est = Estimator(net, loss, val_net=val_net)
 
         Proper namespace match is required for weight sharing between two networks. Most networks
         inheriting :py:class:`Block` can share their parameters correctly. An exception is
@@ -84,6 +81,9 @@ class Estimator(object):
         the  naming in mxnet Gluon API, please refer to the site
         (https://mxnet.apache.org/api/python/docs/tutorials/packages/gluon/blocks/naming.html)
         for future information.
+    val_loss : gluon.loss.loss
+        Loss (objective) function to calculate during validation. If set val_loss
+        None, it will use the same loss function as self.loss
     batch_processor: BatchProcessor
         BatchProcessor provides customized fit_batch() and evaluate_batch() methods
     """
@@ -113,8 +113,8 @@ class Estimator(object):
                  initializer=None,
                  trainer=None,
                  context=None,
-                 evaluation_loss=None,
-                 eval_net=None,
+                 val_net=None,
+                 val_loss=None,
                  batch_processor=None):
         self.net = net
         self.loss = self._check_loss(loss)
@@ -122,12 +122,12 @@ class Estimator(object):
         self._val_metrics = _check_metrics(val_metrics)
         self._add_default_training_metrics()
         self._add_validation_metrics()
-        self.evaluation_loss = self.loss
-        if evaluation_loss is not None:
-            self.evaluation_loss = self._check_loss(evaluation_loss)
-        self.eval_net = self.net
-        if eval_net is not None:
-            self.eval_net = eval_net
+        self.val_loss = self.loss
+        if val_loss is not None:
+            self.val_loss = self._check_loss(val_loss)
+        self.val_net = self.net
+        if val_net is not None:
+            self.val_net = val_net
 
         self.logger = logging.Logger(name='Estimator', level=logging.INFO)
         self.logger.addHandler(logging.StreamHandler(sys.stdout))

--- a/tests/python/unittest/test_gluon_batch_processor.py
+++ b/tests/python/unittest/test_gluon_batch_processor.py
@@ -84,7 +84,7 @@ def test_batch_processor_validation():
     ctx = mx.cpu()
     loss = gluon.loss.L2Loss()
     acc = mx.metric.Accuracy()
-    evaluation_loss = gluon.loss.L1Loss()
+    val_loss = gluon.loss.L1Loss()
     net.initialize(ctx=ctx)
     processor = BatchProcessor()
     trainer = gluon.Trainer(net.collect_params(), 'sgd', {'learning_rate': 0.001})
@@ -93,7 +93,7 @@ def test_batch_processor_validation():
                     train_metrics=acc,
                     trainer=trainer,
                     context=ctx,
-                    evaluation_loss=evaluation_loss,
+                    val_loss=val_loss,
                     batch_processor=processor)
     # Input dataloader
     est.fit(train_data=dataloader,


### PR DESCRIPTION
## Description ##
This fix is to make parameter names of estimator api consistent. Previously, we have `val_metrics`, `eval_net` and `evaluation_loss` refer to the metrics, model and loss used during validation. To make the names consistent, we change these names to `val_metrics`, `val_net` and `val_loss`. So every parameter shares a common prefix of `val_` for validation.


## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

