### PR TITLE
[Numpy] New FFIs for Operator: pad, prod

### DIFF
--- a/benchmark/python/ffi/benchmark_ffi.py
+++ b/benchmark/python/ffi/benchmark_ffi.py
@@ -145,7 +145,7 @@ def prepare_workloads():
     OpArgMngr.add_workload("fmod", pool['2x2'], pool['2x2'])
     OpArgMngr.add_workload("may_share_memory", pool['2x3'][:0], pool['2x3'][:1])
     OpArgMngr.add_workload("pad", pool['2x2'], pad_width=((1,2),(1,2)), mode="constant")
-    OpArgMngr.add_Workload("prod", pool['2x2'], axis=1, dtype="float64", keepdims=False, initial=2.0)
+    OpArgMngr.add_workload("prod", pool['2x2'], axis=1, dtype="float64", keepdims=False, initial=2.0)
     OpArgMngr.add_workload("diag", pool['2x2'], k=1)
     OpArgMngr.add_workload("diagonal", pool['2x2x2'], offset=-1, axis1=0, axis2=1)
     OpArgMngr.add_workload("diag_indices_from", pool['2x2'])

--- a/benchmark/python/ffi/benchmark_ffi.py
+++ b/benchmark/python/ffi/benchmark_ffi.py
@@ -145,7 +145,7 @@ def prepare_workloads():
     OpArgMngr.add_workload("fmod", pool['2x2'], pool['2x2'])
     OpArgMngr.add_workload("may_share_memory", pool['2x3'][:0], pool['2x3'][:1])
     OpArgMngr.add_workload("pad", pool['2x2'], pad_width=((1,2),(1,2)), mode="constant")
-    OpArgMngr.add_Wordload("prod", pool['2x2'], axis=1, dtype="float64", keepdims=False, initial=2.0)
+    OpArgMngr.add_Workload("prod", pool['2x2'], axis=1, dtype="float64", keepdims=False, initial=2.0)
     OpArgMngr.add_workload("diag", pool['2x2'], k=1)
     OpArgMngr.add_workload("diagonal", pool['2x2x2'], offset=-1, axis1=0, axis2=1)
     OpArgMngr.add_workload("diag_indices_from", pool['2x2'])

--- a/benchmark/python/ffi/benchmark_ffi.py
+++ b/benchmark/python/ffi/benchmark_ffi.py
@@ -145,6 +145,7 @@ def prepare_workloads():
     OpArgMngr.add_workload("fmod", pool['2x2'], pool['2x2'])
     OpArgMngr.add_workload("may_share_memory", pool['2x3'][:0], pool['2x3'][:1])
     OpArgMngr.add_workload("pad", pool['2x2'], pad_width=((1,2),(1,2)), mode="constant")
+    OpArgMngr.add_Wordload("prod", pool['2x2'], axis=1, dtype="float64", keepdims=False, initial=2.0)
     OpArgMngr.add_workload("diag", pool['2x2'], k=1)
     OpArgMngr.add_workload("diagonal", pool['2x2x2'], offset=-1, axis1=0, axis2=1)
     OpArgMngr.add_workload("diag_indices_from", pool['2x2'])

--- a/benchmark/python/ffi/benchmark_ffi.py
+++ b/benchmark/python/ffi/benchmark_ffi.py
@@ -144,7 +144,7 @@ def prepare_workloads():
     OpArgMngr.add_workload("fmin", pool['2x2'], pool['2x2'])
     OpArgMngr.add_workload("fmod", pool['2x2'], pool['2x2'])
     OpArgMngr.add_workload("may_share_memory", pool['2x3'][:0], pool['2x3'][:1])
-    OpArgMngr.add_workload("pad", pool['2x2'], pad_width=((1,2),(1,2)), mode=1)
+    OpArgMngr.add_workload("pad", pool['2x2'], pad_width=((1,2),(1,2)), mode="constant")
     OpArgMngr.add_workload("diag", pool['2x2'], k=1)
     OpArgMngr.add_workload("diagonal", pool['2x2x2'], offset=-1, axis1=0, axis2=1)
     OpArgMngr.add_workload("diag_indices_from", pool['2x2'])

--- a/benchmark/python/ffi/benchmark_ffi.py
+++ b/benchmark/python/ffi/benchmark_ffi.py
@@ -144,6 +144,7 @@ def prepare_workloads():
     OpArgMngr.add_workload("fmin", pool['2x2'], pool['2x2'])
     OpArgMngr.add_workload("fmod", pool['2x2'], pool['2x2'])
     OpArgMngr.add_workload("may_share_memory", pool['2x3'][:0], pool['2x3'][:1])
+    OpArgMngr.add_workload("pad", pool['2x2'], pad_width=((1,2),(1,2)), mode=1)
     OpArgMngr.add_workload("diag", pool['2x2'], k=1)
     OpArgMngr.add_workload("diagonal", pool['2x2x2'], offset=-1, axis1=0, axis2=1)
     OpArgMngr.add_workload("diag_indices_from", pool['2x2'])

--- a/benchmark/python/ffi/benchmark_ffi.py
+++ b/benchmark/python/ffi/benchmark_ffi.py
@@ -145,7 +145,7 @@ def prepare_workloads():
     OpArgMngr.add_workload("fmod", pool['2x2'], pool['2x2'])
     OpArgMngr.add_workload("may_share_memory", pool['2x3'][:0], pool['2x3'][:1])
     OpArgMngr.add_workload("pad", pool['2x2'], pad_width=((1,2),(1,2)), mode="constant")
-    OpArgMngr.add_workload("prod", pool['2x2'], axis=1, dtype="float64", keepdims=False, initial=2.0)
+    OpArgMngr.add_workload("prod", pool['2x2'], axis=1, dtype="float64", keepdims=False)
     OpArgMngr.add_workload("diag", pool['2x2'], k=1)
     OpArgMngr.add_workload("diagonal", pool['2x2x2'], offset=-1, axis1=0, axis2=1)
     OpArgMngr.add_workload("diag_indices_from", pool['2x2'])

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8783,7 +8783,7 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None):
     >>> np.prod([1, 2], initial=5)
     10
     """
-    return _api_internal.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial)
+    return _api_internal.prod(a, axis=axis, dtype=dtype, keepdims=keepdims)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8783,7 +8783,7 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None):
     >>> np.prod([1, 2], initial=5)
     10
     """
-    return _api_internal.prod(a, axis, dtype, keepdims, initial, out)
+    return _api_internal.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial, out=out)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8681,30 +8681,30 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         values = kwargs.get("constant_values", 0)
         if isinstance(values, tuple):
             raise TypeError("unsupported constant_values type: {'tuple'}.")
-        return _api_internal.pad(x, pad_width, 'constant', constant_values=values)
+        return _api_internal.pad(x, pad_width, 'constant', values, "even")
     elif mode == "symmetric":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
             raise ValueError("unsupported reflect_type '{}'".format(values))
-        return _api_internal.pad(x, pad_width, mode='symmetric', reflect_type="even")
+        return _api_internal.pad(x, pad_width, 'symmetric',0, "even")
     elif mode == "edge":
-        return _api_internal.pad(x, pad_width, mode='edge')
+        return _api_internal.pad(x, pad_width, 'edge', 0, "even")
     elif mode == "reflect":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
             raise ValueError("unsupported reflect_type '{}'".format(values))
-        return _api_internal.pad(x, pad_width, mode='reflect', reflect_type="even")
+        return _api_internal.pad(x, pad_width, 'reflect', 0, "even")
     elif mode == "maximum":
         values = kwargs.get("stat_length", None)
         if values is not None:
             raise ValueError("unsupported stat_length '{}'".format(values))
-        return _api_internal.pad(x, pad_width, mode='maximum')
+        return _api_internal.pad(x, pad_width, 'maximum', 0, "even")
     elif mode == "minimum":
         values = kwargs.get("stat_length", None)
         if values is not None:
             raise ValueError("unsupported stat_length '{}'".format(values))
         return _api_internal.pad(x, pad_width, mode='minimum')
-    return _api_internal.pad(x, pad_width, mode='constant', constant_values=0)
+    return _api_internal.pad(x, pad_width, 'constant', 0, "constant")
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8708,6 +8708,85 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
 
 
 @set_module('mxnet.ndarray.numpy')
