### PR TITLE
[v1.7.x] Backport #17177 to 1.7.x (Fix incorrect calculation results when the C locale is set to a locale that uses commas as the decimal separator)

### DIFF
--- a/cpp-package/include/mxnet-cpp/optimizer.h
+++ b/cpp-package/include/mxnet-cpp/optimizer.h
@@ -32,6 +32,7 @@
 #include <string>
 #include <memory>
 #include <functional>
+#include <dmlc/strtonum.h>
 #include "mxnet-cpp/base.h"
 #include "dmlc/logging.h"
 #include "mxnet-cpp/ndarray.h"
@@ -84,7 +85,7 @@ class Optimizer {
   Optimizer *SetLRScheduler(std::unique_ptr<LRScheduler> lrScheduler) {
     CHECK(lrScheduler);
     lrScheduler_ = std::move(lrScheduler);
-    lrScheduler_->SetLR(std::stof(params_["lr"]));
+    lrScheduler_->SetLR(dmlc::stof(params_["lr"]));
     return this;
   }
   /*!

--- a/cpp-package/include/mxnet-cpp/optimizer.h
+++ b/cpp-package/include/mxnet-cpp/optimizer.h
@@ -27,12 +27,12 @@
 #ifndef MXNET_CPP_OPTIMIZER_H_
 #define MXNET_CPP_OPTIMIZER_H_
 
+#include <dmlc/strtonum.h>
 #include <map>
 #include <vector>
 #include <string>
 #include <memory>
 #include <functional>
-#include <dmlc/strtonum.h>
 #include "mxnet-cpp/base.h"
 #include "dmlc/logging.h"
 #include "mxnet-cpp/ndarray.h"

--- a/cpp-package/include/mxnet-cpp/optimizer.hpp
+++ b/cpp-package/include/mxnet-cpp/optimizer.hpp
@@ -26,6 +26,7 @@
 #ifndef MXNET_CPP_OPTIMIZER_HPP_
 #define MXNET_CPP_OPTIMIZER_HPP_
 
+#include <dmlc/strtonum.h>
 #include <algorithm>
 #include <utility>
 #include <numeric>
@@ -33,7 +34,6 @@
 #include <cmath>
 #include <string>
 #include <vector>
-#include <dmlc/strtonum.h>
 #include "mxnet-cpp/optimizer.h"
 #include "mxnet-cpp/op.h"
 #include "mxnet-cpp/op_map.h"

--- a/cpp-package/include/mxnet-cpp/optimizer.hpp
+++ b/cpp-package/include/mxnet-cpp/optimizer.hpp
@@ -33,6 +33,7 @@
 #include <cmath>
 #include <string>
 #include <vector>
+#include <dmlc/strtonum.h>
 #include "mxnet-cpp/optimizer.h"
 #include "mxnet-cpp/op.h"
 #include "mxnet-cpp/op_map.h"
@@ -116,11 +117,11 @@ inline float Optimizer::GetLR_(int index) {
   if (nullptr != lrScheduler_) {
     return lrScheduler_->GetLR(num_update_);
   }
-  return std::stof(params_["lr"]);
+  return dmlc::stof(params_["lr"]);
 }
 
 inline float Optimizer::GetWD_(int index) {
-  float wd = std::stof(params_["wd"]);
+  float wd = dmlc::stof(params_["wd"]);
   return wd;
 }
 
@@ -362,9 +363,9 @@ inline void AdamOptimizer::Update(int index, NDArray weight, NDArray grad) {
   auto values = GetParamValues_();
   CHECK_EQ(keys.size(), values.size());
 
-  float lr = std::stof(params_["lr"]);
-  float b1 = std::stof(params_["beta1"]);
-  float b2 = std::stof(params_["beta2"]);
+  float lr = dmlc::stof(params_["lr"]);
+  float b1 = dmlc::stof(params_["beta1"]);
+  float b2 = dmlc::stof(params_["beta2"]);
   float t = count_[index];
   float coef1 = 1.0f - std::pow(b1, t);
   float coef2 = 1.0f - std::pow(b2, t);
@@ -407,15 +408,15 @@ inline void AdaGradOptimizer::Update(int index, NDArray weight, NDArray grad) {
     CreateState_(index, weight);
   }
 
-  float eps = std::stof(params_["eps"]);
+  float eps = dmlc::stof(params_["eps"]);
   float lr = GetLR_(index);
   float wd = GetWD_(index);
   UpdateCount_(index);
   if (params_.count("rescale_grad") > 0) {
-    grad *= std::stof(params_["rescale_grad"]);
+    grad *= dmlc::stof(params_["rescale_grad"]);
   }
   if (params_.count("clip_gradient") > 0) {
-    _clip(grad, std::stof(params_["clip_gradient"]));
+    _clip(grad, dmlc::stof(params_["clip_gradient"]));
   }
   auto& history = *history_[index];
   history += grad * grad;
@@ -448,16 +449,16 @@ inline void AdaDeltaOptimizer::Update(int index, NDArray weight, NDArray grad) {
     CreateState_(index, weight);
   }
 
-  float rho = std::stof(params_["rho"]);
-  float epsilon = std::stof(params_["epsilon"]);
+  float rho = dmlc::stof(params_["rho"]);
+  float epsilon = dmlc::stof(params_["epsilon"]);
   float wd = GetWD_(index);
   UpdateCount_(index);
 
   if (params_.count("rescale_grad") > 0) {
-    grad *= std::stof(params_["rescale_grad"]);
+    grad *= dmlc::stof(params_["rescale_grad"]);
   }
   if (params_.count("clip_gradient") > 0) {
-    _clip(grad, std::stof(params_["clip_gradient"]));
+    _clip(grad, dmlc::stof(params_["clip_gradient"]));
   }
 
   auto& acc_g = *acc_g_[index];

--- a/docs/static_site/src/pages/api/faq/new_op.md
+++ b/docs/static_site/src/pages/api/faq/new_op.md
@@ -204,7 +204,7 @@ Simple arguments can be parsed like
 NNVM_REGISTER_OP(scalar_op)
 .set_attr_parser(
   [](NodeAttrs* attrs) {
-    attrs->parsed = std::stod(attrs->dict["scalar"]);
+    attrs->parsed = dmlc::stod(attrs->dict["scalar"]);
   })
 ```
 

--- a/plugin/torch/torch_function.h
+++ b/plugin/torch/torch_function.h
@@ -34,6 +34,7 @@
 #include <map>
 #include <algorithm>
 #include <vector>
+#include <dmlc/strtonum.h>
 
 namespace mxnet {
 
@@ -69,7 +70,7 @@ void TorchRunOp(std::vector<NDArray> arr_in,
         lua_pushinteger(L, std::stoi(val));
         break;
       case 'f':
-        lua_pushnumber(L, std::stof(val));
+        lua_pushnumber(L, dmlc::stof(val));
         break;
       case 's':
         lua_pushstring(L, val.c_str());

--- a/plugin/torch/torch_function.h
+++ b/plugin/torch/torch_function.h
@@ -28,13 +28,13 @@
 #include "./torch_base.h"
 #include <mxnet/base.h>
 #include <mxnet/ndarray.h>
+#include <dmlc/strtonum.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
 #include <map>
 #include <algorithm>
 #include <vector>
-#include <dmlc/strtonum.h>
 
 namespace mxnet {
 

--- a/src/nnvm/legacy_op_util.cc
+++ b/src/nnvm/legacy_op_util.cc
@@ -23,6 +23,7 @@
  * \brief Utility to adapt OpProperty to the new NNVM registery
  */
 #include <dmlc/base.h>
+#include <dmlc/strtonum.h>
 #include <mxnet/base.h>
 #include <mxnet/operator.h>
 #include <mxnet/op_attr_types.h>
@@ -511,7 +512,7 @@ void RegisterLegacyNDFunc() {
           const std::string& name = reg->arguments[i+reg->num_use_vars].name;
           auto s = dict.find(name);
           CHECK(s != dict.end()) << "Missing scalar param " << name;
-          scalars.push_back(std::stof(s->second));
+          scalars.push_back(dmlc::stof(s->second));
           dict.erase(s);
         }
 

--- a/src/operator/contrib/gradient_multiplier_op.cc
+++ b/src/operator/contrib/gradient_multiplier_op.cc
@@ -23,6 +23,7 @@
  * \brief
  * \author Istvan Fehervari
 */
+#include <dmlc/strtonum.h>
 #include "../tensor/elemwise_unary_op.h"
 #include "../tensor/elemwise_binary_scalar_op.h"
 
@@ -77,7 +78,7 @@ multiplies the gradient from the subsequent level by a scalar factor lambda and 
 the preceding layer.
 )code" ADD_FILELINE)
 .set_attr_parser([](NodeAttrs* attrs) {
-    attrs->parsed = std::stod(attrs->dict["scalar"]);
+    attrs->parsed = dmlc::stod(attrs->dict["scalar"]);
   })
 .set_attr<FInferStorageType>("FInferStorageType", ElemwiseStorageType<1, 1, false, true, true>)
 .set_attr<FCompute>("FCompute<cpu>", UnaryOp::IdentityCompute<cpu>)

