### PR TITLE
[OpPerf] Implement remaining GEMM ops

### DIFF
--- a/benchmark/opperf/nd_operations/gemm_operators.py
+++ b/benchmark/opperf/nd_operations/gemm_operators.py
@@ -83,13 +83,15 @@ def run_gemm_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler='nativ
                  "transpose_a": True,
                  "transpose_b": True}],
         warmup=warmup, runs=runs, profiler=profiler)
-    # Benchmark tests for khatri_rao operator
-    khatri_rao_benchmark_res = run_performance_test(
-        [getattr(MX_OP_MODULE, "khatri_rao")], run_backward=False,
-        dtype=dtype, ctx=ctx,
-        inputs=[{"args": [(32, 32), (32, 32)]},
-                {"args": [(64, 64), (64, 64)]}],
-        warmup=warmup, runs=runs, profiler=profiler)
+    # Operator khatri_rao is not yet implemented for GPU
+    if ctx != mx.gpu():
+        # Benchmark tests for khatri_rao operator
+        khatri_rao_benchmark_res = run_performance_test(
+            [getattr(MX_OP_MODULE, "khatri_rao")], run_backward=False,
+            dtype=dtype, ctx=ctx,
+            inputs=[{"args": [(32, 32), (32, 32)]},
+                    {"args": [(64, 64), (64, 64)]}],
+            warmup=warmup, runs=runs, profiler=profiler)
 
     # Prepare combined results for GEMM operators
     mx_gemm_op_results = merge_map_list(dot_benchmark_res + batch_dot_benchmark_res + khatri_rao_benchmark_res)

--- a/benchmark/opperf/nd_operations/gemm_operators.py
+++ b/benchmark/opperf/nd_operations/gemm_operators.py
@@ -23,6 +23,7 @@ from benchmark.opperf.rules.default_params import MX_OP_MODULE
 
 1. dot
 2. batch_dot
+3. khatri_rao
 
 TODO
 3. As part of default tests, following needs to be added:
@@ -36,7 +37,7 @@ TODO
 
 def run_gemm_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler='native', warmup=25, runs=100):
     """Runs benchmarks with the given context and precision (dtype)for all the GEMM
-    operators (dot, batch_dot) in MXNet.
+    operators (dot, batch_dot, khatri_rao) in MXNet.
 
     Parameters
     ----------
@@ -54,7 +55,7 @@ def run_gemm_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler='nativ
     Dictionary of results. Key -> Name of the operator, Value -> Benchmark results.
 
     """
-    # Benchmark tests for dot and batch_dot operators
+    # Benchmark tests for dot operator
     dot_benchmark_res = run_performance_test(
         [getattr(MX_OP_MODULE, "dot")], run_backward=True,
         dtype=dtype, ctx=ctx,
@@ -68,7 +69,7 @@ def run_gemm_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler='nativ
                  "transpose_a": True,
                  "transpose_b": True}],
         warmup=warmup, runs=runs, profiler=profiler)
-
+    # Benchmark tests for batch_dot operator
     batch_dot_benchmark_res = run_performance_test(
         [getattr(MX_OP_MODULE, "batch_dot")], run_backward=True,
         dtype=dtype, ctx=ctx,
@@ -82,7 +83,14 @@ def run_gemm_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler='nativ
                  "transpose_a": True,
                  "transpose_b": True}],
         warmup=warmup, runs=runs, profiler=profiler)
+    # Benchmark tests for khatri_rao operator
+    khatri_rao_benchmark_res = run_performance_test(
+        [getattr(MX_OP_MODULE, "khatri_rao")], run_backward=False,
+        dtype=dtype, ctx=ctx,
+        inputs=[{"args": [(32, 32), (32, 32)]},
+                {"args": [(64, 64), (64, 64)]}],
+        warmup=warmup, runs=runs, profiler=profiler)
 
     # Prepare combined results for GEMM operators
-    mx_gemm_op_results = merge_map_list(dot_benchmark_res + batch_dot_benchmark_res)
+    mx_gemm_op_results = merge_map_list(dot_benchmark_res + batch_dot_benchmark_res + khatri_rao_benchmark_res)
     return mx_gemm_op_results

--- a/benchmark/opperf/nd_operations/gemm_operators.py
+++ b/benchmark/opperf/nd_operations/gemm_operators.py
@@ -84,6 +84,7 @@ def run_gemm_operators_benchmarks(ctx=mx.cpu(), dtype='float32', profiler='nativ
                  "transpose_b": True}],
         warmup=warmup, runs=runs, profiler=profiler)
     # Operator khatri_rao is not yet implemented for GPU
+    khatri_rao_benchmark_res = []
     if ctx != mx.gpu():
         # Benchmark tests for khatri_rao operator
         khatri_rao_benchmark_res = run_performance_test(


### PR DESCRIPTION
## Description ##
This PR serves to implement the remaining operators from the GEMM category in opperf. To achieve this, I added a call to `run_performance_test` for the `khatri_rao` op within the `run_gemm_operators_benchmarks` function and, since `khatri_rao` has yet to be implemented for GPU, added a check to ensure that the context was GPU before running benchmarks for `khatri_rao`. Since `khatri_rao` was the only remaining op in the GEMM ops category, these were the only required changes.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M benchmark/opperf/nd_operations/gemm_operators.py

## Comments ##
Tested on p2.16xl w/ubuntu 16.04 and Mac OS with:
1. Checkout branch and call function `run_gemm_operators_benchmarks` - runs all gemm ops (`dot`, `batch_dot`, and `khatri_rao`) on relevant data
2. Checkout branch and run `opperf.py` (full run of all ops)

## Performance Results ##
[Group of operator test - all GEMM ops (CPU)](https://gist.github.com/connorgoggins/9452ba1c95486208976c8949b493ea14)
[Full OpPerf test (CPU)](https://gist.github.com/connorgoggins/dfc01a53d4732256c6ea28aac9ec7c19)

[Group of operator test - all GEMM ops (GPU)](https://gist.github.com/connorgoggins/70be016d23c05f36bc2331cf89e4114a)
[Full OpPerf test (GPU)](https://gist.github.com/connorgoggins/51e96e3d62be49c18fe67dfb6c183e65)

@apeforest @access2rohit @ChaiBapchya 
