### PR TITLE
[BugFix] Fixes version comparison algorithm

### DIFF
--- a/tests/python/unittest/common.py
+++ b/tests/python/unittest/common.py
@@ -117,16 +117,10 @@ def _assert_raise_cuxx_version_not_satisfied(min_version, cfg):
 
         # compare each of the version components
         for l, r in zip(left, right):
-            if int(r) < int(l):
-                return False
-
-            # keep track of how many are the same
-            if int(r) == int(l):
-                longest = longest - 1
-
-        # longest = 0 mean version_left == version_right -> False
-        # longest > 0 version_left < version_right -> True
-        return longest > 0
+            if l == r:
+                continue
+            return int(l) < int(r)
+        return False
 
     def test_helper(orig_test):
         @make_decorator(orig_test)


### PR DESCRIPTION
## Description ##
The version comparison algorithm for minimum cuda version decorator was wrong. This PR fixes it.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
