### PR TITLE
Improve test seeding and robustness in test_numpy_interoperablity.py

### DIFF
--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -29,7 +29,7 @@ from mxnet import np
 from mxnet.test_utils import assert_almost_equal
 from mxnet.test_utils import use_np
 from mxnet.test_utils import is_op_runnable
-from common import assertRaises, with_seed, random_seed
+from common import assertRaises, with_seed, random_seed, setup_module, teardown_module
 from mxnet.numpy_dispatch_protocol import with_array_function_protocol, with_array_ufunc_protocol
 from mxnet.numpy_dispatch_protocol import _NUMPY_ARRAY_FUNCTION_LIST, _NUMPY_ARRAY_UFUNC_LIST
 
@@ -62,7 +62,14 @@ class OpArgMngr(object):
 
     @staticmethod
     def get_workloads(name):
+        if OpArgMngr._args == {}:
+            _prepare_workloads()
         return OpArgMngr._args.get(name, None)
+
+    @staticmethod
+    def randomize_workloads():
+        # Force a new _prepare_workloads(), which will be based on new random numbers
+        OpArgMngr._args = {}
 
 
 def _add_workload_all():
@@ -516,8 +523,8 @@ def _add_workload_linalg_cholesky():
     shapes = [(1, 1), (2, 2), (3, 3), (50, 50), (3, 10, 10)]
     dtypes = (np.float32, np.float64)
 
-    for shape, dtype in itertools.product(shapes, dtypes):
-        with random_seed(1):
+    with random_seed(1):
+        for shape, dtype in itertools.product(shapes, dtypes):
             a = _np.random.randn(*shape)
 
         t = list(range(len(shape)))
@@ -3183,9 +3190,6 @@ def _prepare_workloads():
     _add_workload_vander()
 
 
-_prepare_workloads()
-
-
 def _get_numpy_op_output(onp_op, *args, **kwargs):
     onp_args = [arg.asnumpy() if isinstance(arg, np.ndarray) else arg for arg in args]
     onp_kwargs = {k: v.asnumpy() if isinstance(v, np.ndarray) else v for k, v in kwargs.items()}
@@ -3197,7 +3201,7 @@ def _get_numpy_op_output(onp_op, *args, **kwargs):
     return onp_op(*onp_args, **onp_kwargs)
 
 
-def _check_interoperability_helper(op_name, *args, **kwargs):
+def _check_interoperability_helper(op_name, rel_tol, abs_tol, *args, **kwargs):
     strs = op_name.split('.')
     if len(strs) == 1:
         onp_op = getattr(_np, op_name)
@@ -3213,11 +3217,11 @@ def _check_interoperability_helper(op_name, *args, **kwargs):
         assert type(out) == type(expected_out)
         for arr, expected_arr in zip(out, expected_out):
             if isinstance(arr, np.ndarray):
-                assert_almost_equal(arr.asnumpy(), expected_arr, rtol=1e-3, atol=1e-4, use_broadcast=False, equal_nan=True)
+                assert_almost_equal(arr.asnumpy(), expected_arr, rtol=rel_tol, atol=abs_tol, use_broadcast=False, equal_nan=True)
             else:
                 _np.testing.assert_equal(arr, expected_arr)
     elif isinstance(out, np.ndarray):
-        assert_almost_equal(out.asnumpy(), expected_out, rtol=1e-3, atol=1e-4, use_broadcast=False, equal_nan=True)
+        assert_almost_equal(out.asnumpy(), expected_out, rtol=rel_tol, atol=abs_tol, use_broadcast=False, equal_nan=True)
     elif isinstance(out, _np.dtype):
         _np.testing.assert_equal(out, expected_out)
     else:
@@ -3229,6 +3233,7 @@ def _check_interoperability_helper(op_name, *args, **kwargs):
 
 
 def check_interoperability(op_list):
+    OpArgMngr.randomize_workloads()
     for name in op_list:
         if name in _TVM_OPS and not is_op_runnable():
             continue
@@ -3240,13 +3245,17 @@ def check_interoperability(op_list):
         if name in ['full_like', 'zeros_like', 'ones_like'] and \
                 StrictVersion(platform.python_version()) < StrictVersion('3.0.0'):
             continue
