### PR TITLE
[BugFix] fix filter channel calculation in ModulatedDeformableConvV2

### DIFF
--- a/python/mxnet/gluon/contrib/cnn/conv_layers.py
+++ b/python/mxnet/gluon/contrib/cnn/conv_layers.py
@@ -313,7 +313,7 @@ class ModulatedDeformableConvolution(HybridBlock):
                 dilation = (dilation,) * len(kernel_size)
             self._op_name = op_name
 
-            offset_channels = 27
+            offset_channels = num_deformable_group * 3 * kernel_size[0] * kernel_size[1]
             self._kwargs_offset = {
                 'kernel': kernel_size, 'stride': strides, 'dilate': dilation,
                 'pad': padding, 'num_filter': offset_channels, 'num_group': groups,

--- a/python/mxnet/gluon/contrib/cnn/conv_layers.py
+++ b/python/mxnet/gluon/contrib/cnn/conv_layers.py
@@ -314,6 +314,7 @@ class ModulatedDeformableConvolution(HybridBlock):
             self._op_name = op_name
 
             offset_channels = num_deformable_group * 3 * kernel_size[0] * kernel_size[1]
+            self.offset_split_index = num_deformable_group * 2 * kernel_size[0] * kernel_size[1]
             self._kwargs_offset = {
                 'kernel': kernel_size, 'stride': strides, 'dilate': dilation,
                 'pad': padding, 'num_filter': offset_channels, 'num_group': groups,
@@ -377,8 +378,8 @@ class ModulatedDeformableConvolution(HybridBlock):
         else:
             offset = F.Convolution(x, offset_weight, offset_bias, cudnn_off=True, **self._kwargs_offset)
 
-        offset_t = F.slice_axis(offset, axis=1, begin=0, end=18)
-        mask = F.slice_axis(offset, axis=1, begin=18, end=None)
+        offset_t = F.slice_axis(offset, axis=1, begin=0, end=self.offset_split_index)
+        mask = F.slice_axis(offset, axis=1, begin=self.offset_split_index, end=None)
         mask = F.sigmoid(mask) * 2
 
         if deformable_conv_bias is None:

--- a/tests/python/unittest/test_gluon_contrib.py
+++ b/tests/python/unittest/test_gluon_contrib.py
@@ -411,6 +411,10 @@ def test_ModulatedDeformableConvolution():
     net = nn.HybridSequential()
     net.add(
         DeformableConvolution(10, kernel_size=(3, 3), strides=1, padding=0),
+        DeformableConvolution(10, kernel_size=(1, 1), strides=1, padding=0),
+        DeformableConvolution(10, kernel_size=(5, 5), strides=1, padding=0),
+        DeformableConvolution(10, kernel_size=(3, 5), strides=1, padding=0),
+        DeformableConvolution(10, kernel_size=(5, 1), strides=1, padding=0, num_deformable_group=2),
         DeformableConvolution(10, kernel_size=(3, 2), strides=1, padding=0, activation='relu',
                                offset_use_bias=False, use_bias=False),
         DeformableConvolution(10, kernel_size=(3, 2), strides=1, padding=0, activation='relu',


### PR DESCRIPTION
## Description ##
The filter size was incorrectly set to fixed number. This PR fixed the bug.

Should fix https://github.com/apache/incubator-mxnet/pull/16341#issuecomment-565647632



## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
