### PR TITLE
Set CMAKE_CUDA_COMPILER in aarch64-linux-gnu-toolchain.cmake

### DIFF
--- a/ci/docker/toolchains/aarch64-linux-gnu-toolchain.cmake
+++ b/ci/docker/toolchains/aarch64-linux-gnu-toolchain.cmake
@@ -19,6 +19,7 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR "aarch64")
 set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
 set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+set(CMAKE_CUDA_COMPILER nvcc)
 set(CMAKE_CUDA_HOST_COMPILER aarch64-linux-gnu-gcc)
 set(CMAKE_FIND_ROOT_PATH "/usr/aarch64-linux-gnu")
 


### PR DESCRIPTION
CMAKE_CUDA_HOST_COMPILER will be reset if CMAKE_CUDA_COMPILER is not set as of cmake 3.17.3

See https://gitlab.kitware.com/cmake/cmake/-/issues/20826
