### PR TITLE
[NumPy] add random.geometric op

### DIFF
--- a/python/mxnet/ndarray/numpy/random.py
+++ b/python/mxnet/ndarray/numpy/random.py
@@ -480,9 +480,9 @@ def geometric(p, size=None, dtype=None, ctx=None, out=None):
         ctx = current_context()
     if size == ():
         size = None
-    if input_type == (True, True):
-        return _npi.geometric(p, p=None, size=size,
+    if input_type:
+        return _npi.geometric(p, prob=None, size=size,
                               ctx=ctx, dtype=dtype, out=out)
     else:
-        return _npi.geometric(p=p, size=size,
+        return _npi.geometric(prob=p, size=size,
                               ctx=ctx, dtype=dtype, out=out)

--- a/python/mxnet/ndarray/numpy/random.py
+++ b/python/mxnet/ndarray/numpy/random.py
@@ -23,7 +23,7 @@ from . import _internal as _npi
 from ..ndarray import NDArray
 
 
-__all__ = ['randint', 'uniform', 'normal', "choice", "rand", "multinomial", "shuffle", 'gamma']
+__all__ = ['randint', 'uniform', 'normal', "choice", "rand", "multinomial", "shuffle", 'gamma', 'geometric']
 
 
 def randint(low, high=None, size=None, dtype=None, ctx=None, out=None):
@@ -437,3 +437,52 @@ def shuffle(x):
            [0., 1., 2.]])
     """
     _npi.shuffle(x, out=x)
+
+
+def geometric(p, size=None, dtype=None, ctx=None, out=None):
+    r"""Draw samples from a uniform distribution.
+
+    Samples are uniformly distributed over the half-open interval
+    ``[low, high)`` (includes low, but excludes high).  In other words,
+    any value within the given interval is equally likely to be drawn
+    by `uniform`.
+
+    Parameters
+    ----------
+    low : float, ndarray, optional
+        Lower boundary of the output interval.  All values generated will be
+        greater than or equal to low.  The default value is 0.
+    high : float, ndarray, optional
+        Upper boundary of the output interval.  All values generated will be
+        less than high.  The default value is 1.0.
+    size : int or tuple of ints, optional
+        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+        ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+        a scalar tensor containing a single value is returned if
+        ``low`` and ``high`` are both scalars.
+    dtype : {'float16', 'float32', 'float64'}, optional
+        Data type of output samples. Default is 'float32'
+    ctx : Context, optional
+        Device context of output. Default is current context.
+    out : ``ndarray``, optional
+        Store output to an existing ``ndarray``.
+
+    Returns
+    -------
+    out : ndarray
+        Drawn samples from the parameterized uniform distribution.
+    """
+    from ...numpy import ndarray as np_ndarray
+    input_type = isinstance(p, np_ndarray)
+    if dtype is None:
+        dtype = 'float32'
+    if ctx is None:
+        ctx = current_context()
+    if size == ():
+        size = None
+    if input_type == (True, True):
+        return _npi.geometric(p, p=None, size=size,
+                              ctx=ctx, dtype=dtype, out=out)
+    else:
+        return _npi.geometric(p=p, size=size,
+                              ctx=ctx, dtype=dtype, out=out)

--- a/python/mxnet/ndarray/numpy/random.py
+++ b/python/mxnet/ndarray/numpy/random.py
@@ -440,37 +440,29 @@ def shuffle(x):
 
 
 def geometric(p, size=None, dtype=None, ctx=None, out=None):
-    r"""Draw samples from a uniform distribution.
+    """Draw samples from the geometric distribution.
 
-    Samples are uniformly distributed over the half-open interval
-    ``[low, high)`` (includes low, but excludes high).  In other words,
-    any value within the given interval is equally likely to be drawn
-    by `uniform`.
+    Bernoulli trials are experiments with one of two outcomes: success or failure
+    (an example of such an experiment is flipping a coin). The geometric distribution
+    models the number of trials that must be run in order to achieve success.
+    It is therefore supported on the positive integers, k = 1, 2, ....
 
     Parameters
     ----------
-    low : float, ndarray, optional
-        Lower boundary of the output interval.  All values generated will be
-        greater than or equal to low.  The default value is 0.
-    high : float, ndarray, optional
-        Upper boundary of the output interval.  All values generated will be
-        less than high.  The default value is 1.0.
+    p : float or array_like of floats. The probability of success of an individual trial.
     size : int or tuple of ints, optional
-        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-        ``m * n * k`` samples are drawn.  If size is ``None`` (default),
-        a scalar tensor containing a single value is returned if
-        ``low`` and ``high`` are both scalars.
-    dtype : {'float16', 'float32', 'float64'}, optional
-        Data type of output samples. Default is 'float32'
+        Output shape. If the given shape is, e.g., (m, n, k),
+        then m * n * k samples are drawn. If size is None (default), a single value is returned if p is a scalar.
+        Otherwise, np.array(p).size samples are drawn.
     ctx : Context, optional
         Device context of output. Default is current context.
-    out : ``ndarray``, optional
-        Store output to an existing ``ndarray``.
 
     Returns
     -------
-    out : ndarray
-        Drawn samples from the parameterized uniform distribution.
+    out : ndarray or scalar
+        Drawn samples from the parameterized geometric distribution.
+
+    The geometric distribution models the number of trials that must be run in order to achieve success.
     """
     from ...numpy import ndarray as np_ndarray
     input_type = isinstance(p, np_ndarray)

