### PR TITLE
add random.multivariate_normal, fix empty_like dtype problem, fix gat…

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -476,7 +476,7 @@ def empty_like(prototype, dtype=None, order='C', subok=False, shape=None): # pyl
     """
     dtype_list = {None:'None', _np.int8:'int8', _np.uint8:'uint8', _np.int32:'int32',
                   _np.int64:'int64', _np.float16:'float16', _np.float32:'float32',
-                  _np.float64:'float64', _np.bool_:'bool'}
+                  _np.float64:'float64', _np.bool_:'bool_', bool:'bool', int:'int64', float:'float64'}
     if order != 'C':
         raise NotImplementedError("Only support C-order at this moment")
     if subok:

--- a/python/mxnet/ndarray/numpy/random.py
+++ b/python/mxnet/ndarray/numpy/random.py
@@ -23,7 +23,8 @@ from . import _internal as _npi
 from ..ndarray import NDArray
 
 
-__all__ = ['randint', 'uniform', 'normal', "choice", "rand", "multinomial", "shuffle", 'gamma', 'exponential']
+__all__ = ['randint', 'uniform', 'normal', "choice", "rand", "multinomial", "multivariate_normal",
+           "shuffle", 'gamma', 'exponential']
 
 
 def randint(low, high=None, size=None, dtype=None, ctx=None, out=None):
@@ -243,6 +244,87 @@ def multinomial(n, pvals, size=None):
         if any(isinstance(i, list) for i in pvals):
             raise ValueError('object too deep for desired array')
         return _npi.multinomial(n=n, pvals=pvals, size=size)
+
+
+def multivariate_normal(mean, cov, size=None, check_valid=None, tol=None):
+    """
+    multivariate_normal(mean, cov, size=None, check_valid=None, tol=None)
+
+    Draw random samples from a multivariate normal distribution.
+
+    The multivariate normal, multinormal or Gaussian distribution is a
+    generalization of the one-dimensional normal distribution to higher
+    dimensions.  Such a distribution is specified by its mean and
+    covariance matrix.  These parameters are analogous to the mean
+    (average or "center") and variance (standard deviation, or "width,"
+    squared) of the one-dimensional normal distribution.
+
+    This operator is a little different from the one in official NumPy.
+    The official NumPy operator only accepts 1-D ndarray as mean and 2-D ndarray as cov,
+    whereas the operator in DeepNumPy supports batch operation and auto-broadcasting.
+
+    Both `mean` and `cov` may have any number of leading dimensions, which correspond
+    to a batch shape. They are not necessarily assumed to have the same batch shape,
+    just ones which can be broadcasted.
+
+    Parameters
+    ----------
+    mean : K-D ndarray, of shape (..., N)
+        Mean of the N-dimensional distribution.
+    cov : (K+1)-D ndarray, of shape (..., N, N)
+        Covariance matrix of the distribution. The last two dimensions must be symmetric and
+        positive-semidefinite for proper sampling.
+    size : int or tuple of ints, optional
+        Given a shape of, for example, ``(m,n,k)``,
+        ``m*n*k`` identically distributed batchs of samples are
+        generated, and packed in an `m`-by-`n`-by-`k` arrangement.
+        If no shape is specified, a batch of (`N`-D) sample is returned.
+    check_valid : { 'warn', 'raise', 'ignore' }, optional
+        Behavior when the covariance matrix is not positive semidefinite.
+        (Not supported)
+    tol : float, optional
+        Tolerance when checking the singular values in covariance matrix.
+        cov is cast to double before the check.
+        (Not supported)
+
+    Returns
+    -------
+    out : ndarray
+        The input shape of `mean` and `cov` should satisfy the requirements of broadcasting.
+        If the parameter `size` is not provided,
+        the output shape is ``np.broadcast(mean.shape, cov.shape[:-1])``.
+        Otherwise, the output shape is ``size + np.broadcast(mean.shape, cov.shape[:-1])``
+
+    Examples
+    --------
+    >>> mean = np.array([1, 2])
+    >>> cov = np.array([[1, 0], [0, 1]])
+    >>> x = np.random.multivariate_normal(mean, cov, (3, 3))
+    >>> x.shape
+    (3, 3, 2)
+
+    The following is probably true, given that 0.6 is roughly twice the
+    standard deviation:
+
+    >>> list((x[0,0,:] - mean) < 0.6)
+    [True, True] # random
+
+    # Performs autobroadcasting when the batch shape of
+    # `mean` and `cov` is different but compatible.
+
+    >>> mean = np.zeros((3,2)) # shape (3, 2)
+    >>> cov = np.array([[1, 0], [0, 100]]) # shape (2, 2)
+    >>> x = np.random.multivariate_normal(mean, cov)
+    >>> x
+    array([[-1.6115597 , -8.726251  ],
+           [ 2.2425299 ,  2.8104177 ],
+           [ 0.36229908, -8.386591  ]])
+    """
+    if check_valid is not None:
+        raise NotImplementedError('Parameter `check_valid` is not supported')
+    if tol is not None:
+        raise NotImplementedError('Parameter `tol` is not supported')
+    return _npi.mvn_fallback(mean, cov, size=size)
 
 
 def choice(a, size=None, replace=True, p=None, ctx=None, out=None):

--- a/python/mxnet/numpy/random.py
+++ b/python/mxnet/numpy/random.py
@@ -21,8 +21,8 @@ from __future__ import absolute_import
 from ..ndarray import numpy as _mx_nd_np
 
 
-__all__ = ["randint", "uniform", "normal", "choice", "rand", "multinomial", "shuffle", "randn",
-           "gamma", "exponential"]
+__all__ = ["randint", "uniform", "normal", "choice", "rand", "multinomial", "multivariate_normal",
+           "shuffle", "randn", "gamma", "exponential"]
 
 
 def randint(low, high=None, size=None, dtype=None, ctx=None, out=None):
@@ -241,6 +241,84 @@ def multinomial(n, pvals, size=None, **kwargs):
     array([32, 68])
     """
     return _mx_nd_np.random.multinomial(n, pvals, size, **kwargs)
