### PR TITLE
[DO NOT MERGE] Use mkl cmake flag to force DNNL to delegate FC op to MKL

### DIFF
--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -97,6 +97,7 @@ CMAKE_FLAGS = {
         '-DUSE_BLAS=mkl '
         '-DUSE_LAPACK=ON '
         '-DUSE_DIST_KVSTORE=OFF '
+        '-DUSE_MKL -I/opt/intel/mkl/include'
         '-DUSE_MKL_IF_AVAILABLE=ON '
         '-DUSE_MKLDNN=ON '
         '-DCMAKE_BUILD_TYPE=Release')
@@ -110,6 +111,7 @@ CMAKE_FLAGS = {
         '-DUSE_OPENCV=ON '
         '-DUSE_OPENMP=ON '
         '-DUSE_BLAS=mkl '
+        '-DUSE_MKL -I/opt/intel/mkl/include'
         '-DUSE_LAPACK=ON '
         '-DUSE_DIST_KVSTORE=OFF '
         '-DUSE_MKL_IF_AVAILABLE=ON '

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -83,6 +83,7 @@ CMAKE_FLAGS = {
         '-DUSE_LAPACK=ON '
         '-DUSE_DIST_KVSTORE=OFF '
         '-DUSE_MKL_IF_AVAILABLE=ON '
+        '-DUSE_MKL -I/opt/intel/mkl/include'
         '-DUSE_MKLDNN=ON '
         '-DCMAKE_BUILD_TYPE=Release')
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -648,6 +648,7 @@ build_ubuntu_cpu_mkldnn_mkl() {
     set -ex
     cd /work/build
     CC=gcc-7 CXX=g++-7 cmake \
+        -DUSE_MKL -I/opt/intel/mkl/include
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DENABLE_TESTCOVERAGE=ON \
         -DUSE_MKLDNN=ON \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -432,6 +432,7 @@ build_ubuntu_cpu_mkl() {
         -DUSE_CUDA=OFF \
         -DUSE_TVM_OP=ON \
         -DUSE_MKL_IF_AVAILABLE=ON \
+        -DUSE_MKL -I/opt/intel/mkl/include
         -DUSE_BLAS=MKL \
         -GNinja /work/mxnet
     ninja


### PR DESCRIPTION
## Description ##
Currently, for GEMM ops [DNNL delegates that op to MKL]
However, for FC DNNL doesn't.
Workaround : export USE_MKL & pass location of MKL installation.
This forces DNNL to delegate ops to MKL
This PR tries to verify correctness of the workaround [if it breaks any unit-tests]

@leezu @PatricZhao @TaoLv @kpuatamazon @kpu

This PR is not meant to be merged. But to serve as a proxy for internal releases.
If it passes the CI without issues, PR will be closed.
Pipelines to be watched for : windows-cpu, unix-cpu & centos-cpu
Specifically mkldnn/mkl builds.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:

