### PR TITLE
revert changes causing cd failures

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -947,9 +947,7 @@ cd_unittest_ubuntu() {
 
     local mxnet_variant=${1:?"This function requires a mxnet variant as the first argument"}
 
-    pytest -m 'not serial' -k 'not test_operator' -n 4 --durations=50 --verbose tests/python/unittest
-    MXNET_ENGINE_TYPE=NaiveEngine \
-        pytest -m 'not serial' -k 'test_operator' -n 4 --durations=50 --verbose tests/python/unittest
+    pytest -m 'not serial' -n 4 --durations=50 --verbose tests/python/unittest
     pytest -m 'serial' --durations=50 --verbose tests/python/unittest
     pytest -n 4 --durations=50 --verbose tests/python/quantization
 
@@ -968,7 +966,8 @@ cd_unittest_ubuntu() {
 
         # TODO(szha): fix and reenable the hanging issue. tracked in #18098
         # integrationtest_ubuntu_gpu_dist_kvstore
-        integrationtest_ubuntu_gpu_byteps
+        # TODO(eric-haibin-lin): fix and reenable
+        # integrationtest_ubuntu_gpu_byteps
     fi
 
     if [[ ${mxnet_variant} = *mkl ]]; then


### PR DESCRIPTION
## Description ##
Reverting the following changes to  `cd_unittest_ubuntu` causing CD pipeline failures:

1. The first change was using Naive Engine for operator tests, which causes timeout failures in CD
Added here: https://github.com/apache/incubator-mxnet/commit/10b6b4887ef494ea985c9ea75a393a985476d08e

2. Second change was running `integrationtest_ubuntu_gpu_byteps` as part of cu* CD tests, added here: https://github.com/apache/incubator-mxnet/commit/e28e9fec9bba07708ed0093c882b8070a96dfdd5

@eric-haibin-lin is working on fixing this issue and re-enabling this test.