### PR TITLE
remove other language bindings section from website api page

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -28,15 +28,6 @@ RewriteCond %{HTTP_REFERER} !mxnet.apache.org
 RewriteCond %{HTTP_REFERER} !mxnet.incubator.apache.org
 RewriteRule ^(.*)$ /versions/1.6/$1 [r=307,L]
 
-# TODO temporary fix for issue #18604
-Redirect 302 /api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf https://mxnet-public.s3.us-east-2.amazonaws.com/docs/v1.x/mxnet-r-reference-manual.pdf
-Redirect 302 /api/scala/docs/api/ /versions/1.6/api/scala/docs/api/
-Redirect 302 /api/java/docs/api/ /versions/1.6/api/java/docs/api/
-Redirect 302 /api/clojure/docs/api/ /versions/1.6/api/clojure/docs/api/
-Redirect 302 /api/cpp/docs/api/ /versions/1.6/api/cpp/docs/api/
-Redirect 302 /api/julia/docs/api/ /versions/1.6/api/julia/docs/api/
-Redirect 302 /api/julia/docs/api/#tutorials /versions/1.6/api/julia/docs/api/#tutorials
-
 # Redirect Chinese visitors to Chinese CDN, temporary solution for slow site speed in China
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^CN$
 RewriteCond %{HTTP_HOST} !cdn

--- a/docs/static_site/src/_sass/minima/_docs.scss
+++ b/docs/static_site/src/_sass/minima/_docs.scss
@@ -85,3 +85,13 @@
   padding-top: 20px;
   padding-bottom: 20px;
 }
+
+.language-binding-banner {
+  border: 1px solid transparent;
+  border-radius: .25rem;
+  color: #856404;
+  padding: .75rem 1.25rem;
+  margin-bottom: 1rem;
+  background-color: #fff3cd;
+  border-color: #ffeeba;
+}

--- a/docs/static_site/src/pages/api/api.html
+++ b/docs/static_site/src/pages/api/api.html
@@ -76,7 +76,7 @@ docs:
 <div class="row">
   <div class="language-binding-banner">
     <h4>Call for Contribution</h4>
-    The Clojure, Java, Julia, R, and Scala language bindings of MXNet v1.x were removed in v2.x due to some C APIs being deprecated and the bindings rely on the deprecated APIs. You can still use these language bindings in v1.x.
+    The Clojure, Java, Julia, R, and Scala language bindings of MXNet <a href="/versions/{{site.versions[1]}}/api">v1.x</a> were removed in v2.x due to some C APIs being deprecated and the bindings rely on the deprecated APIs. You can still use these language bindings in v1.x.
     MXNet's new C APIs in v2.x can be used to reestablish your preferred language binding. Your contribution is welcome!
   </div>
 </div>

--- a/docs/static_site/src/pages/api/api.html
+++ b/docs/static_site/src/pages/api/api.html
@@ -76,7 +76,7 @@ docs:
 <div class="row">
   <div class="language-binding-banner">
     <h4>Call for Contribution</h4>
-    The Clojure, Java, Julia, R, and Scala language bindings of MXNet <a href="/versions/{{site.versions[1]}}/api">v1.x</a> were removed in v2.x due to some C APIs being deprecated and the bindings rely on the deprecated APIs. You can still use these language bindings in v1.x.
+    The Clojure, Java, Julia, R, and Scala language bindings of <a href="/versions/{{site.versions[1]}}/api">MXNet v1.x</a> were removed in v2.x due to some <a href="https://github.com/apache/incubator-mxnet/issues/17676">C APIs being deprecated</a> and the bindings rely on the deprecated APIs. You can still use these language bindings in v1.x.
     MXNet's new C APIs in v2.x can be used to reestablish your preferred language binding. Your contribution is welcome!
   </div>
 </div>

--- a/docs/static_site/src/pages/api/api.html
+++ b/docs/static_site/src/pages/api/api.html
@@ -21,55 +21,6 @@ docs:
   tutorial_link: /api/python/docs/tutorials
   icon: /assets/img/python_logo.svg
   tag: python
-- title: Scala
-  guide_link: /api/scala.html
-  api_link: /api/scala/docs/api
-  tutorial_link: /api/scala/docs/tutorials
-  description:
-  icon: /assets/img/scala_logo.svg
-  tag: scala
-- title: Java
-  guide_link: /api/java.html
-  api_link: /api/java/docs/api
-  tutorial_link: /api/java/docs/tutorials
-  description:
-  icon: /assets/img/java_logo.svg
-  tag: java
-- title: Clojure
-  guide_link: /api/clojure
-  api_link: /api/clojure/docs/api
-  tutorial_link: /api/clojure/docs/tutorials
-  description:
-  icon: /assets/img/clojure_logo.svg
-  tag: clojure
-- title: C/C++
-  guide_link: /api/cpp
-  api_link: /api/cpp/docs/api
-  tutorial_link: /api/cpp/docs/tutorials
-  description:
-  icon: /assets/img/cpp_logo.svg
-  tag: cpp
-- title: Julia
-  guide_link: /api/julia
-  api_link: /api/julia/docs/api
-  tutorial_link: /api/julia/docs/api/#tutorials
-  description:
-  icon: /assets/img/julia_logo.svg
-  tag: julia
-- title: R
-  guide_link: /api/r
-  api_link: /api/r/docs/api/R-package/build/mxnet-r-reference-manual.pdf
-  tutorial_link: /api/r/docs/tutorials
-  description:
-  icon: /assets/img/R_logo.svg
-  tag: r
-- title: Perl
-  guide_link: /api/perl
-  api_link: https://metacpan.org/release/AI-MXNet
-  tutorial_link: /api/perl/docs/tutorials
-  description:
-  icon: /assets/img/perl_logo.svg
-  tag: perl
 ---
 <!--- Licensed to the Apache Software Foundation (ASF) under one -->
 <!--- or more contributor license agreements.  See the NOTICE file -->
