### PR TITLE
skipping tests that cannot fit in nightly CI machine

### DIFF
--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -16,14 +16,18 @@
 # under the License.
 
 import os
+import sys
 import tempfile
 import math
 import numpy as np
 import mxnet as mx
 
+curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+sys.path.append(os.path.join(curr_path, '../python/unittest/'))
+
 from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, default_context, check_symbolic_forward, create_2d_tensor
 from mxnet import gluon, nd
-from tests.python.unittest.common import with_seed, with_post_test_cleanup, teardown
+from common import with_seed, with_post_test_cleanup
 from nose.tools import with_setup
 import unittest
 
@@ -129,7 +133,8 @@ def test_nn():
         x /= np.sum(x, axis=axis, keepdims=True)
         return x
 
-    @unittest.skip("log_softmax flaky, tracked at https://github.com/apache/incubator-mxnet/issues/17397")
+    @unittest.skip("log_softmax flaky, tracked at "
+                   "https://github.com/apache/incubator-mxnet/issues/17397")
     def check_log_softmax():
         ndim = 2
         shape = (SMALL_Y, LARGE_X)
@@ -476,7 +481,8 @@ def test_tensor():
         a = nd.random.uniform(shape=(LARGE_X, SMALL_Y))
         assert a[-1][0] != 0
 
-    @unittest.skip("Randint flaky, tracked at https://github.com/apache/incubator-mxnet/issues/16172")
+    @unittest.skip("Randint flaky, tracked at "
+                   "https://github.com/apache/incubator-mxnet/issues/16172")
     @with_seed()
     def check_ndarray_random_randint():
         a = nd.random.randint(100, 10000, shape=(LARGE_X, SMALL_Y))
@@ -689,6 +695,8 @@ def test_tensor():
         res = mx.nd.pick(a, b)
         assert res.shape == b.shape
 
+    @unittest.skip("Memory doesn't free up after stacked execution with other ops, "
+                   "tracked at https://github.com/apache/incubator-mxnet/issues/17411")
     def check_depthtospace():
         def numpy_depth_to_space(x, blocksize):
             b, c, h, w = x.shape[0], x.shape[1], x.shape[2], x.shape[3]
@@ -706,6 +714,8 @@ def test_tensor():
         output = mx.nd.depth_to_space(data, 2)
         assert_almost_equal(output.asnumpy(), expected, atol=1e-3, rtol=1e-3)
 
+    @unittest.skip("Memory doesn't free up after stacked execution with other ops, "
+                   "tracked at https://github.com/apache/incubator-mxnet/issues/17411")
     def check_spacetodepth():
         def numpy_space_to_depth(x, blocksize):
             b, c, h, w = x.shape[0], x.shape[1], x.shape[2], x.shape[3]
@@ -769,6 +779,8 @@ def test_tensor():
                                          shape=(LARGE_X, SMALL_Y))
         assert (indices_2d.asnumpy() == np.array(original_2d_indices)).all()
 
+    @unittest.skip("Memory doesn't free up after stacked execution with other ops, " +
+                   "tracked at https://github.com/apache/incubator-mxnet/issues/17411")
     def check_transpose():
         check_dtypes = [np.float32, np.int64]
         for dtype in check_dtypes:
@@ -778,12 +790,16 @@ def test_tensor():
             ref_out = np.transpose(b.asnumpy())
             assert_almost_equal(t.asnumpy(), ref_out, rtol=1e-10)
 
+    @unittest.skip("Memory doesn't free up after stacked execution with other ops, " +
+                   "tracked at https://github.com/apache/incubator-mxnet/issues/17411")
     def check_swapaxes():
         b = create_2d_tensor(rows=LARGE_X, columns=SMALL_Y)
         t = nd.swapaxes(b, dim1=0, dim2=1)
         assert np.sum(t[:, -1].asnumpy() == (LARGE_X - 1)) == b.shape[1]
         assert t.shape == (SMALL_Y, LARGE_X)
 
