### PR TITLE
Install current OpenCV

### DIFF
--- a/docs/static_site/src/pages/get_started/osx_setup.md
+++ b/docs/static_site/src/pages/get_started/osx_setup.md
@@ -88,7 +88,7 @@ Install the dependencies, required for MXNet, with the following commands:
 	brew install graphviz
 	brew install openblas
 	brew tap homebrew/core
-	brew install opencv@3
+	brew install opencv
 
 	# If building with MKLDNN
 	brew install llvm


### PR DESCRIPTION
Install the latest version of OpenCV instead of OpenCV 3, which causes problems during installation.

## Description ##
Update MacOSX build from source instructions to install OpenCV 4.x (current version) from the pinned OpenCV@3

### Changes ###
- `brew install opencv@3` to `brew install opencv`

## Comments ##
Fixes https://github.com/apache/incubator-mxnet/issues/17061#issue-537725608
