### PR TITLE
Fix for out of bound access in QuantizedElemwiseMulOpShape (#18034)

### DIFF
--- a/src/operator/quantization/quantized_elemwise_mul.cc
+++ b/src/operator/quantization/quantized_elemwise_mul.cc
@@ -58,7 +58,6 @@ inline bool QuantizedElemwiseMulOpShape(const nnvm::NodeAttrs& attrs,
   SHAPE_ASSIGN_CHECK(*in_attrs, quantized_elemwise_mul::kRhsMin, mxnet::TShape(1, 1));
   SHAPE_ASSIGN_CHECK(*in_attrs, quantized_elemwise_mul::kRhsMax, mxnet::TShape(1, 1));
 
-  out_attrs->clear();
   SHAPE_ASSIGN_CHECK(*out_attrs, quantized_elemwise_mul::kOut, lshape);
   if (!params.enable_float_output) {
     SHAPE_ASSIGN_CHECK(*out_attrs, quantized_elemwise_mul::kOutMin, mxnet::TShape(1, 1));

--- a/tests/python/quantization/test_quantization.py
+++ b/tests/python/quantization/test_quantization.py
@@ -353,10 +353,6 @@ def test_quantized_elemwise_mul():
         if is_test_for_native_cpu():
             print('skipped testing quantized_elemwise_mul for native cpu since it is not supported yet')
             return
-        if is_test_for_mkldnn():
-            print('skipped testing quantized_elemwise_mul for mkldnn due to '
-                  'https://github.com/apache/incubator-mxnet/issues/18034')
-            return
         elif qtype != 'int8':
             print('skipped testing quantized_elemwise_mul for not supported data type')
             return


### PR DESCRIPTION
* remove vector clear call before accessing memory
* enable test for MKLDNN

## Description ##
Fix for #18034