### PR TITLE
add cd mxnet_lib/static and python/pypi stages to ci

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1879,7 +1879,7 @@ ci_package_pypi() {
     cp include/mkldnn/dnnl_version.h 3rdparty/mkldnn/include/.
     cp include/mkldnn/dnnl_config.h 3rdparty/mkldnn/include/.
     local mxnet_variant=${1:?"This function requires a python command as the first argument"}
-    cd_package_pypi mxnet_variant
+    cd_package_pypi ${mxnet_variant}
     cd_integration_test_pypi
 }
 

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1958,29 +1958,6 @@ build_static_python_cu92() {
     popd
 }
 
-build_static_python_cpu_cmake() {
-    set -ex
-    pushd .
-    export mxnet_variant=cpu
-    export CMAKE_STATICBUILD=1
-    source /opt/rh/devtoolset-7/enable
-    source /opt/rh/rh-python36/enable
-    ./ci/publish/python/build.sh
-    popd
-}
-
-build_static_python_cu92_cmake() {
-    set -ex
-    pushd .
-    export mxnet_variant=cu92
-    export CMAKE_STATICBUILD=1
-    export USE_SYSTEM_CUDA=1
-    source /opt/rh/devtoolset-7/enable
-    source /opt/rh/rh-python36/enable
-    ./ci/publish/python/build.sh
-    popd
-}
-
 publish_scala_build() {
     set -ex
     pushd .

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1871,6 +1871,18 @@ build_static_libmxnet() {
     popd
 }
 
+# Tests CD PyPI packaging in CI
+ci_package_pypi() {
+    set -ex
+    # copies mkldnn header files to 3rdparty/mkldnn/include/ as in CD
+    mkdir -p 3rdparty/mkldnn/include
+    cp include/mkldnn/dnnl_version.h 3rdparty/mkldnn/include/.
+    cp include/mkldnn/dnnl_config.h 3rdparty/mkldnn/include/.
+    local mxnet_variant=${1:?"This function requires a python command as the first argument"}
+    cd_package_pypi mxnet_variant
+    cd_integration_test_pypi
+}
+
 # Packages libmxnet into wheel file
 cd_package_pypi() {
     set -ex

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1294,6 +1294,19 @@ def test_centos7_python3_cd_cpu(lib_name) {
     }]
 }
 