+def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None):
+    """
+    Return the product of array elements over a given axis.
+
+    Parameters
+    ----------
+    a : array_like
+        Input data.
+    axis : None or int or tuple of ints, optional
+        Axis or axes along which a product is performed.  The default,
+        axis=None, will calculate the product of all the elements in the
+        input array. If axis is negative it counts from the last to the
+        first axis.
+        .. versionadded:: 1.7.0
+        If axis is a tuple of ints, a product is performed on all of the
+        axes specified in the tuple instead of a single axis or all the
+        axes as before.
+    dtype : dtype, optional
+        The type of the returned array, as well as of the accumulator in
+        which the elements are multiplied.  The dtype of `a` is used by
+        default unless `a` has an integer dtype of less precision than the
+        default platform integer.  In that case, if `a` is signed then the
+        platform integer is used while if `a` is unsigned then an unsigned
+        integer of the same precision as the platform integer is used.
+    out : ndarray, optional
+        Alternative output array in which to place the result. It must have
+        the same shape as the expected output, but the type of the output
+        values will be cast if necessary.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result
+        will broadcast correctly against the input array.
+        If the default value is passed, then `keepdims` will not be
+        passed through to the `prod` method of sub-classes of
+        `ndarray`, however any non-default value will be.  If the
+        sub-class' method does not implement `keepdims` any
+        exceptions will be raised.
+    initial : scalar, optional
+        The starting value for this product. See `~numpy.ufunc.reduce` for details.
+    where : not supported
+
+    Returns
+    -------
+    product_along_axis : ndarray, see `dtype` parameter above.
+        An array shaped as `a` but with the specified axis removed.
+        Returns a reference to `out` if specified.
+
+    Examples
+    --------
+    By default, calculate the product of all elements:
+    >>> np.prod([1.,2.])
+    2.0
+    Even when the input array is two-dimensional:
+    >>> np.prod([[1.,2.],[3.,4.]])
+    24.0
+    But we can also specify the axis over which to multiply:
+    >>> np.prod([[1.,2.],[3.,4.]], axis=1)
+    array([  2.,  12.])
+    Or select specific elements to include:
+    >>> np.prod([1., np.nan, 3.], where=[True, False, True])
+    3.0
+    If the type of `x` is unsigned, then the output type is
+    the unsigned platform integer:
+    >>> x = np.array([1, 2, 3], dtype=np.uint8)
+    >>> np.prod(x).dtype == np.uint
+    True
+    If `x` is of a signed integer type, then the output type
+    is the default platform integer:
+    >>> x = np.array([1, 2, 3], dtype=np.int8)
+    >>> np.prod(x).dtype == int
+    True
+    You can also start the product with a value other than one:
+    >>> np.prod([1, 2], initial=5)
+    10
+    """
+    return _api_internal.prod(a, axis, dtype, keepdims, initial, out)
+
+
+@set_module('mxnet.ndarray.numpy')
 def cumsum(a, axis=None, dtype=None, out=None):
     """
     Return the cumulative sum of the elements along a given axis.

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8681,7 +8681,7 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         values = kwargs.get("constant_values", 0)
         if isinstance(values, tuple):
             raise TypeError("unsupported constant_values type: {'tuple'}.")
-        _npi.pad(x, pad_width, mode='constant', constant_value=values)
+        return _api_internal.pad(x, pad_width, mode='constant', constant_value=values)
     elif mode == "symmetric":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8783,7 +8783,7 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None):
     >>> np.prod([1, 2], initial=5)
     10
     """
-    return _api_internal.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial, out=out)
+    return _api_internal.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8681,7 +8681,7 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         values = kwargs.get("constant_values", 0)
         if isinstance(values, tuple):
             raise TypeError("unsupported constant_values type: {'tuple'}.")
-        return _api_internal.pad(x, pad_width, mode='constant', constant_values=values)
+        return _api_internal.pad(x, pad_width, 'constant', constant_values=values)
     elif mode == "symmetric":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8783,7 +8783,7 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None):
     >>> np.prod([1, 2], initial=5)
     10
     """
-    return _api_internal.prod(a, axis=axis, dtype=dtype, keepdims=keepdims)
+    return _api_internal.prod(a, axis, dtype, out, keepdims, initial, out)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8708,7 +8708,7 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
 
 
 @set_module('mxnet.ndarray.numpy')
-def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None):
+def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None): # pylint: disable=too-many-arguments
     """
     Return the product of array elements over a given axis.
 

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8681,30 +8681,30 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         values = kwargs.get("constant_values", 0)
         if isinstance(values, tuple):
             raise TypeError("unsupported constant_values type: {'tuple'}.")
-        return _api_internal.pad(x, pad_width, 0, values, "even")
+        return _api_internal.pad(x, pad_width, 'constant', values, "even")
     elif mode == "symmetric":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
             raise ValueError("unsupported reflect_type '{}'".format(values))
-        return _api_internal.pad(x, pad_width, 3, 0, "even")
+        return _api_internal.pad(x, pad_width, 'symmetric',0, "even")
     elif mode == "edge":
-        return _api_internal.pad(x, pad_width, 1, 0, "even")
+        return _api_internal.pad(x, pad_width, 'edge', 0, "even")
     elif mode == "reflect":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
             raise ValueError("unsupported reflect_type '{}'".format(values))
-        return _api_internal.pad(x, pad_width, 2, 0, "even")
+        return _api_internal.pad(x, pad_width, 'reflect', 0, "even")
     elif mode == "maximum":
         values = kwargs.get("stat_length", None)
         if values is not None:
             raise ValueError("unsupported stat_length '{}'".format(values))
-        return _api_internal.pad(x, pad_width, 4, 0, "even")
+        return _api_internal.pad(x, pad_width, 'maximum', 0, "even")
     elif mode == "minimum":
         values = kwargs.get("stat_length", None)
         if values is not None:
             raise ValueError("unsupported stat_length '{}'".format(values))
-        return _api_internal.pad(x, pad_width, 5, 0, 'even')
-    return _api_internal.pad(x, pad_width, 0, 0, "even")
+        return _api_internal.pad(x, pad_width, 'minimum', 0, "even")
+    return _api_internal.pad(x, pad_width, 'constant', 0, "even")
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8686,7 +8686,7 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
             raise ValueError("unsupported reflect_type '{}'".format(values))
-        return _api_internal.pad(x, pad_width, 'symmetric',0, "even")
+        return _api_internal.pad(x, pad_width, 'symmetric', 0, "even")
     elif mode == "edge":
         return _api_internal.pad(x, pad_width, 'edge', 0, "even")
     elif mode == "reflect":

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8686,25 +8686,25 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
             raise ValueError("unsupported reflect_type '{}'".format(values))
-        return _npi.pad(x, pad_width, mode='symmetric', reflect_type="even")
+        return _api_internal.pad(x, pad_width, mode='symmetric', reflect_type="even")
     elif mode == "edge":
-        return _npi.pad(x, pad_width, mode='edge')
+        return _api_internal.pad(x, pad_width, mode='edge')
     elif mode == "reflect":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
             raise ValueError("unsupported reflect_type '{}'".format(values))
-        return _npi.pad(x, pad_width, mode='reflect', reflect_type="even")
+        return _api_internal.pad(x, pad_width, mode='reflect', reflect_type="even")
     elif mode == "maximum":
         values = kwargs.get("stat_length", None)
         if values is not None:
             raise ValueError("unsupported stat_length '{}'".format(values))
-        return _npi.pad(x, pad_width, mode='maximum')
+        return _api_internal.pad(x, pad_width, mode='maximum')
     elif mode == "minimum":
         values = kwargs.get("stat_length", None)
         if values is not None:
             raise ValueError("unsupported stat_length '{}'".format(values))
-        return _npi.pad(x, pad_width, mode='minimum')
-    return _npi.pad(x, pad_width, mode='constant', constant_value=0)
+        return _api_internal.pad(x, pad_width, mode='minimum')
+    return _api_internal.pad(x, pad_width, mode='constant', constant_value=0)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8681,30 +8681,30 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         values = kwargs.get("constant_values", 0)
         if isinstance(values, tuple):
             raise TypeError("unsupported constant_values type: {'tuple'}.")
-        return _api_internal.pad(x, pad_width, 'constant', values, "even")
+        return _api_internal.pad(x, pad_width, 0, values, "even")
     elif mode == "symmetric":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
             raise ValueError("unsupported reflect_type '{}'".format(values))
-        return _api_internal.pad(x, pad_width, 'symmetric',0, "even")
+        return _api_internal.pad(x, pad_width, 3, 0, "even")
     elif mode == "edge":
-        return _api_internal.pad(x, pad_width, 'edge', 0, "even")
+        return _api_internal.pad(x, pad_width, 1, 0, "even")
     elif mode == "reflect":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
             raise ValueError("unsupported reflect_type '{}'".format(values))
-        return _api_internal.pad(x, pad_width, 'reflect', 0, "even")
+        return _api_internal.pad(x, pad_width, 2, 0, "even")
     elif mode == "maximum":
         values = kwargs.get("stat_length", None)
         if values is not None:
             raise ValueError("unsupported stat_length '{}'".format(values))
-        return _api_internal.pad(x, pad_width, 'maximum', 0, "even")
+        return _api_internal.pad(x, pad_width, 4, 0, "even")
     elif mode == "minimum":
         values = kwargs.get("stat_length", None)
         if values is not None:
             raise ValueError("unsupported stat_length '{}'".format(values))