--- a/python/mxnet/numpy/random.py
+++ b/python/mxnet/numpy/random.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 from ..ndarray import numpy as _mx_nd_np
 
 __all__ = ["randint", "uniform", "normal", "choice", "rand", "multinomial", "shuffle", "randn",
-           "gamma"]
+           "gamma", "geometric"]
 
 
 def randint(low, high=None, size=None, dtype=None, ctx=None, out=None):
@@ -433,3 +433,7 @@ def randn(*size, **kwargs):
     for s in size:
         output_shape += (s,)
     return _mx_nd_np.random.normal(0, 1, size=output_shape, **kwargs)
+
+
+def geometric(p, size=None, dtype=None, ctx=None, out=None):
+    return _mx_nd_np.random.geometric(p, size, dtype, ctx, out)

--- a/python/mxnet/numpy/random.py
+++ b/python/mxnet/numpy/random.py
@@ -436,4 +436,28 @@ def randn(*size, **kwargs):
 
 
 def geometric(p, size=None, dtype=None, ctx=None, out=None):
+    """Draw samples from the geometric distribution.
+
+    Bernoulli trials are experiments with one of two outcomes: success or failure
+    (an example of such an experiment is flipping a coin). The geometric distribution
+    models the number of trials that must be run in order to achieve success.
+    It is therefore supported on the positive integers, k = 1, 2, ....
+
+    Parameters
+    ----------
+    p : float or array_like of floats. The probability of success of an individual trial.
+    size : int or tuple of ints, optional
+        Output shape. If the given shape is, e.g., (m, n, k),
+        then m * n * k samples are drawn. If size is None (default), a single value is returned if p is a scalar.
+        Otherwise, np.array(p).size samples are drawn.
+    ctx : Context, optional
+        Device context of output. Default is current context.
+
+    Returns
+    -------
+    out : ndarray or scalar
+        Drawn samples from the parameterized geometric distribution.
+
+    The geometric distribution models the number of trials that must be run in order to achieve success.
+    """
     return _mx_nd_np.random.geometric(p, size, dtype, ctx, out)

