### PR TITLE
[Numpy] Quantile/Percentile-scalar support 

### DIFF
--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -6269,8 +6269,11 @@ def percentile(a, q, axis=None, out=None, overwrite_input=None, interpolation='l
     """
     if overwrite_input is not None:
         raise NotImplementedError('overwrite_input is not supported yet')
+    if isinstance(q, numeric_types):
+        return _npi.percentile(a, axis=axis, interpolation=interpolation,
+                               keepdims=keepdims, q_scalar=q, out=out)
     return _npi.percentile(a, q, axis=axis, interpolation=interpolation,
-                           keepdims=keepdims, out=out)
+                           keepdims=keepdims, q_scalar=None, out=out)
 
 
 @set_module('mxnet.ndarray.numpy')
@@ -6351,8 +6354,11 @@ def quantile(a, q, axis=None, out=None, overwrite_input=None, interpolation='lin
     """
     if overwrite_input is not None:
         raise NotImplementedError('overwrite_input is not supported yet')
+    if isinstance(q, numeric_types):
+        return _npi.percentile(a, axis=axis, interpolation=interpolation,
+                               keepdims=keepdims, q_scalar=q * 100, out=out)
     return _npi.percentile(a, q * 100, axis=axis, interpolation=interpolation,
-                           keepdims=keepdims, out=out)
+                           keepdims=keepdims, q_scalar=None, out=out)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -8270,8 +8270,8 @@ def quantile(a, q, axis=None, out=None, overwrite_input=None, interpolation='lin
     >>> out
     array([6.5, 4.5, 2.5])
     """
-    return _mx_nd_np.quantile(a, q, axis=axis, overwrite_input=overwrite_input,
-                              interpolation=interpolation, keepdims=keepdims, out=out)
+    return _mx_nd_np.quantile(a, q, axis=axis, out=out, overwrite_input=overwrite_input,
+                              interpolation=interpolation, keepdims=keepdims)
 
 
 @set_module('mxnet.numpy')

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -5690,8 +5690,11 @@ def percentile(a, q, axis=None, out=None, overwrite_input=None, interpolation='l
     """
     if overwrite_input is not None:
         raise NotImplementedError('overwrite_input is not supported yet')
+    if isinstance(q, numeric_types):
+        return _npi.percentile(a, axis=axis, interpolation=interpolation,
+                               keepdims=keepdims, q_scalar=q, out=out)
     return _npi.percentile(a, q, axis=axis, interpolation=interpolation,
-                           keepdims=keepdims, out=out)
+                           keepdims=keepdims, q_scalar=None, out=out)
 
 
 @set_module('mxnet.symbol.numpy')
