### PR TITLE
Replace google CDN with JQuery's own CDN

### DIFF
--- a/docs/static_site/src/_includes/head.html
+++ b/docs/static_site/src/_includes/head.html
@@ -11,7 +11,7 @@
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}
   {%- endif -%}
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
   <script src="{{'/assets/js/globalSearch.js'|relative_url}}"></script>
   <script src="{{'/assets/js/clipboard.js'|relative_url}}"></script>


### PR DESCRIPTION
## Description ##
This PR fix #18367 , use JQuery's own CDN instead of google CDN.  Snippet copied from `https://code.jquery.com/jquery/`, from JQuery:
> The integrity and crossorigin attributes are used for Subresource Integrity (SRI) checking. This allows browsers to ensure that resources hosted on third-party servers have not been tampered with. Use of SRI is recommended as a best-practice, whenever libraries are loaded from a third-party source. Read more at srihash.org


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:

### Changes ###
- [x] Update JQuery CDN

## Comments ##
- Preview (using updated CDN): http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/
