### PR TITLE
Fix for gluon.Trainer regression with sparse grad on single context

### DIFF
--- a/python/mxnet/gluon/trainer.py
+++ b/python/mxnet/gluon/trainer.py
@@ -221,7 +221,7 @@ class Trainer(object):
                                      "when sparse gradients are present.")
                 update_on_kvstore = config['update_on_kvstore']
             # raise err if a custom kvstore is used for sparse training
-            if not isinstance(kvstore, KVStore):
+            if kvstore is not None and not isinstance(kvstore, KVStore):
                 raise ValueError("Cannot use {} for multi-device training with sparse gradients"
                                  .format(type(kvstore)))
 


### PR DESCRIPTION
## Description ##
`kvstore is None` in single-context case. Assertion was wrongly triggered.
Fixes regression in https://github.com/apache/incubator-mxnet/pull/17010

@eric-haibin-lin 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Fix for gluon.Trainer regression with sparse grad on single context

## Comments ##
@eric-haibin-lin 