### PR TITLE
[numpy] fix flaky mixed precision binary error

### DIFF
--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3169,7 +3169,7 @@ def test_np_mixed_precision_binary_funcs():
     for func, func_data in funcs.items():
         low, high, lgrad, rgrad = func_data
         for lshape, rshape in shape_pairs:
-            for type1, type2 in itertools.product(ftypes, ftypes):
+            for type1, type2 in itertools.product(itypes, ftypes):
                 check_mixed_precision_binary_func(func, low, high, lshape, rshape, lgrad, rgrad, type1, type2)
                 check_mixed_precision_binary_func(func, low, high, lshape, rshape, lgrad, rgrad, type2, type1)
 

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3143,16 +3143,17 @@ def test_np_mixed_precision_binary_funcs():
         'mod': (1.0, 5.0, None, None),
         'power': (1.0, 3.0, lambda y, x1, x2: _np.power(x1, x2 - 1.0) * x2,
                             lambda y, x1, x2: _np.power(x1, x2) * _np.log(x1)),
-        'equal': (0.0, 2.0, None, None),
-        'not_equal': (0.0, 2.0, None, None),
-        'greater': (0.0, 2.0, None, None),
-        'less': (0.0, 2.0, None, None),
-        'greater_equal': (0.0, 2.0, None, None),
-        'less_equal': (0.0, 2.0, None, None),
-        'logical_and': (0.0, 2.0, None, None),
-        'logical_or': (0.0, 2.0, None, None),
-        'logical_xor': (0.0, 2.0, None, None),
     }
+    if not has_tvm_ops():
+        funcs['equal'] = (0.0, 2.0, None, None)
+        funcs['not_equal'] = (0.0, 2.0, None, None)
+        funcs['greater'] = (0.0, 2.0, None, None)
+        funcs['less'] = (0.0, 2.0, None, None)
+        funcs['greater_equal'] = (0.0, 2.0, None, None)
+        funcs['less_equal'] = (0.0, 2.0, None, None)
+        funcs['logical_and'] = (0.0, 2.0, None, None)
+        funcs['logical_or'] = (0.0, 2.0, None, None)
+        funcs['logical_xor'] = (0.0, 2.0, None, None)
 
     shape_pairs = [((3, 2), (3, 2)),
                    ((3, 2), (3, 1)),
@@ -3168,7 +3169,7 @@ def test_np_mixed_precision_binary_funcs():
     for func, func_data in funcs.items():
         low, high, lgrad, rgrad = func_data
         for lshape, rshape in shape_pairs:
-            for type1, type2 in itertools.product(itypes, ftypes):
+            for type1, type2 in itertools.product(ftypes, ftypes):
                 check_mixed_precision_binary_func(func, low, high, lshape, rshape, lgrad, rgrad, type1, type2)
                 check_mixed_precision_binary_func(func, low, high, lshape, rshape, lgrad, rgrad, type2, type1)
 

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3071,7 +3071,6 @@ def test_np_binary_funcs():
 
 @with_seed()
 @use_np
-# @pytest.mark.skip(reason='https://github.com/apache/incubator-mxnet/issues/16848')
 def test_np_mixed_precision_binary_funcs():
     itypes = [np.bool, np.int8, np.int32, np.int64]
     ftypes = [np.float16, np.float32, np.float64]
@@ -3084,10 +3083,10 @@ def test_np_mixed_precision_binary_funcs():
             def hybrid_forward(self, F, a, b, *args, **kwargs):
                 return getattr(F.np, self._func)(a, b)
 
-        # if (func in ['multiply', 'mod', 'equal', 'not_equal', 'greater',
-        #             'greater_equal', 'less', 'less_equal']) and \
-        #     (lshape == () or rshape == ()) :
-        #     return
+        if (func in ['multiply', 'mod', 'equal', 'not_equal', 'greater',
+                    'greater_equal', 'less', 'less_equal']) and \
+            (lshape == () or rshape == ()) :
+            return
         np_func = getattr(_np, func)
         mx_func = TestMixedBinary(func)
         np_test_x1 = _np.random.uniform(low, high, lshape).astype(ltype)

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3087,9 +3087,23 @@ def test_np_mixed_precision_binary_funcs():
                     'greater_equal', 'less', 'less_equal']) and \
             (lshape == () or rshape == ()) :
         # the behaviors of infer type in dealing with the input shape of '()' are different between np and onp
+        # for example,
+        # mx_test_x1 = np.random.uniform(-2, 2, (2,3)).astype(np.float32)
+        # mx_test_x2 = np.random.uniform(-2, 2, ()).astype(np.float16)
+        # np_out = _np.mod(mx_test_x1.asnumpy(), mx_test_x2.asnumpy()) # float16
+        # mx_out = np.mod(mx_test_x1, mx_test_x2) # float32
+
         # logcial ops: when two numbers are only different in precision, NumPy also has a weird behavior
+        # for example,
+        # a = np.array([[1.441]], dtype = np.float16)
+        # b = np.array(1.4413278, dtype = np.float32)
+        # c = np.array([1.4413278], dtype = np.float32)
+        # np.greater(a,b), np.greater(a,c) # True True
+        # _np.greater(a.asnumpy(),b.asnumpy()), _np.greater(a.asnumpy(),c.asnumpy()) # False True
+
         # thus, skip the tests
             return
