### PR TITLE
Change register_op_hook to take MXNet and Python types instead of C types

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -721,9 +721,13 @@ class Block(object):
         Parameters
         ----------
         callback : function
-            Takes a string and a NDArrayHandle.
+            Function called to inspect the values of the intermediate outputs
+            of blocks after hybridization. It takes 3 parameters:
+            name of the tensor being inspected (str)
+            name of the operator producing or consuming that tensor (str)
+            tensor being inspected (NDArray).
         monitor_all : bool, default False
-            If true, monitor both input and output, otherwise monitor output only.
+            If True, monitor both input and output, otherwise monitor output only.
         """
         for cld in self._children.values():
             cld.register_op_hook(callback, monitor_all)
@@ -1284,14 +1288,29 @@ class HybridBlock(Block):
         Parameters
         ----------
         callback : function
-            Takes a string and a NDArrayHandle.
+            Function called to inspect the values of the intermediate outputs
+            of blocks after hybridization. It takes 3 parameters:
+            name of the tensor being inspected (str)
+            name of the operator producing or consuming that tensor (str)
+            tensor being inspected (NDArray).
         monitor_all : bool, default False
-            If true, monitor both input and output, otherwise monitor output only.
+            If True, monitor both input and output, otherwise monitor output only.
         """
-        self._callback = callback
+        def c_callback(name, op_name, array):
+            """wrapper for user callback"""
+            import ctypes
+            from mxnet.base import NDArrayHandle, py_str
+            from mxnet.ndarray import NDArray
+            array = ctypes.cast(array, NDArrayHandle)
+            array = NDArray(array, writable=False)
+            name = py_str(name)
+            op_name = py_str(op_name)
+            callback(name, op_name, array)
+
+        self._callback = c_callback
         self._monitor_all = monitor_all
         for cld in self._children.values():
-            cld._callback = callback
+            cld._callback = c_callback
             cld._monitor_all = monitor_all
 
     def __call__(self, x, *args):

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -27,7 +27,7 @@ import re
 from collections import OrderedDict, defaultdict
 import numpy as np
 
-from ..base import mx_real_t, MXNetError
+from ..base import mx_real_t, MXNetError, NDArrayHandle, py_str
 from .. import symbol, ndarray, initializer, np_symbol, autograd, _deferred_compute as dc
 from ..symbol import Symbol
 from ..ndarray import NDArray
@@ -1299,8 +1299,6 @@ class HybridBlock(Block):
         def c_callback(name, op_name, array):
             """wrapper for user callback"""
             import ctypes
-            from mxnet.base import NDArrayHandle, py_str
-            from mxnet.ndarray import NDArray
             array = ctypes.cast(array, NDArrayHandle)
             array = NDArray(array, writable=False)
             name = py_str(name)

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1784,8 +1784,9 @@ def test_op_hook_output_names():
         output_names = []
 
         def mon_callback(node_name, opr_name, arr):
-            output_names.append(py_str(node_name))
-            opr_names.append(py_str(opr_name))
+            output_names.append(node_name)
+            opr_names.append(opr_name)
+            assert isinstance(arr, mx.nd.NDArray)
 
         block.register_op_hook(mon_callback, monitor_all)
         if not inputs:


### PR DESCRIPTION
## Description ##
This PR changes the API of the Gluon's `register_op_hook` method to take the Python strings and MXNet NDArray instead of the C string and internal NDArrayHandle. Also it fixes a bug in the documentation (which previously said that the function should take 2 parameters, whereas in fact it takes 3).

This change makes the `register_op_hook` much more user-friendly, especially for people not familiar with MXNet internals.

@szha @eric-haibin-lin @anirudh2290 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
