### PR TITLE
fix basic boolean indexing result shape

### DIFF
--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -467,7 +467,7 @@ class ndarray(NDArray):
             scale = reduce(lambda x, y: x * y, self.shape[:pos], 1)
             keys = mask if scale == 1 else _reshape_view(_npi.stack(*[mask for i in range(scale)]), -1)
             all_shapes = self.shape[:pos] + remaining_shapes
-            return _reshape_view(_npi.boolean_mask(data, keys), -1, *all_shapes)
+            return _reshape_view(_npi.boolean_mask(data, keys), *all_shapes, -1)
 
         elif bool_type == _NDARRAY_INT_BOOLEAN_INDEXING:
             out = self

--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -1194,6 +1194,18 @@ def test_np_ndarray_boolean_indexing():
         assert same(a[0, b].asnumpy(), _np_a[0, _np_b])
         assert same(a[b, 1].asnumpy(), _np_a[_np_b, 1])
 
+        a = np.arange(12).reshape(4,3)
+        b = np.array([1.,2.,3.])
+        _np_a = a.asnumpy()
+        _np_b = b.asnumpy()
+        assert same(a[:, b > 2].shape, _np_a[:, _np_b > 2].shape)
+        assert same(a[:, b > 2].asnumpy(), _np_a[:, _np_b > 2])
+
+        a = np.array([[1,2,3],[3,4,5]])
+        _np_a = a.asnumpy()
+        assert same(a[:,a[1,:] > 0].shape, _np_a[:,_np_a[1,: ] > 0].shape)
+        assert same(a[:,a[1,:] > 0].asnumpy(), _np_a[:,_np_a[1,: ] > 0])
+
     def test_boolean_indexing_assign():
         # test boolean indexing assign
         shape = (3, 2, 3)


### PR DESCRIPTION
## Description ##

Fix the shape error with boolean indexing
```
>>> a = np.arange(12).reshape(4,3)
>>> b = np.array([1.,2.,3.])
>>> a[:,b>2]
# previously -> array([[ 2.,  5.,  8., 11.]]) 
# now: 
array([[ 2.],
           [ 5.],
           [ 8.],
           [11.]])

>>> a = np.array([[1,2,3],[3,4,5]])
>>> a[:,a[1,:]>0] 
# previously -> array([[1., 2.], [3., 3.], [4., 5.]])
# now: 
array([[1., 2., 3.],
            [3., 4., 5.]])
```