### PR TITLE
param.axes check : redundant condition

### DIFF
--- a/src/operator/numpy/np_matrix_op.cc
+++ b/src/operator/numpy/np_matrix_op.cc
@@ -1292,7 +1292,7 @@ inline bool NumpyRot90Shape(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(in_attrs->size(), 1U);
   CHECK_EQ(out_attrs->size(), 1U);
   mxnet::TShape& shp = (*in_attrs)[0];
-  if (!param.axes.has_value() || (param.axes.has_value() && param.axes.value().ndim() != 2)) {
+  if (!param.axes.has_value() || param.axes.value().ndim() != 2) {
     LOG(FATAL) << "The length of axes must be 2.";
   }
   int real_k(param.k);


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)
Logical condition optimization: !A || (A && B)' is equivalent to '!A || B

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
