### PR TITLE
Include lib/libopenblas.so.0 on CD

### DIFF
--- a/cd/mxnet_lib/static/Jenkins_pipeline.groovy
+++ b/cd/mxnet_lib/static/Jenkins_pipeline.groovy
@@ -32,8 +32,8 @@ libmxnet = 'lib/libmxnet.so'
 licenses = 'licenses/*'
 
 // libmxnet dependencies
-mx_native_deps = 'lib/libgfortran.so.4, lib/libquadmath.so.0'
-mx_deps = 'lib/libgfortran.so.4, lib/libquadmath.so.0, include/mkldnn/dnnl_version.h, include/mkldnn/dnnl_config.h'
+mx_native_deps = 'lib/libgfortran.so.4, lib/libquadmath.so.0, lib/libopenblas.so.0'
+mx_deps = 'lib/libgfortran.so.4, lib/libquadmath.so.0, lib/libopenblas.so.0, include/mkldnn/dnnl_version.h, include/mkldnn/dnnl_config.h'
 
 // library type
 // either static or dynamic - depending on how it links to its dependencies


### PR DESCRIPTION
The cmake staticbuild script doesn't link openblas statically, but rather
provides the so file to be included in the distribution. This is intentional, as
it simplifies the build script, but was missed when switching the CD to rely on
cmake.

Fixes https://github.com/apache/incubator-mxnet/issues/18293