### PR TITLE
[v1.x][KVStore]1Bit gradient compression

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1315,8 +1315,10 @@ integrationtest_ubuntu_cpu_dist_kvstore() {
     python3 ../../tools/launch.py -n 7 --launcher local python3 dist_sync_kvstore.py --type=gluon_type_cpu
     python3 ../../tools/launch.py -n 7 --launcher local python3 dist_sync_kvstore.py
     python3 ../../tools/launch.py -n 7 --launcher local python3 dist_sync_kvstore.py --no-multiprecision
-    python3 ../../tools/launch.py -n 7 --launcher local python3 dist_sync_kvstore.py --type=compressed_cpu
-    python3 ../../tools/launch.py -n 7 --launcher local python3 dist_sync_kvstore.py --type=compressed_cpu --no-multiprecision
+    python3 ../../tools/launch.py -n 7 --launcher local python3 dist_sync_kvstore.py --type=compressed_cpu_1bit
+    python3 ../../tools/launch.py -n 7 --launcher local python3 dist_sync_kvstore.py --type=compressed_cpu_1bit --no-multiprecision
+    python3 ../../tools/launch.py -n 7 --launcher local python3 dist_sync_kvstore.py --type=compressed_cpu_2bit
+    python3 ../../tools/launch.py -n 7 --launcher local python3 dist_sync_kvstore.py --type=compressed_cpu_2bit --no-multiprecision
     python3 ../../tools/launch.py -n 3 --launcher local python3 test_server_profiling.py
     popd
 }

--- a/python/mxnet/kvstore/kvstore.py
+++ b/python/mxnet/kvstore/kvstore.py
@@ -498,6 +498,9 @@ class KVStore(KVStoreBase):
         """ Specifies type of low-bit quantization for gradient compression \
          and additional arguments depending on the type of compression being used.
 
+        The 1bit compression works as follows: values which is above the threshold in the
+        gradient will be set to +1, whereas values below threshold will be set to -1.
+
         2bit Gradient Compression takes a positive float `threshold`.
         The technique works by thresholding values such that positive values in the
         gradient above threshold will be set to threshold. Negative values whose absolute
@@ -538,7 +541,7 @@ class KVStore(KVStoreBase):
             A dictionary specifying the type and parameters for gradient compression.
             The key `type` in this dictionary is a
             required string argument and specifies the type of gradient compression.
-            Currently `type` can be only `2bit`
+            Currently `type` can be only `1bit` and `2bit`
             Other keys in this dictionary are optional and specific to the type
             of gradient compression.
         """

