### PR TITLE
Add unit tests for potri and potrf backward and check output shape.

### DIFF
--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1170,26 +1170,34 @@ def test_tensor():
 
 def test_linalg():
     def check_potrf():
-        # creating an identity matrix input
-        A = nd.zeros((LARGE_SQ_X, LARGE_SQ_X))
-        for i in range(LARGE_SQ_X):
-            A[i,i] = 1
+        def run_potrf(inp):
+            inp.attach_grad()
+            with mx.autograd.record():
+                out = mx.nd.linalg.potrf(inp)
+            return inp.grad, out
 
-        out = nd.linalg.potrf(A)
-        # output should be an identity matrix
-        for i in range(LARGE_SQ_X):
-            assert out[i,i] == 1
+        A = get_identity_mat(LARGE_SQ_X)
+        grad, out = run_potrf(A)
+        assert(out.shape == (LARGE_SQ_X, LARGE_SQ_X))
+        assert(out[0, 0] == 1)
+        out.backward()
+        assert(grad.shape == (LARGE_SQ_X, LARGE_SQ_X))
+        assert(grad[0, 0] == 0.5)
 
     def check_potri():
-        # creating an identity matrix input
-        A = nd.zeros((LARGE_SQ_X, LARGE_SQ_X))
-        for i in range(LARGE_SQ_X):
-            A[i,i] = 1
+        def run_potri(inp):
+            inp.attach_grad()
+            with mx.autograd.record():
+                out = mx.nd.linalg.potri(inp)
+            return inp.grad, out
 
-        out = nd.linalg.potri(A)
-        # output should be an identity matrix
-        for i in range(LARGE_SQ_X):
-            assert out[i,i] == 1
+        A = get_identity_mat(LARGE_SQ_X)
+        grad, out = run_potri(A)
+        assert(out.shape == (LARGE_SQ_X, LARGE_SQ_X))
+        assert(out[0, 0] == 1)
+        out.backward()
+        assert(grad.shape == (LARGE_SQ_X, LARGE_SQ_X))
+        assert(grad[0, 0] == -2)
     
     def check_syrk_batch():
         # test both forward and backward


### PR DESCRIPTION
Add unit tests for backward linalg_potri and linalg_potrf operators. Verify output shape.

Test results (with modified function names):
```
python3 -m pytest --verbose tests/nightly/test_large_array.py::test_potrf tests/nightly/test_large_array.py::test_potri
=========================================================================== test session starts ============================================================================
platform linux -- Python 3.7.7, pytest-5.4.1, py-1.8.1, pluggy-0.13.1 -- /home/ubuntu/anaconda3/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/ubuntu/incubator-mxnet/.hypothesis/examples')
rootdir: /home/ubuntu/incubator-mxnet, inifile: pytest.ini
plugins: remotedata-0.3.2, openfiles-0.4.0, astropy-header-0.1.2, timeout-1.4.1, hypothesis-5.8.3, arraydiff-0.3, doctestplus-0.5.0
timeout: 1200.0s
timeout method: signal
timeout func_only: False
collected 2 items

tests/nightly/test_large_array.py::test_potrf PASSED                                                                                                                 [ 50%]
tests/nightly/test_large_array.py::test_potri PASSED                                                                                                                 [100%]

============================================================================ 2 passed in 1654.43s (0:27:34)  ============================================================================
```