+    @unittest.skip("Memory doesn't free up after stacked execution with other ops, " +
+                   "tracked at https://github.com/apache/incubator-mxnet/issues/17411")
     def check_flip():
         b = create_2d_tensor(rows=LARGE_X, columns=SMALL_Y)
         t = nd.flip(b, axis=0)
@@ -1079,12 +1095,16 @@ def test_basic():
         idx = mx.nd.argmin(a, axis=0)
         assert idx.shape[0] == SMALL_Y
 
+    @unittest.skip("Memory doesn't free up after stacked execution with other ops, " +
+                   "tracked at https://github.com/apache/incubator-mxnet/issues/17411")
     def check_argsort():
         b = create_2d_tensor(rows=LARGE_X, columns=SMALL_Y)
         s = nd.argsort(b, axis=0, is_ascend=False, dtype=np.int64)
         mx.nd.waitall()
         assert (s[0].asnumpy() == (LARGE_X - 1)).all()
 
+    @unittest.skip("Memory doesn't free up after stacked execution with other ops, " +
+                   "tracked at https://github.com/apache/incubator-mxnet/issues/17411")
     def check_sort():
         b = create_2d_tensor(rows=LARGE_X, columns=SMALL_Y)
         s = nd.sort(b, axis=0, is_ascend=False)
@@ -1092,7 +1112,8 @@ def test_basic():
         s = nd.sort(b, is_ascend=False)
         assert np.sum(s[0].asnumpy() == 0).all()
 
-    @unittest.skip("Topk takes lot of memory!, tracked at https://github.com/apache/incubator-mxnet/issues/17411")
+    @unittest.skip("Memory doesn't free up after stacked execution with other ops, " +
+                   "tracked at https://github.com/apache/incubator-mxnet/issues/17411")
     def check_topk():
         b = create_2d_tensor(rows=LARGE_X, columns=SMALL_Y)
         k = nd.topk(b, k=10, axis=0, dtype=np.int64)

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -16,14 +16,18 @@
 # under the License.
 
 import os
+import sys
 import tempfile
 import math
 import numpy as np
 import mxnet as mx
 
+curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+sys.path.append(os.path.join(curr_path, '../python/unittest/'))
+
 from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, create_vector
 from mxnet import gluon, nd
-from tests.python.unittest.common import with_seed, teardown
+from tests.python.unittest.common import with_seed
 from nose.tools import with_setup
 import unittest
 
@@ -179,7 +183,8 @@ def test_tensor():
         a = nd.random.uniform(shape=LARGE_X)
         assert a[-1] != 0
 
-    @unittest.skip("Randint flaky, tracked at https://github.com/apache/incubator-mxnet/issues/16172")
+    @unittest.skip("Randint flaky, tracked at "
+                   "https://github.com/apache/incubator-mxnet/issues/16172")
     @with_seed()
     def check_ndarray_random_randint():
         # check if randint can generate value greater than 2**32 (large)
@@ -476,11 +481,15 @@ def test_basic():
         assert idx[0] == 0
         assert idx.shape[0] == 1
 
+    @unittest.skip("Memory doesn't free up after stacked execution with other ops, " +
+                   "tracked at https://github.com/apache/incubator-mxnet/issues/17411")
     def check_argsort():
         a = create_vector(size=LARGE_X)
         s = nd.argsort(a, axis=0, is_ascend=False, dtype=np.int64)
         assert s[0] == (LARGE_X - 1)
 
+    @unittest.skip("Memory doesn't free up after stacked execution with other ops, " +
+                   "tracked at https://github.com/apache/incubator-mxnet/issues/17411")
     def check_sort():
         a = create_vector(size=LARGE_X)
 
@@ -495,6 +504,8 @@ def test_basic():
         check_descend(a)
         check_ascend(a)
 
