### PR TITLE
[OpPerf] Implement remaining nn_conv ops in opperf

### DIFF
--- a/benchmark/opperf/nd_operations/nn_conv_operators.py
+++ b/benchmark/opperf/nd_operations/nn_conv_operators.py
@@ -36,6 +36,7 @@ MXNet NDArray Pooling Operators
 9. GlobalAvgPool2D
 10.GlobalSumPool1D
 11.GlobalSumPool2D
+12.ROIPooling
 
 (Under the hood uses mx.nd.pooling)
 
@@ -90,8 +91,23 @@ def run_pooling_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler='na
                                                                      ],
                                                              warmup=warmup,
                                                              runs=runs)
+    # Run ROI Pooling performance runs
+    roipool_benchmark_res = []
+    for roipool_data in [(32, 3, 256, 256), (32, 3, 64, 64)]:
+        roipool_benchmark_res += run_performance_test([getattr(MX_OP_MODULE, "ROIPooling")],
+                                                      run_backward=True,
+                                                      dtype=dtype,
+                                                      ctx=ctx,
+                                                      profiler=profiler,
+                                                      inputs=[{"data": roipool_data,
+                                                               "rois": (32, 5),
+                                                               "pooled_size": (2, 2),
+                                                               "spatial_scale": .5}
+                                                             ],
+                                                      warmup=warmup,
+                                                      runs=runs)
     # Prepare combined results
-    mx_pooling_op_results = merge_map_list(pool1d_benchmark_res + pool2d_benchmark_res)
+    mx_pooling_op_results = merge_map_list(pool1d_benchmark_res + pool2d_benchmark_res + roipool_benchmark_res)
     return mx_pooling_op_results
 
 

--- a/benchmark/opperf/rules/default_params.py
+++ b/benchmark/opperf/rules/default_params.py
@@ -232,4 +232,4 @@ PARAMS_OF_TYPE_NDARRAY = ["lhs", "rhs", "data", "base", "exp", "sample",
                           "weight", "weight32", "grad", "mean", "var", "mom", "n", "d",
                           "v", "z", "g", "delta", "args", "indices", "shape_like", "y",
                           "x", "condition", "a", "index", "raveL_data", "label", "grid",
-                          "A", "B", "C"]
+                          "A", "B", "C", "rois"]


### PR DESCRIPTION
## Description ##
This PR serves to implement the remaining operators from the nn_conv category in opperf. To achieve this, I added a call to `run_performance_test` for the `ROIPooling` op within the `run_pooling_operators_benchmarks` function and added the `rois` argument to the NDArray list in `default_params.py`. Since `ROIPooling` was the only remaining op in the convolutional ops category, these were the only changes required.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M benchmark/opperf/nd_operations/nn_conv_operators.py
- M benchmark/opperf/rules/default_params.py

## Comments ##
Tested on p2.16xl w/ubuntu 16.04 and Mac OS with:
1. Checkout branch and call function `run_pooling_operators_benchmarks` - runs all pooling ops (`Pooling` and `ROIPooling`) on relevant data
2. Checkout branch and run `opperf.py` (full run of all ops)

## Performance Results ##
[Group of operator test - all Pooling ops (CPU)](https://gist.github.com/connorgoggins/0be00933c0087065bf5702ec2b9f2523)
[Full OpPerf test (CPU)](https://gist.github.com/connorgoggins/cfbcd7661779bd322783c1f288937977)

[Group of operator test - all Pooling ops (GPU)](https://gist.github.com/connorgoggins/125606f8e5243e1a670fa41c40ad420c)
[Full OpPerf test (GPU)](https://gist.github.com/connorgoggins/c65fbe4e7c537653bdae8dec9a1e6d84)

@apeforest @access2rohit @ChaiBapchya 
