### PR TITLE
fix pooling_convention warning when convert model to onnx

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -761,9 +761,10 @@ def convert_pooling(node, **kwargs):
     pooling_convention = attrs.get('pooling_convention', 'valid')
     ceil_mode = False
     if pooling_convention == 'full':
-        pooling_warning = "Pooling: ONNX lower than 1.5.0 doesn't support pooling_convention. " \
-                          "This might lead to shape or accuracy issues. " \
-                          "https://github.com/onnx/onnx/issues/549, fixed in onnx 1.5.0"
+        if onnx.__version__<"1.5.0":
+            pooling_warning = "Pooling: ONNX lower than 1.5.0 doesn't support pooling_convention. " \
+                              "This might lead to shape or accuracy issues. " \
+                              "https://github.com/onnx/onnx/issues/549"
         ceil_mode=True
         logging.warning(pooling_warning)
 

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -761,11 +761,11 @@ def convert_pooling(node, **kwargs):
     pooling_convention = attrs.get('pooling_convention', 'valid')
     ceil_mode = False
     if pooling_convention == 'full':
-        if onnx.__version__<"1.5.0":
+        if onnx.__version__ < "1.5.0":
             pooling_warning = "Pooling: ONNX lower than 1.5.0 doesn't support pooling_convention. " \
                               "This might lead to shape or accuracy issues. " \
                               "https://github.com/onnx/onnx/issues/549"
-        ceil_mode=True
+        ceil_mode = True
         logging.warning(pooling_warning)
 
     pad_dims = list(parse_helper(attrs, "pad", [0, 0]))
@@ -806,7 +806,7 @@ def convert_pooling(node, **kwargs):
                 name=name
             )
         else:
-            if onnx.__version__>="1.5.0":
+            if onnx.__version__ >= "1.5.0":
                 node = onnx.helper.make_node(
                     pool_types[pool_type],
                     input_nodes,  # input


### PR DESCRIPTION
## Description ##
when convert a mxnet model with pooling layers which pool_convention is not set to “valid", there always a warning:  "Pooling: ONNX currently doesn't support pooling_convention. " \
                          "This might lead to shape or accuracy issues. " \
                          "https://github.com/onnx/onnx/issues/549". And the output onnx model maybe have very different result with the mxnet model. However, according to https://github.com/onnx/onnx/issues/549, from onnx 1.5.0, pool_convention has been supported with param ceil_mode
