### PR TITLE
Fix and clean up Ubuntu build from source instructions

### DIFF
--- a/docs/static_site/src/pages/get_started/ubuntu_setup.md
+++ b/docs/static_site/src/pages/get_started/ubuntu_setup.md
@@ -22,19 +22,26 @@ permalink: /get_started/ubuntu_setup
 <!--- specific language governing permissions and limitations -->
 <!--- under the License. -->
 
-# Installing MXNet on Ubuntu
+# Installing MXNet from source on Ubuntu
 
-The following installation instructions are for installing MXNet on computers running **Ubuntu 16.04**. Support for later versions of Ubuntu is [not yet available](#contributions).
-<hr>
+The following installation instructions are for building MXNet from source on
+computers running **Ubuntu 16.04** or higher. For instructions to build MXNet
+from source on other platforms, see the general [Build From Source
+guide](build_from_source).
+
+Instead of building from source, you can install a binary version of MXNet. For
+that, please follow the information at [Get Started](get_started).
+
+Building MXNet from source is a two-step process:
+
+1. Build the shared library from the MXNet C++ source code.
+2. (optional) Install the supported language-specific packages for MXNet.
 
 ## Contents
 
 * [CUDA Dependencies](#cuda-dependencies)
-* [Quick Installation](#quick-installation)
-    * [Python](#install-mxnet-for-python)
-    * [pip Packages](#pip-package-availability)
-* [Build from Source](#build-mxnet-from-source)
-* [Installing Language Packages](#installing-language-packages-for-mxnet)
+* [Build the MXNet shared library from source](#build-mxnet-from-source)
+* [Install Language Packages](#installing-language-packages-for-mxnet)
     * [R](#install-the-mxnet-package-for-r)
     * [Julia](#install-the-mxnet-package-for-julia)
     * [Scala](#install-the-mxnet-package-for-scala)
@@ -65,80 +72,7 @@ Unzip the file and change to the cuDNN root directory. Move the header and libra
 
 <hr>
 
-
-## Quick Installation
-
-### Install MXNet for Python
-
-#### Dependencies
-
-The following scripts will install Ubuntu 16.04 dependencies for MXNet Python development.
-
-```bash
-wget https://raw.githubusercontent.com/apache/incubator-mxnet/master/ci/docker/install/ubuntu_core.sh
-wget https://raw.githubusercontent.com/apache/incubator-mxnet/master/ci/docker/install/ubuntu_python.sh
-sudo ./ubuntu_core.sh
-sudo ./ubuntu_python.sh
-```
-
-Using the latest MXNet with CUDA 9.2 package is recommended for the fastest training speeds with MXNet.
-
-**Recommended for training:**
-```bash
-pip install mxnet-cu92
-```
-
-**Recommended for inference:**
-```bash
-pip install mxnet-cu92mkl
-```
-
-Alternatively, you can use the table below to select the package that suits your purpose.
-
-| MXNet Version | Basic | CUDA | MKL-DNN | CUDA/MKL-DNN |
-|-|-|-|-|-|
-| Latest | mxnet | mxnet-cu92 | mxnet-mkl | mxnet-cu92mkl |
-
-
-#### pip Package Availability
-
-The following table presents the pip packages that are recommended for each version of MXNet.
-
-![pip package table](https://raw.githubusercontent.com/dmlc/web-data/master/mxnet/install/pip-packages-1.4.0.png)
-
-To install an older version of MXNet with one of the packages in the previous table add `==` with the version you require. For example for version 1.1.0 of MXNet with CUDA 8, you would use `pip install mxnet-cu80==1.1.0`.
-
-<hr>
-
-
-## Build MXNet from Source
-
-You can build MXNet from source, and then you have the option of installing language-specific bindings, such as Scala, Java, Julia, R or Perl. This is a two-step process:
-
-1. Build the shared library from the MXNet C++ source code.
-2. (optional) Install the supported language-specific packages for MXNet. Be sure to check that section first, as some scripts may be available to handle all of the dependencies, MXNet build, and language bindings for you. Here they are again for quick access:
-
-* [R](#install-the-mxnet-package-for-r)
-* [Julia](#install-the-mxnet-package-for-julia)
-* [Scala](#install-the-mxnet-package-for-scala)
-* [Java](#install-the-mxnet-package-for-java)
-* [Perl](#install-the-mxnet-package-for-perl)
-
-**Note:** To change the compilation options for your build, edit the ```make/config.mk``` file prior to building MXNet. More information on this is mentioned in the different language package instructions.
-
-### Build the Shared Library
-
-#### Quick MXNet Build
-You can quickly build MXNet from source with the following script found in the `/docs/install` folder:
-
-```bash
-cd docs/install
-./install_mxnet_ubuntu_python.sh
-```
-
-Or you can go through a manual process described next.
-
-#### Manual MXNet Installation
+## Build the MXNet shared library from source
 
 It is recommended that you review the general [build from source](build_from_source) instructions before continuing.
 
@@ -147,62 +81,30 @@ On Ubuntu versions 16.04 or later, you need the following dependencies:
 **Step 1:** Install prerequisite packages.
 ```bash
     sudo apt-get update
-    sudo apt-get install -y build-essential git ninja-build ccache
+    sudo apt-get install -y build-essential git ninja-build ccache python3-pip libopenblas-dev libopencv-dev
+    pip install --user --upgrade cmake  # Instead of using pip, you could also manually install cmake from https://cmake.org
 ```
 
-**For Ubuntu 18.04 and CUDA builds you need to update CMake**
+Instead of `libopenblas-dev` you may also choose a different math library.
+Further information is provided in the source guide's [Math Library
+Selection](build_from_source#math-library-selection) section.
 
-```bash
-#!/usr/bin/env bash
-set -exuo pipefail
-sudo apt remove --purge --auto-remove cmake
+`libopencv-dev` is an optional dependency. You can delete it from above `apt-get
+install` line and build MXNet without OpenCV support by passing
+`-DUSE_OPENCV=OFF` to the `cmake` command below.
 
-# Update CMAKE for correct cuda autotedetection: https://github.com/clab/dynet/issues/1457
-version=3.14
-build=0
-mkdir -p ~/tmp
-cd ~/tmp
-wget https://cmake.org/files/v$version/cmake-$version.$build.tar.gz
-tar -xzvf cmake-$version.$build.tar.gz
-cd cmake-$version.$build/
-./bootstrap
-make -j$(nproc)
-sudo make install
-```
-
-
-**Step 2:** Install a Math Library.
-
-Details on the different math libraries are found in the build from source guide's [Math Library Selection](build_from_source#math-library-selection) section.
-
-For OpenBLAS use:
-
-```bash
-    sudo apt-get install -y libopenblas-dev
-```
-
-For other libraries, visit the [Math Library Selection](build_from_source#math-library-selection) section.
-
-**Step 3:** Install OpenCV.
-
-*MXNet* uses [OpenCV](http://opencv.org/) for efficient image loading and augmentation operations.
-
-```bash
-    sudo apt-get install -y libopencv-dev
-```
-
-**Step 4:** Download MXNet sources and build MXNet core shared library.
-
-If building on CPU and using OpenBLAS:
+**Step 2:** Download MXNet sources
 
 Clone the repository:
 
 ```bash
-    git clone --recursive https://github.com/apache/incubator-mxnet.git
-    cd incubator-mxnet
+    git clone --recursive https://github.com/apache/incubator-mxnet.git mxnet
+    cd mxnet
 ```
 
-Build with CMake and ninja, without GPU and without MKL.
+**Step 3:** Build MXNet core shared library.
+
+For a CPU-only build with OpenBLAS math library run:
 
 ```bash
     rm -rf build
@@ -218,7 +120,11 @@ Build with CMake and ninja, without GPU and without MKL.
     ninja
 ```
 
-If building on CPU and using MKL and MKL-DNN (make sure MKL is installed according to [Math Library Selection](build_from_source#math-library-selection) and [MKL-DNN README](https://mxnet.apache.org/api/python/docs/tutorials/performance/backend/mkldnn/mkldnn_readme.html)):
+For a CPU-only build with MKL math library and MKL-DNN you need to make sure MKL
+is installed according to
+[Math Library Selection](build_from_source#math-library-selection) and
+[MKL-DNN README](https://mxnet.apache.org/api/python/docs/tutorials/performance/backend/mkldnn/mkldnn_readme.html)
+respectively. Then run:
 
 ```bash
     rm -rf build
@@ -234,8 +140,8 @@ If building on CPU and using MKL and MKL-DNN (make sure MKL is installed accordi
     ninja
 ```
 
-If building on GPU (make sure you have installed the [CUDA dependencies first](#cuda-dependencies)):
-Cuda 10.1 in Ubuntu 18.04 builds fine but is not currently tested in CI.
+For a GPU-enabled build make sure you have installed the
+[CUDA dependencies first](#cuda-dependencies)) and run:
 
 ```bash
     rm -rf build
@@ -251,17 +157,9 @@ Cuda 10.1 in Ubuntu 18.04 builds fine but is not currently tested in CI.
     ninja
 ```
 
-*Note* - You can explore and use more compilation options as they are delcared in the top of `CMakeLists.txt` and also review common [usage examples](build_from_source#usage-examples).
-Optionally, you can also use a higher level, scripted version of the above with an editable CMake options file by doing the
-following:
-
-```bash
-cp cmake/cmake_options.yml .
-# Edit cmake_options.yml in the MXNet root to your taste
-$EDITOR cmake_options.yml
-# Launch a local CMake build
-./dev_menu.py build
-```
+*Note* - You can explore and use more compilation options as they are delcared
+in the top of `CMakeLists.txt` and also review common
+[usage examples](build_from_source#usage-examples).
 
 Building from source creates a library called ```libmxnet.so``` in the `build` folder in your MXNet project root.
 

--- a/docs/static_site/src/pages/get_started/ubuntu_setup.md
+++ b/docs/static_site/src/pages/get_started/ubuntu_setup.md
@@ -82,7 +82,7 @@ On Ubuntu versions 16.04 or later, you need the following dependencies:
 ```bash
     sudo apt-get update
     sudo apt-get install -y build-essential git ninja-build ccache python3-pip libopenblas-dev libopencv-dev
-    pip install --user --upgrade cmake  # Instead of using pip, you could also manually install cmake from https://cmake.org
+    pip3 install --user --upgrade "cmake>=3.13.2"  # Instead of using pip, you could also manually install cmake from https://cmake.org
 ```
 
 Instead of `libopenblas-dev` you may also choose a different math library.
@@ -109,7 +109,7 @@ For a CPU-only build with OpenBLAS math library run:
 ```bash
     rm -rf build
     mkdir -p build && cd build
-    cmake -GNinja \
+    ~/.local/bin/cmake -GNinja \
         -DUSE_CUDA=OFF \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
@@ -129,7 +129,7 @@ respectively. Then run:
 ```bash
     rm -rf build
     mkdir -p build && cd build
-    cmake -GNinja \
+    ~/.local/bin/cmake -GNinja \
         -DUSE_CUDA=OFF \
         -DUSE_MKL_IF_AVAILABLE=ON \
         -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
@@ -146,7 +146,7 @@ For a GPU-enabled build make sure you have installed the
 ```bash
     rm -rf build
     mkdir -p build && cd build
-    cmake -GNinja \
+    ~/.local/bin/cmake -GNinja \
         -DUSE_CUDA=ON \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
@@ -188,7 +188,7 @@ To install the MXNet Python binding navigate to the root of the MXNet folder the
 
 ```bash
 $ cd python
-$ pip install -e .
+$ pip install --user -e .
 ```
 
 Note that the `-e` flag is optional. It is equivalent to `--editable` and means that if you edit the source files, these changes will be reflected in the package installed.
@@ -198,8 +198,7 @@ Note that the `-e` flag is optional. It is equivalent to `--editable` and means 
 You may optionally install ```graphviz``` library that is used for visualizing network graphs you build on MXNet. You may also install [Jupyter Notebook](http://jupyter.readthedocs.io/) which is used for running MXNet tutorials and examples.
 
 ```bash
-sudo pip install graphviz==0.8.4 \
-                 jupyter
+pip install --user graphviz==0.8.4 jupyter
 ```
 <hr>
 


### PR DESCRIPTION
## Description ##
Fix and clean up Ubuntu build from source instructions.

Fixes https://github.com/apache/incubator-mxnet/issues/17226

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Simplify and fix Ubuntu build from source instructions

## Comments ##
Justification for respective removals
- Binary Python install instructions: 1) The instructions were outdated and incomplete 2) This is a "Build From Source Guide". Why include binary package install instructions? 3) There are better instructions for the binary python install at the Get Started Page. Thus link to that page instead.
- `ci/docker/install/ubuntu_{core,python}.sh` "quick" install: 1) https://github.com/apache/incubator-mxnet/issues/17226 2) Only supports Ubuntu 16.04
- `./install_mxnet_ubuntu_python.sh`: Does not exist anymore
- `dev_menu.py build`: The `dev_menu.py build` does things differently compared to the simple build instructions in this tutorial. For example, it uses virtualenv and contains other unrelated features such as building docker containers. I think it adds confusion for new users if we include it in the setup guide. (CC @larroy)