### PR TITLE
Fix ci/docker_cache.py

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -71,7 +71,7 @@ def get_docker_binary(use_nvidia_docker: bool) -> str:
 
 
 def build_docker(platform: str, docker_binary: str, registry: str, num_retries: int, no_cache: bool,
-                 cache_intermediate: bool) -> str:
+                 cache_intermediate: bool = False) -> str:
     """
     Build a container for the given platform
     :param platform: Platform

--- a/ci/docker/Dockerfile.build.ubuntu_nightly_cpu
+++ b/ci/docker/Dockerfile.build.ubuntu_nightly_cpu
@@ -42,6 +42,9 @@ RUN /work/ubuntu_perl.sh
 COPY install/ubuntu_clang.sh /work/
 RUN /work/ubuntu_clang.sh
 
+COPY install/ubuntu_gcc8.sh /work/
+RUN /work/ubuntu_gcc8.sh
+
 COPY install/ubuntu_caffe.sh /work/
 RUN /work/ubuntu_caffe.sh
 

--- a/ci/docker/Dockerfile.build.ubuntu_nightly_gpu
+++ b/ci/docker/Dockerfile.build.ubuntu_nightly_gpu
@@ -42,6 +42,9 @@ RUN /work/ubuntu_perl.sh
 COPY install/ubuntu_clang.sh /work/
 RUN /work/ubuntu_clang.sh
 
+COPY install/ubuntu_gcc8.sh /work/
+RUN /work/ubuntu_gcc8.sh
+
 COPY install/ubuntu_tvm.sh /work/
 RUN /work/ubuntu_tvm.sh
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -2084,6 +2084,7 @@ publish_scala_build() {
     pushd .
     scala_prepare
     source /opt/rh/devtoolset-7/enable
+    export USE_SYSTEM_CUDA=1
     ./ci/publish/scala/build.sh
     popd
 }

--- a/julia/deps/build.jl
+++ b/julia/deps/build.jl
@@ -33,7 +33,7 @@ if haskey(ENV, "MXNET_HOME")
   # In case of macOS, if user build libmxnet from source and set the MXNET_HOME,
   # the output is still named as `libmxnet.so`.
   lib = Libdl.find_library(["libmxnet.$(Libdl.dlext)", "libmxnet.so"],
-                           [joinpath(MXNET_HOME, "lib"), MXNET_HOME])
+                           [joinpath(MXNET_HOME, "lib"), joinpath(MXNET_HOME, "build"), MXNET_HOME])
   if !isempty(lib)
     @info("Existing libmxnet detected at $lib, skip building...")
     libmxnet_detected = true

--- a/julia/src/base.jl
+++ b/julia/src/base.jl
@@ -42,6 +42,7 @@ const grad_req_map = Dict{Symbol,GRAD_REQ}(
 ################################################################################
 const MXNET_LIB = Libdl.find_library(["libmxnet.$(Libdl.dlext)", "libmxnet.so"],  # see build.jl
                                      [joinpath(get(ENV, "MXNET_HOME", ""), "lib"),
+                                      joinpath(get(ENV, "MXNET_HOME", ""), "build"),
                                       get(ENV, "MXNET_HOME", ""),
                                       joinpath(@__DIR__, "..",
                                                "deps", "usr", "lib")])


### PR DESCRIPTION
## Description ##
https://github.com/apache/incubator-mxnet/pull/17984 added a `cache_intermediate` option to `build_docker` enabling developers to speed up local docker builds during development. As no default value was provided, this broke the use of `build_docker` function in other places.

Reference: Failing `ci/jenkins/restricted-docker-cache-refresh` on master after merge: http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-docker-cache-refresh/detail/master/2789/pipeline

Also

Fixes https://github.com/apache/incubator-mxnet/issues/18061