### PR TITLE
[Bug Fixed] fix batch norm when `fix_gamma` is True

### DIFF
--- a/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
+++ b/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
@@ -228,7 +228,7 @@ class CuDNNBatchNormOp {
         &a,
         &b,
         &a,
-        req[cudnnbatchnorm::kGamma] == kWriteTo ? &b: &b_add,
+        req[cudnnbatchnorm::kGamma] == kAddTo ? &b_add : &b,
         io_desc_,
         x.dptr_,
         io_desc_,


### PR DESCRIPTION
## Description ##
Fix the issue #16297 #18475
When `fix_gamma` is True, the batch norm will set `grad_req` of `gamma` to `null`.
CudnnBatchNorm will be invoked when `cudnn_off=False and axis=1`, and the gradient of `beta` will be accumulated by mistake.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- Fix the bug of BatchNorm when `fix_gamma=True`.
- Add unittest for fixing gamma.
