### PR TITLE
For mxnet-validation pipeline, require sanity build to complete successfully before running other build pipelines.

### DIFF
--- a/ci/jenkins/Jenkinsfile_full
+++ b/ci/jenkins/Jenkinsfile_full
@@ -1,0 +1,36 @@
+// -*- mode: groovy -*-
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Jenkins pipeline
+// See documents at https://jenkins.io/doc/book/pipeline/jenkinsfile/
+
+// timeout in minutes
+max_time = 180
+
+stage("full-build") {
+    def pipelineName = JOB_NAME.substring(0, JOB_NAME.indexOf('/'))
+    build job: pipelineName + "/sanity/" + BRANCH_NAME, wait: true
+    ['centos-cpu', 'centos-gpu', 'clang', 'edge',
+        'miscellaneous', 'unix-cpu', 'unix-gpu',
+        'website', 'windows-cpu', 'windows-gpu']
+    .each { subJob ->
+        build job: pipelineName + "/" + subJob + "/" + BRANCH_NAME, wait: false
+    }
+}
+

--- a/ci/jenkins/Jenkinsfile_full
+++ b/ci/jenkins/Jenkinsfile_full
@@ -23,13 +23,26 @@
 // timeout in minutes
 max_time = 180
 
+def buildJobs = [
+    'centos-cpu',
+    'centos-gpu',
+    'clang',
+    'edge',
+    'miscellaneous',
+    'unix-cpu',
+    'unix-gpu',
+    'website',
+    'windows-cpu',
+    'windows-gpu'
+]
+
+
 stage("full-build") {
-    def pipelineName = JOB_NAME.substring(0, JOB_NAME.indexOf('/'))
+    // get the base path by removing build and branch portions
+    def jobPath = JOB_NAME.split('/')
+    def pipelineName = jobPath[0..jobPath.size()-3].join('/')
     build job: pipelineName + "/sanity/" + BRANCH_NAME, wait: true
-    ['centos-cpu', 'centos-gpu', 'clang', 'edge',
-        'miscellaneous', 'unix-cpu', 'unix-gpu',
-        'website', 'windows-cpu', 'windows-gpu']
-    .each { subJob ->
+    buildJobs.each { subJob ->
         build job: pipelineName + "/" + subJob + "/" + BRANCH_NAME, wait: false
     }
 }


### PR DESCRIPTION
## Description ##
Add new build pipeline that will run sanity build, and if it completes successfully, run the rest of the mxnet-validation pipelines.

https://github.com/apache/incubator-mxnet/issues/17802