@@ -121,29 +72,6 @@ docs:
     </div>
   {%- endif -%}
 {%- endfor -%}
-<h2>Other Bindings</h2>
-<div class="row">
-{%- for doc in page.docs -%}
-  {%- if doc.tag != 'python' -%}
-  <div class="col-4">
-      <div class="docs-card">
-          <div class="docs-logo-container">
-              <img class="docs-logo-image" src="{{doc.icon | relative_url}}">
-          </div>
-          <div class="docs-action-btn">
-            <a href="{{doc.guide_link | relative_url}}"> <img src="{{'assets/img/compass.svg' | relative_url}}" class="docs-logo-docs">{{doc.title}} Guide  <span class="span-accented">›</span></a>
-          </div>
-          <div class="docs-action-btn">
-            <a href="{{doc.tutorial_link | relative_url}}"> <img src="{{'assets/img/video-tutorial.svg' | relative_url}}" class="docs-logo-docs">{{doc.title}} Tutorials  <span class="span-accented">›</span></a>
-          </div>
-          <div class="docs-action-btn">
-            <a href="{{doc.api_link | relative_url}}"> <img src="{{'assets/img/api.svg' | relative_url}}" class="docs-logo-docs">{{doc.title}} API Reference  <span class="span-accented">›</span></a>
-          </div>
-      </div>
-  </div>
-  {%- endif -%}
-{%- endfor -%}
-</div>
 </div> <!-- closing outer wrapper -->
 <div class="docs-architecture">
     <div class="wrapper">

--- a/docs/static_site/src/pages/api/api.html
+++ b/docs/static_site/src/pages/api/api.html
@@ -77,7 +77,7 @@ docs:
   <div class="language-binding-banner">
     <h4>Call for Contribution</h4>
     The Clojure, Java, Julia, R, and Scala language bindings of MXNet v1.x were removed in v2.x due to some C APIs being deprecated and the bindings rely on the deprecated APIs. You can still use these language bindings in v1.x.
-    Given that MXNet has C APIs and other language bindings can be added. Your contribution is welcome.
+    MXNet's new C APIs in v2.x can be used to reestablish your preferred language binding. Your contribution is welcome!
   </div>
 </div>
 </div> <!-- closing outer wrapper -->

--- a/docs/static_site/src/pages/api/api.html
+++ b/docs/static_site/src/pages/api/api.html
@@ -72,6 +72,14 @@ docs:
     </div>
   {%- endif -%}
 {%- endfor -%}
+<h2>Other Bindings</h2>
+<div class="row">
+  <div class="language-binding-banner">
+    <h4>Call for Contribution</h4>
+    The language bindings of MXNet 1.x were deleted in 2.x due to some C APIs being deprecated and the bindings did rely on the deprecated APIs.
+    Given that MXNet has C APIs and other language bindings can be added. Your contribution is welcome.
+  </div>
+</div>
 </div> <!-- closing outer wrapper -->
 <div class="docs-architecture">
     <div class="wrapper">

--- a/docs/static_site/src/pages/api/api.html
+++ b/docs/static_site/src/pages/api/api.html
@@ -76,7 +76,7 @@ docs:
 <div class="row">
   <div class="language-binding-banner">
     <h4>Call for Contribution</h4>
-    The language bindings of MXNet 1.x were deleted in 2.x due to some C APIs being deprecated and the bindings did rely on the deprecated APIs.
+    The Clojure, Java, Julia, R, and Scala language bindings of MXNet v1.x were removed in v2.x due to some C APIs being deprecated and the bindings rely on the deprecated APIs. You can still use these language bindings in v1.x.
     Given that MXNet has C APIs and other language bindings can be added. Your contribution is welcome.
   </div>
 </div>


### PR DESCRIPTION
## Description ##
Since other language bindings are deprecated in MXNet 2.0, this PR removes the corresponding parts from website.
@ChaiBapchya 
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:

### Changes ###
- [x] Remove "other bindings" block from `/api` page.

## Comments ##
- Preview: http://ec2-18-236-134-13.us-west-2.compute.amazonaws.com/api
