### PR TITLE
[SquareSumRspGradKernel] Add div by zero check for num_cols

### DIFF
--- a/src/operator/tensor/square_sum-inl.h
+++ b/src/operator/tensor/square_sum-inl.h
@@ -182,6 +182,7 @@ struct SquareSumRspGradKernel<req, 0> {
   MSHADOW_XINLINE static void Map(int i, IType* in_grad_row_idx, DType* in_grad,
                                   const DType* out_grad, const IType* in_row_idx,
                                   const DType* in_data, const int64_t num_cols) {
+    CHECK_GT(num_cols, 0) << "num_cols is zero";
     const int64_t row = i / num_cols;
     in_grad_row_idx[row] = in_row_idx[row];
     KERNEL_ASSIGN(in_grad[i], req, 2*in_data[i]*out_grad[i%num_cols]);
@@ -202,6 +203,7 @@ struct SquareSumRspGradKernel<req, 1> {
   MSHADOW_XINLINE static void Map(int i, IType* in_grad_row_idx, DType* in_grad,
                                   const DType* out_grad, const IType* in_row_idx,
                                   const DType* in_data, const int64_t num_cols) {
+    CHECK_GT(num_cols, 0) << "num_cols is zero";
     const int64_t row = i / num_cols;
     in_grad_row_idx[row] = in_row_idx[row];
     KERNEL_ASSIGN(in_grad[i], req, 2*in_data[i]*out_grad[in_row_idx[row]]);
@@ -226,6 +228,7 @@ struct SquareSumRspGradKernel<req, 1, kRowSparseStorage, false> {
   MSHADOW_XINLINE static void Map(int i, IType* in_grad_row_idx, DType* in_grad,
                                   const IType* out_grad_row_idx, const DType* out_grad,
                                   const DType* in_data, const int64_t num_cols) {
+    CHECK_GT(num_cols, 0) << "num_cols is zero";
     const int64_t row = i / num_cols;
     in_grad_row_idx[row] = out_grad_row_idx[row];
     KERNEL_ASSIGN(in_grad[i], req, 2 * in_data[i] * out_grad[row]);
@@ -250,6 +253,7 @@ struct SquareSumRspGradKernel<req, 1, kRowSparseStorage, true> {
   MSHADOW_XINLINE static void Map(int i, IType* in_grad_row_idx, DType* in_grad,
                                   const IType* out_grad_row_idx, const DType* out_grad,
                                   const DType* in_data, const int64_t num_cols) {
+    CHECK_GT(num_cols, 0) << "num_cols is zero";
     const int64_t row = i / num_cols;
     const int64_t row_dns = out_grad_row_idx[row];
     in_grad_row_idx[row] = row_dns;

--- a/src/operator/tensor/square_sum-inl.h
+++ b/src/operator/tensor/square_sum-inl.h
@@ -182,7 +182,7 @@ struct SquareSumRspGradKernel<req, 0> {
   MSHADOW_XINLINE static void Map(int i, IType* in_grad_row_idx, DType* in_grad,
                                   const DType* out_grad, const IType* in_row_idx,
                                   const DType* in_data, const int64_t num_cols) {
-    CHECK_GT(num_cols, 0) << "num_cols is zero";
+    CHECK_GT(num_cols, 0U) << "num_cols is zero";
     const int64_t row = i / num_cols;
     in_grad_row_idx[row] = in_row_idx[row];
     KERNEL_ASSIGN(in_grad[i], req, 2*in_data[i]*out_grad[i%num_cols]);
@@ -203,7 +203,7 @@ struct SquareSumRspGradKernel<req, 1> {
   MSHADOW_XINLINE static void Map(int i, IType* in_grad_row_idx, DType* in_grad,
                                   const DType* out_grad, const IType* in_row_idx,
                                   const DType* in_data, const int64_t num_cols) {
-    CHECK_GT(num_cols, 0) << "num_cols is zero";
+    CHECK_GT(num_cols, 0U) << "num_cols is zero";
     const int64_t row = i / num_cols;
     in_grad_row_idx[row] = in_row_idx[row];
     KERNEL_ASSIGN(in_grad[i], req, 2*in_data[i]*out_grad[in_row_idx[row]]);
@@ -228,7 +228,7 @@ struct SquareSumRspGradKernel<req, 1, kRowSparseStorage, false> {
   MSHADOW_XINLINE static void Map(int i, IType* in_grad_row_idx, DType* in_grad,
                                   const IType* out_grad_row_idx, const DType* out_grad,
                                   const DType* in_data, const int64_t num_cols) {
-    CHECK_GT(num_cols, 0) << "num_cols is zero";
+    CHECK_GT(num_cols, 0U) << "num_cols is zero";
     const int64_t row = i / num_cols;
     in_grad_row_idx[row] = out_grad_row_idx[row];
     KERNEL_ASSIGN(in_grad[i], req, 2 * in_data[i] * out_grad[row]);


### PR DESCRIPTION
Public interface of SquareSumRspGradKernel is not safe. When calling SquareSumRspGradKernel::Map(), if parameter num_cols is 0 that leads to division by zero.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
