### PR TITLE
Fix FInferType of ops to support partial type inference

### DIFF
--- a/src/operator/batch_norm_v1-inl.h
+++ b/src/operator/batch_norm_v1-inl.h
@@ -281,7 +281,10 @@ class BatchNormV1Prop : public OperatorProperty {
     using namespace mshadow;
     CHECK_GE(in_type->size(), 1U);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     // For float16 input type beta, gamma, mean, and average are stored in float32.
     // For other input types, these parameters have the same type as input
     // NOTE: This requirement is from cuDNN (v. 4 and 5)

--- a/src/operator/contrib/batch_norm_relu.cc
+++ b/src/operator/contrib/batch_norm_relu.cc
@@ -85,7 +85,10 @@ static bool BatchNormWithReLUType(const nnvm::NodeAttrs& attrs,
   using namespace mshadow;
   CHECK_GE(in_type->size(), 1U);
   const int dtype = (*in_type)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
   // For float16 input type beta, gamma, mean, and average are stored in float32.
   // For other input types, these parameters have the same type as input
   // NOTE: This requirement is from cuDNN (v. 4 and 5)

--- a/src/operator/contrib/count_sketch-inl.h
+++ b/src/operator/contrib/count_sketch-inl.h
@@ -184,7 +184,10 @@ class CountSketchProp : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     for (size_t i = 0; i < in_type->size(); ++i) {
       if ((*in_type)[i] == -1) {
         (*in_type)[i] = dtype;

--- a/src/operator/contrib/deformable_convolution-inl.h
+++ b/src/operator/contrib/deformable_convolution-inl.h
@@ -454,7 +454,10 @@ class DeformableConvolutionProp : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1U);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     for (size_t i = 0; i < in_type->size(); ++i) {
       if ((*in_type)[i] == -1) {
         (*in_type)[i] = dtype;

--- a/src/operator/contrib/deformable_psroi_pooling-inl.h
+++ b/src/operator/contrib/deformable_psroi_pooling-inl.h
@@ -253,7 +253,10 @@ class DeformablePSROIPoolingProp : public OperatorProperty {
     CHECK_GE(in_type->size(), 2);
     int dtype = (*in_type)[0];
     CHECK_EQ(dtype, (*in_type)[1]);
-    CHECK_NE(dtype, -1) << "Input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
 
     out_type->clear();
     out_type->push_back(dtype);

--- a/src/operator/contrib/fft-inl.h
+++ b/src/operator/contrib/fft-inl.h
@@ -253,7 +253,10 @@ class FFTProp : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     for (size_t i = 0; i < in_type->size(); ++i) {
       if ((*in_type)[i] == -1) {
         (*in_type)[i] = dtype;

--- a/src/operator/contrib/ifft-inl.h
+++ b/src/operator/contrib/ifft-inl.h
@@ -245,7 +245,10 @@ class IFFTProp : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     for (size_t i=0; i < in_type->size(); ++i) {
       if ((*in_type)[i] == -1) {
         (*in_type)[i] = dtype;

--- a/src/operator/contrib/modulated_deformable_convolution-inl.h
+++ b/src/operator/contrib/modulated_deformable_convolution-inl.h
@@ -517,7 +517,10 @@ class ModulatedDeformableConvolutionProp : public OperatorProperty {
     std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1U);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     for (std::size_t i = 0; i < in_type->size(); ++i) {
       if ((*in_type)[i] == -1) {
         (*in_type)[i] = dtype;

--- a/src/operator/contrib/mrcnn_mask_target-inl.h
+++ b/src/operator/contrib/mrcnn_mask_target-inl.h
@@ -109,7 +109,10 @@ inline bool MRCNNMaskTargetType(const NodeAttrs& attrs,
                                 std::vector<int>* out_type) {
   CHECK_EQ(in_type->size(), 4);
   int dtype = (*in_type)[1];
-  CHECK_NE(dtype, -1) << "Input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
 
   out_type->clear();
   out_type->push_back(dtype);

--- a/src/operator/contrib/multi_sum_sq-inl.h
+++ b/src/operator/contrib/multi_sum_sq-inl.h
@@ -69,7 +69,10 @@ inline bool MultiSumSqType(const NodeAttrs& attrs,
   const auto& p = dmlc::get<MultiSumSqParam>(attrs.parsed);
   CHECK_EQ(in_type->size(), p.num_arrays);
   int dtype = (*in_type)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
   for (size_t i = 0; i < in_type->size(); ++i) {
     if ((*in_type)[i] == -1) {
       (*in_type)[i] = dtype;

--- a/src/operator/contrib/psroi_pooling-inl.h
+++ b/src/operator/contrib/psroi_pooling-inl.h
@@ -196,7 +196,10 @@ class PSROIPoolingProp : public OperatorProperty {
     CHECK_EQ(in_type->size(), 2);
     int dtype = (*in_type)[0];
     CHECK_EQ(dtype, (*in_type)[1]);
-    CHECK_NE(dtype, -1) << "Input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
 
     out_type->clear();
     out_type->push_back(dtype);

--- a/src/operator/contrib/roi_align.cc
+++ b/src/operator/contrib/roi_align.cc
@@ -600,7 +600,10 @@ He, Kaiming, et al. "Mask R-CNN." ICCV, 2017
   CHECK_EQ(in_type->size(), 2);
   int dtype = (*in_type)[0];
   CHECK_EQ(dtype, (*in_type)[1]);
-  CHECK_NE(dtype, -1) << "Input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
 
   out_type->clear();
   out_type->push_back(dtype);

--- a/src/operator/contrib/rroi_align.cc
+++ b/src/operator/contrib/rroi_align.cc
@@ -305,7 +305,10 @@ IEEE Transactions on Multimedia, 2018.
   CHECK_EQ(in_type->size(), 2U);
   int dtype = (*in_type)[0];
   CHECK_EQ(dtype, (*in_type)[1]);
-  CHECK_NE(dtype, -1) << "Input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
 
   out_type->clear();
   out_type->push_back(dtype);

--- a/src/operator/contrib/sync_batch_norm-inl.h
+++ b/src/operator/contrib/sync_batch_norm-inl.h
@@ -502,7 +502,10 @@ class SyncBatchNormProp : public OperatorProperty {
     using namespace mshadow;
     CHECK_GE(in_type->size(), 1U);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     // For float16 input type beta, gamma, mean, and average are stored in float32.
     // For other input types, these parameters have the same type as input
     // NOTE: This requirement is from cuDNN (v. 4 and 5)

--- a/src/operator/convolution_v1-inl.h
+++ b/src/operator/convolution_v1-inl.h
@@ -499,7 +499,10 @@ class ConvolutionV1Prop : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     for (size_t i = 0; i < in_type->size(); ++i) {
       if ((*in_type)[i] == -1) {
         (*in_type)[i] = dtype;

--- a/src/operator/make_loss-inl.h
+++ b/src/operator/make_loss-inl.h
@@ -153,7 +153,10 @@ class MakeLossProp : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_EQ(in_type->size(), 1U);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "Input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     out_type->clear();
     out_type->push_back(dtype);
     return true;

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -353,7 +353,10 @@ static bool BatchNormType(const nnvm::NodeAttrs& attrs,
   using namespace mshadow;
   CHECK_GE(in_type->size(), 1U);
   const int dtype = (*in_type)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
   // For float16 input type beta, gamma, mean, and average are stored in float32.
   // For other input types, these parameters have the same type as input
   // NOTE: This requirement is from cuDNN (v. 4 and 5)

--- a/src/operator/nn/convolution.cc
+++ b/src/operator/nn/convolution.cc
@@ -285,7 +285,10 @@ static bool ConvolutionType(const nnvm::NodeAttrs& attrs,
   const ConvolutionParam& param_ = nnvm::get<ConvolutionParam>(attrs.parsed);
   CHECK_GE(in_type->size(), 1U);
   int dtype = (*in_type)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
   for (size_t i = 0; i < in_type->size(); ++i) {
     if ((*in_type)[i] == -1) {
       (*in_type)[i] = dtype;

--- a/src/operator/nn/ctc_loss-inl.h
+++ b/src/operator/nn/ctc_loss-inl.h
@@ -252,7 +252,10 @@ inline bool CTCLossOpType(const nnvm::NodeAttrs& attrs,
     CHECK_GE(in_attrs->size(), 2U);
     CHECK_EQ(out_attrs->size(), 2U);
     int dtype = (*in_attrs)[ctc_loss::kData];
-    CHECK_NE(dtype, -1) << "Input data must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
 
     TYPE_ASSIGN_CHECK(*out_attrs, 0, in_attrs->at(0));  // forward output
     TYPE_ASSIGN_CHECK(*out_attrs, 1, in_attrs->at(0));  // grad output

--- a/src/operator/nn/deconvolution.cc
+++ b/src/operator/nn/deconvolution.cc
@@ -332,7 +332,10 @@ static bool DeconvolutionType(const nnvm::NodeAttrs& attrs,
   const DeconvolutionParam& param_ = nnvm::get<DeconvolutionParam>(attrs.parsed);
   CHECK_GE(in_type->size(), 1U);
   int dtype = (*in_type)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
   for (size_t i = 0; i < in_type->size(); ++i) {
     if ((*in_type)[i] == -1) {
       (*in_type)[i] = dtype;

--- a/src/operator/nn/lrn.cc
+++ b/src/operator/nn/lrn.cc
@@ -56,7 +56,10 @@ bool LRNType(const nnvm::NodeAttrs& attrs,
              std::vector<int> *out_type) {
   CHECK_GE(in_type->size(), 1U);
   int dtype = (*in_type)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
   for (size_t i = 0; i < in_type->size(); ++i) {
     if ((*in_type)[i] == -1) {
       (*in_type)[i] = dtype;

--- a/src/operator/nn/upsampling.cc
+++ b/src/operator/nn/upsampling.cc
@@ -91,7 +91,10 @@ static bool UpSamplingType(const nnvm::NodeAttrs& attrs,
   const UpSamplingParam& param = nnvm::get<UpSamplingParam>(attrs.parsed);
   CHECK_GE(in_type->size(), 1U);
   int dtype = (*in_type)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
   for (size_t i = 0; i < in_type->size(); ++i) {
     if ((*in_type)[i] == -1) {
       (*in_type)[i] = dtype;

--- a/src/operator/quantization/quantized_indexing_op.cc
+++ b/src/operator/quantization/quantized_indexing_op.cc
@@ -57,8 +57,11 @@ inline bool QuantizedEmbeddingOpType(const nnvm::NodeAttrs& attrs,
                                      std::vector<int> *out_type) {
   CHECK_EQ(in_type->size(), 4U);
   CHECK_GE(out_type->size(), 3U);
-  int itype = (*in_type)[0];
-  CHECK_NE(itype, -1) << "First input must have specified type";
+  int dtype = (*in_type)[0];
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
   TYPE_ASSIGN_CHECK(*in_type, 1, mshadow::kInt8);
   TYPE_ASSIGN_CHECK(*in_type, 2, mshadow::kFloat32);
   TYPE_ASSIGN_CHECK(*in_type, 3, mshadow::kFloat32);

--- a/src/operator/rnn.cc
+++ b/src/operator/rnn.cc
@@ -145,7 +145,10 @@ static bool RNNType(const nnvm::NodeAttrs& attrs,
   if (param_.mode != rnn_enum::kLstm)  --seq_len_input_idx;
 
   int dtype = (*in_type)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
   std::vector<std::string> arguments = ListArguments(param_);
   for (size_t i = 0; i < in_type->size(); ++i) {
     if ((*in_type)[i] == -1) {

--- a/src/operator/roi_pooling-inl.h
+++ b/src/operator/roi_pooling-inl.h
@@ -199,7 +199,10 @@ class ROIPoolingProp : public OperatorProperty {
     CHECK_EQ(in_type->size(), 2U);
     int dtype = (*in_type)[0];
     CHECK_EQ(dtype, (*in_type)[1]);
-    CHECK_NE(dtype, -1) << "Input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
 
     out_type->clear();
     out_type->push_back(dtype);

--- a/src/operator/sequence_last-inl.h
+++ b/src/operator/sequence_last-inl.h
@@ -277,7 +277,10 @@ class SequenceLastProp : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), param_.use_sequence_length ? 2U : 1U);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     for (size_t i = 0; i < in_type->size(); ++i) {
       if ((*in_type)[i] == -1) {
         (*in_type)[i] = dtype;

--- a/src/operator/sequence_mask-inl.h
+++ b/src/operator/sequence_mask-inl.h
@@ -221,7 +221,10 @@ class SequenceMaskProp : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), param_.use_sequence_length ? 2U : 1U);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     for (size_t i = 0; i < in_type->size(); ++i) {
       if ((*in_type)[i] == -1) {
         (*in_type)[i] = dtype;

--- a/src/operator/sequence_reverse-inl.h
+++ b/src/operator/sequence_reverse-inl.h
@@ -244,7 +244,10 @@ class SequenceReverseProp : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), param_.use_sequence_length ? 2U : 1U);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     for (size_t i = 0; i < in_type->size(); ++i) {
       if ((*in_type)[i] == -1) {
         (*in_type)[i] = dtype;

--- a/src/operator/softmax_output-inl.h
+++ b/src/operator/softmax_output-inl.h
@@ -377,7 +377,10 @@ class SoftmaxOutputProp : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1U);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     for (size_t i = 0; i < in_type->size(); ++i) {
       if ((*in_type)[i] == -1) {
         (*in_type)[i] = dtype;

--- a/src/operator/softmax_output.cc
+++ b/src/operator/softmax_output.cc
@@ -66,7 +66,10 @@ static bool SoftmaxOutputType(const nnvm::NodeAttrs& attrs,
                               std::vector<int> *out_type) {
   CHECK_EQ(in_type->size(), 2U);
   int dtype = (*in_type)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
   for (size_t i = 0; i < in_type->size(); ++i) {
     if ((*in_type)[i] == -1) {
       (*in_type)[i] = dtype;

--- a/src/operator/svm_output-inl.h
+++ b/src/operator/svm_output-inl.h
@@ -158,7 +158,10 @@ class SVMOutputProp : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_GE(in_type->size(), 1U);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "First input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     for (size_t i = 0; i < in_type->size(); ++i) {
       if ((*in_type)[i] == -1) {
         (*in_type)[i] = dtype;

--- a/src/operator/swapaxis-inl.h
+++ b/src/operator/swapaxis-inl.h
@@ -241,7 +241,10 @@ class SwapAxisProp : public OperatorProperty {
                  std::vector<int> *aux_type) const override {
     CHECK_EQ(in_type->size(), 1U);
     int dtype = (*in_type)[0];
-    CHECK_NE(dtype, -1) << "Input must have specified type";
+    if (type_is_none(dtype)) {
+      // partial type inference
+      return false;
+    }
     out_type->clear();
     out_type->push_back(dtype);
     return true;

--- a/src/operator/tensor/indexing_op.h
+++ b/src/operator/tensor/indexing_op.h
@@ -175,7 +175,10 @@ inline bool EmbeddingOpType(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(in_type->size(), 2U);
   CHECK_GE(out_type->size(), 1U);
   int itype = (*in_type)[0];
-  CHECK_NE(itype, -1) << "First input must have specified type";
+  if (type_is_none(itype)) {
+    // partial type inference
+    return false;
+  }
   int dtype_in = (*in_type)[1];
   int dtype_out = (*out_type)[0];
   int dtype = param.dtype;

--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -2788,7 +2788,10 @@ inline bool SplitOpType(const nnvm::NodeAttrs& attrs,
                         std::vector<int>* out_attrs) {
   CHECK_EQ(in_attrs->size(), 1U);
   int dtype = (*in_attrs)[0];
-  CHECK_NE(dtype, -1) << "First input must have specified type";
+  if (type_is_none(dtype)) {
+    // partial type inference
+    return false;
+  }
   const SplitParam& param = nnvm::get<SplitParam>(attrs.parsed);
   out_attrs->clear();
   int num_outputs = (param.sections > 0) ? param.sections : param.indices.ndim();


### PR DESCRIPTION
## Description ##
As described in #16757 , a list of operators `FInferType` functions were throwing an exception if the input type is not defined (dtype=`-1`).

This was preventing us from running a partial type inference where some not (yet) defined input `dtype`s would trigger an exception.

The expected behavior is that `FInferType` returns false when the type cannot be inferred correctly, a boolean value that the executor inference pass uses to wet the `Graph` attribute `dtype_num_unknown_nodes`.
This attribute is then used by the executor or any graph modules (e.g. Partition API) to determine the correctness, or know if a new inference pass is required.

This PR fixes it by making the `FInferType` functions return `false` when the input dtype is `-1`.

