### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,6 +482,8 @@ set(GTEST_INCLUDE_DIR ${GTEST_ROOT}/include)
 set(GTEST_LIBRARIES gtest gtest_main)
 set(GTEST_MAIN_LIBRARY gtest_main)
 set(GTEST_LIBRARY gtest)
+set(GTEST_LIBRARY_TYPE SHARED)
+set(GTEST_MAIN_LIBRARY_TYPE SHARED)
 
 add_subdirectory(${GTEST_ROOT})
 find_package(GTest REQUIRED)


### PR DESCRIPTION
Added default build type for gtest, in case the library is not installed on the system (primarily on Windows). @leezu suggested to create the PR.

## Description ##
Refer to the related [issue](https://github.com/apache/incubator-mxnet/issues/17943).

