### PR TITLE
redirect api reference on v-master to v1.6

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -23,7 +23,7 @@ RewriteOptions AllowNoSlash
 </IfModule>
 
 # TODO temporary fix for issue #18604
-Redirect 302 /api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf https://s3.amazonaws.com/mxnet-prod/docs/R/mxnet-r-reference-manual.pdf
+Redirect 302 /api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf https://mxnet-public.s3.us-east-2.amazonaws.com/docs/v1.x/mxnet-r-reference-manual.pdf
 Redirect 302 /api/scala/docs/api/ /versions/1.6/api/scala/docs/api/
 Redirect 302 /api/java/docs/api/ /versions/1.6/api/java/docs/api/
 Redirect 302 /api/clojure/docs/api/ /versions/1.6/api/clojure/docs/api/

--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -22,6 +22,14 @@ RewriteOptions AllowNoSlash
   
 </IfModule>
 
+# TODO temporary fix for issue #18604
+Redirect 302 /api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf https://s3.amazonaws.com/mxnet-prod/docs/R/mxnet-r-reference-manual.pdf
+Redirect 302 /api/scala/docs/api/ /versions/1.6/api/scala/docs/api/
+Redirect 302 /api/java/docs/api/ /versions/1.6/api/java/docs/api/
+Redirect 302 /api/clojure/docs/api/ /versions/1.6/api/clojure/docs/api/
+Redirect 302 /api/cpp/docs/api/ /versions/1.6/api/cpp/docs/api/
+Redirect 302 /api/julia/docs/api/ /versions/1.6/api/julia/docs/api/
+
 # Redirect Chinese visitors to Chinese CDN, temporary solution for slow site speed in China
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^CN$
 RewriteCond %{HTTP_HOST} !cdn


### PR DESCRIPTION
## Description ##
Temporary fix for #18604

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:

### Changes ###
- [x] Temporarily redirect docs reference link on website from master to v1.6

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/
