### PR TITLE
Minor fix, use RAII for TensorRT builder and network object

### DIFF
--- a/src/operator/subgraph/tensorrt/onnx_to_tensorrt.cc
+++ b/src/operator/subgraph/tensorrt/onnx_to_tensorrt.cc
@@ -77,8 +77,8 @@ std::tuple<unique_ptr<nvinfer1::ICudaEngine>,
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
   auto trt_logger = std::unique_ptr<TRT_Logger>(new TRT_Logger(verbosity));
-  auto trt_builder = nvinfer1::createInferBuilder(*trt_logger);
-  auto trt_network = trt_builder->createNetwork();
+  auto trt_builder = InferObject(nvinfer1::createInferBuilder(*trt_logger));
+  auto trt_network = InferObject(trt_builder->createNetwork());
   auto trt_parser  = InferObject(nvonnxparser::createParser(*trt_network, *trt_logger));
   ::ONNX_NAMESPACE::ModelProto parsed_model;
   // We check for a valid parse, but the main effect is the side effect
@@ -125,8 +125,6 @@ std::tuple<unique_ptr<nvinfer1::ICudaEngine>,
   trt_builder->setMaxWorkspaceSize(max_workspace_size);
   trt_builder->setDebugSync(debug_builder);
   auto trt_engine = InferObject(trt_builder->buildCudaEngine(*trt_network));
-  trt_builder->destroy();
-  trt_network->destroy();
   return std::make_tuple(std::move(trt_engine), std::move(trt_parser), std::move(trt_logger));
 }
 


### PR DESCRIPTION
## Description ##

Both the `nvinfer1::INetworkDefinition` and `nvinfer1::IBuilder` class has `destroy` method to destruct the object, and can use the RAII class `InferObject`,  but original code before this PR does not use this one. This PR enhanced the robustness, espescially when the function throws. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
