### PR TITLE
Add a timeout to the storage profiler in case mem_counters_ is not yet initialized

### DIFF
--- a/src/profiler/storage_profiler.h
+++ b/src/profiler/storage_profiler.h
@@ -54,12 +54,12 @@ class DeviceStorageProfiler {
       if (prof->IsProfiling(profiler::Profiler::kMemory)) {
         Init();
         const size_t idx = prof->DeviceIndex(handle.ctx.dev_type, handle.ctx.dev_id);
-	// sleep for a few seconds until the mem_counters_ is fully initialized
-	size_t timeout = 1000;
-	while (idx >= mem_counters_.size() && timeout > 0) {
-	  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-	  timeout -= 100;
-	}
+        // sleep for a few seconds until the mem_counters_ is fully initialized
+        size_t timeout = 1000;
+        while (idx >= mem_counters_.size() && timeout > 0) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+          timeout -= 100;
+        }
         CHECK_LT(idx, mem_counters_.size()) << "Invalid device index: " << idx;
         *mem_counters_[idx] += handle.size;
       }
@@ -76,12 +76,12 @@ class DeviceStorageProfiler {
       if (prof->IsProfiling(profiler::Profiler::kMemory)) {
         Init();  // In case of bug which tries to free first
         const size_t idx = prof->DeviceIndex(handle.ctx.dev_type, handle.ctx.dev_id);
-	// sleep for a few seconds until the mem_counters_ is fully initialized
-	size_t timeout = 1000;
-	while (idx >= mem_counters_.size() && timeout > 0) {
-	  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-	  timeout -= 100;
-	}
+        // sleep for a few seconds until the mem_counters_ is fully initialized
+        size_t timeout = 1000;
+        while (idx >= mem_counters_.size() && timeout > 0) {
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
+          timeout -= 100;
+        }
         CHECK_LT(idx, mem_counters_.size()) << "Invalid device index: " << idx;
         if (*mem_counters_[idx] >= handle.size) {
             *mem_counters_[idx] -= handle.size;

--- a/src/profiler/storage_profiler.h
+++ b/src/profiler/storage_profiler.h
@@ -24,7 +24,9 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <thread>
 #include <unordered_map>
+#include <chrono>
 #include "./profiler.h"
 
 namespace mxnet {
@@ -52,6 +54,12 @@ class DeviceStorageProfiler {
       if (prof->IsProfiling(profiler::Profiler::kMemory)) {
         Init();
         const size_t idx = prof->DeviceIndex(handle.ctx.dev_type, handle.ctx.dev_id);
+	// sleep for a few seconds until the mem_counters_ is fully initialized
+	size_t timeout = 1000;
+	while (idx >= mem_counters_.size() && timeout > 0) {
+	  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	  timeout -= 100;
+	}
         CHECK_LT(idx, mem_counters_.size()) << "Invalid device index: " << idx;
         *mem_counters_[idx] += handle.size;
       }
@@ -68,6 +76,12 @@ class DeviceStorageProfiler {
       if (prof->IsProfiling(profiler::Profiler::kMemory)) {
         Init();  // In case of bug which tries to free first
         const size_t idx = prof->DeviceIndex(handle.ctx.dev_type, handle.ctx.dev_id);
+	// sleep for a few seconds until the mem_counters_ is fully initialized
+	size_t timeout = 1000;
+	while (idx >= mem_counters_.size() && timeout > 0) {
+	  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	  timeout -= 100;
+	}
         CHECK_LT(idx, mem_counters_.size()) << "Invalid device index: " << idx;
         if (*mem_counters_[idx] >= handle.size) {
             *mem_counters_[idx] -= handle.size;


### PR DESCRIPTION
## Description ##
If multiple thread access the storage profiler, `mem_counters_` might not be fully initialized.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
