### PR TITLE
[Flaky Test] enable test_dropout with cudnn off

### DIFF
--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -6955,8 +6955,9 @@ def test_stack():
         check_numeric_gradient(out, inputs)
 
 
+## TODO: test fails intermittently when cudnn on. temporarily disabled cudnn until gets fixed.
+## tracked at https://github.com/apache/incubator-mxnet/issues/14288
 @with_seed()
-@unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/14288")
 def test_dropout():
     def zero_count(array, ratio):
         zeros = 0
@@ -7083,18 +7084,18 @@ def test_dropout():
     check_dropout_ratio(1.0, shape)
     check_dropout_ratio(0.75, shape)
     check_dropout_ratio(0.25, shape)
-    check_dropout_ratio(0.5, shape, cudnn_off=False)
-    check_dropout_ratio(0.0, shape, cudnn_off=False)
-    check_dropout_ratio(1.0, shape, cudnn_off=False)
-    check_dropout_ratio(0.75, shape, cudnn_off=False)
-    check_dropout_ratio(0.25, shape, cudnn_off=False)
+    # check_dropout_ratio(0.5, shape, cudnn_off=False)
+    # check_dropout_ratio(0.0, shape, cudnn_off=False)
+    # check_dropout_ratio(1.0, shape, cudnn_off=False)
+    # check_dropout_ratio(0.75, shape, cudnn_off=False)
+    # check_dropout_ratio(0.25, shape, cudnn_off=False)
 
     check_passthrough(0.5, shape)
     check_passthrough(0.0, shape)
     check_passthrough(1.0, shape)
-    check_passthrough(0.5, shape, cudnn_off=False)
-    check_passthrough(0.0, shape, cudnn_off=False)
-    check_passthrough(1.0, shape, cudnn_off=False)
+    # check_passthrough(0.5, shape, cudnn_off=False)
+    # check_passthrough(0.0, shape, cudnn_off=False)
+    # check_passthrough(1.0, shape, cudnn_off=False)
 
     nshape = (10, 10, 10, 10)
     with mx.autograd.train_mode():
@@ -7111,20 +7112,19 @@ def test_dropout():
         check_dropout_axes(0.25, nshape, axes = (0, 1, 2))
         check_dropout_axes(0.25, nshape, axes = (0, 2, 3))
         check_dropout_axes(0.25, nshape, axes = (1, 2, 3))
-        check_dropout_axes(0.25, nshape, axes = (0,), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (1,), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (2,), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (3,), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (0, 1), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (0, 2), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (0, 3), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (1, 2), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (1, 3), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (2, 3), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (0, 1, 2), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (0, 2, 3), cudnn_off=False)
-        check_dropout_axes(0.25, nshape, axes = (1, 2, 3), cudnn_off=False)
-
+        # check_dropout_axes(0.25, nshape, axes = (0,), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (1,), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (2,), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (3,), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (0, 1), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (0, 2), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (0, 3), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (1, 2), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (1, 3), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (2, 3), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (0, 1, 2), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (0, 2, 3), cudnn_off=False)
+        # check_dropout_axes(0.25, nshape, axes = (1, 2, 3), cudnn_off=False)
 
 
 @unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/11290")


### PR DESCRIPTION
## Description ##
dropout has randomness not controlled by fixed random seed. This issue is reported in https://github.com/apache/incubator-mxnet/issues/14288

Before it gets fixed, this PR turns on test_dropout with cudnn off to make sure other scenarios are under test coverage.

@roywei 