### PR TITLE
Enhancements for custom subgraph op

### DIFF
--- a/example/extensions/lib_custom_op/subgraph_lib.cc
+++ b/example/extensions/lib_custom_op/subgraph_lib.cc
@@ -46,20 +46,6 @@ MXReturnValue parseAttrs(std::map<std::string, std::string> attrs,
   return MX_SUCCESS;
 }
 
-MXReturnValue inferType(std::map<std::string, std::string> attrs,
-                        std::vector<int> &intypes,
-                        std::vector<int> &outtypes) {
-  outtypes[0] = intypes[0];
-  return MX_SUCCESS;
-}
-
-MXReturnValue inferShape(std::map<std::string, std::string> attrs,
-                         std::vector<std::vector<unsigned int>> &inshapes,
-                         std::vector<std::vector<unsigned int>> &outshapes) {
-  outshapes[0] = inshapes[0];
-  return MX_SUCCESS;
-}
-
 class MyStatefulOp : public CustomStatefulOp {
  public:
   explicit MyStatefulOp(std::string sym) : subgraph_sym(sym) {}
@@ -98,8 +84,7 @@ MXReturnValue createOpState(std::map<std::string, std::string> attrs,
 
 REGISTER_OP(_custom_subgraph_op)
 .setParseAttrs(parseAttrs)
-.setInferType(inferType)
-.setInferShape(inferShape)
+.isSubgraphOp(true)
 .setCreateOpState(createOpState);
 
 MXReturnValue initialize(int version) {

--- a/example/extensions/lib_custom_op/subgraph_lib.cc
+++ b/example/extensions/lib_custom_op/subgraph_lib.cc
@@ -84,7 +84,7 @@ MXReturnValue createOpState(std::map<std::string, std::string> attrs,
 
 REGISTER_OP(_custom_subgraph_op)
 .setParseAttrs(parseAttrs)
-.isSubgraphOp(true)
+.setIsSubgraphOp()
 .setCreateOpState(createOpState);
 
 MXReturnValue initialize(int version) {

--- a/include/mxnet/lib_api.h
+++ b/include/mxnet/lib_api.h
@@ -541,7 +541,8 @@ class CustomOp {
  public:
   explicit CustomOp(const char* op_name) : name(op_name),
     forward(NULL), backward(NULL), parse_attrs(NULL), infer_type(NULL),
-    infer_shape(NULL), mutate_inputs(NULL), create_opstate(NULL) {}
+    infer_shape(NULL), mutate_inputs(NULL), create_opstate(NULL),
+    isSGop(false) {}
   ~CustomOp() {}
   CustomOp& setForward(fcomp_t fcomp) {
     forward = fcomp;
@@ -571,6 +572,10 @@ class CustomOp {
     create_opstate = func;
     return *this;
   }
+  CustomOp& isSubgraphOp(bool state) {
+    isSGop = state;
+    return *this;
+  }
 
   /*! \brief operator name */
   const char* name;
@@ -582,6 +587,7 @@ class CustomOp {
   inferShape_t infer_shape;
   mutateInputs_t mutate_inputs;
   createOpState_t create_opstate;
+  bool isSGop;
 };
 
 /*!
@@ -658,7 +664,7 @@ typedef int (*opRegSize_t)(void);
 typedef int (*opRegGet_t)(int, const char**, fcomp_t*, fcomp_t*,
                           parseAttrs_t*, inferType_t*,
                           inferShape_t*, mutateInputs_t*,
-                          createOpState_t*);
+                          createOpState_t*, bool*);
 
 #define MXLIB_OPCALLFREE_STR "_opCallFree"
 typedef int (*opCallFree_t)(void*);
@@ -737,7 +743,7 @@ extern "C" {
   _opRegGet(int idx, const char** name, fcomp_t* fcomp, fcomp_t* fgrad,
             parseAttrs_t* parse, inferType_t* type,
             inferShape_t* shape, mutateInputs_t* mutate,
-            createOpState_t* create_op) {
+            createOpState_t* create_op, bool *isSGop) {
     CustomOp op = Registry<CustomOp>::get()->get(idx);
     *name = op.name;
     *fcomp = op.forward;
@@ -747,6 +753,7 @@ extern "C" {
     *shape = op.infer_shape;
     *mutate = op.mutate_inputs;
     *create_op = op.create_opstate;
+    *isSGop = op.isSGop;
   }
 
   /*! \brief calls free from the external library for library allocated arrays */

--- a/include/mxnet/lib_api.h
+++ b/include/mxnet/lib_api.h
@@ -572,8 +572,8 @@ class CustomOp {
     create_opstate = func;
     return *this;
   }
-  CustomOp& isSubgraphOp(bool state) {
-    isSGop = state;
+  CustomOp& setIsSubgraphOp() {
+    isSGop = true;
     return *this;
   }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -169,12 +169,12 @@ int MXLoadLib(const char *path) {
     opRegGet(i, &name, &fcomp_fp, &fgrad_fp, &parse_fp, &type_fp, &shape_fp,
              &mutate_fp, &create_opstate_fp, &isSubgraphOp);
 
+    CHECK(parse_fp != nullptr) << "Error loading '" << name
+                               << "' custom op, ParseAttrs function was not set.";
     if(!isSubgraphOp) {
       // validate custom operator functions from the dynamic library
       CHECK(fcomp_fp != nullptr || create_opstate_fp != nullptr) << "Error loading '" << name
                             << "' custom op, Forward or CreateOpState function was not set.";
-      CHECK(parse_fp != nullptr) << "Error loading '" << name
-                            << "' custom op, ParseAttrs function was not set.";
       CHECK(type_fp  != nullptr) << "Error loading '" << name
                             << "' custom op, InferType function was not set.";
       CHECK(shape_fp != nullptr) << "Error loading '" << name

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -51,6 +51,7 @@
 #include "./c_api_common.h"
 #include "../operator/custom/custom-inl.h"
 #include "../operator/operator_common.h"
+#include "../operator/subgraph/common.h"
 #include "../operator/tensor/matrix_op-inl.h"
 #include "../operator/tvmop/op_module.h"
 #include "../common/utils.h"
@@ -162,21 +163,28 @@ int MXLoadLib(const char *path) {
     fcomp_t fgrad_fp = nullptr;
     mutateInputs_t mutate_fp = nullptr;
     createOpState_t create_opstate_fp = nullptr;
-
+    bool isSubgraphOp = false;
+    
     // get custom operator implemenation from the dynamic library
     opRegGet(i, &name, &fcomp_fp, &fgrad_fp, &parse_fp, &type_fp, &shape_fp,
-                &mutate_fp, &create_opstate_fp);
+             &mutate_fp, &create_opstate_fp, &isSubgraphOp);
 
-    // validate custom operator functions from the dynamic library
-    CHECK(fcomp_fp != nullptr || create_opstate_fp != nullptr) << "Error loading '" << name
+    if(!isSubgraphOp) {
+      // validate custom operator functions from the dynamic library
+      CHECK(fcomp_fp != nullptr || create_opstate_fp != nullptr) << "Error loading '" << name
                             << "' custom op, Forward or CreateOpState function was not set.";
-    CHECK(parse_fp != nullptr) << "Error loading '" << name
+      CHECK(parse_fp != nullptr) << "Error loading '" << name
                             << "' custom op, ParseAttrs function was not set.";
-    CHECK(type_fp  != nullptr) << "Error loading '" << name
+      CHECK(type_fp  != nullptr) << "Error loading '" << name
                             << "' custom op, InferType function was not set.";
-    CHECK(shape_fp != nullptr) << "Error loading '" << name
+      CHECK(shape_fp != nullptr) << "Error loading '" << name
                             << "' custom op, InferShape function was not set.";
-
+    } else {
+      // validate custom operator functions from the dynamic library
+      CHECK(create_opstate_fp != nullptr) << "Error loading '" << name
+                            << "' custom subgraph op, CreateOpState function was not set.";      
+    }
+    
     LOG(INFO) << "\tOp[" << i << "] " << name;
     std::string name_str(name);
 
@@ -646,10 +654,28 @@ int MXLoadLib(const char *path) {
       // TODO(samskalicky): enable constant overwriting of registertion multiple times
       plevel++;
     }
-    regOp.set_attr<nnvm::FInferType>("FInferType", infer_type, plevel);
-    regOp.set_attr<mxnet::FInferShape>("FInferShape", infer_shape, plevel);
-    regOp.set_attr<FInferStorageType>("FInferStorageType", infer_storage_type, plevel);
-    regOp.set_attr<FResourceRequest>("FResourceRequest", resc_req, plevel);
+    if(!isSubgraphOp) {
+      regOp.set_attr<nnvm::FInferType>("FInferType", infer_type, plevel);
+      regOp.set_attr<mxnet::FInferShape>("FInferShape", infer_shape, plevel);
+      regOp.set_attr<FInferStorageType>("FInferStorageType", infer_storage_type, plevel);
+      regOp.set_attr<FResourceRequest>("FResourceRequest", resc_req, plevel);
+      // optionally add fmutate inputs if user specified a function
+      if (mutate_fp != nullptr)
+        regOp.set_attr<nnvm::FMutateInputs>("FMutateInputs", mutate_inputs, plevel);
+    } else {
+      using namespace mxnet::op;
+      regOp.set_attr<nnvm::FInferType>("FInferType",
+                                       DefaultSubgraphOpType, plevel);
+      regOp.set_attr<mxnet::FInferShape>("FInferShape",
+                                         DefaultSubgraphOpShape, plevel);
+      regOp.set_attr<FInferStorageType>("FInferStorageType",
+                                        DefaultSubgraphOpStorageType, plevel);
+      regOp.set_attr<FResourceRequest>("FResourceRequest",
+                                       DefaultSubgraphOpResourceRequest, plevel);
+      regOp.set_attr<nnvm::FMutateInputs>("FMutateInputs",
+                                          DefaultSubgraphOpMutableInputs, plevel);
+    }
+    
     // optionally add stateful forward
     if (create_opstate_fp != nullptr) {
       regOp.set_attr<FCreateOpState>("FCreateOpState", create_opstate, plevel);
@@ -658,9 +684,6 @@ int MXLoadLib(const char *path) {
     } else {
       regOp.set_attr<FComputeEx>("FComputeEx<cpu>", forward_lambda, plevel);
     }
-    // optionally add fmutate inputs if user specified a function
-    if (mutate_fp != nullptr)
-      regOp.set_attr<nnvm::FMutateInputs>("FMutateInputs", mutate_inputs, plevel);
     // optionally add fgradient if user specified a function
     if (fgrad_fp != nullptr || create_opstate_fp != nullptr) {
       regOp.set_attr<nnvm::FGradient>("FGradient", grad_reg, plevel);

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -164,14 +164,14 @@ int MXLoadLib(const char *path) {
     mutateInputs_t mutate_fp = nullptr;
     createOpState_t create_opstate_fp = nullptr;
     bool isSubgraphOp = false;
-    
+
     // get custom operator implemenation from the dynamic library
     opRegGet(i, &name, &fcomp_fp, &fgrad_fp, &parse_fp, &type_fp, &shape_fp,
              &mutate_fp, &create_opstate_fp, &isSubgraphOp);
 
     CHECK(parse_fp != nullptr) << "Error loading '" << name
                                << "' custom op, ParseAttrs function was not set.";
-    if(!isSubgraphOp) {
+    if (!isSubgraphOp) {
       // validate custom operator functions from the dynamic library
       CHECK(fcomp_fp != nullptr || create_opstate_fp != nullptr) << "Error loading '" << name
                             << "' custom op, Forward or CreateOpState function was not set.";
@@ -182,9 +182,9 @@ int MXLoadLib(const char *path) {
     } else {
       // validate custom operator functions from the dynamic library
       CHECK(create_opstate_fp != nullptr) << "Error loading '" << name
-                            << "' custom subgraph op, CreateOpState function was not set.";      
+                            << "' custom subgraph op, CreateOpState function was not set.";
     }
-    
+
     LOG(INFO) << "\tOp[" << i << "] " << name;
     std::string name_str(name);
 
@@ -654,7 +654,7 @@ int MXLoadLib(const char *path) {
       // TODO(samskalicky): enable constant overwriting of registertion multiple times
       plevel++;
     }
-    if(!isSubgraphOp) {
+    if (!isSubgraphOp) {
       regOp.set_attr<nnvm::FInferType>("FInferType", infer_type, plevel);
       regOp.set_attr<mxnet::FInferShape>("FInferShape", infer_shape, plevel);
       regOp.set_attr<FInferStorageType>("FInferStorageType", infer_storage_type, plevel);
@@ -675,7 +675,7 @@ int MXLoadLib(const char *path) {
       regOp.set_attr<nnvm::FMutateInputs>("FMutateInputs",
                                           DefaultSubgraphOpMutableInputs, plevel);
     }
-    
+
     // optionally add stateful forward
     if (create_opstate_fp != nullptr) {
       regOp.set_attr<FCreateOpState>("FCreateOpState", create_opstate, plevel);


### PR DESCRIPTION
## Description ##
Enhancements for custom subgraph operators in external libraries. 
- Adds API to set boolean flag to denote a subgraph operator in an external library
- Removes the requirement to manually implement infer shape/type/storage/mutate/request
- Uses default functions from subgraph/common.h

## Design ##
Its difficult to implement the full shape/type propagation in an external library for a whole subgraph. Rather that re-implement these complex pieces, we'll use the default functions in the subgraph API. 

Starting from the user in the custom library, the registration is now only:
```
REGISTER_OP(_custom_subgraph_op)
.setParseAttrs(parseAttrs)
.isSubgraphOp(true)
.setCreateOpState(createOpState);
```
Here, setting `isSubgraphOp` means we dont have to register the infer shape/type functions. When re-registering the operator in MXNet, if `isSubgraphOp` is true, then we re-use the functions from the subgraph API:
```
if(isSubgraphOp) {
      using namespace mxnet::op;
      regOp.set_attr<nnvm::FInferType>("FInferType",
                                       DefaultSubgraphOpType, plevel);
      regOp.set_attr<mxnet::FInferShape>("FInferShape",
                                         DefaultSubgraphOpShape, plevel);
      regOp.set_attr<FInferStorageType>("FInferStorageType",
                                        DefaultSubgraphOpStorageType, plevel);
      regOp.set_attr<FResourceRequest>("FResourceRequest",
                                       DefaultSubgraphOpResourceRequest, plevel);
      regOp.set_attr<nnvm::FMutateInputs>("FMutateInputs",
                                          DefaultSubgraphOpMutableInputs, plevel);
}
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
