### PR TITLE
Update ccache on CI to fix cuda object caching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,7 +710,8 @@ if(UNIX)
     # 1) variables used in '#pragma omp parallel' are considered unused
     target_compile_options(mxnet_static PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:-Wno-error=unused-variable>")
     if(USE_CUDA)
-      string(APPEND CMAKE_CUDA_FLAGS " -Werror cross-execution-space-call")
+      # Note: "=" is required to avoid breaking ccache
+      string(APPEND CMAKE_CUDA_FLAGS " -Werror=cross-execution-space-call")
     endif()
   endif()
 elseif(MSVC)

--- a/ci/docker/install/centos7_ccache.sh
+++ b/ci/docker/install/centos7_ccache.sh
@@ -23,18 +23,19 @@ set -ex
 
 pushd .
 
-yum -y install autoconf
-yum -y install asciidoc
+yum -y install autoconf libb2-devel libzstd-devel
 
 mkdir -p /work/deps
 cd /work/deps
 
-git clone --recursive -b v3.4.2 https://github.com/ccache/ccache.git
-
+git clone --recursive https://github.com/ccache/ccache.git
 cd ccache
+# Checkout a fixed & tested pre-release commit of ccache 4
+# ccache 4 contains fixes for caching nvcc output: https://github.com/ccache/ccache/pull/381
+git checkout 2e7154e67a5dd56852dae29d4c418d4ddc07c230
 
 ./autogen.sh
-./configure
+CXXFLAGS="-Wno-missing-field-initializers" ./configure --disable-man
 make -j$(nproc)
 make install
 
@@ -42,4 +43,3 @@ cd /work/deps
 rm -rf /work/deps/ccache
 
 popd
-

--- a/ci/docker/install/deb_ubuntu_ccache.sh
+++ b/ci/docker/install/deb_ubuntu_ccache.sh
@@ -25,35 +25,40 @@ pushd .
 
 apt update || true
 apt install -y \
-    libxslt1-dev \
-    docbook-xsl \
-    xsltproc \
-    libxml2-utils
-
-apt install -y --no-install-recommends \
     autoconf \
-    asciidoc \
     xsltproc
 
 mkdir -p /work/deps
 cd /work/deps
 
-git clone --recursive -b v3.4.2 https://github.com/ccache/ccache.git
+# Unset ARM toolchain cross-compilation configuration on dockcross
+unset ARCH
+unset DEFAULT_DOCKCROSS_IMAGE
+unset CROSS_TRIPLE
+unset CC
+unset AS
+unset AR
+unset FC
+unset CXX
+unset CROSS_ROOT
+unset CROSS_COMPILE
+unset PKG_CONFIG_PATH
+unset CMAKE_TOOLCHAIN_FILE
+unset CPP
+unset LD
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+git clone --recursive https://github.com/ccache/ccache.git
 cd ccache
+# Checkout a fixed & tested pre-release commit of ccache 4
+# ccache 4 contains fixes for caching nvcc output: https://github.com/ccache/ccache/pull/381
+git checkout 2e7154e67a5dd56852dae29d4c418d4ddc07c230
 
 ./autogen.sh
-# Manually specify x86 gcc versions so that this script remains compatible with dockcross (which uses an ARM based gcc
-# by default).
-CC=/usr/bin/gcc CXX=/usr/bin/g++ ./configure
-
-# Don't build documentation #11214
-#perl -pi -e 's!\s+\Q$(installcmd) -d $(DESTDIR)$(mandir)/man1\E!!g' Makefile
-#perl -pi -e 's!\s+\Q-$(installcmd) -m 644 ccache.1 $(DESTDIR)$(mandir)/man1/\E!!g' Makefile
+./configure --disable-man --with-libzstd-from-internet --with-libb2-from-internet
 make -j$(nproc)
 make install
 
 rm -rf /work/deps/ccache
 
 popd
-

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -216,8 +216,6 @@ build_jetson() {
     set -ex
     pushd .
 
-    #build_ccache_wrappers
-
     cp make/crosscompile.jetson.mk ./config.mk
     make -j$(nproc)
 
@@ -240,7 +238,6 @@ build_armv6() {
 
     # We do not need OpenMP, since most armv6 systems have only 1 core
 
-    build_ccache_wrappers
     cmake \
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} \
         -DUSE_CUDA=OFF \
@@ -267,7 +264,6 @@ build_armv7() {
     # file tries to add -llapack. Lapack functionality though, requires -lgfortran
     # to be linked additionally.
 
-    build_ccache_wrappers
     cmake \
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} \
         -DCMAKE_CROSSCOMPILING=ON \
@@ -287,7 +283,6 @@ build_armv7() {
 }
 
 build_armv8() {
-    build_ccache_wrappers
     cd /work/build
     cmake \
         -DUSE_CUDA=OFF\
@@ -311,7 +306,6 @@ build_armv8() {
 build_android_armv7() {
     set -ex
     cd /work/build
-    build_ccache_wrappers
     cmake \
         -DANDROID=ON\
         -DUSE_CUDA=OFF\
@@ -329,7 +323,6 @@ build_android_armv7() {
 build_android_armv8() {
     set -ex
     cd /work/build
-    build_ccache_wrappers
     cmake\
         -DANDROID=ON \
         -DUSE_CUDA=OFF\
@@ -454,7 +447,6 @@ build_ubuntu_cpu_mkl() {
 build_ubuntu_cpu_cmake_debug() {
     set -ex
     cd /work/build
-    build_ccache_wrappers
     cmake \
         -DUSE_CUDA=OFF \
         -DUSE_TVM_OP=ON \
@@ -471,7 +463,6 @@ build_ubuntu_cpu_cmake_debug() {
 build_ubuntu_cpu_cmake_no_tvm_op() {
     set -ex
     cd /work/build
-    build_ccache_wrappers
     cmake \
         -DUSE_CUDA=OFF \
         -DUSE_TVM_OP=OFF \
@@ -492,7 +483,6 @@ build_ubuntu_cpu_cmake_asan() {
     cd /work/build
     export CXX=g++-8
     export CC=gcc-8
-    build_ccache_wrappers
     cmake \
         -DUSE_CUDA=OFF \
         -DUSE_MKL_IF_AVAILABLE=OFF \
@@ -647,8 +637,6 @@ build_ubuntu_gpu() {
 build_ubuntu_gpu_tensorrt() {
 
     set -ex
-
-    build_ccache_wrappers
 
     # Build ONNX
     pushd .
@@ -821,7 +809,6 @@ build_ubuntu_amalgamation_min() {
 build_ubuntu_gpu_cmake() {
     set -ex
     cd /work/build
-    build_ccache_wrappers
     cmake \
         -DUSE_SIGNAL_HANDLER=ON                 \
         -DUSE_CUDA=ON                           \
@@ -843,7 +830,6 @@ build_ubuntu_gpu_cmake() {
 build_ubuntu_gpu_cmake_no_rtc() {
     set -ex
     cd /work/build
-    build_ccache_wrappers
     cmake \
         -DUSE_SIGNAL_HANDLER=ON                 \
         -DUSE_CUDA=ON                           \
@@ -866,7 +852,6 @@ build_ubuntu_gpu_cmake_no_rtc() {
 build_ubuntu_gpu_cmake_no_tvm_op() {
     set -ex
     cd /work/build
-    build_ccache_wrappers
     cmake \
         -DUSE_SIGNAL_HANDLER=ON                 \
         -DUSE_CUDA=ON                           \
@@ -888,7 +873,6 @@ build_ubuntu_gpu_cmake_no_tvm_op() {
 build_ubuntu_cpu_large_tensor() {
     set -ex
     cd /work/build
-    build_ccache_wrappers
     cmake \
         -DUSE_SIGNAL_HANDLER=ON                 \
         -DUSE_CUDA=OFF                          \
@@ -905,7 +889,6 @@ build_ubuntu_cpu_large_tensor() {
 build_ubuntu_gpu_large_tensor() {
     set -ex
     cd /work/build
-    build_ccache_wrappers
     cmake \
         -DUSE_SIGNAL_HANDLER=ON                 \
         -DUSE_CUDA=ON                           \


### PR DESCRIPTION
## Description ##
Update ccache on CI to make use of https://github.com/ccache/ccache/pull/381

> CMake always passes -x cu to NVCC. This is recognized by ccache as an explicit language setting, but the language "cu" is not understood by ccache.

Thus ccache on CI currently does not attempt caching any cuda object files.

To fix this, we install a fixed and tested pre-release version of ccache 4.