### PR TITLE
Fix #17164 symbolblock with BatchNorm inside during cast to fp16

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -16,7 +16,7 @@
 # under the License.
 
 # coding: utf-8
-# pylint: disable= arguments-differ, too-many-lines
+# pylint: disable= arguments-differ, too-many-lines, reimported
 """Base container class for all neural network models."""
 __all__ = ['Block', 'HybridBlock', 'SymbolBlock']
 
@@ -1376,7 +1376,7 @@ class SymbolBlock(HybridBlock):
                         self.params.get(node).cast('float32')
                         for sib in sibs:
                             self.params.get(sib).cast('float32')
-                
+
     def hybrid_forward(self, F, x, *args, **kwargs):
         raise NotImplementedError
 

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1299,7 +1299,6 @@ class SymbolBlock(HybridBlock):
             assert len(i.get_internals().list_outputs()) == 1, \
                 "Input symbols must be variable, but %s is an output of operators"%str(i)
             input_names.add(i.name)
-        self._input_names = input_names
 
         # check if any symbol is row_sparse
         row_sparse_storage = ndarray.ndarray._STORAGE_TYPE_STR_TO_ID['row_sparse']

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -596,22 +596,22 @@ def test_hybridblock_mix_ctx_raise():
 
 @with_seed()
 def test_symbol_block_symbolic_bn_fp16_cast():
-    ctx = default_context()
-    net = nn.HybridSequential()
-    sym = mx.sym.var('data')
-    conv = mx.sym.Convolution(sym, kernel=(3, 3), num_filter=16)
-    bn = mx.sym.BatchNorm(conv, name='bn_test')
-    internals = bn.get_internals()
-    net.add(nn.SymbolBlock([internals['bn_test_output']], [mx.sym.var('data')]))
-    net.add(nn.Conv2D(10, kernel_size=1))
-    net.initialize(ctx=ctx)
-    x = mx.nd.zeros((1, 3, 32, 32), dtype='float32', ctx=ctx)
-    y = net(x)
-    assert np.dtype(y.dtype).name == 'float32'
-    net.cast('float16')
-    x = x.astype('float16')
-    y1 = net(x)
-    assert np.dtype(y1.dtype).name == 'float16'
+    with mx.gpu(0):
+        net = mx.gluon.nn.HybridSequential()
+        sym = mx.sym.var('data')
+        conv = mx.sym.Convolution(sym, kernel=(3, 3), num_filter=16)
+        bn = mx.sym.BatchNorm(conv, name='bn_test')
+        internals = bn.get_internals()
+        net.add(mx.gluon.nn.SymbolBlock([internals['bn_test_output']], [mx.sym.var('data')]))
+        net.add(mx.gluon.nn.Conv2D(10, kernel_size=1))
+        net.initialize()
+        x = mx.nd.zeros((1, 3, 32, 32), dtype='float32')
+        y = net(x)
+        assert np.dtype(y.dtype).name == 'float32'
+        net.cast('float16')
+        x = x.astype('float16')
+        y1 = net(x)
+        assert np.dtype(y1.dtype).name == 'float16'
 
 if __name__ == '__main__':
     import nose

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -594,6 +594,24 @@ def test_hybridblock_mix_ctx_raise():
     assert_raises(ValueError, lambda: foo_hybrid(mx.nd.ones((10,), ctx=mx.gpu()),
                                                  mx.nd.ones((10,), ctx=mx.cpu())))
 
+@with_seed()
+def test_symbol_block_symbolic_bn_fp16_cast():
+    ctx = default_context()
+    net = nn.HybridSequential()
+    sym = mx.sym.var('data')
+    conv = mx.sym.Convolution(sym, kernel=(3, 3), num_filter=16)
+    bn = mx.sym.BatchNorm(conv, name='bn_test')
+    internals = bn.get_internals()
+    net.add(nn.SymbolBlock([internals['bn_test_output']], [mx.sym.var('data')]))
+    net.add(nn.Conv2D(10, kernel_size=1))
+    net.initialize(ctx=ctx)
+    x = mx.nd.zeros((1, 3, 32, 32), dtype='float32', ctx=ctx)
+    y = net(x)
+    assert np.dtype(y.dtype).name == 'float32'
+    net.cast('float16')
+    x = x.astype('float16')
+    y1 = net(x)
+    assert np.dtype(y1.dtype).name == 'float16'
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
Should fix https://github.com/apache/incubator-mxnet/issues/17164 where the root cause is
 - BN requires float32 parameters even in fp16 mode
 - SymbolBlock takes symbolic graph but didn't check for BatchNorm inside
 - In contrast, a normal gluon batchnorm layer will be able to check for this special case just like https://github.com/apache/incubator-mxnet/blob/master/python/mxnet/gluon/nn/basic_layers.py#L360

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
