### PR TITLE
Add Large Tensor Test for linalg_syrk

### DIFF
--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1793,22 +1793,26 @@ def test_sparse_dot():
 
 
 def test_linalg_operators():
-     def check_syrk_batch():
-         # test both forward and backward
-         # batch syrk will be applied to the last two dimensions
-         A = nd.zeros((1, LARGE_SQ_X, LARGE_SQ_X))
-         for i in range(LARGE_SQ_X):
-             A[0,i,i] = 1
-         A.attach_grad()
-         with mx.autograd.record():
-             out = nd.linalg.syrk(A, alpha=2, transpose=False)
-         for i in range(LARGE_SQ_X):
-             assert out[0,i,i] == 2
-         out.backward()
-         for i in range(LARGE_SQ_X):
-             assert A.grad[0,0,i] == 4
+    def check_syrk_batch():
+        # test both forward and backward
+        # batch syrk will be applied to the last two dimensions
+        A = nd.zeros((2, LARGE_SQ_X, LARGE_SQ_X))
+        for i in range(LARGE_SQ_X):
+            A[0,i,i] = 1
+            A[1,i,i] = 0.1
+        A.attach_grad()
+        with mx.autograd.record():
+            out = nd.linalg.syrk(A, alpha=2, transpose=False)
+        for i in range(LARGE_SQ_X):
+            assert out[0,i,i] == 2
+            assert_almost_equal(out[1,i,i], nd.array([0.02]), rtol=1e-3, atol=1e-5)
+        out.backward()
+        for i in range(LARGE_SQ_X):
+            # check the first row
+            assert A.grad[0,0,i] == 4
+            assert_almost_equal(A.grad[1,0,i], nd.array([0.4]), rtol=1e-3, atol=1e-5)
 
-     check_syrk_batch()
+    check_syrk_batch()
 
 
 if __name__ == '__main__':

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -40,6 +40,7 @@ SMALL_Y = 50
 LARGE_SIZE = LARGE_X * SMALL_Y
 LARGE_TENSOR_SHAPE = 2**32
 RNN_LARGE_TENSOR = 2**28
+LARGE_SQ_X = 70000
 
 
 def test_nn():
@@ -1789,6 +1790,25 @@ def test_sparse_dot():
     out = nd.dot(sp_mat1, mat2)
     assert out.asnumpy()[0][0] == 2
     assert out.shape == (2, 2)
+
+
+def test_linalg_operators():
+     def check_syrk_batch():
+         # test both forward and backward
+         # batch syrk will be applied to the last two dimensions
+         A = nd.zeros((1, LARGE_SQ_X, LARGE_SQ_X))
+         for i in range(LARGE_SQ_X):
+             A[0,i,i] = 1
+         A.attach_grad()
+         with mx.autograd.record():
+             out = nd.linalg.syrk(A, alpha=2, transpose=False)
+         for i in range(LARGE_SQ_X):
+             assert out[0,i,i] == 2
+         out.backward()
+         for i in range(LARGE_SQ_X):
+             assert A.grad[0,0,i] == 4
+
+     check_syrk_batch()
 
 
 if __name__ == '__main__':

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -37,11 +37,10 @@ VLARGE_X = 4300000000
 LARGE_X = 100000000
 SMALL_X = 100
 SMALL_Y = 50
-LARGE_SQ_X = 80000
+LARGE_SQ_X = 70000
 LARGE_SIZE = LARGE_X * SMALL_Y
 LARGE_TENSOR_SHAPE = 2**32
 RNN_LARGE_TENSOR = 2**28
-LARGE_SQ_X = 70000
 
 
 def test_nn():
@@ -1191,9 +1190,26 @@ def test_linalg():
         # output should be an identity matrix
         for i in range(LARGE_SQ_X):
             assert out[i,i] == 1
+    
+    def check_syrk_batch():
+        # test both forward and backward
+        # batch syrk will be applied to the last two dimensions
+        A = nd.zeros((2, LARGE_SQ_X, LARGE_SQ_X))
+        for i in range(LARGE_SQ_X):
+            A[0,i,i] = 1
+            A[1,i,i] = 0.1
+        A.attach_grad()
+        with mx.autograd.record():
+            out = nd.linalg.syrk(A, alpha=2, transpose=False)
+        assert out[0,0,0] == 2
+        assert_almost_equal(out[1,0,0], nd.array([0.02]), rtol=1e-3, atol=1e-5)
+        out.backward()
+        assert A.grad[0,0,0] == 4
+        assert_almost_equal(A.grad[1,0,0], nd.array([0.4]), rtol=1e-3, atol=1e-5)
 
     check_potrf()
     check_potri()
+    check_syrk_batch()
 
 
 def test_basic():
@@ -1817,29 +1833,6 @@ def test_sparse_dot():
     out = nd.dot(sp_mat1, mat2)
     assert out.asnumpy()[0][0] == 2
     assert out.shape == (2, 2)
-
-
-def test_linalg_operators():
-    def check_syrk_batch():
-        # test both forward and backward
-        # batch syrk will be applied to the last two dimensions
-        A = nd.zeros((2, LARGE_SQ_X, LARGE_SQ_X))
-        for i in range(LARGE_SQ_X):
-            A[0,i,i] = 1
-            A[1,i,i] = 0.1
-        A.attach_grad()
-        with mx.autograd.record():
-            out = nd.linalg.syrk(A, alpha=2, transpose=False)
-        for i in range(LARGE_SQ_X):
-            assert out[0,i,i] == 2
-            assert_almost_equal(out[1,i,i], nd.array([0.02]), rtol=1e-3, atol=1e-5)
-        out.backward()
-        for i in range(LARGE_SQ_X):
-            # check the first row
-            assert A.grad[0,0,i] == 4
-            assert_almost_equal(A.grad[1,0,i], nd.array([0.4]), rtol=1e-3, atol=1e-5)
-
-    check_syrk_batch()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description ##
Check if syrk_batch works correctly with large tensors. This test will fail with the current code base; https://github.com/apache/incubator-mxnet/pull/18752 should fix it.

TODO:
1. make test function naming consistent with other large tensor tests (need to rebase after any of those tests are merged)
2. merge this only after the fix has been merged

This test passes on both BLAS int32 and 64 builds.


```
ubuntu@ip-172-31-43-103:~$ MXNET_TEST_COUNT=10000 nosetests --logging-level=DEBUG --verbose -s mxnet/tests/nightly/test_large_array.py:test_linalg_operators
test_large_array.test_linalg_operators ... [23:14:57] ../src/storage/storage.cc:198: Using Pooled (Naive) StorageManager for CPU
ok

----------------------------------------------------------------------
Ran 1 test in 637.245s

OK
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
