### PR TITLE
Update website instructions for compiling for / on Raspberry Pi.

### DIFF
--- a/docs/static_site/src/_includes/get_started/devices/raspberry_pi.md
+++ b/docs/static_site/src/_includes/get_started/devices/raspberry_pi.md
@@ -1,254 +1,173 @@
+MXNet supports running on ARM devices, such as the Raspberry PI.
 
-MXNet supports the Debian based Raspbian ARM based operating system so you can run MXNet on
-Raspberry Pi 3B
-devices.
+These instructions will walk through how to build MXNet for the Raspberry Pi and
+install the Python bindings for the library.
 
-These instructions will walk through how to build MXNet for the Raspberry Pi and install the
-Python bindings
-for the library.
+You can do a cross compilation build on your local machine (faster) or a native
+build on-device (slower, but more foolproof).
 
-You can do a dockerized cross compilation build on your local machine or a native build
-on-device.
+The complete MXNet library and its requirements can take almost 200MB of RAM,
+and loading large models with the library can take over 1GB of RAM. Because of
+this, we recommend running MXNet on the Raspberry Pi 3 or an equivalent device
+that has more than 1 GB of RAM and a Secure Digital (SD) card that has at least
+4 GB of free memory.
 
-The complete MXNet library and its requirements can take almost 200MB of RAM, and loading
-large models with
-the library can take over 1GB of RAM. Because of this, we recommend running MXNet on the
-Raspberry Pi 3 or
-an equivalent device that has more than 1 GB of RAM and a Secure Digital (SD) card that has
-at least 4 GB of
-free memory.
+## Native build on the Raspberry Pi
 
