### PR TITLE
Enforce DMLC_LOG_FATAL_THROW

### DIFF
--- a/3rdparty/mshadow/mshadow/logging.h
+++ b/3rdparty/mshadow/mshadow/logging.h
@@ -201,7 +201,7 @@ class LogMessageFatal {
                 << line << ": ";
   }
   std::ostringstream &stream() { return log_stream_; }
-  ~LogMessageFatal() DMLC_THROW_EXCEPTION {
+  ~LogMessageFatal() MSHADOW_THROW_EXCEPTION {
     // throwing out of destructor is evil
     // hopefully we can do it here
     throw Error(log_stream_.str());

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ endif()
 add_definitions(-DDMLC_MODERN_THREAD_LOCAL=0)
 # disable stack trace in exception by default.
 add_definitions(-DDMLC_LOG_STACK_TRACE_SIZE=0)
+add_definitions(-DDMLC_LOG_FATAL_THROW=1)
 
 if(MSVC)
   add_definitions(-DWIN32_LEAN_AND_MEAN)

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ CFLAGS = -DMSHADOW_FORCE_STREAM $(WARNFLAGS)
 CFLAGS += -DDMLC_MODERN_THREAD_LOCAL=0
 # disable stack trace in exception by default.
 CFLAGS += -DDMLC_LOG_STACK_TRACE_SIZE=0
+CFLAGS += -DDMLC_LOG_FATAL_THROW=1
 
 ifeq ($(DEV), 1)
 	CFLAGS += -g -Werror


### PR DESCRIPTION
## Description ##
Fixes https://github.com/apache/incubator-mxnet/issues/13956

### Changes ###
- [X] Fix calling abort() on newer compilers

## Comments ##
[Current assumption](https://github.com/apache/incubator-mxnet/issues/13956#issuecomment-457893146) is that `DMLC_LOG_FATAL_THROW` needs to be explicitly set to 0 to enable `abort()` on `CHECK` failure, but this assumption seems false. Rather, if `DMLC_LOG_FATAL_THROW` is unset, `DMLC_LOG_FATAL_THROW == 0` will evaluate true during preprocessing at least if the preprocessor implements the C / C++ standards correctly.

Reference:
> After all replacements due to macro expansion and the defined unary operator have been performed, all remaining identifiers and keywords, except for true and false, are replaced with the pp-number 0

https://stackoverflow.com/a/5085425/2560672

Some older preprocessors may not have conformed to standard and this logic may have thus appeared to work. It does not work on GCC7 or Clang 9.

Further fix the use of an undefined macro `DMLC_THROW_EXCEPTION` in `3rdparty/mshadow/mshadow/logging.h`.