### PR TITLE
license np_einsum file under bsd

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -333,9 +333,11 @@
          cmake/Modules/FindCUDAToolkit.cmake
          3rdparty/mkldnn/cmake/FindOpenCL.cmake
          Copyright 2000-2019 Kitware, Inc. and Contributors
-    10 ittnotify - For details, see, 3rdparty/mkldnn/src/cpu/jit_utils/jitprofiling/
+    10. ittnotify - For details, see, 3rdparty/mkldnn/src/cpu/jit_utils/jitprofiling/
          Copyright (c) 2011, Intel Corporation
-
+    11. Numpy einsum operator - For details, see src/operator/numpy/np_einsum_op-inl.h
+         Copyright (c) 2005-2019, NumPy Developers.
+         Copyright (c) 2019, The Apache Software Foundation.
 
     =======================================================================================
     2-clause BSD licenses

--- a/src/operator/numpy/np_einsum_op-inl.h
+++ b/src/operator/numpy/np_einsum_op-inl.h
@@ -1,24 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
-/*
  * Copyright (c) 2005-2019, NumPy Developers.
+ * Copyright (c) 2019, The Apache Software Foundation.
+ *
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -53,6 +36,8 @@
 /*!
  * \file np_einsum_op-inl.h
  * \brief Function definition of numpy-compatible einsum operator
+ * modified by Haozheng Fan(@hzfan) from:
+ * https://github.com/numpy/numpy/blob/master/numpy/core/src/multiarray/einsum.c.src
  */
 
 #ifndef MXNET_OPERATOR_NUMPY_NP_EINSUM_OP_INL_H_

--- a/tests/nightly/apache_rat_license_check/rat-excludes
+++ b/tests/nightly/apache_rat_license_check/rat-excludes
@@ -76,4 +76,4 @@ searchtools_custom.js
 theme.conf
 LICENSE.binary.dependencies
 cmake/Modules/FindCUDAToolkit.cmake
-src/operator/numpy/np_einsum_op-inl.h
+np_einsum_op-inl.h

--- a/tests/nightly/apache_rat_license_check/rat-excludes
+++ b/tests/nightly/apache_rat_license_check/rat-excludes
@@ -76,3 +76,4 @@ searchtools_custom.js
 theme.conf
 LICENSE.binary.dependencies
 cmake/Modules/FindCUDAToolkit.cmake
+src/operator/numpy/np_einsum_op-inl.h

--- a/tools/license_header.py
+++ b/tools/license_header.py
@@ -99,6 +99,7 @@ _WHITE_LIST = [
                'docs/_static/js/clipboard.min.js',
                'docs/static_site/src/assets/js/clipboard.js',
                'cmake/Modules/FindCUDAToolkit.cmake',
+               'src/operator/numpy/np_einsum_op-inl.h',
 
                # Licensed under 2-Clause BSD in header
                'example/ssd/dataset/pycocotools/coco.py',


### PR DESCRIPTION
## Description ##

- fix part of https://github.com/apache/incubator-mxnet/issues/17329
- As this is a modification of original numpy file under 3-Clause BSD license, we opt not to relicense it under Apache-2.0.
- Keep the BSD license, add copyright from apache contributor. Add white list for license check.


cc @hzfan @haojin2 @reminisce 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
