### PR TITLE
add python3 to run safe_docker_run.py

### DIFF
--- a/cd/python/docker/python_images.sh
+++ b/cd/python/docker/python_images.sh
@@ -57,7 +57,7 @@ test() {
 
     # Ensure the correct context root is passed in when building - Dockerfile.test expects ci directory
     docker build -t "${test_image_name}" --build-arg USER_ID=`id -u` --build-arg GROUP_ID=`id -g` --build-arg BASE_IMAGE="${image_name}" -f ${resources_path}/Dockerfile.test ./ci
-    ./ci/safe_docker_run.py ${runtime_param} --cap-add "SYS_PTRACE" -u `id -u`:`id -g` -v `pwd`:/work/mxnet "${test_image_name}" ${resources_path}/test_python_image.sh "${mxnet_variant}"
+    python3 ci/safe_docker_run.py ${runtime_param} --cap-add "SYS_PTRACE" -u `id -u`:`id -g` -v `pwd`:/work/mxnet "${test_image_name}" ${resources_path}/test_python_image.sh "${mxnet_variant}"
 }
 
 push() {

--- a/ci/test_safe_docker_run.py
+++ b/ci/test_safe_docker_run.py
@@ -408,7 +408,7 @@ class TestSafeDockerRun(unittest.TestCase):
         # to the atexit
         for sig in [None, signal.SIGTERM, signal.SIGINT]:
             # Execute the safe docker run script in a different process
-            proc = subprocess.Popen(['./safe_docker_run.py', "--name", container_name, "ubuntu:18.04", "sleep 10"])
+            proc = subprocess.Popen(['python3','safe_docker_run.py', "--name", container_name, "ubuntu:18.04", "sleep 10"])
             # NOTE: we need to wait for the container to come up as not all operating systems support blocking signals
             if wait_for_container(container_name) is False:
                 raise RuntimeError("Test container did not come up")


### PR DESCRIPTION
## Description ##
The nightly CD release of docker images currently fails as it runs `safe_docker_run.py` as an executable when it is a python script. This PR fixes that along with a test running the same file.

Here's is the link to the broken CD pipeline:
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job/detail/mxnet-cd-release-job/1075/pipeline