### PR TITLE
[Large Tensor] Fix ravel_multi_index op

### DIFF
--- a/src/operator/tensor/ravel.h
+++ b/src/operator/tensor/ravel.h
@@ -93,7 +93,7 @@ inline bool UnravelOpShape(const nnvm::NodeAttrs& attrs,
 
 struct ravel_index {
   template<typename DType>
-  MSHADOW_XINLINE static void Map(int i, index_t N, index_t ndim, index_t *shape,
+  MSHADOW_XINLINE static void Map(index_t i, index_t N, index_t ndim, index_t *shape,
                                   DType *unravelled, DType *ravelled) {
     index_t ret = 0;
     #pragma unroll

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -495,6 +495,14 @@ def test_nn():
         assert res.shape[1] == 536870912
         assert res.shape[2] == 2
         assert res.shape[3] == 6
+        
+    def check_ravel():
+        data = nd.random_normal(shape=(2, LARGE_TENSOR_SHAPE))
+        shape = (2, 10)
+
+        out = nd.ravel_multi_index(data=data, shape=shape)
+
+        assert out.shape[0] == LARGE_TENSOR_SHAPE
 
     check_gluon_embedding()
     check_fully_connected()
@@ -518,6 +526,7 @@ def test_nn():
     check_col2im()
     check_embedding()
     check_spatial_transformer()
+    check_ravel()
 
 
 def test_tensor():


### PR DESCRIPTION
## Description ##
The ravel_multi_index op was previously breaking on large tensor (dimension >= 2^32) data. With the following input:
```
run_performance_test(nd.ravel_multi_index, inputs=[{"data": (2, 2**32), "shape":(2, 10)}], run_backward=True, warmup=1, runs=1)
```
the following error was thrown:
```
Segmentation fault: 11
```

To root cause this issue, I ran the previous command in a Python script with GDB, and found that the underlying problem was in the header of the `ravel_index` struct in `ravel.h`. The index variable `i` used the `int` dtype when it should have been using `index_t` to properly handle long int indices. I switched this variable to `index_t` in the struct header and, after rebuilding, the previous input command displayed the correct output:
```
INFO:root:Begin Benchmark - ravel_multi_index
INFO:root:Complete Benchmark - ravel_multi_index
[{'ravel_multi_index': [{'inputs': {'data': (2, 4294967296), 'shape': (2, 10)}, 'max_storage_mem_alloc_cpu/0': 24696062.0, 'avg_time_forward_ravel_multi_inde
x': 4257.312}]}]
```

To ensure completeness and to prevent future breaking changes, I also added a nightly test for the ravel_multi_index op with large tensor data in `tests/nightly/test_large_array.py`.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M src/operator/ravel.h
- M tests/nightly/test_large_array.py

## Comments ##
Tested on r5dn.24xl-ubuntu 16.04 and p2.16xl-ubuntu 16.04 with
1. Individual op run
2. Full OpPerf run

## Results ##
The key difference between CPU and GPU tests was the instance type (r5dn.24xl for CPU, p2.16xl for GPU). All relevant build flags remain the same, and both were tested using CPU context.

[Single operator test - ravel_multi_index op (GPU)](https://gist.github.com/connorgoggins/826a1008e7d01c2f5653d118e0bf9597)
[Single operator test - ravel_multi_index op (CPU)](https://gist.github.com/connorgoggins/067da6d1d3b1f392c10ec1606f4f963b)

[Full OpPerf test (GPU)](https://gist.github.com/connorgoggins/6227e2ad23de51e5f3a06eb8d5a01092)
[Full OpPerf test (CPU)](https://gist.github.com/connorgoggins/02d298a1498277a85fdfe6a92c59df53)

@apeforest @access2rohit @ChaiBapchya 