### PR TITLE
Enable users to specify BLAS

### DIFF
--- a/config/darwin.cmake
+++ b/config/darwin.cmake
@@ -38,7 +38,7 @@
 #---------------------------------------------
 # Common libraries
 #---------------------------------------------
-set(BLAS "apple" CACHE STRING "BLAS Vendor")
+set(USE_BLAS "apple" CACHE STRING "BLAS Vendor")
 
 set(USE_OPENCV ON CACHE BOOL "Build with OpenCV support")
 set(OPENCV_ROOT "" CACHE BOOL "OpenCV install path. Supports autodetection.")

--- a/config/distribution/darwin_cpu.cmake
+++ b/config/distribution/darwin_cpu.cmake
@@ -19,7 +19,7 @@ set(CMAKE_BUILD_TYPE "Distribution" CACHE STRING "Build type")
 set(CFLAGS "-mno-avx" CACHE STRING "CFLAGS")
 set(CXXFLAGS "-mno-avx" CACHE STRING "CXXFLAGS")
 
-set(BLAS "apple" CACHE STRING "BLAS Vendor")
+set(USE_BLAS "apple" CACHE STRING "BLAS Vendor")
 
 set(USE_CUDA OFF CACHE BOOL "Build with CUDA support")
 set(USE_OPENCV ON CACHE BOOL "Build with OpenCV support")

--- a/config/linux.cmake
+++ b/config/linux.cmake
@@ -56,7 +56,7 @@ set(MXNET_CUDA_ARCH "Auto" CACHE STRING "Target NVIDIA GPU achitecture")
 #---------------------------------------------
 # Common libraries
 #---------------------------------------------
-set(BLAS "open" CACHE STRING "BLAS Vendor")
+set(USE_BLAS "open" CACHE STRING "BLAS Vendor")
 
 set(USE_OPENCV ON CACHE BOOL "Build with OpenCV support")
 set(OPENCV_ROOT "" CACHE BOOL "OpenCV install path. Supports autodetection.")

--- a/config/linux_gpu.cmake
+++ b/config/linux_gpu.cmake
@@ -56,7 +56,7 @@ set(MXNET_CUDA_ARCH "Auto" CACHE STRING "Target NVIDIA GPU achitecture")
 #---------------------------------------------
 # Common libraries
 #---------------------------------------------
-set(BLAS "open" CACHE STRING "BLAS Vendor")
+set(USE_BLAS "open" CACHE STRING "BLAS Vendor")
 
 set(USE_OPENCV ON CACHE BOOL "Build with OpenCV support")
 set(OPENCV_ROOT "" CACHE BOOL "OpenCV install path. Supports autodetection.")


### PR DESCRIPTION
## Description ##
Fix a bug where users can't specify BLAS if MKL is installed in the path. This is caused by the logic in https://github.com/apache/incubator-mxnet/blob/master/cmake/ChooseBlas.cmake#L21

@leezu Please review