### PR TITLE
Fixes #17304 Flaky Test -> test_higher_order_grad.test_tanh

### DIFF
--- a/tests/python/unittest/test_higher_order_grad.py
+++ b/tests/python/unittest/test_higher_order_grad.py
@@ -121,7 +121,7 @@ def test_tanh():
         return nd.tanh(x)
 
     def grad_op(x):
-        return 1 / nd.cosh(x)**2
+        return 1 - tanh(x)**2
 
     def grad_grad_op(x):
         return -2 * tanh(x) * grad_op(x)

--- a/tests/python/unittest/test_higher_order_grad.py
+++ b/tests/python/unittest/test_higher_order_grad.py
@@ -129,7 +129,7 @@ def test_tanh():
     for dim in range(1, 5):
         shape = rand_shape_nd(dim)
         array = random_arrays(shape)
-        check_nth_order_unary(array, tanh, grad_op, 1)
+        check_nth_order_unary(array, tanh, grad_op, 1, rtol=1e-6, atol=1e-6)
         check_second_order_unary(
             array, tanh, grad_grad_op, rtol=1e-6, atol=1e-6)
 

--- a/tests/python/unittest/test_higher_order_grad.py
+++ b/tests/python/unittest/test_higher_order_grad.py
@@ -115,7 +115,7 @@ def test_cosh():
         check_second_order_unary(array, cosh, grad_grad_op)
 
 
-@with_seed(879330121)
+@with_seed()
 def test_tanh():
     def tanh(x):
         return nd.tanh(x)

--- a/tests/python/unittest/test_higher_order_grad.py
+++ b/tests/python/unittest/test_higher_order_grad.py
@@ -115,7 +115,7 @@ def test_cosh():
         check_second_order_unary(array, cosh, grad_grad_op)
 
 
-@with_seed()
+@with_seed(879330121)
 def test_tanh():
     def tanh(x):
         return nd.tanh(x)
@@ -129,6 +129,7 @@ def test_tanh():
     for dim in range(1, 5):
         shape = rand_shape_nd(dim)
         array = random_arrays(shape)
+        check_nth_order_unary(array, tanh, grad_op, 1)
         check_second_order_unary(
             array, tanh, grad_grad_op, rtol=1e-6, atol=1e-6)
 


### PR DESCRIPTION
@apeforest @reminisce 

Going through the code for `_backward_tanh`, it is implemented as `1 - (tanh^2(x))`, which is equivalent to `sech^2(x)` or `(1/cosh(x))^2`. 

However for the failed seed, I have verified that `1 - (tanh^2(x))` is not coming equivalent to `(1/ cosh(x))^2` for the randomly generated array of dim 4 (will try to investigate further for the cause).

For now replacing `grad_op` with its equivalent `1- tanh^2(x)` looks to work without the need to relax tolerance.