### PR TITLE
fix template param as ndim is internally int

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -887,9 +887,9 @@ int MXNDArrayCreateNone(NDArrayHandle *out) {
   API_END();
 }
 
-template<typename DataType, typename dimtype>
+template<typename DataType>
 void CreateNDArray(const DataType* shape,
-                   dimtype ndim,
+                   int ndim,
                    int dev_type,
                    int dev_id,
                    int delay_alloc,
@@ -927,7 +927,7 @@ int MXNDArrayCreateEx64(const int64_t *shape,
                         int dtype,
                         NDArrayHandle *out) {
   API_BEGIN();
-  CreateNDArray<int64_t, int>(shape, ndim, dev_type, dev_id, delay_alloc, dtype, out);
+  CreateNDArray<int64_t>(shape, ndim, dev_type, dev_id, delay_alloc, dtype, out);
   API_END();
 }
 
@@ -939,7 +939,7 @@ int MXNDArrayCreateEx(const uint32_t *shape,
                       int dtype,
                       NDArrayHandle *out) {
   API_BEGIN();
-  CreateNDArray<uint32_t, uint32_t>(shape, ndim, dev_type, dev_id, delay_alloc, dtype, out);
+  CreateNDArray<uint32_t>(shape, static_cast<int>ndim, dev_type, dev_id, delay_alloc, dtype, out);
   API_END();
 }
 

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -939,7 +939,7 @@ int MXNDArrayCreateEx(const uint32_t *shape,
                       int dtype,
                       NDArrayHandle *out) {
   API_BEGIN();
-  CreateNDArray<uint32_t>(shape, static_cast<int>ndim, dev_type, dev_id, delay_alloc, dtype, out);
+  CreateNDArray<uint32_t>(shape, static_cast<int>(ndim), dev_type, dev_id, delay_alloc, dtype, out);
   API_END();
 }
 


### PR DESCRIPTION
## Description ##
Remove the template param for dimtype since internally MXNet uses int (no need for uint32 in that case)
Introduced in https://github.com/apache/incubator-mxnet/pull/15593

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
modified: src/c_api/c_api.cc