### PR TITLE
[CI] Remove print stacktrace (due to security concerns)

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -278,7 +278,6 @@ def main_wrapper(args) {
     currentBuild.result = "SUCCESS"
     update_github_commit_status('SUCCESS', 'Job succeeded')
   } catch (caughtError) {
-    caughtError.printStackTrace(System.out);
     node(NODE_UTILITY) {
       echo "caught ${caughtError}"
       err = caughtError

--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -278,7 +278,7 @@ def main_wrapper(args) {
     currentBuild.result = "SUCCESS"
     update_github_commit_status('SUCCESS', 'Job succeeded')
   } catch (caughtError) {
-    caughtError.printStackTrace();  
+    caughtError.printStackTrace(System.out);
     node(NODE_UTILITY) {
       echo "caught ${caughtError}"
       err = caughtError


### PR DESCRIPTION
## Description ##
Right now with #17465 if a CI Jenkins build fails, we print the stacktrace using `error.printStackTrace()` function

I found that 
a. According to Jenkins Script Security, It is an insecure function that needs to be approved by administrators in Jenkins -> Manage Jenkins -> In-process Script approval
Without the approval it gives SandBox error
```
org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use method java.lang.Throwable getStackTrace
```
This was probably the reason why status of few PR runs (despite success/fail on Jenkins) wasn't reported back to Github. Someone from the admin team likely approved it so as to allow the function to not error out.

b. However, the `error.printStackTrace()` function sends the report to System.err
It doesn't get printed on the console.
To print on console, it has to be passed as a parameter.
Verified it works by adding a failure case in the try (so as to enter the "catch")
```
try {
    update_github_commit_status('PENDING', 'Job has been enqueued')
    System.out.println(12 / 0)
}
```
It enters catch and then prints the stack trace for divide by zero exception as expected.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
Read more about Jenkins Script Security : https://plugins.jenkins.io/script-security/

How to handle printStackTrace - https://stackoverflow.com/questions/12095378/difference-between-e-printstacktrace-and-system-out-printlne