### PR TITLE
Fix Apache RAT License check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -715,15 +715,15 @@ rclean:
 	$(RM) -r R-package/src/image_recordio.h R-package/NAMESPACE R-package/man R-package/R/mxnet_generated.R \
 		R-package/inst R-package/src/*.o R-package/src/*.so mxnet_*.tar.gz
 
-build/rat/apache-rat/target/apache-rat-0.13.jar:
-	mkdir -p build
-	svn co http://svn.apache.org/repos/asf/creadur/rat/tags/apache-rat-project-0.13/ build/rat; \
+build/rat/apache-rat-0.13/apache-rat-0.13.jar:
+	mkdir -p build/rat
 	cd build/rat; \
-	mvn -Dmaven.test.skip=true install;
+	wget http://mirror.metrocast.net/apache//creadur/apache-rat-0.13/apache-rat-0.13-bin.zip; \
+	unzip apache-rat-0.13-bin.zip;
 
-ratcheck: build/rat/apache-rat/target/apache-rat-0.13.jar
+ratcheck: build/rat/apache-rat-0.13/apache-rat-0.13.jar
 	exec 5>&1; \
-	RAT_JAR=build/rat/apache-rat/target/apache-rat-0.13.jar; \
+	RAT_JAR=build/rat/apache-rat-0.13/apache-rat-0.13.jar; \
 	OUTPUT=$(java -jar $(RAT_JAR) -E tests/nightly/apache_rat_license_check/rat-excludes -d .|tee >(cat - >&5)); \
     ERROR_MESSAGE="Printing headers for text files without a valid license header"; \
     echo "-------Process The Output-------"; \


### PR DESCRIPTION
## Description ##
Build from source only works with JDK < 9 due to dependency on
maven-compiler-plugin and `make ratcheck` is thus broken on newer systems.

## Comments ##
Another thing I noticed is that on CI, some `.md` files are wrongly detected as binary files and excluded from license checking.

```
Binary files (which do not require any license headers) will be marked B
[...]
[2020-02-10T20:00:33.314Z]   B     /work/mxnet/tests/python-pytest/onnx/README.md
[2020-02-10T20:00:33.308Z]   B     /work/mxnet/julia/docs/src/api/optimizer.md
```

However, running locally with openjdk 11.0.6 2020-01-14, these files get correctly marked as "missing license". As I'm using the same `apache-rat-0.13.jar` locally, this discrepancy may be due to difference in Java version.

@roywei @szha 