### PR TITLE
[Large Tensor] Fixed Embedding op

### DIFF
--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -67,7 +67,7 @@ enum QuantizedEmbeddingOpResource {kTempSpace};
 
 struct SparseEmbeddingParam: public dmlc::Parameter<SparseEmbeddingParam> {
   index_t input_dim;
-  int output_dim;
+  index_t output_dim;
   int dtype;
   bool deterministic;
   DMLC_DECLARE_PARAMETER(SparseEmbeddingParam) {
@@ -90,7 +90,7 @@ struct SparseEmbeddingParam: public dmlc::Parameter<SparseEmbeddingParam> {
 
 struct EmbeddingParam: public dmlc::Parameter<EmbeddingParam> {
   index_t input_dim;
-  int output_dim;
+  index_t output_dim;
   int dtype;
   bool sparse_grad;
   DMLC_DECLARE_PARAMETER(EmbeddingParam) {

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -66,7 +66,7 @@ enum QuantizedEmbeddingOpResource {kTempSpace};
 
 
 struct SparseEmbeddingParam: public dmlc::Parameter<SparseEmbeddingParam> {
-  int input_dim;
+  index_t input_dim;
   int output_dim;
   int dtype;
   bool deterministic;
@@ -89,7 +89,7 @@ struct SparseEmbeddingParam: public dmlc::Parameter<SparseEmbeddingParam> {
 };
 
 struct EmbeddingParam: public dmlc::Parameter<EmbeddingParam> {
-  int input_dim;
+  index_t input_dim;
   int output_dim;
   int dtype;
   bool sparse_grad;

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -38,7 +38,7 @@ LARGE_X = 100000000
 SMALL_X = 100
 SMALL_Y = 50
 LARGE_SIZE = LARGE_X * SMALL_Y
-LARGE_TENSOR_SHAPE = 4294967296
+LARGE_TENSOR_SHAPE = 2**32
 
 
 def test_nn():
@@ -469,9 +469,9 @@ def test_nn():
         assert res.shape[3] == 2
         assert res.shape[4] == 1
     def check_embedding():
-        data = nd.random_normal(shape=(2**32, 1))
-        weight = nd.random_normal(shape=(2**32, 1))
-        input_dim = 2**32
+        data = nd.random_normal(shape=(LARGE_TENSOR_SHAPE, 1))
+        weight = nd.random_normal(shape=(LARGE_TENSOR_SHAPE, 1))
+        input_dim = LARGE_TENSOR_SHAPE
         output_dim = 1
 
         out = nd.Embedding(data=data, weight=weight, input_dim=input_dim, output_dim=output_dim)

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -467,6 +467,17 @@ def test_nn():
         assert res.shape[2] == 2
         assert res.shape[3] == 2
         assert res.shape[4] == 1
+    def check_embedding():
+        data = nd.random_normal(shape=(2**32, 1))
+        weight = nd.random_normal(shape=(2**32, 1))
+        input_dim = 2**32
+        output_dim = 1
+
+        out = nd.Embedding(data=data, weight=weight, input_dim=input_dim, output_dim=output_dim)
+
+        assert out.shape[0] == 4294967296
+        assert out.shape[1] == 1
+        assert out.shape[2] == 1
 
     check_gluon_embedding()
     check_fully_connected()
@@ -488,6 +499,7 @@ def test_nn():
     check_l2_normalization()
     check_instance_norm()
     check_col2im()
+    check_embedding()
 
 
 def test_tensor():

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -38,6 +38,7 @@ LARGE_X = 100000000
 SMALL_X = 100
 SMALL_Y = 50
 LARGE_SIZE = LARGE_X * SMALL_Y
+LARGE_TENSOR_SHAPE = 4294967296
 
 
 def test_nn():
@@ -475,7 +476,7 @@ def test_nn():
 
         out = nd.Embedding(data=data, weight=weight, input_dim=input_dim, output_dim=output_dim)
 
-        assert out.shape[0] == 4294967296
+        assert out.shape[0] == LARGE_TENSOR_SHAPE
         assert out.shape[1] == 1
         assert out.shape[2] == 1
 


### PR DESCRIPTION
## Description ##
The Embedding op was previously breaking on large tensor (dimension >= 2^32) data. With the following input:
```
nd.Embedding(data=nd.random_normal(shape=(2**32,1)), weight=nd.random_normal(shape=(2**32,1)), input_dim=2**32, output_dim=1)
```
the following error was thrown:
```
mxnet.base.MXNetError: MXNetError: Invalid Parameter format for input_dim expect int but value='4294967296', in operator Embedding(name="", output_dim="1", input_dim="4294967296")
```

To fix this issue, I modified `indexing_op.h` to switch from storing input_dim as an `int` to storing it as an `index_t`. After implementing my fix and rebuilding, the previous input command displayed the correct output:
```
[[[-0.5190417]]

 [[-1.4388928]]

 [[ 1.1367434]]

 ...

 [[-1.4388928]]

 [[-1.4388928]]

 [[-0.5190417]]]
<NDArray 4294967296x1x1 @cpu(0)>
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M src/operator/tensor/indexing_op.h

## Comments ##
Tested on r5dn.24xl-ubuntu 16.04 and p2.16xl-ubuntu 16.04 with
1. Individual op run
2. Full OpPerf run

## Results ##
The key difference between CPU and GPU tests was the instance type (r5dn.24xl for CPU, p2.16xl for GPU). All relevant build flags remain the same, and both were tested using CPU context.

[Single operator test - Embedding op (GPU)](https://gist.github.com/connorgoggins/2ead27ac3b142e458ddba43eb4093bf7)
[Single operator test - Embedding op (CPU)](https://gist.github.com/connorgoggins/cdd5659abd5d2152a29f44a1f1ee03c7)

[Full OpPerf test (GPU)](https://gist.github.com/connorgoggins/09131cdbbdcbba1dc39a93099dccaad4)
[Full OpPerf test (CPU)](https://gist.github.com/connorgoggins/3fc3c7a40dae8b5cea7f82d9ca4b1a72)

@apeforest @access2rohit @ChaiBapchya 