### PR TITLE
Fix typos on crash course tutorial website

### DIFF
--- a/docs/python_docs/python/tutorials/getting-started/crash-course/4-train.md
+++ b/docs/python_docs/python/tutorials/getting-started/crash-course/4-train.md
@@ -45,7 +45,7 @@ X, y = mnist_train[0]
 
 Each example in this dataset is a $28\times 28$ size grey image, which is presented as NDArray with the shape format of `(height, width, channel)`.  The label is a `numpy` scalar.
 
-Next, we visualize the first six examples.
+Next, we visualize the first ten examples.
 
 ```{.python .input  n=3}
 text_labels = ['t-shirt', 'trouser', 'pullover', 'dress', 'coat',

--- a/docs/python_docs/python/tutorials/getting-started/crash-course/5-predict.md
+++ b/docs/python_docs/python/tutorials/getting-started/crash-course/5-predict.md
@@ -62,7 +62,7 @@ transformer = transforms.Compose([
     transforms.Normalize(0.13, 0.31)])
 ```
 
-Now let's try to predict the first six images in the validation dataset and store the predictions into `preds`.
+Now let's try to predict the first ten images in the validation dataset and store the predictions into `preds`.
 
 ```{.python .input  n=5}
 mnist_valid = datasets.FashionMNIST(train=False)


### PR DESCRIPTION
## Description ##
Fix #18007 
There are two typos on crash course tutorial website (Chapter 4 and 5 each).
