### PR TITLE
Initialize docker cache in build.py for docker-compose containers

### DIFF
--- a/ci/build.py
+++ b/ci/build.py
@@ -288,9 +288,17 @@ def list_platforms() -> str:
     return "\nSupported platforms:\n{}".format('\n'.join(get_platforms()))
 
 
-def load_docker_cache(tag, docker_registry) -> None:
+def load_docker_cache(platform, tag, docker_registry) -> None:
     """Imports tagged container from the given docker registry"""
     if docker_registry:
+        if platform in DOCKER_COMPOSE_WHITELIST:
+            env = os.environ.copy()
+            env["DOCKER_CACHE_REGISTRY"] = docker_registry
+            cmd = ['docker-compose', '-f', 'docker/docker-compose.yml', 'pull', platform]
+            logging.info("Running command: 'DOCKER_CACHE_REGISTRY=%s %s'", docker_registry, ' '.join(cmd))
+            check_call(cmd, env=env)
+            return
+
         # noinspection PyBroadException
         try:
             import docker_cache
@@ -398,7 +406,7 @@ def main() -> int:
         platform = args.platform
         tag = get_docker_tag(platform=platform, registry=args.docker_registry)
         if args.docker_registry and not args.no_pull:
-            load_docker_cache(tag=tag, docker_registry=args.docker_registry)
+            load_docker_cache(platform=platform, tag=tag, docker_registry=args.docker_registry)
         if not args.run_only:
             build_docker(platform=platform, registry=args.docker_registry, num_retries=args.docker_build_retries,
                          no_cache=args.no_cache, cache_intermediate=args.cache_intermediate)
@@ -442,7 +450,7 @@ def main() -> int:
         logging.info("Artifacts will be produced in the build/ directory.")
         for platform in platforms:
             tag = get_docker_tag(platform=platform, registry=args.docker_registry)
-            load_docker_cache(tag=tag, docker_registry=args.docker_registry)
+            load_docker_cache(platform=platform, tag=tag, docker_registry=args.docker_registry)
             build_docker(platform, registry=args.docker_registry, num_retries=args.docker_build_retries,
                          no_cache=args.no_cache)
             if args.build_only:


### PR DESCRIPTION
## Description ##
Analogous to https://github.com/apache/incubator-mxnet/pull/18179 we need to manually pull the container in the `build.py` as well.

Previously we'd use `docker pull` to attempt to initialize the cache. But that wouldn't work if `docker-compose` is used to build the container. Thus use `docker-compose pull` for initializing the cache when building with `docker-compose`.