### PR TITLE
[MXNET-978] Higher Order Gradient Support power, elemwise_mul and elemwise_sub and add  unit test funcino check check_nth_order_binary

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -251,6 +251,7 @@ List of Contributors
 * [Piljae Chae](https://github.com/IHateMint)
 * [Oliver Kowalke](https://github.com/olk)
 * [Connor Goggins](https://github.com/connorgoggins)
+* [Deng, Wenqi](https://tbc.dengwenqi%40gmail.com@github.com/tobecontinued)
 
 Label Bot
 ---------

--- a/src/operator/tensor/elemwise_binary_broadcast_op_extended.cc
+++ b/src/operator/tensor/elemwise_binary_broadcast_op_extended.cc
@@ -53,18 +53,27 @@ Example::
    auto y = n->inputs[1];
    auto head_grad_z = ograds[0];
 
-   auto one_like  = nnvm::NodeEntry{mxnet::op::MakeNode("ones_like", n->attrs.name + "_ones_like", {y}, nullptr, &n)};
-   auto y_sub_1 = nnvm::NodeEntry{MakeNode("elemwise_sub", n->attrs.name + "_exp_sub_1",  {y, one_like}, nullptr, &n)};
-   auto x_power_y_sub_1 = nnvm::NodeEntry{MakeNode("broadcast_power", n->attrs.name + "_base_power_exp_sub_1",  {x, y_sub_1}, nullptr, &n)};
-   auto dzdx = nnvm::NodeEntry{MakeNode("elemwise_mul", n->attrs.name + "dpower/dbase",  {y, x_power_y_sub_1}, nullptr, &n)};
+   auto one_like  = nnvm::NodeEntry{mxnet::op::MakeNode("ones_like",
+                                    n->attrs.name + "_ones_like", {y}, nullptr, &n)};
+   auto y_sub_1 = nnvm::NodeEntry{MakeNode("elemwise_sub",
+                                  n->attrs.name + "_exp_sub_1",  {y, one_like}, nullptr, &n)};
+   auto x_power_y_sub_1 = nnvm::NodeEntry{MakeNode("broadcast_power",
+                                          n->attrs.name + "_base_power_exp_sub_1",  {x, y_sub_1}, nullptr, &n)};
+   auto dzdx = nnvm::NodeEntry{MakeNode("elemwise_mul",
+                               n->attrs.name + "dpower/dbase",  {y, x_power_y_sub_1}, nullptr, &n)};
 
-   auto lnx = nnvm::NodeEntry{MakeNode("log", n->attrs.name + "_ln_base",  {x}, nullptr, &n)};
-   auto x_power_y = nnvm::NodeEntry{MakeNode("elemwise_mul", n->attrs.name + "_base_power_exp", {x_power_y_sub_1, x}, nullptr, &n)};
-   auto dzdy = nnvm::NodeEntry{MakeNode("elemwise_mul", n->attrs.name + "dpower/dexp", {x_power_y, lnx}, nullptr, &n)};
+   auto lnx = nnvm::NodeEntry{MakeNode("log",
+                              n->attrs.name + "_ln_base",  {x}, nullptr, &n)};
+   auto x_power_y = nnvm::NodeEntry{MakeNode("elemwise_mul",
+                                    n->attrs.name + "_base_power_exp", {x_power_y_sub_1, x}, nullptr, &n)};
+   auto dzdy = nnvm::NodeEntry{MakeNode("elemwise_mul",
+                               n->attrs.name + "dpower/dexp", {x_power_y, lnx}, nullptr, &n)};
 
    std::vector<nnvm::NodeEntry> ret;
-   ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_base", {head_grad_z, dzdx}, nullptr, &n));
-   ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_exp", {head_grad_z, dzdy}, nullptr, &n));
+   ret.emplace_back(MakeNode("elemwise_mul",
+           n->attrs.name + "_backward_grad_base", {head_grad_z, dzdx}, nullptr, &n));
+   ret.emplace_back(MakeNode("elemwise_mul",
+           n->attrs.name + "_backward_grad_exp", {head_grad_z, dzdy}, nullptr, &n));
    return ret;
 });
 

--- a/src/operator/tensor/elemwise_binary_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_op_basic.cc
@@ -192,23 +192,18 @@ The storage type of ``elemwise_sub`` output depends on storage types of inputs
    - otherwise, ``elemwise_sub`` generates output with default storage
 
 )code")
-.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseNone{"_backward_sub"});
+.set_attr<nnvm::FGradient>("FGradient",
+  [](const nnvm::ObjectPtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
+  auto head_grad = ograds[0];
+  auto x = n->inputs[0];
+  auto y = n->inputs[1];
 
-NNVM_REGISTER_OP(_backward_sub)
-.set_num_inputs(1)
-.set_num_outputs(2)
-.set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_attr<nnvm::FInplaceOption>("FInplaceOption",
-                                [](const NodeAttrs &attrs) {
-                                  return std::vector<std::pair<int, int> >{{0, 0},
-                                                                           {0, 1}};
-                                })
-.set_attr<FCompute>("FCompute<cpu>", ElemwiseBinaryOp::BackwardUseNone<cpu,
-  mshadow_op::identity, mshadow_op::negation>)
-.set_attr<FComputeEx>("FComputeEx<cpu>", ElemwiseBinaryOp::BackwardUseNoneEx<cpu,
-  mshadow_op::identity, mshadow_op::negation>)
-.set_attr<FInferStorageType>("FInferStorageType",
-                             ElemwiseStorageType<1, 2, true, true, true>);
+  std::vector<nnvm::NodeEntry> ret;
+  ret.emplace_back(head_grad);
+  ret.emplace_back(MakeNode("negative", n->attrs.name + "_backward_grad_y",
+                            {head_grad}, nullptr, &n));
+  return ret;
+});
 
 MXNET_OPERATOR_REGISTER_BINARY(elemwise_mul)
 MXNET_ADD_SPARSE_OP_ALIAS(elemwise_mul)
