### PR TITLE
fix julia broken links

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -28,8 +28,6 @@ Redirect 302 /api/scala/docs/api/ /versions/1.6/api/scala/docs/api/
 Redirect 302 /api/java/docs/api/ /versions/1.6/api/java/docs/api/
 Redirect 302 /api/clojure/docs/api/ /versions/1.6/api/clojure/docs/api/
 Redirect 302 /api/cpp/docs/api/ /versions/1.6/api/cpp/docs/api/
-Redirect 302 /api/julia/docs/api/ /versions/1.6/api/julia/docs/api/
-Redirect 302 /api/julia/docs/api/#tutorials /versions/1.6/api/julia/docs/api/#tutorials
 
 # Redirect Chinese visitors to Chinese CDN, temporary solution for slow site speed in China
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^CN$

--- a/docs/static_site/src/pages/api/api.html
+++ b/docs/static_site/src/pages/api/api.html
@@ -51,8 +51,8 @@ docs:
   tag: cpp
 - title: Julia
   guide_link: /api/julia
-  api_link: /api/julia/docs/api
-  tutorial_link: /api/julia/docs/api/#tutorials
+  api_link: /versions/1.6/api/julia/docs/api
+  tutorial_link: /versions/1.6/api/julia/docs/api/#tutorials
   description:
   icon: /assets/img/julia_logo.svg
   tag: julia


### PR DESCRIPTION
## Description ##
On master website api page, currently all language binding api reference links are redirected to v1.6 docs. But only the redirect for Julia does not work as expect. The same rewrite rule that works on a preview host behaves differently on MXNet website. https://mxnet.apache.org/api
After investigation, I found only julia's folder structure changed (was removed) while other languages still preserve the folder with API docs removed and tutorials left. And how Apache's server redirect Julia query is `/api/julia/docs/api/` => `/api/julia.html/docs/api/`, which looks like it searches for `julia` folder first and do not find it, then it try to look for `julia.html` which exists, this redirect executes before our rewrite rules takes effect. While a preview host can't reproduce this with same `htaccess` file, so it is possible a higher level rewrite rule Apache Infra team defined in their server.

To fix this problem, we can 1. put an empty Julia folder and test the result 2. Hard coded the link
In this PR, method 2 is implemented. It hardcoded the endpoint of julia API and tutorials on master directly to `/versions/1.6/api/julia/docs/api`, which should be reverted once new Julia docs completes.


The duplicate `.htaccess` files in each version could also make the redirect work not as expect. Still investigating.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:

### Changes ###
- [x] Remove Julia rewrite rule and hard code the end point

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/api
