### PR TITLE
set website default version to current stable (1.6) version

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -28,7 +28,6 @@ RewriteCond %{REQUEST_URI} ^/versions/1.1.0/community/contribute.html$
 RewriteCond %{HTTP_REFERER} !mxnet.apache.org
 RewriteCond %{HTTP_REFERER} !mxnet.incubator.apache.org
 Rewriterule ^(.*)$ /versions/1.6/$1 [r=307,L]
-# Rewriterule ^(.*)$ /versions/1.6/$1 [r=307,L]
 
 # TODO temporary fix for issue #18604
 Redirect 302 /api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf https://mxnet-public.s3.us-east-2.amazonaws.com/docs/v1.x/mxnet-r-reference-manual.pdf

--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -22,6 +22,14 @@ RewriteOptions AllowNoSlash
   
 </IfModule>
 
+# Set default website version to current stable (v1.6) TODO delete test code and uncomment origin code 
+RewriteCond %{REQUEST_URI} ^/versions/1.1.0/community/contribute.html$
+# RewriteCond %{REQUEST_URI} ^/$
+RewriteCond %{HTTP_REFERER} !mxnet.apache.org
+RewriteCond %{HTTP_REFERER} !mxnet.incubator.apache.org
+Rewriterule ^(.*)$ /versions/1.6/community/contribute.html [r=307,L]
+# Rewriterule ^(.*)$ /versions/1.6/ [r=307,L]
+
 # TODO temporary fix for issue #18604
 Redirect 302 /api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf https://mxnet-public.s3.us-east-2.amazonaws.com/docs/v1.x/mxnet-r-reference-manual.pdf
 Redirect 302 /api/scala/docs/api/ /versions/1.6/api/scala/docs/api/

--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -27,7 +27,7 @@ RewriteCond %{REQUEST_URI} ^/versions/1.1.0/community/contribute.html$
 # RewriteCond %{REQUEST_URI} !^/versions/
 RewriteCond %{HTTP_REFERER} !mxnet.apache.org
 RewriteCond %{HTTP_REFERER} !mxnet.incubator.apache.org
-Rewriterule ^(.*)$ /versions/1.6/$1 [r=307,L]
+RewriteRule ^(.*)$ /versions/1.6/$1 [r=307,L]
 
 # TODO temporary fix for issue #18604
 Redirect 302 /api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf https://mxnet-public.s3.us-east-2.amazonaws.com/docs/v1.x/mxnet-r-reference-manual.pdf

--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -27,7 +27,7 @@ RewriteCond %{REQUEST_URI} ^/versions/1.1.0/community/contribute.html$
 # RewriteCond %{REQUEST_URI} !^/versions/
 RewriteCond %{HTTP_REFERER} !mxnet.apache.org
 RewriteCond %{HTTP_REFERER} !mxnet.incubator.apache.org
-Rewriterule ^(.*)$ /versions/1.6/community/contribute.html [r=307,L]
+Rewriterule ^(.*)$ /versions/1.6/$1 [r=307,L]
 # Rewriterule ^(.*)$ /versions/1.6/$1 [r=307,L]
 
 # TODO temporary fix for issue #18604

--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -22,9 +22,8 @@ RewriteOptions AllowNoSlash
   
 </IfModule>
 
-# Set default website version to current stable (v1.6) TODO delete test code and uncomment origin code 
-RewriteCond %{REQUEST_URI} ^/versions/1.1.0/community/contribute.html$
-# RewriteCond %{REQUEST_URI} !^/versions/
+# Set default website version to current stable (v1.6)
+RewriteCond %{REQUEST_URI} !^/versions/
 RewriteCond %{HTTP_REFERER} !mxnet.apache.org
 RewriteCond %{HTTP_REFERER} !mxnet.incubator.apache.org
 RewriteRule ^(.*)$ /versions/1.6/$1 [r=307,L]

--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -24,11 +24,11 @@ RewriteOptions AllowNoSlash
 
 # Set default website version to current stable (v1.6) TODO delete test code and uncomment origin code 
 RewriteCond %{REQUEST_URI} ^/versions/1.1.0/community/contribute.html$
-# RewriteCond %{REQUEST_URI} ^/$
+# RewriteCond %{REQUEST_URI} !^/versions/
 RewriteCond %{HTTP_REFERER} !mxnet.apache.org
 RewriteCond %{HTTP_REFERER} !mxnet.incubator.apache.org
 Rewriterule ^(.*)$ /versions/1.6/community/contribute.html [r=307,L]
-# Rewriterule ^(.*)$ /versions/1.6/ [r=307,L]
+# Rewriterule ^(.*)$ /versions/1.6/$1 [r=307,L]
 
 # TODO temporary fix for issue #18604
 Redirect 302 /api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf https://mxnet-public.s3.us-east-2.amazonaws.com/docs/v1.x/mxnet-r-reference-manual.pdf


### PR DESCRIPTION
## Description ##
#18429 , To set website default version to v1.6 when users land on main page from other domain.
1. If coming from other domains except `mxnet.apache.org` or `mxnet.incubator.apache.org`,  redirect users to v1.6 website
2. If coming from other pages on MXNet domain, don't redirect to avoid any looping.

Here is the explanation of this PR changes:
```shell
# Apply redirect on master website
RewriteCond %{REQUEST_URI} !^/versions/ 

# Apply redirect only when user visiting from outside of MXNet website
RewriteCond %{HTTP_REFERER} !mxnet.apache.org
RewriteCond %{HTTP_REFERER} !mxnet.incubator.apache.org

# Redirect to corresponding page on v1.6 website
RewriteRule ^(.*)$ /versions/1.6/$1 [r=307,L]
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:


### Changes ###
- [x] Redirect user to v1.6 website when visiting from outside of MXNet website

## Comments ##
- Preview: https://mxnet-beta.staged.apache.org/
