### PR TITLE
fix anchors shift on all main website pages

### DIFF
--- a/docs/static_site/src/_sass/minima/_layout.scss
+++ b/docs/static_site/src/_sass/minima/_layout.scss
@@ -250,14 +250,14 @@
 
 .page-content {
   height: 100%;
-  padding: $spacing-unit 0, 0;
+  padding: $spacing-unit 0 0;
   flex: 1;
   margin-top: 100px;
 }
 
 .page-content-home {
   height: 100%;
-  padding: $spacing-unit 0, 0;
+  padding: $spacing-unit 0 0;
   margin-top: 100px;
 }
 
@@ -365,13 +365,7 @@
   }
 }
 
-#forum::before,
-#mxnet-dev-communications::before,
-#social-media::before,
-#jira::before,
-#confluence-wiki::before,
-#setup-mxnet-for-development::before,
-#your-first-contribution::before {
+:target::before {
   display: block;
   content: " ";
   margin-top: -86px;


### PR DESCRIPTION
## Description ##
There was a previous fix to anchor shifts issue specific to `contribution` page #18567, but I found more pages are using anchors and having the same issue. In this PR, the fix is applied to all anchors by using a common css selector `:target`.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:

### Changes ###
- [x] Fix anchors shift on all main website pages

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/get_started/build_from_source
- Compare to: https://mxnet.apache.org/get_started/build_from_source
> If you still see shift of anchor on preview host, please try clean the cache and load the website again. Thanks