### PR TITLE
[Numpy] Add linalg.eigvals/eig/eigvalsh/eigh op

### DIFF
--- a/python/mxnet/ndarray/numpy/linalg.py
+++ b/python/mxnet/ndarray/numpy/linalg.py
@@ -21,7 +21,8 @@ from __future__ import absolute_import
 from . import _op as _mx_nd_np
 from . import _internal as _npi
 
-__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve']
+__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve',
+           'eigvals', 'eig', 'eigvalsh', 'eigh']
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
@@ -419,7 +420,7 @@ def tensorinv(a, ind=2):
 
     Parameters
     ----------
-    a : array_like
+    a : ndarray
         Tensor to 'invert'. Its shape must be 'square', i. e.,
         ``prod(a.shape[:ind]) == prod(a.shape[ind:])``.
     ind : int, optional
@@ -487,10 +488,6 @@ def tensorsolve(a, b, axes=None):
     Returns
     -------
     x : ndarray, shape Q
-
-    Raises
-    ------
-    MXNetError
         If `a` is singular or not 'square' (in the above sense).
 
     See Also
@@ -509,3 +506,265 @@ def tensorsolve(a, b, axes=None):
     True
     """
     return _npi.tensorsolve(a, b, axes)
+
+
+def eigvals(a):
+    r"""
+    Compute the eigenvalues of a general matrix.
+
+    Main difference between `eigvals` and `eig`: the eigenvectors aren't
+    returned.
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        A real-valued matrix whose eigenvalues will be computed.
+
+    Returns
+    -------
+    w : (..., M,) ndarray
+        The eigenvalues, each repeated according to its multiplicity.
+        They are not necessarily ordered.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eig : eigenvalues and right eigenvectors of general arrays
+    eigh : eigenvalues and eigenvectors of a real symmetric array.
+    eigvalsh : eigenvalues of a real symmetric.
+
+    Notes
+    -----
+    Broadcasting rules apply, see the `numpy.linalg` documentation for
+    details.
+
+    This is implemented using the ``_geev`` LAPACK routines which compute
+    the eigenvalues and eigenvectors of general square arrays.
+
+    This function differs from the original `numpy.linalg.eigvals
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eigvals.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    Illustration, using the fact that the eigenvalues of a diagonal matrix
+    are its diagonal elements, that multiplying a matrix on the left
+    by an orthogonal matrix, `Q`, and on the right by `Q.T` (the transpose
+    of `Q`), preserves the eigenvalues of the "middle" matrix.  In other words,
+    if `Q` is orthogonal, then ``Q * A * Q.T`` has the same eigenvalues as
+    ``A``:
+    >>> from numpy import linalg as LA
+    >>> x = np.random.random()
+    >>> Q = np.array([[np.cos(x), -np.sin(x)], [np.sin(x), np.cos(x)]])
+    >>> LA.norm(Q[0, :]), LA.norm(Q[1, :]), np.dot(Q[0, :],Q[1, :])
+    (1.0, 1.0, 0.0)
+
+    Now multiply a diagonal matrix by ``Q`` on one side and by ``Q.T`` on the other:
+    >>> D = np.diag((-1,1))
+    >>> LA.eigvals(D)
+    array([-1.,  1.])
+    >>> A = np.dot(Q, D)
+    >>> A = np.dot(A, Q.T)
+    >>> LA.eigvals(A)
+    array([ 1., -1.]) # random
+    """
+    return _npi.eigvals(a)
+
+
+def eigvalsh(a, UPLO='L'):
+    r"""
+    Compute the eigenvalues real symmetric matrix.
+
+    Main difference from eigh: the eigenvectors are not computed.
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        A real-valued matrix whose eigenvalues are to be computed.
+    UPLO : {'L', 'U'}, optional
+        Specifies whether the calculation is done with the lower triangular
+        part of `a` ('L', default) or the upper triangular part ('U').
+        Irrespective of this value only the real parts of the diagonal will
+        be considered in the computation to preserve the notion of a Hermitian
+        matrix. It therefore follows that the imaginary part of the diagonal
+        will always be treated as zero.
+
+    Returns
+    -------
+    w : (..., M,) ndarray
+        The eigenvalues in ascending order, each repeated according to
+        its multiplicity.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eig : eigenvalues and right eigenvectors of general arrays
+    eigvals : eigenvalues of a non-symmetric array.
+    eigh : eigenvalues and eigenvectors of a real symmetric array.
+
+    Notes
+    -----
+    Broadcasting rules apply, see the `numpy.linalg` documentation for
+    details.
+
+    The eigenvalues are computed using LAPACK routines ``_syevd``.
+
+    This function differs from the original `numpy.linalg.eigvalsh
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eigvalsh.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    >>> from numpy import linalg as LA
+    >>> a = np.array([[ 5.4119368 ,  8.996273  , -5.086096  ],
+                      [ 0.8866155 ,  1.7490431 , -4.6107802 ],
+                      [-0.08034172,  4.4172044 ,  1.4528792 ]])
+    >>> LA.eigvalsh(a, UPLO='L')
+    array([-2.87381886,  5.10144682,  6.38623114]) # in ascending order
+    """
+    return _npi.eigvalsh(a, UPLO)
+
+
+def eig(a):
+    r"""
+    Compute the eigenvalues and right eigenvectors of a square array.
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        Matrices for which the eigenvalues and right eigenvectors will
+        be computed
+
+    Returns
+    -------
+    w : (..., M) ndarray
+        The eigenvalues, each repeated according to its multiplicity.
+        The eigenvalues are not necessarily ordered.
+    v : (..., M, M) ndarray
+        The normalized (unit "length") eigenvectors, such that the
+        column ``v[:,i]`` is the eigenvector corresponding to the
+        eigenvalue ``w[i]``.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eigvals : eigenvalues of a non-symmetric array.
+    eigh : eigenvalues and eigenvectors of a real symmetric array.
+    eigvalsh : eigenvalues of a real symmetric.
+
+    Notes
+    -----
+    This is implemented using the ``_geev`` LAPACK routines which compute
+    the eigenvalues and eigenvectors of general square arrays.
+
+    The number `w` is an eigenvalue of `a` if there exists a vector
+    `v` such that ``dot(a,v) = w * v``. Thus, the arrays `a`, `w`, and
+    `v` satisfy the equations ``dot(a[:,:], v[:,i]) = w[i] * v[:,i]``
+    for :math:`i \\in \\{0,...,M-1\\}`.
+
+    The array `v` of eigenvectors may not be of maximum rank, that is, some
+    of the columns may be linearly dependent, although round-off error may
+    obscure that fact. If the eigenvalues are all different, then theoretically
+    the eigenvectors are linearly independent.
+
+    This function differs from the original `numpy.linalg.eig
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eig.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    >>> from numpy import linalg as LA
+    >>> a = np.array([[-1.9147992 ,  6.054115  , 18.046988  ],
+                      [ 0.77563655, -4.860152  ,  2.1012988 ],
+                      [ 2.6083658 ,  2.3705218 ,  0.3192524 ]])
+    >>> w, v = LA.eig(a)
+    >>> w
+    array([ 6.9683027, -7.768063 , -5.655937 ])
+    >>> v
+    array([[ 0.90617794,  0.9543622 ,  0.2492316 ],
+           [ 0.13086087, -0.04077047, -0.9325615 ],
+           [ 0.4021404 , -0.29585576,  0.26117516]])
+    """
+    return _npi.eig(a)
+
+
+def eigh(a, UPLO='L'):
+    r"""
+    Return the eigenvalues and eigenvectors real symmetric matrix.
+
+    Returns two objects, a 1-D array containing the eigenvalues of `a`, and
+    a 2-D square array or matrix (depending on the input type) of the
+    corresponding eigenvectors (in columns).
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        real symmetric matrices whose eigenvalues and eigenvectors are to be computed.
+    UPLO : {'L', 'U'}, optional
+        Specifies whether the calculation is done with the lower triangular
+        part of `a` ('L', default) or the upper triangular part ('U').
+        Irrespective of this value only the real parts of the diagonal will
+        be considered in the computation to preserve the notion of a Hermitian
+        matrix. It therefore follows that the imaginary part of the diagonal
+        will always be treated as zero.
+
+    Returns
+    -------
+    w : (..., M) ndarray
+        The eigenvalues in ascending order, each repeated according to
+        its multiplicity.
+    v : {(..., M, M) ndarray, (..., M, M) matrix}
+        The column ``v[:, i]`` is the normalized eigenvector corresponding
+        to the eigenvalue ``w[i]``.  Will return a matrix object if `a` is
+        a matrix object.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eig : eigenvalues and right eigenvectors of general arrays
+    eigvals : eigenvalues of a non-symmetric array.
+    eigvalsh : eigenvalues of a real symmetric.
+
+    Notes
+    -----
+    The eigenvalues/eigenvectors are computed using LAPACK routines ``_syevd``.
+
+    This function differs from the original `numpy.linalg.eigh
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eigh.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    >>> from numpy import linalg as LA
+    >>> a = np.array([[ 6.8189726 , -3.926585  ,  4.3990498 ],
+                      [-0.59656644, -1.9166266 ,  9.54532   ],
+                      [ 2.1093285 ,  0.19688708, -1.1634291 ]])
+    >>> w, v = LA.eigh(a, UPLO='L')
+    >>> w
+    array([-2.175445 , -1.4581827,  7.3725457])
+    >>> v
+    array([[ 0.1805163 , -0.16569263,  0.9695154 ],
+           [ 0.8242942 ,  0.56326365, -0.05721384],
+           [-0.53661287,  0.80949366,  0.23825769]])
+    """
+    return _npi.eigh(a, UPLO)

--- a/python/mxnet/numpy/linalg.py
+++ b/python/mxnet/numpy/linalg.py
@@ -20,7 +20,8 @@
 from __future__ import absolute_import
 from ..ndarray import numpy as _mx_nd_np
 
-__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve']
+__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve',
+           'eigvals', 'eig', 'eigvalsh', 'eigh']
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
@@ -505,10 +506,6 @@ def tensorsolve(a, b, axes=None):
     Returns
     -------
     x : ndarray, shape Q
-
-    Raises
-    ------
-    MXNetError
         If `a` is singular or not 'square' (in the above sense).
 
     See Also
@@ -527,3 +524,265 @@ def tensorsolve(a, b, axes=None):
     True
     """
     return _mx_nd_np.linalg.tensorsolve(a, b, axes)
