### PR TITLE
[mxnet 2.0] deprecate gluon.model_zoo, image.detection

### DIFF
--- a/python/mxnet/gluon/model_zoo/__init__.py
+++ b/python/mxnet/gluon/model_zoo/__init__.py
@@ -17,6 +17,14 @@
 
 # coding: utf-8
 """Predefined and pretrained models."""
+import warnings
+
+# 2020-06-02, mxnet 2.0.0
+warnings.warn(("gluon.model_zoo has been deprecated and will be removed from a future release. "
+               "Please use install `gluoncv` or `gluonnlp` to retrieve the managed models "
+               "For example, you can replace existing code with "
+               "`gluoncv.model_zoo.get_model('resnet18_v1', pretrained=True)`."),
+              DeprecationWarning, stacklevel=2)
 
 from . import model_store
 

--- a/python/mxnet/image/detection.py
+++ b/python/mxnet/image/detection.py
@@ -17,14 +17,19 @@
 
 # pylint: disable=unused-import, too-many-lines
 """Read images and perform augmentations for object detection."""
-
-
 import json
 import logging
 import random
 import warnings
-
 import numpy as np
+
+# 2020-06-02, mxnet 2.0.0
+warnings.warn(("mxnet.image.detection.* functions has been deprecated "
+               "and will be removed from a future release. "
+               "Please use gluon transform functions instead. "
+               "For example, you can replace `ImageDetIter` with "
+               "`gluon.contrib.data.vision.ImageBboxDataLoader`."),
+              DeprecationWarning, stacklevel=2)
 
 from ..base import numeric_types
 from .. import ndarray as nd

--- a/python/mxnet/image/image.py
+++ b/python/mxnet/image/image.py
@@ -1342,6 +1342,11 @@ class ImageIter(io.DataIter):
                  shuffle=False, part_index=0, num_parts=1, aug_list=None, imglist=None,
                  data_name='data', label_name='softmax_label', dtype='float32',
                  last_batch_handle='pad', **kwargs):
+        # 2020-06-02, mxnet 2.0.0
+        warnings.warn(("mxnet.image.ImageIter has been deprecated "
+                       "and will be removed from a future release. "
+                       "Please use `gluon.contrib.data.vision.ImageDataLoader` instead. "),
+                      DeprecationWarning, stacklevel=2)
         super(ImageIter, self).__init__()
         assert path_imgrec or path_imglist or (isinstance(imglist, list))
         assert dtype in ['int32', 'float32', 'int64', 'float64'], dtype + ' label not supported'


### PR DESCRIPTION
## Description ##
Deprecate gluon model zoo,  image.detection in favor of gluon toolkits and gluon transform functions, respectively.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
