### PR TITLE
Fix memory leaks in Gluon

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -23,8 +23,10 @@ __all__ = ['Block', 'HybridBlock', 'SymbolBlock']
 import threading
 import copy
 import warnings
-import re
+import weakref
 from collections import OrderedDict, defaultdict
+
+import re
 import numpy as np
 
 from ..base import mx_real_t, MXNetError, NDArrayHandle, py_str
@@ -48,7 +50,7 @@ class _BlockScope(object):
     _current = threading.local()
 
     def __init__(self, block):
-        self._block = block
+        self._block = weakref.ref(block) if block is not None else None
         self._counter = {}
         self._old_scope = None
         self._name_scope = None
@@ -60,7 +62,8 @@ class _BlockScope(object):
         The profiler scope is to support the GPU memory profiler.
         """
         current = getattr(_BlockScope._current, "value", None)
-        if current is None:
+        block = current._block() if current is not None else None
+        if current is None or block is None:
             if prefix is None:
                 if not hasattr(_name.NameManager._current, "value"):
                     _name.NameManager._current.value = _name.NameManager()
@@ -79,29 +82,31 @@ class _BlockScope(object):
             prefix = '%s%d_'%(hint, count)
             current._counter[hint] = count + 1
         if params is None:
-            parent = current._block.params
+            parent = block.params
             params = ParameterDict(parent.prefix+prefix, parent._shared)
         else:
             params = ParameterDict(params.prefix, params)
         # replace the trailing underscore with colon
         profiler_scope_name = (prefix[:-1] if prefix.endswith('_') \
                                else prefix) + ":"
-        return current._block.prefix + prefix, params, \
-               current._block._profiler_scope_name + profiler_scope_name
+        return block.prefix + prefix, params, \
+               block._profiler_scope_name + profiler_scope_name
 
     def __enter__(self):
-        if self._block._empty_prefix:
+        block = self._block()
+        if block is None or block._empty_prefix:
             return self
         self._old_scope = getattr(_BlockScope._current, "value", None)
         _BlockScope._current.value = self
-        self._name_scope = _name.Prefix(self._block.prefix)
+        self._name_scope = _name.Prefix(block.prefix)
         self._name_scope.__enter__()
-        self._profiler_scope = _profiler.Scope(self._block._profiler_scope_name)
+        self._profiler_scope = _profiler.Scope(block._profiler_scope_name)
         self._profiler_scope.__enter__()
         return self
 
     def __exit__(self, ptype, value, trace):
-        if self._block._empty_prefix:
+        block = self._block()
+        if block is None or block._empty_prefix:
             return
         self._name_scope.__exit__(ptype, value, trace)
         self._name_scope = None

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -3231,6 +3231,10 @@ def test_reqs_switching_training_inference():
     mx.test_utils.assert_almost_equal(grad1, grad2)
 
 def test_no_memory_leak_in_gluon():
+    # Collect all other garbage prior to this test. Otherwise the test may fail
+    # due to unrelated memory leaks.
+    gc.collect()
+
     gc_flags = gc.get_debug()
     gc.set_debug(gc.DEBUG_SAVEALL)
     net = mx.gluon.nn.Dense(10, in_units=10)

--- a/tests/python/unittest/test_thread_local.py
+++ b/tests/python/unittest/test_thread_local.py
@@ -125,8 +125,9 @@ def test_blockscope():
     status = [False]
     event = threading.Event()
     def f():
-        with block._BlockScope(dummy_block("spawned_")):
-            x= NameManager.current.get(None, "hello")
+        net = dummy_block("spawned_")  # BlockScope only keeps a weakref to the Block
+        with block._BlockScope(net):
+            x = NameManager.current.get(None, "hello")
             event.wait()
             if x == "spawned_hello0":
                 status[0] = True


### PR DESCRIPTION
## Description ##
Previously the _BlockScope keeps references to the parameter ndarrays, preventing memory from being freed if a Block is not used anymore. Among other problems, this causes memory usage to increase constantly in unittests (due to testing different blocks and disposing them at the end of the test) until the garbage collector kicks in (which can be too late and the system can run OOM as the parameter arrays can be large).
