### PR TITLE
[WIP] passing ndarrays to acceptSubgraph API

### DIFF
--- a/include/mxnet/lib_api.h
+++ b/include/mxnet/lib_api.h
@@ -917,10 +917,15 @@ typedef int (*partCallSupportedOps_t)(supportedOps_t supportedOps, const char *j
                                       const char* const* opt_vals, int num_opts);
 
 #define MXLIB_PARTCALLACCEPTSUBGRAPH_STR "_partCallAcceptSubgraph"
-typedef int (*partCallAcceptSubgraph_t)(acceptSubgraph_t acceptSubgraph, const char *json,
-                                        int subgraph_id, int *accept, const char* const* opt_keys,
+typedef int (*partCallAcceptSubgraph_t)(acceptSubgraph_t acceptSubgraph,
+                                        const char *json, int subgraph_id,
+                                        int *accept, const char* const* opt_keys,
                                         const char* const* opt_vals, int num_opts,
-                                        char*** attr_keys, char*** attr_vals, int *num_attrs);
+                                        char*** attr_keys, char*** attr_vals,
+                                        int *num_attrs, const char* const* in_args_chars,
+                                        void* const* in_args_data,
+                                        const int64_t* const *in_args_shapes,
+                                        const int* in_args_dims, const int* in_args_types);
 
 #define MXLIB_INITIALIZE_STR "initialize"
 typedef int (*initialize_t)(int version);
@@ -1283,7 +1288,10 @@ extern "C" {
   _partCallAcceptSubgraph(acceptSubgraph_t acceptSubgraph, const char *json,
                           int subgraph_id, int *accept, const char* const* opt_keys,
                           const char* const* opt_vals, int num_opts,
-                          char*** attr_keys, char*** attr_vals, int *num_attrs) {
+                          char*** attr_keys, char*** attr_vals, int *num_attrs,
+                          const char* const* in_args_chars, void* const* in_args_data,
+                          const int64_t* const* in_args_shapes, int* in_args_dims,
+                          int* in_args_types) {
     std::string subgraph_json(json);
     bool accept_bool = false;
     // create map of attributes from list

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -1351,8 +1351,9 @@ int MXOptimizeForBackend(SymbolHandle sym_handle,
   nnvm::Symbol *sym = static_cast<nnvm::Symbol *>(sym_handle);
   *s = sym->Copy();
   nnvm::Graph g = Symbol2Graph(*s);
+  NDArray **in_args_ptr = nullptr;
   if (len) {
-    NDArray **in_args_ptr = reinterpret_cast<NDArray**>(in_args_handle);
+    in_args_ptr = reinterpret_cast<NDArray**>(in_args_handle);
     Context default_ctx = Context::Create(static_cast<Context::DeviceType>(dev_type), 0);
     mxnet::ShapeVector arg_shapes(len);
     nnvm::DTypeVector arg_dtypes(len);
@@ -1382,6 +1383,9 @@ int MXOptimizeForBackend(SymbolHandle sym_handle,
                                           g.GetAttr<StorageTypeVector>("storage_type"));
     }
   }
+  g.attrs["args"] = std::make_shared<nnvm::any>(in_args_ptr);
+  std::vector<std::string> names = sym->ListInputNames(nnvm::Symbol::ListInputOption(1));
+  g.attrs["arg_names"] = std::make_shared<nnvm::any>(names);
   std::vector<std::pair<std::string, std::string>> options_map;
   for (mx_uint i = 0; i < num_options; ++i) {
     options_map.emplace_back(keys[i], vals[i]);


### PR DESCRIPTION
## Description ##
adding support for compilation of subgraphs by passing ndarrays to acceptSubgraph API. This will support compiling subgraphs for TensorRT or TVM backends. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
