### PR TITLE
add flow for getting executor data when batch size is missing

### DIFF
--- a/python/mxnet/module/executor_group.py
+++ b/python/mxnet/module/executor_group.py
@@ -308,8 +308,16 @@ class DataParallelExecutorGroup(object):
     def _collect_arrays(self):
         """Collect internal arrays from executors."""
         # convenient data structures
-        self.data_arrays = [[(self.slices[i], e.arg_dict[name]) for i, e in enumerate(self.execs)]
-                            for name, _ in self.data_shapes]
+
+        # check if self.slices is populated, if not then that means that there is no batch size
+        if self.slices:
+            # based on batch size, slice up data for the given contexts (self.execs)
+            self.data_arrays = [[(self.slices[i], e.arg_dict[name]) for i, e in enumerate(self.execs)]
+                                for name, _ in self.data_shapes]
+        else:
+            # just use the context index as index into the data
+            self.data_arrays = [[(slice(i, i+1), e.arg_dict[name]) for i, e in enumerate(self.execs)]
+                                for name, _ in self.data_shapes]
 
         self.state_arrays = [[e.arg_dict[name] for e in self.execs]
                              for name in self.state_names]


### PR DESCRIPTION
## Description ##
Currently we get this error when batch size is missing
```
[20:57:43] src/nnvm/legacy_json_util.cc:209: Loading symbol saved by previous version v1.3.0. Attempting to upgrade...
[20:57:43] src/nnvm/legacy_json_util.cc:217: Symbol successfully upgraded!
Traceback (most recent call last):
  File "test_wavernn.py", line 26, in <module>
    mod = load_wavernn_model(mx.cpu())
  File "test_wavernn.py", line 17, in load_wavernn_model
    mod.bind(for_training=False, data_shapes=mod_shapes, label_shapes=mod._label_shapes)
  File "/home/ubuntu/.local/lib/python3.5/site-packages/mxnet/module/module.py", line 429, in bind
    state_names=self._state_names)
  File "/home/ubuntu/.local/lib/python3.5/site-packages/mxnet/module/executor_group.py", line 279, in __init__
    self.bind_exec(data_shapes, label_shapes, shared_group)
  File "/home/ubuntu/.local/lib/python3.5/site-packages/mxnet/module/executor_group.py", line 382, in bind_exec
    self._collect_arrays()
  File "/home/ubuntu/.local/lib/python3.5/site-packages/mxnet/module/executor_group.py", line 311, in _collect_arrays
    for name, _ in self.data_shapes]
  File "/home/ubuntu/.local/lib/python3.5/site-packages/mxnet/module/executor_group.py", line 311, in <listcomp>
    for name, _ in self.data_shapes]
  File "/home/ubuntu/.local/lib/python3.5/site-packages/mxnet/module/executor_group.py", line 310, in <listcomp>
    self.data_arrays = [[(self.slices[i], e.arg_dict[name]) for i, e in enumerate(self.execs)]
TypeError: 'NoneType' object is not subscriptable
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
