### PR TITLE
Fix CosineEmbeddingLoss in when symbol API is used

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -247,6 +247,7 @@ List of Contributors
 * [Disi A](https://github.com/adis300)
 * [Vandana Kannan](https://github.com/vandanavk)
 * [Guanxin Qiao](https://github.com/guanxinq)
+* [dithyrambe](https://github.com/dithyrambe)
 
 Label Bot
 ---------

--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -922,9 +922,9 @@ class CosineEmbeddingLoss(Loss):
 
     def _cosine_similarity(self, F, x, y, axis=-1):
         # Calculates the cosine similarity between 2 vectors
-        x_norm = F.norm(x, axis=axis).reshape(-1, 1)
-        y_norm = F.norm(y, axis=axis).reshape(-1, 1)
-        x_dot_y = F.sum(x * y, axis=axis).reshape(-1, 1)
+        x_norm = F.norm(x, axis=axis).reshape((-1, 1))
+        y_norm = F.norm(y, axis=axis).reshape((-1, 1))
+        x_dot_y = F.sum(x * y, axis=axis).reshape((-1, 1))
         if F is ndarray:
             eps_arr = F.array([1e-12])
         else:


### PR DESCRIPTION
Fixes #17275

## Description ##
Fix inconsistances between `ndarray` & `symbol` API regarding `.reshape` method