### PR TITLE
revert installation dropdown change

### DIFF
--- a/docs/static_site/src/_includes/get_started/get_started.html
+++ b/docs/static_site/src/_includes/get_started/get_started.html
@@ -22,19 +22,22 @@
             <div class="col-9 install-right">
                 <div class="dropdown" id="version-dropdown-container">
                     <button class="current-version dropbtn btn" type="button" data-toggle="dropdown">
-                        Version: {{site.versions[1]}}
+                        v1.6.0
                         <svg class="dropdown-caret" viewBox="0 0 32 32" class="icon icon-caret-bottom" aria-hidden="true">
                             <path class="dropdown-caret-path" d="M24 11.305l-7.997 11.39L8 11.305z"></path>
                         </svg>
                     </button>
                     <ul class="opt-group version-dropdown">
-                        {% for version in site.versions %}
-                            {% if version == site.versions[1] %}
-                                <li class="opt active versions"><a href="#">{{version}}</a></li>
-                            {% else %}
-                                <li class="opt versions"><a href="#">{{version}}</a></li>
-                            {% endif %}
-                        {% endfor %}
+                        <li class="opt versions"><a href="#">master</a></li>
+                        <li class="opt active versions"><a href="#">v1.6.0</a></li>
+                        <li class="opt versions"><a href="#">v1.5.1</a></li>
+                        <li class="opt versions"><a href="#">v1.4.1</a></li>
+                        <li class="opt versions"><a href="#">v1.3.1</a></li>
+                        <li class="opt versions"><a href="#">v1.2.1</a></li>
+                        <li class="opt versions"><a href="#">v1.1.0</a></li>
+                        <li class="opt versions"><a href="#">v1.0.0</a></li>
+                        <li class="opt versions"><a href="#">v0.12.1</a></li>
+                        <li class="opt versions"><a href="#">v0.11.0</a></li>
                     </ul>
                 </div>
             </div>

--- a/docs/static_site/src/assets/js/options.js
+++ b/docs/static_site/src/assets/js/options.js
@@ -52,7 +52,7 @@ $(document).ready(function () {
             versionSelect = urlParams.get('version');
             $('li.versions').removeClass('active');
             $('li.versions').each(function () { is_a_match($(this), versionSelect) });
-            $('.current-version').html("Version: " + versionSelect + '<svg class="dropdown-caret" viewBox="0 0 32 32" class="icon icon-caret-bottom" aria-hidden="true"><path class="dropdown-caret-path" d="M24 11.305l-7.997 11.39L8 11.305z"></path></svg>');
+            $('.current-version').html(versionSelect + '<svg class="dropdown-caret" viewBox="0 0 32 32" class="icon icon-caret-bottom" aria-hidden="true"><path class="dropdown-caret-path" d="M24 11.305l-7.997 11.39L8 11.305z"></path></svg>');
             queryString += 'version=' + versionSelect + '&';
         }
         if (urlParams.get('platform')) {
@@ -109,7 +109,7 @@ $(document).ready(function () {
         el.siblings().removeClass('active');
         el.addClass('active');
         if ($(this).hasClass("versions")) {
-            $('.current-version').html("Version: " + $(this).text());
+            $('.current-version').html($(this).text());
             urlParams.set("version", $(this).text());
         } else if ($(this).hasClass("platforms")) {
             urlParams.set("platform", label($(this).text()));


### PR DESCRIPTION
## Description ##
Revert the changes to `get_start` version dropdown in #18473 which caused the dropdown content not responding to version select, will submit another follow up PR with better solution

The reason of the bug is the version dropdown on get start page must use current format, for example "v1.5.1", "v" and "." is mandatory or it will break the parsing rule in `option.js`. But for general version dropdown and global search dropdown, the version format is slightly different from it.

### Changes ###
- [x] Revert changes to get start page version dropdown

## Comments ##
- preview: http://ec2-18-236-134-13.us-west-2.compute.amazonaws.com/get_started?