### PR TITLE
Fixed Install page history broken

### DIFF
--- a/docs/static_site/src/_sass/minima/_getting_started.scss
+++ b/docs/static_site/src/_sass/minima/_getting_started.scss
@@ -174,7 +174,7 @@ ul.dropdown-content {
     }
 
     &:focus {
-      outline:0;
+      outline: 0;
     }
     
   }

--- a/docs/static_site/src/_sass/minima/_getting_started.scss
+++ b/docs/static_site/src/_sass/minima/_getting_started.scss
@@ -172,6 +172,11 @@ ul.dropdown-content {
       background-color: $color-mxnet;
       color: $grey-color-light;
     }
+
+    &:focus {
+      outline:0;
+    }
+    
   }
 
 

--- a/docs/static_site/src/assets/js/options.js
+++ b/docs/static_site/src/assets/js/options.js
@@ -45,7 +45,7 @@ $(document).ready(function () {
         }
     }
 
-    function setSelects(urlParams, doPushState) {
+    function setSelects(urlParams, dontPushState) {
         let queryString = '?';
         $('button.opt').removeClass('active');
         if (urlParams.get('version')) {
@@ -87,7 +87,7 @@ $(document).ready(function () {
 
         showContent();
 
-        if (window.location.href.indexOf("/get_started") >= 0 && !doPushState) {
+        if (window.location.href.indexOf("/get_started") >= 0 && !dontPushState) {
             history.pushState(null, null, queryString);
         }
     }

--- a/docs/static_site/src/assets/js/options.js
+++ b/docs/static_site/src/assets/js/options.js
@@ -45,7 +45,7 @@ $(document).ready(function () {
         }
     }
 
-    function setSelects(urlParams) {
+    function setSelects(urlParams, doPushState) {
         let queryString = '?';
         $('button.opt').removeClass('active');
         if (urlParams.get('version')) {
@@ -87,7 +87,7 @@ $(document).ready(function () {
 
         showContent();
 
-        if (window.location.href.indexOf("/get_started") >= 0) {
+        if (window.location.href.indexOf("/get_started") >= 0 && !doPushState) {
             history.pushState(null, null, queryString);
         }
     }
@@ -129,5 +129,8 @@ $(document).ready(function () {
     $('.opt-group').on('click', '.opt', setContent);
     $('.install-widget').css("visibility", "visible");
     $('.install-content').css("visibility", "visible");
+    $(window).on('popstate', function(){
+        setSelects(urlSearchParams(window.location.search), true);
+    });
 
 });


### PR DESCRIPTION
## Description ##
Fixed issue https://github.com/apache/incubator-mxnet/issues/14583. On [get started page](https://mxnet.apache.org/get_started) when navigating back in session history through browser `back` button, the "Installing MXNet" options block does not update while the url was cut shorter. 
After the fix, when navigating back session history, the install options selection will be updated to previous state.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)

### Changes ###
- [x] Update install options section when navigating back history
- [x] Avoid install options section buttons' default css style, the blue `outline`, when losing focus during selection update

## Comments ##
Preview: http://ec2-52-38-4-82.us-west-2.compute.amazonaws.com/
