### PR TITLE
Add USE_DIST_KVSTORE=ON to GPU build

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1341,17 +1341,7 @@ integrationtest_ubuntu_gpu_scala() {
 
 integrationtest_ubuntu_gpu_dist_kvstore() {
     set -ex
-    pushd .
-    export PYTHONPATH=./python/
-    export MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
-    export MXNET_SUBGRAPH_VERBOSE=0
-    export DMLC_LOG_STACK_TRACE_DEPTH=10
-    cd tests/nightly/
-    python3 ../../tools/launch.py -n 4 --launcher local python3 dist_device_sync_kvstore.py
-    python3 ../../tools/launch.py -n 4 --launcher local python3 dist_device_sync_kvstore_custom.py
-    python3 ../../tools/launch.py --p3 -n 4 --launcher local python3 dist_device_sync_kvstore_custom.py
-    python3 ../../tools/launch.py -n 4 --launcher local python3 dist_sync_kvstore.py --type=init_gpu
-    popd
+    ./test_distributed_training-gpu.sh
 }
 
 test_ubuntu_cpu_python3() {

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1341,7 +1341,10 @@ integrationtest_ubuntu_gpu_scala() {
 
 integrationtest_ubuntu_gpu_dist_kvstore() {
     set -ex
+    pushd .
+    cd tests/nightly
     ./test_distributed_training-gpu.sh
+    popd
 }
 
 test_ubuntu_cpu_python3() {

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -767,6 +767,7 @@ build_ubuntu_gpu_cuda101_cudnn7() {
         -DUSE_CUDNN=ON \
         -DUSE_MKLDNN=OFF \
         -DUSE_CPP_PACKAGE=ON \
+		-DUSE_DIST_KVSTORE=ON \
         -DBUILD_CYTHON_MODULES=ON \
         -G Ninja /work/mxnet
     ninja

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -767,7 +767,7 @@ build_ubuntu_gpu_cuda101_cudnn7() {
         -DUSE_CUDNN=ON \
         -DUSE_MKLDNN=OFF \
         -DUSE_CPP_PACKAGE=ON \
-		-DUSE_DIST_KVSTORE=ON \
+        -DUSE_DIST_KVSTORE=ON \
         -DBUILD_CYTHON_MODULES=ON \
         -G Ninja /work/mxnet
     ninja

--- a/tests/nightly/test_distributed_training-gpu.sh
+++ b/tests/nightly/test_distributed_training-gpu.sh
@@ -1,3 +1,22 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 export PYTHONPATH=./python/
 export MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
 export MXNET_SUBGRAPH_VERBOSE=0

--- a/tests/nightly/test_distributed_training-gpu.sh
+++ b/tests/nightly/test_distributed_training-gpu.sh
@@ -1,9 +1,7 @@
-pushd .
 export PYTHONPATH=./python/
 export MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
 export MXNET_SUBGRAPH_VERBOSE=0
 export DMLC_LOG_STACK_TRACE_DEPTH=10
-cd tests/nightly/
 
 test_args=(
     "-n 4 --launcher local python3 dist_device_sync_kvstore.py"
@@ -19,5 +17,3 @@ for arg in "${test_args[@]}"; do
         return $?
     fi 
 done
-
-popd

--- a/tests/nightly/test_distributed_training-gpu.sh
+++ b/tests/nightly/test_distributed_training-gpu.sh
@@ -22,16 +22,23 @@ export MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
 export MXNET_SUBGRAPH_VERBOSE=0
 export DMLC_LOG_STACK_TRACE_DEPTH=10
 
-test_args=(
-    "-n 4 --launcher local python3 dist_device_sync_kvstore.py"
-    "-n 4 --launcher local python3 dist_device_sync_kvstore_custom.py"
-    "--p3 -n 4 --launcher local python3 dist_device_sync_kvstore_custom.py"
-    "-n 4 --launcher local python3 dist_sync_kvstore.py --type=init_gpu" 
-)
+test_kvstore() {
+    test_args=(
+        "-n 4 --launcher local python3 dist_device_sync_kvstore.py"
+        "-n 4 --launcher local python3 dist_device_sync_kvstore_custom.py"
+        "--p3 -n 4 --launcher local python3 dist_device_sync_kvstore_custom.py"
+        "-n 4 --launcher local python3 dist_sync_kvstore.py --type=init_gpu" 
+    )
 
-for arg in "${test_args[@]}"; do
-    python3 ../../tools/launch.py "$arg"
-    if [ $? -ne 0 ]; then
-        return $?
-    fi 
-done
+    for arg in "${test_args[@]}"; do
+        echo $arg
+        python3 ../../tools/launch.py $arg
+        if [ $? -ne 0 ]; then
+            return $?
+        fi 
+    done
+}
+
+test_kvstore
+
+exit $errors

--- a/tests/nightly/test_distributed_training-gpu.sh
+++ b/tests/nightly/test_distributed_training-gpu.sh
@@ -30,7 +30,6 @@ test_args=(
 )
 
 for arg in "${test_args[@]}"; do
-    echo "$i"
     python3 ../../tools/launch.py "$arg"
     if [ $? -ne 0 ]; then
         return $?

--- a/tests/nightly/test_distributed_training-gpu.sh
+++ b/tests/nightly/test_distributed_training-gpu.sh
@@ -1,0 +1,23 @@
+pushd .
+export PYTHONPATH=./python/
+export MXNET_STORAGE_FALLBACK_LOG_VERBOSE=0
+export MXNET_SUBGRAPH_VERBOSE=0
+export DMLC_LOG_STACK_TRACE_DEPTH=10
+cd tests/nightly/
+
+test_args=(
+    "-n 4 --launcher local python3 dist_device_sync_kvstore.py"
+    "-n 4 --launcher local python3 dist_device_sync_kvstore_custom.py"
+    "--p3 -n 4 --launcher local python3 dist_device_sync_kvstore_custom.py"
+    "-n 4 --launcher local python3 dist_sync_kvstore.py --type=init_gpu" 
+)
+
+for arg in "${test_args[@]}"; do
+    echo "$i"
+    python3 ../../tools/launch.py "$arg"
+    if [ $? -ne 0 ]; then
+        return $?
+    fi 
+done
+
+popd


### PR DESCRIPTION
## Description ##
Add the missing flag in the GPU build stage. Otherwise, the KVStore test would fail

See the error message:

```
[2020-03-25T23:40:56.913Z] mxnet.base.MXNetError: Traceback (most recent call last):

[2020-03-25T23:40:56.913Z]   [bt] (9) python3() [0x539a13]

[2020-03-25T23:40:56.913Z]   [bt] (8) python3(PyEval_EvalFrameEx+0x4f2f) [0x5354af]

[2020-03-25T23:40:56.913Z]   [bt] (7) python3(PyObject_Call+0x47) [0x5c3bd7]

[2020-03-25T23:40:56.913Z]   [bt] (6) /usr/lib/python3.5/lib-dynload/_ctypes.cpython-35m-x86_64-linux-gnu.so(+0x9fcb) [0x7f7119dc6fcb]

[2020-03-25T23:40:56.913Z]   [bt] (5) /usr/lib/python3.5/lib-dynload/_ctypes.cpython-35m-x86_64-linux-gnu.so(_ctypes_callproc+0x49a) [0x7f7119dd301a]

[2020-03-25T23:40:56.913Z]   [bt] (4) /usr/lib/python3.5/lib-dynload/_ctypes.cpython-35m-x86_64-linux-gnu.so(ffi_call+0x2eb) [0x7f7119dd888b]

[2020-03-25T23:40:56.913Z]   [bt] (3) /usr/lib/python3.5/lib-dynload/_ctypes.cpython-35m-x86_64-linux-gnu.so(ffi_call_unix64+0x4c) [0x7f7119dd8e20]

[2020-03-25T23:40:56.913Z]   [bt] (2) /work/mxnet/python/mxnet/../../build/libmxnet.so(MXKVStoreCreate+0x20) [0x7f709627fb00]

[2020-03-25T23:40:56.913Z]   [bt] (1) /work/mxnet/python/mxnet/../../build/libmxnet.so(mxnet::KVStore::Create(char const*)+0x775) [0x7f70964f2bf5]

[2020-03-25T23:40:56.913Z]   [bt] (0) /work/mxnet/python/mxnet/../../build/libmxnet.so(dmlc::LogMessageFatal::~LogMessageFatal()+0x61) [0x7f70961fefd1]

[2020-03-25T23:40:56.913Z]   File "/work/mxnet/src/kvstore/kvstore.cc", line 67

[2020-03-25T23:40:56.913Z] MXNetError: compile with USE_DIST_KVSTORE=1 to use dist_sync
```

http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-gpu/detail/PR-17555/29/pipeline/428