### PR TITLE
[R] Fix incorrect website title for Symbol API in R

### DIFF
--- a/docs/static_site/src/pages/api/r/docs/tutorials/ndarray.md
+++ b/docs/static_site/src/pages/api/r/docs/tutorials/ndarray.md
@@ -149,7 +149,7 @@ If two `NDArray`s are located on different devices, we need to explicitly move t
 ```r
 a <- mx.nd.ones(c(2, 3)) * 2
 b <- mx.nd.ones(c(2, 3), mx.gpu()) / 8
-c <- mx.nd.copyto(a, mx.gpu()) * b
+c <- a.copyto(mx.gpu()) * b
 as.array(c)
 ```
 
@@ -202,7 +202,7 @@ following example, `a <- a + 1` and `c <- c * 3` can be executed in parallel, bu
 ```r
 a <- mx.nd.ones(c(2,3))
 b <- a
-c <- mx.nd.copyto(a, mx.cpu())
+c <- a.copyto(mx.cpu())
 a <- a + 1
 b <- b * 3
 c <- c * 3

--- a/docs/static_site/src/pages/api/r/docs/tutorials/ndarray.md
+++ b/docs/static_site/src/pages/api/r/docs/tutorials/ndarray.md
@@ -149,7 +149,7 @@ If two `NDArray`s are located on different devices, we need to explicitly move t
 ```r
 a <- mx.nd.ones(c(2, 3)) * 2
 b <- mx.nd.ones(c(2, 3), mx.gpu()) / 8
-c <- a.copyto(mx.gpu()) * b
+c <- mx.nd.copyto(a, mx.gpu()) * b
 as.array(c)
 ```
 
@@ -202,7 +202,7 @@ following example, `a <- a + 1` and `c <- c * 3` can be executed in parallel, bu
 ```r
 a <- mx.nd.ones(c(2,3))
 b <- a
-c <- a.copyto(mx.cpu())
+c <- mx.nd.copyto(a, mx.cpu())
 a <- a + 1
 b <- b * 3
 c <- c * 3

--- a/docs/static_site/src/pages/api/r/docs/tutorials/symbol.md
+++ b/docs/static_site/src/pages/api/r/docs/tutorials/symbol.md
@@ -1,6 +1,6 @@
 ---
 layout: page_api
-title: NDArray
+title: Symbol
 is_tutorial: true
 tag: r
 permalink: /api/r/docs/tutorials/symbol


### PR DESCRIPTION
## Description ##
~~1. `mx.nd.copyto` doesnt exist~~
mx.nd.copyto exists for R API [but not for Python API]
2. website title shows ndarray instead of symbol


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

