### PR TITLE
Fix nightly large_vector test caused by incorrect with_seed path

### DIFF
--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -27,7 +27,7 @@ sys.path.append(os.path.join(curr_path, '../python/unittest/'))
 
 from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, default_context, check_symbolic_forward, create_2d_tensor
 from mxnet import gluon, nd
-from common import with_seed, with_post_test_cleanup
+from common import with_seed
 import unittest
 
 # dimension constants

--- a/tests/nightly/test_large_vector.py
+++ b/tests/nightly/test_large_vector.py
@@ -27,7 +27,7 @@ sys.path.append(os.path.join(curr_path, '../python/unittest/'))
 
 from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, create_vector
 from mxnet import gluon, nd
-from tests.python.unittest.common import with_seed
+from common import with_seed
 import unittest
 
 # dimension constants

--- a/tests/python/unittest/common.py
+++ b/tests/python/unittest/common.py
@@ -310,27 +310,6 @@ def teardown_module():
     mx.nd.waitall()
 
 
-def with_post_test_cleanup():
-    """
-    Helper function that cleans up memory by releasing it from memory pool
-    Required especially by large tensor tests that have memory footprints in GBs.
-    """
-    def test_helper(orig_test):
-        @functools.wraps(orig_test)
-        def test_new(*args, **kwargs):
-            logger = default_logger()
-            try:
-                orig_test(*args, **kwargs)
-            except:
-                logger.info(test_msg)
-                raise
-            finally:
-                mx.nd.waitall()
-                mx.cpu().empty_cache()
-        return test_new
-    return test_helper
-
-
 def run_in_spawned_process(func, env, *args):
     """
     Helper function to run a test in its own process.


### PR DESCRIPTION
## Description ##
NightlyTestforBinaries for 1.7.x and master revealed error with with_seed path
Fixing it in master & will cherry-pick the fix to 1.7.x branch
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/NightlyTestsForBinaries/detail/master/670/pipeline
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/NightlyTestsForBinaries/detail/v1.7.x/1/pipeline

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 

@ciyongch @access2rohit @apeforest 