+
+
+# pylint: disable=unused-argument
+def multivariate_normal(mean, cov, size=None, check_valid=None, tol=None):
+    """
+    multivariate_normal(mean, cov, size=None, check_valid=None, tol=None)
+
+    Draw random samples from a multivariate normal distribution.
+
+    The multivariate normal, multinormal or Gaussian distribution is a
+    generalization of the one-dimensional normal distribution to higher
+    dimensions.  Such a distribution is specified by its mean and
+    covariance matrix.  These parameters are analogous to the mean
+    (average or "center") and variance (standard deviation, or "width,"
+    squared) of the one-dimensional normal distribution.
+
+    This operator is a little different from the one in official NumPy.
+    The official NumPy operator only accepts 1-D ndarray as mean and 2-D ndarray as cov,
+    whereas the operator in DeepNumPy supports batch operation and auto-broadcasting.
+
+    Both `mean` and `cov` may have any number of leading dimensions, which correspond
+    to a batch shape. They are not necessarily assumed to have the same batch shape,
+    just ones which can be broadcasted.
+
+    Parameters
+    ----------
+    mean : K-D ndarray, of shape (..., N)
+        Mean of the N-dimensional distribution.
+    cov : (K+1)-D ndarray, of shape (..., N, N)
+        Covariance matrix of the distribution. The last two dimensions must be symmetric and
+        positive-semidefinite for proper sampling.
+    size : int or tuple of ints, optional
+        Given a shape of, for example, ``(m,n,k)``,
+        ``m*n*k`` identically distributed batchs of samples are
+        generated, and packed in an `m`-by-`n`-by-`k` arrangement.
+        If no shape is specified, a batch of (`N`-D) sample is returned.
+    check_valid : { 'warn', 'raise', 'ignore' }, optional
+        Behavior when the covariance matrix is not positive semidefinite.
+        (Not supported)
+    tol : float, optional
+        Tolerance when checking the singular values in covariance matrix.
+        cov is cast to double before the check.
+        (Not supported)
+
+    Returns
+    -------
+    out : ndarray
+        The input shape of `mean` and `cov` should satisfy the requirements of broadcasting.
+        If the parameter `size` is not provided,
+        the output shape is ``np.broadcast(mean.shape, cov.shape[:-1])``.
+        Otherwise, the output shape is ``size + np.broadcast(mean.shape, cov.shape[:-1])``
+
+    Examples
+    --------
+    >>> mean = np.array([1, 2])
+    >>> cov = np.array([[1, 0], [0, 1]])
+    >>> x = np.random.multivariate_normal(mean, cov, (3, 3))
+    >>> x.shape
+    (3, 3, 2)
+
+    The following is probably true, given that 0.6 is roughly twice the
+    standard deviation:
+
+    >>> list((x[0,0,:] - mean) < 0.6)
+    [True, True] # random
+
+    # Performs autobroadcasting when the batch shape of
+    # `mean` and `cov` is different but compatible.
+
+    >>> mean = np.zeros((3,2)) # shape (3, 2)
+    >>> cov = np.array([[1, 0], [0, 100]]) # shape (2, 2)
+    >>> x = np.random.multivariate_normal(mean, cov)
+    >>> x
+    array([[-1.6115597 , -8.726251  ],
+           [ 2.2425299 ,  2.8104177 ],
+           [ 0.36229908, -8.386591  ]])
+    """
+    return _mx_nd_np.random.multivariate_normal(mean, cov, size=size, check_valid=None, tol=None)
 
 
 def choice(a, size=None, replace=True, p=None, ctx=None, out=None):

