### PR TITLE
[Website 2.0] Nightly Build for v1.x

### DIFF
--- a/ci/jenkins/Jenkinsfile_website_full
+++ b/ci/jenkins/Jenkinsfile_website_full
@@ -23,14 +23,14 @@
 // timeout in minutes
 max_time = 180
 
-node('restricted-utility') {
+node('utility') {
   // Loading the utilities requires a node context unfortunately
   checkout scm
   utils = load('ci/Jenkinsfile_utils.groovy')
   custom_steps = load('ci/jenkins/Jenkins_steps.groovy')
 }
 
-utils.assign_node_labels(utility: 'restricted-utility', linux_cpu: 'restricted-mxnetlinux-cpu', linux_gpu: 'restricted-mxnetlinux-gpu', linux_gpu_p3: 'restricted-mxnetlinux-gpu-p3', windows_cpu: 'restricted-mxnetwindows-cpu', windows_gpu: 'restricted-mxnetwindows-gpu')
+utils.assign_node_labels(utility: 'utility', linux_cpu: 'mxnetlinux-cpu', linux_gpu: 'mxnetlinux-gpu', linux_gpu_p3: 'mxnetlinux-gpu-p3', windows_cpu: 'mxnetwindows-cpu', windows_gpu: 'mxnetwindows-gpu')
 
 utils.main_wrapper(
 core_logic: {

--- a/ci/jenkins/Jenkinsfile_website_full
+++ b/ci/jenkins/Jenkinsfile_website_full
@@ -23,14 +23,14 @@
 // timeout in minutes
 max_time = 180
 
-node('utility') {
+node('restricted-utility') {
   // Loading the utilities requires a node context unfortunately
   checkout scm
   utils = load('ci/Jenkinsfile_utils.groovy')
   custom_steps = load('ci/jenkins/Jenkins_steps.groovy')
 }
 
-utils.assign_node_labels(utility: 'utility', linux_cpu: 'mxnetlinux-cpu', linux_gpu: 'mxnetlinux-gpu', linux_gpu_p3: 'mxnetlinux-gpu-p3', windows_cpu: 'mxnetwindows-cpu', windows_gpu: 'mxnetwindows-gpu')
+utils.assign_node_labels(utility: 'restricted-utility', linux_cpu: 'restricted-mxnetlinux-cpu', linux_gpu: 'restricted-mxnetlinux-gpu', linux_gpu_p3: 'restricted-mxnetlinux-gpu-p3', windows_cpu: 'restricted-mxnetwindows-cpu', windows_gpu: 'restricted-mxnetwindows-gpu')
 
 utils.main_wrapper(
 core_logic: {

--- a/ci/jenkins/Jenkinsfile_website_full
+++ b/ci/jenkins/Jenkinsfile_website_full
@@ -52,10 +52,6 @@ core_logic: {
   utils.parallel_stage('Prepare', [
     custom_steps.docs_prepare()
   ])
-
-  utils.parallel_stage('Publish', [
-    custom_steps.docs_publish()
-  ])
 }
 ,
 failure_handler: {

--- a/ci/jenkins/Jenkinsfile_website_nightly
+++ b/ci/jenkins/Jenkinsfile_website_nightly
@@ -30,7 +30,7 @@ node('restricted-utility') {
   custom_steps = load('ci/jenkins/Jenkins_steps.groovy')
 }
 
-utils.assign_node_labels(utility: 'restricted-utility', linux_cpu: 'restricted-mxnetlinux-cpu', linux_gpu: 'restricted-mxnetlinux-gpu', linux_gpu_p3: 'restricted-mxnetlinux-gpu-p3', windows_cpu: 'restricted-mxnetwindows-cpu', windows_gpu: 'restricted-mxnetwindows-gpu')
+utils.assign_node_labels(utility: 'restricted-utility', linux_cpu: 'restricted-mxnetlinux-cpu')
 
 utils.main_wrapper(
 core_logic: {

--- a/ci/jenkins/Jenkinsfile_website_nightly
+++ b/ci/jenkins/Jenkinsfile_website_nightly
@@ -52,10 +52,6 @@ core_logic: {
   utils.parallel_stage('Prepare', [
     custom_steps.docs_prepare()
   ])
-
-  utils.parallel_stage('Publish', [
-    custom_steps.docs_publish()
-  ])
 }
 ,
 failure_handler: {


### PR DESCRIPTION
## Description ##
To add a nightly build Jenkins pipeline for v1.x, we need to create a new Jenkinsfile capable of building all the components without the "Publish" step.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- A ci/jenkins/Jenkinsfile_website_nightly

## Comments ##
Tested successfully on Jenkins dev instance (see build output [here](http://jenkins.mxnet-ci-dev.amazon-ml.com/job/docs/job/connor-website-build-master/38/)).
