### PR TITLE
CI: Attempt fixing illegal instruction errors

### DIFF
--- a/ci/docker/install/deb_ubuntu_ccache.sh
+++ b/ci/docker/install/deb_ubuntu_ccache.sh
@@ -23,8 +23,17 @@ set -ex
 
 pushd .
 
+dist = $(awk -F= '/^NAME/{print $2}' /etc/os-release)
+if [ $dist == "Ubuntu" ]; then
+    zstd = "libzstd1-dev"
+else  # Debian
+    zstd = "libzstd-dev"
+fi
+
 apt update || true
 apt install -y \
+    $zstd \
+    libb2-dev \
     autoconf \
     xsltproc
 
@@ -55,7 +64,7 @@ cd ccache
 git checkout 2e7154e67a5dd56852dae29d4c418d4ddc07c230
 
 ./autogen.sh
-./configure --disable-man --with-libzstd-from-internet --with-libb2-from-internet
+./configure --disable-man
 make -j$(nproc)
 make install
 

--- a/ci/docker/install/deb_ubuntu_ccache.sh
+++ b/ci/docker/install/deb_ubuntu_ccache.sh
@@ -23,17 +23,8 @@ set -ex
 
 pushd .
 
-dist=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
-if [ $dist == "Ubuntu" ]; then
-    zstd="libzstd1-dev"
-else  # Debian
-    zstd="libzstd-dev"
-fi
-
 apt update || true
 apt install -y \
-    $zstd \
-    libb2-dev \
     autoconf \
     xsltproc
 
@@ -63,8 +54,11 @@ cd ccache
 # ccache 4 contains fixes for caching nvcc output: https://github.com/ccache/ccache/pull/381
 git checkout 2e7154e67a5dd56852dae29d4c418d4ddc07c230
 
+
+export CFLAGS="-mno-avx"
+export CXXFLAGS="-mno-avx"
 ./autogen.sh
-./configure --disable-man
+./configure --disable-man --with-libzstd-from-internet --with-libb2-from-internet
 make -j$(nproc)
 make install
 

--- a/ci/docker/install/deb_ubuntu_ccache.sh
+++ b/ci/docker/install/deb_ubuntu_ccache.sh
@@ -23,7 +23,7 @@ set -ex
 
 pushd .
 
-dist = $(awk -F= '/^NAME/{print $2}' /etc/os-release)
+dist=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
 if [ $dist == "Ubuntu" ]; then
     zstd = "libzstd1-dev"
 else  # Debian

--- a/ci/docker/install/deb_ubuntu_ccache.sh
+++ b/ci/docker/install/deb_ubuntu_ccache.sh
@@ -25,9 +25,9 @@ pushd .
 
 dist=$(awk -F= '/^NAME/{print $2}' /etc/os-release)
 if [ $dist == "Ubuntu" ]; then
-    zstd = "libzstd1-dev"
+    zstd="libzstd1-dev"
 else  # Debian
-    zstd = "libzstd-dev"
+    zstd="libzstd-dev"
 fi
 
 apt update || true


### PR DESCRIPTION
Hypothesis: Caching the source-compiled variants of  libzstd1 and libb2 via our Docker cache can lead to "Illegal instruction" errors when deploying the docker image on an older machines. If so, switching to the distribution provided variants will solve the issue.

Follow-up on https://github.com/apache/incubator-mxnet/pull/17828