--- a/python/mxnet/numpy/utils.py
+++ b/python/mxnet/numpy/utils.py
@@ -23,7 +23,8 @@ from __future__ import absolute_import
 import numpy as onp
 
 __all__ = ['float16', 'float32', 'float64', 'uint8', 'int32', 'int8', 'int64',
-           'bool', 'bool_', 'pi', 'inf', 'nan', 'PZERO', 'NZERO', 'newaxis', 'finfo']
+           'bool', 'bool_', 'pi', 'inf', 'nan', 'PZERO', 'NZERO', 'newaxis', 'finfo',
+           '_STR_2_DTYPE_']
 
 float16 = onp.float16
 float32 = onp.float32
@@ -44,6 +45,9 @@ NZERO = onp.NZERO
 newaxis = None
 finfo = onp.finfo
 
+_STR_2_DTYPE_ = {'float16': float16, 'float32': float32, 'float64':float64, 'float': float64,
+                 'uint8': uint8, 'int8': int8, 'int32': int32, 'int64': int64, 'int': int64,
+                 'bool': bool, 'bool_': bool_, 'None': None}
 
 _ONP_OP_MODULES = [onp, onp.linalg, onp.random, onp.fft]
 

--- a/python/mxnet/numpy_op_fallback.py
+++ b/python/mxnet/numpy_op_fallback.py
@@ -25,6 +25,7 @@ import numpy as np
 from . import operator
 from . import numpy as _mx_np  # pylint: disable=reimported
 from .util import np_array, use_np
+from .numpy.utils import _STR_2_DTYPE_
 from .ndarray.numpy import _internal as _nd_npi
 from .symbol.numpy import _internal as _sym_npi
 
@@ -67,7 +68,7 @@ class EmptyLike(operator.CustomOp):
                                 subok=self._subok)
         else:
             out = np.empty_like(in_data[0].asnumpy())
-        self.assign(out_data[0], req[0], _mx_np.array(out, dtype=out.dtype, ctx=out_data[0].ctx))
+        self.assign(out_data[0], req[0], _mx_np.array(out, ctx=in_data[0].ctx))
 
     def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
         raise NotImplementedError('Operator empty_like does not support gradient computation')
@@ -88,6 +89,12 @@ class EmptyLikeProp(operator.CustomOpProp):
 
     def infer_shape(self, in_shape):
         return (in_shape[0],), (in_shape[0],), ()
+
+    def infer_type(self, in_type):
+        if self._dtype is None:
+            return (in_type[0],), (in_type[0],), ()
+        else:
+            return (in_type[0],), (_STR_2_DTYPE_[self._dtype],), ()
 
     def create_operator(self, ctx, in_shapes, in_dtypes):
         return EmptyLike(self._dtype, self._order, self._subok, self._shape)
@@ -158,3 +165,66 @@ class Unravel_indexProp(operator.CustomOpProp):
 
     def create_operator(self, ctx, in_shapes, in_dtypes):
         return Unravel_index(self._shape)
