### PR TITLE
Reducing the number of calls of the NDArray constructors

### DIFF
--- a/include/mxnet/ndarray.h
+++ b/include/mxnet/ndarray.h
@@ -104,8 +104,10 @@ class NDArray {
    */
   NDArray(const NDArrayStorageType stype, const mxnet::TShape &shape, Context ctx,
           bool delay_alloc = true, int dtype = mshadow::default_type_flag,
-          std::vector<int> aux_types = {}, mxnet::ShapeVector aux_shapes = {},
-          mxnet::TShape storage_shape = mxnet::TShape(mshadow::Shape1(0)));
+          const std::vector<int> &aux_types = {}, const mxnet::ShapeVector &aux_shapes = {},
+          const mxnet::TShape &storage_shape = mxnet::TShape(mshadow::Shape1(0))) {
+    ReInit(stype, shape, ctx, dtype, delay_alloc, &aux_types, &aux_shapes, &storage_shape);
+  }
   /*!
    * \brief constructs a new dynamic NDArray whose shape is unknown,
    *        hence the NDArray is inherently lazily created
@@ -187,6 +189,31 @@ class NDArray {
     ptr_->Init(shape, this->dtype_);
     this->shape_ = shape;
   }
+  /*!
+   * \brief re-initialize the NDArray
+   */
+  inline void Init(const NDArrayStorageType stype, const mxnet::TShape &shape, int dtype) {
+    shape_ = shape;
+    dtype_ = dtype;
+    storage_type_ = stype;
+    reuse_ = false;
+    byte_offset_ = 0;
+    autograd_entry_ = nnvm::NodeEntry(nullptr);
+  }
+  void InitDetached(const NDArray *src) {
+    *this = *src;
+    autograd_entry_ = nnvm::NodeEntry(nullptr);
+  }
+  inline void ReInit() {
+    ptr_ = nullptr;
+    Init(kUndefinedStorage, TShape(), -1);
+  }
+  void ReInit(const NDArrayStorageType stype, const mxnet::TShape &shape, Context ctx, int dtype,
+              bool delay_alloc = true, const std::vector<int> *aux_types = nullptr,
+              const mxnet::ShapeVector *aux_shapes = nullptr,
+              const mxnet::TShape *storage_shape = nullptr);
+
+  void SelfReorder2Default();
   /*!
    * \brief set the correct shape of NDArray directly from the storage_shape of its own chunk.
    */
