### PR TITLE
Fix cudnn Dropout reproducibility

### DIFF
--- a/3rdparty/mshadow/mshadow/random.h
+++ b/3rdparty/mshadow/mshadow/random.h
@@ -55,7 +55,7 @@ class Random<cpu, DType> {
 #if MSHADOW_IN_CXX11
     rnd_engine_.seed(seed);
 #endif
-    this->rseed_ = static_cast<unsigned>(seed);
+    this->rseed_ = static_cast<uint64_t>(seed);
   }
   /*!
    * \brief get random seed used in random generator
@@ -274,7 +274,7 @@ class Random<cpu, DType> {
   /*! \brief use c++11 random engine. */
   std::mt19937 rnd_engine_;
   /*! \brief random number seed used in random engine */
-  unsigned rseed_;
+  uint64t rseed_;
 
 #else
 
@@ -404,7 +404,7 @@ class Random<gpu, DType> {
     // Now set the seed.
     curandStatus_t status;
     status = curandSetPseudoRandomGeneratorSeed(gen_, static_cast<uint64_t>(seed));
-    this->rseed_ = static_cast<unsigned>(seed);
+    this->rseed_ = static_cast<uint64_t>(seed);
     CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "Set CURAND seed failed.";
   }
   /*!

--- a/3rdparty/mshadow/mshadow/random.h
+++ b/3rdparty/mshadow/mshadow/random.h
@@ -61,7 +61,7 @@ class Random<cpu, DType> {
    * \brief get random seed used in random generator
    * \return seed in unsigned
    */
