### PR TITLE
[Numpy] Fix np.random.chisquare

### DIFF
--- a/python/mxnet/ndarray/numpy/random.py
+++ b/python/mxnet/ndarray/numpy/random.py
@@ -1003,7 +1003,7 @@ def chisquare(df, size=None, dtype=None, ctx=None):
         ctx = current_context()
     if size == ():
         size = None
-    return gamma(df/2, 1/2, size=size, dtype=dtype, ctx=ctx)
+    return gamma(df/2, 2, size=size, dtype=dtype, ctx=ctx)
 
 
 def rand(*size, **kwargs):

--- a/python/mxnet/symbol/numpy/random.py
+++ b/python/mxnet/symbol/numpy/random.py
@@ -673,7 +673,7 @@ def chisquare(df, size=None, dtype=None, ctx=None):
         ctx = current_context()
     if size == ():
         size = None
-    return gamma(df/2, 1/2, size=size, dtype=dtype, ctx=ctx)
+    return gamma(df/2, 2, size=size, dtype=dtype, ctx=ctx)
 
 
 def exponential(scale=1.0, size=None, ctx=None, out=None):


### PR DESCRIPTION
## Description ##
As np.random.gamma adopts `scale` uses the scale parameterization, a chi2 distribution with `df=k` is equivalent to Gamma(k/2, 2) instead of Gamma(k/2, 1/2)

## References ##
http://en.wikipedia.org/wiki/Chi-squared_distribution

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
