### PR TITLE
[Numpy] add op np.linalg.tensorsolve

### DIFF
--- a/python/mxnet/ndarray/numpy/linalg.py
+++ b/python/mxnet/ndarray/numpy/linalg.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 from . import _op as _mx_nd_np
 from . import _internal as _npi
 
-__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv']
+__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve']
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
@@ -461,3 +461,51 @@ def tensorinv(a, ind=2):
     True
     """
     return _npi.tensorinv(a, ind)
+
+
+def tensorsolve(a, b, axes=None):
+    r"""
+    Solve the tensor equation ``a x = b`` for x.
+    It is assumed that all indices of `x` are summed over in the product,
+    together with the rightmost indices of `a`, as is done in, for example,
+    ``tensordot(a, x, axes=b.ndim)``.
+
+    Parameters
+    ----------
+    a : ndarray
+        Coefficient tensor, of shape ``b.shape + Q``. `Q`, a tuple, equals
+        the shape of that sub-tensor of `a` consisting of the appropriate
+        number of its rightmost indices, and must be such that
+        ``prod(Q) == prod(b.shape)`` (in which sense `a` is said to be
+        'square').
+    b : ndarray
+        Right-hand tensor, which can be of any shape.
+    axes : tuple of ints, optional
+        Axes in `a` to reorder to the right, before inversion.
+        If None (default), no reordering is done.
+
+    Returns
+    -------
+    x : ndarray, shape Q
+
+    Raises
+    ------
+    MXNetError
+        If `a` is singular or not 'square' (in the above sense).
+
+    See Also
+    --------
+    numpy.tensordot, tensorinv, numpy.einsum
+
+    Examples
+    --------
+    >>> a = np.eye(2*3*4)
+    >>> a.shape = (2*3, 4, 2, 3, 4)
+    >>> b = np.random.randn(2*3, 4)
+    >>> x = np.linalg.tensorsolve(a, b)
+    >>> x.shape
+    (2, 3, 4)
+    >>> np.allclose(np.tensordot(a, x, axes=3), b)
+    True
+    """
+    return _npi.tensorsolve(a, b, axes)

--- a/python/mxnet/numpy/linalg.py
+++ b/python/mxnet/numpy/linalg.py
@@ -20,7 +20,7 @@
 from __future__ import absolute_import
 from ..ndarray import numpy as _mx_nd_np
 
-__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv']
+__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve']
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
@@ -479,3 +479,51 @@ def tensorinv(a, ind=2):
     True
     """
     return _mx_nd_np.linalg.tensorinv(a, ind)
+
+
+def tensorsolve(a, b, axes=None):
+    r"""
+    Solve the tensor equation ``a x = b`` for x.
+    It is assumed that all indices of `x` are summed over in the product,
+    together with the rightmost indices of `a`, as is done in, for example,
+    ``tensordot(a, x, axes=b.ndim)``.
+
+    Parameters
+    ----------
+    a : ndarray
+        Coefficient tensor, of shape ``b.shape + Q``. `Q`, a tuple, equals
+        the shape of that sub-tensor of `a` consisting of the appropriate
+        number of its rightmost indices, and must be such that
+        ``prod(Q) == prod(b.shape)`` (in which sense `a` is said to be
+        'square').
+    b : ndarray
+        Right-hand tensor, which can be of any shape.
+    axes : tuple of ints, optional
+        Axes in `a` to reorder to the right, before inversion.
+        If None (default), no reordering is done.
+
+    Returns
+    -------
+    x : ndarray, shape Q
+
+    Raises
+    ------
+    MXNetError
+        If `a` is singular or not 'square' (in the above sense).
+
+    See Also
+    --------
+    numpy.tensordot, tensorinv, numpy.einsum
+
+    Examples
+    --------
+    >>> a = np.eye(2*3*4)
+    >>> a.shape = (2*3, 4, 2, 3, 4)
+    >>> b = np.random.randn(2*3, 4)
+    >>> x = np.linalg.tensorsolve(a, b)
+    >>> x.shape
+    (2, 3, 4)
+    >>> np.allclose(np.tensordot(a, x, axes=3), b)
+    True
+    """
+    return _mx_nd_np.linalg.tensorsolve(a, b, axes)

