### PR TITLE
Use FP32 copy of weights for norm (multitensor LAMB optimizer)

### DIFF
--- a/src/operator/contrib/multi_lamb-inl.h
+++ b/src/operator/contrib/multi_lamb-inl.h
@@ -287,9 +287,9 @@ inline void MultiLAMB(const nnvm::NodeAttrs& attrs,
     std::vector<TBlob> weights_for_norm;
     int position_weights = 0;
     if (!std::is_same<DType, MPDType>::value)
-	position_weights = input_stride - 1;
+      position_weights = input_stride - 1;
     for (size_t index = 0; index < kernel_params.ntensors; ++index) {
-        weights_for_norm.emplace_back(inputs[index * input_stride + position_weights]);
+      weights_for_norm.emplace_back(inputs[index * input_stride + position_weights]);
     }
 
     // Calculate amount of temporary storage (temp_g, r1, r2, block_to_tensor, block_to_chunk)

--- a/src/operator/contrib/multi_lamb-inl.h
+++ b/src/operator/contrib/multi_lamb-inl.h
@@ -282,10 +282,14 @@ inline void MultiLAMB(const nnvm::NodeAttrs& attrs,
     FillMultiLAMBKernelParam<xpu, DType, MPDType, MultiLAMBParam, input_stride>
             (attrs, ctx, inputs, outputs, &kernel_params);
 
-    // create vector of TBlob with all the weights contiguous
-    std::vector<TBlob> weights;
+    // create vector of TBlob with all the weights contiguous to compute the norm
+    // if mixed precision, use fp32 copy
+    std::vector<TBlob> weights_for_norm;
+    int position_weights = 0;
+    if (!std::is_same<DType, MPDType>::value)
+	position_weights = input_stride - 1;
     for (size_t index = 0; index < kernel_params.ntensors; ++index) {
-        weights.emplace_back(inputs[index*input_stride]);
+        weights_for_norm.emplace_back(inputs[index * input_stride + position_weights]);
     }
 
     // Calculate amount of temporary storage (temp_g, r1, r2, block_to_tensor, block_to_chunk)
@@ -327,7 +331,7 @@ inline void MultiLAMB(const nnvm::NodeAttrs& attrs,
     Tensor<xpu, 1, int> block_to_chunk(reinterpret_cast<int*>(&workspace[pos_wspace]),
       Shape1(kernel_params.nchunks), s);
 
-    MultiSumSqRun<xpu>(weights, kernel_params.ntensors, r1.dptr_, ctx);
+    MultiSumSqRun<xpu>(weights_for_norm, kernel_params.ntensors, r1.dptr_, ctx);
     CallKernel1<MPDType, DType>(s, kernel_params, param, temp_g.dptr_,
                                 block_to_tensor.dptr_,
                                 block_to_chunk.dptr_);


### PR DESCRIPTION
## Description ##
When using Mixed Precision, use the master copy of weights (FP32) for computing the norm

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage: test was already available (tests/python/unittesttest_optimizer:test_multilamb)
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Modified the code to use the master copy of weights for computing the norm when mixed precision is used
