### PR TITLE
[OpPerf] Fixed Python profiler bug

### DIFF
--- a/benchmark/opperf/utils/profiler_utils.py
+++ b/benchmark/opperf/utils/profiler_utils.py
@@ -248,11 +248,17 @@ def python_profile(func):
     @functools.wraps(func)
     def python_profile_it(*args, **kwargs):
         runs = args[1]
+
+        if len(args) > 2:
+            modified_args = (args[0], 1, args[2])
+        else:
+            modified_args = (args[0], 1)
+            
         times = []
 
         for _ in range(runs):
             start_time = time.perf_counter()    # 1
-            res = func(*args, **kwargs)
+            res = func(*modified_args, **kwargs)
             end_time = time.perf_counter()      # 2
             run_time = (end_time - start_time)*1000    # 3
             times.append(run_time)

--- a/benchmark/opperf/utils/profiler_utils.py
+++ b/benchmark/opperf/utils/profiler_utils.py
@@ -248,12 +248,11 @@ def python_profile(func):
     @functools.wraps(func)
     def python_profile_it(*args, **kwargs):
         runs = args[1]
-        modified_args = (args[0], 1, args[2])
         times = []
 
         for _ in range(runs):
             start_time = time.perf_counter()    # 1
-            res = func(*modified_args, **kwargs)
+            res = func(*args, **kwargs)
             end_time = time.perf_counter()      # 2
             run_time = (end_time - start_time)*1000    # 3
             times.append(run_time)

--- a/benchmark/opperf/utils/profiler_utils.py
+++ b/benchmark/opperf/utils/profiler_utils.py
@@ -248,12 +248,7 @@ def python_profile(func):
     @functools.wraps(func)
     def python_profile_it(*args, **kwargs):
         runs = args[1]
-
-        if len(args) > 2:
-            modified_args = (args[0], 1, args[2])
-        else:
-            modified_args = (args[0], 1)
-            
+        modified_args = (args[0], 1)
         times = []
 
         for _ in range(runs):


### PR DESCRIPTION
## Description ##
Currently, the Python profiler for the opperf utility is broken. This fix changes the way args are passed to the underlying op during testing.

Fixes #17640 

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M benchmark/opperf/utils/profiler_utils.py

## Comments ##
Test suite was run with Python profiler on Mac OS X, building the latest version of MXNet (with my fix) from source.

[Full OpPerf test suite - CPU (Native profiler)](https://gist.github.com/connorgoggins/1202852d45e106f9e4d1959e1ffd1985)

[Full OpPerf test suite - CPU (Python profiler)](https://gist.github.com/connorgoggins/2422c1dd1fa8a98b2fad889dc7e9bdd4)

@apeforest 