### PR TITLE
[Numpy] Port nd.random.multinomial to npx.sample_categorical

### DIFF
--- a/src/operator/random/sample_multinomial_op.cc
+++ b/src/operator/random/sample_multinomial_op.cc
@@ -32,6 +32,7 @@ DMLC_REGISTER_PARAMETER(SampleMultinomialParam);
 
 NNVM_REGISTER_OP(_sample_multinomial)
 .add_alias("sample_multinomial")
+.add_alias("_npx_sample_categorical")
 .describe(R"code(Concurrent sampling from multiple multinomial distributions.
 
 *data* is an *n* dimensional array whose last dimension has length *k*, where

--- a/src/operator/random/sample_multinomial_op.cc
+++ b/src/operator/random/sample_multinomial_op.cc
@@ -32,7 +32,7 @@ DMLC_REGISTER_PARAMETER(SampleMultinomialParam);
 
 NNVM_REGISTER_OP(_sample_multinomial)
 .add_alias("sample_multinomial")
-.add_alias("_npx_sample_categorical")
+.add_alias("_npx__random_categorical")
 .describe(R"code(Concurrent sampling from multiple multinomial distributions.
 
 *data* is an *n* dimensional array whose last dimension has length *k*, where

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -4545,6 +4545,33 @@ def test_np_multivariate_normal():
 
 @with_seed()
 @use_np
+def test_npx_categorical():
+    class TestNumpyCategorical(HybridBlock):
+        def __init__(self, size=None):
+            super(TestNumpyCategorical, self).__init__()
+            self.size = size
+
+        def hybrid_forward(self, F, prob):
+            if self.size is None:
+                return F.npx.sample_categorical(prob)
+            return F.npx.sample_categorical(prob, shape=self.size)
+
+    batch_sizes = [(2,), (2, 3)]
+    event_shapes = [None, (10,), (10, 12)]
+    num_event = [2, 4, 10]
+    for batch_size, num_event, event_shape in itertools.product(batch_sizes, num_event, event_shapes):
+        for hybridize in [True, False]:
+            prob = np.ones(batch_size + (num_event,)) / num_event
+            net = TestNumpyCategorical(event_shape)
+            if hybridize:
+                net.hybridize()
+            mx_out = net(prob)
+            desired_shape = batch_size + event_shape if event_shape is not None else batch_size
+            assert mx_out.shape == desired_shape
+
+
+@with_seed()
+@use_np
 def test_random_seed():
     for seed in [234, 594, 7240, 20394]:
         ret = []

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -4553,8 +4553,8 @@ def test_npx_categorical():
 
         def hybrid_forward(self, F, prob):
             if self.size is None:
-                return F.npx.sample_categorical(prob)
-            return F.npx.sample_categorical(prob, shape=self.size)
+                return F.npx.random.categorical(prob)
+            return F.npx.random.categorical(prob, shape=self.size)
 
     batch_sizes = [(2,), (2, 3)]
     event_shapes = [None, (10,), (10, 12)]


### PR DESCRIPTION
## Description ##

https://github.com/apache/incubator-mxnet/issues/18270



## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
