### PR TITLE
[v1.7.x] ElementWiseSum fix for oneDNN

### DIFF
--- a/src/operator/tensor/elemwise_sum.cc
+++ b/src/operator/tensor/elemwise_sum.cc
@@ -118,7 +118,6 @@ void ElementWiseSumComputeExCPU(const nnvm::NodeAttrs& attrs,
        inputs[1].storage_type() == kCSRStorage && inputs[2].storage_type() == kDefaultStorage) ||
       (inputs.size() > 4U && common::ContainsStorageType(inputs, kDefaultStorage) &&
        outputs[0].storage_type() == kDefaultStorage)) {
-    
     mshadow::Stream<cpu>* s = ctx.get_stream<cpu>();
     Resource rsc = ResourceManager::Get()->Request(ctx.run_ctx.get_ctx(),
         ResourceRequest(ResourceRequest::kTempSpace));
@@ -129,9 +128,9 @@ void ElementWiseSumComputeExCPU(const nnvm::NodeAttrs& attrs,
         // if ndarray is in default storage and MKLDNN is available,
         // need to make sure cpu layout data is used, instead of MKL layout
         if (in.storage_type() == kDefaultStorage) {
-          in_data.push_back(in.Reorder2Default());
+          in_data.emplace_back(in.Reorder2Default());
         } else {
-          in_data.push_back(in);
+          in_data.emplace_back(in);
         }
       }
     mxnet::ndarray::ElementwiseSum<cpu>(s, rsc, in_data, &out_nd);

--- a/src/operator/tensor/elemwise_sum.cc
+++ b/src/operator/tensor/elemwise_sum.cc
@@ -120,7 +120,7 @@ void ElementWiseSumComputeExCPU(const nnvm::NodeAttrs& attrs,
     FallBackCompute(ElementWiseSumCompute<cpu>, attrs, ctx, inputs, req, outputs);
   }
 #endif
-  else if (common::ContainsOnlyStorage(inputs, kRowSparseStorage) ||
+  else if (common::ContainsOnlyStorage(inputs, kRowSparseStorage) || // NOLINT(*)
       (inputs.size() == 3U && inputs[0].storage_type() == kDefaultStorage &&
        inputs[1].storage_type() == kCSRStorage && inputs[2].storage_type() == kDefaultStorage) ||
       (inputs.size() > 4U && common::ContainsStorageType(inputs, kDefaultStorage) &&

--- a/tests/python/mkl/test_mkldnn.py
+++ b/tests/python/mkl/test_mkldnn.py
@@ -254,6 +254,28 @@ def test_flatten_slice_after_conv():
     print(p[0])
 
 
+def test_mkldnn_sum_with_mkldnn_layout():
+
+    x_shape = (32, 3, 224, 224)
+    x_npy = np.ones(x_shape)
+    w_shape = (32, 3, 3, 3)
+    w_npy = np.ones(w_shape)
+
+    x = mx.sym.Variable("x")
+    w = mx.sym.Variable("w")
+    z = mx.symbol.Convolution(data=x, weight=w, num_filter=32, kernel=(3, 3))
+    num_inputs = [2, 3, 4, 5]
+    for i in num_inputs:
+        inputs = []
+        for n in range(i):
+            inputs.append(z)
+        y = mx.sym.add_n(*inputs) # (only MKLDNN data input)
+        exe = y.simple_bind(ctx=mx.cpu(), x=x_shape, w=w_shape)
+        out = exe.forward(is_train=False, x=x_npy, w=np.ones(w_shape))[0]
+        #conv with kernel (3,3) on ones should give result=27
+        single_cov = 27.0
+        assert_almost_equal(out[0].asnumpy()[0, 0, 0], single_cov*i)
+
 def test_mkldnn_sum_inplace_with_cpu_layout():
 
     x_shape = (32, 3, 224, 224)
@@ -263,7 +285,7 @@ def test_mkldnn_sum_inplace_with_cpu_layout():
     x = mx.sym.Variable("x")
     y = mx.sym.Variable("y")
     z = mx.symbol.Convolution(data=x, num_filter=32, kernel=(3, 3))
-    z = mx.sym.add_n(z, y)
+    z = mx.sym.add_n(z, y) # (MKLDNN data, cpu data)
     exe = z.simple_bind(ctx=mx.cpu(), x=x_shape, y=y_shape)
     out = exe.forward(is_train=False, x=x_npy, y=y_npy)[0]
     assert_almost_equal(out[0].asnumpy()[0, 0, 0], 1.0)


### PR DESCRIPTION
## Description ##
This PR fixes bug which occurs when training gluonCV deeplab with oneDNN support. 
Original issue: https://github.com/dmlc/gluon-cv/issues/1368
 
To reproduce:
```
python3 train.py --dataset pascal_aug --model-zoo deeplab_resnet101_coco --aux --lr 0.001 --checkname res101 --no-cuda
```

where train.py comes from https://gluon-cv.mxnet.io/_downloads/1f67ebbf3e0adc5c6fa863a3bc7672a6/train.py (from  https://gluon-cv.mxnet.io/build/examples_segmentation/train_fcn.html )

## Checklist ##
### Essentials ###
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

## Comments ##
Author of the fix is @anko-intel with my small help
