### PR TITLE
[OpPerf] Implement remaining random sampling ops

### DIFF
--- a/benchmark/opperf/nd_operations/random_sampling_operators.py
+++ b/benchmark/opperf/nd_operations/random_sampling_operators.py
@@ -19,7 +19,7 @@
 1. Operators are automatically fetched from MXNet operator registry.
 2. Default Inputs are generated. See rules/default_params.py. You can override the default values.
 
-Below 19 random sampling Operators are covered:
+Below 18 random sampling Operators are covered:
 
 ['random_exponential', 'random_gamma', 'random_generalized_negative_binomial', 'random_negative_binomial',
 'random_normal', 'random_poisson', 'random_randint', 'random_uniform', 'sample_exponential', 'sample_gamma',

--- a/benchmark/opperf/nd_operations/random_sampling_operators.py
+++ b/benchmark/opperf/nd_operations/random_sampling_operators.py
@@ -19,12 +19,12 @@
 1. Operators are automatically fetched from MXNet operator registry.
 2. Default Inputs are generated. See rules/default_params.py. You can override the default values.
 
-Below 16 random sampling Operators are covered:
+Below 19 random sampling Operators are covered:
 
 ['random_exponential', 'random_gamma', 'random_generalized_negative_binomial', 'random_negative_binomial',
 'random_normal', 'random_poisson', 'random_randint', 'random_uniform', 'sample_exponential', 'sample_gamma',
 'sample_generalized_negative_binomial', 'sample_multinomial', 'sample_negative_binomial', 'sample_normal',
-'sample_poisson', 'sample_uniform']
+'sample_poisson', 'sample_uniform', 'GridGenerator', 'sample_multinomial', 'BilinearSampler']
 
 """
 

--- a/benchmark/opperf/nd_operations/random_sampling_operators.py
+++ b/benchmark/opperf/nd_operations/random_sampling_operators.py
@@ -24,7 +24,7 @@ Below 19 random sampling Operators are covered:
 ['random_exponential', 'random_gamma', 'random_generalized_negative_binomial', 'random_negative_binomial',
 'random_normal', 'random_poisson', 'random_randint', 'random_uniform', 'sample_exponential', 'sample_gamma',
 'sample_generalized_negative_binomial', 'sample_multinomial', 'sample_negative_binomial', 'sample_normal',
-'sample_poisson', 'sample_uniform', 'GridGenerator', 'sample_multinomial', 'BilinearSampler']
+'sample_poisson', 'sample_uniform', 'GridGenerator', 'BilinearSampler']
 
 """
 

--- a/benchmark/opperf/rules/default_params.py
+++ b/benchmark/opperf/rules/default_params.py
@@ -63,6 +63,11 @@ DEFAULT_BETA_ND = [[1.0, 0.7]]
 DEFAULT_LAM = [[1.0, 8.5]]
 DEFAULT_K_ND = [[20, 49]]
 DEFAULT_P_ND = [[0.4, 0.77]]
+DEFAULT_GRID = [(32, 2, 256, 256)]
+DEFAULT_DATA_BILINEAR = [(32, 2, 256, 256)]
+DEFAULT_TRANSFORM_TYPE = ['warp']
+DEFAULT_DATA_GRIDGEN = [(32, 2, 256, 256)]
+DEFAULT_DATA_SM = [(32, 32), (64, 64)]
 
 # For reduction operators
 # NOTE: Data used is DEFAULT_DATA
@@ -194,7 +199,12 @@ DEFAULTS_INPUTS = {"data": DEFAULT_DATA,
                    "data_3d": DEFAULT_DATA_3d,
                    "label_smce": DEFAULT_LABEL_SMCE,
                    "label": DEFAULT_LABEL,
-                   "index": DEFAULT_INDEX}
+                   "index": DEFAULT_INDEX,
+                   "grid": DEFAULT_GRID,
+                   "data_bilinearsampler": DEFAULT_DATA_BILINEAR,
+                   "transform_type": DEFAULT_TRANSFORM_TYPE,
+                   "data_gridgenerator": DEFAULT_DATA_GRIDGEN,
+                   "data_sample_multinomial": DEFAULT_DATA_SM}
 
 
 # These are names of MXNet operator parameters that is of type NDArray.
