### PR TITLE
fix cd for release of docker images

### DIFF
--- a/cd/python/docker/python_images.sh
+++ b/cd/python/docker/python_images.sh
@@ -68,7 +68,7 @@ push() {
 
     # The secret name env var is set in the Jenkins configuration
     # Manage Jenkins -> Configure System
-    ./${ci_utils}/docker_login.py --secret-name "${RELEASE_DOCKERHUB_SECRET_NAME}"
+    python3 ${ci_utils}/docker_login.py --secret-name "${RELEASE_DOCKERHUB_SECRET_NAME}"
 
     # Push image
     docker push "${image_name}"


### PR DESCRIPTION
## Description ##
CD release of docker images fails currently due to incorrect way of running python script
http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job/detail/mxnet-cd-release-job/1177/pipeline

This PR fixes that.