### PR TITLE
fix shared buffer bug in executor

### DIFF
--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1725,7 +1725,7 @@ class Symbol(SymbolBase):
             shared_arg_name_list = shared_arg_names
 
         # prepare shared_buffer
-        if not shared_buffer:
+        if shared_buffer is None:
             shared_buffer_len = ctypes.c_int(-1)
             shared_buffer_names = ctypes.POINTER(ctypes.c_char_p)()
             shared_buffer_handles = ctypes.POINTER(NDArrayHandle)()

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1725,7 +1725,7 @@ class Symbol(SymbolBase):
             shared_arg_name_list = shared_arg_names
 
         # prepare shared_buffer
-        if shared_buffer is None:
+        if not shared_buffer:
             shared_buffer_len = ctypes.c_int(-1)
             shared_buffer_names = ctypes.POINTER(ctypes.c_char_p)()
             shared_buffer_handles = ctypes.POINTER(NDArrayHandle)()

--- a/src/c_api/c_api_executor.cc
+++ b/src/c_api/c_api_executor.cc
@@ -770,12 +770,14 @@ int _SimpleBindImpl(SymbolHandle symbol_handle,
     nd_idx = ret->ret_handles.size();
   }
 
+  size_t num_grads = 0;
   for (const auto& nd : arg_grad_vec) {
     if (nd.is_none()) {
       ret->ret_handles.push_back(nullptr);
     } else {
       ret->ret_handles.push_back(new NDArray(nd));
     }
+    num_grads += 1;
   }
   if (arg_grad_vec.size() > 0) {
     *arg_grads = &(ret->ret_handles[nd_idx]);
@@ -808,6 +810,8 @@ int _SimpleBindImpl(SymbolHandle symbol_handle,
       ret->ret_vec_charp.push_back(ret->ret_vec_str.back().c_str());
     }
     *shared_buffer_len = shared_buffer_map.size();
+    // gradient buffers are shared only if shared_exec is present
+    if (shared_exec_handle == nullptr) nd_idx -= num_grads;
     *updated_shared_buffer_handle_list = &(ret->ret_handles.at(nd_idx));
     *updated_shared_buffer_name_list = &(ret->ret_vec_charp[0]);
   }

--- a/tests/python/unittest/test_init.py
+++ b/tests/python/unittest/test_init.py
@@ -48,7 +48,6 @@ def test_aux_init():
     assert (mod.get_params()[1]['bn_moving_var'].asnumpy() == 1).all()
     assert (mod.get_params()[1]['bn_moving_mean'].asnumpy() == 0).all()
 
-@unittest.skip("rsp const init is broken: https://github.com/apache/incubator-mxnet/issues/17988")
 def test_rsp_const_init():
     def check_rsp_const_init(init, val):
         shape = (10, 10)


### PR DESCRIPTION
## Description ##
Fixes https://github.com/apache/incubator-mxnet/issues/17988 
It turns out to be a general issue in the symbolic graph executor python class, exposed by a sparse ndarray test. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
