### PR TITLE
Implemented final two binary ops, added default params for functionality

### DIFF
--- a/benchmark/opperf/nd_operations/binary_operators.py
+++ b/benchmark/opperf/nd_operations/binary_operators.py
@@ -35,7 +35,34 @@ import mxnet as mx
 
 from benchmark.opperf.utils.benchmark_utils import run_op_benchmarks
 from benchmark.opperf.utils.op_registry_utils import get_all_broadcast_binary_operators, \
-    get_all_elemen_wise_binary_operators
+    get_all_elemen_wise_binary_operators, get_all_misc_binary_operators
+
+
+def run_mx_binary_misc_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler='native', warmup=25, runs=100):
+    """Runs benchmarks with the given context and precision (dtype) for all the miscellaneous
+    binary operators in MXNet.
+
+    Parameters
+    ----------
+    ctx: mx.ctx
+        Context to run benchmarks
+    dtype: str, default 'float32'
+        Precision to use for benchmarks
+    warmup: int, default 25
+        Number of times to run for warmup
+    runs: int, default 100
+        Number of runs to capture benchmark results
+
+    Returns
+    -------
+    Dictionary of results. Key -> Name of the operator, Value -> Benchmark results.
+
+    """
+    # Fetch all Miscellaneous Binary Operators
+    mx_binary_misc_ops = get_all_misc_binary_operators()
+    # Run benchmarks
+    mx_binary_op_results = run_op_benchmarks(mx_binary_misc_ops, dtype, ctx, profiler, warmup, runs)
+    return mx_binary_op_results
 
 
 def run_mx_binary_broadcast_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler='native', warmup=25, runs=100):

--- a/benchmark/opperf/opperf.py
+++ b/benchmark/opperf/opperf.py
@@ -30,7 +30,7 @@ import mxnet as mx
 
 from benchmark.opperf.nd_operations.unary_operators import run_mx_unary_operators_benchmarks
 from benchmark.opperf.nd_operations.binary_operators import run_mx_binary_broadcast_operators_benchmarks, \
-    run_mx_binary_element_wise_operators_benchmarks
+    run_mx_binary_element_wise_operators_benchmarks, run_mx_binary_misc_operators_benchmarks
 from benchmark.opperf.nd_operations.gemm_operators import run_gemm_operators_benchmarks
 from benchmark.opperf.nd_operations.random_sampling_operators import run_mx_random_sampling_operators_benchmarks
 from benchmark.opperf.nd_operations.reduction_operators import run_mx_reduction_operators_benchmarks
