### PR TITLE
If sanity build is not found, wait until Jenkins recognizes it.

### DIFF
--- a/ci/jenkins/Jenkinsfile_full
+++ b/ci/jenkins/Jenkinsfile_full
@@ -21,7 +21,7 @@
 // See documents at https://jenkins.io/doc/book/pipeline/jenkinsfile/
 
 // timeout in minutes
-max_time = 180
+def max_time = 30
 
 def buildJobs = [
     'centos-cpu',
@@ -38,22 +38,24 @@ def buildJobs = [
 
 
 stage("full-build") {
-    // get the base path by removing build and branch portions
-    def jobPath = JOB_NAME.split('/')
-    def pipelineName = jobPath[0..jobPath.size()-3].join('/')
-    def sanityDone = false
-    while (!sanityDone) {
-        try {
-            println("Attempting to run sanity build...")
-            build job: pipelineName + "/sanity/" + BRANCH_NAME, wait: true
-            sanityDone = true
-        } catch (hudson.AbortException e) {
-            println("Job doesn't yet exist, waiting for Jenkins to find job..")
-            sleep(5)
+    timeout(time: max_time, unit: 'MINUTES') {
+        // get the base path by removing build and branch portions
+        def jobPath = JOB_NAME.split('/')
+        def pipelineName = jobPath[0..jobPath.size()-3].join('/')
+        def sanityDone = false
+        while (!sanityDone) {
+            try {
+                println("Attempting to run sanity build...")
+                build job: pipelineName + "/sanity/" + BRANCH_NAME, wait: true
+                sanityDone = true
+            } catch (hudson.AbortException e) {
+                println("Job doesn't yet exist, waiting for Jenkins to find job..")
+                sleep(5)
+            }
         }
-    }
-    buildJobs.each { subJob ->
-        build job: pipelineName + "/" + subJob + "/" + BRANCH_NAME, wait: false
+        buildJobs.each { subJob ->
+            build job: pipelineName + "/" + subJob + "/" + BRANCH_NAME, wait: false
+        }
     }
 }
 

--- a/ci/jenkins/Jenkinsfile_full
+++ b/ci/jenkins/Jenkinsfile_full
@@ -41,7 +41,17 @@ stage("full-build") {
     // get the base path by removing build and branch portions
     def jobPath = JOB_NAME.split('/')
     def pipelineName = jobPath[0..jobPath.size()-3].join('/')
-    build job: pipelineName + "/sanity/" + BRANCH_NAME, wait: true
+    def sanityDone = false
+    while (!sanityDone) {
+        try {
+            println("Attempting to run sanity build...")
+            build job: pipelineName + "/sanity/" + BRANCH_NAME, wait: true
+            sanityDone = true
+        } catch (hudson.AbortException e) {
+            println("Job doesn't yet exist, waiting for Jenkins to find job..")
+            sleep(5)
+        }
+    }
     buildJobs.each { subJob ->
         build job: pipelineName + "/" + subJob + "/" + BRANCH_NAME, wait: false
     }


### PR DESCRIPTION
## Description ##
I ran into some problems when activating the staggered build pipeline in prod. It seems there is a slight delay (on a high-load server) between when Jenkins starts the full-build job and having the sanity job being recognized by Jenkins. This change allows it to retry until the job does exist.