### PR TITLE
[numpy] numpy types support for may_share_memory

### DIFF
--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -10095,6 +10095,10 @@ def shares_memory(a, b, max_work=None):
     - Does not support `max_work`, it is a dummy argument
     - Actually it is same as `may_share_memory` in MXNet DeepNumPy
     """
+    if isinstance(a, _np.ndarray):
+        a = _as_mx_np_array(a)
+    if isinstance(a, _np.ndarray):
+        b = _as_mx_np_array(b)
     return _mx_nd_np.shares_memory(a, b, max_work)
 
 
@@ -10136,6 +10140,10 @@ def may_share_memory(a, b, max_work=None):
     - Does not support `max_work`, it is a dummy argument
     - Actually it is same as `shares_memory` in MXNet DeepNumPy
     """
+    if isinstance(a, _np.ndarray):
+        a = _as_mx_np_array(a)
+    if isinstance(a, _np.ndarray):
+        b = _as_mx_np_array(b)
     return _mx_nd_np.may_share_memory(a, b, max_work)
 
 

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -10097,8 +10097,10 @@ def shares_memory(a, b, max_work=None):
     """
     if isinstance(a, _np.ndarray):
         a = _as_mx_np_array(a)
-    if isinstance(a, _np.ndarray):
+    if isinstance(b, _np.ndarray):
         b = _as_mx_np_array(b)
+    if a.ctx != b.ctx:
+        return False
     return _mx_nd_np.shares_memory(a, b, max_work)
 
 
@@ -10142,8 +10144,10 @@ def may_share_memory(a, b, max_work=None):
     """
     if isinstance(a, _np.ndarray):
         a = _as_mx_np_array(a)
-    if isinstance(a, _np.ndarray):
+    if isinstance(b, _np.ndarray):
         b = _as_mx_np_array(b)
+    if a.ctx != b.ctx:
+        return False
     return _mx_nd_np.may_share_memory(a, b, max_work)
 
 

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -8586,7 +8586,20 @@ def test_np_share_memory():
     dtypes = [np.int8, np.uint8, np.int32, np.int64, np.float16, np.float32, np.float64]
     for op in ops:
         for dt in dtypes:
-            x = np.zeros([13, 21, 23, 22], dtype=dt)
+            if dt != np.int8:
+                y = _np.zeros([13, 21, 23, 22], dtype=dt)
+                x = mx.nd.from_numpy(y, zero_copy=True).as_np_ndarray()
+            else:
+                x = np.zeros([13, 21, 23, 22], dtype=dt)
+            if 'y' in vars():
+                assert not op(y[0,:,:,:], x[1,:,:,:])
+                assert not op(y[2,:,:,:], x[3,:,:,:])
+                assert not op(y[2:5,0,0,0], x[3:4,0,0,0])
+                assert not op(y[2:5,0,0,0], x[4:7,0,0,0])
+                assert op(y[0,0,0,2:5], x[0,0,0,3:4])
+                assert op(y[0,6,0,2:5], x[0,6,0,4:7])
+                assert not op(y[0,5,0,2:5], x[0,6,0,4:7])
+                del y
             assert not op(x[0,:,:,:], x[1,:,:,:])
             assert not op(x[2,:,:,:], x[3,:,:,:])
             assert not op(x[2:5,0,0,0], x[3:4,0,0,0])

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -8582,6 +8582,7 @@ def test_npx_reshape():
 @use_np
 def test_np_share_memory():
     ops = [np.shares_memory, np.may_share_memory]
+    ctx = mx.context.current_context()
     # reshape not support boolean types
     dtypes = [np.int8, np.uint8, np.int32, np.int64, np.float16, np.float32, np.float64]
     for op in ops:
@@ -8591,7 +8592,7 @@ def test_np_share_memory():
                 x = mx.nd.from_numpy(y, zero_copy=True).as_np_ndarray()
             else:
                 x = np.zeros([13, 21, 23, 22], dtype=dt)
-            if 'y' in vars():
+            if 'y' in vars() and ctx.device_type == 'cpu':
                 assert not op(y[0,:,:,:], x[1,:,:,:])
                 assert not op(y[2,:,:,:], x[3,:,:,:])
                 assert not op(y[2:5,0,0,0], x[3:4,0,0,0])


### PR DESCRIPTION
## Description ##
#18561 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
