### PR TITLE
Disable MKL_USE_STATIC_LIBS by default

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -526,6 +526,7 @@ build_ubuntu_cpu_mkldnn_mkl() {
         -DUSE_CUDA=OFF \
         -DUSE_TVM_OP=ON \
         -DUSE_MKL_IF_AVAILABLE=ON \
+        -DMKL_USE_STATIC_LIBS=OFF \
         -DUSE_BLAS=MKL \
         -DBUILD_EXTENSION_PATH=/work/mxnet/example/extensions/lib_external_ops \
         -GNinja /work/mxnet

--- a/python/mxnet/base.py
+++ b/python/mxnet/base.py
@@ -281,7 +281,11 @@ def _load_lib():
         # pylint: disable=E1123
         lib = ctypes.CDLL(lib_path[0], winmode=0x00000008)
     else:
-        lib = ctypes.CDLL(lib_path[0], ctypes.RTLD_LOCAL)
+        # We use RTLD_GLOBAL as, when dynamically linking with MKL,
+        # libmkl_core.so may load libmkl_avx512.so via dlopen. When opening
+        # libmxnet and it's dependencies (libmkl_core.so) via RTLD_LOCAL, MKL's
+        # dlopen calls will fail with undefined symbol errors.
+        lib = ctypes.CDLL(lib_path[0], ctypes.RTLD_GLOBAL)
     # DMatrix functions
     lib.MXGetLastError.restype = ctypes.c_char_p
     return lib


### PR DESCRIPTION
## Description ##
Disable MKL_USE_STATIC_LIBS by default

Fixes https://github.com/apache/incubator-mxnet/issues/17791

#17751 tried to prevent the situation where MKLDNN `dlopens` intel omp after another omp has already been opened by the dynamic linker. #17751 both disabled `MKL_USE_SINGLE_DYNAMIC_LIBRARY` and enabled `MKL_USE_STATIC_LIBS`. Enabling `MKL_USE_STATIC_LIBS` by default is however not needed and causes issues on some systems. Thus disable `MKL_USE_STATIC_LIBS` by default again.
