### PR TITLE
Fix Horovod build error due to missing exported symbols

### DIFF
--- a/make/config/libmxnet.sym
+++ b/make/config/libmxnet.sym
@@ -1,6 +1,5 @@
-MX*
+*MX*
 NN*
-_MX*
 _NN*
 mx*
 nn*
@@ -12,4 +11,3 @@ Java_org_apache_mxnet*
 *Storage*Get*
 *on_enter_api*
 *on_exit_api*
-*MXAPIHandleException*

--- a/make/config/libmxnet.sym
+++ b/make/config/libmxnet.sym
@@ -12,4 +12,4 @@ Java_org_apache_mxnet*
 *Storage*Get*
 *on_enter_api*
 *on_exit_api*
-*MXAPISetLastError*
+*MXAPIHandleException*

--- a/make/config/libmxnet.sym
+++ b/make/config/libmxnet.sym
@@ -1,10 +1,7 @@
 *MX*
-NN*
-_NN*
-mx*
-nn*
-_mx*
-_nn*
+*NN*
+*mx*
+*nn*
 Java_org_apache_mxnet*
 *NDArray*
 *Engine*Get*

--- a/make/config/libmxnet.ver
+++ b/make/config/libmxnet.ver
@@ -14,6 +14,6 @@
         *Storage*Get*;
         *on_enter_api*;
         *on_exit_api*;
-        *MXAPISetLastError*;
+        *MXAPIHandleException*;
     local: *;
 };

--- a/make/config/libmxnet.ver
+++ b/make/config/libmxnet.ver
@@ -1,9 +1,8 @@
 {
     global:
         NN*;
-        MX*;
+        *MX*;
         _NN*;
-        _MX*;
         nn*;
         mx*;
         _nn*;
@@ -14,6 +13,5 @@
         *Storage*Get*;
         *on_enter_api*;
         *on_exit_api*;
-        *MXAPIHandleException*;
     local: *;
 };

--- a/make/config/libmxnet.ver
+++ b/make/config/libmxnet.ver
@@ -1,12 +1,9 @@
 {
     global:
-        NN*;
+        *NN*;
         *MX*;
-        _NN*;
-        nn*;
-        mx*;
-        _nn*;
-        _mx*;
+        *nn*;
+        *mx*;
         Java_org_apache_mxnet*;
         *NDArray*;
         *Engine*Get*;


### PR DESCRIPTION
## Description ##
Export MXAPIHandle symbol and fixes https://github.com/apache/incubator-mxnet/issues/17292

Here are the causes of the problem:

1.  Horovod uses MX_API_BEGIN() and MX_API_END() from mxnet/c_api_error.h to catch and throw errors in horovod APIs: https://github.com/horovod/horovod/blob/master/horovod/mxnet/mpi_ops.cc#L224
MX_API_BEGIN() is a macro that calls MXAPIHandleException https://github.com/apache/incubator-mxnet/blob/master/include/mxnet/c_api_error.h#L36. Before #17128, MXAPIHandleException is an inline function. And therefore when #17128 introduced a new function call NormalizeError() inside MXAPIHandleException it broke Horovod integration because the symbol of NormalizeError is not whitelist by MXNet distribution.
2. #17298 removed NormalizeError() from MXAPIHandleException and made it not inline. https://github.com/apache/incubator-mxnet/pull/17208/files#diff-875aa4c013dbd73b044531e439e8afddR67. This time the error becomes undefined symbol of MXAPIHandleException.

So to summarize, the problem is not that Horovod requires MXAPIHandleException function to be inline. The rootcause is that MXNet did not whitelist the symbol *MXAPIHandleException* but only whitelisted the symbols that are being used inside MXAPIHandleException function. It was okay when the function MXAPIHandleException is inline, but became a problem when it's not. A good practice is to whitelist symbol *MXAPIHandleException* instead of its internal functions.
## Comments ##
@szha Please help to review.