-        return _api_internal.pad(x, pad_width, mode='minimum')
-    return _api_internal.pad(x, pad_width, 'constant', 0, "constant")
+        return _api_internal.pad(x, pad_width, 5, 0, 'even')
+    return _api_internal.pad(x, pad_width, 0, 0, "even")
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8783,7 +8783,7 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None):
     >>> np.prod([1, 2], initial=5)
     10
     """
-    return _api_internal.prod(a, axis, dtype, out, keepdims, initial, out)
+    return _api_internal.prod(a, axis, dtype, keepdims, initial, out)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -49,7 +49,7 @@ __all__ = ['shape', 'zeros', 'zeros_like', 'ones', 'ones_like', 'full', 'full_li
            'true_divide', 'nonzero', 'quantile', 'percentile', 'shares_memory', 'may_share_memory', 'interp',
            'diff', 'ediff1d', 'resize', 'polyval', 'nan_to_num', 'isnan', 'isinf', 'isposinf', 'isneginf', 'isfinite',
            'atleast_1d', 'atleast_2d', 'atleast_3d', 'fill_diagonal',
-           'where', 'bincount', 'rollaxis', 'pad', 'cumsum', 'sum', 'diag', 'diagonal']
+           'where', 'bincount', 'rollaxis', 'prod', 'pad', 'cumsum', 'sum', 'diag', 'diagonal']
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8681,7 +8681,7 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         values = kwargs.get("constant_values", 0)
         if isinstance(values, tuple):
             raise TypeError("unsupported constant_values type: {'tuple'}.")
-        return _api_internal.pad(x, pad_width, mode='constant', constant_value=values)
+        return _api_internal.pad(x, pad_width, mode='constant', constant_values=values)
     elif mode == "symmetric":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
@@ -8704,7 +8704,7 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         if values is not None:
             raise ValueError("unsupported stat_length '{}'".format(values))
         return _api_internal.pad(x, pad_width, mode='minimum')
-    return _api_internal.pad(x, pad_width, mode='constant', constant_value=0)
+    return _api_internal.pad(x, pad_width, mode='constant', constant_values=0)
 
 
 @set_module('mxnet.ndarray.numpy')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -10775,24 +10775,7 @@ def pad(x, pad_width=None, mode="constant", **kwargs): # pylint: disable=too-man
            [10, 10, 10, 10, 10, 10, 10],
            [10, 10, 10, 10, 10, 10, 10]])
     """
-    if mode == "constant":
-        values = kwargs.get("constant_values", 0)
-        return _mx_nd_np.pad(x, pad_width, mode='constant', constant_values=values)
-    elif mode == "symmetric":
-        values = kwargs.get("reflect_type", "even")
-        return _mx_nd_np.pad(x, pad_width, mode='symmetric', reflect_type="even")
-    elif mode == "edge":
-        return _mx_nd_np.pad(x, pad_width, mode='edge')
-    elif mode == "reflect":
-        values = kwargs.get("reflect_type", "even")
-        return _mx_nd_np.pad(x, pad_width, mode='reflect', reflect_type="even")
-    elif mode == "maximum":
-        values = kwargs.get("stat_length", None)
-        return _mx_nd_np.pad(x, pad_width, mode='maximum')
-    elif mode == "minimum":
-        values = kwargs.get("stat_length", None)
-        return _mx_nd_np.pad(x, pad_width, mode='minimum')
-    return _mx_nd_np.pad(x, pad_width, mode='constant', constant_values=0)
+    return _mx_nd_np.pad(x, pad_width=pad_width, mode=mode, **kwargs)
 
 
 # pylint: disable=redefined-outer-name

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -10818,7 +10818,7 @@ def pad(x, pad_width=None, mode="constant", **kwargs): # pylint: disable=too-man
         values = kwargs.get("constant_values", 0)
         if isinstance(values, tuple):
             raise TypeError("unsupported constant_values type: {'tuple'}.")
-        return _mx_nd_np.pad(x, pad_width, mode='constant', constant_value=values)
+        return _mx_nd_np.pad(x, pad_width, mode='constant', constant_values=values)
     elif mode == "symmetric":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
@@ -10841,7 +10841,7 @@ def pad(x, pad_width=None, mode="constant", **kwargs): # pylint: disable=too-man
         if values is not None:
             raise ValueError("unsupported stat_length '{}'".format(values))
         return _mx_nd_np.pad(x, pad_width, mode='minimum')
-    return _mx_nd_np.pad(x, pad_width, mode='constant', constant_value=0)
+    return _mx_nd_np.pad(x, pad_width, mode='constant', constant_values=0)
 
 
 # pylint: disable=redefined-outer-name

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -10680,6 +10680,7 @@ def atleast_3d(*arys):
 
 @set_module('mxnet.numpy')
 def pad(x, pad_width=None, mode="constant", **kwargs): # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-return-statements
     """
     Pad an array.
 
@@ -10846,7 +10847,7 @@ def pad(x, pad_width=None, mode="constant", **kwargs): # pylint: disable=too-man
 
 # pylint: disable=redefined-outer-name
 @set_module('mxnet.numpy')
-def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None):
+def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None): # pylint: disable=too-many-arguments
     """
     Return the product of array elements over a given axis.
 

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -10872,7 +10872,7 @@ def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None): # py
     >>> np.prod([1, 2], initial=5)
     10
     """
-    return _npi.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial, out=out)
+    return _mx_nd_np.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial, out=out)
 
 
 # pylint: disable=redefined-outer-name

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -75,7 +75,7 @@ __all__ = ['ndarray', 'empty', 'empty_like', 'array', 'shape', 'median',
            'quantile', 'percentile', 'shares_memory', 'may_share_memory', 'diff', 'ediff1d', 'resize', 'matmul',
            'nan_to_num', 'isnan', 'isinf', 'isposinf', 'isneginf', 'isfinite', 'polyval', 'where', 'bincount',
            'atleast_1d', 'atleast_2d', 'atleast_3d', 'fill_diagonal',
-           'pad', 'cumsum', 'sum', 'rollaxis', 'diag', 'diagonal']
+           'prod', 'pad', 'cumsum', 'sum', 'rollaxis', 'diag', 'diagonal']
 
 __all__ += fallback.__all__
 

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -10797,7 +10797,7 @@ def pad(x, pad_width=None, mode="constant", **kwargs): # pylint: disable=too-man
 
 # pylint: disable=redefined-outer-name
 @set_module('mxnet.numpy')
-def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None): # pylint: disable=too-many-arguments
+def prod(a, axis=None, dtype=None, keepdims=False, initial=None, out=None): # pylint: disable=too-many-arguments
     """
     Return the product of array elements over a given axis.
 

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -10797,7 +10797,7 @@ def pad(x, pad_width=None, mode="constant", **kwargs): # pylint: disable=too-man
 
 # pylint: disable=redefined-outer-name
 @set_module('mxnet.numpy')
-def prod(a, axis=None, dtype=None, keepdims=False, initial=None, out=None): # pylint: disable=too-many-arguments
+def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None): # pylint: disable=too-many-arguments
     """
     Return the product of array elements over a given axis.
 
@@ -10872,7 +10872,7 @@ def prod(a, axis=None, dtype=None, keepdims=False, initial=None, out=None): # py
     >>> np.prod([1, 2], initial=5)
     10
     """
