### PR TITLE
[Numpy] Fix symbolic basic indexing

### DIFF
--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -96,7 +96,10 @@ class _Symbol(Symbol):
                                 .format(type(key)))
         else:
             if isinstance(key, integer_types):
-                sliced = _npi.slice(self, [key], [key+1])
+                if key == -1:
+                    sliced = _npi.slice(self, [key], [None])
+                else:
+                    sliced = _npi.slice(self, [key], [key+1])
                 return _npi.reshape(sliced, (-3, -4))
             elif isinstance(key, py_slice):
                 if key.step is None or key.step != 0:

--- a/tests/python/unittest/test_numpy_gluon.py
+++ b/tests/python/unittest/test_numpy_gluon.py
@@ -368,7 +368,7 @@ def test_symbolic_basic_slicing():
                 TestSlicingWithVSplit, [x],
                 numpy_func=lambda a: _np.concatenate(_np.vsplit(a, shape[0])[1:-1], axis=0))
 
-    for data_shape, idx in [((4, 6, 8, 5), 2),
+    for data_shape, idx in [((4, 3), 2),
                             ((3,), -1),
                             ((3,), 0)]:
         class IntegerIndexing(gluon.HybridBlock):

--- a/tests/python/unittest/test_numpy_gluon.py
+++ b/tests/python/unittest/test_numpy_gluon.py
@@ -368,6 +368,16 @@ def test_symbolic_basic_slicing():
                 TestSlicingWithVSplit, [x],
                 numpy_func=lambda a: _np.concatenate(_np.vsplit(a, shape[0])[1:-1], axis=0))
 
+    for data_shape, idx in [((4, 6, 8, 5), 2),
+                            ((3,), -1),
+                            ((3,), 0)]:
+        class IntegerIndexing(gluon.HybridBlock):
+            def hybrid_forward(self, F, x):
+                return x[idx]
+        check_gluon_hybridize_consistency(IntegerIndexing,
+                                          [mx.np.ones(data_shape)],
+                                          numpy_func=lambda a: a[idx])
+
 
 @with_seed()
 @use_np


### PR DESCRIPTION
## Description ##
Fix https://github.com/apache/incubator-mxnet/issues/17766

The error is caused by the fact that a[-1:0] will return a shape-0 array.

```python
import numpy as np

a = np.ones((3,))
print(a[-1:0].shape)
print(a[-2:-1].shape)
```

Output:
```
(0,)
(1,)
```


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