--- a/src/kvstore/gradient_compression-inl.h
+++ b/src/kvstore/gradient_compression-inl.h
@@ -32,13 +32,105 @@ namespace mxnet {
 namespace kvstore {
 
 // these gpu functions are defined in gradient_compression.cu
+void Quantize1BitImpl(mshadow::Stream<mshadow::gpu> *s, const std::vector<mxnet::TBlob> &inputs,
+                      const float threshold);
+void Dequantize1BitImpl(mshadow::Stream<mshadow::gpu> *s, const std::vector<mxnet::TBlob> &inputs,
+                        const float threshold);
 void Quantize2BitImpl(mshadow::Stream<mshadow::gpu> *s, const std::vector<mxnet::TBlob> &inputs,
                       const float threshold);
 void Dequantize2BitImpl(mshadow::Stream<mshadow::gpu> *s, const std::vector<mxnet::TBlob> &inputs,
                         const float threshold);
 
+struct quantize_1bit {
+  MSHADOW_XINLINE static void Map(int out_byte_id,
+                                  int original_size,
+                                  float *out,
+                                  float *grad,
+                                  float *residual,
+                                  const float threshold) {
+    // this byte contains the compressed representation of
+    // upto 8 values starting from (char*)out + out_byte_id
+    char *compr_byte = reinterpret_cast<char *>(out) + out_byte_id;
+
+    // init to 0
+    *compr_byte = 0;
+    // start and end are indices in original grad array
+    const int start = out_byte_id << 3;
+    const int end = (start + 8 <= original_size) ? start + 8 : original_size;
+
+    // masks used to quantize data
+    const uint8_t bits[] = {0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01};
+    for (int i = start; i < end; ++i) {
+      // adds gradient to existing residual to get updated grad
+      residual[i] += grad[i];
+      if (residual[i] > threshold) {
+        // set data to 1
+        *compr_byte |= bits[(i & 7)];
+        // reduce residual by 1
+        residual[i] -= 1;
+      } else {
+        // do nothing on compr_byte because it is initialized to 0
+        // add residual by 1
+        // because current position will be dequantized to -1
+        residual[i] += 1;
+      }
+    }
+  }
+};
+
+template<typename xpu>
+void Quantize1BitKernelLaunch(mshadow::Stream<xpu> *s, const std::vector<mxnet::TBlob> &inputs,
+                              const float threshold) {
+  mxnet::op::mxnet_op::Kernel<quantize_1bit, xpu>
+    ::Launch(s,
+            inputs[2].Size() * 4,         // compressed array byte size
+            inputs[0].Size(),             // original size
+            inputs[2].dptr<float>(),      // compressed array
+            inputs[0].dptr<float>(),      // original array
+            inputs[1].dptr<float>(),      // residual array
+            threshold);                   // threshold
+}
+
+struct dequantize_1bit {
+  MSHADOW_XINLINE static void Map(int i,
+                                  float *out,
+                                  float *in,
+                                  const float threshold) {
+    // get position of dequantized value to fill
+    float *outval = out + i;
+    // gets byte which holds quantized value for this position
+    char *ch_ptr = reinterpret_cast < char * > (in + (i >> 5));
+    ch_ptr += ((i & 31) >> 3);
+    // masks used to quantize data
+    const uint8_t bits[] = {0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01};
+    // col denotes which bit of a byte is set for this value
+    // col=0 implies the first bit, col=1 implies the second bit,...
+    const int col = i & 7;
+    const uint8_t mask = bits[col];
+    const uint8_t masked = *ch_ptr & mask;
+    if (masked == mask) {
+      *outval = +1;
+    } else {
+      // if current position of byte is 0
+      // dequantized it to -1
+      *outval = -1;
+    }
+  }
+};
+
+template<typename xpu>
+void Dequantize1BitKernelLaunch(mshadow::Stream<xpu> *s, const std::vector<mxnet::TBlob> &inputs,
+                                const float threshold) {
+  mxnet::op::mxnet_op::Kernel<dequantize_1bit, xpu>
+  ::Launch(s,
+          inputs[1].Size(),         // original size
+          inputs[1].dptr<float>(),  // out array
+          inputs[0].dptr<float>(),  // compressed array
+          threshold);               // threshold
+}
+
 struct quantize_2bit {
-  MSHADOW_XINLINE static void Map(int out_block_id,
+  MSHADOW_XINLINE static void Map(int out_byte_id,
                                   int original_size,
                                   float *out,
                                   float *grad,
@@ -46,15 +138,14 @@ struct quantize_2bit {
                                   const float neg_threshold,
                                   const float pos_threshold) {
     // this block contains the compressed representation of
-    // upto 16 values starting from out_block_id*16
-    float *compr_block = out + out_block_id;
+    // upto 4 values starting from (char*)out + out_byte_id
+    char *compr_byte = reinterpret_cast<char *>(out) + out_byte_id;
     // init to 0
-    *compr_block = 0;
+    *compr_byte = 0;
     // start and end are indices in original grad array
-    const int start = out_block_id << 4;
-    const int end = (start + 16 <= original_size) ? start + 16 : original_size;
-    // cast as char* to manipulate bits of float addresses
-    char *block_ptr = reinterpret_cast < char * > (compr_block);
+    const int start = out_byte_id << 2;
+    const int end = (start + 4 <= original_size) ? start + 4 : original_size;
+
     // masks to set bits when value meets pos_threshold
     // 0xc0 is mask when value is to be represented by the first two bits in a char*
     // 0xc0 means first two bits are set to 11
@@ -62,18 +153,16 @@ struct quantize_2bit {
     // masks to set bits when value meets neg_threshold
     const uint8_t negbits[] = {0x80, 0x20, 0x08, 0x02};
     for (int i = start; i < end; i++) {
-      // adds offset to reach appropriate byte
-      char *curr_byte = block_ptr + ((i - start) >> 2);
       // adds gradient to existing residual to get updated grad
       residual[i] += grad[i];
       if (residual[i] >= pos_threshold) {
         // set data to 11
-        *curr_byte |= posbits[(i & 3)];
+        *compr_byte |= posbits[(i & 3)];
         // reduce residual by pos_threshold
         residual[i] -= pos_threshold;
       } else if (residual[i] <= neg_threshold) {
         // set data to 10
-        *curr_byte |= negbits[(i & 3)];
+        *compr_byte |= negbits[(i & 3)];
         residual[i] -= neg_threshold;
       }
     }
@@ -85,13 +174,13 @@ void Quantize2BitKernelLaunch(mshadow::Stream<xpu> *s, const std::vector<mxnet::
                               const float threshold) {
   mxnet::op::mxnet_op::Kernel<quantize_2bit, xpu>
     ::Launch(s,
-            inputs[2].Size(),         // compressed array size
-            inputs[0].Size(),         // original size
-            inputs[2].dptr<float>(),  // compressed array
-            inputs[0].dptr<float>(),  // original array
-            inputs[1].dptr<float>(),  // residual array
-            -1 *threshold,            // negative threshold
-            threshold);               // positive threshold
+            inputs[2].Size() * 4,         // compressed array byte size
+            inputs[0].Size(),             // original size
+            inputs[2].dptr<float>(),      // compressed array
+            inputs[0].dptr<float>(),      // original array
+            inputs[1].dptr<float>(),      // residual array
+            -1 *threshold,                // negative threshold
+            threshold);                   // positive threshold
 }
 
 struct dequantize_2bit {
@@ -136,6 +225,18 @@ void Dequantize2BitKernelLaunch(mshadow::Stream<xpu> *s, const std::vector<mxnet
           inputs[0].dptr<float>(),  // compressed array
           -1 *threshold,            // negative threshold
           threshold);               // positive threshold
+}
+
+inline void Quantize1BitImpl(mshadow::Stream<mshadow::cpu> *s,
+                             const std::vector<mxnet::TBlob> &inputs,
+                             const float threshold) {
+  Quantize1BitKernelLaunch(s, inputs, threshold);
+}
+
+inline void Dequantize1BitImpl(mshadow::Stream<mshadow::cpu> *s,
+                               const std::vector<mxnet::TBlob> &inputs,
+                               const float threshold) {
+  Dequantize1BitKernelLaunch(s, inputs, threshold);
 }
 
 inline void Quantize2BitImpl(mshadow::Stream<mshadow::cpu> *s,

--- a/src/kvstore/gradient_compression.cc
+++ b/src/kvstore/gradient_compression.cc
@@ -41,8 +41,10 @@ void GradientCompression::SetParams(const std::vector<std::pair<std::string, std
                                     & kwargs) {
   GradientCompressionParam params;
   params.InitAllowUnknown(kwargs);
-  CHECK_GT(params.threshold, 0) << "threshold must be greater than 0";
-  if (params.type == "2bit") {
+  if (params.type == "1bit") {
+    SetOneBitCompression(params.threshold);
+  } else if (params.type == "2bit") {
+    CHECK_GT(params.threshold, 0) << "threshold must be greater than 0 for two bit compression";
     SetTwoBitCompression(params.threshold);
   } else {
     LOG(FATAL) << "Unknown type for gradient compression " << params.type;
@@ -55,6 +57,11 @@ CompressionType GradientCompression::get_type() {
 
 std::string GradientCompression::get_type_str() {
   return std::to_string(static_cast<int>(type_));
+}
+
+void GradientCompression::SetOneBitCompression(const float threshold) {
+  type_ = CompressionType::kOneBit;
+  threshold_ = threshold;
 }
 
 void GradientCompression::SetTwoBitCompression(const float threshold) {
@@ -83,7 +90,9 @@ void GradientCompression::DecodeParams(const std::string &s) {
 }
 
 int GradientCompression::GetCompressionFactor() {
-  if (type_ == CompressionType::kTwoBit) {
+  if (type_ == CompressionType::kOneBit) {
+    return 32;
+  } else if (type_ == CompressionType::kTwoBit) {
     return 16;
   } else {
     LOG(FATAL) << "Unsupported compression type: " << get_type_str();
@@ -106,16 +115,34 @@ void GradientCompression::Quantize(const mxnet::NDArray &from, mxnet::NDArray *t
   const int a = from.ctx().dev_mask();
   const int b = to->ctx().dev_mask();
   const float threshold = threshold_;
-  if (type_ == CompressionType::kTwoBit) {
-    if (a == mshadow::cpu::kDevMask && b == mshadow::cpu::kDevMask) {
+  if (a == mshadow::cpu::kDevMask && b == mshadow::cpu::kDevMask) {
+    if (type_ == CompressionType::kOneBit) {
+      mxnet::Engine::Get()->PushSync([from, to, residual, threshold](mxnet::RunContext ctx) {
+        std::vector<mxnet::TBlob> inputs = {from.data(), residual->data(), to->data()};
+        Quantize1BitImpl(ctx.get_stream<mshadow::cpu>(), inputs, threshold);
+      }, from.ctx(), {from.var()}, {to->var(), residual->var()},
+      mxnet::FnProperty::kNormal, priority, "QuantizeCPU");
+    } else if (type_ == CompressionType::kTwoBit) {
       mxnet::Engine::Get()->PushSync([from, to, residual, threshold](mxnet::RunContext ctx) {
         std::vector<mxnet::TBlob> inputs = {from.data(), residual->data(), to->data()};
         Quantize2BitImpl(ctx.get_stream<mshadow::cpu>(), inputs, threshold);
       }, from.ctx(), {from.var()}, {to->var(), residual->var()},
       mxnet::FnProperty::kNormal, priority, "QuantizeCPU");
     } else {
+      LOG(FATAL) << "Unsupported quantization of type " << get_type_str();
+    }
+  } else {
+    if (a == mshadow::gpu::kDevMask && b == mshadow::gpu::kDevMask) {
 #if MXNET_USE_CUDA
-      if (a == mshadow::gpu::kDevMask && b == mshadow::gpu::kDevMask) {
+      if (type_ == CompressionType::kOneBit) {
+        mxnet::Engine::Get()->PushSync([from, to, residual, threshold](mxnet::RunContext ctx) {
+          std::vector<mxnet::TBlob> inputs = {from.data(), residual->data(), to->data()};
+          Quantize1BitImpl(ctx.get_stream<mshadow::gpu>(), inputs, threshold);
+          // Wait GPU kernel to complete
+          ctx.get_stream<mshadow::gpu>()->Wait();
+        }, from.ctx(), {from.var()}, {to->var(), residual->var()},
+        mxnet::FnProperty::kNormal, priority, "QuantizeGPU");
+      } else if (type_ == CompressionType::kTwoBit) {
         mxnet::Engine::Get()->PushSync([from, to, residual, threshold](mxnet::RunContext ctx) {
           std::vector<mxnet::TBlob> inputs = {from.data(), residual->data(), to->data()};
           Quantize2BitImpl(ctx.get_stream<mshadow::gpu>(), inputs, threshold);
@@ -124,14 +151,14 @@ void GradientCompression::Quantize(const mxnet::NDArray &from, mxnet::NDArray *t
         }, from.ctx(), {from.var()}, {to->var(), residual->var()},
         mxnet::FnProperty::kNormal, priority, "QuantizeGPU");
       } else {
-        LOG(FATAL) << "unknown device mask";
+        LOG(FATAL) << "Unsupported quantization of type " << get_type_str();
       }
 #else
     LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
 #endif
+    } else {
+      LOG(FATAL) << "Unknown device mask, from device mask " << a << " to device mask " << b;
     }
-  } else {
-    LOG(FATAL) << "Unsupported quantization of type " << get_type_str();
   }
 }
 
@@ -142,35 +169,52 @@ void GradientCompression::Dequantize(const mxnet::NDArray &from, mxnet::NDArray 
   const int a = from.ctx().dev_mask();
   const int b = to->ctx().dev_mask();
   const float threshold = threshold_;
-  if (type_ == CompressionType::kTwoBit) {
-    if (a == mshadow::cpu::kDevMask && b == mshadow::cpu::kDevMask) {
+  if (a == mshadow::cpu::kDevMask && b == mshadow::cpu::kDevMask) {
+    if (type_ == CompressionType::kOneBit) {
+      mxnet::Engine::Get()->PushSync([from, to, threshold](mxnet::RunContext ctx) {
+        std::vector<mxnet::TBlob> inputs = {from.data(), to->data()};
+        Dequantize1BitImpl(ctx.get_stream<mshadow::cpu>(), inputs, threshold);
+      }, from.ctx(), {from.var()}, {to->var()},
+      mxnet::FnProperty::kNormal, priority, "DequantizeCPU");
+    } else if (type_ == CompressionType::kTwoBit) {
       mxnet::Engine::Get()->PushSync([from, to, threshold](mxnet::RunContext ctx) {
         std::vector<mxnet::TBlob> inputs = {from.data(), to->data()};
         Dequantize2BitImpl(ctx.get_stream<mshadow::cpu>(), inputs, threshold);
       }, from.ctx(), {from.var()}, {to->var()},
       mxnet::FnProperty::kNormal, priority, "DequantizeCPU");
     } else {
+      LOG(FATAL) << "Unsupported dequantization of type " << get_type_str();
+    }
+  } else {
+    if (a == mshadow::gpu::kDevMask && b == mshadow::gpu::kDevMask) {
 #if MXNET_USE_CUDA
-      if (a == mshadow::gpu::kDevMask && b == mshadow::gpu::kDevMask) {
+      if (type_ == CompressionType::kOneBit) {
         mxnet::Engine::Get()->PushSync([from, to, threshold](mxnet::RunContext ctx) {
           std::vector<mxnet::TBlob> inputs = {from.data(), to->data()};
-          Dequantize2BitImpl(ctx.get_stream<mshadow::gpu>(), inputs, threshold);
+          Dequantize1BitImpl(ctx.get_stream<mshadow::gpu>(), inputs, threshold);
           // Wait GPU kernel to complete
           ctx.get_stream<mshadow::gpu>()->Wait();
         }, from.ctx(), {from.var()}, {to->var()},
         mxnet::FnProperty::kNormal, priority, "DequantizeGPU");
+      } else if (type_ == CompressionType::kTwoBit) {
+        mxnet::Engine::Get()->PushSync([from, to, threshold](mxnet::RunContext ctx) {
+          std::vector<mxnet::TBlob> inputs = {from.data(), to->data()};
+          Dequantize2BitImpl(ctx.get_stream<mshadow::gpu>(), inputs, threshold);
+          // Wait GPU kernel to completes
+          ctx.get_stream<mshadow::gpu>()->Wait();
+        }, from.ctx(), {from.var()}, {to->var()},
+        mxnet::FnProperty::kNormal, priority, "DequantizeGPU");
       } else {
-        LOG(FATAL) << "unknown device mask";
+        LOG(FATAL) << "Unsupported dequantization of type " << get_type_str();
       }
 #else
-      LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
+    LOG(FATAL) << MXNET_GPU_NOT_ENABLED_ERROR;
 #endif
+    } else {
+      LOG(FATAL) << "Unknown device mask, from device mask " << a << " to device mask " << b;
     }
-  } else {
-    LOG(FATAL) << "Unsupported dequantization of type " << get_type_str();
   }
 }
-
 }  // namespace kvstore
 }  // namespace mxnet
 

--- a/src/kvstore/gradient_compression.cu
+++ b/src/kvstore/gradient_compression.cu
@@ -27,6 +27,16 @@
 
 namespace mxnet {
 namespace kvstore {
+void Quantize1BitImpl(mshadow::Stream<gpu>* s, const std::vector<TBlob>& inputs,
+                      const float threshold) {
+  Quantize1BitKernelLaunch(s, inputs, threshold);
+}
+
+void Dequantize1BitImpl(mshadow::Stream<gpu>* s, const std::vector<TBlob>& inputs,
+                        const float threshold) {
+  Dequantize1BitKernelLaunch(s, inputs, threshold);
+}
+
 void Quantize2BitImpl(mshadow::Stream<gpu>* s, const std::vector<TBlob>& inputs,
                       const float threshold) {
   Quantize2BitKernelLaunch(s, inputs, threshold);

--- a/src/kvstore/gradient_compression.h
+++ b/src/kvstore/gradient_compression.h
@@ -35,7 +35,7 @@ namespace mxnet {
 namespace kvstore {
 
 enum class CompressionType {
-  kNone, kTwoBit
+  kNone, kOneBit, kTwoBit
 };
 
 struct GradientCompressionParam : public dmlc::Parameter<GradientCompressionParam> {
@@ -71,6 +71,12 @@ class GradientCompression {
    * \brief returns as string the enum value of compression type
    */
   std::string get_type_str();
+
+  /*!
+   * \biref sets one bit gradient compression
+   * \param threshold float value used for thresholding gradients
+   */
+  void SetOneBitCompression(const float threshold);
 
   /*!
    * \brief sets two bit gradient compression

--- a/tests/nightly/dist_sync_kvstore.py
+++ b/tests/nightly/dist_sync_kvstore.py
@@ -25,13 +25,13 @@ import mxnet as mx
 import numpy as np
 import numpy.random as rnd
 from mxnet.test_utils import assert_almost_equal, assert_exception
-from test_kvstore import compute_expected_2bit_quantization
+from test_kvstore import compute_expected_quantization, compute_1bit, compute_2bit
 
 def check_diff(A, x, rank=None):
     """ assert A == x
         x can be scalar as well as numpy array
     """
-    assert (np.sum(np.abs((A - x).asnumpy())) == 0), (rank, A.asnumpy(), x.asnumpy())
+    assert (np.sum(np.abs((A - x).asnumpy())) == 0), (rank, A.asnumpy(), x)
 
 # setup
 shape = (2, 3)
@@ -88,9 +88,8 @@ def set_optimizer(use_multiprecision):
     kv.set_optimizer(mx.optimizer.create('test', rescale_grad=rate, multi_precision=use_multiprecision))
     return kv
 
-def init_kv_compressed(kv):
-    threshold = 0.5
-    kv.set_gradient_compression({'type': '2bit', 'threshold': threshold})
+def init_kv_compressed(kv, compression='2bit', threshold=.5):
+    kv.set_gradient_compression({'type': compression, 'threshold': threshold})
     # init kv compression keys
     for k, s in compr_keys_shapes:
         kv.init(k, mx.nd.zeros(s))
@@ -230,6 +229,104 @@ def test_sync_push_pull(nrepeat):
         check_big_row_sparse_keys(dtype, nrepeat)
     print('worker ' + str(my_rank) + ' is done with non compression tests')
 
+def test_sync_1bit_compression(threshold, nrepeat):
+
+    def check_compr_pull_before_push():
+        for k, s in compr_keys_shapes:
+            val = mx.nd.ones(s)
+            kv.pull(k, val)
+            check_diff(val, 0)
+        for k, s in compr_init_keys_shapes:
+            # tests that GC is not used for init of a key
+            val = mx.nd.zeros(s)
+            kv.pull(k, val)
+            check_diff(val, 1)
+
+    def check_compr_ones():
+        for k, s in compr_keys_shapes:
+            val = mx.nd.zeros(s)
+            kv.pull(k, val)
+            curr_val = val[0][0].asnumpy()[0]
+            kv.push(k, mx.nd.ones(s))
+            out = mx.nd.zeros(s)
+            kv.pull(k, out=out)
+            newval = curr_val + rate * nworker
+            check_diff(out, newval)
+    
+    def check_compr_neg_ones():
+        for k, s in compr_keys_shapes:
+            val = mx.nd.zeros(s)
+            kv.pull(k, val)
+            curr_val = val[0][0].asnumpy()[0]
+            kv.push(k, -1 * mx.nd.ones(s))
+            out = mx.nd.ones(s)
+            kv.pull(k, out=out)
+            # current value should be zero after call
+            # check_compr_ones and check_compr_neg_ones
+            check_diff(out, 0)
+    
+    def check_compr_residual(threshold):
+        curr_residual = 0
+        curr_val = rate * nworker if 2 + curr_residual > threshold else -rate * nworker
+        for k, s in compr_keys_shapes:
+            kv.push(k, 2 * mx.nd.ones(s))
+            out = mx.nd.zeros(s)
+            kv.pull(k, out)
+            check_diff(out, curr_val)
+
+        curr_residual = 1 if 2 > threshold else 3
+        curr_val += rate * nworker if 0 + curr_residual > threshold else -rate * nworker
+        for k, s in compr_keys_shapes:
+            kv.push(k, mx.nd.zeros(s))
+            out = mx.nd.zeros(s)
+            kv.pull(k, out)
+            check_diff(out, curr_val)
+
+        curr_residual += -1 if curr_residual > threshold else +1
+        curr_val += rate * nworker if -2 + curr_residual > threshold else -rate * nworker
+        for k, s in compr_keys_shapes:
+            kv.push(k, -2 * mx.nd.ones(s))
+            out = mx.nd.zeros(s)
+            kv.pull(k, out)
+            check_diff(out, curr_val)        
+
+    def check_compr_random(threshold, nrepeat):
+        # set a seed so all workers generate same data. knowing this helps
+        # calculate expected value after pull
+        mx.random.seed(123)
+        rnd.seed(123)
+
+        # use new keys so residual is 0 for calculation of expected
+        for k,s in compr_random_keys_shapes:
+            kv.init(k, mx.nd.zeros(s))
+        for k,s in compr_random_keys_shapes:
+            curr_residual = np.zeros(s)
+            for l in range(nrepeat):
+                orig_val = mx.nd.zeros(s)
+                kv.pull(k, orig_val)
+
+                grad = mx.nd.array(rnd.rand(s[0], s[1]))
+                # creates a copy because push changes grad because of assignment
+                grad_cpy = mx.nd.array(grad)
+                kv.push(k, grad)
+                val = mx.nd.zeros(s)
+                kv.pull(k, val)
+
+                diff = val - orig_val
+
+                # compute expected by using simulation of operator
+                compr, curr_residual, decompr = compute_expected_quantization(grad_cpy, curr_residual, threshold, compute_1bit)
+                decompr *= nworker * rate
+                assert_almost_equal(diff.asnumpy(), decompr)
+
+    print ('worker ' + str(my_rank) + ' started with 1bit compression tests')
+    check_compr_pull_before_push()
+    check_compr_ones()
+    check_compr_neg_ones()
+    check_compr_residual(threshold)
+    check_compr_random(threshold, nrepeat)
+    print('worker ' + str(my_rank) + ' is done with 1bit compression tests')   
+
 def test_sync_2bit_compression(threshold, nrepeat):
     def check_compr_residual(threshold):
         for k, s in compr_keys_shapes:
@@ -316,17 +413,17 @@ def test_sync_2bit_compression(threshold, nrepeat):
                 diff = val - orig_val
 
                 # compute expected by using simulation of operator
-                compr, curr_residual, decompr = compute_expected_2bit_quantization(grad_cpy, curr_residual, threshold)
+                compr, curr_residual, decompr = compute_expected_quantization(grad_cpy, curr_residual, threshold, compute_2bit)
                 decompr *= nworker * rate
                 assert_almost_equal(diff.asnumpy(), decompr)
 
-    print ('worker ' + str(my_rank) + ' started with compression tests')
+    print ('worker ' + str(my_rank) + ' started with 2bit compression tests')
     check_compr_pull_before_push()
     check_compr_zero()
     check_compr_residual(threshold)
     check_compr_ones(threshold)
     check_compr_random(threshold, nrepeat)
-    print('worker ' + str(my_rank) + ' is done with compression tests')
+    print('worker ' + str(my_rank) + ' is done with 2bit compression tests')
 
 def test_sync_init(gpu_tests=False):
     def get_dtype(idx, cur_keys):
@@ -454,7 +551,11 @@ if __name__ == "__main__":
         kv = init_kv()
         kv = set_optimizer(use_multiprecision=opt.multiprecision)
         test_sync_push_pull(opt.nrepeat)
-    elif opt.type == 'compressed_cpu':
+    elif opt.type == 'compressed_cpu_1bit':
+        kv, threshold = init_kv_compressed(kv, '1bit', 0)
+        kv = set_optimizer(use_multiprecision=opt.multiprecision)
+        test_sync_1bit_compression(threshold, opt.nrepeat)
+    elif opt.type == 'compressed_cpu_2bit':
         kv, threshold = init_kv_compressed(kv)
         kv = set_optimizer(use_multiprecision=opt.multiprecision)
         test_sync_2bit_compression(threshold, opt.nrepeat)


### PR DESCRIPTION
## Description ##
Added 1bit gradient compression implementation which has similar speedup with 2bit compression. It works with a threshold, values in gradient above the threshold will be quantized to +1, while values below the threshold will be quantizaed to -1. Different with 2bit compression, this implementation of 1bit supports zero threshold. In addition, 1bit compression seems perform better than the current implentation of 2bit compression when batch size increase.

### Important files to review ###
gradient_compression-inl.h
gradient_compression.cc

### Test accuracy of ResNet110 on cifar10 with 1/2/4 workers ###
each worker is equipped with 4 Tesla V100 GPUs
training command: 
```python
python /mxnet/tools/launch.py --launcher ssh -H hosts -n 4 python train_cifar10.py \
--num-epochs 200 --mode hybrid --num-gpus 4 -j 8 --batch-size 128 --wd 0.0001 \
--lr 0.1 --lr-decay 0.1 --lr-decay-epoch 100,150 --model cifar_resnet20_v1 \
--kv-store dist_sync_device --gc-type 1bit --gc-threshold 0 
```
#### 1worker
![resnet20_test](https://user-images.githubusercontent.com/24750212/109163918-cfdb3380-77b4-11eb-9d38-5951e5fa1be0.png)

#### 2workers
![resnet20_test](https://user-images.githubusercontent.com/24750212/109163973-de294f80-77b4-11eb-951a-ffaf1347551e.png)

#### 4workers
![resnet20_test](https://user-images.githubusercontent.com/24750212/109164027-e97c7b00-77b4-11eb-8f7e-dcaf5985e525.png)

#### 4workers, update_on_kvstore=false
![resnet20_test](https://user-images.githubusercontent.com/24750212/109164070-f7320080-77b4-11eb-9d52-5f8efc2b539c.png)



### Result of 2-layer LSTM trained on PTB with 1 worker ###
#### train perplexity
![lstm_train](https://user-images.githubusercontent.com/24750212/109163843-bb973680-77b4-11eb-80e0-fb2cd20f0c1d.png)

#### test perplexity
![lstm_test](https://user-images.githubusercontent.com/24750212/109163877-c5209e80-77b4-11eb-8aa6-8306631d6579.png)

### Throughput 
In this part, we use example/imageclassification/benchmark.py to evaluate the performance of gradient compression. We have tried our best to optimize the kernel function of gradient compression operations. In the original kernel function, each thread manipulates 32 bits (4 bytes) of compressed gradients, whereas in our kernel function, each thread writes 8 bits (1 byte) at once. The difference between the original and our implementations are follows.

original kernel implementation:
```c++
struct quantize_2bit {
  MSHADOW_XINLINE static void Map(int out_block_id,
                                  int original_size,
                                  float *out,
                                  float *grad,
                                  float *residual,
                                  const float neg_threshold,
                                  const float pos_threshold) {
    // this block contains the compressed representation of
    // upto 16 values starting from out_block_id*16
    float *compr_block = out + out_block_id;
    // init to 0
    *compr_block = 0;
    // start and end are indices in original grad array
    const int start = out_block_id << 4;
    const int end = (start + 16 <= original_size) ? start + 16 : original_size;
    // cast as char* to manipulate bits of float addresses
    char *block_ptr = reinterpret_cast < char * > (compr_block);
    // masks to set bits when value meets pos_threshold
    // 0xc0 is mask when value is to be represented by the first two bits in a char*
    // 0xc0 means first two bits are set to 11
    const uint8_t posbits[] = {0xc0, 0x30, 0x0c, 0x03};
    // masks to set bits when value meets neg_threshold
    const uint8_t negbits[] = {0x80, 0x20, 0x08, 0x02};
    for (int i = start; i < end; i++) {
      // adds offset to reach appropriate byte
      char *curr_byte = block_ptr + ((i - start) >> 2);
      // adds gradient to existing residual to get updated grad
      residual[i] += grad[i];
      if (residual[i] >= pos_threshold) {
        // set data to 11
        *curr_byte |= posbits[(i & 3)];
        // reduce residual by pos_threshold
        residual[i] -= pos_threshold;
      } else if (residual[i] <= neg_threshold) {
        // set data to 10
        *curr_byte |= negbits[(i & 3)];
        residual[i] -= neg_threshold;
      }
    }
  }
};
```

our kernel implementation:
```c++
struct quantize_2bit {
  MSHADOW_XINLINE static void Map(int out_byte_id,
                                  int original_size,
                                  float *out,
                                  float *grad,
                                  float *residual,
                                  const float neg_threshold,
                                  const float pos_threshold) {
    // this block contains the compressed representation of
    // upto 4 values starting from (char*)out + out_byte_id
    char *compr_byte = reinterpret_cast<char *>(out) + out_byte_id;
    // init to 0
    *compr_byte = 0;
    // start and end are indices in original grad array
    const int start = out_byte_id << 2;
    const int end = (start + 4 <= original_size) ? start + 4 : original_size;

    // masks to set bits when value meets pos_threshold
    // 0xc0 is mask when value is to be represented by the first two bits in a char*
    // 0xc0 means first two bits are set to 11
    const uint8_t posbits[] = {0xc0, 0x30, 0x0c, 0x03};
    // masks to set bits when value meets neg_threshold
    const uint8_t negbits[] = {0x80, 0x20, 0x08, 0x02};
    for (int i = start; i < end; i++) {
      // adds gradient to existing residual to get updated grad
      residual[i] += grad[i];
      if (residual[i] >= pos_threshold) {
        // set data to 11
        *compr_byte |= posbits[(i & 3)];
        // reduce residual by pos_threshold
        residual[i] -= pos_threshold;
      } else if (residual[i] <= neg_threshold) {
        // set data to 10
        *compr_byte |= negbits[(i & 3)];
        residual[i] -= neg_threshold;
      }
    }
  }
};
```
Our optimized implementation performs well when use multiple GPUs on a single machine. Here is a benchmark test of the VGG16 model on a 4 GPUs machine (unit: samples/sec).
| VGG16 | original | our  |
|---|---|---|
| onebit  | ~626  | ~752  |
| twobit | ~705  | ~761  |
| baseline | ~564 ||

**However, our implementation works not well when the compression operator is lunched on the CPU, especially when we use multiple nodes and set `kvstore=dist_sync`.** Under such circumstance, our new implementation may lead to a little throughput reduction. IMHO, one possible solution is adopting different kernel functions for CPU and GPU respectively. In other words, we can use the original kernel for CPU compression operation while the new kernel for GPU operation (still working in process...).


The following are benchmark tests of AlexNet and Resnet-50 on a cluster with at most 4 nodes.
#### Alexnet, batch size=128 on each GPU, dist_sync_device

![alexnet-speed](https://user-images.githubusercontent.com/24750212/109164609-99ea7f00-77b5-11eb-973e-521da4f822e9.png)

#### ResNet-50, batch size=128 on each GPU, dist_sync_device
![resnet50-speed](https://user-images.githubusercontent.com/24750212/109164814-d027fe80-77b5-11eb-9eca-4fbcc0819c9e.png)

more performance test will be released recently...


### Related issue or pr ###
signum with grad compression #9558
2bit gradient compression #8662

### Reference ###
[Seide F, Fu H, Droppo J, et al. 1-bit stochastic gradient descent and its application to data-parallel distributed training of speech dnns](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/IS140694.pdf)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here