### PR TITLE
MXNET-1452: fix compiler warnings

### DIFF
--- a/3rdparty/mshadow/mshadow/tensor.h
+++ b/3rdparty/mshadow/mshadow/tensor.h
@@ -89,7 +89,16 @@ struct Shape {
    * \return the corresponding dimension size
    */
   MSHADOW_XINLINE index_t &operator[](int idx) {
+// two possible solutions: throw exception if idx is out of bounds
+//                         --> costs runtime performance
+//                         disable warning and let the user take care
+//                         --> UB possible if user doesn't take care
+#pragma GCC diagnostic push
+#if __GNUC__ >= 8
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     return shape_[idx];
+#pragma GCC diagnostic pop
   }
   /*!
    * \brief get corresponding index
@@ -97,7 +106,16 @@ struct Shape {
    * \return the corresponding dimension size
    */
   MSHADOW_XINLINE const index_t &operator[](int idx) const {
+// two possible solutions: throw exception if idx is out of bounds
+//                         --> costs runtime performance
+//                         disable warning and let the user take care
+//                         --> UB possible if user doesn't take care
+#pragma GCC diagnostic push
+#if __GNUC__ >= 8
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     return shape_[idx];
+#pragma GCC diagnostic pop
   }
   /*!
    * \return whether two shape equals

--- a/src/kvstore/kvstore_nccl.h
+++ b/src/kvstore/kvstore_nccl.h
@@ -340,9 +340,8 @@ class KVStoreNCCL : public KVStoreLocal {
           }
         }
       } else {
-        auto& buf = merge_buf_[key];
         int root = src.ctx().dev_id;
-        assert(root == buf.merged.ctx().dev_id);
+        assert(root == merge_buf_[key].merged.ctx().dev_id);
         root_id = FindRootId(dst, root);
 
         // Check whether we got the same set of devices

--- a/src/operator/contrib/adamw-inl.h
+++ b/src/operator/contrib/adamw-inl.h
@@ -416,9 +416,9 @@ void FillMultiAdamKernelParam(const nnvm::NodeAttrs& attrs,
 
     pParam->out_data[i] = outputs[i].FlatTo2D<xpu, DType>(s).dptr_;
   }
-  memcpy(pParam->etas, p.etas.begin(), pParam->count * sizeof(p.etas[0]));
-  memcpy(pParam->lrs, p.lrs.begin(), pParam->count * sizeof(p.lrs[0]));
-  memcpy(pParam->wds, p.wds.begin(), pParam->count * sizeof(p.wds[0]));
+  memcpy(static_cast<void*>(pParam->etas), p.etas.begin(), pParam->count * sizeof(p.etas[0]));
+  memcpy(static_cast<void*>(pParam->lrs), p.lrs.begin(), pParam->count * sizeof(p.lrs[0]));
+  memcpy(static_cast<void*>(pParam->wds), p.wds.begin(), pParam->count * sizeof(p.wds[0]));
 }
 
 template<typename xpu, template<typename> class MPTypeChooser, int input_stride>

--- a/src/operator/contrib/transformer.cu
+++ b/src/operator/contrib/transformer.cu
@@ -50,7 +50,6 @@ void CublasStridedBatchedGemm(mshadow::Stream<gpu>* s, bool transA, bool transB,
       << "Must init CuBLAS handle in stream";
 
   cublasHandle_t blas_handle = mshadow::Stream<gpu>::GetBlasHandle(s);
-  auto err = CUBLAS_STATUS_SUCCESS;
   using TrueFP16Type = DType;
   using PseudoFP16Type = typename CublasType<DType>::ScaleType;
   // Set up alpha and beta values in the possible formats needed (only different when dtype == half)

--- a/src/operator/mshadow_op.h
+++ b/src/operator/mshadow_op.h
@@ -1180,7 +1180,12 @@ struct product {
   /*! \brief do reduction into dst */
   template<typename DType>
   MSHADOW_XINLINE static void Reduce(volatile DType& dst, volatile DType src) { // NOLINT(*)
+#pragma GCC diagnostic push
+#if __GNUC__ >= 8
+#pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#endif
     dst *= src;
+#pragma GCC diagnostic pop
   }
   /*! \brief do reduction into dst */
   template<typename DType>
@@ -1368,7 +1373,12 @@ struct nanprod {
   template<typename DType>
   MSHADOW_XINLINE static void Reduce(volatile DType& dst, volatile DType src) { // NOLINT(*)
     if (IsNan(src)) return;
+#pragma GCC diagnostic push
+#if __GNUC__ >= 8
+#pragma GCC diagnostic ignored "-Wint-in-bool-context"
+#endif
     dst *= src;
+#pragma GCC diagnostic pop
   }
   /*! \brief do reduction into dst */
   template<typename DType>

--- a/src/profiler/profiler.h
+++ b/src/profiler/profiler.h
@@ -54,16 +54,37 @@ struct static_string {
   inline explicit static_string(const char *s) { set(s); }
   inline const char *c_str() const { return &string_[0]; }
   inline void set(const char *s) {
+    // it is not possible to avoid truncation by strncpy
+    // thus the result of strncpy must properly NULL-terminated
+    // the NULL must be added explicitly after strncpy()
+    // GCC tries to detect the addition of NULL in order to avoid issuing the warning (if detected)
+    // GCC 8 does not detect the missing handling
+#pragma GCC diagnostic push
+#if __GNUC__ >= 8
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
     strncpy(&string_[0], s, string_size - 1);
+#pragma GCC diagnostic pop
     string_[string_size - 1] = '\0';
   }
   inline void append(const char *s) {
     const size_t l = strlen(&string_[0]);
     if (l < string_size - 1) {
+    // it is not possible to avoid truncation by strncpy
+    // thus the result of strncpy must properly NULL-terminated
+    // the NULL must be added explicitly after strncpy()
+    // GCC tries to detect the addition of NULL in order to avoid issuing the warning (if detected)
+    // GCC 8 does not detect the missing handling
+#pragma GCC diagnostic push
+#if __GNUC__ >= 8
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
       strncpy(&string_[0] + l, s, string_size - l - 1);
+#pragma GCC diagnostic pop
       string_[string_size - 1] = '\0';
     }
   }
+
  private:
   /*! \brief The actual character array */
   std::array<char, string_size> string_;


### PR DESCRIPTION
- set compiler option -Werror on UNIX in order to get aware of compiler
  warnings
- warnings:
  * fix unused variable warning
  * disable strncpy truncation warning
  * disable warning related to memcpy initialization
  * disable out of bounds warning
    - warning disabled because of performance reasons
  * disable integer in boolean context warning
    - this warnings needs some addtional attention

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
