### PR TITLE
website clipcoard patch - use regex that is supported by all browsers

### DIFF
--- a/docs/static_site/src/assets/js/copycode.js
+++ b/docs/static_site/src/assets/js/copycode.js
@@ -59,7 +59,7 @@ $(document).ready(function () {
   const cleanPrompt = function (line, prompts) {
     let res = line;
     for (let i = 0; i < prompts.length; i++) {
-      let reg = new RegExp("(?<=^\\s*)" + prompts[i]);
+      let reg = new RegExp("(?:^\\s*)" + prompts[i]);
       if (reg.test(res)) {
         res = res.replace(reg, "");
         break;


### PR DESCRIPTION
## Description ##
Fixed issue 3 in https://github.com/apache/incubator-mxnet/issues/18693, @ChaiBapchya 

### Changes ###
- [x] update the regex which is only supported in Chrome 

## Comments ##
- Preview: http://ec2-18-236-134-13.us-west-2.compute.amazonaws.com/get_started/build_from_source
