### PR TITLE
add FAQ redirect rule

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -47,6 +47,9 @@ RewriteCond %{REQUEST_FILENAME} -d
 RewriteCond %{REQUEST_FILENAME}/index.html -f
 RewriteRule ^(.*) $1/index.html [NC,L]
 
+# Redirect FAQ TODO: temporary fix for Github issue #18547
+RewriteRule ^versions/master/faq/(.*)$ /api/faq/$1 [R,NC,L]
+
 # 404
 ErrorDocument 404 /404.html
 


### PR DESCRIPTION
## Description ##
This pr fix #18547, rewrite `/versions/master/faq/` to `/api/faq/`

### Changes ###
- [x] Add temporary rewrite rule for FAQ

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/

For testing:
- http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/versions/master/faq/model_parallel_lstm.html 
- http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/versions/master/faq/multi_devices.html 