### PR TITLE
[COMMUNITY] add 'needs triage' label to new bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'Bug'
+labels: 'Bug, needs triage'
 assignees: ''
 
 ---


### PR DESCRIPTION
## Description ##
add 'needs triage' label to new bug reports

## Checklist ##
### Changes ###
- [x] add 'needs triage' label to new bug reports