### PR TITLE
[v1.x] Fix CI: Remove manually created symbolic link to ninja-build in CentOS pipelines

### DIFF
--- a/ci/docker/install/centos7_core.sh
+++ b/ci/docker/install/centos7_core.sh
@@ -40,9 +40,6 @@ yum -y install wget
 yum -y install unzip
 yum -y install ninja-build
 
-# Centos 7 only provides ninja-build
-ln -s /usr/bin/ninja-build /usr/bin/ninja
-
 # CMake 3.13.2+ is required
 mkdir /opt/cmake && cd /opt/cmake
 wget -nv https://cmake.org/files/v3.13/cmake-3.13.5-Linux-x86_64.sh


### PR DESCRIPTION
## Description ##
Fixes CI pipeline failures:

http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Fcentos-cpu/detail/PR-18268/3/pipeline

http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Fcentos-cpu/detail/v1.x/29/pipeline

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Remove a manually created symbolic link to ninja-build since the newer versions of the package already include one

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