@@ -569,6 +596,20 @@ class NDArray {
     ret.dtype_ = dtype;
     ret.reuse_ = true;
     return ret;
+  }
+
+  inline void InitAsArray(const NDArray &src, const mxnet::TShape &shape, int dtype) {
+    CHECK_EQ(src.storage_type(), kDefaultStorage)
+      << "AsArray is intended only for kDefaultStorage.";
+    CHECK_GE(src.ptr_->shandle.size,
+             shape.Size() * mshadow::mshadow_sizeof(dtype))
+      << "NDArray.AsArray: target memory size is bigger";
+    // We can't reuse memory in a view.
+    CHECK(!src.IsView());
+    *this = src;
+    shape_ = shape;
+    dtype_ = dtype;
+    reuse_ = true;
   }
 
   /*!

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -606,6 +606,34 @@ void CachedOp::StaticRunOps(
   }
 }
 
+#define INIT_DETACHED(x, y)   if (!y->is_none()) x->InitDetached(y)
+
+static void PrepareOutputs(const nnvm::Graph& g, const Context& default_ctx,
+                           const std::vector<NDArray*> &outputs,
+                           std::vector<NDArray*> *pArrays, bool detach) {
+  using namespace nnvm;
+  const auto& dtypes = g.GetAttr<DTypeVector>("dtype");
+  const auto& shapes = g.GetAttr<mxnet::ShapeVector>("shape");
+  const auto& stypes = g.GetAttr<StorageTypeVector>("storage_type");
+
+  const auto& idx = g.indexed_graph();
+  auto &arrays = *pArrays;
+  for (size_t i = 0; i < outputs.size(); ++i) {
+    const auto eid = idx.entry_id(idx.outputs()[i]);
+    // An input and an output may share the same array.
+    if (detach)
+      INIT_DETACHED(outputs[i], arrays[eid]);
+
+    arrays[eid] = outputs[i];
+    if (arrays[eid]->is_none())
+      arrays[eid]->ReInit(static_cast<NDArrayStorageType>(stypes[eid]),
+                          shapes[eid], default_ctx, dtypes[eid]);
+    const nnvm::NodeAttrs& attrs = idx[idx.outputs()[i].node_id].source->attrs;
+    outputs[i]->AssignStorageInfo(common::NodeAttrsGetProfilerScope(attrs),
+                                  attrs.name);
+  }
+}
+
 OpStatePtr CachedOp::StaticForward(
     const Context& default_ctx,
     const std::vector<NDArray*>& inputs,
@@ -664,24 +692,7 @@ OpStatePtr CachedOp::StaticForward(
     StaticInitExec(state_ptr, recording, false);
   }
 
-  const auto& dtypes = g.GetAttr<DTypeVector>("dtype");
-  const auto& shapes = g.GetAttr<mxnet::ShapeVector>("shape");
-  const auto& stypes = g.GetAttr<StorageTypeVector>("storage_type");
-
-  for (size_t i = 0; i < outputs.size(); ++i) {
-    auto eid = idx.entry_id(idx.outputs()[i]);
-    // An input and an output may share the same array.
-    if (!arrays[eid]->is_none())
-      *outputs[i] = arrays[eid]->Detach();
-    arrays[eid] = outputs[i];
-    if (!outputs[i]->is_none()) continue;
-    *outputs[i] = NDArray(static_cast<NDArrayStorageType>(stypes[eid]),
-                          shapes[eid], default_ctx, true, dtypes[eid]);
-    const nnvm::NodeAttrs& attrs = idx[idx.outputs()[i].node_id].source->attrs;
-    outputs[i]->AssignStorageInfo(common::NodeAttrsGetProfilerScope(attrs),
-                                  attrs.name);
-  }
-
+  PrepareOutputs(g, default_ctx, outputs, &arrays, true);
   StaticRunOps(default_ctx, g, state_ptr, arrays, 0, idx.num_nodes());
 
   return recording ? state_ptr : OpStatePtr();
@@ -871,10 +882,9 @@ void CachedOp::DynamicBackward(
   }
   for (size_t i = 0, j = num_forward_outputs; i < reqs.size(); ++i) {
     if (reqs[i] == kNullOp) continue;
-    auto eid = idx.entry_id(idx.outputs()[j++]);
+    const auto eid = idx.entry_id(idx.outputs()[j++]);
     // An input and an output may share the same array.
-    if (!arrays[eid]->is_none())
-      *outputs[i] = arrays[eid]->Detach();
+    INIT_DETACHED(outputs[i], arrays[eid]);
     arrays[eid] = outputs[i];
   }
 
@@ -963,8 +973,7 @@ void CachedOp::StaticBackward(
         match = false;
         state.array_reqs[eid] = reqs[iter->second];
         // An input and an output may share the same array.
-        if (!arrays[eid]->is_none())
-          *outputs[iter->second] = arrays[eid]->Detach();
+        INIT_DETACHED(outputs[iter->second], arrays[eid]);
         *arrays[eid] = *outputs[iter->second];
         state.dynamic_entries[eid] = false;
       }
@@ -977,8 +986,7 @@ void CachedOp::StaticBackward(
       auto eid = idx.entry_id(entry);
       state.array_reqs[eid] = reqs[iter->second];
       // An input and an output may share the same array.
-      if (!arrays[eid]->is_none())
-        *outputs[iter->second] = arrays[eid]->Detach();
+      INIT_DETACHED(outputs[iter->second], arrays[eid]);
       arrays[eid] = outputs[iter->second];
     }
   } else {
@@ -988,8 +996,7 @@ void CachedOp::StaticBackward(
       auto eid = idx.entry_id(entry);
       state.array_reqs[eid] = reqs[i];
       // An input and an output may share the same array.
-      if (!arrays[eid]->is_none())
-        *outputs[i] = arrays[eid]->Detach();
+      INIT_DETACHED(outputs[i], arrays[eid]);
       arrays[eid] = outputs[i];
     }
   }

--- a/src/imperative/imperative.cc
+++ b/src/imperative/imperative.cc
@@ -591,13 +591,9 @@ std::vector<NDArray*> Imperative::Backward(
     auto num_outputs = idx[i].source->num_outputs();
     for (size_t j = 0; j < num_outputs; ++j) {
       auto eid = idx.entry_id(i, j);
-      if (!arrays[eid]->is_none()) continue;
-      if (stypes[eid] == kDefaultStorage) {
-        *arrays[eid] = NDArray(shapes[eid], vctx[i], true, dtypes[eid]);
-      } else {
-        *arrays[eid] = NDArray(static_cast<NDArrayStorageType>(stypes[eid]),
-                               shapes[eid], vctx[i], true, dtypes[eid]);
-      }
+      if (arrays[eid]->is_none())
+        arrays[eid]->ReInit(static_cast<NDArrayStorageType>(stypes[eid]),
+                            shapes[eid], vctx[i], dtypes[eid]);
     }
   }
 

--- a/src/imperative/imperative_utils.cc
+++ b/src/imperative/imperative_utils.cc
@@ -108,16 +108,15 @@ void InvokeOperator(const nnvm::IndexedGraph& idx,
     invoke(OpStatePtr());
   }
   for (const auto& j : node.inputs) {
-    size_t eid = idx.entry_id(j);
-    --ref_count[eid];
-    if (ref_count[eid] == 0) {
-      *arrays[eid] = NDArray();
+    const size_t eid = idx.entry_id(j);
+    if (--ref_count[eid] == 0) {
+      arrays[eid]->ReInit();
     }
   }
   for (size_t j = 0; j < ndoutputs.size(); ++j) {
-    size_t eid = idx.entry_id(node_idx, j);
+    const size_t eid = idx.entry_id(node_idx, j);
     if (ref_count[eid] == 0) {
-      *arrays[eid] = NDArray();
+      arrays[eid]->ReInit();
     }
   }
 }

--- a/src/imperative/imperative_utils.h
+++ b/src/imperative/imperative_utils.h
@@ -37,6 +37,65 @@
 #define MXNET_IMPERATIVE_IMPERATIVE_UTILS_H_
 
 namespace mxnet {
+
+#if MXNET_USE_MKLDNN == 1
+template<typename T>T *pntr(T &obj)           { return &obj; }  // NOLINT
+template<typename T>T *pntr(T *obj)           { return obj; }
+
+template<typename T>
+void InvalidateOutputs(const std::vector<T> *pArrs,
+                        const std::vector<OpReqType> &reqs) {
+  auto arrs = *pArrs;
+  for (size_t i = 0; i < arrs.size(); i++) {
+    if (reqs[i] == kWriteTo || reqs[i] == kNullOp)
+      pntr(arrs[i])->InvalidateMKLDNNData();
+  }
+}
+
+static inline void CreateDefaultInputs(const std::vector<NDArray> &arrs,
+                                       std::vector<NDArray> *out_arrs) {
+  out_arrs->clear();
+  for (size_t i = 0; i < arrs.size(); ++i) {
+    if (arrs[i].IsMKLDNNData())
+      out_arrs->push_back(arrs[i].Reorder2Default());
+    else
+      out_arrs->push_back(arrs[i]);
+  }
+}
+
+static inline void CreateDefaultInputs(std::vector<NDArray> *pArrs) {
+  auto arrs =  *pArrs;
+  for (size_t i = 0; i < arrs.size(); ++i)
+    arrs[i].SelfReorder2Default();
+}
+
+#define INVALIDATE_OUTPUTS(outputs, req) InvalidateOutputs(&outputs, req)
+// kCrossDeviceCopy is used for `_copy_to` operator, which doesn't compute immediately in
+// its FCcomputeEx, but AsyncPush the copy operation to engine.
+// So for the case that A is holding mkldnn memory, and then copy A to B, and then copy B
+// back to A, we shouldn't invalidate outputs for copying B back to A, because at this time,
+// copying A to B may not happen, and will corrupt A's memory.
+#define INVALIDATE_OUTPUTS_COND(cond, outputs, req) if (cond) INVALIDATE_OUTPUTS(outputs, req)
+
+// add for mkldnn OP + no mkldnn OP
+#define CREATE_DEFAULT_INPUTS(cond, attrs, func_call)  \
+                          if (cond) {                                               \
+                            const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");  \
+                            if (!is_mkldnn.get(attrs.op, false)) func_call;         \
+                          }
+
+#else
+#define INVALIDATE_OUTPUTS(outputs, ...)       // empty macros
+#define INVALIDATE_OUTPUTS_COND(outputs, ...)  // empty macro
+#define CREATE_DEFAULT_INPUTS(input, ...)      // empty macro
+#endif
+
+#if MXNET_USE_MKLDNN == 1
+#else
+#define CREATE_DEFAULT_INPUTS_MKLDNN(in_array, in_array_fallback, attrs)  // empty macro
+#endif
+
+
 namespace imperative {
 
 namespace {
@@ -227,23 +286,19 @@ inline void SetShapeType(const Context& ctx,
   CHECK_EQ(out_storage_types.size(), outputs.size());
   CHECK(*dispatch_mode != DispatchMode::kUndefined);
 
+  NDArrayStorageType storage_type = kDefaultStorage;
+  // for dynamic shape, we could not pre-determine the shape
+  auto &&shape = mxnet::TShape(mshadow::Shape1(0));
   for (size_t i = 0; i < outputs.size(); ++i) {
-    NDArrayStorageType storage_type = static_cast<NDArrayStorageType>(out_storage_types[i]);
     if (outputs[i]->is_none() || (mxnet::op::shape_is_none(outputs[i]->shape()) &&
                                    Imperative::DCInfo::IsNone(*outputs[i]))) {
-      if (is_dynamic_shape_existing) {
-        // once there is dynamic shape somewhere, we could not pre-determine the shape.
-        *outputs[i] = NDArray(ctx, out_types[i]);
-        outputs[i]->AssignStorageInfo(common::NodeAttrsGetProfilerScope(attrs), attrs.name);
-      } else if (storage_type == kDefaultStorage) {
-        *outputs[i] = NDArray(out_shapes[i], ctx, true, out_types[i]);
-        outputs[i]->AssignStorageInfo(common::NodeAttrsGetProfilerScope(attrs), attrs.name);
-      } else {
-        *outputs[i] = NDArray(storage_type, out_shapes[i], ctx, true, out_types[i]);
-        outputs[i]->AssignStorageInfo(common::NodeAttrsGetProfilerScope(attrs), attrs.name);
+      if (!is_dynamic_shape_existing) {
+        storage_type = static_cast<NDArrayStorageType>(out_storage_types[i]);
+        shape = out_shapes[i];
       }
-    } else if (mxnet::op::shape_is_none(outputs[i]->shape()) &&
-               !Imperative::DCInfo::IsNone(*outputs[i])) {
+      outputs[i]->ReInit(storage_type, out_shapes[i], ctx, out_types[i]);
+      outputs[i]->AssignStorageInfo(common::NodeAttrsGetProfilerScope(attrs), attrs.name);
+    } else if (mxnet::op::shape_is_none(outputs[i]->shape())) {
       // For deferred computed arrays with unknown shape (following dynamic
       // shape operator), don't use copy assignment as it would destroy the
       // deferredcompute metadata.
@@ -437,15 +492,157 @@ inline void SetNumOutputs(const nnvm::Op *op,
 /*!
  * \brief Copy-construct NDArrays referenced by inputs and outputs to p_inputs and p_outputs
  */
