### PR TITLE
Fix crash when accessing already destructed static variables

### DIFF
--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1316,6 +1316,7 @@ int MXNotifyShutdown() {
   API_BEGIN();
   mxnet::op::custom::CustomOperator::Get()->Stop();
   Engine::Get()->NotifyShutdown();
+  Engine::Get()->WaitForAll();
   API_END();
 }
 


### PR DESCRIPTION
## Description ##
Fixes #18765
When the script terminates, the threads in the engine are still free to execute ops. If those ops use `static` variables they may already be destroyed by the time a thread tries to access them, which causes a segfault.

Previously there was a little bit of protection against it by setting `shutdown_phase_` in the engine and not executing new ops when it was set. However, if the op takes a long time, it is possible for it to already be inside the op, therefore still triggering the segfault. 

@leezu @eric-haibin-lin @szha 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)