-## Quick installation
-You can use this [pre-built Python
-wheel](https://mxnet-public.s3.amazonaws.com/install/raspbian/mxnet-1.5.0-py2.py3-none-any.whl)
-on a
-Raspberry Pi 3B with Stretch. You will likely need to install several dependencies to get
-MXNet to work.
-Refer to the following **Build** section for details.
+To build MXNet directly on the Raspberry Pi device, you can mainly follow the
+standard [Ubuntu setup]({{'/get_started/ubuntu_setup|relative_url}})
+instructions. However, skip the step of copying the `config/linux.cmake` to
+`config.cmake` and instead run the `cmake` in the "Build MXNet core shared
+library" step as follows:
 
-## Docker installation
-**Step 1** Install Docker on your machine by following the [docker installation
-instructions](https://docs.docker.com/engine/installation/linux/ubuntu/#install-using-the-repository).
 
-*Note* - You can install Community Edition (CE)
-
-**Step 2** [Optional] Post installation steps to manage Docker as a non-root user.
-
-Follow the four steps in this [docker
-documentation](https://docs.docker.com/engine/installation/linux/linux-postinstall/#manage-docker-as-a-non-root-user)
-to allow managing docker containers without *sudo*.
-
-## Build
-
-**This cross compilation build is experimental.**
-
-**Please use a Native build with gcc 4 as explained below, higher compiler versions
-currently cause test
-failures on ARM.**
-
-The following command will build a container with dependencies and tools,
-and then compile MXNet for ARMv7.
-You will want to run this on a fast cloud instance or locally on a fast PC to save time.
-The resulting artifact will be located in `build/mxnet-x.x.x-py2.py3-none-any.whl`.
-Copy this file to your Raspberry Pi.
-The previously mentioned pre-built wheel was created using this method.
-
-{% highlight bash %}
-ci/build.py -p armv7
-            {% endhighlight %}
-
-## Install using a pip wheel
-
-Your Pi will need several dependencies.
-
-Install MXNet dependencies with the following:
-
-{% highlight bash %}
-sudo apt-get update
-sudo apt-get install -y \
-apt-transport-https \
-build-essential \
-ca-certificates \
-cmake \
-curl \
-git \
-libatlas-base-dev \
-libcurl4-openssl-dev \
-libjemalloc-dev \
-liblapack-dev \
-libopenblas-dev \
-libopencv-dev \
-libzmq3-dev \
-ninja-build \
-python-dev \
-python-pip \
-software-properties-common \
-sudo \
-unzip \
-virtualenv \
-wget
-{% endhighlight %}
-
-Install virtualenv with:
-
-{% highlight bash %}
-sudo pip install virtualenv
-{% endhighlight %}
-
-Create a Python 2.7 environment for MXNet with:
-
-{% highlight bash %}
-virtualenv -p `which python` mxnet_py27
-{% endhighlight %}
-
-You may use Python 3, however the [wine bottle detection
-example](https://mxnet.apache.org/api/python/docs/tutorials/deploy/inference/wine_detector.html)
-for the
-Pi with camera requires Python 2.7.
-
-Activate the environment, then install the wheel we created previously, or install this
-[prebuilt
-wheel](https://mxnet-public.s3.amazonaws.com/install/raspbian/mxnet-1.5.0-py2.py3-none-any.whl).
-
-{% highlight bash %}
-source mxnet_py27/bin/activate
-pip install mxnet-x.x.x-py2.py3-none-any.whl
-{% endhighlight %}
-
-Test MXNet with the Python interpreter:
-
-{% highlight python %}
-$ python
-
->>> import mxnet
-{% endhighlight %}
-
-If there are no errors then you're ready to start using MXNet on your Pi!
-
-## Native Build
-
-Installing MXNet from source is a two-step process:
-
-1. Build the shared library from the MXNet C++ source code.
-2. Install the supported language-specific packages for MXNet.
-
-**Step 1** Build the Shared Library
-
-On Raspbian versions Wheezy and later, you need the following dependencies:
-
-- Git (to pull code from GitHub)
-
-- libblas (for linear algebraic operations)
-
-- libopencv (for computer vision operations. This is optional if you want to save RAM and
-Disk Space)
-
-- A C++ compiler that supports C++ 11. The C++ compiler compiles and builds MXNet source
-code. Supported
-compilers include the following:
-
-- [G++ (4.8 or later)](https://gcc.gnu.org/gcc-4.8/). Make sure to use gcc 4 and not 5 or 6
-as there are
-known bugs with these compilers.
-- [Clang (3.9 - 6)](https://clang.llvm.org/)
-
-Install these dependencies using the following commands in any directory:
-
-{% highlight bash %}
-sudo apt-get update
-sudo apt-get -y install git cmake ninja-build build-essential g++-4.9 c++-4.9 liblapack*
-libblas* libopencv*
-libopenblas* python3-dev python-dev virtualenv
-{% endhighlight %}
-
-Clone the MXNet source code repository using the following `git` command in your home
-directory:
-
-{% highlight bash %}
-git clone https://github.com/apache/incubator-mxnet.git --recursive
-cd incubator-mxnet
-{% endhighlight %}
-
-Build:
-
-{% highlight bash %}
+```
+rm -rf build
 mkdir -p build && cd build
 cmake \
--DUSE_SSE=OFF \
--DUSE_CUDA=OFF \
--DUSE_OPENCV=ON \
--DUSE_OPENMP=ON \
--DUSE_MKL_IF_AVAILABLE=OFF \
--DUSE_SIGNAL_HANDLER=ON \
--DCMAKE_BUILD_TYPE=Release \
--GNinja ..
+  -DUSE_SSE=OFF \
+  -DUSE_CUDA=OFF \
+  -DUSE_OPENCV=ON \
+  -DUSE_OPENMP=ON \
+  -DUSE_MKL_IF_AVAILABLE=OFF \
+  -DUSE_SIGNAL_HANDLER=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -GNinja ..
 ninja -j$(nproc)
-{% endhighlight %}
-Some compilation units require memory close to 1GB, so it's recommended that you enable swap
-as
-explained below and be cautious about increasing the number of jobs when building (-j)
+```
 
-Executing these commands start the build process, which can take up to a couple hours, and
-creates a file
-called `libmxnet.so` in the build directory.
+Some compilation units require memory close to 1GB, so it's recommended that you
+enable swap as explained below and be cautious about increasing the number of
+jobs when building (-j). Executing these commands start the build process, which
+can take up to a couple hours, and creates a file called `libmxnet.so` in the
+build directory.
 
-If you are getting build errors in which the compiler is being killed, it is likely that the
-compiler is running out of memory (especially if you are on Raspberry Pi 1, 2 or Zero, which
-have
-less than 1GB of RAM), this can often be rectified by increasing the swapfile size on the Pi
-by
-editing the file /etc/dphys-swapfile and changing the line CONF_SWAPSIZE=100 to
-CONF_SWAPSIZE=1024,
-then running:
-{% highlight bash %}sudo /etc/init.d/dphys-swapfile stop
+If you are getting build errors in which the compiler is being killed, it is
+likely that the compiler is running out of memory (especially if you are on
+Raspberry Pi 1, 2 or Zero, which have less than 1GB of RAM), this can often be
+rectified by increasing the swapfile size on the Pi by editing the file
+/etc/dphys-swapfile and changing the line CONF_SWAPSIZE=100 to
+CONF_SWAPSIZE=1024, then running:
+
+```
+sudo /etc/init.d/dphys-swapfile stop
 sudo /etc/init.d/dphys-swapfile start
 free -m # to verify the swapfile size has been increased
-{% endhighlight %}
+```
 
-**Step 2** Build cython modules (optional)
+## Cross-compiling on your local machine
 
-{% highlight bash %}
-$ pip install Cython
-$ make cython # You can set the python executable with `PYTHON` flag, e.g., make cython
-PYTHON=python3
-{% endhighlight %}
+### Obtaining the toolchain
 
-*MXNet* tries to use the cython modules unless the environment variable
-`MXNET_ENABLE_CYTHON` is set to `0`.
-If loading the cython modules fails, the default behavior is falling back to ctypes without
-any warning. To
-raise an exception at the failure, set the environment variable `MXNET_ENFORCE_CYTHON` to
-`1`. See
-[here](https://mxnet.apache.org/api/faq/env_var) for more details.
+You first need to setup the cross-compilation toolchain on your local machine.
+On Debian based systems, you can install `crossbuild-essential-armel` to obtain
+a cross-toolchain for the ARMv4T, 5T, and 6, `crossbuild-essential-armhf` ARMv7
+architecture and `crossbuild-essential-arm64` for ARMv8 (also called aarch64).
+See for example
+[Wikipedia](https://en.wikipedia.org/wiki/Raspberry_Pi#Specifications) to
+determine the architecture of your Raspberry PI devices. If none of the Debian
+toolchains works for you, you may like to refer to
+[toolchains.bootlin.com](https://toolchains.bootlin.com/) for a large number of
+ready-to-use cross-compilation toolchains.
 
+### Cross-compiling MXNet dependencies
+Before compiling MXNet, you need to cross-compile MXNet's dependencies. At the
+very minimum, you'll need OpenBLAS. You can cross-compile it as follows,
+replacing the `CC=aarch64-linux-gnu-gcc` and `PREFIX=/usr/aarch64-linux-gnu`
+based on your architecture:
 
-**Step 3** Install MXNet Python Bindings
+```
+git clone --recursive https://github.com/xianyi/OpenBLAS.git
+cd OpenBLAS
+make NOFORTRAN=1 NO_SHARED=1 CC=aarch64-linux-gnu-gcc
+make PREFIX=/usr/local/aarch64-linux-gnu NO_SHARED=1 install
+```
 
-To install Python bindings run the following commands in the MXNet directory:
+If you would like to compile MXNet with OpenCV support, enabling various image
+transformation related features, you also need to cross-compile OpenCV.
 
-{% highlight bash %}
+### Cross-compiling MXNet
+
+Before you cross-compile MXNet, create a CMake toolchain file specifying all settings for your compilation. For example, `aarch64-linux-gnu-toolchain.cmake`:
+
+```
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR "aarch64")
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+set(CMAKE_CUDA_HOST_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_FIND_ROOT_PATH "/usr/aarch64-linux-gnu;/usr/local/aarch64-linux-gnu")
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+```
+
+`CMAKE_FIND_ROOT_PATH` should be a list of directories containing the
+cross-compilation toolchain and MXNet's cross-compiled dependencies. If you use
+a toolchain from the bootlin site linked above, you can find the respective
+CMake toolchain file at `share/buildroot/toolchainfile.cmake`.
+
+You can then cross-compile MXNet via
+
+```
+mkdir build; cd build
+cmake -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} \
+  -DUSE_CUDA=OFF \
+  -DSUPPORT_F16C=OFF \
+  -DUSE_OPENCV=OFF \
+  -DUSE_OPENMP=ON \
+  -DUSE_LAPACK=OFF \
+  -DUSE_SIGNAL_HANDLER=ON \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DUSE_MKL_IF_AVAILABLE=OFF \
+  -G Ninja ..
+ninja
+cd ..
+```
+
+We would like to simplify this setup by integrating the Conan C++ dependency
+manager. Please send an email to the MXNet development mailinglist or open an
+issue on Github if you would like to help.
+
+### Building the Python wheel
+
+To build the wheel, you can follow the following process
+
+```
+export MXNET_LIBRARY_PATH=$(pwd)/build/libmxnet.so
+
 cd python
-pip install --upgrade pip
-pip install -e .
-{% endhighlight %}
-
-Note that the `-e` flag is optional. It is equivalent to `--editable` and means that if you
-edit the source
-files, these changes will be reflected in the package installed.
-
-Alternatively you can create a whl package installable with pip with the following command:
-
-{% highlight bash %}ci/docker/runtime_functions.sh build_wheel python/ $(realpath build)
-{% endhighlight %}
+python3 setup.py bdist_wheel
 
 
-You are now ready to run MXNet on your Raspberry Pi device. You can get started by following
-the tutorial on
-[Real-time Object Detection with MXNet On The Raspberry
+# Fix pathing issues in the wheel.  We need to move libmxnet.so from the data folder to the
+# mxnet folder, then repackage the wheel.
+WHEEL=`readlink -f dist/*.whl`
+TMPDIR=`mktemp -d`
+unzip -d ${TMPDIR} ${WHEEL}
+rm ${WHEEL}
+cd ${TMPDIR}
+mv *.data/data/mxnet/libmxnet.so mxnet
+zip -r ${WHEEL} .
+cp ${WHEEL} ..
+rm -rf ${TMPDIR}
+```
+
+We intend to fix the `setup.py` to avoid the repackaging step. If you would like
+to help, please send an email to the MXNet development mailinglist or open an
+issue on Github.
+
+
+### Final remarks
+
+You are now ready to run MXNet on your Raspberry Pi device. You can get started
+by following the tutorial on [Real-time Object Detection with MXNet On The
+Raspberry
 Pi](https://mxnet.io/api/python/docs/tutorials/deploy/inference/wine_detector.html).
 
-*Note - Because the complete MXNet library takes up a significant amount of the Raspberry
-Pi's limited RAM,
-when loading training data or large models into memory, you might have to turn off the GUI
-and terminate
-running processes to free RAM.*
+*Note - Because the complete MXNet library takes up a significant amount of the
+Raspberry Pi's limited RAM, when loading training data or large models into
+memory, you might have to turn off the GUI and terminate running processes to
+free RAM.*


### PR DESCRIPTION
Current instructions have some problems: https://github.com/apache/incubator-mxnet/issues/18471

Remove instructions referring to the use of CI Docker-containers for cross-compilation. Instead explain how to set-up a cross-compilation toolchain. The binary resulting from the CI scripts is not intended to be used on any other system than the container's operating system (eg Ubuntu 20.04). That's very limiting to users. Further, using the CI scripts, users can't modify the compilation options.

Remove link to non-ASF wheel as per http://www.apache.org/legal/release-policy.html#what