### PR TITLE
Fix coredumps

### DIFF
--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -63,7 +63,7 @@ namespace mxnet {
 static void SegfaultLogger(int sig) {
   fprintf(stderr, "\nSegmentation fault: %d\n\n", sig);
   fprintf(stderr, "%s", dmlc::StackTrace().c_str());
-  exit(-1);
+  abort();
 }
 #endif
 


### PR DESCRIPTION
Fix MXNet trapping the segfault signal and preventing coredumps being generated.

Edit: Comparison of user experience during segfault with and without this PR:

```
[ins] In [1]: import gc
         ...: import objgraph
         ...: gc.set_debug(gc.DEBUG_SAVEALL)
         ...: import mxnet as mx
         ...: net = mx.gluon.nn.Dense(10, in_units=10)
         ...: net.initialize()
         ...: objgraph.show_refs([net.weight._data[0]], filename='weight_array.png')
         ...: del net
         ...: print(gc.collect())
Graph written to /tmp/objgraph-2ypakr86.dot (28 nodes)
Image generated as weight_array.png
38

[ins] In [2]: gc.garbage
Out[2]:
Segmentation fault: 11

%  
```

ipython crashed and user is back to shell. With this PR 

```
[ins] In [1]: import gc
         ...: import objgraph
         ...: gc.set_debug(gc.DEBUG_SAVEALL)
         ...: import mxnet as mx
         ...: net = mx.gluon.nn.Dense(10, in_units=10)
         ...: net.initialize()
         ...: objgraph.show_refs([net.weight._data[0]], filename='weight_array.png')
         ...: del net
         ...: print(gc.collect())
Graph written to /tmp/objgraph-b0i9rl27.dot (28 nodes)
Image generated as weight_array.png
38

[ins] In [2]: gc.garbage
Out[2]:
Segmentation fault: 11

zsh: abort      ipython
% echo $?                                                                                                                                                          9s ~/src/mxnet-master/build fixcoredumps
134
```

After this PR, if the user set `ulimit -c unlimited` prior to running the segfault inducing program, they will get a coredump for analysis in gdb.