### PR TITLE
Ensure destination directory exists before attempting to write.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -673,10 +673,13 @@ endif
 extension_libs: $(EXT_LIBS)
 
 custom_op_lib:
+	@mkdir -p build
 	$(CXX) -shared -fPIC -std=c++11 example/extensions/lib_custom_op/gemm_lib.cc -o build/libcustomop_lib.so -I include/mxnet
 custom_op_gpu_lib:
+	@mkdir -p build
 	$(NVCC) -shared -std=c++11 -Xcompiler -fPIC example/extensions/lib_custom_op/relu_lib.cu -o build/libcustomop_gpu_lib.so -I include/mxnet
 subgraph_lib:
+	@mkdir -p build
 	$(CXX) -shared -fPIC -std=c++11 example/extensions/lib_subgraph/subgraph_lib.cc -o build/libsubgraph_lib.so -I include/mxnet
 
 # Cython build


### PR DESCRIPTION
## Description ##
Make sure build destination directory exists. Fixes race condition when compiling (with GNU make) with multiple jobs (-jX). 

Build fail log:

`
g++ -shared -fPIC -std=c++11 example/extensions/lib_custom_op/gemm_lib.cc -o build/libcustomop_lib.so -I include/mxnet
/usr/bin/ld: cannot open output file build/libcustomop_lib.so: No such file or directory
collect2: error: ld returned 1 exit status
Makefile:676: recipe for target 'custom_op_lib' failed
make: *** [custom_op_lib] Error 1
make: *** Waiting for unfinished jobs....
`
