### PR TITLE
[Numpy] np.linalg.qr forward implementation

### DIFF
--- a/python/mxnet/ndarray/numpy/linalg.py
+++ b/python/mxnet/ndarray/numpy/linalg.py
@@ -22,8 +22,8 @@ from . import _op as _mx_nd_np
 from . import _internal as _npi
 from . import _api_internal
 
-__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve', 'pinv',
-           'eigvals', 'eig', 'eigvalsh', 'eigh', 'lstsq']
+__all__ = ['norm', 'svd', 'cholesky', 'qr', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve',
+           'pinv', 'eigvals', 'eig', 'eigvalsh', 'eigh', 'lstsq']
 
 
 def lstsq(a, b, rcond='warn'):
@@ -467,6 +467,65 @@ def cholesky(a):
            [ 4., 10.]])
     """
     return _api_internal.cholesky(a, True)
+
+
+def qr(a, mode='reduced'):
+    r"""
+    Compute the qr factorization of a matrix a.
+    Factor the matrix a as qr, where q is orthonormal and r is upper-triangular.
+
+    Parameters
+    ----------
+    a : (..., M, N) ndarray
+        Matrix or stack of matrices to be qr factored.
+    mode: {‘reduced’, ‘complete’, ‘r’, ‘raw’, ‘full’, ‘economic’}, optional
+        Only default mode, 'reduced', is implemented. If K = min(M, N), then
+        * 'reduced’ : returns q, r with dimensions (M, K), (K, N) (default)
+
+    Returns
+    -------
+    q : (..., M, K) ndarray
+        A matrix or stack of matrices with K orthonormal columns, with K = min(M, N).
+    r : (..., K, N) ndarray
+        A matrix or stack of upper triangular matrices.
+
+    Raises
+    ------
+    MXNetError
+        If factoring fails.
+
+    Examples
+    --------
+    >>> from mxnet import np
+    >>> a = np.random.uniform(-10, 10, (2, 2))
+    >>> q, r = np.linalg.qr(a)
+    >>> q
+    array([[-0.22121978, -0.97522414],
+           [-0.97522414,  0.22121954]])
+    >>> r
+    array([[-4.4131265 , -7.1255064 ],
+           [ 0.        , -0.28771925]])
+    >>> a = np.random.uniform(-10, 10, (2, 3))
+    >>> q, r = np.linalg.qr(a)
+    >>> q
+    array([[-0.28376842, -0.9588929 ],
+           [-0.9588929 ,  0.28376836]])
+    >>> r
+    array([[-7.242763  , -0.5673361 , -2.624416  ],
+           [ 0.        , -7.297918  , -0.15949416]])
+    >>> a = np.random.uniform(-10, 10, (3, 2))
+    >>> q, r = np.linalg.qr(a)
+    >>> q
+    array([[-0.34515655,  0.10919492],
+           [ 0.14765628, -0.97452265],
+           [-0.92685735, -0.19591334]])
+    >>> r
+    array([[-8.453794,  8.4175  ],
+           [ 0.      ,  5.430561]])
+    """
+    if mode is not None and mode != 'reduced':
+        raise NotImplementedError("Only default mode='reduced' is implemented.")
+    return tuple(_npi.qr(a))
 
 
 def inv(a):

--- a/python/mxnet/numpy/fallback_linalg.py
+++ b/python/mxnet/numpy/fallback_linalg.py
@@ -25,12 +25,10 @@ __all__ = [
     'cond',
     'matrix_power',
     'matrix_rank',
-    'multi_dot',
-    'qr',
+    'multi_dot'
 ]
 
 cond = onp.linalg.cond
 matrix_power = onp.linalg.matrix_power
 matrix_rank = onp.linalg.matrix_rank
 multi_dot = onp.linalg.multi_dot
-qr = onp.linalg.qr

--- a/python/mxnet/numpy/linalg.py
+++ b/python/mxnet/numpy/linalg.py
@@ -21,8 +21,8 @@ from ..ndarray import numpy as _mx_nd_np
 from .fallback_linalg import *  # pylint: disable=wildcard-import,unused-wildcard-import
 from . import fallback_linalg
 
-__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve', 'pinv',
-           'eigvals', 'eig', 'eigvalsh', 'eigh', 'lstsq']
+__all__ = ['norm', 'svd', 'cholesky', 'qr', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve',
+           'pinv', 'eigvals', 'eig', 'eigvalsh', 'eigh', 'lstsq']
 __all__ += fallback_linalg.__all__
 
 
@@ -360,6 +360,63 @@ def cholesky(a):
            [ 4., 10.]])
     """
     return _mx_nd_np.linalg.cholesky(a)
