### PR TITLE
Improving performance of broadcast_axis on GPU

### DIFF
--- a/src/operator/numpy/np_matmul_op-inl.h
+++ b/src/operator/numpy/np_matmul_op-inl.h
@@ -157,12 +157,15 @@ inline void MatmulImpl(const OpContext& ctx,
     DType* bc_b_ptr = bc_a_ptr + bc_size_a;
     MSHADOW_TYPE_SWITCH_WITH_BOOL(input_a.type_flag_, IType, {
       MSHADOW_TYPE_SWITCH_WITH_BOOL(input_b.type_flag_, OType, {
+        struct ShapeAndStride aux_data_a, aux_data_b;
+        PrepareAUXData(&aux_data_a, k_a_shape, k_a_shape_bc, ndim);
+        PrepareAUXData(&aux_data_b, k_b_shape, k_b_shape_bc, ndim);
         Kernel<broadcast_kernel<mshadow_op::identity>, xpu>::Launch(
           s, bc_size_a, input_a.dptr<IType>(), bc_a_ptr,
-          k_a_shape, k_a_shape_bc, OpReqType::kWriteTo, ndim);
+          aux_data_a, OpReqType::kWriteTo, ndim);
         Kernel<broadcast_kernel<mshadow_op::identity>, xpu>::Launch(
           s, bc_size_b, input_b.dptr<IType>(), bc_b_ptr,
-          k_b_shape, k_b_shape_bc, OpReqType::kWriteTo, ndim);
+          aux_data_b, OpReqType::kWriteTo, ndim);
       });
     });
     ans = mshadow::Tensor<xpu, 3, DType>(output.dptr<DType>(),

--- a/src/operator/tensor/broadcast_reduce_op.h
+++ b/src/operator/tensor/broadcast_reduce_op.h
@@ -1077,6 +1077,58 @@ struct broadcast_kernel {
   }
 };
 
