### PR TITLE
Fix NCCL Cmake autodetect issue

### DIFF
--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -43,6 +43,18 @@ find_path(NCCL_INCLUDE_DIRS
   $ENV{NCCL_DIR}/include
   )
 
+# if CUDA_TOOLKIT_ROOT_DIR is not specified, try symlink
+if (NOT CUDA_TOOLKIT_ROOT_DIR)
+  if (UNIX)
+    set (search_paths "/usr/local/cuda")
+  endif()
+
+  find_path(NCCL_INCLUDE_DIRS
+  NAMES nccl.h
+  PATHS ${search_paths}
+  )
+endif()
+
 find_library(NCCL_LIBRARIES
   NAMES nccl
   HINTS

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -42,8 +42,6 @@ endif()
 find_path(NCCL_INCLUDE_DIRS
   NAMES nccl.h
   HINTS
-  ${NCCL_ROOT}
-  ${NCCL_ROOT}/include
   ${NCCL_INCLUDE_DIR}
   ${NCCL_ROOT_DIR}
   ${NCCL_ROOT_DIR}/include
@@ -55,10 +53,6 @@ find_library(NCCL_LIBRARIES
   NAMES nccl
   HINTS
   ${NCCL_LIB_DIR}
-  ${NCCL_ROOT}
-  ${NCCL_ROOT}/lib
-  ${NCCL_ROOT}/lib/x86_64-linux-gnu
-  ${NCCL_ROOT}/lib64
   ${NCCL_ROOT_DIR}
   ${NCCL_ROOT_DIR}/lib
   ${NCCL_ROOT_DIR}/lib/x86_64-linux-gnu
@@ -72,15 +66,15 @@ if (UNIX)
   set (search_paths "/usr/local/cuda")
 
   find_path(NCCL_INCLUDE_DIRS
-   NAMES nccl.h
-   PATHS ${search_paths}
-   PATH_SUFFIXES include
+    NAMES nccl.h
+    PATHS ${search_paths}
+    PATH_SUFFIXES include
   )
 
   find_library(NCCL_LIBRARIES
-   NAMES nccl
-   PATHS ${search_paths}
-   PATH_SUFFIXES lib
+    NAMES nccl
+    PATHS ${search_paths}
+    PATH_SUFFIXES lib
   )
 endif()
 

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -31,28 +31,19 @@
 # install NCCL in the same location as the CUDA toolkit.
 # See https://github.com/caffe2/caffe2/issues/1601
 
-set(NCCL_ROOT_DIR "" CACHE PATH "Folder contains NVIDIA NCCL")
+set(NCCL_ROOT $ENV{NCCL_ROOT} CACHE PATH "Folder contains NVIDIA NCCL")
+set(NCCL_INCLUDE_DIR $ENV{NCCL_INCLUDE_DIR} CACHE PATH "Folder contains NVIDIA NCCL headers")
+set(NCCL_LIB_DIR $ENV{NCCL_LIB_DIR} CACHE PATH "Folder contains NVIDIA NCCL libraries")
 
-# first check in the /usr/local/cuda before other paths
-if (UNIX)
-  set (search_paths "/usr/local/cuda")
-
-  find_path(NCCL_INCLUDE_DIRS
-  NAMES nccl.h
-  PATHS ${search_paths}
-  PATH_SUFFIXES include
-  )
-
-  find_library(NCCL_LIBRARIES
-  NAMES nccl
-  PATHS ${search_paths}
-  PATH_SUFFIXES lib
-  )
+if ($ENV{NCCL_ROOT_DIR})
+  message(WARNING "NCCL_ROOT_DIR is deprecated. Please set NCCL_ROOT instead.")
 endif()
 
 find_path(NCCL_INCLUDE_DIRS
   NAMES nccl.h
   HINTS
+  ${NCCL_ROOT}
+  ${NCCL_ROOT}/include
   ${NCCL_INCLUDE_DIR}
   ${NCCL_ROOT_DIR}
   ${NCCL_ROOT_DIR}/include
@@ -64,6 +55,10 @@ find_library(NCCL_LIBRARIES
   NAMES nccl
   HINTS
   ${NCCL_LIB_DIR}
+  ${NCCL_ROOT}
+  ${NCCL_ROOT}/lib
+  ${NCCL_ROOT}/lib/x86_64-linux-gnu
+  ${NCCL_ROOT}/lib64
   ${NCCL_ROOT_DIR}
   ${NCCL_ROOT_DIR}/lib
   ${NCCL_ROOT_DIR}/lib/x86_64-linux-gnu
@@ -71,6 +66,23 @@ find_library(NCCL_LIBRARIES
   ${CUDA_TOOLKIT_ROOT_DIR}/lib64
   $ENV{NCCL_DIR}/lib
   )
+
+# if not found in any of the above paths, finally, check in the /usr/local/cuda for UNIX systems
+if (UNIX)
+  set (search_paths "/usr/local/cuda")
+
+  find_path(NCCL_INCLUDE_DIRS
+   NAMES nccl.h
+   PATHS ${search_paths}
+   PATH_SUFFIXES include
+  )
+
+  find_library(NCCL_LIBRARIES
+   NAMES nccl
+   PATHS ${search_paths}
+   PATH_SUFFIXES lib
+  )
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(NCCL DEFAULT_MSG NCCL_INCLUDE_DIRS NCCL_LIBRARIES)

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -31,10 +31,6 @@
 # install NCCL in the same location as the CUDA toolkit.
 # See https://github.com/caffe2/caffe2/issues/1601
 
-set(NCCL_ROOT $ENV{NCCL_ROOT} CACHE PATH "Folder contains NVIDIA NCCL")
-set(NCCL_INCLUDE_DIR $ENV{NCCL_INCLUDE_DIR} CACHE PATH "Folder contains NVIDIA NCCL headers")
-set(NCCL_LIB_DIR $ENV{NCCL_LIB_DIR} CACHE PATH "Folder contains NVIDIA NCCL libraries")
-
 if ($ENV{NCCL_ROOT_DIR})
   message(WARNING "NCCL_ROOT_DIR is deprecated. Please set NCCL_ROOT instead.")
 endif()

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -33,17 +33,7 @@
 
 set(NCCL_ROOT_DIR "" CACHE PATH "Folder contains NVIDIA NCCL")
 
-find_path(NCCL_INCLUDE_DIRS
-  NAMES nccl.h
-  HINTS
-  ${NCCL_INCLUDE_DIR}
-  ${NCCL_ROOT_DIR}
-  ${NCCL_ROOT_DIR}/include
-  ${CUDA_TOOLKIT_ROOT_DIR}/include
-  $ENV{NCCL_DIR}/include
-  )
-
-# if CUDAToolkit_FOUND is not found, try default location 
+# if CUDAToolkit_FOUND is not found, try default location
 if (NOT CUDAToolkit_FOUND)
   if (UNIX)
     set (search_paths "/usr/local/cuda")
@@ -53,8 +43,25 @@ if (NOT CUDAToolkit_FOUND)
     PATHS ${search_paths}
     PATH_SUFFIXES include
     )
+
+    find_library(NCCL_LIBRARIES
+    NAMES nccl
+    PATHS ${search_paths}
+    PATH_SUFFIXES lib
+    )
+
   endif()
 endif()
+
+find_path(NCCL_INCLUDE_DIRS
+  NAMES nccl.h
+  HINTS
+  ${NCCL_INCLUDE_DIR}
+  ${NCCL_ROOT_DIR}
+  ${NCCL_ROOT_DIR}/include
+  ${CUDA_TOOLKIT_ROOT_DIR}/include
+  $ENV{NCCL_DIR}/include
+  )
 
 find_library(NCCL_LIBRARIES
   NAMES nccl

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -43,8 +43,8 @@ find_path(NCCL_INCLUDE_DIRS
   $ENV{NCCL_DIR}/include
   )
 
-# if CUDA_TOOLKIT_ROOT_DIR is not specified, try symlink
-if (NOT CUDA_TOOLKIT_ROOT_DIR)
+# if CUDAToolkit_FOUND is not found, try default location 
+if (NOT CUDAToolkit_FOUND)
   if (UNIX)
     set (search_paths "/usr/local/cuda")
 

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -34,7 +34,7 @@
 set(NCCL_ROOT_DIR "" CACHE PATH "Folder contains NVIDIA NCCL")
 
 # if CUDAToolkit_FOUND is not found, try default location
-if (NOT CUDAToolkit_FOUND)
+#if (NOT CUDAToolkit_FOUND)
   if (UNIX)
     set (search_paths "/usr/local/cuda")
 
@@ -51,7 +51,7 @@ if (NOT CUDAToolkit_FOUND)
     )
 
   endif()
-endif()
+  #endif()
 
 find_path(NCCL_INCLUDE_DIRS
   NAMES nccl.h

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -47,12 +47,13 @@ find_path(NCCL_INCLUDE_DIRS
 if (NOT CUDA_TOOLKIT_ROOT_DIR)
   if (UNIX)
     set (search_paths "/usr/local/cuda")
-  endif()
 
-  find_path(NCCL_INCLUDE_DIRS
-  NAMES nccl.h
-  PATHS ${search_paths}
-  )
+    find_path(NCCL_INCLUDE_DIRS
+    NAMES nccl.h
+    PATHS ${search_paths}
+    PATH_SUFFIXES include
+    )
+  endif()
 endif()
 
 find_library(NCCL_LIBRARIES

--- a/cmake/Modules/FindNCCL.cmake
+++ b/cmake/Modules/FindNCCL.cmake
@@ -33,25 +33,22 @@
 
 set(NCCL_ROOT_DIR "" CACHE PATH "Folder contains NVIDIA NCCL")
 
-# if CUDAToolkit_FOUND is not found, try default location
-#if (NOT CUDAToolkit_FOUND)
-  if (UNIX)
-    set (search_paths "/usr/local/cuda")
+# first check in the /usr/local/cuda before other paths
+if (UNIX)
+  set (search_paths "/usr/local/cuda")
 
-    find_path(NCCL_INCLUDE_DIRS
-    NAMES nccl.h
-    PATHS ${search_paths}
-    PATH_SUFFIXES include
-    )
+  find_path(NCCL_INCLUDE_DIRS
+  NAMES nccl.h
+  PATHS ${search_paths}
+  PATH_SUFFIXES include
+  )
 
-    find_library(NCCL_LIBRARIES
-    NAMES nccl
-    PATHS ${search_paths}
-    PATH_SUFFIXES lib
-    )
-
-  endif()
-  #endif()
+  find_library(NCCL_LIBRARIES
+  NAMES nccl
+  PATHS ${search_paths}
+  PATH_SUFFIXES lib
+  )
+endif()
 
 find_path(NCCL_INCLUDE_DIRS
   NAMES nccl.h


### PR DESCRIPTION
## Description ##
Fixes https://github.com/apache/incubator-mxnet/issues/17239

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
modified:   cmake/Modules/FindNCCL.cmake

## Test ##
Tested with following command
```
cmake -GNinja -DUSE_CUDA=ON -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release -DUSE_CUDNN=ON -DUSE_NCCL=ON ..
```

Without this branch, it failed with NCCL not found
```
Could NOT find NCCL (missing: NCCL_INCLUDE_DIRS NCCL_LIBRARIES)
CMake Warning at CMakeLists.txt:636 (message):
  Could not find NCCL libraries
```

With this PR, it passes.