### PR TITLE
Implement remaining nn_activation ops in opperf

### DIFF
--- a/benchmark/opperf/nd_operations/nn_activation_operators.py
+++ b/benchmark/opperf/nd_operations/nn_activation_operators.py
@@ -65,9 +65,8 @@ def run_activation_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler=
     """
 
     # Fetch all NN Activation Operators
-    mx_nn_activation_broadcast_ops = get_all_nn_activation_operators()
+    mx_activation_ops = get_all_nn_activation_operators()
 
     # Run benchmarks
-    mx_nn_activation_op_results = run_op_benchmarks(mx_nn_activation_broadcast_ops, dtype, ctx, profiler, warmup, runs)
-    return mx_nn_activation_op_results
-    
+    mx_activation_op_results = run_op_benchmarks(mx_activation_ops, dtype, ctx, profiler, warmup, runs)
+    return mx_activation_op_results

--- a/benchmark/opperf/nd_operations/nn_activation_operators.py
+++ b/benchmark/opperf/nd_operations/nn_activation_operators.py
@@ -70,3 +70,4 @@ def run_activation_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler=
     # Run benchmarks
     mx_activation_op_results = run_op_benchmarks(mx_activation_ops, dtype, ctx, profiler, warmup, runs)
     return mx_activation_op_results
+    

--- a/benchmark/opperf/nd_operations/nn_activation_operators.py
+++ b/benchmark/opperf/nd_operations/nn_activation_operators.py
@@ -53,6 +53,8 @@ def run_activation_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler=
         Context to run benchmarks
     dtype: str, default 'float32'
         Precision to use for benchmarks
+    profiler: str, default 'native'
+        Module to use for tracking benchmark excecution time
     warmup: int, default 25
         Number of times to run for warmup
     runs: int, default 100

--- a/benchmark/opperf/rules/default_params.py
+++ b/benchmark/opperf/rules/default_params.py
@@ -134,6 +134,10 @@ DEFAULT_DATA_3d = [(1024, 100, 100)]
 DEFAULT_LABEL = [(100,100)]
 DEFAULT_DATA_SMCE = [(1024, 1024)]
 DEFAULT_LABEL_SMCE = [(1024,)]
+# For NN operators
+DEFAULT_ACT_TYPE_LR = ['leaky', 'elu', 'selu', 'gelu']
+DEFAULT_ACT_TYPE_ACTIVATION = ['relu', 'sigmoid', 'softrelu', 'softsign', 'tanh']
+DEFAULT_LABEL_SOFTMAX = [(1024, 1024), (10000, 1), (10000, 100)]
 
 # For linalg operators
 DEFAULT_A = [(1024, 1024)]
@@ -218,7 +222,10 @@ DEFAULTS_INPUTS = {"data": DEFAULT_DATA,
                    "B": DEFAULT_B,
                    "C": DEFAULT_C,
                    "A_linalg_maketrian": DEFAULT_A_MT,
-                   "axes": DEFAULT_AXES}
+                   "axes": DEFAULT_AXES,
+                   "act_type_leakyrelu": DEFAULT_ACT_TYPE_LR,
+                   "label_softmax": DEFAULT_LABEL_SOFTMAX,
+                   "act_type_activation": DEFAULT_ACT_TYPE_ACTIVATION}
 
 
 # These are names of MXNet operator parameters that is of type NDArray.

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -310,6 +310,26 @@ def get_all_reduction_operators():
     return reduction_mx_operators
 
 
+def get_all_nn_activation_operators():
+    """Gets all NN Activation operators registered with MXNet.
+
+     Returns
+     -------
+     {"operator_name": {"has_backward", "nd_op_handle", "params"}}
+     """
+    nn_activation_ops = ['Softmax', 'SoftmaxActivation', 'softmin', 'Activation', 'LeakyReLU', 'hard_sigmoid', 'softmax', 'log_softmax']
+
+    # Get all mxnet operators
+    mx_operators = _get_all_mxnet_operators()
+
+    # Filter for NN Activation operators
+    nn_activation_mx_operators = {}
+    for op_name, _ in mx_operators.items():
+         if op_name in nn_activation_ops and op_name not in unique_ops:
+             nn_activation_mx_operators[op_name] = mx_operators[op_name]
+    return nn_activation_mx_operators
+
+
 def get_all_optimizer_operators():
     """Gets all Optimizer operators registered with MXNet.
 

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -117,11 +117,9 @@ def prepare_op_inputs(op, arg_params):
 
     # 3d tensor is needed by following ops
     ops_3d = ['CTCLoss', 'ctc_loss']
-    
-    custom_data = ['BilinearSampler', 'GridGenerator', 'sample_multinomial', 'linalg_maketrian']
 
     # For ops with args that need to change shape/value for different ops
-    custom_data = ['Activation', 'LeakyReLU', 'Softmax']
+    custom_data = ['Activation', 'LeakyReLU', 'Softmax', 'BilinearSampler', 'GridGenerator', 'sample_multinomial', 'linalg_maketrian']
 
     # Prepare op to default input mapping
     arg_values = {}

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -326,7 +326,7 @@ def get_all_nn_activation_operators():
     # Filter for NN Activation operators
     nn_activation_mx_operators = {}
     for op_name, _ in mx_operators.items():
-         if op_name in nn_activation_ops and op_name not in unique_ops:
+         if op_name in nn_activation_ops:
              nn_activation_mx_operators[op_name] = mx_operators[op_name]
     return nn_activation_mx_operators
 

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -120,6 +120,9 @@ def prepare_op_inputs(op, arg_params):
     
     custom_data = ['BilinearSampler', 'GridGenerator', 'sample_multinomial', 'linalg_maketrian']
 
+    # For ops with args that need to change shape/value for different ops
+    custom_data = ['Activation', 'LeakyReLU', 'Softmax']
+
     # Prepare op to default input mapping
     arg_values = {}
     for arg_name, arg_type in zip(arg_params["params"]["arg_names"],


### PR DESCRIPTION
## Description ##
This PR serves to implement the remaining operators from the nn_activation category in opperf. To achieve this, I refactored the preexisting individual `run_performance_test` calls (for the four operators that had already been implemented) into a single generalized function call to `run_op_benchmarks`. I also implemented Softmax, SoftmaxActivation, softmin, and Activation ops, which are also called via the `run_op_benchmarks` function.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M benchmark/opperf/nd_operations/nn_activation_operators.py
- M benchmark/opperf/rules/default_params.py
- M benchmark/opperf/utils/op_registry_utils.py

## Comments ##
Tested on c5.18xl & p2.16xl w/ubuntu 16.04 and Mac OS with:
1. Checkout branch and call function `run_activation_operators_benchmarks` - runs all activation ops on default data
2. Checkout branch and run `opperf.py` (full run of all ops)