--- a/src/operator/numpy/np_boolean_mask_assign.cc
+++ b/src/operator/numpy/np_boolean_mask_assign.cc
@@ -22,6 +22,7 @@
  * \brief CPU implementation of Boolean Mask Assign
  */
 
+#include <dmlc/strtonum.h>
 #include "../../common/utils.h"
 #include "../contrib/boolean_mask-inl.h"
 
@@ -272,7 +273,7 @@ void NumpyBooleanAssignForwardCPU(const nnvm::NodeAttrs& attrs,
     MSHADOW_TYPE_SWITCH_WITH_BOOL(data.type_flag_, DType, {
       Kernel<BooleanAssignCPUKernel<true>, cpu>::Launch(
         s, valid_num, data.dptr<DType>(), prefix_sum.data(), prefix_sum.size(),
-        leading, middle, trailing, static_cast<DType>(std::stod(attrs.dict.at("value"))));
+        leading, middle, trailing, static_cast<DType>(dmlc::stod(attrs.dict.at("value"))));
     });
   }
 }

--- a/src/operator/numpy/np_boolean_mask_assign.cu
+++ b/src/operator/numpy/np_boolean_mask_assign.cu
@@ -23,6 +23,7 @@
  */
 
 #include <cub/cub.cuh>
+#include <dmlc/strtonum.h>
 #include "../../common/utils.h"
 #include "../contrib/boolean_mask-inl.h"
 