+
         np_func = getattr(_np, func)
         mx_func = TestMixedBinary(func)
         np_test_x1 = _np.random.uniform(low, high, lshape).astype(ltype)

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3143,17 +3143,16 @@ def test_np_mixed_precision_binary_funcs():
         'mod': (1.0, 5.0, None, None),
         'power': (1.0, 3.0, lambda y, x1, x2: _np.power(x1, x2 - 1.0) * x2,
                             lambda y, x1, x2: _np.power(x1, x2) * _np.log(x1)),
+        'equal': (0.0, 2.0, None, None),
+        'not_equal': (0.0, 2.0, None, None),
+        'greater': (0.0, 2.0, None, None),
+        'less': (0.0, 2.0, None, None),
+        'greater_equal': (0.0, 2.0, None, None),
+        'less_equal': (0.0, 2.0, None, None),
+        'logical_and': (0.0, 2.0, None, None),
+        'logical_or': (0.0, 2.0, None, None),
+        'logical_xor': (0.0, 2.0, None, None),
     }
-    if not has_tvm_ops():
-        funcs['equal'] = (0.0, 2.0, None, None)
-        funcs['not_equal'] = (0.0, 2.0, None, None)
-        funcs['greater'] = (0.0, 2.0, None, None)
-        funcs['less'] = (0.0, 2.0, None, None)
-        funcs['greater_equal'] = (0.0, 2.0, None, None)
-        funcs['less_equal'] = (0.0, 2.0, None, None)
-        funcs['logical_and'] = (0.0, 2.0, None, None)
-        funcs['logical_or'] = (0.0, 2.0, None, None)
-        funcs['logical_xor'] = (0.0, 2.0, None, None)
 
     shape_pairs = [((3, 2), (3, 2)),
                    ((3, 2), (3, 1)),

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3086,6 +3086,9 @@ def test_np_mixed_precision_binary_funcs():
         if (func in ['multiply', 'mod', 'equal', 'not_equal', 'greater',
                     'greater_equal', 'less', 'less_equal']) and \
             (lshape == () or rshape == ()) :
+        # the behaviors of infer type in dealing with the input shape of '()' are different between np and onp
+        # logcial ops: when two numbers are only different in precision, NumPy also has a weird behavior
+        # thus, skip the tests
             return
         np_func = getattr(_np, func)
         mx_func = TestMixedBinary(func)

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -3071,7 +3071,7 @@ def test_np_binary_funcs():
 
 @with_seed()
 @use_np
-@pytest.mark.skip(reason='https://github.com/apache/incubator-mxnet/issues/16848')
+# @pytest.mark.skip(reason='https://github.com/apache/incubator-mxnet/issues/16848')
 def test_np_mixed_precision_binary_funcs():
     itypes = [np.bool, np.int8, np.int32, np.int64]
     ftypes = [np.float16, np.float32, np.float64]
@@ -3084,6 +3084,10 @@ def test_np_mixed_precision_binary_funcs():
             def hybrid_forward(self, F, a, b, *args, **kwargs):
                 return getattr(F.np, self._func)(a, b)
 
+        # if (func in ['multiply', 'mod', 'equal', 'not_equal', 'greater',
+        #             'greater_equal', 'less', 'less_equal']) and \
+        #     (lshape == () or rshape == ()) :
+        #     return
         np_func = getattr(_np, func)
         mx_func = TestMixedBinary(func)
         np_test_x1 = _np.random.uniform(low, high, lshape).astype(ltype)


### PR DESCRIPTION
## Description ##
#16848 
Delete the tests which may cause bug because of the following reasons:
1. There are differences about type inference between NumPy and Deep Numpy when there's a input with shape ():
If both inputs of np are of floating number types, the output is the more precise type, while onp will use the type of the matrix with higher dimension.
```python
from mxnet import np, npx
npx.set_np()
import numpy as _np

mx_test_x1 = np.random.uniform(-2, 2, (2,3)).astype(np.float32)
mx_test_x2 = np.random.uniform(-2, 2, ()).astype(np.float16)

np_out = _np.mod(mx_test_x1.asnumpy(), mx_test_x2.asnumpy()) # float16
mx_out = np.mod(mx_test_x1, mx_test_x2) # float32
```

2. As for logical ops, NumPy also has a weird behavior.
```python
from mxnet import np, npx
npx.set_np()
import numpy as _np

a = np.array([[1.441]], dtype = np.float16)
b = np.array(1.4413278, dtype = np.float32)
c = np.array([1.4413278], dtype = np.float32)

np.greater(a,b), np.greater(a,c) # True True
_np.greater(a.asnumpy(),b.asnumpy()), _np.greater(a.asnumpy(),c.asnumpy()) # False True
np.less_equal(a,b), np.less_equal(a,c) # False False
_np.less_equal(a.asnumpy(),b.asnumpy()), _np.less_equal(a.asnumpy(),c.asnumpy()) # True False
```
Disable mixed type test for tvm ops

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
