### PR TITLE
Fix language selection in get_started options.js

### DIFF
--- a/docs/static_site/src/assets/js/options.js
+++ b/docs/static_site/src/assets/js/options.js
@@ -62,7 +62,11 @@ $(document).ready(function () {
         $('li.versions').each(function(){is_a_match($(this), versionSelect)});
         $('button.opt').removeClass('active');
         $('button.opt').each(function(){is_a_match($(this), platformSelect)});
-        $('button.opt').each(function(){is_a_match($(this), languageSelect)});
+        $('button.opt').each(function(){
+            if (label($(this).text()) === label(languageSelect)) {
+                $(this).addClass(('active'))
+            }
+        });
         $('button.opt').each(function(){is_a_match($(this), processorSelect)});
         $('button.opt').each(function(){is_a_match($(this), environSelect)});
 


### PR DESCRIPTION
## Description ##
Previously, selecting 'R' will highlight 'Clojure' and 'Perl', as both of them contain 'r'. Further the documentation for Clojure and Perl will be included, which is confusing.

![image](https://user-images.githubusercontent.com/946903/72279346-38f5fb00-3636-11ea-8f91-102ebf466b88.png)
