### PR TITLE
Improve performance of broadcast_axis on CPU

### DIFF
--- a/3rdparty/mshadow/mshadow/extension/slice.h
+++ b/3rdparty/mshadow/mshadow/extension/slice.h
@@ -45,10 +45,10 @@ struct SliceExp : public TRValue<SliceExp<SrcExp,
                                  Device, srcdim, DType> {
   static const int dimslice = srcdim - dimsrc_m_slice;
   const SrcExp &src_;
-  index_t ch_begin_;
-  index_t ch_old_;
+  int ch_begin_;
+  int ch_old_;
   Shape<srcdim> shape_;
-  SliceExp(const SrcExp &src, index_t begin, index_t end)
+  SliceExp(const SrcExp &src, int begin, int end)
       : src_(src), ch_begin_(begin) {
     shape_ = ShapeCheck<srcdim, SrcExp>::Check(src_);
     ch_old_ = shape_[dimslice];
@@ -81,7 +81,7 @@ struct SliceExp : public TRValue<SliceExp<SrcExp,
 template<int sdim, typename SrcExp,
          typename Device, typename DType, int srcdim>
 inline SliceExp<SrcExp, Device, DType, srcdim, srcdim - sdim>
-slice(const TRValue<SrcExp, Device, srcdim, DType> &src, index_t begin, index_t end) {
+slice(const TRValue<SrcExp, Device, srcdim, DType> &src, int begin, int end) {
   TypeCheckPass<sdim < srcdim && ExpInfo<SrcExp>::kDim == srcdim>
       ::Error_Expression_Does_Not_Meet_Dimension_Req();
   return SliceExp<SrcExp, Device, DType, srcdim, srcdim - sdim>(src.self(), begin, end);
@@ -129,26 +129,26 @@ struct Plan<SliceExp<SrcExp, Device, DType, srcdim, dimsrc_m_slice>, DType> {
       : src_(MakePlan(e.src_)),
         height_(e.shape_.ProdShape(dimslice + 1, srcdim - 1)),
         ch_begin_(e.ch_begin_), ch_old_(e.ch_old_), ch_(e.shape_[dimslice]) {}
-  MSHADOW_XINLINE DType Eval(index_t i, index_t j) const {
-    const index_t y = i % height_;
+  MSHADOW_XINLINE DType Eval(int i, int j) const {
+    const int y = i % height_;
     i /= height_;
-    const index_t c = i % ch_ + ch_begin_;
-    const index_t b = i / ch_;
-    const index_t x = j;
+    const int c = i % ch_ + ch_begin_;
+    const int b = i / ch_;
+    const int x = j;
     return src_.Eval((b * ch_old_ + c) * height_ + y, x);
   }
-  MSHADOW_XINLINE DType &REval(index_t i, index_t j) {
-    const index_t y = i % height_;
+  MSHADOW_XINLINE DType &REval(int i, int j) {
+    const int y = i % height_;
     i /= height_;
-    const index_t c = i % ch_ + ch_begin_;
-    const index_t b = i / ch_;
-    const index_t x = j;
+    const int c = i % ch_ + ch_begin_;
+    const int b = i / ch_;
+    const int x = j;
     return src_.REval((b * ch_old_ + c) * height_ + y, x);
   }
 
  private:
   Plan<SrcExp, DType> src_;
-  const index_t height_, ch_begin_, ch_old_, ch_;
+  const int height_, ch_begin_, ch_old_, ch_;
 };  // struct Plan
 
 template<typename SrcExp,
@@ -159,16 +159,16 @@ struct Plan<SliceExp<SrcExp, Device, DType, srcdim, 1>, DType> {
   explicit Plan(const SliceExp<SrcExp, Device, DType, srcdim, 1> &e)
       : src_(MakePlan(e.src_)),
         ch_begin_(e.ch_begin_) {}
-  MSHADOW_XINLINE DType Eval(index_t y, index_t x) const {
+  MSHADOW_XINLINE DType Eval(int y, int x) const {
     return src_.Eval(y, x + ch_begin_);
   }
-  MSHADOW_XINLINE DType &REval(index_t y, index_t x) {
+  MSHADOW_XINLINE DType &REval(int y, int x) {
     return src_.REval(y, x + ch_begin_);
   }
 
  private:
   Plan<SrcExp, DType> src_;
-  const index_t ch_begin_;
+  const int ch_begin_;
 };
 }  // namespace expr
 }   // namespace mshadow

--- a/src/operator/numpy/np_matmul_op-inl.h
+++ b/src/operator/numpy/np_matmul_op-inl.h
@@ -138,6 +138,7 @@ inline void MatmulImpl(const OpContext& ctx,
   mshadow::Tensor<xpu, 1, DType*> workspace;
   mshadow::Tensor<xpu, 3, DType> ans, mlhs, mrhs;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
+  bool isCPU = std::is_same<xpu, cpu>::value;
   if (MatmulNeedBroadcast(a_shape, b_shape)) {
     // e.g. a.shape = (2, 3, 1, 4, 2)
     //      b.shape =       (5, 2, 4)
@@ -160,12 +161,21 @@ inline void MatmulImpl(const OpContext& ctx,
         struct ShapeAndStride aux_data_a, aux_data_b;
         PrepareAUXData(&aux_data_a, k_a_shape, k_a_shape_bc, ndim);
         PrepareAUXData(&aux_data_b, k_b_shape, k_b_shape_bc, ndim);
-        Kernel<broadcast_kernel<mshadow_op::identity>, xpu>::Launch(
-          s, bc_size_a, input_a.dptr<IType>(), bc_a_ptr,
-          aux_data_a, OpReqType::kWriteTo, ndim);
-        Kernel<broadcast_kernel<mshadow_op::identity>, xpu>::Launch(
-          s, bc_size_b, input_b.dptr<IType>(), bc_b_ptr,
-          aux_data_b, OpReqType::kWriteTo, ndim);
+        if (isCPU) {
+          Kernel<broadcast_kernel_cpu<mshadow_op::identity>, xpu>::Launch(
+            s, input_a.Size(), input_a.dptr<IType>(), bc_a_ptr,
+            aux_data_a, OpReqType::kWriteTo, ndim);
+          Kernel<broadcast_kernel_cpu<mshadow_op::identity>, xpu>::Launch(
+            s, input_b.Size(), input_b.dptr<IType>(), bc_b_ptr,
+            aux_data_b, OpReqType::kWriteTo, ndim);
+        } else {
+          Kernel<broadcast_kernel_gpu<mshadow_op::identity>, xpu>::Launch(
+            s, bc_size_a, input_a.dptr<IType>(), bc_a_ptr,
+            aux_data_a, OpReqType::kWriteTo, ndim);
+          Kernel<broadcast_kernel_gpu<mshadow_op::identity>, xpu>::Launch(
+            s, bc_size_b, input_b.dptr<IType>(), bc_b_ptr,
+            aux_data_b, OpReqType::kWriteTo, ndim);
+        }
       });
     });
     ans = mshadow::Tensor<xpu, 3, DType>(output.dptr<DType>(),

--- a/src/operator/numpy/np_matmul_op-inl.h
+++ b/src/operator/numpy/np_matmul_op-inl.h
@@ -139,6 +139,7 @@ inline void MatmulImpl(const OpContext& ctx,
   mshadow::Tensor<xpu, 3, DType> ans, mlhs, mrhs;
   mshadow::Stream<xpu> *s = ctx.get_stream<xpu>();
   bool isCPU = std::is_same<xpu, cpu>::value;
+  // Is true if either a or b requires broadcast or not
   if (MatmulNeedBroadcast(a_shape, b_shape)) {
     // e.g. a.shape = (2, 3, 1, 4, 2)
     //      b.shape =       (5, 2, 4)
@@ -162,12 +163,26 @@ inline void MatmulImpl(const OpContext& ctx,
         PrepareAUXData(&aux_data_a, k_a_shape, k_a_shape_bc, ndim);
         PrepareAUXData(&aux_data_b, k_b_shape, k_b_shape_bc, ndim);
         if (isCPU) {
-          Kernel<broadcast_kernel_cpu<mshadow_op::identity>, xpu>::Launch(
-            s, input_a.Size(), input_a.dptr<IType>(), bc_a_ptr,
-            aux_data_a, OpReqType::kWriteTo, ndim);
-          Kernel<broadcast_kernel_cpu<mshadow_op::identity>, xpu>::Launch(
-            s, input_b.Size(), input_b.dptr<IType>(), bc_b_ptr,
-            aux_data_b, OpReqType::kWriteTo, ndim);
+          if (!aux_data_a.shape_changed) {
+            Kernel<direct_copy<mshadow_op::identity>, xpu>::Launch(
+              s, bc_size_a, input_a.dptr<IType>(), bc_a_ptr, OpReqType::kWriteTo);
+            Kernel<broadcast_kernel_cpu<mshadow_op::identity>, xpu>::Launch(
+              s, input_b.Size(), input_b.dptr<IType>(), bc_b_ptr,
+              aux_data_b, OpReqType::kWriteTo, ndim);
+          } else if (!aux_data_b.shape_changed) {
+            Kernel<direct_copy<mshadow_op::identity>, xpu>::Launch(
+              s, bc_size_b, input_b.dptr<IType>(), bc_b_ptr, OpReqType::kWriteTo);
+            Kernel<broadcast_kernel_cpu<mshadow_op::identity>, xpu>::Launch(
+              s, input_a.Size(), input_a.dptr<IType>(), bc_a_ptr,
+              aux_data_a, OpReqType::kWriteTo, ndim);
+          } else {
+            Kernel<broadcast_kernel_cpu<mshadow_op::identity>, xpu>::Launch(
+              s, input_a.Size(), input_a.dptr<IType>(), bc_a_ptr,
+              aux_data_a, OpReqType::kWriteTo, ndim);
+            Kernel<broadcast_kernel_cpu<mshadow_op::identity>, xpu>::Launch(
+              s, input_b.Size(), input_b.dptr<IType>(), bc_b_ptr,
+              aux_data_b, OpReqType::kWriteTo, ndim);
+          }
         } else {
           Kernel<broadcast_kernel_gpu<mshadow_op::identity>, xpu>::Launch(
             s, bc_size_a, input_a.dptr<IType>(), bc_a_ptr,

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -1156,7 +1156,7 @@ struct broadcast_kernel_cpu {
     // Each case is based on the number of axis to be broadcasted
     // (1, 2 or 3) after merging axes.
     switch (aux_data.num_broadcast_axes) {
-      // when input shape is one of the follwing forms
+      // when input shape is one of the following forms
       // (x_1,1) or (x_1,1,x_2) or (1,x_1)
       // x_1, x_2 are size of the dimensions that are not to be broadcasted
       // in case of (x_1,1) the system leverages vectorization but in other 2


### PR DESCRIPTION
## Description ##
Improves the performance of broadcast axis by reducing ALU operations and caching stride values. This operator is crucial in performance of SSD which gets slowed down by over 50%(total training time) when MXNet is built with Large Tensor Support enabled.

This PR leverages vectorization or SIMD architecture of the CPU. It is described as follows:

### Vectorization ### 
is the term for converting a scalar program to a vector program. Vectorized programs can run multiple operations from a single instruction(SIMD), whereas scalar can only operate on pairs of operands at once.

Consider the following very simple loop that adds the elements of two arrays and stores the results to a third array.
```
for (int i=0; i<16; ++i)
    C[i] = A[i] + B[i];
```
Vectorizing it, produces something like this:
```
for (int i=0; i<16; i+=4)
    C[i:i+3] = A[i:i+3] + B[i:i+3];
```
Note: The key here is that the elements need to be adjacent (so they can be loaded into vector registors. Note:avx 512 ISA does have "gatherd" intstruction for gathering sparse data from scattred locations into avx512 register but that operation is still slow compared to adjacent data being loaded into the register) and there should not be any fundamental dependency(or read after write dependency) in subsequent iterations of the loop. For e.g. the following loop cannot be vectorized because C[i+1] depends on the value of C[i] which needs to bew calculated first.
```
for (int i=0; i<16; ++i)
    C[i] = A[i] + C[i-1];
```
because if we unroll the loop and substitute values:
```
for (int i=0; i<16; i+=4) {
    C[i]   = A[i]   + C[i-1];
     |
     |-------------------------|
                               |
    C[i+1] = A[i+1] + C[i]; <--|
     |
     |---------------------------|
                                 |
    C[i+2] = A[i+2] + C[i+1]; <--|
     |
     |---------------------------|
                                 |
    C[i+3] = A[i+3] + C[i+2]; <--|
}
```
The arrows above show read after write dependency.the above statements cannot be executed in parallel by loading A[1:4] and C[1:4] into vector registers(here 1:4 is just for illustration purposes depending on the word size and register size it can load more data elements).

How is it different from loop unrolling? Unrolling transforms the loop into something that looks like this:
```
for (int i=0; i<16; i+=4) {
    C[i]   = A[i]   + B[i];
    C[i+1] = A[i+1] + B[i+1];
    C[i+2] = A[i+2] + B[i+2];
    C[i+3] = A[i+3] + B[i+3];
}
```

### Side Effects ###
for cases where 1 or very few elements need to be broadcasted to very large no. of locations the performance is not optimized. There is a slowdown when compared to master(int32 w/o large tensor support)

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Performance ###

Opperf code used to benchmark
```
add_res = run_performance_test(nd.broadcast_axis, run_backward=True, dtype='float32', ctx=mx.cpu(),
                               inputs=[{'data': (1000, 1, 100, 1), 'axis': (1, 3), 'size': (10, 5)}],
                               warmup=100, runs=1000, profiler='python')
print(add_res)

add_res = run_performance_test(nd.broadcast_axis, run_backward=True, dtype='float32', ctx=mx.cpu(),
                               inputs=[{'data': (1000, 1, 1, 100), 'axis': (1, 2), 'size': (10, 5)}],
                               warmup=100, runs=1000, profiler='python')
print(add_res)

add_res = run_performance_test(nd.broadcast_axis, run_backward=True, dtype='float32', ctx=mx.cpu(),
                               inputs=[{'data': (1, 1, 1, 1), 'axis': (0, 1, 2, 3), 'size': (1000, 10, 100, 5)}],
                               warmup=100, runs=1000, profiler='python')
print(add_res)

add_res = run_performance_test(nd.broadcast_axis, run_backward=True, dtype='float32', ctx=mx.cpu(),
                               inputs=[{'data': (1, 1000, 1, 100, 1), 'axis': (0, 2, 4), 'size': (2, 10, 5)}],
                               warmup=100, runs=1000, profiler='python')
print(add_res)
```

### Results ###

| code version | cases                                       | avg    | p50    | p90    |
|--------------|---------------------------------------------|--------|--------|--------|
|  master LT   | (1000, 1, 100, 1)->(1000, 10, 100, 5)       | 27.5   | 26.05  | 21.47  |
|              | (1000, 1, 1, 100)->(1000, 10, 5, 100)       | 29.68  | 28.59  | 35.93  |
|              | (1, 1, 1, 1)->(1000, 10, 100, 5)            | 129.80 | 123.30 | 169.04 |
|              | (1, 1000, 1, 100, 1)->(2, 1000, 10, 100, 5) | 63.60  | 58.88  | 74.74  |
|              |                                             |        |        |        |
| master no-LT | (1000, 1, 100, 1)->(1000, 10, 100, 5)       | 14.30  | 12.76  | 18.00  |
|              | (1000, 1, 1, 100)->(1000, 10, 5, 100)       | 13.21  | 12.33  | 15.67  |
|              | (1, 1, 1, 1)->(1000, 10, 100, 5)            | 66.80  | 60.77  | 83.80  |
|              | (1, 1000, 1, 100, 1)->(2, 1000, 10, 100, 5) | 31.81  | 29.71  | 40.23  |
|              |                                             |        |        |        |
| new LT       | (1000, 1, 100, 1)->(1000, 10, 100, 5)       | 17.53  | 17.36  | 22.42  |
|              | (1000, 1, 1, 100)->(1000, 10, 5, 100)       | 15.49  | 14.79  | 17.64  |
|              | (1, 1, 1, 1)->(1000, 10, 100, 5)            | 127.74 | 126.06 | 131.19 |
|              | (1, 1000, 1, 100, 1)->(2, 1000, 10, 100, 5) | 39.23  | 38.95  | 39.48  |
|              |                                             |        |        |        |
| new no-LT    | (1000, 1, 100, 1)->(1000, 10, 100, 5)       | 9.41   | 8.38   | 11.84  |
|              | (1000, 1, 1, 100)->(1000, 10, 5, 100)       | 8.29   | 7.65   | 10.61  |
|              | (1, 1, 1, 1)->(1000, 10, 100, 5)            | 67.54  | 63.63  | 86.17  |
|              | (1, 1000, 1, 100, 1)->(2, 1000, 10, 100, 5) | 23.57  | 23.39  | 23.92  |

