### PR TITLE
upgrade sphinx and autodocsumm

### DIFF
--- a/docs/python_docs/environment.yml
+++ b/docs/python_docs/environment.yml
@@ -23,7 +23,7 @@ dependencies:
 - pip
 - python
 - jupyter
-- sphinx==2.2.2
+- sphinx==2.4.0
 - matplotlib
 - notebook
 - pip:
@@ -35,4 +35,4 @@ dependencies:
   - breathe==4.13.1
   - mock==3.0.5
   - awscli==1.16.266
-  - autodocsumm==0.1.11
+  - autodocsumm==0.1.12


### PR DESCRIPTION
## Description ##
Rollback of #17561

A new version of autodocsumm came out. It supports the most recent version of Sphinx.

This reverts the emergency patch to rollback these packages, but also pins the versions for both packages.

Tested the build and it passes.
