### PR TITLE
Fix Windows GPU CI

### DIFF
--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -37,11 +37,6 @@ from subprocess import check_call
 
 from util import *
 
-
-# Fix for broken PATH with newline inserted presumably by VS studio installation of SQL server or
-# other component which makes visual studio stop working.
-os.environ['PATH']=os.environ.get('PATH').replace('\n','')
-
 KNOWN_VCVARS = {
     # https://gitlab.kitware.com/cmake/cmake/issues/18920
     'VS 2015': r'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\vcvarsx86_amd64.bat',
@@ -67,8 +62,6 @@ CMAKE_FLAGS = {
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
         '-DUSE_OPENCV=ON '
-        '-DOpenCV_RUNTIME=vc15 '
-        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -84,8 +77,6 @@ CMAKE_FLAGS = {
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
         '-DUSE_OPENCV=ON '
-        '-DOpenCV_RUNTIME=vc15 '
-        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -101,8 +92,6 @@ CMAKE_FLAGS = {
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
         '-DUSE_OPENCV=ON '
-        '-DOpenCV_RUNTIME=vc15 '
-        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=mkl '
         '-DUSE_LAPACK=ON '
@@ -118,8 +107,6 @@ CMAKE_FLAGS = {
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
         '-DUSE_OPENCV=ON '
-        '-DOpenCV_RUNTIME=vc15 '
-        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=mkl '
         '-DUSE_LAPACK=ON '
@@ -135,8 +122,6 @@ CMAKE_FLAGS = {
         '-DUSE_CUDNN=ON '
         '-DENABLE_CUDA_RTC=ON '
         '-DUSE_OPENCV=ON  '
-        '-DOpenCV_RUNTIME=vc15 '
-        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -153,8 +138,6 @@ CMAKE_FLAGS = {
         '-DUSE_CUDNN=ON '
         '-DENABLE_CUDA_RTC=ON '
         '-DUSE_OPENCV=ON '
-        '-DOpenCV_RUNTIME=vc15 '
-        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -37,9 +37,16 @@ from subprocess import check_call
 
 from util import *
 
+
+# Fix for broken PATH with newline inserted presumably by VS studio installation of SQL server or
+# other component which makes visual studio stop working.
+os.environ['PATH']=os.environ.get('PATH').replace('\n','')
+
 KNOWN_VCVARS = {
+    # https://gitlab.kitware.com/cmake/cmake/issues/18920
     'VS 2015': r'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\x86_amd64\vcvarsx86_amd64.bat',
-    'VS 2017': r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat'
+    'VS 2017': r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsx86_amd64.bat',
+    'VS 2019': r'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat',
 }
 
 
@@ -54,10 +61,14 @@ class BuildFlavour(Enum):
 
 CMAKE_FLAGS = {
     'WIN_CPU': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
         '-DUSE_OPENCV=ON '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -67,10 +78,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_CPU_MKLDNN': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
         '-DUSE_OPENCV=ON '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -80,10 +95,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_CPU_MKLDNN_MKL': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
         '-DUSE_OPENCV=ON '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=mkl '
         '-DUSE_LAPACK=ON '
@@ -93,10 +112,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_CPU_MKL': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
         '-DUSE_CUDA=OFF '
         '-DUSE_CUDNN=OFF '
         '-DENABLE_CUDA_RTC=OFF '
         '-DUSE_OPENCV=ON '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=mkl '
         '-DUSE_LAPACK=ON '
@@ -106,10 +129,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
         '-DUSE_CUDA=ON '
         '-DUSE_CUDNN=ON '
         '-DENABLE_CUDA_RTC=ON '
         '-DUSE_OPENCV=ON  '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -120,10 +147,14 @@ CMAKE_FLAGS = {
         '-DCMAKE_BUILD_TYPE=Release')
 
     , 'WIN_GPU_MKLDNN': (
+        '-DCMAKE_C_COMPILER=cl '
+        '-DCMAKE_CXX_COMPILER=cl '
         '-DUSE_CUDA=ON '
         '-DUSE_CUDNN=ON '
         '-DENABLE_CUDA_RTC=ON '
         '-DUSE_OPENCV=ON '
+        '-DOpenCV_RUNTIME=vc15 '
+        '-DOpenCV_ARCH=x64 '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
@@ -145,33 +176,25 @@ def windows_build(args):
     mxnet_root = get_mxnet_root()
     logging.info("Found MXNet root: {}".format(mxnet_root))
 
-    url = 'https://github.com/Kitware/CMake/releases/download/v3.16.1/cmake-3.16.1-win64-x64.zip'
-    with tempfile.TemporaryDirectory() as tmpdir:
-        cmake_file_path = download_file(url, tmpdir)
-        with zipfile.ZipFile(cmake_file_path, 'r') as zip_ref:
-            # Create $tmpdir\cmake-3.16.1-win64-x64\bin\cmake.exe
-            zip_ref.extractall(tmpdir)
+    with remember_cwd():
+        os.chdir(path)
+        cmd = "\"{}\" && cmake -GNinja {} {}".format(
+            args.vcvars,
+            CMAKE_FLAGS[args.flavour], mxnet_root)
+        logging.info("Generating project with CMake:\n{}".format(cmd))
+        check_call(cmd, shell=True)
 
-        with remember_cwd():
-            os.chdir(path)
-            cmd = "\"{}\" && {} -G \"NMake Makefiles JOM\" {} {}".format(
-                args.vcvars,
-                os.path.join(tmpdir, 'cmake-3.16.1-win64-x64', 'bin', 'cmake.exe'),
-                CMAKE_FLAGS[args.flavour], mxnet_root)
-            logging.info("Generating project with CMake:\n{}".format(cmd))
-            check_call(cmd, shell=True)
+        cmd = "\"{}\" && ninja".format(args.vcvars)
+        logging.info("Building:\n{}".format(cmd))
 
-            cmd = "\"{}\" && jom".format(args.vcvars)
-            logging.info("Building with jom:\n{}".format(cmd))
+        t0 = int(time.time())
+        check_call(cmd, shell=True)
 
-            t0 = int(time.time())
-            check_call(cmd, shell=True)
-
-            logging.info(
-                "Build flavour: {} complete in directory: \"{}\"".format(
-                    args.flavour, os.path.abspath(path)))
-            logging.info("Build took {}".format(
-                datetime.timedelta(seconds=int(time.time() - t0))))
+        logging.info(
+            "Build flavour: {} complete in directory: \"{}\"".format(
+                args.flavour, os.path.abspath(path)))
+        logging.info("Build took {}".format(
+            datetime.timedelta(seconds=int(time.time() - t0))))
     windows_package(args)
 
 
@@ -233,7 +256,7 @@ def main():
 
     parser.add_argument("--vcvars",
         help="vcvars batch file location, typically inside vs studio install dir",
-        default=KNOWN_VCVARS['VS 2015'],
+        default=KNOWN_VCVARS['VS 2019'],
         type=str)
 
     parser.add_argument("--arch",
@@ -258,7 +281,7 @@ def main():
         if 'OpenCV_DIR' not in os.environ:
             os.environ["OpenCV_DIR"] = "C:\\Program Files\\OpenCV-v3.4.1\\build"
         if 'CUDA_PATH' not in os.environ:
-            os.environ["CUDA_PATH"] = "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v9.2"
+            os.environ["CUDA_PATH"] = "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v10.2"
         if 'MKL_ROOT' not in os.environ:
             os.environ["MKL_ROOT"] = "C:\\Program Files (x86)\\IntelSWTools\\compilers_and_libraries\\windows\\mkl"
         windows_build(args)


### PR DESCRIPTION
## Description ##
Minimal version of https://github.com/apache/incubator-mxnet/pull/17808 

Update Windows CI to use VS 2019 and enable x64 bit toolchain. Previously we are using an older 32 bit toolchain causing OOM errors during linking.  Switching to x64 bit toolchain on the older VS version previously used by the CI was attempted in https://github.com/apache/incubator-mxnet/pull/17912 and did not work. Update to Cuda 10.2 as it is required by VS 2019. Switch to ninja-build on Windows to speed up build as ninja-build is now preinstalled. Remove logic to install cmake 3.16 on every PR as cmake 3.17 is now preinstalled.

CC: @marcoabreu 