### PR TITLE
enabling build stage gpu_int64 to enable large tensor nightly runs

### DIFF
--- a/tests/nightly/JenkinsfileForBinaries
+++ b/tests/nightly/JenkinsfileForBinaries
@@ -40,25 +40,16 @@ core_logic: {
           utils.pack_lib('gpu', mx_lib_cpp_example_mkl)
         }
       }
-    }/*,
+    },
     'CPU: USE_INT64_TENSOR_SIZE': {
-      node(NODE_LINUX_CPU) {
+      node(NODE_LINUX_GPU) {
         ws('workspace/build-cpu-int64') {
           utils.init_git()
           utils.docker_run('ubuntu_nightly_cpu', 'build_ubuntu_cpu_large_tensor', false)
           utils.pack_lib('cpu_int64', mx_cmake_lib)
         }
       }
-    },
-    'GPU: USE_INT64_TENSOR_SIZE': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/build-gpu-int64') {
-          utils.init_git()
-          utils.docker_run('ubuntu_nightly_gpu', 'build_ubuntu_gpu_large_tensor', true)
-          utils.pack_lib('gpu_int64', mx_cmake_lib)
-        }
-      }
-    }*/
+    }
   }
 
   stage('NightlyTests'){
@@ -86,21 +77,12 @@ core_logic: {
         }
       }
     },
-    // https://github.com/apache/incubator-mxnet/issues/14980
-    /*'Test Large Tensor Size: CPU': {
-      node(NODE_LINUX_CPU) {
+    'Test Large Tensor Size: CPU': {
+      node(NODE_LINUX_GPU) {
         ws('workspace/large_tensor-cpu') {
             utils.unpack_and_init('cpu_int64', mx_cmake_lib)
             utils.docker_run('ubuntu_nightly_cpu', 'nightly_test_large_tensor', false)
-        }
-      }
-    },*/
-    'Test Large Tensor Size: GPU': {
-      node(NODE_LINUX_GPU) {
-        ws('workspace/large_tensor-gpu') {
-            utils.unpack_and_init('gpu_int64', mx_cmake_lib)
-            utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_large_tensor', true)
-            utils.docker_run('ubuntu_nightly_gpu', 'nightly_test_large_vector', true)
+            utils.docker_run('ubuntu_nightly_cpu', 'nightly_test_large_vector', false)
         }
       }
     },


### PR DESCRIPTION
## Description ##
Fixes nightly build failure due to absence of large tensor build artifact required for testing large tensor support on a nightly basis.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
