### PR TITLE
Fixing gather op in large vector and array

### DIFF
--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1672,10 +1672,10 @@ def test_gather():
     idx = mx.nd.random.randint(0, LARGE_X, SMALL_X)
     # Calls gather_nd internally
     tmp = arr[idx]
-    assert np.sum(tmp[0] == 1) == SMALL_Y
+    assert np.sum(tmp[0].asnumpy() == 1) == SMALL_Y
     # Calls gather_nd internally
     arr[idx] += 1
-    assert np.sum(arr[idx[0]] == 2) == SMALL_Y
+    assert np.sum(arr[idx[0]].asnumpy() == 2) == SMALL_Y
 
 
 if __name__ == '__main__':

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -1049,10 +1049,10 @@ def test_gather():
     idx = mx.nd.random.randint(0, LARGE_X, 10, dtype=np.int64)
     # Calls gather_nd internally
     tmp = arr[idx]
-    assert np.sum(tmp == 1) == 10
+    assert np.sum(tmp.asnumpy() == 1) == 10
     # Calls gather_nd internally
     arr[idx] += 1
-    assert np.sum(arr[idx] == 2) == 10
+    assert np.sum(arr[idx].asnumpy() == 2) == 10
 
 
 def test_infer_shape():


### PR DESCRIPTION
adding asnumpy() to output of gather(implicitly called) to fix gather test in large vector and tensor tests

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Testing ##
```
ubuntu@ip-172-31-82-110 ~/incubator-mxnet (array_grouping) $ MXNET_TEST_COUNT=1 nosetests --logging-level=DEBUG --verbose -s tests/nightly/test_large_array.py:test_gather
/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters
test_large_array.test_gather ... ok

----------------------------------------------------------------------
Ran 1 test in 1.838s

OK

ubuntu@ip-172-31-82-110 ~/incubator-mxnet (array_grouping) $ MXNET_TEST_COUNT=1 nosetests --logging-level=DEBUG --verbose -s tests/nightly/test_large_vector.py:test_gather
/home/ubuntu/anaconda3/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
  from ._conv import register_converters as _register_converters
test_large_vector.test_gather ... ok

----------------------------------------------------------------------
Ran 1 test in 1.608s

OK
```