### PR TITLE
Set cache_intermediate to True

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -86,6 +86,7 @@ def build_docker(platform: str, registry: str, num_retries: int, no_cache: bool,
     :param registry: Dockerhub registry name
     :param num_retries: Number of retries to build the docker image
     :param no_cache: pass no-cache to docker to rebuild the images
+    :param cache_intermediate: cache intermediate steps while building the docker image
     :return: Id of the top level image
     """
     tag = get_docker_tag(platform=platform, registry=registry)

--- a/ci/build.py
+++ b/ci/build.py
@@ -79,7 +79,7 @@ def get_dockerfile(platform: str, path=get_dockerfiles_path()) -> str:
 
 
 def build_docker(platform: str, registry: str, num_retries: int, no_cache: bool,
-                 cache_intermediate: bool = False) -> str:
+                 cache_intermediate: bool = True) -> str:
     """
     Build a container for the given platform
     :param platform: Platform


### PR DESCRIPTION
## Description ##
Force the docker to use cache for intermediate layers.
cache_intermediate flag prevents removal of intermediate layers while building docker containers in the slave instances.

However, by setting it to False by default, this caching of intermediate layers is never used in our CI docker containers.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] Code is well-documented: 
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
This should hopefully cache the intermediate steps for subsequent CI runs on an instance that has already build the docker container. It will help expedite the time to build the container on those subsequent CI runs.

Note : This comes into the picture only when the CI files aren't changed i.e. instructions to build docker container remain unchanged.