### PR TITLE
Remove dtype from Variable created from Gluon Parameter

### DIFF
--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -621,7 +621,7 @@ class Parameter(object):
     def var(self):
         """Returns a symbol representing this parameter."""
         if self._var is None:
-            self._var = symbol.var(self.name,
+            self._var = symbol.var(self.name, shape=self.shape,
                                    lr_mult=self.lr_mult, wd_mult=self.wd_mult,
                                    init=self.init, stype=self._stype)
             if is_np_array():

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -621,7 +621,7 @@ class Parameter(object):
     def var(self):
         """Returns a symbol representing this parameter."""
         if self._var is None:
-            self._var = symbol.var(self.name, shape=self.shape, dtype=self.dtype,
+            self._var = symbol.var(self.name,
                                    lr_mult=self.lr_mult, wd_mult=self.wd_mult,
                                    init=self.init, stype=self._stype)
             if is_np_array():


### PR DESCRIPTION
## Description ##
This PR removes the dtype information from `mx.sym.Variable` created from Gluon `Parameter`. Gluon does not need that information anyway (as it performs its own type and shape inference), but it actually makes it impossible to import the model for inference when Gluon's `SymbolBlock` was the source of the model.

For example, this code:
```
from mxnet import gluon
import mxnet as mx
alexnet = gluon.model_zoo.vision.alexnet(pretrained=True, ctx=mx.cpu(),
                                         prefix='model_')
inputs = mx.sym.var('data')
out = alexnet(inputs)
internals = out.get_internals()
outputs = [internals['model_dense0_relu_fwd_output'],
           internals['model_dense1_relu_fwd_output']]
# Create SymbolBlock that shares parameters with alexnet
feat_model = gluon.SymbolBlock(outputs, inputs, params=alexnet.collect_params())
x = mx.nd.random.normal(shape=(16, 3, 224, 224))
print(feat_model(x))
# Save the model
feat_model.export("test_symbolblock", 0)
# Import the symbolic model for inference
sym, _, _ = mx.model.load_checkpoint('test_symbolblock', 0)
# Change the type of data to float16
e = sym.simple_bind(ctx=mx.gpu(), data=(1,3,224,224), type_dict={'data': 'float16'})
```
crashes with
```
MXNetError: Error in operator model_conv0_fwd: [17:02:30] src/operator/nn/convolution.cc:297: Check failed: (*in_type)[i] == dtype (0 vs. 2) : This layer requires uniform type. Expected 'float16' v.s. given 'float32' at 'weight'
```
because the `weight` Variable has dtype set explicitly to `float32`.

This also workarounds a problem in `SymbolBlock` where, due to the fact that graph is not recreated when casting to a different `dtype`, the saved graph still expects `float32` (the default type) for parameters. This code:
```
from mxnet import gluon
import mxnet as mx
alexnet = gluon.model_zoo.vision.alexnet(pretrained=True, ctx=mx.gpu(),
                                         prefix='model_')
inputs = mx.sym.var('data')
out = alexnet(inputs)
internals = out.get_internals()
outputs = [internals['model_dense0_relu_fwd_output'],
           internals['model_dense1_relu_fwd_output']]
# Create SymbolBlock that shares parameters with alexnet
feat_model = gluon.SymbolBlock(outputs, inputs, params=alexnet.collect_params())
feat_model.cast('float16')   # This time cast the model to fp16
x = mx.nd.random.normal(shape=(16, 3, 224, 224), ctx=mx.gpu(), dtype='float16')
print(feat_model(x))
feat_model.export("test_symbolblock", 0)
sym, _, _ = mx.model.load_checkpoint('test_symbolblock', 0)
e = sym.simple_bind(ctx=mx.gpu(), data=(1,3,224,224), type_dict={'data': 'float16'})
```
crashes with the same error as the previous one (`weight` in the graph is `float32`).

I believe `stype` should also be omitted, for the same reasons - @eric-haibin-lin thoughts?

@kexinyu FYI

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change