### PR TITLE
Additional fix for vector access. 

### DIFF
--- a/3rdparty/mshadow/mshadow/dot_engine-inl.h
+++ b/3rdparty/mshadow/mshadow/dot_engine-inl.h
@@ -421,12 +421,9 @@ struct BLASEngine<cpu, double> {
   CBLAS_TRANSPOSE p_transa[GROUP_SIZE] = {cblas_a_trans};
   CBLAS_TRANSPOSE p_transb[GROUP_SIZE] = {cblas_b_trans};
 
-  std::vector<const double*> pp_A;
-  std::vector<const double*> pp_B;
-  std::vector<double*> pp_C;
-  pp_A.reserve(batch_count);
-  pp_B.reserve(batch_count);
-  pp_C.reserve(batch_count);
+  std::vector<const double*> pp_A(batch_count, nullptr);
+  std::vector<const double*> pp_B(batch_count, nullptr);
+  std::vector<double*> pp_C(batch_count, nullptr);
 
   auto m_k = m * k;
   auto k_n = k * n;


### PR DESCRIPTION
See https://github.com/apache/incubator-mxnet/commit/9634786f96388004f68c223d72e120ad425c2f12 for the original.

## Description ##
Fixes an assertion thrown by operator[] of std::vector when MxNet is compiled with certain STL hardening flags, especially since GCC 8. This pull request is to fix a small block that was missed in the original PR.
