### PR TITLE
pin Sphinx due to autodocsumm issue with v2.4.0

### DIFF
--- a/docs/python_docs/environment.yml
+++ b/docs/python_docs/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - pip
 - python
 - jupyter
-- sphinx
+- sphinx==2.2.2
 - matplotlib
 - notebook
 - pip:


### PR DESCRIPTION
## Description ##https://github.com/apache/incubator-mxnet/pull/17561/commits
Fixes #17560 

Comin' in 🌶  - haven't had a chance to run it through the full tests yet, but this issue is blocking, so let's see what CI thinks!

Edit: The reason I chose 2.2.2 is that 2.2.x was the latest version that was passing [autodocsumm's CI](https://travis-ci.org/Chilipp/autodocsumm). And v2.2.2 is the [latest minor version of Sphinx offered on PyPi](https://pypi.org/project/Sphinx/#history).