### PR TITLE
Specify mxnetci dockerhub user in docker-compose.yml

### DIFF
--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -28,8 +28,9 @@ services:
   ###################################################################################################
   centos7_cpu:
     # The resulting image will be named build.centos7_cpu:latest and will be
-    # pushed to mxnetci under this name
-    image: mxnetci/build.centos7_cpu:latest
+    # pushed to the dockerhub user specified in the environment variable
+    # ${DOCKER_CACHE_REGISTRY} (typicall "mxnetci") under this name
+    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_cpu:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -39,9 +40,9 @@ services:
         # BASE_IMAGE is used to dynamically specify the FROM image in Dockerfile.build.centos7
         BASE_IMAGE: centos:7
       cache_from:
-        - mxnetci/build.centos7_cpu:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.centos7_cpu:latest
   centos7_gpu_cu92:
-    image: mxnetci/build.centos7_gpu_cu92:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu92:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -49,9 +50,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:9.2-cudnn7-devel-centos7
       cache_from:
-        - mxnetci/build.centos7_gpu_cu92:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu92:latest
   centos7_gpu_cu100:
-    image: mxnetci/build.centos7_gpu_cu100:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu100:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -59,9 +60,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.0-cudnn7-devel-centos7
       cache_from:
-        - mxnetci/build.centos7_gpu_cu100:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu100:latest
   centos7_gpu_cu101:
-    image: mxnetci/build.centos7_gpu_cu101:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu101:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -69,9 +70,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.1-cudnn7-devel-centos7
       cache_from:
-        - mxnetci/build.centos7_gpu_cu101:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu101:latest
   centos7_gpu_cu102:
-    image: mxnetci/build.centos7_gpu_cu102:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu102:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -79,7 +80,7 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.2-cudnn7-devel-centos7
       cache_from:
-        - mxnetci/build.centos7_gpu_cu102:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.centos7_gpu_cu102:latest
   ###################################################################################################
   # Dockerfile.build.ubuntu based images. On Ubuntu we test more recent
   # toolchain and dependency versions compared to CentOS7. We attempt to update
@@ -88,7 +89,7 @@ services:
   # Ubuntu release.
   ###################################################################################################
   ubuntu_cpu:
-    image: mxnetci/build.ubuntu_cpu:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.ubuntu_cpu:latest
     build:
       context: .
       dockerfile: Dockerfile.build.ubuntu
@@ -96,9 +97,9 @@ services:
       args:
         BASE_IMAGE: ubuntu:18.04
       cache_from:
-        - mxnetci/build.ubuntu_cpu:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_cpu:latest
   ubuntu_gpu_cu101:
-    image: mxnetci/build.ubuntu_gpu_cu101:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.ubuntu_gpu_cu101:latest
     build:
       context: .
       dockerfile: Dockerfile.build.ubuntu
@@ -106,9 +107,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
       cache_from:
-        - mxnetci/build.ubuntu_gpu_cu101:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_gpu_cu101:latest
   ubuntu_build_cuda:
-    image: mxnetci/build.ubuntu_build_cuda:latest
+    image: ${DOCKER_CACHE_REGISTRY}/build.ubuntu_build_cuda:latest
     build:
       context: .
       dockerfile: Dockerfile.build.ubuntu
@@ -116,25 +117,25 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
       cache_from:
-        - mxnetci/build.ubuntu_build_cuda:latest
+        - ${DOCKER_CACHE_REGISTRY}/build.ubuntu_build_cuda:latest
   ###################################################################################################
   # Dockerfile.publish.test based images used for testing binary artifacts on minimal systems.
   ###################################################################################################
   publish.test.centos7_cpu:
-    image: mxnetci/publish.test.centos7_cpu:latest
+    image: ${DOCKER_CACHE_REGISTRY}/publish.test.centos7_cpu:latest
     build:
       context: .
       dockerfile: Dockerfile.publish.test.centos7
       args:
         BASE_IMAGE: centos:7
       cache_from:
-        - mxnetci/publish.test.centos7_cpu:latest
+        - ${DOCKER_CACHE_REGISTRY}/publish.test.centos7_cpu:latest
   publish.test.centos7_gpu:
-    image: mxnetci/publish.test.centos7_gpu:latest
+    image: ${DOCKER_CACHE_REGISTRY}/publish.test.centos7_gpu:latest
     build:
       context: .
       dockerfile: Dockerfile.publish.test.centos7
       args:
         BASE_IMAGE: nvidia/cuda:9.2-cudnn7-devel-centos7
       cache_from:
-        - mxnetci/publish.test.centos7_gpu:latest
+        - ${DOCKER_CACHE_REGISTRY}/publish.test.centos7_gpu:latest

--- a/ci/docker/docker-compose.yml
+++ b/ci/docker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   centos7_cpu:
     # The resulting image will be named build.centos7_cpu:latest and will be
     # pushed to mxnetci under this name
