### PR TITLE
CI: Prime docker cache in "Docker cache build" job

### DIFF
--- a/ci/Jenkinsfile_docker_cache
+++ b/ci/Jenkinsfile_docker_cache
@@ -38,7 +38,7 @@ core_logic: {
         timeout(time: total_timeout, unit: 'MINUTES') {
           utils.init_git()
           sh "python3 ./ci/docker_cache.py --docker-registry ${env.DOCKER_CACHE_REGISTRY}"
-          sh "cd ci && python3 ./docker_login.py --secret-name ${env.DOCKERHUB_SECRET_NAME} && docker-compose -f docker/docker-compose.yml build --parallel && COMPOSE_HTTP_TIMEOUT=600 docker-compose -f docker/docker-compose.yml push && docker logout"
+          sh "cd ci && python3 ./docker_login.py --secret-name ${env.DOCKERHUB_SECRET_NAME} && docker-compose -f docker/docker-compose.yml pull && docker-compose -f docker/docker-compose.yml build --parallel && COMPOSE_HTTP_TIMEOUT=600 docker-compose -f docker/docker-compose.yml push && docker logout"
         }
       }
     }

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1743,7 +1743,7 @@ def misc_test_docker_cache_build() {
       ws('workspace/docker_cache') {
         utils.init_git()
         sh "python3 ./ci/docker_cache.py --docker-registry ${env.DOCKER_CACHE_REGISTRY} --no-publish"
-        sh "cd ci && docker-compose -f docker/docker-compose.yml build --parallel"
+        sh "cd ci && docker-compose -f docker/docker-compose.yml pull && docker-compose -f docker/docker-compose.yml build --parallel"
       }
     }
   }]


### PR DESCRIPTION
Cache priming was previously only handled when using the ./ci/build.py or
./ci/docker_cache.py script. The former is used during most CI jobs. The latter
is used for containers not declared in docker-compose.yml during the "Docker
cache build" job. As more and more containers are declared in
docker-compose.yml, we need to fix the cache priming issue.