### PR TITLE
Fix race condition in FusedOp

### DIFF
--- a/src/operator/fusion/fused_op.cc
+++ b/src/operator/fusion/fused_op.cc
@@ -61,6 +61,7 @@ FusedOp::FusedOp(const nnvm::NodeAttrs* attrs, const FusedOpConfig& config) :
 bool FusedOp::InferShape(const nnvm::NodeAttrs &attrs,
                          std::vector<mxnet::TShape> *in_attrs,
                          std::vector<mxnet::TShape> *out_attrs) {
+  std::lock_guard<std::mutex> lock(my_mutex_);
   subgraph_.attrs.erase("shape");
   subgraph_.attrs.erase("shape_inputs");
   std::vector<mxnet::TShape> input_shapes(*in_attrs);
@@ -95,7 +96,6 @@ bool FusedOp::InferShape(const nnvm::NodeAttrs &attrs,
     inferred = inferred && !op::shape_is_none(attr);
   }
   if (inferred) {
-    std::lock_guard<std::mutex> lock(my_mutex_);
     intermediate_shapes_.push_back({*in_attrs, *out_attrs, shapes});
   }
   return inferred;
@@ -104,6 +104,7 @@ bool FusedOp::InferShape(const nnvm::NodeAttrs &attrs,
 bool FusedOp::InferType(const nnvm::NodeAttrs &attrs,
                         std::vector<int> *in_attrs,
                         std::vector<int> *out_attrs) {
+  std::lock_guard<std::mutex> lock(my_mutex_);
   subgraph_.attrs.erase("dtype");
   subgraph_.attrs.erase("dtype_inputs");
   std::vector<int> input_types(*in_attrs);
@@ -138,7 +139,6 @@ bool FusedOp::InferType(const nnvm::NodeAttrs &attrs,
     inferred = inferred && !op::type_is_none(attr);
   }
   if (inferred) {
-    std::lock_guard<std::mutex> lock(my_mutex_);
     intermediate_dtypes_.push_back({*in_attrs, *out_attrs, types});
   }
   return inferred;


### PR DESCRIPTION
## Description ##
Both `InferShape` and `InferType` functions can be called from different threads than the worker thread calling forward. Previously only `intermediate_shapes_`/`intermediate_dtypes_` were protected, but those methods change also the `subgraph_` filed of `FusedOp`. That is why the lock needs to guard both functions from the beginning.

FYI @eric-haibin-lin 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change