### PR TITLE
Fix LSTM and GRU layers gradient calculations

### DIFF
--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -195,7 +195,8 @@ inline size_t GetRNNWorkspaceSize(index_t seq_length,
     case rnn_enum::kLstm:
       size = seq_length * batch_size * hidden_size * (4 + direction) +  // wx*x + inter-y
           batch_size * hidden_size * 6 +                                // wh*h + h + c
-          seq_length * hidden_size * 8;                    // Used in Backward, Δbx, Δbh
+          seq_length * hidden_size * 8 +                   // Used in Backward, Δbx, Δbh
+          seq_length * batch_size * hidden_size * (direction - 1 ? direction : 0); // temporary dy in backward computation for bidirectional layers
       break;
     case rnn_enum::kGru:
       // Differs with Lstm, the outputs of three gates are also held in memory

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -196,7 +196,8 @@ inline size_t GetRNNWorkspaceSize(index_t seq_length,
       size = seq_length * batch_size * hidden_size * (4 + direction) +  // wx*x + inter-y
           batch_size * hidden_size * 6 +                                // wh*h + h + c
           seq_length * hidden_size * 8 +                   // Used in Backward, Δbx, Δbh
-          seq_length * batch_size * hidden_size * (direction - 1 ? direction : 0); // temporary dy in backward computation for bidirectional layers
+          // temporary dy in backward computation for bidirectional layers
+          seq_length * batch_size * hidden_size * (direction - 1 ? direction : 0);
       break;
     case rnn_enum::kGru:
       // Differs with Lstm, the outputs of three gates are also held in memory

--- a/src/operator/rnn_impl.h
+++ b/src/operator/rnn_impl.h
@@ -1511,7 +1511,7 @@ void GruBackward(DType* ws,
       if (dhy_l)
         dhy_l = dhy_l - D * N * H;
       y_l = y_l - T * N * H * D;
-      y_tmp = y_l;
+      y_tmp = y_tmp - T * N * H * D;
       if (l == 1) {
         wx_l = wx_l - (inputsize + H) * H * 3 * D;
         wh_l = wx_l + inputsize * 3 * H;

--- a/src/operator/rnn_impl.h
+++ b/src/operator/rnn_impl.h
@@ -597,7 +597,8 @@ void LstmBackward(DType* ws,
                                      dhy_cur_ptr, dcy_cur_ptr, w_cur_ptr, dw_cur_ptr, db_cur_ptr,
                                      req_data, req_params, req_state, req_statecell);
 
-      dy_tmp_ptr = loop_iter++ % 2 ? dy_tmp_ptr - y_size : dy_tmp_ptr + y_size; // prevent overwritting dy while calculation dx in left2right layer
+      // Prevent overwritting dy while calculating dx in left2right layer
+      dy_tmp_ptr = loop_iter++ % 2 ? dy_tmp_ptr - y_size : dy_tmp_ptr + y_size;
     }
     if (dropout > 0.0f && i > 0 && req_data != kNullOp) {
       dropout_random = dropout_random - T * N * D * H;

--- a/src/operator/rnn_impl.h
+++ b/src/operator/rnn_impl.h
@@ -564,7 +564,9 @@ void LstmBackward(DType* ws,
   const index_t w_size1 = (I + H) * H * 4;      // first layer
   const index_t w_size2 = (D * H + H) * H * 4;  // other layers
   const index_t cell_size = N * H;
+  const index_t y_size = T * N * H * D;
   DType* dy_tmp_ptr = ws2 + T * cell_size * 4 + cell_size * 3;
+  int loop_iter = 0;
   for (int i = L - 1; i >= 0; --i) {
     const index_t input_size = i ? H * D : I;
     const index_t w_size = i ? w_size2 : w_size1;
@@ -594,6 +596,8 @@ void LstmBackward(DType* ws,
                                      x, hx[idx], cx[idx], y, dy, dx, dhx[idx], dcx[idx],
                                      dhy_cur_ptr, dcy_cur_ptr, w_cur_ptr, dw_cur_ptr, db_cur_ptr,
                                      req_data, req_params, req_state, req_statecell);
+
+      dy_tmp_ptr = loop_iter++ % 2 ? dy_tmp_ptr - y_size : dy_tmp_ptr + y_size; // prevent overwritting dy while calculation dx in left2right layer
     }
     if (dropout > 0.0f && i > 0 && req_data != kNullOp) {
       dropout_random = dropout_random - T * N * D * H;

--- a/src/operator/rnn_impl.h
+++ b/src/operator/rnn_impl.h
@@ -566,7 +566,6 @@ void LstmBackward(DType* ws,
   const index_t cell_size = N * H;
   const index_t y_size = T * N * H * D;
   DType* dy_tmp_ptr = ws2 + T * cell_size * 4 + cell_size * 3;
-  int loop_iter = 0;
   for (int i = L - 1; i >= 0; --i) {
     const index_t input_size = i ? H * D : I;
     const index_t w_size = i ? w_size2 : w_size1;
@@ -598,7 +597,8 @@ void LstmBackward(DType* ws,
                                      req_data, req_params, req_state, req_statecell);
 
       // Prevent overwritting dy while calculating dx in left2right layer
-      dy_tmp_ptr = loop_iter++ % 2 ? dy_tmp_ptr - y_size : dy_tmp_ptr + y_size;
+      const int loop_iteration = (L - 1) - i;
+      dy_tmp_ptr = loop_iteration % 2 ? dy_tmp_ptr - y_size : dy_tmp_ptr + y_size;
     }
     if (dropout > 0.0f && i > 0 && req_data != kNullOp) {
       dropout_random = dropout_random - T * N * D * H;

--- a/tests/python/unittest/test_gluon_rnn.py
+++ b/tests/python/unittest/test_gluon_rnn.py
@@ -714,15 +714,10 @@ def check_rnn_consistency(fused_layer, stack_layer, loss, input_size, hidden_siz
     stack_input_grad = sx.grad.asnumpy()
 
     assert_allclose(fused_out.asnumpy(), stack_out.asnumpy(), rtol=rtol, atol=atol)
-    if mx.context.current_context().device_type == 'cpu' and \
-            not mx.runtime.Features().is_enabled('MKLDNN') and \
-            'rnn' not in fused_layer.prefix:
-        print("LSTM and GRU on native CPU give wrong gradients. "
-              "Tracking issue: https://github.com/apache/incubator-mxnet/issues/17898.")
-    else:
-        assert_allclose(fused_input_grad, stack_input_grad, rtol=rtol, atol=atol)
-        for key, value in fused_grads.items():
-            assert_allclose(value.asnumpy(), stack_grads[key].asnumpy(), rtol=rtol, atol=atol)
+    assert_allclose(fused_input_grad, stack_input_grad, rtol=rtol, atol=atol)
+    for key, value in fused_grads.items():
+        assert_allclose(value.asnumpy(), stack_grads[key].asnumpy(), rtol=rtol, atol=atol)
+
     num_layers = fused_begin_state[0].shape[0] // (2 if bidirectional else 1)
     check_rnn_states(fused_states, stack_states, num_layers, bidirectional, len(fused_begin_state) == 2)
 


### PR DESCRIPTION
## Description ##
Fix for LSTM and GRU layers without DNNL enabled give wrong gradients #17898

For bidiractional LSTM with number of layers > 2 input gradient calculation was incorrect.
Reason of wrong calculations was overwriting y derivative (dy) tensor by
calculated x derivative (dx) tensor before right2left layer could use dy for own
gradient calculations.

For GRU with number of layers > 2 i2h_weight gradient for
layers in the middle (all except last and first) was incorrect.
Wrong caluculations were caused by assigning output pointer to
input instead of calculating new input pointer.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

