### PR TITLE
Enable test_amp_conversion

### DIFF
--- a/tests/python/gpu/test_contrib_amp.py
+++ b/tests/python/gpu/test_contrib_amp.py
@@ -104,7 +104,6 @@ def test_amp_coverage(amp_tests):
                        - If you are not sure which list to choose, FP32_FUNCS is the
                          safest option""")
 
-@pytest.mark.skip(reason='Error during waitall(). Tracked in #18099')
 @with_seed()
 def test_amp_conversion(amp_tests):
     def check_amp_convert_symbol():


### PR DESCRIPTION
TVMOP feature is now disabled on GPU builds, which caused this test to fail previously

Fixes https://github.com/apache/incubator-mxnet/issues/18099