--- a/python/mxnet/numpy_dispatch_protocol.py
+++ b/python/mxnet/numpy_dispatch_protocol.py
@@ -136,6 +136,7 @@ _NUMPY_ARRAY_FUNCTION_LIST = [
     'linalg.inv',
     'linalg.solve',
     'linalg.tensorinv',
+    'linalg.tensorsolve',
     'shape',
     'trace',
     'tril',

--- a/python/mxnet/symbol/numpy/linalg.py
+++ b/python/mxnet/symbol/numpy/linalg.py
@@ -22,7 +22,7 @@ from . import _symbol
 from . import _op as _mx_sym_np
 from . import _internal as _npi
 
-__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv']
+__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve']
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
@@ -448,3 +448,51 @@ def tensorinv(a, ind=2):
     True
     """
     return _npi.tensorinv(a, ind)
+
+
+def tensorsolve(a, b, axes=None):
+    r"""
+    Solve the tensor equation ``a x = b`` for x.
+    It is assumed that all indices of `x` are summed over in the product,
+    together with the rightmost indices of `a`, as is done in, for example,
+    ``tensordot(a, x, axes=b.ndim)``.
+
+    Parameters
+    ----------
+    a : ndarray
+        Coefficient tensor, of shape ``b.shape + Q``. `Q`, a tuple, equals
+        the shape of that sub-tensor of `a` consisting of the appropriate
+        number of its rightmost indices, and must be such that
+        ``prod(Q) == prod(b.shape)`` (in which sense `a` is said to be
+        'square').
+    b : ndarray
+        Right-hand tensor, which can be of any shape.
+    axes : tuple of ints, optional
+        Axes in `a` to reorder to the right, before inversion.
+        If None (default), no reordering is done.
+
+    Returns
+    -------
+    x : ndarray, shape Q
+
+    Raises
+    ------
+    MXNetError
+        If `a` is singular or not 'square' (in the above sense).
+
+    See Also
+    --------
+    numpy.tensordot, tensorinv, numpy.einsum
+
+    Examples
+    --------
+    >>> a = np.eye(2*3*4)
+    >>> a.shape = (2*3, 4, 2, 3, 4)
+    >>> b = np.random.randn(2*3, 4)
+    >>> x = np.linalg.tensorsolve(a, b)
+    >>> x.shape
+    (2, 3, 4)
+    >>> np.allclose(np.tensordot(a, x, axes=3), b)
+    True
+    """
+    return _npi.tensorsolve(a, b, axes)

--- a/src/operator/numpy/linalg/np_tensorsolve-inl.h
+++ b/src/operator/numpy/linalg/np_tensorsolve-inl.h
@@ -1,0 +1,557 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_tensorsolve-inl.h
+ * \brief Placeholder for tensor solve
+ */
+#ifndef MXNET_OPERATOR_NUMPY_LINALG_NP_TENSORSOLVE_INL_H_
+#define MXNET_OPERATOR_NUMPY_LINALG_NP_TENSORSOLVE_INL_H_
+
+#include <mxnet/operator_util.h>
+#include <vector>
+#include "../../operator_common.h"
+#include "../../mshadow_op.h"
+#include "../../tensor/la_op.h"
+#include "../../tensor/la_op-inl.h"
+#include "../np_tensordot_op-inl.h"
+#include "./np_solve-inl.h"
+
+namespace mxnet {
+namespace op {
+
+using namespace mshadow;
+
+struct TensorsolveParam : public dmlc::Parameter<TensorsolveParam> {
+  mxnet::Tuple<int> a_axes;
+  DMLC_DECLARE_PARAMETER(TensorsolveParam) {
+    DMLC_DECLARE_FIELD(a_axes)
+    .set_default(mxnet::Tuple<int>())
+    .describe("Tuple of ints, optional. Axes in a to reorder to the right, before inversion.");
+  }
+};
+
+// Fix negative axes.
+inline void FixNegativeAxes(mxnet::Tuple<int> *a_axes_param,
+                            const mxnet::TShape& a_shape) {
+  if (-1 == a_axes_param->ndim()) { return; }
+  const int a_ndim = a_shape.ndim();
+  for (auto& i : *a_axes_param) {
+    i = (i + a_ndim) % a_ndim;
+  }
+}
+
+// Get remained axes and axes of a.
+inline void GetReorderedAxes(const mxnet::Tuple<int>& a_axes_param,
+                             mxnet::Tuple<int> *a_axes_remained,
+                             mxnet::Tuple<int> *a_axes,
+                             const mxnet::TShape& a_shape) {
+  std::vector<int> a_axes_vec;
+  for (int i = 0; i < a_shape.ndim(); ++i) {
+    a_axes_vec.push_back(i);
+  }
+  // Get remained axes and axes.
+  if (-1 == a_axes_param.ndim()) {
+    *a_axes_remained = mxnet::Tuple<int>(a_axes_vec);
+    *a_axes = mxnet::Tuple<int>(a_axes_vec);
+    return;
+  }
+  for (const auto& i : a_axes_param) {
+    a_axes_vec.erase(std::find(a_axes_vec.begin(), a_axes_vec.end(), i));
+  }
+  *a_axes_remained = mxnet::Tuple<int>(a_axes_vec);
+
+  a_axes_vec.clear();
+  for (const auto& i : *a_axes_remained) {
+    a_axes_vec.push_back(i);
+  }
+  for (const auto& i : a_axes_param) {
+    a_axes_vec.push_back(i);
+  }
+  *a_axes = mxnet::Tuple<int>(a_axes_vec);
+}
+
+// Calculate output shape if a and b is tensor
+inline mxnet::TShape GetOutShape(const mxnet::TShape& a_shape,
+                                 const mxnet::TShape& b_shape) {
+  const int a_ndim = a_shape.ndim(), b_ndim = b_shape.ndim();
+  const int temp = a_ndim > b_ndim ? b_ndim : b_ndim - a_ndim;
+  mxnet::TShape out_shape(a_ndim - temp, -1);
+  for (int i = temp; i < a_ndim; ++i) {
+    out_shape[i - temp] = a_shape[i];
+  }
+  return out_shape;
+}
+
+// Calculates workspace size of tensorsolve forward.
+template<typename xpu>
+size_t TensorsolveForwardWorkspaceSize(const Tuple<int>& a_axes_param,
+                                       const TBlob& a,
+                                       const TBlob& b,
+                                       const TBlob& out,
+                                       const std::vector<OpReqType>& req) {
+  if (kNullOp == req[0]) { return 0U; }
+
+  // Zero-size output, no need to launch kernel
+  if (0U == out.shape_.Size()) { return 0U; }
+
+  const mxnet::TShape& a_shape = a.shape_;
+  const mxnet::TShape& b_shape = b.shape_;
+  MSHADOW_SGL_DBL_TYPE_SWITCH(out.type_flag_, DType, {
+    if (0U == a_shape.Size() || 0U == b_shape.Size()) {
+      // 0-size input
+      return 0U;
+    } else if (0 == a_shape.ndim() || 0 == b_shape.ndim()) {
+      // At least 1 scalar.
+      return (a.Size() + b.Size()) * sizeof(DType) + b.Size() * sizeof(int);
+    } else {
+      // Two tensors of at least 1 dimensions.
+      return (2 * a.Size() + b.Size()) * sizeof(DType) + b.Size() * sizeof(int);
+    }
+  });
+  LOG(FATAL) << "InternalError: cannot reach here";
+  return 0U;
+}
+
+template<int req>
+struct assign_helper {
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, const DType *in_data, DType *out_data) {
+    KERNEL_ASSIGN(out_data[i], req, in_data[i]);
+  }
+};
+
+struct tensorsolve {
+  template<typename xpu, typename DType>
+  static void op(const Tensor<xpu, 2, DType>& A,
+                 const Tensor<xpu, 2, DType>& X,
+                 const Tensor<xpu, 1, int>& ipiv,
+                 const OpContext& ctx) {
+    mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+    linalg_solve(A, X, ipiv, s);  // ipiv for work_space in Lapacke_#gesv
+  }
+};
+
+template<typename xpu, typename laop>
+void TensorsolveOpForward(const nnvm::NodeAttrs& attrs,
+                          const OpContext& ctx,
+                          const std::vector<TBlob>& inputs,
+                          const std::vector<OpReqType>& req,
+                          const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 2U);
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  const TBlob& a = inputs[0];
+  const TBlob& b = inputs[1];
+  const TBlob& out = outputs[0];
+  const mxnet::TShape a_shape = a.shape_;
+  const mxnet::TShape b_shape = b.shape_;
+  const mxnet::TShape out_shape = out.shape_;
+  const TensorsolveParam& param = nnvm::get<TensorsolveParam>(attrs.parsed);
+  mxnet::Tuple<int> a_axes_param = param.a_axes;
+  FixNegativeAxes(&a_axes_param, a_shape);
+
+  size_t workspace_size = TensorsolveForwardWorkspaceSize<xpu>(a_axes_param, a, b, out, req);
+  Tensor<xpu, 1, char> workspace = ctx.requested[0].get_space_typed<xpu, 1, char>(
+    Shape1(workspace_size), ctx.get_stream<xpu>());
+
+  if (kNullOp == req[0]) { return; }
+
+  // Zero-size output, no need to launch kernel
+  if (0U == out.shape_.Size()) { return; }
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(out.type_flag_, DType, {
+    if (0U == a_shape.Size() || 0U == b_shape.Size()) {  // 0-size input
+      if (req[0] != kAddTo) {
+        Tensor<xpu, 1, DType> out_tensor =
+          out.get_with_shape<xpu, 1, DType>(Shape1(out.shape_.Size()), s);
+        out_tensor = static_cast<DType>(0);
+      }
+    } else if (0U == a_shape.ndim() || 0U ==  b_shape.ndim()) {  // At least 1 scalar.
+      // Check again
+      CHECK_EQ(a_shape.Size(), 1U)
+        << "a's and b's dimensions don't match";
+      CHECK_EQ(b_shape.Size(), 1U)
+        << "a's and b's dimensions don't match";
+
+      DType* a_ptr =
+        reinterpret_cast<DType*>(workspace.dptr_);
+      DType* b_ptr =
+        reinterpret_cast<DType*>(workspace.dptr_+ a.Size() * sizeof(DType));
+      int* ipiv_ptr =
+        reinterpret_cast<int*>(workspace.dptr_ + (a.Size() + b.Size()) * sizeof(DType));
+
+      // Cast type
+      MSHADOW_TYPE_SWITCH(a.type_flag_, AType, {
+        mxnet_op::Kernel<mshadow_op::identity_with_cast, xpu>::Launch(
+          s, a_shape.Size(), a_ptr, a.dptr<AType>());
+      });
+      MSHADOW_TYPE_SWITCH(b.type_flag_, BType, {
+        mxnet_op::Kernel<mshadow_op::identity_with_cast, xpu>::Launch(
+          s, b_shape.Size(), b_ptr, b.dptr<BType>());
+      });
+
+      mxnet::TBlob a_tblob(a_ptr, Shape2(1, 1), a.dev_mask(), a.dev_id());
+      mxnet::TBlob b_tblob(b_ptr, Shape2(1, 1), b.dev_mask(), b.dev_id());
+      mxnet::TBlob ipiv_tblob(ipiv_ptr, Shape1(1), out.dev_mask(), out.dev_id());
+      Tensor<xpu, 2, DType> a_tensor = a_tblob.get<xpu, 2, DType>(s);
+      Tensor<xpu, 2, DType> b_tensor = b_tblob.get<xpu, 2, DType>(s);
+      Tensor<xpu, 1, int> ipiv_tensor = ipiv_tblob.get<xpu, 1, int>(s);
+
+      // Solve linear equation
+      laop::op(a_tensor, b_tensor, ipiv_tensor, ctx);
+      MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+          mxnet_op::Kernel<assign_helper<req_type>, xpu>::Launch(
+            s, out_shape.Size(), b_tensor.dptr_, out.dptr<DType>());
+      });
+    } else {
+      // Two tensors of at least 1 dimensions.
+      Tuple<int> a_axes_remained;
+      Tuple<int> a_axes;
+      GetReorderedAxes(a_axes_param, &a_axes_remained, &a_axes, a_shape);
+      mxnet::TShape a_transpose_shape = GetReorderedShape(a_shape, a_axes);
+      const int N = b_shape.Size();
+
+      DType* a_ptr =
+        reinterpret_cast<DType*>(workspace.dptr_);
+      DType* a_trans_ptr =
+        reinterpret_cast<DType*>(workspace.dptr_ + a.Size() * sizeof(DType));
+      DType* b_ptr =
+        reinterpret_cast<DType*>(workspace.dptr_ + 2 * a.Size() * sizeof(DType));
+      int* ipiv_ptr =
+        reinterpret_cast<int*>(workspace.dptr_ + (2 * a.Size() + b.Size()) * sizeof(DType));
+
+      // Cast type
+      MSHADOW_TYPE_SWITCH(a.type_flag_, AType, {
+        mxnet_op::Kernel<mshadow_op::identity_with_cast, xpu>::Launch(
+          s, a_shape.Size(), a_ptr, a.dptr<AType>());
+      });
+      // Cast type
+      MSHADOW_TYPE_SWITCH(b.type_flag_, BType, {
+        mxnet_op::Kernel<mshadow_op::identity_with_cast, xpu>::Launch(
+          s, b_shape.Size(), b_ptr, b.dptr<BType>());
+      });
+
+      mxnet::TBlob a_tblob =
+        TBlob(a_ptr, a_shape, a.dev_mask(), a.dev_id());
+      mxnet::TBlob a_transpose_tblob =
+        TBlob(a_trans_ptr, a_transpose_shape, a.dev_mask(), a.dev_id());
+      mxnet::TBlob b_tblob =
+        TBlob(b_ptr, b_shape, b.dev_mask(), b.dev_id());
+      mxnet::TBlob ipiv_tblob =
+        TBlob(ipiv_ptr, b_shape, out.dev_mask(), out.dev_id());
+      mxnet::op::TransposeImpl<xpu>(ctx.run_ctx,
+                                    a_tblob,            // src
+                                    a_transpose_tblob,  // res
+                                    mxnet::TShape(a_axes.begin(), a_axes.end()));
+
+      Tensor<xpu, 2, DType> a_tensor =
+        a_tblob.get_with_shape<xpu, 2, DType>(Shape2(N, N), s);
+      Tensor<xpu, 1, int> ipiv_tensor =
+        ipiv_tblob.get_with_shape<xpu, 1, int>(Shape1(N), s);
+      Tensor<xpu, 2, DType> b_tensor =
+        b_tblob.get_with_shape<xpu, 2, DType>(Shape2(1, N), s);
+      Tensor<xpu, 2, DType> out_tensor =
+        out.get_with_shape<xpu, 2, DType>(Shape2(1, N), s);
+
+      a_tblob = a_tblob.reshape(Shape2(N, N));
+      a_transpose_tblob = a_transpose_tblob.reshape(Shape2(N, N));
+      Tuple<int> a_axes_2D(std::vector<int>{1, 0});
+      mxnet::op::TransposeImpl<xpu>(ctx.run_ctx,
+                                    a_transpose_tblob,  // src
+                                    a_tblob,            // res
+                                    mxnet::TShape(a_axes_2D.begin(), a_axes_2D.end()));
+      // Solve linear equation
+      laop::op(a_tensor, b_tensor, ipiv_tensor, ctx);
+      MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+        mxnet_op::Kernel<assign_helper<req_type>, xpu>::Launch(
+          s, out_shape.Size(), b_tensor.dptr_, out_tensor.dptr_);
+      });
+    }
+  });
+}
+
+// Calculates workspace size of tensordot backward.
+template<typename xpu>
+size_t TensorsolveBackwardWorkspaceSize(const TBlob& out_grad,
+                                        const TBlob& a,
+                                        const TBlob& b,
+                                        const TBlob& x) {
+  const mxnet::TShape& a_shape = a.shape_;
+  const mxnet::TShape& b_shape = b.shape_;
+  const mxnet::TShape& x_shape = x.shape_;
+
+  // Zero-size output, no need to launch kernel
+  if (0U == a_shape.Size() || 0U == b_shape.Size()) { return 0U; }
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(out_grad.type_flag_, DType, {
+    int work_space_size = 0;
+    if (0U == a_shape.ndim() || 0U == b_shape.ndim()) {
+      // At least 1 scalar.
+      work_space_size += sizeof(DType) * a_shape.Size();  // for tensorinv(a)
+      work_space_size += sizeof(DType) * a_shape.Size();  // for getri work space lu
+      work_space_size += sizeof(int) * b_shape.Size();    // for getri work space pivot
+    } else {
+      // Two tensors of at least 1 dimensions.
+      work_space_size += sizeof(DType) * a_shape.Size();  // for tensorinv(a)
+      work_space_size += sizeof(DType) * a_shape.Size();  // for getri work space lu
+      work_space_size += sizeof(DType) * b_shape.Size();  // for b
+      work_space_size += sizeof(DType) * x_shape.Size();  // for x
+      work_space_size += sizeof(DType) * a_shape.Size();  // for grad_a
+      work_space_size += sizeof(DType) * b_shape.Size();  // for grad_b
+      work_space_size += sizeof(int) * b_shape.Size();    // for getri work space pivot
+    }
+    return work_space_size;
+  });
+  LOG(FATAL) << "InternalError: cannot reach here";
+  return 0U;
+}
+
+// Get original axes for tensor a.
+inline void GetOriginAxes(const mxnet::TShape& a_shape,
+                          const mxnet::Tuple<int>& a_axes,
+                          mxnet::Tuple<int> *a_origin_axes) {
+  std::vector<int> a_origin_axes_vec(a_shape.ndim(), -1);
+  for (int i = 0; i < a_shape.ndim(); ++i) {
+    a_origin_axes_vec[a_axes[i]] = i;
+  }
+  *a_origin_axes = mxnet::Tuple<int>(a_origin_axes_vec);
+}
+
+struct tensorsolve_backward {
+  template<typename xpu, typename DType>
+  static void op(const Tensor<xpu, 3, DType>& dX,
+                 const Tensor<xpu, 3, DType>& inv_A,
+                 const Tensor<xpu, 3, DType>& B,
+                 const Tensor<xpu, 3, DType>& X,
+                 const Tensor<xpu, 3, DType>& dA,
+                 const Tensor<xpu, 3, DType>& dB,
+                 const OpContext& ctx) {
+    // (1) calcualte dB = trans(tensorinv(A)) * dX
+    // (2) calcualte dA = dB * trans(X)
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    gemm2::op(inv_A, dX, dB, DType(1), true, false, s);
+    gemm2::op(dB, X, dA, DType(-1), false, true, s);
+  }
+};
+
+template<typename xpu, typename laop>
+void TensorsolveBackwardImpl(const Tuple<int>& a_axes_param,
+                             const TBlob& out_grad,
+                             const TBlob& a,
+                             const TBlob& b,
+                             const TBlob& x,
+                             const TBlob& grad_a,
+                             const TBlob& grad_b,
+                             const OpContext& ctx,
+                             const std::vector<OpReqType>& req,
+                             const Tensor<xpu, 1, char>& workspace) {
+  mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  const mxnet::TShape& a_shape = a.shape_;
+  const mxnet::TShape& b_shape = b.shape_;
+  const mxnet::TShape& x_shape = x.shape_;
+
+  if (kNullOp == req[0] && kNullOp == req[1]) { return; }
+
+  // Zero-size output, no need to launch kernel
+  if (0U == a_shape.Size() || 0U == b_shape.Size()) { return; }
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(out_grad.type_flag_, DType, {
+    if (0 == a_shape.ndim() || 0 == b_shape.ndim()) {
+      // At least 1 scalar.
+      CHECK_EQ(a_shape.Size(), 1U)
+        << "a's and b's dimensions don't match";
+      CHECK_EQ(b_shape.Size(), 1U)
+        << "a's and b's dimensions don't match";
+
+      // Allocate workspace.
+      DType *tensorinv_a_ptr = reinterpret_cast<DType*>(workspace.dptr_);
+      DType *lu_ptr = reinterpret_cast<DType*>(workspace.dptr_ + a_shape.Size() * sizeof(DType));
+      int *ipiv_ptr = reinterpret_cast<int*>(workspace.dptr_ + 2 * a_shape.Size() * sizeof(DType));
+      TBlob tensorinv_a(tensorinv_a_ptr, a_shape, xpu::kDevMask);
+      TBlob lu(lu_ptr, a_shape, xpu::kDevMask);
+      TBlob ipiv(ipiv_ptr, b_shape, xpu::kDevMask);
+
+      MSHADOW_TYPE_SWITCH(a.type_flag_, AType, {
+        mxnet_op::Kernel<mshadow_op::identity_with_cast, xpu>::Launch(
+          s, a_shape.Size(),
+          tensorinv_a_ptr,
+          a.dptr<AType>());
+      });
+      // Calculate tensorinv(a)
+      Tensor<xpu, 3, DType> tensorinv_a_tensor =
+        tensorinv_a.get_with_shape<xpu, 3, DType>(Shape3(1, 1, 1), s);
+      Tensor<xpu, 3, DType> lu_tensor =
+        lu.get_with_shape<xpu, 3, DType>(Shape3(1, 1, 1), s);
+      Tensor<xpu, 2, int> ipiv_tensor =
+        ipiv.get_with_shape<xpu, 2, int>(Shape2(1, 1), s);
+      batch_inverse(tensorinv_a_tensor, lu_tensor, ipiv_tensor, ctx);
+
+      MSHADOW_TYPE_SWITCH(x.type_flag_, XType, {
+        DType temp1 = (*(tensorinv_a_tensor.dptr_)) * (*(out_grad.dptr<DType>()));
+        DType temp2 = -temp1 * static_cast<DType>(*x.dptr<XType>());
+        ASSIGN_DISPATCH(*grad_b.dptr<DType>(), req[1], temp1);
+        ASSIGN_DISPATCH(*grad_a.dptr<DType>(), req[0], temp2);
+      });
+    } else {
+      // Two tensors of at least 1 dimensions.
+      const int N = b_shape.Size();
+      Tuple<int> a_axes_remained;
+      Tuple<int> a_axes;
+      Tuple<int> a_origin_axes;
+      // Use a_axes to transpose (a_shape) --> (a_reordered_shape).
+      GetReorderedAxes(a_axes_param, &a_axes_remained, &a_axes, a_shape);
+      // Use a_origin_axes to transpose (a_reordered_shape) --> (a_shape).
+      GetOriginAxes(a_shape, a_axes, &a_origin_axes);
+      mxnet::TShape reordered_a_shape = GetReorderedShape(a_shape, a_axes);
+
+      // Allocate workspace.
+      DType *tensorinv_a_ptr = reinterpret_cast<DType*>(
+        workspace.dptr_);
+      DType *lu_ptr = reinterpret_cast<DType*>(
+        workspace.dptr_ + a_shape.Size() * sizeof(DType));
+      DType *b_ptr = reinterpret_cast<DType*>(
+        workspace.dptr_ + 2 * a_shape.Size() * sizeof(DType));
+      DType *x_ptr = reinterpret_cast<DType*>(
+        workspace.dptr_ + (2 * a_shape.Size() + b_shape.Size()) * sizeof(DType));
+      DType *grad_a_ptr = reinterpret_cast<DType*>(
+        workspace.dptr_ + 2 * (a_shape.Size() + b_shape.Size()) * sizeof(DType));
+      DType *grad_b_ptr = reinterpret_cast<DType*>(
+        workspace.dptr_ + (3 * a_shape.Size() + 2 * b_shape.Size()) * sizeof(DType));
+      int *ipiv_ptr = reinterpret_cast<int*>(
+        workspace.dptr_ + 3 * (a_shape.Size() + b_shape.Size()) * sizeof(DType));
+
+      TBlob tensorinv_a_data(tensorinv_a_ptr, a_shape, xpu::kDevMask);
+      TBlob lu_data(lu_ptr, a_shape, xpu::kDevMask);
+      TBlob b_data(b_ptr, b_shape, xpu::kDevMask);
+      TBlob x_data(x_ptr, x_shape, xpu::kDevMask);
+      TBlob grad_a_data(grad_a_ptr, reordered_a_shape, xpu::kDevMask);
+      TBlob grad_b_data(grad_b_ptr, b_shape, xpu::kDevMask);
+      TBlob ipiv_data(ipiv_ptr, b_shape, xpu::kDevMask);
+      MSHADOW_TYPE_SWITCH(a.type_flag_, AType, {
+        mxnet_op::Kernel<mshadow_op::identity_with_cast, xpu>::Launch(
+          s, a_shape.Size(),
+          lu_ptr,
+          a.dptr<AType>());
+      });
+      MSHADOW_TYPE_SWITCH(b.type_flag_, BType, {
+        mxnet_op::Kernel<mshadow_op::identity_with_cast, xpu>::Launch(
+          s, b_shape.Size(),
+          b_ptr,
+          b.dptr<BType>());
+      });
+      MSHADOW_TYPE_SWITCH(x.type_flag_, XType, {
+        mxnet_op::Kernel<mshadow_op::identity_with_cast, xpu>::Launch(
+          s, x_shape.Size(),
+          x_ptr,
+          x.dptr<XType>());
+      });
+      // Eg: lu_data(2, 3, 2, 15, 4, 5) -> tensorinv_a_data(3, 4, 5, 15, 2, 2)
+      tensorinv_a_data = tensorinv_a_data.reshape(reordered_a_shape);
+      mxnet::op::TransposeImpl<xpu>(ctx.run_ctx,
+                                    lu_data,           // src
+                                    tensorinv_a_data,  // res
+                                    mxnet::TShape(a_axes.begin(), a_axes.end()));
+
+      Tensor<xpu, 3, DType> tensorinv_a_tensor =
+        tensorinv_a_data.get_with_shape<xpu, 3, DType>(Shape3(1, N, N), s);
+      Tensor<xpu, 3, DType> lu_tensor =
+        lu_data.get_with_shape<xpu, 3, DType>(Shape3(1, N, N), s);
+      Tensor<xpu, 3, DType> b_tensor =
+        b_data.get_with_shape<xpu, 3, DType>(Shape3(1, N, 1), s);
+      Tensor<xpu, 3, DType> x_tensor =
+        x_data.get_with_shape<xpu, 3, DType>(Shape3(1, N, 1), s);
+      Tensor<xpu, 3, DType> grad_a_tensor =
+        grad_a_data.get_with_shape<xpu, 3, DType>(Shape3(1, N, N), s);
+      Tensor<xpu, 3, DType> grad_b_tensor =
+        grad_b_data.get_with_shape<xpu, 3, DType>(Shape3(1, N, 1), s);
+      Tensor<xpu, 2, int> ipiv_tensor =
+        ipiv_data.get_with_shape<xpu, 2, int>(Shape2(1, N), s);
+
+      // Calculate tensorinv(a).
+      batch_inverse(tensorinv_a_tensor, lu_tensor, ipiv_tensor, ctx);
+      // No need to transpose tensorinv_a
+      // because transpose(tensorinv_a).shape == reordered_a_shape.
+      laop::op(out_grad.get_with_shape<xpu, 3, DType>(x_tensor.shape_, s),
+               tensorinv_a_tensor,
+               b_tensor,
+               x_tensor,
+               grad_a_tensor,
+               grad_b_tensor,
+               ctx);
+      // Eg: grad_a_src(3, 4, 5, 15, 2, 2) --> lu_data(2, 3, 2, 15, 4, 5)
+      mxnet::op::TransposeImpl<xpu>(ctx.run_ctx,
+                                    grad_a_data,  // src
+                                    lu_data,      // res
+                                    mxnet::TShape(a_origin_axes.begin(), a_origin_axes.end()));
+
+      MXNET_ASSIGN_REQ_SWITCH(req[1], req_type, {
+        mxnet_op::Kernel<assign_helper<req_type>, xpu>::Launch(
+          s, b_shape.Size(), grad_b_tensor.dptr_, grad_b.dptr<DType>());
+      });
+      MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+        mxnet_op::Kernel<assign_helper<req_type>, xpu>::Launch(
+          s, a_shape.Size(), lu_tensor.dptr_, grad_a.dptr<DType>());
+      });
+    }
+  });
+}
+
+template<typename xpu, typename laop>
+void TensorsolveOpBackward(const nnvm::NodeAttrs& attrs,
+                           const OpContext& ctx,
+                           const std::vector<TBlob>& inputs,
+                           const std::vector<OpReqType>& req,
+                           const std::vector<TBlob>& outputs) {
+  using namespace mshadow;
+  CHECK_EQ(inputs.size(), 4U);
+  CHECK_EQ(outputs.size(), 2U);
+  CHECK_EQ(req.size(), 2U);
+
+  const TBlob& out_grad = inputs[0];
+  const TBlob& a = inputs[1];
+  const TBlob& b = inputs[2];
+  const TBlob& x = inputs[3];
+  const TBlob& grad_a = outputs[0];
+  const TBlob& grad_b = outputs[1];
+  const mxnet::TShape a_shape = a.shape_;
+  const mxnet::TShape b_shape = b.shape_;
+  const TensorsolveParam& param = nnvm::get<TensorsolveParam>(attrs.parsed);
+  mxnet::Tuple<int> a_axes_param = param.a_axes;
+  FixNegativeAxes(&a_axes_param, a_shape);
+
+  size_t workspace_size = TensorsolveBackwardWorkspaceSize<xpu>(out_grad, a, b, x);
+  Tensor<xpu, 1, char> workspace =
+    ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size),
+                                                   ctx.get_stream<xpu>());
+  TensorsolveBackwardImpl<xpu, laop>(a_axes_param,
+                                     out_grad,
+                                     a, b, x,
+                                     grad_a, grad_b,
+                                     ctx, req,
+                                     workspace);
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NUMPY_LINALG_NP_TENSORSOLVE_INL_H_

--- a/src/operator/numpy/linalg/np_tensorsolve.cc
+++ b/src/operator/numpy/linalg/np_tensorsolve.cc
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_tensorsolve.cc
+ * \brief CPU implementation placeholder of Tensor Solve Operator
+ */
+#include "./np_tensorsolve-inl.h"
+
+namespace mxnet {
+namespace op {
+
+bool TensorsolveOpShape(const nnvm::NodeAttrs& attrs,
+                        mxnet::ShapeVector *in_attrs,
+                        mxnet::ShapeVector *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 2U);
+  CHECK_EQ(out_attrs->size(), 1U);
+
+  const mxnet::TShape& a_shape = in_attrs->at(0);
+  const mxnet::TShape& b_shape = in_attrs->at(1);
+  const int a_ndim = a_shape.ndim();
+  const int b_ndim = b_shape.ndim();
+
+  if (!ndim_is_known(a_shape) || !ndim_is_known(b_shape)) {
+    return false;
+  }
+
+  if (0 == a_ndim && 0 == b_ndim) {
+    // a and b is scalar
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, b_shape);
+  } else if (0 == a_ndim && 0 != b_ndim) {
+    // a is scalar, b is tensor
+    CHECK_EQ(b_shape.Size(), 1U)
+      << "a's and b's dimensions don't match";
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, a_shape);
+  } else if (0 != a_ndim && 0 == b_ndim) {
+    // a is tensor, a is scalar
+    CHECK_EQ(a_shape.Size(), 1U)
+      << "a's and b's dimensions don't match";
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, a_shape);
+  } else {
+    // a and b of at least 1 dimensions.
+    const TensorsolveParam& param = nnvm::get<TensorsolveParam>(attrs.parsed);
+    mxnet::Tuple<int> a_axes_param = param.a_axes;
+    FixNegativeAxes(&a_axes_param, a_shape);
+
+    mxnet::Tuple<int> a_axes_remained;
+    mxnet::Tuple<int> a_axes;
+    GetReorderedAxes(a_axes_param, &a_axes_remained, &a_axes, a_shape);
+    mxnet::TShape a_transpose_shape = GetReorderedShape(a_shape, a_axes);
+
+    // Calculate output shape
+    const int temp = a_ndim > b_ndim ? b_ndim : b_ndim - a_ndim;
+    int prod_front = 1, prod_back = 1;
+    mxnet::TShape out_shape(a_ndim - temp > 0 ? a_ndim - temp : 0, -1);
+    for (int i = 0; i < a_ndim; ++i) {
+      if (i < temp) {
+        prod_front *= a_transpose_shape[i];
+      } else {
+        prod_back *= a_transpose_shape[i];
+        out_shape[i - temp] = a_transpose_shape[i];
+      }
+    }
+    CHECK_EQ(prod_front, prod_back) << "a shape must be square.";
+    CHECK_EQ(prod_back, b_shape.Size()) << "a's and b's dimensions don't match";
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, out_shape);
+  }
+
+  return shape_is_known(*in_attrs) && shape_is_known(*out_attrs);
+}
+
+inline bool TensorsolveOpType(const nnvm::NodeAttrs& attrs,
+                              std::vector<int>* in_attrs,
+                              std::vector<int>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 2U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  int a_type = in_attrs->at(0);
+  int b_type = in_attrs->at(1);
+  // unsupport float16
+  CHECK_NE(a_type, mshadow::kFloat16)
+    << "array type float16 is unsupported in linalg";
+  CHECK_NE(b_type, mshadow::kFloat16)
+    << "array type float16 is unsupported in linalg";
+  if (mshadow::kFloat32 == a_type && mshadow::kFloat32 == b_type) {
+    TYPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(1));
+  } else {
+    TYPE_ASSIGN_CHECK(*out_attrs, 0, mshadow::kFloat64);
+  }
+  return out_attrs->at(0) != -1;
+}
+
+DMLC_REGISTER_PARAMETER(TensorsolveParam);
+
+NNVM_REGISTER_OP(_npi_tensorsolve)
+.set_attr_parser(mxnet::op::ParamParser<TensorsolveParam>)
+.set_num_inputs(2)
+.set_num_outputs(1)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    return std::vector<std::string>{"a", "b"};
+  })
+.set_attr<mxnet::FInferShape>("FInferShape", TensorsolveOpShape)
+.set_attr<nnvm::FInferType>("FInferType", TensorsolveOpType)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const NodeAttrs& attrs) {
+    return std::vector<ResourceRequest>(1, ResourceRequest::kTempSpace);
+  })
+.set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
+.set_attr<FCompute>("FCompute<cpu>", TensorsolveOpForward<cpu, tensorsolve>)
+.set_attr<nnvm::FGradient>("FGradient",
+  mxnet::op::ElemwiseGradUseInOut{"_backward_npi_tensorsolve"})
+.add_argument("a", "NDArray-or-Symbol", "First input")
+.add_argument("b", "NDArray-or-Symbol", "Second input")
+.add_arguments(TensorsolveParam::__FIELDS__());
+
+NNVM_REGISTER_OP(_backward_npi_tensorsolve)
+.set_attr_parser(mxnet::op::ParamParser<TensorsolveParam>)
+.set_num_inputs(4)
+.set_num_outputs(2)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const NodeAttrs& ){
+    return std::vector<ResourceRequest>{1, ResourceRequest::kTempSpace};
+  })
+.set_attr<nnvm::TIsBackward>("TIsBackward", true)
+.set_attr<FCompute>("FCompute<cpu>", TensorsolveOpBackward<cpu, tensorsolve_backward>);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/linalg/np_tensorsolve.cu
+++ b/src/operator/numpy/linalg/np_tensorsolve.cu
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file np_tensorsolve.cu
+ * \brief GPU implementation placeholder of Tensor Solve Operator
+ */
+
+#include <mxnet/operator_util.h>
+#include "./np_tensorsolve-inl.h"
+
+namespace mxnet {
+namespace op {
+
+#if MXNET_USE_CUSOLVER == 1
+
+NNVM_REGISTER_OP(_npi_tensorsolve)
+.set_attr<FCompute>("FCompute<gpu>", TensorsolveOpForward<gpu, tensorsolve>);
+
+NNVM_REGISTER_OP(_backward_npi_tensorsolve)
+.set_attr<FCompute>("FCompute<gpu>", TensorsolveOpBackward<gpu, tensorsolve_backward>);
+
+#endif
+
+}  // namespace op
+}  // namespace mxnet

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -416,6 +416,66 @@ def _add_workload_linalg_tensorinv():
                 OpArgMngr.add_workload('linalg.tensorinv', np.array(a, dtype=dtype), ind)
 
 
+def _add_workload_linalg_tensorsolve():
+    shapes = [
+        # a_shape.ndim <= 6
+        # (a_shape, b_shape, axes)
+        ((1, 1), (1,), None),
+        ((1, 1), (1, 1, 1, 1, 1), None),
+        ((4, 4), (4,), None),
+        ((2, 3, 3, 4, 2), (3, 4), (0, 2, 4)),
+        ((1, 3, 3, 4, 4), (1, 3, 4), (1, 3)),
+        ((1, 4, 1, 12, 3), (1, 2, 1, 2, 1, 3, 1), (1, 2, 4)),
+    ]
+    dtypes = (np.float32, np.float64)
+    for dtype in dtypes:
+        for a_shape, b_shape, axes in shapes:
+            a_ndim = len(a_shape)
+            b_ndim = len(b_shape)
+            a_trans_shape = list(a_shape)
+            a_axes = list(range(0, a_ndim))
+            if axes is not None:
+                for k in axes:
+                    a_axes.remove(k)
+                    a_axes.insert(a_ndim, k)
+                for k in range(a_ndim):
+                    a_trans_shape[k] = a_shape[a_axes[k]]
+            x_shape = a_trans_shape[-(a_ndim - b_ndim):]
+            prod = 1
+            for k in x_shape:
+                prod *= k
+            if prod * prod != _np.prod(a_shape):
+                raise ValueError("a is not square")
+            if prod != _np.prod(b_shape):
+                raise ValueError("a's shape and b's shape dismatch")
+            mat_shape = (prod, prod)
+            a_trans_shape = tuple(a_trans_shape)
+            x_shape = tuple(x_shape)
+
+            a_np = _np.eye(prod)
+            shape = mat_shape
+            while 1:
+                # generate well-conditioned matrices with small eigenvalues
+                D = _np.diag(_np.random.uniform(-1.0, 1.0, shape[-1]))
+                I = _np.eye(shape[-1]).reshape(shape)
+                v = _np.random.uniform(-1., 1., shape[-1]).reshape(shape[:-1] + (1,))
+                v = v / _np.linalg.norm(v, axis=-2, keepdims=True)
+                v_T = _np.swapaxes(v, -1, -2)
+                U = I - 2 * _np.matmul(v, v_T)
+                a = _np.matmul(U, D)
+                if (_np.linalg.cond(a, 2) < 4):
+                    a_np = a.reshape(a_trans_shape)
+                    break
+            x_np = _np.random.randn(*x_shape)
+            b_np = _np.tensordot(a_np, x_np, axes=len(x_shape))
+            a_origin_axes = list(range(a_np.ndim))
+            if axes is not None:
+                for k in range(a_np.ndim):
+                    a_origin_axes[a_axes[k]] = k
+            a_np = a_np.transpose(a_origin_axes)
+            OpArgMngr.add_workload('linalg.tensorsolve', np.array(a_np, dtype=dtype), np.array(b_np, dtype=dtype), axes)
+
+
 def _add_workload_linalg_slogdet():
     OpArgMngr.add_workload('linalg.slogdet', np.array(_np.ones((2, 2)), dtype=np.float32))
     OpArgMngr.add_workload('linalg.slogdet', np.array(_np.ones((0, 1, 1)), dtype=np.float64))
@@ -1495,6 +1555,7 @@ def _prepare_workloads():
     _add_workload_linalg_solve()
     _add_workload_linalg_det()
     _add_workload_linalg_tensorinv()
+    _add_workload_linalg_tensorsolve()
     _add_workload_linalg_slogdet()
     _add_workload_trace()
     _add_workload_tril()

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3986,6 +3986,160 @@ def test_np_linalg_tensorinv():
 
 @with_seed()
 @use_np
+def test_np_linalg_tensorsolve():
+    class TestTensorsolve(HybridBlock):
+        def __init__(self, axes):
+            super(TestTensorsolve, self).__init__()
+            self._axes = axes
+
+        def hybrid_forward(self, F, a, b):
+            return F.np.linalg.tensorsolve(a, b, axes=self._axes)
+
+    def get_tensorsolve_backward(a_np, b_np, mx_out_np, a_axes, a_origin_axes, a_trans_shape):
+        if (a_np.ndim == 0 or b_np.ndim == 0) or (a_np.ndim == b_np.ndim):
+            a_shape = a_np.shape
+            b_shape = b_np.shape
+            a_np = a_np.reshape((1, 1))
+            b_np = b_np.reshape((1,))
+            mx_out_np = mx_out_np.reshape((1,))
+            dx = _np.ones_like(mx_out_np)
+            inv_a_temp_np = _np.linalg.inv(a_np)
+            grad_b = inv_a_temp_np[0][0] * dx[0]
+            grad_a = -grad_b * mx_out_np[0]
+            return grad_a.reshape(a_shape), grad_b.reshape(b_shape)
+        else:
+            dx = _np.ones_like(mx_out_np)
+            a_np = a_np.transpose(a_axes)
+            ind = a_np.ndim - mx_out_np.ndim
+            tensorinv_a_np = _np.linalg.tensorinv(a_np, ind=ind)
+            a_trans_axes = list(range(a_np.ndim))[a_np.ndim - ind:] + list(range(a_np.ndim))[:a_np.ndim - ind]
+            trans_tensorinv_a_np = tensorinv_a_np.transpose(a_trans_axes)
+            grad_b = _np.tensordot(trans_tensorinv_a_np, dx, axes=dx.ndim)
+            grad_a = _np.tensordot(grad_b, mx_out_np, axes=0)
+            grad_a = grad_a.transpose(a_origin_axes)
+            return -grad_a, grad_b.reshape(b_np.shape)
+
+    def check_tensorsolve(x, a_np, b_np, axes):
+        try:
+            x_expected = _np.linalg.tensorsolve(a_np, b_np, axes=axes)
+        except Exception as e:
+            print("a:", a_np)
+            print("a shape:", a_np.shape)
+            print("b", b_np)
+            print("b shape:", b_np.shape)
+            print(e)
+        else:
+            assert x.shape == x_expected.shape
+            assert_almost_equal(x.asnumpy(), x_expected, rtol=rtol, atol=atol)
+
+    def shapeInfer(a_shape, b_shape, axes=None):
+        # b_shape - Right-hand tensor shape, which can be of any shape.
+        a_ndim = len(a_shape)
+        b_ndim = len(b_shape)
+        a_trans_shape = list(a_shape)
+        a_axes = list(range(0, a_ndim))
+        if axes is not None:
+            for k in axes:
+                a_axes.remove(k)
+                a_axes.insert(a_ndim, k)
+            for k in range(a_ndim):
+                a_trans_shape[k] = a_shape[a_axes[k]]
+        x_shape = a_trans_shape[-(a_ndim - b_ndim):]
+        prod = 1
+        for k in x_shape:
+            prod *= k
+        if prod * prod != _np.prod(a_shape):
+            raise ValueError("a is not square")
+        if prod != _np.prod(b_shape):
+            raise ValueError("a's shape and b's shape dismatch")
+        return a_axes, (prod, prod), tuple(a_trans_shape), tuple(x_shape)
+
+    def newInvertibleMatrix_2D(shape, max_cond=4):
+        while 1:
+            # generate well-conditioned matrices with small eigenvalues
+            D = _np.diag(_np.random.uniform(-1.0, 1.0, shape[-1]))
+            I = _np.eye(shape[-1]).reshape(shape)
+            v = _np.random.uniform(-1., 1., shape[-1]).reshape(shape[:-1] + (1,))
+            v = v / _np.linalg.norm(v, axis=-2, keepdims=True)
+            v_T = _np.swapaxes(v, -1, -2)
+            U = I - 2 * _np.matmul(v, v_T)
+            a = _np.matmul(U, D)
+            if (_np.linalg.cond(a, 2) < max_cond):
+                return a
+
+    shapes = [
+        # a_shape.ndim <= 6,
+        # (a_shape, b_shape, axes)
+        ((), (), None),                     # a.ndim == 0, b.ndim == 0, with axes must be None
+        ((), (1, 1, 1), None),              # a.ndim == 0, b.ndim != 0, with axes must be None
+        ((1, 1, 1), (), None),              # a.ndim != 0, b.ndim == 0, with axes == None
+        ((1, 1, 1), (), (0, 1, 2)),         # a.ndim != 0, b.ndim == 0, with axes != None
+        ((1, 1, 1), (1, 1, 1), None),       # a.ndim != 0, b.ndim != 0, a.ndim == b.ndim with axes == None
+        ((1, 1, 1), (1, 1, 1), (2, 0, 1)),  # a.ndim != 0, b.ndim != 0, a.ndim == b.ndim with axes != None
+        ((1, 1), (1,), None),               # a.ndim != 0, b.ndim != 0, a.ndim > b.ndim
+        ((1, 1), (1, 1, 1, 1, 1), None),    # a.ndim != 0, b.ndim != 0, a.ndim < b.ndim - a.ndim
+        ((4, 4), (4,), None),
+        ((6, 2, 3), (6,), None),
+        ((2, 3, 6), (6,), (0, 1)),
+        ((3, 4, 2, 3, 2), (3, 4), None),
+        ((2, 1, 4, 2, 4), (2, 4), (0, 1, 2)),
+        ((2, 3, 3, 4, 2), (3, 4), (0, 2, 4)),
+        ((1, 3, 3, 4, 4), (1, 3, 4), (1, 3)),
+        ((1, 12, 4, 1, 3), (1, 2, 1, 2, 1, 3, 1), None),
+        ((1, 4, 1, 12, 3), (1, 2, 1, 2, 1, 3, 1), (1, 2, 4)),
+    ]
+    dtypes = ['float32', 'float64']
+    for hybridize in [True, False]:
+        for dtype in dtypes:
+            for a_shape, b_shape, axes in shapes:
+                rtol = 1e-2 if dtype == 'float32' else 1e-3
+                atol = 1e-4 if dtype == 'float32' else 1e-5
+                test_tensorsolve = TestTensorsolve(axes)
+                if hybridize:
+                    test_tensorsolve.hybridize()
+
+                a_axes, mat_shape, a_trans_shape, x_shape = shapeInfer(a_shape, b_shape, axes)
+                # generate coefficient tensor a and right side tensor b
+                if (len(a_shape) == 0 or len(b_shape) == 0) or (len(a_shape) == len(b_shape)):
+                    a_np = _np.asarray(1).astype(dtype).reshape(a_shape)
+                    b_np = _np.asarray(2).astype(dtype).reshape(b_shape)
+                else:
+                    a_np = newInvertibleMatrix_2D(mat_shape, max_cond=3).reshape(a_trans_shape)
+                    x_np = _np.random.randn(*x_shape)
+                    b_np = _np.tensordot(a_np, x_np, axes=len(x_shape))
+
+                # resume original shape of tensor a
+                a_origin_axes = list(range(a_np.ndim))
+                if axes is not None:
+                    for k in range(a_np.ndim):
+                        a_origin_axes[a_axes[k]] = k
+                a_np = a_np.transpose(a_origin_axes)
+                a = np.array(a_np, dtype=dtype).reshape(a_shape)
+                b = np.array(b_np, dtype=dtype).reshape(b_shape)
+                a.attach_grad()
+                b.attach_grad()
+
+                with mx.autograd.record():
+                    mx_out = test_tensorsolve(a, b)
+                # check tensorsolve validity
+                assert mx_out.shape == x_shape
+                check_tensorsolve(mx_out, a.asnumpy(), b.asnumpy(), axes)
+
+                # check backward
+                if len(a_shape) != 0 and len(b_shape) != 0:
+                    mx.autograd.backward(mx_out)
+                    grad_a_expected, grad_b_expected = get_tensorsolve_backward(
+                        a.asnumpy(), b.asnumpy(), mx_out.asnumpy(), a_axes, a_origin_axes, a_trans_shape)
+                    assert_almost_equal(a.grad.asnumpy(), grad_a_expected, rtol=rtol, atol=atol)
+                    assert_almost_equal(b.grad.asnumpy(), grad_b_expected, rtol=rtol, atol=atol)
+
+                # check imperative once again
+                mx_out = test_tensorsolve(a, b)
+                check_tensorsolve(mx_out, a.asnumpy(), b.asnumpy(), axes)
+
+
+@with_seed()
+@use_np
 def test_np_linalg_det():
     class TestDet(HybridBlock):
         def __init__(self):


### PR DESCRIPTION
## Description ##
Add op np.linalg.tensorsolve

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
