### PR TITLE
Fix scipy dependency in probability module

### DIFF
--- a/python/mxnet/gluon/probability/distributions/utils.py
+++ b/python/mxnet/gluon/probability/distributions/utils.py
@@ -52,7 +52,7 @@ def digamma(F):
         """
         if isinstance(value, Number):
             if sc is not None:
-                return sc.digamma(value)
+                return sc.digamma(value, dtype='float32')
             else:
                 raise ValueError('Numbers are not supported as input if scipy is not installed')
         return F.npx.digamma(value)
@@ -67,7 +67,7 @@ def gammaln(F):
         """
         if isinstance(value, Number):
             if sc is not None:
-                return sc.gammaln(value)
+                return sc.gammaln(value, dtype='float32')
             else:
                 raise ValueError('Numbers are not supported as input if scipy is not installed')
         return F.npx.gammaln(value)

--- a/python/mxnet/gluon/probability/distributions/utils.py
+++ b/python/mxnet/gluon/probability/distributions/utils.py
@@ -52,7 +52,7 @@ def digamma(F):
         """
         if isinstance(value, Number):
             if sc is not None:
-                return sc.digamma(value, dtype='float32')
+                return sc.digamma(value)
             else:
                 raise ValueError('Numbers are not supported as input if scipy is not installed')
         return F.npx.digamma(value)
@@ -67,7 +67,7 @@ def gammaln(F):
         """
         if isinstance(value, Number):
             if sc is not None:
-                return sc.gammaln(value, dtype='float32')
+                return sc.gammaln(value)
             else:
                 raise ValueError('Numbers are not supported as input if scipy is not installed')
         return F.npx.gammaln(value)
@@ -80,7 +80,7 @@ def erf(F):
     def compute(value):
         if isinstance(value, Number):
             if sc is not None:
-                return sc.erf(value, dtype='float32')
+                return sc.erf(value)
             else:
                 raise ValueError('Numbers are not supported as input if scipy is not installed')
         return F.npx.erf(value)
@@ -93,7 +93,7 @@ def erfinv(F):
     def compute(value):
         if isinstance(value, Number):
             if sc is not None:
-                return sc.erfinv(value, dtype='float32')
+                return sc.erfinv(value)
             else:
                 raise ValueError('Numbers are not supported as input if scipy is not installed')
         return F.npx.erfinv(value)

--- a/python/mxnet/gluon/probability/distributions/utils.py
+++ b/python/mxnet/gluon/probability/distributions/utils.py
@@ -24,7 +24,10 @@ __all__ = ['getF', 'prob2logit', 'logit2prob', 'cached_property', 'sample_n_shap
 from functools import update_wrapper
 from numbers import Number
 import numpy as onp
-import scipy.special as sc
+try:
+    import scipy.special as sc
+except ImportError:
+    sc = None
 from .... import symbol as sym
 from .... import ndarray as nd
 
@@ -48,7 +51,10 @@ def digamma(F):
         """Return digamma(value)
         """
         if isinstance(value, Number):
-            return sc.digamma(value, dtype='float32')
+            if sc is not None:
+                return sc.digamma(value, dtype='float32')
+            else:
+                raise ValueError('Numbers are not supported as input if scipy is not installed')
         return F.npx.digamma(value)
     return compute
 
@@ -60,7 +66,10 @@ def gammaln(F):
         """Return log(gamma(value))
         """
         if isinstance(value, Number):
-            return sc.gammaln(value, dtype='float32')
+            if sc is not None:
+                return sc.gammaln(value, dtype='float32')
+            else:
+                raise ValueError('Numbers are not supported as input if scipy is not installed')
         return F.npx.gammaln(value)
     return compute
 
@@ -70,7 +79,10 @@ def erf(F):
     """
     def compute(value):
         if isinstance(value, Number):
-            return sc.erf(value)
+            if sc is not None:
+                return sc.erf(value, dtype='float32')
+            else:
+                raise ValueError('Numbers are not supported as input if scipy is not installed')
         return F.npx.erf(value)
     return compute
 
@@ -80,7 +92,10 @@ def erfinv(F):
     """
     def compute(value):
         if isinstance(value, Number):
-            return sc.erfinv(value)
+            if sc is not None:
+                return sc.erfinv(value, dtype='float32')
+            else:
+                raise ValueError('Numbers are not supported as input if scipy is not installed')
         return F.npx.erfinv(value)
     return compute
 


### PR DESCRIPTION
Scipy is an optional dependency of mxnet. Requiring it breaks the website build (and will also break mxnet in other environments where scipy isn't present)

Fixes https://github.com/apache/incubator-mxnet/issues/18680