### PR TITLE
[R][v1.6.x] Fix blocked pipelines [windows,unix-cpu,unix-gpu] on v1.6.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -706,7 +706,6 @@ rpkg:
 	echo "import(Rcpp)" >> R-package/NAMESPACE
 	R CMD INSTALL R-package
 	Rscript -e "require(mxnet); mxnet:::mxnet.export('R-package'); warnings()"
-	rm R-package/NAMESPACE
 	Rscript -e "devtools::document('R-package');warnings()"
 	R CMD INSTALL R-package
 

--- a/R-package/R/callback.R
+++ b/R-package/R/callback.R
@@ -16,6 +16,7 @@
 # under the License.
 
 #' @export mx.metric.logger
+library(methods)
 mx.metric.logger <- setRefClass("mx.metric.logger", fields = list(train = "numeric", eval="numeric"))
 
 #' Log training metric each period

--- a/R-package/R/zzz.R
+++ b/R-package/R/zzz.R
@@ -34,8 +34,8 @@ NULL
 .onLoad <- function(libname, pkgname) {
   # Require methods for older versions of R
   require(methods)
-  tryCatch(library.dynam("libmxnet", pkgname, libname, local=FALSE), error = function(e) { print('Loading local: inst/libs/libmxnet.so'); dyn.load("R-package/inst/libs/libmxnet.so", local=FALSE) })
-  tryCatch(library.dynam("mxnet", pkgname, libname), error = function(e) { print('Loading local: src/mxnet.so'); dyn.load("R-package/src/mxnet.so") })
+  tryCatch(library.dynam("libmxnet", pkgname, libname, local=FALSE), error = function(e) { print(e); print('Loading local: inst/libs/libmxnet.so'); dyn.load("R-package/inst/libs/libmxnet.so", local=FALSE) })
+  tryCatch(library.dynam("mxnet", pkgname, libname), error = function(e) { print(e); print('Loading local: src/mxnet.so'); dyn.load("R-package/src/mxnet.so") })
   loadModule("mxnet", TRUE)
   init.symbol.methods()
   init.context.default()

--- a/ci/docker/Dockerfile.build.ubuntu_cpu_jekyll
+++ b/ci/docker/Dockerfile.build.ubuntu_cpu_jekyll
@@ -43,7 +43,7 @@ RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - && \
 
 RUN source /etc/profile.d/rvm.sh && \
     rvm requirements && \
-    rvm install 2.6 && \
+    rvm install 2.6.3 && \
     rvm use 2.6.3 --default
 
 ENV BUNDLE_HOME=/work/deps/bundle

--- a/ci/docker/install/ubuntu_publish.sh
+++ b/ci/docker/install/ubuntu_publish.sh
@@ -20,6 +20,10 @@
 # Build on Ubuntu 14.04 LTS for LINUX CPU/GPU
 set -ex
 
+# replace https with http to force apt-get update to use http
+# nvidia-docker no longer supports ubuntu 14.04
+# refer https://github.com/apache/incubator-mxnet/issues/18005
+sudo sed -i 's/https/http/g' /etc/apt/sources.list.d/*.list
 apt-get update
 apt-get install -y software-properties-common
 add-apt-repository ppa:ubuntu-toolchain-r/test -y

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -178,7 +178,7 @@ def test_requantize_int32_to_int8():
                                                                           max_range.asscalar(),
                                                                           min_calib_range=min_calib_range,
                                                                           max_calib_range=max_calib_range)
-        assert_almost_equal(qdata_int8.asnumpy(), qdata_int8_np)
+        assert_almost_equal(qdata_int8.asnumpy(), qdata_int8_np, atol = 1)
         assert_almost_equal(min_output.asnumpy(), np.array([min_output_np]))
         assert_almost_equal(max_output.asnumpy(), np.array([max_output_np]))
 


### PR DESCRIPTION
Fixes following issues in the following pipelines

Fix setRefClass not found issue by adding import of library `methods`
Fixes https://github.com/apache/incubator-mxnet/issues/17920
[unix-cpu] - R: CPU
[unix-cpu] - R: MKLDNN-CPU
[unix-gpu] - R: GPU
[website] - R Docs

[website] - Jekyll website
rvm version error [fix by pinning the updated version 2.6.3]

[unix-cpu]  - Tests / Python3: MKLDNN-MKL-CPU 
test_quantize flaky test
Fix : cherrypick the commit from master that fixed this flakiness issue

[unix-gpu] - Static build GPU 14.04 Python
gnu_tls handshake failed [NVIDIA Docker no longer supported on Ubuntu 14.04 hence TLS / certificate issue upon apt-get update]
Fix : switch from https to http