### PR TITLE
32 to 64 bit toolchain for windows-gpu build

### DIFF
--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -43,7 +43,7 @@ from util import *
 
 KNOWN_VCVARS = {
     'VS 2015': r'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\vcvarsx86_amd64.bat',
-    'VS 2017': r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat
+    'VS 2017': r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat',
     'VS 2019': r'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat'
 }
 

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -183,14 +183,14 @@ def windows_build(args):
 
         with remember_cwd():
             os.chdir(path)
-            cmd = "\"{}\" && {} -A x64 -T host=x64 {} {}".format(
+            cmd = "\"{}\" && {} -G Ninja -A x64 -T host=x64 {} {}".format(
                 args.vcvars,
                 os.path.join(tmpdir, 'cmake-3.16.1-win64-x64', 'bin', 'cmake.exe'),
                 CMAKE_FLAGS[args.flavour], mxnet_root)
             logging.info("Generating project with CMake:\n{}".format(cmd))
             check_call(cmd, shell=True)
 
-            cmd = "\"{}\" && cmake --build .".format(args.vcvars)
+            cmd = "\"{}\" && ninja".format(args.vcvars)
             logging.info("Building:\n{}".format(cmd))
 
             t0 = int(time.time())

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -122,7 +122,6 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU': (
-        '-DUSE_SPLIT_ARCH_DLL=OFF '
         '-DCMAKE_C_COMPILER=cl '
         '-DCMAKE_CXX_COMPILER=cl '
         '-DOpenCV_RUNTIME=vc15 '
@@ -141,7 +140,6 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU_MKLDNN': (
-        '-DUSE_SPLIT_ARCH_DLL=OFF '
         '-DCMAKE_C_COMPILER=cl '
         '-DCMAKE_CXX_COMPILER=cl '
         '-DOpenCV_RUNTIME=vc15 '

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -44,7 +44,7 @@ os.environ['PATH']=os.environ.get('PATH').replace('\n','')
 KNOWN_VCVARS = {
     'VS 2015': r'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\vcvarsx86_amd64.bat',
     'VS 2017': r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat',
-    'VS 2019': r'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat'
+    'VS 2019': r'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat'
 }
 
 

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -38,8 +38,8 @@ from subprocess import check_call
 from util import *
 
 # Fix for broken PATH with newline inserted presumably by VS studio installation of SQL server or
- # other component which makes visual studio stop working.
- os.environ['PATH']=os.environ.get('PATH').replace('\n','')
+# other component which makes visual studio stop working.
+os.environ['PATH']=os.environ.get('PATH').replace('\n','')
 
 KNOWN_VCVARS = {
     'VS 2015': r'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\vcvarsx86_amd64.bat',

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -37,9 +37,14 @@ from subprocess import check_call
 
 from util import *
 
+# Fix for broken PATH with newline inserted presumably by VS studio installation of SQL server or
+ # other component which makes visual studio stop working.
+ os.environ['PATH']=os.environ.get('PATH').replace('\n','')
+
 KNOWN_VCVARS = {
     'VS 2015': r'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\vcvarsx86_amd64.bat',
-    'VS 2017': r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat'
+    'VS 2017': r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat
+    'VS 2019': r'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat'
 }
 
 
@@ -257,7 +262,7 @@ def main():
 
     parser.add_argument("--vcvars",
         help="vcvars batch file location, typically inside vs studio install dir",
-        default=KNOWN_VCVARS['VS 2015'],
+        default=KNOWN_VCVARS['VS 2019'],
         type=str)
 
     parser.add_argument("--arch",

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -122,6 +122,7 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU': (
+        '-DUSE_SPLIT_ARCH_DLL=OFF '
         '-DCMAKE_C_COMPILER=cl '
         '-DCMAKE_CXX_COMPILER=cl '
         '-DOpenCV_RUNTIME=vc15 '
@@ -140,6 +141,7 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU_MKLDNN': (
+        '-DUSE_SPLIT_ARCH_DLL=OFF '
         '-DCMAKE_C_COMPILER=cl '
         '-DCMAKE_CXX_COMPILER=cl '
         '-DOpenCV_RUNTIME=vc15 '

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -154,7 +154,7 @@ def windows_build(args):
 
         with remember_cwd():
             os.chdir(path)
-            cmd = "\"{}\" && {} -G \"NMake Makefiles JOM\" {} {}".format(
+            cmd = "\"{}\" && {} -A x64 -T host=x64 -G \"NMake Makefiles JOM\" {} {}".format(
                 args.vcvars,
                 os.path.join(tmpdir, 'cmake-3.16.1-win64-x64', 'bin', 'cmake.exe'),
                 CMAKE_FLAGS[args.flavour], mxnet_root)

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -154,15 +154,15 @@ def windows_build(args):
 
         with remember_cwd():
             os.chdir(path)
-            cmd = "\"{}\" && {} -A x64 -T host=x64 -G \"NMake Makefiles JOM\" {} {}".format(
+            cmd = "\"{}\" && {} -A x64 -T host=x64 {} {}".format(
                 args.vcvars,
                 os.path.join(tmpdir, 'cmake-3.16.1-win64-x64', 'bin', 'cmake.exe'),
                 CMAKE_FLAGS[args.flavour], mxnet_root)
             logging.info("Generating project with CMake:\n{}".format(cmd))
             check_call(cmd, shell=True)
 
-            cmd = "\"{}\" && jom".format(args.vcvars)
-            logging.info("Building with jom:\n{}".format(cmd))
+            cmd = "\"{}\" && cmake --build".format(args.vcvars)
+            logging.info("Building:\n{}".format(cmd))
 
             t0 = int(time.time())
             check_call(cmd, shell=True)

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -185,7 +185,7 @@ def windows_build(args):
             logging.info("Generating project with CMake:\n{}".format(cmd))
             check_call(cmd, shell=True)
 
-            cmd = "\"{}\" && cmake --build".format(args.vcvars)
+            cmd = "\"{}\" && cmake --build .".format(args.vcvars)
             logging.info("Building:\n{}".format(cmd))
 
             t0 = int(time.time())

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -54,10 +54,14 @@ class BuildFlavour(Enum):
 
 CMAKE_FLAGS = {
     'WIN_CPU': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
-        '-DUSE_OPENCV=ON '
+        '-DUSE_OPENCV=OFF '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -67,10 +71,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_CPU_MKLDNN': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
-        '-DUSE_OPENCV=ON '
+        '-DUSE_OPENCV=OFF '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -80,10 +88,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_CPU_MKLDNN_MKL': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
-        '-DUSE_OPENCV=ON '
+        '-DUSE_OPENCV=OFF '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=mkl '
         '-DUSE_LAPACK=ON '
@@ -93,10 +105,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_CPU_MKL': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
-        '-DUSE_OPENCV=ON '
+        '-DUSE_OPENCV=OFF '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=mkl '
         '-DUSE_LAPACK=ON '
@@ -106,10 +122,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=ON '
         '-DUSE_CUDNN=ON '
         '-DENABLE_CUDA_RTC=ON '
-        '-DUSE_OPENCV=ON  '
+        '-DUSE_OPENCV=OFF  '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -120,10 +140,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU_MKLDNN': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_CUDA=ON '
         '-DUSE_CUDNN=ON '
         '-DENABLE_CUDA_RTC=ON '
-        '-DUSE_OPENCV=ON '
+        '-DUSE_OPENCV=OFF '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '


### PR DESCRIPTION
Changes
1. Switch from 32 to 64bit toolchain
Trying out @snnn suggestion : 
https://github.com/apache/incubator-mxnet/pull/17711#issuecomment-604659219

2. Update dmlc-core to include the latest master (fix VS 2019 in dmlc)
3. Switch from 2015 to 2019 VS