### PR TITLE
[v1.x]Add constraint to numpy version to <1.19.0 in CI

### DIFF
--- a/ci/docker/install/centos7_python.sh
+++ b/ci/docker/install/centos7_python.sh
@@ -29,4 +29,5 @@ yum -y install python36u
 # Install PIP
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 python3.6 get-pip.py
-pip3 install nose pylint numpy nose-timer requests h5py scipy==1.2.3
+# Restrict numpy version to < 1.19.0 due to https://github.com/apache/incubator-mxnet/issues/18600
+pip3 install nose pylint 'numpy>1.16.0,<1.19.0' nose-timer requests h5py scipy==1.2.3

--- a/ci/docker/install/requirements
+++ b/ci/docker/install/requirements
@@ -26,9 +26,9 @@ h5py==2.8.0rc1
 mock==2.0.0
 nose==1.3.7
 nose-timer==0.7.3
-numpy>1.16.0,<2.0.0
-pylint==2.3.1  # pylint and astroid need to be aligned 
-astroid==2.3.3  # pylint and astroid need to be aligned 
+numpy>1.16.0,<1.19.0  # Restrict numpy version to < 1.19.0 due to https://github.com/apache/incubator-mxnet/issues/18600
+pylint==2.3.1  # pylint and astroid need to be aligned
+astroid==2.3.3  # pylint and astroid need to be aligned
 requests<2.19.0,>=2.18.4
 scipy==1.2.1
 six==1.11.0

--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -22,5 +22,6 @@ export HOMEBREW_NO_AUTO_UPDATE=1
 
 if [ ${TRAVIS_OS_NAME} == "osx" ]; then
     brew install opencv
-    python -m pip install --user nose numpy cython scipy requests mock nose-timer nose-exclude mxnet-to-coreml
+    # Restrict numpy version to < 1.19.0 due to https://github.com/apache/incubator-mxnet/issues/18600
+    python -m pip install --user nose 'numpy>1.16.0,<1.19.0' cython scipy requests mock nose-timer nose-exclude mxnet-to-coreml
 fi

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,5 +4,5 @@ mock
 nose
 nose-timer
 ipython
-numpy
+numpy>1.16.0,<1.19.0  # Restrict numpy version to < 1.19.0 due to https://github.com/apache/incubator-mxnet/issues/18600
 scipy


### PR DESCRIPTION
## Description ##
As reported in https://github.com/apache/incubator-mxnet/issues/18600, there're some failures related to numpy operators with numpy 1.19.0 (which was released on Jun 21, 2020). Since numpy doesn't follow semantic versioning, and it requires more integration/functionality tests to make sure MXNet is compatible to the latest numpy version. Before all this works are completed, this PR adds constraint to numpy version < 1.19.0 to enable CI pipeline.

@szha @TaoLv @leezu 