### PR TITLE
[MKLDNN] support using any format in pooling backward

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_pooling.cc
+++ b/src/operator/nn/mkldnn/mkldnn_pooling.cc
@@ -30,9 +30,8 @@
 namespace mxnet {
 namespace op {
 
-// This can be replaced by mkldnn::memory::desc::data_type() after 1.2 release
 static inline mkldnn::memory::data_type get_data_type(const mkldnn::memory::desc &md) {
-  return static_cast<mkldnn::memory::data_type>(md.data.data_type);
+  return static_cast<mkldnn::memory::data_type>(md.data_type());
 }
 
 void MKLDNNPoolingFwd::Init(const mxnet::NDArray &input, const mxnet::NDArray &output,


### PR DESCRIPTION
## Description ##
Support using `any` format in pooling backward. For performance reasons, backward computations of pooling requires consistent memory format with the corresponding forward computations. Hence, using `any` format means it will align with forward memory format automatically, this avoids unnecessary reorder.

@TaoLv @rongzha1 @PatricZhao please review.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
