### PR TITLE
[Large Tensor] Add support to Random Sample & Pdf ops

### DIFF
--- a/src/operator/random/multisample_op.h
+++ b/src/operator/random/multisample_op.h
@@ -86,7 +86,7 @@ inline bool MultiSampleOpShape(const nnvm::NodeAttrs& attrs,
   }
   if (tshape.ndim() > 0) {
     // Shape assignment/check for propagation from inputs to output.
-    std::vector<int> cshape(tshape.begin(), tshape.end());
+    std::vector<index_t> cshape(tshape.begin(), tshape.end());
     cshape.insert(cshape.end(), sshape.begin(), sshape.end());
     mxnet::TShape oshape(cshape.begin(), cshape.end());
     SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);

--- a/src/operator/random/multisample_op.h
+++ b/src/operator/random/multisample_op.h
@@ -77,7 +77,7 @@ inline bool MultiSampleOpShape(const nnvm::NodeAttrs& attrs,
     // Promote down by removing last dimensions which represent the samples.
     tshape = mxnet::TShape(tshape.begin(), tshape.begin()+(tshape.ndim()-sshape.ndim()));
   }
-  // Shape assignemnt/checking for inputs.
+  // Shape assignment/checking for inputs.
   for (const auto& in_attr : *in_attrs) {
     if ( !shape_assign(&tshape, in_attr)) return false;
   }

