### PR TITLE
Fix Julia API reference and tutorials redirect on master

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -29,6 +29,7 @@ Redirect 302 /api/java/docs/api/ /versions/1.6/api/java/docs/api/
 Redirect 302 /api/clojure/docs/api/ /versions/1.6/api/clojure/docs/api/
 Redirect 302 /api/cpp/docs/api/ /versions/1.6/api/cpp/docs/api/
 Redirect 302 /api/julia/docs/api/ /versions/1.6/api/julia/docs/api/
+Redirect 302 /api/julia/docs/api/#tutorials /versions/1.6/api/julia/docs/api/#tutorials
 
 # Redirect Chinese visitors to Chinese CDN, temporary solution for slow site speed in China
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^CN$
@@ -42,6 +43,7 @@ RewriteCond %{REQUEST_FILENAME}\.html -f
 RewriteRule ^(.*) $1.html [NC,L]
 
 # Prettify some files like tutorials/io to tutorials/io.html
+RewriteCond %{REQUEST_URI} !/julia/
 RewriteCond %{REQUEST_FILENAME}\.html -f
 RewriteRule ^(.*) $1.html [NC,L]
 

--- a/docs/static_site/src/pages/api/api.html
+++ b/docs/static_site/src/pages/api/api.html
@@ -52,7 +52,7 @@ docs:
 - title: Julia
   guide_link: /api/julia
   api_link: /api/julia/docs/api
-  tutorial_link: https://mxnet.incubator.apache.org/api/julia/docs/api/#tutorials
+  tutorial_link: /api/julia/docs/api/#tutorials
   description:
   icon: /assets/img/julia_logo.svg
   tag: julia


### PR DESCRIPTION
## Description ##
The redirect rules in #18607 for Julia does not work as expected. Julia micro site has different structure than any other languages and below rule only applies to Julia, it imports some strange behavior. Disable it on Julia make the redirect works as expect.
```
RewriteCond %{REQUEST_FILENAME}\.html -f
RewriteRule ^(.*) $1.html [NC,L]
```
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:

### Changes ###
- [x] Fix Julia redirect rule: master => v1.6 

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/api