-    return _mx_nd_np.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial, out=out)
+    return _npi.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial, out=out)
 
 
 # pylint: disable=redefined-outer-name

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -10775,72 +10775,22 @@ def pad(x, pad_width=None, mode="constant", **kwargs): # pylint: disable=too-man
            [10, 10, 10, 10, 10, 10, 10],
            [10, 10, 10, 10, 10, 10, 10]])
     """
-    if not _np.asarray(pad_width).dtype.kind == 'i':
-        raise TypeError('`pad_width` must be of integral type.')
-    if not isinstance(pad_width, tuple):
-        raise TypeError("`pad_width` must be tuple.")
-    if mode == "linear_ramp":
-        raise ValueError("mode {'linear_ramp'} is not supported.")
-    if mode == "wrap":
-        raise ValueError("mode {'wrap'} is not supported.")
-    if mode == "median":
-        raise ValueError("mode {'median'} is not supported.")
-    if mode == "mean":
-        raise ValueError("mode {'mean'} is not supported.")
-    if mode == "empty":
-        raise ValueError("mode {'empty'} is not supported.")
-    if callable(mode):
-        raise ValueError("mode {'<function>'} is not supported.")
-
-    allowedkwargs = {
-        'constant': ['constant_values'],
-        'edge': [],
-        'linear_ramp': ['end_values'],
-        'maximum': ['stat_length'],
-        'mean': ['stat_length'],
-        'median': ['stat_length'],
-        'minimum': ['stat_length'],
-        'reflect': ['reflect_type'],
-        'symmetric': ['reflect_type'],
-        'wrap': [],
-        }
-
-    if isinstance(mode, _np.compat.basestring):
-        # Make sure have allowed kwargs appropriate for mode
-        for key in kwargs:
-            if key not in allowedkwargs[mode]:
-                raise ValueError('%s keyword not in allowed keywords %s' %(key, allowedkwargs[mode]))
-
-    unsupported_kwargs = set(kwargs) - set(allowedkwargs[mode])
-    if unsupported_kwargs:
-        raise ValueError("unsupported keyword arguments for mode '{}': {}"
-                         .format(mode, unsupported_kwargs))
     if mode == "constant":
         values = kwargs.get("constant_values", 0)
-        if isinstance(values, tuple):
-            raise TypeError("unsupported constant_values type: {'tuple'}.")
         return _mx_nd_np.pad(x, pad_width, mode='constant', constant_values=values)
     elif mode == "symmetric":
         values = kwargs.get("reflect_type", "even")
-        if values != "even" and values is not None:
-            raise ValueError("unsupported reflect_type '{}'".format(values))
         return _mx_nd_np.pad(x, pad_width, mode='symmetric', reflect_type="even")
     elif mode == "edge":
         return _mx_nd_np.pad(x, pad_width, mode='edge')
     elif mode == "reflect":
         values = kwargs.get("reflect_type", "even")
-        if values != "even" and values is not None:
-            raise ValueError("unsupported reflect_type '{}'".format(values))
         return _mx_nd_np.pad(x, pad_width, mode='reflect', reflect_type="even")
     elif mode == "maximum":
         values = kwargs.get("stat_length", None)
-        if values is not None:
-            raise ValueError("unsupported stat_length '{}'".format(values))
         return _mx_nd_np.pad(x, pad_width, mode='maximum')
     elif mode == "minimum":
         values = kwargs.get("stat_length", None)
-        if values is not None:
-            raise ValueError("unsupported stat_length '{}'".format(values))
         return _mx_nd_np.pad(x, pad_width, mode='minimum')
     return _mx_nd_np.pad(x, pad_width, mode='constant', constant_values=0)
 

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -10846,6 +10846,86 @@ def pad(x, pad_width=None, mode="constant", **kwargs): # pylint: disable=too-man
 
 # pylint: disable=redefined-outer-name
 @set_module('mxnet.numpy')
+def prod(a, axis=None, dtype=None, out=None, keepdims=False, initial=None):
+    """
+    Return the product of array elements over a given axis.
+
+    Parameters
+    ----------
+    a : array_like
+        Input data.
+    axis : None or int or tuple of ints, optional
+        Axis or axes along which a product is performed.  The default,
+        axis=None, will calculate the product of all the elements in the
+        input array. If axis is negative it counts from the last to the
+        first axis.
+        .. versionadded:: 1.7.0
+        If axis is a tuple of ints, a product is performed on all of the
+        axes specified in the tuple instead of a single axis or all the
+        axes as before.
+    dtype : dtype, optional
+        The type of the returned array, as well as of the accumulator in
+        which the elements are multiplied.  The dtype of `a` is used by
+        default unless `a` has an integer dtype of less precision than the
+        default platform integer.  In that case, if `a` is signed then the
+        platform integer is used while if `a` is unsigned then an unsigned
+        integer of the same precision as the platform integer is used.
+    out : ndarray, optional
+        Alternative output array in which to place the result. It must have
+        the same shape as the expected output, but the type of the output
+        values will be cast if necessary.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result
+        will broadcast correctly against the input array.
+        If the default value is passed, then `keepdims` will not be
+        passed through to the `prod` method of sub-classes of
+        `ndarray`, however any non-default value will be.  If the
+        sub-class' method does not implement `keepdims` any
+        exceptions will be raised.
+    initial : scalar, optional
+        The starting value for this product. See `~numpy.ufunc.reduce` for details.
+    where : not supported
+
+    Returns
+    -------
+    product_along_axis : ndarray, see `dtype` parameter above.
+        An array shaped as `a` but with the specified axis removed.
+        Returns a reference to `out` if specified.
+
+    Examples
+    --------
+    By default, calculate the product of all elements:
+    >>> np.prod([1.,2.])
+    2.0
+    Even when the input array is two-dimensional:
+    >>> np.prod([[1.,2.],[3.,4.]])
+    24.0
+    But we can also specify the axis over which to multiply:
+    >>> np.prod([[1.,2.],[3.,4.]], axis=1)
+    array([  2.,  12.])
+    Or select specific elements to include:
+    >>> np.prod([1., np.nan, 3.], where=[True, False, True])
+    3.0
+    If the type of `x` is unsigned, then the output type is
+    the unsigned platform integer:
+    >>> x = np.array([1, 2, 3], dtype=np.uint8)
+    >>> np.prod(x).dtype == np.uint
+    True
+    If `x` is of a signed integer type, then the output type
+    is the default platform integer:
+    >>> x = np.array([1, 2, 3], dtype=np.int8)
+    >>> np.prod(x).dtype == int
+    True
+    You can also start the product with a value other than one:
+    >>> np.prod([1, 2], initial=5)
+    10
+    """
+    return _mx_nd_np.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial, out=out)
+
+
+# pylint: disable=redefined-outer-name
+@set_module('mxnet.numpy')
 def cumsum(a, axis=None, dtype=None, out=None):
     """
     Return the cumulative sum of the elements along a given axis.

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -10774,7 +10774,74 @@ def pad(x, pad_width=None, mode="constant", **kwargs): # pylint: disable=too-man
            [10, 10, 10, 10, 10, 10, 10],
            [10, 10, 10, 10, 10, 10, 10]])
     """
-    return _mx_nd_np.pad(x, pad_width, mode, **kwargs)
+    if not _np.asarray(pad_width).dtype.kind == 'i':
+        raise TypeError('`pad_width` must be of integral type.')
+    if not isinstance(pad_width, tuple):
+        raise TypeError("`pad_width` must be tuple.")
+    if mode == "linear_ramp":
+        raise ValueError("mode {'linear_ramp'} is not supported.")
+    if mode == "wrap":
+        raise ValueError("mode {'wrap'} is not supported.")
+    if mode == "median":
+        raise ValueError("mode {'median'} is not supported.")
+    if mode == "mean":
+        raise ValueError("mode {'mean'} is not supported.")
+    if mode == "empty":
+        raise ValueError("mode {'empty'} is not supported.")
+    if callable(mode):
+        raise ValueError("mode {'<function>'} is not supported.")
+
+    allowedkwargs = {
+        'constant': ['constant_values'],
+        'edge': [],
+        'linear_ramp': ['end_values'],
+        'maximum': ['stat_length'],
+        'mean': ['stat_length'],
+        'median': ['stat_length'],
+        'minimum': ['stat_length'],
+        'reflect': ['reflect_type'],
+        'symmetric': ['reflect_type'],
+        'wrap': [],
+        }
+
+    if isinstance(mode, _np.compat.basestring):
+        # Make sure have allowed kwargs appropriate for mode
+        for key in kwargs:
+            if key not in allowedkwargs[mode]:
+                raise ValueError('%s keyword not in allowed keywords %s' %(key, allowedkwargs[mode]))
+
+    unsupported_kwargs = set(kwargs) - set(allowedkwargs[mode])
+    if unsupported_kwargs:
+        raise ValueError("unsupported keyword arguments for mode '{}': {}"
+                         .format(mode, unsupported_kwargs))
+    if mode == "constant":
+        values = kwargs.get("constant_values", 0)
+        if isinstance(values, tuple):
+            raise TypeError("unsupported constant_values type: {'tuple'}.")
+        return _mx_nd_np.pad(x, pad_width, mode='constant', constant_value=values)
+    elif mode == "symmetric":
+        values = kwargs.get("reflect_type", "even")
+        if values != "even" and values is not None:
+            raise ValueError("unsupported reflect_type '{}'".format(values))
+        return _mx_nd_np.pad(x, pad_width, mode='symmetric', reflect_type="even")
+    elif mode == "edge":
+        return _mx_nd_np.pad(x, pad_width, mode='edge')
+    elif mode == "reflect":
+        values = kwargs.get("reflect_type", "even")
+        if values != "even" and values is not None:
+            raise ValueError("unsupported reflect_type '{}'".format(values))
+        return _mx_nd_np.pad(x, pad_width, mode='reflect', reflect_type="even")
+    elif mode == "maximum":
+        values = kwargs.get("stat_length", None)
+        if values is not None:
+            raise ValueError("unsupported stat_length '{}'".format(values))
+        return _mx_nd_np.pad(x, pad_width, mode='maximum')
+    elif mode == "minimum":
+        values = kwargs.get("stat_length", None)
+        if values is not None:
+            raise ValueError("unsupported stat_length '{}'".format(values))
+        return _mx_nd_np.pad(x, pad_width, mode='minimum')
+    return _mx_nd_np.pad(x, pad_width, mode='constant', constant_value=0)
 
 
 # pylint: disable=redefined-outer-name

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -7417,7 +7417,7 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
 
 
 @set_module('mxnet.symbol.numpy')
-def prod(a, axis=None, dtype=None, output=None, keepdims=False, initial=None):
+def prod(a, axis=None, dtype=None, output=None, keepdims=False, initial=None): # pylint: disable=too-many-arguments
     """
     Return the product of array elements over a given axis.
 

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -7390,7 +7390,7 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         values = kwargs.get("constant_values", 0)
         if isinstance(values, tuple):
             raise TypeError("unsupported constant_values type: {'tuple'}.")
-        _npi.pad(x, pad_width, mode='constant', constant_value=values)
+        _npi.pad(x, pad_width, mode='constant', constant_values=values)
     elif mode == "symmetric":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:
@@ -7413,7 +7413,7 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         if values is not None:
             raise ValueError("unsupported stat_length '{}'".format(values))
         return _npi.pad(x, pad_width, mode='minimum')
-    return _npi.pad(x, pad_width, mode='constant', constant_value=0)
+    return _npi.pad(x, pad_width, mode='constant', constant_values=0)
 
 
 @set_module('mxnet.symbol.numpy')

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -7417,7 +7417,7 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
 
 
 @set_module('mxnet.symbol.numpy')
