### PR TITLE
[Large Tensor] Fix multi_lars op

### DIFF
--- a/src/operator/contrib/multi_lars-inl.h
+++ b/src/operator/contrib/multi_lars-inl.h
@@ -59,7 +59,7 @@ struct LARSParam : public dmlc::Parameter<LARSParam> {
 };
 
 struct MultiLARSKernel {
-  MSHADOW_XINLINE static void Map(int i, float* out_data, const float* lrs,
+  MSHADOW_XINLINE static void Map(index_t i, float* out_data, const float* lrs,
                                   const float* weights_sum_sq, const float* grads_sum_sq,
                                   const float* wds, const float eta, const float eps,
                                   const float rescale_grad, const OpReqType req) {

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -514,6 +514,20 @@ def test_nn():
         assert res.shape[1] == SMALL_Y
         assert res[0][SMALL_Y - 1] == 50.
 
+    def check_multi_lars():
+        lrs = nd.random_normal(shape=(LARGE_TENSOR_SHAPE + 1, 1))
+        weights_sum_sq = nd.random_normal(shape=(LARGE_TENSOR_SHAPE + 1, 1))
+        grads_sum_sq = nd.random_normal(shape=(LARGE_TENSOR_SHAPE + 1, 1))
+        wds = nd.random_normal(shape=(LARGE_TENSOR_SHAPE + 1, 1))
+        eta = .1
+        eps = .9
+
+        out = nd.multi_lars(lrs=lrs, weights_sum_sq=weights_sum_sq, grads_sum_sq=grads_sum_sq,
+                            wds=wds, eta=eta, eps=eps)
+
+        assert out.shape[0] == LARGE_TENSOR_SHAPE + 1
+        assert out.shape[1] == 1
+
     check_gluon_embedding()
     check_fully_connected()
     check_dense()
@@ -538,6 +552,7 @@ def test_nn():
     check_spatial_transformer()
     check_ravel()
     check_cumsum()
+    check_multi_lars()
 
 
 def test_tensor():

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -528,6 +528,9 @@ def test_nn():
         assert out.shape[0] == LARGE_TENSOR_SHAPE + 1
         assert out.shape[1] == 1
 
+        # Trigger lazy evaluation of the output NDArray and ensure that it has been filled
+        assert type(out[0, 0].asscalar()).__name__ == 'float32'
+
     check_gluon_embedding()
     check_fully_connected()
     check_dense()


### PR DESCRIPTION
## Description ##
The multi_lars op was previously breaking on large tensor (dimension >= 2^32) data. With the following input:
```
run_performance_test(nd.multi_lars, inputs=[{"lrs": nd.random_normal(shape=(2**32 + 1, 1)), "weights_sum_sq": nd.random_normal(shape=(2**32 + 1, 1)), "grads_sum_sq": nd.random_normal(shape=(2**32 + 1, 1)), "wds": nd.random_normal(shape=(2**32 + 1, 1)), "eta": .1, "eps": .9}], run_backward=False, warmup=1, runs=1)
```
the following error was thrown:
```
Segmentation fault: 11
```

To root cause this issue, I ran the previous command in a Python script with GDB, and found that the underlying problem was in the data type of the `MultiLARS` kernel in `multi_lars-inl.h.h`. The index variable `i` used the `int` dtype when it should have been using `index_t` to properly handle long int indices. I switched this variable to `index_t` in the struct header and, after rebuilding, the previous input command displayed the correct output:
```
INFO:root:Begin Benchmark - multi_lars
INFO:root:Complete Benchmark - multi_lars
[{'multi_lars': [{'inputs': {'lrs': '<NDArray 4294967297x1 @cpu(0)>', 'weights_sum_sq': '<NDArray 4294967297x1 @cpu(0)>', 'grads_sum_sq': '<NDArray 4294967297x1 @cpu(0)>', 'wds': '<NDArray 4294967297x1 @cpu(0)>', 'eta': 0.1, 'eps': 0.9}, 'max_storage_mem_alloc_cpu/0': 16106127.0, 'avg_time_forward_multi_lars': 4904.6128}]}]
```

To ensure completeness and to prevent future breaking changes, I also added a nightly test for the multi_lars op with large tensor data in `tests/nightly/test_large_array.py`.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M src/operator/contrib/multi_lars-inl.h
- M tests/nightly/test_large_array.py

## Comments ##
Tested on r5dn.24xl-ubuntu 16.04 with
1. Individual op run
2. Full OpPerf run

## Results ##
[Single operator test - multi_lars op (CPU)](https://gist.github.com/connorgoggins/c4c3c672a25d6845b01cd1a5f5e15d5f)

[Full OpPerf test (CPU)](https://gist.github.com/connorgoggins/19ca07c40be4f5751567677b79ca0272)

@apeforest @access2rohit @ChaiBapchya 