### PR TITLE
Fix storage type infer of softmax backward

### DIFF
--- a/src/operator/nn/softmax.cc
+++ b/src/operator/nn/softmax.cc
@@ -94,8 +94,6 @@ inline static bool SoftmaxGradStorageType(const nnvm::NodeAttrs& attrs,
                                       DispatchMode* dispatch_mode,
                                       std::vector<int> *in_attrs,
                                       std::vector<int> *out_attrs) {
-  const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
-
   bool support = true;
   if (softmax_use_length(attrs) || softmax_has_dtype_override(attrs)) {
     support = false;

--- a/src/operator/nn/softmax.cc
+++ b/src/operator/nn/softmax.cc
@@ -95,15 +95,15 @@ inline static bool SoftmaxGradStorageType(const nnvm::NodeAttrs& attrs,
                                       std::vector<int> *in_attrs,
                                       std::vector<int> *out_attrs) {
   const SoftmaxParam& param = nnvm::get<SoftmaxParam>(attrs.parsed);
-  if (param.use_length.value() || softmax_has_dtype_override(attrs)) {
-    auto& out_stype = out_attrs->at(0);
-    return storage_type_assign(&out_stype, kDefaultStorage,
-                               dispatch_mode, DispatchMode::kFCompute);
+
+  bool support = true;
+  if (softmax_use_length(attrs) || softmax_has_dtype_override(attrs)) {
+    support = false;
   }
-  CHECK_EQ(in_attrs->size(), 2U);
-  CHECK_EQ(out_attrs->size(), 1U);
-  return MKLDNNStorageType(attrs, dev_mask, true, dispatch_mode, in_attrs,
-                           out_attrs);
+
+  CHECK_EQ(in_attrs->size(), SoftmaxGradOpNumInputs(attrs));
+  CHECK_EQ(out_attrs->size(), softmax_use_length(attrs) ? 2U : 1U);
+  return MKLDNNStorageType(attrs, dev_mask, support, dispatch_mode, in_attrs, out_attrs);
 }
 #endif
 


### PR DESCRIPTION
## Description ##
This PR fixes an issue introduced by #17170 , which causes below error when fine-tuning a bert model with latest gluonnlp and mxnet-mkl.

```bash
INFO:root:07:12:20 Namespace(accumulate=None, batch_size=32, bert_dataset='book_corpus_wiki_en_uncased', bert_model='bert_12_768_12', calib_mode='customize', deploy=False, dev_batch_size=8, dtype='float32', early_stop=None, epochs=3, epsilon=1e-06, gpu=None, log_interval=10, lr=2e-05, max_len=128, model_parameters=None, model_prefix=None, num_calib_batches=5, only_calibration=False, only_inference=False, optimizer='bertadam', output_dir='./output_dir', pretrained_bert_parameters=None, quantized_dtype='auto', round_to=None, seed=2, task_name='MRPC', training_steps=None, warmup_ratio=0.1)
INFO:root:07:12:21 processing dataset...
INFO:root:07:12:22 Now we are doing BERT classification training on cpu(0)!
INFO:root:07:12:22 training steps=343
Traceback (most recent call last):
  File "finetune_classifier.py", line 720, in <module>
    train(task.metrics)
  File "finetune_classifier.py", line 605, in train
    ls.backward()
  File "/home/lvtao/Workspace/mxnet-official/python/mxnet/ndarray/ndarray.py", line 2858, in backward
    ctypes.c_void_p(0)))
  File "/home/lvtao/Workspace/mxnet-official/python/mxnet/base.py", line 273, in check_call
    raise get_last_ffi_error()
mxnet.base.MXNetError: Traceback (most recent call last):
  File "src/imperative/./imperative_utils.h", line 774
MXNetError: Check failed: g.GetAttr<size_t>("storage_type_num_unknown_nodes") == 0U (12 vs. 0) :
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
