### PR TITLE
Don't unnecessarily relicense FindCUDAToolkit.cmake

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -326,7 +326,7 @@
          Copyright 2005-2015, Google Inc.
     8. OpenMP Testsuite - For details, see, 3rdparty/openmp/testsuite/LICENSE
          Copyright (c) 2011, 2012 University of Houston System
-    9. CMake FindCUDAToolkit.cmake - For details, see, cmake/Module/FindCUDAToolkit.cmake
+    9. CMake FindCUDAToolkit.cmake - For details, see, cmake/Modules/FindCUDAToolkit.cmake
          Copyright 2000-2019 Kitware, Inc. and Contributors
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -326,6 +326,8 @@
          Copyright 2005-2015, Google Inc.
     8. OpenMP Testsuite - For details, see, 3rdparty/openmp/testsuite/LICENSE
          Copyright (c) 2011, 2012 University of Houston System
+    9. CMake FindCUDAToolkit.cmake - For details, see, cmake/Module/FindCUDAToolkit.cmake
+         Copyright 2000-2019 Kitware, Inc. and Contributors
 
 
     =======================================================================================

--- a/cmake/Modules/FindCUDAToolkit.cmake
+++ b/cmake/Modules/FindCUDAToolkit.cmake
@@ -1,22 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
-# Original license notice, prior to modification by MXNet Contributors:
-#
 # Copyright 2000-2019 Kitware, Inc. and Contributors
 # All rights reserved.
 #

--- a/tests/nightly/apache_rat_license_check/rat-excludes
+++ b/tests/nightly/apache_rat_license_check/rat-excludes
@@ -75,3 +75,4 @@ include/*
 searchtools_custom.js
 theme.conf
 LICENSE.binary.dependencies
+cmake/Module/FindCUDAToolkit.cmake

--- a/tests/nightly/apache_rat_license_check/rat-excludes
+++ b/tests/nightly/apache_rat_license_check/rat-excludes
@@ -75,4 +75,4 @@ include/*
 searchtools_custom.js
 theme.conf
 LICENSE.binary.dependencies
-cmake/Module/FindCUDAToolkit.cmake
+cmake/Modules/FindCUDAToolkit.cmake

--- a/tools/license_header.py
+++ b/tools/license_header.py
@@ -76,7 +76,7 @@ _WHITE_LIST = [
 
                 # Docs Jekyll website under different licenses
                'docs/static_site',
-  
+
                # Code shared with project by author - see file for details
                'src/operator/special_functions-inl.h',
 
@@ -98,6 +98,7 @@ _WHITE_LIST = [
                'docs/_static/js/clipboard.js',
                'docs/_static/js/clipboard.min.js',
                'docs/static_site/src/assets/js/clipboard.js',
+               'cmake/Modules/FindCUDAToolkit.cmake',
 
                # Licensed under 2-Clause BSD in header
                'example/ssd/dataset/pycocotools/coco.py',


### PR DESCRIPTION
## Description ##
Don't unnecessarily relicense FindCUDAToolkit.cmake. As per recommendation in https://www.apache.org/legal/src-headers.html#3party

@roywei 

https://github.com/apache/incubator-mxnet/issues/17329

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Don't unnecessarily relicense FindCUDAToolkit.cmake
