### PR TITLE
redirect visitors based on geolocation - update host condition

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -5,7 +5,7 @@ RewriteOptions AllowNoSlash
 
 # Redirect Chinese visitors to Chinese CDN, temporary solution for slow site speed in China
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^CN$
-RewriteCond %{HTTP_HOST} mxnet.apache.org
+RewriteCond %{HTTP_HOST} !cdn
 RewriteRule ^(.*) https://mxnet.cdn.apache.org%{REQUEST_URI} [R,NC,L]
 
 # Show file instead of folder for example /api/docs/tutorials.html


### PR DESCRIPTION
## Description ##
This is a fix for #18431 . The rewrite rule is not redirecting users because of the tight host filter rule. Update the rewrite condition to not only match `mxnet.apache.org`, but reverse it to match all hostname except `mxnet.cdn.apache.org`.

According to Apache Intra team's [response](https://issues.apache.org/jira/browse/INFRA-20203#comment-17121024),
> Try removing the following condition:
RewriteCond %{HTTP_HOST} mxnet.apache.org
Most of your visits go to mxnet.incubator.apache.org

Because we don't know how Apache's server is configured, remove the whole condition could possibly import looping. To safely fix this problem we can first test the updated rewrite rule.
