### PR TITLE
Fix gnu_tls handshake error on Ubuntu 14.04 Nvidia Docker

### DIFF
--- a/ci/docker/install/ubuntu_publish.sh
+++ b/ci/docker/install/ubuntu_publish.sh
@@ -20,6 +20,10 @@
 # Build on Ubuntu 14.04 LTS for LINUX CPU/GPU
 set -ex
 
+# replace https with http to force apt-get update to use http
+# nvidia-docker no longer supports ubuntu 14.04
+# refer https://github.com/apache/incubator-mxnet/issues/18005
+sudo sed -i 's/https/http/g' /etc/apt/sources.list.d/*.list
 apt-get update
 apt-get install -y software-properties-common
 add-apt-repository ppa:ubuntu-toolchain-r/test -y


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-mxnet/issues/18005

It doesn't occur on Master branch yet due to docker cache caching the Nvidia docker image for Ubuntu 14.04

This switches the dep link in /etc/apt/sources.list.d/*.list from https to http
Specifically 2 files exit
nvidia-ml.list and cuda.list

With this switch, TLS is no longer needed and hence the handshake error gets circumvented.

@leezu @zachgk Thanks for the help with investigation.
Pl review