### PR TITLE
[website] Redirect Chinese visitors to Apache Chinese CDN provider PART 1

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -3,6 +3,11 @@ DirectorySlash off
 RewriteEngine on
 RewriteOptions AllowNoSlash
 
+# Redirect Chinese visitors to Chinese CDN, temporary solution for slow site speed in China
+RewriteCond %{HTTP:Accept-Language} ^zh
+RewriteCond %{HTTP_HOST} mxnet.apache.org
+RewriteRule ^(.*) https://mxnet.cdn.apache.org%{REQUEST_URI} [R,NC,L]
+
 # Show file instead of folder for example /api/docs/tutorials.html
 # instead of /api/docs/tutorials/
 RewriteCond %{REQUEST_FILENAME} -d

--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -4,7 +4,7 @@ RewriteEngine on
 RewriteOptions AllowNoSlash
 
 # Redirect Chinese visitors to Chinese CDN, temporary solution for slow site speed in China
-RewriteCond %{HTTP:Accept-Language} ^zh
+RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^CN$
 RewriteCond %{HTTP_HOST} mxnet.apache.org
 RewriteRule ^(.*) https://mxnet.cdn.apache.org%{REQUEST_URI} [R,NC,L]
 


### PR DESCRIPTION
## Description ##
This PR is the part1 of #18422 .To fix slow site speed in China and improve overall loading speed. It adds server side logic to redirect Chinese visitors to Chinese CDN based on Geo IP. This is the most accurate and fastest way to filter visitors.
 
There are 2 checks to each incoming HTTP requests. 
1. Check user Geoip country code, whether it equals to `CN` 
2. Check host name in URL to ensure redirect only happens when user initially attempts to access the website. Avoid any loops and subsequent redirect.

If all conditions match, redirect user to Chinese CDN with same URI. For example, redirect from `https://mxnet.apache.org/features` to `https://mxnet.cdn.apache.org/features`

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:

### Changes ###
- [x] Add logic to redirect Chinese visitors to Apache's Chinese CDN provider

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com
- Please note: Geo_ip is set up on this preview server. If you visit `http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/testgeoip.php`, you should see your ip and geolocation data.
Following settings are used to stimulate the process:
```shell
RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^CN$
RewriteCond %{HTTP_HOST} ec2-34-219-134-42.us-west-2.compute.amazonaws.com
RewriteRule ^(.*) https://mxnet.cdn.apache.org%{REQUEST_URI} [R,L]
```
- Tested by several users in China, redirect works properly and there is a boost of loading speed

