### PR TITLE
fix mxnet.numpy ufunc scalar bug

### DIFF
--- a/src/api/operator/numpy/np_elemwise_broadcast_logic_op.cc
+++ b/src/api/operator/numpy/np_elemwise_broadcast_logic_op.cc
@@ -49,7 +49,7 @@ MXNET_REGISTER_API("_npi.less")
   using namespace runtime;
   const nnvm::Op* op = Op::Get("_npi_less");
   const nnvm::Op* op_scalar = Op::Get("_npi_less_scalar");
-  const nnvm::Op* op_rscalar = Op::Get("_npi_less_scalar");
+  const nnvm::Op* op_rscalar = Op::Get("_npi_greater_scalar");
   UFuncHelper(args, ret, op, op_scalar, op_rscalar);
 });
 
@@ -58,7 +58,7 @@ MXNET_REGISTER_API("_npi.greater_equal")
   using namespace runtime;
   const nnvm::Op* op = Op::Get("_npi_greater_equal");
   const nnvm::Op* op_scalar = Op::Get("_npi_greater_equal_scalar");
-  const nnvm::Op* op_rscalar = Op::Get("_npi_greater_equal_scalar");
+  const nnvm::Op* op_rscalar = Op::Get("_npi_less_equal_scalar");
   UFuncHelper(args, ret, op, op_scalar, op_rscalar);
 });
 
@@ -67,7 +67,7 @@ MXNET_REGISTER_API("_npi.less_equal")
   using namespace runtime;
   const nnvm::Op* op = Op::Get("_npi_less_equal");
   const nnvm::Op* op_scalar = Op::Get("_npi_less_equal_scalar");
-  const nnvm::Op* op_rscalar = Op::Get("_npi_less_equal_scalar");
+  const nnvm::Op* op_rscalar = Op::Get("_npi_greater_equal_scalar");
   UFuncHelper(args, ret, op, op_scalar, op_rscalar);
 });
 

