### PR TITLE
[Numpy] Bugfix of slice operator export (MXNet to ONNX) v2

### DIFF
--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -118,6 +118,7 @@ def convert_string_to_list(string_val):
 
     return result_list
 
+
 def get_boolean_attribute_value(attrs, attr_name):
     """ Helper function to convert a string version
     of Boolean attributes to integer for ONNX.
@@ -125,6 +126,7 @@ def get_boolean_attribute_value(attrs, attr_name):
     parameters.
     """
     return 1 if attrs.get(attr_name, 0) in ["True", "1"] else 0
+
 
 def get_inputs(node, kwargs):
     """Helper function to get inputs"""
@@ -137,9 +139,15 @@ def get_inputs(node, kwargs):
     input_nodes = []
     for ip in inputs:
         input_node_id = index_lookup[ip[0]]
-        input_nodes.append(proc_nodes[input_node_id].name)
+        try:
+            # ip[1] defines which output index to use
+            input_nodes.append(proc_nodes[input_node_id].output[ip[1]])
+        except AttributeError:
+            # fallback to the name attribute as output if the output attribute does not exist (e.g. for data nodes)
+            input_nodes.append(proc_nodes[input_node_id].name)
 
     return name, input_nodes, attrs
+
 
 def create_basic_op_node(op_name, node, kwargs):
     """Helper function to create a basic operator
@@ -153,6 +161,7 @@ def create_basic_op_node(op_name, node, kwargs):
         name=name
     )
     return [node]
+
 
 @mx_op.register("null")
 def convert_weights_and_inputs(node, **kwargs):

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -128,15 +128,17 @@ def get_boolean_attribute_value(attrs, attr_name):
     return 1 if attrs.get(attr_name, 0) in ["True", "1"] else 0
 
 
-def get_inputs(node, kwargs):
+def get_inputs(node, kwargs, with_shapes=False):
     """Helper function to get inputs"""
     name = node["name"]
     proc_nodes = kwargs["proc_nodes"]
     index_lookup = kwargs["index_lookup"]
+    graph_shapes = kwargs["graph_shapes"]
     inputs = node["inputs"]
     attrs = node.get("attrs", {})
 
     input_nodes = []
+    input_shapes = []
     for ip in inputs:
         input_node_id = index_lookup[ip[0]]
         try:
@@ -145,6 +147,11 @@ def get_inputs(node, kwargs):
         except AttributeError:
             # fallback to the name attribute as output if the output attribute does not exist (e.g. for data nodes)
             input_nodes.append(proc_nodes[input_node_id].name)
+
+        input_shapes.append(graph_shapes.get(input_nodes[-1]))
+
+    if with_shapes:
+        return name, input_nodes, input_shapes, attrs
 
     return name, input_nodes, attrs
 

--- a/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py
@@ -1619,7 +1619,7 @@ def convert_slice_axis(node, **kwargs):
     """Map MXNet's slice_axis operator attributes to onnx's Slice operator
     and return the created node.
     """
-    name, input_nodes, attrs = get_inputs(node, kwargs)
+    name, input_nodes, input_shapes, attrs = get_inputs(node, kwargs, with_shapes=True)
 
     axes = int(attrs.get("axis"))
     starts = int(attrs.get("begin"))
@@ -1627,7 +1627,7 @@ def convert_slice_axis(node, **kwargs):
     if not ends or ends == 'None':
         # ONNX doesn't support None for ends. Since ends=None depicts
         # length of dimension, passing dimension in this case.
-        in_shape = kwargs['in_shape'][0]
+        in_shape = input_shapes[0]
         ends = in_shape[axes]
 
     export_nodes = []
@@ -1666,7 +1666,7 @@ def convert_slice_channel(node, **kwargs):
     operator based on squeeze_axis attribute
     and return the created node.
     """
-    name, input_nodes, attrs = get_inputs(node, kwargs)
+    name, input_nodes, input_shapes, attrs = get_inputs(node, kwargs, with_shapes=True)
 
     num_outputs = int(attrs.get("num_outputs"))
     axis = int(attrs.get("axis", 1))
@@ -1682,7 +1682,7 @@ def convert_slice_channel(node, **kwargs):
         )
         return [node]
     elif squeeze_axis == 0 and num_outputs > 1:
-        in_shape = kwargs.get('in_shape')[0]
+        in_shape = input_shapes[0]
         split = in_shape[axis] // num_outputs
         node = onnx.helper.make_node(
             "Split",

--- a/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
@@ -203,8 +203,9 @@ class MXNetGraph(object):
         onnx_processed_outputs = []
         index_lookup = []
 
-        # Determine output shape
+        # Determine output and internal shapes
         graph_outputs = MXNetGraph.get_outputs(sym, params, in_shape, output_label)
+        graph_shapes = MXNetGraph.get_outputs(sym.get_internals(), params, in_shape, output_label)
 
         graph_input_idx = 0
         for idx, node in enumerate(mx_graph):
@@ -230,6 +231,7 @@ class MXNetGraph(object):
                     in_shape=in_shape[graph_input_idx],
                     in_type=in_type,
                     proc_nodes=all_processed_nodes,
+                    graph_shapes=graph_shapes,
                     initializer=initializer,
                     index_lookup=index_lookup)
                 graph_input_idx += 1
@@ -244,6 +246,7 @@ class MXNetGraph(object):
                     in_shape=in_shape,
                     in_type=in_type,
                     proc_nodes=all_processed_nodes,
+                    graph_shapes=graph_shapes,
                     initializer=initializer,
                     index_lookup=index_lookup,
                     idx=idx

