### PR TITLE
adding stacktrace in Jenkinsfile_utils.groovy 

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -278,6 +278,7 @@ def main_wrapper(args) {
     currentBuild.result = "SUCCESS"
     update_github_commit_status('SUCCESS', 'Job succeeded')
   } catch (caughtError) {
+    println(caughtError.getStackTrace());  
     node(NODE_UTILITY) {
       echo "caught ${caughtError}"
       err = caughtError


### PR DESCRIPTION
## Description ##
to inspect cause of Python2 failure in CI (Unix CPU)
To identify root cause of : https://github.com/apache/incubator-mxnet/issues/16995

Upon Inspecting different timeout on Unix CPU in the following runs: 
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/PR-16965/12/pipeline/296 Py3 CPU Debug
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/PR-16971/8/pipeline/294 Py2 CPU
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/PR-17018/5/pipeline/294 Py2 CPU
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-cpu/detail/master/1387/pipeline/47 CPU MKLDNN / CPU_MKLDNN_MKL (build)

http://jenkins.mxnet-ci.amazon-ml.com/blue/rest/organizations/jenkins/pipelines/mxnet-validation/pipelines/unix-cpu/branches/PR-16885/runs/9/nodes/294/steps/786/log/?start=0 Py2 CPU
http://jenkins.mxnet-ci.amazon-ml.com/blue/rest/organizations/jenkins/pipelines/mxnet-validation/pipelines/unix-cpu/branches/master/runs/1371/nodes/294/steps/747/log/?start=0 Py2 CPU
http://jenkins.mxnet-ci.amazon-ml.com/blue/rest/organizations/jenkins/pipelines/mxnet-validation/pipelines/unix-cpu/branches/master/runs/1336/nodes/294/steps/796/log/?start=0 Py2 CPU
http://jenkins.mxnet-ci.amazon-ml.com/blue/rest/organizations/jenkins/pipelines/mxnet-validation/pipelines/unix-cpu/branches/master/runs/1337/nodes/294/steps/784/log/?start=0 Py2 CPU

All the tests passed when looked into the logs of Jenkin's run but it fails with message:
```
End of Pipeline
Timeout has been exceeded
Finished: ABORTED
```
you can see many files when you grep for Cancelling nested steps due to timeout, but all of them have just one line : caught "Exception name"

This PR prints the stacktrace of the exception to help identify the root cause of CI timeouts in jenkins

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
