### PR TITLE
[Large Tensor] Fixed SoftmaxActivation op

### DIFF
--- a/src/operator/nn/softmax_activation-inl.h
+++ b/src/operator/nn/softmax_activation-inl.h
@@ -82,9 +82,9 @@ void SoftmaxActivationCompute(const nnvm::NodeAttrs& attrs,
   } else {
     CHECK_GE(in_data.ndim(), 3)
         << "Input need to have a least 3 dimensions when mode=channel";
-    int n = in_data.size(0);
-    int k = in_data.size(1);
-    Shape<3> s3 = Shape3(n, k, static_cast<int>(in_data.Size()/n/k));
+    index_t n = in_data.size(0);
+    index_t k = in_data.size(1);
+    Shape<3> s3 = Shape3(n, k, static_cast<index_t>(in_data.Size()/n/k));
     Tensor<xpu, 3, real_t> data = in_data.get_with_shape<xpu, 3, real_t>(s3, s);
     Tensor<xpu, 3, real_t> out = out_data.get_with_shape<xpu, 3, real_t>(s3, s);
     Softmax(out, data);
@@ -107,10 +107,10 @@ void SoftmaxActivationGradCompute(const nnvm::NodeAttrs& attrs,
   const OpReqType &req = reqs[0];
   const TBlob &in_grad = outputs[0];
   // Use 3d tensor for both mode -> {instance, channel}. Get shapes
-  int total_size = in_grad.Size();
-  int batch_size = in_grad.shape_[0];
-  int channel_num = in_grad.shape_[1];
-  int rest_size = total_size / (batch_size * channel_num);
+  index_t total_size = in_grad.Size();
+  index_t batch_size = in_grad.shape_[0];
+  index_t channel_num = in_grad.shape_[1];
+  index_t rest_size = total_size / (batch_size * channel_num);
   const Shape<3> data_shape = Shape3(batch_size, channel_num, rest_size);
   // Get tensors
   Stream<xpu> *s = ctx.get_stream<xpu>();

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -127,6 +127,17 @@ def test_nn():
         expected_grad_out[k] = -1
         assert np.isclose(grad_out - softmax_out, expected_grad_out).all()
 
+    def check_softmax_activation():
+        data = nd.random_normal(shape=(2**29, 2, 2, 2))
+        out = nd.random_normal(shape=(2**29, 2, 2, 2))
+
+        res = nd.SoftmaxActivation(data=data, out=out)
+
+        assert res.shape[0] == 536870912
+        assert res.shape[1] == 2
+        assert res.shape[2] == 2
+        assert res.shape[3] == 2
+
     def np_softmax(x, axis=-1, temperature=1.0):
         x = x - np.max(x, axis=axis, keepdims=True)
         x = np.exp(x/temperature)
@@ -450,6 +461,7 @@ def test_nn():
     check_softmax()
     check_softmax_cross_entropy()
     check_softmax_output()
+    check_softmax_activation()
     check_log_softmax()
     check_leaky_relu()
     check_pooling()


### PR DESCRIPTION
## Description ##
The Softmax Activation op was previously breaking on large tensor (dimension >= 2^32) data. With the following input:
```
run_performance_test(nd.SoftmaxActivation, run_backward=True, inputs=[{'data': (2**29,2,2,2), 'out': nd.random_normal(shape=(2**29,2,2,2))}], warmup=1, runs=1)
```
the following error was thrown:
```
TBlob.get_with_shape: Check failed: this->shape_.Size() == static_cast<size_t>(shape.Size()) (4294967296 vs. 0) : new and old shape do not match total elements
```

To root cause this issue, I ran the previous command in a Python script with GDB, and found that the underlying problem was in the shape construction logic of `softmax_activation-inl.h`. In the functions for computing the forward pass result and the gradient, several of the variables used the `int` dtype when they should have been using `index_t` to properly handle long int dimensions. I switched these variables to `index_t` and, after rebuilding, the previous input command displayed the correct output:
```
INFO:root:Begin Benchmark - SoftmaxActivation
INFO:root:Complete Benchmark - SoftmaxActivation
[{'SoftmaxActivation': [{'inputs': {'data': (536870912, 2, 2, 2), 'out': '<NDArray 536870912x2x2x2 @cpu(0)>'}, 'max_storage_mem_alloc_cpu/0': 24696062.0, 'avg_time_forward_SoftmaxActivation': 7426.1191, 'avg_time_backward_SoftmaxActivation': 16664.0254}]}]
```

To ensure completeness and to prevent future breaking changes, I also added a nightly test for the Softmax Activation op with large tensor data in `tests/nightly/test_large_array.py`.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M src/operator/nn/softmax_activation-inl.h
- M tests/nightly/test_large_array.py

## Comments ##
Tested on r5dn.24xl-ubuntu 16.04 and p2.16xl-ubuntu 16.04 with
1. Individual op run
2. Full OpPerf run

## Results ##
The key difference between CPU and GPU tests was the instance type (r5dn.24xl for CPU, p2.16xl for GPU). All relevant build flags remain the same, and both were tested using CPU context.

[Single operator test - SoftmaxActivation op (GPU)](https://gist.github.com/connorgoggins/5062d3043d04c68e23a80b23f5c0edb1)
[Single operator test - SoftmaxActivation op (CPU)](https://gist.github.com/connorgoggins/09ebe15c3f3aefb34b2a854847d22030)

[Full OpPerf test (GPU)]() - pending
[Full OpPerf test (CPU)]() - pending

@apeforest @access2rohit @ChaiBapchya 