+    @unittest.skip("Memory doesn't free up after stacked execution with other ops, " +
+                   "tracked at https://github.com/apache/incubator-mxnet/issues/17411")
     def check_topk():
         a = create_vector(size=LARGE_X)
         ind = nd.topk(a, k=10, axis=0, dtype=np.int64)


### PR DESCRIPTION
## Description ##
skipping following tests as they require memory more than present in nightly CI.
A Stacked run of tests of these operators along with other ops doesn't free up memory on time resulting in Memory Error on nightly CI machine. Also updates system path for correct imports

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Tests ##
```
ci/build.py --docker-registry mxnetci --nvidiadocker --platform ubuntu_nightly_gpu --docker-build-retries 3 --shm-size 500m /work/runtime_functions.sh nightly_test_large_tensor

2020-01-28 01:08:03,925 - root - INFO - Started container: 5bceca2b8f26
+ NOSE_COVERAGE_ARGUMENTS='--with-coverage --cover-inclusive --cover-xml --cover-branches --cover-package=mxnet'
+ NOSE_TIMER_ARGUMENTS='--with-timer --timer-ok 1 --timer-warning 15 --timer-filter warning,error'
+ CI_CUDA_COMPUTE_CAPABILITIES='-gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_70,code=sm_70'
+ CI_CMAKE_CUDA_ARCH='5.2 7.0'
+ set +x
+ export PYTHONPATH=./python/
+ PYTHONPATH=./python/
+ export DMLC_LOG_STACK_TRACE_DEPTH=10
+ DMLC_LOG_STACK_TRACE_DEPTH=10
+ nosetests-3.4 tests/nightly/test_large_array.py:test_tensor
S
----------------------------------------------------------------------
Ran 1 test in 125.654s

OK (SKIP=1)
+ nosetests-3.4 tests/nightly/test_large_array.py:test_nn
[01:15:48] src/executor/graph_executor.cc:2062: Subgraph backend MKLDNN is activated.
[01:15:52] src/executor/graph_executor.cc:2062: Subgraph backend MKLDNN is activated.
S
----------------------------------------------------------------------
Ran 1 test in 344.892s

OK (SKIP=1)
+ nosetests-3.4 tests/nightly/test_large_array.py:test_basic
S
----------------------------------------------------------------------
Ran 1 test in 156.411s

OK (SKIP=1)

ci/build.py --docker-registry mxnetci --nvidiadocker --platform ubuntu_nightly_gpu --docker-build-retries 3 --shm-size 500m /work/runtime_functions.sh nightly_test_large_vector

+ NOSE_TIMER_ARGUMENTS='--with-timer --timer-ok 1 --timer-warning 15 --timer-filter warning,error'
+ CI_CUDA_COMPUTE_CAPABILITIES='-gencode=arch=compute_52,code=sm_52 -gencode=arch=compute_70,code=sm_70'
+ CI_CMAKE_CUDA_ARCH='5.2 7.0'
+ set +x
+ export PYTHONPATH=./python/
+ PYTHONPATH=./python/
+ export DMLC_LOG_STACK_TRACE_DEPTH=10
+ DMLC_LOG_STACK_TRACE_DEPTH=10
+ nosetests-3.4 tests/nightly/test_large_vector.py:test_tensor
S
----------------------------------------------------------------------
Ran 1 test in 107.439s

OK (SKIP=1)
+ nosetests-3.4 tests/nightly/test_large_vector.py:test_nn
[06:22:40] src/executor/graph_executor.cc:1982: Subgraph backend MKLDNN is activated.
[06:27:34] src/executor/graph_executor.cc:1982: Subgraph backend MKLDNN is activated.
.
----------------------------------------------------------------------
Ran 1 test in 653.536s

OK
+ nosetests-3.4 tests/nightly/test_large_vector.py:test_basic
S
----------------------------------------------------------------------
Ran 1 test in 65.930s

OK (SKIP=1)
```