### PR TITLE
CI: switch to patched ccache 3 version

### DIFF
--- a/ci/docker/install/deb_ubuntu_ccache.sh
+++ b/ci/docker/install/deb_ubuntu_ccache.sh
@@ -26,6 +26,7 @@ pushd .
 apt update || true
 apt install -y \
     autoconf \
+    gperf \
     xsltproc
 
 mkdir -p /work/deps
@@ -50,15 +51,15 @@ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 git clone --recursive https://github.com/ccache/ccache.git
 cd ccache
-# Checkout a fixed & tested pre-release commit of ccache 4
-# ccache 4 contains fixes for caching nvcc output: https://github.com/ccache/ccache/pull/381
-git checkout 2e7154e67a5dd56852dae29d4c418d4ddc07c230
+git checkout v3.7.8
+# Backport cuda related fixes: https://github.com/ccache/ccache/pull/381
+git config user.name "MXNet CI"
+git config user.email "MXNetCI@example.com"
+git cherry-pick --strategy-option=theirs c4fffda031034f930df2cf188878b8f9160027df
+git cherry-pick 0dec5c2df3e3ebc1fbbf33f74c992bef6264f37a
 
-
-export CFLAGS="-mno-avx"
-export CXXFLAGS="-mno-avx"
 ./autogen.sh
-./configure --disable-man --with-libzstd-from-internet --with-libb2-from-internet
+./configure --disable-man
 make -j$(nproc)
 make install
 


### PR DESCRIPTION
## Description ##
ccache version introduced in #17828 causes illegal instruction errors on various builds. Most builds were fixed by #17842, but "Build / GPU: USE_INT64_TENSOR_SIZE" remains buggy and fails with illegal instruction errors.

Thus, let's switch back to ccache 3 and manually backport the cuda related fixes instead of switching to ccache 4.