+def test_centos7_pypi_package_cd_cpu(lib_name) {
+    return ['PyPI package: CentOS 7 CPU CD': {
+      node(NODE_LINUX_CPU) {
+        ws('workspace/test-cd-pypi/cpu') {
+          timeout(time: max_time, unit: 'MINUTES') {
+            utils.unpack_and_init(lib_name, mx_cd_lib)
+            utils.docker_run('centos7_cpu', 'ci_package_pypi cpu', false)
+          }
+        }
+      }
+    }]
+}
+
 def test_centos7_python3_gpu(lib_name) {
     return ['Python3: CentOS 7 GPU': {
       node(NODE_LINUX_GPU) {
@@ -1332,6 +1345,19 @@ def test_centos7_quantization_cd_gpu(lib_name) {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.unpack_and_init(lib_name, mx_cd_lib)
             utils.docker_run('centos7_gpu_cu102', 'unittest_ubuntu_python3_quantization_gpu', true)
+          }
+        }
+      }
+    }]
+}
+
+def test_centos7_pypi_package_cd_gpu(lib_name) {
+    return ['PyPI package: CentOS 7 GPU CD': {
+      node(NODE_LINUX_GPU) {
+        ws('workspace/test-cd-pypi/gpu') {
+          timeout(time: max_time, unit: 'MINUTES') {
+            utils.unpack_and_init(lib_name, mx_cd_lib)
+            utils.docker_run('centos7_gpu_cu102', 'ci_package_pypi cu102', true)
           }
         }
       }

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -394,20 +394,6 @@ def compile_centos7_cpu_mkldnn() {
     }]
 }
 
-def compile_static_cd_cpu(lib_name) {
-    return ['CPU: CD Static Build' : {
-      node(NODE_LINUX_CPU) {
-        ws('workspace/build-cd-static/cpu/') {
-          timeout(time: max_time, unit: 'MINUTES') {
-            utils.init_git()
-            utils.docker_run('centos7_cpu', 'build_static_libmxnet cpu', false)
-            utils.pack_lib(lib_name, mx_cd_lib)
-          }
-        }
-      }
-    }]
-}
-
 def compile_centos7_gpu(lib_name) {
     return ['GPU: CentOS 7': {
       node(NODE_LINUX_CPU) {
@@ -416,20 +402,6 @@ def compile_centos7_gpu(lib_name) {
             utils.init_git()
             utils.docker_run('centos7_gpu_cu92', 'build_centos7_gpu', false)
             utils.pack_lib(lib_name, mx_lib)
-          }
-        }
-      }
-    }]
-}
-
-def compile_static_cd_gpu(lib_name) {
-    return ['GPU: CD Static Build' : {
-      node(NODE_LINUX_CPU) {
-        ws('workspace/build-cd-static/gpu/') {
-          timeout(time: max_time, unit: 'MINUTES') {
-            utils.init_git()
-            utils.docker_run('centos7_gpu_cu102', 'build_static_libmxnet cu102', false)
-            utils.pack_lib(lib_name, mx_cd_lib)
           }
         }
       }
@@ -776,13 +748,14 @@ def compile_static_python_cpu() {
   }]
 }
 
-def compile_static_python_cpu_cmake() {
-  return ['Static build CPU CentOS7 Python with CMake' : {
+def compile_static_cd_cpu(lib_name) {
+  return ['CPU: CD Static Build' : {
     node(NODE_LINUX_CPU) {
-        ws('workspace/ut-publish-python-cpu') {
+        ws('workspace/build-cd-static/cpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
-            utils.docker_run('centos7_cpu', 'build_static_python_cpu_cmake', false)
+            utils.docker_run('centos7_cpu', 'build_static_libmxnet cpu', false)
+            utils.pack_lib(lib_name, mx_cd_lib)
           }
         }
     }
@@ -802,13 +775,14 @@ def compile_static_python_gpu() {
   }]
 }
 
-def compile_static_python_gpu_cmake() {
-  return ['Static build GPU CentOS7 Python with CMake' : {
-    node(NODE_LINUX_GPU) {
-        ws('workspace/ut-publish-python-gpu') {
+def compile_static_cd_gpu(lib_name) {
+  return ['GPU: CD Static Build' : {
+    node(NODE_LINUX_CPU) {
+        ws('workspace/build-cd-static/gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
-            utils.docker_run('centos7_gpu_cu92', 'build_static_python_cu92_cmake')
+            utils.docker_run('centos7_gpu_cu102', 'build_static_libmxnet cu102', false)
+            utils.pack_lib(lib_name, mx_cd_lib)
           }
         }
     }

--- a/ci/jenkins/Jenkinsfile_centos_cpu
+++ b/ci/jenkins/Jenkinsfile_centos_cpu
@@ -37,10 +37,9 @@ core_logic: {
     custom_steps.compile_centos7_cpu('centos7_cpu'),
     custom_steps.compile_centos7_cpu_make('centos7_cpu_make'),
     custom_steps.compile_centos7_cpu_mkldnn(),
-    custom_steps.compile_static_cd_cpu('centos7_cpu_cd'),
     custom_steps.compile_static_scala_cpu(),
     custom_steps.compile_static_python_cpu(),
-    custom_steps.compile_static_python_cpu_cmake()
+    custom_steps.compile_static_cd_cpu('centos7_cpu_cd')
   ])
 
   utils.parallel_stage('Tests', [

--- a/ci/jenkins/Jenkinsfile_centos_cpu
+++ b/ci/jenkins/Jenkinsfile_centos_cpu
@@ -37,6 +37,7 @@ core_logic: {
     custom_steps.compile_centos7_cpu('centos7_cpu'),
     custom_steps.compile_centos7_cpu_make('centos7_cpu_make'),
     custom_steps.compile_centos7_cpu_mkldnn(),
+    custom_steps.compile_static_cd_cpu('centos7_cpu_cd'),
     custom_steps.compile_static_scala_cpu(),
     custom_steps.compile_static_python_cpu(),
     custom_steps.compile_static_python_cpu_cmake()
@@ -44,7 +45,8 @@ core_logic: {
 
   utils.parallel_stage('Tests', [
     custom_steps.test_centos7_python3_cpu('centos7_cpu'),
-    custom_steps.test_centos7_scala_cpu('centos7_cpu_make')
+    custom_steps.test_centos7_scala_cpu('centos7_cpu_make'),
+    custom_steps.test_centos7_python3_cd_cpu('centos7_cpu_cd')
   ])
 }
 ,

--- a/ci/jenkins/Jenkinsfile_centos_cpu
+++ b/ci/jenkins/Jenkinsfile_centos_cpu
@@ -46,7 +46,8 @@ core_logic: {
   utils.parallel_stage('Tests', [
     custom_steps.test_centos7_python3_cpu('centos7_cpu'),
     custom_steps.test_centos7_scala_cpu('centos7_cpu_make'),
-    custom_steps.test_centos7_python3_cd_cpu('centos7_cpu_cd')
+    custom_steps.test_centos7_python3_cd_cpu('centos7_cpu_cd'),
+    custom_steps.test_centos7_pypi_package_cd_cpu('centos7_cpu_cd')
   ])
 }
 ,

--- a/ci/jenkins/Jenkinsfile_centos_gpu
+++ b/ci/jenkins/Jenkinsfile_centos_gpu
@@ -35,12 +35,15 @@ utils.main_wrapper(
 core_logic: {
   utils.parallel_stage('Build', [
     custom_steps.compile_centos7_gpu('centos7_gpu'),
+    custom_steps.compile_static_cd_gpu('centos7_gpu_cd'),
     custom_steps.compile_static_python_gpu(),
     custom_steps.compile_static_python_gpu_cmake()
   ])
 
   utils.parallel_stage('Tests', [
-    custom_steps.test_centos7_python3_gpu('centos7_gpu')
+    custom_steps.test_centos7_python3_gpu('centos7_gpu'),
+    custom_steps.test_centos7_python3_cd_gpu('centos7_gpu_cd'),
+    custom_steps.test_centos7_quantization_cd_gpu('centos7_gpu_cd')
   ])
 }
 ,

--- a/ci/jenkins/Jenkinsfile_centos_gpu
+++ b/ci/jenkins/Jenkinsfile_centos_gpu
@@ -35,9 +35,8 @@ utils.main_wrapper(
 core_logic: {
   utils.parallel_stage('Build', [
     custom_steps.compile_centos7_gpu('centos7_gpu'),
-    custom_steps.compile_static_cd_gpu('centos7_gpu_cd'),
     custom_steps.compile_static_python_gpu(),
-    custom_steps.compile_static_python_gpu_cmake()
+    custom_steps.compile_static_cd_gpu('centos7_gpu_cd')
   ])
 
   utils.parallel_stage('Tests', [

--- a/ci/jenkins/Jenkinsfile_centos_gpu
+++ b/ci/jenkins/Jenkinsfile_centos_gpu
@@ -43,7 +43,8 @@ core_logic: {
   utils.parallel_stage('Tests', [
     custom_steps.test_centos7_python3_gpu('centos7_gpu'),
     custom_steps.test_centos7_python3_cd_gpu('centos7_gpu_cd'),
-    custom_steps.test_centos7_quantization_cd_gpu('centos7_gpu_cd')
+    custom_steps.test_centos7_quantization_cd_gpu('centos7_gpu_cd'),
+    custom_steps.test_centos7_pypi_package_cd_gpu('centos7_gpu_cd')
   ])
 }
 ,


### PR DESCRIPTION
## Description ##
Add CD "mxnet_lib/static" and "python/pypi" pipelines build and test stages to CI to enable catching issues before merging PRs.

The following CI stages have been added/removed.

- centos-cpu
  - (Added) CPU: CD Static Build
  - (Added) Python3: CentOS 7 CPU CD
  - (Added) PyPI package: CentOS 7 CPU CD
  - (Removed) Static build CPU CentOS7 Python with CMake
- centos-gpu
  - (Added) GPU: CD Static Build
  - (Added) Python3: CentOS 7 CPU CD
  - (Added) Quantization Python3: CentOS 7 GPU CD
  - (Added) PyPI package: CentOS 7 GPU CD
  - (Removed) Static build GPU CentOS7 Python with CMake