-inline void DerefInputOutput(const std::vector<NDArray*>& inputs,
-                             const std::vector<NDArray*>& outputs,
+inline void DerefInputOutput(const std::vector<NDArray *>& inputs,
+                             const std::vector<NDArray *>& outputs,
                              std::vector<NDArray>* p_inputs,
                              std::vector<NDArray>* p_outputs) {
   p_inputs->reserve(inputs.size());
   p_outputs->reserve(outputs.size());
-  for (NDArray* i : inputs) p_inputs->emplace_back(*i);
-  for (NDArray* i : outputs) p_outputs->emplace_back(*i);
+  for (const auto i : inputs) p_inputs->emplace_back(*i);
+  for (const auto i : outputs) p_outputs->emplace_back(*i);
 }
+
+inline void DerefInputOutput(const std::vector<NDArray*>& inputs,
+                             const std::vector<NDArray*>& outputs,
+                             std::vector<NDArray *>* p_inputs,
+                             std::vector<NDArray *>* p_outputs) {
+  p_inputs->reserve(inputs.size());
+  p_outputs->reserve(outputs.size());
+  for (const auto i : inputs) p_inputs->emplace_back(new NDArray(*i));
+  for (const auto i : outputs) p_outputs->emplace_back(new NDArray(*i));
+}
+
+inline void DerefInputOutputRelease(const std::vector<NDArray *>& inputs,
+                                    const std::vector<NDArray *>& outputs) {
+  for (auto i : inputs) delete i;
+  for (auto i : outputs) delete i;
+}
+
+
+/*
+ * \brief setup default-storage tblobs from source NDArrays. If any source NDArray has non-default
+ *        storage, it creates a temp NDArray with default storage and uses the temp tblob. The
+ *        function also records the indices of non-default source NDArrays and the indices of
+ *        their corresponding temporary NDArrays in the temp array.
+ * \param src list of source NDArray
+ * \param blobs list of tblobs to return
+ * \param temp_src list of source NDArrays which requires temporary default storage representation
+ * \param temp_dst list of temporary destination NDArrays for default storage representation
+ * \param idx_map mapping from indices in source NDArrays to indices in temp_dst. When not set,
+          indices are not recorded
+ * \return true if any source NDArray need to cast storage
+ */
+inline bool SetupDefaultBlobsIn(const std::vector<NDArray *>& src,
+                                const std::vector<NDArray> *bufs,
+                                std::vector<TBlob> *blobs,
+                                std::vector<NDArray> *temp_src,
+                                std::vector<NDArray> *temp_dst,
+                                std::unordered_map<uint32_t, uint32_t> *idx_map) {
+  bool require_cast = false;
+  for (size_t i = 0; i < src.size(); i++) {
+    const auto& nd = *src[i];
+    if (!DEFAULT_DATA(nd)) {
+      (*idx_map)[i] = temp_dst->size();
+      NDArray temp = bufs != nullptr ? bufs->at(i) : NDArray(nd.shape(), nd.ctx(),
+                                                             true, nd.dtype());
+#if MXNET_USE_MKLDNN == 1
+      CHECK(temp.IsDefaultData());
+#endif
+      temp_src->emplace_back(nd);
+      temp_dst->emplace_back(temp);
+      blobs->emplace_back(temp.data());
+      require_cast = true;
+    } else {
+      blobs->push_back(nd.data());
+    }
+  }
+  return require_cast;
+}
+
+inline bool SetupDefaultBlobsOut(const std::vector<NDArray *>& src,
+                                 const std::vector<NDArray> *bufs,
+                                 std::vector<OpReqType> *req,
+                                 std::vector<TBlob> *blobs,
+                                 std::vector<NDArray> *temp_src,
+                                 std::vector<NDArray> *temp_dst) {
+  bool require_cast = false;
+  for (size_t i = 0; i < src.size(); i++) {
+    const auto& nd = *src[i];
+
+#if MXNET_USE_MKLDNN == 1
+    if (req->at(i) == kWriteInplace && nd.IsMKLDNNData())
+      // If it's write inplace and the output array doesn't use the default
+      // layout, we'll generate a temporary output array below, which means
+      // the input array and the output array are no longer the same array.
+      // we should change the request type.
+      req->at(i) = kWriteTo;
+#endif
+    if (!DEFAULT_DATA(nd)) {
+#if MXNET_USE_MKLDNN == 1
+      NDArray temp;
+      if (bufs != nullptr) {
+        temp = bufs->at(i);
+      } else if (kAddTo == req->at(i)) {
+        temp = nd.IsMKLDNNData()? nd.Reorder2Default() : nd;
+      } else {
+        temp = NDArray(nd.shape(), nd.ctx(), true, nd.dtype());
+      }
+      CHECK(temp.IsDefaultData());
+#else
+      NDArray temp = bufs != nullptr ? bufs->at(i) : NDArray(nd.shape(), nd.ctx(),
+          true, nd.dtype());
+#endif
+      temp_src->emplace_back(nd);
+      temp_dst->emplace_back(temp);
+      blobs->emplace_back(temp.data());
+      require_cast = true;
+    } else {
+      blobs->push_back(nd.data());
+    }
+  }
+  return require_cast;
+}
+
+/*
+ * \brief setup default-storage tblobs for input and output NDArrays.
+ *        If any NDArray has non-default storage,
+ *        it creates a temp NDArray with default storage and uses the temp tblob. The
+ *        function also records the indices of non-default source NDArrays and the indices of
+ *        their corresponding temporary NDArrays in the temp array.
+ */
+inline void SetupDefaultBlobsInOut(const std::vector<NDArray *> &ndinputs,
+                                   const std::vector<NDArray *> &ndoutputs,
+                                   const std::vector<NDArray> *in_bufs,
+                                   const std::vector<NDArray> *out_bufs,
+                                   std::vector<OpReqType> *req,
+                                   std::vector<TBlob> *input_blobs,
+                                   std::vector<TBlob> *output_blobs,
+                                   std::vector<NDArray> *pre_temp_src,
+                                   std::vector<NDArray> *pre_temp_dst,
+                                   std::vector<NDArray> *post_temp_src,
+                                   std::vector<NDArray> *post_temp_dst,
+                                   std::unordered_map<uint32_t, uint32_t> *in_temp_idx_map,
+                                   const std::vector<uint32_t> &mutate_idx) {
+  // populate input blobs
+  SetupDefaultBlobsIn(ndinputs, in_bufs, input_blobs, pre_temp_src, pre_temp_dst,
+                      in_temp_idx_map);
+  // populate output blobs
+  SetupDefaultBlobsOut(ndoutputs, out_bufs, req, output_blobs, post_temp_dst,
+                       post_temp_src);
+  // add mutable inputs to post temp list
+  for (const auto idx : mutate_idx) {
+    auto map_iter = in_temp_idx_map->find(idx);
+    if (map_iter != in_temp_idx_map->end()) {
+      post_temp_src->push_back(pre_temp_dst->at(map_iter->second));
+      post_temp_dst->push_back(*ndinputs[idx]);
+    }
+  }
+}
+
+#define REDEFINE_INPUTS_OUTPUTS(in, out, newIn, newOut)       \
+      std::vector<NDArray> newIn, newOut;                     \
+      DerefInputOutput(in, out, &newIn, &newOut);             \
+      DerefInputOutputRelease(in, out)
 
 inline void PushFCompute(const FCompute& fn,
                   const nnvm::Op* op,
@@ -465,7 +662,7 @@ inline void PushFCompute(const FCompute& fn,
   bool need_grad = Imperative::Get()->is_recording();
   ExecType exec_type = fexec_type.count(op) ? fexec_type[op](attrs) : ExecType::kSync;
   CHECK(exec_type == ExecType::kSync);
-  std::vector<NDArray> inputs, outputs;
+  std::vector<NDArray *> inputs, outputs;
   DerefInputOutput(p_inputs, p_outputs, &inputs, &outputs);
   const auto& run = [=](RunContext rctx) {
     std::vector<TBlob> input_blobs, output_blobs;
@@ -473,16 +670,7 @@ inline void PushFCompute(const FCompute& fn,
     std::vector<NDArray> pre_temp_src, pre_temp_dst, post_temp_dst, post_temp_src;
     // mapping from index in input_blobs to index in pre_temp_dst
     std::unordered_map<uint32_t, uint32_t> in_temp_idx_map;
-#if MXNET_USE_MKLDNN == 1
-    if (exec_type != ExecType::kCrossDeviceCopy) {
-      // kCrossDeviceCopy is used for `_copy_to` operator, which doesn't compute immediately in
-      // its FCcomputeEx, but AsyncPush the copy operation to engine.
-      // So for the case that A is holding mkldnn memory, and then copy A to B, and then copy B
-      // back to A, we shouldn't invalidate outputs for copying B back to A, because at this time,
-      // copying A to B may not happen, and will corrupt A's memory.
-      InvalidateOutputs(outputs, req);
-    }
-#endif
+    INVALIDATE_OUTPUTS_COND(exec_type != ExecType::kCrossDeviceCopy, outputs, req);
     std::vector<OpReqType> tmp_req = req;
     // setup blobs
     SetupDefaultBlobsInOut(inputs, outputs, nullptr, nullptr, &tmp_req,
@@ -499,6 +687,7 @@ inline void PushFCompute(const FCompute& fn,
     if (is_gpu && !rctx.is_bulk) {
       rctx.get_stream<gpu>()->Wait();
     }
+    DerefInputOutputRelease(inputs, outputs);
   };
   if (CheckIfSkipEngine(attrs)) {
     // execute without engine
@@ -522,39 +711,23 @@ inline void PushFComputeEx(const FComputeEx& fn,
                     const std::vector<OpReqType>& req) {
   static auto& fexec_type = nnvm::Op::GetAttr<FExecType>("FExecType");
 
-  bool is_train = Imperative::Get()->is_training();
-  bool need_grad = Imperative::Get()->is_recording();
-  ExecType exec_type = fexec_type.count(op) ? fexec_type[op](attrs) : ExecType::kSync;
-  std::vector<NDArray> inputs, outputs;
+  const bool is_train = Imperative::Get()->is_training();
+  const bool need_grad = Imperative::Get()->is_recording();
+  const auto exec_type = fexec_type.count(op) ? fexec_type[op](attrs) : ExecType::kSync;
+  const auto cross_device_copy = exec_type == ExecType::kCrossDeviceCopy;
+  std::vector<NDArray *> inputs, outputs;
   DerefInputOutput(p_inputs, p_outputs, &inputs, &outputs);
   const auto& run = [=](RunContext rctx) {
       OpContext opctx{need_grad, is_train, rctx, engine::CallbackOnComplete(), requested};
-#if MXNET_USE_MKLDNN == 1
-      if (exec_type != ExecType::kCrossDeviceCopy) {
-        // kCrossDeviceCopy is used for `_copy_to` operator, which doesn't compute immediately in
-        // its FCcomputeEx, but AsyncPush the copy operation to engine.
-        // So for the case that A is holding mkldnn memory, and then copy A to B, and then copy B
-        // back to A, we shouldn't invalidate outputs for copying B back to A, because at this time,
-        // copying A to B may not happen, and will corrupt A's memory.
-        InvalidateOutputs(outputs, req);
-      }
-      // add for mkldnn OP + no mkldnn OP
-      const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
-      if (!is_mkldnn.get(attrs.op, false) && exec_type != ExecType::kCrossDeviceCopy) {
-        std::vector<NDArray> inputs_fallback;
-        CreateDefaultInputs(inputs, &inputs_fallback);
-        fn(attrs, opctx, inputs_fallback, req, outputs);
-      } else {
-        fn(attrs, opctx, inputs, req, outputs);
-      }
-#else
-      fn(attrs, opctx, inputs, req, outputs);
-#endif
+      REDEFINE_INPUTS_OUTPUTS(inputs, outputs, inputsA, outputsA);
+      INVALIDATE_OUTPUTS_COND(!cross_device_copy, outputsA, req);
+      CREATE_DEFAULT_INPUTS(!cross_device_copy, attrs, CreateDefaultInputs(&inputsA));
+      fn(attrs, opctx, inputsA, req, outputsA);
       if (ctx.dev_mask() == gpu::kDevMask && exec_type == ExecType::kSync && !rctx.is_bulk) {
         rctx.get_stream<gpu>()->Wait();
       }
     };
-  if (exec_type == ExecType::kCrossDeviceCopy || CheckIfSkipEngine(attrs)) {
+  if (cross_device_copy || CheckIfSkipEngine(attrs)) {
     run(RunContext{ctx, nullptr, nullptr, false});
   } else {
     CHECK(exec_type == ExecType::kSync);
@@ -581,38 +754,19 @@ inline void PushOperator(const OpStatePtr& state,
   bool is_train = Imperative::Get()->is_training();
   bool need_grad = Imperative::Get()->is_recording();
   ExecType exec_type = fexec_type.count(op) ? fexec_type[op](attrs) : ExecType::kSync;
-  std::vector<NDArray> inputs, outputs;
+  std::vector<NDArray *> inputs, outputs;
   DerefInputOutput(p_inputs, p_outputs, &inputs, &outputs);
 
-  auto fcompute =
-      common::GetFCompute<FStatefulCompute>(op, "FStatefulCompute", ctx);
-  auto fcompute_ex =
-      common::GetFCompute<FStatefulComputeEx>(op, "FStatefulComputeEx", ctx);
+  auto fcompute_ex = common::GetFCompute<FStatefulComputeEx>(op, "FStatefulComputeEx", ctx);
   if (fcompute_ex != nullptr && dispatch_mode == DispatchMode::kFComputeEx) {
     const auto& run = [=](RunContext rctx,
                           engine::CallbackOnComplete on_complete) {
       OpContext opctx{need_grad, is_train, rctx, on_complete, requested};
-#if MXNET_USE_MKLDNN == 1
-      if (exec_type != ExecType::kCrossDeviceCopy) {
-        // kCrossDeviceCopy is used for `_copy_to` operator, which doesn't compute immediately in
-        // its FCcomputeEx, but AsyncPush the copy operation to engine.
-        // So for the case that A is holding mkldnn memory, and then copy A to B, and then copy B
-        // back to A, we shouldn't invalidate outputs for copying B back to A, because at this time,
-        // copying A to B may not happen, and will corrupt A's memory.
-        InvalidateOutputs(outputs, req);
-      }
-      // add for mkldnn OP + no mkldnn OP
-      const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN");
-      if (!is_mkldnn.get(attrs.op, false) && exec_type != ExecType::kCrossDeviceCopy) {
-        std::vector<NDArray> inputs_fallback;
-        CreateDefaultInputs(inputs, &inputs_fallback);
-        fcompute_ex(state, opctx, inputs_fallback, req, outputs);
-      } else {
-        fcompute_ex(state, opctx, inputs, req, outputs);
-      }
-#else
-      fcompute_ex(state, opctx, inputs, req, outputs);
-#endif
+      REDEFINE_INPUTS_OUTPUTS(inputs, outputs, inputsA, outputsA);
+      INVALIDATE_OUTPUTS_COND(exec_type != ExecType::kCrossDeviceCopy, outputsA, req);
+      CREATE_DEFAULT_INPUTS(exec_type != ExecType::kCrossDeviceCopy, attrs,
+                            CreateDefaultInputs(&inputsA));
+      fcompute_ex(state, opctx, inputsA, req, outputsA);
       if (ctx.dev_mask() == gpu::kDevMask && exec_type == ExecType::kSync
           && rctx.get_stream<gpu>() && !rctx.is_bulk) {
         rctx.get_stream<gpu>()->Wait();
@@ -636,6 +790,7 @@ inline void PushOperator(const OpStatePtr& state,
                                op->name.c_str());
     }
   } else {
+    auto fcompute = common::GetFCompute<FStatefulCompute>(op, "FStatefulCompute", ctx);
     CHECK(fcompute != nullptr)
         << "One of FStatefulCompute and FStatefulComputeEx must be registered "
         << "for stateful operator " << op->name;
@@ -648,23 +803,15 @@ inline void PushOperator(const OpStatePtr& state,
         std::vector<NDArray> pre_temp_src, pre_temp_dst, post_temp_dst, post_temp_src;
         // mapping from index in input_blobs to index in pre_temp_dst
         std::unordered_map<uint32_t, uint32_t> in_temp_idx_map;
-#if MXNET_USE_MKLDNN == 1
-      if (exec_type != ExecType::kCrossDeviceCopy) {
-        // kCrossDeviceCopy is used for `_copy_to` operator, which doesn't compute immediately in
-        // its FCcomputeEx, but AsyncPush the copy operation to engine.
-        // So for the case that A is holding mkldnn memory, and then copy A to B, and then copy B
-        // back to A, we shouldn't invalidate outputs for copying B back to A, because at this time,
-        // copying A to B may not happen, and will corrupt A's memory.
-        InvalidateOutputs(outputs, req);
-      }
-#endif
+        INVALIDATE_OUTPUTS_COND(exec_type != ExecType::kCrossDeviceCopy, outputs, req);
+
         std::vector<OpReqType> tmp_req = req;
         // populate input blobs and output blobs
         SetupDefaultBlobsInOut(inputs, outputs, nullptr, nullptr, &tmp_req,
                                &input_blobs, &output_blobs, &pre_temp_src, &pre_temp_dst,
                                &post_temp_src, &post_temp_dst, &in_temp_idx_map, mutate_idx);
         // setup contexts
-        bool is_gpu = rctx.get_ctx().dev_mask() == gpu::kDevMask;
+        const bool is_gpu = rctx.get_ctx().dev_mask() == gpu::kDevMask;
         // pre-fcompute fallback
         CastNonDefaultStorage(pre_temp_src, pre_temp_dst, opctx, is_gpu);
         fcompute(state, opctx, input_blobs, tmp_req, output_blobs);
@@ -674,6 +821,7 @@ inline void PushOperator(const OpStatePtr& state,
             && rctx.get_stream<gpu>() && !rctx.is_bulk) {
           rctx.get_stream<gpu>()->Wait();
         }
+        DerefInputOutputRelease(inputs, outputs);
       };
 
     if (exec_type == ExecType::kSubgraphExec || CheckIfSkipEngine(attrs)) {
@@ -971,10 +1119,12 @@ inline std::multimap<size_t, NDArray> AllocateMemory(
     }
   }
 
+  const NDArray *pntr;
   for (uint32_t i = entry_start; i < entry_end; ++i) {
-    if (mem_plan[i].storage_id == exec::kExternalStorageID) continue;
+    const auto &plan = mem_plan[i];
+    if (plan.storage_id == exec::kExternalStorageID) continue;
     CHECK(arrays[i]->is_none());
-    if (mem_plan[i].storage_id == exec::kDynamicStorageID) {
+    if (plan.storage_id == exec::kDynamicStorageID) {
       *arrays[i] = NDArray(static_cast<NDArrayStorageType>(stypes[i]),
                            shapes[i], default_ctx, true, dtypes[i]);
       arrays[i]->AssignStorageInfo(data_entry_profiler_scopes[i - entry_start],
@@ -982,27 +1132,25 @@ inline std::multimap<size_t, NDArray> AllocateMemory(
       continue;
     }
     CHECK_EQ(stypes[i], kDefaultStorage);
-    if (mem_plan[i].root == i) {
-      auto iter = pool.lower_bound(mem_plan[i].size);
+    if (plan.root == i) {
+      auto iter = pool.lower_bound(plan.size);
       if (iter != pool.end()) {
-        *arrays[i] = iter->second.AsArray(shapes[i], dtypes[i]);
-        new_pool.insert(*iter);
+        pntr = &new_pool.insert(*iter)->second;
         pool.erase(iter);
       } else {
-        NDArray buff(mxnet::TShape({static_cast<nnvm::dim_t>(mem_plan[i].size)}),
+        NDArray buff(mxnet::TShape({static_cast<nnvm::dim_t>(plan.size)}),
                      default_ctx, true, mshadow::kUint8);
         buff.AssignStorageInfo(data_entry_profiler_scopes[i - entry_start],
                                data_entry_names[i - entry_start]);
-        *arrays[i] = buff.AsArray(shapes[i], dtypes[i]);
-        new_pool.insert({mem_plan[i].size, buff});
+        pntr = &new_pool.insert({plan.size, buff})->second;
       }
     } else {
-      CHECK_GE(mem_plan[mem_plan[i].root].storage_id, 0);
-      *arrays[i] = arrays[mem_plan[i].root]->AsArray(shapes[i], dtypes[i]);
-      if (mem_plan[i].inplace && array_reqs->at(i) == kWriteTo) {
+      CHECK_GE(mem_plan[plan.root].storage_id, 0);
+      pntr = arrays[plan.root];
+      if (plan.inplace && array_reqs->at(i) == kWriteTo)
         array_reqs->at(i) = kWriteInplace;
-      }
     }
+    arrays[i]->InitAsArray(*pntr, shapes[i], dtypes[i]);
   }
 
   return new_pool;

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -48,50 +48,37 @@ DMLC_REGISTRY_ENABLE(::mxnet::NDArrayFunctionReg);
 
 namespace mxnet {
 
-NDArray::NDArray(const NDArrayStorageType stype, const mxnet::TShape &shape, Context ctx,
-    bool delay_alloc, int dtype, std::vector<int> aux_types,
-    mxnet::ShapeVector aux_shapes, mxnet::TShape storage_shape) : shape_(shape),
-  dtype_(dtype), storage_type_(stype), autograd_entry_(nullptr) {
-  // Assign default aux types if not given
-  if (aux_types.size() == 0
-      && stype != kDefaultStorage) {
-    if (stype == kRowSparseStorage) {
-      aux_types = {mshadow::kInt64};
-    } else if (stype == kCSRStorage) {
-      aux_types = {mshadow::kInt64, mshadow::kInt64};
-    } else {
+void NDArray::ReInit(const NDArrayStorageType stype, const mxnet::TShape &shape,
+                     Context ctx, int dtype, bool delay_alloc, const std::vector<int> *pAux_types,
+                     const mxnet::ShapeVector *pAux_shapes, const mxnet::TShape *pStorage_shapes) {
+  Init(stype, shape, dtype);
+  if (stype != kDefaultStorage) {
+    const auto sparseStorage = stype == kRowSparseStorage;
+    if (!sparseStorage && stype != kCSRStorage)
       LOG(FATAL) << "Unknown storage type " << stype;
-    }
-  }
-  // Assign default shapes if not given
-  // unknown shapes are intialized as {0} such that Size() would return 0
-  if (aux_shapes.size() == 0
-      && stype != kDefaultStorage) {
-    if (stype == kRowSparseStorage) {
-      aux_shapes = {mxnet::TShape(mshadow::Shape1(0))};
-    } else if (stype == kCSRStorage) {
-      // aux shapes for indptr and indices
-      aux_shapes = {mxnet::TShape(mshadow::Shape1(0)), mxnet::TShape(mshadow::Shape1(0))};
+
+    const auto &aux_types = (pAux_types && pAux_types->size())? *pAux_types :
+                             std::vector<int>(sparseStorage? 1 : 2, mshadow::kInt64);
+
+    const auto &aux_shapes = (pAux_shapes && pAux_shapes->size()) ? *pAux_shapes :
+                             ShapeVector(sparseStorage? 1 : 2, TShape(mshadow::Shape1(0)));
+
+    mxnet::TShape storage_shape;
+    if (!pStorage_shapes || !pStorage_shapes->Size()) {
+      if (sparseStorage) {
+        storage_shape = shape;
+        storage_shape[0] = aux_shapes[rowsparse::kIdx][0];
+      } else {
+        storage_shape = aux_shapes[csr::kIdx];
+      }
     } else {
-      LOG(FATAL) << "Unknown storage type " << stype;
+      storage_shape = *pStorage_shapes;
     }
-  }
-  if (storage_shape.Size() == 0
-      && stype != kDefaultStorage) {
-    if (stype == kRowSparseStorage) {
-      storage_shape = shape;
-      storage_shape[0] = aux_shapes[rowsparse::kIdx][0];
-    } else if (stype == kCSRStorage) {
-      storage_shape = aux_shapes[csr::kIdx];
-    } else {
-      LOG(FATAL) << "Unknown storage type " << stype;
-    }
-  }
-  if (stype == kDefaultStorage)
-    ptr_ = std::make_shared<Chunk>(shape, ctx, delay_alloc, dtype);
-  else
     ptr_ = std::make_shared<Chunk>(stype, storage_shape, ctx, delay_alloc,
-        dtype, aux_types, aux_shapes);
+                                   dtype, aux_types, aux_shapes);
+  } else {
+    ptr_ = std::make_shared<Chunk>(shape, ctx, delay_alloc, dtype);
+  }
 }
 
 void NDArray::AssignStorageInfo(const std::string& profiler_scope,
@@ -671,6 +658,37 @@ NDArray NDArray::Reorder2Default() const {
   return ret;
 }
 
+void NDArray::SelfReorder2Default() {
+  if (!IsMKLDNNData())
+    return;
+
+  CHECK(storage_type() == kDefaultStorage);
+
+  const auto mkl_mem = ptr_->mkl_mem_;
+  if (mkl_mem == nullptr || !mkl_mem->IsMKLDNN())
+    return;
+
+  // create new ndarray from  mkldnn layout
+  mkldnn::memory::desc from_desc = mkl_mem->GetDesc();
+  mxnet::TShape tshape(from_desc.data.ndims, -1);
+  for (int i = 0; i < from_desc.data.ndims; i++)
+    tshape[i] = from_desc.data.dims[i];
+
+  const auto saved_shape = shape_;
+  const auto saved_byte_offset = byte_offset_;
+  this->ReInit(kDefaultStorage, tshape,  ctx(), dtype(), false);
+
+  mkldnn_format_tag_t format = mkl_mem->GetDefaultFormat();
+  mkldnn::memory::desc def_desc = mkl_mem->GetDesc(format);
+  CHECK(ptr_->shandle.size >= def_desc.get_size());
+  mkldnn::memory def_mem(def_desc, CpuEngine::Get()->get_engine(), ptr_->shandle.dptr);
+  mkl_mem->ReorderTo(&def_mem);
+  // reshape as needed
+  shape_ = saved_shape;
+  byte_offset_ = saved_byte_offset;
+  reuse_ = false;
+}
+
 void NDArray::Reorder2DefaultAsync() const {
   std::vector<Engine::VarHandle> const_vars;
   std::vector<Engine::VarHandle> mutable_vars(1, this->var());
@@ -716,7 +734,7 @@ void NDArray::MKLDNNDataReorderAsync(const mkldnn::memory::desc &desc) const {
 
 const mkldnn::memory *NDArray::GetMKLDNNData() const {
   CHECK(storage_type() == kDefaultStorage);
-  bool is_view = IsView();
+  const auto is_view = IsView();
   if (IsMKLDNNData()) {
     // If this array uses MKLDNN layout, we have to make sure it's not a view.
     // Otherwise, we'll have to change the layout inside the array.
@@ -725,32 +743,32 @@ const mkldnn::memory *NDArray::GetMKLDNNData() const {
     // If this array uses MKLDNN format, we should return now. Otherwise,
     // SetMKLMem may mess up mkl_mem_.
     return ptr_->mkl_mem_->GetRaw();
-  } else if (is_view) {
+  }
+
+  CheckAndAlloc();
+  if (is_view) {
     // If this is a view, we can't create a MKLDNN memory for the chunk
     // because we don't have the complete data type and shape information for
     // the chunk.
-    CheckAndAlloc();
     void *off_addr = static_cast<char *>(ptr_->shandle.dptr) + byte_offset_;
     // Create the primitive desc for the new mkldnn memory.
     mkldnn::memory::dims dims(shape().ndim());
     for (size_t i = 0; i < dims.size(); i++)
       dims[i] = shape()[i];
-    mkldnn::memory::format_tag cpp_format = static_cast<mkldnn::memory::format_tag>(
+
+    const auto cpp_format = static_cast<mkldnn::memory::format_tag>(
         GetDefaultFormat(shape().ndim()));
-    mkldnn::memory::data_type cpp_type = get_mkldnn_type(dtype_);
-    mkldnn::memory::desc data_md(dims, cpp_type, cpp_format);
+    mkldnn::memory::desc data_md(dims, get_mkldnn_type(dtype_), cpp_format);
     std::shared_ptr<mkldnn::memory> ret(
         new mkldnn::memory(data_md, CpuEngine::Get()->get_engine(), off_addr));
     MKLDNNStream::Get()->RegisterMem(ret);
     return ret.get();
-  } else {
-    // If this isn't a view, we can create a MKLDNN memory and store it in the
-    // chunk.
-    CheckAndAlloc();
-    ptr_->SetMKLMem(shape_, dtype_);
-    MKLDNNStream::Get()->RegisterMem(ptr_->mkl_mem_->GetMem());
-    return ptr_->mkl_mem_->GetRaw();
   }
+
+  // If this isn't a view, we can create a MKLDNN memory and store it in the chunk
+  ptr_->SetMKLMem(shape_, dtype_);
+  MKLDNNStream::Get()->RegisterMem(ptr_->mkl_mem_->GetMem());
+  return ptr_->mkl_mem_->GetRaw();
 }
 
 void NDArray::InvalidateMKLDNNData() {

--- a/src/operator/nn/mkldnn/mkldnn_base-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_base-inl.h
@@ -524,27 +524,6 @@ mkldnn_output_t CreateMKLDNNWeightGrad(const NDArray &out_arr,
 /* This function has to be used with one of the functions above. */
 void CommitOutput(const NDArray &arr, const mkldnn_output_t &res);
 
-static inline void InvalidateOutputs(const std::vector<NDArray> &arrs,
-                                     const std::vector<OpReqType> &reqs) {
-  for (size_t i = 0; i < arrs.size(); i++) {
-    if (reqs[i] == kWriteTo || reqs[i] == kNullOp) {
-      const_cast<NDArray &>(arrs[i]).InvalidateMKLDNNData();
-    }
-  }
-}
-
-// TODO(alexzai): (MXNET-856) Remove helper function after subgraph feature added
-static inline void CreateDefaultInputs(const std::vector<NDArray> &arrs,
-                                       std::vector<NDArray> *out_arrs) {
-  out_arrs->clear();
-  for (size_t i = 0; i < arrs.size(); ++i) {
-    if (arrs[i].IsMKLDNNData())
-      out_arrs->push_back(arrs[i].Reorder2Default());
-    else
-      out_arrs->push_back(arrs[i]);
-  }
-}
-
 const mkldnn::memory *GetWeights(const NDArray &arr, int num_groups);
 
 const mkldnn::memory *GetWeights(const NDArray &arr,


### PR DESCRIPTION
## Description ##
During training, MxNet reinitiates data stored in the instances of `NDArray` class by making a lot of `NDArray` constructor's calls and assigning the newly constructed objects to the existing ones.
First of all, it is not very effective, because 

- (a) usually we call some `NDArray` constructor AND NDArray` copy constructor 
- (b) after each such call the NDArray destructor will be called.

Second, lots of such calls are done "under the hood" and are not effective at all. For instance, the usage of 
```cpp
          std::vector<NDArray> inputs, outputs
```
in lambda expressions generates more `NDArray` constructor calls than it's actually necessary:

- 3 times more for `PushFCompute(...)` and 
- 1.5 time more for `PushFComputeEx(...)`,  `PushOperator(...)`;
 
Third, it's hard to debug.

To fix this problem we propose to use 

- the newly implemented `NDArray::Init(...), NDArray::ReInit(...)` methods
- `std::vector<NDArray *> inputs, outputs;` instead of `std::vector<NDArray> inputs, outputs;`

Our experiments show that these changes reduce the number of `NDArray` constructor calls by approx. 80%:

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] Code is well-documented: 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] The usage of
```
std::vector<NDArray> inputs, outputs
```
in `PushFCompute(...)` , `PushFComputeEx(...)`,  `PushOperator(...)`
was replaced by 
```cpp
std::vector<NDArray> inputs, outputs
```
- [x] The usage of macros, similar to the following ones, which are defined in different ways  for fifferent values of `MXNET_USE_MKLDNN` simplifies the code
```cpp
#if MXNET_USE_MKLDNN == 1
#define INVALIDATE_OUTPUTS(outputs, req) InvalidateOutputs(&outputs, req)
#define INVALIDATE_OUTPUTS_COND(cond, outputs, req) if (cond) INVALIDATE_OUTPUTS(outputs, req)
// add for mkldnn OP + no mkldnn OP
#define CREATE_DEFAULT_INPUTS(cond, attrs, func_call) \
 if (cond) { \
 const auto is_mkldnn = Op::GetAttr<bool>("TIsMKLDNN"); \
 if (!is_mkldnn.get(attrs.op, false)) func_call; \
 }

#else
#define INVALIDATE_OUTPUTS(outputs, ...)       // empty macros
#define INVALIDATE_OUTPUTS_COND(outputs, ...)  // empty macro
#define CREATE_DEFAULT_INPUTS(input, ...)      // empty macro
#endif
```
- [x] Implementation of constructor:
```cpp
  NDArray(const NDArrayStorageType stype, const mxnet::TShape &shape, Context ctx,
          bool delay_alloc = true, int dtype = mshadow::default_type_flag,
          std::vector<int> aux_types = {}, mxnet::ShapeVector aux_shapes = {},
          mxnet::TShape storage_shape = mxnet::TShape(mshadow::Shape1(0)));
```
was moved into newly implemented:
```cpp
void NDArray::ReInit(const NDArrayStorageType stype, const mxnet::TShape &shape,
 Context ctx, int dtype, bool delay_alloc, const std::vector<int> *pAux_types,
 const mxnet::ShapeVector *pAux_shapes, const mxnet::TShape *pStorage_shapes)
```

## Comments ##
