### PR TITLE
adding docs for 64bit C APIs of large tensor and removing not required int64 C APIs 

### DIFF
--- a/include/mxnet/c_api.h
+++ b/include/mxnet/c_api.h
@@ -585,6 +585,8 @@ MXNET_DLL int MXNDArrayCreate(const uint32_t *shape,
 
 /*!
  * \brief create a NDArray with specified shape and data type
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=0 (by default)
  * \param shape the pointer to the shape
  * \param ndim the dimension of the shape
  * \param dev_type device type, specify device we want to take
@@ -603,6 +605,20 @@ MXNET_DLL int MXNDArrayCreateEx(const uint32_t *shape,
                                 int dtype,
                                 NDArrayHandle *out);
 
+/*!
+ * \brief create a NDArray with specified shape and data type
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=1 (not default) i.e. Large Tensor Support
+ * \param shape the pointer to int64_t shape
+ * \param ndim the dimension of the shape
+ * \param dev_type device type, specify device we want to take
+ * \param dev_id the device id of the specific device
+ * \param delay_alloc whether to delay allocation until
+ *    the narray is first mutated
+ * \param dtype data type of created array
+ * \param out the returning handle
+ * \return 0 when success, -1 when failure happens
+ */
 MXNET_DLL int MXNDArrayCreateEx64(const int64_t *shape,
                                   int ndim,
                                   int dev_type,
@@ -613,6 +629,8 @@ MXNET_DLL int MXNDArrayCreateEx64(const int64_t *shape,
 
 /*!
  * \brief create an empty sparse NDArray with specified shape and data type
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=0 (by default)
  * \param storage_type the storage type of the ndarray
  * \param shape the pointer to the shape
  * \param ndim the dimension of the shape
@@ -641,6 +659,25 @@ MXNET_DLL int MXNDArrayCreateSparseEx(int storage_type,
                                       const uint32_t *aux_shape,
                                       NDArrayHandle *out);
 
+/*!
+ * \brief create an empty sparse NDArray with specified shape and data type
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=1 (not default) i.e. Large Tensor Support
+ * \param storage_type the storage type of the ndarray
+ * \param shape the pointer to the shape
+ * \param ndim the dimension of the shape
+ * \param dev_type device type, specify device we want to take
+ * \param dev_id the device id of the specific device
+ * \param delay_alloc whether to delay allocation until
+ *        the narray is first mutated
+ * \param dtype data type of created array
+ * \param num_aux the number of aux data to support this ndarray
+ * \param aux_type data type of the aux data for the created array
+ * \param aux_ndims the dimension of the shapes of aux data
+ * \param aux_shape the shapes of aux data
+ * \param out the returning handle
+ * \return 0 when success, -1 when failure happens
+ */
 MXNET_DLL int MXNDArrayCreateSparseEx64(int storage_type,
                                         const int64_t *shape,
                                         int ndim,
@@ -768,6 +805,7 @@ MXNET_DLL int MXNDArraySyncCopyFromNDArray(NDArrayHandle handle_dst,
  *    Otherwise basic check, O(1) operations
  */
 MXNET_DLL int MXNDArraySyncCheckFormat(NDArrayHandle handle, const bool full_check);
+
 /*!
  * \brief Wait until all the pending writes with respect NDArray are finished.
  *  Always call this before read data out synchronizely.
@@ -775,6 +813,7 @@ MXNET_DLL int MXNDArraySyncCheckFormat(NDArrayHandle handle, const bool full_che
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArrayWaitToRead(NDArrayHandle handle);
+
 /*!
  * \brief Wait until all the pending read/write with respect NDArray are finished.
  *  Always call this before write data into NDArray synchronizely.
@@ -782,20 +821,25 @@ MXNET_DLL int MXNDArrayWaitToRead(NDArrayHandle handle);
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArrayWaitToWrite(NDArrayHandle handle);
+
 /*!
  * \brief wait until all delayed operations in
  *   the system is completed
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArrayWaitAll();
+
 /*!
  * \brief free the narray handle
  * \param handle the handle to be freed
  * \return 0 when success, -1 when failure happens
  */
 MXNET_DLL int MXNDArrayFree(NDArrayHandle handle);
+
 /*!
  * \brief Slice the NDArray along axis 0.
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=0 (by default)
  * \param handle the handle to the NDArray
  * \param slice_begin The beginning index of slice
  * \param slice_end The ending index of slice
@@ -807,6 +851,16 @@ MXNET_DLL int MXNDArraySlice(NDArrayHandle handle,
                              uint32_t slice_end,
                              NDArrayHandle *out);
 
+/*!
+ * \brief Slice the NDArray along axis 0.
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=1 (not default) i.e. Large Tensor Support
+ * \param handle the handle to the NDArray
+ * \param slice_begin The beginning index of slice
+ * \param slice_end The ending index of slice
+ * \param out The NDArrayHandle of sliced NDArray
+ * \return 0 when success, -1 when failure happens
+ */
 MXNET_DLL int MXNDArraySlice64(NDArrayHandle handle,
                                int64_t slice_begin,
                                int64_t slice_end,
@@ -814,6 +868,8 @@ MXNET_DLL int MXNDArraySlice64(NDArrayHandle handle,
 
 /*!
  * \brief Index the NDArray along axis 0.
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=0 (by default)
  * \param handle the handle to the NDArray
  * \param idx the index
  * \param out The NDArrayHandle of output NDArray
@@ -823,6 +879,15 @@ MXNET_DLL int MXNDArrayAt(NDArrayHandle handle,
                           uint32_t idx,
                           NDArrayHandle *out);
 
+/*!
+ * \brief Index the NDArray along axis 0.
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=1 (not default) i.e. Large Tensor Support
+ * \param handle the handle to the NDArray
+ * \param idx the index
+ * \param out The NDArrayHandle of output NDArray
+ * \return 0 when success, -1 when failure happens
+ */
 MXNET_DLL int MXNDArrayAt64(NDArrayHandle handle,
                             int64_t idx,
                             NDArrayHandle *out);
@@ -871,12 +936,10 @@ MXNET_DLL int MXNDArrayGetShape(NDArrayHandle handle,
                                 uint32_t *out_dim,
                                 const uint32_t **out_pdata);
 
-MXNET_DLL int MXNDArrayGetShape64(NDArrayHandle handle,
-                                  int *out_dim,
-                                  const int64_t **out_pdata);
-
 /*!
  * \brief get the shape of the array
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=0 (by default)
  * \param handle the handle to the narray
  * \param out_dim the output dimension
  * \param out_pdata pointer holder to get data pointer of the shape
@@ -886,6 +949,15 @@ MXNET_DLL int MXNDArrayGetShapeEx(NDArrayHandle handle,
                                   int *out_dim,
                                   const int **out_pdata);
 
+/*!
+ * \brief get the shape of the array
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=1 (not default) i.e. Large Tensor Support
+ * \param handle the handle to the narray
+ * \param out_dim the output dimension
+ * \param out_pdata pointer holder to get data pointer of the shape
+ * \return 0 when success, -1 when failure happens
+ */
 MXNET_DLL int MXNDArrayGetShapeEx64(NDArrayHandle handle,
                                     int *out_dim,
                                     const int64_t **out_pdata);
@@ -964,6 +1036,8 @@ MXNET_DLL int MXNDArrayGetDType(NDArrayHandle handle,
 
 /*!
  * \brief get the type of the ith aux data in NDArray
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=0 (by default)
  * \param handle the handle to the narray
  * \param i the index of the aux data
  * \param out_type pointer holder to get type of aux data
@@ -973,12 +1047,23 @@ MXNET_DLL int MXNDArrayGetAuxType(NDArrayHandle handle,
                                   uint32_t i,
                                   int *out_type);
 
+/*!
+ * \brief get the type of the ith aux data in NDArray
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=1 (not default) i.e. Large Tensor Support
+ * \param handle the handle to the narray
+ * \param i the index of the aux data
+ * \param out_type pointer holder to get type of aux data
+ * \return 0 when success, -1 when failure happens
+ */
 MXNET_DLL int MXNDArrayGetAuxType64(NDArrayHandle handle,
                                     int64_t i,
                                     int *out_type);
 
 /*!
  * \brief Get a deep copy of the ith aux data blob
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=0 (by default)
  * in the form of an NDArray of default storage type.
  * This function blocks. Do not use it in performance critical code.
  */
@@ -986,6 +1071,13 @@ MXNET_DLL int MXNDArrayGetAuxNDArray(NDArrayHandle handle,
                                      uint32_t i,
                                      NDArrayHandle *out);
 
+/*!
+ * \brief Get a deep copy of the ith aux data blob
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=1 (not default) i.e. Large Tensor Support
+ * in the form of an NDArray of default storage type.
+ * This function blocks. Do not use it in performance critical code.
+ */
 MXNET_DLL int MXNDArrayGetAuxNDArray64(NDArrayHandle handle,
                                        int64_t i,
                                        NDArrayHandle *out);
@@ -1646,13 +1738,13 @@ MXNET_DLL int MXSymbolGrad(SymbolHandle sym,
  * \param arg_ind_ptr the head pointer of the rows in CSR
  * \param arg_shape_data the content of the CSR
  * \param in_shape_size sizeof the returning array of in_shapes
- * \param in_shape_ndim returning array of shape dimensions of eachs input shape.
+ * \param in_shape_ndim returning array of shape dimensions of each input shape.
  * \param in_shape_data returning array of pointers to head of the input shape.
  * \param out_shape_size sizeof the returning array of out_shapes
- * \param out_shape_ndim returning array of shape dimensions of eachs input shape.
- * \param out_shape_data returning array of pointers to head of the input shape.
+ * \param out_shape_ndim returning array of shape dimensions of each output shape.
+ * \param out_shape_data returning array of pointers to head of the output shape.
  * \param aux_shape_size sizeof the returning array of aux_shapes
- * \param aux_shape_ndim returning array of shape dimensions of eachs auxiliary shape.
+ * \param aux_shape_ndim returning array of shape dimensions of each auxiliary shape.
  * \param aux_shape_data returning array of pointers to head of the auxiliary shape.
  * \param complete whether infer shape completes or more information is needed.
  * \return 0 when success, -1 when failure happens
@@ -1673,29 +1765,14 @@ MXNET_DLL int MXSymbolInferShape(SymbolHandle sym,
                                  const uint32_t ***aux_shape_data,
                                  int *complete);
 
-MXNET_DLL int MXSymbolInferShape64(SymbolHandle sym,
-                                   uint32_t num_args,
-                                   const char** keys,
-                                   const int64_t *arg_ind_ptr,
-                                   const int64_t *arg_shape_data,
-                                   size_t *in_shape_size,
-                                   const int **in_shape_ndim,
-                                   const int64_t ***in_shape_data,
-                                   size_t *out_shape_size,
-                                   const int **out_shape_ndim,
-                                   const int64_t ***out_shape_data,
-                                   size_t *aux_shape_size,
-                                   const int **aux_shape_ndim,
-                                   const int64_t ***aux_shape_data,
-                                   int *complete);
-
 /*!
  * \brief infer shape of unknown input shapes given the known one.
  *  The shapes are packed into a CSR matrix represented by arg_ind_ptr and arg_shape_data
  *  The call will be treated as a kwargs call if key != nullptr or num_args==0, otherwise it is positional.
- *
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=0 (by default)
  * \param sym symbol handle
- * \param num_args numbe of input arguments.
+ * \param num_args number of input arguments.
  * \param keys the key of keyword args (optional)
  * \param arg_ind_ptr the head pointer of the rows in CSR
  * \param arg_shape_data the content of the CSR
@@ -1703,10 +1780,10 @@ MXNET_DLL int MXSymbolInferShape64(SymbolHandle sym,
  * \param in_shape_ndim returning array of shape dimensions of eachs input shape.
  * \param in_shape_data returning array of pointers to head of the input shape.
  * \param out_shape_size sizeof the returning array of out_shapes
- * \param out_shape_ndim returning array of shape dimensions of eachs input shape.
- * \param out_shape_data returning array of pointers to head of the input shape.
+ * \param out_shape_ndim returning array of shape dimensions of each output shape.
+ * \param out_shape_data returning array of pointers to head of the output shape.
  * \param aux_shape_size sizeof the returning array of aux_shapes
- * \param aux_shape_ndim returning array of shape dimensions of eachs auxiliary shape.
+ * \param aux_shape_ndim returning array of shape dimensions of each auxiliary shape.
  * \param aux_shape_data returning array of pointers to head of the auxiliary shape.
  * \param complete whether infer shape completes or more information is needed.
  * \return 0 when success, -1 when failure happens
@@ -1727,6 +1804,29 @@ MXNET_DLL int MXSymbolInferShapeEx(SymbolHandle sym,
                                    const int ***aux_shape_data,
                                    int *complete);
 
+/*!
+ * \brief infer shape of unknown input shapes given the known one.
+ *  The shapes are packed into a CSR matrix represented by arg_ind_ptr and arg_shape_data
+ *  The call will be treated as a kwargs call if key != nullptr or num_args==0, otherwise it is positional.
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=1 (not default) i.e. Large Tensor Support
+ * \param sym symbol handle
+ * \param num_args number of input arguments.
+ * \param keys the key of keyword args (optional)
+ * \param arg_ind_ptr the head pointer of the rows in CSR
+ * \param arg_shape_data the content of the CSR
+ * \param in_shape_size sizeof the returning array of in_shapes
+ * \param in_shape_ndim returning array of shape dimensions of each input shape.
+ * \param in_shape_data returning array of pointers to head of the input shape.
+ * \param out_shape_size sizeof the returning array of out_shapes
+ * \param out_shape_ndim returning array of shape dimensions of each output shape.
+ * \param out_shape_data returning array of pointers to head of the output shape.
+ * \param aux_shape_size sizeof the returning array of aux_shapes
+ * \param aux_shape_ndim returning array of shape dimensions of each auxiliary shape.
+ * \param aux_shape_data returning array of pointers to head of the auxiliary shape.
+ * \param complete whether infer shape completes or more information is needed.
+ * \return 0 when success, -1 when failure happens
+ */
 MXNET_DLL int MXSymbolInferShapeEx64(SymbolHandle sym,
                                      uint32_t num_args,
                                      const char** keys,
@@ -1757,13 +1857,13 @@ MXNET_DLL int MXSymbolInferShapeEx64(SymbolHandle sym,
  * \param arg_ind_ptr the head pointer of the rows in CSR
  * \param arg_shape_data the content of the CSR
  * \param in_shape_size sizeof the returning array of in_shapes
- * \param in_shape_ndim returning array of shape dimensions of eachs input shape.
+ * \param in_shape_ndim returning array of shape dimensions of each input shape.
  * \param in_shape_data returning array of pointers to head of the input shape.
  * \param out_shape_size sizeof the returning array of out_shapes
- * \param out_shape_ndim returning array of shape dimensions of eachs input shape.
- * \param out_shape_data returning array of pointers to head of the input shape.
+ * \param out_shape_ndim returning array of shape dimensions of each output shape.
+ * \param out_shape_data returning array of pointers to head of the output shape.
  * \param aux_shape_size sizeof the returning array of aux_shapes
- * \param aux_shape_ndim returning array of shape dimensions of eachs auxiliary shape.
+ * \param aux_shape_ndim returning array of shape dimensions of each auxiliary shape.
  * \param aux_shape_data returning array of pointers to head of the auxiliary shape.
  * \param complete whether infer shape completes or more information is needed.
  * \return 0 when success, -1 when failure happens
@@ -1784,42 +1884,28 @@ MXNET_DLL int MXSymbolInferShapePartial(SymbolHandle sym,
                                         const uint32_t ***aux_shape_data,
                                         int *complete);
 
-MXNET_DLL int MXSymbolInferShapePartial64(SymbolHandle sym,
-                                          uint32_t num_args,
-                                          const char** keys,
-                                          const int64_t *arg_ind_ptr,
-                                          const int64_t *arg_shape_data,
-                                          size_t *in_shape_size,
-                                          const int **in_shape_ndim,
-                                          const int64_t ***in_shape_data,
-                                          size_t *out_shape_size,
-                                          const int **out_shape_ndim,
-                                          const int64_t ***out_shape_data,
-                                          size_t *aux_shape_size,
-                                          const int **aux_shape_ndim,
-                                          const int64_t ***aux_shape_data,
-                                          int *complete);
-
 /*!
  * \brief partially infer shape of unknown input shapes given the known one.
  *
  *  Return partially inferred results if not all shapes could be inferred.
  *  The shapes are packed into a CSR matrix represented by arg_ind_ptr and arg_shape_data
  *  The call will be treated as a kwargs call if key != nullptr or num_args==0, otherwise it is positional.
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=0 (by default)
  *
  * \param sym symbol handle
- * \param num_args numbe of input arguments.
+ * \param num_args number of input arguments.
  * \param keys the key of keyword args (optional)
  * \param arg_ind_ptr the head pointer of the rows in CSR
  * \param arg_shape_data the content of the CSR
  * \param in_shape_size sizeof the returning array of in_shapes
- * \param in_shape_ndim returning array of shape dimensions of eachs input shape.
+ * \param in_shape_ndim returning array of shape dimensions of each input shape.
  * \param in_shape_data returning array of pointers to head of the input shape.
  * \param out_shape_size sizeof the returning array of out_shapes
- * \param out_shape_ndim returning array of shape dimensions of eachs input shape.
- * \param out_shape_data returning array of pointers to head of the input shape.
+ * \param out_shape_ndim returning array of shape dimensions of each output shape.
+ * \param out_shape_data returning array of pointers to head of the output shape.
  * \param aux_shape_size sizeof the returning array of aux_shapes
- * \param aux_shape_ndim returning array of shape dimensions of eachs auxiliary shape.
+ * \param aux_shape_ndim returning array of shape dimensions of each auxiliary shape.
  * \param aux_shape_data returning array of pointers to head of the auxiliary shape.
  * \param complete whether infer shape completes or more information is needed.
  * \return 0 when success, -1 when failure happens
@@ -1840,6 +1926,32 @@ MXNET_DLL int MXSymbolInferShapePartialEx(SymbolHandle sym,
                                           const int ***aux_shape_data,
                                           int *complete);
 
+/*!
+ * \brief partially infer shape of unknown input shapes given the known one.
+ *
+ *  Return partially inferred results if not all shapes could be inferred.
+ *  The shapes are packed into a CSR matrix represented by arg_ind_ptr and arg_shape_data
+ *  The call will be treated as a kwargs call if key != nullptr or num_args==0, otherwise it is positional.
+ *  This api is available when MXNet is built with flag
+ *  USE_INT64_TENSOR_SIZE=1 (not default) i.e. Large Tensor Support
+ *
+ * \param sym symbol handle
+ * \param num_args number of input arguments.
+ * \param keys the key of keyword args (optional)
+ * \param arg_ind_ptr the head pointer of the rows in CSR
+ * \param arg_shape_data the content of the CSR
+ * \param in_shape_size sizeof the returning array of in_shapes
+ * \param in_shape_ndim returning array of shape dimensions of each input shape.
+ * \param in_shape_data returning array of pointers to head of the input shape.
+ * \param out_shape_size sizeof the returning array of out_shapes
+ * \param out_shape_ndim returning array of shape dimensions of each output shape.
+ * \param out_shape_data returning array of pointers to head of the output shape.
+ * \param aux_shape_size sizeof the returning array of aux_shapes
+ * \param aux_shape_ndim returning array of shape dimensions of each auxiliary shape.
+ * \param aux_shape_data returning array of pointers to head of the auxiliary shape.
+ * \param complete whether infer shape completes or more information is needed.
+ * \return 0 when success, -1 when failure happens
+ */
 MXNET_DLL int MXSymbolInferShapePartialEx64(SymbolHandle sym,
                                             uint32_t num_args,
                                             const char** keys,
@@ -1868,7 +1980,7 @@ MXNET_DLL int MXSymbolInferShapePartialEx64(SymbolHandle sym,
  * \param in_type_size sizeof the returning array of in_types
  * \param in_type_data returning array of pointers to head of the input type.
  * \param out_type_size sizeof the returning array of out_types
- * \param out_type_data returning array of pointers to head of the input type.
+ * \param out_type_data returning array of pointers to head of the output type.
  * \param aux_type_size sizeof the returning array of aux_types
  * \param aux_type_data returning array of pointers to head of the auxiliary type.
  * \param complete whether infer type completes or more information is needed.
@@ -1900,7 +2012,7 @@ MXNET_DLL int MXSymbolInferType(SymbolHandle sym,
  * \param in_type_size sizeof the returning array of in_types
  * \param in_type_data returning array of pointers to head of the input type.
  * \param out_type_size sizeof the returning array of out_types
- * \param out_type_data returning array of pointers to head of the input type.
+ * \param out_type_data returning array of pointers to head of the output type.
  * \param aux_type_size sizeof the returning array of aux_types
  * \param aux_type_data returning array of pointers to head of the auxiliary type.
  * \param complete whether infer type completes or more information is needed.


### PR DESCRIPTION
## Description ##
adding docs for 64bit C APIs of large tensor and removing not required int64 C APIs:
MXNDArrayGetShape64
MXSymbolInferShape64
MXSymbolInferShapePartial64

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
