### PR TITLE
Improve the speed of the pointwise fusion graph pass

### DIFF
--- a/src/executor/pointwise_fusion_pass.cc
+++ b/src/executor/pointwise_fusion_pass.cc
@@ -35,7 +35,6 @@
 #include "../operator/fusion/fused_op-inl.h"
 #include "../operator/fusion/fused_op.h"
 #include "../operator/operator_common.h"
-#include <chrono>
 
 namespace mxnet {
 namespace exec {
@@ -287,42 +286,21 @@ void AddInputsOnlyCompatible(const Graph &g,
   }
 }
 
-#define TIMEIT(x) \
-{\
-  auto time_start = std::chrono::high_resolution_clock::now();\
-  x;\
-  auto time_end = std::chrono::high_resolution_clock::now();\
-  std::chrono::duration<double> diff = time_end - time_start;\
-  std::cout << #x << " took " << diff.count() << std::endl;\
-}
-
-
 Graph FusePointwiseForward(Graph &&g) {
-  std::cout << "Fuse forward" << std::endl;
-  auto start_time = std::chrono::high_resolution_clock::now();
   Graph ret;
   g.indexed_graph();
   const auto& num_forward_outputs = g.GetAttr<size_t>("num_forward_outputs");
   Graph fg;
   fg.outputs.insert(fg.outputs.begin(), g.outputs.begin(),
                     g.outputs.begin() + num_forward_outputs);
-  auto subsets_start = std::chrono::high_resolution_clock::now();
   auto subsets = GetCompatibleSubsets(fg, IsFusionCompatible);
-  auto subsets_end = std::chrono::high_resolution_clock::now();
-  std::chrono::duration<double> subsets_diff = subsets_end - subsets_start;
-  std::cout << "subsets took " << subsets_diff.count() << std::endl;
-  TIMEIT(AddInputsOnlyCompatible(fg, &subsets, IsInputsOnlyCompatible));
-  TIMEIT(g = ReplaceSubgraphsPointwise(std::move(g), subsets, CreateSubgraphNode));
+  AddInputsOnlyCompatible(fg, &subsets, IsInputsOnlyCompatible);
+  g = ReplaceSubgraphsPointwise(std::move(g), subsets, CreateSubgraphNode);
   ret.outputs = g.outputs;
-  auto end_time = std::chrono::high_resolution_clock::now();
-  std::chrono::duration<double> diff = end_time - start_time;
-  std::cout << "END Fuse forward: " << diff.count() << std::endl;
   return ret;
 }
 
 Graph FusePointwiseBackward(Graph &&g) {
-  std::cout << "Fuse backward" << std::endl;
-  auto start_time = std::chrono::high_resolution_clock::now();
   Graph ret;
   g.indexed_graph();
   const auto& num_forward_outputs = g.GetAttr<size_t>("num_forward_outputs");
@@ -340,9 +318,6 @@ Graph FusePointwiseBackward(Graph &&g) {
   });
   g = ReplaceSubgraphsPointwise(std::move(g), subsets, CreateSubgraphNode);
   ret.outputs = g.outputs;
-  auto end_time = std::chrono::high_resolution_clock::now();
-  std::chrono::duration<double> diff = end_time - start_time;
-  std::cout << "END Fuse backward: " << diff.count() << std::endl;
   return ret;
 }
 #endif  // MXNET_USE_CUDA && MXNET_ENABLE_CUDA_RTC

--- a/src/executor/simple_partition_pass.h
+++ b/src/executor/simple_partition_pass.h
@@ -114,19 +114,13 @@ class BidirectionalGraph {
     }
     for (Node& node : nodes) {
       if (incomp_set.count(&node) != 0) {
-        // Check if all your inputs and outputs are incompatible too.
-        // If so, then your separation set does not matter
+        // Check if all your inputs are incompatible too.
+        // If so, then your separation set does not matter,
+        // because it will covered by the sets of your inputs
         bool inside_node = true;
         for (Node* input : node.inputs) {
           if (incomp_set.count(input) == 0) {
             inside_node = false;
-          }
-        }
-        if (inside_node) {
-          for (Node* output : node.outputs) {
-            if (incomp_set.count(output) == 0) {
-              inside_node = false;
-            }
           }
         }
         if (!inside_node) {

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -1032,17 +1032,19 @@ OpStatePtr CachedOp::Forward(
   CHECK_EQ(inputs.size(), num_inputs());
 
   Context default_ctx = inputs[0]->ctx();
-  auto state_ptr = GetCachedOpState(default_ctx);
-  auto& state = state_ptr.get_state<CachedOpState>();
+  {
+    auto state_ptr = GetCachedOpState(default_ctx);
+    auto& state = state_ptr.get_state<CachedOpState>();
 
-  const auto& idx = state.info.fwd_graph.indexed_graph();
-  for (size_t i = 0; i < inputs.size(); ++i) {
-    CHECK_EQ(inputs[i]->ctx(), default_ctx)
-        << "CachedOp requires all inputs to live on the same context. But "
-        << idx[idx.input_nodes()[0]].source->attrs.name
-        << " is on " << default_ctx << " while "
-        << idx[idx.input_nodes()[i]].source->attrs.name
-        << " is on " << inputs[i]->ctx();
+    const auto& idx = state.info.fwd_graph.indexed_graph();
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      CHECK_EQ(inputs[i]->ctx(), default_ctx)
+          << "CachedOp requires all inputs to live on the same context. But "
+          << idx[idx.input_nodes()[0]].source->attrs.name
+          << " is on " << default_ctx << " while "
+          << idx[idx.input_nodes()[i]].source->attrs.name
+          << " is on " << inputs[i]->ctx();
+    }
   }
 
   int prev_bulk_size = Engine::Get()->set_bulk_size(config_.forward_bulk_size);


### PR DESCRIPTION
## Description ##
Fixes #17105 

This PR fixes 2 problems (that together lead to the huge time spent doing fusion reported in #17105).

The first problem was the `get_subsets` function - a part of the pointwise fusion graph pass. It involves a step that ensures there are no cycles created in a graph after the fusion step. It does so in 2 steps:
 - first it looks at each incompatible node and separates its inputs and outputs into disjoint sets
 - then for each node `n` it looks at those separations and creates a set of nodes that are incompatible to be in the same fusion with `n`

Both of those steps were improved:
 - the first step was optimized via observation that if all inputs to an incompatible node `n` are also incompatible, then the separation set produced by that node is strictly smaller than the ones produced by those inputs, so there is no need to create it
 - the second step was greatly optimized by the observation, that when considering which nodes are incompatible for fusion with a given node `n`, if the incompatible node producing the separation set was already part of the set of nodes `n` is incompatible with, then also every node in that separation set was already included there as well. In the repro script from the issue, this change cut the number of insertion trials in the forward fusion pass from ~1M to ~2000.

The other problem fixed in this PR is that due to variable scope of `state_ptr` in `CachedOp::Forward` method, the state of `CachedOp` was taken twice for any context, resulting in 2 calls into graph optimization methods instead of 1.

In my local environment, the time spent on fusion pass in the repro script came down from over 200s to 4.5s on a single GPU.

@leezu @zburning @Caenorst @samskalicky FYI 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Improved the speed of finding the subsets compatible with fusion
- [x] Fixed a bug in `CachedOp::Forward` method where the shared_ptr to `CachedOpState` was taken twice, resulting in launching the optimization step twice. 