@@ -207,4 +217,4 @@ PARAMS_OF_TYPE_NDARRAY = ["lhs", "rhs", "data", "base", "exp", "sample",
                           "low", "high", "weight", "bias", "moving_mean", "moving_var",
                           "weight", "weight32", "grad", "mean", "var", "mom", "n", "d",
                           "v", "z", "g", "delta", "args", "indices", "shape_like", "y",
-                          "x", "condition", "a", "index", "raveL_data", "label"]
+                          "x", "condition", "a", "index", "raveL_data", "label", "grid"]

--- a/benchmark/opperf/rules/default_params.py
+++ b/benchmark/opperf/rules/default_params.py
@@ -65,8 +65,9 @@ DEFAULT_K_ND = [[20, 49]]
 DEFAULT_P_ND = [[0.4, 0.77]]
 DEFAULT_GRID = [(32, 2, 256, 256)]
 DEFAULT_DATA_BILINEAR = [(32, 2, 256, 256)]
-DEFAULT_TRANSFORM_TYPE = ['warp']
-DEFAULT_DATA_GRIDGEN = [(32, 2, 256, 256)]
+DEFAULT_TRANSFORM_TYPE = ['warp', 'affine']
+DEFAULT_DATA_GRIDGEN = [(32, 2, 256, 256), (256, 6)]
+DEFAULT_TARGET_SHAPE = [(256, 6)]
 DEFAULT_DATA_SM = [(32, 32), (64, 64)]
 
 # For reduction operators
@@ -204,6 +205,7 @@ DEFAULTS_INPUTS = {"data": DEFAULT_DATA,
                    "data_bilinearsampler": DEFAULT_DATA_BILINEAR,
                    "transform_type": DEFAULT_TRANSFORM_TYPE,
                    "data_gridgenerator": DEFAULT_DATA_GRIDGEN,
+                   "target_shape_gridgenerator": DEFAULT_TARGET_SHAPE,
                    "data_sample_multinomial": DEFAULT_DATA_SM}
 
 

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -387,7 +387,7 @@ def get_all_loss_operators():
     # Filter for NN Loss operators
     loss_mx_operators = {}
     for op_name, op_params in mx_operators.items():
-        if op_name in loss_ops and op_name not in unique_ops:
+        if op_name in loss_ops:
             loss_mx_operators[op_name] = mx_operators[op_name]
     return loss_mx_operators
 

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -22,9 +22,6 @@ import mxnet as mx
 
 from benchmark.opperf.rules.default_params import DEFAULTS_INPUTS, MX_OP_MODULE
 