-def prod(a, axis=None, dtype=None, output=None, keepdims=False, initial=None): # pylint: disable=too-many-arguments
+def prod(a, axis=None, dtype=None, keepdims=False, initial=None, output=None): # pylint: disable=too-many-arguments
     """
     Return the product of array elements over a given axis.
 

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -54,7 +54,7 @@ __all__ = ['zeros', 'zeros_like', 'ones', 'ones_like', 'full', 'full_like', 'emp
            'true_divide', 'quantile', 'percentile', 'shares_memory', 'may_share_memory', 'diff', 'ediff1d',
            'resize', 'polyval', 'nan_to_num', 'isnan', 'isinf', 'isposinf', 'isneginf', 'isfinite',
            'atleast_1d', 'atleast_2d', 'atleast_3d',
-           'where', 'bincount', 'rollaxis', 'pad', 'cumsum', 'sum', 'diag', 'diagonal']
+           'where', 'bincount', 'rollaxis', 'prod', 'pad', 'cumsum', 'sum', 'diag', 'diagonal']
 
 
 @set_module('mxnet.symbol.numpy')

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -7417,6 +7417,84 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
 
 
 @set_module('mxnet.symbol.numpy')
+def prod(a, axis=None, dtype=None, output=None, keepdims=False, initial=None):
+    """
+    Return the product of array elements over a given axis.
+
+    Parameters
+    ----------
+    a : array_like
+        Input data.
+    axis : None or int or tuple of ints, optional
+        Axis or axes along which a product is performed.  The default,
+        axis=None, will calculate the product of all the elements in the
+        input array. If axis is negative it counts from the last to the
+        first axis.
+        .. versionadded:: 1.7.0
+        If axis is a tuple of ints, a product is performed on all of the
+        axes specified in the tuple instead of a single axis or all the
+        axes as before.
+    dtype : dtype, optional
+        The type of the returned array, as well as of the accumulator in
+        which the elements are multiplied.  The dtype of `a` is used by
+        default unless `a` has an integer dtype of less precision than the
+        default platform integer.  In that case, if `a` is signed then the
+        platform integer is used while if `a` is unsigned then an unsigned
+        integer of the same precision as the platform integer is used.
+    out : ndarray, optional
+        Alternative output array in which to place the result. It must have
+        the same shape as the expected output, but the type of the output
+        values will be cast if necessary.
+    keepdims : bool, optional
+        If this is set to True, the axes which are reduced are left in the
+        result as dimensions with size one. With this option, the result
+        will broadcast correctly against the input array.
+        If the default value is passed, then `keepdims` will not be
+        passed through to the `prod` method of sub-classes of
+        `ndarray`, however any non-default value will be.  If the
+        sub-class' method does not implement `keepdims` any
+        exceptions will be raised.
+    initial : scalar, optional
+        The starting value for this product. See `~numpy.ufunc.reduce` for details.
+    where : not supported
+
+    Returns
+    -------
+    product_along_axis : ndarray, see `dtype` parameter above.
+        An array shaped as `a` but with the specified axis removed.
+        Returns a reference to `out` if specified.
+
+    Examples
+    --------
+    By default, calculate the product of all elements:
+    >>> np.prod([1.,2.])
+    2.0
+    Even when the input array is two-dimensional:
+    >>> np.prod([[1.,2.],[3.,4.]])
+    24.0
+    But we can also specify the axis over which to multiply:
+    >>> np.prod([[1.,2.],[3.,4.]], axis=1)
+    array([  2.,  12.])
+    Or select specific elements to include:
+    >>> np.prod([1., np.nan, 3.], where=[True, False, True])
+    3.0
+    If the type of `x` is unsigned, then the output type is
+    the unsigned platform integer:
+    >>> x = np.array([1, 2, 3], dtype=np.uint8)
+    >>> np.prod(x).dtype == np.uint
+    True
+    If `x` is of a signed integer type, then the output type
+    is the default platform integer:
+    >>> x = np.array([1, 2, 3], dtype=np.int8)
+    >>> np.prod(x).dtype == int
+    True
+    You can also start the product with a value other than one:
+    >>> np.prod([1, 2], initial=5)
+    10
+    """
+    return _npi.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial, out=out)
+
+@set_module('mxnet.symbol.numpy')
 def cumsum(a, axis=None, dtype=None, out=None):
     """
     Return the cumulative sum of the elements along a given axis.

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -7492,7 +7492,7 @@ def prod(a, axis=None, dtype=None, output=None, keepdims=False, initial=None):
     >>> np.prod([1, 2], initial=5)
     10
     """
-    return _npi.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial, out=out)
+    return _npi.prod(a, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial)
 
 @set_module('mxnet.symbol.numpy')
 def cumsum(a, axis=None, dtype=None, out=None):

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -7390,7 +7390,7 @@ def pad(x, pad_width, mode='constant', **kwargs): # pylint: disable=too-many-arg
         values = kwargs.get("constant_values", 0)
         if isinstance(values, tuple):
             raise TypeError("unsupported constant_values type: {'tuple'}.")
-        _npi.pad(x, pad_width, mode='constant', constant_values=values)
+        return _npi.pad(x, pad_width, mode='constant', constant_values=values)
     elif mode == "symmetric":
         values = kwargs.get("reflect_type", "even")
         if values != "even" and values is not None:

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -186,7 +186,7 @@ MXNET_REGISTER_API("_npi.prod")
   // outputs
   NDArray* out = args[5].operator mxnet::NDArray*();
   NDArray** outputs = out == nullptr ? nullptr : &out;
-  int num_outputs = out != nullptr;
+  int num_outputs = 1;
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);
   if (out) {
     *ret = PythonArg(5);

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -181,8 +181,8 @@ MXNET_REGISTER_API("_npi.prod")
   op::NumpyReduceAxesParam param;
   if (args[1].type_code() == kNull) {
     param.axis = dmlc::nullopt;
-  } else if (args[1].type_code() ==kDLInt) {
-    param.axis = args[1].operator int();
+  } else if (args[1].type_code() == kDLInt) {
+    param.axis = Tuple<int>(1, args[1].operator int64_t());
   } else {
     param.axis = Tuple<int>(args[1].operator ObjectRef());
   }

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -47,9 +47,9 @@ inline int String2MXNetProdType(const std::string& s) {
   } else if (s == "bool") {
     return mshadow::kBool;
   } else {
-    LOG(FATAL) << "unknown type " << s;
+    LOG(FATAL) << "unknown type" << s;
   }
-  LOG(FATAL) << "should not reach here ";
+  LOG(FATAL) << "should not reach here";
   return 0;
 }
 
@@ -174,7 +174,7 @@ MXNET_REGISTER_API("_npi.mean")
 });
 
 MXNET_REGISTER_API("_npi.prod")
-.set_body([](runtime::MXNetArgs, args, runtime::MXNetRetValue* ret) {
+.set_body([](runtime::MXNetArgs args, runtime::MXNetRetValue* ret) {
   using namespace runtime;
   const nnvm::Op* op = Op::Get("_npi_prod");
   nnvm::NodeAttrs attrs;

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -191,7 +191,7 @@ MXNET_REGISTER_API("_npi.prod")
   }
   param.keepdims = args[4].operator bool();
   if (args[5].type_code() == kDLFloat) {
-    param.initial = args[5].operator float();
+    param.initial = args[5].operator double();
   } else {
     param.initial = dmlc::nullopt;
   }

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -189,7 +189,7 @@ MXNET_REGISTER_API("_npi.prod")
   int num_outputs = out != nullptr;
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);
   if (out) {
-    *ret = PythonArg(3);
+    *ret = PythonArg(5);
   } else {
     *ret = reinterpret_cast<mxnet::NDArray*>(ndoutputs[0]);
   }

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -178,7 +178,7 @@ MXNET_REGISTER_API("_npi.prod")
   using namespace runtime;
   const nnvm::Op* op = Op::Get("_npi_prod");
   nnvm::NodeAttrs attrs;
-  op::NumpyReduceAxesParam param;
+  op::ReduceAxesParam param;
   if (args[1].type_code() == kNull) {
     param.axis = dmlc::nullopt;
   } else {
@@ -189,20 +189,28 @@ MXNET_REGISTER_API("_npi.prod")
   } else {
     param.dtype = String2MXNetProdType(args[2].operator std::string());
   }
-  param.keepdims = args[3].operator bool();
-  if (args[4].type_code() == kDLFloat) {
-    param.initial = args[4].operator float();
+  param.keepdims = args[4].operator bool();
+  if (args[5].type_code() == kDLFloat) {
+    param.initial = args[5].operator float();
   } else {
     param.initial = dmlc::nullopt;
   }
   attrs.op = op;
   attrs.parsed = std::move(param);
-  SetAttrDict<op::NumpyReduceAxesParam>(&attrs);
-  int num_inputs = 1;
-  int num_outputs = 1;
+  SetAttrDict<op::ReduceAxesParam>(&attrs);
+  // inputs
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
-  auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, nullptr);
-  *ret = reinterpret_cast<mxnet::NDArray*>(ndoutputs[0]);
+  int num_inputs = 1;
+  // outputs
+  NDArray* out = args[3].operator mxnet::NDArray*();
+  NDArray** outputs = out == nullptr ? nullptr : &out;
+  int num_outputs = out != nullptr;
+  auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);
+  if (out) {
+    *ret = PythonArg(3);
+  } else {
+    *ret = reinterpret_cast<mxnet::NDArray*>(ndoutputs[0]);
+  }
 });
 
 }  // namespace mxnet

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -184,17 +184,20 @@ MXNET_REGISTER_API("_npi.prod")
   } else {
     param.axis = Tuple<int>(args[1].operator ObjectRef());
   }
+  std::cout<<"!!!!"
   if (args[2].type_code() == kNull) {
     param.dtype = dmlc::nullopt;
   } else {
     param.dtype = String2MXNetProdType(args[2].operator std::string());
   }
-  param.keepdims = args[4].operator bool();
-  if (args[5].type_code() == kNull) {
+  std::cout<<"!!!!"
+  param.keepdims = args[3].operator bool();
+  if (args[4].type_code() == kNull) {
     param.initial = dmlc::nullopt;
   } else {
-    param.initial = args[5].operator double();
+    param.initial = args[4].operator double();
   }
+  std::cout<<"!!!!"
   attrs.op = op;
   attrs.parsed = std::move(param);
   SetAttrDict<op::NumpyReduceAxesParam>(&attrs);
@@ -202,7 +205,7 @@ MXNET_REGISTER_API("_npi.prod")
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   int num_inputs = 1;
   // outputs
-  NDArray* out = args[3].operator mxnet::NDArray*();
+  NDArray* out = args[5].operator mxnet::NDArray*();
   NDArray** outputs = out == nullptr ? nullptr : &out;
   int num_outputs = out != nullptr;
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -178,7 +178,7 @@ MXNET_REGISTER_API("_npi.prod")
   using namespace runtime;
   const nnvm::Op* op = Op::Get("_npi_prod");
   nnvm::NodeAttrs attrs;
-  op::ReduceAxesParam param;
+  op::NumpyReduceAxesParam param;
   if (args[1].type_code() == kNull) {
     param.axis = dmlc::nullopt;
   } else {
@@ -197,7 +197,7 @@ MXNET_REGISTER_API("_npi.prod")
   }
   attrs.op = op;
   attrs.parsed = std::move(param);
-  SetAttrDict<op::ReduceAxesParam>(&attrs);
+  SetAttrDict<op::NumpyReduceAxesParam>(&attrs);
   // inputs
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   int num_inputs = 1;

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -177,21 +177,19 @@ MXNET_REGISTER_API("_npi.prod")
   } else {
     param.initial = args[4].operator double();
   }
-  attrs.op = op;
   attrs.parsed = std::move(param);
+  attrs.op = op;
   SetAttrDict<op::NumpyReduceAxesParam>(&attrs);
-  // inputs
-  NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   int num_inputs = 1;
-  // outputs
-  NDArray* out = args[5].operator mxnet::NDArray*();
+  NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
+  NDArray* out = args[4].operator mxnet::NDArray*();
   NDArray** outputs = out == nullptr ? nullptr : &out;
-  int num_outputs = 1;
+  int num_outputs = out != nullptr;
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);
   if (out) {
-    *ret = PythonArg(5);
+    *ret = PythonArg(4);
   } else {
-    *ret = reinterpret_cast<mxnet::NDArray*>(ndoutputs[0]);
+    *ret = ndoutputs[0];
   }
 });
 

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -25,7 +25,6 @@
 #include <mxnet/api_registry.h>
 #include <mxnet/runtime/packed_func.h>
 #include "../utils.h"
-#include "../../../operator/tensor/broadcast_reduce_op.h"
 #include "../../../operator/numpy/np_broadcast_reduce_op.h"
 
 namespace mxnet {

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -181,23 +181,22 @@ MXNET_REGISTER_API("_npi.prod")
   op::NumpyReduceAxesParam param;
   if (args[1].type_code() == kNull) {
     param.axis = dmlc::nullopt;
+  } else if (args[1].type_code() ==kDLInt) {
+    param.axis = args[1].operator int();
   } else {
     param.axis = Tuple<int>(args[1].operator ObjectRef());
   }
-  std::cout<<"!!!!"
   if (args[2].type_code() == kNull) {
     param.dtype = dmlc::nullopt;
   } else {
     param.dtype = String2MXNetProdType(args[2].operator std::string());
   }
-  std::cout<<"!!!!"
   param.keepdims = args[3].operator bool();
   if (args[4].type_code() == kNull) {
     param.initial = dmlc::nullopt;
   } else {
     param.initial = args[4].operator double();
   }
-  std::cout<<"!!!!"
   attrs.op = op;
   attrs.parsed = std::move(param);
   SetAttrDict<op::NumpyReduceAxesParam>(&attrs);

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -190,10 +190,10 @@ MXNET_REGISTER_API("_npi.prod")
     param.dtype = String2MXNetProdType(args[2].operator std::string());
   }
   param.keepdims = args[4].operator bool();
-  if (args[5].type_code() == kDLFloat) {
-    param.initial = args[5].operator double();
-  } else {
+  if (args[5].type_code() == kNull) {
     param.initial = dmlc::nullopt;
+  } else {
+    param.initial = args[5].operator double();
   }
   attrs.op = op;
   attrs.parsed = std::move(param);

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -182,12 +182,12 @@ MXNET_REGISTER_API("_npi.prod")
   SetAttrDict<op::NumpyReduceAxesParam>(&attrs);
   int num_inputs = 1;
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
-  NDArray* out = args[4].operator mxnet::NDArray*();
+  NDArray* out = args[5].operator mxnet::NDArray*();
   NDArray** outputs = out == nullptr ? nullptr : &out;
   int num_outputs = out != nullptr;
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);
   if (out) {
-    *ret = PythonArg(4);
+    *ret = PythonArg(5);
   } else {
     *ret = ndoutputs[0];
   }

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -203,5 +203,6 @@ MXNET_REGISTER_API("_npi.prod")
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, nullptr);
   *ret = reinterpret_cast<mxnet::NDArray*>(ndoutputs[0]);
-})
+});
+
 }  // namespace mxnet

--- a/src/api/operator/numpy/np_pad_op.cc
+++ b/src/api/operator/numpy/np_pad_op.cc
@@ -82,4 +82,4 @@ MXNET_REGISTER_API("_npi.pad")
   *ret = reinterpret_cast<mxnet::NDArray*>(ndoutputs[0]);
 });
 
-}
+}  // namespace mxnet

--- a/src/api/operator/numpy/np_pad_op.cc
+++ b/src/api/operator/numpy/np_pad_op.cc
@@ -76,7 +76,7 @@ MXNET_REGISTER_API("_npi.pad")
   attrs.parsed = std::move(param);
   SetAttrDict<op::NumpyPadParam>(&attrs);
   int num_inputs = 1;
-  int num_outputs = 1;
+  int num_outputs = 0;
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, nullptr);
   *ret = reinterpret_cast<mxnet::NDArray*>(ndoutputs[0]);

--- a/src/api/operator/numpy/np_pad_op.cc
+++ b/src/api/operator/numpy/np_pad_op.cc
@@ -46,7 +46,7 @@ MXNET_REGISTER_API("_npi.pad")
   param.pad_width = Tuple<Tuple<int>>(temp.begin(), temp.end());
   param.mode = args[2].operator int();
   if (args[3].type_code() != kNull) {
-    param.constant_value = args[3].operator double();
+    param.constant_values = args[3].operator double();
   }
   if (args[4].type_code() != kNull) {
     param.reflect_type = args[3].operator std::string();

--- a/src/api/operator/numpy/np_pad_op.cc
+++ b/src/api/operator/numpy/np_pad_op.cc
@@ -1,0 +1,64 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file np_pad_op.cc
+ * \brief Implementation of the API of functions in src/operator/numpy/np_pad_op.cc
+ */
+#include <dmlc/optional.h>
+#include <mxnet/api_registry.h>
+#include <mxnet/runtime/packed_func.h>
+#include "../utils.h"
+#include "../../../operator/numpy/np_pad_op-inl.h"
+
+namespace mxnet {
+
+MXNET_REGISTER_API("_npi.pad")
+.set_body([](runtime::MXNetArgs args, runtime::MXNetRetValue* ret) {
+  using namespace runtime;
+  const nnvm::Op* op = Op::Get("_npi_pad");
+  nnvm::NodeAttrs attrs;
+  op::NumpyPadParam param;
+  ADT adt = Downcast<ADT, ObjectRef>(args[1].operator ObjectRef());
+  int ndim = adt.size();
+  std::vector<mxnet::Tuple<int>> temp;
+  int counter = 0;
+  for (counter = 0; counter < ndim; counter++) {
+    temp.push_back(mxnet::Tuple<int>(adt[counter]));
+  }
+  param.pad_width = Tuple<Tuple<int>>(temp.begin(), temp.end());
+  param.mode = args[2].operator int();
+  if (args[3].type_code() != kNull) {
+    param.constant_value = args[3].operator double();
+  }
+  if (args[4].type_code() != kNull) {
+    param.reflect_type = args[3].operator std::string();
+  }
+  attrs.op = op;
+  attrs.parsed = std::move(param);
+  SetAttrDict<op::NumpyPadParam>(&attrs);
+  int num_inputs = 1;
+  int num_outputs = 1;
+  NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
+  auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, nullptr);
+  *ret = reinterpret_cast<mxnet::NDArray*>(ndoutputs[0]);
+});
+
+}

--- a/src/api/operator/numpy/np_pad_op.cc
+++ b/src/api/operator/numpy/np_pad_op.cc
@@ -30,6 +30,27 @@
 
 namespace mxnet {
 
+inline int String2MXNetPadType(const std::string& s) {
+  using namespace op;
+  if (s == "constant") {
+    return pad_enum::kConstant;
+  } else if (s == "edge") {
+    return pad_enum::kEdge;
+  } else if (s == "reflect") {
+    return pad_enum::kReflect;
+  } else if (s == "symmetric") {
+    return pad_enum::kSymmetric;
+  } else if (s == "maximum") {
+    return pad_enum::kMaximum;
+  } else if (s == "minimum") {
+    return pad_enum::kMinimum;
+  } else {
+    LOG(FATAL) << "unknown type " << s;
+  }
+  LOG(FATAL) << "should not reach here ";
+  return 0;
+}
+
 MXNET_REGISTER_API("_npi.pad")
 .set_body([](runtime::MXNetArgs args, runtime::MXNetRetValue* ret) {
   using namespace runtime;
@@ -44,7 +65,7 @@ MXNET_REGISTER_API("_npi.pad")
     temp.push_back(mxnet::Tuple<int>(adt[counter]));
   }
   param.pad_width = Tuple<Tuple<int>>(temp.begin(), temp.end());
-  param.mode = args[2].operator int();
+  param.mode = String2MXNetPadType(args[2].operator std::string());
   if (args[3].type_code() != kNull) {
     param.constant_values = args[3].operator double();
   }

--- a/src/api/operator/numpy/np_pad_op.cc
+++ b/src/api/operator/numpy/np_pad_op.cc
@@ -46,7 +46,7 @@ MXNET_REGISTER_API("_npi.pad")
   param.pad_width = Tuple<Tuple<int>>(temp.begin(), temp.end());
   param.mode = args[2].operator int();
   if (args[3].type_code() != kNull) {
-    param.constant_values = args[3].operator double();
+    param.constant_value = args[3].operator double();
   }
   if (args[4].type_code() != kNull) {
     param.reflect_type = args[3].operator std::string();

--- a/src/api/operator/numpy/np_pad_op.cc
+++ b/src/api/operator/numpy/np_pad_op.cc
@@ -44,9 +44,9 @@ MXNET_REGISTER_API("_npi.pad")
     temp.push_back(mxnet::Tuple<int>(adt[counter]));
   }
   param.pad_width = Tuple<Tuple<int>>(temp.begin(), temp.end());
-  param.mode = args[2].operator std::string();
+  param.mode = args[2].operator int();
   if (args[3].type_code() != kNull) {
-    param.constant_value = args[3].operator double();
+    param.constant_values = args[3].operator double();
   }
   if (args[4].type_code() != kNull) {
     param.reflect_type = args[3].operator std::string();

--- a/src/api/operator/numpy/np_pad_op.cc
+++ b/src/api/operator/numpy/np_pad_op.cc
@@ -44,7 +44,7 @@ MXNET_REGISTER_API("_npi.pad")
     temp.push_back(mxnet::Tuple<int>(adt[counter]));
   }
   param.pad_width = Tuple<Tuple<int>>(temp.begin(), temp.end());
-  param.mode = args[2].operator int();
+  param.mode = args[2].operator std::string();
   if (args[3].type_code() != kNull) {
     param.constant_value = args[3].operator double();
   }

--- a/src/api/operator/numpy/np_pad_op.cc
+++ b/src/api/operator/numpy/np_pad_op.cc
@@ -70,7 +70,7 @@ MXNET_REGISTER_API("_npi.pad")
     param.constant_values = args[3].operator double();
   }
   if (args[4].type_code() != kNull) {
-    param.reflect_type = args[3].operator std::string();
+    param.reflect_type = args[4].operator std::string();
   }
   attrs.op = op;
   attrs.parsed = std::move(param);

--- a/src/api/operator/numpy/np_pad_op.cc
+++ b/src/api/operator/numpy/np_pad_op.cc
@@ -62,7 +62,7 @@ MXNET_REGISTER_API("_npi.pad")
   std::vector<mxnet::Tuple<int>> temp;
   int counter = 0;
   for (counter = 0; counter < ndim; counter++) {
-    temp.push_back(mxnet::Tuple<int>(adt[counter]));
+    temp.emplace_back(mxnet::Tuple<int>(adt[counter]));
   }
   param.pad_width = Tuple<Tuple<int>>(temp.begin(), temp.end());
   param.mode = String2MXNetPadType(args[2].operator std::string());

--- a/src/operator/numpy/np_broadcast_reduce_op.h
+++ b/src/operator/numpy/np_broadcast_reduce_op.h
@@ -36,29 +36,6 @@
 namespace mxnet {
 namespace op {
 
-inline std::string MXNetReduceAxesType2String(const int s) {
-  using namespace op;
-  if (s == mshadow::kFloat16) {
-    return "float16";
-  } else if (s == mshadow::kFloat32) {
-    return "float32";
-  } else if (s == mshadow::kFloat64) {
-    return "float64";
-  } else if (s == mshadow::kInt8) {
-    return "int8";
-  } else if (s == mshadow::kInt32) {
-    return "int32";
-  } else if (s == mshadow::kInt64) {
-    return "int64";
-  } else if (s == mshadow::kBool) {
-    return "bool";
-  } else {
-    LOG(FATAL) << "unknown type " << s;
-  }
-  LOG(FATAL) << "should not reach here ";
-  return 0;
-}
-
 struct NumpyReduceAxesParam : public dmlc::Parameter<NumpyReduceAxesParam> {
   dmlc::optional<mxnet::Tuple<int>> axis;
   dmlc::optional<int> dtype;

--- a/src/operator/numpy/np_broadcast_reduce_op.h
+++ b/src/operator/numpy/np_broadcast_reduce_op.h
@@ -94,7 +94,6 @@ struct NumpyReduceAxesParam : public dmlc::Parameter<NumpyReduceAxesParam> {
   void SetAttrDict(std::unordered_map<std::string, std::string>* dict) {
     std::ostringstream axis_s, dtype_s, keepdims_s, initial_s;
     axis_s << axis;
-    //
     dtype_s << dtype;
     keepdims_s << keepdims;
     initial_s << initial;

--- a/src/operator/numpy/np_broadcast_reduce_op.h
+++ b/src/operator/numpy/np_broadcast_reduce_op.h
@@ -36,7 +36,7 @@
 namespace mxnet {
 namespace op {
 
-inline std::string MXNetReduceAxesType2String(const int s) {
+inline std::string MXNetReduceAxesType2String(const dmlc::optional<int> s) {
   using namespace op;
   if (s == mshadow::kFloat16) {
     return "float16";

--- a/src/operator/numpy/np_broadcast_reduce_op.h
+++ b/src/operator/numpy/np_broadcast_reduce_op.h
@@ -36,6 +36,29 @@
 namespace mxnet {
 namespace op {
 
+inline std::string MXNetReduceAxesType2String(const int s) {
+  using namespace op;
+  if (s == mshadow::kFloat16) {
+    return "float16";
+  } else if (s == mshadow::kFloat32) {
+    return "float32";
+  } else if (s == mshadow::kFloat64) {
+    return "float64";
+  } else if (s == mshadow::kInt8) {
+    return "int8";
+  } else if (s == mshadow::kInt32) {
+    return "int32";
+  } else if (s == mshadow::kInt64) {
+    return "int64";
+  } else if (s == mshadow::kBool) {
+    return "bool";
+  } else {
+    LOG(FATAL) << "unknown type " << s;
+  }
+  LOG(FATAL) << "should not reach here ";
+  return 0;
+}
+
 struct NumpyReduceAxesParam : public dmlc::Parameter<NumpyReduceAxesParam> {
   dmlc::optional<mxnet::Tuple<int>> axis;
   dmlc::optional<int> dtype;

--- a/src/operator/numpy/np_broadcast_reduce_op.h
+++ b/src/operator/numpy/np_broadcast_reduce_op.h
@@ -94,6 +94,7 @@ struct NumpyReduceAxesParam : public dmlc::Parameter<NumpyReduceAxesParam> {
   void SetAttrDict(std::unordered_map<std::string, std::string>* dict) {
     std::ostringstream axis_s, dtype_s, keepdims_s, initial_s;
     axis_s << axis;
+    //
     dtype_s << dtype;
     keepdims_s << keepdims;
     initial_s << initial;

--- a/src/operator/numpy/np_broadcast_reduce_op.h
+++ b/src/operator/numpy/np_broadcast_reduce_op.h
@@ -36,7 +36,7 @@
 namespace mxnet {
 namespace op {
 
-inline std::string MXNetReduceAxesType2String(const dmlc::optional<int> s) {
+inline std::string MXNetReduceAxesType2String(const int s) {
   using namespace op;
   if (s == mshadow::kFloat16) {
     return "float16";

--- a/src/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -223,7 +223,7 @@ NNVM_REGISTER_OP(_backward_np_min)
 .set_num_inputs(3)
 .set_attr<FCompute>("FCompute<cpu>", NumpyReduceAxesNoDTypeBackward<cpu, mshadow_op::eq>);
 
-NNVM_REGISTER_OP(_np_prod)
+NNVM_REGISTER_OP(_npi_prod)
 .add_alias("_np_product")
 .set_num_inputs(1)
 .set_num_outputs(1)
@@ -244,7 +244,7 @@ NNVM_REGISTER_OP(_np_prod)
 .set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
 .set_attr<nnvm::FGradient>("FGradient", ReduceGrad{"_backward_np_prod"});
 
-NNVM_REGISTER_OP(_backward_np_prod)
+NNVM_REGISTER_OP(_backward_npi_prod)
 .set_num_inputs(3)
 .set_num_outputs(1)
 .set_attr_parser(ParamParser<NumpyReduceAxesParam>)

--- a/src/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -242,7 +242,7 @@ NNVM_REGISTER_OP(_npi_prod)
     return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
   })
 .set_attr<THasDeterministicOutput>("THasDeterministicOutput", true)
-.set_attr<nnvm::FGradient>("FGradient", ReduceGrad{"_backward_np_prod"});
+.set_attr<nnvm::FGradient>("FGradient", ReduceGrad{"_backward_npi_prod"});
 
 NNVM_REGISTER_OP(_backward_npi_prod)
 .set_num_inputs(3)

--- a/src/operator/numpy/np_broadcast_reduce_op_value.cu
+++ b/src/operator/numpy/np_broadcast_reduce_op_value.cu
@@ -44,10 +44,10 @@ NNVM_REGISTER_OP(_np_min)
 NNVM_REGISTER_OP(_backward_np_min)
 .set_attr<FCompute>("FCompute<gpu>", NumpyReduceAxesNoDTypeBackward<gpu, mshadow_op::eq>);
 
-NNVM_REGISTER_OP(_np_prod)
+NNVM_REGISTER_OP(_npi_prod)
 .set_attr<FCompute>("FCompute<gpu>", NumpyReduceAxesCompute<gpu, mshadow_op::product, true>);
 
-NNVM_REGISTER_OP(_backward_np_prod)
+NNVM_REGISTER_OP(_backward_npi_prod)
 .set_attr<FCompute>("FCompute<gpu>", NumpyReduceAxesBackwardUseInOut<gpu, mshadow_op::rdiv>);
 
 NNVM_REGISTER_OP(_npi_average)

--- a/src/operator/numpy/np_pad_op-inl.h
+++ b/src/operator/numpy/np_pad_op-inl.h
@@ -143,11 +143,9 @@ struct NumpyPadParam : public dmlc::Parameter<NumpyPadParam> {
                   "the extended part of the array is created by subtracting the "
                   "reflected values from two times the edge value.");
   }
-  // Added SetAttrDict function here
   void SetAttrDict(std::unordered_map<std::string, std::string>* dict) {
     std::ostringstream pad_width_s, mode_s, constant_values_s, reflect_type_s;
     pad_width_s << pad_width;
-    // mode_s << mode;
     constant_values_s << constant_values;
     reflect_type_s << reflect_type;
     (*dict)["pad_width"] = pad_width_s.str();

--- a/src/operator/numpy/np_pad_op-inl.h
+++ b/src/operator/numpy/np_pad_op-inl.h
@@ -122,6 +122,18 @@ struct NumpyPadParam : public dmlc::Parameter<NumpyPadParam> {
                   "the extended part of the array is created by subtracting the "
                   "reflected values from two times the edge value.");
   }
+  // Added SetAttrDict function here
+  void SetAttrDict(std::unordered_map<std::string, std::string>* dict) {
+    std::ostringstream pad_width_s, mode_s, constant_value_s, reflect_type_s;
+    pad_width_s << pad_width;
+    mode_s << mode;
+    constant_value_s << constant_value;
+    reflect_type_s << reflect_type;
+    (*dict)["pad_width"] = pad_width_s.str();
+    (*dict)["mode"] = mode_s.str();
+    (*dict)["constant_value"] = constant_value_s.str();
+    (*dict)["reflect_type"] = reflect_type_s.str();
+  }
 };
 
 inline mxnet::TShape NumpyPadShapeImpl(const mxnet::TShape& ishape,

--- a/src/operator/numpy/np_pad_op-inl.h
+++ b/src/operator/numpy/np_pad_op-inl.h
@@ -74,7 +74,7 @@ enum PadOpType { kConstant, kEdge, kReflect, kSymmetric, kMinimum, kMaximum };
 struct NumpyPadParam : public dmlc::Parameter<NumpyPadParam> {
   mxnet::Tuple<mxnet::Tuple<int>> pad_width;
   int mode;
-  double constant_value;
+  double constant_values;
   std::string reflect_type;
   DMLC_DECLARE_PARAMETER(NumpyPadParam) {
     DMLC_DECLARE_FIELD(pad_width)
@@ -95,7 +95,7 @@ struct NumpyPadParam : public dmlc::Parameter<NumpyPadParam> {
         .set_default(pad_enum::kConstant)
         .describe(
             "Padding type to use."
-            " \"constant\" pads with `constant_value`"
+            " \"constant\" pads with `constant_values`"
             " \"edge\" pads using the edge values of the input array"
             " \"reflect\" Pads with the reflection of the vector mirrored"
             "on the first and last values of the vector along each axis."
@@ -105,7 +105,7 @@ struct NumpyPadParam : public dmlc::Parameter<NumpyPadParam> {
             "vector along each axis."
             " \"minimum\" Pads with the minimum value of all or part of the"
             "vector along each axis.");
-    DMLC_DECLARE_FIELD(constant_value)
+    DMLC_DECLARE_FIELD(constant_values)
         .set_default(0.0)
         .describe("Used in ‘constant’. The values to set the padded values for each axis."
                   "((before_1, after_1), ... (before_N, after_N)) unique pad constants for"
@@ -124,14 +124,14 @@ struct NumpyPadParam : public dmlc::Parameter<NumpyPadParam> {
   }
   // Added SetAttrDict function here
   void SetAttrDict(std::unordered_map<std::string, std::string>* dict) {
-    std::ostringstream pad_width_s, mode_s, constant_value_s, reflect_type_s;
+    std::ostringstream pad_width_s, mode_s, constant_values_s, reflect_type_s;
     pad_width_s << pad_width;
     mode_s << mode;
-    constant_value_s << constant_value;
+    constant_values_s << constant_values;
     reflect_type_s << reflect_type;
     (*dict)["pad_width"] = pad_width_s.str();
     (*dict)["mode"] = mode_s.str();
-    (*dict)["constant_value"] = constant_value_s.str();
+    (*dict)["constant_values"] = constant_values_s.str();
     (*dict)["reflect_type"] = reflect_type_s.str();
   }
 };
@@ -161,7 +161,7 @@ struct constant_pad {
                                   const index_t* ishape,
                                   const index_t* oshape,
                                   mshadow::Shape<ndim*2> width,
-                                  double constant_value) {
+                                  double constant_values) {
     using namespace mxnet_op;
     auto j = uunravel<ndim>(i, oshape);
     size_t m;
@@ -173,7 +173,7 @@ struct constant_pad {
         continue;
       } else {
         origin = false;
-        KERNEL_ASSIGN(out[i], req, constant_value);
+        KERNEL_ASSIGN(out[i], req, constant_values);
       }
     }
     if (origin) {
@@ -566,7 +566,7 @@ void NumpyPadOpImpl(const TBlob& in_data,
             MXNET_ASSIGN_REQ_SWITCH(req[0], req_type, {
               Kernel<constant_pad<xpu, req_type, NDim>, xpu>::Launch(
                 s, dsize, out_data.dptr<DType>(), in_data.dptr<DType>(),
-                idptr, odptr, width, param.constant_value);
+                idptr, odptr, width, param.constant_values);
             });
           });
           // constant padding end

--- a/src/operator/numpy/np_pad_op-inl.h
+++ b/src/operator/numpy/np_pad_op-inl.h
@@ -67,6 +67,27 @@ MSHADOW_XINLINE mshadow::Shape<ndim> uunravel(const int idx,
   return ret;
 }
 
+inline std::string MXNetPadType2String(const int s) {
+  using namespace op;
+  if (s == pad_enum::kConstant) {
+    return "constant";
+  } else if (s == pad_enum::kEdge) {
+    return "edge";
+  } else if (s == pad_enum::kReflect) {
+    return "reflect";
+  } else if (s == pad_enum::kSymmetric) {
+    return "symmetric";
+  } else if (s == pad_enum::kMaximum) {
+    return "maximum";
+  } else if (s == pad_enum::kMinimum) {
+    return "minimum";
+  } else {
+    LOG(FATAL) << "unknown type " << s;
+  }
+  LOG(FATAL) << "should not reach here ";
+  return 0;
+}
+
 namespace pad_enum {
 enum PadOpType { kConstant, kEdge, kReflect, kSymmetric, kMinimum, kMaximum };
 }
@@ -126,11 +147,11 @@ struct NumpyPadParam : public dmlc::Parameter<NumpyPadParam> {
   void SetAttrDict(std::unordered_map<std::string, std::string>* dict) {
     std::ostringstream pad_width_s, mode_s, constant_values_s, reflect_type_s;
     pad_width_s << pad_width;
-    mode_s << mode;
+    // mode_s << mode;
     constant_values_s << constant_values;
     reflect_type_s << reflect_type;
     (*dict)["pad_width"] = pad_width_s.str();
-    (*dict)["mode"] = mode_s.str();
+    (*dict)["mode"] = MXNetPadType2String(mode);
     (*dict)["constant_values"] = constant_values_s.str();
     (*dict)["reflect_type"] = reflect_type_s.str();
   }

--- a/src/operator/numpy/np_pad_op-inl.h
+++ b/src/operator/numpy/np_pad_op-inl.h
@@ -41,6 +41,10 @@
 namespace mxnet {
 namespace op {
 
+namespace pad_enum {
+enum PadOpType { kConstant, kEdge, kReflect, kSymmetric, kMinimum, kMaximum };
+}
+
 template <int ndim>
 MSHADOW_XINLINE index_t rravel(const mshadow::Shape<ndim>& coord,
                                const index_t* shape) {
@@ -86,10 +90,6 @@ inline std::string MXNetPadType2String(const int s) {
   }
   LOG(FATAL) << "should not reach here ";
   return 0;
-}
-
-namespace pad_enum {
-enum PadOpType { kConstant, kEdge, kReflect, kSymmetric, kMinimum, kMaximum };
 }
 
 struct NumpyPadParam : public dmlc::Parameter<NumpyPadParam> {


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
