### PR TITLE
safe load for yaml

### DIFF
--- a/dev_menu.py
+++ b/dev_menu.py
@@ -67,7 +67,7 @@ class CMake(object):
     def read_config(self):
         assert os.path.isfile(self.cmake_options_yaml)
         with open(self.cmake_options_yaml, 'r') as f:
-            self.cmake_options = yaml.load(f)
+            self.cmake_options = yaml.safe_load(f)
 
     def _cmdlineflags(self):
         res = []


### PR DESCRIPTION
## Description ##
Fixes the warning 
```
/dev_menu.py:70: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  self.cmake_options = yaml.load(f)
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
modified:   dev_menu.py
