### PR TITLE
Use multi-tensor sumSQ in clip_global_norm

### DIFF
--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -31,8 +31,6 @@ import collections
 import weakref
 import requests
 
-import mxnet as mx
-from mxnet import nd
 import numpy as np
 
 from .. import ndarray
@@ -145,12 +143,12 @@ def clip_global_norm(arrays, max_norm, check_isfinite=True):
     all_ctx_sum = []
     ctx = arrays[0].context
     for group in arrays_groups:
-        sum_sq = mx.nd.multi_sum_sq(*arrays_groups[group],
-                                    num_arrays=len(arrays_groups[group]))
-        sum_sq = nd.add_n(*sum_sq)
+        sum_sq = ndarray.multi_sum_sq(*arrays_groups[group],
+                                      num_arrays=len(arrays_groups[group]))
+        sum_sq = ndarray.add_n(*sum_sq)
         all_ctx_sum.append(sum_sq.as_in_context(ctx))
     # global reduce
-    total_norm = nd.add_n(*all_ctx_sum).sqrt()
+    total_norm = ndarray.add_n(*all_ctx_sum).sqrt()
     if check_isfinite:
         if not np.isfinite(total_norm.asscalar()):
             warnings.warn(

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -336,14 +336,18 @@ def test_global_norm_clip_multi_device():
     for check_isfinite in [True, False]:
         x1 = mx.nd.ones((3, 3), ctx=mx.gpu(0))
         x2 = mx.nd.ones((4, 4), ctx=mx.cpu(0))
+        x3 = mx.nd.ones((7, 4), ctx=mx.gpu(0))
+        x4 = mx.nd.ones((7, 4), ctx=mx.cpu(0))
         norm = gluon.utils.clip_global_norm(
-            [x1, x2], 1.0, check_isfinite=check_isfinite)
+            [x1, x2, x3, x4], 1.0, check_isfinite=check_isfinite)
         if check_isfinite:
-            assert norm == 5.0
+            assert norm == 9.0
         else:
-            assert norm.asscalar() == 5.0
-        assert_almost_equal(x1, np.ones((3, 3)) / 5)
-        assert_almost_equal(x2, np.ones((4, 4)) / 5)
+            assert norm.asscalar() == 9.0
+        assert_almost_equal(x1, np.ones((3, 3)) / 9)
+        assert_almost_equal(x2, np.ones((4, 4)) / 9)
+        assert_almost_equal(x3, np.ones((7, 4)) / 9)
+        assert_almost_equal(x4, np.ones((7, 4)) / 9)
 
 
 def _check_batchnorm_result(input, num_devices=1, cuda=False):


### PR DESCRIPTION
## Description ##
Using multi-tensor sum of squares in gluon: clip_global_norm.
Instead of computing the sum of squares of each input array sequentially, compute them in parallel (multi-tensor). 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] gluon: clip_global_norm was modified to use mxnet.nd.multi_sum_sq op and compute the sumSq of several arrays in parallel
- [x] Test in tests/python/gpu/test_gluon_gpu:test_global_norm_clip_multi_device was extended to have 2 arrays on gpu(0) and 2 arrays on cpu(0), so that multi-tensor sumSq is tested for each of these contexts
