### PR TITLE
[v1.6] Cherry pick Increase staggered build timeout (#18568)

### DIFF
--- a/ci/jenkins/Jenkinsfile_full
+++ b/ci/jenkins/Jenkinsfile_full
@@ -21,7 +21,7 @@
 // See documents at https://jenkins.io/doc/book/pipeline/jenkinsfile/
 
 // timeout in minutes
-def max_time = 30
+def max_time = 60
 
 def buildJobs = [
     'centos-cpu',

--- a/ci/jenkins/Jenkinsfile_sanity
+++ b/ci/jenkins/Jenkinsfile_sanity
@@ -21,7 +21,7 @@
 // See documents at https://jenkins.io/doc/book/pipeline/jenkinsfile/
 
 // timeout in minutes
-max_time = 180
+max_time = 60
 
 node('utility') {
   // Loading the utilities requires a node context unfortunately


### PR DESCRIPTION
* Increase staggered build timeout to 180 min, since sanity build has 180 min timeout.

* Decrease timeout so everyone is happy.

Co-authored-by: Joe Evans <joeev@amazon.com>
