### PR TITLE
[Bug Fixed] Fix batch norm when grad_req is `add`

### DIFF
--- a/src/operator/nn/batch_norm-inl.h
+++ b/src/operator/nn/batch_norm-inl.h
@@ -267,8 +267,8 @@ void BatchNormBackward(const OpContext &ctx, const BatchNormParam& param,
     else if (r == kAddTo) req_addto_existed = true;
   }
   CHECK_EQ(req_write_existed && req_addto_existed, false) \
-    << "BatchNorm does not support `grad_req` of two inputs \
-are `write` and `add` simultaneously";
+    << "BatchNorm does not support `grad_req` of two inputs"
+       "are `write` and `add` simultaneously";
 
   std::vector<TBlob> out_grad(1);
   std::vector<TBlob> out_data(3);

--- a/src/operator/nn/batch_norm-inl.h
+++ b/src/operator/nn/batch_norm-inl.h
@@ -259,6 +259,17 @@ void BatchNormBackward(const OpContext &ctx, const BatchNormParam& param,
                        const std::vector<TBlob> &outputs) {
   CHECK_EQ(inputs.size(), 8U);
   CHECK_EQ(outputs.size(), 3U);
+
+  // check req
+  bool req_write_existed = false, req_addto_existed = false;
+  for (const OpReqType &r : req) {
+    if (IsBNWriting(r)) req_write_existed = true;
+    else if (r == kAddTo) req_addto_existed = true;
+  }
+  CHECK_EQ(req_write_existed && req_addto_existed, true) \
+    << "BatchNorm does not support `grad_req` of two inputs \
+are `write` and `add` simultaneously";
+
   std::vector<TBlob> out_grad(1);
   std::vector<TBlob> out_data(3);
   std::vector<TBlob> in_data(3);

--- a/src/operator/nn/batch_norm-inl.h
+++ b/src/operator/nn/batch_norm-inl.h
@@ -266,7 +266,7 @@ void BatchNormBackward(const OpContext &ctx, const BatchNormParam& param,
     if (IsBNWriting(r)) req_write_existed = true;
     else if (r == kAddTo) req_addto_existed = true;
   }
-  CHECK_EQ(req_write_existed && req_addto_existed, true) \
+  CHECK_EQ(req_write_existed && req_addto_existed, false) \
     << "BatchNorm does not support `grad_req` of two inputs \
 are `write` and `add` simultaneously";
 

--- a/src/operator/nn/batch_norm-inl.h
+++ b/src/operator/nn/batch_norm-inl.h
@@ -260,16 +260,6 @@ void BatchNormBackward(const OpContext &ctx, const BatchNormParam& param,
   CHECK_EQ(inputs.size(), 8U);
   CHECK_EQ(outputs.size(), 3U);
 
-  // check req
-  bool req_write_existed = false, req_addto_existed = false;
-  for (const OpReqType &r : req) {
-    if (IsBNWriting(r)) req_write_existed = true;
-    else if (r == kAddTo) req_addto_existed = true;
-  }
-  CHECK_EQ(req_write_existed && req_addto_existed, false) \
-    << "BatchNorm does not support `grad_req` of two inputs"
-       "are `write` and `add` simultaneously";
-
   std::vector<TBlob> out_grad(1);
   std::vector<TBlob> out_data(3);
   std::vector<TBlob> in_data(3);

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -345,7 +345,9 @@ void BatchNormBackwardImpl(mshadow::Stream<cpu> *,
     if (!param_.fix_gamma) {
       KERNEL_ASSIGN(gradWeightData[channel], req[batchnorm::kGamma], scale * dotp * invstd);
     } else {
-      gradWeightData[channel] = AccReal(0);
+      if (IsBNWriting(req[batchnorm::kGamma])) {
+        gradWeightData[channel] = AccReal(0);
+      }
     }
 
     KERNEL_ASSIGN(gradBiasData[channel], req[batchnorm::kBeta], scale * sumGradOut);

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -85,6 +85,31 @@ static inline void ForEachFast(const BNTensor3<DType1> &in_data,
   }
 }
 
+template<typename DType1, typename DType2, typename DType3, typename OnData>
+static inline void ForEachFast(const BNTensor3<DType1> &in_data,
+                               const BNTensor3<DType2> &in_data2,
+                               const BNTensor3<DType3> &out_data,
+                               const size_t channel,
+                               OnData onData) {
+  const size_t num         = in_data.OuterSize();
+  const size_t matrixSize  = in_data.InnerSize();
+  const size_t skipLength  = in_data.SkipLengthToNextSameChannelData();
+  const size_t startOffset = in_data.StartOffset(channel);
+
+  DType1 *data = in_data.dptr_  + startOffset;
+  DType2 *data2 = in_data2.dptr_  + startOffset;
+  DType3 *odata = out_data.dptr_ + startOffset;
+
+  for (size_t outer = 0; outer < num; ++outer) {
+    for (size_t i = 0; i < matrixSize; ++i) {
+      onData(data++, data2++, odata++);
+    }
+    data  += skipLength;
+    data2 += skipLength;
+    odata += skipLength;
+  }
+}
+
 }  // namespace batchnorm
 
 /*! \brief Forward CPU */
@@ -263,7 +288,7 @@ void BatchNormBackwardImpl(mshadow::Stream<cpu> *,
                   dotp += (*thisInputData - mean) * (*gradOut_data);
                 });
 
