### PR TITLE
Fix parse operator attributes in new FFI

### DIFF
--- a/src/api/operator/utils.cc
+++ b/src/api/operator/utils.cc
@@ -26,10 +26,6 @@
 
 namespace mxnet {
 
-bool is_recording() {
-  return Imperative::Get()->is_recording();
-}
-
 void SetInOut(std::vector<NDArray*>* ndinputs,
               std::vector<NDArray*>* ndoutputs,
               int num_inputs,

--- a/src/api/operator/utils.cc
+++ b/src/api/operator/utils.cc
@@ -26,6 +26,14 @@
 
 namespace mxnet {
 
+bool is_recording() {
+  return Imperative::Get()->is_recording();
+}
+
+bool is_deferred_compute() {
+  return Imperative::Get()->is_deferred_compute();
+}
+
 void SetInOut(std::vector<NDArray*>* ndinputs,
               std::vector<NDArray*>* ndoutputs,
               int num_inputs,
@@ -90,7 +98,7 @@ std::vector<NDArray*> Invoke(const nnvm::Op* op,
       Imperative::DCInfo::Compute(*input);
     }
     auto state = Imperative::Get()->Invoke(Context::CPU(), *attrs, ndinputs, ndoutputs);
-    if (Imperative::Get()->is_recording()) {
+    if (is_recording()) {
       Imperative::Get()->RecordOp(std::move(*attrs), ndinputs, ndoutputs, state);
     }
   }

--- a/src/api/operator/utils.h
+++ b/src/api/operator/utils.h
@@ -47,13 +47,9 @@ std::vector<NDArray*> Invoke(const nnvm::Op* op,
                              int* num_outputs,
                              NDArray** outputs);
 
-bool is_recording();
-
 template<typename T>
 void SetAttrDict(nnvm::NodeAttrs* attrs) {
-  if (is_recording()) {
-    ::dmlc::get<T>(attrs->parsed).SetAttrDict(&(attrs->dict));
-  }
+  ::dmlc::get<T>(attrs->parsed).SetAttrDict(&(attrs->dict));
 }
 
 template<typename ValueType, typename T>

--- a/src/api/operator/utils.h
+++ b/src/api/operator/utils.h
@@ -47,9 +47,14 @@ std::vector<NDArray*> Invoke(const nnvm::Op* op,
                              int* num_outputs,
                              NDArray** outputs);
 
+bool is_recording();
+bool is_deferred_compute();
+
 template<typename T>
 void SetAttrDict(nnvm::NodeAttrs* attrs) {
-  ::dmlc::get<T>(attrs->parsed).SetAttrDict(&(attrs->dict));
+  if (is_recording() || is_deferred_compute()) {
+    ::dmlc::get<T>(attrs->parsed).SetAttrDict(&(attrs->dict));
+  }
 }
 
 template<typename ValueType, typename T>

--- a/tests/python/unittest/test_deferred_compute.py
+++ b/tests/python/unittest/test_deferred_compute.py
@@ -170,8 +170,7 @@ def test_dc_numpy_tril():
         c = nd.tril(a, -1)
         return [b, c]
 
-    # for mode in ('all', 'symbolic', 'imperative', 'imperativewithnondccompute'):
-    for mode in ('symbolic', ):
+    for mode in ('all', 'symbolic', 'imperative', 'imperativewithnondccompute'):
         _assert_dc(_dc_simple_setup, f, mode=mode)
 
 

--- a/tests/python/unittest/test_deferred_compute.py
+++ b/tests/python/unittest/test_deferred_compute.py
@@ -162,6 +162,19 @@ def test_dc_no_inputs_subset_of_output():
     _all_assert_dc(_dc_empty_setup, f)
 
 
+def test_dc_numpy_tril():
+    def f(a, *, nd):
+        assert nd is mx.np
+        a = nd.ones((2, 2))
+        b = nd.tril(a, 1)
+        c = nd.tril(a, -1)
+        return [b, c]
+
+    # for mode in ('all', 'symbolic', 'imperative', 'imperativewithnondccompute'):
+    for mode in ('symbolic', ):
+        _assert_dc(_dc_simple_setup, f, mode=mode)
+
+
 ###############################################################################
 # Test cases with inputs
 ###############################################################################


### PR DESCRIPTION
## Description ##
Previously attributes are only parsed if autograd is active, causing https://github.com/apache/incubator-mxnet/issues/18004 