+template<typename OP>
+struct broadcast_kernel_gpu {
+  template<typename IType, typename OType>
+  MSHADOW_XINLINE static void Map(int32_t i,
+                                  IType *input,
+                                  OType *output,
+                                  const int32_t *input_shape,
+                                  const int32_t *output_shape,
+                                  const int32_t *in_stride,
+                                  const int32_t *out_stride,
+                                  const OpReqType req,
+                                  const int32_t ndim) {
+    int32_t idx = i;
+    int32_t in_idx = i;
+    for (int32_t iter = ndim - 1; iter >= 0; --iter) {
+      int32_t dim_idx = idx % output_shape[iter];
+      if (input_shape[iter] != 1) {
+        in_idx += dim_idx * (in_stride[iter] - out_stride[iter]);
+      } else {
+        in_idx -= dim_idx * out_stride[iter];
+      }
+      idx /= output_shape[iter];
+    }
+    KERNEL_ASSIGN(output[i], req, OP::Map(input[in_idx]));
+  }
+};
+
+template<int req>
+struct compute_offset {
+  MSHADOW_XINLINE static void Map(int32_t i,
+                                  int32_t *in_stride,
+                                  int32_t *out_stride,
+                                  int32_t *input_shape,
+                                  int32_t *output_shape,
+                                  const mshadow::Shape<MXNET_SPECIAL_MAX_NDIM> in_shape,
+                                  const mshadow::Shape<MXNET_SPECIAL_MAX_NDIM> dst_shape,
+                                  const int32_t ndim) {
+    int32_t iter = ndim - 1;
+    out_stride[iter] = 1;
+    in_stride[iter] = 1;
+    input_shape[iter] = (int32_t)in_shape[iter];
+    output_shape[iter] = (int32_t)dst_shape[iter];
+    iter--;
+    for (; iter >= 0; --iter) {
+      out_stride[iter] = out_stride[iter+1] * dst_shape[iter+1];
+      in_stride[iter] = in_stride[iter+1] * in_shape[iter+1];
+      input_shape[iter] = (int32_t)in_shape[iter];
+      output_shape[iter] = (int32_t)dst_shape[iter];
+    }
+  }
+};
+
 template<typename xpu>
 inline void BroadcastComputeImpl(const nnvm::NodeAttrs& attrs,
                                  const OpContext& ctx,
@@ -1108,16 +1160,60 @@ inline void BroadcastComputeImpl(const nnvm::NodeAttrs& attrs,
           outputs[0].get_with_shape<xpu, 2, OType>(dst_shape.get<2>(), s);
         Tensor<xpu, 2, IType> data =
           inputs[0].get_with_shape<xpu, 2, IType>(src_shape.get<2>(), s);
-        Kernel<broadcast_kernel<mshadow_op::identity>, xpu>::Launch(
-          s, out.shape_.Size(), data.dptr_, out.dptr_, in_shape, out_shape, req[0], 2);
+        if (ctx.run_ctx.get_ctx().dev_type == Context::kGPU) {
+          mshadow::Tensor<xpu, 1, char> workspace =
+              ctx.requested.at(0).get_space_typed<xpu, 1, char>
+              (mshadow::Shape1(sizeof(int32_t) * dst_shape.ndim() * 4), s);
+          char* workspace_curr_ptr = workspace.dptr_;
+          int32_t* out_stride = reinterpret_cast<int32_t*>(workspace_curr_ptr);
+          int32_t* in_stride =
+            reinterpret_cast<int32_t*>(workspace_curr_ptr +
+            sizeof(int32_t) * dst_shape.ndim());
+          int32_t* input_shape =
+            reinterpret_cast<int32_t*>(workspace_curr_ptr +
+            sizeof(int32_t) * dst_shape.ndim() * 2);
+          int32_t* output_shape =
+            reinterpret_cast<int32_t*>(workspace_curr_ptr +
+            sizeof(int32_t) * dst_shape.ndim() * 3);
+          Kernel<compute_offset<1>, xpu>::Launch(s, 1, in_stride, out_stride,
+            input_shape, output_shape, in_shape, out_shape, dst_shape.ndim());
+          Kernel<broadcast_kernel_gpu<mshadow_op::identity>, xpu>::Launch(
+            s, out.shape_.Size(), data.dptr_, out.dptr_, input_shape, output_shape,
+            in_stride, out_stride, req[0], 2);
+        } else {
+          Kernel<broadcast_kernel<mshadow_op::identity>, xpu>::Launch(
+            s, out.shape_.Size(), data.dptr_, out.dptr_, in_shape, out_shape, req[0], 2);
+        }
       } else {
         const int ndim = MXNET_SPECIAL_MAX_NDIM;
         Tensor<xpu, ndim, OType> out =
           outputs[0].get_with_shape<xpu, ndim, OType>(dst_shape.get<ndim>(), s);
         Tensor<xpu, ndim, IType> data =
           inputs[0].get_with_shape<xpu, ndim, IType>(src_shape.get<ndim>(), s);
-        Kernel<broadcast_kernel<mshadow_op::identity>, xpu>::Launch(
-          s, out.shape_.Size(), data.dptr_, out.dptr_, in_shape, out_shape, req[0], ndim);
+        if (ctx.run_ctx.get_ctx().dev_type == Context::kGPU) {
+          mshadow::Tensor<xpu, 1, char> workspace =
+              ctx.requested.at(0).get_space_typed<xpu, 1, char>
+              (mshadow::Shape1(sizeof(int32_t) * dst_shape.ndim() * 4), s);
+          char* workspace_curr_ptr = workspace.dptr_;
+          int32_t* out_stride = reinterpret_cast<int32_t*>(workspace_curr_ptr);
+          int32_t* in_stride =
+            reinterpret_cast<int32_t*>(workspace_curr_ptr +
+            sizeof(int32_t) * dst_shape.ndim());
+          int32_t* input_shape =
+            reinterpret_cast<int32_t*>(workspace_curr_ptr +
+            sizeof(int32_t) * dst_shape.ndim() * 2);
+          int32_t* output_shape =
+            reinterpret_cast<int32_t*>(workspace_curr_ptr +
+            sizeof(int32_t) * dst_shape.ndim() * 3);
+          Kernel<compute_offset<1>, xpu>::Launch(s, 1, in_stride, out_stride,
+            input_shape, output_shape, in_shape, out_shape, dst_shape.ndim());
+          Kernel<broadcast_kernel_gpu<mshadow_op::identity>, xpu>::Launch(
+            s, out.shape_.Size(), data.dptr_, out.dptr_, input_shape, output_shape,
+            in_stride, out_stride, req[0], ndim);
+        } else {
+          Kernel<broadcast_kernel<mshadow_op::identity>, xpu>::Launch(
+            s, out.shape_.Size(), data.dptr_, out.dptr_, in_shape, out_shape, req[0], ndim);
+        }
       }
     });
   });

--- a/src/operator/tensor/broadcast_reduce_op_value.cc
+++ b/src/operator/tensor/broadcast_reduce_op_value.cc
@@ -94,7 +94,11 @@ Example::
 .set_attr_parser(ParamParser<BroadcastAxesParam>)
 .add_arguments(BroadcastAxesParam::__FIELDS__())
 .set_attr<mxnet::FInferShape>("FInferShape", BroadcastAxesShape)
