### PR TITLE
Fix get_started pip instructions

### DIFF
--- a/docs/static_site/src/_includes/get_started/linux/python/cpu/pip.md
+++ b/docs/static_site/src/_includes/get_started/linux/python/cpu/pip.md
@@ -1,6 +1,6 @@
 Run the following command:
 
-<div class="v1-5-0">
+<div class="v1-5-1">
 {% highlight bash %}
 $ pip install mxnet
 {% endhighlight %}
@@ -13,7 +13,7 @@ in the <a href="https://mxnet.io/api/faq/perf#intel-cpu">MXNet tuning guide</a>.
 $ pip install mxnet-mkl
 {% endhighlight %}
 
-</div> <!-- End of v1-5-0 -->
+</div> <!-- End of v1-5-1 -->
 
 <div class="v1-4-1">
 

--- a/docs/static_site/src/_includes/get_started/linux/python/gpu/pip.md
+++ b/docs/static_site/src/_includes/get_started/linux/python/gpu/pip.md
@@ -1,11 +1,11 @@
 Run the following command:
 
-<div class="v1-5-0">
+<div class="v1-5-1">
 {% highlight bash %}
 $ pip install mxnet-cu101
 {% endhighlight %}
 
-</div> <!-- End of v1-5-0 -->
+</div> <!-- End of v1-5-1 -->
 <div class="v1-4-1">
 
 {% highlight bash %}

--- a/docs/static_site/src/_includes/get_started/macos/python/cpu/pip.md
+++ b/docs/static_site/src/_includes/get_started/macos/python/cpu/pip.md
@@ -1,11 +1,11 @@
 Run the following command:
 
-<div class="v1-5-0">
+<div class="v1-5-1">
 
 {% highlight bash %}
 $ pip install mxnet
 {% endhighlight %}
-</div> <!-- End of v1-5-0 -->
+</div> <!-- End of v1-5-1 -->
 <div class="v1-4-1">
 
 {% highlight bash %}

--- a/docs/static_site/src/_includes/get_started/windows/python/cpu/pip.md
+++ b/docs/static_site/src/_includes/get_started/windows/python/cpu/pip.md
@@ -1,12 +1,12 @@
 Run the following command:
 
-<div class="v1-5-0">
+<div class="v1-5-1">
 
 {% highlight bash %}
 $ pip install mxnet
 {% endhighlight %}
 
-</div> <!-- End of v1-5-0 -->
+</div> <!-- End of v1-5-1 -->
 <div class="v1-4-1">
 
 {% highlight bash %}

--- a/docs/static_site/src/_includes/get_started/windows/python/gpu/pip.md
+++ b/docs/static_site/src/_includes/get_started/windows/python/gpu/pip.md
@@ -1,12 +1,12 @@
 Run the following command:
 
-<div class="v1-5-0">
+<div class="v1-5-1">
 
 {% highlight bash %}
 $ pip install mxnet-cu101
 {% endhighlight %}
 
-</div> <!-- End of v1-5-0 -->
+</div> <!-- End of v1-5-1 -->
 <div class="v1-4-1">
 
 {% highlight bash %}


### PR DESCRIPTION
The class attribute in the respective .md files must match one of the versions
listed in the version dropdown specified in get_started.html

Without this fix, the instructions for installing version 1.5 will always be shown, even if users select another version in the dropdown.

CC @TaoLv, as this error was introduced in #16442.