+
+
+@use_np
+class MultivariateNormal(operator.CustomOp):
+    """Fallback to the front-end implementation of random.multivariate_normal."""
+    def __init__(self, size=None):
+        super(MultivariateNormal, self).__init__()
+        self._size = size
+
+    def forward(self, is_train, req, in_data, out_data, aux):
+        loc = in_data[0]
+        cov = in_data[1]
+        if cov.dtype == np.float16:
+            scale = _mx_np.linalg.cholesky(cov.astype(np.float32)).astype(np.float16)
+        else:
+            scale = _mx_np.linalg.cholesky(cov)
+        #set context
+        noise = _mx_np.random.normal(size=out_data[0].shape, dtype=loc.dtype, ctx=loc.ctx)
+        out = loc + _mx_np.einsum('...jk,...j->...k', scale, noise)
+        self.assign(out_data[0], req[0], out)
+
+    def backward(self, req, out_grad, in_data, out_data, in_grad, aux):
+        raise NotImplementedError('Operator random.multivariate_normal'
+                                  ' does not support gradient computation')
+
+
+@register('mvn_fallback')
+class MultivariateNormalProp(operator.CustomOpProp):
+    """Fallback np.random.multivariate_normal operator properties."""
+
+    def __init__(self, size=None):
+        super(MultivariateNormalProp, self).__init__(need_top_grad=True)
+        self._size = ast.literal_eval(
+            size) if size is not None else None
+
+    def list_arguments(self):
+        return ['mean', 'cov']
+
+    def infer_shape(self, in_shape):
+        loc_shape = in_shape[0]
+        cov_shape = in_shape[1]
+        if len(loc_shape) < 1:
+            raise ValueError("mean must be at least 1 dimensional")
+        if len(cov_shape) < 2:
+            raise ValueError("cov must be at least 2 dimensional")
+        if cov_shape[-1] != cov_shape[-2]:
+            raise ValueError("the last two dimentions of the parameter cov have to be the same,"
+                             " whereas the shape of cov is {}".format(cov_shape))
+        if cov_shape[-1] != loc_shape[-1]:
+            raise ValueError("mean and cov must have same length."
+                             "The shape of mean is {} but the shape of cov is {}"
+                             .format(loc_shape[-1:], cov_shape[-2:]))
+        # handle shape mismatch here
+        out_shape = np.broadcast(np.empty(loc_shape), np.empty(cov_shape[:-1])).shape
+        if self._size is not None:
+            self._size = (self._size,) if np.isscalar(
+                self._size) else self._size
+            out_shape = self._size + out_shape
+
+        return in_shape, (out_shape,), ()
+
+    def create_operator(self, ctx, in_shapes, in_dtypes):
+        return MultivariateNormal(self._size)

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -1804,7 +1804,7 @@ def empty_like(prototype, dtype=None, order='C', subok=False, shape=None): # pyl
     """
     dtype_list = {None:'None', _np.int8:'int8', _np.uint8:'uint8', _np.int32:'int32',
                   _np.int64:'int64', _np.float16:'float16', _np.float32:'float32',
-                  _np.float64:'float64', _np.bool_:'bool'}
+                  _np.float64:'float64', _np.bool_:'bool_', bool:'bool', int:'int64', float:'float64'}
     if order != 'C':
         raise NotImplementedError("Only support C order at this moment")
     if subok:

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -7169,25 +7169,16 @@ def test_scatter_gather_nd():
 
 @with_seed()
 def test_gather_nd_check_bound():
+    def _test_gather_nd_exception(data, indices):
+        output = mx.nd.gather_nd(data, indices).asnumpy()
     # check if indices is out of bound
     data = mx.nd.array([[0, 1, 2], [3, 4, 5]])
     indices1 = mx.nd.array([[0, 1, 0], [0, 1, 3]])
     indices2 = mx.nd.array([[0, 1, 0], [0, 1, -5]])
-    try:
-        mx.nd.gather_nd(data, indices1)
-        mx.nd.waitall()
-    except IndexError:
-            # skip errors since the test is supposed to raise error
-            # IndexError: index 3 is out of bounds for axis 1 with size 3
-            pass
-
-    try:
-        mx.nd.gather_nd(data, indices2)
-        mx.nd.waitall()
-    except IndexError:
-            # skip errors since the test is supposed to raise error
-            # IndexError: index -5 is out of bounds for axis 1 with size 3
-            pass
+    assertRaises(IndexError, _test_gather_nd_exception, data, indices1)
+    # IndexError: index 3 is out of bounds for axis 1 with size 3
+    assertRaises(IndexError, _test_gather_nd_exception, data, indices2)
+    # IndexError: index -5 is out of bounds for axis 1 with size 3
 
     # check if the negative indices are wrapped correctly
     indices1 = mx.nd.array([[0, 1, -1], [0, 1, -2]])


### PR DESCRIPTION
1. add operator random.multivariate_normal

2. modify the test for gather_nd check bound: change the way to raise error

3. fix the infer_shape problem in custom op: empty_like, and add more dtype support

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
