### PR TITLE
fix for number of inputs/outputs for backward custom ops

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -265,7 +265,7 @@ int MXLoadLib(const char *path) {
                            &num_in, &num_out))
       << "Error calling ParseAttrs::num_outputs for custom operator '" << name_str << "'";
 
-      return num_in + num_out;
+      return num_in + 2*num_out;
     };
 
     // lambda function to call infer shape


### PR DESCRIPTION
## Description ##
The initial custom operator support provides all possible inputs to backward operators: inputs, outputs, and gradients. The user is responsible for compute the correct number of inputs and outputs, and the abstraction logic tells MXNet that the backward operator will have the correct number of inputs.

This fixes the problem where we dont account for the number of gradients in computing the number of inputs for a backward operator. Previously we computed: "num_inputs + num_outputs", but the correct computation should be: "num_inputs + 2*num_outputs" since there is an input gradient for each output argument of the forward operator. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
