### PR TITLE
fix contrib ops do not render correctly

### DIFF
--- a/src/operator/contrib/transformer.cc
+++ b/src/operator/contrib/transformer.cc
@@ -701,14 +701,16 @@ of queries, keys and values following the layout:
 and the attention weights following the layout:
 (batch_size, seq_length, seq_length)
 
-the equivalent code would be:
-tmp = mx.nd.reshape(queries_keys_values, shape=(0, 0, num_heads, 3, -1))
-v_proj = mx.nd.transpose(tmp[:,:,:,2,:], axes=(1, 2, 0, 3))
-v_proj = mx.nd.reshape(v_proj, shape=(-1, 0, 0), reverse=True)
-output = mx.nd.batch_dot(attention, v_proj)
-output = mx.nd.reshape(output, shape=(-1, num_heads, 0, 0), reverse=True)
-output = mx.nd.transpose(output, axes=(2, 0, 1, 3))
-output = mx.nd.reshape(output, shape=(0, 0, -1))
+the equivalent code would be::
+
+  tmp = mx.nd.reshape(queries_keys_values, shape=(0, 0, num_heads, 3, -1))
+  v_proj = mx.nd.transpose(tmp[:,:,:,2,:], axes=(1, 2, 0, 3))
+  v_proj = mx.nd.reshape(v_proj, shape=(-1, 0, 0), reverse=True)
+  output = mx.nd.batch_dot(attention, v_proj)
+  output = mx.nd.reshape(output, shape=(-1, num_heads, 0, 0), reverse=True)
+  output = mx.nd.transpose(output, axes=(2, 0, 1, 3))
+  output = mx.nd.reshape(output, shape=(0, 0, -1))
+
 )code" ADD_FILELINE)
 .set_num_inputs(2)
 .set_num_outputs(1)
@@ -745,14 +747,16 @@ the inputs must be a tensor of projections of queries following the layout:
 and a tensor of interleaved projections of values and keys following the layout:
 (seq_length, batch_size, num_heads * head_dim * 2)
 
-the equivalent code would be:
-q_proj = mx.nd.transpose(queries, axes=(1, 2, 0, 3))
-q_proj = mx.nd.reshape(q_proj, shape=(-1, 0, 0), reverse=True)
-q_proj = mx.nd.contrib.div_sqrt_dim(q_proj)
-tmp = mx.nd.reshape(keys_values, shape=(0, 0, num_heads, 2, -1))
-k_proj = mx.nd.transpose(tmp[:,:,:,0,:], axes=(1, 2, 0, 3))
-k_proj = mx.nd.reshap(k_proj, shape=(-1, 0, 0), reverse=True)
-output = mx.nd.batch_dot(q_proj, k_proj, transpose_b=True)
+the equivalent code would be::
+
+  q_proj = mx.nd.transpose(queries, axes=(1, 2, 0, 3))
+  q_proj = mx.nd.reshape(q_proj, shape=(-1, 0, 0), reverse=True)
+  q_proj = mx.nd.contrib.div_sqrt_dim(q_proj)
+  tmp = mx.nd.reshape(keys_values, shape=(0, 0, num_heads, 2, -1))
+  k_proj = mx.nd.transpose(tmp[:,:,:,0,:], axes=(1, 2, 0, 3))
+  k_proj = mx.nd.reshap(k_proj, shape=(-1, 0, 0), reverse=True)
+  output = mx.nd.batch_dot(q_proj, k_proj, transpose_b=True)
+
 )code" ADD_FILELINE)
 .set_num_inputs(2)
 .set_num_outputs(1)
@@ -790,15 +794,16 @@ keys and values following the layout:
 and the attention weights following the layout:
 (batch_size, seq_length, seq_length)
 
-the equivalent code would be:
+the equivalent code would be::
 
-tmp = mx.nd.reshape(queries_keys_values, shape=(0, 0, num_heads, 3, -1))
-v_proj = mx.nd.transpose(tmp[:,:,:,1,:], axes=(1, 2, 0, 3))
-v_proj = mx.nd.reshape(v_proj, shape=(-1, 0, 0), reverse=True)
-output = mx.nd.batch_dot(attention, v_proj, transpose_b=True)
-output = mx.nd.reshape(output, shape=(-1, num_heads, 0, 0), reverse=True)
-output = mx.nd.transpose(output, axes=(0, 2, 1, 3))
-output = mx.nd.reshape(output, shape=(0, 0, -1))
+  tmp = mx.nd.reshape(queries_keys_values, shape=(0, 0, num_heads, 3, -1))
+  v_proj = mx.nd.transpose(tmp[:,:,:,1,:], axes=(1, 2, 0, 3))
+  v_proj = mx.nd.reshape(v_proj, shape=(-1, 0, 0), reverse=True)
+  output = mx.nd.batch_dot(attention, v_proj, transpose_b=True)
+  output = mx.nd.reshape(output, shape=(-1, num_heads, 0, 0), reverse=True)
+  output = mx.nd.transpose(output, axes=(0, 2, 1, 3))
+  output = mx.nd.reshape(output, shape=(0, 0, -1))
+
 )code" ADD_FILELINE)
 .set_num_inputs(2)
 .set_num_outputs(1)


### PR DESCRIPTION
## Description ##
fix #17295 the following code snippet:
+ interleaved_matmul_encdec_qk
+ interleaved_matmul_encdec_valatt
+ interleaved_matmul_selfatt_qk
+ interleaved_matmul_selfatt_valatt

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:

### Changes ###
- [x] Update docs format for contrib ops api

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/api/python/docs/api/contrib/ndarray/index.html#mxnet.contrib.ndarray.interleaved_matmul_selfatt_valatt