### PR TITLE
Split up CI sanity test functions to enable fine-grained trigger

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -735,6 +735,7 @@ build_ubuntu_blc() {
 # Testing
 
 sanity_check() {
+    set -ex
     sanity_license
     sanity_python
     sanity_cpp


### PR DESCRIPTION
For example, users can trigger fine grained checks:

python ci/build.py -R --platform ubuntu_cpu /work/runtime_functions.sh sanity_python

python ci/build.py -R --platform ubuntu_cpu /work/runtime_functions.sh sanity_license