### PR TITLE
[MXNET-1451] Enable MXNet-TRT for building Jetson wheels

### DIFF
--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -38,6 +38,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     python3 \
     python3-pip \
     awscli \
+    autoconf \
+    automake \
+    libtool \
     crossbuild-essential-arm64 \
  && rm -rf /var/lib/apt/lists/*
 

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -42,7 +42,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     automake \
     libtool \
     crossbuild-essential-arm64 \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && alias python=python3
 
 # cmake on Ubuntu 18.04 is too old
 RUN python3 -m pip install cmake

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -61,6 +61,7 @@ RUN git clone --recursive -b v0.3.9 https://github.com/xianyi/OpenBLAS.git && \
 # Install aarch64 cross depedencies based on Jetpack 4.3
 # Manually downloaded using SDK Manager tool and placed in a private S3 bucket.
 # We're not allowed to redistribute these files and there is no public version.
+# Install protobuf and protobuf-compiler for TensorRT integration.
 RUN aws s3 cp s3://mxnet-ci-prod-private-slave-data/nvidia/sdkm_downloads/cuda-repo-ubuntu1804-10-0-local-10.0.326-410.108_1.0-1_amd64.deb . && \
     dpkg -i cuda-repo-ubuntu1804-10-0-local-10.0.326-410.108_1.0-1_amd64.deb && \
     rm cuda-repo-ubuntu1804-10-0-local-10.0.326-410.108_1.0-1_amd64.deb && \
@@ -71,6 +72,7 @@ RUN aws s3 cp s3://mxnet-ci-prod-private-slave-data/nvidia/sdkm_downloads/cuda-r
     apt-get update && \
     apt-get install -y -f && \
     apt-get install -y cuda-cross-aarch64 cuda-cross-aarch64-10-0 && \
+    apt-get install -y libprotobuf-dev protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
 ARG USER_ID=0

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -42,8 +42,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     automake \
     libtool \
     crossbuild-essential-arm64 \
- && rm -rf /var/lib/apt/lists/* \
- && alias python=python3
+ && rm -rf /var/lib/apt/lists/*
 
 # cmake on Ubuntu 18.04 is too old
 RUN python3 -m pip install cmake

--- a/ci/docker/Dockerfile.build.jetson
+++ b/ci/docker/Dockerfile.build.jetson
@@ -58,10 +58,18 @@ RUN git clone --recursive -b v0.3.9 https://github.com/xianyi/OpenBLAS.git && \
     cd /usr/local && \
     rm -rf OpenBLAS
 
+# Install protoc 3.5 and build protobuf for onnx and onnx-tensorrt
+RUN git clone --recursive -b 3.5.1.1 https://github.com/google/protobuf.git && \
+    cd protobuf && \
+    ./autogen.sh && \
+    ./configure && \
+    make -j$(nproc) install && \
+    rm -rf /protobuf && \
+    ldconfig
+
 # Install aarch64 cross depedencies based on Jetpack 4.3
 # Manually downloaded using SDK Manager tool and placed in a private S3 bucket.
 # We're not allowed to redistribute these files and there is no public version.
-# Install protobuf and protobuf-compiler for TensorRT integration.
 RUN aws s3 cp s3://mxnet-ci-prod-private-slave-data/nvidia/sdkm_downloads/cuda-repo-ubuntu1804-10-0-local-10.0.326-410.108_1.0-1_amd64.deb . && \
     dpkg -i cuda-repo-ubuntu1804-10-0-local-10.0.326-410.108_1.0-1_amd64.deb && \
     rm cuda-repo-ubuntu1804-10-0-local-10.0.326-410.108_1.0-1_amd64.deb && \
@@ -72,7 +80,6 @@ RUN aws s3 cp s3://mxnet-ci-prod-private-slave-data/nvidia/sdkm_downloads/cuda-r
     apt-get update && \
     apt-get install -y -f && \
     apt-get install -y cuda-cross-aarch64 cuda-cross-aarch64-10-0 && \
-    apt-get install -y libprotobuf-dev protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
 
 ARG USER_ID=0

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -202,6 +202,10 @@ build_jetson() {
         -DUSE_SIGNAL_HANDLER=ON \
         -DCMAKE_BUILD_TYPE=Release \
         -DUSE_MKL_IF_AVAILABLE=OFF \
+        -DGPU_ARCH="52" \
+        -DUSE_CUDNN=ON \
+        -DUSE_TENSORRT=ON \
+        -DCMAKE_CXX_FLAGS=-I/usr/local/cuda/targets/aarch64-linux/inlude \
         -G Ninja /work/mxnet
     ninja
     build_wheel

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -197,7 +197,6 @@ build_onnx_and_onnx_tensorrt() {
     mkdir -p build
     cd build
     cmake \
-        -DCMAKE_CXX_FLAGS=-I/usr/include/python${PYVER}\
         -DBUILD_SHARED_LIBS=ON ..\
         -G Ninja
     ninja -j 1 -v onnx/onnx.proto
@@ -224,7 +223,6 @@ build_onnx_and_onnx_tensorrt() {
 
 build_jetson() {
     set -ex
-    PYVER=3
     build_onnx_and_onnx_tensorrt
     cd /work/build
     cmake \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -200,7 +200,6 @@ build_onnx_and_onnx_tensorrt() {
         -DCMAKE_CXX_FLAGS=-I/usr/include/python${PYVER}\
         -DBUILD_SHARED_LIBS=ON ..\
         -G Ninja
-    ninja -j 1 -v onnx/onnx.proto
     ninja -j 1 -v
     export LIBRARY_PATH=`pwd`:`pwd`/onnx/:$LIBRARY_PATH
     export CPLUS_INCLUDE_PATH=`pwd`:$CPLUS_INCLUDE_PATH

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -197,6 +197,7 @@ build_onnx_and_onnx_tensorrt() {
     mkdir -p build
     cd build
     cmake \
+        -DCMAKE_CXX_FLAGS=-I/usr/include/python${PYVER}\
         -DBUILD_SHARED_LIBS=ON ..\
         -G Ninja
     ninja -j 1 -v onnx/onnx.proto

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -193,7 +193,7 @@ build_jetson() {
     cmake \
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} \
         -DUSE_CUDA=ON \
-        -DMXNET_CUDA_ARCH="5.2" \
+        -DMXNET_CUDA_ARCH="5.3" \
         -DENABLE_CUDA_RTC=OFF \
         -DSUPPORT_F16C=OFF \
         -DUSE_OPENCV=OFF \
@@ -202,7 +202,6 @@ build_jetson() {
         -DUSE_SIGNAL_HANDLER=ON \
         -DCMAKE_BUILD_TYPE=Release \
         -DUSE_MKL_IF_AVAILABLE=OFF \
-        -DGPU_ARCH="52" \
         -DUSE_CUDNN=ON \
         -DUSE_TENSORRT=ON \
         -DCMAKE_CXX_FLAGS=-I/usr/local/cuda/targets/aarch64-linux/inlude \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -224,6 +224,7 @@ build_onnx_and_onnx_tensorrt() {
 
 build_jetson() {
     set -ex
+    PYVER=3
     build_onnx_and_onnx_tensorrt
     cd /work/build
     cmake \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -198,8 +198,8 @@ build_onnx_and_onnx_tensorrt() {
     cd build
     cmake \
         -DCMAKE_CXX_FLAGS=-I/usr/include/python${PYVER}\
+        -DPYTHON_EXECUTABLE=/usr/bin/python3 \
         -DBUILD_SHARED_LIBS=ON ..\
-        -DPYTHON_EXECUTABLE=/usr/bin/python3
         -G Ninja
     ninja -j 1 -v
     export LIBRARY_PATH=`pwd`:`pwd`/onnx/:$LIBRARY_PATH

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -187,8 +187,44 @@ build_dynamic_libmxnet() {
     ninja
 }
 
+build_onnx_and_onnx_tensorrt() {
+    set -ex
+    # Build ONNX
+    pushd .
+    echo "Installing ONNX."
+    cd 3rdparty/onnx-tensorrt/third_party/onnx
+    rm -rf build
+    mkdir -p build
+    cd build
+    cmake \
+        -DCMAKE_CXX_FLAGS=-I/usr/include/python${PYVER}\
+        -DBUILD_SHARED_LIBS=ON ..\
+        -G Ninja
+    ninja -j 1 -v onnx/onnx.proto
+    ninja -j 1 -v
+    export LIBRARY_PATH=`pwd`:`pwd`/onnx/:$LIBRARY_PATH
+    export CPLUS_INCLUDE_PATH=`pwd`:$CPLUS_INCLUDE_PATH
+    popd
+
+    # Build ONNX-TensorRT
+    pushd .
+    cd 3rdparty/onnx-tensorrt/
+    mkdir -p build
+    cd build
+    cmake ..
+    make -j$(nproc)
+    export LIBRARY_PATH=`pwd`:$LIBRARY_PATH
+    popd
+
+    mkdir -p /work/mxnet/lib/
+    cp 3rdparty/onnx-tensorrt/third_party/onnx/build/*.so /work/mxnet/lib/
+    cp -L 3rdparty/onnx-tensorrt/build/libnvonnxparser_runtime.so.0 /work/mxnet/lib/
+    cp -L 3rdparty/onnx-tensorrt/build/libnvonnxparser.so.0 /work/mxnet/lib/
+}
+
 build_jetson() {
     set -ex
+    build_onnx_and_onnx_tensorrt
     cd /work/build
     cmake \
         -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} \
@@ -672,39 +708,7 @@ build_ubuntu_gpu_tensorrt() {
 
     export CC=gcc-7
     export CXX=g++-7
-
-    # Build ONNX
-    pushd .
-    echo "Installing ONNX."
-    cd 3rdparty/onnx-tensorrt/third_party/onnx
-    rm -rf build
-    mkdir -p build
-    cd build
-    cmake \
-        -DCMAKE_CXX_FLAGS=-I/usr/include/python${PYVER}\
-        -DBUILD_SHARED_LIBS=ON ..\
-        -G Ninja
-    ninja -j 1 -v onnx/onnx.proto
-    ninja -j 1 -v
-    export LIBRARY_PATH=`pwd`:`pwd`/onnx/:$LIBRARY_PATH
-    export CPLUS_INCLUDE_PATH=`pwd`:$CPLUS_INCLUDE_PATH
-    popd
-
-    # Build ONNX-TensorRT
-    pushd .
-    cd 3rdparty/onnx-tensorrt/
-    mkdir -p build
-    cd build
-    cmake ..
-    make -j$(nproc)
-    export LIBRARY_PATH=`pwd`:$LIBRARY_PATH
-    popd
-
-    mkdir -p /work/mxnet/lib/
-    cp 3rdparty/onnx-tensorrt/third_party/onnx/build/*.so /work/mxnet/lib/
-    cp -L 3rdparty/onnx-tensorrt/build/libnvonnxparser_runtime.so.0 /work/mxnet/lib/
-    cp -L 3rdparty/onnx-tensorrt/build/libnvonnxparser.so.0 /work/mxnet/lib/
-
+    build_onnx_and_onnx_tensorrt
     cd /work/build
     cmake -DUSE_CUDA=1                            \
           -DUSE_CUDNN=1                           \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -199,6 +199,7 @@ build_onnx_and_onnx_tensorrt() {
     cmake \
         -DCMAKE_CXX_FLAGS=-I/usr/include/python${PYVER}\
         -DBUILD_SHARED_LIBS=ON ..\
+        -DPYTHON_EXECUTABLE=/usr/bin/python3
         -G Ninja
     ninja -j 1 -v
     export LIBRARY_PATH=`pwd`:`pwd`/onnx/:$LIBRARY_PATH


### PR DESCRIPTION
## Description ##
It enables build MXNet on Jetson with TensorRT support. Without this, the TensorRT integration source code under mxnet/src/operator/subgraph/tensorrt will not be correctly compiled. 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- 
- [x] The PR title starts with [MXNET-1451], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Turn USE_TENSRORT option on for cmake to enable tensorrt source files under src/operator/subgraph/tenssorrt
- Change the CUDA arch from 5.2 to 5.3

## Comments ##
- This change should only affect MXNet jetson wheels. Current jetson wheel build is done on only one GPU arch.