+
+
+def qr(a, mode='reduced'):
+    r"""
+    Compute the qr factorization of a matrix a.
+    Factor the matrix a as qr, where q is orthonormal and r is upper-triangular.
+
+    Parameters
+    ----------
+    a : (..., M, N) ndarray
+        Matrix or stack of matrices to be qr factored.
+    mode: {‘reduced’, ‘complete’, ‘r’, ‘raw’, ‘full’, ‘economic’}, optional
+        Only default mode, 'reduced', is implemented. If K = min(M, N), then
+        * 'reduced’ : returns q, r with dimensions (M, K), (K, N) (default)
+
+    Returns
+    -------
+    q : (..., M, K) ndarray
+        A matrix or stack of matrices with K orthonormal columns, with K = min(M, N).
+    r : (..., K, N) ndarray
+        A matrix or stack of upper triangular matrices.
+
+    Raises
+    ------
+    MXNetError
+        If factoring fails.
+
+    Examples
+    --------
+    >>> from mxnet import np
+    >>> a = np.random.uniform(-10, 10, (2, 2))
+    >>> q, r = np.linalg.qr(a)
+    >>> q
+    array([[-0.22121978, -0.97522414],
+           [-0.97522414,  0.22121954]])
+    >>> r
+    array([[-4.4131265 , -7.1255064 ],
+           [ 0.        , -0.28771925]])
+    >>> a = np.random.uniform(-10, 10, (2, 3))
+    >>> q, r = np.linalg.qr(a)
+    >>> q
+    array([[-0.28376842, -0.9588929 ],
+           [-0.9588929 ,  0.28376836]])
+    >>> r
+    array([[-7.242763  , -0.5673361 , -2.624416  ],
+           [ 0.        , -7.297918  , -0.15949416]])
+    >>> a = np.random.uniform(-10, 10, (3, 2))
+    >>> q, r = np.linalg.qr(a)
+    >>> q
+    array([[-0.34515655,  0.10919492],
+           [ 0.14765628, -0.97452265],
+           [-0.92685735, -0.19591334]])
+    >>> r
+    array([[-8.453794,  8.4175  ],
+           [ 0.      ,  5.430561]])
+    """
+    return _mx_nd_np.linalg.qr(a, mode)
 
 
 def inv(a):

