### PR TITLE
Partition API adding and deleting new params to Block and Symbol

### DIFF
--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1544,8 +1544,35 @@ class Symbol(SymbolBase):
             raise RuntimeError('Cannot add new aux in optimize_for since aux is None\n' +
                                'Provide a dictionary to the aux argument to optimize_for')
 
-        # return modified symbol
-        return Symbol(out)
+        new_sym = Symbol(out)
+
+        arg_names = self.list_arguments()
+        new_arg_names = new_sym.list_arguments()
+        deleted_arg_names = set([item for item in arg_names
+                                    if item not in set(new_arg_names)])
+
+        if len(deleted_arg_names) > 0:
+            if args is not None:
+                for a_n in deleted_arg_names:
+                    if a_n in args:
+                        args.pop(a_n)
+            else:
+                warnings.warn('optimize_for deleted some argument. \n' +
+                              'Provide a dictionary to the arg argument to optimize_for')
+        aux_names = self.list_auxiliary_states()
+        new_aux_names = new_sym.list_auxiliary_states()
+        deleted_aux_names = set([item for item in aux_names
+                                    if item not in set(new_aux_names)])
+        if len(deleted_aux_names) > 0:
+            if aux is not None:
+                for a_n in deleted_aux_names:
+                    if a_n in aux:
+                        aux.pop(a_n)
+            else:
+                warnings.warn('optimize_for deleted some aux argument. \n' +
+                              'Provide a dictionary to the aux argument to optimize_for')
+
+        return new_sym
 
     # pylint: disable=too-many-locals
     def _simple_bind(self, ctx, grad_req='write', type_dict=None, stype_dict=None,

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1557,8 +1557,9 @@ class Symbol(SymbolBase):
                     if a_n in args:
                         args.pop(a_n)
             else:
-                warnings.warn('optimize_for deleted some argument. \n' +
-                              'Provide a dictionary to the arg argument to optimize_for')
+                warnings.warn('A param was deleted during optimization, but no args dictionary was provided.\n' +
+                              'Please ensure that your model weights match the newly optimized model.')
+
         aux_names = self.list_auxiliary_states()
         new_aux_names = new_sym.list_auxiliary_states()
         deleted_aux_names = set([item for item in aux_names
@@ -1569,8 +1570,8 @@ class Symbol(SymbolBase):
                     if a_n in aux:
                         aux.pop(a_n)
             else:
-                warnings.warn('optimize_for deleted some aux argument. \n' +
-                              'Provide a dictionary to the aux argument to optimize_for')
+                warnings.warn('A param was deleted during optimization, but no args dictionary was provided.\n' +
+                              'Please ensure that your model weights match the newly optimized model.')
 
         return new_sym
 

--- a/python/mxnet/symbol/symbol.py
+++ b/python/mxnet/symbol/symbol.py
@@ -1549,7 +1549,7 @@ class Symbol(SymbolBase):
         arg_names = self.list_arguments()
         new_arg_names = new_sym.list_arguments()
         deleted_arg_names = set([item for item in arg_names
-                                    if item not in set(new_arg_names)])
+                                 if item not in set(new_arg_names)])
 
         if len(deleted_arg_names) > 0:
             if args is not None:
@@ -1562,7 +1562,7 @@ class Symbol(SymbolBase):
         aux_names = self.list_auxiliary_states()
         new_aux_names = new_sym.list_auxiliary_states()
         deleted_aux_names = set([item for item in aux_names
-                                    if item not in set(new_aux_names)])
+                                 if item not in set(new_aux_names)])
         if len(deleted_aux_names) > 0:
             if aux is not None:
                 for a_n in deleted_aux_names:


### PR DESCRIPTION
## Description ##

A custom Partition API backend may add new parameters or delete during the partitioning.

In the Gluon API, the CachedOp needs to received a list of the same size as the number input nodes in the graph. Not deleting the args/aux after partitioning was causing the CachedOp to fail.

### Changes
- Sym: reflects the deletion of parameters in the arg and aux dicts. 
- Gluon: refactor `_build_cache` to allow `_cached_op_args` (the list of parameters passed to the CachedOp) to contain only the subset of parameters needed (excluding the ones deleted by the optimization) from the Block parameters and the ones created during the optimization. The original parameters are not deleted from Block, and _cached_op_args only references the Parameters needed by the model.