### PR TITLE
replace the default value of context in load_checkpoint to cpu()

### DIFF
--- a/julia/src/model.jl
+++ b/julia/src/model.jl
@@ -647,7 +647,7 @@ end
 
 Load a mx.FeedForward model from the checkpoint *prefix*, *epoch* and optionally provide a context.
 """
-function load_checkpoint(prefix::AbstractString, epoch::Int, ::Type{FeedForward}; context = nothing)
+function load_checkpoint(prefix::AbstractString, epoch::Int, ::Type{FeedForward}; context = cpu())
   arch, arg_params, aux_params = load_checkpoint(prefix, epoch)
   model = FeedForward(arch, context = context)
   model.arg_params = arg_params


### PR DESCRIPTION
## Description ##
When we call load_checkpoint(prefix, epoch, ::mx.FeedForward; context) without specifying context, the following error occurs:
```
TypeError: in keyword argument context, expected Union{Context, Array{Context,1}}, got Nothing

Stacktrace:
 [1] (::Core.var"#kw#Type")(::NamedTuple{(:context,),Tuple{Nothing}}, ::Type{FeedForward}, ::SymbolicNode) at ./none:0
 [2] #load_checkpoint#8955(::Nothing, ::typeof(MXNet.mx.load_checkpoint), ::String, ::Int64, ::Type{FeedForward}) at /home/gino244/bin/mxnet/julia/src/model.jl:652
 [3] load_checkpoint(::String, ::Int64, ::Type{FeedForward}) at /home/gino244/bin/mxnet/julia/src/model.jl:651
 [4] top-level scope at In[]:1
```

This is because the default value of context argument in load_checkpoint is nothing. The FeedForward constructor doesn't accept Nothing Type as context argument.

context argument in load_checkpoint(prefix, epoch, ::mx.FeedForward; context) should be Context type. I propose cpu().