### PR TITLE
[WIP] Add Large Tensor Test for linalg_syrk

### DIFF
--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -40,6 +40,7 @@ SMALL_Y = 50
 LARGE_SIZE = LARGE_X * SMALL_Y
 LARGE_TENSOR_SHAPE = 2**32
 RNN_LARGE_TENSOR = 2**28
+LARGE_SQ_X = 80000
 
 
 @pytest.mark.timeout(0)
@@ -1755,3 +1756,16 @@ def test_sparse_dot():
     assert out.asnumpy()[0][0] == 2
     assert out.shape == (2, 2)
 
+
+def test_linalg_operators():
+    def check_syrk_batch():
+        A = nd.zeros((2, LARGE_SQ_X, LARGE_SQ_X))
+        for i in range(LARGE_SQ_X):
+            A[0,i,i] = 1
+            A[1,i,i] = 0.1
+        out = nd.linalg.syrk(A, alpha=2, transpose=False)
+        for i in range(LARGE_SQ_X):
+            assert out[0,i,i] == 2
+            assert_almost_equal(out[1,i,i], nd.array([0.02]), rtol=1e-3, atol=1e-5)
+
+    check_syrk_batch()

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1759,19 +1759,18 @@ def test_sparse_dot():
 
 def test_linalg_operators():
     def check_syrk_batch():
-        A = nd.zeros((2, LARGE_SQ_X, LARGE_SQ_X))
+        # test both forward and backward
+        # batch syrk will be applied to the last two dimensions
+        A = nd.zeros((1, LARGE_SQ_X, LARGE_SQ_X))
         for i in range(LARGE_SQ_X):
             A[0,i,i] = 1
-            A[1,i,i] = 0.1
         A.attach_grad()
         with mx.autograd.record():
             out = nd.linalg.syrk(A, alpha=2, transpose=False)
         for i in range(LARGE_SQ_X):
             assert out[0,i,i] == 2
-            assert_almost_equal(out[1,i,i], nd.array([0.02]), rtol=1e-3, atol=1e-5)
         out.backward()
         for i in range(LARGE_SQ_X):
             assert A.grad[0,0,i] == 4
-            assert_almost_equal(out[1,i,i], nd.array([0.02]), rtol=1e-3, atol=1e-5)
 
     check_syrk_batch()

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1763,9 +1763,15 @@ def test_linalg_operators():
         for i in range(LARGE_SQ_X):
             A[0,i,i] = 1
             A[1,i,i] = 0.1
-        out = nd.linalg.syrk(A, alpha=2, transpose=False)
+        A.attach_grad()
+        with mx.autograd.record():
+            out = nd.linalg.syrk(A, alpha=2, transpose=False)
         for i in range(LARGE_SQ_X):
             assert out[0,i,i] == 2
+            assert_almost_equal(out[1,i,i], nd.array([0.02]), rtol=1e-3, atol=1e-5)
+        out.backward()
+        for i in range(LARGE_SQ_X):
+            assert A.grad[0,0,i] == 4
             assert_almost_equal(out[1,i,i], nd.array([0.02]), rtol=1e-3, atol=1e-5)
 
     check_syrk_batch()


### PR DESCRIPTION
## Description ##
Check if syrk_batch works correctly with large tensors. This test will fail with the current code base; https://github.com/apache/incubator-mxnet/pull/18752 should fix it.

TODO:
1. make test function naming consistent with other large tensor tests (need to rebase after any of those tests are merged)
2. merge this only after the fix has been merged

This test passes on both BLAS int32 and 64 builds.


```
ubuntu@ip-172-31-43-103:~$ MXNET_TEST_COUNT=10000 nosetests --logging-level=DEBUG --verbose -s mxnet/tests/nightly/test_large_array.py:test_linalg_operators
test_large_array.test_linalg_operators ... [23:14:57] ../src/storage/storage.cc:198: Using Pooled (Naive) StorageManager for CPU
ok

----------------------------------------------------------------------
Ran 1 test in 637.245s

OK
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