@@ -63,11 +63,14 @@ def run_all_mxnet_operator_benchmarks(ctx=mx.cpu(), dtype='float32', profiler='n
     # Run all Unary operations benchmarks with default input values
     mxnet_operator_benchmark_results.append(run_mx_unary_operators_benchmarks(ctx=ctx, dtype=dtype, profiler=profiler))
 
-    # Run all Binary Broadcast, element_wise operations benchmarks with default input values
+    # Run all Binary Broadcast, element_wise, and miscellaneous operations benchmarks with default input values
     mxnet_operator_benchmark_results.append(run_mx_binary_broadcast_operators_benchmarks(ctx=ctx,
                                                                                          dtype=dtype, profiler=profiler))
     mxnet_operator_benchmark_results.append(run_mx_binary_element_wise_operators_benchmarks(ctx=ctx,
                                                                                             dtype=dtype, profiler=profiler))
+
+    mxnet_operator_benchmark_results.append(run_mx_binary_misc_operators_benchmarks(ctx=ctx,
+                                                                                         dtype=dtype, profiler=profiler))
 
     # Run all GEMM operations benchmarks with default input values
     mxnet_operator_benchmark_results.append(run_gemm_operators_benchmarks(ctx=ctx,

--- a/benchmark/opperf/rules/default_params.py
+++ b/benchmark/opperf/rules/default_params.py
@@ -32,6 +32,11 @@ DEFAULT_ARGS = [(1024, 1024)]
 # For Unary operators like abs, arccos, arcsin etc..
 DEFAULT_DATA = [(1024, 1024), (10000, 1), (10000, 100)]
 
+# For Binary miscellaneous operators like choose_element0_index
+# argument data must be indexed via an NDArray.
+# NOTE: Data used is DEFAULT_DATA
+DEFAULT_INDEX = [(1, 1024), (1, 1), (1, 100)]
+
 # For Binary broadcast operators like - broadcast_add/sub/mod/logical_and etc..
 DEFAULT_LHS = [(1024, 1024), (10000, 10), (10000, 1)]
 DEFAULT_RHS = [(1024, 1024), (10000, 10), (10000, 1)]
@@ -188,7 +193,8 @@ DEFAULTS_INPUTS = {"data": DEFAULT_DATA,
                    "data_smce": DEFAULT_DATA_SMCE,
                    "data_3d": DEFAULT_DATA_3d,
                    "label_smce": DEFAULT_LABEL_SMCE,
-                   "label": DEFAULT_LABEL}
+                   "label": DEFAULT_LABEL,
+                   "index": DEFAULT_INDEX}
 
 
 # These are names of MXNet operator parameters that is of type NDArray.

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -222,8 +222,6 @@ def get_all_misc_binary_operators():
             binary_misc_mx_operators[op_name] = mx_operators[op_name]
         elif "reshape_like" == op_name:
             binary_misc_mx_operators[op_name] = mx_operators[op_name]
-        elif "ElementWiseSum" == op_name:
-            binary_misc_mx_operators[op_name] = mx_operators[op_name]
     return binary_misc_mx_operators
 
 
@@ -243,6 +241,8 @@ def get_all_elemen_wise_binary_operators():
         if op_name.startswith("elemwise_") and op_params["params"]["narg"] == 2 and \
                 "lhs" in op_params["params"]["arg_names"] and \
                 "rhs" in op_params["params"]["arg_names"]:
+            binary_elemen_wise_mx_operators[op_name] = mx_operators[op_name]
+        elif "ElementWiseSum" == op_name:
             binary_elemen_wise_mx_operators[op_name] = mx_operators[op_name]
     return binary_elemen_wise_mx_operators
 

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -218,13 +218,9 @@ def get_all_misc_binary_operators():
     # Filter for miscellaneous binary operators
     binary_misc_mx_operators = {}
     for op_name, op_params in mx_operators.items():
-        if "choose_element_0index" == op_name and op_params["params"]["narg"] == 5 and \
-                "data" in op_params["params"]["arg_names"] and \
-                "index" in op_params["params"]["arg_names"]:
+        if "choose_element_0index" == op_name:
             binary_misc_mx_operators[op_name] = mx_operators[op_name]
-        elif "reshape_like" == op_name and op_params["params"]["narg"] == 6 and \
-                "lhs" in op_params["params"]["arg_names"] and \
-                "rhs" in op_params["params"]["arg_names"]:
+        elif "reshape_like" == op_name:
             binary_misc_mx_operators[op_name] = mx_operators[op_name]
     return binary_misc_mx_operators
 

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -205,6 +205,30 @@ def get_all_broadcast_binary_operators():
     return binary_broadcast_mx_operators
 
 
+def get_all_misc_binary_operators():
+    """Gets all miscellaneous binary operators registered with MXNet.
+
+    Returns
+    -------
+    {"operator_name": {"has_backward", "nd_op_handle", "params"}}
+    """
+    # Get all mxnet operators
+    mx_operators = _get_all_mxnet_operators()
+
+    # Filter for miscellaneous binary operators
+    binary_misc_mx_operators = {}
+    for op_name, op_params in mx_operators.items():
+        if "choose_element_0index" == op_name and op_params["params"]["narg"] == 5 and \
+                "data" in op_params["params"]["arg_names"] and \
+                "index" in op_params["params"]["arg_names"]:
+            binary_misc_mx_operators[op_name] = mx_operators[op_name]
+        elif "reshape_like" == op_name and op_params["params"]["narg"] == 6 and \
+                "lhs" in op_params["params"]["arg_names"] and \
+                "rhs" in op_params["params"]["arg_names"]:
+            binary_misc_mx_operators[op_name] = mx_operators[op_name]
+    return binary_misc_mx_operators
+
+
 def get_all_elemen_wise_binary_operators():
     """Gets all binary elemen_wise operators registered with MXNet.
 

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -222,6 +222,8 @@ def get_all_misc_binary_operators():
             binary_misc_mx_operators[op_name] = mx_operators[op_name]
         elif "reshape_like" == op_name:
             binary_misc_mx_operators[op_name] = mx_operators[op_name]
+        elif "ElementWiseSum" == op_name:
+            binary_misc_mx_operators[op_name] = mx_operators[op_name]
     return binary_misc_mx_operators
 
 


### PR DESCRIPTION
## Description ##
Added implementation for `reshape_like` and `choose_element_0index` in opperf, as well as supporting variables in `rules/default_params.py`.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] M benchmark/opperf/nd_operations/binary_operators.py
- [x] M benchmark/opperf/utils/op_registry_utils.py
- [x] M benchmark/opperf/rules/default_params.py
- [x] M benchmark/opperf/opperf.py
