### PR TITLE
Update get_started page for master cpu build

### DIFF
--- a/docs/static_site/src/_includes/get_started/linux/python/cpu/pip.md
+++ b/docs/static_site/src/_includes/get_started/linux/python/cpu/pip.md
@@ -2,7 +2,7 @@ Run the following command:
 
 <div class="v1-6-0">
 {% highlight bash %}
-$ pip install mxnet
+pip install mxnet
 {% endhighlight %}
 
 MKL-DNN enabled pip packages are optimized for Intel hardware. You can find
@@ -10,14 +10,14 @@ performance numbers
 in the <a href="https://mxnet.io/api/faq/perf#intel-cpu">MXNet tuning guide</a>.
 
 {% highlight bash %}
-$ pip install mxnet-mkl
+pip install mxnet-mkl
 {% endhighlight %}
 
 </div> <!-- End of v1-6-0 -->
 
 <div class="v1-5-1">
 {% highlight bash %}
-$ pip install mxnet==1.5.1
+pip install mxnet==1.5.1
 {% endhighlight %}
 
 MKL-DNN enabled pip packages are optimized for Intel hardware. You can find
@@ -25,7 +25,7 @@ performance numbers
 in the <a href="https://mxnet.io/api/faq/perf#intel-cpu">MXNet tuning guide</a>.
 
 {% highlight bash %}
-$ pip install mxnet-mkl==1.5.1
+pip install mxnet-mkl==1.5.1
 {% endhighlight %}
 
 </div> <!-- End of v1-5-1 -->
@@ -33,7 +33,7 @@ $ pip install mxnet-mkl==1.5.1
 <div class="v1-4-1">
 
 {% highlight bash %}
-$ pip install mxnet==1.4.1
+pip install mxnet==1.4.1
 {% endhighlight %}
 
 MKL-DNN enabled pip packages are optimized for Intel hardware. You can find
@@ -41,14 +41,14 @@ performance numbers
 in the <a href="https://mxnet.io/api/faq/perf#intel-cpu">MXNet tuning guide</a>.
 
 {% highlight bash %}
-$ pip install mxnet-mkl==1.4.1
+pip install mxnet-mkl==1.4.1
 {% endhighlight %}
 
 </div> <!-- End of v1-4-1 -->
 <div class="v1-3-1">
 
 {% highlight bash %}
-$ pip install mxnet==1.3.1
+pip install mxnet==1.3.1
 {% endhighlight %}
 
 MKL-DNN enabled pip packages are optimized for Intel hardware. You can find
@@ -56,14 +56,14 @@ performance numbers
 in the <a href="https://mxnet.io/api/faq/perf#intel-cpu">MXNet tuning guide</a>.
 
 {% highlight bash %}
-$ pip install mxnet-mkl==1.3.1
+pip install mxnet-mkl==1.3.1
 {% endhighlight %}
 
 </div> <!-- End of v1-3-1 -->
 <div class="v1-2-1">
 
 {% highlight bash %}
-$ pip install mxnet==1.2.1
+pip install mxnet==1.2.1
 {% endhighlight %}
 
 MKL-DNN enabled pip packages are optimized for Intel hardware. You can find
@@ -71,7 +71,7 @@ performance numbers
 in the <a href="https://mxnet.io/api/faq/perf#intel-cpu">MXNet tuning guide</a>.
 
 {% highlight bash %}
-$ pip install mxnet-mkl==1.2.1
+pip install mxnet-mkl==1.2.1
 {% endhighlight %}
 
 </div> <!-- End of v1-2-1 -->
@@ -79,7 +79,7 @@ $ pip install mxnet-mkl==1.2.1
 <div class="v1-1-0">
 
 {% highlight bash %}
-$ pip install mxnet==1.1.0
+pip install mxnet==1.1.0
 {% endhighlight %}
 
 </div> <!-- End of v1-1-0-->
@@ -87,7 +87,7 @@ $ pip install mxnet==1.1.0
 <div class="v1-0-0">
 
 {% highlight bash %}
-$ pip install mxnet==1.0.0
+pip install mxnet==1.0.0
 {% endhighlight %}
 
 </div> <!-- End of v1-0-0-->
@@ -96,13 +96,13 @@ $ pip install mxnet==1.0.0
 <div class="v0-12-1">
 
 {% highlight bash %}
-$ pip install mxnet==0.12.1
+pip install mxnet==0.12.1
 {% endhighlight %}
 
 For MXNet 0.12.0:
 
 {% highlight bash %}
-$ pip install mxnet==0.12.0
+pip install mxnet==0.12.0
 {% endhighlight %}
 
 </div> <!-- End of v0-12-1-->
@@ -110,7 +110,7 @@ $ pip install mxnet==0.12.0
 <div class="v0-11-0">
 
 {% highlight bash %}
-$ pip install mxnet==0.11.0
+pip install mxnet==0.11.0
 {% endhighlight %}
 
 </div> <!-- End of v0-11-0-->
@@ -118,15 +118,7 @@ $ pip install mxnet==0.11.0
 <div class="master">
 
 {% highlight bash %}
-$ pip install --pre mxnet -f https://dist.mxnet.io/python/all
-{% endhighlight %}
-
-MKL-DNN enabled pip packages are optimized for Intel hardware. You can find
-performance numbers
-in the <a href="https://mxnet.io/api/faq/perf#intel-cpu">MXNet tuning guide</a>.
-
-{% highlight bash %}
-$ pip install --pre mxnet-mkl -f https://dist.mxnet.io/python/all
+pip install --pre mxnet -f https://dist.mxnet.io/python/all
 {% endhighlight %}
 
 </div> <!-- End of master-->


### PR DESCRIPTION
## Description ##
1. Remove mkl build since CPU by default is using mkl in master
2. Remove $ prompt to make instruction copy-paste friendly.

@leezu @aaronmarkham Please review.