### PR TITLE
Add gelu fuse ops

### DIFF
--- a/src/executor/pointwise_fusion_pass.cc
+++ b/src/executor/pointwise_fusion_pass.cc
@@ -71,6 +71,20 @@ namespace {
                   op_name) !=
         variable_io_ops.end())
       return true;
+    if (op_name == "LeakyReLU"){
+        std::string act_type = n->attrs.dict.at("act_type");
+        if (LeakyReLU_ops.count(act_type))
+          return true;
+        else
+          return false;
+    }
+    if (op_name == "_backward_LeakyReLU"){
+        std::string act_type = n->attrs.dict.at("act_type");
+        if (LeakyReLU_bwd_ops.count(act_type))
+          return true;
+        else
+          return false;
+    }
     return false;
   }
 

--- a/src/executor/pointwise_fusion_pass.cc
+++ b/src/executor/pointwise_fusion_pass.cc
@@ -71,14 +71,14 @@ namespace {
                   op_name) !=
         variable_io_ops.end())
       return true;
-    if (op_name == "LeakyReLU"){
+    if (op_name == "LeakyReLU") {
         std::string act_type = n->attrs.dict.at("act_type");
         if (LeakyReLU_ops.count(act_type))
           return true;
         else
           return false;
     }
-    if (op_name == "_backward_LeakyReLU"){
+    if (op_name == "_backward_LeakyReLU") {
         std::string act_type = n->attrs.dict.at("act_type");
         if (LeakyReLU_bwd_ops.count(act_type))
           return true;

--- a/src/operator/fusion/fused_op-inl.h
+++ b/src/operator/fusion/fused_op-inl.h
@@ -232,7 +232,6 @@ const std::map<std::string, std::vector<std::vector<std::string>>> LeakyReLU_bwd
   {"gelu"                              , {{"op::backward_gelu(%, %)", "_1", "_0"}}},
 };
 
-
 const std::map<std::string, std::string> slice_ops = {
   {"slice_axis"   , ""},
   {"slice"   , ""},
@@ -552,7 +551,7 @@ __device__ inline DType relu(const DType val) {
   return val > 0 ? val : 0;
 }
 
-__constant__ const float SQRT_2 = 1.4142135623730950488016887242096;
+const float SQRT_2 = 1.4142135623730950488016887242096;
 template <typename DType>
 __device__ inline DType gelu(const DType val) {
   return DType(0.5f * static_cast<float>(val) *

--- a/src/operator/fusion/fused_op-inl.h
+++ b/src/operator/fusion/fused_op-inl.h
@@ -552,6 +552,7 @@ __device__ inline DType relu(const DType val) {
 }
 
 const float SQRT_2 = 1.4142135623730950488016887242096;
+// compatible with mshadow_op.h version
 template <typename DType>
 __device__ inline DType gelu(const DType val) {
   return DType(0.5f * static_cast<float>(val) *
@@ -1002,6 +1003,7 @@ __device__ inline DTypeGrad backward_smooth_l1(const DType val, const DType2 sca
   }
 }
 
+// compatible with mshadow_op.h version
 template <typename DType, typename DTypeGrad>
 __device__ inline DTypeGrad backward_gelu(const DType val, const DTypeGrad grad) {
   return grad * DType(0.5f * (1.0f + erf(static_cast<float>(val) / SQRT_2) +

--- a/src/operator/fusion/fused_op.cu
+++ b/src/operator/fusion/fused_op.cu
@@ -463,7 +463,8 @@ std::string FusedOp::GenerateCode(const std::vector<OpReqType> &req,
         // LeakyReLU, look for act_type
         if (op_name == "LeakyReLU") {
             std::string act_type = node.source->attrs.dict.at("act_type");
-            const std::vector<std::vector<std::string>>& op_descs = fusion::LeakyReLU_ops.at(act_type);
+            const std::vector<std::vector<std::string>>& op_descs =
+                fusion::LeakyReLU_ops.at(act_type);
             if (fusion::LeakyReLU_ops.find(act_type) != fusion::LeakyReLU_ops.end()) {
               CHECK_EQ(outputs[i], op_descs.size());
               size_t count = 0;
@@ -479,7 +480,8 @@ std::string FusedOp::GenerateCode(const std::vector<OpReqType> &req,
         }
         if (op_name == "_backward_LeakyReLU") {
             std::string act_type = node.source->attrs.dict.at("act_type");
-            const std::vector<std::vector<std::string>>& op_descs = fusion::LeakyReLU_bwd_ops.at(act_type);
+            const std::vector<std::vector<std::string>>& op_descs =
+                fusion::LeakyReLU_bwd_ops.at(act_type);
             if (fusion::LeakyReLU_ops.find(act_type) != fusion::LeakyReLU_bwd_ops.end()) {
               CHECK_EQ(outputs[i], op_descs.size());
               size_t count = 0;

--- a/tests/python/gpu/test_fusion.py
+++ b/tests/python/gpu/test_fusion.py
@@ -230,11 +230,24 @@ def check_other_ops():
     arr2 = mx.random.uniform(shape=(2,2,2,3))
     check_fused_symbol(mx.sym.broadcast_like(a, b, lhs_axes=[0], rhs_axes=[0]), a=arr1, b=arr2)
 
+def check_leakyrelu_ops():
+    a = mx.sym.Variable('a')
+    b = mx.sym.Variable('b')
+    shape = rand_shape_2d()
+    arr1 = mx.random.uniform(shape=shape)
+    arr2 = mx.random.uniform(shape=shape)
+
+    # Testing gelu
+    print("Checking fusion of LeakyReLU:gelu")
+    check_fused_symbol(mx.sym.LeakyReLU(a+b, act_type='gelu'), a=arr1, b=arr2)
+
+
 @with_seed()
 def test_fusion():
     check_unary_ops()
     check_binary_ops()
     check_other_ops()
+    check_leakyrelu_ops()
 
 @with_seed()
 def test_fusion_compiler_cache():


### PR DESCRIPTION
## Description ##
This PR adds into elementwise fused-operators LeakyReLU:gelu

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] In pointwise fusion pass, set as fusion-compatible both LeakyReLU and _backward_LeakyReLU if activation type is in the provided list (only "gelu" for now)
- [x] In the fused-ops code generator, include functions for LeakyReLU:gelu and _backward_LeakyReLU:gelu (they are equivalent to mshadow_op.h version)
- [x] Included test into tests/python/gpu/test_fusion.py

## Comments ##
