### PR TITLE
[CD] switch CD_RELEASE_JOB_NAME from global env var to job argument

### DIFF
--- a/cd/Jenkinsfile_cd_pipeline
+++ b/cd/Jenkinsfile_cd_pipeline
@@ -46,7 +46,7 @@ pipeline {
         script {
           cd_utils = load('cd/Jenkinsfile_utils.groovy')
           // Update release job state in Jenkins
-          cd_utils.update_release_job_state()
+          cd_utils.update_release_job_state(params.CD_RELEASE_JOB_NAME)
         }
       }
     }
@@ -58,17 +58,17 @@ pipeline {
 
             "Static libmxnet based release": {
               stage("Build") {
-                cd_utils.trigger_release_job("Build static libmxnet", "mxnet_lib/static", params.MXNET_VARIANTS)
+                cd_utils.trigger_release_job(params.CD_RELEASE_JOB_NAME, "Build static libmxnet", "mxnet_lib/static", params.MXNET_VARIANTS)
               }
               stage("Releases") {
                 cd_utils.error_checked_parallel([
                   "PyPI Release": {
                     echo "Building PyPI Release"
-                    cd_utils.trigger_release_job("Release PyPI Packages", "python/pypi", params.MXNET_VARIANTS)
+                    cd_utils.trigger_release_job(params.CD_RELEASE_JOB_NAME, "Release PyPI Packages", "python/pypi", params.MXNET_VARIANTS)
                   },
                   "Python Docker Release": {
                     echo "Building Python Docker Release"
-                    cd_utils.trigger_release_job("Release Python Docker Images", "python/docker", params.MXNET_VARIANTS)
+                    cd_utils.trigger_release_job(params.CD_RELEASE_JOB_NAME, "Release Python Docker Images", "python/docker", params.MXNET_VARIANTS)
                   }
                 ])
               }
@@ -76,9 +76,10 @@ pipeline {
 
             "Dynamic libmxnet based release": {
               stage("Build") {
-                cd_utils.trigger_release_job("Build dynamic libmxnet", "mxnet_lib/dynamic", params.MXNET_VARIANTS)
+                cd_utils.trigger_release_job(params.CD_RELEASE_JOB_NAME, "Build dynamic libmxnet", "mxnet_lib/dynamic", params.MXNET_VARIANTS)
               }
             }
+
           ])
         }
       }

--- a/cd/Jenkinsfile_release_job
+++ b/cd/Jenkinsfile_release_job
@@ -74,7 +74,7 @@ pipeline {
             |Release Build: ${params.RELEASE_BUILD}
             |Commit Id: ${env.GIT_COMMIT}
             |Branch: ${env.GIT_BRANCH}
-            |Variants: ${env.MXNET_VARIANTS}""".stripMargin()
+            |Variants: ${params.MXNET_VARIANTS}""".stripMargin()
           }
         }
       }

--- a/cd/Jenkinsfile_utils.groovy
+++ b/cd/Jenkinsfile_utils.groovy
@@ -19,16 +19,16 @@
 
 // Triggers a downstream jenkins job responsible for building, testing
 // and publishing all the variants for a particular 'job_type'.
-// The 'job_type' should be the name of the directory that contains the 
-// 'Jenkins_pipeline.groovy' file and has the pipeline definition for the 
+// The 'job_type' should be the name of the directory that contains the
+// 'Jenkins_pipeline.groovy' file and has the pipeline definition for the
 // artifact (docker image, binary, pypi or maven package, etc.) that should
 // be published.
 
 STATE_UPDATE="State Update"
 
-def trigger_release_job(job_name, job_type, mxnet_variants) {
+def trigger_release_job(cd_release_job, job_name, job_type, mxnet_variants) {
   def run = build(
-    job: env.CD_RELEASE_JOB_NAME, 
+    job: cd_release_job,
     parameters: [
       string(name: "RELEASE_JOB_NAME", value: "${job_name}"),
       string(name: "RELEASE_JOB_TYPE", value: "${job_type}"),
@@ -49,7 +49,7 @@ def trigger_release_job(job_name, job_type, mxnet_variants) {
   // continue with the pipeline and try to post as many releases as possible
   // but mark it as unstable
   if (result == "UNSTABLE" || result == "ABORTED") {
-    currentBuild.result = "UNSTABLE" 
+    currentBuild.result = "UNSTABLE"
   }
 
   // Throw an exception on failure, because this would mean the whole
@@ -65,12 +65,12 @@ def trigger_release_job(job_name, job_type, mxnet_variants) {
 // the configuration of the release job in jenkins
 // to the configuration of release job as defined in the
 // Jenkinsfile _release_job for env.GIT_COMMIT revision
-def update_release_job_state() {
+def update_release_job_state(cd_release_job) {
   build(
-    job: env.CD_RELEASE_JOB_NAME, 
+    job: cd_release_job,
     parameters: [
       string(name: "RELEASE_JOB_TYPE", value: STATE_UPDATE),
-  
+
       // Should be set to the current git commit
       string(name: "COMMIT_ID", value: "${env.GIT_COMMIT}")
     ])
@@ -103,7 +103,7 @@ def wrap_variant_pipeline_fn(variant_pipeline, total_num_pipelines) {
 // The outcome of the execution of each parallel step will affect
 // the result (SUCCESS, FAILURE, ABORTED, UNSTABLE) of the overall job.
 // If all steps fail or are aborted, the job will be set to failed.
-// If some steps fail or are aborted, the job will be set to unstable. 
+// If some steps fail or are aborted, the job will be set to unstable.
 def error_checked_parallel(variant_pipelines) {
   pipelines = variant_pipelines.inject([:]) { mp, key, value ->
     mp << ["${key}": wrap_variant_pipeline_fn(value, variant_pipelines.size())]
@@ -179,7 +179,7 @@ def restore_dynamic_libmxnet(variant) {
 // NOTE: Be mindful of the expected time that a step should take. If it will take a long time,
 // and it can be done in a CPU node, do it in a CPU node. We should avoid using GPU instances unless
 // we *have* to.
-// However, if it is only packaging libmxnet and that doesn't take long. Then, the pipeline can 
+// However, if it is only packaging libmxnet and that doesn't take long. Then, the pipeline can
 // just run on a single node. As is done bellow.
 // For examples of multi-node CD pipelines, see the the binary_release/static and binary_release/dynamic
 // pipeline.


### PR DESCRIPTION
## Description ##
switch CD_RELEASE_JOB_NAME from global env var to job argument

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] switch CD_RELEASE_JOB_NAME from global env var to job argument

## Comments ##
- This is preparation work for the nightly releases for v1.x and v2.0.
- Once merged, I will cherry pick this change to the v1.x branch.