### PR TITLE
allclose_op: Fix non-ascii characters in comments

### DIFF
--- a/src/operator/contrib/allclose_op.cc
+++ b/src/operator/contrib/allclose_op.cc
@@ -34,7 +34,7 @@ NNVM_REGISTER_OP(_contrib_allclose)
 
 .. math::
 
-    f(x) = |a−b|≤atol+rtol|b|
+    f(x) = |a-b|<=atol+rtol|b|
 
 where
 :math:`a, b` are the input tensors of equal types an shapes


### PR DESCRIPTION
## Description ##

Without this PR, building MXNet Python package from source using Python3 causes the following error:

```
$ python3 setup.py bdist_wheel
Traceback (most recent call last):
  File "setup.py", line 170, in <module>
    _generate_op_module_signature('mxnet', 'symbol', _generate_symbol_function_code)
  File "/mxnet_src/tools/pip/mxnet/base.py", line 731, in _generate_op_module_signature
    cur_module_file.write(code)
UnicodeEncodeError: 'ascii' codec can't encode character '\u2212' in position 247: ordinal not in range(128)
```