### PR TITLE
[Large Tensor] Fix cumsum op

### DIFF
--- a/src/operator/numpy/np_cumsum-inl.h
+++ b/src/operator/numpy/np_cumsum-inl.h
@@ -62,12 +62,12 @@ struct cumsum_forward {
   template<typename IType, typename OType>
   MSHADOW_XINLINE static void Map(index_t i,
                                   OType *out,
-                                  const index_t *in,
+                                  const IType *in,
                                   const index_t middle,
                                   const index_t trailing) {
     index_t left = i / trailing, right = i % trailing;
     index_t offset = left * middle * trailing + right;
-    const index_t *lane_in = in + offset;
+    const IType *lane_in = in + offset;
     OType *lane_out = out + offset;
     lane_out[0] = OType(lane_in[0]);
     for (index_t j = 1; j < middle; ++j) {
@@ -126,14 +126,14 @@ void CumsumForward(const nnvm::NodeAttrs& attrs,
 struct cumsum_backward {
   template<typename IType, typename OType>
   MSHADOW_XINLINE static void Map(index_t i,
-                                  index_t *igrad,
+                                  IType *igrad,
                                   const OType *ograd,
                                   const index_t middle,
                                   const index_t trailing) {
     index_t left = i / trailing, right = i % trailing;
     index_t offset = left * middle * trailing + right;
     const OType *lane_ograd = ograd + offset;
-    index_t *lane_igrad = igrad + offset;
+    IType *lane_igrad = igrad + offset;
     lane_igrad[(middle - 1) * trailing] = index_t(lane_ograd[(middle - 1) * trailing]);
     for (index_t j = middle - 2; j >= 0; --j) {
       lane_igrad[j * trailing] = lane_igrad[(j + 1) * trailing] + index_t(lane_ograd[j * trailing]);

--- a/src/operator/numpy/np_cumsum-inl.h
+++ b/src/operator/numpy/np_cumsum-inl.h
@@ -60,17 +60,17 @@ struct CumsumParam : public dmlc::Parameter<CumsumParam> {
 
 struct cumsum_forward {
   template<typename IType, typename OType>
-  MSHADOW_XINLINE static void Map(int i,
+  MSHADOW_XINLINE static void Map(index_t i,
                                   OType *out,
                                   const IType *in,
-                                  const int middle,
-                                  const int trailing) {
-    int left = i / trailing, right = i % trailing;
-    int offset = left * middle * trailing + right;
+                                  const index_t middle,
+                                  const index_t trailing) {
+    index_t left = i / trailing, right = i % trailing;
+    index_t offset = left * middle * trailing + right;
     const IType *lane_in = in + offset;
     OType *lane_out = out + offset;
     lane_out[0] = OType(lane_in[0]);
-    for (int j = 1; j < middle; ++j) {
+    for (index_t j = 1; j < middle; ++j) {
       lane_out[j * trailing] = lane_out[(j - 1) * trailing] + OType(lane_in[j * trailing]);
     }
   }
@@ -125,17 +125,17 @@ void CumsumForward(const nnvm::NodeAttrs& attrs,
 
 struct cumsum_backward {
   template<typename IType, typename OType>
-  MSHADOW_XINLINE static void Map(int i,
+  MSHADOW_XINLINE static void Map(index_t i,
                                   IType *igrad,
                                   const OType *ograd,
-                                  const int middle,
-                                  const int trailing) {
-    int left = i / trailing, right = i % trailing;
-    int offset = left * middle * trailing + right;
+                                  const index_t middle,
+                                  const index_t trailing) {
+    index_t left = i / trailing, right = i % trailing;
+    index_t offset = left * middle * trailing + right;
     const OType *lane_ograd = ograd + offset;
     IType *lane_igrad = igrad + offset;
     lane_igrad[(middle - 1) * trailing] = IType(lane_ograd[(middle - 1) * trailing]);
-    for (int j = middle - 2; j >= 0; --j) {
+    for (index_t j = middle - 2; j >= 0; --j) {
       lane_igrad[j * trailing] = lane_igrad[(j + 1) * trailing] + IType(lane_ograd[j * trailing]);
     }
   }

--- a/src/operator/numpy/np_cumsum-inl.h
+++ b/src/operator/numpy/np_cumsum-inl.h
@@ -134,9 +134,9 @@ struct cumsum_backward {
     index_t offset = left * middle * trailing + right;
     const OType *lane_ograd = ograd + offset;
     IType *lane_igrad = igrad + offset;
-    lane_igrad[(middle - 1) * trailing] = index_t(lane_ograd[(middle - 1) * trailing]);
+    lane_igrad[(middle - 1) * trailing] = IType(lane_ograd[(middle - 1) * trailing]);
     for (index_t j = middle - 2; j >= 0; --j) {
-      lane_igrad[j * trailing] = lane_igrad[(j + 1) * trailing] + index_t(lane_ograd[j * trailing]);
+      lane_igrad[j * trailing] = lane_igrad[(j + 1) * trailing] + IType(lane_ograd[j * trailing]);
     }
   }
 };

--- a/src/operator/numpy/np_cumsum-inl.h
+++ b/src/operator/numpy/np_cumsum-inl.h
@@ -98,11 +98,11 @@ void CumsumForwardImpl(const OpContext& ctx,
   }
 
   Stream<xpu> *s = ctx.get_stream<xpu>();
-  MSHADOW_TYPE_SWITCH_WITH_BOOL(in.type_flag_, index_t, {
+  MSHADOW_TYPE_SWITCH_WITH_BOOL(in.type_flag_, IType, {
     MSHADOW_TYPE_SWITCH(out.type_flag_, OType, {
       Kernel<cumsum_forward, xpu>::Launch(
         s, out.Size() / middle, out.dptr<OType>(),
-        in.dptr<index_t>(), middle, trailing);
+        in.dptr<IType>(), middle, trailing);
     });
   });
 }
@@ -157,10 +157,10 @@ void CumsumBackwardImpl(const OpContext& ctx,
     }
   }
   Stream<xpu> *s = ctx.get_stream<xpu>();
-  MSHADOW_TYPE_SWITCH_WITH_BOOL(igrad.type_flag_, index_t, {
+  MSHADOW_TYPE_SWITCH_WITH_BOOL(igrad.type_flag_, IType, {
     MSHADOW_TYPE_SWITCH(ograd.type_flag_, OType, {
       Kernel<cumsum_backward, xpu>::Launch(
-        s, igrad.Size() / middle, igrad.dptr<index_t>(),
+        s, igrad.Size() / middle, igrad.dptr<IType>(),
         ograd.dptr<OType>(), middle, trailing);
     });
   });

--- a/src/operator/numpy/np_cumsum-inl.h
+++ b/src/operator/numpy/np_cumsum-inl.h
@@ -62,12 +62,12 @@ struct cumsum_forward {
   template<typename IType, typename OType>
   MSHADOW_XINLINE static void Map(index_t i,
                                   OType *out,
-                                  const IType *in,
+                                  const index_t *in,
                                   const index_t middle,
                                   const index_t trailing) {
     index_t left = i / trailing, right = i % trailing;
     index_t offset = left * middle * trailing + right;
-    const IType *lane_in = in + offset;
+    const index_t *lane_in = in + offset;
     OType *lane_out = out + offset;
     lane_out[0] = OType(lane_in[0]);
     for (index_t j = 1; j < middle; ++j) {
@@ -98,11 +98,11 @@ void CumsumForwardImpl(const OpContext& ctx,
   }
 
   Stream<xpu> *s = ctx.get_stream<xpu>();
-  MSHADOW_TYPE_SWITCH_WITH_BOOL(in.type_flag_, IType, {
+  MSHADOW_TYPE_SWITCH_WITH_BOOL(in.type_flag_, index_t, {
     MSHADOW_TYPE_SWITCH(out.type_flag_, OType, {
       Kernel<cumsum_forward, xpu>::Launch(
         s, out.Size() / middle, out.dptr<OType>(),
-        in.dptr<IType>(), middle, trailing);
+        in.dptr<index_t>(), middle, trailing);
     });
   });
 }

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -510,6 +510,7 @@ def test_nn():
         res = nd.cumsum(a=a)
 
         assert res.shape[0] == LARGE_TENSOR_SHAPE + 1
+        assert type(res[0].asscalar()).__name__ == 'float32'
 
     check_gluon_embedding()
     check_fully_connected()

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -504,6 +504,13 @@ def test_nn():
 
         assert out.shape[0] == LARGE_TENSOR_SHAPE
 
+    def check_cumsum():
+        a = nd.random_normal(shape=(LARGE_TENSOR_SHAPE + 1, 1))
+
+        res = nd.cumsum(a=a)
+
+        assert res.shape[0] == LARGE_TENSOR_SHAPE + 1
+
     check_gluon_embedding()
     check_fully_connected()
     check_dense()
@@ -527,6 +534,7 @@ def test_nn():
     check_embedding()
     check_spatial_transformer()
     check_ravel()
+    check_cumsum()
 
 
 def test_tensor():

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -505,12 +505,14 @@ def test_nn():
         assert out.shape[0] == LARGE_TENSOR_SHAPE
 
     def check_cumsum():
-        a = nd.random_normal(shape=(LARGE_TENSOR_SHAPE + 1, 1))
+        a = nd.ones((LARGE_X, SMALL_Y))
+        axis = 1
 
-        res = nd.cumsum(a=a)
+        res = nd.cumsum(a=a, axis=axis)
 
-        assert res.shape[0] == LARGE_TENSOR_SHAPE + 1
-        assert type(res[0].asscalar()).__name__ == 'float32'
+        assert res.shape[0] == LARGE_X
+        assert res.shape[1] == SMALL_Y
+        assert res[0][SMALL_Y - 1] == 50.
 
     check_gluon_embedding()
     check_fully_connected()


### PR DESCRIPTION
## Description ##
The cumsum op was previously breaking on large tensor (dimension > 2^32) data. With the following input:
```
run_performance_test(nd.cumsum, inputs=[{"a": nd.random_normal(shape=(2**32 + 1, 1))}], run_backward=True, warmup=1, runs=1)
```
the following error was thrown:
```
Segmentation fault (core dumped)
```

To root cause this issue, I ran the previous command in a Python script with GDB, and found that the underlying problem was in the data type of several variables in the forward/backward structs in `np_cumsum-inl.h.h`. These variables used the `int` dtype when they should have been using `index_t` to properly handle long int indices. I switched these variables to `index_t` in the struct header and, after rebuilding, the previous input command displayed the correct output:
```
INFO:root:Begin Benchmark - cumsum
INFO:root:Complete Benchmark - cumsum
[{'cumsum': [{'inputs': {'a': '<NDArray 4294967297x1 @cpu(0)>'}, 'max_storage_mem_alloc_cpu/0': 33285996.0, 'avg_time_forward_cumsum': 4366.7148, 'avg_time_backward_cumsum': 12744.9971}]}]
```

To ensure completeness and to prevent future breaking changes, I also added a nightly test for the cumsum op with large tensor data in `tests/nightly/test_large_array.py`.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M src/operator/numpy/np_cumsum-inl.h
- M tests/nightly/test_large_array.py

## Comments ##
Tested on r5dn.24xl-ubuntu 16.04 with
1. Individual op run
2. Full OpPerf run

## Results ##
[Single operator test - cumsum op (CPU)](https://gist.github.com/connorgoggins/7d1a5912512b1dbbacff350e3cd576ee)

[Full OpPerf test (CPU)](https://gist.github.com/connorgoggins/4538df906c3fbe36f989bb9067b8feb8)

@apeforest @access2rohit @ChaiBapchya 