### PR TITLE
Match the CUDA arch to the GPU used for CI testing on Windows

### DIFF
--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -127,7 +127,7 @@ CMAKE_FLAGS = {
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
         '-DUSE_DIST_KVSTORE=OFF '
-        '-DMXNET_CUDA_ARCH="5.2" '
+        '-DMXNET_CUDA_ARCH="7.5" '
         '-DUSE_MKL_IF_AVAILABLE=OFF '
         '-DCMAKE_BUILD_TYPE=Release')
 
@@ -142,7 +142,7 @@ CMAKE_FLAGS = {
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
         '-DUSE_DIST_KVSTORE=OFF '
-        '-DMXNET_CUDA_ARCH="5.2" '
+        '-DMXNET_CUDA_ARCH="7.5" '
         '-DUSE_MKLDNN=ON '
         '-DCMAKE_BUILD_TYPE=Release')
 

--- a/ci/build_windows.py
+++ b/ci/build_windows.py
@@ -127,7 +127,7 @@ CMAKE_FLAGS = {
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
         '-DUSE_DIST_KVSTORE=OFF '
-        '-DMXNET_CUDA_ARCH="7.5" '
+        '-DMXNET_CUDA_ARCH="7.0" '
         '-DUSE_MKL_IF_AVAILABLE=OFF '
         '-DCMAKE_BUILD_TYPE=Release')
 
@@ -142,7 +142,7 @@ CMAKE_FLAGS = {
         '-DUSE_BLAS=open '
         '-DUSE_LAPACK=ON '
         '-DUSE_DIST_KVSTORE=OFF '
-        '-DMXNET_CUDA_ARCH="7.5" '
+        '-DMXNET_CUDA_ARCH="7.0" '
         '-DUSE_MKLDNN=ON '
         '-DCMAKE_BUILD_TYPE=Release')
 


### PR DESCRIPTION
## Description ##
Current build script used by CI on Windows sets the CUDA arch to 5.2, which results in the need to do ptx -> sass compilation at the beginning of the tests (depending on whether the kernels are already in driver jit cache or not). This adds 15-20 minutes to the windows-gpu CI runs that do not have the jit cache populated. This PR changes the CUDA arch used for building in Windows CI to 7.5, which is the used for testing.

FYI @ChaiBapchya @leezu 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)