@@ -235,25 +230,20 @@ The storage type of ``elemwise_mul`` output depends on storage types of inputs
                               })
 .set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
 .add_alias("_mul").add_alias("_Mul")
-.set_attr<nnvm::FGradient>("FGradient", ElemwiseGradUseIn{"_backward_mul"});
+.set_attr<nnvm::FGradient>("FGradient",
+  [](const nnvm::ObjectPtr& n, const std::vector<nnvm::NodeEntry>& ograds) {
+  auto head_grad = ograds[0];
+  auto x = n->inputs[0];
+  auto y = n->inputs[1];
 
-NNVM_REGISTER_OP(_backward_mul)
-.set_num_inputs(3)
-.set_num_outputs(2)
-.set_attr<nnvm::TIsBackward>("TIsBackward", true)
-.set_attr<nnvm::FInplaceOption>("FInplaceOption",
-                                [](const NodeAttrs &attrs) {
-                                  return std::vector<std::pair<int, int> >{{0, 1}};
-                                })
-.set_attr<FInferStorageType>("FInferStorageType", ElemwiseBinaryOp::BackwardUseInStorageType)
-.set_attr<FResourceRequest>("FResourceRequest",  /* For Sparse CSR */
-                              [](const NodeAttrs& attrs) {
-                                return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-                              })
-.set_attr<FCompute>("FCompute<cpu>", ElemwiseBinaryOp::BackwardUseIn<
-  cpu, mshadow_op::right, mshadow_op::left>)
-.set_attr<FComputeEx>("FComputeEx<cpu>", ElemwiseBinaryOp::BackwardUseInEx<
-  cpu, mshadow_op::right, mshadow_op::left>);
+  std::vector<nnvm::NodeEntry> ret;
+  ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad_0",
+                            {head_grad, y}, nullptr, &n));
+  ret.emplace_back(MakeNode("elemwise_mul", n->attrs.name + "_backward_grad_grad_1",
+                            {head_grad, x}, nullptr, &n));
+  return ret;
+});
+
 
 MXNET_OPERATOR_REGISTER_BINARY_WITH_SPARSE_CPU_DR(elemwise_div, op::mshadow_op::div)
 MXNET_ADD_SPARSE_OP_ALIAS(elemwise_div)


### PR DESCRIPTION
## Description ##
* add unittest funtinon check check_nth_order_binary
* support higher order gradient for power,  elemwise_mul and elemwise_sub.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] add unittest funtinon check check_nth_order_binary
- [x] support higher order gradient for power,  elemwise_mul and elemwise_sub.
- [x] unittest of higher order gradient of them.
