### PR TITLE
[Website 2.0] Fix RVM version to satisfy Jekyll build in v1.7.x

### DIFF
--- a/ci/docker/Dockerfile.build.ubuntu_cpu_jekyll
+++ b/ci/docker/Dockerfile.build.ubuntu_cpu_jekyll
@@ -43,7 +43,7 @@ RUN curl -sSL https://rvm.io/mpapis.asc | gpg2 --import - && \
 
 RUN source /etc/profile.d/rvm.sh && \
     rvm requirements && \
-    rvm install 2.6 && \
+    rvm install 2.6.3 && \
     rvm use 2.6.3 --default
 
 ENV BUNDLE_HOME=/work/deps/bundle


### PR DESCRIPTION
## Description ##
Backporting my fix from master and v1.x to v1.7.x to fix Jekyll builds. See #18016 and #17948.

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- M ci/docker/Dockerfile.build.ubuntu_cpu_jekyll

@samskalicky 