### PR TITLE
remove unnecessary nvtx set

### DIFF
--- a/cmake/Modules/FindNVTX.cmake
+++ b/cmake/Modules/FindNVTX.cmake
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set(NVTX_ROOT_DIR "" CACHE PATH "Folder contains NVIDIA NVTX")
-
 find_path(NVTX_INCLUDE_DIRS
   NAMES nvToolsExt.h
   PATHS $ENV{NVTOOLSEXT_PATH} ${NVTX_ROOT_DIR}  ${CUDA_TOOLKIT_ROOT_DIR}


### PR DESCRIPTION
## Description ##
Setting empty string as Cmake Cache variable isn't correct. Fixing it.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- [ ] Code is well-documented: 
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
modified cmake/Modules/FindNVTX.cmake 