### PR TITLE
Fix #18382 use tmpdir fixture to CSVIter test

### DIFF
--- a/tests/python/unittest/test_io.py
+++ b/tests/python/unittest/test_io.py
@@ -324,12 +324,11 @@ def test_NDArrayIter_csr():
         begin += batch_size
 
 
-def test_LibSVMIter():
+def test_LibSVMIter(tmpdir):
 
     def check_libSVMIter_synthetic():
-        cwd = os.getcwd()
-        data_path = os.path.join(cwd, 'data.t')
-        label_path = os.path.join(cwd, 'label.t')
+        data_path = os.path.join(str(tmpdir), 'data.t')
+        label_path = os.path.join(str(tmpdir), 'label.t')
         with open(data_path, 'w') as fout:
             fout.write('1.0 0:0.5 2:1.2\n')
             fout.write('-2.0\n')
@@ -342,7 +341,7 @@ def test_LibSVMIter():
             fout.write('-3.0 2:1.2\n')
             fout.write('4 1:1.0 2:-1.2\n')
 
-        data_dir = os.path.join(cwd, 'data')
+        data_dir = os.path.join(str(tmpdir), 'data')
         data_train = mx.io.LibSVMIter(data_libsvm=data_path, label_libsvm=label_path,
                                       data_shape=(3, ), label_shape=(3, ), batch_size=3)
 
@@ -367,7 +366,7 @@ def test_LibSVMIter():
         }
         batch_size = 33
         num_examples = news_metadata['num_examples']
-        data_dir = os.path.join(os.getcwd(), 'data')
+        data_dir = os.path.join(str(tmpdir), 'data')
         get_bz2_data(data_dir, news_metadata['name'], news_metadata['url'],
                      news_metadata['origin_name'])
         path = os.path.join(data_dir, news_metadata['name'])
@@ -388,9 +387,8 @@ def test_LibSVMIter():
             data_train.reset()
 
     def check_libSVMIter_exception():
-        cwd = os.getcwd()
-        data_path = os.path.join(cwd, 'data.t')
-        label_path = os.path.join(cwd, 'label.t')
+        data_path = os.path.join(str(tmpdir), 'data.t')
+        label_path = os.path.join(str(tmpdir), 'label.t')
         with open(data_path, 'w') as fout:
             fout.write('1.0 0:0.5 2:1.2\n')
             fout.write('-2.0\n')
@@ -403,7 +401,7 @@ def test_LibSVMIter():
             fout.write('-2.0 0:0.125\n')
             fout.write('-3.0 2:1.2\n')
             fout.write('4 1:1.0 2:-1.2\n')
-        data_dir = os.path.join(cwd, 'data')
+        data_dir = os.path.join(str(tmpdir), 'data')
         data_train = mx.io.LibSVMIter(data_libsvm=data_path, label_libsvm=label_path,
                                       data_shape=(3, ), label_shape=(3, ), batch_size=3)
         for batch in iter(data_train):
@@ -426,11 +424,10 @@ def test_DataBatch():
         r'DataBatch: data shapes: \[\(2L?, 3L?\), \(7L?, 8L?\)\] label shapes: \[\(4L?, 5L?\)\]', str(batch))
 
 
-def test_CSVIter():
+def test_CSVIter(tmpdir):
     def check_CSVIter_synthetic(dtype='float32'):
-        cwd = os.getcwd()
-        data_path = os.path.join(cwd, 'data.t')
-        label_path = os.path.join(cwd, 'label.t')
+        data_path = os.path.join(str(tmpdir), 'data.t')
+        label_path = os.path.join(str(tmpdir), 'label.t')
         entry_str = '1'
         if dtype is 'int32':
             entry_str = '200000001'


### PR DESCRIPTION
## Description ##
Fix #18382

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
