### PR TITLE
Fix setting CMAKE_GENERATOR "Ninja" in config.cmake

### DIFF
--- a/config/darwin.cmake
+++ b/config/darwin.cmake
@@ -55,8 +55,6 @@ set(USE_TVM_OP OFF CACHE BOOL "Enable use of TVM operator build system.")
 #---------------------
 # Compilers
 #--------------------
-set(CMAKE_GENERATOR "Ninja" CACHE STRING "Build Tool Generator used by CMake")
-
 # Compilers are usually autodetected. Uncomment and modify the next 3 lines to
 # choose manually:
 

--- a/config/linux.cmake
+++ b/config/linux.cmake
@@ -73,8 +73,6 @@ set(USE_TVM_OP OFF CACHE BOOL "Enable use of TVM operator build system.")
 #---------------------
 # Compilers
 #--------------------
-set(CMAKE_GENERATOR "Ninja" CACHE STRING "Build Tool Generator used by CMake")
-
 # Compilers are usually autodetected. Uncomment and modify the next 3 lines to
 # choose manually:
 

--- a/config/linux_gpu.cmake
+++ b/config/linux_gpu.cmake
@@ -73,8 +73,6 @@ set(USE_TVM_OP OFF CACHE BOOL "Enable use of TVM operator build system.")
 #---------------------
 # Compilers
 #--------------------
-set(CMAKE_GENERATOR "Ninja" CACHE STRING "Build Tool Generator used by CMake")
-
 # Compilers are usually autodetected. Uncomment and modify the next 3 lines to
 # choose manually:
 

--- a/docs/static_site/src/pages/get_started/osx_setup.md
+++ b/docs/static_site/src/pages/get_started/osx_setup.md
@@ -110,7 +110,7 @@ the guide in [Math Library Selection](build_from_source#math-library-selection).
 ```bash
 rm -rf build
 mkdir -p build && cd build
-cmake ..
+cmake -GNinja ..
 cmake --build .
 ```
 

--- a/docs/static_site/src/pages/get_started/ubuntu_setup.md
+++ b/docs/static_site/src/pages/get_started/ubuntu_setup.md
@@ -130,7 +130,7 @@ the guide in [Math Library Selection](build_from_source#math-library-selection).
 ```bash
 rm -rf build
 mkdir -p build && cd build
-cmake ..
+cmake -GNinja ..
 cmake --build .
 ```
 


### PR DESCRIPTION
This is not supported anymore, as we moved from `cmake -C ../config.cmake ..`
syntax to `cmake ..`. Without `-C`, the config file is read too late and we
can't modify the generator anymore. Ask users to run `cmake -GNinja ..` instead.

Thanks @apeforest 