### PR TITLE
Include broadcast_add into fused operators

### DIFF
--- a/src/executor/pointwise_fusion_pass.cc
+++ b/src/executor/pointwise_fusion_pass.cc
@@ -105,6 +105,8 @@ namespace {
       }
       return true;
     }
+    if (broadcast_ops.count(op_name))
+      return true;
     return false;
   }
 

--- a/src/operator/fusion/fused_op-inl.h
+++ b/src/operator/fusion/fused_op-inl.h
@@ -239,6 +239,10 @@ const std::map<std::string, std::string> slice_ops = {
   {"broadcast_like"   , ""},
 };
 
+const std::map<std::string, std::string> broadcast_ops = {
+  {"broadcast_add"   , "add"}
+};
+
 const std::vector<std::string> variable_io_ops = {
   "add_n",
   "_backward_Activation",


### PR DESCRIPTION
## Description ##
This PR includes broadcast_add into fused operators (still to complete)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.

- [ ] Changes are complete (i.e. I finished coding on this PR): 
Does not work in case input0_dims =! input1_dims => need to expand_dims of smaller input (in progress)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
Still to include
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Created a new list of fused compatible ops (InputsOnly) for broadcast ops. For now only added broadcast_add
- [x] Generation of code for  broadcast ops was included.

## Comments ##
TODO: 
- Expand the dimension of inputs when input0_dims =! input1_dims
- Include test