### PR TITLE
fix error "TypeError: 'zip' object is not subscriptable" in deepspeec…

### DIFF
--- a/example/speech_recognition/stt_io_bucketingiter.py
+++ b/example/speech_recognition/stt_io_bucketingiter.py
@@ -83,7 +83,7 @@ class BucketSTTIter(mx.io.DataIter):
             durations = durations
             audio_paths = audio_paths
             texts = texts
-        self.trainDataList = zip(durations, audio_paths, texts)
+        self.trainDataList = list(zip(durations, audio_paths, texts))
 
         self.trainDataIter = iter(self.trainDataList)
         self.is_first_epoch = True


### PR DESCRIPTION
…h.cfg training

## Description ##
When traing speech_recognition by command `python main.py --configfile deepspeech.cfg`, I will get an error:
`Traceback (most recent call last):
  File "main.py", line 299, in <module>
    data_train, data_val, args = load_data(args)
  File "main.py", line 173, in load_data
    save_feature_as_csvfile=save_feature_as_csvfile)
  File "/home/luke/tmp/mxnet/example/speech_recognition/stt_io_bucketingiter.py", line 105, in __init__
    self.data[buck].append(self.trainDataList[i])
TypeError: 'zip' object is not subscriptable`


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] All changes have test coverage:
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


## Comments ##
Just like file https://github.com/apache/incubator-mxnet/blob/master/example/speech_recognition/stt_io_iter.py, use the same logic:
`self.trainDataList = list(zip(durations, audio_paths, texts))`