+
+
+def eigvals(a):
+    r"""
+    Compute the eigenvalues of a general matrix.
+
+    Main difference between `eigvals` and `eig`: the eigenvectors aren't
+    returned.
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        A real-valued matrix whose eigenvalues will be computed.
+
+    Returns
+    -------
+    w : (..., M,) ndarray
+        The eigenvalues, each repeated according to its multiplicity.
+        They are not necessarily ordered.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eig : eigenvalues and right eigenvectors of general arrays
+    eigh : eigenvalues and eigenvectors of a real symmetric array.
+    eigvalsh : eigenvalues of a real symmetric.
+
+    Notes
+    -----
+    Broadcasting rules apply, see the `numpy.linalg` documentation for
+    details.
+
+    This is implemented using the ``_geev`` LAPACK routines which compute
+    the eigenvalues and eigenvectors of general square arrays.
+
+    This function differs from the original `numpy.linalg.eigvals
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eigvals.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    Illustration, using the fact that the eigenvalues of a diagonal matrix
+    are its diagonal elements, that multiplying a matrix on the left
+    by an orthogonal matrix, `Q`, and on the right by `Q.T` (the transpose
+    of `Q`), preserves the eigenvalues of the "middle" matrix.  In other words,
+    if `Q` is orthogonal, then ``Q * A * Q.T`` has the same eigenvalues as
+    ``A``:
+    >>> from numpy import linalg as LA
+    >>> x = np.random.random()
+    >>> Q = np.array([[np.cos(x), -np.sin(x)], [np.sin(x), np.cos(x)]])
+    >>> LA.norm(Q[0, :]), LA.norm(Q[1, :]), np.dot(Q[0, :],Q[1, :])
+    (1.0, 1.0, 0.0)
+
+    Now multiply a diagonal matrix by ``Q`` on one side and by ``Q.T`` on the other:
+    >>> D = np.diag((-1,1))
+    >>> LA.eigvals(D)
+    array([-1.,  1.])
+    >>> A = np.dot(Q, D)
+    >>> A = np.dot(A, Q.T)
+    >>> LA.eigvals(A)
+    array([ 1., -1.]) # random
+    """
+    return _mx_nd_np.linalg.eigvals(a)
+
+
+def eigvalsh(a, UPLO='L'):
+    r"""
+    Compute the eigenvalues real symmetric matrix.
+
+    Main difference from eigh: the eigenvectors are not computed.
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        A real-valued matrix whose eigenvalues are to be computed.
+    UPLO : {'L', 'U'}, optional
+        Specifies whether the calculation is done with the lower triangular
+        part of `a` ('L', default) or the upper triangular part ('U').
+        Irrespective of this value only the real parts of the diagonal will
+        be considered in the computation to preserve the notion of a Hermitian
+        matrix. It therefore follows that the imaginary part of the diagonal
+        will always be treated as zero.
+
+    Returns
+    -------
+    w : (..., M,) ndarray
+        The eigenvalues in ascending order, each repeated according to
+        its multiplicity.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eig : eigenvalues and right eigenvectors of general arrays
+    eigvals : eigenvalues of a non-symmetric array.
+    eigh : eigenvalues and eigenvectors of a real symmetric array.
+
+    Notes
+    -----
+    Broadcasting rules apply, see the `numpy.linalg` documentation for
+    details.
+
+    The eigenvalues are computed using LAPACK routines ``_syevd``.
+
+    This function differs from the original `numpy.linalg.eigvalsh
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eigvalsh.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    >>> from numpy import linalg as LA
+    >>> a = np.array([[ 5.4119368 ,  8.996273  , -5.086096  ],
+                      [ 0.8866155 ,  1.7490431 , -4.6107802 ],
+                      [-0.08034172,  4.4172044 ,  1.4528792 ]])
+    >>> LA.eigvalsh(a, UPLO='L')
+    array([-2.87381886,  5.10144682,  6.38623114]) # in ascending order
+    """
+    return _mx_nd_np.linalg.eigvalsh(a, UPLO)
+
+
+def eig(a):
+    r"""
+    Compute the eigenvalues and right eigenvectors of a square array.
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        Matrices for which the eigenvalues and right eigenvectors will
+        be computed
+
+    Returns
+    -------
+    w : (..., M) ndarray
+        The eigenvalues, each repeated according to its multiplicity.
+        The eigenvalues are not necessarily ordered.
+    v : (..., M, M) ndarray
+        The normalized (unit "length") eigenvectors, such that the
+        column ``v[:,i]`` is the eigenvector corresponding to the
+        eigenvalue ``w[i]``.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eigvals : eigenvalues of a non-symmetric array.
+    eigh : eigenvalues and eigenvectors of a real symmetric array.
+    eigvalsh : eigenvalues of a real symmetric.
+
+    Notes
+    -----
+    This is implemented using the ``_geev`` LAPACK routines which compute
+    the eigenvalues and eigenvectors of general square arrays.
+
+    The number `w` is an eigenvalue of `a` if there exists a vector
+    `v` such that ``dot(a,v) = w * v``. Thus, the arrays `a`, `w`, and
+    `v` satisfy the equations ``dot(a[:,:], v[:,i]) = w[i] * v[:,i]``
+    for :math:`i \\in \\{0,...,M-1\\}`.
+
+    The array `v` of eigenvectors may not be of maximum rank, that is, some
+    of the columns may be linearly dependent, although round-off error may
+    obscure that fact. If the eigenvalues are all different, then theoretically
+    the eigenvectors are linearly independent.
+
+    This function differs from the original `numpy.linalg.eig
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eig.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    >>> from numpy import linalg as LA
+    >>> a = np.array([[-1.9147992 ,  6.054115  , 18.046988  ],
+                      [ 0.77563655, -4.860152  ,  2.1012988 ],
+                      [ 2.6083658 ,  2.3705218 ,  0.3192524 ]])
+    >>> w, v = LA.eig(a)
+    >>> w
+    array([ 6.9683027, -7.768063 , -5.655937 ])
+    >>> v
+    array([[ 0.90617794,  0.9543622 ,  0.2492316 ],
+           [ 0.13086087, -0.04077047, -0.9325615 ],
+           [ 0.4021404 , -0.29585576,  0.26117516]])
+    """
+    return _mx_nd_np.linalg.eig(a)
+
+
+def eigh(a, UPLO='L'):
+    r"""
+    Return the eigenvalues and eigenvectors real symmetric matrix.
+
+    Returns two objects, a 1-D array containing the eigenvalues of `a`, and
+    a 2-D square array or matrix (depending on the input type) of the
+    corresponding eigenvectors (in columns).
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        real symmetric matrices whose eigenvalues and eigenvectors are to be computed.
+    UPLO : {'L', 'U'}, optional
+        Specifies whether the calculation is done with the lower triangular
+        part of `a` ('L', default) or the upper triangular part ('U').
+        Irrespective of this value only the real parts of the diagonal will
+        be considered in the computation to preserve the notion of a Hermitian
+        matrix. It therefore follows that the imaginary part of the diagonal
+        will always be treated as zero.
+
+    Returns
+    -------
+    w : (..., M) ndarray
+        The eigenvalues in ascending order, each repeated according to
+        its multiplicity.
+    v : {(..., M, M) ndarray, (..., M, M) matrix}
+        The column ``v[:, i]`` is the normalized eigenvector corresponding
+        to the eigenvalue ``w[i]``.  Will return a matrix object if `a` is
+        a matrix object.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eig : eigenvalues and right eigenvectors of general arrays
+    eigvals : eigenvalues of a non-symmetric array.
+    eigvalsh : eigenvalues of a real symmetric.
+
+    Notes
+    -----
+    The eigenvalues/eigenvectors are computed using LAPACK routines ``_syevd``.
+
+    This function differs from the original `numpy.linalg.eigh
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eigh.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    >>> from numpy import linalg as LA
+    >>> a = np.array([[ 6.8189726 , -3.926585  ,  4.3990498 ],
+                      [-0.59656644, -1.9166266 ,  9.54532   ],
+                      [ 2.1093285 ,  0.19688708, -1.1634291 ]])
+    >>> w, v = LA.eigh(a, UPLO='L')
+    >>> w
+    array([-2.175445 , -1.4581827,  7.3725457])
+    >>> v
+    array([[ 0.1805163 , -0.16569263,  0.9695154 ],
+           [ 0.8242942 ,  0.56326365, -0.05721384],
+           [-0.53661287,  0.80949366,  0.23825769]])
+    """
+    return _mx_nd_np.linalg.eigh(a, UPLO)

