### PR TITLE
correctly printing stacktrace instead of printing array object

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -278,7 +278,7 @@ def main_wrapper(args) {
     currentBuild.result = "SUCCESS"
     update_github_commit_status('SUCCESS', 'Job succeeded')
   } catch (caughtError) {
-    println(caughtError.getStackTrace());  
+    caughtError.printStackTrace();  
     node(NODE_UTILITY) {
       echo "caught ${caughtError}"
       err = caughtError


### PR DESCRIPTION
## Description ##
earlier exception.getStackTrace() prints [ "array object" ]
now it will correctly print error stacktrace

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
