### PR TITLE
fix issue #17389: Indexing ndarray should give empty array output

### DIFF
--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -3095,9 +3095,9 @@ def _get_index_range(start, stop, length, step=1):
     elif start < 0:
         start += length
         if start < 0:
-            raise IndexError('Slicing start %d exceeds limit of %d' % (start-length, length))
+            start = 0
     elif start >= length:
-        raise IndexError('Slicing start %d exceeds limit of %d' % (start, length))
+        start = length
 
     if stop is None:
         if step > 0:
@@ -3110,9 +3110,9 @@ def _get_index_range(start, stop, length, step=1):
     elif stop < 0:
         stop += length
         if stop < 0:
-            raise IndexError('Slicing stop %d exceeds limit of %d' % (stop-length, length))
+            stop = 0
     elif stop > length:
-        raise IndexError('Slicing stop %d exceeds limit of %d' % (stop, length))
+        stop = length
 
     return start, stop, step
 

--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -683,6 +683,21 @@ def test_np_ndarray_indexing():
             mx_indexed_array = mx_indexed_array.asnumpy()
             assert same(np_indexed_array, mx_indexed_array), 'Failed with index = {}'.format(index)
 
+    def test_getitem_slice_bound():
+        mx_array = np.arange(10)
+        np_array = mx_array.asnumpy()
+        assert_almost_equal(mx_array[100:], np_array[100:])
+        assert_almost_equal(mx_array[:100], np_array[:100])
+        assert_almost_equal(mx_array[-100:], np_array[-100:])
+        assert_almost_equal(mx_array[:-100], np_array[:-100])
+
+        mx_array = np.arange(81).reshape(3, 3, 3, 3)
+        np_array = mx_array.asnumpy()
+        assert_almost_equal(mx_array[100:], np_array[100:])
+        assert_almost_equal(mx_array[:100], np_array[:100])
+        assert_almost_equal(mx_array[-100:], np_array[-100:])
+        assert_almost_equal(mx_array[:-100], np_array[:-100])
+
     def test_setitem(np_array, index):
         def assert_same(np_array, np_index, mx_array, mx_index, mx_value, np_value=None):
             if np_value is not None:
@@ -977,6 +992,7 @@ def test_np_ndarray_indexing():
             test_setitem(np_array, index)
             test_getitem_autograd(np_array, index)
             test_setitem_autograd(np_array, index)
+    test_getitem_slice_bound()
 
 
 @with_seed()


### PR DESCRIPTION
This pr is to fix the indexing problem in issue #17389: Indexing ndarray should give empty array output