### PR TITLE
[OpPerf] Add example of using opperf with internal op locally

### DIFF
--- a/benchmark/opperf/README.md
+++ b/benchmark/opperf/README.md
@@ -167,6 +167,41 @@ Output for the above benchmark run, on a CPU machine, would look something like 
              ]}
 
 ```
+
+## Usecase 5 - Profile internal operators locally
+Currently, opperf supports operators in `mx.nd.*` namespace.
+However, locally, one can profile internal operators in `mx.nd.internal.*` namespace.
+
+#### Changes
+Remove the hasattr check for `op.__name__` to be in `mx.nd`
+
+The resulting diff would look like :
+```
+-        if hasattr(mx.nd, op.__name__):
+-            benchmark_result = _run_nd_operator_performance_test(op, inputs, run_backward, warmup, runs, kwargs_list, profiler)
+-        else:
+-            raise ValueError("Unknown NDArray operator provided to benchmark. -  ", op.__name__)
++        #if hasattr(mx.nd, op.__name__):
++        benchmark_result = _run_nd_operator_performance_test(op, inputs, run_backward, warmup, runs, kwargs_list, profiler)
++        #else:
++            #raise ValueError("Unknown NDArray operator provided to benchmark. -  ", op.__name__)
+```
+
+#### Result
+This should allow profiling of any operator in MXNet provided user provides valid parameters [`inputs`, `run_backward`, etc] to the `run_performance_test` function.
+
+#### Example
+Provided the source code change is made in the `benchmark/opperf/utils/benchmark_utils.py`
+```
+>>> import mxnet as mx
+>>> from mxnet import nd
+>>> from benchmark.opperf.utils.benchmark_utils import run_performance_test
+>>> run_performance_test(mx.nd._internal._copyto,inputs=[{"data":mx.nd.array([1,2]),"out":mx.nd.empty(shape=mx.nd.array([1,2]).shape,ctx=mx.cpu())}])
+INFO:root:Begin Benchmark - _copyto
+INFO:root:Complete Benchmark - _copyto
+[{'_copyto': [{'inputs': {'data': '<NDArray 2 @cpu(0)>', 'out': '<NDArray 2 @cpu(0)>'}, 'max_storage_mem_alloc_cpu/0': 0.004}]}]
+```
+
 # How does it work under the hood?
 
 Under the hood, executes NDArray operator using randomly generated data. Use MXNet profiler to get summary of the operator execution:
@@ -196,6 +231,7 @@ add_res = run_performance_test([nd.add, nd.subtract], run_backward=True, dtype='
                                warmup=10, runs=25, profiler='python')
 ```
 By default, MXNet profiler is used as the profiler engine.
+
 
 # TODO
 

--- a/benchmark/opperf/README.md
+++ b/benchmark/opperf/README.md
@@ -176,11 +176,15 @@ However, locally, one can profile internal operators in `mx.nd.internal.*` names
 Remove the hasattr check for `op.__name__` to be in `mx.nd`
 
 The resulting diff would look like :
+##### Old Code
 ```
 -        if hasattr(mx.nd, op.__name__):
 -            benchmark_result = _run_nd_operator_performance_test(op, inputs, run_backward, warmup, runs, kwargs_list, profiler)
 -        else:
 -            raise ValueError("Unknown NDArray operator provided to benchmark. -  ", op.__name__)
+```
+##### New Code
+```
 +        #if hasattr(mx.nd, op.__name__):
 +        benchmark_result = _run_nd_operator_performance_test(op, inputs, run_backward, warmup, runs, kwargs_list, profiler)
 +        #else:

--- a/docs/static_site/src/pages/api/r/docs/tutorials/ndarray.md
+++ b/docs/static_site/src/pages/api/r/docs/tutorials/ndarray.md
@@ -149,7 +149,7 @@ If two `NDArray`s are located on different devices, we need to explicitly move t
 ```r
 a <- mx.nd.ones(c(2, 3)) * 2
 b <- mx.nd.ones(c(2, 3), mx.gpu()) / 8
-c <- mx.nd.copyto(a, mx.gpu()) * b
+c <- a.copyto(mx.gpu()) * b
 as.array(c)
 ```
 
@@ -202,7 +202,7 @@ following example, `a <- a + 1` and `c <- c * 3` can be executed in parallel, bu
 ```r
 a <- mx.nd.ones(c(2,3))
 b <- a
-c <- mx.nd.copyto(a, mx.cpu())
+c <- a.copyto(mx.cpu())
 a <- a + 1
 b <- b * 3
 c <- c * 3

--- a/docs/static_site/src/pages/api/r/docs/tutorials/ndarray.md
+++ b/docs/static_site/src/pages/api/r/docs/tutorials/ndarray.md
@@ -149,7 +149,7 @@ If two `NDArray`s are located on different devices, we need to explicitly move t
 ```r
 a <- mx.nd.ones(c(2, 3)) * 2
 b <- mx.nd.ones(c(2, 3), mx.gpu()) / 8
-c <- a.copyto(mx.gpu()) * b
+c <- mx.nd.copyto(a, mx.gpu()) * b
 as.array(c)
 ```
 
@@ -202,7 +202,7 @@ following example, `a <- a + 1` and `c <- c * 3` can be executed in parallel, bu
 ```r
 a <- mx.nd.ones(c(2,3))
 b <- a
-c <- a.copyto(mx.cpu())
+c <- mx.nd.copyto(a, mx.cpu())
 a <- a + 1
 b <- b * 3
 c <- c * 3

--- a/docs/static_site/src/pages/api/r/docs/tutorials/symbol.md
+++ b/docs/static_site/src/pages/api/r/docs/tutorials/symbol.md
@@ -1,6 +1,6 @@
 ---
 layout: page_api
-title: Symbol
+title: NDArray
 is_tutorial: true
 tag: r
 permalink: /api/r/docs/tutorials/symbol


### PR DESCRIPTION
## Description ##
Currently opperf supports for mx.nd operators alone.
However, locally, one can test internal ops. Documenting it in readme.


@access2rohit @sandeep-krishnamurthy @connorgoggins 