@@ -5748,8 +5751,11 @@ def quantile(a, q, axis=None, out=None, overwrite_input=None, interpolation='lin
     """
     if overwrite_input is not None:
         raise NotImplementedError('overwrite_input is not supported yet')
+    if isinstance(q, numeric_types):
+        return _npi.percentile(a, axis=axis, interpolation=interpolation,
+                               keepdims=keepdims, q_scalar=q * 100, out=out)
     return _npi.percentile(a, q * 100, axis=axis, interpolation=interpolation,
-                           keepdims=keepdims, out=out)
+                           keepdims=keepdims, q_scalar=None, out=out)
 
 
 @set_module('mxnet.symbol.numpy')

--- a/src/operator/numpy/np_percentile_op-inl.h
+++ b/src/operator/numpy/np_percentile_op-inl.h
@@ -44,6 +44,7 @@ struct NumpyPercentileParam : public dmlc::Parameter<NumpyPercentileParam> {
   dmlc::optional<mxnet::Tuple<int>> axis;
   int interpolation;
   bool keepdims;
+  dmlc::optional<double> q_scalar;
   DMLC_DECLARE_PARAMETER(NumpyPercentileParam) {
     DMLC_DECLARE_FIELD(axis)
       .set_default(dmlc::optional<mxnet::Tuple<int>>())
@@ -61,6 +62,8 @@ struct NumpyPercentileParam : public dmlc::Parameter<NumpyPercentileParam> {
     DMLC_DECLARE_FIELD(keepdims).set_default(false)
       .describe("If this is set to `True`, the reduced axes are left "
                 "in the result as dimension with size one.");
+    DMLC_DECLARE_FIELD(q_scalar).set_default(dmlc::optional<double>())
+      .describe("inqut q is a scalar");
   }
 };
 
@@ -133,22 +136,22 @@ void NumpyPercentileForward(const nnvm::NodeAttrs& attrs,
   if (req[0] == kNullOp) return;
   using namespace mxnet;
   using namespace mxnet_op;
-  CHECK_EQ(inputs.size(), 2U);
+  CHECK_GE(inputs.size(), 1U);
   CHECK_EQ(outputs.size(), 1U);
 
   Stream<xpu> *s = ctx.get_stream<xpu>();
   const TBlob &data = inputs[0];
-  const TBlob &percentile = inputs[1];
   const TBlob &out = outputs[0];
   const NumpyPercentileParam& param = nnvm::get<NumpyPercentileParam>(attrs.parsed);
   const int interpolation = param.interpolation;
   dmlc::optional<mxnet::Tuple<int>> axis = param.axis;
+  dmlc::optional<double> q_scalar = param.q_scalar;
 
   auto small = NumpyReduceAxesShapeImpl(data.shape_, axis, false);
 
   TShape r_shape;
   r_shape = TShape(small.ndim()+1, 1);
-  r_shape[0] = percentile.Size();
+  r_shape[0] = q_scalar.has_value()? 1 : inputs[1].Size();
   for (int i = 1; i < r_shape.ndim(); ++i) {
     r_shape[i] = small[i-1];
   }
@@ -216,7 +219,7 @@ void NumpyPercentileForward(const nnvm::NodeAttrs& attrs,
     size_t temp_data_size = data.Size() * sizeof(DType);
     size_t idx_size = data.Size() * sizeof(index_t);
     size_t temp_mem_size = 2 * temp_data_size + idx_size;
-    size_t workspace_size = topk_workspace_size * 2 + temp_mem_size + 8;
+    size_t workspace_size = topk_workspace_size * 2 + temp_mem_size + 16;
 
     Tensor<xpu, 1, char> temp_mem =
       ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size), s);
@@ -224,6 +227,20 @@ void NumpyPercentileForward(const nnvm::NodeAttrs& attrs,
     char* workspace_curr_ptr = temp_mem.dptr_;
     DType* trans_ptr, *sort_ptr;
     index_t* idx_ptr;
+    TBlob percentile;
+    double q;
+
+    if (q_scalar.has_value()) {
+      q = q_scalar.value();
+      Tensor<cpu, 1, double> host_q(&q, Shape1(1), ctx.get_stream<cpu>());
+      Tensor<xpu, 1, double> device_q(reinterpret_cast<double*>(workspace_curr_ptr),
+                                      Shape1(1), ctx.get_stream<xpu>());
+      mshadow::Copy(device_q, host_q, ctx.get_stream<xpu>());
+      percentile = TBlob(device_q.dptr_, TShape(0, 1), xpu::kDevMask);
+      workspace_curr_ptr += 8;
+    } else {
+      percentile = inputs[1];
+    }   // handle input q is a scalar
 
     char* is_valid_ptr = reinterpret_cast<char*>(workspace_curr_ptr);
     MSHADOW_TYPE_SWITCH(percentile.type_flag_, QType, {

--- a/src/operator/numpy/np_percentile_op.cc
+++ b/src/operator/numpy/np_percentile_op.cc
@@ -42,15 +42,16 @@ bool CheckInvalidInput(mshadow::Stream<cpu> *s, const QType *data,
 inline bool NumpyPercentileShape(const nnvm::NodeAttrs& attrs,
                                  std::vector<TShape> *in_attrs,
                                  std::vector<TShape> *out_attrs) {
-  CHECK_EQ(in_attrs->size(), 2U);
+  CHECK_GE(in_attrs->size(), 1U);
   CHECK_EQ(out_attrs->size(), 1U);
-  mxnet::TShape qshape = in_attrs->at(1);
-  CHECK_LE(qshape.ndim(), 1U);
   if (!shape_is_known(in_attrs->at(0))) {
     return false;
   }
   const NumpyPercentileParam& param = nnvm::get<NumpyPercentileParam>(attrs.parsed);
   mxnet::TShape shape = NumpyReduceAxesShapeImpl((*in_attrs)[0], param.axis, param.keepdims);
+
+  mxnet::TShape qshape = param.q_scalar.has_value()? mxnet::TShape(0, 1) : in_attrs->at(1);
+  CHECK_LE(qshape.ndim(), 1U);
 
   if (qshape.ndim() == 0) {
     SHAPE_ASSIGN_CHECK(*out_attrs, 0, shape);
@@ -67,7 +68,7 @@ inline bool NumpyPercentileShape(const nnvm::NodeAttrs& attrs,
 inline bool NumpyPercentileType(const nnvm::NodeAttrs& attrs,
                                 std::vector<int> *in_attrs,
                                 std::vector<int> *out_attrs) {
-  CHECK_EQ(in_attrs->size(), 2U);
+  CHECK_GE(in_attrs->size(), 1U);
   CHECK_EQ(out_attrs->size(), 1U);
 
   if (in_attrs->at(0) == mshadow::kFloat64) {
@@ -81,7 +82,11 @@ inline bool NumpyPercentileType(const nnvm::NodeAttrs& attrs,
 DMLC_REGISTER_PARAMETER(NumpyPercentileParam);
 
 NNVM_REGISTER_OP(_npi_percentile)
-.set_num_inputs(2)
+.set_num_inputs([](const NodeAttrs& attrs) {
+  const NumpyPercentileParam& param =
+    nnvm::get<NumpyPercentileParam>(attrs.parsed);
+  return param.q_scalar.has_value()? 1 : 2;
+  })
 .set_num_outputs(1)
 .set_attr_parser(ParamParser<NumpyPercentileParam>)
 .set_attr<mxnet::FInferShape>("FInferShape", NumpyPercentileShape)

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -172,6 +172,7 @@ def _add_workload_quantile():
     q2 = np.array(1)
     q3 = np.array(0.5)
     q4 = np.array([0, 0.75, 0.25, 0.5, 1.0])
+    q5 = 0.4
 
     OpArgMngr.add_workload('quantile', x1, q1)
     OpArgMngr.add_workload('quantile', x1, q2)
@@ -179,6 +180,9 @@ def _add_workload_quantile():
     OpArgMngr.add_workload('quantile', x2, q4, interpolation="midpoint")
     OpArgMngr.add_workload('quantile', x2, q4, interpolation="nearest")
     OpArgMngr.add_workload('quantile', x2, q4, interpolation="lower")
+    OpArgMngr.add_workload('quantile', x2, q5, interpolation="midpoint")
+    OpArgMngr.add_workload('quantile', x2, q5, interpolation="nearest")
+    OpArgMngr.add_workload('quantile', x2, q5, interpolation="lower")
 
 
 def _add_workload_percentile():
@@ -192,6 +196,7 @@ def _add_workload_percentile():
     q2 = np.array(60)
     x3 = np.arange(10)
     q3 = np.array([25, 50, 100])
+    q4 = 65
     x4 = np.arange(11 * 2).reshape(11, 1, 2, 1)
     x5 = np.array([0, np.nan])
 
@@ -206,12 +211,12 @@ def _add_workload_percentile():
     OpArgMngr.add_workload('percentile', x3, q3)
     OpArgMngr.add_workload('percentile', x4, q2, axis=0)
     OpArgMngr.add_workload('percentile', x4, q2, axis=1)
-    OpArgMngr.add_workload('percentile', x4, q2, axis=2)
-    OpArgMngr.add_workload('percentile', x4, q2, axis=3)
+    OpArgMngr.add_workload('percentile', x4, q4, axis=2)
+    OpArgMngr.add_workload('percentile', x4, q4, axis=3)
     OpArgMngr.add_workload('percentile', x4, q2, axis=-1)
     OpArgMngr.add_workload('percentile', x4, q2, axis=-2)
-    OpArgMngr.add_workload('percentile', x4, q2, axis=-3)
-    OpArgMngr.add_workload('percentile', x4, q2, axis=-4)
+    OpArgMngr.add_workload('percentile', x4, q4, axis=-3)
+    OpArgMngr.add_workload('percentile', x4, q4, axis=-4)
     OpArgMngr.add_workload('percentile', x4, q2, axis=(1,2))
     OpArgMngr.add_workload('percentile', x4, q3, axis=(-2,-1))
     OpArgMngr.add_workload('percentile', x4, q2, axis=(1,2), keepdims=True)

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -6710,8 +6710,8 @@ def test_np_quantile():
         ((2, 3, 4), (3,), (0, 2)),
         ((2, 3, 4), (3,), 1)
     ]
-    for hybridize, keepdims, (a_shape, q_shape, axis), interpolation, dtype in \
-        itertools.product(flags, flags, tensor_shapes, interpolation_options, dtypes):
+    for hybridize, keepdims, q_scalar, (a_shape, q_shape, axis), interpolation, dtype in \
+        itertools.product(flags, flags, flags, tensor_shapes, interpolation_options, dtypes):
         if dtype == np.float16 and interpolation == 'linear': continue
         atol = 3e-4 if dtype == np.float16 else 1e-4
         rtol = 3e-2 if dtype == np.float16 else 1e-2
@@ -6725,9 +6725,13 @@ def test_np_quantile():
         mx_out = test_quantile(a, q)
         assert mx_out.shape == np_out.shape
         assert_almost_equal(mx_out.asnumpy(), np_out, atol=atol, rtol=rtol)
-
+        
+        np_q = q.asnumpy()
+        if q_scalar and q_shape == ():
+            q = q.item()
+            np_q = q
         mx_out = np.quantile(a, q, axis=axis, interpolation=interpolation, keepdims=keepdims)
-        np_out = _np.quantile(a.asnumpy(), q.asnumpy(), axis=axis, interpolation=interpolation, keepdims=keepdims)
+        np_out = _np.quantile(a.asnumpy(), np_q, axis=axis, interpolation=interpolation, keepdims=keepdims)
         assert_almost_equal(mx_out.asnumpy(), np_out, atol=atol, rtol=rtol)
 
 
@@ -6757,8 +6761,8 @@ def test_np_percentile():
         ((2, 3, 4), (3,), (0, 2)),
         ((2, 3, 4), (3,), 1)
     ]
-    for hybridize, keepdims, (a_shape, q_shape, axis), interpolation, dtype in \
-        itertools.product(flags, flags, tensor_shapes, interpolation_options, dtypes):
+    for hybridize, keepdims, q_scalar, (a_shape, q_shape, axis), interpolation, dtype in \
+        itertools.product(flags, flags, flags, tensor_shapes, interpolation_options, dtypes):
         if dtype == np.float16 and interpolation == 'linear': continue
         atol = 3e-4 if dtype == np.float16 else 1e-4
         rtol = 3e-2 if dtype == np.float16 else 1e-2
@@ -6773,8 +6777,12 @@ def test_np_percentile():
         assert mx_out.shape == np_out.shape
         assert_almost_equal(mx_out.asnumpy(), np_out, atol=atol, rtol=rtol)
 
+        np_q = q.asnumpy()
+        if q_scalar and q_shape == ():
+            q = q.item()
+            np_q = q
         mx_out = np.percentile(a, q, axis=axis, interpolation=interpolation, keepdims=keepdims)
-        np_out = _np.percentile(a.asnumpy(), q.asnumpy(), axis=axis, interpolation=interpolation, keepdims=keepdims)
+        np_out = _np.percentile(a.asnumpy(), np_q, axis=axis, interpolation=interpolation, keepdims=keepdims)
         assert_almost_equal(mx_out.asnumpy(), np_out, atol=atol, rtol=rtol)
 
 


### PR DESCRIPTION
## Description ##
Add scalar support for the input q as Numpy.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
