### PR TITLE
[numpy] add fallback ops

### DIFF
--- a/include/mxnet/tensor_blob.h
+++ b/include/mxnet/tensor_blob.h
@@ -411,6 +411,7 @@ class TBlob {
         break;
       case kDLUInt:
         switch (dldata_type.bits) {
+          case 1: return mshadow::kBool;
           case 8: return mshadow::kUint8;
         }
         break;

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -5031,7 +5031,7 @@ def dl_managed_tensor_deleter(dl_managed_tensor_handle):
     ctypes.pythonapi.Py_DecRef(pyobj)
 
 
-def from_numpy(ndarray, zero_copy=True):
+def from_numpy(ndarray, zero_copy=True, array_cls=NDArray):
     """Returns an MXNet's ndarray backed by numpy's ndarray.
     When `zero_copy` is set to be true,
     this API consumes numpy's ndarray and produces MXNet's ndarray
@@ -5043,10 +5043,11 @@ def from_numpy(ndarray, zero_copy=True):
     ----------
     ndarray: numpy.ndarray
         input data
-
     zero_copy: bool
         Whether we use DLPack's zero-copy conversion to convert to MXNet's NDArray.
         This is only available for c-contiguous arrays, i.e. array.flags[C_CONTIGUOUS] == True.
+    array_cls: ndarray class type
+        The class type of the output array.
 
     Returns
     -------
@@ -5090,4 +5091,4 @@ def from_numpy(ndarray, zero_copy=True):
     c_obj = _make_dl_managed_tensor(ndarray)
     handle = NDArrayHandle()
     check_call(_LIB.MXNDArrayFromDLPackEx(ctypes.byref(c_obj), True, ctypes.byref(handle)))
-    return NDArray(handle=handle)
+    return array_cls(handle=handle)

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -4995,6 +4995,7 @@ class DLDataType(ctypes.Structure):
         "int32": (0, 32, 1),
         "int64": (0, 64, 1),
         "bool": (1, 1, 1),
+        "uint8": (1, 8, 1),
         "uint32": (1, 32, 1),
         "uint64": (1, 64, 1),
         'float16': (2, 16, 1),

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -789,7 +789,7 @@ def insert(arr, obj, values, axis=None):
 
 
 #pylint: disable= too-many-arguments, no-member, protected-access
-def _ufunc_helper(lhs, rhs, fn_array, fn_scalar, lfn_scalar, rfn_scalar=None, out=None):
+def _ufunc_helper(lhs, rhs, fn_array, fn_scalar, lfn_scalar, rfn_scalar=None, out=None, np_fallback_op=None):
     """ Helper function for element-wise operation.
     The function will perform numpy-like broadcasting if needed and call different functions.
 
@@ -820,6 +820,7 @@ def _ufunc_helper(lhs, rhs, fn_array, fn_scalar, lfn_scalar, rfn_scalar=None, ou
         result array or scalar
     """
     from ...numpy import ndarray
+    from ..ndarray import from_numpy
     if isinstance(lhs, numeric_types):
         if isinstance(rhs, numeric_types):
             return fn_scalar(lhs, rhs, out=out)
@@ -831,8 +832,12 @@ def _ufunc_helper(lhs, rhs, fn_array, fn_scalar, lfn_scalar, rfn_scalar=None, ou
                 return rfn_scalar(rhs, float(lhs), out=out)
     elif isinstance(rhs, numeric_types):
         return lfn_scalar(lhs, float(rhs), out=out)
-    elif isinstance(rhs, ndarray):
+    elif isinstance(lhs, ndarray) and isinstance(rhs, ndarray):
         return fn_array(lhs, rhs, out=out)
+    elif isinstance(lhs, _np.ndarray) and isinstance(rhs, ndarray):
+        return from_numpy(np_fallback_op(lhs, rhs.asnumpy()), array_cls=ndarray).as_in_ctx(rhs.ctx)
+    elif isinstance(lhs, ndarray) and isinstance(rhs, _np.ndarray):
+        return from_numpy(np_fallback_op(lhs.asnumpy(), rhs), array_cls=ndarray).as_in_ctx(lhs.ctx)
     else:
         raise TypeError('type {} not supported'.format(str(type(rhs))))
 #pylint: enable= too-many-arguments, no-member, protected-access
@@ -1045,7 +1050,7 @@ def multiply(x1, x2, out=None, **kwargs):
         * If only one of the inputs is floating number type, the result is that type.
         * If both inputs are of integer types (including boolean), not supported yet.
     """
-    return _ufunc_helper(x1, x2, _npi.multiply, _np.multiply, _npi.multiply_scalar, None, out)
+    return _ufunc_helper(x1, x2, _npi.multiply, _np.multiply, _npi.multiply_scalar, None, out, _np.multiply)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -26,7 +26,7 @@ from ...util import wrap_np_unary_func, wrap_np_binary_func
 from ...context import current_context
 from . import _internal as _npi
 from ..ndarray import NDArray
-import pdb
+
 
 __all__ = ['shape', 'zeros', 'zeros_like', 'ones', 'ones_like', 'full', 'full_like', 'empty_like', 'invert', 'delete',
            'add', 'broadcast_to', 'subtract', 'multiply', 'divide', 'mod', 'remainder', 'power', 'bitwise_not',

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -821,7 +821,7 @@ def _ufunc_helper(lhs, rhs, fn_array, fn_scalar, lfn_scalar, rfn_scalar=None, ou
         result array or scalar
     """
     from ...numpy import ndarray
-    from ..ndarray import from_numpy
+    from ..ndarray import from_numpy  # pylint: disable=unused-import
     if isinstance(lhs, numeric_types):
         if isinstance(rhs, numeric_types):
             return fn_scalar(lhs, rhs, out=out)

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -789,7 +789,7 @@ def insert(arr, obj, values, axis=None):
 
 
 #pylint: disable= too-many-arguments, no-member, protected-access
-def _ufunc_helper(lhs, rhs, fn_array, fn_scalar, lfn_scalar, rfn_scalar=None, out=None, np_fallback_op=None):
+def _ufunc_helper(lhs, rhs, fn_array, fn_scalar, lfn_scalar, rfn_scalar=None, out=None):
     """ Helper function for element-wise operation.
     The function will perform numpy-like broadcasting if needed and call different functions.
 
@@ -834,10 +834,6 @@ def _ufunc_helper(lhs, rhs, fn_array, fn_scalar, lfn_scalar, rfn_scalar=None, ou
         return lfn_scalar(lhs, float(rhs), out=out)
     elif isinstance(lhs, ndarray) and isinstance(rhs, ndarray):
         return fn_array(lhs, rhs, out=out)
-    elif isinstance(lhs, _np.ndarray) and isinstance(rhs, ndarray):
-        return from_numpy(np_fallback_op(lhs, rhs.asnumpy()), array_cls=ndarray).as_in_ctx(rhs.ctx)
-    elif isinstance(lhs, ndarray) and isinstance(rhs, _np.ndarray):
-        return from_numpy(np_fallback_op(lhs.asnumpy(), rhs), array_cls=ndarray).as_in_ctx(lhs.ctx)
     else:
         raise TypeError('type {} not supported'.format(str(type(rhs))))
 #pylint: enable= too-many-arguments, no-member, protected-access
@@ -1050,7 +1046,7 @@ def multiply(x1, x2, out=None, **kwargs):
         * If only one of the inputs is floating number type, the result is that type.
         * If both inputs are of integer types (including boolean), not supported yet.
     """
-    return _ufunc_helper(x1, x2, _npi.multiply, _np.multiply, _npi.multiply_scalar, None, out, _np.multiply)
+    return _ufunc_helper(x1, x2, _npi.multiply, _np.multiply, _npi.multiply_scalar, None, out)
 
 
 @set_module('mxnet.ndarray.numpy')
@@ -4912,7 +4908,7 @@ def ravel(x, order='C'):
     >>> print(np.ravel(x.T))
     [1. 4. 2. 5. 3. 6.]
     """
-    if order != 'C':
+    if order == 'F':
         raise NotImplementedError('order {} is not supported'.format(order))
     if isinstance(x, numeric_types):
         return _np.reshape(x, -1)

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -26,6 +26,7 @@ from ...util import wrap_np_unary_func, wrap_np_binary_func
 from ...context import current_context
 from . import _internal as _npi
 from ..ndarray import NDArray
+import pdb
 
 __all__ = ['shape', 'zeros', 'zeros_like', 'ones', 'ones_like', 'full', 'full_like', 'empty_like', 'invert', 'delete',
            'add', 'broadcast_to', 'subtract', 'multiply', 'divide', 'mod', 'remainder', 'power', 'bitwise_not',

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -21,10 +21,41 @@
 import numpy as onp
 
 __all__ = [
+    'allclose',
+    'alltrue',
     'angle',
+    'apply_along_axis',
+    'apply_over_axes',
+    'argpartition',
+    'argwhere',
+    'array_equal',
+    'array_equiv',
+    'choose',
+    'compress',
+    'corrcoef',
+    'correlate',
+    'count_nonzero',
+    'cov',
     'cross',
+    'diag_indices_from',
+    'digitize',
+    'divmod',
+    'ediff1d',
+    'extract',
+    'fabs',
+    'fill_diagonal',
+    'flatnonzero',
+    'float_power',
+    'fmax',
+    'fmin',
+    'fmod',
+    'frexp',
     'heaviside',
+    'interp',
     'isneginf',
+    'intersect1d',
+    'isclose',
+    'isfinite',
     'spacing',
     'nanargmax',
     'nanargmin',
@@ -53,7 +84,6 @@ __all__ = [
     'put_along_axis',
     'putmask',
     'pv',
-    'rank',
     'rate',
     'ravel_multi_index',
     'real',
@@ -70,10 +100,41 @@ __all__ = [
     'unwrap',
 ]
 
-heaviside = onp.heaviside
-spacing = onp.spacing
+allclose = onp.allclose
+alltrue = onp.alltrue
 angle = onp.angle
+apply_along_axis = onp.apply_along_axis
+apply_over_axes = onp.apply_over_axes
+argpartition = onp.argpartition
+argwhere = onp.argwhere
+array_equal = onp.array_equal
+array_equiv = onp.array_equiv
+choose = onp.choose
+compress = onp.compress
+corrcoef = onp.corrcoef
+correlate = onp.correlate
+count_nonzero = onp.count_nonzero
+cov = onp.cov
 cross = onp.cross
+diag_indices_from = onp.diag_indices_from
+digitize = onp.digitize
+divmod = onp.divmod
+ediff1d = onp.ediff1d
+extract = onp.extract
+fabs = onp.fabs
+fill_diagonal = onp.fill_diagonal
+flatnonzero = onp.flatnonzero
+float_power = onp.float_power
+fmax = onp.fmax
+fmin = onp.fmin
+fmod = onp.fmod
+frexp = onp.frexp
+geomspace = onp.geomspace
+heaviside = onp.heaviside
+interp = onp.interp
+intersect1d = onp.intersect1d
+isclose = onp.isclose
+isfinite = onp.isfinite
 isneginf = onp.isneginf
 nanargmax = onp.nanargmax
 nanargmin = onp.nanargmin
@@ -103,7 +164,6 @@ promote_types = onp.promote_types
 put_along_axis = onp.put_along_axis
 putmask = onp.putmask
 pv = onp.pv
-rank = onp.rank
 rate = onp.rate
 ravel_multi_index = onp.ravel_multi_index
 real = onp.real
@@ -112,6 +172,7 @@ roots = onp.roots
 round_ = onp.round_
 safe_eval = onp.safe_eval
 signbit = onp.signbit
+spacing = onp.spacing
 take_along_axis = onp.take_along_axis
 tril_indices_from = onp.tril_indices_from
 trim_zeros = onp.trim_zeros

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -21,9 +21,100 @@
 import numpy as onp
 
 __all__ = [
+    'angle',
+    'cross',
     'heaviside',
+    'isneginf',
     'spacing',
+    'nanargmax',
+    'nanargmin',
+    'nancumprod',
+    'nancumsum',
+    'nanprod',
+    'nanquantile',
+    'ndim',
+    'nper',
+    'npv',
+    'partition',
+    'piecewise',
+    'packbits',
+    'place',
+    'poly',
+    'polyadd',
+    'polyder',
+    'polydiv',
+    'polyfit',
+    'polyint',
+    'polymul',
+    'polysub',
+    'positive',
+    'ppmt',
+    'promote_types',
+    'put_along_axis',
+    'putmask',
+    'pv',
+    'rank',
+    'rate',
+    'ravel_multi_index',
+    'real',
+    'real_if_close',
+    'roots',
+    'round_',
+    'safe_eval',
+    'signbit',
+    'take_along_axis',
+    'tril_indices_from',
+    'trim_zeros',
+    'triu',
+    'triu_indices_from',
+    'unwrap',
 ]
 
 heaviside = onp.heaviside
 spacing = onp.spacing
+angle = onp.angle
+cross = onp.cross
+isneginf = onp.isneginf
+nanargmax = onp.nanargmax
+nanargmin = onp.nanargmin
+nancumprod = onp.nancumprod
+nancumsum = onp.nancumsum
+nanprod = onp.nanprod
+nanquantile = onp.nanquantile
+ndim = onp.ndim
+nper = onp.nper
+npv = onp.npv
+partition = onp.partition
+packbits = onp.packbits
+piecewise = onp.piecewise
+place = onp.place
+pmt = onp.pmt
+poly = onp.poly
+polyadd = onp.polyadd
+polyder = onp.polyder
+polydiv = onp.polydiv
+polyfit = onp.polyfit
+polyint = onp.polyint
+polymul = onp.polymul
+polysub = onp.polysub
+positive = onp.positive
+ppmt = onp.ppmt
+promote_types = onp.promote_types
+put_along_axis = onp.put_along_axis
+putmask = onp.putmask
+pv = onp.pv
+rank = onp.rank
+rate = onp.rate
+ravel_multi_index = onp.ravel_multi_index
+real = onp.real
+real_if_close = onp.real_if_close
+roots = onp.roots
+round_ = onp.round_
+safe_eval = onp.safe_eval
+signbit = onp.signbit
+take_along_axis = onp.take_along_axis
+tril_indices_from = onp.tril_indices_from
+trim_zeros = onp.trim_zeros
+triu = onp.triu
+triu_indices_from = onp.triu_indices_from
+unwrap = onp.unwrap

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -62,8 +62,6 @@ __all__ = [
     'isclose',
     'isfinite',
     'isin',
-    'isinf',
-    'isnan',
     'isposinf',
     'ix_',
     'lexsort',
@@ -177,8 +175,6 @@ intersect1d = onp.intersect1d
 isclose = onp.isclose
 isfinite = onp.isfinite
 isin = onp.isin
-isinf = onp.isinf
-isnan = onp.isnan
 isneginf = onp.isneginf
 isposinf = onp.isposinf
 ix_ = onp.ix_

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -26,111 +26,111 @@ __all__ = [
     'apply_along_axis',
     'apply_over_axes',
     'argpartition',
-    'argwhere',
-    'array_equal',
-    'array_equiv',
-    'choose',
-    'compress',
-    'corrcoef',
-    'correlate',
-    'count_nonzero',
-    'cov',
-    'cross',
-    'diag_indices_from',
-    'digitize',
-    'divmod',
-    'ediff1d',
-    'extract',
-    'fabs',
-    'fill_diagonal',
-    'flatnonzero',
-    'float_power',
-    'fmax',
-    'fmin',
-    'fmod',
-    'frexp',
+    # 'argwhere',
+    # 'array_equal',
+    # 'array_equiv',
+    # 'choose',
+    # 'compress',
+    # 'corrcoef',
+    # 'correlate',
+    # 'count_nonzero',
+    # 'cov',
+    # 'cross',
+    # 'diag_indices_from',
+    # 'digitize',
+    # 'divmod',
+    # 'ediff1d',
+    # 'extract',
+    # 'fabs',
+    # 'fill_diagonal',
+    # 'flatnonzero',
+    # 'float_power',
+    # 'fmax',
+    # 'fmin',
+    # 'fmod',
+    # 'frexp',
     'heaviside',
-    'histogram2d',
-    'histogram_bin_edges',
-    'histogramdd',
-    'i0',
-    'in1d',
-    'interp',
-    'isneginf',
-    'intersect1d',
-    'isclose',
-    'isfinite',
-    'isin',
-    'isposinf',
-    'ix_',
-    'lexsort',
-    'min_scalar_type',
-    'mirr',
-    'modf',
-    'msort',
-    'nanargmax',
-    'nanargmin',
-    'nancumprod',
-    'nancumsum',
-    'nanmax',
-    'nanmedian',
-    'nanmin',
-    'nanpercentile',
-    'nanprod',
-    'nanquantile',
-    'ndim',
-    'nper',
-    'npv',
-    'partition',
-    'piecewise',
-    'packbits',
-    'place',
-    'poly',
-    'polyadd',
-    'polyder',
-    'polydiv',
-    'polyfit',
-    'polyint',
-    'polymul',
-    'polysub',
-    'positive',
-    'ppmt',
-    'product',
-    'promote_types',
-    'ptp',
-    'put',
-    'put_along_axis',
-    'putmask',
-    'pv',
-    'rate',
-    'ravel_multi_index',
-    'real',
-    'real_if_close',
-    'result_type',
-    'rollaxis',
-    'roots',
-    'round',
-    'round_',
-    'safe_eval',
-    'searchsorted',
-    'select',
-    'setdiff1d',
-    'setxor1d',
-    'signbit',
-    'size',
-    'sometrue',
+    # 'histogram2d',
+    # 'histogram_bin_edges',
+    # 'histogramdd',
+    # 'i0',
+    # 'in1d',
+    # 'interp',
+    # 'isneginf',
+    # 'intersect1d',
+    # 'isclose',
+    # 'isfinite',
+    # 'isin',
+    # 'isposinf',
+    # 'ix_',
+    # 'lexsort',
+    # 'min_scalar_type',
+    # 'mirr',
+    # 'modf',
+    # 'msort',
+    # 'nanargmax',
+    # 'nanargmin',
+    # 'nancumprod',
+    # 'nancumsum',
+    # 'nanmax',
+    # 'nanmedian',
+    # 'nanmin',
+    # 'nanpercentile',
+    # 'nanprod',
+    # 'nanquantile',
+    # 'ndim',
+    # 'nper',
+    # 'npv',
+    # 'partition',
+    # 'piecewise',
+    # 'packbits',
+    # 'place',
+    # 'poly',
+    # 'polyadd',
+    # 'polyder',
+    # 'polydiv',
+    # 'polyfit',
+    # 'polyint',
+    # 'polymul',
+    # 'polysub',
+    # 'positive',
+    # 'ppmt',
+    # 'product',
+    # 'promote_types',
+    # 'ptp',
+    # 'put',
+    # 'put_along_axis',
+    # 'putmask',
+    # 'pv',
+    # 'rate',
+    # 'ravel_multi_index',
+    # 'real',
+    # 'real_if_close',
+    # 'result_type',
+    # 'rollaxis',
+    # 'roots',
+    # 'round',
+    # 'round_',
+    # 'safe_eval',
+    # 'searchsorted',
+    # 'select',
+    # 'setdiff1d',
+    # 'setxor1d',
+    # 'signbit',
+    # 'size',
+    # 'sometrue',
     'spacing',
-    'take_along_axis',
-    'trapz',
-    'tril_indices_from',
-    'trim_zeros',
-    'triu',
-    'triu_indices_from',
-    'union1d',
-    'unpackbits',
-    'unwrap',
-    'vander',
-    'matmul',
+    # 'take_along_axis',
+    # 'trapz',
+    # 'tril_indices_from',
+    # 'trim_zeros',
+    # 'triu',
+    # 'triu_indices_from',
+    # 'union1d',
+    # 'unpackbits',
+    # 'unwrap',
+    # 'vander',
+    # 'matmul',
 ]
 
 allclose = onp.allclose
@@ -138,116 +138,116 @@ alltrue = onp.alltrue
 apply_along_axis = onp.apply_along_axis
 apply_over_axes = onp.apply_over_axes
 argpartition = onp.argpartition
-argwhere = onp.argwhere
-array_equal = onp.array_equal
-array_equiv = onp.array_equiv
-choose = onp.choose
-compress = onp.compress
-corrcoef = onp.corrcoef
-correlate = onp.correlate
-count_nonzero = onp.count_nonzero
-cov = onp.cov
-cross = onp.cross
-diag_indices_from = onp.diag_indices_from
-digitize = onp.digitize
-divmod = onp.divmod
-ediff1d = onp.ediff1d
-extract = onp.extract
-fabs = onp.fabs
-fill_diagonal = onp.fill_diagonal
-flatnonzero = onp.flatnonzero
-float_power = onp.float_power
-fmax = onp.fmax
-fmin = onp.fmin
-fmod = onp.fmod
-frexp = onp.frexp
-geomspace = onp.geomspace
+# argwhere = onp.argwhere
+# array_equal = onp.array_equal
+# array_equiv = onp.array_equiv
+# choose = onp.choose
+# compress = onp.compress
+# corrcoef = onp.corrcoef
+# correlate = onp.correlate
+# count_nonzero = onp.count_nonzero
+# cov = onp.cov
+# cross = onp.cross
+# diag_indices_from = onp.diag_indices_from
+# digitize = onp.digitize
+# divmod = onp.divmod
+# ediff1d = onp.ediff1d
+# extract = onp.extract
+# fabs = onp.fabs
+# fill_diagonal = onp.fill_diagonal
+# flatnonzero = onp.flatnonzero
+# float_power = onp.float_power
+# fmax = onp.fmax
+# fmin = onp.fmin
+# fmod = onp.fmod
+# frexp = onp.frexp
+# geomspace = onp.geomspace
 heaviside = onp.heaviside
-histogram2d = onp.histogram2d
-histogram_bin_edges = onp.histogram_bin_edges
-histogramdd = onp.histogramdd
-i0 = onp.i0
-in1d = onp.in1d
-interp = onp.interp
-intersect1d = onp.intersect1d
-isclose = onp.isclose
-isfinite = onp.isfinite
-isin = onp.isin
-isneginf = onp.isneginf
-isposinf = onp.isposinf
-ix_ = onp.ix_
-lexsort = onp.lexsort
-min_scalar_type = onp.min_scalar_type
-mirr = onp.mirr
-modf = onp.modf
-msort = onp.msort
-nanargmax = onp.nanargmax
-nanargmin = onp.nanargmin
-nancumprod = onp.nancumprod
-nancumsum = onp.nancumsum
-nanmax = onp.nanmax
-nanmedian = onp.nanmedian
-nanmin = onp.nanmin
-nanpercentile = onp.nanpercentile
-nanprod = onp.nanprod
-nanquantile = onp.nanquantile
-nanstd = onp.nanstd
-nansum = onp.nansum
-nanvar = onp.nanvar
-ndim = onp.ndim
-nper = onp.nper
-npv = onp.npv
-partition = onp.partition
-packbits = onp.packbits
-piecewise = onp.piecewise
-place = onp.place
-pmt = onp.pmt
-poly = onp.poly
-polyadd = onp.polyadd
-polyder = onp.polyder
-polydiv = onp.polydiv
-polyfit = onp.polyfit
-polyint = onp.polyint
-polymul = onp.polymul
-polysub = onp.polysub
-positive = onp.positive
-ppmt = onp.ppmt
-promote_types = onp.promote_types
-ptp = onp.ptp
-put = onp.put
-put_along_axis = onp.put_along_axis
-putmask = onp.putmask
-pv = onp.pv
-rate = onp.rate
-ravel_multi_index = onp.ravel_multi_index
-real = onp.real
-real_if_close = onp.real_if_close
-result_type = onp.result_type
-rollaxis = onp.rollaxis
-roots = onp.roots
-round = onp.round
-round_ = onp.round_
-safe_eval = onp.safe_eval
-searchsorted = onp.searchsorted
-select = onp.select
-setdiff1d = onp.setdiff1d
-setxor1d = onp.setxor1d
-signbit = onp.signbit
-size = onp.size
-sometrue = onp.sometrue
+# histogram2d = onp.histogram2d
+# histogram_bin_edges = onp.histogram_bin_edges
+# histogramdd = onp.histogramdd
+# i0 = onp.i0
+# in1d = onp.in1d
+# interp = onp.interp
+# intersect1d = onp.intersect1d
+# isclose = onp.isclose
+# isfinite = onp.isfinite
+# isin = onp.isin
+# isneginf = onp.isneginf
+# isposinf = onp.isposinf
+# ix_ = onp.ix_
+# lexsort = onp.lexsort
+# min_scalar_type = onp.min_scalar_type
+# mirr = onp.mirr
+# modf = onp.modf
+# msort = onp.msort
+# nanargmax = onp.nanargmax
+# nanargmin = onp.nanargmin
+# nancumprod = onp.nancumprod
+# nancumsum = onp.nancumsum
+# nanmax = onp.nanmax
+# nanmedian = onp.nanmedian
+# nanmin = onp.nanmin
+# nanpercentile = onp.nanpercentile
+# nanprod = onp.nanprod
+# nanquantile = onp.nanquantile
+# nanstd = onp.nanstd
+# nansum = onp.nansum
+# nanvar = onp.nanvar
+# ndim = onp.ndim
+# nper = onp.nper
+# npv = onp.npv
+# partition = onp.partition
+# packbits = onp.packbits
+# piecewise = onp.piecewise
+# place = onp.place
+# pmt = onp.pmt
+# poly = onp.poly
+# polyadd = onp.polyadd
+# polyder = onp.polyder
+# polydiv = onp.polydiv
+# polyfit = onp.polyfit
+# polyint = onp.polyint
+# polymul = onp.polymul
+# polysub = onp.polysub
+# positive = onp.positive
+# ppmt = onp.ppmt
+# promote_types = onp.promote_types
+# ptp = onp.ptp
+# put = onp.put
+# put_along_axis = onp.put_along_axis
+# putmask = onp.putmask
+# pv = onp.pv
+# rate = onp.rate
+# ravel_multi_index = onp.ravel_multi_index
+# real = onp.real
+# real_if_close = onp.real_if_close
+# result_type = onp.result_type
+# rollaxis = onp.rollaxis
+# roots = onp.roots
+# round = onp.round
+# round_ = onp.round_
+# safe_eval = onp.safe_eval
+# searchsorted = onp.searchsorted
+# select = onp.select
+# setdiff1d = onp.setdiff1d
+# setxor1d = onp.setxor1d
+# signbit = onp.signbit
+# size = onp.size
+# sometrue = onp.sometrue
 spacing = onp.spacing
-take_along_axis = onp.take_along_axis
-trapz = onp.trapz
-tril_indices_from = onp.tril_indices_from
-trim_zeros = onp.trim_zeros
-triu = onp.triu
-triu_indices_from = onp.triu_indices_from
-union1d = onp.union1d
-unpackbits = onp.unpackbits
-unwrap = onp.unwrap
-vander = onp.vander
+# take_along_axis = onp.take_along_axis
+# trapz = onp.trapz
+# tril_indices_from = onp.tril_indices_from
+# trim_zeros = onp.trim_zeros
+# triu = onp.triu
+# triu_indices_from = onp.triu_indices_from
+# union1d = onp.union1d
+# unpackbits = onp.unpackbits
+# unwrap = onp.unwrap
+# vander = onp.vander
 
 # TODO(junwu): delete this after https://github.com/apache/incubator-mxnet/pull/16990 is merged
-matmul = onp.matmul
+# matmul = onp.matmul
 # TODO(junwu): In pr review, delete this after the pr is merged.
-product = onp.product
+# product = onp.product

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -23,7 +23,6 @@ import numpy as onp
 __all__ = [
     'allclose',
     'alltrue',
-    'angle',
     'apply_along_axis',
     'apply_over_axes',
     'argpartition',
@@ -136,7 +135,6 @@ __all__ = [
 
 allclose = onp.allclose
 alltrue = onp.alltrue
-angle = onp.angle
 apply_along_axis = onp.apply_along_axis
 apply_over_axes = onp.apply_over_axes
 argpartition = onp.argpartition

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -51,16 +51,34 @@ __all__ = [
     'fmod',
     'frexp',
     'heaviside',
+    'histogram2d',
+    'histogram_bin_edges',
+    'histogramdd',
+    'i0',
+    'in1d',
     'interp',
     'isneginf',
     'intersect1d',
     'isclose',
     'isfinite',
-    'spacing',
+    'isin',
+    'isinf',
+    'isnan',
+    'isposinf',
+    'ix_',
+    'lexsort',
+    'min_scalar_type',
+    'mirr',
+    'modf',
+    'msort',
     'nanargmax',
     'nanargmin',
     'nancumprod',
     'nancumsum',
+    'nanmax',
+    'nanmedian',
+    'nanmin',
+    'nanpercentile',
     'nanprod',
     'nanquantile',
     'ndim',
@@ -80,7 +98,10 @@ __all__ = [
     'polysub',
     'positive',
     'ppmt',
+    'product',
     'promote_types',
+    'ptp',
+    'put',
     'put_along_axis',
     'putmask',
     'pv',
@@ -88,16 +109,29 @@ __all__ = [
     'ravel_multi_index',
     'real',
     'real_if_close',
+    'rollaxis',
     'roots',
+    'round',
     'round_',
     'safe_eval',
+    'searchsorted',
+    'select',
+    'setdiff1d',
+    'setxor1d',
     'signbit',
+    'size',
+    'sometrue',
+    'spacing',
     'take_along_axis',
+    'trapz',
     'tril_indices_from',
     'trim_zeros',
     'triu',
     'triu_indices_from',
+    'union1d',
+    'unpackbits',
     'unwrap',
+    'vander',
 ]
 
 allclose = onp.allclose
@@ -131,17 +165,39 @@ fmod = onp.fmod
 frexp = onp.frexp
 geomspace = onp.geomspace
 heaviside = onp.heaviside
+histogram2d = onp.histogram2d
+histogram_bin_edges = onp.histogram_bin_edges
+histogramdd = onp.histogramdd
+i0 = onp.i0
+in1d = onp.in1d
 interp = onp.interp
 intersect1d = onp.intersect1d
 isclose = onp.isclose
 isfinite = onp.isfinite
+isin = onp.isin
+isinf = onp.isinf
+isnan = onp.isnan
 isneginf = onp.isneginf
+isposinf = onp.isposinf
+ix_ = onp.ix_
+lexsort = onp.lexsort
+min_scalar_type = onp.min_scalar_type
+mirr = onp.mirr
+modf = onp.modf
+msort = onp.msort
 nanargmax = onp.nanargmax
 nanargmin = onp.nanargmin
 nancumprod = onp.nancumprod
 nancumsum = onp.nancumsum
+nanmax = onp.nanmax
+nanmedian = onp.nanmedian
+nanmin = onp.nanmin
+nanpercentile = onp.nanpercentile
 nanprod = onp.nanprod
 nanquantile = onp.nanquantile
+nanstd = onp.nanstd
+nansum = onp.nansum
+nanvar = onp.nanvar
 ndim = onp.ndim
 nper = onp.nper
 npv = onp.npv
@@ -159,8 +215,11 @@ polyint = onp.polyint
 polymul = onp.polymul
 polysub = onp.polysub
 positive = onp.positive
+product = onp.product
 ppmt = onp.ppmt
 promote_types = onp.promote_types
+ptp = onp.ptp
+put = onp.put
 put_along_axis = onp.put_along_axis
 putmask = onp.putmask
 pv = onp.pv
@@ -168,14 +227,26 @@ rate = onp.rate
 ravel_multi_index = onp.ravel_multi_index
 real = onp.real
 real_if_close = onp.real_if_close
+rollaxis = onp.rollaxis
 roots = onp.roots
+round = onp.round
 round_ = onp.round_
 safe_eval = onp.safe_eval
+searchsorted = onp.searchsorted
+select = onp.select
+setdiff1d = onp.setdiff1d
+setxor1d = onp.setxor1d
 signbit = onp.signbit
+size = onp.size
+sometrue = onp.sometrue
 spacing = onp.spacing
 take_along_axis = onp.take_along_axis
+trapz = onp.trapz
 tril_indices_from = onp.tril_indices_from
 trim_zeros = onp.trim_zeros
 triu = onp.triu
 triu_indices_from = onp.triu_indices_from
+union1d = onp.union1d
+unpackbits = onp.unpackbits
 unwrap = onp.unwrap
+vander = onp.vander

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -29,7 +29,7 @@ __all__ = [
     'argwhere',
     'array_equal',
     'array_equiv',
-    # 'choose',    #dtype  error
+    'choose',
     'compress',
     'corrcoef',
     'correlate',
@@ -48,26 +48,20 @@ __all__ = [
     'fmin',
     'fmod',
     'frexp',
-    # 'geomspace',   # AssertionError: <class 'numpy.ndarray'> is not a scalar type
+    # 'geomspace', # return <class 'numpy.ndarray'>
     'heaviside',
     'histogram2d',
-    'histogram_bin_edges',   # AssertionError: <class 'numpy.ndarray'> is not a scalar type
-                             # when inputs are list   + interp, isneginf
+    'histogram_bin_edges',
     'histogramdd',
-    'i0',                   # AssertionError: <class 'numpy.ndarray'> is not a scalar type
-                            # when input is scalar
+    'i0',
     'in1d',
     'interp',
-    'isneginf',
     'intersect1d',
     'isclose',
-    'isfinite',
     'isin',
-    'isposinf',
     'ix_',
-    'lexsort',    # only size-1 arrays can be converted to Python scalars
-                  # keys : (k, N) array or tuple containing k (N,)-shaped sequences
-    'min_scalar_type',     #AssertionError: <class 'numpy.dtype'> is not a scalar type
+    'lexsort',
+    'min_scalar_type',
     'mirr',
     'modf',
     'msort',
@@ -82,16 +76,15 @@ __all__ = [
     'nanprod',
     'nanquantile',
     'ndim',
-    # 'nper',     # <class 'numpy.ndarray'> is not a scalar type      // scalar input return ndarray
-                  # return is array(21.5449442)
+    # 'nper', # return <class 'numpy.ndarray'>
     'npv',
-    'partition',   # could input tuple param2
+    'partition',
     'piecewise',
-    'packbits',   # ValueError: uint8 is not supported.
-    # 'place',     #TypeError: Does not support converting <class 'NoneType'> to mx.np.ndarray.
+    'packbits',
+    # 'place',
     'poly',
     'polyadd',
-    # 'polyder',  #return poly1d
+    # 'polyder',
     'polydiv',
     'polyfit',
     'polyint',
@@ -100,23 +93,21 @@ __all__ = [
     'positive',
     'ppmt',
     'product',
-    'promote_types',   # return dtype   <class 'numpy.dtype'> is not a scalar type
+    'promote_types',
     'ptp',
-    #'put',   # test    no return
-    # 'put_along_axis',  # no return
-    # 'putmask',   # no return
+    # 'put',
+    # 'put_along_axis',
+    # 'putmask',
     'pv',
     'rate',
-    # 'ravel_multi_index',  # Converts a tuple of index arrays into an array of flat indices, applying boundary modes to the multi-index.
-                            # input tuple like
+    # 'ravel_multi_index',
     'real',
-    # 'real_if_close',  # If complex input returns a real array if complex parts are close to zero.
-                      # AssertionError: <class 'numpy.ndarray'> is not a scalar type      input scalar output ndarray
-    'result_type',  # return dtype
+    # 'real_if_close',
+    'result_type',
     'rollaxis',
     'roots',
     'round_',
-    # 'safe_eval',   #  input is  string
+    # 'safe_eval',
     'searchsorted',
     'select',
     'setdiff1d',
@@ -132,8 +123,7 @@ __all__ = [
     'triu',
     'triu_indices_from',
     'union1d',
-    'unpackbits',   # TypeError: Expected an input array of unsigned byte data type
-                    # dtype=np.uint8: ValueError: uint8 is not supported.
+    'unpackbits',
     'unwrap',
     'vander',
 ]
@@ -175,10 +165,7 @@ in1d = onp.in1d
 interp = onp.interp
 intersect1d = onp.intersect1d
 isclose = onp.isclose
-isfinite = onp.isfinite
 isin = onp.isin
-isneginf = onp.isneginf
-isposinf = onp.isposinf
 ix_ = onp.ix_
 lexsort = onp.lexsort
 min_scalar_type = onp.min_scalar_type

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -29,108 +29,113 @@ __all__ = [
     'argwhere',
     'array_equal',
     'array_equiv',
-    # 'choose',    #dtype
+    # 'choose',    #dtype  error
     'compress',
     'corrcoef',
     'correlate',
     'count_nonzero',
     'cov',
-    # 'cross',
-    # 'diag_indices_from',
-    # 'digitize',
-    # 'divmod',
-    # 'ediff1d',
-    # 'extract',
-    # 'fabs',
+    'cross',
+    'digitize',
+    'divmod',
+    'ediff1d',
+    'extract',
+    'fabs',
     # 'fill_diagonal',
-    # 'flatnonzero',
-    # 'float_power',
-    # 'fmax',
-    # 'fmin',
-    # 'fmod',
-    # 'frexp',
+    'flatnonzero',
+    'float_power',
+    'fmax',
+    'fmin',
+    'fmod',
+    'frexp',
+    # 'geomspace',   # AssertionError: <class 'numpy.ndarray'> is not a scalar type
     'heaviside',
-    # 'histogram2d',
-    # 'histogram_bin_edges',
-    # 'histogramdd',
-    # 'i0',
-    # 'in1d',
-    # 'interp',
-    # 'isneginf',
-    # 'intersect1d',
-    # 'isclose',
-    # 'isfinite',
-    # 'isin',
-    # 'isposinf',
-    # 'ix_',
-    # 'lexsort',
-    # 'min_scalar_type',
-    # 'mirr',
-    # 'modf',
-    # 'msort',
-    # 'nanargmax',
-    # 'nanargmin',
-    # 'nancumprod',
-    # 'nancumsum',
-    # 'nanmax',
-    # 'nanmedian',
-    # 'nanmin',
-    # 'nanpercentile',
-    # 'nanprod',
-    # 'nanquantile',
-    # 'ndim',
-    # 'nper',
-    # 'npv',
-    # 'partition',
-    # 'piecewise',
-    # 'packbits',
-    # 'place',
-    # 'poly',
-    # 'polyadd',
-    # 'polyder',
-    # 'polydiv',
-    # 'polyfit',
-    # 'polyint',
-    # 'polymul',
-    # 'polysub',
-    # 'positive',
-    # 'ppmt',
-    # 'product',
-    # 'promote_types',
-    # 'ptp',
-    # 'put',
-    # 'put_along_axis',
-    # 'putmask',
-    # 'pv',
-    # 'rate',
-    # 'ravel_multi_index',
-    # 'real',
-    # 'real_if_close',
-    # 'result_type',
-    # 'rollaxis',
-    # 'roots',
-    # 'round',
-    # 'round_',
-    # 'safe_eval',
-    # 'searchsorted',
-    # 'select',
-    # 'setdiff1d',
-    # 'setxor1d',
-    # 'signbit',
-    # 'size',
-    # 'sometrue',
+    'histogram2d',
+    'histogram_bin_edges',   # AssertionError: <class 'numpy.ndarray'> is not a scalar type
+                             # when inputs are list   + interp, isneginf
+    'histogramdd',
+    'i0',                   # AssertionError: <class 'numpy.ndarray'> is not a scalar type
+                            # when input is scalar
+    'in1d',
+    'interp',
+    'isneginf',
+    'intersect1d',
+    'isclose',
+    'isfinite',
+    'isin',
+    'isposinf',
+    'ix_',
+    'lexsort',    # only size-1 arrays can be converted to Python scalars
+                  # keys : (k, N) array or tuple containing k (N,)-shaped sequences
+    'min_scalar_type',     #AssertionError: <class 'numpy.dtype'> is not a scalar type
+    'mirr',
+    'modf',
+    'msort',
+    'nanargmax',
+    'nanargmin',
+    'nancumprod',
+    'nancumsum',
+    'nanmax',
+    'nanmedian',
+    'nanmin',
+    'nanpercentile',
+    'nanprod',
+    'nanquantile',
+    'ndim',
+    # 'nper',     # <class 'numpy.ndarray'> is not a scalar type      // scalar input return ndarray
+                  # return is array(21.5449442)
+    'npv',
+    'partition',   # could input tuple param2
+    'piecewise',
+    'packbits',   # ValueError: uint8 is not supported.
+    # 'place',     #TypeError: Does not support converting <class 'NoneType'> to mx.np.ndarray.
+    'poly',
+    'polyadd',
+    # 'polyder',  #return poly1d
+    'polydiv',
+    'polyfit',
+    'polyint',
+    'polymul',
+    'polysub',
+    'positive',
+    'ppmt',
+    'product',
+    'promote_types',   # return dtype   <class 'numpy.dtype'> is not a scalar type
+    'ptp',
+    #'put',   # test    no return
+    # 'put_along_axis',  # no return
+    # 'putmask',   # no return
+    'pv',
+    'rate',
+    # 'ravel_multi_index',  # Converts a tuple of index arrays into an array of flat indices, applying boundary modes to the multi-index.
+                            # input tuple like
+    'real',
+    # 'real_if_close',  # If complex input returns a real array if complex parts are close to zero.
+                      # AssertionError: <class 'numpy.ndarray'> is not a scalar type      input scalar output ndarray
+    'result_type',  # return dtype
+    'rollaxis',
+    'roots',
+    'round_',
+    # 'safe_eval',   #  input is  string
+    'searchsorted',
+    'select',
+    'setdiff1d',
+    'setxor1d',
+    'signbit',
+    'size',
+    'sometrue',
     'spacing',
-    # 'take_along_axis',
-    # 'trapz',
-    # 'tril_indices_from',
-    # 'trim_zeros',
-    # 'triu',
-    # 'triu_indices_from',
-    # 'union1d',
-    # 'unpackbits',
-    # 'unwrap',
-    # 'vander',
-    # 'matmul',
+    'take_along_axis',
+    'trapz',
+    'tril_indices_from',
+    'trim_zeros',
+    'triu',
+    'triu_indices_from',
+    'union1d',
+    'unpackbits',   # TypeError: Expected an input array of unsigned byte data type
+                    # dtype=np.uint8: ValueError: uint8 is not supported.
+    'unwrap',
+    'vander',
 ]
 
 allclose = onp.allclose
@@ -141,113 +146,107 @@ argpartition = onp.argpartition
 argwhere = onp.argwhere
 array_equal = onp.array_equal
 array_equiv = onp.array_equiv
-# choose = onp.choose
+choose = onp.choose
 compress = onp.compress
 corrcoef = onp.corrcoef
 correlate = onp.correlate
 count_nonzero = onp.count_nonzero
 cov = onp.cov
-# cross = onp.cross
-# diag_indices_from = onp.diag_indices_from
-# digitize = onp.digitize
-# divmod = onp.divmod
-# ediff1d = onp.ediff1d
-# extract = onp.extract
-# fabs = onp.fabs
-# fill_diagonal = onp.fill_diagonal
-# flatnonzero = onp.flatnonzero
-# float_power = onp.float_power
-# fmax = onp.fmax
-# fmin = onp.fmin
-# fmod = onp.fmod
-# frexp = onp.frexp
-# geomspace = onp.geomspace
+cross = onp.cross
+digitize = onp.digitize
+divmod = onp.divmod
+ediff1d = onp.ediff1d
+extract = onp.extract
+fabs = onp.fabs
+fill_diagonal = onp.fill_diagonal
+flatnonzero = onp.flatnonzero
+float_power = onp.float_power
+fmax = onp.fmax
+fmin = onp.fmin
+fmod = onp.fmod
+frexp = onp.frexp
+geomspace = onp.geomspace
 heaviside = onp.heaviside
-# histogram2d = onp.histogram2d
-# histogram_bin_edges = onp.histogram_bin_edges
-# histogramdd = onp.histogramdd
-# i0 = onp.i0
-# in1d = onp.in1d
-# interp = onp.interp
-# intersect1d = onp.intersect1d
-# isclose = onp.isclose
-# isfinite = onp.isfinite
-# isin = onp.isin
-# isneginf = onp.isneginf
-# isposinf = onp.isposinf
-# ix_ = onp.ix_
-# lexsort = onp.lexsort
-# min_scalar_type = onp.min_scalar_type
-# mirr = onp.mirr
-# modf = onp.modf
-# msort = onp.msort
-# nanargmax = onp.nanargmax
-# nanargmin = onp.nanargmin
-# nancumprod = onp.nancumprod
-# nancumsum = onp.nancumsum
-# nanmax = onp.nanmax
-# nanmedian = onp.nanmedian
-# nanmin = onp.nanmin
-# nanpercentile = onp.nanpercentile
-# nanprod = onp.nanprod
-# nanquantile = onp.nanquantile
-# nanstd = onp.nanstd
-# nansum = onp.nansum
-# nanvar = onp.nanvar
-# ndim = onp.ndim
-# nper = onp.nper
-# npv = onp.npv
-# partition = onp.partition
-# packbits = onp.packbits
-# piecewise = onp.piecewise
-# place = onp.place
-# pmt = onp.pmt
-# poly = onp.poly
-# polyadd = onp.polyadd
-# polyder = onp.polyder
-# polydiv = onp.polydiv
-# polyfit = onp.polyfit
-# polyint = onp.polyint
-# polymul = onp.polymul
-# polysub = onp.polysub
-# positive = onp.positive
-# ppmt = onp.ppmt
-# promote_types = onp.promote_types
-# ptp = onp.ptp
-# put = onp.put
-# put_along_axis = onp.put_along_axis
-# putmask = onp.putmask
-# pv = onp.pv
-# rate = onp.rate
-# ravel_multi_index = onp.ravel_multi_index
-# real = onp.real
-# real_if_close = onp.real_if_close
-# result_type = onp.result_type
-# rollaxis = onp.rollaxis
-# roots = onp.roots
-# round = onp.round
-# round_ = onp.round_
-# safe_eval = onp.safe_eval
-# searchsorted = onp.searchsorted
-# select = onp.select
-# setdiff1d = onp.setdiff1d
-# setxor1d = onp.setxor1d
-# signbit = onp.signbit
-# size = onp.size
-# sometrue = onp.sometrue
+histogram2d = onp.histogram2d
+histogram_bin_edges = onp.histogram_bin_edges
+histogramdd = onp.histogramdd
+i0 = onp.i0
+in1d = onp.in1d
+interp = onp.interp
+intersect1d = onp.intersect1d
+isclose = onp.isclose
+isfinite = onp.isfinite
+isin = onp.isin
+isneginf = onp.isneginf
+isposinf = onp.isposinf
+ix_ = onp.ix_
+lexsort = onp.lexsort
+min_scalar_type = onp.min_scalar_type
+mirr = onp.mirr
+modf = onp.modf
+msort = onp.msort
+nanargmax = onp.nanargmax
+nanargmin = onp.nanargmin
+nancumprod = onp.nancumprod
+nancumsum = onp.nancumsum
+nanmax = onp.nanmax
+nanmedian = onp.nanmedian
+nanmin = onp.nanmin
+nanpercentile = onp.nanpercentile
+nanprod = onp.nanprod
+nanquantile = onp.nanquantile
+nanstd = onp.nanstd
+nansum = onp.nansum
+nanvar = onp.nanvar
+ndim = onp.ndim
+nper = onp.nper
+npv = onp.npv
+partition = onp.partition
+packbits = onp.packbits
+piecewise = onp.piecewise
+place = onp.place
+pmt = onp.pmt
+poly = onp.poly
+polyadd = onp.polyadd
+polyder = onp.polyder
+polydiv = onp.polydiv
+polyfit = onp.polyfit
+polyint = onp.polyint
+polymul = onp.polymul
+polysub = onp.polysub
+positive = onp.positive
+ppmt = onp.ppmt
+product = onp.product
+promote_types = onp.promote_types
+ptp = onp.ptp
+put = onp.put
+put_along_axis = onp.put_along_axis
+putmask = onp.putmask
+pv = onp.pv
+rate = onp.rate
+ravel_multi_index = onp.ravel_multi_index
+real = onp.real
+real_if_close = onp.real_if_close
+result_type = onp.result_type
+rollaxis = onp.rollaxis
+roots = onp.roots
+round_ = onp.round_
+safe_eval = onp.safe_eval
+searchsorted = onp.searchsorted
+select = onp.select
+setdiff1d = onp.setdiff1d
+setxor1d = onp.setxor1d
+signbit = onp.signbit
+size = onp.size
+sometrue = onp.sometrue
 spacing = onp.spacing
-# take_along_axis = onp.take_along_axis
-# trapz = onp.trapz
-# tril_indices_from = onp.tril_indices_from
-# trim_zeros = onp.trim_zeros
-# triu = onp.triu
-# triu_indices_from = onp.triu_indices_from
-# union1d = onp.union1d
-# unpackbits = onp.unpackbits
-# unwrap = onp.unwrap
-# vander = onp.vander
-
-# TODO(junwu): delete this after https://github.com/apache/incubator-mxnet/pull/16990 is merged
-# matmul = onp.matmul
-# TODO(junwu): In pr review, delete this after the pr is merged.
-# product = onp.product
+take_along_axis = onp.take_along_axis
+trapz = onp.trapz
+tril_indices_from = onp.tril_indices_from
+trim_zeros = onp.trim_zeros
+triu = onp.triu
+triu_indices_from = onp.triu_indices_from
+union1d = onp.union1d
+unpackbits = onp.unpackbits
+unwrap = onp.unwrap
+vander = onp.vander

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -35,20 +35,12 @@ __all__ = [
     'correlate',
     'count_nonzero',
     'cov',
-    'cross',
     'digitize',
     'divmod',
-    'ediff1d',
     'extract',
-    'fabs',
-    # 'fill_diagonal',
     'flatnonzero',
     'float_power',
-    'fmax',
-    'fmin',
-    'fmod',
     'frexp',
-    # 'geomspace', # return <class 'numpy.ndarray'>
     'heaviside',
     'histogram2d',
     'histogram_bin_edges',
@@ -76,15 +68,12 @@ __all__ = [
     'nanprod',
     'nanquantile',
     'ndim',
-    # 'nper', # return <class 'numpy.ndarray'>
     'npv',
     'partition',
     'piecewise',
     'packbits',
-    # 'place',
     'poly',
     'polyadd',
-    # 'polyder',
     'polydiv',
     'polyfit',
     'polyint',
@@ -92,35 +81,25 @@ __all__ = [
     'polysub',
     'positive',
     'ppmt',
-    'product',
     'promote_types',
     'ptp',
-    # 'put',
-    # 'put_along_axis',
-    # 'putmask',
     'pv',
     'rate',
-    # 'ravel_multi_index',
     'real',
-    # 'real_if_close',
     'result_type',
     'rollaxis',
     'roots',
-    'round_',
-    # 'safe_eval',
     'searchsorted',
     'select',
     'setdiff1d',
     'setxor1d',
     'signbit',
     'size',
-    'sometrue',
     'spacing',
     'take_along_axis',
     'trapz',
     'tril_indices_from',
     'trim_zeros',
-    'triu',
     'triu_indices_from',
     'union1d',
     'unpackbits',
@@ -142,20 +121,12 @@ corrcoef = onp.corrcoef
 correlate = onp.correlate
 count_nonzero = onp.count_nonzero
 cov = onp.cov
-cross = onp.cross
 digitize = onp.digitize
 divmod = onp.divmod
-ediff1d = onp.ediff1d
 extract = onp.extract
-fabs = onp.fabs
-fill_diagonal = onp.fill_diagonal
 flatnonzero = onp.flatnonzero
 float_power = onp.float_power
-fmax = onp.fmax
-fmin = onp.fmin
-fmod = onp.fmod
 frexp = onp.frexp
-geomspace = onp.geomspace
 heaviside = onp.heaviside
 histogram2d = onp.histogram2d
 histogram_bin_edges = onp.histogram_bin_edges
@@ -186,16 +157,13 @@ nanstd = onp.nanstd
 nansum = onp.nansum
 nanvar = onp.nanvar
 ndim = onp.ndim
-nper = onp.nper
 npv = onp.npv
 partition = onp.partition
 packbits = onp.packbits
 piecewise = onp.piecewise
-place = onp.place
 pmt = onp.pmt
 poly = onp.poly
 polyadd = onp.polyadd
-polyder = onp.polyder
 polydiv = onp.polydiv
 polyfit = onp.polyfit
 polyint = onp.polyint
@@ -203,35 +171,25 @@ polymul = onp.polymul
 polysub = onp.polysub
 positive = onp.positive
 ppmt = onp.ppmt
-product = onp.product
 promote_types = onp.promote_types
 ptp = onp.ptp
-put = onp.put
-put_along_axis = onp.put_along_axis
-putmask = onp.putmask
 pv = onp.pv
 rate = onp.rate
-ravel_multi_index = onp.ravel_multi_index
 real = onp.real
-real_if_close = onp.real_if_close
 result_type = onp.result_type
 rollaxis = onp.rollaxis
 roots = onp.roots
-round_ = onp.round_
-safe_eval = onp.safe_eval
 searchsorted = onp.searchsorted
 select = onp.select
 setdiff1d = onp.setdiff1d
 setxor1d = onp.setxor1d
 signbit = onp.signbit
 size = onp.size
-sometrue = onp.sometrue
 spacing = onp.spacing
 take_along_axis = onp.take_along_axis
 trapz = onp.trapz
 tril_indices_from = onp.tril_indices_from
 trim_zeros = onp.trim_zeros
-triu = onp.triu
 triu_indices_from = onp.triu_indices_from
 union1d = onp.union1d
 unpackbits = onp.unpackbits

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -132,6 +132,7 @@ __all__ = [
     'unpackbits',
     'unwrap',
     'vander',
+    'matmul',
 ]
 
 allclose = onp.allclose
@@ -250,3 +251,6 @@ union1d = onp.union1d
 unpackbits = onp.unpackbits
 unwrap = onp.unwrap
 vander = onp.vander
+
+# TODO(junwu): delete this after https://github.com/apache/incubator-mxnet/pull/16990 is merged
+matmul = onp.matmul

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -26,15 +26,15 @@ __all__ = [
     'apply_along_axis',
     'apply_over_axes',
     'argpartition',
-    # 'argwhere',
-    # 'array_equal',
-    # 'array_equiv',
-    # 'choose',
-    # 'compress',
-    # 'corrcoef',
-    # 'correlate',
-    # 'count_nonzero',
-    # 'cov',
+    'argwhere',
+    'array_equal',
+    'array_equiv',
+    # 'choose',    #dtype
+    'compress',
+    'corrcoef',
+    'correlate',
+    'count_nonzero',
+    'cov',
     # 'cross',
     # 'diag_indices_from',
     # 'digitize',
@@ -138,15 +138,15 @@ alltrue = onp.alltrue
 apply_along_axis = onp.apply_along_axis
 apply_over_axes = onp.apply_over_axes
 argpartition = onp.argpartition
-# argwhere = onp.argwhere
-# array_equal = onp.array_equal
-# array_equiv = onp.array_equiv
+argwhere = onp.argwhere
+array_equal = onp.array_equal
+array_equiv = onp.array_equiv
 # choose = onp.choose
-# compress = onp.compress
-# corrcoef = onp.corrcoef
-# correlate = onp.correlate
-# count_nonzero = onp.count_nonzero
-# cov = onp.cov
+compress = onp.compress
+corrcoef = onp.corrcoef
+correlate = onp.correlate
+count_nonzero = onp.count_nonzero
+cov = onp.cov
 # cross = onp.cross
 # diag_indices_from = onp.diag_indices_from
 # digitize = onp.digitize

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -109,6 +109,7 @@ __all__ = [
     'ravel_multi_index',
     'real',
     'real_if_close',
+    'result_type',
     'rollaxis',
     'roots',
     'round',
@@ -216,7 +217,6 @@ polyint = onp.polyint
 polymul = onp.polymul
 polysub = onp.polysub
 positive = onp.positive
-product = onp.product
 ppmt = onp.ppmt
 promote_types = onp.promote_types
 ptp = onp.ptp
@@ -228,6 +228,7 @@ rate = onp.rate
 ravel_multi_index = onp.ravel_multi_index
 real = onp.real
 real_if_close = onp.real_if_close
+result_type = onp.result_type
 rollaxis = onp.rollaxis
 roots = onp.roots
 round = onp.round
@@ -254,3 +255,5 @@ vander = onp.vander
 
 # TODO(junwu): delete this after https://github.com/apache/incubator-mxnet/pull/16990 is merged
 matmul = onp.matmul
+# TODO(junwu): In pr review, delete this after the pr is merged.
+product = onp.product

--- a/python/mxnet/numpy/fallback_linalg.py
+++ b/python/mxnet/numpy/fallback_linalg.py
@@ -23,6 +23,14 @@ import numpy as onp
 
 __all__ = [
     'cond',
+    'qr',
+    'matrix_power',
+    'matrix_rank',
+    'multi_dot',
 ]
 
 cond = onp.linalg.cond
+qr = onp.linalg.qr
+matrix_power = onp.linalg.matrix_power
+matrix_rank = onp.linalg.matrix_rank
+multi_dot = onp.linalg.multi_dot

--- a/python/mxnet/numpy/fallback_linalg.py
+++ b/python/mxnet/numpy/fallback_linalg.py
@@ -23,16 +23,16 @@ import numpy as onp
 
 __all__ = [
     'cond',
-    'lstsq',
-    'matrix_power',
-    'matrix_rank',
-    'multi_dot',
-    'qr',
+    # 'lstsq',
+    # 'matrix_power',
+    # 'matrix_rank',
+    # 'multi_dot',
+    # 'qr',
 ]
 
 cond = onp.linalg.cond
-lstsq = onp.linalg.lstsq
-matrix_power = onp.linalg.matrix_power
-matrix_rank = onp.linalg.matrix_rank
-multi_dot = onp.linalg.multi_dot
-qr = onp.linalg.qr
+# lstsq = onp.linalg.lstsq
+# matrix_power = onp.linalg.matrix_power
+# matrix_rank = onp.linalg.matrix_rank
+# multi_dot = onp.linalg.multi_dot
+# qr = onp.linalg.qr

--- a/python/mxnet/numpy/fallback_linalg.py
+++ b/python/mxnet/numpy/fallback_linalg.py
@@ -23,14 +23,16 @@ import numpy as onp
 
 __all__ = [
     'cond',
-    'qr',
+    'lstsq',
     'matrix_power',
     'matrix_rank',
     'multi_dot',
+    'qr',
 ]
 
 cond = onp.linalg.cond
-qr = onp.linalg.qr
+lstsq = onp.linalg.lstsq
 matrix_power = onp.linalg.matrix_power
 matrix_rank = onp.linalg.matrix_rank
 multi_dot = onp.linalg.multi_dot
+qr = onp.linalg.qr

--- a/python/mxnet/numpy/fallback_linalg.py
+++ b/python/mxnet/numpy/fallback_linalg.py
@@ -23,16 +23,16 @@ import numpy as onp
 
 __all__ = [
     'cond',
-    # 'lstsq',
-    # 'matrix_power',
-    # 'matrix_rank',
-    # 'multi_dot',
-    # 'qr',
+    'lstsq',
+    'matrix_power',
+    'matrix_rank',
+    'multi_dot',
+    'qr',
 ]
 
 cond = onp.linalg.cond
-# lstsq = onp.linalg.lstsq
-# matrix_power = onp.linalg.matrix_power
-# matrix_rank = onp.linalg.matrix_rank
-# multi_dot = onp.linalg.multi_dot
-# qr = onp.linalg.qr
+lstsq = onp.linalg.lstsq
+matrix_power = onp.linalg.matrix_power
+matrix_rank = onp.linalg.matrix_rank
+multi_dot = onp.linalg.multi_dot
+qr = onp.linalg.qr

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -135,6 +135,8 @@ def _reshape_view(a, *shape):  # pylint: disable=redefined-outer-name
 def _as_mx_np_array(object, ctx=None):
     """Convert object to mxnet.numpy.ndarray."""
     if isinstance(object, _np.ndarray):
+        if not object.flags['C_CONTIGUOUS']:
+            object = _np.ascontiguousarray(object, dtype=object.dtype)
         ret = from_numpy(object, array_cls=ndarray)
         return ret if ctx is None else ret.as_in_ctx(ctx=ctx)
     elif isinstance(object, (integer_types, numeric_types)):

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -134,8 +134,10 @@ def _reshape_view(a, *shape):  # pylint: disable=redefined-outer-name
 
 def _as_mx_np_array(object, ctx=None):
     """Convert object to mxnet.numpy.ndarray."""
-    if isinstance(object, (_np.ndarray, integer_types, numeric_types)):
+    if isinstance(object, _np.ndarray):
         return array(object, dtype=object.dtype, ctx=ctx)
+    elif isinstance(object, (integer_types, numeric_types)):
+        return object
     elif isinstance(object, (list, tuple)):
         tmp = [_as_mx_np_array(arr) for arr in object]
         return object.__class__(tmp)

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -46,7 +46,7 @@ from ..ndarray.ndarray import _storage_type, from_numpy
 from .utils import _get_np_op
 from .fallback import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from . import fallback
-import pdb
+
 
 __all__ = ['ndarray', 'empty', 'empty_like', 'array', 'shape',
            'zeros', 'zeros_like', 'ones', 'ones_like', 'full', 'full_like', 'broadcast_to',
@@ -257,8 +257,6 @@ class ndarray(NDArray):
             mx_ufunc = _NUMPY_ARRAY_UFUNC_DICT.get(name, None)
             if mx_ufunc is None:
                 # try to fallback to official NumPy op
-                # print(name)
-                # pdb.set_trace()
                 onp_op = _get_np_op(name)
                 new_inputs = [arg.asnumpy() if isinstance(arg, ndarray) else arg for arg in inputs]
                 out = onp_op(*new_inputs, **kwargs)
@@ -277,9 +275,7 @@ class ndarray(NDArray):
         mx_np_func = _NUMPY_ARRAY_FUNCTION_DICT.get(func, None)
         if mx_np_func is None:
             # try to fallback to official NumPy op
-            # print(type(args), args, func)
             new_args, cur_ctx = _as_onp_array(args)
-            # print(new_args)
             if cur_ctx is None:
                 raise ValueError('Unknown context for the input ndarrays. It is probably a bug. Please'
                                  ' create an issue on GitHub.')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -1146,7 +1146,7 @@ class ndarray(NDArray):
         check_call(_LIB.MXNDArrayDetach(self.handle, ctypes.byref(hdl)))
         return _np_ndarray_cls(hdl)
 
-    def astype(self, dtype, **kwargs):  # pylint: disable=arguments-differ,unused-argument
+    def astype(self, dtype, order='K', casting='unsafe', subok=True, copy=True):  # pylint: disable=arguments-differ,unused-argument
         """
         Copy of the array, cast to a specified type.
 
@@ -1154,6 +1154,26 @@ class ndarray(NDArray):
         ----------
         dtype : str or dtype
             Typecode or data-type to which the array is cast.
+        order : {'C', 'F', 'A', 'K'}, optional
+            Controls the memory layout order of the result.
+            'C' means C order, 'F' means Fortran order, 'A'
+            means 'F' order if all the arrays are Fortran contiguous,
+            'C' order otherwise, and 'K' means as close to the
+            order the array elements appear in memory as possible.
+            Default is 'K'.
+        casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
+            Controls what kind of data casting may occur. Defaults to 'unsafe'
+            for backwards compatibility.
+
+              * 'no' means the data types should not be cast at all.
+              * 'equiv' means only byte-order changes are allowed.
+              * 'safe' means only casts which can preserve values are allowed.
+              * 'same_kind' means only safe casts or casts within a kind,
+                like float64 to float32, are allowed.
+              * 'unsafe' means any data conversions may be done.
+        subok : bool, optional
+            If True, then sub-classes will be passed-through (default), otherwise
+            the returned array will be forced to be a base-class array.
         copy : bool, optional
             Default `True`. By default, astype always returns a newly
             allocated ndarray on the same context. If this is set to
@@ -1166,9 +1186,21 @@ class ndarray(NDArray):
             Unless `copy` is False and the other conditions for returning the input
             array are satisfied (see description for `copy` input parameter), `arr_t`
             is a new array of the same shape as the input array with `dtype`.
+
+        Notes
+        -----
+        This function differs from the official `ndarray`'s ``astype`` function in the following
+        aspects:
+            - `order` only supports 'C' and 'K'.
+            - `casting` only supports 'unsafe'.
+            - `subok` only supports ``True``.
         """
-        _sanity_check_params('astype', ['order', 'casting', 'subok'], kwargs)
-        copy = kwargs.get('copy', True)
+        if order is not None and order != 'K' and order != 'C':
+            raise ValueError('order must be either \'K\' or \'C\'')
+        if casting != 'unsafe':
+            raise ValueError('casting must be equal to \'unsafe\'')
+        if not subok:
+            raise ValueError('subok must be equal to True')
         if not copy and _np.dtype(dtype) == self.dtype:
             return self
 

--- a/python/mxnet/numpy/utils.py
+++ b/python/mxnet/numpy/utils.py
@@ -23,7 +23,7 @@ import numpy as onp
 
 __all__ = ['float16', 'float32', 'float64', 'uint8', 'int32', 'int8', 'int64',
            'bool', 'bool_', 'pi', 'inf', 'nan', 'PZERO', 'NZERO', 'newaxis', 'finfo',
-           'e', 'NINF', 'PINF',
+           'e', 'NINF', 'PINF', 'NAN', 'NaN',
            '_STR_2_DTYPE_']
 
 float16 = onp.float16
@@ -44,6 +44,8 @@ NZERO = onp.NZERO
 NINF = onp.NINF
 PINF = onp.PINF
 e = onp.e
+NAN = onp.NAN
+NaN = onp.NaN
 
 newaxis = None
 finfo = onp.finfo

--- a/python/mxnet/numpy/utils.py
+++ b/python/mxnet/numpy/utils.py
@@ -23,6 +23,7 @@ import numpy as onp
 
 __all__ = ['float16', 'float32', 'float64', 'uint8', 'int32', 'int8', 'int64',
            'bool', 'bool_', 'pi', 'inf', 'nan', 'PZERO', 'NZERO', 'newaxis', 'finfo',
+           'e', 'NINF', 'PINF',
            '_STR_2_DTYPE_']
 
 float16 = onp.float16
@@ -40,6 +41,9 @@ inf = onp.inf
 nan = onp.nan
 PZERO = onp.PZERO
 NZERO = onp.NZERO
+NINF = onp.NINF
+PINF = onp.PINF
+e = onp.e
 
 newaxis = None
 finfo = onp.finfo

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -4591,7 +4591,7 @@ def ravel(x, order='C'):
     This function differs from the original numpy.arange in the following aspects:
         - Only support row-major, C-style order.
     """
-    if order != 'C':
+    if order == 'F':
         raise NotImplementedError('order {} is not supported'.format(order))
     if isinstance(x, numeric_types):
         return _np.reshape(x, -1)

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -296,7 +296,7 @@ class _Symbol(Symbol):
         return self.transpose()
     # pylint: enable= invalid-name, undefined-variable
 
-    def astype(self, dtype, **kwargs):  # pylint: disable=arguments-differ,unused-argument
+    def astype(self, dtype, order='K', casting='unsafe', subok=True, copy=True):  # pylint: disable=arguments-differ,unused-argument
         """
         Copy of the array, cast to a specified type.
 
@@ -304,6 +304,26 @@ class _Symbol(Symbol):
         ----------
         dtype : str or dtype
             Typecode or data-type to which the array is cast.
+        order : {'C', 'F', 'A', 'K'}, optional
+            Controls the memory layout order of the result.
+            'C' means C order, 'F' means Fortran order, 'A'
+            means 'F' order if all the arrays are Fortran contiguous,
+            'C' order otherwise, and 'K' means as close to the
+            order the array elements appear in memory as possible.
+            Default is 'K'.
+        casting : {'no', 'equiv', 'safe', 'same_kind', 'unsafe'}, optional
+            Controls what kind of data casting may occur. Defaults to 'unsafe'
+            for backwards compatibility.
+
+              * 'no' means the data types should not be cast at all.
+              * 'equiv' means only byte-order changes are allowed.
+              * 'safe' means only casts which can preserve values are allowed.
+              * 'same_kind' means only safe casts or casts within a kind,
+                like float64 to float32, are allowed.
+              * 'unsafe' means any data conversions may be done.
+        subok : bool, optional
+            If True, then sub-classes will be passed-through (default), otherwise
+            the returned array will be forced to be a base-class array.
         copy : bool, optional
             Default `True`. By default, astype always returns a newly
             allocated ndarray on the same context. If this is set to
@@ -316,8 +336,21 @@ class _Symbol(Symbol):
             Unless `copy` is False and the other conditions for returning the input
             array are satisfied (see description for `copy` input parameter), `arr_t`
             is a new array of the same shape as the input array with `dtype`.
+
+        Notes
+        -----
+        This function differs from the official `ndarray`'s ``astype`` function in the following
+        aspects:
+            - `order` only supports 'C' and 'K'.
+            - `casting` only supports 'unsafe'.
+            - `subok` only supports ``True``.
         """
-        _sanity_check_params('astype', ['order', 'casting', 'subok'], kwargs)
+        if order is not None and order != 'K' and order != 'C':
+            raise ValueError('order must be either \'K\' or \'C\'')
+        if casting != 'unsafe':
+            raise ValueError('casting must be equal to \'unsafe\'')
+        if not subok:
+            raise ValueError('subok must be equal to True')
         return _npi.cast(self, dtype=dtype)
 
     def dot(self, b, out=None):

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -296,7 +296,7 @@ class _Symbol(Symbol):
         return self.transpose()
     # pylint: enable= invalid-name, undefined-variable
 
-    def astype(self, dtype, order='K', casting='unsafe', subok=True, copy=True):  # pylint: disable=arguments-differ,unused-argument
+    def astype(self, dtype, order='K', casting='unsafe', subok=True, copy=True):  # pylint: disable=arguments-differ,unused-argument,too-many-arguments
         """
         Copy of the array, cast to a specified type.
 

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -277,7 +277,6 @@ def use_np_shape(func):
         A function or class wrapped in the NumPy-shape scope.
     """
 
-    # print(func,'-------------------------')
     if inspect.isclass(func):
         for name, method in inspect.getmembers(
                 func,
@@ -462,7 +461,6 @@ def use_np_array(func):
     Function or class
         A function or class wrapped in the NumPy-array scope.
     """
-    # print(func,'+++++++++++++++++++++++')
     if inspect.isclass(func):
         for name, method in inspect.getmembers(
                 func,

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -277,6 +277,7 @@ def use_np_shape(func):
         A function or class wrapped in the NumPy-shape scope.
     """
 
+    # print(func,'-------------------------')
     if inspect.isclass(func):
         for name, method in inspect.getmembers(
                 func,
@@ -461,6 +462,7 @@ def use_np_array(func):
     Function or class
         A function or class wrapped in the NumPy-array scope.
     """
+    # print(func,'+++++++++++++++++++++++')
     if inspect.isclass(func):
         for name, method in inspect.getmembers(
                 func,

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -2094,9 +2094,9 @@ def _add_workload_choose():
 
 def _add_workload_compress():
     a = np.array([[1, 2], [3, 4], [5, 6]])
-    b = [0, 1]
-    c = [False, True, True]
-    d = [False, True]
+    b = np.array([0, 1])
+    c = np.array([False, True, True])
+    d = np.array([False, True])
     OpArgMngr.add_workload('compress', b, a, axis=0)
     OpArgMngr.add_workload('compress', c, a, axis=0)
     OpArgMngr.add_workload('compress', d, a, axis=1)
@@ -2147,17 +2147,6 @@ def _add_workload_cov():
     OpArgMngr.add_workload('cov', y, rowvar=False, bias=True)
 
 
-def _add_workload_cross():
-    a = np.array([1, 2])
-    b = np.array([3, 4, 5])
-    c = np.array([4, 5, 6])
-    u = np.ones((10, 3, 5))
-    v = np.ones((2, 5))
-    OpArgMngr.add_workload('cross', a, b)
-    OpArgMngr.add_workload('cross', b, c)
-    OpArgMngr.add_workload('cross', u, v, axisa=1, axisb=0)
-
-
 def _add_workload_digitize():
     a = np.array([1, 2, 3, 4])
     b = np.array([1, 3])
@@ -2173,38 +2162,12 @@ def _add_workload_divmod():
     OpArgMngr.add_workload('divmod', a, 3)
 
 
-def _add_workload_ediff1d():
-    zero_elem = np.array([])
-    one_elem = np.array([1])
-    two_elem = np.array([1, 2])
-    OpArgMngr.add_workload('ediff1d', zero_elem)
-    OpArgMngr.add_workload('ediff1d', one_elem)
-    OpArgMngr.add_workload('ediff1d', two_elem)
-    OpArgMngr.add_workload('ediff1d', zero_elem, to_begin=-1, to_end=0)
-    OpArgMngr.add_workload('ediff1d', two_elem, to_begin=[5,6], to_end=[7,8])
-    OpArgMngr.add_workload('ediff1d', two_elem, to_end=9)
-
-
 def _add_workload_extract():
     arr = np.arange(12).reshape((3, 4))
-    condition = np.mod(arr, 3)==0
+    condition = np.array([[ True, False, False,  True],  # np.mod(arr, 3)==0
+                          [False, False,  True, False],
+                          [False,  True, False, False]])
     OpArgMngr.add_workload('extract', condition, arr)
-
-
-def _add_workload_fabs():
-    a = -1
-    b = np.array([-1.2, 1.2])
-    OpArgMngr.add_workload('fabs', a)
-    OpArgMngr.add_workload('fabs', b)
-
-
-# def _add_workload_fill_diagonal():
-#     a = np.zeros((3, 3), int)
-#     b = np.zeros((10, 3), int)
-#     c = np.zeros((3, 3, 3, 3), int)
-#     OpArgMngr.add_workload('fill_diagonal', a, 5)
-#     OpArgMngr.add_workload('fill_diagonal', b, 5)
-#     OpArgMngr.add_workload('fill_diagonal', c, 4)
 
 
 def _add_workload_flatnonzero():
@@ -2221,50 +2184,9 @@ def _add_workload_float_power():
     OpArgMngr.add_workload('float_power', x1, x3)
 
 
-def _add_workload_fmod():
-    a = np.array([-3, -2, -1, 1, 2, 3])
-    b = np.array([5, 3])
-    c = np.array([2, 2.])
-    d = np.arange(-3, 3).reshape(3, 2)
-    OpArgMngr.add_workload('fmod', a, 2)
-    OpArgMngr.add_workload('fmod', b, c)
-    OpArgMngr.add_workload('fmod', d, c)
-
-
 def _add_workload_frexp():
     x = np.arange(9)
     OpArgMngr.add_workload('frexp', x)
-
-
-def _add_workload_geomspace():
-    OpArgMngr.add_workload('geomspace', 1, 1000, num=4)
-    # OpArgMngr.add_workload('geomspace', 1, 1000, num=3, endpoint=False)
-    # OpArgMngr.add_workload('geomspace', -1000, -1, num=4)
-    # OpArgMngr.add_workload('geomspace', 1, 256, num=9, dtype=int)
-
-
-def _add_workload_fmax():
-    a = np.array([2, 3, 4])
-    b = np.array([1, 5, 2])
-    c = np.eye(2)
-    d = np.array([0.5, 2])
-    e = np.array([np.nan, 0, np.nan])
-    f = np.array([0, np.nan, np.nan])
-    OpArgMngr.add_workload('fmax', a, b)
-    OpArgMngr.add_workload('fmax', c, d)
-    OpArgMngr.add_workload('fmax', e, f)
-
-
-def _add_workload_fmin():
-    a = np.array([2, 3, 4])
-    b = np.array([1, 5, 2])
-    c = np.eye(2)
-    d = np.array([0.5, 2])
-    e = np.array([np.nan, 0, np.nan])
-    f = np.array([0, np.nan, np.nan])
-    OpArgMngr.add_workload('fmin', a, b)
-    OpArgMngr.add_workload('fmin', c, d)
-    OpArgMngr.add_workload('fmin', e, f)
 
 
 def _add_workload_histogram2d():
@@ -2493,12 +2415,8 @@ def _add_workload_ndim():
     OpArgMngr.add_workload('ndim', b)
 
 
-# def _add_workload_nper():
-#     OpArgMngr.add_workload('nper', 0.075, -2000, 0, 100000.)
-
-
 def _add_workload_npv():
-    rate, cashflows = 0.08, np.array([-40_000, 5_000, 8_000, 12_000, 30_000])
+    rate, cashflows = 0.281, np.array([-100, 39, 59, 55, 20])
     OpArgMngr.add_workload('npv', rate, cashflows)
 
 
@@ -2513,7 +2431,8 @@ def _add_workload_piecewise():
     b = np.array([1, 0])
     c = np.array([1])
     x = np.linspace(-2.5, 2.5, 6)
-    y = np.array([x < 0, x >= 0])
+    y = np.array([[ True,  True,  True, False, False, False],
+                  [False, False, False,  True,  True,  True]])
     z = np.array([-1, 1])
     OpArgMngr.add_workload('piecewise', a, b, c)
     OpArgMngr.add_workload('piecewise', x, y, z)
@@ -2527,16 +2446,6 @@ def _add_workload_packbits():
     OpArgMngr.add_workload('packbits', a, bitorder='little')
 
 
-# def _add_workload_place():
-#     a = np.array([1, 4, 3, 2, 5, 8, 7])
-#     b = np.array([0, 1, 0, 1, 0, 1, 0])
-#     c = np.array([2, 4, 6])
-#     d = np.zeros(7)
-#     e = np.array([])
-#     OpArgMngr.add_workload('place', a, b, c)
-#     OpArgMngr.add_workload('place', a, d, e)
-
-
 def _add_workload_poly():
     a = np.array([3, -np.sqrt(2), np.sqrt(2)])
     b = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 0]])
@@ -2548,9 +2457,6 @@ def _add_workload_polyadd():
     a = np.array([1, 2])
     b = np.array([9, 5, 4])
     OpArgMngr.add_workload('polyadd', a, b)
-
-
-# def _add_workload_polyder():
 
 
 def _add_workload_polydiv():
@@ -2589,10 +2495,6 @@ def _add_workload_positive(array_pool):
 
 def _add_workload_ppmt():
     OpArgMngr.add_workload('ppmt', 0.1 / 12, 1, 60, 55000)
-
-
-def _add_workload_product(array_pool):
-    OpArgMngr.add_workload('product', array_pool['4x1'])
 
 
 def _add_workload_promote_types():
@@ -2648,10 +2550,6 @@ def _add_workload_roots():
     OpArgMngr.add_workload('roots', a)
 
 
-def _add_workload_round_():
-    OpArgMngr.add_workload('round_', np.array([1.56, 72.54, 6.35, 3.25]), decimals=1)
-
-
 def _add_workload_searchsorted():
     a = np.array([1,2,3,4,5])
     b = np.array([-10, 10, 2, 3])
@@ -2662,8 +2560,12 @@ def _add_workload_searchsorted():
 
 def _add_workload_select():
     x = np.arange(10)
-    condlist = np.array([x<3, x>5], dtype = np.bool)
-    choicelist = np.array([x, x**2], dtype = np.bool)
+    condlist = np.array([[ True,  True,  True, False, False,
+                           False, False, False, False, False],
+                         [ False, False, False, False, False,
+                           False,  True,  True,  True, True]], dtype=np.bool)
+    choicelist = np.array([[ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9],
+                           [ 0,  1,  4,  9, 16, 25, 36, 49, 64, 81]])
     OpArgMngr.add_workload('select', condlist, choicelist)
 
 
@@ -2691,19 +2593,6 @@ def _add_workload_size():
     OpArgMngr.add_workload('size', a)
     OpArgMngr.add_workload('size', a, 1)
     OpArgMngr.add_workload('size', a, 0)
-
-
-def _add_workload_sometrue():
-    # check bad element in all positions
-    for i in range(256-7):
-        d = np.array([False] * 256, dtype=bool)[7::]
-        d[i] = True
-        OpArgMngr.add_workload('any', d)
-    # big array test for blocked libc loops
-    for i in list(range(9, 6000, 507)) + [7764, 90021, -10]:
-        d = np.array([False] * 100043, dtype=bool)
-        d[i] = True
-        OpArgMngr.add_workload('sometrue', d)
 
 
 def _add_workload_take_along_axis():
@@ -2737,11 +2626,6 @@ def _add_workload_trim_zeros():
     a = np.array((0, 0, 0, 1, 2, 3, 0, 2, 1, 0))
     OpArgMngr.add_workload('trim_zeros', a)
     OpArgMngr.add_workload('trim_zeros', a, 'b')
-
-
-def _add_workload_triu():
-    a  =np.array([[1,2,3],[4,5,6],[7,8,9],[10,11,12]])
-    OpArgMngr.add_workload('triu', a, -1)
 
 
 def _add_workload_triu_indices_from():
@@ -2967,20 +2851,12 @@ def _prepare_workloads():
     _add_workload_correlate()
     _add_workload_count_nonzero()
     _add_workload_cov()
-    _add_workload_cross()
     _add_workload_digitize()
     _add_workload_divmod()
-    _add_workload_ediff1d()
     _add_workload_extract()
-    _add_workload_fabs()
-    # _add_workload_fill_diagonal()
     _add_workload_flatnonzero()
     _add_workload_float_power()
-    _add_workload_fmod()
     _add_workload_frexp()
-    _add_workload_geomspace()
-    _add_workload_fmax()
-    _add_workload_fmin()
     _add_workload_histogram2d()
     _add_workload_histogram_bin_edges()
     _add_workload_histogramdd()
@@ -3007,15 +2883,12 @@ def _prepare_workloads():
     _add_workload_nanprod()
     _add_workload_nanquantile()
     _add_workload_ndim()
-    # _add_workload_nper()
     _add_workload_npv()
     _add_workload_partition()
     _add_workload_piecewise()
     _add_workload_packbits()
-    # _add_workload_place()
     _add_workload_poly()
     _add_workload_polyadd()
-    # _add_workload_polyder()
     _add_workload_polydiv()
     _add_workload_polyfit()
     _add_workload_polyint()
@@ -3023,34 +2896,25 @@ def _prepare_workloads():
     _add_workload_polysub()
     _add_workload_positive(array_pool)
     _add_workload_ppmt()
-    _add_workload_product(array_pool)
     _add_workload_promote_types()
     _add_workload_ptp()
-    # _add_workload_put()
-    # _add_workload_put_along_axis()
-    # _add_workload_putmask()
     _add_workload_pv()
     _add_workload_rate()
-    # _add_workload_ravel_multi_index()
     _add_workload_real()
     _add_workload_real_if_close()
     _add_workload_result_type()
     _add_workload_rollaxis()
     _add_workload_roots()
-    _add_workload_round_()
-    # _add_workload_safe_eval()
     _add_workload_searchsorted()
     _add_workload_select()
     _add_workload_setdiff1d()
     _add_workload_setxor1d()
     _add_workload_signbit()
     _add_workload_size()
-    _add_workload_sometrue()
     _add_workload_take_along_axis()
     _add_workload_trapz()
     _add_workload_tril_indices_from()
     _add_workload_trim_zeros()
-    _add_workload_triu()
     _add_workload_triu_indices_from()
     _add_workload_union1d()
     _add_workload_unpackbits()

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -2086,14 +2086,10 @@ def _add_workload_array_equiv():
     OpArgMngr.add_workload('array_equiv', a, g)
 
 
-# def _add_workload_choose():
-#     x = 2*np.ones((3,), dtype=int)
-#     y = 3*np.ones((3,), dtype=int)
-#     x2 = 2*np.ones((2, 3), dtype=int)
-#     y2 = 3*np.ones((2, 3), dtype=int)
-#     OpArgMngr.add_workload('choose', x, y)
-#     OpArgMngr.add_workload('choose', x2, y2)
-#     OpArgMngr.add_workload('choose', x, y2)
+def _add_workload_choose():
+    a = np.array([[1, 0, 1], [0, 1, 0], [1, 0, 1]], dtype=np.int64)
+    choices = np.array([-10, 10])
+    OpArgMngr.add_workload('choose', a, choices)
 
 
 def _add_workload_compress():
@@ -2334,17 +2330,6 @@ def _add_workload_interp():
     OpArgMngr.add_workload('interp', x, xp, fp)
 
 
-def _add_workload_isneginf():
-    a = np.NINF
-    b = np.inf
-    c = np.PINF
-    d = np.array([-np.inf, 0., np.inf])
-    OpArgMngr.add_workload('isneginf', a)
-    OpArgMngr.add_workload('isneginf', b)
-    OpArgMngr.add_workload('isneginf', c)
-    OpArgMngr.add_workload('isneginf', d)
-
-
 def _add_workload_intersect1d():
     a = np.array([5, 7, 1, 2])
     b = np.array([2, 4, 3, 1, 5])
@@ -2369,16 +2354,6 @@ def _add_workload_isclose():
     OpArgMngr.add_workload('isclose', d, e, atol=0.0)
 
 
-def _add_workload_isfinite():
-    x = np.array([np.log(-1.),1.,np.log(0)])
-    OpArgMngr.add_workload('isfinite', 1)
-    OpArgMngr.add_workload('isfinite', 0)
-    OpArgMngr.add_workload('isfinite', np.nan)
-    OpArgMngr.add_workload('isfinite', np.inf)
-    OpArgMngr.add_workload('isfinite', np.NINF)
-    OpArgMngr.add_workload('isfinite', x)
-
-
 def _add_workload_isin():
     element = 2*np.arange(4).reshape((2, 2))
     test_elements = [1, 2, 4, 8]
@@ -2386,17 +2361,6 @@ def _add_workload_isin():
     OpArgMngr.add_workload('isin', element, test_elements)
     OpArgMngr.add_workload('isin', element, test_elements, invert=True)
     OpArgMngr.add_workload('isin', element, list(test_set))
-
-
-def _add_workload_isposinf():
-    a = np.NINF
-    b = np.inf
-    c = np.PINF
-    d = np.array([-np.inf, 0., np.inf])
-    OpArgMngr.add_workload('isposinf', a)
-    OpArgMngr.add_workload('isposinf', b)
-    OpArgMngr.add_workload('isposinf', c)
-    OpArgMngr.add_workload('isposinf', d)
 
 
 def _add_workload_ix_():
@@ -2641,14 +2605,6 @@ def _add_workload_ptp():
     OpArgMngr.add_workload('ptp', x, axis=0)
     OpArgMngr.add_workload('ptp', x, axis=1)
     OpArgMngr.add_workload('ptp', x, keepdims=True)
-
-
-# def _add_workload_put():
-#     a = np.arange(5)
-#     b = np.array([0, 2])
-#     c = np.array([-44, -55])
-#     OpArgMngr.add_workload('put', a, b, c) # TypeError: Cannot cast array data from dtype('float32') to dtype('int64') according to the rule 'safe'
-#     OpArgMngr.add_workload('put', a, 22, -5, mode='clip') # TypeError: Does not support converting <class 'NoneType'> to mx.np.ndarray.
 
 
 def _add_workload_pv():
@@ -3005,7 +2961,7 @@ def _prepare_workloads():
     _add_workload_argwhere()
     _add_workload_array_equal()
     _add_workload_array_equiv()
-    # _add_workload_choose()
+    _add_workload_choose()
     _add_workload_compress()
     _add_workload_corrcoef()
     _add_workload_correlate()
@@ -3031,12 +2987,9 @@ def _prepare_workloads():
     _add_workload_i0()
     _add_workload_in1d()
     _add_workload_interp()
-    _add_workload_isneginf()
     _add_workload_intersect1d()
     _add_workload_isclose()
-    _add_workload_isfinite()
     _add_workload_isin()
-    _add_workload_isposinf()
     _add_workload_ix_()
     _add_workload_lexsort()
     _add_workload_min_scalar_type()

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -1996,6 +1996,21 @@ def _add_workload_apply_along_axis():
     OpArgMngr.add_workload('apply_along_axis', double, 1, m)
 
 
+def _add_workload_apply_over_axes():
+    a = np.arange(24).reshape(2, 3, 4)
+    OpArgMngr.add_workload('apply_over_axes', _np.sum, a, [0, 2])
+
+
+def _add_workload_argpartition():
+    # TODO: move more test cases from numpy to here
+    OpArgMngr.add_workload('argpartition', np.array([]), 0, kind='introselect')
+    OpArgMngr.add_workload('argpartition', np.ones(1), 0, kind='introselect')
+    for r in ([2, 1], [1, 2], [1, 1], [3, 2, 1], [1, 2, 3], [2, 1, 3], [2, 3, 1],
+              [1, 1, 1], [1, 2, 2], [2, 2, 1], [1, 2, 1]):
+        d = np.array(r)
+        OpArgMngr.add_workload('argpartition', d, 0, kind='introselect')
+
+
 @use_np
 def _prepare_workloads():
     array_pool = {
@@ -2168,6 +2183,8 @@ def _prepare_workloads():
     _add_workload_allclose()
     _add_workload_alltrue()
     _add_workload_apply_along_axis()
+    _add_workload_apply_over_axes()
+    _add_workload_argpartition()
 
 
 _prepare_workloads()

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -1950,6 +1950,43 @@ def _add_workload_linalg_cond():
     OpArgMngr.add_workload('linalg.cond', A, 'fro')
 
 
+def _add_workload_linalg_lstsq():
+    y = np.array([-1, 0.2, 0.9, 2.1])
+    A = np.array([[ 0.,  1.],
+                  [ 1.,  1.],
+                  [ 2.,  1.],
+                  [ 3.,  1.]])
+    OpArgMngr.add_workload('linalg.lstsq', A, y, rcond=None)
+
+
+def _add_workload_linalg_matrix_power():
+    i = np.array([[0, 1], [-1, 0]])
+    OpArgMngr.add_workload('linalg.matrix_power', i, 3)
+
+
+def _add_workload_linalg_matrix_rank():
+    a = np.eye(4)
+    b = a; b[-1,-1] = 0
+    c = np.ones((4,))
+    OpArgMngr.add_workload('linalg.matrix_rank', a)
+    OpArgMngr.add_workload('linalg.matrix_rank', b)
+    OpArgMngr.add_workload('linalg.matrix_rank', c)
+
+
+def _add_workload_linalg_multi_dot():
+    E = np.ones((4,6,6))
+    F = np.ones((6,6))
+    OpArgMngr.add_workload('linalg.multi_dot', E)
+    OpArgMngr.add_workload('linalg.multi_dot', [F,F])
+
+
+
+def _add_workload_linalg_qr():
+    A = np.array([[0, 1], [1, 1], [1, 1], [2, 1]])
+    OpArgMngr.add_workload('linalg.qr', A)
+    OpArgMngr.add_workload('linalg.qr', A, mode='r')
+
+
 def _add_workload_heaviside():
     x = np.array([[-30.0, -0.1, 0.0, 0.2], [7.5, np.nan, np.inf, -np.inf]], dtype=np.float64)
     OpArgMngr.add_workload('heaviside', x, 0.5)
@@ -1972,7 +2009,10 @@ def _add_workload_spacing():
 def _add_workload_allclose():
     a = np.random.randn(10)
     b = a + np.random.rand(10) * 1e-6
+    c = [1e10,1e-7]
+    d = [1.00001e10,1e10,1e-7]
     OpArgMngr.add_workload('allclose', a, b)
+    # OpArgMngr.add_workload('allclose', c, d)
 
 
 def _add_workload_alltrue():
@@ -2111,6 +2151,678 @@ def _add_workload_cov():
     OpArgMngr.add_workload('cov', y, rowvar=False, bias=True)
 
 
+def _add_workload_cross():
+    a = np.array([1, 2])
+    b = np.array([3, 4, 5])
+    c = np.array([4, 5, 6])
+    u = np.ones((10, 3, 5))
+    v = np.ones((2, 5))
+    OpArgMngr.add_workload('cross', a, b)
+    OpArgMngr.add_workload('cross', b, c)
+    OpArgMngr.add_workload('cross', u, v, axisa=1, axisb=0)
+
+
+def _add_workload_digitize():
+    a = np.array([1, 2, 3, 4])
+    b = np.array([1, 3])
+    c = np.array([0, 1, 2, 3, 4])
+    e = [1, 3]
+    OpArgMngr.add_workload('digitize', a, b)
+    OpArgMngr.add_workload('digitize', b, c)
+    OpArgMngr.add_workload('digitize', a, e)
+
+
+def _add_workload_divmod():
+    a = [0., 1., 2., 3., 4.]
+    OpArgMngr.add_workload('divmod', a, 3)
+
+
+def _add_workload_ediff1d():
+    zero_elem = np.array([])
+    one_elem = np.array([1])
+    two_elem = np.array([1, 2])
+    OpArgMngr.add_workload('ediff1d', zero_elem)
+    OpArgMngr.add_workload('ediff1d', one_elem)
+    OpArgMngr.add_workload('ediff1d', two_elem)
+    OpArgMngr.add_workload('ediff1d', zero_elem, to_begin=-1, to_end=0)
+    OpArgMngr.add_workload('ediff1d', two_elem, to_begin=[5,6], to_end=[7,8])
+    OpArgMngr.add_workload('ediff1d', two_elem, to_end=9)
+
+
+def _add_workload_extract():
+    arr = np.arange(12).reshape((3, 4))
+    condition = np.mod(arr, 3)==0
+    OpArgMngr.add_workload('extract', condition, arr)
+
+
+def _add_workload_fabs():
+    a = -1
+    b = np.array([-1.2, 1.2])
+    OpArgMngr.add_workload('fabs', a)
+    OpArgMngr.add_workload('fabs', b)
+
+
+# def _add_workload_fill_diagonal():
+#     a = np.zeros((3, 3), int)
+#     b = np.zeros((10, 3), int)
+#     c = np.zeros((3, 3, 3, 3), int)
+#     OpArgMngr.add_workload('fill_diagonal', a, 5)
+#     OpArgMngr.add_workload('fill_diagonal', b, 5)
+#     OpArgMngr.add_workload('fill_diagonal', c, 4)
+
+
+def _add_workload_flatnonzero():
+    x = np.array([-2, -1,  0,  1,  2])
+    OpArgMngr.add_workload('flatnonzero', x)
+
+
+def _add_workload_float_power():
+    x1 = np.array([1, 2, 3, 4, 5, 6])
+    x2 = np.array([1.0, 2.0, 3.0, 3.0, 2.0, 1.0])
+    x3 = np.array([[1, 2, 3, 3, 2, 1], [1, 2, 3, 3, 2, 1]])
+    OpArgMngr.add_workload('float_power', x1, 3)
+    OpArgMngr.add_workload('float_power', x1, x2)
+    OpArgMngr.add_workload('float_power', x1, x3)
+
+
+def _add_workload_fmod():
+    a = np.array([-3, -2, -1, 1, 2, 3])
+    b = np.array([5, 3])
+    c = np.array([2, 2.])
+    d = np.arange(-3, 3).reshape(3, 2)
+    OpArgMngr.add_workload('fmod', a, 2)
+    OpArgMngr.add_workload('fmod', b, c)
+    OpArgMngr.add_workload('fmod', d, c)
+
+
+def _add_workload_frexp():
+    x = np.arange(9)
+    OpArgMngr.add_workload('frexp', x)
+
+
+def _add_workload_geomspace():
+    OpArgMngr.add_workload('geomspace', 1, 1000, num=4)
+    # OpArgMngr.add_workload('geomspace', 1, 1000, num=3, endpoint=False)
+    # OpArgMngr.add_workload('geomspace', -1000, -1, num=4)
+    # OpArgMngr.add_workload('geomspace', 1, 256, num=9, dtype=int)
+
+
+def _add_workload_fmax():
+    a = np.array([2, 3, 4])
+    b = np.array([1, 5, 2])
+    c = np.eye(2)
+    d = np.array([0.5, 2])
+    e = np.array([np.nan, 0, np.nan])
+    f = np.array([0, np.nan, np.nan])
+    OpArgMngr.add_workload('fmax', a, b)
+    OpArgMngr.add_workload('fmax', c, d)
+    OpArgMngr.add_workload('fmax', e, f)
+
+
+def _add_workload_fmin():
+    a = np.array([2, 3, 4])
+    b = np.array([1, 5, 2])
+    c = np.eye(2)
+    d = np.array([0.5, 2])
+    e = np.array([np.nan, 0, np.nan])
+    f = np.array([0, np.nan, np.nan])
+    OpArgMngr.add_workload('fmin', a, b)
+    OpArgMngr.add_workload('fmin', c, d)
+    OpArgMngr.add_workload('fmin', e, f)
+
+
+def _add_workload_histogram2d():
+    x = np.array([0.41702200, 0.72032449, 1.1437481e-4, 0.302332573, 0.146755891])
+    y = np.array([0.09233859, 0.18626021, 0.34556073, 0.39676747, 0.53881673])
+    xedges = np.linspace(0, 1, 10)
+    yedges = np.linspace(0, 1, 10)
+    OpArgMngr.add_workload('histogram2d', x, y, (xedges, yedges))
+    OpArgMngr.add_workload('histogram2d', x, y, xedges)
+    OpArgMngr.add_workload('histogram2d', list(range(10)), list(range(10)))
+
+
+def _add_workload_histogram_bin_edges():
+    a = [1, 2, 3, 4]
+    b = [1, 2]
+    arr = np.array([0.,  0.,  0.,  1.,  2.,  3.,  3.,  4.,  5.])
+    # OpArgMngr.add_workload('histogram_bin_edges', a, b)
+    OpArgMngr.add_workload('histogram_bin_edges', arr, bins=30, range=(-0.5, 5))
+    OpArgMngr.add_workload('histogram_bin_edges', arr, bins='auto', range=(0, 1))
+
+
+def _add_workload_histogramdd():
+    x = np.array([[-.5, .5, 1.5], [-.5, 1.5, 2.5], [-.5, 2.5, .5],
+                      [.5,  .5, 1.5], [.5,  1.5, 2.5], [.5,  2.5, 2.5]])
+    ed = [[-2, 0, 2], [0, 1, 2, 3], [0, 1, 2, 3]]
+    z = [np.squeeze(y) for y in np.split(x, 3, axis=1)]
+    OpArgMngr.add_workload('histogramdd', x, (2, 3, 3), range=[[-1, 1], [0, 3], [0, 3]])
+    OpArgMngr.add_workload('histogramdd', x, bins=ed, density=True)
+    OpArgMngr.add_workload('histogramdd', x, (2, 3, 4), range=[[-1, 1], [0, 3], [0, 4]],
+                                          density=True)
+    OpArgMngr.add_workload('histogramdd', z, bins=(4, 3, 2),
+                                          range=[[-2, 2], [0, 3], [0, 2]])
+
+
+def _add_workload_i0():
+    a = 0
+    b = np.array([2, 3, 4])
+    # OpArgMngr.add_workload('i0', a)
+    OpArgMngr.add_workload('i0', b)
+
+
+def _add_workload_in1d():
+    test = np.array([0, 1, 2, 5, 0])
+    states = [0, 2]
+    OpArgMngr.add_workload('in1d', test, states)
+    OpArgMngr.add_workload('in1d', test, states, invert=True)
+
+
+def _add_workload_interp():
+    x = np.linspace(0, 1, 5)
+    y = np.linspace(0, 1, 5)
+    x0 = np.linspace(0, 1, 50)
+    x1 = 0
+    x2 = .3
+    x3 = np.float32(.3)
+    OpArgMngr.add_workload('interp', x0, x, y)
+    OpArgMngr.add_workload('interp', x1, x, y)
+    OpArgMngr.add_workload('interp', x2, x, y)
+    OpArgMngr.add_workload('interp', x3, x, y)
+    x = np.array([1, 2, 2.5, 3, 4])
+    xp = np.array([1, 2, 3, 4])
+    fp = np.array([1, 2, np.inf, 4])
+    OpArgMngr.add_workload('interp', x, xp, fp)
+
+
+def _add_workload_isneginf():
+    a = np.NINF
+    b = np.inf
+    c = np.PINF
+    d = np.array([-np.inf, 0., np.inf])
+    OpArgMngr.add_workload('isneginf', a)
+    OpArgMngr.add_workload('isneginf', b)
+    OpArgMngr.add_workload('isneginf', c)
+    OpArgMngr.add_workload('isneginf', d)
+
+
+def _add_workload_intersect1d():
+    a = np.array([5, 7, 1, 2])
+    b = np.array([2, 4, 3, 1, 5])
+    c = np.array([[2, 4, 5, 6, 6], [4, 7, 8, 7, 2]])
+    d = np.array([[3, 2, 7, 7], [10, 12, 8, 7]])
+    OpArgMngr.add_workload('intersect1d', a, b, assume_unique=True)
+    OpArgMngr.add_workload('intersect1d', a, b)
+    OpArgMngr.add_workload('intersect1d', a, b, assume_unique=True,
+                                                return_indices=True)
+    OpArgMngr.add_workload('intersect1d', c, d)
+
+
+def _add_workload_isclose():
+    a = np.array([1e10,1e-7])
+    b = np.array([1.00001e10,1e-8])
+    c = np.array([1.0, np.nan])
+    d = np.array([0.0, 0.0])
+    e = np.array([1e-100, 1e-7])
+    OpArgMngr.add_workload('isclose', a, b)
+    OpArgMngr.add_workload('isclose', c, c)
+    OpArgMngr.add_workload('isclose', c, c, equal_nan=True)
+    OpArgMngr.add_workload('isclose', d, e, atol=0.0)
+
+
+def _add_workload_isfinite():
+    x = np.array([np.log(-1.),1.,np.log(0)])
+    OpArgMngr.add_workload('isfinite', 1)
+    OpArgMngr.add_workload('isfinite', 0)
+    OpArgMngr.add_workload('isfinite', np.nan)
+    OpArgMngr.add_workload('isfinite', np.inf)
+    OpArgMngr.add_workload('isfinite', np.NINF)
+    OpArgMngr.add_workload('isfinite', x)
+
+
+def _add_workload_isin():
+    element = 2*np.arange(4).reshape((2, 2))
+    test_elements = [1, 2, 4, 8]
+    test_set = {1, 2, 4, 8}
+    OpArgMngr.add_workload('isin', element, test_elements)
+    OpArgMngr.add_workload('isin', element, test_elements, invert=True)
+    OpArgMngr.add_workload('isin', element, list(test_set))
+
+
+def _add_workload_isposinf():
+    a = np.NINF
+    b = np.inf
+    c = np.PINF
+    d = np.array([-np.inf, 0., np.inf])
+    OpArgMngr.add_workload('isposinf', a)
+    OpArgMngr.add_workload('isposinf', b)
+    OpArgMngr.add_workload('isposinf', c)
+    OpArgMngr.add_workload('isposinf', d)
+
+
+def _add_workload_ix_():
+    a = np.array([0, 1])
+    b = np.array([True, True])
+    c = np.array([2, 4])
+    d = np.array([False, False, True, False, True])
+    OpArgMngr.add_workload('ix_', a, c)
+    OpArgMngr.add_workload('ix_', b, c)
+    OpArgMngr.add_workload('ix_', b, d)
+
+
+def _add_workload_lexsort():
+    a = np.array([1,5,1,4,3,4,4])
+    b = np.array([9,4,0,4,0,2,1])
+    OpArgMngr.add_workload('lexsort', (a, b))
+
+
+def _add_workload_min_scalar_type():
+    a = 10
+    OpArgMngr.add_workload('min_scalar_type', a)
+
+
+def _add_workload_mirr():
+    val = np.array([-4500, -800, 800, 800, 600, 600, 800, 800, 700, 3000])
+    OpArgMngr.add_workload('mirr', val, 0.08, 0.055)
+
+
+def _add_workload_modf():
+    a = np.array([0, 3.5])
+    b = -0.5
+    OpArgMngr.add_workload('modf', a)
+    OpArgMngr.add_workload('modf', b)
+
+
+def _add_workload_msort():
+    A = np.array([[0.44567325, 0.79115165, 0.54900530],
+                  [0.36844147, 0.37325583, 0.96098397],
+                  [0.64864341, 0.52929049, 0.39172155]])
+    OpArgMngr.add_workload('msort', A)
+
+
+def _add_workload_nanargmax():
+    a = np.array([[np.nan, 4], [2, 3]])
+    OpArgMngr.add_workload('nanargmax', a)
+    OpArgMngr.add_workload('nanargmax', a, axis=0)
+    OpArgMngr.add_workload('nanargmax', a, axis=1)
+
+
+def _add_workload_nanargmin():
+    a = np.array([[np.nan, 4], [2, 3]])
+    OpArgMngr.add_workload('nanargmin', a)
+    OpArgMngr.add_workload('nanargmin', a, axis=0)
+    OpArgMngr.add_workload('nanargmin', a, axis=1)
+
+
+def _add_workload_nancumprod():
+    a = np.array([[1, 2], [3, np.nan]])
+    OpArgMngr.add_workload('nancumprod', a)
+    OpArgMngr.add_workload('nancumprod', a, axis=0)
+    OpArgMngr.add_workload('nancumprod', a, axis=1)
+
+
+def _add_workload_nancumsum():
+    a = np.array([[1, 2], [3, np.nan]])
+    OpArgMngr.add_workload('nancumsum', a)
+    OpArgMngr.add_workload('nancumsum', a, axis=0)
+    OpArgMngr.add_workload('nancumsum', a, axis=1)
+
+
+def _add_workload_nanmax():
+    a = np.array([[1, 2], [3, np.nan]])
+    OpArgMngr.add_workload('nanmax', a)
+    OpArgMngr.add_workload('nanmax', a, axis=0)
+    OpArgMngr.add_workload('nanmax', a, axis=1)
+
+
+def _add_workload_nanmedian():
+    a = np.array([[10.0, np.nan, 4], [3, 2, 1]])
+    OpArgMngr.add_workload('nanmedian', a)
+    OpArgMngr.add_workload('nanmedian', a, axis=0)
+    OpArgMngr.add_workload('nanmedian', a, axis=1)
+
+
+def _add_workload_nanmin():
+    a = np.array([[1, 2], [3, np.nan]])
+    OpArgMngr.add_workload('nanmin', a)
+    OpArgMngr.add_workload('nanmin', a, axis=0)
+    OpArgMngr.add_workload('nanmin', a, axis=1)
+
+
+def _add_workload_nanpercentile():
+    a = np.array([[10.0, np.nan, 4], [3, 2, 1]])
+    OpArgMngr.add_workload('nanpercentile', a, 50)
+    OpArgMngr.add_workload('nanpercentile', a, 50, axis=0)
+    OpArgMngr.add_workload('nanpercentile', a, 50, axis=1)
+    OpArgMngr.add_workload('nanpercentile', a, 50, axis=1, keepdims=True)
+    OpArgMngr.add_workload('nanpercentile', a, 50, interpolation='lower')
+    OpArgMngr.add_workload('nanpercentile', a, 50, interpolation='higher')
+    OpArgMngr.add_workload('nanpercentile', a, 50, interpolation='midpoint')
+    OpArgMngr.add_workload('nanpercentile', a, 50, interpolation='nearest')
+
+
+def _add_workload_nanprod():
+    a = 1
+    b = np.array([1, np.nan])
+    c = np.array([[1, 2], [3, np.nan]])
+    OpArgMngr.add_workload('nanprod', a)
+    OpArgMngr.add_workload('nanprod', b)
+    OpArgMngr.add_workload('nanprod', c)
+    OpArgMngr.add_workload('nanprod', c, axis=0)
+
+
+def _add_workload_nanquantile():
+    a = np.array([[10.0, np.nan, 4], [3, 2, 1]])
+    OpArgMngr.add_workload('nanquantile', a, 0.4)
+    OpArgMngr.add_workload('nanquantile', a, 0.4, axis=0)
+    OpArgMngr.add_workload('nanquantile', a, 0.4, axis=1)
+    OpArgMngr.add_workload('nanquantile', a, 0.4, axis=1, keepdims=True)
+    OpArgMngr.add_workload('nanquantile', a, 0.4, interpolation='lower')
+    OpArgMngr.add_workload('nanquantile', a, 0.4, interpolation='higher')
+    OpArgMngr.add_workload('nanquantile', a, 0.4, interpolation='midpoint')
+    OpArgMngr.add_workload('nanquantile', a, 0.4, interpolation='nearest')
+
+
+def _add_workload_ndim():
+    a = 1
+    b = np.array([[1,2,3],[4,5,6]])
+    OpArgMngr.add_workload('ndim', a)
+    OpArgMngr.add_workload('ndim', b)
+
+
+# def _add_workload_nper():
+#     OpArgMngr.add_workload('nper', 0.075, -2000, 0, 100000.)
+
+
+def _add_workload_npv():
+    rate, cashflows = 0.08, np.array([-40_000, 5_000, 8_000, 12_000, 30_000])
+    OpArgMngr.add_workload('npv', rate, cashflows)
+
+
+def _add_workload_partition():
+    a = np.array([3, 4, 2, 1])
+    OpArgMngr.add_workload('partition', a, 3)
+    OpArgMngr.add_workload('partition', a, (2,3))  #
+
+
+def _add_workload_piecewise():
+    a = np.array([0, 0])
+    b = np.array([1, 0])
+    c = np.array([1])
+    x = np.linspace(-2.5, 2.5, 6)
+    y = np.array([x < 0, x >= 0])
+    z = np.array([-1, 1])
+    OpArgMngr.add_workload('piecewise', a, b, c)
+    OpArgMngr.add_workload('piecewise', x, y, z)
+
+
+def _add_workload_packbits():
+    a = np.array([[[1, 0, 1], [0, 1, 0]],
+                  [[1, 1, 0], [0, 0, 1]]], dtype = np.int64)
+    OpArgMngr.add_workload('packbits', a)
+    OpArgMngr.add_workload('packbits', a, axis=-1)
+    OpArgMngr.add_workload('packbits', a, bitorder='little')
+
+
+# def _add_workload_place():
+#     a = np.array([1, 4, 3, 2, 5, 8, 7])
+#     b = np.array([0, 1, 0, 1, 0, 1, 0])
+#     c = np.array([2, 4, 6])
+#     d = np.zeros(7)
+#     e = np.array([])
+#     OpArgMngr.add_workload('place', a, b, c)
+#     OpArgMngr.add_workload('place', a, d, e)
+
+
+def _add_workload_poly():
+    a = np.array([3, -np.sqrt(2), np.sqrt(2)])
+    b = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 0]])
+    OpArgMngr.add_workload('poly', a)
+    OpArgMngr.add_workload('poly', b)
+
+
+def _add_workload_polyadd():
+    a = np.array([1, 2])
+    b = np.array([9, 5, 4])
+    OpArgMngr.add_workload('polyadd', a, b)
+
+
+# def _add_workload_polyder():
+
+
+def _add_workload_polydiv():
+    x = np.array([3.0, 5.0, 2.0])
+    y = np.array([2.0, 1.0])
+    OpArgMngr.add_workload('polydiv', x, y)
+
+
+def _add_workload_polyfit():
+    x = np.array([0.0, 1.0, 2.0, 3.0,  4.0,  5.0])
+    y = np.array([0.0, 0.8, 0.9, 0.1, -0.8, -1.0])
+    OpArgMngr.add_workload('polyfit', x, y, 3)
+
+
+def _add_workload_polyint():
+    a = np.array([1,2,3])
+    OpArgMngr.add_workload('polyint', a)
+    OpArgMngr.add_workload('polyint', a, m=2)
+
+
+def _add_workload_polymul():
+    a = np.array([1, 2, 3])
+    b = np.array([9, 5, 4])
+    OpArgMngr.add_workload('polymul', a, b)
+
+
+def _add_workload_polysub():
+    a = np.array([1, 2, 3])
+    b = np.array([9, 5, 4])
+    OpArgMngr.add_workload('polysub', a, b)
+
+
+def _add_workload_positive(array_pool):
+    OpArgMngr.add_workload('positive', array_pool['4x1'])
+
+
+def _add_workload_ppmt():
+    OpArgMngr.add_workload('ppmt', 0.1 / 12, 1, 60, 55000)
+
+
+def _add_workload_product(array_pool):
+    OpArgMngr.add_workload('product', array_pool['4x1'])
+
+
+def _add_workload_promote_types():
+    OpArgMngr.add_workload('promote_types', np.float16, np.float64)
+
+
+def _add_workload_ptp():
+    x = np.arange(4).reshape((2,2))
+    OpArgMngr.add_workload('ptp', x)
+    OpArgMngr.add_workload('ptp', x, axis=0)
+    OpArgMngr.add_workload('ptp', x, axis=1)
+    OpArgMngr.add_workload('ptp', x, keepdims=True)
+
+
+# def _add_workload_put():
+#     a = np.arange(5)
+#     b = np.array([0, 2])
+#     c = np.array([-44, -55])
+#     OpArgMngr.add_workload('put', a, b, c) # TypeError: Cannot cast array data from dtype('float32') to dtype('int64') according to the rule 'safe'
+#     OpArgMngr.add_workload('put', a, 22, -5, mode='clip') # TypeError: Does not support converting <class 'NoneType'> to mx.np.ndarray.
+
+
+def _add_workload_pv():
+    a = np.array((0.05, 0.04, 0.03))/12
+    OpArgMngr.add_workload('pv', 0.05/12, 10*12, -100, 15692.93)
+    OpArgMngr.add_workload('pv', a, 10*12, -100, 15692.93)
+
+
+def _add_workload_rate():
+    OpArgMngr.add_workload('rate', 10, 0, -3500, 10000)
+
+
+def _add_workload_real():
+    a = np.array([1, 3, 5])
+    b = 2
+    OpArgMngr.add_workload('real', a)
+    OpArgMngr.add_workload('real', b)
+
+
+def _add_workload_real_if_close():
+    a = np.array([1, 3, 5])
+    b = 2
+    OpArgMngr.add_workload('real_if_close', a)
+    OpArgMngr.add_workload('real_if_close', b)
+    # OpArgMngr.add_workload('real_if_close', b, tol=1000)
+
+
+def _add_workload_result_type():
+    OpArgMngr.add_workload('result_type', 3.0, 2)
+
+
+def _add_workload_rollaxis():
+    a = np.ones((3,4,5,6))
+    OpArgMngr.add_workload('rollaxis', a, 3, 1)
+    OpArgMngr.add_workload('rollaxis', a, 2)
+    OpArgMngr.add_workload('rollaxis', a, 1, 4)
+
+
+def _add_workload_roots():
+    a = np.array([1,2,1])
+    OpArgMngr.add_workload('roots', a)
+
+
+def _add_workload_round_():
+    OpArgMngr.add_workload('round_', np.array([1.56, 72.54, 6.35, 3.25]), decimals=1)
+
+
+def _add_workload_searchsorted():
+    a = np.array([1,2,3,4,5])
+    b = np.array([-10, 10, 2, 3])
+    OpArgMngr.add_workload('searchsorted', a, 3)
+    OpArgMngr.add_workload('searchsorted', a, 3, side='right')
+    OpArgMngr.add_workload('searchsorted', a, b)
+
+
+def _add_workload_select():
+    x = np.arange(10)
+    condlist = np.array([x<3, x>5], dtype = np.bool)
+    choicelist = np.array([x, x**2], dtype = np.bool)
+    OpArgMngr.add_workload('select', condlist, choicelist)
+
+
+def _add_workload_setdiff1d():
+    a = np.array([1, 2, 3, 2, 4, 1])
+    b = np.array([3, 4, 5, 6])
+    OpArgMngr.add_workload('setdiff1d', a, b)
+
+
+def _add_workload_setxor1d():
+    a = np.array([1, 2, 3, 2, 4])
+    b = np.array([2, 3, 5, 7, 5])
+    OpArgMngr.add_workload('setxor1d', a, b)
+
+
+def _add_workload_signbit():
+    a = -1.2
+    b = np.array([1, -2.3, 2.1])
+    OpArgMngr.add_workload('signbit', a)
+    OpArgMngr.add_workload('signbit', b)
+
+
+def _add_workload_size():
+    a = np.array([[1,2,3],[4,5,6]])
+    OpArgMngr.add_workload('size', a)
+    OpArgMngr.add_workload('size', a, 1)
+    OpArgMngr.add_workload('size', a, 0)
+
+
+def _add_workload_sometrue():
+    # check bad element in all positions
+    for i in range(256-7):
+        d = np.array([False] * 256, dtype=bool)[7::]
+        d[i] = True
+        OpArgMngr.add_workload('any', d)
+    # big array test for blocked libc loops
+    for i in list(range(9, 6000, 507)) + [7764, 90021, -10]:
+        d = np.array([False] * 100043, dtype=bool)
+        d[i] = True
+        OpArgMngr.add_workload('sometrue', d)
+
+
+def _add_workload_take_along_axis():
+    a = np.array([[10, 30, 20], [60, 40, 50]])
+    ai = np.argsort(a, axis=1)
+    OpArgMngr.add_workload('take_along_axis', a, ai, axis=1)
+
+
+def _add_workload_trapz():
+    a = np.array([1,2,3])
+    b = np.arange(6).reshape(2, 3)
+    x = np.array([4,6,8])
+    OpArgMngr.add_workload('trapz', a)
+    OpArgMngr.add_workload('trapz', a, x=x)
+    OpArgMngr.add_workload('trapz', a, dx=2)
+    OpArgMngr.add_workload('trapz', b, axis=1)
+    OpArgMngr.add_workload('trapz', b, axis=0)
+
+
+def _add_workload_tril_indices_from():
+    for dt in ['float16', 'float32', 'float64', 'int32', 'int64', 'int8', 'uint8']:
+        OpArgMngr.add_workload('tril_indices_from', np.ones((2, 2), dtype=dt))
+        arr = np.array([[1, 1, np.inf],
+                        [1, 1, 1],
+                        [np.inf, 1, 1]])
+        OpArgMngr.add_workload('tril_indices_from', arr)
+        OpArgMngr.add_workload('tril_indices_from', np.zeros((3, 3), dtype=dt))
+
+
+def _add_workload_trim_zeros():
+    a = np.array((0, 0, 0, 1, 2, 3, 0, 2, 1, 0))
+    OpArgMngr.add_workload('trim_zeros', a)
+    OpArgMngr.add_workload('trim_zeros', a, 'b')
+
+
+def _add_workload_triu():
+    a  =np.array([[1,2,3],[4,5,6],[7,8,9],[10,11,12]])
+    OpArgMngr.add_workload('triu', a, -1)
+
+
+def _add_workload_triu_indices_from():
+    a  =np.array([[1,2,3],[4,5,6],[7,8,9],[10,11,12]])
+    OpArgMngr.add_workload('triu_indices_from', a, -1)
+
+
+def _add_workload_union1d():
+    a = np.array([5, 4, 7, 1, 2])
+    b = np.array([2, 4, 3, 3, 2, 1, 5])
+    x = np.array([[0, 1, 2], [3, 4, 5]])
+    y = np.array([0, 1, 2, 3, 4])
+    OpArgMngr.add_workload('union1d', a, b)
+    OpArgMngr.add_workload('union1d', x, y)
+
+
+def _add_workload_unpackbits():
+    a = np.array([[2], [7], [23]], dtype=np.uint8)
+    OpArgMngr.add_workload('unpackbits', a)
+    OpArgMngr.add_workload('unpackbits', a, axis=1)
+
+
+def _add_workload_unwrap():
+    phase = np.linspace(0, np.pi, num=5)
+    phase[3:] += np.pi
+    phase_s = np.vstack((phase,phase))
+    OpArgMngr.add_workload('unwrap', phase)
+    print(phase_s.shape)
+    OpArgMngr.add_workload('unwrap', phase_s, axis=1)
+
+
+def _add_workload_vander():
+    x = np.array([1, 2, 3, 5])
+    OpArgMngr.add_workload('vander', x, 3)
+    OpArgMngr.add_workload('vander', x, 3, increasing=True)
+
+
 @use_np
 def _prepare_workloads():
     array_pool = {
@@ -2195,6 +2907,11 @@ def _prepare_workloads():
     _add_workload_linalg_eigh()
     _add_workload_linalg_slogdet()
     _add_workload_linalg_cond()
+    _add_workload_linalg_lstsq()
+    _add_workload_linalg_matrix_power()
+    _add_workload_linalg_matrix_rank()
+    _add_workload_linalg_multi_dot()
+    _add_workload_linalg_qr()
     _add_workload_trace()
     _add_workload_tril()
     _add_workload_outer()
@@ -2294,6 +3011,98 @@ def _prepare_workloads():
     _add_workload_correlate()
     _add_workload_count_nonzero()
     _add_workload_cov()
+    _add_workload_cross()
+    _add_workload_digitize()
+    _add_workload_divmod()
+    _add_workload_ediff1d()
+    _add_workload_extract()
+    _add_workload_fabs()
+    # _add_workload_fill_diagonal()
+    _add_workload_flatnonzero()
+    _add_workload_float_power()
+    _add_workload_fmod()
+    _add_workload_frexp()
+    _add_workload_geomspace()
+    _add_workload_fmax()
+    _add_workload_fmin()
+    _add_workload_histogram2d()
+    _add_workload_histogram_bin_edges()
+    _add_workload_histogramdd()
+    _add_workload_i0()
+    _add_workload_in1d()
+    _add_workload_interp()
+    _add_workload_isneginf()
+    _add_workload_intersect1d()
+    _add_workload_isclose()
+    _add_workload_isfinite()
+    _add_workload_isin()
+    _add_workload_isposinf()
+    _add_workload_ix_()
+    _add_workload_lexsort()
+    _add_workload_min_scalar_type()
+    _add_workload_mirr()
+    _add_workload_modf()
+    _add_workload_msort()
+    _add_workload_nanargmax()
+    _add_workload_nanargmin()
+    _add_workload_nancumprod()
+    _add_workload_nancumsum()
+    _add_workload_nanmax()
+    _add_workload_nanmedian()
+    _add_workload_nanmin()
+    _add_workload_nanpercentile()
+    _add_workload_nanprod()
+    _add_workload_nanquantile()
+    _add_workload_ndim()
+    # _add_workload_nper()
+    _add_workload_npv()
+    _add_workload_partition()
+    _add_workload_piecewise()
+    _add_workload_packbits()
+    # _add_workload_place()
+    _add_workload_poly()
+    _add_workload_polyadd()
+    # _add_workload_polyder()
+    _add_workload_polydiv()
+    _add_workload_polyfit()
+    _add_workload_polyint()
+    _add_workload_polymul()
+    _add_workload_polysub()
+    _add_workload_positive(array_pool)
+    _add_workload_ppmt()
+    _add_workload_product(array_pool)
+    _add_workload_promote_types()
+    _add_workload_ptp()
+    # _add_workload_put()
+    # _add_workload_put_along_axis()
+    # _add_workload_putmask()
+    _add_workload_pv()
+    _add_workload_rate()
+    # _add_workload_ravel_multi_index()
+    _add_workload_real()
+    _add_workload_real_if_close()
+    _add_workload_result_type()
+    _add_workload_rollaxis()
+    _add_workload_roots()
+    _add_workload_round_()
+    # _add_workload_safe_eval()
+    _add_workload_searchsorted()
+    _add_workload_select()
+    _add_workload_setdiff1d()
+    _add_workload_setxor1d()
+    _add_workload_signbit()
+    _add_workload_size()
+    _add_workload_sometrue()
+    _add_workload_take_along_axis()
+    _add_workload_trapz()
+    _add_workload_tril_indices_from()
+    _add_workload_trim_zeros()
+    _add_workload_triu()
+    _add_workload_triu_indices_from()
+    _add_workload_union1d()
+    _add_workload_unpackbits()
+    _add_workload_unwrap()
+    _add_workload_vander()
 
 
 _prepare_workloads()
@@ -2331,6 +3140,8 @@ def _check_interoperability_helper(op_name, *args, **kwargs):
                 _np.testing.assert_equal(arr, expected_arr)
     elif isinstance(out, np.ndarray):
         assert_almost_equal(out.asnumpy(), expected_out, rtol=1e-3, atol=1e-4, use_broadcast=False, equal_nan=True)
+    elif isinstance(out, _np.dtype):
+        _np.testing.assert_equal(out, expected_out)
     else:
         assert _np.isscalar(out), "{} is not a scalar type".format(str(type(out)))
         if isinstance(out, _np.float):

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -2011,6 +2011,106 @@ def _add_workload_argpartition():
         OpArgMngr.add_workload('argpartition', d, 0, kind='introselect')
 
 
+def _add_workload_argwhere():
+    a = np.arange(6).reshape((2, 3))
+    b = np.array([4, 0, 2, 1, 3])
+    OpArgMngr.add_workload('argwhere', a>1)
+    OpArgMngr.add_workload('argwhere', b)
+
+
+def _add_workload_array_equal():
+    a = np.array([1, 2])
+    b = np.array([1, 2, 3])
+    c = np.array([3, 4])
+    d = np.array([1, 3])
+    OpArgMngr.add_workload('array_equal', a, a)
+    OpArgMngr.add_workload('array_equal', a, b)
+    OpArgMngr.add_workload('array_equal', a, c)
+    OpArgMngr.add_workload('array_equal', a, d)
+
+
+def _add_workload_array_equiv():
+    a = np.array([1, 2])
+    b = np.array([1, 2, 3])
+    c = np.array([3, 4])
+    d = np.array([1, 3])
+    e = np.array([2])
+    f = np.array([[1], [2]])
+    g = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    OpArgMngr.add_workload('array_equiv', a, a)
+    OpArgMngr.add_workload('array_equiv', a, b)
+    OpArgMngr.add_workload('array_equiv', a, c)
+    OpArgMngr.add_workload('array_equiv', a, d)
+    OpArgMngr.add_workload('array_equiv', a, e)
+    OpArgMngr.add_workload('array_equiv', a, f)
+    OpArgMngr.add_workload('array_equiv', a, g)
+
+
+# def _add_workload_choose():
+#     x = 2*np.ones((3,), dtype=int)
+#     y = 3*np.ones((3,), dtype=int)
+#     x2 = 2*np.ones((2, 3), dtype=int)
+#     y2 = 3*np.ones((2, 3), dtype=int)
+#     OpArgMngr.add_workload('choose', x, y)
+#     OpArgMngr.add_workload('choose', x2, y2)
+#     OpArgMngr.add_workload('choose', x, y2)
+
+
+def _add_workload_compress():
+    a = np.array([[1, 2], [3, 4], [5, 6]])
+    b = [0, 1]
+    c = [False, True, True]
+    d = [False, True]
+    OpArgMngr.add_workload('compress', b, a, axis=0)
+    OpArgMngr.add_workload('compress', c, a, axis=0)
+    OpArgMngr.add_workload('compress', d, a, axis=1)
+
+
+def _add_workload_corrcoef():
+    a = np.array([0, 1, 0])
+    b = np.array([1, 0, 1])
+    c = np.array(
+        [[0.15391142, 0.18045767, 0.14197213],
+         [0.70461506, 0.96474128, 0.27906989],
+         [0.9297531, 0.32296769, 0.19267156]])
+    OpArgMngr.add_workload('corrcoef', a, b)
+    OpArgMngr.add_workload('corrcoef', c)
+
+
+def _add_workload_correlate():
+    x = np.array([1, 2, 3, 4, 5])
+    xs = np.arange(1, 20)[::3]
+    y = np.array([-1, -2, -3])
+    OpArgMngr.add_workload('correlate', x, y)
+    OpArgMngr.add_workload('correlate', x, y, 'full')
+    OpArgMngr.add_workload('correlate', x, y[:-1], 'full')
+    OpArgMngr.add_workload('correlate', x[::-1], y, 'full')
+    OpArgMngr.add_workload('correlate', xs, y, 'full')
+    OpArgMngr.add_workload('correlate', x, y,"same")
+
+
+def _add_workload_count_nonzero():
+    m = np.array([[0, 1, 7, 0, 0], [3, 0, 0, 2, 19]])
+    a = np.array([])
+    b = np.eye(3)
+    OpArgMngr.add_workload('count_nonzero', m, axis=0)
+    OpArgMngr.add_workload('count_nonzero', m, axis=1)
+    OpArgMngr.add_workload('count_nonzero', a)
+    OpArgMngr.add_workload('count_nonzero', b)
+
+
+def _add_workload_cov():
+    x = np.array(np.random.rand(12))
+    y = x.reshape(3, 4)
+    OpArgMngr.add_workload('cov', x)
+    OpArgMngr.add_workload('cov', x, rowvar=False)
+    OpArgMngr.add_workload('cov', x, rowvar=False, bias=True)
+    OpArgMngr.add_workload('cov', y)
+    OpArgMngr.add_workload('cov', y, y[::-1])
+    OpArgMngr.add_workload('cov', y, rowvar=False)
+    OpArgMngr.add_workload('cov', y, rowvar=False, bias=True)
+
+
 @use_np
 def _prepare_workloads():
     array_pool = {
@@ -2185,6 +2285,15 @@ def _prepare_workloads():
     _add_workload_apply_along_axis()
     _add_workload_apply_over_axes()
     _add_workload_argpartition()
+    _add_workload_argwhere()
+    _add_workload_array_equal()
+    _add_workload_array_equiv()
+    # _add_workload_choose()
+    _add_workload_compress()
+    _add_workload_corrcoef()
+    _add_workload_correlate()
+    _add_workload_count_nonzero()
+    _add_workload_cov()
 
 
 _prepare_workloads()


### PR DESCRIPTION
## Description ##
This PR implements a mechanism of easily falling back to the official NumPy if operators do not have the corresponding native implementations in MXNet. This allows us to quickly have a decent coverage of NumPy operators in order to test MXNet as a backend compute engine for other machine learning libraries heavily depending on NumPy, such as sklearn, while adding more operators with native implementations in parallel.

The mechanism implemented in this PR only supports calling operators in the imperative way without autograd, i.e., through the module `mxnet.numpy`. More sophisticated fallback mechanism for supporting symbolic paradigm and autograd should resort to https://github.com/apache/incubator-mxnet/pull/16923.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
