### PR TITLE
Dynamically Generate Version Dropdown

### DIFF
--- a/docs/static_site/src/_includes/get_started/get_started.html
+++ b/docs/static_site/src/_includes/get_started/get_started.html
@@ -22,22 +22,19 @@
             <div class="col-9 install-right">
                 <div class="dropdown" id="version-dropdown-container">
                     <button class="current-version dropbtn btn" type="button" data-toggle="dropdown">
-                        v1.6.0
+                        Version: {{site.versions[1]}}
                         <svg class="dropdown-caret" viewBox="0 0 32 32" class="icon icon-caret-bottom" aria-hidden="true">
                             <path class="dropdown-caret-path" d="M24 11.305l-7.997 11.39L8 11.305z"></path>
                         </svg>
                     </button>
                     <ul class="opt-group version-dropdown">
-                        <li class="opt versions"><a href="#">master</a></li>
-                        <li class="opt active versions"><a href="#">v1.6.0</a></li>
-                        <li class="opt versions"><a href="#">v1.5.1</a></li>
-                        <li class="opt versions"><a href="#">v1.4.1</a></li>
-                        <li class="opt versions"><a href="#">v1.3.1</a></li>
-                        <li class="opt versions"><a href="#">v1.2.1</a></li>
-                        <li class="opt versions"><a href="#">v1.1.0</a></li>
-                        <li class="opt versions"><a href="#">v1.0.0</a></li>
-                        <li class="opt versions"><a href="#">v0.12.1</a></li>
-                        <li class="opt versions"><a href="#">v0.11.0</a></li>
+                        {% for version in site.versions %}
+                            {% if version == site.versions[1] %}
+                                <li class="opt active versions"><a href="#">{{version}}</a></li>
+                            {% else %}
+                                <li class="opt versions"><a href="#">{{version}}</a></li>
+                            {% endif %}
+                        {% endfor %}
                     </ul>
                 </div>
             </div>

--- a/docs/static_site/src/_includes/header.html
+++ b/docs/static_site/src/_includes/header.html
@@ -93,7 +93,7 @@
           <div class="dropdown-content">
             {% for version in site.versions %}
               {% if version == site.versions[0] %}
-                <a class="dropdown-option-active" href="/">master</a>
+                <a class="dropdown-option-active" href="/">{{version}}</a>
               {% else %}
                 <a href="/versions/{{version}}/">{{version}}</a>
               {% endif %}

--- a/docs/static_site/src/_includes/header.html
+++ b/docs/static_site/src/_includes/header.html
@@ -91,16 +91,13 @@
             <svg class="dropdown-caret" viewBox="0 0 32 32" class="icon icon-caret-bottom" aria-hidden="true"><path class="dropdown-caret-path" d="M24 11.305l-7.997 11.39L8 11.305z"></path></svg>
           </span>
           <div class="dropdown-content">
-            <a class="dropdown-option-active" href="/">master</a>
-            <a href="/versions/1.6/">1.6</a>
-            <a href="/versions/1.5.0/">1.5.0</a>
-            <a href="/versions/1.4.1/">1.4.1</a>
-            <a href="/versions/1.3.1/">1.3.1</a>
-            <a href="/versions/1.2.1/">1.2.1</a>
-            <a href="/versions/1.1.0/">1.1.0</a>
-            <a href="/versions/1.0.0/">1.0.0</a>
-            <a href="/versions/0.12.1/">0.12.1</a>
-            <a href="/versions/0.11.0/">0.11.0</a>
+            {% for version in site.versions %}
+              {% if version == site.versions[0] %}
+                <a class="dropdown-option-active" href="/">master</a>
+              {% else %}
+                <a href="/versions/{{version}}/">{{version}}</a>
+              {% endif %}
+            {% endfor %}
           </div>
         </div>
       </div>

--- a/docs/static_site/src/assets/js/options.js
+++ b/docs/static_site/src/assets/js/options.js
@@ -52,7 +52,7 @@ $(document).ready(function () {
             versionSelect = urlParams.get('version');
             $('li.versions').removeClass('active');
             $('li.versions').each(function () { is_a_match($(this), versionSelect) });
-            $('.current-version').html(versionSelect + '<svg class="dropdown-caret" viewBox="0 0 32 32" class="icon icon-caret-bottom" aria-hidden="true"><path class="dropdown-caret-path" d="M24 11.305l-7.997 11.39L8 11.305z"></path></svg>');
+            $('.current-version').html("Version: " + versionSelect + '<svg class="dropdown-caret" viewBox="0 0 32 32" class="icon icon-caret-bottom" aria-hidden="true"><path class="dropdown-caret-path" d="M24 11.305l-7.997 11.39L8 11.305z"></path></svg>');
             queryString += 'version=' + versionSelect + '&';
         }
         if (urlParams.get('platform')) {
@@ -109,7 +109,7 @@ $(document).ready(function () {
         el.siblings().removeClass('active');
         el.addClass('active');
         if ($(this).hasClass("versions")) {
-            $('.current-version').html($(this).text());
+            $('.current-version').html("Verision: " + $(this).text());
             urlParams.set("version", $(this).text());
         } else if ($(this).hasClass("platforms")) {
             urlParams.set("platform", label($(this).text()));

--- a/docs/static_site/src/assets/js/options.js
+++ b/docs/static_site/src/assets/js/options.js
@@ -109,7 +109,7 @@ $(document).ready(function () {
         el.siblings().removeClass('active');
         el.addClass('active');
         if ($(this).hasClass("versions")) {
-            $('.current-version').html("Verision: " + $(this).text());
+            $('.current-version').html("Version: " + $(this).text());
             urlParams.set("version", $(this).text());
         } else if ($(this).hasClass("platforms")) {
             urlParams.set("platform", label($(this).text()));


### PR DESCRIPTION
## Description ##
To make several website version dropdowns more manageable and easier to update, this PR includes the change to dynamically generate all version dropdown using the `versions` constant in `_config.yml`. This matches the implementation in global search https://github.com/apache/incubator-mxnet/pull/18288#issuecomment-628990327.
**Updated version dropdown in this PR:**
+ Installation guide dropdown
+ General version dropdown (on top nav)

**Existing dynamically generate version dropdown:**
+ 2 global search version dropdown(desktop & mobile)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:

### Changes ###
- [x] Update the general version dropdown on top navigation bar. 
- [x] Update the installation guide version dropdown  

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/
- cc @connorgoggins 