@@ -252,7 +253,7 @@ void NumpyBooleanAssignForwardGPU(const nnvm::NodeAttrs& attrs,
     }
   } else {
     CHECK(attrs.dict.find("value") != attrs.dict.end()) << "value is not provided";
-    double value = std::stod(attrs.dict.at("value"));
+    double value = dmlc::stod(attrs.dict.at("value"));
     MSHADOW_TYPE_SWITCH_WITH_BOOL(data.type_flag_, DType, {
       Kernel<BooleanAssignGPUKernel<true>, gpu>::Launch(
         s, leading * valid_num * trailing, data.dptr<DType>(), prefix_sum, mask_size + 1,

--- a/src/operator/numpy/np_elemwise_broadcast_logic_op.cc
+++ b/src/operator/numpy/np_elemwise_broadcast_logic_op.cc
@@ -30,6 +30,7 @@
 #include "../tvmop/op_module.h"
 #endif  // MXNET_USE_TVM_OP
 
+#include <dmlc/strtonum.h>
 #include "../tensor/elemwise_binary_broadcast_op.h"
 #include "../tensor/elemwise_binary_scalar_op.h"
 
@@ -225,7 +226,7 @@ struct TVMBinaryBroadcastScalarCompute {
   .set_num_inputs(1)                                                                        \
   .set_num_outputs(1)                                                                       \
   .set_attr_parser([](NodeAttrs* attrs) {                                                   \
-    attrs->parsed = std::stod(attrs->dict["scalar"]);                                       \
+    attrs->parsed = dmlc::stod(attrs->dict["scalar"]);                                       \
   })                                                                                        \
   .set_attr<nnvm::FListInputNames>("FListInputNames",                                       \
   [](const NodeAttrs& attrs) {                                                              \

--- a/src/operator/numpy/np_elemwise_broadcast_op.cc
+++ b/src/operator/numpy/np_elemwise_broadcast_op.cc
@@ -23,6 +23,7 @@
  * \brief CPU Implementation of basic functions for elementwise numpy binary broadcast operator.
  */
 
+#include <dmlc/strtonum.h>
 #include "./np_elemwise_broadcast_op.h"
 
 namespace mxnet {
@@ -33,7 +34,7 @@ namespace op {
   .set_num_inputs(1)                                                \
   .set_num_outputs(1)                                               \
   .set_attr_parser([](NodeAttrs* attrs) {                           \
-      attrs->parsed = std::stod(attrs->dict["scalar"]);             \
+      attrs->parsed = dmlc::stod(attrs->dict["scalar"]);             \
     })                                                              \
   .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>) \
   .set_attr<nnvm::FInferType>("FInferType", NumpyBinaryScalarType)  \

--- a/src/operator/numpy/np_elemwise_broadcast_op_extended.cc
+++ b/src/operator/numpy/np_elemwise_broadcast_op_extended.cc
@@ -23,6 +23,7 @@
  * \brief CPU Implementation of extended functions for elementwise numpy binary broadcast operator.
  */
 
+#include <dmlc/strtonum.h>
 #include "../../common/utils.h"
 #include "./np_elemwise_broadcast_op.h"
 
@@ -34,7 +35,7 @@ namespace op {
   .set_num_inputs(1)                                                \
   .set_num_outputs(1)                                               \
   .set_attr_parser([](NodeAttrs* attrs) {                           \
-      attrs->parsed = std::stod(attrs->dict["scalar"]);             \
+      attrs->parsed = dmlc::stod(attrs->dict["scalar"]);             \
     })                                                              \
   .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>) \
   .set_attr<nnvm::FInferType>("FInferType", NumpyBinaryScalarType)  \
@@ -87,7 +88,7 @@ NNVM_REGISTER_OP(_npi_lcm_scalar)
 .set_num_inputs(1)
 .set_num_outputs(1)
 .set_attr_parser([](NodeAttrs* attrs) {
-    attrs->parsed = std::stod(attrs->dict["scalar"]);
+    attrs->parsed = dmlc::stod(attrs->dict["scalar"]);
   })
 .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseIntType<1, 1>)
@@ -175,7 +176,7 @@ NNVM_REGISTER_OP(_npi_bitwise_xor_scalar)
 .set_num_inputs(1)
 .set_num_outputs(1)
 .set_attr_parser([](NodeAttrs* attrs) {
-    attrs->parsed = std::stod(attrs->dict["scalar"]);
+    attrs->parsed = dmlc::stod(attrs->dict["scalar"]);
   })
 .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseIntType<1, 1>)
@@ -192,7 +193,7 @@ NNVM_REGISTER_OP(_npi_bitwise_or_scalar)
 .set_num_inputs(1)
 .set_num_outputs(1)
 .set_attr_parser([](NodeAttrs* attrs) {
-    attrs->parsed = std::stod(attrs->dict["scalar"]);
+    attrs->parsed = dmlc::stod(attrs->dict["scalar"]);
   })
 .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
 .set_attr<nnvm::FInferType>("FInferType", ElemwiseIntType<1, 1>)
@@ -275,13 +276,13 @@ MXNET_OPERATOR_REGISTER_NP_BINARY_SCALAR(_npi_rarctan2_scalar)
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_npi_arctan2_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>",
                     BinaryScalarOp::Backward<cpu, mshadow_op::arctan2_grad>);
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_npi_rarctan2_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>",
                     BinaryScalarOp::Backward<cpu, mshadow_op::arctan2_rgrad>);
 
@@ -363,12 +364,12 @@ NNVM_REGISTER_OP(_backward_npi_ldexp)
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_npi_ldexp_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>", BinaryScalarOp::Backward<cpu, mshadow_op::ldexp_grad>);
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_npi_rldexp_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>", BinaryScalarOp::Backward<cpu, mshadow_op::rldexp_grad>);
 
 }  // namespace op

--- a/src/operator/numpy/np_true_divide.cc
+++ b/src/operator/numpy/np_true_divide.cc
@@ -23,6 +23,7 @@
  * \brief CPU Implementation of true_divide operator.
  */
 
+#include <dmlc/strtonum.h>
 #include "./np_true_divide-inl.h"
 
 namespace mxnet {
@@ -88,7 +89,7 @@ NNVM_REGISTER_OP(_npi_true_divide_scalar)
 .set_num_inputs(1)
 .set_num_outputs(1)
 .set_attr_parser([](NodeAttrs* attrs) {
-    attrs->parsed = std::stod(attrs->dict["scalar"]);
+    attrs->parsed = dmlc::stod(attrs->dict["scalar"]);
   })
 .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
 .set_attr<nnvm::FInferType>("FInferType", TrueDivideType<1>)
@@ -111,7 +112,7 @@ NNVM_REGISTER_OP(_npi_rtrue_divide_scalar)
 .set_num_inputs(1)
 .set_num_outputs(1)
 .set_attr_parser([](NodeAttrs* attrs) {
-  attrs->parsed = std::stod(attrs->dict["scalar"]);
+  attrs->parsed = dmlc::stod(attrs->dict["scalar"]);
   })
 .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)
 .set_attr<nnvm::FInferType>("FInferType", TrueDivideType<1>)

--- a/src/operator/subgraph/mkldnn/mkldnn_post_quantize_align_scale_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_post_quantize_align_scale_property.h
@@ -21,9 +21,9 @@
 #define MXNET_OPERATOR_SUBGRAPH_MKLDNN_MKLDNN_POST_QUANTIZE_ALIGN_SCALE_PROPERTY_H_
 #if MXNET_USE_MKLDNN == 1
 
+#include <dmlc/strtonum.h>
 #include <string>
 #include <vector>
-#include <dmlc/strtonum.h>
 #include "../common.h"
 #include "mkldnn_subgraph_base-inl.h"
 

--- a/src/operator/subgraph/mkldnn/mkldnn_post_quantize_align_scale_property.h
+++ b/src/operator/subgraph/mkldnn/mkldnn_post_quantize_align_scale_property.h
@@ -23,6 +23,7 @@
 
 #include <string>
 #include <vector>
+#include <dmlc/strtonum.h>
 #include "../common.h"
 #include "mkldnn_subgraph_base-inl.h"
 
@@ -146,8 +147,8 @@ class SgMKLDNNPostQuantizeAlignScaleProperty : public SubgraphProperty {
     float min_calib = 0.0f;
     float max_calib = 0.0f;
     for (size_t i = 0; i < subgraph_nodes.size(); ++i) {
-      auto this_min_calib = std::stof(subgraph_nodes[i]->attrs.dict["min_calib_range"]);
-      auto this_max_calib = std::stof(subgraph_nodes[i]->attrs.dict["max_calib_range"]);
+      auto this_min_calib = dmlc::stof(subgraph_nodes[i]->attrs.dict["min_calib_range"]);
+      auto this_max_calib = dmlc::stof(subgraph_nodes[i]->attrs.dict["max_calib_range"]);
       if (min_calib > this_min_calib) min_calib = this_min_calib;
       if (max_calib < this_max_calib) max_calib = this_max_calib;
     }

--- a/src/operator/tensor/elemwise_binary_scalar_op.h
+++ b/src/operator/tensor/elemwise_binary_scalar_op.h
@@ -28,6 +28,7 @@
 #include <mxnet/operator_util.h>
 #include <vector>
 #include <utility>
+#include <dmlc/strtonum.h>
 #include "../mshadow_op.h"
 #include "../elemwise_op_common.h"
 #include "elemwise_unary_op.h"
@@ -400,7 +401,7 @@ class BinaryScalarOp : public UnaryOp {
   .set_num_inputs(1)                                                \
   .set_num_outputs(1)                                               \
   .set_attr_parser([](NodeAttrs* attrs) {                           \
-      attrs->parsed = std::stod(attrs->dict["scalar"]);             \
+      attrs->parsed = dmlc::stod(attrs->dict["scalar"]);            \
     })                                                              \
   .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)  \
   .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)     \

--- a/src/operator/tensor/elemwise_binary_scalar_op.h
+++ b/src/operator/tensor/elemwise_binary_scalar_op.h
@@ -26,9 +26,9 @@
 #define MXNET_OPERATOR_TENSOR_ELEMWISE_BINARY_SCALAR_OP_H_
 
 #include <mxnet/operator_util.h>
+#include <dmlc/strtonum.h>
 #include <vector>
 #include <utility>
-#include <dmlc/strtonum.h>
 #include "../mshadow_op.h"
 #include "../elemwise_op_common.h"
 #include "elemwise_unary_op.h"

--- a/src/operator/tensor/elemwise_binary_scalar_op_basic.cc
+++ b/src/operator/tensor/elemwise_binary_scalar_op_basic.cc
@@ -22,6 +22,7 @@
  * \file elemwise_binary_scalar_op_basic.cc
  * \brief CPU Implementation of basic binary scalar functions.
  */
+#include <dmlc/strtonum.h>
 #include "../../common/utils.h"
 #include "./elemwise_binary_op.h"
 #include "./elemwise_binary_scalar_op.h"
@@ -31,7 +32,7 @@
   .set_num_inputs(1)                                                \
   .set_num_outputs(1)                                               \
   .set_attr_parser([](NodeAttrs* attrs) {                           \
-      attrs->parsed = std::stod(attrs->dict["scalar"]);             \
+      attrs->parsed = dmlc::stod(attrs->dict["scalar"]);             \
     })                                                              \
   .set_attr<mxnet::FInferShape>("FInferShape", ElemwiseShape<1, 1>)  \
   .set_attr<nnvm::FInferType>("FInferType", ElemwiseType<1, 1>)     \
@@ -189,7 +190,7 @@ MXNET_OPERATOR_REGISTER_BINARY_SCALAR(_rdiv_scalar)
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_rdiv_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>", BinaryScalarOp::Backward<
   cpu, mshadow_op::rdiv_grad>);
 
@@ -200,7 +201,7 @@ MXNET_OPERATOR_REGISTER_BINARY_SCALAR(_mod_scalar)
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_mod_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>", BinaryScalarOp::Backward<
   cpu, mshadow_op::mod_grad>);
 
@@ -211,7 +212,7 @@ MXNET_OPERATOR_REGISTER_BINARY_SCALAR(_rmod_scalar)
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_rmod_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>", BinaryScalarOp::Backward<
   cpu, mshadow_op::rmod_grad>);
 

