### PR TITLE
Remove downloading of the non-ASF binary build

### DIFF
--- a/julia/deps/build.jl
+++ b/julia/deps/build.jl
@@ -111,44 +111,7 @@ using BinDeps
 @BinDeps.setup
 if !libmxnet_detected
   if Sys.iswindows()
-    if Sys.ARCH != :x86_64
-      @info("Prebuilt windows binaries are only available on 64bit. You will have to built MXNet yourself.")
-      return
-    end
-    @info("Downloading pre-built packages for Windows.")
-    base_url = "https://github.com/yajiedesign/mxnet/releases/download/weekly_binary_build_v2/prebuildbase_win10_x64_vc14_v2.7z"
-
-    if libmxnet_curr_ver == "master"
-      _cmd = "{
-        [System.Net.ServicePointManager]::SecurityProtocol='tls12';
-        Invoke-WebRequest -Uri 'https://api.github.com/repos/yajiedesign/mxnet/releases/latest'
-        -OutFile 'mxnet.json'}"
-      # download_cmd uses powershell 2, but we need powershell 3 to do this
-      run(`powershell -NoProfile -Command $_cmd`)
-      curr_win = JSON.parsefile("mxnet.json")["tag_name"]
-      @info("Can't use MXNet master on Windows, using latest binaries from $curr_win.")
-    end
-    # TODO: Get url from JSON.
-    # TODO: detect cuda version and select corresponding url.
-    name = "mxnet_x64_$(HAS_CUDA ? "vc141_gpu_cu101" : "vc14_cpu").7z"
-    package_url = "https://github.com/yajiedesign/mxnet/releases/download/$(curr_win)/$(curr_win)_$(name)"
-
-    if isdefined(Base, :LIBEXECDIR)
-        exe7z = joinpath(Sys.BINDIR, Base.LIBEXECDIR, "7z.exe")
-    else
-        exe7z = joinpath(Sys.BINDIR, "7z.exe")
-    end
-
-    run(download_cmd(package_url, "mxnet.7z"))
-    # this command will create the dir "usr\\lib"
-    run(`$exe7z e mxnet.7z *\\build\\* *\\lib\\* -y -ousr\\lib`)
-
-    run(download_cmd(base_url, "mxnet_base.7z"))
-    run(`$exe7z x mxnet_base.7z -y -ousr`)
-    run(`cmd /c copy "usr\\prebuildbase_win10_x64_vc14_v2\\3rdparty\\bin\\*.dll" "usr\\lib"`)
-
-    # testing
-    run(`cmd /c dir "usr\\lib"`)
+    @info("Prebuilt windows binaries is not available currently. You will have to built MXNet yourself.")
     return
   end
 


### PR DESCRIPTION
## Description ##
As discussed in https://github.com/apache/incubator-mxnet/issues/18463, it could be in violation of ASF policy to download non-ASF binary build in julia. 
This PR is a hot-fix to address this issue, and @iblis17 will help to provide the binary in future.

@leezu @szha @TaoLv @pengzhao-intel 