--- a/python/mxnet/symbol/numpy/linalg.py
+++ b/python/mxnet/symbol/numpy/linalg.py
@@ -22,7 +22,8 @@ from . import _symbol
 from . import _op as _mx_sym_np
 from . import _internal as _npi
 
-__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve']
+__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve',
+           'eigvals', 'eig', 'eigvalsh', 'eigh']
 
 
 def norm(x, ord=None, axis=None, keepdims=False):
@@ -474,10 +475,6 @@ def tensorsolve(a, b, axes=None):
     Returns
     -------
     x : ndarray, shape Q
-
-    Raises
-    ------
-    MXNetError
         If `a` is singular or not 'square' (in the above sense).
 
     See Also
@@ -496,3 +493,265 @@ def tensorsolve(a, b, axes=None):
     True
     """
     return _npi.tensorsolve(a, b, axes)
+
+
+def eigvals(a):
+    r"""
+    Compute the eigenvalues of a general matrix.
+
+    Main difference between `eigvals` and `eig`: the eigenvectors aren't
+    returned.
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        A real-valued matrix whose eigenvalues will be computed.
+
+    Returns
+    -------
+    w : (..., M,) ndarray
+        The eigenvalues, each repeated according to its multiplicity.
+        They are not necessarily ordered.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eig : eigenvalues and right eigenvectors of general arrays
+    eigh : eigenvalues and eigenvectors of a real symmetric array.
+    eigvalsh : eigenvalues of a real symmetric.
+
+    Notes
+    -----
+    Broadcasting rules apply, see the `numpy.linalg` documentation for
+    details.
+
+    This is implemented using the ``_geev`` LAPACK routines which compute
+    the eigenvalues and eigenvectors of general square arrays.
+
+    This function differs from the original `numpy.linalg.eigvals
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eigvals.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    Illustration, using the fact that the eigenvalues of a diagonal matrix
+    are its diagonal elements, that multiplying a matrix on the left
+    by an orthogonal matrix, `Q`, and on the right by `Q.T` (the transpose
+    of `Q`), preserves the eigenvalues of the "middle" matrix.  In other words,
+    if `Q` is orthogonal, then ``Q * A * Q.T`` has the same eigenvalues as
+    ``A``:
+    >>> from numpy import linalg as LA
+    >>> x = np.random.random()
+    >>> Q = np.array([[np.cos(x), -np.sin(x)], [np.sin(x), np.cos(x)]])
+    >>> LA.norm(Q[0, :]), LA.norm(Q[1, :]), np.dot(Q[0, :],Q[1, :])
+    (1.0, 1.0, 0.0)
+
+    Now multiply a diagonal matrix by ``Q`` on one side and by ``Q.T`` on the other:
+    >>> D = np.diag((-1,1))
+    >>> LA.eigvals(D)
+    array([-1.,  1.])
+    >>> A = np.dot(Q, D)
+    >>> A = np.dot(A, Q.T)
+    >>> LA.eigvals(A)
+    array([ 1., -1.]) # random
+    """
+    return _npi.eigvals(a)
+
+
+def eigvalsh(a, UPLO='L'):
+    r"""
+    Compute the eigenvalues real symmetric matrix.
+
+    Main difference from eigh: the eigenvectors are not computed.
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        A real-valued matrix whose eigenvalues are to be computed.
+    UPLO : {'L', 'U'}, optional
+        Specifies whether the calculation is done with the lower triangular
+        part of `a` ('L', default) or the upper triangular part ('U').
+        Irrespective of this value only the real parts of the diagonal will
+        be considered in the computation to preserve the notion of a Hermitian
+        matrix. It therefore follows that the imaginary part of the diagonal
+        will always be treated as zero.
+
+    Returns
+    -------
+    w : (..., M,) ndarray
+        The eigenvalues in ascending order, each repeated according to
+        its multiplicity.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eig : eigenvalues and right eigenvectors of general arrays
+    eigvals : eigenvalues of a non-symmetric array.
+    eigh : eigenvalues and eigenvectors of a real symmetric array.
+
+    Notes
+    -----
+    Broadcasting rules apply, see the `numpy.linalg` documentation for
+    details.
+
+    The eigenvalues are computed using LAPACK routines ``_syevd``.
+
+    This function differs from the original `numpy.linalg.eigvalsh
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eigvalsh.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    >>> from numpy import linalg as LA
+    >>> a = np.array([[ 5.4119368 ,  8.996273  , -5.086096  ],
+                      [ 0.8866155 ,  1.7490431 , -4.6107802 ],
+                      [-0.08034172,  4.4172044 ,  1.4528792 ]])
+    >>> LA.eigvalsh(a, UPLO='L')
+    array([-2.87381886,  5.10144682,  6.38623114]) # in ascending order
+    """
+    return _npi.eigvalsh(a, UPLO)
+
+
+def eig(a):
+    r"""
+    Compute the eigenvalues and right eigenvectors of a square array.
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        Matrices for which the eigenvalues and right eigenvectors will
+        be computed
+
+    Returns
+    -------
+    w : (..., M) ndarray
+        The eigenvalues, each repeated according to its multiplicity.
+        The eigenvalues are not necessarily ordered.
+    v : (..., M, M) ndarray
+        The normalized (unit "length") eigenvectors, such that the
+        column ``v[:,i]`` is the eigenvector corresponding to the
+        eigenvalue ``w[i]``.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eigvals : eigenvalues of a non-symmetric array.
+    eigh : eigenvalues and eigenvectors of a real symmetric array.
+    eigvalsh : eigenvalues of a real symmetric.
+
+    Notes
+    -----
+    This is implemented using the ``_geev`` LAPACK routines which compute
+    the eigenvalues and eigenvectors of general square arrays.
+
+    The number `w` is an eigenvalue of `a` if there exists a vector
+    `v` such that ``dot(a,v) = w * v``. Thus, the arrays `a`, `w`, and
+    `v` satisfy the equations ``dot(a[:,:], v[:,i]) = w[i] * v[:,i]``
+    for :math:`i \\in \\{0,...,M-1\\}`.
+
+    The array `v` of eigenvectors may not be of maximum rank, that is, some
+    of the columns may be linearly dependent, although round-off error may
+    obscure that fact. If the eigenvalues are all different, then theoretically
+    the eigenvectors are linearly independent.
+
+    This function differs from the original `numpy.linalg.eig
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eig.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    >>> from numpy import linalg as LA
+    >>> a = np.array([[-1.9147992 ,  6.054115  , 18.046988  ],
+                      [ 0.77563655, -4.860152  ,  2.1012988 ],
+                      [ 2.6083658 ,  2.3705218 ,  0.3192524 ]])
+    >>> w, v = LA.eig(a)
+    >>> w
+    array([ 6.9683027, -7.768063 , -5.655937 ])
+    >>> v
+    array([[ 0.90617794,  0.9543622 ,  0.2492316 ],
+           [ 0.13086087, -0.04077047, -0.9325615 ],
+           [ 0.4021404 , -0.29585576,  0.26117516]])
+    """
+    return _npi.eig(a)
+
+
+def eigh(a, UPLO='L'):
+    r"""
+    Return the eigenvalues and eigenvectors real symmetric matrix.
+
+    Returns two objects, a 1-D array containing the eigenvalues of `a`, and
+    a 2-D square array or matrix (depending on the input type) of the
+    corresponding eigenvectors (in columns).
+
+    Parameters
+    ----------
+    a : (..., M, M) ndarray
+        real symmetric matrices whose eigenvalues and eigenvectors are to be computed.
+    UPLO : {'L', 'U'}, optional
+        Specifies whether the calculation is done with the lower triangular
+        part of `a` ('L', default) or the upper triangular part ('U').
+        Irrespective of this value only the real parts of the diagonal will
+        be considered in the computation to preserve the notion of a Hermitian
+        matrix. It therefore follows that the imaginary part of the diagonal
+        will always be treated as zero.
+
+    Returns
+    -------
+    w : (..., M) ndarray
+        The eigenvalues in ascending order, each repeated according to
+        its multiplicity.
+    v : {(..., M, M) ndarray, (..., M, M) matrix}
+        The column ``v[:, i]`` is the normalized eigenvector corresponding
+        to the eigenvalue ``w[i]``.  Will return a matrix object if `a` is
+        a matrix object.
+
+    Raises
+    ------
+    MXNetError
+        If the eigenvalue computation does not converge.
+
+    See Also
+    --------
+    eig : eigenvalues and right eigenvectors of general arrays
+    eigvals : eigenvalues of a non-symmetric array.
+    eigvalsh : eigenvalues of a real symmetric.
+
+    Notes
+    -----
+    The eigenvalues/eigenvectors are computed using LAPACK routines ``_syevd``.
+
+    This function differs from the original `numpy.linalg.eigh
+    <https://docs.scipy.org/doc/numpy/reference/generated/numpy.linalg.eigh.html>`_ in
+    the following way(s):
+     - Does not support complex input and output.
+
+    Examples
+    --------
+    >>> from numpy import linalg as LA
+    >>> a = np.array([[ 6.8189726 , -3.926585  ,  4.3990498 ],
+                      [-0.59656644, -1.9166266 ,  9.54532   ],
+                      [ 2.1093285 ,  0.19688708, -1.1634291 ]])
+    >>> w, v = LA.eigh(a, UPLO='L')
+    >>> w
+    array([-2.175445 , -1.4581827,  7.3725457])
+    >>> v
+    array([[ 0.1805163 , -0.16569263,  0.9695154 ],
+           [ 0.8242942 ,  0.56326365, -0.05721384],
+           [-0.53661287,  0.80949366,  0.23825769]])
+    """
+    return _npi.eigh(a, UPLO)

--- a/src/operator/c_lapack_api.cc
+++ b/src/operator/c_lapack_api.cc
@@ -78,6 +78,16 @@
     return 1; \
   }
 
+  #define MXNET_LAPACK_CWRAPPER8(func, dtype) \
+  int MXNET_LAPACK_##func(int matrix_layout, char jobvl, char jobvr, \
+                          int n, dtype *a, int lda, \
+                          dtype *wr, dtype *wi, \
+                          dtype *vl, int ldvl, dtype *vr, int ldvr, \
+                          dtype *work, int lwork) { \
+    LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
+    return 1; \
+  }
+
   #define MXNET_LAPACK_UNAVAILABLE(func) \
   int mxnet_lapack_##func(...) { \
     LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
@@ -110,5 +120,8 @@
 
   MXNET_LAPACK_CWRAPPER7(sgesv, float)
   MXNET_LAPACK_CWRAPPER7(dgesv, double)
+
+  MXNET_LAPACK_CWRAPPER8(sgeev, float)
+  MXNET_LAPACK_CWRAPPER8(dgeev, double)
 
 #endif  // MSHADOW_USE_MKL == 0

--- a/src/operator/numpy/linalg/np_eig-inl.h
+++ b/src/operator/numpy/linalg/np_eig-inl.h
@@ -1,0 +1,261 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_eig-inl.h
+ * \brief Placeholder for eig
+ */
+#ifndef MXNET_OPERATOR_NUMPY_LINALG_NP_EIG_INL_H_
+#define MXNET_OPERATOR_NUMPY_LINALG_NP_EIG_INL_H_
+
+#include <vector>
+#include "./np_eigvals-inl.h"
+
+namespace mxnet {
+namespace op {
+
+using namespace mshadow;
+
+template<int req>
+struct eigvec_assign_helper {
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, const DType *in_data, DType *out_data,
+                                  const int nrow, const int ld, const int step) {
+    int idx = i / step, row = (i % step) / ld, col = (i % step) % ld;
+    KERNEL_ASSIGN(out_data[idx * step + row + col * ld], req, in_data[i]);
+  }
+};
+
+// Calculates workspace size of eig forward op.
+// The dimension of the array WORK in LAPACKE_#GEEV should >= max(1,3*N), and
+// if JOBVL = 'V' or JOBVR = 'V', LWORK >= 4*N.
+// For good performance, LWORK must generally be larger.
+template<typename xpu>
+size_t EigForwardWorkspaceSize(const TBlob& a,
+                               const TBlob& w,
+                               const TBlob& v,
+                               const std::vector<OpReqType>& req) {
+  if (kNullOp == req[0] && kNullOp == req[1]) { return 0U; }
+
+  // Zero-size input, no need to launch kernel
+  if (0U == a.Size()) { return 0U; }
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(w.type_flag_, DType, {
+    size_t work_space_size = 0;
+    size_t n = a.size(a.ndim() - 1);
+    work_space_size += a.Size();      // For matrix.
+    work_space_size += 2 * w.Size();  // For eigenvalues' real and image component.
+    work_space_size += n * n;         // For left eigenvectors temp memory
+    work_space_size += v.Size();      // For right eigenvectors real and image component.
+    work_space_size += 4 * n;         // For workspace size in LAPACKE_#GEEV.
+    work_space_size *= sizeof(DType);
+    return work_space_size;
+  });
+  LOG(FATAL) << "InternalError: cannot reach here";
+  return 0U;
+}
+
+template<typename xpu>
+void EigOpForwardImpl(const TBlob& a,
+                      const TBlob& w,
+                      const TBlob& v,
+                      const std::vector<OpReqType>& req,
+                      std::vector<char> *workspace,
+                      mshadow::Stream<xpu> *s) {
+  if (kNullOp == req[0] && kNullOp == req[1]) { return; }
+  const mxnet::TShape& a_shape = a.shape_;
+  const mxnet::TShape& w_shape = w.shape_;
+  const mxnet::TShape& v_shape = v.shape_;
+  const int a_ndim = a_shape.ndim();
+
+  // Zero-size output, no need to launch kernel
+  if (0U == a.Size()) { return; }
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(w.type_flag_, DType, {
+    const int N = a_shape[a_ndim - 1];
+    DType *a_ptr =
+      reinterpret_cast<DType*>(workspace->data());
+    DType *wr_ptr =
+      reinterpret_cast<DType*>(workspace->data() + a.Size() * sizeof(DType));
+    DType *wi_ptr =
+      reinterpret_cast<DType*>(workspace->data() + (w.Size() + a.Size()) * sizeof(DType));
+    DType *vl_ptr =
+      reinterpret_cast<DType*>(workspace->data() + (2 * w.Size() + a.Size()) * sizeof(DType));
+    DType *vr_ptr =
+      reinterpret_cast<DType*>(
+        workspace->data() + (2 * w.Size() + N * N + a.Size()) * sizeof(DType));
+    DType *work_ptr =
+      reinterpret_cast<DType*>(
+        workspace->data() + (2 * w.Size() + v.Size() + N * N + a.Size()) * sizeof(DType));
+    MSHADOW_TYPE_SWITCH(a.type_flag_, AType, {
+      // Cast type and transpose.
+      mxnet_op::Kernel<SolveTypeTransposeHelper, xpu>::Launch(
+        s, a_shape.Size(), a.dptr<AType>(), a_ptr, N, N, N * N);
+    });
+    char jobvl = 'N', jobvr = 'V';
+    mxnet::TBlob a_trans_data(a_ptr, a_shape, a.dev_mask(), a.dev_id());
+    mxnet::TBlob wr_data(wr_ptr, w_shape, w.dev_mask(), w.dev_id());
+    mxnet::TBlob wi_data(wi_ptr, w_shape, w.dev_mask(), w.dev_id());
+    mxnet::TBlob vl_data(vl_ptr, Shape3(1, N, N), v.dev_mask(), v.dev_id());
+    mxnet::TBlob vr_data(vr_ptr, v_shape, v.dev_mask(), v.dev_id());
+    mxnet::TBlob work_data(work_ptr, Shape1(4 * N), a.dev_mask(), a.dev_id());
+    eig_eigvals::op(jobvl, jobvr,
+                    a_trans_data.FlatToKD<xpu, 3, DType>(s),
+                    wr_data.FlatToKD<xpu, 2, DType>(s),
+                    wi_data.FlatToKD<xpu, 2, DType>(s),
+                    vl_data.get<xpu, 3, DType>(s),
+                    vr_data.FlatToKD<xpu, 3, DType>(s),
+                    work_data.get<xpu, 1, DType>(s));
+    for (size_t i = 0; i < wi_data.Size(); ++i) {
+      CHECK_LE(fabs(wi_ptr[i]), 1e-15)
+        << "Complex eigvals is unsupported in linalg temporary.";
+    }
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+      mxnet_op::Kernel<eigvals_assign_helper<req_type>, xpu>::Launch(
+        s, w.Size(), wr_ptr, w.dptr<DType>());
+    });
+    MXNET_ASSIGN_REQ_SWITCH(req[1], req_type, {
+      mxnet_op::Kernel<eigvec_assign_helper<req_type>, xpu>::Launch(
+        s, v.Size(), vr_ptr, v.dptr<DType>(), N, N, N * N);
+    });
+  });
+}
+
+template<typename xpu>
+void EigOpForward(const nnvm::NodeAttrs& attrs,
+                  const OpContext& ctx,
+                  const std::vector<TBlob>& inputs,
+                  const std::vector<OpReqType>& req,
+                  const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK_EQ(outputs.size(), 2U);
+  CHECK_EQ(req.size(), 2U);
+  const TBlob& a = inputs[0];
+  const TBlob& w = outputs[0];
+  const TBlob& v = outputs[1];
+
+  // Calculate workspace size.
+  size_t workspace_size = EigForwardWorkspaceSize<cpu>(a, w, v, req);
+  std::vector<char> workspace(workspace_size, 0);
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(w.type_flag_, WType, {
+    MSHADOW_SGL_DBL_TYPE_SWITCH(a.type_flag_, AType, {
+      if (xpu::kDevCPU) {
+        // Op forward implement.
+        EigOpForwardImpl<cpu>(a, w, v, req, &workspace, ctx.get_stream<cpu>());
+      } else {
+#if __CUDACC__
+        mshadow::Stream<gpu> *s = ctx.get_stream<gpu>();
+        cudaStream_t stream = Stream<gpu>::GetStream(s);
+        std::vector<AType> a_vec(a.Size(), 0);
+        std::vector<WType> w_vec(w.Size(), 0);
+        std::vector<WType> v_vec(v.Size(), 0);
+        AType* a_cp_ptr = a_vec.data();
+        WType* w_cp_ptr = w_vec.data();
+        WType* v_cp_ptr = v_vec.data();
+        CUDA_CALL(cudaMemcpyAsync(a_cp_ptr, a.dptr<AType>(), sizeof(AType) * a.Size(),
+                                  cudaMemcpyDeviceToHost, stream));
+        CUDA_CALL(cudaMemcpyAsync(w_cp_ptr, w.dptr<WType>(), sizeof(WType) * w.Size(),
+                                  cudaMemcpyDeviceToHost, stream));
+        CUDA_CALL(cudaMemcpyAsync(v_cp_ptr, v.dptr<WType>(), sizeof(WType) * v.Size(),
+                                  cudaMemcpyDeviceToHost, stream));
+        CUDA_CALL(cudaStreamSynchronize(stream));
+        mxnet::TBlob a_data(a_cp_ptr, a.shape_, cpu::kDevMask);
+        mxnet::TBlob w_data(w_cp_ptr, w.shape_, cpu::kDevMask);
+        mxnet::TBlob v_data(v_cp_ptr, v.shape_, cpu::kDevMask);
+        // Op forward implement on cpu.
+        EigOpForwardImpl<cpu>(a_data, w_data, v_data, req, &workspace, ctx.get_stream<cpu>());
+        // Copy back to gpu.
+        CUDA_CALL(cudaMemcpyAsync(w.dptr<WType>(), w_cp_ptr, sizeof(WType) * w.Size(),
+                                  cudaMemcpyHostToDevice, stream));
+        CUDA_CALL(cudaMemcpyAsync(v.dptr<WType>(), v_cp_ptr, sizeof(WType) * v.Size(),
+                                  cudaMemcpyHostToDevice, stream));
+        CUDA_CALL(cudaStreamSynchronize(stream));
+#else
+        LOG(FATAL) << "Please build with USE_CUDA=1 to enable GPU";
+#endif  // __CUDACC__
+      }
+    });
+  });
+}
+
+struct EighParam : public dmlc::Parameter<EighParam> {
+  char UPLO;
+  DMLC_DECLARE_PARAMETER(EighParam) {
+    DMLC_DECLARE_FIELD(UPLO)
+    .set_default('L')
+    .describe("Specifies whether the calculation is done with the lower or upper triangular part.");
+  }
+};
+
+template<typename xpu>
+void EighOpForward(const nnvm::NodeAttrs& attrs,
+                   const OpContext& ctx,
+                   const std::vector<TBlob>& inputs,
+                   const std::vector<OpReqType>& req,
+                   const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK_EQ(outputs.size(), 2U);
+  CHECK_EQ(req.size(), 2U);
+  const TBlob& a = inputs[0];
+  const TBlob& w = outputs[0];
+  const TBlob& v = outputs[1];
+  const char UPLO = nnvm::get<EighParam>(attrs.parsed).UPLO;
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+
+  if (kNullOp == req[0] && kNullOp == req[0]) { return; }
+  // Zero-size output, no need to launch kernel
+  if (0U == a.Size()) { return; }
+
+  // Calculate workspace size.
+  size_t workspace_size = EighEigvalshForwardWorkspaceSize<xpu>(a, w, req, ctx);
+  Tensor<xpu, 1, char> workspace =
+    ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size), s);
+
+  EighEigvalshOpForwardImpl(a, w, UPLO, attrs, ctx, req, workspace);
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(w.type_flag_, DType, {
+    DType *a_ptr = reinterpret_cast<DType*>(workspace.dptr_);
+    DType *w_ptr = reinterpret_cast<DType*>(workspace.dptr_ + a.Size() * sizeof(DType));
+    TBlob a_data(a_ptr, a.shape_, a.dev_mask(), a.dev_id());
+    Tensor<xpu, 3, DType> A = a_data.FlatToKD<xpu, 3, DType>(s);
+
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+      mxnet_op::Kernel<eigvals_assign_helper<req_type>, xpu>::Launch(
+        s, w.Size(), w_ptr, w.dptr<DType>());
+    });
+
+    // Set signs of eigenvectors in a deterministic way
+    mxnet_op::Kernel<SyevdEigenVecSigns, xpu>::Launch(
+      s, A.size(0) * A.size(1), A.size(1), A.dptr_, A.stride_);
+
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+      mxnet_op::Kernel<eigvec_assign_helper<req_type>, xpu>::Launch(
+        s, v.Size(), a_ptr, v.dptr<DType>(),
+        A.size(1), A.stride_,
+        A.size(1) * A.stride_);
+    });
+  });
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NUMPY_LINALG_NP_EIG_INL_H_

--- a/src/operator/numpy/linalg/np_eig.cc
+++ b/src/operator/numpy/linalg/np_eig.cc
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_eig.cc
+ * \brief CPU implementation placeholder of Eig Operator
+ */
+#include "./np_eig-inl.h"
+
+namespace mxnet {
+namespace op {
+
+// Inputs: A.
+// Outputs: Eig, EigVec
+bool EigOpShape(const nnvm::NodeAttrs& attrs,
+                mxnet::ShapeVector *in_attrs,
+                mxnet::ShapeVector *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 2U);
+  const mxnet::TShape& a_shape = (*in_attrs)[0];
+  const mxnet::TShape& eig_shape = (*out_attrs)[0];
+  const mxnet::TShape& eigv_shape = (*out_attrs)[1];
+
+  if (shape_is_known(a_shape)) {
+    // Forward shape inference.
+    const int a_ndim = a_shape.ndim();
+    CHECK_GE(a_ndim, 2)
+      << "Array must be at least two-dimensional";
+    CHECK_EQ(a_shape[a_ndim - 2], a_shape[a_ndim - 1])
+      << "Input A's last two dimension must be equal";
+
+    // Calculate eig shape.
+    std::vector<int> eig_shape_vec(a_ndim - 1, -1);
+    for (int i = 0; i < a_ndim - 1; ++i) {
+      eig_shape_vec[i] = a_shape[i];
+    }
+    mxnet::TShape eig_shape(eig_shape_vec.begin(), eig_shape_vec.end());
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, eig_shape);
+    // Calculate eig vec shape: must have the same shape as A
+    SHAPE_ASSIGN_CHECK(*out_attrs, 1, a_shape);
+  } else {
+    // Backward shape inference.
+    if (shape_is_known(eig_shape) && shape_is_known(eigv_shape)) {
+      const int eig_ndim = eig_shape.ndim();
+      const int eigv_ndim = eigv_shape.ndim();
+      CHECK_GE(eigv_ndim, 2)
+        << "Outputs V must be at least two-dimensional";
+      CHECK_EQ(eigv_shape[eigv_ndim - 2], eigv_shape[eigv_ndim - 1])
+        << "Outputs V's last two dimension must be equal";
+      CHECK_EQ(eig_ndim + 1, eigv_ndim)
+        << "Outputs W, V must satisfy W.ndim == V.ndim - 1";
+      for (int i = 0; i < eig_ndim; ++i) {
+        CHECK_EQ(eig_shape[i], eigv_shape[i])
+          << "Outputs W, V's shape dismatch";
+      }
+      SHAPE_ASSIGN_CHECK(*in_attrs, 0, eigv_shape);
+    } else if (shape_is_known(eig_shape)) {
+      const int eig_ndim = eig_shape.ndim();
+      CHECK_GE(eig_ndim, 1)
+        << "Outputs W must be at least one-dimensional";
+      std::vector<int> eigv_shape_vec(eig_ndim + 1);
+      for (int i = 0; i < eig_ndim; ++i) {
+        eigv_shape_vec[i] = eig_shape[i];
+      }
+      eigv_shape_vec[eig_ndim] = eig_shape[eig_ndim - 1];
+      mxnet::TShape eigv_shape(eigv_shape_vec.begin(), eigv_shape_vec.end());
+      SHAPE_ASSIGN_CHECK(*in_attrs, 0, eigv_shape);
+      SHAPE_ASSIGN_CHECK(*out_attrs, 1, eigv_shape);
+    } else {
+      const int eigv_ndim = eigv_shape.ndim();
+      CHECK_GE(eigv_ndim, 2)
+        << "Outputs V must be at least two-dimensional";
+      CHECK_EQ(eigv_shape[eigv_ndim - 2], eigv_shape[eigv_ndim - 1])
+        << "Outputs V's last two dimension must be equal";
+      std::vector<int> eig_shape_vec(eigv_ndim - 1);
+      for (int i = 0; i < eigv_ndim - 1; ++i) {
+        eig_shape_vec[i] = eigv_shape[i];
+      }
+      mxnet::TShape eig_shape(eig_shape_vec.begin(), eig_shape_vec.end());
+      SHAPE_ASSIGN_CHECK(*in_attrs, 0, eigv_shape);
+      SHAPE_ASSIGN_CHECK(*out_attrs, 0, eig_shape);
+    }
+  }
+  return shape_is_known(*in_attrs) && shape_is_known(*out_attrs);
+}
+
+inline bool EigOpType(const nnvm::NodeAttrs& attrs,
+                      std::vector<int>* in_attrs,
+                      std::vector<int>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 2U);
+  int a_type = in_attrs->at(0);
+  // unsupport float16
+  CHECK_NE(a_type, mshadow::kFloat16)
+    << "array type float16 is unsupported in linalg";
+  if (mshadow::kFloat32 == a_type) {
+    TYPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
+    TYPE_ASSIGN_CHECK(*out_attrs, 1, in_attrs->at(0));
+  } else {
+    TYPE_ASSIGN_CHECK(*out_attrs, 0, mshadow::kFloat64);
+    TYPE_ASSIGN_CHECK(*out_attrs, 1, mshadow::kFloat64);
+  }
+  return out_attrs->at(0) != -1 && out_attrs->at(1) != -1;
+}
+
+NNVM_REGISTER_OP(_npi_eig)
+.set_num_inputs(1)
+.set_num_outputs(2)
+.set_attr<nnvm::FListInputNames>("FListInputNames", [](const NodeAttrs& attrs){
+  return std::vector<std::string>{"A"};
+})
+.set_attr<mxnet::FInferShape>("FInferShape", EigOpShape)
+.set_attr<nnvm::FInferType>("FInferType", EigOpType)
+.set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
+.set_attr<FCompute>("FCompute<cpu>", EigOpForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+.add_argument("A", "NDArray-or-Symbol", "Tensor of square matrix");
+
+DMLC_REGISTER_PARAMETER(EighParam);
+
+NNVM_REGISTER_OP(_npi_eigh)
+.set_attr_parser(mxnet::op::ParamParser<EighParam>)
+.set_num_inputs(1)
+.set_num_outputs(2)
+.set_attr<nnvm::FListInputNames>("FListInputNames", [](const NodeAttrs& attrs){
+  return std::vector<std::string>{"A"};
+})
+.set_attr<mxnet::FInferShape>("FInferShape", EigOpShape)
+.set_attr<nnvm::FInferType>("FInferType", EigOpType)
+.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& attrs){
+  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+})
+.set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
+.set_attr<FCompute>("FCompute<cpu>", EighOpForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+.add_argument("A", "NDArray-or-Symbol", "Tensor of real matrices")
+.add_arguments(EighParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/linalg/np_eig.cu
+++ b/src/operator/numpy/linalg/np_eig.cu
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file np_eigvals.cu
+ * \brief GPU implementation placeholder of Eigvals Operator
+ */
+
+#include <mxnet/operator_util.h>
+#include "./np_eig-inl.h"
+
+namespace mxnet {
+namespace op {
+
+template<>
+size_t EigForwardWorkspaceSize<gpu>(const TBlob& a,
+                                    const TBlob& w,
+                                    const TBlob& v,
+                                    const std::vector<OpReqType>& req) {
+  LOG(FATAL) << "EigForwardWorkspaceSize in gpu is unsupported";
+  return 0U;
+}
+
+template<>
+void EigOpForwardImpl<gpu>(const TBlob& a,
+                           const TBlob& w,
+                           const TBlob& v,
+                           const std::vector<OpReqType>& req,
+                           std::vector<char> *workspace,
+                           mshadow::Stream<gpu> *s) {
+  LOG(FATAL) << "EigOpForwardImpl in gpu is unsupported";
+}
+
+NNVM_REGISTER_OP(_npi_eig)
+.set_attr<FCompute>("FCompute<gpu>", EigOpForward<gpu>);
+
+#if MXNET_USE_CUSOLVER == 1
+
+NNVM_REGISTER_OP(_npi_eigh)
+.set_attr<FCompute>("FCompute<gpu>", EighOpForward<gpu>);
+
+#endif
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/linalg/np_eigvals-inl.h
+++ b/src/operator/numpy/linalg/np_eigvals-inl.h
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_eigvals-inl.h
+ * \brief Placeholder for eigvals
+ */
+#ifndef MXNET_OPERATOR_NUMPY_LINALG_NP_EIGVALS_INL_H_
+#define MXNET_OPERATOR_NUMPY_LINALG_NP_EIGVALS_INL_H_
+
+#include <mxnet/operator_util.h>
+#include <vector>
+#include "../../operator_common.h"
+#include "../../mshadow_op.h"
+#include "../../tensor/la_op.h"
+#include "../../tensor/la_op-inl.h"
+#include "./np_solve-inl.h"
+
+namespace mxnet {
+namespace op {
+
+using namespace mshadow;
+
+template<int req>
+struct eigvals_assign_helper {
+  template<typename DType>
+  MSHADOW_XINLINE static void Map(int i, const DType *in_data, DType *out_data) {
+    KERNEL_ASSIGN(out_data[i], req, in_data[i]);
+  }
+};
+
+struct eigh_eigvalsh_helper {
+  template<typename InDType, typename OutDType>
+  MSHADOW_XINLINE static void Map(int i, const InDType *in_data, OutDType *out_data,
+                                  const int nrow, const int ld, const int step, bool USE_UP) {
+    int idx = i / step, row = (i % step) / ld, col = (i % step) % ld;
+    if ((USE_UP && row > col) || (!USE_UP && row < col)) {
+      out_data[idx * step + col + row * ld] =
+        static_cast<OutDType>(in_data[idx * step + row + col * ld]);
+    } else {
+      out_data[idx * step + col + row * ld] =
+        static_cast<OutDType>(in_data[idx * step + col + row * ld]);
+    }
+  }
+};
+
+template<typename xpu, typename DType>
+void linalg_geev(char jobvl,
+                 char jobvr,
+                 const Tensor<xpu, 2, DType>& a,
+                 const Tensor<xpu, 1, DType>& wr,
+                 const Tensor<xpu, 1, DType>& wi,
+                 const Tensor<xpu, 2, DType>& vl,
+                 const Tensor<xpu, 2, DType>& vr,
+                 const Tensor<xpu, 1, DType>& work_array);
+
+#define LINALG_CPU_EIG(fname, DType) \
+template<> inline \
+void linalg_geev<cpu, DType>(char jobvl, \
+                             char jobvr, \
+                             const Tensor<cpu, 2, DType>& a, \
+                             const Tensor<cpu, 1, DType>& wr, \
+                             const Tensor<cpu, 1, DType>& wi, \
+                             const Tensor<cpu, 2, DType>& vl, \
+                             const Tensor<cpu, 2, DType>& vr, \
+                             const Tensor<cpu, 1, DType>& work_array) { \
+  const int n = a.size(1), lda = a.size(0); \
+  const int lwork = work_array.shape_.Size(); \
+  const int ldvl = vl.size(0), ldvr = vr.size(0); \
+  int res(MXNET_LAPACK_##fname(MXNET_LAPACK_COL_MAJOR, jobvl, jobvr, \
+                               n, a.dptr_, lda, \
+                               wr.dptr_, wi.dptr_, \
+                               vl.dptr_, ldvl, \
+                               vr.dptr_, ldvr, \
+                               work_array.dptr_, lwork)); \
+  CHECK_LE(res, 0) << #fname << "the QR algorithm failed to compute all the" \
+    << "eigenvalues, and no eigenvectors have been computed; elements " \
+    << res + 1 << ":N" << " of WR and WI contain eigenvalues which have converged"; \
+  CHECK_GE(res, 0) << #fname << ": the " << -res \
+    << "-th argument had an illegal value"; \
+}
+LINALG_CPU_EIG(sgeev, float)
+LINALG_CPU_EIG(dgeev, double)
+
+#ifdef __CUDACC__
+
+#define LINALG_GPU_EIG(fname, DType) \
+template<> inline \
+void linalg_geev<gpu, DType>(char jobvl, \
+                             char jobvr, \
+                             const Tensor<gpu, 2, DType>& a, \
+                             const Tensor<gpu, 1, DType>& wr, \
+                             const Tensor<gpu, 1, DType>& wi, \
+                             const Tensor<gpu, 2, DType>& vl, \
+                             const Tensor<gpu, 2, DType>& vr, \
+                             const Tensor<gpu, 1, DType>& work_array) { \
+  LOG(FATAL) << "Lapack _geev routines in gpu is unsupported"; \
+}
+LINALG_GPU_EIG(sgeev, float)
+LINALG_GPU_EIG(dgeev, double)
+
+#endif  // __CUDACC__
+
+struct eig_eigvals {
+  template<typename xpu, typename DType>
+  static void op(char jobvl,
+                 char jobvr,
+                 const Tensor<xpu, 3, DType>& a,
+                 const Tensor<xpu, 2, DType>& wr,
+                 const Tensor<xpu, 2, DType>& wi,
+                 const Tensor<xpu, 3, DType>& vl,
+                 const Tensor<xpu, 3, DType>& vr,
+                 const Tensor<xpu, 1, DType>& work_array) {
+    const mxnet::TShape& a_shape = a.shape_;
+    const int a_ndim = a_shape.ndim();
+    if (jobvl == 'N' && jobvr == 'N') {
+      CHECK_GE(work_array.shape_.Size(), 3 * a.shape_[a_ndim - 1])
+        << "The dimension of the array WORK in LAPACKE_#GEEV should >= max(1,3*N).";
+    } else {
+      CHECK_GE(work_array.shape_.Size(), 4 * a.shape_[a_ndim - 1])
+        << "If JOBVL = 'V' or JOBVR = 'V', "
+        << "the dimension of the array WORK in LAPACKE_#GEEV should >= 4*N.";
+    }
+    for (int i = 0; i < a_shape[0]; ++i) {
+      if (jobvl == 'N' && jobvr == 'N') {
+        linalg_geev(jobvl, jobvr, a[i], wr[i], wi[i], vl[0], vr[0], work_array);
+      } else if (jobvl == 'N' && jobvr == 'V') {
+        linalg_geev(jobvl, jobvr, a[i], wr[i], wi[i], vl[0], vr[i], work_array);
+      } else if (jobvl == 'V' && jobvr == 'N') {
+        linalg_geev(jobvl, jobvr, a[i], wr[i], wi[i], vl[i], vr[0], work_array);
+      } else {
+        linalg_geev(jobvl, jobvr, a[i], wr[i], wi[i], vl[i], vr[i], work_array);
+      }
+    }
+  }
+};
+
+// Calculates workspace size of eigvals forward op.
+// The dimension of the array WORK in LAPACKE_#GEEV should >= max(1,3*N), and
+// if JOBVL = 'V' or JOBVR = 'V', LWORK >= 4*N.
+// For good performance, LWORK must generally be larger.
+template<typename xpu>
+size_t EigvalsForwardWorkspaceSize(const TBlob& a,
+                                   const TBlob& w,
+                                   const std::vector<OpReqType>& req) {
+  if (kNullOp == req[0]) { return 0U; }
+
+  // Zero-size input, no need to launch kernel
+  if (0U == a.Size()) { return 0U; }
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(w.type_flag_, DType, {
+    size_t work_space_size = 0;
+    size_t n = a.size(a.ndim() - 1);
+    work_space_size += a.Size();      // For matrix.
+    work_space_size += 2 * w.Size();  // For eigenvalues' real and image component.
+    work_space_size += 2 * n * n;     // For left and right eigenvectors temp memory
+    work_space_size += 3 * n;         // For workspace size in LAPACKE_#GEEV.
+    work_space_size *= sizeof(DType);
+    return work_space_size;
+  });
+  LOG(FATAL) << "InternalError: cannot reach here";
+  return 0U;
+}
+
+template<typename xpu>
+void EigvalsOpForwardImpl(const TBlob& a,
+                          const TBlob& w,
+                          const std::vector<OpReqType>& req,
+                          std::vector<char> *workspace,
+                          mshadow::Stream<xpu> *s) {
+  if (kNullOp == req[0]) { return; }
+  const mxnet::TShape& a_shape = a.shape_;
+  const mxnet::TShape& w_shape = w.shape_;
+  const int a_ndim = a_shape.ndim();
+
+  // Zero-size output, no need to launch kernel
+  if (0U == a.Size()) { return; }
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(w.type_flag_, DType, {
+    const int N = a.size(a_ndim - 1);
+    DType *a_ptr =
+      reinterpret_cast<DType*>(workspace->data());
+    DType *wr_ptr =
+      reinterpret_cast<DType*>(workspace->data() + a.Size() * sizeof(DType));
+    DType *wi_ptr =
+      reinterpret_cast<DType*>(workspace->data() + (w.Size() + a.Size()) * sizeof(DType));
+    DType *vl_ptr =
+      reinterpret_cast<DType*>(workspace->data() + (2 * w.Size() + a.Size()) * sizeof(DType));
+    DType *vr_ptr =
+      reinterpret_cast<DType*>(
+        workspace->data() + (N * N + 2 * w.Size() + a.Size()) * sizeof(DType));
+    DType *work_ptr =
+      reinterpret_cast<DType*>(
+        workspace->data() + (2 * (N * N + w.Size()) + a.Size()) * sizeof(DType));
+    MSHADOW_TYPE_SWITCH(a.type_flag_, AType, {
+      // Cast type and transpose.
+      mxnet_op::Kernel<SolveTypeTransposeHelper, xpu>::Launch(
+        s, a.Size(), a.dptr<AType>(), a_ptr, N, N, N * N);
+    });
+    s->Wait();
+    char jobvl = 'N', jobvr = 'N';
+    mxnet::TBlob a_trans_data(a_ptr, a_shape, a.dev_mask(), a.dev_id());
+    mxnet::TBlob wr_data(wr_ptr, w_shape, w.dev_mask(), w.dev_id());
+    mxnet::TBlob wi_data(wi_ptr, w_shape, w.dev_mask(), w.dev_id());
+    mxnet::TBlob vl_data(vl_ptr, Shape3(1, N, N), w.dev_mask(), w.dev_id());
+    mxnet::TBlob vr_data(vr_ptr, Shape3(1, N, N), w.dev_mask(), w.dev_id());
+    mxnet::TBlob work_data(work_ptr, Shape1(3 * N), a.dev_mask(), a.dev_id());
+    eig_eigvals::op(jobvl, jobvr,
+                    a_trans_data.FlatToKD<xpu, 3, DType>(s),
+                    wr_data.FlatToKD<xpu, 2, DType>(s),
+                    wi_data.FlatToKD<xpu, 2, DType>(s),
+                    vl_data.get<xpu, 3, DType>(s),
+                    vr_data.get<xpu, 3, DType>(s),
+                    work_data.get<xpu, 1, DType>(s));
+    for (size_t i = 0; i < wi_data.Size(); ++i) {
+      CHECK_LE(fabs(wi_ptr[i]), 1e-15)
+        << "Complex eigvals is unsupported in linalg temporary.";
+    }
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+      mxnet_op::Kernel<eigvals_assign_helper<req_type>, xpu>::Launch(
+        s, w.Size(), wr_ptr, w.dptr<DType>());
+    });
+  });
+}
+
+template<typename xpu>
+void EigvalsOpForward(const nnvm::NodeAttrs& attrs,
+                      const OpContext& ctx,
+                      const std::vector<TBlob>& inputs,
+                      const std::vector<OpReqType>& req,
+                      const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+  const TBlob& a = inputs[0];
+  const TBlob& w = outputs[0];
+
+  // Calculate workspace size.
+  size_t workspace_size = EigvalsForwardWorkspaceSize<cpu>(a, w, req);
+  std::vector<char> workspace(workspace_size, 0);
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(w.type_flag_, WType, {
+    MSHADOW_SGL_DBL_TYPE_SWITCH(a.type_flag_, AType, {
+      if (xpu::kDevCPU) {
+        // Op forward implement.
+        EigvalsOpForwardImpl<cpu>(a, w, req, &workspace, ctx.get_stream<cpu>());
+      } else {
+#if __CUDACC__
+        mshadow::Stream<gpu> *s = ctx.get_stream<gpu>();
+        cudaStream_t stream = Stream<gpu>::GetStream(s);
+        std::vector<AType> a_vec(a.Size(), 0);
+        std::vector<WType> w_vec(w.Size(), 0);
+        AType* a_cp_ptr = a_vec.data();
+        WType* w_cp_ptr = w_vec.data();
+        CUDA_CALL(cudaMemcpyAsync(a_cp_ptr, a.dptr<AType>(), sizeof(AType) * a.Size(),
+                                  cudaMemcpyDeviceToHost, stream));
+        CUDA_CALL(cudaMemcpyAsync(w_cp_ptr, w.dptr<WType>(), sizeof(WType) * w.Size(),
+                                  cudaMemcpyDeviceToHost, stream));
+        CUDA_CALL(cudaStreamSynchronize(stream));
+        mxnet::TBlob a_data(a_cp_ptr, a.shape_, cpu::kDevMask);
+        mxnet::TBlob w_data(w_cp_ptr, w.shape_, cpu::kDevMask);
+        // Op forward implement on cpu.
+        EigvalsOpForwardImpl<cpu>(a_data, w_data, req, &workspace, ctx.get_stream<cpu>());
+        // Copy back to gpu.
+        CUDA_CALL(cudaMemcpyAsync(w.dptr<WType>(), w_cp_ptr, sizeof(WType) * w.Size(),
+                                  cudaMemcpyHostToDevice, stream));
+        CUDA_CALL(cudaStreamSynchronize(stream));
+#else
+        LOG(FATAL) << "Please build with USE_CUDA=1 to enable GPU";
+#endif
+      }
+    });
+  });
+}
+
+struct EigvalshParam : public dmlc::Parameter<EigvalshParam> {
+  char UPLO;
+  DMLC_DECLARE_PARAMETER(EigvalshParam) {
+    DMLC_DECLARE_FIELD(UPLO)
+    .set_default('L')
+    .describe("Specifies whether the calculation is done with the lower or upper triangular part.");
+  }
+};
+
+template<typename xpu>
+size_t EighEigvalshForwardWorkspaceSize(const TBlob& a,
+                                    const TBlob& w,
+                                    const std::vector<OpReqType>& req,
+                                    const OpContext& ctx) {
+  if (kNullOp == req[0]) { return 0U; }
+
+  // Zero-size input, no need to launch kernel
+  if (0U == a.Size()) { return 0U; }
+
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+  MSHADOW_SGL_DBL_TYPE_SWITCH(a.type_flag_, AType, {
+    MSHADOW_SGL_DBL_TYPE_SWITCH(w.type_flag_, WType, {
+      Tensor<xpu, 2, AType> a_temp_tensor = a.FlatToKD<xpu, 3, AType>(s)[0];
+      WType *a_ptr = nullptr;
+      if (xpu::kDevCPU) {
+        std::vector<WType> A_data(a_temp_tensor.shape_.Size(), 0);
+        a_ptr = A_data.data();
+      } else {
+        Storage::Handle A_data =
+          Storage::Get()->Alloc(sizeof(WType) * a_temp_tensor.shape_.Size(), Context::GPU());
+        a_ptr = static_cast<WType*>(A_data.dptr);
+      }
+      TBlob a_data(a_ptr, a_temp_tensor.shape_, a.dev_mask(), a.dev_id());
+      size_t work_space_size = 0;
+      work_space_size += a.Size();  // For matrix.
+      work_space_size += w.Size();  // For eigenvalues.
+      work_space_size +=            // For workspace size in LAPACKE_#SYEVD.
+        linalg_syevd_workspace_query(a_data.get<xpu, 2, WType>(s),
+                                     w.FlatToKD<xpu, 2, WType>(s)[0], s);
+      return work_space_size * sizeof(WType);
+    });
+  });
+  LOG(FATAL) << "InternalError: cannot reach here";
+  return 0U;
+}
+
+template<typename xpu>
+void EighEigvalshOpForwardImpl(const TBlob& a,
+                               const TBlob& w,
+                               const char& UPLO,
+                               const nnvm::NodeAttrs& attrs,
+                               const OpContext& ctx,
+                               const std::vector<OpReqType>& req,
+                               const Tensor<xpu, 1, char>& workspace) {
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+  MSHADOW_SGL_DBL_TYPE_SWITCH(w.type_flag_, DType, {
+    const size_t workspace_size =
+      (workspace.shape_.Size() + sizeof(DType) - 1) / sizeof(DType);
+    DType *a_ptr =
+      reinterpret_cast<DType*>(workspace.dptr_);
+    DType *w_ptr =
+      reinterpret_cast<DType*>(workspace.dptr_ + a.Size() * sizeof(DType));
+    DType *work_ptr =
+      reinterpret_cast<DType*>(workspace.dptr_ + (a.Size() + w.Size()) * sizeof(DType));
+    TBlob a_data(a_ptr, a.shape_, a.dev_mask(), a.dev_id());
+    TBlob w_data(w_ptr, w.shape_, w.dev_mask(), w.dev_id());
+    TBlob work_data(work_ptr,
+                    Shape1(workspace_size - a.Size() - w.Size()),
+                    w.dev_mask(), w.dev_id());
+    Tensor<xpu, 3, DType> A = a_data.FlatToKD<xpu, 3, DType>(s);
+    Tensor<xpu, 2, DType> W = w_data.FlatToKD<xpu, 2, DType>(s);
+    Tensor<xpu, 1, DType> Work = work_data.get<xpu, 1, DType>(s);
+    // Copy used upper triangle part of 'a'.
+    MSHADOW_SGL_DBL_TYPE_SWITCH(a.type_flag_, AType, {
+      mxnet_op::Kernel<eigh_eigvalsh_helper, xpu>::Launch(
+        s, a.Size(),
+        a.dptr<AType>(), a_ptr,
+        A.size(1), A.stride_,
+        A.size(1) * A.stride_,
+        UPLO == 'U');
+    });
+    // Loop over items in batch
+    for (index_t i = 0; i < A.size(0); ++i) {
+      // Input 'a' must be symmetric, only lower triangle is useds
+      // Needs workspace (both DType and int), size of which is determined by a workspace query
+      linalg_syevd(A[i], W[i], Work, s);
+    }
+  });
+}
+
+template<typename xpu>
+void EigvalshOpForward(const nnvm::NodeAttrs& attrs,
+                       const OpContext& ctx,
+                       const std::vector<TBlob>& inputs,
+                       const std::vector<OpReqType>& req,
+                       const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK_EQ(outputs.size(), 1U);
+  CHECK_EQ(req.size(), 1U);
+  const TBlob& a = inputs[0];
+  const TBlob& w = outputs[0];
+  char UPLO = nnvm::get<EigvalshParam>(attrs.parsed).UPLO;
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+
+  if (kNullOp == req[0]) { return; }
+  // Zero-size output, no need to launch kernel
+  if (0U == a.Size()) { return; }
+
+  // Calculate workspace size.
+  size_t workspace_size = EighEigvalshForwardWorkspaceSize<xpu>(a, w, req, ctx);
+  Tensor<xpu, 1, char> workspace =
+    ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size), s);
+
+  EighEigvalshOpForwardImpl(a, w, UPLO, attrs, ctx, req, workspace);
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(w.type_flag_, DType, {
+    MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
+      mxnet_op::Kernel<eigvals_assign_helper<req_type>, xpu>::Launch(
+        s, w.Size(),
+        reinterpret_cast<DType*>(workspace.dptr_ + a.Size() * sizeof(DType)),
+        w.dptr<DType>());
+    });
+  });
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NUMPY_LINALG_NP_EIGVALS_INL_H_

--- a/src/operator/numpy/linalg/np_eigvals.cc
+++ b/src/operator/numpy/linalg/np_eigvals.cc
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_eigvals.cc
+ * \brief CPU implementation placeholder of Eigvals Operator
+ */
+#include "./np_eigvals-inl.h"
+
+namespace mxnet {
+namespace op {
+
+// Inputs: A.
+// Outputs: Eig.
+bool EigvalsOpShape(const nnvm::NodeAttrs& attrs,
+                mxnet::ShapeVector *in_attrs,
+                mxnet::ShapeVector *out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  const mxnet::TShape& a_shape = (*in_attrs)[0];
+  const mxnet::TShape& eig_shape = (*out_attrs)[0];
+
+  if (shape_is_known(a_shape)) {
+    // Forward shape inference.
+    const int a_ndim = a_shape.ndim();
+    CHECK_GE(a_ndim, 2)
+      << "Array must be at least two-dimensional";
+    CHECK_EQ(a_shape[a_ndim - 2], a_shape[a_ndim - 1])
+      << "Input A's last two dimension must be equal";
+
+    // Calculate eig shape.
+    std::vector<int> eig_shape_vec(a_ndim - 1, -1);
+    for (int i = 0; i < a_ndim - 1; ++i) {
+      eig_shape_vec[i] = a_shape[i];
+    }
+    mxnet::TShape eig_shape(eig_shape_vec.begin(), eig_shape_vec.end());
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, eig_shape);
+  } else {
+    // Backward shape inference.
+    if (shape_is_known(eig_shape)) {
+      const int eig_ndim = eig_shape.ndim();
+      CHECK_GE(eig_ndim, 1)
+        << "Outputs W must be at least one-dimensional";
+      std::vector<int> a_shape_vec(eig_ndim + 1);
+      for (int i = 0; i < eig_ndim; ++i) {
+        a_shape_vec[i] = eig_shape[i];
+      }
+      a_shape_vec[eig_ndim] = eig_shape[eig_ndim - 1];
+      mxnet::TShape a_shape(a_shape_vec.begin(), a_shape_vec.end());
+      SHAPE_ASSIGN_CHECK(*in_attrs, 0, a_shape);
+    }
+  }
+  return shape_is_known(*in_attrs) && shape_is_known(*out_attrs);
+}
+
+inline bool EigvalsOpType(const nnvm::NodeAttrs& attrs,
+                      std::vector<int>* in_attrs,
+                      std::vector<int>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 1U);
+  int a_type = in_attrs->at(0);
+  // unsupport float16
+  CHECK_NE(a_type, mshadow::kFloat16)
+    << "array type float16 is unsupported in linalg";
+  if (mshadow::kFloat32 == a_type) {
+    TYPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
+  } else {
+    TYPE_ASSIGN_CHECK(*out_attrs, 0, mshadow::kFloat64);
+  }
+  return out_attrs->at(0) != -1;
+}
+
+NNVM_REGISTER_OP(_npi_eigvals)
+.set_num_inputs(1)
+.set_num_outputs(1)
+.set_attr<nnvm::FListInputNames>("FListInputNames", [](const NodeAttrs& attrs){
+  return std::vector<std::string>{"A"};
+})
+.set_attr<mxnet::FInferShape>("FInferShape", EigvalsOpShape)
+.set_attr<nnvm::FInferType>("FInferType", EigvalsOpType)
+.set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
+.set_attr<FCompute>("FCompute<cpu>", EigvalsOpForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+.add_argument("A", "NDArray-or-Symbol", "Tensor of square matrix");
+
+DMLC_REGISTER_PARAMETER(EigvalshParam);
+
+NNVM_REGISTER_OP(_npi_eigvalsh)
+.set_attr_parser(mxnet::op::ParamParser<EigvalshParam>)
+.set_num_inputs(1)
+.set_num_outputs(1)
+.set_attr<nnvm::FListInputNames>("FListInputNames", [](const NodeAttrs& attrs){
+  return std::vector<std::string>{"A"};
+})
+.set_attr<mxnet::FInferShape>("FInferShape", EigvalsOpShape)
+.set_attr<nnvm::FInferType>("FInferType", EigvalsOpType)
+.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& attrs){
+  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+})
+.set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
+.set_attr<FCompute>("FCompute<cpu>", EigvalshOpForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+.add_argument("A", "NDArray-or-Symbol", "Tensor of square matrix")
+.add_arguments(EigvalshParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/linalg/np_eigvals.cu
+++ b/src/operator/numpy/linalg/np_eigvals.cu
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file np_eigvals.cu
+ * \brief GPU implementation placeholder of Eigvals Operator
+ */
+
+#include <mxnet/operator_util.h>
+#include "./np_eigvals-inl.h"
+
+namespace mxnet {
+namespace op {
+
+template<>
+size_t EigvalsForwardWorkspaceSize<gpu>(const TBlob& a,
+                                        const TBlob& w,
+                                        const std::vector<OpReqType>& req) {
+  LOG(FATAL) << "EigvalsForwardWorkspaceSize in gpu is unsupported";
+  return 0U;
+}
+
+template<>
+void EigvalsOpForwardImpl<gpu>(const TBlob& a,
+                               const TBlob& w,
+                               const std::vector<OpReqType>& req,
+                               std::vector<char> *workspace,
+                               mshadow::Stream<gpu> *s) {
+  LOG(FATAL) << "EigvalsOpForwardImpl in gpu is unsupported";
+}
+
+NNVM_REGISTER_OP(_npi_eigvals)
+.set_attr<FCompute>("FCompute<gpu>", EigvalsOpForward<gpu>);
+
+#if MXNET_USE_CUSOLVER == 1
+
+NNVM_REGISTER_OP(_npi_eigvalsh)
+.set_attr<FCompute>("FCompute<gpu>", EigvalshOpForward<gpu>);
+
+#endif
+
+}  // namespace op
+}  // namespace mxnet


### PR DESCRIPTION
## Description ##
[Numpy] Add linalg.eigvals/eig/eigvalsh/eigh op

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
