### PR TITLE
Set Ninja build generator in config.cmake instead of commmand line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ endif()
 
 project(mxnet C CXX)
 
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/config.cmake)
+  # Load config.cmake only if mxnet is not compiled as a dependency of another project
+  include(${CMAKE_CURRENT_SOURCE_DIR}/config.cmake)
+endif()
+
 if(__CMAKE_CROSSCOMPILING_OVERRIDE)
   set(CMAKE_CROSSCOMPILING ${__CMAKE_CROSSCOMPILING})
 endif()

--- a/config/darwin.cmake
+++ b/config/darwin.cmake
@@ -55,6 +55,8 @@ set(USE_TVM_OP OFF CACHE BOOL "Enable use of TVM operator build system.")
 #---------------------
 # Compilers
 #--------------------
+set(CMAKE_GENERATOR "Ninja" CACHE STRING "Build Tool Generator used by CMake")
+
 # Compilers are usually autodetected. Uncomment and modify the next 3 lines to
 # choose manually:
 

--- a/config/darwin.cmake
+++ b/config/darwin.cmake
@@ -27,11 +27,11 @@
 #  Next modify the according entries, and then compile by
 #
 #  $ mkdir build; cd build
-#  $ cmake -C ../config.cmake ..
-#  $ cmake --build . --parallel 8
+#  $ cmake  ..
+#  $ cmake --build .
 #
-# You can increase the --parallel 8 argument to match the number of processor
-# cores of your computer.
+# Specify `cmake --build . --parallel N` to set the number of parallel compilation jobs.
+# Default is derived from CPUs available.
 #
 #-------------------------------------------------------------------------------
 

--- a/config/linux.cmake
+++ b/config/linux.cmake
@@ -73,6 +73,8 @@ set(USE_TVM_OP OFF CACHE BOOL "Enable use of TVM operator build system.")
 #---------------------
 # Compilers
 #--------------------
+set(CMAKE_GENERATOR "Ninja" CACHE STRING "Build Tool Generator used by CMake")
+
 # Compilers are usually autodetected. Uncomment and modify the next 3 lines to
 # choose manually:
 

--- a/config/linux.cmake
+++ b/config/linux.cmake
@@ -27,11 +27,11 @@
 #  Next modify the according entries, and then compile by
 #
 #  $ mkdir build; cd build
-#  $ cmake -C ../config.cmake ..
-#  $ cmake --build . --parallel 8
+#  $ cmake ..
+#  $ cmake --build .
 #
-# You can increase the --parallel 8 argument to match the number of processor
-# cores of your computer.
+# Specify `cmake --build . --parallel N` to set the number of parallel compilation jobs.
+# Default is derived from CPUs available.
 #
 #-------------------------------------------------------------------------------
 

--- a/config/linux_gpu.cmake
+++ b/config/linux_gpu.cmake
@@ -73,6 +73,8 @@ set(USE_TVM_OP OFF CACHE BOOL "Enable use of TVM operator build system.")
 #---------------------
 # Compilers
 #--------------------
+set(CMAKE_GENERATOR "Ninja" CACHE STRING "Build Tool Generator used by CMake")
+
 # Compilers are usually autodetected. Uncomment and modify the next 3 lines to
 # choose manually:
 

--- a/config/linux_gpu.cmake
+++ b/config/linux_gpu.cmake
@@ -27,11 +27,11 @@
 #  Next modify the according entries, and then compile by
 #
 #  $ mkdir build; cd build
-#  $ cmake -C ../config.cmake ..
-#  $ cmake --build . --parallel 8
+#  $ cmake ..
+#  $ cmake --build .
 #
-# You can increase the --parallel 8 argument to match the number of processor
-# cores of your computer.
+# Specify `cmake --build . --parallel N` to set the number of parallel compilation jobs.
+# Default is derived from CPUs available.
 #
 #-------------------------------------------------------------------------------
 

--- a/docs/static_site/src/pages/get_started/osx_setup.md
+++ b/docs/static_site/src/pages/get_started/osx_setup.md
@@ -110,9 +110,12 @@ the guide in [Math Library Selection](build_from_source#math-library-selection).
 ```bash
 rm -rf build
 mkdir -p build && cd build
-cmake -C ../config.cmake ..
+cmake ..
 cmake --build .
 ```
+
+Specify `cmake --build . --parallel N` to set the number of parallel compilation
+jobs. Default is derived from CPUs available.
 
 After a successful build, you will find the `libmxnet.dylib` in the `build`
 folder in your MXNet project root. `libmxnet.dylib` is required to install

--- a/docs/static_site/src/pages/get_started/osx_setup.md
+++ b/docs/static_site/src/pages/get_started/osx_setup.md
@@ -110,12 +110,9 @@ the guide in [Math Library Selection](build_from_source#math-library-selection).
 ```bash
 rm -rf build
 mkdir -p build && cd build
-cmake -GNinja -C ../config.cmake ..
-cmake --build . --parallel 8
+cmake -C ../config.cmake ..
+cmake --build .
 ```
-
-You can increase the `--parallel 8` argument to match the number of processor
-cores of your computer.
 
 After a successful build, you will find the `libmxnet.dylib` in the `build`
 folder in your MXNet project root. `libmxnet.dylib` is required to install

--- a/docs/static_site/src/pages/get_started/ubuntu_setup.md
+++ b/docs/static_site/src/pages/get_started/ubuntu_setup.md
@@ -130,12 +130,9 @@ the guide in [Math Library Selection](build_from_source#math-library-selection).
 ```bash
 rm -rf build
 mkdir -p build && cd build
-cmake -GNinja -C ../config.cmake ..
-cmake --build . --parallel 8
+cmake -C ../config.cmake ..
+cmake --build .
 ```
-
-You can increase the `--parallel 8` argument to match the number of processor
-cores of your computer.
 
 After a successful build, you will find the `libmxnet.so` in the `build` folder
 in your MXNet project root. `libmxnet.so` is required to install language

--- a/docs/static_site/src/pages/get_started/ubuntu_setup.md
+++ b/docs/static_site/src/pages/get_started/ubuntu_setup.md
@@ -130,9 +130,12 @@ the guide in [Math Library Selection](build_from_source#math-library-selection).
 ```bash
 rm -rf build
 mkdir -p build && cd build
-cmake -C ../config.cmake ..
+cmake ..
 cmake --build .
 ```
+
+Specify `cmake --build . --parallel N` to set the number of parallel compilation
+jobs. Default is derived from CPUs available.
 
 After a successful build, you will find the `libmxnet.so` in the `build` folder
 in your MXNet project root. `libmxnet.so` is required to install language


### PR DESCRIPTION
### Changes ###
- [X] Set Ninja build generator in config.cmake instead of commmand line

## Comments ##
Thanks to @apeforest for the suggestion.

Also remove `--parallel 8` argument from doc, as with ninja the number of cores is autodetected.