### PR TITLE
[Large Tensor] Fixed Spatial Transformer op

### DIFF
--- a/src/operator/spatial_transformer.cc
+++ b/src/operator/spatial_transformer.cc
@@ -58,10 +58,10 @@ inline void BilinearSamplingForward(const Tensor<cpu, 4, DType> &output,
           const DType top_left_x_w = 1.0 - (x_real - top_left_x);
           const index_t data_index = n * i_c * i_h * i_w + c * i_h * i_w +
                                  top_left_y * i_w + top_left_x;
-          index_t top_left_v = 0;
-          index_t top_right_v = 0;
-          index_t bottom_left_v = 0;
-          index_t bottom_right_v = 0;
+          DType top_left_v = 0;
+          DType top_right_v = 0;
+          DType bottom_left_v = 0;
+          DType bottom_right_v = 0;
           index_t lower_bound = 0;
           if (between(top_left_x, lower_bound, i_w-1) &&
               between(top_left_y, lower_bound, i_h-1))
@@ -114,10 +114,10 @@ inline void BilinearSamplingBackward(const Tensor<cpu, 4, DType> &input_grad,
             const index_t data_index = n * i_c * i_h * i_w + c * i_h * i_w +
                                    top_left_y * i_w + top_left_x;
             // calc 4 vertex value in input data
-            index_t top_left_v = 0;
-            index_t top_right_v = 0;
-            index_t bottom_left_v = 0;
-            index_t bottom_right_v = 0;
+            DType top_left_v = 0;
+            DType top_right_v = 0;
+            DType bottom_left_v = 0;
+            DType bottom_right_v = 0;
             index_t lower_bound = 0;
             if (between(top_left_x, lower_bound, i_w-1) &&
                 between(top_left_y, lower_bound, i_h-1)) {

--- a/src/operator/spatial_transformer.cc
+++ b/src/operator/spatial_transformer.cc
@@ -41,8 +41,8 @@ inline void BilinearSamplingForward(const Tensor<cpu, 4, DType> &output,
   DType *out = output.dptr_;
   const DType *data = input.dptr_;
   const DType *grid = grid_src.dptr_;
-  const int o_n = output.size(0), o_c = output.size(1), o_h = output.size(2), o_w = output.size(3);
-  const int i_c = input.size(1), i_h = input.size(2), i_w = input.size(3);
+  const index_t o_n = output.size(0), o_c = output.size(1), o_h = output.size(2), o_w = output.size(3);
+  const index_t i_c = input.size(1), i_h = input.size(2), i_w = input.size(3);
   for (index_t n = 0; n < static_cast<index_t>(o_n); ++n) {
     for (index_t c = 0; c < static_cast<index_t>(o_c); ++c) {
       for (index_t h = 0; h < static_cast<index_t>(o_h); ++h) {
@@ -51,23 +51,23 @@ inline void BilinearSamplingForward(const Tensor<cpu, 4, DType> &output,
           const index_t grid_index = n * o_h * o_w * 2 + h * o_w + w;
           const DType y_real = (*(grid + grid_index + o_h * o_w) + 1) * (i_h - 1) / 2;
           const DType x_real = (*(grid + grid_index) + 1) * (i_w - 1) / 2;
-          const auto top_left_y = static_cast<int>(std::floor(y_real));
-          const auto top_left_x = static_cast<int>(std::floor(x_real));
+          const auto top_left_y = static_cast<index_t>(std::floor(y_real));
+          const auto top_left_x = static_cast<index_t>(std::floor(x_real));
           const DType top_left_y_w = 1.0 - (y_real - top_left_y);
           const DType top_left_x_w = 1.0 - (x_real - top_left_x);
-          const int data_index = n * i_c * i_h * i_w + c * i_h * i_w +
+          const index_t data_index = n * i_c * i_h * i_w + c * i_h * i_w +
                                  top_left_y * i_w + top_left_x;
-          DType top_left_v = 0;
-          DType top_right_v = 0;
-          DType bottom_left_v = 0;
-          DType bottom_right_v = 0;
-          if (between(top_left_x, 0, i_w-1) && between(top_left_y, 0, i_h-1))
+          index_t top_left_v = 0;
+          index_t top_right_v = 0;
+          index_t bottom_left_v = 0;
+          index_t bottom_right_v = 0;
+          if (between(top_left_x, 0L, i_w-1) && between(top_left_y, 0L, i_h-1))
             top_left_v = *(data + data_index);
-          if (between(top_left_x + 1, 0, i_w-1) && between(top_left_y, 0, i_h-1))
+          if (between(top_left_x + 1, 0L, i_w-1) && between(top_left_y, 0L, i_h-1))
             top_right_v = *(data + data_index + 1);
-          if (between(top_left_x, 0, i_w-1) && between(top_left_y + 1, 0, i_h-1))
+          if (between(top_left_x, 0L, i_w-1) && between(top_left_y + 1, 0L, i_h-1))
             bottom_left_v = *(data + data_index + i_w);
-          if (between(top_left_x+1, 0, i_w-1) && between(top_left_y + 1, 0, i_h-1))
+          if (between(top_left_x+1, 0L, i_w-1) && between(top_left_y + 1, 0L, i_h-1))
             bottom_right_v = *(data + data_index + i_w + 1);
           *(out+out_index) = top_left_v * top_left_y_w * top_left_x_w +
                              top_right_v * top_left_y_w * (1.0 - top_left_x_w) +

--- a/src/operator/spatial_transformer.cc
+++ b/src/operator/spatial_transformer.cc
@@ -63,13 +63,17 @@ inline void BilinearSamplingForward(const Tensor<cpu, 4, DType> &output,
           index_t bottom_left_v = 0;
           index_t bottom_right_v = 0;
           index_t lower_bound = 0;
-          if (between(top_left_x, lower_bound, i_w-1) && between(top_left_y, lower_bound, i_h-1))
+          if (between(top_left_x, lower_bound, i_w-1) &&
+              between(top_left_y, lower_bound, i_h-1))
             top_left_v = *(data + data_index);
-          if (between(top_left_x + 1, lower_bound, i_w-1) && between(top_left_y, lower_bound, i_h-1))
+          if (between(top_left_x + 1, lower_bound, i_w-1) && 
+              between(top_left_y, lower_bound, i_h-1))
             top_right_v = *(data + data_index + 1);
-          if (between(top_left_x, lower_bound, i_w-1) && between(top_left_y + 1, lower_bound, i_h-1))
+          if (between(top_left_x, lower_bound, i_w-1) &&
+              between(top_left_y + 1, lower_bound, i_h-1))
             bottom_left_v = *(data + data_index + i_w);
-          if (between(top_left_x+1, lower_bound, i_w-1) && between(top_left_y + 1, lower_bound, i_h-1))
+          if (between(top_left_x+1, lower_bound, i_w-1) &&
+              between(top_left_y + 1, lower_bound, i_h-1))
             bottom_right_v = *(data + data_index + i_w + 1);
           *(out+out_index) = top_left_v * top_left_y_w * top_left_x_w +
                              top_right_v * top_left_y_w * (1.0 - top_left_x_w) +
@@ -115,21 +119,25 @@ inline void BilinearSamplingBackward(const Tensor<cpu, 4, DType> &input_grad,
             index_t bottom_left_v = 0;
             index_t bottom_right_v = 0;
             index_t lower_bound = 0;
-            if (between(top_left_x, lower_bound, i_w-1) && between(top_left_y, lower_bound, i_h-1)) {
+            if (between(top_left_x, lower_bound, i_w-1) &&
+                between(top_left_y, lower_bound, i_h-1)) {
               *(g_input + data_index) += *(grad + grad_index) * top_left_y_w * top_left_x_w;
               top_left_v = *(data + data_index);
             }
-            if (between(top_left_x+1, lower_bound, i_w-1) && between(top_left_y, lower_bound, i_h-1)) {
+            if (between(top_left_x+1, lower_bound, i_w-1) &&
+                between(top_left_y, lower_bound, i_h-1)) {
               *(g_input + data_index + 1) += *(grad + grad_index) * top_left_y_w
                                              * (1.0 - top_left_x_w);
               top_right_v = *(data + data_index + 1);
             }
-            if (between(top_left_x, lower_bound, i_w-1) && between(top_left_y+1, lower_bound, i_h-1)) {
+            if (between(top_left_x, lower_bound, i_w-1) &&
+                between(top_left_y+1, lower_bound, i_h-1)) {
               *(g_input + data_index+ i_w) += *(grad + grad_index) * (1.0 - top_left_y_w)
                                               * top_left_x_w;
               bottom_left_v = *(data + data_index + i_w);
             }
-            if (between(top_left_x+1, lower_bound, i_w-1) && between(top_left_y+1, lower_bound, i_h-1)) {
+            if (between(top_left_x+1, lower_bound, i_w-1) &&
+                between(top_left_y+1, lower_bound, i_h-1)) {
               *(g_input + data_index+ i_w + 1) += *(grad + grad_index) * (1.0 - top_left_y_w)
                                                   * (1.0 - top_left_x_w);
               bottom_right_v = *(data + data_index + i_w + 1);

--- a/src/operator/spatial_transformer.cc
+++ b/src/operator/spatial_transformer.cc
@@ -41,7 +41,8 @@ inline void BilinearSamplingForward(const Tensor<cpu, 4, DType> &output,
   DType *out = output.dptr_;
   const DType *data = input.dptr_;
   const DType *grid = grid_src.dptr_;
-  const index_t o_n = output.size(0), o_c = output.size(1), o_h = output.size(2), o_w = output.size(3);
+  const index_t o_n = output.size(0), o_c = output.size(1),
+    o_h = output.size(2), o_w = output.size(3);
   const index_t i_c = input.size(1), i_h = input.size(2), i_w = input.size(3);
   for (index_t n = 0; n < static_cast<index_t>(o_n); ++n) {
     for (index_t c = 0; c < static_cast<index_t>(o_c); ++c) {

--- a/src/operator/spatial_transformer.cc
+++ b/src/operator/spatial_transformer.cc
@@ -66,7 +66,7 @@ inline void BilinearSamplingForward(const Tensor<cpu, 4, DType> &output,
           if (between(top_left_x, lower_bound, i_w-1) &&
               between(top_left_y, lower_bound, i_h-1))
             top_left_v = *(data + data_index);
-          if (between(top_left_x + 1, lower_bound, i_w-1) && 
+          if (between(top_left_x + 1, lower_bound, i_w-1) &&
               between(top_left_y, lower_bound, i_h-1))
             top_right_v = *(data + data_index + 1);
           if (between(top_left_x, lower_bound, i_w-1) &&

--- a/src/operator/spatial_transformer.cc
+++ b/src/operator/spatial_transformer.cc
@@ -62,13 +62,14 @@ inline void BilinearSamplingForward(const Tensor<cpu, 4, DType> &output,
           index_t top_right_v = 0;
           index_t bottom_left_v = 0;
           index_t bottom_right_v = 0;
-          if (between(top_left_x, 0L, i_w-1) && between(top_left_y, 0L, i_h-1))
+          index_t lower_bound = 0;
+          if (between(top_left_x, lower_bound, i_w-1) && between(top_left_y, lower_bound, i_h-1))
             top_left_v = *(data + data_index);
-          if (between(top_left_x + 1, 0L, i_w-1) && between(top_left_y, 0L, i_h-1))
+          if (between(top_left_x + 1, lower_bound, i_w-1) && between(top_left_y, lower_bound, i_h-1))
             top_right_v = *(data + data_index + 1);
-          if (between(top_left_x, 0L, i_w-1) && between(top_left_y + 1, 0L, i_h-1))
+          if (between(top_left_x, lower_bound, i_w-1) && between(top_left_y + 1, lower_bound, i_h-1))
             bottom_left_v = *(data + data_index + i_w);
-          if (between(top_left_x+1, 0L, i_w-1) && between(top_left_y + 1, 0L, i_h-1))
+          if (between(top_left_x+1, lower_bound, i_w-1) && between(top_left_y + 1, lower_bound, i_h-1))
             bottom_right_v = *(data + data_index + i_w + 1);
           *(out+out_index) = top_left_v * top_left_y_w * top_left_x_w +
                              top_right_v * top_left_y_w * (1.0 - top_left_x_w) +
@@ -113,21 +114,22 @@ inline void BilinearSamplingBackward(const Tensor<cpu, 4, DType> &input_grad,
             index_t top_right_v = 0;
             index_t bottom_left_v = 0;
             index_t bottom_right_v = 0;
-            if (between(top_left_x, 0L, i_w-1) && between(top_left_y, 0L, i_h-1)) {
+            index_t lower_bound = 0;
+            if (between(top_left_x, lower_bound, i_w-1) && between(top_left_y, lower_bound, i_h-1)) {
               *(g_input + data_index) += *(grad + grad_index) * top_left_y_w * top_left_x_w;
               top_left_v = *(data + data_index);
             }
-            if (between(top_left_x+1, 0L, i_w-1) && between(top_left_y, 0L, i_h-1)) {
+            if (between(top_left_x+1, lower_bound, i_w-1) && between(top_left_y, lower_bound, i_h-1)) {
               *(g_input + data_index + 1) += *(grad + grad_index) * top_left_y_w
                                              * (1.0 - top_left_x_w);
               top_right_v = *(data + data_index + 1);
             }
-            if (between(top_left_x, 0L, i_w-1) && between(top_left_y+1, 0L, i_h-1)) {
+            if (between(top_left_x, lower_bound, i_w-1) && between(top_left_y+1, lower_bound, i_h-1)) {
               *(g_input + data_index+ i_w) += *(grad + grad_index) * (1.0 - top_left_y_w)
                                               * top_left_x_w;
               bottom_left_v = *(data + data_index + i_w);
             }
-            if (between(top_left_x+1, 0L, i_w-1) && between(top_left_y+1, 0L, i_h-1)) {
+            if (between(top_left_x+1, lower_bound, i_w-1) && between(top_left_y+1, lower_bound, i_h-1)) {
               *(g_input + data_index+ i_w + 1) += *(grad + grad_index) * (1.0 - top_left_y_w)
                                                   * (1.0 - top_left_x_w);
               bottom_right_v = *(data + data_index + i_w + 1);

--- a/src/operator/spatial_transformer.cc
+++ b/src/operator/spatial_transformer.cc
@@ -88,9 +88,9 @@ inline void BilinearSamplingBackward(const Tensor<cpu, 4, DType> &input_grad,
   DType *grid_src = grid_src_data.dptr_;
   const DType *grad = output_grad.dptr_;
   const DType *data = input_data.dptr_;
-  const int o_n = output_grad.size(0), o_c = output_grad.size(1),
+  const index_t o_n = output_grad.size(0), o_c = output_grad.size(1),
     o_h = output_grad.size(2), o_w = output_grad.size(3);
-  const int i_c = input_data.size(1), i_h = input_data.size(2), i_w = input_data.size(3);
+  const index_t i_c = input_data.size(1), i_h = input_data.size(2), i_w = input_data.size(3);
   for (index_t n = 0; n < static_cast<index_t>(o_n); ++n) {
      for (index_t h = 0; h < static_cast<index_t>(o_h); ++h) {
         for (index_t w = 0; w < static_cast<index_t>(o_w); ++w) {
@@ -99,34 +99,34 @@ inline void BilinearSamplingBackward(const Tensor<cpu, 4, DType> &input_grad,
           const index_t grid_src_index = n * o_h * o_w * 2 + h * o_w + w;
           const DType y_real = (*(grid_src + grid_src_index + o_h * o_w) + 1) * (i_h - 1) / 2;
           const DType x_real = (*(grid_src + grid_src_index) + 1) * (i_w - 1) / 2;
-          const auto top_left_y = static_cast<int>(std::floor(y_real));
-          const auto top_left_x = static_cast<int>(std::floor(x_real));
+          const auto top_left_y = static_cast<index_t>(std::floor(y_real));
+          const auto top_left_x = static_cast<index_t>(std::floor(x_real));
           const DType top_left_y_w = 1.0 - (y_real - top_left_y);
           const DType top_left_x_w = 1.0 - (x_real - top_left_x);
           for (index_t c = 0; c < static_cast<index_t>(o_c); ++c) {
             index_t grad_index = n * o_c * o_h * o_w + c * o_h * o_w + h * o_w + w;
-            const int data_index = n * i_c * i_h * i_w + c * i_h * i_w +
+            const index_t data_index = n * i_c * i_h * i_w + c * i_h * i_w +
                                    top_left_y * i_w + top_left_x;
             // calc 4 vertex value in input data
-            DType top_left_v = 0;
-            DType top_right_v = 0;
-            DType bottom_left_v = 0;
-            DType bottom_right_v = 0;
-            if (between(top_left_x, 0, i_w-1) && between(top_left_y, 0, i_h-1)) {
+            index_t top_left_v = 0;
+            index_t top_right_v = 0;
+            index_t bottom_left_v = 0;
+            index_t bottom_right_v = 0;
+            if (between(top_left_x, 0L, i_w-1) && between(top_left_y, 0L, i_h-1)) {
               *(g_input + data_index) += *(grad + grad_index) * top_left_y_w * top_left_x_w;
               top_left_v = *(data + data_index);
             }
-            if (between(top_left_x+1, 0, i_w-1) && between(top_left_y, 0, i_h-1)) {
+            if (between(top_left_x+1, 0L, i_w-1) && between(top_left_y, 0L, i_h-1)) {
               *(g_input + data_index + 1) += *(grad + grad_index) * top_left_y_w
                                              * (1.0 - top_left_x_w);
               top_right_v = *(data + data_index + 1);
             }
-            if (between(top_left_x, 0, i_w-1) && between(top_left_y+1, 0, i_h-1)) {
+            if (between(top_left_x, 0L, i_w-1) && between(top_left_y+1, 0L, i_h-1)) {
               *(g_input + data_index+ i_w) += *(grad + grad_index) * (1.0 - top_left_y_w)
                                               * top_left_x_w;
               bottom_left_v = *(data + data_index + i_w);
             }
-            if (between(top_left_x+1, 0, i_w-1) && between(top_left_y+1, 0, i_h-1)) {
+            if (between(top_left_x+1, 0L, i_w-1) && between(top_left_y+1, 0L, i_h-1)) {
               *(g_input + data_index+ i_w + 1) += *(grad + grad_index) * (1.0 - top_left_y_w)
                                                   * (1.0 - top_left_x_w);
               bottom_right_v = *(data + data_index + i_w + 1);

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -468,6 +468,7 @@ def test_nn():
         assert res.shape[2] == 2
         assert res.shape[3] == 2
         assert res.shape[4] == 1
+        
     def check_embedding():
         data = nd.random_normal(shape=(LARGE_TENSOR_SHAPE, 1))
         weight = nd.random_normal(shape=(LARGE_TENSOR_SHAPE, 1))
@@ -479,6 +480,21 @@ def test_nn():
         assert out.shape[0] == LARGE_TENSOR_SHAPE
         assert out.shape[1] == 1
         assert out.shape[2] == 1
+        
+    def check_spatial_transformer():
+        data = nd.random_normal(shape=(2, 2**29, 1, 6))
+        loc = nd.random_normal(shape=(2, 6))
+        transform_type = 'affine'
+        sampler_type = 'bilinear'
+        target_shape = (2, 6)
+
+        res = nd.SpatialTransformer(data=data, loc=loc, transform_type=transform_type,
+                                    sampler_type=sampler_type, target_shape=target_shape)
+
+        assert res.shape[0] == 2
+        assert res.shape[1] == 536870912
+        assert res.shape[2] == 2
+        assert res.shape[3] == 6
 
     check_gluon_embedding()
     check_fully_connected()
@@ -501,6 +517,7 @@ def test_nn():
     check_instance_norm()
     check_col2im()
     check_embedding()
+    check_spatial_transformer()
 
 
 def test_tensor():


### PR DESCRIPTION
## Description ##
The Spatial Transformer op was previously breaking on large tensor (dimension >= 2^32) data. With the following input:
```
run_performance_test(nd.SpatialTransformer, run_backward=True, inputs=[{'data': (2, 2**29,1,6), 'loc': nd.random_normal(shape=(2,6)), 'transform_type': 'affine', 'sampler_type': 'bilinear', 'target_shape': (2,6)}], warmup=1, runs=1)
```
the following error was thrown:
```
*** Error in `python3': double free or corruption (out): 0x00007f36bbffe010 ***
```

To root cause this issue, I ran the previous command in a Python script with GDB, and found that the underlying problem was in the iteration portion of the forward and backward methods of `spatial_transformer.cc`. Several of the variables used in the iteration used the `int` dtype when they should have been using `index_t` to properly handle long int indices. I switched these variables to `index_t` in the forward and backward methods, and after rebuilding, the previous input command displayed the correct output:
```
INFO:root:Begin Benchmark - SpatialTransformer
INFO:root:Complete Benchmark - SpatialTransformer
[{'SpatialTransformer': [{'inputs': {'data': (2, 536870912, 1, 6), 'loc': '<NDArray 2x6 @cpu(0)>', 'transform_type': 'affine', 'sampler_type': 'bilinear', 't
arget_shape': (2, 6)}, 'max_storage_mem_alloc_cpu/0': 102005472.0, 'avg_time_forward_SpatialTransformer': 551614.125, 'avg_time_backward_SpatialTransformer':
 511034.0938}]}]
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M src/operator/tensor/spatial_transformer.cc

## Comments ##
Tested on r5dn.24xl-ubuntu 16.04 and p2.16xl-ubuntu 16.04 with
1. Individual op run
2. Full OpPerf run

## Results ##
The key difference between CPU and GPU tests was the instance type (r5dn.24xl for CPU, p2.16xl for GPU). All relevant build flags remain the same, and both were tested using CPU context.

[Single operator test - SpatialTransformer op (GPU)](https://gist.github.com/connorgoggins/7b3765e4e6f54f7841fb14e0930221ca)
[Single operator test - SpatialTransformer op (CPU)](https://gist.github.com/connorgoggins/d97d64e73702a342bdeb170d30aef04f)

[Full OpPerf test (GPU)](https://gist.github.com/connorgoggins/8b0563eaf98119980a5d36b7c61d796e)
[Full OpPerf test (CPU)](https://gist.github.com/connorgoggins/4bebae70a85f7d9f754124187f52f383)

@apeforest @access2rohit @ChaiBapchya 