### PR TITLE
Fix #17267, add expected and got datatype for concat error msgs

### DIFF
--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -149,9 +149,10 @@ bool ConcatType(const nnvm::NodeAttrs& attrs,
     if (dtype == -1) {
       dtype = i;
     } else {
-      CHECK(i == dtype ||
-          i == -1) <<
-          "Non-uniform data type in Concat";
+      CHECK( i == dtype || i == -1) 
+          << "Non-uniform data type in Concat: " 
+          << "expected data type " << mxnet::op::type_string(dtype) 
+          << ", got data type " << mxnet::op::type_string(i);
     }
   }
 

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -145,14 +145,15 @@ bool ConcatType(const nnvm::NodeAttrs& attrs,
   int dtype = -1;
 
   // checks uniformity of input
-  for (int i : *in_type) {
+  for (size_t i =0; i<in_type->size(); ++i) {
     if (dtype == -1) {
-      dtype = i;
+      dtype = in_type->at(i);
     } else {
-      CHECK( i == dtype || i == -1) 
-          << "Non-uniform data type in Concat: " 
-          << "expected data type " << mxnet::op::type_string(dtype) 
-          << ", got data type " << mxnet::op::type_string(i);
+      CHECK( in_type->at(i) == dtype || in_type->at(i) == -1) 
+          << "Non-uniform data type in "  << attrs.op->name
+          << ", expected data type " << mxnet::op::type_string(dtype) 
+          << ", got data type " << mxnet::op::type_string(in_type->at(i))
+          << " for input " << i;
     }
   }
 

--- a/src/operator/nn/concat.cc
+++ b/src/operator/nn/concat.cc
@@ -145,13 +145,13 @@ bool ConcatType(const nnvm::NodeAttrs& attrs,
   int dtype = -1;
 
   // checks uniformity of input
-  for (size_t i =0; i<in_type->size(); ++i) {
+  for (size_t i =0; i < in_type->size(); ++i) {
     if (dtype == -1) {
       dtype = in_type->at(i);
     } else {
-      CHECK( in_type->at(i) == dtype || in_type->at(i) == -1) 
+      CHECK(in_type->at(i) == dtype || in_type->at(i) == -1)
           << "Non-uniform data type in "  << attrs.op->name
-          << ", expected data type " << mxnet::op::type_string(dtype) 
+          << ", expected data type " << mxnet::op::type_string(dtype)
           << ", got data type " << mxnet::op::type_string(in_type->at(i))
           << " for input " << i;
     }


### PR DESCRIPTION
## Description ##
Fix #17267, add expected and got datatype for concat error msgs

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
