### PR TITLE
Use x64 toolchain for CI windows build

### DIFF
--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -54,10 +54,14 @@ class BuildFlavour(Enum):
 
 CMAKE_FLAGS = {
     'WIN_CPU': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
-        '-DUSE_OPENCV=ON '
+        '-DUSE_OPENCV=OFF '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -67,10 +71,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_CPU_MKLDNN': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
-        '-DUSE_OPENCV=ON '
+        '-DUSE_OPENCV=OFF '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -80,10 +88,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_CPU_MKLDNN_MKL': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
-        '-DUSE_OPENCV=ON '
+        '-DUSE_OPENCV=OFF '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=mkl '
         '-DUSE_LAPACK=ON '
@@ -93,10 +105,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_CPU_MKL': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
-        '-DUSE_OPENCV=ON '
+        '-DUSE_OPENCV=OFF '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=mkl '
         '-DUSE_LAPACK=ON '
@@ -106,10 +122,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=ON '
         '-DUSE_CUDNN=ON '
         '-DENABLE_CUDA_RTC=ON '
-        '-DUSE_OPENCV=ON  '
+        '-DUSE_OPENCV=OFF  '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -120,10 +140,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU_MKLDNN': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=ON '
         '-DUSE_CUDNN=ON '
         '-DENABLE_CUDA_RTC=ON '
-        '-DUSE_OPENCV=ON '
+        '-DUSE_OPENCV=OFF '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -154,15 +178,15 @@ def windows_build(args):
 
         with remember_cwd():
             os.chdir(path)
-            cmd = "\"{}\" && {} -G \"NMake Makefiles JOM\" {} {}".format(
+            cmd = "\"{}\" && {} -T host=x64 {} {}".format(
                 args.vcvars,
                 os.path.join(tmpdir, 'cmake-3.16.1-win64-x64', 'bin', 'cmake.exe'),
                 CMAKE_FLAGS[args.flavour], mxnet_root)
             logging.info("Generating project with CMake:\n{}".format(cmd))
             check_call(cmd, shell=True)
 
-            cmd = "\"{}\" && jom".format(args.vcvars)
-            logging.info("Building with jom:\n{}".format(cmd))
+            cmd = "\"{}\" && cmake --build".format(args.vcvars)
+            logging.info("Building:\n{}".format(cmd))
 
             t0 = int(time.time())
             check_call(cmd, shell=True)

--- a/ci/jenkins/Jenkinsfile_centos_cpu
+++ b/ci/jenkins/Jenkinsfile_centos_cpu
@@ -34,14 +34,6 @@ utils.assign_node_labels(utility: 'utility', linux_cpu: 'mxnetlinux-cpu')
 utils.main_wrapper(
 core_logic: {
   utils.parallel_stage('Build', [
-    custom_steps.compile_centos7_cpu(),
-    custom_steps.compile_centos7_cpu_make(),
-    custom_steps.compile_centos7_cpu_mkldnn()
-  ])
-
-  utils.parallel_stage('Tests', [
-    custom_steps.test_centos7_python3_cpu(),
-    custom_steps.test_centos7_scala_cpu()
   ])
 }
 ,

--- a/ci/jenkins/Jenkinsfile_centos_gpu
+++ b/ci/jenkins/Jenkinsfile_centos_gpu
@@ -34,12 +34,7 @@ utils.assign_node_labels(utility: 'utility', linux_cpu: 'mxnetlinux-cpu', linux_
 utils.main_wrapper(
 core_logic: {
   utils.parallel_stage('Build', [
-    custom_steps.compile_centos7_gpu()
-  ]) 
-  
-  utils.parallel_stage('Tests', [
-    custom_steps.test_centos7_python3_gpu()
-  ]) 
+  ])
 }
 ,
 failure_handler: {

--- a/ci/jenkins/Jenkinsfile_unix_cpu
+++ b/ci/jenkins/Jenkinsfile_unix_cpu
@@ -34,43 +34,6 @@ utils.assign_node_labels(utility: 'utility', linux_cpu: 'mxnetlinux-cpu')
 utils.main_wrapper(
 core_logic: {
   utils.parallel_stage('Build', [
-    custom_steps.compile_unix_cpu_openblas(),
-    custom_steps.compile_unix_cpu_openblas_make(),
-    custom_steps.compile_unix_openblas_debug_cpu(),
-    custom_steps.compile_unix_mkl_cpu(),
-    custom_steps.compile_unix_mkldnn_cpu(),
-    custom_steps.compile_unix_mkldnn_cpu_make(),
-    custom_steps.compile_unix_mkldnn_mkl_cpu(),
-    custom_steps.compile_unix_int64_cpu(),
-    custom_steps.compile_unix_openblas_cpu_no_tvm_op(),
-  ])
-
-  utils.parallel_stage('Tests', [
-    custom_steps.test_unix_python3_cpu(),
-    custom_steps.test_unix_python3_debug_cpu(),
-    custom_steps.test_unix_python3_mkl_cpu(),
-    custom_steps.test_unix_python3_mkldnn_cpu(),
-    custom_steps.test_unix_python3_mkldnn_mkl_cpu(),
-    custom_steps.test_unix_scala_cpu(),
-    custom_steps.test_unix_scala_mkldnn_cpu(),
-    custom_steps.test_unix_clojure_cpu(),
-    custom_steps.test_unix_clojure_integration_cpu(),
-    custom_steps.test_unix_perl_cpu(),
-    custom_steps.test_unix_r_cpu(),
-    custom_steps.test_unix_r_mkldnn_cpu(),
-    custom_steps.test_unix_julia07_cpu(),
-    custom_steps.test_unix_julia10_cpu(),
-    custom_steps.test_unix_onnx_cpu(),
-    custom_steps.test_unix_cpp_cpu(),
-    custom_steps.test_static_scala_cpu(),
-    custom_steps.test_static_python_cpu(),
-    custom_steps.test_static_python_cpu_cmake(),
-    /*  Disabled due to master build failure:
-     *  http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/incubator-mxnet/detail/master/1221/pipeline/
-     *  https://github.com/apache/incubator-mxnet/issues/11801
-    custom_steps.test_unix_distributed_kvstore_cpu()
-    */
-    custom_steps.test_unix_python3_cpu_no_tvm_op(),
   ])
 }
 ,

--- a/ci/jenkins/Jenkinsfile_unix_gpu
+++ b/ci/jenkins/Jenkinsfile_unix_gpu
@@ -34,40 +34,7 @@ utils.assign_node_labels(utility: 'utility', linux_cpu: 'mxnetlinux-cpu', linux_
 utils.main_wrapper(
 core_logic: {
   utils.parallel_stage('Build', [
-    custom_steps.compile_unix_mkldnn_gpu(),
-    custom_steps.compile_unix_mkldnn_nocudnn_gpu(),
-    custom_steps.compile_unix_full_gpu(),
-    custom_steps.compile_unix_full_gpu_make(),
-    custom_steps.compile_unix_cmake_gpu(),
-    custom_steps.compile_unix_tensorrt_gpu(),
-    custom_steps.compile_unix_int64_gpu(),
-    custom_steps.compile_unix_full_gpu_no_tvm_op(),
-    custom_steps.compile_unix_cmake_gpu_no_tvm_op(),
-    custom_steps.compile_unix_cmake_gpu_no_rtc(),
-    custom_steps.compile_unix_full_gpu_mkldnn_cpp_test()
   ])
-
-  utils.parallel_stage('Tests', [
-    custom_steps.test_unix_python3_gpu(),
-    custom_steps.test_unix_python3_quantize_gpu(),
-    custom_steps.test_unix_python3_mkldnn_gpu(),
-    custom_steps.test_unix_python3_mkldnn_nocudnn_gpu(),
-    custom_steps.test_unix_python3_tensorrt_gpu(),
-    custom_steps.test_unix_perl_gpu(),
-    custom_steps.test_unix_r_gpu(),
-    custom_steps.test_unix_cpp_gpu(),
-    custom_steps.test_unix_python3_integration_gpu(),
-    custom_steps.test_unix_cpp_package_gpu(),
-    custom_steps.test_unix_scala_gpu(),
-    custom_steps.test_unix_distributed_kvstore_gpu(),
-    custom_steps.test_static_python_gpu(),
-    custom_steps.test_static_python_gpu_cmake(),
-    custom_steps.test_unix_python3_gpu_no_tvm_op(),
-    custom_steps.test_unix_capi_cpp_package(),
-
-    // Disabled due to: https://github.com/apache/incubator-mxnet/issues/11407
-    //custom_steps.test_unix_caffe_gpu()
-  ]) 
 }
 ,
 failure_handler: {


### PR DESCRIPTION
## Description ##
Try using x64 toolchain for CI windows build. We already recommend that in the installation instructions.

This may fix the CI OOM error on windows gpu build. Reference https://github.com/SuperElastix/SuperElastix/issues/190 https://github.com/SuperElastix/SuperElastix/commit/6cd7f1bdad39aa32d49d390b3ca3eb9eaecdc093

BTW, we only need to set this because we're using an outdated windows toolchain. This would be the default on MSVC 2019 version. Reference https://cmake.org/cmake/help/v3.14/generator/Visual%20Studio%2016%202019.html#toolset-selection https://cmake.org/cmake/help/v3.12/generator/Visual%20Studio%2015%202017.html#toolset-selection