### PR TITLE
Optimizing tests in test_loss.py

### DIFF
--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -221,7 +221,7 @@ def test_ctc_loss_train():
     loss = Loss(output, l)
     loss = mx.sym.make_loss(loss)
     mod = mx.mod.Module(loss, data_names=('data',), label_names=('label',))
-    mod.fit(data_iter, num_epoch=200, optimizer_params={'learning_rate': 0.01},
+    mod.fit(data_iter, num_epoch=10, optimizer_params={'learning_rate': 0.0256},
             initializer=mx.init.Xavier(magnitude=2), eval_metric=mx.metric.Loss(),
             optimizer='adam')
     assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 10
@@ -473,7 +473,7 @@ def test_bce_loss_with_pos_weight():
     loss = Loss(output, l, None, pos_w)
     loss = mx.sym.make_loss(loss)
     mod = mx.mod.Module(loss, data_names=('data',), label_names=('label', 'pos_w'))
-    mod.fit(data_iter, num_epoch=200, optimizer_params={'learning_rate': 0.01},
+    mod.fit(data_iter, num_epoch=20, optimizer_params={'learning_rate': 0.0844},
             eval_metric=mx.metric.Loss(), optimizer='adam',
             initializer=mx.init.Xavier(magnitude=2))
     assert mod.score(data_iter, eval_metric=mx.metric.Loss())[0][1] < 0.01


### PR DESCRIPTION
## Description ##
Changing some parameters in test_loss to reduce the running time of tests

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete 

### Changes ###
- [ ] Updated `test_bce_loss_with_pos_weight` and `test_ctc_loss_train`. Reduces the run time of each test from >2 seconds to less than 1.3 seconds locally. Tests pass with multiple seeds (>30).

## Comments ##
- There are multiple opportunities for reducing the running time of tests by tuning some parameters like iterations, learning rate, etc.
- For these changes, I verified that the tests still pass with multiple seeds
- Would you guys be interested in such optimizations? If yes, I can help contribute more and look at optimizing other *more expensive* tests in the test suite. Please let me know if you have any other suggestions or any necessary checks that I should do on these tests.

Thanks!