-# Operators where parameter have special criteria that cannot be cleanly automated.
-unique_ops = ()
-
 
 def _select_ops(operator_names, filters=("_contrib", "_"), merge_op_forward_backward=True):
     """From a given list of operators, filter out all operator names starting with given filters and prepares
@@ -264,9 +261,8 @@ def get_all_random_sampling_operators():
 
     # Filter for Random Sampling operators
     random_sampling_mx_operators = {}
-    for op_name, op_params in mx_operators.items():
-        if (op_name.startswith(("random_", "sample_")) or \
-            op_name in additional_random_sampling_ops) and op_name not in unique_ops:
+    for op_name, _ in mx_operators.items():
+        if (op_name.startswith(("random_", "sample_")) or op_name in additional_random_sampling_ops):
             random_sampling_mx_operators[op_name] = mx_operators[op_name]
     return random_sampling_mx_operators
 
@@ -285,8 +281,7 @@ def get_all_reduction_operators():
     reduction_mx_operators = {}
     for op_name, op_params in mx_operators.items():
         if op_params["params"]["narg"] == 4 and \
-                set(["data", "axis", "exclude", "keepdims"]).issubset(set(op_params["params"]["arg_names"])) \
-                and op_name not in unique_ops:
+                set(["data", "axis", "exclude", "keepdims"]).issubset(set(op_params["params"]["arg_names"])):
             reduction_mx_operators[op_name] = mx_operators[op_name]
     return reduction_mx_operators
 
@@ -307,9 +302,9 @@ def get_all_optimizer_operators():
 
     # Filter for Optimizer operators
     optimizer_mx_operators = {}
-    for op_name, _ in mx_operators.items():
-        if op_name in optimizer_ops and op_name not in unique_ops:
-            optimizer_mx_operators[op_name] = mx_operators[op_name]
+    for op_name, op_params in mx_operators.items():
+         if op_name in optimizer_ops:
+             optimizer_mx_operators[op_name] = mx_operators[op_name]
     return optimizer_mx_operators
 
 def get_all_sorting_searching_operators():
@@ -326,8 +321,8 @@ def get_all_sorting_searching_operators():
 
     # Filter for Sort and search operators
     sort_search_mx_operators = {}
-    for op_name, _ in mx_operators.items():
-        if op_name in sort_search_ops and op_name not in unique_ops:
+    for op_name, op_params in mx_operators.items():
+        if op_name in sort_search_ops:
             sort_search_mx_operators[op_name] = mx_operators[op_name]
     return sort_search_mx_operators
 
@@ -346,8 +341,8 @@ def get_all_rearrange_operators():
 
     # Filter for Array Rearrange operators
     rearrange_mx_operators = {}
-    for op_name, _ in mx_operators.items():
-        if op_name in rearrange_ops and op_name not in unique_ops:
+    for op_name, op_params in mx_operators.items():
+        if op_name in rearrange_ops:
             rearrange_mx_operators[op_name] = mx_operators[op_name]
     return rearrange_mx_operators
 

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -367,7 +367,7 @@ def get_all_indexing_routines():
     # Filter for Indexing routines
     indexing_mx_routines = {}
     for op_name, _ in mx_operators.items():
-        if op_name in indexing_routines and op_name not in unique_ops:
+        if op_name in indexing_routines:
             indexing_mx_routines[op_name] = mx_operators[op_name]
     return indexing_mx_routines
 

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -303,8 +303,8 @@ def get_all_optimizer_operators():
     # Filter for Optimizer operators
     optimizer_mx_operators = {}
     for op_name, op_params in mx_operators.items():
-         if op_name in optimizer_ops:
-             optimizer_mx_operators[op_name] = mx_operators[op_name]
+        if op_name in optimizer_ops:
+            optimizer_mx_operators[op_name] = mx_operators[op_name]
     return optimizer_mx_operators
 
 def get_all_sorting_searching_operators():

--- a/benchmark/opperf/utils/op_registry_utils.py
+++ b/benchmark/opperf/utils/op_registry_utils.py
@@ -262,7 +262,7 @@ def get_all_random_sampling_operators():
     # Filter for Random Sampling operators
     random_sampling_mx_operators = {}
     for op_name, _ in mx_operators.items():
-        if (op_name.startswith(("random_", "sample_")) or op_name in additional_random_sampling_ops):
+        if op_name.startswith(("random_", "sample_")) or op_name in additional_random_sampling_ops:
             random_sampling_mx_operators[op_name] = mx_operators[op_name]
     return random_sampling_mx_operators
 


### PR DESCRIPTION
## Description ##
This PR serves to implement the remaining operators from the Random Sampling category (`BilinearSampler`, `GridGenerator`, and `sample_multinomial`) in opperf. To achieve this, I added a list to track ops requiring `custom_data` in `op_registry_utils.py` (same strategy @ChaiBapchya used) and added the new random sampling ops to the list, which allowed me to add custom data dimensions for each new op in `default_params.py`. I then added these new ops to the comments in `random_sampling_operators.py`.

Furthermore, I investigated the `sample_multinomial` op, a Random Sampling op which had previously been added to the `unique_ops` tuple in `op_registry_utils.py`. This inclusion of the op in `unique_ops` effectively removed the op from opperf. While the documentation claimed that this op only worked when all values on the last axis summed to 1, I tested the op extensively and found that the op did in fact work on random data. With this in mind, I added this op to opperf and assigned its data parameter to lower dimensional data than the standard data shape to facilitate quick testing (on the standard data shape, the op took several minutes to complete a single forward pass).

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M benchmark/opperf/nd_operations/random_sampling_operators.py
- M benchmark/opperf/utils/op_registry_utils.py
- M benchmark/opperf/rules/default_params.py

## Comments ##
Tested on p2.16xl w/ubuntu 16.04 and Mac OS with:
1. Checkout branch and call function `run_mx_random_sampling_operators_benchmarks` - runs all Random Sampling ops on relevant data
2. Checkout branch and run `opperf.py` (full run of all ops)

## Performance Results ##
[Group of operator test - all Random Sampling ops (CPU)](https://gist.github.com/connorgoggins/de07fe539b84a37ebb916cb4c5f0af4f)
[Full OpPerf test (CPU)](https://gist.github.com/connorgoggins/a2ea86e186c62154fbb2b98f0ec5d262)

[Group of operator test - all Random Sampling ops (GPU)](https://gist.github.com/connorgoggins/adb2195c4bb409ccca68c22b3bcf4459)
[Full OpPerf test (GPU)](https://gist.github.com/connorgoggins/f156bfbfadd9f39cf015f8c6fa685dcf)

@apeforest @access2rohit @ChaiBapchya 