--- a/src/operator/random/pdf_op.h
+++ b/src/operator/random/pdf_op.h
@@ -48,12 +48,12 @@ MSHADOW_XINLINE mshadow::half::half_t ceph_psi(mshadow::half::half_t val) {
 template<bool logpdf>
 struct PDF_Uniform {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size,
                                   DType *out, IType1 *sample, IType2 *lower, IType2 *upper) {
-    const int index(start / sample_size);
+    const index_t index(start / sample_size);
     const DType l(lower[index]), h(upper[index]);
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         // No check whether sample is in the support.
         out[i] = logpdf ? -DType(log(h - l)) : DType(1.0) / (h - l);
     }
@@ -63,14 +63,14 @@ struct PDF_Uniform {
 template<bool logpdf>
 struct PDF_Uniform_Grad {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size, OpReqType req,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size, OpReqType req,
                   DType *out, IType1 *sample, IType2 *lower, IType2 *upper,
                   DType *grad_out, IType1 *grad_sample, IType2 *grad_lower, IType2 *grad_upper) {
-    const int index(start / sample_size);
+    const index_t index(start / sample_size);
     const DType l(lower[index]), h(upper[index]);
 
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         const DType scaling(grad_out[i]*(logpdf ? DType(1) : out[i]));
         grad_lower[i]  = scaling / (h - l);
         grad_upper[i]  = scaling / (l - h);
@@ -120,13 +120,13 @@ struct PDF_Normal_Grad {
 template<bool logpdf>
 struct PDF_Gamma {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size,
                                   DType *out, IType1 *sample, IType2 *alpha, IType2 *beta) {
-    const int index(start / sample_size);
+    const index_t index(start / sample_size);
     const DType a(alpha[index]), b(beta[index]), lgamma_a(lgamma(a)), a_log_b(a * log(b));
 
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         const DType x(sample[i]);
         const DType lpdf(a_log_b + (a - 1) * log(x) - b * x - lgamma_a);
         out[i] = logpdf ? lpdf : DType(exp(lpdf));
@@ -137,14 +137,14 @@ struct PDF_Gamma {
 template<bool logpdf>
 struct PDF_Gamma_Grad {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size, OpReqType req,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size, OpReqType req,
                   DType *out, IType1 *sample, IType2 *alpha, IType2 *beta,
                   DType *grad_out, IType1 *grad_sample, IType2 *grad_alpha, IType2 *grad_beta) {
-    const int index(start / sample_size);
+    const index_t index(start / sample_size);
     const DType a(alpha[index]), b(beta[index]), log_b(log(b)), ceph_psi_a(ceph_psi(a));
 
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         const DType x(sample[i]);
         const DType scaling(grad_out[i]*(logpdf ? DType(1) : out[i]));
         grad_alpha[i]  = scaling * (log_b + log(x) - ceph_psi_a);
@@ -157,13 +157,13 @@ struct PDF_Gamma_Grad {
 template<bool logpdf>
 struct PDF_Exponential {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size,
                                   DType *out, IType1 *sample, IType2 *lambda) {
-    const int index(start / sample_size);
+    const index_t index(start / sample_size);
     const DType l(lambda[index]), log_l(log(l));
 
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         const DType x(sample[i]);
         out[i] = logpdf ? log_l - l * x : l * exp(-l * x);
     }
@@ -173,14 +173,14 @@ struct PDF_Exponential {
 template<bool logpdf>
 struct PDF_Exponential_Grad {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size, OpReqType req,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size, OpReqType req,
                   DType *out, IType1 *sample, IType2 *lambda,
                   DType *grad_out, IType1 *grad_sample, IType2 *grad_lambda) {
-    const int index(start / sample_size);
+    const index_t index(start / sample_size);
     const DType l(lambda[index]);
 
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         const DType x(sample[i]);
         const DType scaling(grad_out[i]*(logpdf ? DType(1) : out[i]));
         grad_lambda[i] = scaling * (DType(1) / l - x);
@@ -192,13 +192,13 @@ struct PDF_Exponential_Grad {
 template<bool logpdf>
 struct PDF_Poisson {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size,
                                   DType *out, IType1 *sample, IType2 *lambda) {
-    const int index(start / sample_size);
+    const index_t index(start / sample_size);
     const DType l(lambda[index]), log_l(log(l));
 
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         const DType x(sample[i]);
         const DType lpdf((x * log_l - lgamma(x + 1)) - l);
         out[i] = logpdf ? lpdf  : DType(exp(lpdf));
@@ -209,14 +209,14 @@ struct PDF_Poisson {
 template<bool logpdf>
 struct PDF_Poisson_Grad {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size, OpReqType req,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size, OpReqType req,
                   DType *out, IType1 *sample, IType2 *lambda,
                   DType *grad_out, IType1 *grad_sample, IType2 *grad_lambda) {
-    const int index(start / sample_size);
+    const index_t index(start / sample_size);
     const DType l(lambda[index]);
 
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         const DType x(sample[i]);
         const DType scaling(grad_out[i]*(logpdf ? DType(1) : out[i]));
         grad_lambda[i] = scaling * (x / l - DType(1));
@@ -229,13 +229,13 @@ struct PDF_Poisson_Grad {
 template<bool logpdf>
 struct PDF_NegativeBinomial {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size,
                                   DType *out, IType1 *sample, IType2 *limit, IType2 *prob) {
-    const int index(start / sample_size);
+    const index_t index(start / sample_size);
     const DType l(limit[index]), p(prob[index]), lgamma_l(lgamma(l));
 
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         const DType x(sample[i]);
         const DType lpdf((lgamma(x + l) - lgamma(x + 1) - lgamma_l) + l * log(p) + x * log(1 - p));
         out[i] = logpdf ? lpdf : DType(exp(lpdf));
@@ -252,12 +252,12 @@ struct PDF_NegativeBinomial {
 template<bool logpdf>
 struct PDF_NegativeBinomial_Grad {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size, OpReqType req,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size, OpReqType req,
                   DType *out, IType1 *sample, IType2 *limit, IType2 *prob,
                   DType *grad_out, IType1 *grad_sample, IType2 *grad_limit, IType2 *grad_prob) {
-    const int index(start / sample_size);
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t index(start / sample_size);
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         DType grad_l(0), grad_p(0);
         LPDF_GRAD(DType(limit[index]), DType(prob[index]),
                   DType(sample[i]), out[i],
@@ -280,15 +280,15 @@ struct PDF_NegativeBinomial_Grad {
 template<bool logpdf>
 struct PDF_GeneralizedNegativeBinomial {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size,
                                   DType *out, IType1 *sample, IType2 *mu, IType2 *alpha) {
-    const int index(start / sample_size);
+    const index_t index(start / sample_size);
 
     // Reparameterize with limit = 1 / alpha, prob = 1 / (mu * alpha + 1)
     const DType limit(1.0 / alpha[index]), prob(1.0 / (mu[index]*alpha[index]+1.0));
 
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         const DType lpdf(PDF_NegativeBinomial<logpdf>::LPDF(limit, prob, DType(sample[i])));
         out[i] = logpdf ? lpdf : DType(exp(lpdf));
     }
@@ -298,17 +298,17 @@ struct PDF_GeneralizedNegativeBinomial {
 template<bool logpdf>
 struct PDF_GeneralizedNegativeBinomial_Grad {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size, OpReqType req,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size, OpReqType req,
                   DType *out, IType1 *sample, IType2 *mu, IType2 *alpha,
                   DType *grad_out, IType1 *grad_sample, IType2 *grad_mu, IType2 *grad_alpha) {
-    const int index(start / sample_size);
+    const index_t index(start / sample_size);
     const DType fmu(mu[index]), falpha(alpha[index]), den(fmu * falpha + 1.0);
 
     // Reparameterize with limit = 1 / alpha, prob = 1 / (mu * alpha + 1)
     const DType limit(1.0 / falpha), prob(1.0 / (fmu * falpha + 1.0));
 
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         // Grad returned as d_limit, d_prob
         DType grad_l(0), grad_p(0);
         PDF_NegativeBinomial_Grad<logpdf>::LPDF_GRAD(limit, prob,
@@ -324,15 +324,15 @@ struct PDF_GeneralizedNegativeBinomial_Grad {
 template<bool logpdf>
 struct PDF_Dirichlet {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size, int k,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size, index_t k,
                                   DType *out, IType1 *sample, IType2 *alpha) {
-    const int index(start / sample_size);
-    const int end = start + length;
-    for (int i = start; i < end; ++i) {
+    const index_t index(start / sample_size);
+    const index_t end = start + length;
+    for (index_t i = start; i < end; ++i) {
         const IType1 *cur_sample = sample + i * k;
         const IType2 *cur_alpha  = alpha + index * k;
         DType sum_alpha(0), sum_lgamma(0), sum_sample(0);
-        for (int j = 0; j < k; ++j) {
+        for (index_t j = 0; j < k; ++j) {
           sum_alpha  += cur_alpha[j];
           sum_lgamma += lgamma(cur_alpha[j]);
           sum_sample += (cur_alpha[j]-1) * log(cur_sample[j]);
@@ -347,27 +347,27 @@ struct PDF_Dirichlet {
 template<bool logpdf>
 struct PDF_Dirichlet_Grad {
   template<typename DType, typename IType1, typename IType2>
-  MSHADOW_XINLINE static void Map(int start, int length, int sample_size,
-                  OpReqType req, int k,
+  MSHADOW_XINLINE static void Map(index_t start, index_t length, index_t sample_size,
+                  OpReqType req, index_t k,
                   DType *out, IType1 *sample, IType2 *alpha,
                   DType *grad_out, IType1 *grad_sample, IType2 *grad_alpha
                   ) {
-    const int index(start / sample_size);
-    const int end = start + length;
+    const index_t index(start / sample_size);
+    const index_t end = start + length;
 
-    for (int i = start; i < end; ++i) {
+    for (index_t i = start; i < end; ++i) {
         // Digamma function
         const IType1 *cur_sample = sample + i * k;
         const IType2 *cur_alpha = alpha + index * k;
 
         const DType scaling(grad_out[i]*(logpdf ? DType(1) : out[i]));
         DType sum_alpha(0);
-        for (int j = 0; j < k; ++j) {
+        for (index_t j = 0; j < k; ++j) {
           sum_alpha += cur_alpha[j];
         }
         const DType psi_sum(ceph_psi(sum_alpha));
 
-        for (int j = 0; j < k; ++j) {
+        for (index_t j = 0; j < k; ++j) {
           size_t grad_alpha_index = i%sample_size + sample_size * (j + k * index);
           size_t grad_sample_index = i * k + j;
 

--- a/src/operator/random/pdf_op.h
+++ b/src/operator/random/pdf_op.h
@@ -433,8 +433,8 @@ inline bool PdfOpShape(const nnvm::NodeAttrs& attrs,
 template<typename OP>
 struct LaunchExWrapper {
   template<typename ...Args>
-  MSHADOW_XINLINE static void Map(const index_t start, const index_t length, const index_t sample_size,
-        Args... args) {
+  MSHADOW_XINLINE static void Map(const index_t start, const index_t length,
+                                  const index_t sample_size, Args... args) {
     // Apply the operator to the sample in strides of sample_size, so that
     // the operators can assume that their distribution parameters are constant.
     index_t i = start;


### PR DESCRIPTION
## Description ##
Extend LT support to all the random family operators


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] modified:   src/operator/random/multisample_op.h
- [x] modified:   src/operator/random/pdf_op.h

## Tests ##

## PDF Ops
```
>>> mx.nd.random_pdf_negative_binomial(sample=mx.nd.random_normal(shape=(1, 2**32 + 1)), k=mx.nd.random_normal(shape=(1)), p=mx.nd.random_normal(shape=(1)))
[[ 3.6517045   0.08385151  0.33836576 ...  1.2580111   1.200235232.96391   ]]
<NDArray 1x4294967297 @cpu(0)>
```
```
>>> mx.nd.random_pdf_dirichlet(sample=mx.nd.random_uniform(shape=(2**32 + 1,5),low=0, high=1), alpha=mx.nd.random_uniform(shape=(5), low=0, high=1))
[0.02400445 0.09834412 0.00485084 ... 0.00059637 0.00062773 0.00020362]
<NDArray 4294967297 @cpu(0)>
```
```
>>> mx.nd.random_pdf_exponential(sample=mx.nd.random_normal(shape=(1,2**32 + 1)), lam=mx.nd.random_normal(shape=(1)))
[[0.7160165 0.8786655  1.8491699  ... 0.590301   0.19441505 0.99005574]]
<NDArray 1x4294967297 @cpu(0)>
```
```
>>> mx.nd.random_pdf_normal(sample=mx.nd.random_normal(shape=(1,2**32)), mu=mx.nd.random_normal(shape=(1)), sigma=mx.nd.random_normal(shape=(1)))
[[-0.08357255 -0.7204103  -0.52567625 ... -0.03446919 -0.02720401-0.27186853]]
<NDArray 1x4294967296 @cpu(0)>
```
```
>>> mx.nd.random_pdf_poisson(sample=mx.nd.random_normal(shape=(1, 2**32 + 1)), lam=mx.nd.random_normal(shape=(1)))
[[0.39283866 0.3568688  0.46852896 ... 0.1435355  0.19014826 0.1828634 ]]
<NDArray 1x4294967297 @cpu(0)>
```
```
>>> mx.nd.random_pdf_uniform(sample=mx.nd.random_normal(shape=(1,2**32 + 1)), low=mx.nd.random_normal(shape=(1)), high=mx.nd.random_normal(shape=(1)))
[[-0.53082603 -0.53082603 -0.53082603 ... -0.53082603 -0.53082603-0.53082603]]
<NDArray 1x4294967297 @cpu(0)>

```

## Sample Ops
```
>>> mx.nd.sample_uniform(shape=(2**32), low=mx.nd.random_normal(shape=(1,)), high=mx.nd.random_normal(shape=(1,)))

[[1.3453104  0.9783068  1.4285539  ... 2.1584532  0.990888   0.97627187]]
<NDArray 1x4294967296 @cpu(0)>
```
```
>>> mx.nd.sample_poisson(shape=(2**32 + 1), lam=mx.nd.random_normal(shape=(1)))

[[0. 0. 0. ... 0. 0. 0.]]
<NDArray 1x4294967297 @cpu(0)>
```
```
>>> mx.nd.sample_normal(mu=mx.nd.random_normal(shape=(2**32 + 1)), sigma=mx.nd.random_normal(shape=(2**32 + 1)))

[ 0.7192631   1.8029252  -3.1244457  ...  1.3172784  -0.44950533
  0.5782782 ]
<NDArray 4294967297 @cpu(0)>
```
```
>>> mx.nd.sample_exponential(shape=(1), lam=mx.nd.random_normal(shape=(2**32 + 1)))

[[-2.564538 ]
 [ 1.3046274]
 [ 3.4207358]
 ...
 [ 5.2444887]
 [ 1.7304702]
 [ 1.6264884]]
<NDArray 4294967297x1 @cpu(0)>
```
```
>>> mx.nd.sample_negative_binomial(k=mx.nd.random_uniform(shape=(2**32), low=0, high=1), p=mx.nd.random_uniform(shape=(2**32), low=0, high=1))

[ 0.  0.  0. ... 19.  1.  0.]
<NDArray 4294967296 @cpu(0)>
```
```
>>> mx.nd.sample_generalized_negative_binomial(alpha=mx.nd.random_uniform(shape=(2**32), low=0, high=1), mu=mx.nd.random_uniform(shape=(2**32), low=0, high=1))

[0. 0. 0. ... 2. 1. 0.]
<NDArray 4294967296 @cpu(0)>
```
```
>>> mx.nd.sample_gamma(alpha=mx.nd.random_uniform(shape=(2**32), low=0, high=1), beta=mx.nd.random_uniform(shape=(2**32), low=0, high=1))

[3.9847539e-05 9.7578183e-02 3.0167744e-04 ... 2.7813488e-03 5.8879163e-03
 3.3052340e-01]
<NDArray 4294967296 @cpu(0)>
```