### PR TITLE
Make GPU kernel for argsort use int32

### DIFF
--- a/src/operator/tensor/init_op.h
+++ b/src/operator/tensor/init_op.h
@@ -637,8 +637,8 @@ void EyeFill(const nnvm::NodeAttrs& attrs,
 
 
 struct range_fwd {
-  template<typename DType>
-  MSHADOW_XINLINE static void Map(index_t i, index_t repeat, DType start, DType step,
+  template<typename DType, typename IDXType = index_t>
+  MSHADOW_XINLINE static void Map(index_t i, IDXType repeat, DType start, DType step,
                                   int req, DType* out) {
     KERNEL_ASSIGN(out[i], req, start + (i/repeat) * step);
   }

--- a/src/operator/tensor/ordering_op-inl.h
+++ b/src/operator/tensor/ordering_op-inl.h
@@ -132,13 +132,14 @@ struct ArgSortParam : public dmlc::Parameter<ArgSortParam> {
   }
 };
 
+template<typename IDXType = index_t>
 inline void ParseTopKParam(const TShape& src_shape,
                            const TopKParam& param,
                            TShape *target_shape,
                            size_t *batch_size,
-                           index_t *element_num,
+                           IDXType *element_num,
                            int *axis,
-                           index_t *k,
+                           IDXType *k,
                            bool *do_transpose,
                            bool *is_ascend) {
   *do_transpose = false;
@@ -190,8 +191,8 @@ using namespace mshadow;
 
 
 struct fill_ind_to_one {
-  template<typename DType>
-  MSHADOW_XINLINE static void Map(int i, const index_t* indices, DType* out) {
+  template<typename DType, typename IDXType = index_t>
+  MSHADOW_XINLINE static void Map(int i, const IDXType* indices, DType* out) {
     out[indices[i]] = static_cast<DType>(1);
   }
 };
@@ -204,45 +205,45 @@ struct fill_ind {
   }
 };
 
-template<typename DType>
+template<typename DType, typename IDXType>
 MSHADOW_FORCE_INLINE void TopKSort(const Tensor<cpu, 1, DType>& dat,
-                                   const Tensor<cpu, 1, index_t>& ind,
+                                   const Tensor<cpu, 1, IDXType>& ind,
                                    const Tensor<cpu, 1, char>& work,
-                                   index_t K, index_t N, bool is_ascend,
+                                   IDXType K, IDXType N, bool is_ascend,
                                    Stream<cpu> *s) {
   // Use full sort when K is relatively large.
   const bool full_sort(K*8 > N);
   // Batch size.
-  const index_t M(work.size(0)/(sizeof(DType)*N));
+  const IDXType M(work.size(0)/(sizeof(DType)*N));
   const int omp_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount());
   #pragma omp parallel for num_threads(omp_threads)
-  for (index_t i = 0; i < M; ++i) {
+  for (IDXType i = 0; i < M; ++i) {
     // Tensor `work` stores the flattened source data, while `dat` stores the sorted result.
     DType *vals = reinterpret_cast<DType*>(work.dptr_);
     DType *sorted_vals = dat.dptr_+i*N;
-    index_t *indices = ind.dptr_+i*N;
+    IDXType *indices = ind.dptr_+i*N;
     if (is_ascend) {
       if (full_sort) {
         std::sort(indices, indices+N,
-                  [&](const index_t& i1, const index_t& i2){
+                  [&](const IDXType& i1, const IDXType& i2){
           return vals[i1] < vals[i2]; });
       } else {
         std::partial_sort(indices, indices+K, indices+N,
-                          [&](const index_t& i1, const index_t& i2){
+                          [&](const IDXType& i1, const IDXType& i2){
           return vals[i1] < vals[i2]; });
       }
     } else {
       if (full_sort) {
         std::sort(indices, indices+N,
-                  [&](const index_t& i1, const index_t& i2){
+                  [&](const IDXType& i1, const IDXType& i2){
           return vals[i1] > vals[i2]; });
       } else {
         std::partial_sort(indices, indices+K, indices+N,
-                          [&](const index_t& i1, const index_t& i2){
+                          [&](const IDXType& i1, const IDXType& i2){
           return vals[i1] > vals[i2]; });
       }
     }
-    for (index_t j = 0; j < K; ++j) {
+    for (IDXType j = 0; j < K; ++j) {
       sorted_vals[j] = vals[indices[j]];
     }
   }
@@ -250,20 +251,20 @@ MSHADOW_FORCE_INLINE void TopKSort(const Tensor<cpu, 1, DType>& dat,
 
 #ifdef __CUDACC__
 
-template<typename DType>
-MSHADOW_XINLINE bool TopKCompare(DType val1, index_t ind1, DType val2, index_t ind2,
+template<typename DType, typename IDXType>
+MSHADOW_XINLINE bool TopKCompare(DType val1, IDXType ind1, DType val2, int32_t ind2,
                                  bool is_ascend) {
   // Negative indices denote undefined values which are considered arbitrary small resp. large.
   return (ind2 < 0) || (ind1 >= 0 && ((is_ascend && val1 < val2) || (!is_ascend && val1 > val2)));
 }
 
-template<typename DType>
-MSHADOW_XINLINE void MergeTopK(index_t K, DType *val1, index_t *ind1, DType *val2, index_t *ind2,
+template<typename DType, typename IDXType>
+MSHADOW_XINLINE void MergeTopK(IDXType K, DType *val1, int32_t *ind1, DType *val2, int32_t *ind2,
                                bool is_ascend) {
   // In-place merge of two sorted top-K lists into val1/ind1. First determine the intervals
   // [0,..,i1], [0,..i2] of the two lists that will be part of the merged list.
-  index_t i1(K-1), i2(K-1);
-  for (index_t i = 0; i < K; ++i) {
+  IDXType i1(K-1), i2(K-1);
+  for (IDXType i = 0; i < K; ++i) {
     if (TopKCompare(val1[i1], ind1[i1], val2[i2], ind2[i2], is_ascend)) {
       --i2;
     } else {
@@ -271,7 +272,7 @@ MSHADOW_XINLINE void MergeTopK(index_t K, DType *val1, index_t *ind1, DType *val
     }
   }
   // Now merge the lists from back to front.
-  for (index_t i = K; i--;) {
+  for (IDXType i = K; i--;) {
     if (i2 < 0 || i1 >= 0 && TopKCompare(val2[i2], ind2[i2], val1[i1], ind1[i1], is_ascend)) {
       val1[i] = val1[i1];
       ind1[i] = ind1[i1];
@@ -284,29 +285,29 @@ MSHADOW_XINLINE void MergeTopK(index_t K, DType *val1, index_t *ind1, DType *val
   }
 }
 
-template<typename DType>
-__global__ void PartialSortSmallK(index_t K, index_t N, DType *val, index_t *ind, bool is_ascend) {
+template<typename DType, typename IDXType = int32_t>
+__global__ void PartialSortSmallK(IDXType K, IDXType N, DType *val, IDXType *ind, bool is_ascend) {
   // Buffer for pairwise reduction.
-  extern __shared__ index_t buff[];
+  extern __shared__ int32_t buff[];
   // Start of buffer sections associated with this thread.
-  const index_t offset(threadIdx.x*K);
-  index_t *ind_buff = &buff[offset];
+  const IDXType offset(threadIdx.x*K);
+  int32_t *ind_buff = &buff[offset];
   DType *val_buff = reinterpret_cast<DType*>(&buff[blockDim.x*K])+offset;
   // Initialize top-K values for this thread.
-  for (index_t i = 0; i < K; ++i) {
+  for (IDXType i = 0; i < K; ++i) {
     ind_buff[i] = -1;
   }
   // Range of values this thread cares about. Each thread block processes
   // a different batch item (i.e. a different set of ind/val where we
   // have to select the top-K elements). All threads within the same
   // block work on the same batch item.
-  const index_t first(blockIdx.x*N+threadIdx.x), last((blockIdx.x+1)*N);
+  const IDXType first(blockIdx.x*N+threadIdx.x), last((blockIdx.x+1)*N);
   // Select top-K from this range and store it sorted in the buffer.
   // We assume a small K, so linear insertion is o.k.
-  for (index_t i = first; i < last; i += blockDim.x) {
+  for (IDXType i = first; i < last; i += blockDim.x) {
     DType cur_val(val[i]);
-    index_t cur_ind(ind[i]);
-    for (index_t j = K; j-- && TopKCompare(cur_val, cur_ind, val_buff[j],
+    IDXType cur_ind(ind[i]);
+    for (IDXType j = K; j-- && TopKCompare(cur_val, cur_ind, val_buff[j],
                                            ind_buff[j], is_ascend); ) {
       if (j+1 < K) {
         val_buff[j+1] = val_buff[j];
@@ -318,7 +319,7 @@ __global__ void PartialSortSmallK(index_t K, index_t N, DType *val, index_t *ind
   }
   // Recursive merge of sorted lists for this thread block. Note that blockDim.x is not
   // necessary a power of two, therefore the additional checks for last_s.
-  for (index_t s = (blockDim.x+1)/2, last_s = blockDim.x;
+  for (IDXType s = (blockDim.x+1)/2, last_s = blockDim.x;
        last_s > 1; last_s = s, s = (s+1)/2) {
     __syncthreads();
     if (threadIdx.x < s && threadIdx.x+s < last_s) {
@@ -327,29 +328,29 @@ __global__ void PartialSortSmallK(index_t K, index_t N, DType *val, index_t *ind
   }
   // Final updates on master thread.
   if (threadIdx.x == 0) {
-    for (index_t i = 0; i < K; ++i) {
+    for (IDXType i = 0; i < K; ++i) {
       ind[blockIdx.x*N+i] = ind_buff[i];
       val[blockIdx.x*N+i] = val_buff[i];
     }
   }
 }
 
-template<typename DType>
+template<typename DType, typename IDXType>
 MSHADOW_FORCE_INLINE void TopKSort(const Tensor<gpu, 1, DType>& dat,
-                                   const Tensor<gpu, 1, index_t>& ind,
+                                   const Tensor<gpu, 1, IDXType>& ind,
                                    const Tensor<gpu, 1, char>& work,
-                                   index_t K, index_t N, bool is_ascend,
+                                   IDXType K, IDXType N, bool is_ascend,
                                    Stream<gpu> *s) {
   // Use full sort for all but very small K for which we
   // can do a partial sort entirely within shared memory.
   const bool full_sort(K > 5);
   // Batch size.
-  const index_t M(dat.size(0)/N);
+  const IDXType M(dat.size(0)/N);
   if (full_sort) {
     // Divide workspace into two parts. The first one is needed to store batch ids.
-    size_t alignment = std::max(sizeof(DType), sizeof(index_t));
-    size_t id_size = PadBytes(sizeof(index_t) * ind.size(0), alignment);
-    Tensor<gpu, 1, index_t> batch_id(reinterpret_cast<index_t*>(work.dptr_),
+    size_t alignment = std::max(sizeof(DType), sizeof(IDXType));
+    size_t id_size = PadBytes(sizeof(IDXType) * ind.size(0), alignment);
+    Tensor<gpu, 1, IDXType> batch_id(reinterpret_cast<IDXType*>(work.dptr_),
                                      Shape1(ind.size(0)), s);
     Tensor<gpu, 1, char> sort_work(work.dptr_+id_size, Shape1(work.size(0)-id_size), s);
     mxnet::op::SortByKey(dat, ind, is_ascend, &sort_work);
@@ -362,7 +363,7 @@ MSHADOW_FORCE_INLINE void TopKSort(const Tensor<gpu, 1, DType>& dat,
     }
   } else {
     const int nthreads(mshadow::cuda::kBaseThreadNum);
-    PartialSortSmallK<<<M, nthreads, nthreads*K*(sizeof(index_t)+sizeof(DType)),
+    PartialSortSmallK<<<M, nthreads, nthreads*K*(sizeof(IDXType)+sizeof(DType)),
                         mshadow::Stream<gpu>::GetStream(s)>>>
                         (K, N, dat.dptr_, ind.dptr_, is_ascend);
   }
@@ -384,7 +385,7 @@ MSHADOW_FORCE_INLINE void TopKSort(const Tensor<gpu, 1, DType>& dat,
    * \tparam DType type of the output value/mask.
    * \tparam IDType type of the output indices.
    */
-template<typename xpu, typename DType, typename IDType>
+template<typename xpu, typename DType, typename IDType, typename IDXType = index_t>
 void TopKImpl(const RunContext &ctx,
               const Resource &resource,
               const std::vector<OpReqType>& req,
@@ -400,53 +401,53 @@ void TopKImpl(const RunContext &ctx,
   Tensor<xpu, 1, char> workspace;
   Tensor<xpu, 1, char> temp_workspace;
   Tensor<xpu, 1, DType> sorted_dat;
-  Tensor<xpu, 1, index_t> indices, sel_indices;
+  Tensor<xpu, 1, IDXType> indices, sel_indices;
   size_t batch_size = 0;
-  index_t element_num = 0;  // number of batches + the size of each batch
+  IDXType element_num = 0;  // number of batches + the size of each batch
   int axis = 0;
   bool do_transpose = false;
   bool is_ascend = false;
-  index_t k = 0;
-  size_t alignment = std::max(sizeof(DType), sizeof(index_t));
+  IDXType k = 0;
+  size_t alignment = std::max(sizeof(DType), sizeof(IDXType));
   mxnet::TShape target_shape;
   ParseTopKParam(src.shape_, param,
                  &target_shape, &batch_size, &element_num, &axis, &k, &do_transpose, &is_ascend);
-  CHECK_LE(element_num, mxnet::common::MaxIntegerValue<index_t>())
+  CHECK_LE(element_num, mxnet::common::MaxIntegerValue<IDXType>())
     << "'index_t' does not have a sufficient precision to represent "
     << "the indices of the input array. The total element_num is "
     << element_num << ", but the selected index_t can only represent "
-    << mxnet::common::MaxIntegerValue<index_t>() << " elements";
+    << mxnet::common::MaxIntegerValue<IDXType>() << " elements";
   Tensor<xpu, 3, DType> dat = src.FlatTo3D<xpu, DType>(axis, axis, s);
   // Temp space needed by the full sorts.
   size_t temp_size = std::max(
-      mxnet::op::SortByKeyWorkspaceSize<index_t, DType, xpu>(src.Size()),
-      mxnet::op::SortByKeyWorkspaceSize<DType, index_t, xpu>(src.Size()));
+      mxnet::op::SortByKeyWorkspaceSize<IDXType, DType, xpu>(src.Size()),
+      mxnet::op::SortByKeyWorkspaceSize<DType, IDXType, xpu>(src.Size()));
 
   temp_size = std::max(temp_size,
-      mxnet::op::SortByKeyWorkspaceSize<index_t, index_t, xpu>(src.Size()));
+      mxnet::op::SortByKeyWorkspaceSize<IDXType, IDXType, xpu>(src.Size()));
   // Additional temp space for gpu full sorts for batch ids.
-  temp_size += PadBytes(sizeof(index_t) * src.Size(), alignment);
+  temp_size += PadBytes(sizeof(IDXType) * src.Size(), alignment);
   // Temp space for cpu sorts.
   temp_size = std::max(temp_size, sizeof(DType) * src.Size());
 
   size_t workspace_size = temp_size + PadBytes(sizeof(DType) * src.Size(), alignment)
-                                    + PadBytes(sizeof(index_t) * src.Size(), alignment);
+                                    + PadBytes(sizeof(IDXType) * src.Size(), alignment);
   if (param.ret_typ == topk_enum::kReturnMask) {
-    workspace_size += PadBytes(sizeof(index_t) * batch_size * k, alignment);
+    workspace_size += PadBytes(sizeof(IDXType) * batch_size * k, alignment);
   }
   workspace = resource.get_space_typed<xpu, 1, char>(Shape1(workspace_size), s);
   char* workspace_curr_ptr = workspace.dptr_;
   sorted_dat = Tensor<xpu, 1, DType>(reinterpret_cast<DType*>(workspace_curr_ptr),
       Shape1(src.Size()), s);  // contain sorted dat
   workspace_curr_ptr += PadBytes(sizeof(DType) * src.Size(), alignment);
-  indices = Tensor<xpu, 1, index_t>(reinterpret_cast<index_t*>(workspace_curr_ptr),
+  indices = Tensor<xpu, 1, IDXType>(reinterpret_cast<IDXType*>(workspace_curr_ptr),
       Shape1(src.Size()), s);  // indices in the original matrix
-  workspace_curr_ptr += PadBytes(sizeof(index_t) * src.Size(), alignment);
+  workspace_curr_ptr += PadBytes(sizeof(IDXType) * src.Size(), alignment);
 
   if (param.ret_typ == topk_enum::kReturnMask) {
-    sel_indices = Tensor<xpu, 1, index_t>(reinterpret_cast<index_t*>(workspace_curr_ptr),
+    sel_indices = Tensor<xpu, 1, IDXType>(reinterpret_cast<IDXType*>(workspace_curr_ptr),
                                       Shape1(batch_size * k), s);
-    workspace_curr_ptr += PadBytes(sizeof(index_t) * batch_size * k, alignment);
+    workspace_curr_ptr += PadBytes(sizeof(IDXType) * batch_size * k, alignment);
     CHECK_EQ(sel_indices.CheckContiguous(), true);
   }
 
@@ -475,8 +476,7 @@ void TopKImpl(const RunContext &ctx,
     temp_workspace = Tensor<xpu, 1, char>(workspace_curr_ptr, Shape1(temp_size), s);  // temp space
     workspace_curr_ptr += temp_size;
   }
-
-  mxnet_op::Kernel<range_fwd, xpu>::Launch(s, batch_size * element_num, 1, index_t{0}, index_t{1},
+  mxnet_op::Kernel<range_fwd, xpu>::Launch(s, batch_size * element_num, 1, IDXType{0}, IDXType{1},
     kWriteTo, indices.dptr_);
   CHECK_EQ(indices.CheckContiguous(), true);
 
@@ -807,8 +807,13 @@ void ArgSort(const nnvm::NodeAttrs& attrs,
   topk_param.ret_typ = topk_enum::kReturnIndices;
   MXNET_NO_FLOAT16_TYPE_SWITCH(inputs[0].type_flag_, DType, {
     MSHADOW_TYPE_SWITCH(param.dtype, IDType, {
-      TopKImpl<xpu, DType, IDType>(ctx.run_ctx,
-                                   ctx.requested[0], req, inputs[0], outputs, topk_param);
+      if (ctx.run_ctx.get_ctx().dev_type == Context::kGPU) {
+        TopKImpl<xpu, DType, IDType, int32_t>(ctx.run_ctx,
+                                     ctx.requested[0], req, inputs[0], outputs, topk_param);
+      } else {
+        TopKImpl<xpu, DType, IDType>(ctx.run_ctx,
+                                     ctx.requested[0], req, inputs[0], outputs, topk_param);
+      }
     });
   });
 }


### PR DESCRIPTION
## Description ##
Making GPU kernel for argsort use int32_t. Existing implementation already uses optimized thrust library. Slowdown is only due to index_t -> int64_t when building with Large Tensor Support(LTS). Also, LTS is only supported for CPU for now. Changes are have been made in such a way that if MXNet support int64_t for GPU later the changes required would be minimal.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Testing ##
- will be updated

## Benchmark code: ##

```
import mxnet as mx
import mxnet.ndarray as nd
from benchmark.opperf.utils.benchmark_utils import run_performance_test

#local_ctx = mx.cpu()
local_ctx = mx.gpu()


add_res = run_performance_test(nd.argsort, run_backward=True, dtype='float32', ctx=local_ctx,
                               inputs=[{'data': (500000, 10, 10), 'axis': 0}],
                               warmup=50, runs=500, profiler='python')
print(add_res)

add_res = run_performance_test(nd.argsort, run_backward=True, dtype='float32', ctx=local_ctx,
                               inputs=[{'data': (1, 5000000, 10), 'axis': 1}],
                               warmup=50, runs=500, profiler='python')
print(add_res)

add_res = run_performance_test(nd.argsort, run_backward=True, dtype='float32', ctx=local_ctx,
                               inputs=[{'data': (10, 5000000), 'axis': 1}],
                               warmup=50, runs=500, profiler='python')
print(add_res)

add_res = run_performance_test(nd.argsort, run_backward=True, dtype='float32', ctx=local_ctx,
                               inputs=[{'data': (5000000, 1, 10), 'axis': None}],
                               warmup=50, runs=500, profiler='python')
print(add_res)
```

## Performance Results ##
time in ms

| code version | cases                                      | avg    | p50    | p90    |
|--------------|--------------------------------------------|--------|--------|--------|
|  master LT   | 'input': (500000, 10, 10), 'axis': 0     | 91.56  | 91.61  | 91.98  |
|              | 'input': (1, 5000000, 10), 'axis': 1      | 80.36  | 80.33  | 80.50  |
|              | 'input': (10, 5000000), 'axis': 1         | 77.10  | 77.09  | 77.15  |
|              | 'input': (5000000, 1, 10), 'axis': None | 24.04 | 24.01 | 24.05 |
|              |                                            |        |        |        |
|  master  no-LT   | 'input': (500000, 10, 10), 'axis': 0     | 45.09  | 45.08  | 45.40  |
|              | 'input': (1, 5000000, 10), 'axis': 1      | 35.84  | 35.82  | 35.92  |
|              | 'input': (10, 5000000), 'axis': 1         | 33.10  | 33.04  | 33.15  |
|              | 'input': (5000000, 1, 10), 'axis': None | 15.81 | 15.80 | 15.90 |
|              |                                            |        |        |        |
|  new LT   | 'input': (500000, 10, 10), 'axis': 0     | 45.24  | 45.26  | 45.61  |
|              | 'input': (1, 5000000, 10), 'axis': 1      | 36.48  | 36.44  | 36.62  |
|              | 'input': (10, 5000000), 'axis': 1         | 33.06  | 33.03  | 33.12  |
|              | 'input': (5000000, 1, 10), 'axis': None | 15.81 | 15.79 | 15.85 |
|              |                                            |        |        |        |
|  new no-LT   | 'input': (500000, 10, 10), 'axis': 0     | 45.12  | 45.11  | 45.39  |
|              | 'input': (1, 5000000, 10), 'axis': 1      | 35.86  | 35.85  | 35.96  |
|              | 'input': (10, 5000000), 'axis': 1         | 33.06  | 33.03  | 33.10  |
|              | 'input': (5000000, 1, 10), 'axis': None | 15.76 | 15.75 | 15.80 |


## SSD Performance ##

| Code Version | Samples/sec    | |            | Epoch time(sec) |        |        |
|--------------|-------------|-------|-------|------------|--------|--------|
|              | avg         | p50   | p90   | avg        | p50    | p90    |
| master LT    | 61.70       | 74.20 | 75.46 | 338.64     | 338.81 | 341.47 |
| master no-LT | 73.80       | 74.47 | 75.24 | 225.79     | 225.81 | 225.98 |
| new LT       | 63.15       | 74.66 | 75.77 | 339.50     | 339.68 | 342.18 |
| new no-LT    | 73.51       | 74.28 | 75.08 | 226.38     | 226.39 | 226.77 |