### PR TITLE
prevent master version for installation widget

### DIFF
--- a/docs/static_site/src/assets/js/options.js
+++ b/docs/static_site/src/assets/js/options.js
@@ -22,6 +22,10 @@
 */
 
 $(document).ready(function () {
+    const dropdownVersions = $("#version-dropdown-container ul li")
+        .toArray()
+        .map((li) => li.innerText);
+
     function label(lbl) {
         lbl = lbl.replace(/[ .]/g, '-').toLowerCase();
 
@@ -33,6 +37,9 @@ $(document).ready(function () {
         let searchParams = searchString.substring(1).split("&");
         searchParams.forEach(function (element) {
             kvPair = element.split("=");
+            if (kvPair[0] === 'version' && dropdownVersions.indexOf(kvPair[1]) == -1) {
+                kvPair[1] = dropdownVersions[0];
+            }
             searchDict.set(kvPair[0], kvPair[1]);
         });
         return searchDict;


### PR DESCRIPTION
## Description ##
Fix #17244 . It prevents to land on any unsupported version of installation guide on `get started` page. 

**How the fix works:**
It grabs the available versions from the version drop down, and checks if the target version is within the available versions before updating the installation guide. If invalid version is specified, update it to the newest version instead.

**Bug description:**
Current `Get Started` page has no check if the version is valid. While we removed `master` from the version dropdown, users can still see the contents by typing `version=master` in browser. And what is more, any string can be typed in browser and the `Get Started` page will show the wired page. See screen shot: 
+ Current available versions: 
<img width="1440" alt="Screen Shot 2020-06-18 at 3 36 03 PM" src="https://user-images.githubusercontent.com/23468760/85078740-f2bf3d80-b179-11ea-860f-e44c33b1e953.png">

+ Type `version=master` in browser, contents show and dropdown update incorrectly
<img width="1440" alt="Screen Shot 2020-06-18 at 3 36 38 PM" src="https://user-images.githubusercontent.com/23468760/85078742-f4890100-b179-11ea-85da-e35e86974cf4.png">

+ Type random string in browser, contents show and dropdown update incorrectly
<img width="1440" alt="Screen Shot 2020-06-18 at 3 37 42 PM" src="https://user-images.githubusercontent.com/23468760/85078780-0b2f5800-b17a-11ea-966e-77726441befd.png">

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)

### Changes ###
- [x] Add version check before updating the installation instruction

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/