-  inline unsigned GetSeed() const {
+  inline uint64_t GetSeed() const {
     return rseed_;
   }
   /*!
@@ -411,7 +411,7 @@ class Random<gpu, DType> {
     * \brief get random seed used in random generator
     * \return seed in unsigned
     */
-  inline unsigned GetSeed() const {
+  inline uint64_t GetSeed() const {
     return rseed_;
   }
   /*!
@@ -474,7 +474,7 @@ class Random<gpu, DType> {
   uniform(Shape<dim> shape);
 
  private:
-  unsigned rseed_;
+  uint64_t rseed_;
   inline void GenGaussian(float *dptr, size_t size, float mu, float sigma) {
     curandStatus_t status;
     status = curandGenerateNormal(gen_, dptr, size, mu, sigma);

--- a/3rdparty/mshadow/mshadow/random.h
+++ b/3rdparty/mshadow/mshadow/random.h
@@ -404,7 +404,15 @@ class Random<gpu, DType> {
     // Now set the seed.
     curandStatus_t status;
     status = curandSetPseudoRandomGeneratorSeed(gen_, static_cast<uint64_t>(seed));
+    this->rseed_ = static_cast<unsigned>(seed);
     CHECK_EQ(status, CURAND_STATUS_SUCCESS) << "Set CURAND seed failed.";
+  }
+  /*!
+    * \brief get random seed used in random generator
+    * \return seed in unsigned
+    */
+  inline unsigned GetSeed() const {
+    return rseed_;
   }
   /*!
    * \brief get a set of random integers
@@ -466,6 +474,7 @@ class Random<gpu, DType> {
   uniform(Shape<dim> shape);
 
  private:
+  unsigned rseed_;
   inline void GenGaussian(float *dptr, size_t size, float mu, float sigma) {
     curandStatus_t status;
     status = curandGenerateNormal(gen_, dptr, size, mu, sigma);

--- a/3rdparty/mshadow/mshadow/random.h
+++ b/3rdparty/mshadow/mshadow/random.h
@@ -274,7 +274,7 @@ class Random<cpu, DType> {
   /*! \brief use c++11 random engine. */
   std::mt19937 rnd_engine_;
   /*! \brief random number seed used in random engine */
-  uint64t rseed_;
+  uint64_t rseed_;
 
 #else
 

--- a/include/mxnet/resource.h
+++ b/include/mxnet/resource.h
@@ -202,9 +202,8 @@ struct Resource {
   void get_cudnn_dropout_desc(
       cudnnDropoutDescriptor_t *dropout_desc,
       mshadow::Stream<gpu> *stream,
-      const float dropout, uint64_t seed,
-      const std::string &name = MXNET_RESOURCE_DEFAULT_NAME_FARG("cudnn_dropout_state"),
-      bool reset) const;
+      const float dropout, uint64_t seed, bool reset,
+      const std::string &name = MXNET_RESOURCE_DEFAULT_NAME_FARG("cudnn_dropout_state")) const;
 #endif  // MXNET_USE_CUDNN == 1
 
   /*!

--- a/include/mxnet/resource.h
+++ b/include/mxnet/resource.h
@@ -203,7 +203,8 @@ struct Resource {
       cudnnDropoutDescriptor_t *dropout_desc,
       mshadow::Stream<gpu> *stream,
       const float dropout, uint64_t seed,
-      const std::string &name = MXNET_RESOURCE_DEFAULT_NAME_FARG("cudnn_dropout_state")) const;
+      const std::string &name = MXNET_RESOURCE_DEFAULT_NAME_FARG("cudnn_dropout_state"),
+      bool reset) const;
 #endif  // MXNET_USE_CUDNN == 1
 
   /*!

--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -256,7 +256,7 @@ class DropoutOp {
 
       // set dropout state.
       Random<xpu, unsigned> *prnd = ctx.requested[1].get_random<xpu, unsigned>(s);
-      uint64_t rng_seed = (uint64_t) prnd->GetSeed();
+      uint64_t rng_seed = prnd->GetSeed();
       // reset dropout descriptor if rng seed changed.
       bool reset = seed_ != rng_seed;
       seed_ = rng_seed;

--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -255,8 +255,9 @@ class DropoutOp {
       Stream<xpu> *s = ctx.get_stream<xpu>();
 
       // set dropout state.
-      ctx.requested[0].get_cudnn_dropout_desc(&dropout_desc_, s, 1.0f - this->pkeep_, seed_);
-
+      Random<xpu, unsigned> *prnd = ctx.requested[0].get_random<xpu, unsigned>(s);
+      unsigned seed = prnd->GetSeed();
+      ctx.requested[0].get_cudnn_dropout_desc(&dropout_desc_, s, 1.0f - this->pkeep_, seed);
       // describe input/output tensor
       int dim[4], stride[4];
       dim[0] = 1;
@@ -492,7 +493,6 @@ class DropoutOp {
   Context ctx_;
   cudnnDataType_t dtype_;
   cudnnDropoutDescriptor_t dropout_desc_;
-  uint64_t seed_ = 17 + rand() % 4096;  // NOLINT(runtime/threadsafe_fn)
   size_t dropout_reserve_byte_;
   cudnnTensorDescriptor_t x_desc_, y_desc_, dx_desc_, dy_desc_;
 #endif  // MXNET_USE_CUDNN_DROPOUT

--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -258,7 +258,7 @@ class DropoutOp {
       Random<xpu, unsigned> *prnd = ctx.requested[1].get_random<xpu, unsigned>(s);
       uint64_t rng_seed = (uint64_t) prnd->GetSeed();
       // reset dropout descriptor if rng seed changed.
-      bool reset = seed_ == rng_seed;
+      bool reset = seed_ != rng_seed;
       seed_ = rng_seed;
       ctx.requested[0].get_cudnn_dropout_desc(&dropout_desc_, s, 1.0f - this->pkeep_,
           seed_, reset);

--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -255,9 +255,10 @@ class DropoutOp {
       Stream<xpu> *s = ctx.get_stream<xpu>();
 
       // set dropout state.
-      Random<xpu, unsigned> *prnd = ctx.requested[0].get_random<xpu, unsigned>(s);
+      Random<xpu, unsigned> *prnd = ctx.requested[1].get_random<xpu, unsigned>(s);
       unsigned seed = prnd->GetSeed();
-      ctx.requested[0].get_cudnn_dropout_desc(&dropout_desc_, s, 1.0f - this->pkeep_, seed);
+      ctx.requested[0].get_cudnn_dropout_desc(&dropout_desc_, s, 1.0f - this->pkeep_,
+          static_cast<uint64_t>(seed));
       // describe input/output tensor
       int dim[4], stride[4];
       dim[0] = 1;

--- a/src/operator/nn/dropout.cc
+++ b/src/operator/nn/dropout.cc
@@ -157,6 +157,7 @@ Example::
           && !(param.cudnn_off && param.cudnn_off.value())
           && param.axes.ndim() == 0) {
         request.emplace_back(ResourceRequest::kCuDNNDropoutDesc);
+        request.emplace_back(ResourceRequest::kRandom);
         return request;
       }
 #endif

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -1337,7 +1337,7 @@ class RNNOp {
       // Create Dropout descriptors
       if (param_.p > 0) {
          Random<xpu, unsigned> *prnd = ctx.requested[2].get_random<xpu, unsigned>(s);
-         uint64_t rng_seed = (uint64_t) prnd->GetSeed();
+         uint64_t rng_seed = prnd->GetSeed();
          // reset dropout descriptor if rng seed changed.
          bool reset = seed_ != rng_seed;
          seed_ = rng_seed;

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -1337,7 +1337,7 @@ class RNNOp {
       // Create Dropout descriptors
       if (param_.p > 0) {
          ctx.requested[rnn_enum::kCuDNNDropoutDescSpace].get_cudnn_dropout_desc
-            (&dropout_desc_, s, 1.0f - param_.p, seed_);
+            (&dropout_desc_, s, 1.0f - param_.p, seed_, false);
       }
       // Only update the probability by passing in a null dropout_states ptr
       DType* dropout_states = nullptr;

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -180,6 +180,7 @@ static std::vector<ResourceRequest> RNNResourceEx(const NodeAttrs& attrs, const 
     const RNNParam& param = nnvm::get<RNNParam>(attrs.parsed);
     if (param.p != 0 && 1.0f - param.p > 0) {
       request.emplace_back(ResourceRequest::kCuDNNDropoutDesc);
+        request.emplace_back(ResourceRequest::kRandom);
     }
 #endif
   } else {

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -180,7 +180,7 @@ static std::vector<ResourceRequest> RNNResourceEx(const NodeAttrs& attrs, const 
     const RNNParam& param = nnvm::get<RNNParam>(attrs.parsed);
     if (param.p != 0 && 1.0f - param.p > 0) {
       request.emplace_back(ResourceRequest::kCuDNNDropoutDesc);
-        request.emplace_back(ResourceRequest::kRandom);
+      request.emplace_back(ResourceRequest::kRandom);
     }
 #endif
   } else {

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -96,7 +96,7 @@ class ResourceManagerImpl : public ResourceManager {
     cpu_temp_space_copy_ = dmlc::GetEnv("MXNET_CPU_TEMP_COPY", 4);
     gpu_temp_space_copy_ = dmlc::GetEnv("MXNET_GPU_TEMP_COPY", 1);
     cpu_native_rand_copy_ = dmlc::GetEnv("MXNET_CPU_PARALLEL_RAND_COPY", 1);
-    gpu_native_rand_copy_ = dmlc::GetEnv("MXNET_GPU_PARALLEL_RAND_COPY", 4);
+    gpu_native_rand_copy_ = dmlc::GetEnv("MXNET_GPU_PARALLEL_RAND_COPY", 1);
 #if MXNET_USE_CUDNN == 1
     gpu_cudnn_dropout_state_copy_ = dmlc::GetEnv("MXNET_GPU_CUDNN_DROPOUT_STATE_COPY", 4);
 #endif  // MXNET_USE_CUDNN == 1

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -428,9 +428,8 @@ void* Resource::get_host_space_internal(size_t size) const {
 void Resource::get_cudnn_dropout_desc(
     cudnnDropoutDescriptor_t *dropout_desc,
     mshadow::Stream<gpu> *stream,
-    const float dropout, uint64_t seed,
-    const std::string &name,
-    bool reset) const {
+    const float dropout, uint64_t seed, bool reset,
+    const std::string &name) const {
 
   CHECK_EQ(req.type, ResourceRequest::kCuDNNDropoutDesc);
   auto state_space = static_cast<resource::SpaceAllocator*>(ptr_);

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -7133,6 +7133,36 @@ def test_dropout():
         # check_dropout_axes(0.25, nshape, axes = (0, 2, 3), cudnn_off=False)
         # check_dropout_axes(0.25, nshape, axes = (1, 2, 3), cudnn_off=False)
 
+@with_seed()
+def test_dropout():
+    info = np.iinfo(np.int32)
+    seed1 = np.random.randint(info.min, info.max)
+    seed2 = np.random.randint(info.min, info.max)
+    data = mx.nd.ones((100, 100), ctx=default_context())
+    dropout = mx.gluon.nn.Dropout(0.5)
+    mx.random.seed(seed1)
+    with mx.autograd.record():
+        result1 = dropout(data)
+        result2 = dropout(result1)
+
+    mx.random.seed(seed2)
+    with mx.autograd.record():
+        result3 = dropout(data)
+        result4 = dropout(result3)
+
+    mx.random.seed(seed1)
+    with mx.autograd.record():
+        result5 = dropout(data)
+        result6 = dropout(result5)
+
+    assert_almost_equal(result1.asnumpy(), result5.asnumpy())
+    assert_almost_equal(result2.asnumpy(), result6.asnumpy())
+    with assert_raises(AssertionError):
+        assert_almost_equal(result1.asnumpy(), result2.asnumpy())
+    with assert_raises(AssertionError):
+        assert_almost_equal(result1.asnumpy(), result3.asnumpy())
+    with assert_raises(AssertionError):
+        assert_almost_equal(result2.asnumpy(), result4.asnumpy())
 
 @unittest.skip("test fails intermittently. temporarily disabled till it gets fixed. tracked at https://github.com/apache/incubator-mxnet/issues/11290")
 @with_seed()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -335,31 +335,6 @@ def test_rnnrelu_dropout():
     out = exe.forward(is_train=True)
     out[0].wait_to_read()
 
-@with_seed()
-def test_rnn_dropout_reproducibility():
-    info = np.iinfo(np.int32)
-    seed1 = np.random.randint(info.min, info.max)
-    seed2 = np.random.randint(info.min, info.max)
-    data = mx.nd.ones((5, 3, 10), ctx=default_context())
-    rnn = mx.gluon.rnn.RNN(100, 3, dropout=0.5)
-    rnn.initialize(ctx=default_context())
-    mx.random.seed(seed1)
-    with mx.autograd.record():
-        result1 = rnn(data)
-
-    mx.random.seed(seed2)
-    with mx.autograd.record():
-        result2 = rnn(data)
-
-    mx.random.seed(seed1)
-    with mx.autograd.record():
-        result3 = rnn(data)
-    # dropout on gpu should return same result with fixed seed
-    assert_almost_equal(result1.asnumpy(), result3.asnumpy())
-    with assert_raises(AssertionError):
-        assert_almost_equal(result1.asnumpy(), result2.asnumpy())
-
-
 def test_RNN_float64():
     if default_context().device_type == 'gpu':
         return

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -7134,7 +7134,7 @@ def test_dropout():
         # check_dropout_axes(0.25, nshape, axes = (1, 2, 3), cudnn_off=False)
 
 @with_seed()
-def test_dropout():
+def test_dropout_reproducibility():
     info = np.iinfo(np.int32)
     seed1 = np.random.randint(info.min, info.max)
     seed2 = np.random.randint(info.min, info.max)

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -335,6 +335,31 @@ def test_rnnrelu_dropout():
     out = exe.forward(is_train=True)
     out[0].wait_to_read()
 
+@with_seed()
+def test_rnn_dropout_reproducibility():
+    info = np.iinfo(np.int32)
+    seed1 = np.random.randint(info.min, info.max)
+    seed2 = np.random.randint(info.min, info.max)
+    data = mx.nd.ones((5, 3, 10), ctx=default_context())
+    rnn = mx.gluon.rnn.RNN(100, 3, dropout=0.5)
+    rnn.initialize(ctx=default_context())
+    mx.random.seed(seed1)
+    with mx.autograd.record():
+        result1 = rnn(data)
+
+    mx.random.seed(seed2)
+    with mx.autograd.record():
+        result2 = rnn(data)
+
+    mx.random.seed(seed1)
+    with mx.autograd.record():
+        result3 = rnn(data)
+    # dropout on gpu should return same result with fixed seed
+    assert_almost_equal(result1.asnumpy(), result3.asnumpy())
+    with assert_raises(AssertionError):
+        assert_almost_equal(result1.asnumpy(), result2.asnumpy())
+
+
 def test_RNN_float64():
     if default_context().device_type == 'gpu':
         return


### PR DESCRIPTION
Fix https://github.com/apache/incubator-mxnet/issues/15662
This will replace #16532 with an alternative solution.
Please refer to the discussion in  https://github.com/apache/incubator-mxnet/pull/16532#discussion_r339268855

1. Added `GetSeed()` in GPU random resource, it's similar to CPU version.
2. During cudnn dropout, check whether random seed has been changed and reset cudnn dropout descriptor's seed if random seed changed.

Benefit:
1. This avoided generating a random int (tensor on gpu) on GPU, copy to CPU and and pass it to `cudnnDropoutGetStatesSize`.
2. get the seed from gpu random resource is fast, we can afford to do it every forward.

Drawback:
Will be affected by https://github.com/apache/incubator-mxnet/issues/7410, by default mxnet's random seed is fixed.
