### PR TITLE
Remove SM_75 architecture when compiling with CUDA 10.0

### DIFF
--- a/config/distribution/linux_cu100.cmake
+++ b/config/distribution/linux_cu100.cmake
@@ -33,4 +33,6 @@ set(USE_F16C OFF CACHE BOOL "Build with x86 F16C instruction support")
 set(USE_LIBJPEG_TURBO ON CACHE BOOL "Build with libjpeg-turbo")
 
 set(CUDACXX "/usr/local/cuda-10.0/bin/nvcc" CACHE STRING "Cuda compiler")
-set(MXNET_CUDA_ARCH "3.0;5.0;6.0;7.0;7.5" CACHE STRING "Cuda architectures")
+set(MXNET_CUDA_ARCH "3.0;5.0;6.0;7.0" CACHE STRING "Cuda architectures")
+# SM_75 (Turing) not included because issue https://github.com/apache/incubator-mxnet/issues/17713
+# Turing GPUs will execute code generated for SM_70 successfully


### PR DESCRIPTION
## Description ##
Avoid compilation of code for SM_75 architecture when compiling with CUDA 10.0 to solve bug [https://github.com/apache/incubator-mxnet/issues/17713](https://github.com/apache/incubator-mxnet/issues/17713)
GPUs based on SM_75 architecture are able to run code generated for SM_70 architecture:
[https://docs.nvidia.com/cuda/turing-compatibility-guide/index.html#turing-volta-compatibility](https://docs.nvidia.com/cuda/turing-compatibility-guide/index.html#turing-volta-compatibility)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Remove SM_75 as target architecture in linux_cu100 compilation
