### PR TITLE
Fix description of setting Debug build type for cmake

### DIFF
--- a/config/darwin.cmake
+++ b/config/darwin.cmake
@@ -62,8 +62,6 @@ set(USE_TVM_OP OFF CACHE BOOL "Enable use of TVM operator build system.")
 # set(CMAKE_CXX_COMPILER "" CACHE BOOL "C++ compiler")
 # set(CMAKE_CUDA_COMPILER "" CACHE BOOL "Cuda compiler (nvcc)")
 
-# Uncomment the following line to compile with debug information
-# set(CMAKE_BUILD_TYPE Debug CACHE STRING "CMake build type")
 
 #---------------------------------------------
 # CPU instruction sets: The support is autodetected if turned ON

--- a/config/linux.cmake
+++ b/config/linux.cmake
@@ -80,8 +80,6 @@ set(USE_TVM_OP OFF CACHE BOOL "Enable use of TVM operator build system.")
 # set(CMAKE_CXX_COMPILER "" CACHE BOOL "C++ compiler")
 # set(CMAKE_CUDA_COMPILER "" CACHE BOOL "Cuda compiler (nvcc)")
 
-# Uncomment the following line to compile with debug information
-# set(CMAKE_BUILD_TYPE Debug CACHE STRING "CMake build type")
 
 #---------------------------------------------
 # CPU instruction sets: The support is autodetected if turned ON

--- a/config/linux_gpu.cmake
+++ b/config/linux_gpu.cmake
@@ -80,8 +80,6 @@ set(USE_TVM_OP OFF CACHE BOOL "Enable use of TVM operator build system.")
 # set(CMAKE_CXX_COMPILER "" CACHE BOOL "C++ compiler")
 # set(CMAKE_CUDA_COMPILER "" CACHE BOOL "Cuda compiler (nvcc)")
 
-# Uncomment the following line to compile with debug information
-# set(CMAKE_BUILD_TYPE Debug CACHE STRING "CMake build type")
 
 #---------------------------------------------
 # CPU instruction sets: The support is autodetected if turned ON

--- a/docs/static_site/src/pages/get_started/osx_setup.md
+++ b/docs/static_site/src/pages/get_started/osx_setup.md
@@ -114,6 +114,9 @@ cmake -GNinja ..
 cmake --build .
 ```
 
+Specify `cmake -DCMAKE_BUILD_TYPE=Debug -GNinja ..` if you wish to build the
+Debug version.
+
 Specify `cmake --build . --parallel N` to set the number of parallel compilation
 jobs. Default is derived from CPUs available.
 

--- a/docs/static_site/src/pages/get_started/ubuntu_setup.md
+++ b/docs/static_site/src/pages/get_started/ubuntu_setup.md
@@ -134,6 +134,9 @@ cmake -GNinja ..
 cmake --build .
 ```
 
+Specify `cmake -DCMAKE_BUILD_TYPE=Debug -GNinja ..` if you wish to build the
+Debug version.
+
 Specify `cmake --build . --parallel N` to set the number of parallel compilation
 jobs. Default is derived from CPUs available.
 


### PR DESCRIPTION
## Description ##
Setting CMAKE_BUILD_TYPE in config.cmake not works properly as the
config file is read too late. Instead, ask user to setup build type
from the command line to generate proper cache file.

It fixes #18091 
Thanks @leezu 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

