### PR TITLE
Update CUB and include it only for CUDA < 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,7 +298,6 @@ foreach(var ${C_CXX_INCLUDE_DIRECTORIES})
 endforeach()
 
 include_directories("include")
-include_directories("3rdparty/nvidia_cub")
 include_directories("3rdparty/tvm/nnvm/include")
 include_directories("3rdparty/tvm/include")
 include_directories("3rdparty/dmlc-core/include")
@@ -604,6 +603,10 @@ if(USE_CUDA)
 
   include_directories(${CUDAToolkit_INCLUDE_DIRS})
   link_directories(${CUDAToolkit_LIBRARY_DIR})
+endif()
+
+if(CUDAToolkit_VERSION_MAJOR LESS "11")
+  include_directories("3rdparty/nvidia_cub")
 endif()
 
 if(MSVC)


### PR DESCRIPTION
## Description ##
Update CUB submodule (fixes #15569).

With CUDA 11, cub is included in the toolkit, so it is not necessary to include the submodule.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)