### PR TITLE
[v1.x] add large matrix tests for linalg ops: det, inverse, trsm, trmm

### DIFF
--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -298,11 +298,17 @@ def create_vector(size, dtype=np.int64):
     return a
 
 # For testing Large Square Matrix with total size > 2^32 elements
-def get_large_identity_mat(size):
+def get_identity_mat(size):
     A = mx.nd.zeros((size, size))
     for i in range(size):
         A[i, i] = 1
     return A
+
+# For testing Batch of Large Square Matrix with total size > 2^32 elements
+def get_identity_mat_batch(size):
+    A = get_identity_mat(size)
+    A_np = A.asnumpy()
+    return nd.array([A_np, A_np])
 
 def rand_sparse_ndarray(shape, stype, density=None, dtype=None, distribution=None,
                         data_init=None, rsp_indices=None, modifier_func=None,

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -308,7 +308,7 @@ def get_identity_mat(size):
 def get_identity_mat_batch(size):
     A = get_identity_mat(size)
     A_np = A.asnumpy()
-    return nd.array([A_np, A_np])
+    return mx.nd.array([A_np, A_np])
 
 def rand_sparse_ndarray(shape, stype, density=None, dtype=None, distribution=None,
                         data_init=None, rsp_indices=None, modifier_func=None,

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -298,9 +298,9 @@ def create_vector(size, dtype=np.int64):
     return a
 
 # For testing Large Square Matrix with total size > 2^32 elements
-def get_large_identity_mat():
-    A = nd.zeros((LARGE_SQ_X, LARGE_SQ_X))
-    for i in range(LARGE_SQ_X):
+def get_large_identity_mat(size):
+    A = nd.zeros((size, size))
+    for i in range(size):
         A[i,i] = 1
     return A
 

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -299,7 +299,7 @@ def create_vector(size, dtype=np.int64):
 
 # For testing Large Square Matrix with total size > 2^32 elements
 def get_large_identity_mat(size):
-    A = nd.zeros((size, size))
+    A = mx.nd.zeros((size, size))
     for i in range(size):
         A[i, i] = 1
     return A

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -297,6 +297,13 @@ def create_vector(size, dtype=np.int64):
     a = mx.nd.arange(0, size, dtype=dtype)
     return a
 
+# For testing Large Square Matrix with total size > 2^32 elements
+def get_large_identity_mat():
+    A = nd.zeros((LARGE_SQ_X, LARGE_SQ_X))
+    for i in range(LARGE_SQ_X):
+        A[i,i] = 1
+    return A
+
 def rand_sparse_ndarray(shape, stype, density=None, dtype=None, distribution=None,
                         data_init=None, rsp_indices=None, modifier_func=None,
                         shuffle_csr_indices=False, ctx=None):

--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -301,7 +301,7 @@ def create_vector(size, dtype=np.int64):
 def get_large_identity_mat(size):
     A = nd.zeros((size, size))
     for i in range(size):
-        A[i,i] = 1
+        A[i, i] = 1
     return A
 
 def rand_sparse_ndarray(shape, stype, density=None, dtype=None, distribution=None,

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1247,7 +1247,7 @@ def test_linalg():
             out = trsm(inp, inp)
         return inp.grad, out
 
-    A = get_large_identity_mat()
+    A = get_large_identity_mat(LARGE_SQ_X)
 
     grad, out = run_det(A)
     check_diag(grad, 0)

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -25,7 +25,7 @@ import mxnet as mx
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.append(os.path.join(curr_path, '../python/unittest/'))
 
-from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, default_context, check_symbolic_forward, create_2d_tensor
+from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, default_context, check_symbolic_forward, create_2d_tensor, get_large_identity_mat
 from mxnet import gluon, nd
 from common import with_seed, with_post_test_cleanup
 from nose.tools import with_setup
@@ -1214,7 +1214,8 @@ def test_linalg():
 
 def test_linalg():
     def batchify(mat):
-        return nd.array([mat.asnumpy()])
+        mat_np = mat.asnumpy()
+        return nd.array([mat_np, mat_np])
 
     def check_diag(mat, val):
         for i in range(LARGE_SQ_X):
@@ -1222,6 +1223,7 @@ def test_linalg():
 
     def check_batch_diag(mat, val):
         check_diag(mat[0], val)
+        check_diag(mat[1], val)
 
     def run_det(inp):
         inp.attach_grad()

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1253,17 +1253,17 @@ def test_linalg():
     grad, out = run_det(A)
     assert(out[0] == 1)
     out.backward()
-    check_diag(grad, 0)
+    check_diag(grad, 1)
 
     grad, out = run_inverse(A)
     check_diag(out, 1)
     out.backward()
-    check_diag(grad, 0)
+    check_diag(grad, -1)
 
     grad, out = run_trmm(A)
     check_diag(out, 1)
     out.backward()
-    check_diag(grad, 0)
+    check_diag(grad, 2)
 
     grad, out = run_trsm(A)
     check_diag(out, 1)
@@ -1275,12 +1275,12 @@ def test_linalg():
     grad, out = run_inverse(B)
     check_batch_diag(out, 1)
     out.backward()
-    check_batch_diag(grad, 0)
+    check_batch_diag(grad, -1)
 
     grad, out = run_trmm(B)
     check_batch_diag(out, 1)
     out.backward()
-    check_batch_diag(grad, 0)
+    check_batch_diag(grad, 2)
 
     grad, out = run_trsm(B)
     check_batch_diag(out, 1)

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1219,10 +1219,8 @@ def test_linalg():
             A[i,i] = 1
         return A
 
-    def batchify(A):
-        A_np = A.asnumpy()
-        B = nd.array([A_np, A_np])
-        return B
+    def batchify(mat):
+        return nd.array([mat.asnumpy()])
 
     def check_diag(mat, val):
         for i in range(LARGE_SQ_X):
@@ -1230,7 +1228,6 @@ def test_linalg():
 
     def check_batch_diag(mat, val):
         check_diag(mat[0], val)
-        check_diag(mat[1], val)
 
     def run_det(inp):
         inp.attach_grad()

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1228,58 +1228,65 @@ def test_linalg():
     def run_det(inp):
         inp.attach_grad()
         with mx.autograd.record():
-            out = det(inp)
+            out = mx.nd.linalg.det(inp)
         return inp.grad, out
 
     def run_inverse(inp):
         inp.attach_grad()
         with mx.autograd.record():
-            out = inverse(inp)
+            out = mx.nd.linalg.inverse(inp)
         return inp.grad, out
 
     def run_trmm(inp):
         inp.attach_grad()
         with mx.autograd.record():
-            out = trmm(inp, inp)
+            out = mx.nd.linalg.trmm(inp, inp)
         return inp.grad, out
 
     def run_trsm(inp):
         inp.attach_grad()
         with mx.autograd.record():
-            out = trsm(inp, inp)
+            out = mx.nd.linalg.trsm(inp, inp)
         return inp.grad, out
 
     A = get_large_identity_mat(LARGE_SQ_X)
 
     grad, out = run_det(A)
-    check_diag(grad, 0)
     assert(out[0] == 1)
+    out.backward()
+    check_diag(grad, 0)
 
     grad, out = run_inverse(A)
-    check_diag(grad, 0)
     check_diag(out, 1)
+    out.backward()
+    check_diag(grad, 0)
 
     grad, out = run_trmm(A)
-    check_diag(grad, 0)
     check_diag(out, 1)
+    out.backward()
+    check_diag(grad, 0)
 
     grad, out = run_trsm(A)
-    check_diag(grad, 0)
     check_diag(out, 1)
+    out.backward()
+    check_diag(grad, 0)
 
     B = batchify(A)
 
     grad, out = run_inverse(B)
-    check_batch_diag(grad, 0)
     check_batch_diag(out, 1)
+    out.backward()
+    check_batch_diag(grad, 0)
 
     grad, out = run_trmm(B)
-    check_batch_diag(grad, 0)
     check_batch_diag(out, 1)
+    out.backward()
+    check_batch_diag(grad, 0)
 
     grad, out = run_trsm(B)
-    check_batch_diag(grad, 0)
     check_batch_diag(out, 1)
+    out.backward()
+    check_batch_diag(grad, 0)
 
 
 def test_basic():

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1216,8 +1216,10 @@ def test_linalg():
 
         A = get_identity_mat(LARGE_SQ_X)
         grad, out = run_det(A)
+        assert(out.shape == (1,))
         assert(out[0] == 1)
         out.backward()
+        assert(grad.shape == (LARGE_SQ_X, LARGE_SQ_X))
         assert(grad[0, 0] == 1)
 
     def check_inverse():
@@ -1229,8 +1231,10 @@ def test_linalg():
 
         A = get_identity_mat(LARGE_SQ_X)
         grad, out = run_inverse(A)
+        assert(out.shape == (LARGE_SQ_X, LARGE_SQ_X))
         assert(out[0, 0] == 1)
         out.backward()
+        assert(grad.shape == (LARGE_SQ_X, LARGE_SQ_X))
         assert(grad[0, 0] == -1)
 
     def check_trmm():
@@ -1242,8 +1246,10 @@ def test_linalg():
 
         A = get_identity_mat(LARGE_SQ_X)
         grad, out = run_trmm(A)
+        assert(out.shape == (LARGE_SQ_X, LARGE_SQ_X))
         assert(out[0, 0] == 1)
         out.backward()
+        assert(grad.shape == (LARGE_SQ_X, LARGE_SQ_X))
         assert(grad[0, 0] == 2)
 
     def check_trsm():
@@ -1255,8 +1261,10 @@ def test_linalg():
 
         A = get_identity_mat(LARGE_SQ_X)
         grad, out = run_trsm(A)
+        assert(out.shape == (LARGE_SQ_X, LARGE_SQ_X))
         assert(out[0, 0] == 1)
         out.backward()
+        assert(grad.shape == (LARGE_SQ_X, LARGE_SQ_X))
         assert(grad[0, 0] == 0)
 
     def check_batch_inverse():
@@ -1268,9 +1276,11 @@ def test_linalg():
 
         B = get_identity_mat_batch(LARGE_SQ_X)
         grad, out = run_inverse(B)
+        assert(out.shape == (2, LARGE_SQ_X, LARGE_SQ_X))
         assert(out[0, 0, 0] == 1)
         assert(out[1, 0, 0] == 1)
         out.backward()
+        assert(grad.shape == (2, LARGE_SQ_X, LARGE_SQ_X))
         assert(grad[0, 0, 0] == -1)
         assert(grad[1, 0, 0] == -1)
 
@@ -1283,9 +1293,11 @@ def test_linalg():
 
         B = get_identity_mat_batch(LARGE_SQ_X)
         grad, out = run_trmm(B)
+        assert(out.shape == (2, LARGE_SQ_X, LARGE_SQ_X))
         assert(out[0, 0, 0] == 1)
         assert(out[1, 0, 0] == 1)
         out.backward()
+        assert(grad.shape == (2, LARGE_SQ_X, LARGE_SQ_X))
         assert(grad[0, 0, 0] == 2)
         assert(grad[1, 0, 0] == 2)
 
@@ -1298,9 +1310,11 @@ def test_linalg():
 
         B = get_identity_mat_batch(LARGE_SQ_X)
         grad, out = run_trsm(B)
+        assert(out.shape == (2, LARGE_SQ_X, LARGE_SQ_X))
         assert(out[0, 0, 0] == 1)
         assert(out[1, 0, 0] == 1)
         out.backward()
+        assert(grad.shape == (2, LARGE_SQ_X, LARGE_SQ_X))
         assert(grad[0, 0, 0] == 0)
         assert(grad[1, 0, 0] == 0)
 

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1212,6 +1212,55 @@ def test_linalg():
     check_syrk_batch()
 
 
+def test_linalg():
+    def check_det():
+        # creating an identity matrix input
+        A = nd.zeros((LARGE_SQ_X, LARGE_SQ_X))
+        for i in range(LARGE_SQ_X):
+            A[i,i] = 1
+
+        out = nd.linalg.det(A)
+        assert out == 1
+
+    def check_inverse():
+        # creating an identity matrix input
+        A = nd.zeros((LARGE_SQ_X, LARGE_SQ_X))
+        for i in range(LARGE_SQ_X):
+            A[i,i] = 1
+
+        out = nd.linalg.inverse(A)
+        # output should be an identity matrix
+        for i in range(LARGE_SQ_X):
+            assert out[i,i] == 1
+
+    def check_trmm():
+        # creating an identity matrix input
+        A = nd.zeros((LARGE_SQ_X, LARGE_SQ_X))
+        for i in range(LARGE_SQ_X):
+            A[i,i] = 1
+
+        out = nd.linalg.trmm(A, A)
+        # output should be an identity matrix
+        for i in range(LARGE_SQ_X):
+            assert out[i,i] == 1
+
+    def check_trsm():
+        # creating an identity matrix input
+        A = nd.zeros((LARGE_SQ_X, LARGE_SQ_X))
+        for i in range(LARGE_SQ_X):
+            A[i,i] = 1
+
+        out = nd.linalg.trsm(A, A)
+        # output should be an identity matrix
+        for i in range(LARGE_SQ_X):
+            assert out[i,i] == 1
+
+    check_det()
+    check_inverse()
+    check_trmm()
+    check_trsm()
+
+
 def test_basic():
     def check_elementwise():
         a = nd.ones(shape=(LARGE_X, SMALL_Y))

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1213,12 +1213,6 @@ def test_linalg():
 
 
 def test_linalg():
-    def get_large_identity_mat():
-        A = nd.zeros((LARGE_SQ_X, LARGE_SQ_X))
-        for i in range(LARGE_SQ_X):
-            A[i,i] = 1
-        return A
-
     def batchify(mat):
         return nd.array([mat.asnumpy()])
 

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1212,7 +1212,6 @@ def test_linalg():
     check_syrk_batch()
 
 
-def test_linalg():
     def batchify(mat):
         mat_np = mat.asnumpy()
         return nd.array([mat_np, mat_np])


### PR DESCRIPTION
## Description ##
In this PR, we add large matrix (Input Size > 2^32 -1) tests for the following linear algebra ops: det, inverse, trsm, trmm
We test for shape and numerical correctness of forward and backward passes, with normal and batched inputs.

Here's the pytest output:
```
>>> pytest tests/nightly/test_large_array.py::test_linalg
================================================================================= test session starts =================================================================================
platform linux -- Python 3.7.7, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/ubuntu/incubator-mxnet
plugins: remotedata-0.3.2, openfiles-0.4.0, astropy-header-0.1.2, hypothesis-5.8.3, arraydiff-0.3, doctestplus-0.5.0
collected 1 item                                                                                                                                                                      

tests/nightly/test_large_array.py .                                                                                                                                             [100%]

================================================================================== warnings summary ===================================================================================
python/mxnet/contrib/onnx/mx2onnx/_op_translations.py:67
  /home/ubuntu/incubator-mxnet/python/mxnet/contrib/onnx/mx2onnx/_op_translations.py:67: DeprecationWarning: invalid escape sequence \(
    tuple_re = re.compile('\([0-9L|,| ]+\)')

/home/ubuntu/anaconda3/lib/python3.7/site-packages/nose/importer.py:12
  /home/ubuntu/anaconda3/lib/python3.7/site-packages/nose/importer.py:12: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    from imp import find_module, load_module, acquire_lock, release_lock

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================================================================== 1 passed, 2 warnings in 8859.56s (2:27:39) ======================================================================
```