### PR TITLE
Fix reverse shape inference in LayerNorm

### DIFF
--- a/src/operator/nn/layer_norm.cc
+++ b/src/operator/nn/layer_norm.cc
@@ -52,10 +52,12 @@ static bool LayerNormShape(const nnvm::NodeAttrs& attrs,
   if (!mxnet::ndim_is_known(dshape)) {
     return false;
   }
-
-  in_shape->at(layernorm::kGamma) = mxnet::TShape(Shape1(channelCount));
-  in_shape->at(layernorm::kBeta) = mxnet::TShape(Shape1(channelCount));
-
+  SHAPE_ASSIGN_CHECK(*in_shape,
+                layernorm::kGamma,
+                mxnet::TShape(Shape1(channelCount)));
+  SHAPE_ASSIGN_CHECK(*in_shape,
+                     layernorm::kBeta,
+                     mxnet::TShape(Shape1(channelCount)));
   out_shape->clear();
   out_shape->push_back(dshape);                // kOut
   mxnet::TShape moments_shape(dshape.begin(), dshape.end());

--- a/src/operator/nn/layer_norm.cc
+++ b/src/operator/nn/layer_norm.cc
@@ -53,8 +53,8 @@ static bool LayerNormShape(const nnvm::NodeAttrs& attrs,
     return false;
   }
   SHAPE_ASSIGN_CHECK(*in_shape,
-                layernorm::kGamma,
-                mxnet::TShape(Shape1(channelCount)));
+                     layernorm::kGamma,
+                     mxnet::TShape(Shape1(channelCount)));
   SHAPE_ASSIGN_CHECK(*in_shape,
                      layernorm::kBeta,
                      mxnet::TShape(Shape1(channelCount)));

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -21,7 +21,7 @@ import tempfile
 import mxnet as mx
 from mxnet import gluon
 from mxnet.gluon import nn
-from mxnet.base import py_str
+from mxnet.base import py_str, MXNetError
 from mxnet.test_utils import assert_almost_equal
 from mxnet.util import is_np_array
 from mxnet.ndarray.ndarray import _STORAGE_TYPE_STR_TO_ID
@@ -894,7 +894,13 @@ def test_instancenorm():
 def test_layernorm():
     layer = nn.LayerNorm(in_channels=10)
     check_layer_forward(layer, (2, 10, 10, 10))
-
+    # Check for the case of error raising
+    for hybridize in [False, True]:
+        layer = nn.LayerNorm(in_channels=10)
+        layer.initialize()
+        if hybridize:
+            layer.hybridize()
+        assert_raises(MXNetError, lambda: layer(mx.nd.ones((2, 11))))
 
 @with_seed()
 def test_groupnorm():


### PR DESCRIPTION
Fix https://github.com/apache/incubator-mxnet/issues/17654. Now, the user will see an error message if the `in_channels` does not match with the corresponding dimension in the input

After the PR, the following will raise an error
```python
import mxnet as mx
from mxnet.gluon import nn
net = nn.LayerNorm(in_channels=10)
net.initialize()
net.hybridize()
out = net(mx.nd.ones((2, 11)))  # Trigger the error
```

Error:
```
MXNetError: MXNetError: Error in operator layernorm0_layernorm0: Shape inconsistent, Provided = [10], inferred shape=[11]

```
