### PR TITLE
More clear description to `transform_first`

### DIFF
--- a/python/mxnet/gluon/data/dataset.py
+++ b/python/mxnet/gluon/data/dataset.py
@@ -165,8 +165,10 @@ class Dataset(object):
         """Returns a new dataset with the first element of each sample
         transformed by the transformer function `fn`.
 
-        This is useful, for example, when you only want to transform data
-        while keeping label as is.
+        This is mostly applicable when each sample contains two components
+        - features and label, i.e., (X, y), and you only want to transform 
+        the first element X (i.e., the features) while keeping the label y 
+        unchanged.
 
         Parameters
         ----------

--- a/python/mxnet/gluon/data/dataset.py
+++ b/python/mxnet/gluon/data/dataset.py
@@ -166,8 +166,8 @@ class Dataset(object):
         transformed by the transformer function `fn`.
 
         This is mostly applicable when each sample contains two components
-        - features and label, i.e., (X, y), and you only want to transform 
-        the first element X (i.e., the features) while keeping the label y 
+        - features and label, i.e., (X, y), and you only want to transform
+        the first element X (i.e., the features) while keeping the label y
         unchanged.
 
         Parameters


### PR DESCRIPTION
After teaching an MLU-CV class, some students feel confused when they are using the `transform_first` function. So I modified it a bit to make it more clear. :)