-    image: build.centos7_cpu:latest
+    image: mxnetci/build.centos7_cpu:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -39,12 +39,9 @@ services:
         # BASE_IMAGE is used to dynamically specify the FROM image in Dockerfile.build.centos7
         BASE_IMAGE: centos:7
       cache_from:
-        # Due to https://github.com/moby/moby/issues/32612, we have to specify
-        # the local image tag in in addition to the dockerhub tag.
-        - build.centos7_cpu:latest
         - mxnetci/build.centos7_cpu:latest
   centos7_gpu_cu92:
-    image: build.centos7_gpu_cu92:latest
+    image: mxnetci/build.centos7_gpu_cu92:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -52,10 +49,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:9.2-cudnn7-devel-centos7
       cache_from:
-        - build.centos7_gpu_cu92:latest
         - mxnetci/build.centos7_gpu_cu92:latest
   centos7_gpu_cu100:
-    image: build.centos7_gpu_cu100:latest
+    image: mxnetci/build.centos7_gpu_cu100:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -63,10 +59,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.0-cudnn7-devel-centos7
       cache_from:
-        - build.centos7_gpu_cu100:latest
         - mxnetci/build.centos7_gpu_cu100:latest
   centos7_gpu_cu101:
-    image: build.centos7_gpu_cu101:latest
+    image: mxnetci/build.centos7_gpu_cu101:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -74,10 +69,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.1-cudnn7-devel-centos7
       cache_from:
-        - build.centos7_gpu_cu101:latest
         - mxnetci/build.centos7_gpu_cu101:latest
   centos7_gpu_cu102:
-    image: build.centos7_gpu_cu102:latest
+    image: mxnetci/build.centos7_gpu_cu102:latest
     build:
       context: .
       dockerfile: Dockerfile.build.centos7
@@ -85,7 +79,6 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.2-cudnn7-devel-centos7
       cache_from:
-        - build.centos7_gpu_cu102:latest
         - mxnetci/build.centos7_gpu_cu102:latest
   ###################################################################################################
   # Dockerfile.build.ubuntu based images. On Ubuntu we test more recent
@@ -95,7 +88,7 @@ services:
   # Ubuntu release.
   ###################################################################################################
   ubuntu_cpu:
-    image: build.ubuntu_cpu:latest
+    image: mxnetci/build.ubuntu_cpu:latest
     build:
       context: .
       dockerfile: Dockerfile.build.ubuntu
@@ -103,10 +96,9 @@ services:
       args:
         BASE_IMAGE: ubuntu:18.04
       cache_from:
-        - build.ubuntu_cpu:latest
         - mxnetci/build.ubuntu_cpu:latest
   ubuntu_gpu_cu101:
-    image: build.ubuntu_gpu_cu101:latest
+    image: mxnetci/build.ubuntu_gpu_cu101:latest
     build:
       context: .
       dockerfile: Dockerfile.build.ubuntu
@@ -114,10 +106,9 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
       cache_from:
-        - build.ubuntu_gpu_cu101:latest
         - mxnetci/build.ubuntu_gpu_cu101:latest
   ubuntu_build_cuda:
-    image: build.ubuntu_build_cuda:latest
+    image: mxnetci/build.ubuntu_build_cuda:latest
     build:
       context: .
       dockerfile: Dockerfile.build.ubuntu
@@ -125,28 +116,25 @@ services:
       args:
         BASE_IMAGE: nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04
       cache_from:
-        - build.ubuntu_build_cuda:latest
         - mxnetci/build.ubuntu_build_cuda:latest
   ###################################################################################################
   # Dockerfile.publish.test based images used for testing binary artifacts on minimal systems.
   ###################################################################################################
   publish.test.centos7_cpu:
-    image: publish.test.centos7_cpu:latest
+    image: mxnetci/publish.test.centos7_cpu:latest
     build:
       context: .
       dockerfile: Dockerfile.publish.test.centos7
       args:
         BASE_IMAGE: centos:7
       cache_from:
-        - publish.test.centos7_cpu:latest
         - mxnetci/publish.test.centos7_cpu:latest
   publish.test.centos7_gpu:
-    image: publish.test.centos7_gpu:latest
+    image: mxnetci/publish.test.centos7_gpu:latest
     build:
       context: .
       dockerfile: Dockerfile.publish.test.centos7
       args:
         BASE_IMAGE: nvidia/cuda:9.2-cudnn7-devel-centos7
       cache_from:
-        - publish.test.centos7_gpu:latest
         - mxnetci/publish.test.centos7_gpu:latest


### PR DESCRIPTION
As `docker-compose push` is now used to push the respective images to the dockerhub, we must specify the username in the `docker-compose.yml`.

Reference http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-docker-cache-refresh/detail/master/2841/pipeline where CI attempts to push the image to the docker.io/library/build.centos7_cpu repository instead of docker.io/mxnetci/build.centos7_cpu