### PR TITLE
[RecordIO] switch fid in multithreading

### DIFF
--- a/python/mxnet/recordio.py
+++ b/python/mxnet/recordio.py
@@ -18,6 +18,7 @@
 """Read and write for the RecordIO data format."""
 from collections import namedtuple
 from multiprocessing import current_process
+from threading import get_ident
 
 import ctypes
 import struct
@@ -66,6 +67,7 @@ class MXRecordIO(object):
         self.handle = RecordIOHandle()
         self.flag = flag
         self.pid = None
+        self.tid = None
         self.is_open = False
         self.open()
 
@@ -82,6 +84,7 @@ class MXRecordIO(object):
         # pylint: disable=not-callable
         # It's bug from pylint(astroid). See https://github.com/PyCQA/pylint/issues/1699
         self.pid = current_process().pid
+        self.tid = get_ident()
         self.is_open = True
 
     def __del__(self):
@@ -117,7 +120,7 @@ class MXRecordIO(object):
         """Check process id to ensure integrity, reset if in new process."""
         # pylint: disable=not-callable
         # It's bug from pylint(astroid). See https://github.com/PyCQA/pylint/issues/1699
-        if not self.pid == current_process().pid:
+        if not self.pid == current_process().pid or not self.tid == get_ident():
             if allow_reset:
                 self.reset()
             else:
@@ -133,6 +136,7 @@ class MXRecordIO(object):
             check_call(_LIB.MXRecordIOReaderFree(self.handle))
         self.is_open = False
         self.pid = None
+        self.tid = None
 
     def reset(self):
         """Resets the pointer to first item.


### PR DESCRIPTION
## Description ##
Fix multithreading access to single RecordIO file.
The ref issue: https://github.com/apache/incubator-mxnet/issues/13945

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
