### PR TITLE
Fix PyPI Packages and Python Docker Images nightly release

### DIFF
--- a/cd/Jenkinsfile_utils.groovy
+++ b/cd/Jenkinsfile_utils.groovy
@@ -116,12 +116,12 @@ def push_artifact(libmxnet_path, variant, libtype, license_paths = '', dependenc
   if(license_paths == null) license_paths = ''
   if(dependency_paths == null) dependency_paths = ''
 
-  sh "python3 ./cd/utils/artifact_repository.py --push --verbose --libtype ${libtype} --variant ${variant} --libmxnet ${libmxnet_path} --licenses ${license_paths} --dependencies ${dependency_paths}"
+  sh "python3 ./cd/utils/artifact_repository.py --push --verbose --libtype ${libtype} --variant ${variant} --libmxnet ${libmxnet_path} --licenses ${license_paths} --dependencies ${dependency_paths} --os ubuntu18.04"
 }
 
 // pull artifact from repository
 def pull_artifact(variant, libtype, destination = '') {
-  sh "python3 ./cd/utils/artifact_repository.py --pull --verbose --libtype ${libtype} --variant ${variant} --destination ${destination}"
+  sh "python3 ./cd/utils/artifact_repository.py --pull --verbose --libtype ${libtype} --variant ${variant} --destination ${destination} --os ubuntu18.04"
 }
 
 // pulls artifact from repository and places files in the appropriate directories

--- a/cd/python/docker/Jenkins_pipeline.groovy
+++ b/cd/python/docker/Jenkins_pipeline.groovy
@@ -49,21 +49,21 @@ def build(mxnet_variant) {
     ci_utils.docker_run(environment, "cd_package_pypi ${mxnet_variant}", nvidia_docker)
 
     // build python docker images
-    sh "python3 ./cd/python/docker/python_images.sh build ${mxnet_variant}"
+    sh "./cd/python/docker/python_images.sh build ${mxnet_variant}"
   }
 }
 
 def test(mxnet_variant) {
   ws("workspace/python_docker/${mxnet_variant}/${env.BUILD_NUMBER}") {
     // test python docker images
-    sh "python3 ./cd/python/docker/python_images.sh test ${mxnet_variant}"
+    sh "./cd/python/docker/python_images.sh test ${mxnet_variant}"
   }
 }
 
 def push(mxnet_variant) {
   ws("workspace/python_docker/${mxnet_variant}/${env.BUILD_NUMBER}") {
     // push python docker images
-    sh "python3 ./cd/python/docker/python_images.sh push ${mxnet_variant}"
+    sh "./cd/python/docker/python_images.sh push ${mxnet_variant}"
   }
 }
 

--- a/cd/python/pypi/Jenkins_pipeline.groovy
+++ b/cd/python/pypi/Jenkins_pipeline.groovy
@@ -66,11 +66,11 @@ def push(mxnet_variant) {
   ws("workspace/python_pypi/${mxnet_variant}/${env.BUILD_NUMBER}") {
     // publish package to pypi
     if (mxnet_variant in pypi_releases) {
-      sh "python3 ./ci/docker/runtime_functions.sh cd_pypi_publish"
+      sh "./ci/docker/runtime_functions.sh cd_pypi_publish"
     } else {
       echo "Temporarily skipping publishing PyPI package for '${mxnet_variant}'."
     }
-    sh "python3 ./ci/docker/runtime_functions.sh cd_s3_publish"
+    sh "./ci/docker/runtime_functions.sh cd_s3_publish"
   }
 }
 

--- a/cd/utils/artifact_repository.py
+++ b/cd/utils/artifact_repository.py
@@ -396,7 +396,7 @@ def get_s3_key_prefix(args: argparse.Namespace, subdir: str = '') -> str:
     :param subdir: An optional subdirectory in which to store the files. Post-pended to the end of the prefix.
     :return: A string containing the S3 key prefix to be used to uploading and downloading files to the artifact repository
     """
-    prefix = "{git_sha}/{libtype}/{variant}/".format(**vars(args))
+    prefix = "{git_sha}/{libtype}/{os}/{variant}/".format(**vars(args))
     if subdir:
         return "{}{}/".format(prefix, subdir)
     return prefix

--- a/cd/utils/artifact_repository.py
+++ b/cd/utils/artifact_repository.py
@@ -396,7 +396,7 @@ def get_s3_key_prefix(args: argparse.Namespace, subdir: str = '') -> str:
     :param subdir: An optional subdirectory in which to store the files. Post-pended to the end of the prefix.
     :return: A string containing the S3 key prefix to be used to uploading and downloading files to the artifact repository
     """
-    prefix = "{git_sha}/{libtype}/{os}/{variant}/".format(**vars(args))
+    prefix = "{git_sha}/{libtype}/{variant}/".format(**vars(args))
     if subdir:
         return "{}{}/".format(prefix, subdir)
     return prefix


### PR DESCRIPTION
## Description ##
Nightly PyPI packages are currently not getting published to https://dist.mxnet.io/python/all

There is an error in pipeline Build stage for GPU variants [link](http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job/detail/mxnet-cd-release-job/1053/pipeline/77). The logs state the following error - `ERROR: No artifacts found for this configuration.`

The binaries for all variants are present in s3, but GPU builds couldn't find them as they are searching at the wrong path. This issue arises because the s3 bucket path contains OS version, which is different during upload and download of GPU binaries. This PR fixes this issue by hard-coding OS to be the same for both upload and download.

This also resolves a similar error in Python docker images pipeline [link](http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job/detail/mxnet-cd-release-job/1054/pipeline/124)

There is another error in both pipelines: [link1](http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job/detail/mxnet-cd-release-job/1053/pipeline/308) [link2](http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job/detail/mxnet-cd-release-job/1054/pipeline/62), which is due to a `SyntaxError` caused by incorrect bash script trigger command. This PR also resolves these bugs.