### PR TITLE
Fix R-package/src/Makevars for OpenCV 4

### DIFF
--- a/R-package/src/Makevars
+++ b/R-package/src/Makevars
@@ -1,4 +1,4 @@
 CXX_STD = CXX11
-PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) `pkg-config --libs opencv`
-PKG_CFLAGS = `pkg-config --cflags opencv`
-PKG_CPPFLAGS = -I../inst/include `pkg-config --cflags opencv` `Rscript -e 'Rcpp:::CxxFlags()'`
+PKG_LIBS = $(LAPACK_LIBS) $(BLAS_LIBS) `(pkg-config --libs opencv || pkg-config --libs opencv4)`
+PKG_CFLAGS = `(pkg-config --cflags opencv || pkg-config --cflags opencv4)`
+PKG_CPPFLAGS = -I../inst/include `(pkg-config --cflags opencv || pkg-config --cflags opencv4)` `Rscript -e 'Rcpp:::CxxFlags()'`


### PR DESCRIPTION
## Description ##
For OpenCV 4, the `pkg-config` file is named `opencv4.pc` instead of `opencv.pc`.
See for example `opencv.pc` in Debian Stable https://packages.debian.org/search?searchon=contents&keywords=opencv.pc&mode=exactfilename&suite=stable&arch=any and `opencv4.pc` in Debian Testing.

Fixes https://github.com/apache/incubator-mxnet/issues/17359

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [X] Fix R-package/src/Makevars for OpenCV 4
