### PR TITLE
stop running test_conv.py script as it no longer exists

### DIFF
--- a/cd/python/docker/test_python_image.sh
+++ b/cd/python/docker/test_python_image.sh
@@ -37,7 +37,7 @@ if [[ $mxnet_variant == cu* ]]; then
     test_conv_params="--gpu"
 fi
 
-if [[ $mxnet_variant != native ]]; then
+if [[ $mxnet_variant == cpu ]]; then
     python3 tests/python/mkl/test_mkldnn.py
 fi
 

--- a/cd/python/docker/test_python_image.sh
+++ b/cd/python/docker/test_python_image.sh
@@ -37,10 +37,9 @@ if [[ $mxnet_variant == cu* ]]; then
     test_conv_params="--gpu"
 fi
 
-if [[ $mxnet_variant == cpu ]]; then
+if [[ $mxnet_variant != native ]]; then
     python3 tests/python/mkl/test_mkldnn.py
 fi
 
-python3 tests/python/train/test_conv.py ${test_conv_params}
 python3 example/image-classification/train_mnist.py ${mnist_params}
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1938,7 +1938,6 @@ cd_integration_test_pypi() {
     pip3 install --user ./wheel_build/dist/*.whl
 
     # execute tests
-    python3 /work/mxnet/tests/python/train/test_conv.py ${test_conv_params}
     python3 /work/mxnet/example/image-classification/train_mnist.py ${mnist_params}
 }
 

--- a/docker/docker-python/README.md
+++ b/docker/docker-python/README.md
@@ -47,7 +47,6 @@ For example:
 `./build_python_dockerfile.sh 1.3.0 1.3.0.post0 ~/build-docker/incubator-mxnet`
 
 ### Tests run
-* [test_conv.py](https://github.com/apache/incubator-mxnet/blob/master/tests/python/train/test_conv.py)
 * [train_mnist.py](https://github.com/apache/incubator-mxnet/blob/master/example/image-classification/train_mnist.py)
 * [test_mxnet.py](https://github.com/apache/incubator-mxnet/blob/master/docker/docker-python/test_mxnet.py): This script is used to make sure that the docker image builds the expected mxnet version. That is, the version picked by pip is the same as as the version passed as a parameter.
 

--- a/docker/docker-python/build_python_dockerfile.sh
+++ b/docker/docker-python/build_python_dockerfile.sh
@@ -58,7 +58,6 @@ docker_test_image_cpu(){
     python_version="${2}"
     echo "Running tests on mxnet/python:${image_tag}"
     docker run -v ${test_dir}:/mxnet mxnet/python:${image_tag} bash -c "${python_version} /mxnet/docker/docker-python/test_mxnet.py ${mxnet_version}"
-    docker run -v ${test_dir}:/mxnet mxnet/python:${image_tag} bash -c "${python_version} /mxnet/tests/python/train/test_conv.py"
     docker run -v ${test_dir}:/mxnet mxnet/python:${image_tag} bash -c "${python_version} /mxnet/example/image-classification/train_mnist.py"
 }
 
@@ -67,7 +66,6 @@ docker_test_image_gpu(){
     python_version="${2}"
     echo "Running tests on mxnet/python:${1}"
     nvidia-docker run -v ${test_dir}:/mxnet mxnet/python:${image_tag} bash -c "${python_version} /mxnet/docker/docker-python/test_mxnet.py ${mxnet_version}"
-    nvidia-docker run -v ${test_dir}:/mxnet mxnet/python:${image_tag} bash -c "${python_version} /mxnet/tests/python/train/test_conv.py --gpu"
     nvidia-docker run -v ${test_dir}:/mxnet mxnet/python:${image_tag} bash -c "${python_version} /mxnet/example/image-classification/train_mnist.py --gpus 0,1,2,3"
 }
 


### PR DESCRIPTION
## Description ##
The script `tests/python/train/test_conv.py` is deleted as part of the PR #18394 .
This PR removes the references to this test script from other places in the repo. There still remains one doc that needs to be updated. Created an issue for that. #18454 