--- a/src/operator/tensor/elemwise_binary_scalar_op_extended.cc
+++ b/src/operator/tensor/elemwise_binary_scalar_op_extended.cc
@@ -22,6 +22,7 @@
  * \file elemwise_binary_scalar_op_extended.cc
  * \brief CPU Implementation of extended binary scalar functions.
  */
+#include <dmlc/strtonum.h>
 #include "./elemwise_unary_op.h"
 #include "./elemwise_binary_op.h"
 #include "./elemwise_binary_scalar_op.h"
@@ -36,7 +37,7 @@ MXNET_OPERATOR_REGISTER_BINARY_SCALAR(_maximum_scalar)
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_maximum_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>", BinaryScalarOp::Backward<cpu, mshadow_op::ge>);
 
 MXNET_OPERATOR_REGISTER_BINARY_SCALAR(_minimum_scalar)
@@ -47,7 +48,7 @@ MXNET_OPERATOR_REGISTER_BINARY_SCALAR(_minimum_scalar)
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_minimum_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>", BinaryScalarOp::Backward<cpu, mshadow_op::le>);
 
 MXNET_OPERATOR_REGISTER_BINARY_SCALAR(_power_scalar)
@@ -57,7 +58,7 @@ MXNET_OPERATOR_REGISTER_BINARY_SCALAR(_power_scalar)
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_power_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>", BinaryScalarOp::Backward<
   cpu, mshadow_op::power_grad>);
 
