### PR TITLE
Add syrk test shape check

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -252,6 +252,7 @@ List of Contributors
 * [Oliver Kowalke](https://github.com/olk)
 * [Connor Goggins](https://github.com/connorgoggins)
 * [Joe Evans](https://github.com/josephevans)
+* [Zhaoqi Zhu](https://github.com/zha0q1)
 
 Label Bot
 ---------

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -25,7 +25,7 @@ import mxnet as mx
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.append(os.path.join(curr_path, '../python/unittest/'))
 
-from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, default_context, check_symbolic_forward, create_2d_tensor#, get_identity_mat, get_identity_mat_batch
+from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, default_context, check_symbolic_forward, create_2d_tensor, get_identity_mat, get_identity_mat_batch
 from mxnet import gluon, nd
 from common import with_seed, with_post_test_cleanup
 from nose.tools import with_setup
@@ -1339,17 +1339,17 @@ def test_linalg():
         assert(grad[0, 0, 0] == 0)
         assert(grad[1, 0, 0] == 0)
 
-    #check_potrf()
-    #check_potri()
+    check_potrf()
+    check_potri()
     check_syrk_batch()
-    #check_gemm2()
-    #check_det()
-    #check_inverse()
-    #check_trmm()
-    #check_trsm()
-    #check_batch_inverse()
-    #check_batch_trmm()
-    #check_batch_trsm()
+    check_gemm2()
+    check_det()
+    check_inverse()
+    check_trmm()
+    check_trsm()
+    check_batch_inverse()
+    check_batch_trmm()
+    check_batch_trsm()
 
 
 def test_basic():

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -25,7 +25,7 @@ import mxnet as mx
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.append(os.path.join(curr_path, '../python/unittest/'))
 
-from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, default_context, check_symbolic_forward, create_2d_tensor, get_identity_mat, get_identity_mat_batch
+from mxnet.test_utils import rand_ndarray, assert_almost_equal, rand_coord_2d, default_context, check_symbolic_forward, create_2d_tensor#, get_identity_mat, get_identity_mat_batch
 from mxnet import gluon, nd
 from common import with_seed, with_post_test_cleanup
 from nose.tools import with_setup
@@ -1201,9 +1201,11 @@ def test_linalg():
         A.attach_grad()
         with mx.autograd.record():
             out = nd.linalg.syrk(A, alpha=2, transpose=False)
+        assert out.shape == (2, LARGE_SQ_X, LARGE_SQ_X)
         assert out[0,0,0] == 2
         assert_almost_equal(out[1,0,0], nd.array([0.02]), rtol=1e-3, atol=1e-5)
         out.backward()
+        assert A.grad.shape == (2, LARGE_SQ_X, LARGE_SQ_X)
         assert A.grad[0,0,0] == 4
         assert_almost_equal(A.grad[1,0,0], nd.array([0.4]), rtol=1e-3, atol=1e-5)
 
@@ -1337,17 +1339,17 @@ def test_linalg():
         assert(grad[0, 0, 0] == 0)
         assert(grad[1, 0, 0] == 0)
 
-    check_potrf()
-    check_potri()
+    #check_potrf()
+    #check_potri()
     check_syrk_batch()
-    check_gemm2()
-    check_det()
-    check_inverse()
-    check_trmm()
-    check_trsm()
-    check_batch_inverse()
-    check_batch_trmm()
-    check_batch_trsm()
+    #check_gemm2()
+    #check_det()
+    #check_inverse()
+    #check_trmm()
+    #check_trsm()
+    #check_batch_inverse()
+    #check_batch_trmm()
+    #check_batch_trsm()
 
 
 def test_basic():


### PR DESCRIPTION
Add shape check to syrk test case. Local run passed.
```
ubuntu@ip-172-31-6-47:~/newnew/incubator-mxnet$ nosetests --logging-level=DEBUG --verbose -s tests
/nightly/test_large_array.p                                                                       
y:test_linalg                                                                                     
test_large_array.test_linalg ... [19:00:02] ../src/storage/storage.cc:198: Using Pooled (Naive) St
orageManager for CPU                                                                              
[19:07:00] ../src/base.cc:84: Upgrade advisory: this mxnet has been built against cuDNN lib versio
n 7501, which is older than the oldest version tested by CI (7600).  Set MXNET_CUDNN_LIB_CHECKING=
0 to quiet this warning.                                                                          

ok                                                                                     
                                                                                                  
----------------------------------------------------------------------                            
Ran 1 test in 1828.874s                                                                           
                                                                                                  
OK      
```

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
