### PR TITLE
cmake: check compiler supports C++17 sufficiently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,20 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS ON)  # GNU extensions used by src/operator/random/shuffle_op.cc
 
+# Sanity checks for some popular compilers. Make sure their version is
+# sufficient. Cmake also automatically checks if a compiler supports c++17. But
+# some compilers claim they support c++17 without actually implementing crucial
+# parts of the standard leading to hard to understand compilation errors.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7.0)
+    message(FATAL_ERROR "MXNet 2 requires a C++17 compatible compiler. Please update to GCC version 7 or newer.")
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 6.0)
+    message(FATAL_ERROR "MXNet 2 requires a C++17 compatible compiler. Please update to Clang version 6 or newer.")
+  endif()
+endif()
+
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/config.cmake)
   # Load config.cmake only if mxnet is not compiled as a dependency of another project
   include(${CMAKE_CURRENT_SOURCE_DIR}/config.cmake)


### PR DESCRIPTION
By default cmake accepts any compiler that supports at least some part of C++17.
In practice this leads to hard to understand error messages at later stages
during compilation, as for example gcc5 supports part of C++17 but does not
support C++17 sufficiently to compile MXNet.

cc @apeforest 