### PR TITLE
[MKLDNN] Fix _copyto 

### DIFF
--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -477,18 +477,8 @@ inline void PushFComputeEx(const FComputeEx& fn,
         // copying A to B may not happen, and will corrupt A's memory.
         InvalidateOutputs(outputs, req);
       }
-      // add for mkldnn OP + no mkldnn OP
-      const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
-      if (!is_mkldnn.get(attrs.op, false)) {
-        std::vector<NDArray> inputs_fallback;
-        CreateDefaultInputs(inputs, &inputs_fallback);
-        fn(attrs, opctx, inputs_fallback, req, outputs);
-      } else {
-        fn(attrs, opctx, inputs, req, outputs);
-      }
-#else
-      fn(attrs, opctx, inputs, req, outputs);
 #endif
+      fn(attrs, opctx, inputs, req, outputs);
       if (ctx.dev_mask() == gpu::kDevMask && exec_type == ExecType::kSync && !rctx.is_bulk) {
         rctx.get_stream<gpu>()->Wait();
       }
@@ -541,18 +531,8 @@ inline void PushOperator(const OpStatePtr& state,
         // copying A to B may not happen, and will corrupt A's memory.
         InvalidateOutputs(outputs, req);
       }
-      // add for mkldnn OP + no mkldnn OP
-      const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
-      if (!is_mkldnn.get(attrs.op, false)) {
-        std::vector<NDArray> inputs_fallback;
-        CreateDefaultInputs(inputs, &inputs_fallback);
-        fcompute_ex(state, opctx, inputs_fallback, req, outputs);
-      } else {
-        fcompute_ex(state, opctx, inputs, req, outputs);
-      }
-#else
-      fcompute_ex(state, opctx, inputs, req, outputs);
 #endif
+      fcompute_ex(state, opctx, inputs, req, outputs);
       if (ctx.dev_mask() == gpu::kDevMask && exec_type == ExecType::kSync
           && rctx.get_stream<gpu>() && !rctx.is_bulk) {
         rctx.get_stream<gpu>()->Wait();

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -477,8 +477,18 @@ inline void PushFComputeEx(const FComputeEx& fn,
         // copying A to B may not happen, and will corrupt A's memory.
         InvalidateOutputs(outputs, req);
       }
-#endif
+      // add for mkldnn OP + no mkldnn OP
+      const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
+      if (!is_mkldnn.get(attrs.op, false) && exec_type != ExecType::kCrossDeviceCopy) {
+        std::vector<NDArray> inputs_fallback;
+        CreateDefaultInputs(inputs, &inputs_fallback);
+        fn(attrs, opctx, inputs_fallback, req, outputs);
+      } else {
+        fn(attrs, opctx, inputs, req, outputs);
+      }
+#else
       fn(attrs, opctx, inputs, req, outputs);
+#endif
       if (ctx.dev_mask() == gpu::kDevMask && exec_type == ExecType::kSync && !rctx.is_bulk) {
         rctx.get_stream<gpu>()->Wait();
       }
@@ -531,8 +541,18 @@ inline void PushOperator(const OpStatePtr& state,
         // copying A to B may not happen, and will corrupt A's memory.
         InvalidateOutputs(outputs, req);
       }
-#endif
+      // add for mkldnn OP + no mkldnn OP
+      const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
+      if (!is_mkldnn.get(attrs.op, false) && exec_type != ExecType::kCrossDeviceCopy) {
+        std::vector<NDArray> inputs_fallback;
+        CreateDefaultInputs(inputs, &inputs_fallback);
+        fcompute_ex(state, opctx, inputs_fallback, req, outputs);
+      } else {
+        fcompute_ex(state, opctx, inputs, req, outputs);
+      }
+#else
       fcompute_ex(state, opctx, inputs, req, outputs);
+#endif
       if (ctx.dev_mask() == gpu::kDevMask && exec_type == ExecType::kSync
           && rctx.get_stream<gpu>() && !rctx.is_bulk) {
         rctx.get_stream<gpu>()->Wait();

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -1137,15 +1137,17 @@ def test_quantize_gluon_with_forward():
         quantized_resnet18_v1.hybridize(static_alloc=True, static_shape=True)
         quantized_resnet18_v1(random_data)
 
-        quantized_resnet18_v1 = mx.contrib.quant.quantize_net(resnet18_v1, quantized_dtype=qdtype,
-                                                              exclude_layers=None,
-                                                              exclude_layers_match=excluded_names_match,
-                                                              calib_data=calib_data,
-                                                              calib_mode='naive',
-                                                              num_calib_examples=num_calib_examples,
-                                                              ctx=mx.current_context())
-        quantized_resnet18_v1.hybridize(static_alloc=True, static_shape=True)
-        quantized_resnet18_v1(random_data)
+        for mode in ['naive', 'entropy']:
+            qdtype = qdtype if mode is 'naive' else 'auto'
+            quantized_resnet18_v1 = mx.contrib.quant.quantize_net(resnet18_v1, quantized_dtype=qdtype,
+                                                                  exclude_layers=None,
+                                                                  exclude_layers_match=excluded_names_match,
+                                                                  calib_data=calib_data,
+                                                                  calib_mode=mode,
+                                                                  num_calib_examples=num_calib_examples,
+                                                                  ctx=mx.current_context())
+            quantized_resnet18_v1.hybridize(static_alloc=True, static_shape=True)
+            quantized_resnet18_v1(random_data)
 
     for qdtype in ['int8', 'uint8']:
         check_quantize_net(qdtype)


### PR DESCRIPTION
## Description ##
@pengzhao-intel @TaoLv @ZhennanQin @rongzha1 

This PR is to address the segmentation fault when calibrating FP32 models in entropy mode (calling `_copyto` op). 

1. not use fallback inputs for `_copyto`
2. add unittest for quantization in entropy mode

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
