### PR TITLE
fix contribute page anchor position shifted

### DIFF
--- a/docs/static_site/src/_sass/minima/_layout.scss
+++ b/docs/static_site/src/_sass/minima/_layout.scss
@@ -364,3 +364,18 @@
     color: $grey-color-light;
   }
 }
+
+#forum::before,
+#mxnet-dev-communications::before,
+#social-media::before,
+#jira::before,
+#confluence-wiki::before,
+#setup-mxnet-for-development::before,
+#your-first-contribution::before {
+  display: block;
+  content: " ";
+  margin-top: -86px;
+  height: 86px;
+  visibility: hidden;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Description ##
Fix #18567 . Original posted from https://github.com/apache/incubator-mxnet/issues/17982#issuecomment-634850809. When clicking an anchor on "contribute" page, the landing position shifts.
The cause: The header's position is `fix` which takes it out of normal flow. But the anchors are not aware of it and not counting the height of the header, which leads to the overlap between anchor's landing spot and the header.
This is a common problem from fixed header, here is a bug fix discussed in this article https://css-tricks.com/hash-tag-links-padding/. Fix this issue by adding extra padding to each anchor's headings to avoid overlapping with header.
@ChaiBapchya 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)

### Changes ###
- [x] Add css fix to each headings linked by anchors on "contribute" page

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/