### PR TITLE
Fix mshadow broken basic_stream example

### DIFF
--- a/3rdparty/mshadow/guide/Makefile
+++ b/3rdparty/mshadow/guide/Makefile
@@ -12,7 +12,12 @@ export NVCCFLAGS = -O3 --use_fast_math -ccbin $(CXX) $(MSHADOW_NVCCFLAGS)
 BIN = basic defop
 OBJ =
 CUOBJ =
+ifeq ($(USE_CUDA), 1)
+CUBIN = basic_stream
+else
 CUBIN =
+endif
+
 .PHONY: clean all
 
 all: $(BIN) $(OBJ) $(CUBIN) $(CUOBJ)

--- a/3rdparty/mshadow/guide/basic_stream.cu
+++ b/3rdparty/mshadow/guide/basic_stream.cu
@@ -9,20 +9,22 @@ int main(void) {
   // intialize tensor engine before using tensor operation, needed for CuBLAS
   InitTensorEngine<gpu>();
   // create a 2 x 5 tensor, from existing space
-  Stream<gpu> *sm1 = NewStream<gpu>();
-  Stream<gpu> *sm2 = NewStream<gpu>();
-  Tensor<gpu, 2, float> ts1 = NewTensor<gpu, float>(Shape2(2, 5), 0.0f, sm1);
-  Tensor<gpu, 2, float> ts2 = NewTensor<gpu, float>(Shape2(2, 5), 0.0f, sm2);
-  ts1 = 1; // Should use stream 0.
-  ts2 = 2; // Should use stream 1. Can run in parallel with stream 0.
-  Tensor<gpu, 2> res = NewTensor<gpu, float>(Shape2(2, 2), 0.0f);
-  res.stream_ = NewStream<gpu>();
-  res = dot(ts1, ts2.T()); //Should use stream 2.
+  Stream<gpu> *sm1 = NewStream<gpu>(0);
+  Stream<gpu> *sm2 = NewStream<gpu>(0);
+  Tensor<gpu, 2, float> ts1 =
+      NewTensor<gpu, float>(Shape2(2, 5), 0.0f, false, sm1);
+  Tensor<gpu, 2, float> ts2 =
+      NewTensor<gpu, float>(Shape2(2, 5), 0.0f, false, sm2);
+  ts1 = 1; // Should use stream 1.
+  ts2 = 2; // Should use stream 2. Can run in parallel with stream 1.
+  Stream<gpu> *sm3 = NewStream<gpu>(0);
+  Tensor<gpu, 2> res = NewTensor<gpu, float>(Shape2(2, 2), 0.0f, false, sm3);
+  res = dot(ts1, ts2.T()); // Should use stream 3.
 
   Tensor<cpu, 2> cpu_res = NewTensor<cpu, float>(Shape2(2, 2), 0.0f);
-  Copy(cpu_res, res); // default stream, should be 0.
-  for (index_t i = 0; i < cpu_res.size(0); ++i){
-    for (index_t j = 0; j < cpu_res.size(1); ++j){
+  Copy(cpu_res, res, sm3);
+  for (index_t i = 0; i < cpu_res.size(0); ++i) {
+    for (index_t j = 0; j < cpu_res.size(1); ++j) {
       printf("%.2f ", cpu_res[i][j]);
     }
     printf("\n");
@@ -30,6 +32,7 @@ int main(void) {
   // shutdown tensor enigne after usage
   DeleteStream(sm1);
   DeleteStream(sm2);
+  DeleteStream(sm3);
   ShutdownTensorEngine<gpu>();
   return 0;
 }

--- a/3rdparty/mshadow/make/mshadow.mk
+++ b/3rdparty/mshadow/make/mshadow.mk
@@ -64,6 +64,7 @@ endif
 ifeq ($(USE_CUDA), 0)
 	MSHADOW_CFLAGS += -DMSHADOW_USE_CUDA=0
 else
+	MSHADOW_CFLAGS += -DMSHADOW_USE_CUDA=1
 	MSHADOW_LDFLAGS += -lcudart -lcublas -lcurand -lcusolver
 endif
 ifneq ($(USE_CUDA_PATH), NONE)


### PR DESCRIPTION
#16781  Description ##

The NewTensor and NewStream API had changed to different signature while the basic_stream.cu sample still use the wrong incorrect interface, thus it will always error when compile this sample.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x ] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