--- a/python/mxnet/symbol/numpy/random.py
+++ b/python/mxnet/symbol/numpy/random.py
@@ -381,3 +381,52 @@ def shuffle(x):
            [0., 1., 2.]])
     """
     _npi.shuffle(x, out=x)
+
+
+def geometric(p, size=None, dtype=None, ctx=None, out=None):
+    r"""Draw samples from a uniform distribution.
+
+    Samples are uniformly distributed over the half-open interval
+    ``[low, high)`` (includes low, but excludes high).  In other words,
+    any value within the given interval is equally likely to be drawn
+    by `uniform`.
+
+    Parameters
+    ----------
+    low : float, ndarray, optional
+        Lower boundary of the output interval.  All values generated will be
+        greater than or equal to low.  The default value is 0.
+    high : float, ndarray, optional
+        Upper boundary of the output interval.  All values generated will be
+        less than high.  The default value is 1.0.
+    size : int or tuple of ints, optional
+        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
+        ``m * n * k`` samples are drawn.  If size is ``None`` (default),
+        a scalar tensor containing a single value is returned if
+        ``low`` and ``high`` are both scalars.
+    dtype : {'float16', 'float32', 'float64'}, optional
+        Data type of output samples. Default is 'float32'
+    ctx : Context, optional
+        Device context of output. Default is current context.
+    out : ``ndarray``, optional
+        Store output to an existing ``ndarray``.
+
+    Returns
+    -------
+    out : ndarray
+        Drawn samples from the parameterized uniform distribution.
+    """
+    from ._symbol import _Symbol as np_symbol
+    input_type = isinstance(p, np_symbol)
+    if dtype is None:
+        dtype = 'float32'
+    if ctx is None:
+        ctx = current_context()
+    if size == ():
+        size = None
+    if input_type:
+        return _npi.geometric(p, prob=None, size=size,
+                              ctx=ctx, dtype=dtype, out=out)
+    else:
+        return _npi.geometric(prob=p, size=size,
+                              ctx=ctx, dtype=dtype, out=out)

--- a/python/mxnet/symbol/numpy/random.py
+++ b/python/mxnet/symbol/numpy/random.py
@@ -384,37 +384,29 @@ def shuffle(x):
 
 
 def geometric(p, size=None, dtype=None, ctx=None, out=None):
-    r"""Draw samples from a uniform distribution.
+    """Draw samples from the geometric distribution.
 
-    Samples are uniformly distributed over the half-open interval
-    ``[low, high)`` (includes low, but excludes high).  In other words,
-    any value within the given interval is equally likely to be drawn
-    by `uniform`.
+    Bernoulli trials are experiments with one of two outcomes: success or failure
+    (an example of such an experiment is flipping a coin). The geometric distribution
+    models the number of trials that must be run in order to achieve success.
+    It is therefore supported on the positive integers, k = 1, 2, ....
 
     Parameters
     ----------
-    low : float, ndarray, optional
-        Lower boundary of the output interval.  All values generated will be
-        greater than or equal to low.  The default value is 0.
-    high : float, ndarray, optional
-        Upper boundary of the output interval.  All values generated will be
-        less than high.  The default value is 1.0.
+    p : float or array_like of floats. The probability of success of an individual trial.
     size : int or tuple of ints, optional
-        Output shape.  If the given shape is, e.g., ``(m, n, k)``, then
-        ``m * n * k`` samples are drawn.  If size is ``None`` (default),
-        a scalar tensor containing a single value is returned if
-        ``low`` and ``high`` are both scalars.
-    dtype : {'float16', 'float32', 'float64'}, optional
-        Data type of output samples. Default is 'float32'
+        Output shape. If the given shape is, e.g., (m, n, k),
+        then m * n * k samples are drawn. If size is None (default), a single value is returned if p is a scalar.
+        Otherwise, np.array(p).size samples are drawn.
     ctx : Context, optional
         Device context of output. Default is current context.
-    out : ``ndarray``, optional
-        Store output to an existing ``ndarray``.
 
     Returns
     -------
-    out : ndarray
-        Drawn samples from the parameterized uniform distribution.
+    out : ndarray or scalar
+        Drawn samples from the parameterized geometric distribution.
+
+    The geometric distribution models the number of trials that must be run in order to achieve success.
     """
     from ._symbol import _Symbol as np_symbol
     input_type = isinstance(p, np_symbol)

