### PR TITLE
[OpPerf] Fixes the issue when you pass NDArray to run_perf_test

### DIFF
--- a/benchmark/opperf/utils/ndarray_utils.py
+++ b/benchmark/opperf/utils/ndarray_utils.py
@@ -116,7 +116,7 @@ def get_mx_ndarray(ctx, in_tensor, dtype, initializer, attach_grad=True):
         tensor = nd.array(in_tensor, ctx=ctx, dtype=dtype)
     elif isinstance(in_tensor, np.ndarray):
         tensor = nd.array(in_tensor, ctx=ctx, dtype=dtype)
-    elif isinstance(in_tensor, mx.ndarray):
+    elif isinstance(in_tensor, nd.NDArray):
         tensor = in_tensor.as_in_context(ctx=ctx).astype(dtype=dtype)
     else:
         raise ValueError("Invalid input type for creating input tensor. Input can be tuple() of shape or Numpy Array or"

--- a/benchmark/opperf/utils/ndarray_utils.py
+++ b/benchmark/opperf/utils/ndarray_utils.py
@@ -117,7 +117,7 @@ def get_mx_ndarray(ctx, in_tensor, dtype, initializer, attach_grad=True):
     elif isinstance(in_tensor, np.ndarray):
         tensor = nd.array(in_tensor, ctx=ctx, dtype=dtype)
     elif isinstance(in_tensor, nd.NDArray):
-        tensor = in_tensor.as_in_context(ctx=ctx).astype(dtype=dtype)
+        tensor = in_tensor.as_in_context(ctx).astype(dtype=dtype)
     else:
         raise ValueError("Invalid input type for creating input tensor. Input can be tuple() of shape or Numpy Array or"
                          " MXNet NDArray. Given - ", in_tensor)


### PR DESCRIPTION
## Description ##
Upon running run_performance_test, user can input shape (as tuple) or NDArray directly in parameters that need NDArray.

Internally, opperf creates an NDArray if user has given shape as input. (default initializer is random_normal)

Now, when I pass an NDArray to run_perf_test follow issues occur
1. Fix typeError in isinstance check for NDArray
It errors out 
```
run_performance_test(nd.gather_nd, inputs=[{"data": (2, 22), "indices":nd.random_uniform(low=0,high=1,shape=(1,2))}], run_backward=T
rue, warmup=1, runs=1)
TypeError: isinstance() arg 2 must be a type or tuple of types
```

The issue is at this line 
     elif isinstance(in_tensor, mx.ndarray): 

It should check for nd.NDArray and not mx.ndarray

2. subsequently, as_in_context doesn't take keyword argument. Fixed that by removing 'ctx='

Test
```
run_performance_test(nd.gather_nd, inputs=[{"data": (2, 22), "indices":nd.random_uniform(low=0,high=1,shape=(1,2))}], run_backward=True, warmup=1, runs=1)
INFO:root:Begin Benchmark - gather_nd
INFO:root:Complete Benchmark - gather_nd
[{'gather_nd': [{'avg_time_forward_gather_nd': 0.099, 'avg_time_backward_gather_nd': 0.048, 'max_storage_mem_alloc_cpu/0': 0.09, 'inputs': {'data': (2, 22), 'indices':
[[0.5488135 0.5928446]]
<NDArray 1x2 @cpu(0)>}}]}]
```
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

