### PR TITLE
Update cmake/upstream/FindCUDAToolkit.cmake

### DIFF
--- a/cmake/upstream/FindCUDAToolkit.cmake
+++ b/cmake/upstream/FindCUDAToolkit.cmake
@@ -738,8 +738,15 @@ find_path(CUDAToolkit_INCLUDE_DIR
 # And find the CUDA Runtime Library libcudart
 find_library(CUDA_CUDART
   NAMES cudart
-  PATH_SUFFIXES lib64 lib64/stubs lib/x64
+  PATH_SUFFIXES lib64 lib/x64
 )
+if (NOT CUDA_CUDART)
+  find_library(CUDA_CUDART
+    NAMES cudart
+    PATH_SUFFIXES lib64/stubs lib/x64/stubs
+  )
+endif()
+
 if (NOT CUDA_CUDART AND NOT CUDAToolkit_FIND_QUIETLY)
   message(STATUS "Unable to find cudart library.")
 endif()
@@ -788,9 +795,20 @@ if(CUDAToolkit_FOUND)
       NAMES ${search_names}
       HINTS ${CUDAToolkit_LIBRARY_DIR}
             ENV CUDA_PATH
-      PATH_SUFFIXES nvidia/current lib64 lib64/stubs lib/x64 lib lib/stubs stubs
+      PATH_SUFFIXES nvidia/current lib64 lib/x64 lib
                     ${arg_EXTRA_PATH_SUFFIXES}
     )
+    # Don't try any stub directories intil we have exhausted all other
+    # search locations.
+    if(NOT CUDA_${lib_name}_LIBRARY)
+      find_library(CUDA_${lib_name}_LIBRARY
+        NAMES ${search_names}
+        HINTS ${CUDAToolkit_LIBRARY_DIR}
+              ENV CUDA_PATH
+        PATH_SUFFIXES lib64/stubs lib/x64/stubs lib/stubs stubs
+      )
+    endif()
+
     mark_as_advanced(CUDA_${lib_name}_LIBRARY)
 
     if (NOT TARGET CUDA::${lib_name} AND CUDA_${lib_name}_LIBRARY)


### PR DESCRIPTION
Previously MXNet includes a hotfix for a cross-compiling bug in upstream FindCUDAToolkit.cmake. Upstream has fixed the bug now. Thus remove MXNet patch and replace by upstream fix

cf https://gitlab.kitware.com/cmake/cmake/-/issues/20572