### PR TITLE
[Website 2.0] Nightly Build for v2.x (master)

### DIFF
--- a/ci/jenkins/Jenkinsfile_website_nightly
+++ b/ci/jenkins/Jenkinsfile_website_nightly
@@ -1,0 +1,63 @@
+// -*- mode: groovy -*-
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Jenkins pipeline
+// See documents at https://jenkins.io/doc/book/pipeline/jenkinsfile/
+
+// timeout in minutes
+max_time = 180
+
+node('restricted-utility') {
+  // Loading the utilities requires a node context unfortunately
+  checkout scm
+  utils = load('ci/Jenkinsfile_utils.groovy')
+  custom_steps = load('ci/jenkins/Jenkins_steps.groovy')
+}
+
+utils.assign_node_labels(utility: 'restricted-utility', linux_cpu: 'restricted-mxnetlinux-cpu', linux_gpu: 'restricted-mxnetlinux-gpu', linux_gpu_p3: 'restricted-mxnetlinux-gpu-p3', windows_cpu: 'restricted-mxnetwindows-cpu', windows_gpu: 'restricted-mxnetwindows-gpu')
+
+utils.main_wrapper(
+core_logic: {
+  utils.parallel_stage('Build', [
+    custom_steps.compile_unix_lite()
+  ])
+
+  utils.parallel_stage('Build Docs', [
+    custom_steps.docs_jekyll(),
+    custom_steps.docs_c(),
+    custom_steps.docs_python(),
+    custom_steps.docs_julia(),
+    custom_steps.docs_r(),
+    custom_steps.docs_scala(),
+    custom_steps.docs_java(),
+    custom_steps.docs_clojure()
+  ])
+
+  utils.parallel_stage('Prepare', [
+    custom_steps.docs_prepare()
+  ])
+}
+,
+failure_handler: {
+  // Only send email if master or release branches failed
+  if (currentBuild.result == "FAILURE" && (env.BRANCH_NAME == "master" || env.BRANCH_NAME.startsWith("v"))) {
+    emailext body: 'Build for MXNet branch ${BRANCH_NAME} has broken. Please view the build at ${BUILD_URL}', replyTo: '${EMAIL}', subject: '[BUILD FAILED] Branch ${BRANCH_NAME} build ${BUILD_NUMBER}', to: '${EMAIL}'
+  }
+}
+)

--- a/ci/jenkins/Jenkinsfile_website_nightly
+++ b/ci/jenkins/Jenkinsfile_website_nightly
@@ -30,7 +30,7 @@ node('restricted-utility') {
   custom_steps = load('ci/jenkins/Jenkins_steps.groovy')
 }
 
-utils.assign_node_labels(utility: 'restricted-utility', linux_cpu: 'restricted-mxnetlinux-cpu', linux_gpu: 'restricted-mxnetlinux-gpu', linux_gpu_p3: 'restricted-mxnetlinux-gpu-p3', windows_cpu: 'restricted-mxnetwindows-cpu', windows_gpu: 'restricted-mxnetwindows-gpu')
+utils.assign_node_labels(utility: 'restricted-utility', linux_cpu: 'restricted-mxnetlinux-cpu')
 
 utils.main_wrapper(
 core_logic: {


### PR DESCRIPTION
## Description ##
To add a nightly build Jenkins pipeline for v2.x (master), we need to create a new Jenkinsfile capable of building all the components without the "Publish" step.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- A ci/jenkins/Jenkinsfile_website_nightly

## Comments ##
Tested successfully on Jenkins dev instance (see build output [here](http://jenkins.mxnet-ci-dev.amazon-ml.com/job/docs/job/connor-website-build-master/36/)).

Pipeline is available [here](http://jenkins.mxnet-ci.amazon-ml.com/job/restricted-nightly-website-build-2.x/).