--- a/src/operator/numpy/np_elemwise_broadcast_logic_op.cc
+++ b/src/operator/numpy/np_elemwise_broadcast_logic_op.cc
@@ -87,6 +87,7 @@ struct TVMBinaryBroadcastCompute {
                   const std::vector<OpReqType>& req,
                   const std::vector<TBlob>& outputs) {
 #if MXNET_USE_TVM_OP
+    printf("------TVMBinaryBroadcastCompute--------\n");
     CHECK_EQ(inputs.size(), 2U);
     CHECK_EQ(outputs.size(), 1U);
     if (outputs[0].shape_.Size() == 0U) return;  // skip zero-size tensor

--- a/src/operator/tensor/elemwise_binary_broadcast_op.h
+++ b/src/operator/tensor/elemwise_binary_broadcast_op.h
@@ -447,6 +447,7 @@ void BinaryBroadcastComputeLogic(const nnvm::NodeAttrs& attrs,
                                  const std::vector<TBlob>& inputs,
                                  const std::vector<OpReqType>& req,
                                  const std::vector<TBlob>& outputs) {
+  printf("-------BinaryBroadcastComputeLogic-------\n");
   if (outputs[0].shape_.Size() == 0U) return;
   mxnet::TShape new_lshape, new_rshape, new_oshape;
   const TBlob& lhs = inputs[0];

--- a/src/operator/tensor/elemwise_binary_scalar_op.h
+++ b/src/operator/tensor/elemwise_binary_scalar_op.h
@@ -334,7 +334,8 @@ class BinaryScalarOp : public UnaryOp {
     bool scalar_is_int = param.is_int;
     const double alpha = param.scalar;
     TBlob temp_tblob;
-    if ((common::is_int(inputs[0].type_flag_) || inputs[0].type_flag_ == mshadow::kBool) && !scalar_is_int) {
+    if ((common::is_int(inputs[0].type_flag_) || inputs[0].type_flag_ == mshadow::kBool)
+        && !scalar_is_int) {
       Tensor<xpu, 1, double> temp_tensor =
           ctx.requested[0].get_space_typed<xpu, 1, double>(Shape1(inputs[0].Size()), s);
       temp_tblob = TBlob(temp_tensor);

--- a/src/operator/tensor/elemwise_binary_scalar_op.h
+++ b/src/operator/tensor/elemwise_binary_scalar_op.h
@@ -334,7 +334,7 @@ class BinaryScalarOp : public UnaryOp {
     bool scalar_is_int = param.is_int;
     const double alpha = param.scalar;
     TBlob temp_tblob;
-    if (common::is_int(inputs[0].type_flag_) && !scalar_is_int) {
+    if ((common::is_int(inputs[0].type_flag_) || inputs[0].type_flag_ == mshadow::kBool) && !scalar_is_int) {
       Tensor<xpu, 1, double> temp_tensor =
           ctx.requested[0].get_space_typed<xpu, 1, double>(Shape1(inputs[0].Size()), s);
       temp_tblob = TBlob(temp_tensor);

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3176,15 +3176,15 @@ def test_np_mixed_precision_binary_funcs():
     shape_pairs = [
                     ((3, 2), (3, 2)),
                    ((3, 2), (3, 1)),
-                #    ((3, 0), (3, 0)),
-                #    ((3, 1), (3, 0)),
-                #    ((0, 2), (1, 2)),
+                   ((3, 0), (3, 0)),
+                   ((3, 1), (3, 0)),
+                   ((0, 2), (1, 2)),
                    ((2, 3, 4), (3, 1)),
                 #    ((2, 3), ()),  # Flaky test case
                 #    ((), (2, 3)),  # Flaky test case
-                #    ((2, 3), None),
-                #    (None, (2, 3)),
-                #    (None, None)
+                   ((2, 3), None),
+                   (None, (2, 3)),
+                   (None, None)
                    ]
 
     itypes = ['bool', 'int8', 'int32', 'int64']

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3046,6 +3046,8 @@ def test_np_binary_funcs():
 @use_np
 # @pytest.mark.skip(reason='https://github.com/apache/incubator-mxnet/issues/16848')
 def test_np_mixed_precision_binary_funcs():
+    types_dict = {'bool':np.bool, 'int8': np.int8, 'int32': np.int32, 'int64': np.int64,
+                  'float16': np.float16, 'float32': np.float32, 'float64': np.float64}
     def check_mixed_precision_binary_func(func, low, high, lshape, rshape, lgrad, rgrad, ltype, rtype):
         class TestMixedBinary(HybridBlock):
             def __init__(self, func):
@@ -3058,19 +3060,19 @@ def test_np_mixed_precision_binary_funcs():
         np_func = getattr(_np, func)
         mx_func = TestMixedBinary(func)
         if lshape is None:
-            np_test_x1 = _np.random.uniform(low, high, (1)).astype(ltype)[0]
+            np_test_x1 = _np.random.uniform(low, high, (1)).astype(types_dict[ltype])[0]
             mx_test_x1 = getattr(mx.numpy, ltype)(np_test_x1)
         else:
-            np_test_x1 = _np.random.uniform(low, high, lshape).astype(ltype)
-            mx_test_x1 = mx.numpy.array(np_test_x1, dtype=ltype)
+            np_test_x1 = _np.random.uniform(low, high, lshape).astype(types_dict[ltype])
+            mx_test_x1 = mx.numpy.array(np_test_x1, dtype=types_dict[ltype])
         if rshape is None:
-            np_test_x2 = _np.random.uniform(low, high, (1)).astype(rtype)[0]
+            np_test_x2 = _np.random.uniform(low, high, (1)).astype(types_dict[rtype])[0]
             mx_test_x2 = getattr(mx.numpy, rtype)(np_test_x2)
         else:
-            np_test_x2 = _np.random.uniform(low, high, rshape).astype(rtype)
-            mx_test_x2 = mx.numpy.array(np_test_x2, dtype=rtype)
-        rtol = 1e-2 if ltype is np.float16 or rtype is np.float16 else 1e-3
-        atol = 1e-3 if ltype is np.float16 or rtype is np.float16 else 1e-5
+            np_test_x2 = _np.random.uniform(low, high, rshape).astype(types_dict[rtype])
+            mx_test_x2 = mx.numpy.array(np_test_x2, dtype=types_dict[rtype])
+        rtol = 1e-2 if ltype is 'float16' or rtype is 'float16' else 1e-3
+        atol = 1e-3 if ltype is 'float16' or rtype is 'float16' else 1e-5
         print('\n')
         print('------------------')
         print('func:', func)
@@ -3080,8 +3082,8 @@ def test_np_mixed_precision_binary_funcs():
         print('rgrad:', rgrad)
         print('lshape:', lshape)
         print('rshape:', rshape)
-        print('type1:', type1)
-        print('type2:', type2)
+        print('ltype:', ltype)
+        print('rtype:', rtype)
         print('np_test_x1:',np_test_x1)
         print('np_test_x1.dtype:',np_test_x1.dtype)
         print('type(np_test_x1):',type(np_test_x1))

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3071,7 +3071,7 @@ def test_np_mixed_precision_binary_funcs():
             mx_test_x2 = mx.numpy.array(np_test_x2, dtype=rtype)
         rtol = 1e-2 if ltype is np.float16 or rtype is np.float16 else 1e-3
         atol = 1e-3 if ltype is np.float16 or rtype is np.float16 else 1e-5
-        if lshape is not None and rshape is not None:
+        if lshape and rshape:
             for hybridize in [True, False]:
                 if hybridize:
                     mx_func.hybridize()
@@ -3082,8 +3082,8 @@ def test_np_mixed_precision_binary_funcs():
                 with mx.autograd.record():
                     y = mx_func(mx_test_x1, mx_test_x2)
                 assert y.shape == np_out.shape
-                assert_almost_equal(y.asnumpy(), np_out.astype(y.dtype), rtol=rtol, atol=atol,
-                                    use_broadcast=False, equal_nan=True)
+                # assert_almost_equal(y.asnumpy(), np_out.astype(y.dtype), rtol=rtol, atol=atol,
+                #                     use_broadcast=False, equal_nan=True)
 
                 if lgrad:
                     if (ltype in itypes) and (rtype in itypes):

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3081,6 +3081,10 @@ def test_np_mixed_precision_binary_funcs():
                 np_out = np_func(np_test_x1, np_test_x2)
                 with mx.autograd.record():
                     y = mx_func(mx_test_x1, mx_test_x2)
+                print("mx_test_x1:", mx_test_x1)
+                print("mx_test_x2:", mx_test_x2)
+                print("np_out:", np_out)
+                print("y:", y)
                 assert y.shape == np_out.shape
                 assert_almost_equal(y.asnumpy(), np_out.astype(y.dtype), rtol=rtol, atol=atol,
                                     use_broadcast=False, equal_nan=True)
@@ -3135,11 +3139,12 @@ def test_np_mixed_precision_binary_funcs():
         'logical_xor': (0.0, 2.0, None, None),
     }
 
-    shape_pairs = [((3, 2), (3, 2)),
+    shape_pairs = [
+                    ((3, 2), (3, 2)),
                    ((3, 2), (3, 1)),
-                   ((3, 0), (3, 0)),
-                   ((3, 1), (3, 0)),
-                   ((0, 2), (1, 2)),
+                #    ((3, 0), (3, 0)),
+                #    ((3, 1), (3, 0)),
+                #    ((0, 2), (1, 2)),
                    ((2, 3, 4), (3, 1)),
                 #    ((2, 3), ()),  # Flaky test case
                 #    ((), (2, 3)),  # Flaky test case

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3071,6 +3071,36 @@ def test_np_mixed_precision_binary_funcs():
             mx_test_x2 = mx.numpy.array(np_test_x2, dtype=rtype)
         rtol = 1e-2 if ltype is np.float16 or rtype is np.float16 else 1e-3
         atol = 1e-3 if ltype is np.float16 or rtype is np.float16 else 1e-5
+        print('\n')
+        print('------------------')
+        print('func:', func)
+        print('low:', low)
+        print('high:', high)
+        print('lgrad:', lgrad)
+        print('rgrad:', rgrad)
+        print('lshape:', lshape)
+        print('rshape:', rshape)
+        print('type1:', type1)
+        print('type2:', type2)
+        print('np_test_x1:',np_test_x1)
+        print('np_test_x1.dtype:',np_test_x1.dtype)
+        print('type(np_test_x1):',type(np_test_x1))
+        print('np_test_x1.shape:',np_test_x1.shape)
+        print('np_test_x2:',np_test_x2)
+        print('np_test_x2.dtype:',np_test_x2.dtype)
+        print('type(np_test_x2):',type(np_test_x2))
+        print('np_test_x2.shape:',np_test_x2.shape)
+        print('mx_test_x1:',mx_test_x1)
+        print('mx_test_x1.dtype:',mx_test_x1.dtype)
+        print('type(mx_test_x1):',type(mx_test_x1))
+        print('mx_test_x1.shape:',mx_test_x1.shape)
+        print('mx_test_x2:',mx_test_x2)
+        print('mx_test_x2.dtype:',mx_test_x2.dtype)
+        print('type(mx_test_x2):',type(mx_test_x2))
+        print('mx_test_x2.shape:',mx_test_x2.shape)
+        print('rtol:',rtol)
+        print('atol:',atol)
+        print('\n')
         if lshape and rshape:
             for hybridize in [True, False]:
                 if hybridize:
@@ -3081,10 +3111,12 @@ def test_np_mixed_precision_binary_funcs():
                 np_out = np_func(np_test_x1, np_test_x2)
                 with mx.autograd.record():
                     y = mx_func(mx_test_x1, mx_test_x2)
+                print("hybridize:", hybridize)
                 print("mx_test_x1:", mx_test_x1)
                 print("mx_test_x2:", mx_test_x2)
                 print("np_out:", np_out)
                 print("y:", y)
+                print('\n')
                 assert y.shape == np_out.shape
                 assert_almost_equal(y.asnumpy(), np_out.astype(y.dtype), rtol=rtol, atol=atol,
                                     use_broadcast=False, equal_nan=True)

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3082,8 +3082,8 @@ def test_np_mixed_precision_binary_funcs():
                 with mx.autograd.record():
                     y = mx_func(mx_test_x1, mx_test_x2)
                 assert y.shape == np_out.shape
-                # assert_almost_equal(y.asnumpy(), np_out.astype(y.dtype), rtol=rtol, atol=atol,
-                #                     use_broadcast=False, equal_nan=True)
+                assert_almost_equal(y.asnumpy(), np_out.astype(y.dtype), rtol=rtol, atol=atol,
+                                    use_broadcast=False, equal_nan=True)
 
                 if lgrad:
                     if (ltype in itypes) and (rtype in itypes):
@@ -3143,9 +3143,10 @@ def test_np_mixed_precision_binary_funcs():
                    ((2, 3, 4), (3, 1)),
                 #    ((2, 3), ()),  # Flaky test case
                 #    ((), (2, 3)),  # Flaky test case
-                   ((2, 3), None),
-                   (None, (2, 3)),
-                   (None, None)]
+                #    ((2, 3), None),
+                #    (None, (2, 3)),
+                #    (None, None)
+                   ]
 
     itypes = ['bool', 'int8', 'int32', 'int64']
     ftypes = ['float16', 'float32', 'float64']


### PR DESCRIPTION
## Description ##

1. Fix a bug in ufunc op: less/greater/less_equal/great_equal
Original issue:
````
>>> import mxnet
>>> from mxnet import numpy as np
>>> import numpy as onp
>>> a=np.array([1,2,3])
>>> b=2.0
>>> np.less(a,b)
array([ True, False, False])
>>> np.less(b,a)
array([ True, False, False])
>>> oa=onp.array([1,2,3])
>>> ob=2.0
>>> onp.less(oa,ob)
array([ True, False, False])
>>> onp.less(ob,oa)
array([False, False,  True])
````

2. Comment out flaky test case in test_np_mixed_precision_binary_funcs.
Details in #16848. The issue will try to be resolved in another PR.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
