### PR TITLE
[v1.7.x] Backport fixing batch_norm and layer_norm for large tensors (#17805)

### DIFF
--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -330,7 +330,7 @@ static bool BatchNormShape(const nnvm::NodeAttrs& attrs,
       : param.axis);
   CHECK_LT(channelAxis, dshape.ndim()) << "Channel axis out of range: " << param.axis;
 
-  const int channelCount = dshape[channelAxis];
+  const index_t channelCount = dshape[channelAxis];
 
   if (!mxnet::ndim_is_known(dshape)) {
     return false;

--- a/src/operator/nn/layer_norm.cc
+++ b/src/operator/nn/layer_norm.cc
@@ -47,7 +47,7 @@ static bool LayerNormShape(const nnvm::NodeAttrs& attrs,
   CHECK(axis >= 0 && axis < dshape.ndim())
     << "Channel axis out of range: axis=" << param.axis;
 
-  const int channelCount = dshape[axis];
+  const index_t channelCount = dshape[axis];
 
   if (!mxnet::ndim_is_known(dshape)) {
     return false;


### PR DESCRIPTION
Backport to fix large tensor nightly test issue
Co-authored-by: Rohit Kumar Srivastava <srivastava.141@buckeyemail.osu.edu>

Verified the changes locally by

setting up the Infra https://cwiki.apache.org/confluence/display/MXNET/Reproducing+test+results
Build : 
```
sudo ci/build.py --docker-registry mxnetci --platform ubuntu_nightly_cpu --docker-build-retries 3 --shm-size 500m /work/runtime_functions.sh build_ubuntu_cpu_large_tensor
```
Test
```
sudo ci/build.py --docker-registry mxnetci --platform ubuntu_nightly_cpu --docker-build-retries 3 --shm-size 500m /work/runtime_functions.sh nightly_test_large_vector
```
```