### PR TITLE
[Large Tensor] Fixed col2im op

### DIFF
--- a/src/operator/nn/im2col.h
+++ b/src/operator/nn/im2col.h
@@ -182,7 +182,7 @@ inline void im2col_nd_core_cpu(const DType* data_input, const bool im2col,
       // Loop over spatial axes in forward order to compute the indices in the
       // image and column, and whether the index lies in the padding.
       index_t index_col = c_col;
-      int index_im = c_col / kernel_size;
+      index_t index_im = c_col / kernel_size;
       bool is_padding = false;
       for (index_t d_i = 0; d_i < num_spatial_axes; ++d_i) {
         const index_t d = d_iter[d_i];
@@ -191,7 +191,7 @@ inline void im2col_nd_core_cpu(const DType* data_input, const bool im2col,
         is_padding |= d_im < 0 || d_im >= static_cast<int>(im_shape[d_i + 2]);
         index_col *= col_shape[d_i + 1];
         index_col += d;
-        index_im *= static_cast<int>(im_shape[d_i + 2]);
+        index_im *= static_cast<index_t>(im_shape[d_i + 2]);
         index_im += d_im;
       }
       if (im2col) {

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -455,6 +455,19 @@ def test_nn():
         assert_almost_equal(out, out_nd.asnumpy(), forward_check_eps,
                             forward_check_eps)
 
+    def check_col2im():
+        data = nd.random_normal(shape=(1, 2**30, 4))
+        output_size = (2, 2, 1)
+        kernel = (1, 1, 1)
+
+        res = nd.col2im(data=data, output_size=output_size, kernel=kernel)
+
+        assert res.shape[0] == 1
+        assert res.shape[1] == 1073741824
+        assert res.shape[2] == 2
+        assert res.shape[3] == 2
+        assert res.shape[4] == 1
+
     check_gluon_embedding()
     check_fully_connected()
     check_dense()
@@ -474,6 +487,7 @@ def test_nn():
     check_linear_and_logistic_regression()
     check_l2_normalization()
     check_instance_norm()
+    check_col2im()
 
 
 def test_tensor():


### PR DESCRIPTION
## Description ##
The col2im op was previously breaking on large tensor (dimension >= 2^32) data. With the following input:
```
run_performance_test(nd.col2im, run_backward=True, inputs=[{'data': (1,2**30,4), 'output_size': (2,2,1), 'kernel': (1,1,1)}], warmup=1, runs=1)
```
the following error was thrown:
```
Segmentation fault: 11
```

To root cause this issue, I ran the previous command in a Python script with GDB, and found that the underlying problem was in the dtype of the image index variable (`index_im`) within the col2im op's kernel in `im2col.h`. This image index variable used the `int` dtype when it should have been using `index_t` to properly handle long int indices. I switched this variable to `index_t` in the kernel and, after rebuilding, the previous input command displayed the correct output:
```
INFO:root:Begin Benchmark - col2im
INFO:root:Complete Benchmark - col2im
[{'col2im': [{'inputs': {'data': (1, 1073741824, 4), 'output_size': (2, 2, 1), 'kernel': (1, 1, 1)}, 'max_storage_mem_alloc_cpu/0': 33285996.0, 'avg_time_forward_col2im': 1290522.25, 'avg_time_backward_col2im': 1291033.5}]}]
```

Note: I also confirmed that, with my revisions, the op works with a large tensor (>= 2^32) output size, as the following command passes without errors.
```
run_performance_test(nd.col2im, run_backward=True, inputs=[{'data': (1,2**32,1), 'output_size': (1,2**32), 'kernel': (1,2**32)}], warmup=1, runs=1)
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M src/operator/nn/im2col.h
- M tests/nightly/test_large_array.py

## Comments ##
Tested on r5dn.24xl-ubuntu 16.04 and p2.16xl-ubuntu 16.04 with
1. Individual op run
2. Full OpPerf run

## Results ##
The key difference between CPU and GPU tests was the instance type (r5dn.24xl for CPU, p2.16xl for GPU). All relevant build flags remain the same, and both were tested using CPU context.

[Single operator test - col2im op (GPU)](https://gist.github.com/connorgoggins/21cac922d9efb1d4ffea59fe940b18f0)
[Single operator test - col2im op (CPU)](https://gist.github.com/connorgoggins/2082b435b97099cbb4c995203134fa85)

[Full OpPerf test (GPU)](https://gist.github.com/connorgoggins/a9938b8fdfc53262a2a769121ebb515d)
[Full OpPerf test (CPU)](https://gist.github.com/connorgoggins/2efad04af643bb44d0e6dc17d894693f)

@apeforest @access2rohit 