--- a/python/mxnet/numpy_dispatch_protocol.py
+++ b/python/mxnet/numpy_dispatch_protocol.py
@@ -164,6 +164,7 @@ _NUMPY_ARRAY_FUNCTION_LIST = [
     'linalg.eig',
     'linalg.eigvalsh',
     'linalg.eigh',
+    'linalg.qr',
     'shape',
     'trace',
     'tril',

--- a/python/mxnet/symbol/numpy/linalg.py
+++ b/python/mxnet/symbol/numpy/linalg.py
@@ -22,8 +22,8 @@ from . import _symbol
 from . import _op as _mx_sym_np
 from . import _internal as _npi
 
-__all__ = ['norm', 'svd', 'cholesky', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve', 'pinv',
-           'eigvals', 'eig', 'eigvalsh', 'eigh', 'lstsq']
+__all__ = ['norm', 'svd', 'cholesky', 'qr', 'inv', 'det', 'slogdet', 'solve', 'tensorinv', 'tensorsolve',
+           'pinv', 'eigvals', 'eig', 'eigvalsh', 'eigh', 'lstsq']
 
 
 def lstsq(a, b, rcond='warn'):
@@ -444,6 +444,65 @@ def cholesky(a):
            [ 4., 10.]])
     """
     return _npi.cholesky(a, True)
+
+
+def qr(a, mode='reduced'):
+    r"""
+    Compute the qr factorization of a matrix a.
+    Factor the matrix a as qr, where q is orthonormal and r is upper-triangular.
+
+    Parameters
+    ----------
+    a : (..., M, N) _Symbol
+        Matrix or stack of matrices to be qr factored.
+    mode: {‘reduced’, ‘complete’, ‘r’, ‘raw’, ‘full’, ‘economic’}, optional
+        Only default mode, 'reduced', is implemented. If K = min(M, N), then
+        * 'reduced’ : returns q, r with dimensions (M, K), (K, N) (default)
+
+    Returns
+    -------
+    q : (..., M, K) _Symbol
+        A matrix or stack of matrices with K orthonormal columns, with K = min(M, N).
+    r : (..., K, N) _Symbol
+        A matrix or stack of upper triangular matrices.
+
+    Raises
+    ------
+    MXNetError
+        If factoring fails.
+
+    Examples
+    --------
+    >>> from mxnet import np
+    >>> a = np.random.uniform(-10, 10, (2, 2))
+    >>> q, r = np.linalg.qr(a)
+    >>> q
+    array([[-0.22121978, -0.97522414],
+           [-0.97522414,  0.22121954]])
+    >>> r
+    array([[-4.4131265 , -7.1255064 ],
+           [ 0.        , -0.28771925]])
+    >>> a = np.random.uniform(-10, 10, (2, 3))
+    >>> q, r = np.linalg.qr(a)
+    >>> q
+    array([[-0.28376842, -0.9588929 ],
+           [-0.9588929 ,  0.28376836]])
+    >>> r
+    array([[-7.242763  , -0.5673361 , -2.624416  ],
+           [ 0.        , -7.297918  , -0.15949416]])
+    >>> a = np.random.uniform(-10, 10, (3, 2))
+    >>> q, r = np.linalg.qr(a)
+    >>> q
+    array([[-0.34515655,  0.10919492],
+           [ 0.14765628, -0.97452265],
+           [-0.92685735, -0.19591334]])
+    >>> r
+    array([[-8.453794,  8.4175  ],
+           [ 0.      ,  5.430561]])
+    """
+    if mode is not None and mode != 'reduced':
+        raise NotImplementedError("Only default mode='reduced' is implemented.")
+    return _npi.qr(a)
 
 
 def inv(a):

--- a/src/operator/c_lapack_api.cc
+++ b/src/operator/c_lapack_api.cc
@@ -98,11 +98,25 @@
     return 1; \
   }
 
+  #define MXNET_LAPACK_CWRAPPER10(func, dtype) \
+  int MXNET_LAPACK_##func(int matrix_layout, int m, int n, dtype* a, \
+                          int lda, dtype* tau, dtype* work, int lwork) { \
+    LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
+    return 1; \
+  }
+
   #define MXNET_LAPACK_CWRAPPER11(func, dtype) \
   int MXNET_LAPACK_##func(int matrix_layout, int m, int n, int nrhs, \
                           dtype *a, int lda, dtype *b, int ldb, \
                           dtype *s, dtype rcond, int *rank, \
                           dtype *work, int lwork, int *iwork) { \
+    LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
+    return 1; \
+  }
+
+  #define MXNET_LAPACK_CWRAPPER12(func, dtype) \
+  int MXNET_LAPACK_##func(int matrix_layout, int m, int n, int k, dtype* a, \
+                          int lda, dtype* tau, dtype* work, int lwork) { \
     LOG(FATAL) << "MXNet build without lapack. Function " << #func << " is not available."; \
     return 1; \
   }
@@ -146,7 +160,13 @@
   MXNET_LAPACK_CWRAPPER9(sgesdd, float)
   MXNET_LAPACK_CWRAPPER9(dgesdd, double)
 
+  MXNET_LAPACK_CWRAPPER10(sgeqrf, float)
+  MXNET_LAPACK_CWRAPPER10(dgeqrf, double)
+
   MXNET_LAPACK_CWRAPPER11(sgelsd, float)
   MXNET_LAPACK_CWRAPPER11(dgelsd, double)
+
+  MXNET_LAPACK_CWRAPPER12(sorgqr, float)
+  MXNET_LAPACK_CWRAPPER12(dorgqr, double)
 
 #endif  // MSHADOW_USE_MKL == 0

--- a/src/operator/numpy/linalg/np_qr-inl.h
+++ b/src/operator/numpy/linalg/np_qr-inl.h
@@ -1,0 +1,481 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2020 by Contributors
+ * \file np_qr-inl.h
+ * \brief Function definition of the QR Operator.
+ */
+#ifndef MXNET_OPERATOR_NUMPY_LINALG_NP_QR_INL_H_
+#define MXNET_OPERATOR_NUMPY_LINALG_NP_QR_INL_H_
+
+#include <mxnet/operator_util.h>
+#include <vector>
+#include <algorithm>
+#include "../../tensor/la_op.h"
+#include "../../tensor/la_op-inl.h"
+#include "../../linalg.h"
+#include "../../operator_common.h"
+#include "../../mshadow_op.h"
+
+namespace mxnet {
+namespace op {
+
+using namespace mshadow;
+
+//////////////////////////////// QR ////////////////////////////////////////////
+
+// CPU/GPU-versions of LAPACK function "geqrf", "orgqr". Please refer to the
+// LAPACK documentation for further details.
+// Note:
+// - Both functions have A as input and output parameter
+// - Both functions require extra workspace, passed as 1D tensor
+// - We call orgqr after geqrf. Apart from A, they also communicate via the
+//   first part of the workspace.
+
+template<typename xpu, typename DType>
+void linalg_geqrf(const Tensor<xpu, 2, DType>& A,
+                  const Tensor<xpu, 1, DType>& work,
+                  Stream<xpu> *s = 0);
+
+template<typename xpu, typename DType>
+void linalg_orgqr(const Tensor<xpu, 2, DType>& A,
+                  const Tensor<xpu, 1, DType>& work,
+                  Stream<xpu> *s = 0);
+
+// This function determines the amount of workspace needed for linalg_geqrf,
+// linalg_orgqr. The workspace can be used for both. The first mn entries are
+// used to communicate information from geqrf to orgqr (tau).
+
+template<typename xpu, typename DType>
+int linalg_qr_workspace_query(const Tensor<xpu, 2, DType>& A,
+                              Stream<xpu> *s = 0);
+
+//////////////////////////////// QR ////////////////////////////////////////////
+
+// CPU/GPU-versions of LAPACK function "geqrf", "orqrq." to be used in QR op.
+
+template<typename xpu, typename DType> inline
+void check_geqrf(const Tensor<xpu, 2, DType>& A,
+                 const Tensor<xpu, 1, DType>& work) {
+  CHECK_LE(A.size(0), work.size(0))
+    << "Size of work is too small";
+}
+
+// transpose helper
+struct QrTypeTransposeHelper {
+  template<typename InDType, typename OutDType>
+  MSHADOW_XINLINE static void Map(int i, const InDType *in_data, OutDType *out_data,
+                                  const int ncol1, const int ncol2, const int step) {
+    int idx = i / step, row = (i % step) / ncol1, col = (i % step) % ncol1;
+    out_data[idx * step + row + col * ncol2] = static_cast<OutDType>(in_data[i]);
+  }
+};
+
+#define LINALG_CPU_GEQRF(fname, DType) \
+template<> inline \
+void linalg_geqrf<cpu, DType>(const Tensor<cpu, 2, DType>& A, \
+                              const Tensor<cpu, 1, DType>& work, \
+                              Stream<cpu> *s) { \
+  check_geqrf(A, work); \
+  const int m = A.size(1); \
+  const int n = A.size(0); \
+  const int mn = (m > n ? n : m); \
+  int lwork = work.shape_.Size() - mn; \
+  int ret(MXNET_LAPACK_##fname(MXNET_LAPACK_COL_MAJOR, m, n, \
+                               A.dptr_, A.stride_, work.dptr_, \
+                               work.dptr_ + mn, lwork)); \
+  CHECK_EQ(ret, 0) << #fname << " failed in lapack on cpu."; \
+}
+LINALG_CPU_GEQRF(sgeqrf, float)
+LINALG_CPU_GEQRF(dgeqrf, double)
+
+#define LINALG_CPU_ORGQR(fname, DType) \
+template<> inline \
+void linalg_orgqr<cpu, DType>(const Tensor<cpu, 2, DType>& A, \
+                              const Tensor<cpu, 1, DType>& work, \
+                              Stream<cpu> *s) { \
+  check_geqrf(A, work); \
+  const int m = A.size(1); \
+  const int n = A.size(0); \
+  const int mn = (m > n ? n : m); \
+  int lwork = work.shape_.Size() - mn; \
+  int ret(MXNET_LAPACK_##fname(MXNET_LAPACK_COL_MAJOR, m, mn, mn, \
+                               A.dptr_, A.stride_, work.dptr_, \
+                               work.dptr_ + mn, lwork)); \
+  CHECK_EQ(ret, 0) << #fname << " failed in lapack on cpu."; \
+}
+LINALG_CPU_ORGQR(sorgqr, float)
+LINALG_CPU_ORGQR(dorgqr, double)
+
+#define LINALG_CPU_QR_WORKSPACE_QUERY(prefix, DType) \
+template<> inline \
+int linalg_qr_workspace_query<cpu, DType>(const Tensor<cpu, 2, DType>& A, \
+                                          Stream<cpu> *s) { \
+  const int m(A.size(1)); \
+  const int n(A.size(0)); \
+  const int mn = (m > n ? n : m); \
+  DType work = 0; \
+  int ret(MXNET_LAPACK_##prefix##geqrf(MXNET_LAPACK_COL_MAJOR, m, \
+                                       n, A.dptr_, A.stride_, &work, \
+                                       &work, -1)); \
+  CHECK_EQ(ret, 0) << #prefix << "geqrf: Workspace query failed on CPU."; \
+  int ws_size(static_cast<int>(work)); \
+  ret = MXNET_LAPACK_##prefix##orgqr(MXNET_LAPACK_COL_MAJOR, m, mn, \
+                                     mn, A.dptr_, \
+                                     A.stride_, &work, &work, -1); \
+  CHECK_EQ(ret, 0) << #prefix << "orgqr: Workspace query failed on CPU."; \
+  int wsz2(static_cast<int>(work)); \
+  if (wsz2 > ws_size) ws_size = wsz2; \
+  return ws_size + mn; \
+}
+LINALG_CPU_QR_WORKSPACE_QUERY(s, float)
+LINALG_CPU_QR_WORKSPACE_QUERY(d, double)
+
+#ifdef __CUDACC__
+
+#define LINALG_GPU_GEQRF(fname, DType) \
+template<> inline \
+void linalg_geqrf<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
+                              const Tensor<gpu, 1, DType>& work, \
+                              Stream<gpu> *s) { \
+  using namespace mxnet; \
+  using mshadow::gpu; \
+  CHECK_NOTNULL(s); \
+  check_geqrf(A, work); \
+  const int m = A.size(1); \
+  const int n = A.size(0); \
+  const int mn = (m > n ? n : m); \
+  int lwork(work.size(0) - mn); \
+  Storage::Handle info = Storage::Get()->Alloc(sizeof(int), Context::GPU()); \
+  CUSOLVER_CALL(cusolver##fname(Stream<gpu>::GetSolverHandle(s), \
+                m, n, A.dptr_, A.stride_, work.dptr_, \
+                work.dptr_ + mn, lwork, static_cast<int *>(info.dptr))); \
+  Storage::Get()->Free(info); \
+}
+LINALG_GPU_GEQRF(DnSgeqrf, float)
+LINALG_GPU_GEQRF(DnDgeqrf, double)
+
+// ORGQR only available with cuda8 or higher.
+#if CUDA_VERSION >= 8000
+
+#define LINALG_GPU_ORGQR(fname, DType) \
+template<> inline \
+void linalg_orgqr<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
+                              const Tensor<gpu, 1, DType>& work, \
+                              Stream<gpu> *s) { \
+  using namespace mxnet; \
+  using mshadow::gpu; \
+  CHECK_NOTNULL(s); \
+  check_geqrf(A, work); \
+  const int m = A.size(1); \
+  const int n = A.size(0); \
+  const int mn = (m > n ? n : m); \
+  int lwork(work.size(0) - mn); \
+  Storage::Handle info = Storage::Get()->Alloc(sizeof(int), Context::GPU()); \
+  CUSOLVER_CALL(cusolver##fname(Stream<gpu>::GetSolverHandle(s), \
+                m, mn, mn, A.dptr_, A.stride_, work.dptr_, \
+                work.dptr_ + mn, lwork, static_cast<int *>(info.dptr))); \
+  Storage::Get()->Free(info); \
+}
+
+#else
+
+#define LINALG_GPU_ORGQR(fname, DType) \
+template<> inline \
+void linalg_orgqr<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
+                              const Tensor<gpu, 1, DType>& work, \
+                              Stream<gpu> *s) { \
+  LOG(FATAL) << "orgqr requires CUDA version >= 8.0!"; \
+}
+
+#endif  // CUDA_VERSION >= 8000
+
+LINALG_GPU_ORGQR(DnSorgqr, float)
+LINALG_GPU_ORGQR(DnDorgqr, double)
+
+// ORGQR only available with cuda8 or higher.
+#if CUDA_VERSION >= 8000
+
+#define LINALG_GPU_QR_WORKSPACE_QUERY(prefix, DType) \
+template<> inline \
+int linalg_qr_workspace_query<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
+                                          Stream<gpu> *s) { \
+  using namespace mxnet; \
+  using mshadow::gpu; \
+  const int m(A.size(1)); \
+  const int n(A.size(0)); \
+  const int mn = (m > n ? n : m); \
+  int work1(0); \
+  CUSOLVER_CALL(cusolverDn##prefix##geqrf_bufferSize(Stream<gpu>::GetSolverHandle(s), \
+                m, n, A.dptr_, A.stride_, &work1)); \
+  int work2(0);  \
+  Storage::Handle tau = Storage::Get()->Alloc(sizeof(DType), Context::GPU()); \
+  CUSOLVER_CALL(cusolverDn##prefix##orgqr_bufferSize(Stream<gpu>::GetSolverHandle(s), \
+                m, mn, mn, A.dptr_, A.stride_, static_cast<DType *>(tau.dptr), &work2)); \
+  Storage::Get()->Free(tau); \
+  return std::max(work1, work2) + mn; \
+}
+
+#else
+
+#define LINALG_GPU_QR_WORKSPACE_QUERY(prefix, DType) \
+template<> inline \
+int linalg_qr_workspace_query<gpu, DType>(const Tensor<gpu, 2, DType>& A, \
+                                          Stream<gpu> *s) { \
+  LOG(FATAL) << "orgqr requires CUDA version >= 8.0!"; \
+  return 0; \
+}
+
+#endif  // CUDA_VERSION >= 8000
+
+LINALG_GPU_QR_WORKSPACE_QUERY(S, float)
+LINALG_GPU_QR_WORKSPACE_QUERY(D, double)
+
+#endif  // __CUDACC__
+
+// (Q, R) = qr(A)
+// - Works on transposed A, At of shape (n, m) = Qt of shape (m, k) @ Rt of shape (k, n)
+// - k = min(m, n)
+// - Needs workspace (DType), size of which is determined by a workspace query
+
+struct qr {
+  template<typename xpu, typename DType>
+  static void op(const Tensor<xpu, 3, DType>& a,
+                 const Tensor<xpu, 3, DType>& q,
+                 const Tensor<xpu, 1, DType>& work,
+                 const OpContext& ctx,
+                 const nnvm::NodeAttrs& attrs) {
+    Stream<xpu> *s = ctx.get_stream<xpu>();
+    const mxnet::TShape& a_shape = a.shape_;
+    for (index_t i = 0; i < a_shape[0]; ++i) {
+      const Tensor<xpu, 2, DType>& ai = a[i];
+      const Tensor<xpu, 2, DType>& qi = q[i];
+      linalg_geqrf(ai, work, s);  // get R
+      Copy(qi, ai, s);
+      linalg_orgqr(qi, work, s);  // get Q
+    }
+  }
+};
+
+// Calculate the necessary workspace size
+template<typename xpu>
+size_t QrForwardWorkspaceSize(const TBlob& a,
+                              const TBlob& q,
+                              const TBlob& r,
+                              const std::vector<OpReqType>& req,
+                              const OpContext& ctx) {
+  if (kNullOp == req[0]) { return 0U; }
+  // Zero-size input, no need to launch kernel
+  if (0U == a.Size()) { return 0U; }
+
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+  const mxnet::TShape& a_shape = a.shape_;
+  const int a_ndim = a_shape.ndim();
+  const int n = a.size(a_ndim - 1);
+  const int m = a.size(a_ndim - 2);
+
+  MSHADOW_TYPE_SWITCH(a.type_flag_, AType, {
+    MSHADOW_SGL_DBL_TYPE_SWITCH(q.type_flag_, DType, {
+      size_t work_space_size = 0;
+      if (m == n) {
+        // For transposed input matrix a and q
+        work_space_size += 2 * a.Size();
+      } else if (m > n) {
+        // For transposed input matrix a and q of same shape and r transpose
+        work_space_size += 2 * a.Size();
+        work_space_size += r.Size();
+      } else {
+        // For transposed input matrix a and q of same shape and q transpose
+        work_space_size += 2 * a.Size();
+        work_space_size += q.Size();
+      }
+      // For workspace size in query; done for all (m, n) shapes
+      Tensor<xpu, 2, AType> a_temp_tensor = a.FlatToKD<xpu, 3, AType>(s)[0];
+      if (xpu::kDevCPU) {
+        std::vector<DType> A_data(a_temp_tensor.MSize(), 0);
+        TBlob a_data(A_data.data(), a_temp_tensor.shape_, a.dev_mask(), a.dev_id());
+        work_space_size +=
+          linalg_qr_workspace_query(a_data.get<xpu, 2, DType>(s), s);
+      } else {
+        Storage::Handle a_handle =
+          Storage::Get()->Alloc(sizeof(DType) * a_temp_tensor.shape_.Size(), Context::GPU());
+        TBlob a_data(static_cast<DType*>(a_handle.dptr), a_temp_tensor.shape_,
+                                         a.dev_mask(), a.dev_id());
+        work_space_size +=
+          linalg_qr_workspace_query(a_data.get<xpu, 2, DType>(s), s);
+        Storage::Get()->Free(a_handle);
+      }
+      return work_space_size * sizeof(DType);
+    });
+  });
+  LOG(FATAL) << "InternalError: cannot reach here";
+  return 0U;
+}
+
+template<typename xpu>
+void QrOpForwardImpl(const TBlob& a,
+                     const TBlob& q,
+                     const TBlob& r,
+                     const std::vector<OpReqType>& req,
+                     const Tensor<xpu, 1, char>& workspace,
+                     const OpContext& ctx,
+                     const nnvm::NodeAttrs& attrs) {
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+  const mxnet::TShape& a_shape = a.shape_;
+  const int a_ndim = a_shape.ndim();
+
+  MSHADOW_SGL_DBL_TYPE_SWITCH(q.type_flag_, DType, {
+    const int n = a.size(a_ndim - 1);
+    const int m = a.size(a_ndim - 2);
+    // a shape transposed
+    mxnet::TShape transp_shape(a_shape);
+    transp_shape[a_ndim - 1] = m;
+    transp_shape[a_ndim - 2] = n;
+    // Common for all (m, n) shapes
+    const size_t workspace_size = (workspace.shape_.Size() + sizeof(DType) - 1) / sizeof(DType);
+    DType *a_ptr = reinterpret_cast<DType*>(workspace.dptr_);
+    DType *qt_ptr = a_ptr + a_shape.Size();
+    TBlob a_trans_data(a_ptr, transp_shape, a.dev_mask(), a.dev_id());
+    TBlob q_trans_data(qt_ptr, transp_shape, a.dev_mask(), a.dev_id());
+    Tensor<xpu, 3, DType> At = a_trans_data.FlatToKD<xpu, 3, DType>(s);
+    Tensor<xpu, 3, DType> Qt = q_trans_data.FlatToKD<xpu, 3, DType>(s);
+    Tensor<xpu, 3, DType> R = r.FlatToKD<xpu, 3, DType>(s);
+    Tensor<xpu, 3, DType> Q = q.FlatToKD<xpu, 3, DType>(s);
+
+    MSHADOW_TYPE_SWITCH(a.type_flag_, AType, {
+      // Cast type and transpose a
+        mxnet_op::Kernel<QrTypeTransposeHelper, xpu>::Launch(
+          s, a.Size(), a.dptr<AType>(), a_ptr, n, m, m * n);
+      });
+
+    if (m == n) {
+      DType *work_ptr = qt_ptr + a_shape.Size();
+      TBlob work_data(work_ptr, Shape1(workspace_size - a_shape.Size()),
+                      a.dev_mask(), a.dev_id());
+      Tensor<xpu, 1, DType> Work = work_data.get<xpu, 1, DType>(s);
+      qr::op(At,
+             Qt,
+             Work, ctx, attrs);
+      // Transpose into R
+      mxnet_op::Kernel<QrTypeTransposeHelper, xpu>::Launch(
+        s, r.Size(), At.dptr_, R.dptr_, m, m, m * m);
+      // Transpose into Q
+      mxnet_op::Kernel<QrTypeTransposeHelper, xpu>::Launch(
+        s, q.Size(), Qt.dptr_, Q.dptr_, m, m, m * m);
+      // R is triu
+      mxnet_op::Kernel<ZeroTriangular, xpu>::Launch(
+        s, R.MSize(), m * R.stride_, R.stride_, R.dptr_, true);
+    } else if (m > n) {
+      // r shape transposed
+      mxnet::TShape r_shape(transp_shape);
+      r_shape[a_ndim - 1] = n;
+      DType *rtemp_ptr = qt_ptr + a_shape.Size();
+      DType *work_ptr = rtemp_ptr + r_shape.Size();
+      TBlob rtemp_data(rtemp_ptr, r_shape, a.dev_mask(), a.dev_id());
+      TBlob work_data(work_ptr, Shape1(workspace_size - 2 * a_shape.Size()),
+                      a.dev_mask(), a.dev_id());
+      Tensor<xpu, 3, DType> Rtemp = rtemp_data.FlatToKD<xpu, 3, DType>(s);
+      Tensor<xpu, 1, DType> Work = work_data.get<xpu, 1, DType>(s);
+      qr::op(At,
+             Qt,
+             Work, ctx, attrs);
+      // Final Rt of shape (N, N)
+      for (index_t i = 0; i < At.size(0); ++i) {
+        const Tensor<xpu, 2, DType>& Ati = At[i];
+        const Tensor<xpu, 2, DType>& Rtempi = Rtemp[i];
+        Tensor<xpu, 2, DType> Rk(Ati.dptr_, Shape2(n, n), Ati.stride_, s);
+        Copy(Rtempi, Rk, s);
+      }
+      // Transpose into R of shape (N, N)
+      mxnet_op::Kernel<QrTypeTransposeHelper, xpu>::Launch(
+        s, r.Size(), Rtemp.dptr_, R.dptr_, n, n, n * n);
+      // Transpose resulting qt(N, M) into q of shape (M, N)
+      mxnet_op::Kernel<QrTypeTransposeHelper, xpu>::Launch(
+        s, q.Size(), Qt.dptr_, Q.dptr_, m, n, m * n);
+      // R is triu
+      mxnet_op::Kernel<ZeroTriangular, xpu>::Launch(
+        s, R.MSize(), n * R.stride_, R.stride_, R.dptr_, true);
+    // case m < n
+    } else {
+      // q shape transposed
+      mxnet::TShape q_shape(transp_shape);
+      q_shape[a_ndim - 2] = m;
+      DType *qtemp_ptr = qt_ptr + a_shape.Size();
+      DType *work_ptr = qtemp_ptr + q_shape.Size();
+      TBlob qtemp_data(qtemp_ptr, q_shape, a.dev_mask(), a.dev_id());
+      TBlob work_data(work_ptr, Shape1(workspace_size - 2 * a_shape.Size()),
+                      a.dev_mask(), a.dev_id());
+      Tensor<xpu, 3, DType> Qtemp = qtemp_data.FlatToKD<xpu, 3, DType>(s);
+      Tensor<xpu, 1, DType> Work = work_data.get<xpu, 1, DType>(s);
+      qr::op(At,
+             Qt,
+             Work, ctx, attrs);
+      // Transpose into R of shape (M, N)
+      mxnet_op::Kernel<QrTypeTransposeHelper, xpu>::Launch(
+        s, r.Size(), At.dptr_, R.dptr_, m, n, n * m);
+      // Get Qt(M, M) from Qt(N, M)
+      for (index_t i = 0; i < Qt.size(0); ++i) {
+        const Tensor<xpu, 2, DType>& Qti = Qt[i];
+        const Tensor<xpu, 2, DType>& Qtempi = Qtemp[i];
+        Tensor<xpu, 2, DType> Qk(Qti.dptr_, Shape2(m, m), Qti.stride_, s);
+        Copy(Qtempi, Qk, s);
+      }
+      // Transpose resulting qt into q of shape (M, M)
+      mxnet_op::Kernel<QrTypeTransposeHelper, xpu>::Launch(
+        s, q.Size(), Qtemp.dptr_, Q.dptr_, m, m, m * m);
+      // R is triu
+      mxnet_op::Kernel<ZeroTriangular, xpu>::Launch(
+        s, R.MSize(), m * R.stride_, R.stride_, R.dptr_, true);
+    }
+  });
+}
+
+// (A) => (Q, R)
+template<typename xpu>
+void NumpyLaQrForward(const nnvm::NodeAttrs& attrs,
+                      const OpContext& ctx,
+                      const std::vector<TBlob>& inputs,
+                      const std::vector<OpReqType>& req,
+                      const std::vector<TBlob>& outputs) {
+  CHECK_EQ(inputs.size(), 1U);
+  CHECK_EQ(outputs.size(), 2U);
+  CHECK_EQ(req.size(), 2U);
+
+  Stream<xpu> *s = ctx.get_stream<xpu>();
+  const TBlob& a = inputs[0];
+  const TBlob& q = outputs[0];
+  const TBlob& r = outputs[1];
+
+  if (kNullOp == req[0]) { return; }
+  // Zero-size input, no need to launch kernel
+  if (0U == a.Size()) { return; }
+
+  // Calculate workspace size
+  size_t workspace_size = QrForwardWorkspaceSize<xpu>(a, q, r, req, ctx);
+  Tensor<xpu, 1, char> workspace =
+    ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(workspace_size), s);
+  // Op
+  QrOpForwardImpl<xpu>(a, q, r, req, workspace, ctx, attrs);
+}
+
+}  // namespace op
+}  // namespace mxnet
+
+#endif  // MXNET_OPERATOR_NUMPY_LINALG_NP_QR_INL_H_

--- a/src/operator/numpy/linalg/np_qr.cc
+++ b/src/operator/numpy/linalg/np_qr.cc
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * Copyright (c) 2020 by Contributors
+ * \file np_qr.cc
+ * \brief CPU implementation of the QR Operator
+ */
+#include <mxnet/operator_util.h>
+#include <vector>
+#include "../../mshadow_op.h"
+#include "../../mxnet_op.h"
+#include "../../operator_common.h"
+#include "../../elemwise_op_common.h"
+#include "./np_qr-inl.h"
+
+namespace mxnet {
+namespace op {
+
+// Shape inference function for qr
+// Inputs: A. Outputs: Q, R
+inline bool NumpyLaQrShape(const nnvm::NodeAttrs& attrs,
+                           mxnet::ShapeVector* in_attrs,
+                           mxnet::ShapeVector* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 2U);
+  const mxnet::TShape& in_a = (*in_attrs)[0];
+
+  if (in_a.ndim() >= 2) {
+    // Forward shape inference.
+    const int ndim(in_a.ndim());
+    const int k = in_a[ndim - 2] > in_a[ndim - 1] ? in_a[ndim - 1] : in_a[ndim - 2];
+    // Q
+    std::vector<int> oshape_q(ndim);
+    for (int i = 0; i < ndim - 1; ++i) {
+      oshape_q[i] = in_a[i];
+    }
+    oshape_q[ndim - 1] = k;
+    mxnet::TShape tshape_q(oshape_q.begin(), oshape_q.end());
+    SHAPE_ASSIGN_CHECK(*out_attrs, 0, tshape_q);
+    // R
+    std::vector<int> oshape_r(ndim);
+    for (int i = 0; i < ndim - 2; ++i) {
+      oshape_r[i] = in_a[i];
+    }
+    oshape_r[ndim - 2] = k;
+    oshape_r[ndim - 1] = in_a[ndim - 1];
+    mxnet::TShape tshape_r(oshape_r.begin(), oshape_r.end());
+    SHAPE_ASSIGN_CHECK(*out_attrs, 1, tshape_r);
+    return true;
+  }
+  return false;
+}
+
+inline bool NumpyLaQrType(const nnvm::NodeAttrs& attrs,
+                        std::vector<int>* in_attrs,
+                        std::vector<int>* out_attrs) {
+  CHECK_EQ(in_attrs->size(), 1U);
+  CHECK_EQ(out_attrs->size(), 2U);
+  int a_type = in_attrs->at(0);
+  // unsupport float16
+  CHECK_NE(a_type, mshadow::kFloat16)
+    << "array type float16 is unsupported in linalg";
+  if (mshadow::kFloat32 == a_type) {
+    TYPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));
+    TYPE_ASSIGN_CHECK(*out_attrs, 1, in_attrs->at(0));
+  } else {
+    TYPE_ASSIGN_CHECK(*out_attrs, 0, mshadow::kFloat64);
+    TYPE_ASSIGN_CHECK(*out_attrs, 1, mshadow::kFloat64);
+  }
+  return out_attrs->at(0) != -1 && out_attrs->at(1) != -1;
+}
+
+NNVM_REGISTER_OP(_npi_qr)
+.describe(R"code()code" ADD_FILELINE)
+.set_num_inputs(1)
+.set_num_outputs(2)
+.set_attr<nnvm::FListInputNames>("FListInputNames", [](const NodeAttrs& attrs) {
+  return std::vector<std::string>{"A"}; })
+.set_attr<mxnet::FInferShape>("FInferShape", NumpyLaQrShape)
+.set_attr<nnvm::FInferType>("FInferType", NumpyLaQrType)
+.set_attr<FResourceRequest>("FResourceRequest", [](const NodeAttrs& attrs) {
+  return std::vector<ResourceRequest>{ResourceRequest::kTempSpace}; })
+.set_attr<FCompute>("FCompute<cpu>", NumpyLaQrForward<cpu>)
+.set_attr<nnvm::FGradient>("FGradient", MakeZeroGradNodes)
+.add_argument("A", "NDArray-or-Symbol", "Input matrices to be factorized");
+
+}  // namespace op
+}  // namespace mxnet

--- a/src/operator/numpy/linalg/np_qr.cu
+++ b/src/operator/numpy/linalg/np_qr.cu
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file np_qr.cu
+ * \brief GPU implementation of the QR Operator
+ */
+
+#include <mxnet/operator_util.h>
+#include <vector>
+#include "./np_qr-inl.h"
+
+namespace mxnet {
+namespace op {
+
+#if MXNET_USE_CUSOLVER == 1
+
+NNVM_REGISTER_OP(_npi_qr)
+.set_attr<FCompute>("FCompute<gpu>", NumpyLaQrForward<gpu>);
+
+#endif
+
+}  // namespace op
+}  // namespace mxnet

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -497,6 +497,13 @@ def _add_workload_linalg_cholesky():
         OpArgMngr.add_workload('linalg.cholesky', np.array(a, dtype=dtype))
 
 
+def _add_workload_linalg_qr():
+    A = np.array([[0, 1], [1, 1], [1, 1], [2, 1]])
+    OpArgMngr.add_workload('linalg.qr', A)
+    # default mode in numpy is 'reduced'
+    OpArgMngr.add_workload('linalg.qr', A, mode='reduced')
+
+
 def _add_workload_linalg_inv():
     OpArgMngr.add_workload('linalg.inv', np.array(_np.ones((0, 0)), dtype=np.float32))
     OpArgMngr.add_workload('linalg.inv', np.array(_np.ones((0, 1, 1)), dtype=np.float64))
@@ -2089,13 +2096,6 @@ def _add_workload_linalg_multi_dot():
     OpArgMngr.add_workload('linalg.multi_dot', [F,F])
 
 
-
-def _add_workload_linalg_qr():
-    A = np.array([[0, 1], [1, 1], [1, 1], [2, 1]])
-    OpArgMngr.add_workload('linalg.qr', A)
-    OpArgMngr.add_workload('linalg.qr', A, mode='r')
-
-
 def _add_workload_heaviside():
     x = np.array([[-30.0, -0.1, 0.0, 0.2], [7.5, np.nan, np.inf, -np.inf]], dtype=np.float64)
     OpArgMngr.add_workload('heaviside', x, 0.5)
@@ -2849,6 +2849,7 @@ def _prepare_workloads():
     _add_workload_zeros_like(array_pool)
     _add_workload_linalg_norm()
     _add_workload_linalg_cholesky()
+    _add_workload_linalg_qr()
     _add_workload_linalg_inv()
     _add_workload_linalg_solve()
     _add_workload_linalg_det()
@@ -2865,7 +2866,6 @@ def _prepare_workloads():
     _add_workload_linalg_matrix_power()
     _add_workload_linalg_matrix_rank()
     _add_workload_linalg_multi_dot()
-    _add_workload_linalg_qr()
     _add_workload_trace()
     _add_workload_tril()
     _add_workload_outer()


### PR DESCRIPTION
Implement Numpy's qr decomposition. Only forward for now. For all input shapes (M, N).

Implements the default mode ('reduced') of original Numpy's qr, where Q(M,K) and R(K,N) are returned, with K=min(M,N).



## Checklist ##
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Added QR forward implementation
- Added test

