### PR TITLE
add multi-formated feature and multi-label dataiter for recommendation

### DIFF
--- a/python/mxnet/io/__init__.py
+++ b/python/mxnet/io/__init__.py
@@ -24,7 +24,7 @@
 from . import io
 from .io import CSVIter, DataBatch, DataDesc, DataIter, ImageDetRecordIter, ImageRecordInt8Iter, ImageRecordIter,\
     ImageRecordIter_v1, ImageRecordUInt8Iter, ImageRecordUInt8Iter_v1, LibSVMIter, MNISTIter, MXDataIter, NDArrayIter,\
-    PrefetchingIter, ResizeIter
+    PrefetchingIter, ResizeIter, RMFIter
 
 from . import utils
 from .utils import _init_data, _getdata_by_idx, _has_instance

--- a/src/io/image_iter_common.h
+++ b/src/io/image_iter_common.h
@@ -185,10 +185,16 @@ struct BatchParam : public dmlc::Parameter<BatchParam> {
   uint32_t batch_size;
   /*! \brief use round roubin to handle overflow batch */
   bool round_batch;
+  size_t data_size;
+  size_t label_width;
   // declare parameters
   DMLC_DECLARE_PARAMETER(BatchParam) {
     DMLC_DECLARE_FIELD(batch_size)
         .describe("Batch size.");
+    DMLC_DECLARE_FIELD(data_size).set_default(1)
+        .describe("The number of input data.");
+    DMLC_DECLARE_FIELD(label_width).set_default(1)
+        .describe("The number of label.");
     DMLC_DECLARE_FIELD(round_batch).set_default(true)
         .describe("Whether to use round robin to handle overflow batch or not.");
   }
@@ -390,6 +396,8 @@ struct PrefetcherParam : public dmlc::Parameter<PrefetcherParam> {
   int device_id;
   /*! \brief data type */
   dmlc::optional<int> dtype;
+  size_t data_size;
+  size_t label_width;
 
   // declare parameters
   DMLC_DECLARE_PARAMETER(PrefetcherParam) {
@@ -406,6 +414,10 @@ struct PrefetcherParam : public dmlc::Parameter<PrefetcherParam> {
                   "it will use cpu_pinned(device_id) as ctx");
     DMLC_DECLARE_FIELD(device_id).set_default(-1)
         .describe("The default device id for context. -1 indicate it's on default device");
+    DMLC_DECLARE_FIELD(data_size).set_default(1)
+        .describe("The number of input data.");
+    DMLC_DECLARE_FIELD(label_width).set_default(1)
+        .describe("The number of label.");
     DMLC_DECLARE_FIELD(dtype)
       .add_enum("float32", mshadow::kFloat32)
       .add_enum("float64", mshadow::kFloat64)

--- a/src/io/iter_libsvm.cc
+++ b/src/io/iter_libsvm.cc
@@ -148,12 +148,12 @@ class LibSVMIter: public SparseIIterator<DataInst> {
     return out_;
   }
 
-  virtual const NDArrayStorageType GetStorageType(bool is_data) const {
+  virtual const NDArrayStorageType GetStorageType(size_t ind, bool is_data) const {
     if (is_data) return kCSRStorage;
     return param_.label_shape.Size() > 1 ? kCSRStorage : kDefaultStorage;
   }
 
-  virtual const mxnet::TShape GetShape(bool is_data) const {
+  virtual const mxnet::TShape GetShape(size_t ind, bool is_data) const {
     if (is_data) return param_.data_shape;
     return param_.label_shape;
   }
@@ -161,6 +161,8 @@ class LibSVMIter: public SparseIIterator<DataInst> {
  private:
   inline TBlob AsDataBlob(const dmlc::Row<uint64_t>& row) {
     const real_t* ptr = row.value;
+    if (ptr == nullptr)
+      return TBlob((real_t*) ptr, mshadow::Shape1(0), cpu::kDevMask);  // NOLINT(*)
     mxnet::TShape shape(mshadow::Shape1(row.length));
     return TBlob((real_t*) ptr, shape, cpu::kDevMask);  // NOLINT(*)
   }

--- a/src/io/iter_rmf.cc
+++ b/src/io/iter_rmf.cc
@@ -1,0 +1,406 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file iter_rmf.cc
+ * \brief define a Recommendation Multi-Format Feature Sample Reader to read in arrays
+ */
+#include <mxnet/io.h>
+#include <dmlc/base.h>
+#include <dmlc/logging.h>
+#include <dmlc/parameter.h>
+#include <dmlc/data.h>
+#include "./iter_sparse_prefetcher.h"
+#include "./iter_sparse_batchloader.h"
+
+namespace mxnet {
+namespace io {
+// RMF parameters
+struct RMFIterParam : public dmlc::Parameter<RMFIterParam> {
+  /*! \brief path to data RMF file */
+  std::string data;
+  /*! \brief data shape */
+  TShape data_shape;
+  /*! \brief dense shape */
+  TShape dense_shape;
+  /*! \brief cate shape */
+  TShape cate_shape;
+  /*! \brief sparse shape */
+  TShape sparse_shape;
+  /*! \brief label shape */
+  TShape label_shape;
+  /*! \brief sparse shape */
+  std::vector<TShape> multi_field_shape;
+  /*! \brief partition the data into multiple parts */
+  int num_parts;
+  /*! \brief the index of the part will read*/
+  int part_index;
+  /*! \brief the number of multiple field feature*/
+  size_t multi_field_num;
+  /*! \brief the number of label*/
+  size_t label_width;
+  std::string multi_field_shape_str;
+  // declare parameters 
+  DMLC_DECLARE_PARAMETER(RMFIterParam) {
+    DMLC_DECLARE_FIELD(label_width).set_default(1)
+        .describe("the number of label");
+    DMLC_DECLARE_FIELD(data)
+        .describe("The input zero-base indexed RMF data file or a directory path.");
+    index_t shape4[] = {6};
+    DMLC_DECLARE_FIELD(data_shape).set_default(TShape(shape4, shape4 + 1))
+        .describe("The shape of data feature for one example.");
+    index_t shape3[] = {12};
+    DMLC_DECLARE_FIELD(dense_shape).set_default(TShape(shape3, shape3 + 1))
+        .describe("The shape of dense feature for one example.");
+    index_t shape2[] = {6};
+    DMLC_DECLARE_FIELD(cate_shape).set_default(TShape(shape2, shape2 + 1))
+        .describe("The shape of cate feature for one example.");
+    index_t shape0[] = {10000000};
+    DMLC_DECLARE_FIELD(sparse_shape).set_default(TShape(shape0, shape0 + 1))
+        .describe("The shape of sparse feature for one example.");
+    DMLC_DECLARE_FIELD(multi_field_shape_str).set_default("10000,10000,10000,10000,10000")
+        .describe("The shape of multiple field feature for one example.");
+    index_t shape1[] = {1};
+    DMLC_DECLARE_FIELD(label_shape).set_default(TShape(shape1, shape1 + 1))
+        .describe("The shape of one label.");
+    DMLC_DECLARE_FIELD(num_parts).set_default(1)
+        .describe("partition the data into multiple parts");
+    DMLC_DECLARE_FIELD(part_index).set_default(0)
+        .describe("the index of the part will read");
+    DMLC_DECLARE_FIELD(multi_field_num).set_default(0)
+        .describe("the number of multiple field for one feature");
+  }
+};
+
+std::vector<std::string> split(std::string str, char delimiter) {
+  std::vector<std::string> internal;
+  std::stringstream ss(str);
+  std::string tok;
+
+  while (std::getline(ss, tok, delimiter)) {
+    internal.push_back(tok);
+  }
+  return internal;
+}
+
+class RMFIter: public SparseIIterator<DataInst> {
+ public:
+  RMFIter() {}
+  virtual ~RMFIter() {}
+
+  // intialize iterator loads data in
+  virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+    param_.InitAllowUnknown(kwargs);
+    CHECK_EQ(param_.dense_shape.ndim(), 1) << "dimension of dense_shape is expected to be 1";
+    CHECK_EQ(param_.cate_shape.ndim(), 1) << "dimension of cate_shape is expected to be 1";
+    CHECK_EQ(param_.sparse_shape.ndim(), 1) << "dimension of sparse_shape is expected to be 1";
+    CHECK_GT(param_.num_parts, 0) << "number of parts should be positive";
+    CHECK_GE(param_.part_index, 0) << "part index should be non-negative";
+    data_parser_.reset(dmlc::Parser<uint64_t>::Create(param_.data.c_str(),
+                                                      param_.part_index,
+                                                      param_.num_parts, "rmf"));
+    CHECK_EQ(param_.label_shape.Size(), 1)
+      << "label_shape is expected to be (1,) when param_.label_RMF is NULL";
+    std::vector<std::string> multi_shape_str = split(param_.multi_field_shape_str, ',');
+    CHECK_EQ(multi_shape_str.size(), param_.multi_field_num) 
+      << "length of multi_field_shape_str is expected to be equal to multi_field_num";
+    //TODO to fill multi_shape_str in multi_shape
+    for (size_t i = 0; i < param_.multi_field_num; ++i) {
+      index_t shape0[] = {std::stoi(multi_shape_str[i])};
+      param_.multi_field_shape.push_back(TShape(shape0, shape0 + 1));
+    }
+    // both data and label are of multi Storage in RMF format
+    if (param_.label_shape.Size() > 1) {
+      out_.data.resize(5 + 3 * param_.multi_field_num + 3);
+    } else {
+      // only data is of CSRStorage in RMF format.
+      // dense cate sparse multi_field
+      // csv 1
+      // libsvm 3
+      out_.data.resize(5 + 3 * param_.multi_field_num + 1);
+    }
+    if (param_.label_width > 1) {
+      index_t label_shape[] = {param_.label_width};
+      param_.label_shape = TShape(label_shape, label_shape + 1);
+    }
+  }
+
+  virtual void BeforeFirst() {
+    data_parser_->BeforeFirst();
+    if (label_parser_.get() != nullptr) {
+      label_parser_->BeforeFirst();
+    }
+    data_ptr_ = label_ptr_ = 0;
+    data_size_ = label_size_ = 0;
+    inst_counter_ = 0;
+    end_ = false;
+  }
+
+  virtual bool Next() {
+    if (end_) return false;
+    while (data_ptr_ >= data_size_) {
+      if (!data_parser_->Next()) {
+        end_ = true; return false;
+      }
+      data_ptr_ = 0;
+      data_size_ = data_parser_->Value().size;
+    }
+    out_.index = inst_counter_++;
+    CHECK_LT(data_ptr_, data_size_);
+    const auto data_row = data_parser_->Value()[data_ptr_++];
+    // dense   
+    out_.data[0] = AsCSVTBlob(data_row, param_.dense_shape, 0);
+    // cate
+    out_.data[1] = AsCSVTBlob(data_row, param_.cate_shape, 1);
+    //sparse data, indices and indptr
+    out_.data[2] = AsCSRDataBlob(data_row, 2);
+    out_.data[3] = AsCSRIdxBlob(data_row, 2);
+    out_.data[4] = AsCSRIndPtrPlaceholder(data_row, 2);
+    //multi_fields
+    size_t ind = 5;
+    for(size_t i = 0; i < param_.multi_field_num; i++) {
+      out_.data[ind] = AsCSRDataBlob(data_row, i + 3);
+      ++ind;
+      out_.data[ind] = AsCSRIdxBlob(data_row, i + 3);
+      ++ind;
+      out_.data[ind] = AsCSRIndPtrPlaceholder(data_row, i + 3);
+      ++ind;
+    }
+    if (label_parser_.get() != nullptr) {
+      while (label_ptr_ >= label_size_) {
+        CHECK(label_parser_->Next())
+            << "Data RMF's row is smaller than the number of rows in label_RMF";
+        label_ptr_ = 0;
+        label_size_ = label_parser_->Value().size;
+      }
+      CHECK_LT(label_ptr_, label_size_);
+      const auto label_row = label_parser_->Value()[label_ptr_++];
+      // data, indices and indptr
+      out_.data[ind++] = AsCSRDataBlob(label_row, 0);
+      out_.data[ind++] = AsCSRIdxBlob(label_row, 0);
+      out_.data[ind] = AsCSRIndPtrPlaceholder(label_row, 0);
+    } else {
+      if (param_.label_width > 1)
+        out_.data[ind] = AsMultiLabelBlob(data_row);
+      else
+        out_.data[ind] = AsScalarLabelBlob(data_row);
+    }
+    //LOG(INFO) << "total ind = " << ind;
+    return true;
+  }
+
+  virtual const DataInst &Value(void) const {
+    return out_;
+  }
+
+  virtual const NDArrayStorageType GetStorageType(size_t ind, bool is_data) const {
+    if (ind == 0 || ind == 1) return kDefaultStorage;
+    if (ind == 2) return kCSRStorage;
+    size_t index = ind - 3;
+    if (index < param_.multi_field_num) return kCSRStorage;
+    return param_.label_shape.Size() > 1 ? (param_.label_width > 1? kDefaultStorage : kCSRStorage ) : kDefaultStorage;
+  }
+
+  virtual const TShape GetShape(size_t ind, bool is_data) const {
+    if (ind == 0) return param_.dense_shape;
+    if (ind == 1) return param_.cate_shape;
+    if (ind == 2) return param_.sparse_shape;
+    size_t index = ind - 3;
+    if (index < param_.multi_field_num) {
+      return param_.multi_field_shape[index];
+    }
+    return param_.label_shape;
+  }
+
+  bool IsIndPtr(size_t ind) {
+    if (ind > 1 && (ind % 3 == 1)) return true; 
+    return false;
+  }
+
+ private:
+  // csv TODO process csv with different datatype
+  inline TBlob AsCSVTBlob(const dmlc::Row<uint64_t>& row, const TShape& shape, size_t ind) {
+    CHECK_LT(ind, 2)
+        << "Index of csv data is less than size of Row's extra";
+    CHECK_EQ(row.extra[ind].length, shape.Size())
+        << "The data size in CSV do not match size of shape: "
+        << "specified shape=" << shape << ", the csv row-length=" << row.length;
+    const real_t* ptr = row.extra[ind].value;
+    return TBlob((real_t*)ptr, shape, cpu::kDevMask, 0);  // NOLINT(*)
+  }
+
+  //libsvm
+  inline TBlob AsCSRDataBlob(const dmlc::Row<uint64_t>& row, size_t ind) {
+    //TODO check
+    CHECK_LT(ind, param_.multi_field_num + 3)
+        << "Index of csr data is less than size of Row's extra";
+    const real_t* ptr = row.extra[ind].value;
+    if (ptr == nullptr)
+      return TBlob((real_t*) ptr, mshadow::Shape1(0), cpu::kDevMask);  // NOLINT(*)
+    TShape shape(mshadow::Shape1(row.extra[ind].length));
+    return TBlob((real_t*) ptr, shape, cpu::kDevMask);  // NOLINT(*)
+  }
+
+  inline TBlob AsCSRIdxBlob(const dmlc::Row<uint64_t>& row, size_t ind) {
+    const uint64_t* ptr = row.extra[ind].index;
+    TShape shape(mshadow::Shape1(row.extra[ind].length));
+    return TBlob((int64_t*) ptr, shape, cpu::kDevMask, mshadow::kInt64);  // NOLINT(*)
+  }
+
+  inline TBlob AsCSRIndPtrPlaceholder(const dmlc::Row<uint64_t>& row, size_t ind) {
+    return TBlob(nullptr, mshadow::Shape1(0), cpu::kDevMask, mshadow::kInt64);
+  }
+
+  inline TBlob AsScalarLabelBlob(const dmlc::Row<uint64_t>& row) {
+    const real_t* ptr = row.label;
+    return TBlob((real_t*) ptr, mshadow::Shape1(1), cpu::kDevMask);  // NOLINT(*)
+  }
+ 
+  inline TBlob AsMultiLabelBlob(const dmlc::Row<uint64_t>& row) {
+    const real_t* ptr = row.label;
+    return TBlob((real_t*) ptr, param_.label_shape, cpu::kDevMask);  // NOLINT(*)
+  }
+
+  RMFIterParam param_;
+  // output instance
+  DataInst out_;
+  // internal instance counter
+  unsigned inst_counter_{0};
+  // at end
+  bool end_{false};
+  // label parser
+  size_t label_ptr_{0}, label_size_{0};
+  size_t data_ptr_{0}, data_size_{0};
+  std::unique_ptr<dmlc::Parser<uint64_t> > label_parser_;
+  std::unique_ptr<dmlc::Parser<uint64_t> > data_parser_;
+};
+
+
+DMLC_REGISTER_PARAMETER(RMFIterParam);
+
+MXNET_REGISTER_IO_ITER(RMFIter)
+.describe(R"code(Returns the RMF iterator which returns data with `csr`
+storage type. This iterator is experimental and should be used with care.
+
+The input data is stored in a format similar to RMF file format, except that the **indices
+are expected to be zero-based instead of one-based, and the column indices for each row are
+expected to be sorted in ascending order**. Details of the RMF format are available
+`here. <https://www.csie.ntu.edu.tw/~cjlin/RMFtools/datasets/>`_
+
+
+The `data_shape` parameter is used to set the shape of each line of the data.
+The dimension of both `data_shape` and `label_shape` are expected to be 1.
+
+The `data` parameter is used to set the path input RMF file.
+When it is set to a directory, all the files in the directory will be read.
+
+When `label_RMF` is set to ``NULL``, both data and label are read from the file specified
+by `data`. In this case, the data is stored in `csr` storage type, while the label is a 1D
+dense array.
+
+The `RMFIter` only support `round_batch` parameter set to ``True``. Therefore, if `batch_size`
+is 3 and there are 4 total rows in RMF file, 2 more examples are consumed at the first round.
+
+When `num_parts` and `part_index` are provided, the data is split into `num_parts` partitions,
+and the iterator only reads the `part_index`-th partition. However, the partitions are not
+guaranteed to be even.
+
+``reset()`` is expected to be called only after a complete pass of data.
+
+Example::
+
+  # Contents of RMF file ``data.t``.
+  1.0 0:0.5 2:1.2
+  -2.0
+  -3.0 0:0.6 1:2.4 2:1.2
+  4 2:-1.2
+
+  # Creates a `RMFIter` with `batch_size`=3.
+  >>> data_iter = mx.io.RMFIter(data = 'data.t', data_shape = (3,), batch_size = 3)
+  # The data of the first batch is stored in csr storage type
+  >>> batch = data_iter.next()
+  >>> csr = batch.data[0]
+  <CSRNDArray 3x3 @cpu(0)>
+  >>> csr.asnumpy()
+  [[ 0.5        0.          1.2 ]
+  [ 0.          0.          0.  ]
+  [ 0.6         2.4         1.2]]
+  # The label of first batch
+  >>> label = batch.label[0]
+  >>> label
+  [ 1. -2. -3.]
+  <NDArray 3 @cpu(0)>
+
+  >>> second_batch = data_iter.next()
+  # The data of the second batch
+  >>> second_batch.data[0].asnumpy()
+  [[ 0.          0.         -1.2 ]
+   [ 0.5         0.          1.2 ]
+   [ 0.          0.          0. ]]
+  # The label of the second batch
+  >>> second_batch.label[0].asnumpy()
+  [ 4.  1. -2.]
+
+  >>> data_iter.reset()
+  # To restart the iterator for the second pass of the data
+
+When `label_RMF` is set to the path to another RMF file,
+data is read from `data` and label from `label_RMF`.
+In this case, both data and label are stored in the csr format.
+If the label column in the `data` file is ignored.
+
+Example::
+
+  # Contents of RMF file ``label.t``
+  1.0
+  -2.0 0:0.125
+  -3.0 2:1.2
+  4 1:1.0 2:-1.2
+
+  # Creates a `RMFIter` with specified label file
+  >>> data_iter = mx.io.RMFIter(data = 'data.t', data_shape = (3,),
+                   label_RMF = 'label.t', label_shape = (3,), batch_size = 3)
+
+  # Both data and label are in csr storage type
+  >>> batch = data_iter.next()
+  >>> csr_data = batch.data[0]
+  <CSRNDArray 3x3 @cpu(0)>
+  >>> csr_data.asnumpy()
+  [[ 0.5         0.          1.2  ]
+   [ 0.          0.          0.   ]
+   [ 0.6         2.4         1.2 ]]
+  >>> csr_label = batch.label[0]
+  <CSRNDArray 3x3 @cpu(0)>
+  >>> csr_label.asnumpy()
+  [[ 0.          0.          0.   ]
+   [ 0.125       0.          0.   ]
+   [ 0.          0.          1.2 ]]
+
+)code" ADD_FILELINE)
+.add_arguments(RMFIterParam::__FIELDS__())
+.add_arguments(BatchParam::__FIELDS__())
+.add_arguments(PrefetcherParam::__FIELDS__())
+.set_body([]() {
+    return new SparsePrefetcherIter(
+        new SparseBatchLoader(
+            new RMFIter()));
+  });
+
+}  // namespace io
+}  // namespace mxnet

--- a/src/io/iter_sparse.h
+++ b/src/io/iter_sparse.h
@@ -36,9 +36,12 @@ template<typename DType>
 class SparseIIterator : public IIterator<DType> {
  public:
   /*! \brief storage type of the data or label */
-  virtual const NDArrayStorageType GetStorageType(bool is_data) const = 0;
+  virtual const NDArrayStorageType GetStorageType(size_t ind, bool is_data) const = 0;
   /*! \brief shape of the data or label */
-  virtual const mxnet::TShape GetShape(bool is_data) const = 0;
+  virtual const mxnet::TShape GetShape(size_t ind, bool is_data) const = 0;
+  virtual bool IsIndPtr(size_t ind) {
+    LOG(FATAL) << "cannot call IsIndPtr"; return false;
+  }
 };  // class SparseIIterator
 
 }  // namespace mxnet

--- a/src/io/iter_sparse_batchloader.h
+++ b/src/io/iter_sparse_batchloader.h
@@ -50,8 +50,8 @@ class SparseBatchLoader : public BatchLoader, public SparseIIterator<TBlobBatch>
 
   inline void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
     BatchLoader::Init(kwargs);
-    data_stype_ = sparse_base_->GetStorageType(true);
-    label_stype_ = sparse_base_->GetStorageType(false);
+    data_stype_ = sparse_base_->GetStorageType(0, true);
+    label_stype_ = sparse_base_->GetStorageType(0, false);
     if (param_.round_batch == 0) {
       LOG(FATAL) << "sparse batch loader doesn't support round_batch == false yet";
     }
@@ -104,12 +104,12 @@ class SparseBatchLoader : public BatchLoader, public SparseIIterator<TBlobBatch>
     return BatchLoader::Value();
   }
 
-  virtual const NDArrayStorageType GetStorageType(bool is_data) const {
-    return sparse_base_->GetStorageType(is_data);
+  virtual const NDArrayStorageType GetStorageType(size_t ind, bool is_data) const {
+    return sparse_base_->GetStorageType(ind, is_data);
   }
 
-  virtual const mxnet::TShape GetShape(bool is_data) const {
-    mxnet::TShape inst_shape = sparse_base_->GetShape(is_data);
+  virtual const mxnet::TShape GetShape(size_t ind, bool is_data) const {
+    mxnet::TShape inst_shape = sparse_base_->GetShape(ind, is_data);
     std::vector<index_t> shape_vec;
     shape_vec.push_back(param_.batch_size);
     for (index_t dim = 0; dim < inst_shape.ndim(); ++dim) {
@@ -123,6 +123,8 @@ class SparseBatchLoader : public BatchLoader, public SparseIIterator<TBlobBatch>
   SparseIIterator<DataInst> *sparse_base_;
   /*! \brief data storage type */
   NDArrayStorageType data_stype_;
+  /*! \brief data shape */
+  std::vector<TShape> shape_;
   /*! \brief data label type */
   NDArrayStorageType label_stype_;
   /*! \brief tensor offsets for slicing */
@@ -134,6 +136,9 @@ class SparseBatchLoader : public BatchLoader, public SparseIIterator<TBlobBatch>
 
   // check whether ith position is the indptr tensor for a CSR tensor
   inline bool IsIndPtr(size_t i) {
+    if (param_.data_size > 1) {
+      return sparse_base_->IsIndPtr(i);
+    }
     auto data_num_aux = num_aux_data(data_stype_);
     auto label_num_aux = num_aux_data(label_stype_);
     auto label_indptr_offset = data_num_aux + 1 + label_num_aux;
@@ -151,7 +156,7 @@ class SparseBatchLoader : public BatchLoader, public SparseIIterator<TBlobBatch>
 
   // initialize the data holder by using from the batch
   inline void InitData(const DataInst& first_inst) {
-    CHECK(data_stype_ == kCSRStorage || label_stype_ == kCSRStorage);
+    CHECK(data_stype_ == kCSRStorage || label_stype_ == kCSRStorage || param_.data_size > 1);
     out_.data.clear();
     data_.clear();
     offsets_.clear();
@@ -162,6 +167,7 @@ class SparseBatchLoader : public BatchLoader, public SparseIIterator<TBlobBatch>
     // num_arrays will be 3 + 3 = 6.
     size_t num_arrays = first_inst.data.size();
     data_.resize(num_arrays);
+    shape_.resize(num_arrays);
     offsets_.resize(num_arrays, 0);
     indptr_.resize(num_arrays, false);
     // tensor buffer sizes
@@ -182,12 +188,24 @@ class SparseBatchLoader : public BatchLoader, public SparseIIterator<TBlobBatch>
       dtypes_[i] = first_inst.data[i].type_flag_;
     }
 
-    CHECK_EQ(buff_sizes[0], buff_sizes[1]);
+    //CHECK_EQ(buff_sizes[0], buff_sizes[1]);
     // allocate buffer
     for (size_t i = 0; i < num_arrays; ++i) {
       // init object attributes
-      mxnet::TShape dst_shape(mshadow::Shape1(buff_sizes[i]));
-      data_[i].resize(mshadow::Shape1(buff_sizes[i]), dtypes_[i]);
+      if ((param_.data_size > 1 && i < 2) || (param_.label_width > 1 && i + 1== num_arrays)) { //csv
+        mxnet::TShape src_shape = first_inst.data[i].shape_;
+        std::vector<index_t> shape_vec;
+        shape_vec.push_back(param_.batch_size);
+        for (index_t dim = 0; dim < src_shape.ndim(); ++dim) {
+          shape_vec.push_back(src_shape[dim]);
+        }
+        mxnet::TShape dst_shape(shape_vec.begin(), shape_vec.end());
+        shape_[i] = dst_shape;
+        data_[i].resize(mshadow::Shape1(dst_shape.Size()), dtypes_[i]);
+      } else {
+        mxnet::TShape dst_shape(mshadow::Shape1(buff_sizes[i]));
+        data_[i].resize(mshadow::Shape1(buff_sizes[i]), dtypes_[i]);
+      }
       CHECK(data_[i].dptr_ != nullptr);
     }
   }
@@ -195,13 +213,26 @@ class SparseBatchLoader : public BatchLoader, public SparseIIterator<TBlobBatch>
   /* \brief set the shape of the outputs based on actual shapes */
   inline void SetOutputShape() {
     for (size_t i = 0; i < out_.data.size(); i++) {
-      out_.data[i] = TBlob(data_[i].dptr_, mshadow::Shape1(offsets_[i]),
-                           Context::kCPU, dtypes_[i]);
+      if ( i < 2 && param_.data_size > 1)
+        out_.data[i] = TBlob(data_[i].dptr_, shape_[i],
+                             Context::kCPU, dtypes_[i]);
+      else {
+        if (i + 1 == out_.data.size()&& param_.label_width > 1)
+          out_.data[i] = TBlob(data_[i].dptr_, shape_[i],
+                               Context::kCPU, dtypes_[i]);
+        else
+          out_.data[i] = TBlob(data_[i].dptr_, mshadow::Shape1(offsets_[i]),
+                               Context::kCPU, dtypes_[i]);
+      }
     }
   }
 
   /* \brief increase the size of i-th data buffer by a factor of 2, while retaining the content */
-  inline void ResizeBuffer(size_t src_size, size_t i) {
+  inline void ResizeBuffer(size_t src_size, size_t i, size_t len) {
+    if ((param_.data_size > 1 && i < 2) || (param_.label_width > 1 && i == len - 1)) { //csv
+      LOG(ERROR) << "CSV neednot resize!";
+      return;
+    }
     MSHADOW_TYPE_SWITCH(data_[i].type_flag_, DType, {
       TBlobContainer temp;
       temp.resize(mshadow::Shape1(src_size), dtypes_[i]);
@@ -220,6 +251,7 @@ class SparseBatchLoader : public BatchLoader, public SparseIIterator<TBlobBatch>
   void CopyData(const DataInst& inst, const size_t top) {
     int64_t unit_size = 0;
     out_.inst_index[top] = inst.index;
+    size_t len = inst.data.size();
     for (size_t i = 0; i < inst.data.size(); ++i) {
       if (!indptr_[i]) {
         // indices and values tensor
@@ -230,7 +262,7 @@ class SparseBatchLoader : public BatchLoader, public SparseIIterator<TBlobBatch>
           size_t capacity = data_[i].Size();
           // resize the data buffer if estimated space is not sufficient
           while (capacity < end) {
-            ResizeBuffer(begin, i);
+            ResizeBuffer(begin, i, len);
             capacity = data_[i].Size();
           }
           mshadow::Copy(data_[i].get<cpu, 1, DType>().Slice(begin, end),

--- a/src/io/iter_sparse_prefetcher.h
+++ b/src/io/iter_sparse_prefetcher.h
@@ -65,18 +65,18 @@ class SparsePrefetcherIter : public PrefetcherIter {
           (*dptr)->num_batch_padd = batch.num_batch_padd;
           // (*dptr)->data.at(0) => data
           // (*dptr)->data.at(1) => label
-          (*dptr)->data.resize(2);
+          (*dptr)->data.resize(param_.data_size + 1);
           (*dptr)->index.resize(batch.batch_size);
           size_t data_iter = 0;
           for (size_t i = 0; i < (*dptr)->data.size(); ++i) {
             bool is_data = i == 0;
-            auto stype = this->GetStorageType(is_data);
+            auto stype = this->GetStorageType(i, is_data);
             auto dtype = param_.dtype ? param_.dtype.value() : batch.data[data_iter].type_flag_;
             if (stype == kDefaultStorage) {
               (*dptr)->data.at(i) = NDArray(batch.data[data_iter].shape_,
                                             Context::CPU(), false, dtype);
             } else {
-              (*dptr)->data.at(i) = NDArray(stype, this->GetShape(is_data),
+              (*dptr)->data.at(i) = NDArray(stype, this->GetShape(i, is_data),
                                             Context::CPU(), false, dtype);
             }
             data_iter += num_aux_data(stype) + 1;
@@ -89,18 +89,32 @@ class SparsePrefetcherIter : public PrefetcherIter {
           auto stype = nd.storage_type();
           auto& data_i = ((*dptr)->data)[i];
           if (stype == kDefaultStorage) {
-            CopyFromTo(data_i.data(), batch.data[data_iter]);
+            CHECK_EQ(data_i.shape(), batch.data[data_iter].shape_);
+            if (param_.data_size > 1 && i < 2) {
+              MSHADOW_TYPE_SWITCH(batch.data[data_iter].type_flag_, DType, {
+                  mshadow::Copy(data_i.data().FlatTo2D<cpu, DType>(),
+                        batch.data[data_iter].FlatTo2D<cpu, DType>());
+              });
+            } else {
+              CopyFromTo(data_i.data(), batch.data[data_iter]);
+            }
           } else if (stype == kCSRStorage) {
             auto& values = batch.data[data_iter];
             auto& indices = batch.data[data_iter + 1];
             auto& indptr = batch.data[data_iter + 2];
+            if (values.shape_.Size() != 0) {
+               CHECK_EQ(indices.shape_.Size(), values.shape_.Size());
+               nd.CheckAndAllocData(values.shape_);
+               CopyFromTo(data_i.data(), values);
+            } else {
+               nd.CheckAndAllocData(indices.shape_);
+               SetOne(data_i.data());
+            }
             // allocate memory
-            CHECK_EQ(indices.shape_.Size(), values.shape_.Size());
             nd.CheckAndAllocAuxData(csr::kIdx, indices.shape_);
-            nd.CheckAndAllocData(values.shape_);
             nd.CheckAndAllocAuxData(csr::kIndPtr, indptr.shape_);
             // copy values, indices and indptr
-            CopyFromTo(data_i.data(), values);
+            //CopyFromTo(data_i.data(), values);
             CopyFromTo(data_i.aux_data(csr::kIdx), indices);
             CopyFromTo(data_i.aux_data(csr::kIndPtr), indptr);
           } else {
@@ -130,12 +144,12 @@ class SparsePrefetcherIter : public PrefetcherIter {
     return PrefetcherIter::Value();
   }
 
-  virtual const NDArrayStorageType GetStorageType(bool is_data) const {
-    return sparse_loader_->GetStorageType(is_data);
+  virtual const NDArrayStorageType GetStorageType(size_t ind, bool is_data) const {
+    return sparse_loader_->GetStorageType(ind, is_data);
   }
 
-  virtual const mxnet::TShape GetShape(bool is_data) const {
-    return sparse_loader_->GetShape(is_data);
+  virtual const mxnet::TShape GetShape(size_t ind, bool is_data) const {
+    return sparse_loader_->GetShape(ind, is_data);
   }
 
  private:
@@ -145,6 +159,12 @@ class SparsePrefetcherIter : public PrefetcherIter {
   inline void CopyFromTo(TBlob dst, const TBlob src) {
     MSHADOW_TYPE_SWITCH(src.type_flag_, DType, {
       mshadow::Copy(dst.FlatTo1D<cpu, DType>(), src.FlatTo1D<cpu, DType>());
+    });
+  }
+
+  inline void SetOne(TBlob data) {
+    MSHADOW_TYPE_SWITCH(data.type_flag_, DType, {
+      data.FlatTo1D<cpu, DType>() = 1;
     });
   }
 };


### PR DESCRIPTION
## Description ##
(Brief description on what this PR is about)
In recommendation, there appear many features: 
- dense features, for instance, ctr, item exposure, item click, item statis features, etc.
- one-hot categorical features, for instance, user's network, user's gender, item_id to score
- mulit-hot categorical features, for instance, user profiles which describes interest, and there exists much interests for a user. So the length of the multi-hot categorical features is variable.
The sample can be as followed.
![image](https://user-images.githubusercontent.com/5248288/82135079-33513180-9831-11ea-92a4-83b6fe0d8aba.png)
The row is splited by ^A(\001). There are five columns. The first column is label, supporting multi labels. And the second column is dense feature, and the third column is categorical feature, and the the fourth column is multi-hot categorical feature which can be splited by comma , and the fifth column is sparse feature which is support wide input for google wide and deep model. 

The sample contains many formated features which are storaged by csv or sparse. So it is complicated. To high performance parse the sample, i implent c++ DataIter. Train at gpu will not be hold back by cpu parsing sample.

In the meantimes, part code of dmlc-core is mended where is in https://github.com/moveforever/dmlc-core-recomm_data_iter/commit/7aa77953799d0ac152ddc5d3d32bf36988bbac36
Reference:https://github.com/apache/incubator-mxnet/issues/18346 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