+        default_tols = (1e-3, 1e-4)
+        tols = {'linalg.tensorinv': (1e-2, 5e-3),
+                'linalg.solve':     (1e-3, 5e-2)}
+        (rel_tol, abs_tol) = tols.get(name, default_tols)
         print('Dispatch test:', name)
         workloads = OpArgMngr.get_workloads(name)
         assert workloads is not None, 'Workloads for operator `{}` has not been ' \
                                       'added for checking interoperability with ' \
                                       'the official NumPy.'.format(name)
         for workload in workloads:
-            _check_interoperability_helper(name, *workload['args'], **workload['kwargs'])
+            _check_interoperability_helper(name, rel_tol, abs_tol, *workload['args'], **workload['kwargs'])
 
 
 @with_seed()


### PR DESCRIPTION
## Description ##
I recently ran into a CI failure in test_numpy_interoperability.py::test_np_array_function_protocol: http://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/mxnet-validation%2Fwindows-cpu/detail/PR-18694/14/pipeline.  I was not able to use the  reported seed for the failure to reproduce it.  I have investigated why and am supplying this PR as a fix- now reported seeds can be used to repro failures.  I was then able to use the new facility to troubleshoot which tests needed loosened tolerances for increased test robustness, and have supplied that as well- the failure rate I estimate now is around 1:10000.

As a review, the robustness of a test should be able to be explored with:
```
MXNET_TEST_COUNT=10000 pytest --verbose -s --log-cli-level=DEBUG <my_test>
<see a failure, note failure seed NNN>
MXNET_TEST_SEED=NNN pytest --verbose -s <my_test>
```
The issue with test_numpy_interoperability.py was that it was creating a test workload at file import time using unseeded random values.  The fix makes the workload be regenerated for each test at test runtime in a manner that will depend on the seed of the test.

The two tests that required loosened tolerances were linalg.tensorinv and linalg.solve.  At the setting as I left them, I saw 1 failure in 10K trials.  Rather than loosening the tolerances further, I will leave it to the code owners to diagnose the situation and propose a fix if they see fit to.  The tolerances could be loosened further, but other approaches could involve changing the scale or other properties of the input data.  The remaining failure can (after the PR is merged) be repro'd with:
```
MXNET_TEST_SEED=801992040 pytest --verbose -s tests/python/unittest/test_numpy_interoperability.py::test_np_array_function_protocol
```
A curious property of the remaining failure is that so many of the values are consistently smaller than the golden copy by 1.9%:
```
Dispatch test: linalg.tensorinv

*** Maximum errors for vector of size 3600:  rtol=0.01, atol=0.005

  1: Error 1.934343  Location of error: (1, 1, 0, 10, 4), a=128.42663574, b=130.96971130
  2: Error 1.933410  Location of error: (2, 0, 2, 6, 0), a=80.68855286, b=82.28920746
  3: Error 1.933032  Location of error: (2, 0, 2, 8, 3), a=61.98265076, b=63.21426773
  4: Error 1.931998  Location of error: (1, 2, 2, 4, 4), a=-151.11050415, b=-154.09732056
  5: Error 1.931560  Location of error: (1, 1, 0, 4, 4), a=-97.56709290, b=-99.49862671
  6: Error 1.931458  Location of error: (0, 0, 2, 10, 4), a=343.97329712, b=350.75769043
  7: Error 1.931435  Location of error: (1, 2, 2, 10, 4), a=199.16923523, b=203.10166931
  8: Error 1.931303  Location of error: (1, 2, 2, 9, 0), a=116.00872803, b=118.30317688
  9: Error 1.931238  Location of error: (1, 2, 0, 4, 2), a=1058.37841797, b=1079.23059082
 10: Error 1.931191  Location of error: (1, 1, 1, 10, 4), a=702.60571289, b=716.45141602
[WARNING] Setting test np/mx/python random seeds, use MXNET_TEST_SEED=801992040 to reproduce.
```

[This PR may have additional fixes to other tests if I can't get a clean CI]

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [X] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [X] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [X] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
