### PR TITLE
fix errors for partition given a backend

### DIFF
--- a/include/mxnet/c_api_test.h
+++ b/include/mxnet/c_api_test.h
@@ -54,10 +54,26 @@ MXNET_DLL int MXSetSubgraphPropertyOpNames(const char* prop_name,
                                            const char** op_names);
 
 /*!
+ * \brief Given a subgraph property name, use the provided op names
+ * as the op_names attribute for that subgraph property, instead of
+ * the predefined one. This is only for the purpose of testing.
+ * Compared to MXSetSubgraphPropertyOpNames(), this API will add
+ * op_names to the backend property.
+ */
+MXNET_DLL int MXSetSubgraphPropertyOpNamesV2(const char* prop_name,
+                                           const uint32_t num_ops,
+                                           const char** op_names);
+/*!
  * \brief Given a subgraph property name, delete the op name set
  * in the SubgraphPropertyOpNameSet.
  */
 MXNET_DLL int MXRemoveSubgraphPropertyOpNames(const char* prop_name);
+/*!
+ * \brief Given a subgraph property name, remove op_names attribute of
+ * the in the SubgraphBackend property.
+ */
+MXNET_DLL int MXRemoveSubgraphPropertyOpNamesV2(const char* prop_name);
+
 
 #ifdef __cplusplus
 }

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -1303,11 +1303,8 @@ int MXOptimizeForBackend(SymbolHandle sym_handle,
   const auto& subgraph_prop_list = backend->GetSubgraphProperties();
   for (auto property : subgraph_prop_list) {
     property->PrePartition(g, options_map);
-    property->SetAttr("graph", g);
-    property->SetAttr("op_names", (*mxnet::op::SubgraphPropertyOpNameSet::Get())[backend_name]);
     g.attrs["subgraph_property"] = std::make_shared<nnvm::any>(property);
     g = ApplyPass(std::move(g), "BuildSubgraph");
-    property->RemoveAttr("graph");
     g.attrs.erase("subgraph_property");
     property->PostPartition(g);
   }

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -1303,8 +1303,11 @@ int MXOptimizeForBackend(SymbolHandle sym_handle,
   const auto& subgraph_prop_list = backend->GetSubgraphProperties();
   for (auto property : subgraph_prop_list) {
     property->PrePartition(g, options_map);
+    property->SetAttr("graph", g);
+    property->SetAttr("op_names", (*mxnet::op::SubgraphPropertyOpNameSet::Get())[backend_name]);
     g.attrs["subgraph_property"] = std::make_shared<nnvm::any>(property);
     g = ApplyPass(std::move(g), "BuildSubgraph");
+    property->RemoveAttr("graph");
     g.attrs.erase("subgraph_property");
     property->PostPartition(g);
   }

--- a/src/c_api/c_api_test.cc
+++ b/src/c_api/c_api_test.cc
@@ -73,8 +73,36 @@ int MXSetSubgraphPropertyOpNames(const char* prop_name,
   API_END();
 }
 
+int MXSetSubgraphPropertyOpNamesV2(const char* prop_name,
+                                 const uint32_t num_ops,
+                                 const char** op_names) {
+  API_BEGIN();
+  std::unordered_set<std::string> op_name_set;
+  for (size_t i = 0; i < num_ops; ++i) {
+    op_name_set.emplace(op_names[i]);
+  }
+  auto& backend =
+      mxnet::op::SubgraphBackendRegistry::Get()->GetSubgraphBackend(prop_name);
+  const auto& subgraph_prop_list = backend->GetSubgraphProperties();
+  for (auto& property : subgraph_prop_list) {
+    property->SetAttr("op_names", op_name_set);
+  }
+  API_END();
+}
+
 int MXRemoveSubgraphPropertyOpNames(const char* prop_name) {
   API_BEGIN();
   mxnet::op::SubgraphPropertyOpNameSet::Get()->erase(prop_name);
+  API_END();
+}
+
+int MXRemoveSubgraphPropertyOpNamesV2(const char* prop_name) {
+  API_BEGIN();
+  auto& backend =
+      mxnet::op::SubgraphBackendRegistry::Get()->GetSubgraphBackend(prop_name);
+  const auto& subgraph_prop_list = backend->GetSubgraphProperties();
+  for (auto& property : subgraph_prop_list) {
+    property->RemoveAttr("op_names");
+  }
   API_END();
 }

--- a/tests/python/unittest/test_subgraph_op.py
+++ b/tests/python/unittest/test_subgraph_op.py
@@ -174,10 +174,10 @@ def _test_subgraph_exe(subgraph_backend):
         exe1.forward()
 
         # partition before simple_bind
-        check_call(_LIB.MXSetSubgraphPropertyOpNames(c_str(subgraph_backend), mx_uint(len(op_names)),
+        check_call(_LIB.MXSetSubgraphPropertyOpNamesV2(c_str(subgraph_backend), mx_uint(len(op_names)),
                                                      c_str_array(op_names)))
         part_sym = sym.optimize_for(subgraph_backend)
-        check_call(_LIB.MXRemoveSubgraphPropertyOpNames(c_str(subgraph_backend)))
+        check_call(_LIB.MXRemoveSubgraphPropertyOpNamesV2(c_str(subgraph_backend)))
 
         exe2 = part_sym.simple_bind(ctx=mx.current_context(), grad_req='null')
         copy_inputs_between_executors(exe1, exe2, input_names)
@@ -200,10 +200,10 @@ def _test_subgraph_exe(subgraph_backend):
         exe1.forward()
 
         # infer shape/type before partition before simple_bind
-        check_call(_LIB.MXSetSubgraphPropertyOpNames(c_str(subgraph_backend), mx_uint(len(op_names)),
+        check_call(_LIB.MXSetSubgraphPropertyOpNamesV2(c_str(subgraph_backend), mx_uint(len(op_names)),
                                                      c_str_array(op_names)))
         part_sym = sym.optimize_for(subgraph_backend, exe1.arg_dict)
-        check_call(_LIB.MXRemoveSubgraphPropertyOpNames(c_str(subgraph_backend)))
+        check_call(_LIB.MXRemoveSubgraphPropertyOpNamesV2(c_str(subgraph_backend)))
 
         exe2 = part_sym.simple_bind(ctx=mx.current_context(), grad_req='null')
         copy_inputs_between_executors(exe1, exe2, input_names)
@@ -227,10 +227,10 @@ def _test_subgraph_exe(subgraph_backend):
         exe1.forward()
 
         # partition before bind
-        check_call(_LIB.MXSetSubgraphPropertyOpNames(c_str(subgraph_backend), mx_uint(len(op_names)),
+        check_call(_LIB.MXSetSubgraphPropertyOpNamesV2(c_str(subgraph_backend), mx_uint(len(op_names)),
                                                      c_str_array(op_names)))
         part_sym = sym.optimize_for(subgraph_backend)
-        check_call(_LIB.MXRemoveSubgraphPropertyOpNames(c_str(subgraph_backend)))
+        check_call(_LIB.MXRemoveSubgraphPropertyOpNamesV2(c_str(subgraph_backend)))
 
         exe2 = part_sym.bind(ctx=mx.current_context(), args=arg_array, aux_states=aux_array, grad_req='null')
         exe2.forward()
@@ -253,10 +253,10 @@ def _test_subgraph_exe(subgraph_backend):
         exe1.forward()
 
         # infer shape/type before partition before bind
-        check_call(_LIB.MXSetSubgraphPropertyOpNames(c_str(subgraph_backend), mx_uint(len(op_names)),
+        check_call(_LIB.MXSetSubgraphPropertyOpNamesV2(c_str(subgraph_backend), mx_uint(len(op_names)),
                                                      c_str_array(op_names)))
         part_sym = sym.optimize_for(subgraph_backend, arg_array)
-        check_call(_LIB.MXRemoveSubgraphPropertyOpNames(c_str(subgraph_backend)))
+        check_call(_LIB.MXRemoveSubgraphPropertyOpNamesV2(c_str(subgraph_backend)))
 
         exe2 = part_sym.bind(ctx=mx.current_context(), args=arg_array, aux_states=aux_array, grad_req='null')
         exe2.forward()


### PR DESCRIPTION
## Description ##
This PR fixes https://github.com/apache/incubator-mxnet/issues/17285. Tests for graph partitioning  given a backend now are able to run separately. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