-.set_attr<FCompute>("FCompute<cpu>", BroadcastAxisComputeCPU);
+.set_attr<FCompute>("FCompute<cpu>", BroadcastAxisComputeCPU)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const NodeAttrs& n) {
+    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+});
 
 MXNET_OPERATOR_REGISTER_BROADCAST(broadcast_to)
 .describe(R"code(Broadcasts the input array to a new shape.
@@ -118,7 +122,11 @@ So with `shape=(2,0)`, we will obtain the same result as in the above example.
 .set_attr_parser(ParamParser<BroadcastToParam>)
 .add_arguments(BroadcastToParam::__FIELDS__())
 .set_attr<mxnet::FInferShape>("FInferShape", BroadcastToShape)
-.set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>);
+.set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const NodeAttrs& n) {
+    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+});
 
 // backward op for broadcast.
 NNVM_REGISTER_OP(_broadcast_backward)
@@ -172,7 +180,11 @@ For example::
 .set_attr_parser(ParamParser<BroadcastLikeParam>)
 .add_arguments(BroadcastLikeParam::__FIELDS__())
 .set_attr<mxnet::FInferShape>("FInferShape", BroadcastLikeShape)
-.set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>);
+.set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>)
+.set_attr<FResourceRequest>("FResourceRequest",
+  [](const NodeAttrs& n) {
+    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
+});
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/broadcast_reduce_op_value.cc
+++ b/src/operator/tensor/broadcast_reduce_op_value.cc
@@ -94,11 +94,7 @@ Example::
 .set_attr_parser(ParamParser<BroadcastAxesParam>)
 .add_arguments(BroadcastAxesParam::__FIELDS__())
 .set_attr<mxnet::FInferShape>("FInferShape", BroadcastAxesShape)
-.set_attr<FCompute>("FCompute<cpu>", BroadcastAxisComputeCPU)
-.set_attr<FResourceRequest>("FResourceRequest",
-  [](const NodeAttrs& n) {
-    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-});
+.set_attr<FCompute>("FCompute<cpu>", BroadcastAxisComputeCPU);
 
 MXNET_OPERATOR_REGISTER_BROADCAST(broadcast_to)
 .describe(R"code(Broadcasts the input array to a new shape.
@@ -122,11 +118,7 @@ So with `shape=(2,0)`, we will obtain the same result as in the above example.
 .set_attr_parser(ParamParser<BroadcastToParam>)
 .add_arguments(BroadcastToParam::__FIELDS__())
 .set_attr<mxnet::FInferShape>("FInferShape", BroadcastToShape)
-.set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>)
-.set_attr<FResourceRequest>("FResourceRequest",
-  [](const NodeAttrs& n) {
-    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-});
+.set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>);
 
 // backward op for broadcast.
 NNVM_REGISTER_OP(_broadcast_backward)
@@ -136,7 +128,7 @@ NNVM_REGISTER_OP(_broadcast_backward)
 .set_attr<FResourceRequest>("FResourceRequest",
   [](const NodeAttrs& attrs) {
     return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-  });
+});
 
 NNVM_REGISTER_OP(broadcast_like)
 .add_alias("_npx_broadcast_like")
@@ -180,11 +172,7 @@ For example::
 .set_attr_parser(ParamParser<BroadcastLikeParam>)
 .add_arguments(BroadcastLikeParam::__FIELDS__())
 .set_attr<mxnet::FInferShape>("FInferShape", BroadcastLikeShape)
-.set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>)
-.set_attr<FResourceRequest>("FResourceRequest",
-  [](const NodeAttrs& n) {
-    return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-});
+.set_attr<FCompute>("FCompute<cpu>", BroadcastCompute<cpu>);
 
 }  // namespace op
 }  // namespace mxnet

--- a/src/operator/tensor/broadcast_reduce_op_value.cc
+++ b/src/operator/tensor/broadcast_reduce_op_value.cc
@@ -128,7 +128,7 @@ NNVM_REGISTER_OP(_broadcast_backward)
 .set_attr<FResourceRequest>("FResourceRequest",
   [](const NodeAttrs& attrs) {
     return std::vector<ResourceRequest>{ResourceRequest::kTempSpace};
-});
+  });
 
 NNVM_REGISTER_OP(broadcast_like)
 .add_alias("_npx_broadcast_like")


### PR DESCRIPTION
## Description ##
improving GPU kernel performance with cached stride calculations and shape data to improve performance. 
- passing mshadow::Shape slowed the kernel speed by approx 15% so passed it separately in a struct. 
- unroll gives boost of about 4%
- major chunk of improvement by caching stride calculations and combining 2 redundant multiplications