-    if (!gradIn.IsEmpty() && IsBNWriting(req[batchnorm::kData])) {  // if there's a grad input
+    if (!gradIn.IsEmpty() && req[batchnorm::kData] != kNullOp) {  // if there's a grad input
       if (is_train_and_not_global_stats) {
         // when in training mode
         // Q(X) = X - E[x] ; i.e. input centered to zero mean
@@ -272,44 +297,59 @@ void BatchNormBackwardImpl(mshadow::Stream<cpu> *,
 
         // projection of gradOutput on to output scaled by std
         const AccReal k = dotp * invstd * invstd / itemCount;
-        ForEachFast(inputData, gradIn, static_cast<size_t>(channel),
-                    [&mean, &k](const DType *inputDataPtr, DType *gradIn_data) {
-                      *gradIn_data = (*inputDataPtr - mean) * k;
-                    });
-
         const AccReal iw = invstd * w;
         const AccReal gradMean = sumGradOut / itemCount;
-        ForEachFast(gradOut, gradIn, static_cast<size_t>(channel),
-                    [iw, gradMean](const DType *gradOut_data, DType *gradIn_data) {
-                      *gradIn_data = (*gradOut_data - gradMean - *gradIn_data) * iw;
-                    });
+        if (req[batchnorm::kData != kAddTo) {
+          ForEachFast(inputData, gradIn, static_cast<size_t>(channel),
+                      [&mean, &k](const DType *inputDataPtr, DType *gradIn_data) {
+                        *gradIn_data = (*inputDataPtr - mean) * k;
+                      });
+
+          ForEachFast(gradOut, gradIn, static_cast<size_t>(channel),
+                      [iw, gradMean](const DType *gradOut_data, DType *gradIn_data) {
+                        *gradIn_data = (*gradOut_data - gradMean - *gradIn_data) * iw;
+                      });
+        } else {
+          ForEachFast(inputData, gradOut, gradIn, static_cast<size_t>(channel),
+                      [&mean, &k, iw, gradMean](const DType *inputDataPtr,
+                                                const DType *gradOut_data,
+                                                DType *gradIn_data) {
+                        DType normal_val = (*inputDataPtr - mean) * k;
+                        *gradIn_data += (*gradOut_data - gradMean -
+                            normal_val) * iw;
+                      });
+        }
       } else {
         // when in evaluation mode
         // Q(X) = X - running_mean  ; i.e. input centered to zero mean
         // Y = Q(X) / running_std    ; i.e. BN output before weight and bias
         // dL/dX = w / running_std
         const AccReal iw = invstd * w;
-        ForEachFast(gradOut, gradIn, static_cast<size_t>(channel),
-                    [iw](const DType *gradOut_data, DType *gradIn_data) {
-                      *gradIn_data = *gradOut_data * iw;
-                    });
+        if (req[batchnorm::kData != kAddTo) {
+          ForEachFast(gradOut, gradIn, static_cast<size_t>(channel),
+                      [iw](const DType *gradOut_data, DType *gradIn_data) {
+                        *gradIn_data = *gradOut_data * iw;
+                      });
+        } else {
+          ForEachFast(gradOut, gradIn, static_cast<size_t>(channel),
+                      [iw](const DType *gradOut_data, DType *gradIn_data) {
+                        *gradIn_data += *gradOut_data * iw;
+                      });
+        }
       }
     }
 
     // May want to make this a param eventually
     const AccReal scale = 1.0f;
 
-    if (IsBNWriting(req[batchnorm::kGamma])) {
-      if (!param_.fix_gamma) {
-        gradWeightData[channel] = scale * dotp * invstd;
-      } else {
+    if (!param_.fix_gamma) {
+      KERNEL_ASSIGN(gradWeightData[channel], req[batchnorm::kGamma], scale * dotp * invstd);
+    } else {
+      if (req[batchnorm::kGamma] != kNullOp)
         gradWeightData[channel] = AccReal(0);
-      }
     }
 
-    if (IsBNWriting(req[batchnorm::kBeta])) {
-      gradBiasData[channel] = scale * sumGradOut;
-    }
+    KERNEL_ASSIGN(gradBiasData[channel], req[batchnorm::kBeta], scale * sumGradOut);
   }
 }
 

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -299,7 +299,7 @@ void BatchNormBackwardImpl(mshadow::Stream<cpu> *,
         const AccReal k = dotp * invstd * invstd / itemCount;
         const AccReal iw = invstd * w;
         const AccReal gradMean = sumGradOut / itemCount;
-        if (req[batchnorm::kData != kAddTo) {
+        if (req[batchnorm::kData] != kAddTo) {
           ForEachFast(inputData, gradIn, static_cast<size_t>(channel),
                       [&mean, &k](const DType *inputDataPtr, DType *gradIn_data) {
                         *gradIn_data = (*inputDataPtr - mean) * k;
@@ -325,7 +325,7 @@ void BatchNormBackwardImpl(mshadow::Stream<cpu> *,
         // Y = Q(X) / running_std    ; i.e. BN output before weight and bias
         // dL/dX = w / running_std
         const AccReal iw = invstd * w;
-        if (req[batchnorm::kData != kAddTo) {
+        if (req[batchnorm::kData] != kAddTo) {
           ForEachFast(gradOut, gradIn, static_cast<size_t>(channel),
                       [iw](const DType *gradOut_data, DType *gradIn_data) {
                         *gradIn_data = *gradOut_data * iw;

--- a/src/operator/nn/batch_norm.cc
+++ b/src/operator/nn/batch_norm.cc
@@ -345,8 +345,7 @@ void BatchNormBackwardImpl(mshadow::Stream<cpu> *,
     if (!param_.fix_gamma) {
       KERNEL_ASSIGN(gradWeightData[channel], req[batchnorm::kGamma], scale * dotp * invstd);
     } else {
-      if (req[batchnorm::kGamma] != kNullOp)
-        gradWeightData[channel] = AccReal(0);
+      gradWeightData[channel] = AccReal(0);
     }
 
     KERNEL_ASSIGN(gradBiasData[channel], req[batchnorm::kBeta], scale * sumGradOut);

--- a/src/operator/nn/batch_norm.cu
+++ b/src/operator/nn/batch_norm.cu
@@ -34,6 +34,9 @@
 #define FIX_GAMMA_FLAG        8
 #define IS_TRAINING_FLAG      16
 #define USE_GLOBAL_STATS_FLAG 32
+#define ADDTO_DATA_FLAG       (1 << 6)
+#define ADDTO_GAMMA_FLAG      (1 << 7)
+#define ADDTO_BETA_FLAG       (1 << 8)
 
 #if MXNET_USE_CUDNN == 1
 #include "./cudnn/cudnn_batch_norm-inl.h"
@@ -361,33 +364,58 @@ static __global__ void BatchNormalizationBackwardKernel(
                                 * momentum + localVariance * (AccReal(1) - momentum);
   }
 
-  if (gradInput.Size() > 0 && (flags & WRITE_DATA_FLAG) != 0) {
-    for (int batch = 0, nbatch = gradOutput.OuterSize(); batch < nbatch; ++batch) {
-      for (int x = threadIdx.x, nx = gradOutput.InnerSize(); x < nx; x += blockDim.x) {
-        const DType gradOut = gradOutput.get_ref(batch, plane, x);
-        if (is_train_and_not_global_stats) {
-          const DType inp = input.get_ref(batch, plane, x);
-          const AccReal proj = (inp - mean) * projScale;
-          gradInput.get_ref(batch, plane, x) =
-            ScalarConvert<AccReal, DType>::to((gradOut - proj - gradMean) * gradScale);
-        } else {
-          gradInput.get_ref(batch, plane, x) = ScalarConvert<AccReal, DType>::to(
-            gradOut * gradScale);
+  if (gradInput.Size() > 0 && (flags & (WRITE_DATA_FLAG | ADDTO_DATA_FLAG)) != 0) {
+    const bool grad_write = flags & WRITE_DATA_FLAG;
+    if (grad_write) {
+      for (int batch = 0, nbatch = gradOutput.OuterSize(); batch < nbatch; ++batch) {
+        for (int x = threadIdx.x, nx = gradOutput.InnerSize(); x < nx; x += blockDim.x) {
+          const DType gradOut = gradOutput.get_ref(batch, plane, x);
+          if (is_train_and_not_global_stats) {
+            const DType inp = input.get_ref(batch, plane, x);
+            const AccReal proj = (inp - mean) * projScale;
+            gradInput.get_ref(batch, plane, x) =
+              ScalarConvert<AccReal, DType>::to((gradOut - proj - gradMean) * gradScale);
+          } else {
+            gradInput.get_ref(batch, plane, x) = ScalarConvert<AccReal, DType>::to(
+              gradOut * gradScale);
+          }
+        }
+      }
+    } else {
+      // grad addto
+      for (int batch = 0, nbatch = gradOutput.OuterSize(); batch < nbatch; ++batch) {
+        for (int x = threadIdx.x, nx = gradOutput.InnerSize(); x < nx; x += blockDim.x) {
+          const DType gradOut = gradOutput.get_ref(batch, plane, x);
+          if (is_train_and_not_global_stats) {
+            const DType inp = input.get_ref(batch, plane, x);
+            const AccReal proj = (inp - mean) * projScale;
+            gradInput.get_ref(batch, plane, x) +=
+              ScalarConvert<AccReal, DType>::to((gradOut - proj - gradMean) * gradScale);
+          } else {
+            gradInput.get_ref(batch, plane, x) += ScalarConvert<AccReal, DType>::to(
+              gradOut * gradScale);
+          }
         }
       }
     }
   }
 
-  if (tensors.gradWeight.numElements() > 0 && threadIdx.x == 0 && (flags & WRITE_GAMMA_FLAG) != 0) {
+  if (tensors.gradWeight.numElements() > 0 && threadIdx.x == 0 && (flags & (WRITE_GAMMA_FLAG | ADDTO_GAMMA_FLAG)) != 0) {
     if ((flags & FIX_GAMMA_FLAG) == 0) {
-      tensors.gradWeight[plane] = ScalarConvert<AccReal, DType>::to(dotP * invstd);
+      if (flags & WRITE_GAMMA_FLAG)
+        tensors.gradWeight[plane] = ScalarConvert<AccReal, DType>::to(dotP * invstd);
+      else
+        tensors.gradWeight[plane] += ScalarConvert<AccReal, DType>::to(dotP * invstd);
     } else {
       tensors.gradWeight[plane] = DType(0);
     }
   }
 
-  if (tensors.gradBias.numElements() > 0 && threadIdx.x == 0 && (flags & WRITE_BETA_FLAG) != 0) {
-    tensors.gradBias[plane] = ScalarConvert<AccReal, DType>::to(gradOutputSum);
+  if (tensors.gradBias.numElements() > 0 && threadIdx.x == 0 && (flags & (WRITE_BETA_FLAG | ADDTO_BETA_FLAG)) != 0) {
+    if (flags & WRITE_BETA_FLAG)
+      tensors.gradBias[plane] = ScalarConvert<AccReal, DType>::to(gradOutputSum);
+    else
+      tensors.gradBias[plane] += ScalarConvert<AccReal, DType>::to(gradOutputSum);
   }
 }
 
@@ -579,12 +607,18 @@ static inline uint32_t SetupFlags(const OpContext &ctx,
   flags |= params.use_global_stats ? USE_GLOBAL_STATS_FLAG : 0;
   if (IsBNWriting(req[batchnorm::kData])) {
     flags |= WRITE_DATA_FLAG;
+  } else if (req[batchnorm::kData] == kAddTo) {
+    flags |= ADDTO_DATA_FLAG;
   }
   if (IsBNWriting(req[batchnorm::kGamma])) {
     flags |= WRITE_GAMMA_FLAG;
+  } else if (req[batchnorm::kGamma] == kAddTo) {
+    flags |= ADDTO_GAMMA_FLAG;
   }
   if (IsBNWriting(req[batchnorm::kBeta])) {
     flags |= WRITE_BETA_FLAG;
+  } else if (req[batchnorm::kBeta] == kAddTo) {
+    flags |= ADDTO_BETA_FLAG;
   }
   return flags;
 }

--- a/src/operator/nn/batch_norm.cu
+++ b/src/operator/nn/batch_norm.cu
@@ -400,7 +400,8 @@ static __global__ void BatchNormalizationBackwardKernel(
     }
   }
 
-  if (tensors.gradWeight.numElements() > 0 && threadIdx.x == 0 && (flags & (WRITE_GAMMA_FLAG | ADDTO_GAMMA_FLAG)) != 0) {
+  if (tensors.gradWeight.numElements() > 0 && threadIdx.x == 0 &&
+      (flags & (WRITE_GAMMA_FLAG | ADDTO_GAMMA_FLAG)) != 0) {
     if ((flags & FIX_GAMMA_FLAG) == 0) {
       if (flags & WRITE_GAMMA_FLAG)
         tensors.gradWeight[plane] = ScalarConvert<AccReal, DType>::to(dotP * invstd);
@@ -411,7 +412,8 @@ static __global__ void BatchNormalizationBackwardKernel(
     }
   }
 
-  if (tensors.gradBias.numElements() > 0 && threadIdx.x == 0 && (flags & (WRITE_BETA_FLAG | ADDTO_BETA_FLAG)) != 0) {
+  if (tensors.gradBias.numElements() > 0 && threadIdx.x == 0 &&
+      (flags & (WRITE_BETA_FLAG | ADDTO_BETA_FLAG)) != 0) {
     if (flags & WRITE_BETA_FLAG)
       tensors.gradBias[plane] = ScalarConvert<AccReal, DType>::to(gradOutputSum);
     else

--- a/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
+++ b/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
@@ -239,7 +239,7 @@ class CuDNNBatchNormOp {
         &a,
         req[cudnnbatchnorm::kData] == kAddTo ? &b_add : &b,
         &a,
-        grad_add_gamma_beta ? &b_add : &b, // gamma and beta
+        grad_add_gamma_beta ? &b_add : &b,  // gamma and beta
         io_desc_,
         x.dptr_,
         io_desc_,

--- a/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
+++ b/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
@@ -228,7 +228,7 @@ class CuDNNBatchNormOp {
         &a,
         &b,
         &a,
-        req[cudnnbatchnorm::kGamma] == kWriteTo ? &b: &b_add,
+        req[cudnnbatchnorm::kGamma] == kAddTo ? &b_add : &b,
         io_desc_,
         x.dptr_,
         io_desc_,

--- a/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
+++ b/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
@@ -222,8 +222,8 @@ class CuDNNBatchNormOp {
 
       if (param_.fix_gamma) gamma = 1.f;
 
-      bool grad_add_gamma_beta = req[cudnnbatchnorm::kGamma] ||
-                                 req[cudnnbatchnorm::kBeta];
+      bool grad_add_gamma_beta = (req[cudnnbatchnorm::kGamma] == kAddTo) ||
+                                 (req[cudnnbatchnorm::kBeta] == kAddTo);
       if (grad_add_gamma_beta) {
         if (IsBNWriting(req[cudnnbatchnorm::kGamma])) {
           dgamma = 0.f;

--- a/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
+++ b/src/operator/nn/cudnn/cudnn_batch_norm-inl.h
@@ -222,13 +222,24 @@ class CuDNNBatchNormOp {
 
       if (param_.fix_gamma) gamma = 1.f;
 
+      bool grad_add_gamma_beta = req[cudnnbatchnorm::kGamma] ||
+                                 req[cudnnbatchnorm::kBeta];
+      if (grad_add_gamma_beta) {
+        if (IsBNWriting(req[cudnnbatchnorm::kGamma])) {
+          dgamma = 0.f;
+        }
+        if (IsBNWriting(req[cudnnbatchnorm::kBeta])) {
+          dbeta = 0.f;
+        }
+      }
+
       CUDNN_CALL(cudnnBatchNormalizationBackward(
         s->dnn_handle_,
         mode,
         &a,
-        &b,
+        req[cudnnbatchnorm::kData] == kAddTo ? &b_add : &b,
         &a,
-        req[cudnnbatchnorm::kGamma] == kAddTo ? &b_add : &b,
+        grad_add_gamma_beta ? &b_add : &b, // gamma and beta
         io_desc_,
         x.dptr_,
         io_desc_,

--- a/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_batch_norm-inl.h
@@ -402,15 +402,13 @@ void MKLDNNBatchNormBackward(const nnvm::NodeAttrs &attrs, const OpContext &ctx,
       }
       net_args[MKLDNN_ARG_MEAN] = *(out_mean.GetMKLDNNData());
       net_args[MKLDNN_ARG_VARIANCE] = var_mem;
-      MKLDNNStream::Get()->RegisterPrimArgs(bwd.GetBwd(), net_args);
-      CommitOutput(gradIn, gradi_mem);
-      MKLDNNStream::Get()->Submit();
     } else {
       net_args[MKLDNN_ARG_MEAN] =  *(moving_mean.GetMKLDNNData());
       net_args[MKLDNN_ARG_VARIANCE] = *(moving_var.GetMKLDNNData());
-      MKLDNNStream::Get()->RegisterPrimArgs(bwd.GetBwd(), net_args);
-      MKLDNNStream::Get()->Submit();
     }
+    MKLDNNStream::Get()->RegisterPrimArgs(bwd.GetBwd(), net_args);
+    CommitOutput(gradIn, gradi_mem);
+    MKLDNNStream::Get()->Submit();
 
     // copy data from gradw_mem to in_grad[1] and in_grad[2]
     DType *gw_buf = reinterpret_cast<DType *>(bwd.GetGradw().get_data_handle());

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -1714,8 +1714,8 @@ def test_npx_batch_norm(shape, fix_gamma, cudnn_off, output_mean_var):
                                     data_mean_flat.asnumpy(),
                                     atol=atol, rtol=rtol)
                 assert_almost_equal(output_std.asnumpy(),
-                                    (1.0 / (data_var_flat +
-                                            epsilon).sqrt()).asnumpy(),
+                                    (1.0 / np.sqrt(data_var_flat +
+                                            epsilon)).asnumpy(),
                                     atol=atol, rtol=rtol)
             assert_almost_equal(output.asnumpy(), target_output.asnumpy(),
                                 atol=atol, rtol=rtol)
@@ -1739,15 +1739,15 @@ def test_npx_batch_norm(shape, fix_gamma, cudnn_off, output_mean_var):
                 assert_almost_equal(
                     bn_beta.grad.asnumpy(), adb.asnumpy(), atol=atol, rtol=rtol)
 
-        grad_reqs = ['write'] if len(shape) != 4 else ['null', 'write', 'add']
-        for data_grad_req in grad_reqs:
-            for gamma_grad_req in grad_reqs:
-                if fix_gamma and gamma_grad_req != 'null':
-                    continue
-                for beta_grad_req in grad_reqs:
-                    for axis in range(len(shape)):
-                        _test_batchnorm_impl(axis,
-                            data_grad_req, gamma_grad_req, beta_grad_req)
+    grad_reqs = ['write'] if len(shape) != 4 else ['null', 'write', 'add']
+    for data_grad_req in grad_reqs:
+        for gamma_grad_req in grad_reqs:
+            if fix_gamma and gamma_grad_req != 'null':
+                continue
+            for beta_grad_req in grad_reqs:
+                for axis in range(len(shape)):
+                    _test_batchnorm_impl(axis,
+                        data_grad_req, gamma_grad_req, beta_grad_req)
 
 @with_seed()
 @use_np

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1982,15 +1982,15 @@ def test_batchnorm(op_name, shape, fix_gamma, cudnn_off, output_mean_var):
                 assert_almost_equal(
                     bn_beta.grad.asnumpy(), adb.asnumpy(), atol=atol, rtol=rtol)
 
-        grad_reqs = ['write'] if len(shape) != 4 else ['null', 'write', 'add']
-        for data_grad_req in grad_reqs:
-            for gamma_grad_req in grad_reqs:
-                if fix_gamma and gamma_grad_req != 'null':
-                    continue
-                for beta_grad_req in grad_reqs:
-                    for axis in range(len(shape)):
-                        _test_batchnorm_impl(axis,
-                            data_grad_req, gamma_grad_req, beta_grad_req)
+    grad_reqs = ['write'] if len(shape) != 4 else ['null', 'write', 'add']
+    for data_grad_req in grad_reqs:
+        for gamma_grad_req in grad_reqs:
+            if fix_gamma and gamma_grad_req != 'null':
+                continue
+            for beta_grad_req in grad_reqs:
+                for axis in range(len(shape)):
+                    _test_batchnorm_impl(axis,
+                        data_grad_req, gamma_grad_req, beta_grad_req)
 
 
 @with_seed()

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1839,20 +1839,12 @@ def test_batchnorm_training():
 @xfail_when_nonstandard_decimal_separator
 @with_seed()
 @pytest.mark.parametrize('op_name', ['BatchNorm', 'SyncBatchNorm'])
-@pytest.mark.parametrize('shape', [(24, 2), (24, 3, 4), (24, 4, 4, 5),
+@pytest.mark.parametrize('shape', [(24, 2), (24, 3, 4),
     (24, 8, 4, 5), (24, 5, 6, 4, 5)])
 @pytest.mark.parametrize('fix_gamma', [False, True])
-@pytest.mark.parametrize('data_grad_req', ['null', 'write', 'add'])
-@pytest.mark.parametrize('gamma_grad_req', ['null', 'write', 'add'])
-@pytest.mark.parametrize('beta_grad_req', ['null', 'write', 'add'])
 @pytest.mark.parametrize('cudnn_off', [False, True])
 @pytest.mark.parametrize('output_mean_var', [False, True])
-def test_batchnorm(op_name, shape, fix_gamma,
-        data_grad_req, gamma_grad_req, beta_grad_req,
-        cudnn_off, output_mean_var):
-    if fix_gamma and gamma_grad_req != 'null':
-        # skip redundant test when fixing gamma
-        return
+def test_batchnorm(op_name, shape, fix_gamma, cudnn_off, output_mean_var):
     if op_name == 'BatchNorm':
         op = mx.nd.BatchNorm
     elif op_name == 'SyncBatchNorm':
@@ -1862,7 +1854,8 @@ def test_batchnorm(op_name, shape, fix_gamma,
     momentum = 0.9
     epsilon = 1e-5
 
-    def _test_batchnorm_impl(axis):
+    def _test_batchnorm_impl(axis,
+                             data_grad_req, gamma_grad_req, beta_grad_req):
         kwargs = dict(output_mean_var=output_mean_var)
         if op_name == 'SyncBatchNorm':
             if axis != 1:
@@ -1989,8 +1982,16 @@ def test_batchnorm(op_name, shape, fix_gamma,
                 assert_almost_equal(
                     bn_beta.grad.asnumpy(), adb.asnumpy(), atol=atol, rtol=rtol)
 
-    for axis in range(len(shape)):
-        _test_batchnorm_impl(axis)
+        grad_reqs = ['write'] if len(shape) != 4 else ['null', 'write', 'add']
+        for data_grad_req in grad_reqs:
+            for gamma_grad_req in grad_reqs:
+                if fix_gamma and gamma_grad_req != 'null':
+                    continue
+                for beta_grad_req in grad_reqs:
+                    for axis in range(len(shape)):
+                        _test_batchnorm_impl(axis,
+                            data_grad_req, gamma_grad_req, beta_grad_req)
+
 
 @with_seed()
 def test_groupnorm():

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1838,7 +1838,7 @@ def test_batchnorm_training():
 
 @xfail_when_nonstandard_decimal_separator
 @with_seed()
-@pytest.mark.parametrize('op', [mx.nd.BatchNorm, mx.nd.contrib.SyncBatchNorm])
+@pytest.mark.parametrize('op_name', ['BatchNorm', 'SyncBatchNorm'])
 @pytest.mark.parametrize('shape', [(24, 2), (24, 3, 4), (24, 4, 4, 5),
     (24, 8, 4, 5), (24, 5, 6, 4, 5)])
 @pytest.mark.parametrize('fix_gamma', [False, True])
@@ -1847,18 +1847,24 @@ def test_batchnorm_training():
 @pytest.mark.parametrize('beta_grad_req', ['null', 'write', 'add'])
 @pytest.mark.parametrize('cudnn_off', [False, True])
 @pytest.mark.parametrize('output_mean_var', [False, True])
-def test_batchnorm(op, shape, fix_gamma,
+def test_batchnorm(op_name, shape, fix_gamma,
         data_grad_req, gamma_grad_req, beta_grad_req,
         cudnn_off, output_mean_var):
     if fix_gamma and gamma_grad_req != 'null':
         # skip redundant test when fixing gamma
         return
+    if op_name == 'BatchNorm':
+        op = mx.nd.BatchNorm
+    elif op_name == 'SyncBatchNorm':
+        op = mx.nd.contrib.SyncBatchNorm
+    else:
+        raise ValueError(f'Not supported {op_name}')
     momentum = 0.9
     epsilon = 1e-5
 
     def _test_batchnorm_impl(axis):
         kwargs = dict(output_mean_var=output_mean_var)
-        if op == mx.nd.contrib.SyncBatchNorm:
+        if op_name == 'SyncBatchNorm':
             if axis != 1:
                 return
             key = str(op) + str(shape) + str(axis)

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1938,7 +1938,7 @@ def test_batchnorm():
                 adX, adW, adb = dX, dW, db
 
             if grad_req == 'add':
-                atol, rtol = 5e-1, 5e-1
+                atol, rtol = 5e-2, 5e-2
             else:
                 atol, rtol = 1e-2, 1e-2
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1937,7 +1937,7 @@ def test_batchnorm():
             else:
                 adX, adW, adb = dX, dW, db
 
-            atol, rtol = 1e-2, 5e-2
+            atol, rtol = 5e-2, 5e-2
 
             if output_mean_var:
                 assert_almost_equal(output_mean.asnumpy(),

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1937,10 +1937,7 @@ def test_batchnorm():
             else:
                 adX, adW, adb = dX, dW, db
 
-            if grad_req == 'add':
-                atol, rtol = 5e-2, 5e-2
-            else:
-                atol, rtol = 1e-2, 1e-2
+            atol, rtol = 1e-2, 5e-2
 
             if output_mean_var:
                 assert_almost_equal(output_mean.asnumpy(),

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1838,7 +1838,14 @@ def test_batchnorm_training():
 
 @xfail_when_nonstandard_decimal_separator
 @with_seed()
-def test_batchnorm():
+@pytest.mark.parametrize('op', [mx.nd.BatchNorm, mx.nd.contrib.SyncBatchNorm])
+@pytest.mark.parametrize('shape', [(24, 2), (24, 3, 4), (24, 4, 4, 5),
+    (24, 8, 4, 5), (24, 5, 6, 4, 5)])
+@pytest.mark.parametrize('fix_gamma', [False, True])
+@pytest.mark.parametrize('grad_req', ['write', 'add'])
+@pytest.mark.parametrize('cudnn_off', [False, True])
+@pytest.mark.parametrize('output_mean_var', [False, True])
+def test_batchnorm(op, shape, fix_gamma, grad_req, cudnn_off, output_mean_var):
     momentum = 0.9
     epsilon = 1e-5
 
@@ -1970,17 +1977,9 @@ def test_batchnorm():
             assert_almost_equal(
                 bn_beta.grad.asnumpy(), adb.asnumpy(), atol=atol, rtol=rtol)
 
-    for op in [mx.nd.BatchNorm, mx.nd.contrib.SyncBatchNorm]:
-        for shape in [(24, 2), (24, 3, 4), (24, 4, 4, 4),
-                (24, 8, 4, 4), (24, 5, 6, 4, 4)]:
-            for axis in range(len(shape)):
-                for fix_gamma in [False, True]:
-                    for grad_req in ['write', 'add']:
-                        for cudnn_off in [False, True]:
-                            for output_mean_var in [False, True]:
-                                _test_batchnorm_impl(op, shape, axis, fix_gamma,
-                                                     grad_req,
-                                                     cudnn_off, output_mean_var)
+    for axis in range(len(shape)):
+        _test_batchnorm_impl(op, shape, axis, fix_gamma,
+                             grad_req, cudnn_off, output_mean_var)
 
 @with_seed()
 def test_groupnorm():

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -1850,6 +1850,9 @@ def test_batchnorm_training():
 def test_batchnorm(op, shape, fix_gamma,
         data_grad_req, gamma_grad_req, beta_grad_req,
         cudnn_off, output_mean_var):
+    if fix_gamma and gamma_grad_req != 'null':
+        # skip redundant test when fixing gamma
+        return
     momentum = 0.9
     epsilon = 1e-5
 


### PR DESCRIPTION
## Description ##
Fix #18499 
In this PR, it is supported to set `data.grad_req`, `gamma.grad_req`, `beta.grad_req` to `null, addto, write, inplace` individually.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
Fix the bug in the following implementation
[x] The naive batch norm
[x] CUDNN Batch Norm
[x] MKLDNN Batch Norm
[x] Add unittest for `grad_req=add`