### PR TITLE
Disable tests of numpy operators implemented with CustomOp

### DIFF
--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -4382,6 +4382,7 @@ def test_np_randn():
 
 @with_seed()
 @use_np
+@pytest.mark.skip(reason='Test hangs. Tracked in #18144')
 def test_np_multivariate_normal():
     class TestMultivariateNormal(HybridBlock):
         def __init__(self, size=None):
@@ -8178,6 +8179,7 @@ def test_np_column_stack():
 
 @with_seed()
 @use_np
+@pytest.mark.skip(reason='Test hangs. Tracked in #18144')
 def test_np_resize():
     class TestResize(HybridBlock):
         def __init__(self, new_shape):
@@ -8742,6 +8744,7 @@ def test_np_expand_dims():
 
 @with_seed()
 @use_np
+@pytest.mark.skip(reason='Test hangs. Tracked in #18144')
 def test_np_unravel_index():
     class TestUnravel_index(HybridBlock):
         def __init__(self, shape, order='C') :

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -557,7 +557,6 @@ def test_np_matmul():
 
 @with_seed()
 @use_np
-@pytest.mark.skip(reason='Test hangs. Tracked in #18144')
 def test_np_kron():
     def np_kron_backward(ograd, a, b):
         ndim = ograd.ndim

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -557,6 +557,7 @@ def test_np_matmul():
 
 @with_seed()
 @use_np
+@pytest.mark.skip(reason='Test hangs. Tracked in #18144')
 def test_np_kron():
     def np_kron_backward(ograd, a, b):
         ndim = ograd.ndim
@@ -8516,13 +8517,13 @@ def test_np_unary_bool_funcs():
             mx_out_imperative = getattr(mx.np, func)(mx_data)
             assert_almost_equal(mx_out_imperative.asnumpy(), np_out, rtol, atol)
             # if `out` is given and dtype == np.bool
-            mx_x = np.empty_like(mx_data).astype(np.bool)
+            mx_x = np.ones_like(mx_data).astype(np.bool)
             np_x = mx_x.asnumpy()
             getattr(mx.np, func)(mx_data, mx_x)
             np_func(np_data, np_x)
             assert_almost_equal(mx_out_imperative .asnumpy(), np_out, rtol, atol)
             # if `out` is given but dtype mismatches
-            mx_y = np.empty_like(mx_data)
+            mx_y = np.ones_like(mx_data)
             assertRaises(TypeError, getattr(np, func), mx_data, out=mx_y)
 
             assertRaises(NotImplementedError, getattr(np, func), mx_data, where=False)


### PR DESCRIPTION
## Description ##
https://github.com/apache/incubator-mxnet/issues/18144, https://github.com/apache/incubator-mxnet/pull/18025 disabled `empty_like` which causes hangs. The other 3 CustomOp based fallback operators are also prone to cause deadlock, as exemplified by http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Funix-gpu/detail/PR-18025/59/pipeline/425 where the hang occurs without `np_empty_like` test being run