### PR TITLE
Fix MXNET_PROFILER_MODE doc in env var documentation

### DIFF
--- a/docs/static_site/src/pages/api/faq/env_var.md
+++ b/docs/static_site/src/pages/api/faq/env_var.md
@@ -212,9 +212,14 @@ The following environments can be used to profile the application without changi
   - Set to 1, MXNet starts the profiler automatically. The profiling result is stored into profile.json in the working directory.
 
 * MXNET_PROFILER_MODE
-  - Values: 0(false) or 1(true) ```(default=0)```
-  - If set to '0', profiler records the events of the symbolic operators.
-  - If set to '1', profiler records the events of all operators.
+  - Values: 0(false) to 15(profile everything) ```(default=13)```
+  - If set to '0', turns off all profiling.
+  - If set to '1', profiler records the events of symbolic operators.
+  - If set to '2', profiler records the events of imperative operators.
+  - If set to '4', profiler records the C API events.
+  - If set to '8', profiler records the events of memory (i.e. storage alloc and free calls).
+  - You need to sum the values above for a custom combination. For example, for symbolic and imperative operators, set ```MXNET_PROFILER_MODE=3```(2 + 1).
+  - If set to '15', profiler records all the above listed events (API, Memory, Symbolic, Imperative).
 
 ## Interface between Python and the C API
 


### PR DESCRIPTION
## Description ##
Fix MXNET_PROFILER_MODE doc in env var documentation
@nswamy 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
