### PR TITLE
[MKL-DNN] MKL-DNN RNN backward path enhancement

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -132,9 +132,12 @@ static inline bool SupportMKLDNN(int dtype, const mxnet::TShape &shape) {
   return dtype == mshadow::kFloat32 && (ndim == 1 || ndim == 2 || ndim == 4);
 }
 
-static inline bool SupportMKLDNNRNN(const NDArray &input) {
-  int ndim = input.shape().ndim();
-  return (input.dtype() == mshadow::kFloat32) && (ndim == 3);
+static inline bool SupportMKLDNNRnn(const NDArray &input) {
+  if (input.dtype() == mshadow::kFloat32 && input.shape().ndim() == 3
+      && dmlc::GetEnv("MXNET_USE_MKLDNN_RNN", 1)) {
+    return true;
+  }
+  return false;
 }
 
 static inline bool SupportMKLDNNQuantize(int dtype) {

--- a/src/operator/nn/mkldnn/mkldnn_rnn-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_rnn-inl.h
@@ -369,9 +369,10 @@ class MKLDNNRnnBackward {
   void SetDataGradsMem(void* diff_src, void* diff_state, void* diff_statecell,
                        void* diff_out, void* diff_state_out, void* diff_statecell_out,
                        const int dtype = mshadow::kFloat32);
-  void CommitWeightsDiff(void* diff_weights, void* diff_bias,
-                         const OpReqType req,
-                         const int dtype = mshadow::kFloat32);
+  void SetNativeWeightsGrads() const;
+  void CommitWeightsGrads(void* diff_weights, void* diff_bias,
+                          const OpReqType req,
+                          const int dtype = mshadow::kFloat32);
 
   const mkldnn::primitive& GetBwd() const { return *bwd_.primitive_; }
   const mkldnn_args_map_t& GetArgsMap() const { return net_args_; }
@@ -386,6 +387,8 @@ class MKLDNNRnnBackward {
 
   mkldnn_shared_mem_t diff_weights_layer_;
   mkldnn_shared_mem_t diff_weights_iter_;
+  mkldnn_shared_mem_t diff_weights_layer_r_;
+  mkldnn_shared_mem_t diff_weights_iter_r_;
   mkldnn_shared_mem_t diff_bias_;
 
   mkldnn_args_map_t net_args_;

--- a/src/operator/operator_common.h
+++ b/src/operator/operator_common.h
@@ -561,6 +561,24 @@ class OpSignature {
       case mkldnn_format_kind_rnn_packed:
         hash = hash * 2 + desc.data.format_desc.rnn_packed_desc.format;
         eles.push_back(desc.data.format_desc.rnn_packed_desc.format);
+        hash = hash * 2 + desc.data.format_desc.rnn_packed_desc.n_parts;
+        eles.push_back(desc.data.format_desc.rnn_packed_desc.n_parts);
+        for (int i = 0; i < desc.data.format_desc.rnn_packed_desc.n_parts; ++i) {
+          hash = hash * 2 + desc.data.format_desc.rnn_packed_desc.parts[i];
+          hash = hash * 2 + desc.data.format_desc.rnn_packed_desc.part_pack_size[i];
+          hash = hash * 2 + desc.data.format_desc.rnn_packed_desc.pack_part[i];
+          eles.push_back(desc.data.format_desc.rnn_packed_desc.parts[i]);
+          eles.push_back(desc.data.format_desc.rnn_packed_desc.part_pack_size[i]);
+          eles.push_back(desc.data.format_desc.rnn_packed_desc.pack_part[i]);
+        }
+        hash = hash * 2 + desc.data.format_desc.rnn_packed_desc.n;
+        hash = hash * 2 + desc.data.format_desc.rnn_packed_desc.ldb;
+        hash = hash * 2 + desc.data.format_desc.rnn_packed_desc.offset_compensation;
+        hash = hash * 2 + desc.data.format_desc.rnn_packed_desc.size;
+        eles.push_back(desc.data.format_desc.rnn_packed_desc.n);
+        eles.push_back(desc.data.format_desc.rnn_packed_desc.ldb);
+        eles.push_back(desc.data.format_desc.rnn_packed_desc.offset_compensation);
+        eles.push_back(desc.data.format_desc.rnn_packed_desc.size);
         break;
       default:
       // nothing need to add

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -274,8 +274,7 @@ static void RNNStatefulComputeExCPU(const OpStatePtr& state_ptr,
                                     const std::vector<NDArray>& inputs,
                                     const std::vector<OpReqType>& req,
                                     const std::vector<NDArray>& outputs) {
-  if ((inputs[0].dtype() == mshadow::kFloat32 || inputs[0].dtype() == mshadow::kFloat16) &&
-      inputs[0].shape().ndim() == 3 && dmlc::GetEnv("MXNET_USE_MKLDNN_RNN", 1)) {
+  if (SupportMKLDNNRnn(inputs[0])) {
     MKLDNNRnnOp& op = state_ptr.get_state<MKLDNNRnnOp>();
     op.Forward(ctx, inputs, req, outputs);
   } else {
@@ -288,8 +287,7 @@ static void RNNStatefulGradComputeExCPU(const OpStatePtr& state_ptr,
                                         const std::vector<NDArray>& inputs,
                                         const std::vector<OpReqType>& req,
                                         const std::vector<NDArray>& outputs) {
-  if ((inputs[0].dtype() == mshadow::kFloat32 || inputs[0].dtype() == mshadow::kFloat16) &&
-      inputs[0].shape().ndim() == 3 && dmlc::GetEnv("MXNET_USE_MKLDNN_RNN", 1)) {
+  if (SupportMKLDNNRnn(inputs[0])) {
     MKLDNNRnnOp& op = state_ptr.get_state<MKLDNNRnnOp>();
     op.Backward(ctx, inputs, req, outputs);
   } else {

--- a/tests/python/unittest/test_gluon_rnn.py
+++ b/tests/python/unittest/test_gluon_rnn.py
@@ -19,6 +19,8 @@ import mxnet as mx
 from mxnet import gluon, nd
 import numpy as np
 import copy
+from itertools import product
+from functools import partial
 from numpy.testing import assert_allclose
 import unittest
 from mxnet.test_utils import almost_equal, assert_almost_equal
@@ -543,6 +545,128 @@ def test_rnn_layers_fp32():
 @unittest.skipIf(mx.context.num_gpus() == 0, "RNN FP16 only implemented for GPU for now")
 def test_rnn_layers_fp16():
     run_rnn_layers('float16', 'float32', mx.gpu())
+
+
+def check_rnn_consistency(fused_layer, stack_layer, loss, input_size, hidden_size, bidirectional=False, rtol=1e-2, atol=1e-4):
+    fused_begin_state = fused_layer.begin_state(1)
+    stack_state = stack_layer.begin_state(batch_size=1)
+    x = nd.random.normal(shape=(1, 5, input_size))
+    x.attach_grad()
+    y = nd.random.normal(shape=(1, 5, hidden_size * 2 if bidirectional else hidden_size))
+
+    with mx.autograd.record():
+        fused_out, fused_state = fused_layer(x, fused_begin_state)
+        l = loss(fused_out, y).mean()
+    l.backward()
+    fused_grads = dict([(name, p.grad()) for name, p in fused_layer.collect_params().items()])
+    fused_input_grad = x.grad.asnumpy()
+
+    with mx.autograd.record():
+        stack_out, stack_state = stack_layer.unroll(5, x, stack_state, merge_outputs=True)
+        l = loss(stack_out, y).mean()
+    l.backward()
+    stack_grads = dict([(name, p.grad()) for name, p in stack_layer.collect_params().items()])
+    stack_input_grad = x.grad.asnumpy()
+
+    assert_allclose(fused_out.asnumpy(), stack_out.asnumpy(), rtol=rtol, atol=atol)
+    assert_allclose(fused_input_grad, stack_input_grad, rtol=rtol, atol=atol)
+    for key, value in fused_grads.items():
+        assert_allclose(value.asnumpy(), stack_grads[key].asnumpy(), rtol=rtol, atol=atol)
+
+
+def create_op_by_mode(mode):
+    if mode == 'lstm':
+        fused_op = gluon.rnn.LSTM
+        stack_op = gluon.rnn.LSTMCell
+        recurrent_block_prefix = 'lstm0_'
+    elif mode == 'gru':
+        fused_op = gluon.rnn.GRU
+        stack_op = gluon.rnn.GRUCell
+        recurrent_block_prefix = 'gru0_'
+    elif mode == 'rnn_relu':
+        fused_op = partial(gluon.rnn.RNN, activation='relu')
+        stack_op = partial(gluon.rnn.RNNCell, activation='relu')
+        recurrent_block_prefix = 'rnn0_'
+    elif mode == 'rnn_tanh':
+        fused_op = partial(gluon.rnn.RNN, activation='tanh')
+        stack_op = partial(gluon.rnn.RNNCell, activation='tanh')
+        recurrent_block_prefix = 'rnn0_'
+
+    return fused_op, stack_op, recurrent_block_prefix
+
+
+def check_rnn_unidir_layer_gradients(mode, input_size, hidden_size, loss):
+    fused_op, stack_op, recurrent_block_prefix = create_op_by_mode(mode)
+    # ==== Single layer ====
+    fused_layer = fused_op(hidden_size, num_layers=1, layout='NTC', bidirectional=False)
+    fused_layer.collect_params().initialize()
+
+    params = fused_layer.collect_params()
+    stack_layer = mx.gluon.rnn.HybridSequentialRNNCell(prefix=recurrent_block_prefix, params=params)
+    with stack_layer.name_scope():
+        stack_layer.add(stack_op(hidden_size, prefix='l0_'))
+    stack_layer.initialize()
+
+    check_rnn_consistency(fused_layer, stack_layer, loss, input_size, hidden_size)
+
+    # ==== Multiple layer ====
+    fused_layer = fused_op(hidden_size, num_layers=3, layout='NTC', bidirectional=False)
+    fused_layer.collect_params().initialize()
+
+    params = fused_layer.collect_params()
+    stack_layer = mx.gluon.rnn.HybridSequentialRNNCell(prefix=recurrent_block_prefix, params=params)
+    with stack_layer.name_scope():
+        stack_layer.add(stack_op(hidden_size, prefix='l0_'))
+        stack_layer.add(stack_op(hidden_size, prefix='l1_'))
+        stack_layer.add(stack_op(hidden_size, prefix='l2_'))
+    stack_layer.initialize()
+
+    check_rnn_consistency(fused_layer, stack_layer, loss, input_size, hidden_size)
+
+
+def check_rnn_bidir_layer_gradients(mode, input_size, hidden_size, loss):
+    fused_op, stack_op, recurrent_block_prefix = create_op_by_mode(mode)
+    # ==== Single layer ====
+    fused_layer = fused_op(hidden_size, num_layers=1, layout='NTC', bidirectional=True)
+    fused_layer.collect_params().initialize()
+
+    params = fused_layer.collect_params()
+    stack_layer = mx.gluon.rnn.HybridSequentialRNNCell(prefix=recurrent_block_prefix, params=params)
+    with stack_layer.name_scope():
+        stack_layer.add(gluon.rnn.BidirectionalCell(stack_op(hidden_size, prefix='l0_'),
+                                                    stack_op(hidden_size, prefix='r0_')))
+    stack_layer.initialize()
+
+    check_rnn_consistency(fused_layer, stack_layer, loss, input_size, hidden_size, bidirectional=True)
+
+    # ==== Multiple layer ====
+    fused_layer = fused_op(hidden_size, num_layers=3, layout='NTC', bidirectional=True)
+    fused_layer.collect_params().initialize()
+
+    params = fused_layer.collect_params()
+    stack_layer = mx.gluon.rnn.HybridSequentialRNNCell(prefix=recurrent_block_prefix, params=params)
+    with stack_layer.name_scope():
+        stack_layer.add(gluon.rnn.BidirectionalCell(stack_op(hidden_size, prefix='l0_'),
+                                                    stack_op(hidden_size, prefix='r0_')))
+        stack_layer.add(gluon.rnn.BidirectionalCell(stack_op(hidden_size, prefix='l1_'),
+                                                    stack_op(hidden_size, prefix='r1_')))
+        stack_layer.add(gluon.rnn.BidirectionalCell(stack_op(hidden_size, prefix='l2_'),
+                                                    stack_op(hidden_size, prefix='r2_')))
+    stack_layer.initialize()
+
+    check_rnn_consistency(fused_layer, stack_layer, loss, input_size, hidden_size, bidirectional=True)
+
+
+@assert_raises_cudnn_not_satisfied(min_version='5.1.10')
+def test_fused_rnn_layer():
+    input_sizes = [128]
+    hidden_sizes = [128, 256]
+    modes = ['lstm', 'gru', 'rnn_relu', 'rnn_tanh']
+    # single layer
+    for mode, input_size, hidden_size in product(modes, input_sizes, hidden_sizes):
+        loss = mx.gluon.loss.L2Loss()
+        check_rnn_unidir_layer_gradients(mode, input_size, hidden_size, loss)
+        check_rnn_bidir_layer_gradients(mode, input_size, hidden_size, loss)
 
 
 def test_rnn_unroll_variant_length():


### PR DESCRIPTION
## Description ##
Mainly aims to fix the gradients' explosion reported by https://github.com/apache/incubator-mxnet/issues/17086. Other enhancements are also enabled, which are listed in the Changes section. 

## Checklist ##
### Changes ###
* Flush memory before RNN backward primitive
* Add gluon-rnn unit test for gradients check
* Cache reorder
* Re-write rnn supporting check
* Update OpSignature.AddSign to avoid potential hash collision for rnn-packed memory

## Comments ##
- Backward performance should have been improved to some degree as we cached the reorder primitives. A performance comparison will be posted later. Besides, this patch is supposed to have no impact on the Forward path.

@ciyongch @TaoLv @pengzhao-intel 
