### PR TITLE
[Website 2.0] Fix RVM version to satisfy Jekyll build in v1.x

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu_cpu_jekyll
+++ b/ci/docker/Dockerfile.build.ubuntu_cpu_jekyll
@@ -43,7 +43,7 @@ RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - && \
 
 RUN source /etc/profile.d/rvm.sh && \
     rvm requirements && \
-    rvm install 2.6 && \
+    rvm install 2.6.3 && \
     rvm use 2.6.3 --default
 
 ENV BUNDLE_HOME=/work/deps/bundle


### PR DESCRIPTION
## Description ##
I noticed that recently my nightly build pipeline for v1.x (drawing on the v1.x branch from the main repository as its source) began to fail. I hadn't changed any code, but I noticed that the error being generated stemmed from an RVM version issue that I fixed in master by pinning the dependency version as part of my [General Version Dropdown PR](https://github.com/apache/incubator-mxnet/pull/17948). Since v1.x doesn't include changes to master, I realized that I would need to incorporate this fix in v1.x as well in order to get my nightly builds (or any website builds on this branch) to pass.

I tested my fix for this branch via my [v1.x nightly build Jenkins pipeline](http://jenkins.mxnet-ci.amazon-ml.com/job/restricted-nightly-website-build-1.x/), and it passed with my changes.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M ci/docker/Dockerfile.build.ubuntu_cpu_jekyll
