### PR TITLE
[MXNET-889] Implement ONNX export for gluon LSTM.

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -950,6 +950,220 @@ def convert_concat(node, **kwargs):
     )
     return [concat_node]
 
+@mx_op.register("RNN")
+def convert_RNN(node, **kwargs):
+    """Map MXNet's RNN operator attributes to onnx's RNN operator
+    and return the created node.
+    """
+    name, input_nodes, attrs = get_inputs(node, kwargs)
+    nodes = []
+
+    # ============================== Attributes ==============================
+    mode = attrs['mode'].upper()
+    rnn_kwargs = {}
+    if mode != 'LSTM':
+        raise NotImplementedError(
+            "Only LSTM mode RNN conversion to ONNX is currently supported."
+        )
+
+    hidden_size = rnn_kwargs['hidden_size'] = int(attrs.get("state_size"))
+    if eval(attrs.get('bidirectional', 'False')):
+        rnn_kwargs['direction'] = 'bidirectional'
+        num_directions = 2
+    else:
+        rnn_kwargs['direction'] = 'forward'
+        num_directions = 1
+
+    clip_min = eval(attrs.get('lstm_state_clip_min', 'None'))
+    clip_max = eval(attrs.get('lstm_state_clip_max', 'None'))
+    if clip_min is not None or clip_max is not None:
+        # ONNX LSTMs have the `clip` attribute, however it seems to give
+        # slightly different results, when compared to the MXNet equivalent
+        raise NotImplementedError(
+            "Conversion of RNNs with lstm_state_clip_min/max "
+            "to ONNX is currently not supported."
+        )
+
+    if eval(attrs.get('lstm_state_clip_nan', 'False')):
+        raise NotImplementedError(
+            "ONNX RNN operator doesn't support lstm_state_clip_nan"
+        )
+
+    if eval(attrs.get('use_sequence_length', 'False')):
+        # This can maybe be implemented using the `sequence_len` optional input
+        raise NotImplementedError(
+            "Conversion of RNNs with variable input sequence length "
+            "to ONNX is currently not supported."
+        )
+
+    if eval(attrs.get('num_layers', '1')) != 1:
+        raise NotImplementedError(
+            "Conversion of RNNs with num_layers > 1 "
+            "to ONNX is currently not supported."
+        )
+
+    if eval(attrs.get('p', '0')) != 0:
+        # WARNING! The `p` attribute in mxnet is "dropout probability" while
+        # the `p` optional input of ONNX LSTMs is the peephole weights tensor.
+        raise NotImplementedError(
+            "Conversion of RNNs with dropout "
+            "to ONNX is currently not supported."
+        )
+
+    if eval(attrs.get('projection_size', 'None')) is not None:
+        raise NotImplementedError(
+            "Conversion of RNNs with custom projection_size "
+            "to ONNX is currently not supported."
+        )
+
+    if not eval(attrs.get('state_outputs', 'True')):
+        raise NotImplementedError(
+            "Conversion of RNNs with state_outputs=False "
+            "to ONNX is currently not supported."
+        )
+
+    # ============================== Parameters ==============================
+
+    # (See _rnn_param_concat for part 1 of this comment section)
+
+    # Unfortunately, mxnets version of _rnn_param_concat concatenates *ALL*
+    # the parameters, instead of grouping them like ONNX. The workaround,
+    # used here, is that the _rnn_param_concat node conversion code will
+    # produce multiple nodes with names ending in rnn_param_concatN__P
+    # (Where P is the parameter group name W, R or B)
+    # We then use regular expressions to get the "extra outputs" of the
+    # _rnn_param_concat node.
+
+    x, param_concat, *initial_states = input_nodes
+    param_pattern = re.compile(r'(.*rnn_param_concat[0-9]+__)[WRB]$')
+    if not param_pattern.match(param_concat):
+        # ToDo: Maybe do something more sane after Issue #17621 gets resolved
+        raise NotImplementedError(
+            "The order of RNN parameters is different between mxnet and ONNX. "
+            "Currently, an automatic conversion is only possible, if the RNN "
+            "parameters were concatenated using the internal "
+            "_rnn_param_concat operator."
+        )
+    w, r, b = (
+        param_pattern.sub(r'\1' + param, param_concat)
+        for param in 'WRB'
+    )
+
+    # The second conversion step handles
+    #     * parameter shapes, since mxnet uses flattened parameters, while
+    #       ONNX requires specific tensor shapes
+    #     * gate order, since both frameworks require the weights and biases
+    #       of the 4 basic gates (forget, input, cell and output) to be
+    #       concatenated, but in different order
+    #       ([ifco] for mxnet and [iofc] for ONNX)
+
+    def fix_rnn_parameter(p, p_shape_in, p_shape_out, p_order=(0, 3, 1, 2)):
+        p_ = p
+
+        # 1) Reshape flat parameters to their original shape, such that
+        #    the gates are concatenated along axis=1
+        p_reshaped_in = create_helper_reshape_node(
+            p, p_ + "__reshaped_in", p_shape_in, kwargs
+        )
+        nodes.extend(p_reshaped_in)
+        p = p_reshaped_in[-1].name
+
+        # 2) Use a Gather node to pick gates along axis=1, permuting them
+        p_reordered = create_helper_gather_node(
+            p, p_ + "__reordered", p_order, kwargs, axis=1
+        )
+        nodes.extend(p_reordered)
+        p = p_reordered[-1].name
+
+        # 3) Reshape the parameters to their final shape, squeezing the gate
+        #    and hidden dimensions together
+        p_reshaped_out = create_helper_reshape_node(
+            p, p_ + "__reshaped_out", p_shape_out, kwargs
+        )
+        nodes.extend(p_reshaped_out)
+        return p_reshaped_out[-1].name
+
+    w = fix_rnn_parameter(
+        w,
+        p_shape_in=(num_directions, 4, hidden_size, -1),
+        p_shape_out=(num_directions, 4 * hidden_size, -1),
+    )
+
+    r = fix_rnn_parameter(
+        r,
+        p_shape_in=(num_directions, 4, hidden_size, hidden_size),
+        p_shape_out=(num_directions, 4 * hidden_size, hidden_size),
+    )
+
+    b = fix_rnn_parameter(
+        b,
+        p_shape_in=(2 * num_directions, 4, hidden_size),
+        p_shape_out=(num_directions, 8 * hidden_size),
+    )
+
+    # ============================= Inputs/States ============================
+    input_shape = create_helper_shape_node(x, x + "__shape")
+    nodes.extend(input_shape)
+    input_shape = input_shape[-1].name
+
+    batch_size = create_helper_gather_node(
+        input_shape,
+        x + "__batch_size",
+        indices=[1],
+        axis=0,
+        kwargs=kwargs,
+    )
+    nodes.extend(batch_size)
+    batch_size = batch_size[-1].name
+
+    state_shape = create_helper_build_values_node(
+        [num_directions, batch_size, hidden_size],
+        name + "__state_shape",
+        dtype=np.int64,
+        kwargs=kwargs,
+    )
+    nodes.extend(state_shape)
+    state_shape = state_shape[-1].name
+
+    expanded_states = []
+    for state in initial_states:
+        expanded_state = create_helper_expand_node(
+            state, state + "__expanded", state_shape
+        )
+        nodes.extend(expanded_state)
+        expanded_states.append(expanded_state[-1].name)
+    initial_states = expanded_states
+
+    # =========================== RNN node/outputs ===========================
+    y_out = [onnx.helper.make_node(
+        mode,  # RNN or LSTM or GRU
+        inputs=[x, w, r, b, '', *initial_states],
+        outputs=[name + '__Y'],
+        name=name + '__Y',
+        **rnn_kwargs
+    )]
+    nodes.extend(y_out)
+    y = y_out[-1].name
+
+    # We are almost done. The only thing left to do is to convert the output
+    # of the RNN node from the [S, D, B, H] layout, which ONNX returns
+    # to the [S, B, D*H] layout, which mxnet uses
+
+    # 1) Transpose [S, D, B, H] -> [S, B, D, H]
+    y_perm = (0, 2, 1, 3)
+    y_transposed = create_helper_trans_node(
+        y, y + "__transposed", y_perm
+    )
+    nodes.extend(y_transposed)
+    y = y_transposed[-1].name
+
+    # 2) Reshape [S, B, D, H] -> [S, B, D*H]
+    y_shape = (0, 0, -1)
+    y_reshaped = create_helper_reshape_node(y, name, y_shape, kwargs)
+    nodes.extend(y_reshaped)
+
+    return nodes
+
 @mx_op.register('_rnn_param_concat')
 def convert_rnn_param_concat(node, **kwargs):
     """Map MXNet's _rnn_param_concat operator attributes to onnx's Concat


### PR DESCRIPTION
## Description ##
Implements 3 new node conversion functions, to facilitate the conversion of `gluon.rnn.LSTM` blocks to ONNX. (fixes #15341)

1) `_zeros` (as well as `_ones` and `_full` as a bonus)
    `gluon.rnn.LSTM` uses `sym.zeros` to [initialize the initial recurrent states](https://github.com/apache/incubator-mxnet/blob/10a12d59f67ad21032a94b1721aaf9b96fddac85/python/mxnet/gluon/rnn/rnn_layer.py#L234).
2) `_rnn_param_concat` which is used by mxnet to [concatenate all the flattened parameters](https://github.com/apache/incubator-mxnet/blob/10a12d59f67ad21032a94b1721aaf9b96fddac85/python/mxnet/gluon/rnn/rnn_layer.py#L278), before passing them to the `RNN` node.
3) `RNN` which is the backend op for the actual `LSTM` computation.

I've also implemented/updated a couple helper functions in the [`_op_translations.py`](https://github.com/RuRo/incubator-mxnet/blob/onnx_export_RNN/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py) file in a separate commit to hopefully reduce the boilerplate amount.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Tests ##

I didn't add any tests for this node yet, since I am not 100% sure, how exactly to do that.
Some other PRs with ONNX exports, just add the new node names to a list in [`tests/python-pytest/onnx/test_cases.py`](https://github.com/apache/incubator-mxnet/blob/10a12d59f67ad21032a94b1721aaf9b96fddac85/tests/python-pytest/onnx/test_cases.py#L96), however, I don't see, how would this add any actual tests, without a reference ONNX implementation available.

I would gladly add some unittests, if someone can point the right direction though. For now, I've verified the correctness of my conversion by
1) Running this script:

    <details>
    <summary>test_rnn_export_onnx.py</summary>

    ```python
    #!/bin/env python3
    import numpy as np
    import mxnet as mx
    import onnxruntime as rt

    import logging
    import shutil
    import os
    logging.getLogger().setLevel(logging.INFO)


    # Configuration
    path = 'lstm-model'
    seq_len = 10
    batch_size = 32
    input_size = 16
    hidden_size = 8
    bidirectional = True


    # Create input data
    shape = (seq_len, batch_size, input_size)
    I = mx.nd.random.randn(*shape)


    # Create LSTM network
    seq = mx.gluon.nn.HybridSequential()
    with seq.name_scope():
        seq.add(mx.gluon.rnn.LSTM(hidden_size, bidirectional=bidirectional))
    seq.initialize()
    seq(I)


    # Init all parameters with random values
    for k, p in seq.collect_params().items():
        p.data()[...] = np.random.randn(*p.data().shape)
    seq.hybridize(static_alloc=True, static_shape=True)
    res_mx = seq(I)
    res_mx = res_mx.asnumpy()


    # Export to symbol and then to ONNX and forward with onnxruntime
    seq.export(path)
    mx.contrib.onnx.export_model(
        f'{path}-symbol.json',
        f'{path}-0000.params',
        [shape], np.float32,
        onnx_file_path=f'{path}.onnx',
        verbose=True
    )


    # Forward, using onnxruntime
    sess = rt.InferenceSession(f'{path}.onnx')
    res_onnx, = sess.run(None, {'data': I.asnumpy()})


    # Check results
    diff = np.abs(res_mx - res_onnx)
    print(f"{diff.mean()=}")
    print(f"{diff.max()=}")
    np.testing.assert_almost_equal(res_mx, res_onnx, decimal=4)
    # decimal=4 is the same as mxnet unittests for other ONNX ops


    # Clean up files
    os.remove(f"{path}-symbol.json")
    os.remove(f"{path}-0000.params")
    os.remove(f"{path}.onnx")
    ```

    </details>

    Which generates a model with an `LSTM` node, fills all the parameters with random data, exports it to a `symbol.json` and `0000.params` and then converts the model to `ONNX`. It then loads the model using `onnxruntime` and forwards some random data through both the `mxnet` as well as the `onnx` models and asserts, that the results are close.

2) Using this conversion on a CRNN network, I trained at my job and verifying that the prediction results are the same on a subset of out test set. (unfortunately, I can't give too much details about this model, so you'll have to trust me here)

## Comments ##
There are a few details in my current implementation that should be noted:
1) `_zeros`
    - It seems, that `mx.sym` can broadcast a `_zeros`/`_ones`/`_full` node along an axis with dimension 0 as if it were a 1, while `ONNX` can't do that.
        ```python
        import mxnet as mx
        a = mx.sym.zeros((10, 0, 30))
        b = mx.sym.Variable('b')
        (a * b).eval(b=mx.nd.zeros((10, 20, 30)))[0].shape
        ```
        Currently, my implementation converts all the 0 dims to 1s. Is this correct?
    - The version of `ONNX`, that mxnet uses doesn't support some newer nodes like `ConstantOfShape` and I was not able to find a working onnx implementation, which actually supported the currently deprecated `ConstantFill` op, so I had to actually store the `_zeros` data in a tensor, which ends up being stored in the onnx model file.<br/>
    This also applies to the helper funtions and the other nodes. I've had to settle for some "less than elegant" solutions in some cases, because of the lacking opset support. I might have also missed a better way to do some operations, so if you have any better alternatives, I would gladly change my implementation.<br/>

2) `_rnn_param_concat`
    You can read more about my implementation in the code (comments), but the general outline is that since `ONNX` expects the `RNN` parameters prepared in a completely different way compared to mxnet, I've had to employ some "dark" magic, involving `convert_rnn_param_concat` generating multiple nodes and `convert_RNN` 'guessing' these node names, using regular expressions.<br/>
    As a result, the current conversion mechanism only works, if the parameters of the RNN block are concatenated using `_rnn_param_concat` (and not for example `Concat`). If the conversion of of `mx.sym.RNN` (without `gluon`) is a widely requested feature, we would have to convert the `_rnn_param_concat` node to a regular `Concat`, and then split the parameters back apart in the `RNN` conversion, which is not very nice IMO.<br/>

3) `RNN`
    Even though, this PR implements the conversion of the `RNN` node, currently only the `LSTM` mode is supported and many of the "customization" options are also not implemented.
    **Implemented:**
    - `mode=LSTM`
    - `layout='TNC'`
    - `bidirectional=True` and `False`
    
    **Not Implemented**, but probably supported by ONNX (easy to implement):
    - `mode=GRU, RNN_relu, RNN_tanh` (via GRU and RNN ONNX nodes and the `activations` attribute)
    - `use_sequence_length` (via ONNX `sequence_lens` optional input)
    - custom `states` inputs and `states` outputs (input states might already work, output states - via 'Y_h' and 'Y_c' optional outputs)
    - custom `layout != TNC` (need `SwapAxis` op conversion)
    
    **Not Implemented**, and probably **not** supported by ONNX (hard to implement):
    - `dropout` (the `p` input in ONNX is `peephole`, *not* dropout probability)
    - `state_clip_min` and `state_clip_max` (the `clip` attribute in ONNX seems to produce different results than `state_clip_min`/`max`)
    - `state_clip_nan`
    - `projection_size`
    - `num_layers`