--- a/src/operator/numpy/random/np_geometric_op.cc
+++ b/src/operator/numpy/random/np_geometric_op.cc
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_geometric_op.cc
+ * \brief Operator for numpy sampling from geometric distributions
+ */
+
+#include "./np_geometric_op.h"
+#include "./dist_common.h"
+
+namespace mxnet {
+namespace op {
+
+DMLC_REGISTER_PARAMETER(NumpyGeometricParam);
+
+NNVM_REGISTER_OP(_npi_geometric)
+.set_num_inputs(
+  [](const nnvm::NodeAttrs& attrs) {
+    const NumpyGeometricParam& param = nnvm::get<NumpyGeometricParam>(attrs.parsed);
+    int num_inputs = 1;
+    if (param.prob.has_value()) {
+      num_inputs -= 1;
+    }
+    return num_inputs;
+  }
+)
+.set_num_outputs(1)
+.set_attr<nnvm::FListInputNames>("FListInputNames",
+  [](const NodeAttrs& attrs) {
+    const NumpyGeometricParam& param = nnvm::get<NumpyGeometricParam>(attrs.parsed);
+    int num_inputs = 1;
+    if (param.prob.has_value()) {
+      num_inputs -= 1;
+    }
+    return (num_inputs == 0) ? std::vector<std::string>() : std::vector<std::string>{"input1"};
+  })
+.set_attr_parser(ParamParser<NumpyGeometricParam>)
+.set_attr<mxnet::FInferShape>("FInferShape", UnaryDistOpShape<NumpyGeometricParam>)
+.set_attr<nnvm::FInferType>("FInferType", NumpyGeometricOpType)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const nnvm::NodeAttrs& attrs) {
+      return std::vector<ResourceRequest>{
+        ResourceRequest::kRandom, ResourceRequest::kTempSpace};
+  })
+.set_attr<FCompute>("FCompute<cpu>", NumpyGeometricForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+.add_argument("input1", "NDArray-or-Symbol", "Source input")
+.add_arguments(NumpyGeometricParam::__FIELDS__());
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/random/np_geometric_op.cu
+++ b/src/operator/numpy/random/np_geometric_op.cu
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_geometric_op.cu
+ * \brief Operator for numpy sampling from geometric distributions
+ */
+
+#include "./np_geometric_op.h"
+
+namespace mxnet {
+namespace op {
+
+NNVM_REGISTER_OP(_npi_geometric)
+.set_attr<FCompute>("FCompute<gpu>", NumpyGeometricForward<gpu>);
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/random/np_geometric_op.h
+++ b/src/operator/numpy/random/np_geometric_op.h
@@ -89,7 +89,7 @@ struct geometric_kernel {
     Shape<ndim> coord = unravel(i, oshape);
     auto idx = static_cast<index_t>(dot(coord, stride));
     IType prob = probs[idx];
-    out[i] = floor(log(uniforms[i]) / log(1 - prob));
+    out[i] = floor(log(uniforms[i]) / log(1 - prob)) + 1;
   }
 };
 
@@ -97,7 +97,7 @@ template <typename OType>
 struct scalar_geometric_kernel {
   MSHADOW_XINLINE static void Map(index_t i, float prob, float *uniforms,
                                   OType *out) {
-    out[i] = floor(log(uniforms[i]) / log(1 - prob));
+    out[i] = floor(log(uniforms[i]) / log(1 - prob)) + 1;
   }
 };
 

--- a/src/operator/numpy/random/np_geometric_op.h
+++ b/src/operator/numpy/random/np_geometric_op.h
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2019 by Contributors
+ * \file np_geometric_op.h
+ * \brief Operator for numpy sampling from geometric distribution.
+ */
+#ifndef MXNET_OPERATOR_NUMPY_RANDOM_NP_GEOMETRIC_OP_H_
+#define MXNET_OPERATOR_NUMPY_RANDOM_NP_GEOMETRIC_OP_H_
+
+#include <mxnet/operator_util.h>
+#include <algorithm>
+#include <string>
+#include <vector>
+#include "../../elemwise_op_common.h"
+#include "../../mshadow_op.h"
+#include "../../mxnet_op.h"
+#include "../../operator_common.h"
+#include "../../tensor/elemwise_binary_broadcast_op.h"
+#include "./dist_common.h"
+
+namespace mxnet {
+namespace op {
+
+struct NumpyGeometricParam : public dmlc::Parameter<NumpyGeometricParam> {
+  dmlc::optional<float> prob;
+  std::string ctx;
+  int dtype;
+  dmlc::optional<mxnet::Tuple<int>> size;
+  DMLC_DECLARE_PARAMETER(NumpyGeometricParam) {
+    DMLC_DECLARE_FIELD(prob);
+    DMLC_DECLARE_FIELD(size)
+        .set_default(dmlc::optional<mxnet::Tuple<int>>())
+        .describe(
+            "Output shape. If the given shape is, "
+            "e.g., (m, n, k), then m * n * k samples are drawn. "
+            "Default is None, in which case a single value is returned.");
+    DMLC_DECLARE_FIELD(ctx).set_default("cpu").describe(
+        "Context of output, in format [cpu|gpu|cpu_pinned](n)."
+        " Only used for imperative calls.");
+    DMLC_DECLARE_FIELD(dtype)
+        .add_enum("uint8", mshadow::kUint8)
+        .add_enum("int32", mshadow::kInt32)
+        .add_enum("float32", mshadow::kFloat32)
+        .add_enum("float64", mshadow::kFloat64)
+        .add_enum("float16", mshadow::kFloat16)
+        .add_enum("bool", mshadow::kBool)
+        .set_default(mshadow::kFloat32)
+        .describe(
+            "DType of the output in case this can't be inferred. "
+            "Defaults to float32 if not defined (dtype=None).");
+  }
+};
+
+inline bool NumpyGeometricOpType(const nnvm::NodeAttrs &attrs,
+                               std::vector<int> *in_attrs,
+                               std::vector<int> *out_attrs) {
+  const NumpyGeometricParam &param = nnvm::get<NumpyGeometricParam>(attrs.parsed);
+  int otype = param.dtype;
+  (*out_attrs)[0] = otype;
+  return true;
+}
+
+namespace mxnet_op {
+
+template <int ndim, typename IType, typename OType>
+struct geometric_kernel {
+  MSHADOW_XINLINE static void Map(index_t i,
+                                  const Shape<ndim> &stride,
+                                  const Shape<ndim> &oshape,
+                                  IType *probs, float* uniforms, OType *out) {
+    Shape<ndim> coord = unravel(i, oshape);
+    auto idx = static_cast<index_t>(dot(coord, stride));
+    IType prob = probs[idx];
+    out[i] = floor(log(uniforms[i]) / log(1 - prob));
+  }
+};
+
+template <typename OType>
+struct scalar_geometric_kernel {
+  MSHADOW_XINLINE static void Map(index_t i, float prob, float *uniforms,
+                                  OType *out) {
+    out[i] = floor(log(uniforms[i]) / log(1 - prob));
+  }
+};
+
+template <typename IType>
+struct check_legal_prob_kernel {
+  MSHADOW_XINLINE static void Map(index_t i, IType *scalar, float* flag) {
+    if (scalar[i] < 0.0 || scalar[i] > 1.0) {
+      flag[0] = -1.0;
+    }
+  }
+};
+
+}  // namespace mxnet_op
+
+template <typename xpu>
+void NumpyGeometricForward(const nnvm::NodeAttrs &attrs,
+                         const OpContext &ctx,
+                         const std::vector<TBlob> &inputs,
+                         const std::vector<OpReqType> &req,
+                         const std::vector<TBlob> &outputs) {
+  using namespace mshadow;
+  using namespace mxnet_op;
+  const NumpyGeometricParam &param = nnvm::get<NumpyGeometricParam>(attrs.parsed);
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+  index_t output_len = outputs[0].Size();
+  Random<xpu, float> *prnd = ctx.requested[0].get_random<xpu, float>(s);
+  Tensor<xpu, 1, float> workspace =
+      ctx.requested[1].get_space_typed<xpu, 1, float>(Shape1(output_len + 1), s);
+  Tensor<xpu, 1, float> uniform_tensor = workspace.Slice(0, output_len);
+  Tensor<xpu, 1, float> indicator_device = workspace.Slice(output_len, output_len + 1);
+  float indicator_host = 1.0;
+  float *indicator_device_ptr = indicator_device.dptr_;
+  Kernel<set_zero, xpu>::Launch(s, 1, indicator_device_ptr);
+  prnd->SampleUniform(&uniform_tensor, 0.0, 1.0);
+  if (inputs.size() == 0U) {
+    // scalar prob input
+    CHECK_LE(param.prob.value(), 1.0) << "ValueError: expect probs >= 0 && probs <= 1";
+    CHECK_GE(param.prob.value(), 0.0) << "ValueError: expect probs >= 0 && probs <= 1";
+    MSHADOW_TYPE_SWITCH_WITH_BOOL(outputs[0].type_flag_, OType, {
+      Kernel<scalar_geometric_kernel<OType>, xpu>::Launch(
+        s, outputs[0].Size(), param.prob.value(),
+        uniform_tensor.dptr_, outputs[0].dptr<OType>());
+    });
+  } else if (inputs.size() == 1U) {
+    mxnet::TShape new_lshape, new_oshape;
+    int ndim = FillShape(inputs[0].shape_, inputs[0].shape_, outputs[0].shape_,
+                         &new_lshape, &new_lshape, &new_oshape);
+    MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, IType, {
+      MSHADOW_TYPE_SWITCH_WITH_BOOL(outputs[0].type_flag_, OType, {
+        BROADCAST_NDIM_SWITCH(ndim, NDim, {
+          Shape<NDim> oshape = new_oshape.get<NDim>();
+          Shape<NDim> stride = calc_stride(new_lshape.get<NDim>());
+          // tensor prob input
+          MSHADOW_TYPE_SWITCH(inputs[0].type_flag_, IType, {
+            Kernel<check_legal_prob_kernel<IType>, xpu>::Launch(
+              s, inputs[0].Size(), inputs[0].dptr<IType>(), indicator_device_ptr);
+          });
+          _copy<xpu>(s, &indicator_host, indicator_device_ptr);
+          CHECK_GE(indicator_host, 0.0)
+              << "ValueError: expect probs >= 0 && probs <= 1";
+          Kernel<geometric_kernel<NDim, IType, OType>, xpu>::Launch(
+            s, outputs[0].Size(), stride, oshape, inputs[0].dptr<IType>(),
+            uniform_tensor.dptr_, outputs[0].dptr<OType>());
+
+//          Kernel<geometric_kernel<NDim, IType, OType>, xpu>::Launch(
+//              s, outputs[0].Size(), stride, oshape, inputs[0].dptr<IType>(),
+//              uniform_tensor.dptr_, outputs[0].dptr<OType>());
+        });
+      });
+    });
+  }
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NUMPY_RANDOM_NP_GEOMETRIC_OP_H_

--- a/src/operator/numpy/random/np_geometric_op.h
+++ b/src/operator/numpy/random/np_geometric_op.h
@@ -47,7 +47,7 @@ struct NumpyGeometricParam : public dmlc::Parameter<NumpyGeometricParam> {
   DMLC_DECLARE_PARAMETER(NumpyGeometricParam) {
     DMLC_DECLARE_FIELD(prob);
     DMLC_DECLARE_FIELD(size)
-        .set_default(dmlc::optional<mxnet::Tuple<int>>())
+      .set_default(dmlc::optional<mxnet::Tuple<int>>())
         .describe(
             "Output shape. If the given shape is, "
             "e.g., (m, n, k), then m * n * k samples are drawn. "

--- a/tests/nightly/test_np_random.py
+++ b/tests/nightly/test_np_random.py
@@ -71,7 +71,7 @@ def test_np_normal():
     num_buckets = 5
     for dtype in types:
         for loc, scale in [(0.0, 1.0), (1.0, 5.0)]:
-            buckets, probs = gen_buckets_probs_with_ppf(lambda x: ss.norm.pdf(x, loc=low, scale=scale), num_buckets)
+            buckets, probs = gen_buckets_probs_with_ppf(lambda x: ss.norm.ppf(x, loc=loc, scale=scale), num_buckets)
             buckets = np.array(buckets, dtype=dtype).tolist()
             probs = [(buckets[i][1] - buckets[i][0])/scale for i in range(num_buckets)]
             generator_mx_np = lambda x: np.random.normal(loc, scale, size=x, ctx=ctx, dtype=dtype).asnumpy()

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3384,7 +3384,7 @@ def test_npx_sample_n():
 def test_np_random():
     shapes = [(), (1,), (2, 3), (4, 0, 5), 6, (7, 8), None]
     dtypes = ['float16', 'float32', 'float64']
-    op_names = ['uniform', 'normal', 'gamma']
+    op_names = ['uniform', 'normal', 'gamma', 'geometric']
     for shape in shapes:
         for dtype in dtypes:
             for op_name in op_names:
@@ -3392,6 +3392,8 @@ def test_np_random():
                 assert op is not None
                 if op_name == 'gamma':
                     out = op(1, size=shape, dtype=dtype)
+                elif op_name == 'geometric':
+                    out = op(0.5, size=shape, dtype=dtype)
                 else:
                     out = op(size=shape, dtype=dtype)
                 expected_shape = shape
@@ -3420,6 +3422,8 @@ def test_np_random():
             for hybridize in [False, True]:
                 if op_name == "gamma":
                     net = TestRandom(shape, op_name, 1)
+                elif op_name == "geometric":
+                    net = TestRandom(shape, op_name, 0.5)
                 else:
                     net = TestRandom(shape, op_name)
                 if hybridize:


### PR DESCRIPTION
## Description ##
add numpy.random.geometric op and write the unit test

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
