### PR TITLE
Use chain.from_iterable in artifact_repository.py

### DIFF
--- a/cd/utils/artifact_repository.py
+++ b/cd/utils/artifact_repository.py
@@ -496,7 +496,7 @@ def sanitize_path_array(paths: List[str]) -> List[str]:
     :return: A sanitized list of paths
     :raises FileNotFoundError if a file does not exist
     """
-    expanded_paths = list(chain(*[glob.glob(path.strip()) for path in paths if path.strip() != '']))
+    expanded_paths = list(chain.from_iterable(glob.glob(path.strip()) for path in paths if path.strip() != ''))
     return [path.strip() for path in expanded_paths if path.strip() != '' and is_file(path)]
 
 


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.