@@ -69,7 +70,7 @@ MXNET_OPERATOR_REGISTER_BINARY_SCALAR(_rpower_scalar)
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_rpower_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>", BinaryScalarOp::Backward<
   cpu, mshadow_op::rpower_grad>);
 
@@ -82,7 +83,7 @@ MXNET_OPERATOR_REGISTER_BINARY_SCALAR(_hypot_scalar)
 
 MXNET_OPERATOR_REGISTER_BINARY(_backward_hypot_scalar)
 .add_argument("scalar", "float", "scalar value")
-.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = std::stod(attrs->dict["scalar"]); })
+.set_attr_parser([](NodeAttrs *attrs) { attrs->parsed = dmlc::stod(attrs->dict["scalar"]); })
 .set_attr<FCompute>("FCompute<cpu>", BinaryScalarOp::Backward<
   cpu, mshadow_op::hypot_grad_left>);
 
@@ -110,7 +111,7 @@ Example::
 .set_num_outputs(1)
 .set_attr_parser([](NodeAttrs* attrs) {
     if (attrs->dict.find("scalar") != attrs->dict.end()) {
-      attrs->parsed = std::stod(attrs->dict["scalar"]);
+      attrs->parsed = dmlc::stod(attrs->dict["scalar"]);
     } else {
       attrs->parsed = 1.0;
     }
@@ -129,7 +130,7 @@ Example::
 MXNET_OPERATOR_REGISTER_BINARY(_backward_smooth_l1)
   .set_attr_parser([](NodeAttrs *attrs) {
       if (attrs->dict.find("scalar") != attrs->dict.end()) {
-        attrs->parsed = std::stod(attrs->dict["scalar"]);
+        attrs->parsed = dmlc::stod(attrs->dict["scalar"]);
       } else {
         attrs->parsed = 1.0;
       }

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -9994,10 +9994,20 @@ def test_scalarop_locale_invariance():
             except locale.Error as e:
                 print("Couldn't enable locale", loc, ": ", str(e))
                 
-        assert locale_set, "Couldn't find any suitable locales for test_elemwise_locale_invariance!"
-        scalar = 0.3
-        assert "," in locale.str(scalar)
-        assert_almost_equal(arr.asnumpy() + scalar, (arr + scalar).asnumpy(), rtol=1e-5, atol=1e-5)
+        if locale_set:
+            scalar = 0.3
+            assert "," in locale.str(scalar)
+            assert_almost_equal(
+                arr.asnumpy() + scalar,
+                (arr + scalar).asnumpy(),
+                rtol=1e-5,
+                atol=1e-5
+            )
+        else:
+            # Shouldn't happen on Windows: "German" should always be available.
+            raise unittest.SkipTest("Couldn't find a locale suitable for "
+                                    "test_scalarop_locale_invariance. Please install en_DK.UTF-8 "
+                                    "or ru_RU.UTF-8 to run this test.")
     finally:
         locale.setlocale(locale.LC_NUMERIC, prev)
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -9974,7 +9974,7 @@ def test_broadcast_ops_on_misaligned_input_oneside():
                 mx.nd.waitall()
                 assert_almost_equal(f, expected)
 
-def test_elemwise_locale_invariance():
+def test_scalarop_locale_invariance():
     arr = mx.nd.zeros((1,))
     prev = locale.getlocale(locale.LC_NUMERIC)
     try:


### PR DESCRIPTION
## Description ##
Backport #17177 to the branch for v1.7.x.

Currently, many operators utilize `std::stod` to convert strings into floating point numbers. This causes incorrect calculations (#17140, #16134) when the C locale is set to a locale which uses commas (`,`) as decimal separators.

This pull request replaces calls to `std::stod` and `std::stof` to the locale-invariant `dmlc::stod` and `dmlc::stof` respectively.

### The scope of this patch ###

This patch should fix a large portion of interactions through Python and JVM frontends, since they use locale-invariant serialization in order to pass parameters into MXNet's C API.

However, frontends which utilize C locale-aware serialization (i.e. call `sprintf` or similar) may break when using locales which don't use `.` as the decimal separator. They will have to be fixed in a separate patch. I also suspect that they are already broken, because operators utilising dmlc-core parameter parsing were already using locale-invariant serialization.

### Further steps ###
STL streams are heavily used within the codebase, both for serialization and for forming user-friendly messages. Fortunately, they don't seem to be affected by the C standard library locale settings. However, if someone sets the STL locale by calling [std::locale::global](https://en.cppreference.com/w/cpp/locale/locale/global), MXNet's API will be broken. In order to ensure that this doesn't happen, all streams which are used for serialization will have to be imbued with the "C" locale (not the locale set in the C standard library).

It would be nice to see a more principled approach to serialization in MXNet 2.0, e.g. using a binary format for communication between the frontend and the backend. In addition to solving locale-related issues, this would probably result in a smaller invocation overhead.

### Locale-invariant serialization vs locale-aware serialization ###

As a side-note, using locale-aware serialization is not an option, simply because using `,` as the decimal separator adds ambiguities to tuple serialization, e.g. `(4,4,3)` can be a tuple of 3 integers, or a tuple of 2 floats.



## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Replace `std::stod` with `dmlc::stod` and `std::stof with `dmlc::stof`.
- [x] Add a test that tests locale invariance for scalar ops.

## Comments ##
- May break Julia and R code when using a locale that uses `,` as the decimal separator. However, since there was no consistency between the various operators before, it is not unlikely that the code was already broken. 
