### PR TITLE
fix when clicking version dropdown it jumps to top of the page

### DIFF
--- a/docs/static_site/src/assets/js/options.js
+++ b/docs/static_site/src/assets/js/options.js
@@ -149,4 +149,8 @@ $(document).ready(function () {
         .mouseenter(toggleDropdown.bind(null, true))
         .mouseleave(toggleDropdown.bind(null, false))
         .click(function() {$(".version-dropdown").toggle()});
+
+    $("ul.version-dropdown").click(function(e) {
+        e.preventDefault();
+    });
 });


### PR DESCRIPTION
## Description ##
This PR fixes #16231 ,  the fix is to delegate an event handler to parent node `ul` to prevent all its child nodes`<a/>` from triggering default click action (direct to target url, which cause the page to jump to the top). 

To verify the change: 
Go to `get started` page and see "Mxnet version" drop down, scroll down a little bit and hover on the version drop down. After selecting any of the version, the page should stay at where is was (compare to unexpectedly jump to top of the page). 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Tested on Chrome, Edge, Safari and Firefox
- [x] Tested on mobile

### Changes ###
- [x] Fixed MXNet Version selection Drop-down makes page jump to top of page

## Comments ##
- Preview - http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/
