### PR TITLE
[MXNET-1449] Expose activation and recurrent activation in GRUCell

### DIFF
--- a/tests/python/unittest/test_gluon_rnn.py
+++ b/tests/python/unittest/test_gluon_rnn.py
@@ -150,7 +150,7 @@ def test_lstm_cpu_inference():
 
 
 def test_gru():
-    cell = gluon.rnn.GRUCell(100, prefix='rnn_')
+    cell = gluon.rnn.GRUCell(100, prefix='rnn_', activation='relu', recurrent_activation='tanh')
     inputs = [mx.sym.Variable('rnn_t%d_data'%i) for i in range(3)]
     outputs, _ = cell.unroll(3, inputs)
     outputs = mx.sym.Group(outputs)


### PR DESCRIPTION
## Description ##

Make Gluon `GRUCell` compatible with `LSTMCell` by exposing activation and recurrent activation. Moreover, in [LSTNet paper](https://arxiv.org/abs/1703.07015), GRU with `relu` was used that's not possible with current API. Note that LSTNet was recently added to [GluonTS](https://github.com/awslabs/gluon-ts/pull/596).

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
`/mxnet/python/gluon/rnn/rnn_cell.py`

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
