### PR TITLE
Update visualize.jl

### DIFF
--- a/julia/src/visualize.jl
+++ b/julia/src/visualize.jl
@@ -208,7 +208,6 @@ function _format_graphviz_edge(io::IOBuffer, head, tail, attrs)
 end
 function _extract_shape(str :: AbstractString)
   shape = collect(m.match for m in eachmatch(r"\d+", str))
-
   shape = reverse(shape) # JSON in libmxnet has reversed shape (column vs row majoring)
   return "(" * join(shape, ",") * ")"
 end

--- a/julia/src/visualize.jl
+++ b/julia/src/visualize.jl
@@ -207,7 +207,7 @@ function _format_graphviz_edge(io::IOBuffer, head, tail, attrs)
   _format_graphviz_attr(io, attrs)
 end
 function _extract_shape(str :: AbstractString)
-  shape = collect(m.match for m in eachmatch(r"\d+", str))
+  shape = collect(m.match for m ∈ eachmatch(r"\d+", str))
   shape = reverse(shape) # JSON in libmxnet has reversed shape (column vs row majoring)
   return "(" * join(shape, ",") * ")"
 end

--- a/julia/src/visualize.jl
+++ b/julia/src/visualize.jl
@@ -207,7 +207,9 @@ function _format_graphviz_edge(io::IOBuffer, head, tail, attrs)
   _format_graphviz_attr(io, attrs)
 end
 function _extract_shape(str :: AbstractString)
-  shape = matchall(r"\d+", str)
+  #shape = matchall(r"\d+", str)
+  shape = collect(m.match for m in eachmatch(r"\d+", str))
+
   shape = reverse(shape) # JSON in libmxnet has reversed shape (column vs row majoring)
   return "(" * join(shape, ",") * ")"
 end

--- a/julia/src/visualize.jl
+++ b/julia/src/visualize.jl
@@ -207,7 +207,6 @@ function _format_graphviz_edge(io::IOBuffer, head, tail, attrs)
   _format_graphviz_attr(io, attrs)
 end
 function _extract_shape(str :: AbstractString)
-  #shape = matchall(r"\d+", str)
   shape = collect(m.match for m in eachmatch(r"\d+", str))
 
   shape = reverse(shape) # JSON in libmxnet has reversed shape (column vs row majoring)


### PR DESCRIPTION

Fixes  #18491 

##matchall has been deprecated as of Julia 1.3. Changes made to fix.

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
