### PR TITLE
[v1.x] Work around two pylint false positives in mxnet/io/io.py

### DIFF
--- a/python/mxnet/io/io.py
+++ b/python/mxnet/io/io.py
@@ -226,7 +226,7 @@ class DataIter(object):
             raise StopIteration
 
     def __next__(self):
-        return self.next()
+        return self.next() # pylint: disable=E1102
 
     def iter_next(self):
         """Move to the next batch.
@@ -830,7 +830,7 @@ class MXDataIter(DataIter):
 
         # load the first batch to get shape information
         self.first_batch = None
-        self.first_batch = self.next()
+        self.first_batch = self.next() # pylint: disable=E1102
         data = self.first_batch.data[0]
         label = self.first_batch.label[0]
 


### PR DESCRIPTION
## Description ##

With the latest pylint, lint checks fail due to the following errors:

```
************* Module mxnet.io.io
python/mxnet/io/io.py:229:15: E1102: self.next is not callable (not-callable)
python/mxnet/io/io.py:833:27: E1102: self.next is not callable (not-callable)
```

Original CI log: http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Fsanity/detail/PR-18268/2/pipeline

You may reproduce this by running `python3 -m pylint --rcfile=./ci/other/pylintrc --ignore-patterns=".*\.so$$,.*\.dll$$,.*\.dylib$$" python/mxnet/io/io.py`.

This PR simply disables the rule that is giving false positives on these lines.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Disable linter checks where they are giving false positives

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