--- a/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
+++ b/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py
@@ -116,7 +116,7 @@ class MXNetGraph(object):
         return arg_params, aux_params
 
     @staticmethod
-    def get_outputs(sym, params, in_shape, in_label):
+    def get_outputs(sym, params, in_shape, in_label, verbose=True):
         """ Infer output shapes and return dictionary of output name to shape
 
         :param :class:`~mxnet.symbol.Symbol` sym: symbol to perform infer shape on
@@ -124,6 +124,7 @@ class MXNetGraph(object):
         :param list of tuple(int, ...) in_shape: list of all input shapes
         :param  in_label: name of label typically used in loss that may be left in graph. This name is
             removed from list of inputs required by symbol
+        :param verbose: If false, info logging messages are deactivated
         :return: dictionary of output name to shape
         :rtype: dict of (str, tuple(int, ...))
         """
@@ -142,7 +143,8 @@ class MXNetGraph(object):
             if name.endswith('_output'):
                 out_names.append(name[:-len('_output')])
             else:
-                logging.info("output '%s' does not end with '_output'", name)
+                if verbose:
+                    logging.info("output '%s' does not end with '_output'", name)
                 out_names.append(name)
 
         assert len(out_shapes) == len(out_names)
@@ -205,7 +207,7 @@ class MXNetGraph(object):
 
         # Determine output and internal shapes
         graph_outputs = MXNetGraph.get_outputs(sym, params, in_shape, output_label)
-        graph_shapes = MXNetGraph.get_outputs(sym.get_internals(), params, in_shape, output_label)
+        graph_shapes = MXNetGraph.get_outputs(sym.get_internals(), params, in_shape, output_label, verbose=False)
 
         graph_input_idx = 0
         for idx, node in enumerate(mx_graph):


### PR DESCRIPTION
## Description ##
This PR fixes the slice operator export from MXNet into ONNX.

@MoritzMaxeiner reported this problem already: **Incorrect ONNX export of SliceChannel** https://github.com/apache/incubator-mxnet/issues/13061.
The corresponding pull request **ONNX export: Support equal length splits** https://github.com/apache/incubator-mxnet/pull/14121 however, only partially solved the problem.

The output of the slice operator was corrected but it is still not properly handled in the `get_inputs()` function.

The following unit test demonstrates this:

```python
class SplitConcatBlock(HybridBlock):
    """Block which creates two splits and later concatenates them"""
    def __init__(self, name):
        super(SplitConcatBlock, self).__init__(name)

    def hybrid_forward(self, F, x):
        splits = F.split(x, axis=1, num_outputs=2)
        return F.concat(*splits)

def test_onnx_export_slice(self):
     net = nn.HybridSequential(prefix='slice_net')
     with net.name_scope():
         net.add(nn.Dense(100, activation='relu'), SplitConcatBlock("splitConcat"), nn.Dense(10))
     _check_onnx_export(net)
```

Before this PR, the conversion of the model from MXNet into ONNX resulted in the following error:
```python
Traceback (most recent call last):
  File "mxnet_export_test.py", line 134, in test_onnx_export_slice
    _check_onnx_export(net)
  File "mxnet_export_test.py", line 66, in _check_onnx_export
    onnx_file_path=onnx_file_path)
  File "/opt/mxnet/python/mxnet/contrib/onnx/mx2onnx/export_model.py", line 87, in export_model
    verbose=verbose)
  File "/opt/mxnet/python/mxnet/contrib/onnx/mx2onnx/export_onnx.py", line 312, in create_onnx_graph_proto
    checker.check_graph(graph)
  File "/usr/local/lib/python3.6/dist-packages/onnx/checker.py", line 51, in checker
    proto.SerializeToString(), ctx)
onnx.onnx_cpp2py_export.checker.ValidationError: Nodes in a graph must be topologically sorted, however input 'slice_netsplitConcatsplit0' of node: 
input: "slice_netsplitConcatsplit0" input: "slice_netsplitConcatsplit0" output: "slice_netsplitConcatconcat0" name: "slice_netsplitConcatconcat0" op_type: "Concat" attribute { name: "axis" i: 1 type: INT }
 is not output of any previous nodes.
```

Now, this is resolved by replacing:
```python
        input_nodes.append(proc_nodes[input_node_id].name)
```
with:
```python
        try:
            # ip[1] defines which output index to use
            input_nodes.append(proc_nodes[input_node_id].output[ip[1]])
        except AttributeError:
            # fallback to the name attribute as output if the output attribute does not exist (e.g. for data nodes)
            input_nodes.append(proc_nodes[input_node_id].name)
```

Next, @RuRo fixed the shape inference problem in https://github.com/QueensGambit/incubator-mxnet/pull/1 because previously the ONNX export assumed that the shape is fixed throughout the whole network.
Another unit-test was added to verify this:

```python
    @with_seed()
    def test_onnx_export_slice_changing_shape(self):
        net = nn.HybridSequential(prefix='slice_net_changing_shape')
        with net.name_scope():
            net.add(nn.Dense(100, activation='relu'), SplitConcatBlock("splitConcat"),
                    nn.Dense(50, activation='relu'), SplitConcatBlock("splitConcat2"), nn.Dense(10))
        _check_onnx_export(net)
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Added unit test: `test_onnx_export_slice()`
- [x] Added unit test: `test_onnx_export_slice_changing_shape()`
- [x] Updated: `get_inputs()`
- [x] Updated: `get_outputs()`

## Comments ##
- This PR is backward compatible