This change is done in order to maintain BERT performance when large tensor is enabled by default.

CPU performance remains identical or better than master-lt and master respectively(no changes there)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Testing ##
```
ubuntu@ip-172-31-0-156 ~/workspace/incubator-mxnet (typedef) $ MXNET_TEST_COUNT=1 nosetests --logging-level=DEBUG --verbose -s tests/python/gpu/test_operator_gpu.py:test_broadcast

[DEBUG] 1000 of 1000: Setting test np/mx/python random seeds, use MXNET_TEST_SEED=1707871653 to reproduce.
ok

----------------------------------------------------------------------
Ran 1 test in 1772.105s

OK
```

## Results ##
Profiling Code:
```
import mxnet as mx
import mxnet.ndarray as nd
from benchmark.opperf.utils.benchmark_utils import run_performance_test

#local_ctx = mx.cpu()
local_ctx = mx.gpu()


add_res = run_performance_test(nd.broadcast_axis, run_backward=True, dtype='float32', ctx=local_ctx,
                               inputs=[{'data': (10, 1, 10, 1), 'axis': (1, 3), 'size': (1000, 5000)}],
                               warmup=50, runs=500, profiler='python')
print(add_res)

add_res = run_performance_test(nd.broadcast_axis, run_backward=True, dtype='float32', ctx=local_ctx,
                               inputs=[{'data': (100, 1, 1, 10), 'axis': (1, 2), 'size': (1000, 500)}],
                               warmup=50, runs=500, profiler='python')
print(add_res)

add_res = run_performance_test(nd.broadcast_axis, run_backward=True, dtype='float32', ctx=local_ctx,
                               inputs=[{'data': (1, 1, 1, 1), 'axis': (0, 1, 2, 3), 'size': (10000, 10, 100, 50)}],
                               warmup=50, runs=500, profiler='python')
print(add_res)

add_res = run_performance_test(nd.broadcast_axis, run_backward=True, dtype='float32', ctx=local_ctx,
                               inputs=[{'data': (1, 10, 1, 10, 1), 'axis': (0, 2, 4), 'size': (200, 1000, 50)}],
                               warmup=50, runs=500, profiler='python')
print(add_res)
```


| code version | cases                                      | avg    | p50    | p90    |
|--------------|--------------------------------------------|--------|--------|--------|
|  master LT   | (10, 1, 10, 1) -> (10, 1000, 10, 5000)     | 65.75  | 65.71  | 65.82  |
|              | (100, 1, 1, 10)->(100, 1000, 500, 10)      | 64.65  | 64.57  | 64.68  |
|              | (1, 1, 1, 1)->(10000, 10, 100, 50)         | 46.61  | 46.54  | 46.64  |
|              | (1, 10, 1, 10, 1)->(200, 10, 1000, 10, 50) | 128.52 | 128.49 | 128.71 |
|              |                                            |        |        |        |
| master no-LT | (10, 1, 10, 1) -> (10, 1000, 10, 5000)     | 28.42  | 28.37  | 28.45  |
|              | (100, 1, 1, 10)->(100, 1000, 500, 10)      | 27.38  | 27.30  | 27.37  |
|              | (1, 1, 1, 1)->(10000, 10, 100, 50)         | 20.48  | 20.35  | 20.41  |
|              | (1, 10, 1, 10, 1)->(200, 10, 1000, 10, 50) | 53.68  | 53.57  | 53.74  |
|              |                                            |        |        |        |
| new LT       | (10, 1, 10, 1) -> (10, 1000, 10, 5000)     | 27.24  | 27.10  | 27.18  |
|              | (100, 1, 1, 10)->(100, 1000, 500, 10)      | 25.42  | 25.34  | 25.40  |
|              | (1, 1, 1, 1)->(10000, 10, 100, 50)         | 14.99  | 14.83  | 14.93  |
|              | (1, 10, 1, 10, 1)->(200, 10, 1000, 10, 50) | 51.66  | 51.80  | 51.90  |
|              |                                            |        |        |        |
| new no-LT    | (10, 1, 10, 1) -> (10, 1000, 10, 5000)     | 22.18  | 22.10  | 22.18  |
|              | (100, 1, 1, 10)->(100, 1000, 500, 10)      | 20.28  | 20.27  | 20.32  |
|              | (1, 1, 1, 1)->(10000, 10, 100, 50)         | 12.73  | 12.69  | 12.73  |
|              | (1, 10, 1, 10, 1)->(200, 10, 1000, 10, 50) | 40.21  | 40.11  | 40.28  |
