### PR TITLE
for OPECV4.X

### DIFF
--- a/src/io/image_aug_default.cc
+++ b/src/io/image_aug_default.cc
@@ -470,14 +470,24 @@ class DefaultImageAugmenter : public ImageAugmenter {
         }
         if (i == 1) {
           // contrast
+#if CV_MAJOR_VERSION < 4
           cvtColor(res, temp_, CV_RGB2GRAY);
+#else
+          cvtColor(res, temp_, cv::COLOR_RGB2GRAY);
+#endif
+
           float gray_mean = cv::mean(temp_)[0];
           res.convertTo(res, -1, alpha_c, (1 - alpha_c) * gray_mean);
         }
         if (i == 2) {
           // saturation
+#if CV_MAJOR_VERSION < 4
           cvtColor(res, temp_, CV_RGB2GRAY);
           cvtColor(temp_, temp_, CV_GRAY2BGR);
+#else
+          cvtColor(res, temp_, cv::COLOR_RGB2GRAY);
+          cvtColor(temp_, temp_, cv::COLOR_GRAY2BGR);
+#endif
           cv::addWeighted(res, alpha_s, temp_, 1 - alpha_s, 0.0, res);
         }
       }
@@ -486,7 +496,11 @@ class DefaultImageAugmenter : public ImageAugmenter {
     // color space augmentation
     if (param_.random_h != 0 || param_.random_s != 0 || param_.random_l != 0) {
       std::uniform_real_distribution<float> rand_uniform(0, 1);
+#if CV_MAJOR_VERSION < 4
       cvtColor(res, res, CV_BGR2HLS);
+#else
+      cvtColor(res, res, cv::COLOR_BGR2HLS);
+#endif
       // use an approximation of gaussian distribution to reduce extreme value
       float rh = rand_uniform(*prnd); rh += 4 * rand_uniform(*prnd); rh = rh / 5;
       float rs = rand_uniform(*prnd); rs += 4 * rand_uniform(*prnd); rs = rs / 5;
@@ -506,7 +520,11 @@ class DefaultImageAugmenter : public ImageAugmenter {
           }
         }
       }
+#if CV_MAJOR_VERSION < 4
       cvtColor(res, res, CV_HLS2BGR);
+#else
+      cvtColor(res, res, cv::COLOR_HLS2BGR);
+#endif
     }
 
     // pca noise

--- a/src/io/image_det_aug_default.cc
+++ b/src/io/image_det_aug_default.cc
@@ -548,7 +548,11 @@ class DefaultImageDetAugmenter : public ImageAugmenter {
       if (h != 0 || s != 0 || l != 0) {
         int temp[3] = {h, l, s};
         int limit[3] = {180, 255, 255};
+#if CV_MAJOR_VERSION < 4
         cv::cvtColor(res, res, CV_BGR2HLS);
+#else
+        cv::cvtColor(res, res, cv::COLOR_BGR2HLS);
+#endif
         for (int i = 0; i < res.rows; ++i) {
           for (int j = 0; j < res.cols; ++j) {
             for (int k = 0; k < 3; ++k) {
@@ -559,7 +563,11 @@ class DefaultImageDetAugmenter : public ImageAugmenter {
             }
           }
         }
+#if CV_MAJOR_VERSION < 4
         cv::cvtColor(res, res, CV_HLS2BGR);
+#else
+        cv::cvtColor(res, res, cv::COLOR_HLS2BGR);
+#endif
       }
       if (std::fabs(c) > 1e-3) {
         cv::Mat tmp = res;

--- a/src/io/image_io.cc
+++ b/src/io/image_io.cc
@@ -170,7 +170,11 @@ void ImdecodeImpl(int flag, bool to_rgb, void* data, size_t size,
   }
   CHECK_EQ(static_cast<void*>(dst.ptr()), out->data().dptr_);
   if (to_rgb && flag != 0) {
+#if CV_MAJOR_VERSION < 4
     cv::cvtColor(dst, dst, CV_BGR2RGB);
+#else
+    cv::cvtColor(dst, dst, cv::COLOR_BGR2RGB);
+#endif
   }
 }
 #endif  // MXNET_USE_OPENCV


### PR DESCRIPTION
## Description ##
support OPENCV4 for Jetson Nano
## Checklist ##
### Essentials ###
### Changes ###
src/io/image_aug_default.cc 
src/io/image_det_aug_default.cc 
src/io/image_io.cc
## Comments ##
spport Jetson Nano, OpenCV 4.X
