### PR TITLE
Update clang-tidy integration

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,45 +17,33 @@
 
 # The checks defined here will be run and will display by default as warnings.
 Checks: >
-    -*, cppcoreguidelines-c-copy-assignment-signature,
-    cppcoreguidelines-interfaces-global-init, cppcoreguidelines-no-malloc,
-    cppcoreguidelines-pro-bounds-constant-array-index, cppcoreguidelines-pro-type-const-cast,
-    cppcoreguidelines-pro-type-cstyle-cast, cppcoreguidelines-pro-type-member-init,
-    cppcoreguidelines-pro-type-static-cast-downcast, cppcoreguidelines-pro-type-union-access,
-    cppcoreguidelines-pro-type-vararg, cppcoreguidelines-slicing,
-    cppcoreguidelines-special-member-functions, clang-analyzer-security.FloatLoopCounter,
-    clang-analyzer-security.insecureAPI.*, clang-analyzer-core.CallAndMessage,
-    clang-analyzer-core.DivideZero, clang-analyzer-core.DynamicTypePropagation,
-    clang-analyzer-core.NonNullParamChecker, clang-analyzer-core.NullDereference,
-    clang-analyzer-core.StackAddressEscape, clang-analyzer-core.UndefinedBinaryOperatorResult,
-    clang-analyzer-core.VLASize, clang-analyzer-core.builtin.BuiltinFunctions,
-    clang-analyzer-core.builtin.NoReturnFunctions, clang-analyzer-core.uninitialized.ArraySubscript,
-    clang-analyzer-core.uninitialized.Assign, clang-analyzer-core.uninitialized.Branch,
-    clang-analyzer-core.uninitialized.CapturedBlockVariable,
-    clang-analyzer-core.uninitialized.UndefReturn, clang-analyzer-cplusplus.NewDelete,
-    clang-analyzer-cplusplus.NewDeleteLeaks, clang-analyzer-cplusplus.SelfAssignment,
-    clang-analyzer-deadcode.DeadStores, modernize-avoid-bind, modernize-deprecated-headers,
-    modernize-loop-convert, modernize-make-shared, modernize-pass-by-value,
+    -*, cppcoreguidelines-* clang-analyzer-*, modernize-*,
+    performance-faster-string-find, performance-for-range-copy,
+    performance-implicit-conversion-in-loop, performance-inefficient-algorithm,
+    performance-inefficient-string-concatenation, performance-trivially-destructible,
+    performance-inefficient-vector-operation, performance-move-const-arg,
+    performance-move-constructor-init, performance-noexcept-move-constructor,
+    performance-no-automatic-move, performance-unnecessary-copy-initialization,
+    performance-type-promotion-in-math-fn
+
+# performance checks not enabled due to segmentation fault in clang-tidy v8+:
+# performance-unnecessary-value-param
+
+# In order to trigger an error, you must have a rule defined both in checks and in this section.
+WarningsAsErrors: >
+    cppcoreguidelines-no-malloc, modernize-deprecated-headers,
+    modernize-loop-convert, modernize-make-shared, modernize-pass-by-value, modernize-make-unique,
     modernize-raw-string-literal, modernize-redundant-void-arg, modernize-replace-auto-ptr,
     modernize-replace-random-shuffle, modernize-return-braced-init-list, modernize-shrink-to-fit,
     modernize-unary-static-assert, modernize-use-bool-literals, modernize-use-default-member-init,
     modernize-use-emplace, modernize-use-equals-default, modernize-use-equals-delete,
     modernize-use-noexcept, modernize-use-nullptr, modernize-use-override,
-    modernize-use-transparent-functors, modernize-use-using, performance-*
+    modernize-use-transparent-functors, modernize-use-using,
+    performance-unnecessary-copy-initialization, performance-move-const-arg
 
-# cppcoreguidelines checks not enabled:
-# cppcoreguidelines-pro-bounds-pointer-arithmetic
-# cppcoreguidelines-pro-bounds-array-to-pointer-decay
-# cppcoreguidelines-pro-type-reinterpret-cast
-
-# modernize checks not enabled:
+# modernize checks not enforced:
 # modernize-use-auto
-# modernize-make-unique (C++14 and newer only)
-
-# In order to trigger an error, you must have a rule defined both in checks and in this section.
-WarningsAsErrors: >
-    cppcoreguidelines-no-malloc, modernize-use-nullptr, performance-unnecessary-copy-initialization,
-    modernize-use-emplace, performance-move-const-arg
+# modernize-avoid-bind
 
 # Todo: define a better regex match that includes most project headers, but excludes third party
 # code.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,6 +275,7 @@ if(USE_MKLDNN)
   include_directories(${PROJECT_BINARY_DIR}/3rdparty/mkldnn/include)
   add_definitions(-DMXNET_USE_MKLDNN=1)
   list(APPEND mxnet_LINKER_LIBS dnnl)
+  set_target_properties(dnnl PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
 endif()
 
 # Allow Cuda compiles outside of src tree to find things in 'src' and 'include'
@@ -405,6 +406,7 @@ if(USE_OPENMP)
      AND NOT CMAKE_CROSSCOMPILING)
     load_omp()
     list(APPEND mxnet_LINKER_LIBS omp)
+    set_target_properties(omp PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
     if(UNIX)
       list(APPEND mxnet_LINKER_LIBS pthread)
     endif()
@@ -462,6 +464,8 @@ set(GTEST_MAIN_LIBRARY gtest_main)
 set(GTEST_LIBRARY gtest)
 
 add_subdirectory(${GTEST_ROOT})
+set_target_properties(gtest PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
+set_target_properties(gtest_main PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
 find_package(GTest REQUIRED)
 
 # cudnn detection
@@ -478,6 +482,7 @@ endif()
 
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/dmlc-core/cmake)
   add_subdirectory("3rdparty/dmlc-core")
+  set_target_properties(dmlc PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
 endif()
 
 FILE(GLOB_RECURSE SOURCE "src/*.cc" "src/*.h" "include/*.h")
@@ -492,7 +497,9 @@ FILE(GLOB_RECURSE NNVMSOURCE
   3rdparty/tvm/nnvm/src/core/*.h
   3rdparty/tvm/nnvm/src/pass/*.h
   3rdparty/tvm/nnvm/include/*.h)
-list(APPEND SOURCE ${NNVMSOURCE})
+add_library(nnvm STATIC ${NNVMSOURCE})
+set_target_properties(nnvm PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
+list(APPEND mxnet_LINKER_LIBS nnvm)
 
 # add source group
 FILE(GLOB_RECURSE GROUP_SOURCE "src/*.cc" "3rdparty/tvm/nnvm/*.cc" "plugin/*.cc")
@@ -743,6 +750,7 @@ if(USE_DIST_KVSTORE)
   add_subdirectory("3rdparty/ps-lite")
   add_definitions(-DMXNET_USE_DIST_KVSTORE)
   list(APPEND mxnet_LINKER_LIBS pslite)
+  set_target_properties(pslite PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
 endif()
 
 if(USE_MKLDNN)
@@ -757,6 +765,7 @@ function(BuildTVMOP)
   # scope the variables in BuildTVM.cmake to avoid conflict
   include(cmake/BuildTVM.cmake)
   add_subdirectory("3rdparty/tvm")
+  set_target_properties(pslite PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
 endfunction()
 
 if(USE_TVM_OP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,9 +497,9 @@ FILE(GLOB_RECURSE NNVMSOURCE
   3rdparty/tvm/nnvm/src/core/*.h
   3rdparty/tvm/nnvm/src/pass/*.h
   3rdparty/tvm/nnvm/include/*.h)
-add_library(nnvm STATIC ${NNVMSOURCE})
+add_library(nnvm OBJECT ${NNVMSOURCE})
 set_target_properties(nnvm PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
-list(APPEND mxnet_LINKER_LIBS nnvm)
+list(APPEND SOURCE $<TARGET_OBJECTS:nnvm>)
 
 # add source group
 FILE(GLOB_RECURSE GROUP_SOURCE "src/*.cc" "3rdparty/tvm/nnvm/*.cc" "plugin/*.cc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,7 +765,9 @@ function(BuildTVMOP)
   # scope the variables in BuildTVM.cmake to avoid conflict
   include(cmake/BuildTVM.cmake)
   add_subdirectory("3rdparty/tvm")
-  set_target_properties(pslite PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
+  set_target_properties(tvm PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
+  set_target_properties(tvm_topi PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
+  set_target_properties(tvm_runtime PROPERTIES CXX_CLANG_TIDY "")  # don't lint 3rdparty dependency
 endfunction()
 
 if(USE_TVM_OP)

--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -53,7 +53,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         protobuf-compiler \
         libprotobuf-dev \
         clang-6.0 \
-        clang-tidy-6.0 \
         python-yaml \
         clang-10 \
         clang-tidy-10 \

--- a/ci/docker/Dockerfile.build.ubuntu
+++ b/ci/docker/Dockerfile.build.ubuntu
@@ -56,6 +56,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         clang-tidy-6.0 \
         python-yaml \
         clang-10 \
+        clang-tidy-10 \
         g++ \
         g++-8 \
         intel-mkl-2020.0-088 \

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -462,9 +462,8 @@ build_ubuntu_cpu_clang100() {
 build_ubuntu_cpu_clang_tidy() {
     set -ex
     cd /work/build
-    export CLANG_TIDY=/usr/lib/llvm-6.0/share/clang/run-clang-tidy.py
     # TODO(leezu) USE_OPENMP=OFF 3rdparty/dmlc-core/CMakeLists.txt:79 broken?
-    CXX=clang++-6.0 CC=clang-6.0 cmake \
+    CXX=clang++-10 CC=clang-10 cmake \
        -DUSE_MKL_IF_AVAILABLE=OFF \
        -DUSE_MKLDNN=OFF \
        -DUSE_CUDA=OFF \
@@ -472,11 +471,9 @@ build_ubuntu_cpu_clang_tidy() {
        -DCMAKE_BUILD_TYPE=Debug \
        -DUSE_DIST_KVSTORE=ON \
        -DUSE_CPP_PACKAGE=ON \
-       -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+       -DCMAKE_CXX_CLANG_TIDY=clang-tidy-10 \
        -G Ninja /work/mxnet
     ninja
-    cd /work/mxnet
-    $CLANG_TIDY -p /work/build -j $(nproc) -clang-tidy-binary clang-tidy-6.0 /work/mxnet/src
 }
 
 build_ubuntu_cpu_clang6_mkldnn() {

--- a/example/extensions/lib_custom_op/gemm_lib.cc
+++ b/example/extensions/lib_custom_op/gemm_lib.cc
@@ -24,6 +24,7 @@
  */
 
 #include <iostream>
+#include <utility>
 #include "lib_api.h"
 
 // main matrix multiplication routine
@@ -179,23 +180,23 @@ REGISTER_OP(my_gemm)
 class MyStatefulGemm : public CustomStatefulOp {
  public:
   explicit MyStatefulGemm(int count,
-                          const std::unordered_map<std::string, std::string>& attrs)
-    : count(count), attrs_(attrs) {}
+                          std::unordered_map<std::string, std::string>  attrs)
+    : count(count), attrs_(std::move(attrs)) {}
 
   MXReturnValue Forward(std::vector<MXTensor>* inputs,
                         std::vector<MXTensor>* outputs,
-                        const OpResource& op_res) {
+                        const OpResource& op_res) override {
     std::cout << "Info: keyword + number of forward: " << ++count << std::endl;
     return forward(attrs_, inputs, outputs, op_res);
   }
 
   MXReturnValue Backward(std::vector<MXTensor>* inputs,
                          std::vector<MXTensor>* outputs,
-                         const OpResource& op_res) {
+                         const OpResource& op_res) override {
     return backward(attrs_, inputs, outputs, op_res);
   }
 
-  ~MyStatefulGemm() {}
+  ~MyStatefulGemm() = default;
 
  private:
   int count;

--- a/example/extensions/lib_custom_op/transposecsr_lib.cc
+++ b/example/extensions/lib_custom_op/transposecsr_lib.cc
@@ -24,6 +24,7 @@
  */
 
 #include <iostream>
+#include <utility>
 #include "lib_api.h"
 
 void transpose(MXTensor& src, MXTensor& dst, const OpResource& res) {
@@ -151,19 +152,19 @@ REGISTER_OP(my_transposecsr)
 class MyStatefulTransposeCSR : public CustomStatefulOp {
   public:
     explicit MyStatefulTransposeCSR(int count,
-                                    const std::unordered_map<std::string, std::string>& attrs)
-      : count(count), attrs_(attrs) {}
+                                    std::unordered_map<std::string, std::string>  attrs)
+      : count(count), attrs_(std::move(attrs)) {}
 
     MXReturnValue Forward(std::vector<MXTensor>* inputs,
                           std::vector<MXTensor>* outputs,
-                          const OpResource& op_res) {
+                          const OpResource& op_res) override {
       std::cout << "Info: keyword + number of forward: " << ++count << std::endl;
       return forward(attrs_, inputs, outputs, op_res);
     }
 
     MXReturnValue Backward(std::vector<MXTensor>* inputs,
                            std::vector<MXTensor>* outputs,
-                           const OpResource& op_res) {
+                           const OpResource& op_res) override {
       return backward(attrs_, inputs, outputs, op_res);
     }
 

--- a/example/extensions/lib_custom_op/transposerowsp_lib.cc
+++ b/example/extensions/lib_custom_op/transposerowsp_lib.cc
@@ -24,6 +24,7 @@
  */
 
 #include <iostream>
+#include <utility>
 #include "lib_api.h"
 
 void transpose(MXTensor& src, MXTensor& dst, const OpResource& res) {
@@ -153,19 +154,19 @@ REGISTER_OP(my_transposerowsp)
 class MyStatefulTransposeRowSP : public CustomStatefulOp {
   public:
     explicit MyStatefulTransposeRowSP(int count,
-                                      const std::unordered_map<std::string, std::string>& attrs)
-      : count(count), attrs_(attrs) {}
+                                      std::unordered_map<std::string, std::string>  attrs)
+      : count(count), attrs_(std::move(attrs)) {}
 
     MXReturnValue Forward(std::vector<MXTensor>* inputs,
                           std::vector<MXTensor>* outputs,
-                          const OpResource& op_res) {
+                          const OpResource& op_res) override {
       std::cout << "Info: keyword + number of forward: " << ++count << std::endl;
       return forward(attrs_, inputs, outputs, op_res);
     }
 
     MXReturnValue Backward(std::vector<MXTensor>* inputs,
                            std::vector<MXTensor>* outputs,
-                           const OpResource& op_res) {
+                           const OpResource& op_res) override {
       return backward(attrs_, inputs, outputs, op_res);
     }
 

--- a/example/extensions/lib_pass/pass_lib.cc
+++ b/example/extensions/lib_pass/pass_lib.cc
@@ -23,7 +23,7 @@
  * \brief subgraph operator implementation library file
  */
 
-#include <math.h>
+#include <cmath>
 #include <iostream>
 #include <algorithm>
 #include "lib_api.h"
@@ -67,8 +67,7 @@ MXReturnValue jsonPass(const std::string& in_graph, const std::string** out_grap
   JsonVal nodes = json_val.map[JsonVal("nodes")];
 
   // loop over nodes
-  for(int i=0; i<nodes.list.size(); i++) {
-    JsonVal node = nodes.list[i];
+  for(auto node : nodes.list) {
     // get the op name
     std::string op = node.map[JsonVal("op")].str;
     // get node ID inputs to op

--- a/example/extensions/lib_subgraph/subgraph_lib.cc
+++ b/example/extensions/lib_subgraph/subgraph_lib.cc
@@ -84,7 +84,7 @@ MXReturnValue myExecutor(std::vector<MXTensor>* inputs,
       // get input tensor based on node ID inputs from data storage
       MXTensor &input = data[node_inputs.list[0].list[0].num];
       // create temporary storage
-      MXTensor tmp(malloc(input.size()*4), input.shape, input.dtype, 0, MXContext::CPU(0), kDefaultStorage);
+      MXTensor tmp(malloc(input.size()*4), input.shape, input.dtype, 0, MXContext::CPU(0), kDefaultStorage);  // NOLINT
       // save allocated ptr to free later
       to_free.push_back(tmp.data_ptr);
       // execute log operator
@@ -95,7 +95,7 @@ MXReturnValue myExecutor(std::vector<MXTensor>* inputs,
       // get input tensor based on node ID inputs from data storage
       MXTensor &input = data[node_inputs.list[0].list[0].num];
       // create temporary storage
-      MXTensor tmp(malloc(input.size()*4), input.shape, input.dtype, 0, MXContext::CPU(0), kDefaultStorage);
+      MXTensor tmp(malloc(input.size()*4), input.shape, input.dtype, 0, MXContext::CPU(0), kDefaultStorage);  // NOLINT
       // save allocated ptr to free later
       to_free.push_back(tmp.data_ptr);
       // execute exp operator 
@@ -106,7 +106,7 @@ MXReturnValue myExecutor(std::vector<MXTensor>* inputs,
       std::cout << "Error! Unsupported op '" << op << "' found in myExecutor";
       // free allocated temporary storage
       for (void* ptr : to_free)
-        free(ptr);
+        free(ptr);  // NOLINT
       return MX_FAIL;
     }
   }
@@ -129,7 +129,7 @@ MXReturnValue myExecutor(std::vector<MXTensor>* inputs,
 
   // free allocated temporary storage
   for (void* ptr : to_free) {
-    free(ptr);
+    free(ptr);  // NOLINT
   }
   
   return MX_SUCCESS;

--- a/src/api/operator/numpy/linalg/np_norm.cc
+++ b/src/api/operator/numpy/linalg/np_norm.cc
@@ -44,7 +44,7 @@ MXNET_REGISTER_API("_npi.norm")
   param.flag = args[4].operator int();
 
   attrs.op = op;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   SetAttrDict<op::NumpyNormParam>(&attrs);
 
   // inputs

--- a/src/api/operator/numpy/np_broadcast_reduce_op_boolean.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_boolean.cc
@@ -48,7 +48,7 @@ MXNET_REGISTER_API("_npi.all")
   param.keepdims = args[2].operator bool();
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   int num_inputs = 1;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyReduceAxesBoolParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);
@@ -79,7 +79,7 @@ MXNET_REGISTER_API("_npi.any")
   param.keepdims = args[2].operator bool();
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   int num_inputs = 1;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyReduceAxesBoolParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);

--- a/src/api/operator/numpy/np_broadcast_reduce_op_index.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_index.cc
@@ -44,7 +44,7 @@ MXNET_REGISTER_API("_npi.argmax")
   // param.keepdims
   param.keepdims = args[2].operator bool();
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::ReduceAxisParam>(&attrs);
   // inputs
@@ -77,7 +77,7 @@ MXNET_REGISTER_API("_npi.argmin")
   // param.keepdims
   param.keepdims = args[2].operator bool();
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::ReduceAxisParam>(&attrs);
   // inputs

--- a/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
+++ b/src/api/operator/numpy/np_broadcast_reduce_op_value.cc
@@ -40,7 +40,7 @@ MXNET_REGISTER_API("_npi.broadcast_to")
   } else {
     param.shape = TShape(args[1].operator ObjectRef());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::BroadcastToParam>(&attrs);
 
@@ -91,7 +91,7 @@ MXNET_REGISTER_API("_npi.sum")
     param.initial = args[4].operator double();
   }
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
 
   SetAttrDict<op::NumpyReduceAxesParam>(&attrs);
 
@@ -133,7 +133,7 @@ MXNET_REGISTER_API("_npi.mean")
     param.keepdims = args[3].operator bool();
   }
   param.initial = dmlc::optional<double>();
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyReduceAxesParam>(&attrs);
   int num_inputs = 1;
@@ -177,7 +177,7 @@ MXNET_REGISTER_API("_npi.prod")
   } else {
     param.initial = args[4].operator double();
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyReduceAxesParam>(&attrs);
   int num_inputs = 1;
@@ -213,7 +213,7 @@ MXNET_REGISTER_API("_npi.max")
   param.keepdims = args[2].operator bool();
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   int num_inputs = 1;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyReduceAxesNoDTypeParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);
@@ -244,7 +244,7 @@ MXNET_REGISTER_API("_npi.min")
   param.keepdims = args[2].operator bool();
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   int num_inputs = 1;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyReduceAxesNoDTypeParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);
@@ -275,7 +275,7 @@ MXNET_REGISTER_API("_npi.amax")
   param.keepdims = args[2].operator bool();
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   int num_inputs = 1;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyReduceAxesNoDTypeParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);
@@ -306,7 +306,7 @@ MXNET_REGISTER_API("_npi.amin")
   param.keepdims = args[2].operator bool();
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   int num_inputs = 1;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyReduceAxesNoDTypeParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);

--- a/src/api/operator/numpy/np_cumsum.cc
+++ b/src/api/operator/numpy/np_cumsum.cc
@@ -46,7 +46,7 @@ MXNET_REGISTER_API("_npi.cumsum")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[2].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::CumsumParam>(&attrs);
   // inputs

--- a/src/api/operator/numpy/np_delete_op.cc
+++ b/src/api/operator/numpy/np_delete_op.cc
@@ -90,7 +90,7 @@ MXNET_REGISTER_API("_npi.delete")
   for (int i = 0; i < num_inputs; ++i) {
     inputs.push_back(args[i].operator mxnet::NDArray*());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyDeleteParam>(&attrs);
   int num_outputs = 0;

--- a/src/api/operator/numpy/np_ediff1d_op.cc
+++ b/src/api/operator/numpy/np_ediff1d_op.cc
@@ -63,7 +63,7 @@ MXNET_REGISTER_API("_npi.ediff1d")
     num_inputs++;
   }
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::EDiff1DParam>(&attrs);
 

--- a/src/api/operator/numpy/np_einsum_op.cc
+++ b/src/api/operator/numpy/np_einsum_op.cc
@@ -43,7 +43,7 @@ MXNET_REGISTER_API("_npi.einsum")
   // param.optimize
   param.optimize = args[args_size - 1].operator int();
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyEinsumParam>(&attrs);
 

--- a/src/api/operator/numpy/np_elemwise_unary_op_basic.cc
+++ b/src/api/operator/numpy/np_elemwise_unary_op_basic.cc
@@ -98,7 +98,7 @@ MXNET_REGISTER_API("_npi.around")
   nnvm::NodeAttrs attrs;
   op::AroundParam param;
   param.decimals = args[1].operator int64_t();
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::AroundParam>(&attrs);
   int num_inputs = 1;

--- a/src/api/operator/numpy/np_fill_diagonal_op.cc
+++ b/src/api/operator/numpy/np_fill_diagonal_op.cc
@@ -44,7 +44,7 @@ MXNET_REGISTER_API("_npi.fill_diagonal")
   }
   param.wrap = args[2].operator bool();
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyFillDiagonalParam>(&attrs);
 

--- a/src/api/operator/numpy/np_histogram_op.cc
+++ b/src/api/operator/numpy/np_histogram_op.cc
@@ -49,7 +49,7 @@ MXNET_REGISTER_API("_npi.histogram")
     param.range = Obj2Tuple<double, Float>(args[3].operator ObjectRef());
   }
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::HistogramParam>(&attrs);
 

--- a/src/api/operator/numpy/np_init_op.cc
+++ b/src/api/operator/numpy/np_init_op.cc
@@ -47,7 +47,7 @@ MXNET_REGISTER_API("_npi.zeros")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[1].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::InitOpParam>(&attrs);
   if (args[2].type_code() != kNull) {
@@ -70,7 +70,7 @@ MXNET_REGISTER_API("_npi.full_like")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[2].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   if (args[3].type_code() != kNull) {
     attrs.dict["ctx"] = args[3].operator std::string();
@@ -107,7 +107,7 @@ MXNET_REGISTER_API("_npi.indices")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[1].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::IndicesOpParam>(&attrs);
   // param.ctx
@@ -223,7 +223,7 @@ MXNET_REGISTER_API("_npi.arange")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[3].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::RangeParam>(&attrs);
   if (args[4].type_code() != kNull) {
@@ -252,7 +252,7 @@ MXNET_REGISTER_API("_npi.eye")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[4].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyEyeParam>(&attrs);
   if (args[3].type_code() != kNull) {
@@ -282,7 +282,7 @@ MXNET_REGISTER_API("_npi.linspace")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[5].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::LinspaceParam>(&attrs);
   if (args[4].type_code() != kNull) {
@@ -317,7 +317,7 @@ MXNET_REGISTER_API("_npi.logspace")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[6].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::LogspaceParam>(&attrs);
   if (args[5].type_code() != kNull) {
@@ -344,7 +344,7 @@ MXNET_REGISTER_API("_npi.ones")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[1].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   if (args[2].type_code() != kNull) {
     attrs.dict["ctx"] = args[2].operator std::string();
@@ -372,7 +372,7 @@ MXNET_REGISTER_API("_npi.full")
     param.dtype = String2MXNetTypeWithBool(args[1].operator std::string());
   }
   param.value = args[2].operator double();
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   if (args[3].type_code() != kNull) {
     attrs.dict["ctx"] = args[3].operator std::string();
@@ -401,7 +401,7 @@ MXNET_REGISTER_API("_npi.identity")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[1].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   if (args[2].type_code() != kNull) {
     attrs.dict["ctx"] = args[2].operator std::string();

--- a/src/api/operator/numpy/np_insert_op.cc
+++ b/src/api/operator/numpy/np_insert_op.cc
@@ -57,7 +57,7 @@ MXNET_REGISTER_API("_npi.insert_scalar")
   } else {
     param.axis = args[3].operator int();
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyInsertParam>(&attrs);
   std::vector<NDArray*> inputs;
@@ -105,7 +105,7 @@ MXNET_REGISTER_API("_npi.insert_slice")
   } else {
     param.axis = args[5].operator int();
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyInsertParam>(&attrs);
   std::vector<NDArray*> inputs;
@@ -141,7 +141,7 @@ MXNET_REGISTER_API("_npi.insert_tensor")
   } else {
     param.axis = args[3].operator int();
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyInsertParam>(&attrs);
   std::vector<NDArray*> inputs;

--- a/src/api/operator/numpy/np_interp_op.cc
+++ b/src/api/operator/numpy/np_interp_op.cc
@@ -53,7 +53,7 @@ MXNET_REGISTER_API("_npi.interp")
     param.x_scalar = args[2].operator double();
     param.x_is_scalar = true;
     attrs.op = op;
-    attrs.parsed = std::move(param);
+    attrs.parsed = param;
     SetAttrDict<op::NumpyInterpParam>(&attrs);
     NDArray* inputs[] = {args[0].operator mxnet::NDArray*(), args[1].operator mxnet::NDArray*()};
     int num_inputs = 2;
@@ -64,7 +64,7 @@ MXNET_REGISTER_API("_npi.interp")
     param.x_scalar = 0.0;
     param.x_is_scalar = false;
     attrs.op = op;
-    attrs.parsed = std::move(param);
+    attrs.parsed = param;
     SetAttrDict<op::NumpyInterpParam>(&attrs);
     NDArray* inputs[] = {args[0].operator mxnet::NDArray*(), args[1].operator mxnet::NDArray*(),
                          args[2].operator mxnet::NDArray*()};

--- a/src/api/operator/numpy/np_matrix_op.cc
+++ b/src/api/operator/numpy/np_matrix_op.cc
@@ -44,7 +44,7 @@ MXNET_REGISTER_API("_npi.transpose")
   } else {
     param.axes = TShape(args[1].operator ObjectRef());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyTransposeParam>(&attrs);
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
@@ -92,7 +92,7 @@ MXNET_REGISTER_API("_npi.stack")
 
   param.num_args = i;
   param.axis = args[i].operator int64_t();
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::StackParam>(&attrs);
   NDArray* out = args[i+1].operator mxnet::NDArray*();
@@ -126,7 +126,7 @@ MXNET_REGISTER_API("_npi.flip")
   }
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
   int num_inputs = 1;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::FlipParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);
@@ -150,7 +150,7 @@ MXNET_REGISTER_API("_npi.concatenate")
   } else {
     param.axis = args[arg_size - 2].operator int();
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyConcatenateParam>(&attrs);
   int num_inputs = arg_size - 2;
@@ -222,7 +222,7 @@ MXNET_REGISTER_API("_npi.split")
     }
     param.sections = 0;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::SplitParam>(&attrs);
 
@@ -256,7 +256,7 @@ MXNET_REGISTER_API("_npi.roll")
   } else {
     param.axis = TShape(args[2].operator ObjectRef());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyRollParam>(&attrs);
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
@@ -280,7 +280,7 @@ MXNET_REGISTER_API("_npi.rot90")
   } else {
     param.axes = TShape(args[2].operator ObjectRef());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyRot90Param>(&attrs);
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
@@ -351,7 +351,7 @@ MXNET_REGISTER_API("_npi.array_split")
     }
     param.sections = 0;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::SplitParam>(&attrs);
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
@@ -393,7 +393,7 @@ MXNET_REGISTER_API("_npi.dsplit")
     }
     param.sections = 0;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::SplitParam>(&attrs);
   int num_outputs = 0;
@@ -431,7 +431,7 @@ MXNET_REGISTER_API("_npi.hsplit")
     }
     param.sections = 0;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::SplitParam>(&attrs);
   int num_outputs = 0;
@@ -471,7 +471,7 @@ MXNET_REGISTER_API("_npi.vsplit")
     }
     param.sections = 0;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::SplitParam>(&attrs);
   int num_outputs = 0;
@@ -560,7 +560,7 @@ MXNET_REGISTER_API("_npi.diagflat")
   param.k = args[1].operator int();
   int num_inputs = 1;
   int num_outputs = 0;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyDiagflatParam>(&attrs);
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
@@ -583,7 +583,7 @@ MXNET_REGISTER_API("_npi.squeeze")
   }
   int num_inputs = 1;
   int num_outputs = 0;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::SqueezeParam>(&attrs);
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};

--- a/src/api/operator/numpy/np_moments_op.cc
+++ b/src/api/operator/numpy/np_moments_op.cc
@@ -65,7 +65,7 @@ MXNET_REGISTER_API("_npi.std")
     param.keepdims = args[4].operator bool();
   }
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
 
   SetAttrDict<op::NumpyMomentsParam>(&attrs);
 
@@ -120,7 +120,7 @@ MXNET_REGISTER_API("_npi.var")
     param.keepdims = args[4].operator bool();
   }
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
 
   SetAttrDict<op::NumpyMomentsParam>(&attrs);
 
@@ -168,7 +168,7 @@ MXNET_REGISTER_API("_npi.average")
     << "weighted cannot be None";
   param.weighted = args[4].operator bool();
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
 
   SetAttrDict<op::NumpyWeightedAverageParam>(&attrs);
 

--- a/src/api/operator/numpy/np_nan_to_num_op.cc
+++ b/src/api/operator/numpy/np_nan_to_num_op.cc
@@ -53,7 +53,7 @@ MXNET_REGISTER_API("_npi.nan_to_num")
     param.neginf = args[4].operator double();
   }
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyNanToNumParam>(&attrs);
 

--- a/src/api/operator/numpy/np_pad_op.cc
+++ b/src/api/operator/numpy/np_pad_op.cc
@@ -73,7 +73,7 @@ MXNET_REGISTER_API("_npi.pad")
     param.reflect_type = args[4].operator std::string();
   }
   attrs.op = op;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   SetAttrDict<op::NumpyPadParam>(&attrs);
   int num_inputs = 1;
   int num_outputs = 0;

--- a/src/api/operator/numpy/np_percentile_op.cc
+++ b/src/api/operator/numpy/np_percentile_op.cc
@@ -70,7 +70,7 @@ MXNET_REGISTER_API("_npi.percentile")
     param.q_scalar = args[1].operator double();
     NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};
     int num_inputs = 1;
-    attrs.parsed = std::move(param);
+    attrs.parsed = param;
     attrs.op = op;
     SetAttrDict<op::NumpyPercentileParam>(&attrs);
     auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);
@@ -83,7 +83,7 @@ MXNET_REGISTER_API("_npi.percentile")
     param.q_scalar = dmlc::nullopt;
     NDArray* inputs[] = {args[0].operator mxnet::NDArray*(), args[1].operator mxnet::NDArray*()};
     int num_inputs = 2;
-    attrs.parsed = std::move(param);
+    attrs.parsed = param;
     attrs.op = op;
     SetAttrDict<op::NumpyPercentileParam>(&attrs);
     auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs, &num_outputs, outputs);

--- a/src/api/operator/numpy/np_repeat_op.cc
+++ b/src/api/operator/numpy/np_repeat_op.cc
@@ -41,7 +41,7 @@ MXNET_REGISTER_API("_npi.repeats")
   }
   int num_inputs = 1;
   int num_outputs = 0;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::RepeatsParam>(&attrs);
   NDArray* inputs[] = {args[0].operator mxnet::NDArray*()};

--- a/src/api/operator/numpy/np_tensordot_op.cc
+++ b/src/api/operator/numpy/np_tensordot_op.cc
@@ -62,7 +62,7 @@ inline static void _npi_tensordot(runtime::MXNetArgs args,
     param.b_axes_summed = Tuple<int>(adt[1]);
   }
   attrs.op = op;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   SetAttrDict<op::TensordotParam>(&attrs);
   int num_outputs = 0;
   int num_inputs = 2;

--- a/src/api/operator/numpy/np_unique_op.cc
+++ b/src/api/operator/numpy/np_unique_op.cc
@@ -44,7 +44,7 @@ MXNET_REGISTER_API("_npi.unique")
   } else {
     param.axis = args[4].operator int();
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyUniqueParam>(&attrs);
   // inputs

--- a/src/api/operator/numpy/np_window_op.cc
+++ b/src/api/operator/numpy/np_window_op.cc
@@ -45,7 +45,7 @@ inline static void SetNumpyWindowsParam(runtime::MXNetArgs args,
   } else {
     param.dtype = String2MXNetTypeWithBool(args[1].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyWindowsParam>(&attrs);
   if (args[2].type_code() != kNull) {

--- a/src/api/operator/numpy/random/np_choice_op.cc
+++ b/src/api/operator/numpy/random/np_choice_op.cc
@@ -70,7 +70,7 @@ MXNET_REGISTER_API("_npi.choice")
     num_inputs++;
   }
 
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   if (args[4].type_code() != kNull) {
     attrs.dict["ctx"] = args[4].operator std::string();

--- a/src/api/operator/numpy/random/np_exponential_op.cc
+++ b/src/api/operator/numpy/random/np_exponential_op.cc
@@ -58,7 +58,7 @@ MXNET_REGISTER_API("_npi.exponential")
     inputs[0] = args[0].operator mxnet::NDArray*();
     num_inputs = 1;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   SetAttrDict<op::NumpyExponentialParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs,
                           &num_outputs, outputs);

--- a/src/api/operator/numpy/random/np_laplace_op.cc
+++ b/src/api/operator/numpy/random/np_laplace_op.cc
@@ -73,7 +73,7 @@ MXNET_REGISTER_API("_npi.laplace")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[3].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::NumpyLaplaceParam>(&attrs);
   if (args[4].type_code() != kNull) {

--- a/src/api/operator/numpy/random/np_location_scale_op.cc
+++ b/src/api/operator/numpy/random/np_location_scale_op.cc
@@ -82,7 +82,7 @@ MXNET_REGISTER_API("_npi.gumbel")
     }
     num_inputs = 1;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   SetAttrDict<op::NumpyLocationScaleParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs.data(),
                           &num_outputs, outputs);
@@ -137,7 +137,7 @@ MXNET_REGISTER_API("_npi.logistic")
     }
     num_inputs = 1;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   SetAttrDict<op::NumpyLocationScaleParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs.data(),
                           &num_outputs, outputs);

--- a/src/api/operator/numpy/random/np_pareto_op.cc
+++ b/src/api/operator/numpy/random/np_pareto_op.cc
@@ -58,7 +58,7 @@ MXNET_REGISTER_API("_npi.pareto")
     inputs[0] = args[0].operator mxnet::NDArray*();
     num_inputs = 1;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   SetAttrDict<op::NumpyParetoParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs,
                           &num_outputs, outputs);

--- a/src/api/operator/numpy/random/np_power_op.cc
+++ b/src/api/operator/numpy/random/np_power_op.cc
@@ -58,7 +58,7 @@ MXNET_REGISTER_API("_npi.powerd")
     inputs[0] = args[0].operator mxnet::NDArray*();
     num_inputs = 1;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   SetAttrDict<op::NumpyPowerParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs,
                           &num_outputs, outputs);

--- a/src/api/operator/numpy/random/np_rayleigh_op.cc
+++ b/src/api/operator/numpy/random/np_rayleigh_op.cc
@@ -58,7 +58,7 @@ MXNET_REGISTER_API("_npi.rayleigh")
     inputs[0] = args[0].operator mxnet::NDArray*();
     num_inputs = 1;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   SetAttrDict<op::NumpyRayleighParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs,
                           &num_outputs, outputs);

--- a/src/api/operator/numpy/random/np_weibull_op.cc
+++ b/src/api/operator/numpy/random/np_weibull_op.cc
@@ -58,7 +58,7 @@ MXNET_REGISTER_API("_npi.weibull")
     inputs[0] = args[0].operator mxnet::NDArray*();
     num_inputs = 1;
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   SetAttrDict<op::NumpyWeibullParam>(&attrs);
   auto ndoutputs = Invoke(op, &attrs, num_inputs, inputs,
                           &num_outputs, outputs);

--- a/src/api/operator/random/np_gamma_op.cc
+++ b/src/api/operator/random/np_gamma_op.cc
@@ -91,7 +91,7 @@ MXNET_REGISTER_API("_npi.gamma")
   NDArray* out = args[5].operator mxnet::NDArray*();
   NDArray** outputs = out == nullptr ? nullptr : &out;
   int num_outputs = out != nullptr;
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   if (args[3].type_code() != kNull) {
     attrs.dict["ctx"] = args[3].operator std::string();

--- a/src/api/operator/random/np_normal_op.cc
+++ b/src/api/operator/random/np_normal_op.cc
@@ -77,7 +77,7 @@ MXNET_REGISTER_API("_npi.normal")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[4].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   if (args[3].type_code() != kNull) {
     attrs.dict["ctx"] = args[3].operator std::string();

--- a/src/api/operator/random/np_uniform_op.cc
+++ b/src/api/operator/random/np_uniform_op.cc
@@ -76,7 +76,7 @@ MXNET_REGISTER_API("_npi.uniform")
   } else {
     param.dtype = String2MXNetTypeWithBool(args[4].operator std::string());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   if (args[3].type_code() != kNull) {
     attrs.dict["ctx"] = args[3].operator std::string();

--- a/src/api/operator/tensor/matrix_op.cc
+++ b/src/api/operator/tensor/matrix_op.cc
@@ -79,7 +79,7 @@ MXNET_REGISTER_API("_npi.tile")
   } else {
   param.reps = Tuple<int>(args[1].operator ObjectRef());
   }
-  attrs.parsed = std::move(param);
+  attrs.parsed = param;
   attrs.op = op;
   SetAttrDict<op::TileParam>(&attrs);
   int num_outputs = 0;

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -236,13 +236,13 @@ void CustomFComputeDispatcher(const std::string op_name,
     return static_cast<void*>((*cpualloc)(size));
   };
 
-  typedef decltype(gpu_alloc) alloc_type_gpu;
+  using alloc_type_gpu = decltype(gpu_alloc);
   auto gpu_malloc = [](void* _gpu_alloc, int size) {
     alloc_type_gpu* gpualloc = static_cast<alloc_type_gpu*>(_gpu_alloc);
     return static_cast<void*>((*gpualloc)(size));
   };
 
-  typedef decltype(sparse_alloc) alloc_type_sparse;
+  using alloc_type_sparse = decltype(sparse_alloc);
   auto sparse_malloc = [](void* _sparse_alloc, int index, int indices_len, int idxptr_len,
                            void** data, int64_t** indices, int64_t** indptr) {
     alloc_type_sparse* sparsealloc = static_cast<alloc_type_sparse*>(_sparse_alloc);
@@ -1209,7 +1209,7 @@ void registerPasses(void *lib, int verbose) {
       // create no-capture lambda so that we can cast it to function pointer
       // lambda with captures cannot be cast to function pointer and pass to lib_api.h
       // this needs to be a lambda function so that we can do the decltype cast
-      typedef decltype(ndarray_alloc) alloc_type_ndarray;
+      using alloc_type_ndarray = decltype(ndarray_alloc);
       auto ndarray_malloc = [](const void* _ndarray_alloc, const int64_t* shapes, int num_shapes,
                                const char* dev_str, int dev_id, int dtype, const char* name,
                                int isArg, void** data) {
@@ -2160,7 +2160,7 @@ int MXDataIterCreateIter(DataIterCreator creator,
   iter = e->body();
   std::vector<std::pair<std::string, std::string> > kwargs;
   for (uint32_t i = 0; i < num_param; ++i) {
-    kwargs.push_back({std::string(keys[i]), std::string(vals[i])});
+    kwargs.emplace_back(std::string(keys[i]), std::string(vals[i]));
   }
   iter->Init(kwargs);
   *out = iter;
@@ -2287,7 +2287,7 @@ int MXDatasetCreateDataset(DatasetCreator handle,
   DatasetReg *e = static_cast<DatasetReg *>(handle);
   std::vector<std::pair<std::string, std::string> > kwargs;
   for (uint32_t i = 0; i < num_param; ++i) {
-    kwargs.push_back({std::string(keys[i]), std::string(vals[i])});
+    kwargs.emplace_back(std::string(keys[i]), std::string(vals[i]));
   }
   dataset = e->body(kwargs);
   *out = new std::shared_ptr<Dataset>(dataset);
@@ -2304,7 +2304,7 @@ int MXDatasetGetDatasetInfo(DatasetCreator creator,
   DatasetReg *e = static_cast<DatasetReg *>(creator);
   return MXAPIGetFunctionRegInfo(e, name, description, num_args,
                                  arg_names, arg_type_infos, arg_descriptions,
-                                 NULL);
+                                 nullptr);
 }
 
 int MXDatasetFree(DatasetHandle handle) {
@@ -2375,7 +2375,7 @@ int MXBatchifyFunctionCreateFunction(BatchifyFunctionCreator handle,
   BatchifyFunctionReg *e = static_cast<BatchifyFunctionReg *>(handle);
   std::vector<std::pair<std::string, std::string> > kwargs;
   for (uint32_t i = 0; i < num_param; ++i) {
-    kwargs.push_back({std::string(keys[i]), std::string(vals[i])});
+    kwargs.emplace_back(std::string(keys[i]), std::string(vals[i]));
   }
   bf = e->body(kwargs);
   *out = new BatchifyFunctionPtr(bf);
@@ -2392,7 +2392,7 @@ int MXBatchifyFunctionGetFunctionInfo(BatchifyFunctionCreator creator,
   BatchifyFunctionReg *e = static_cast<BatchifyFunctionReg *>(creator);
   return MXAPIGetFunctionRegInfo(e, name, description, num_args,
                                  arg_names, arg_type_infos, arg_descriptions,
-                                 NULL);
+                                 nullptr);
 }
 int MXBatchifyFunctionInvoke(BatchifyFunctionHandle handle,
                              int batch_size,
@@ -3149,8 +3149,8 @@ int MXNDArrayCreateFromSharedMemEx(int shared_pid, int shared_id, const int *sha
   API_END();
 }
 
-typedef Engine::VarHandle VarHandle;
-typedef Engine::CallbackOnComplete CallbackOnComplete;
+using VarHandle = Engine::VarHandle;
+using CallbackOnComplete = Engine::CallbackOnComplete;
 
 void AssertValidNumberVars(int num_const_vars, int num_mutable_vars) {
   CHECK_GE(num_const_vars, 0) << "Non-negative number of const vars expected.";

--- a/src/c_api/c_api_profile.cc
+++ b/src/c_api/c_api_profile.cc
@@ -61,7 +61,7 @@ class ProfilingThreadData {
   /*!
    * \brief Constructor, nothrow
    */
-  inline ProfilingThreadData() noexcept = default;
+  inline ProfilingThreadData() = default;
 
   /*!
    * \brief Retreive ProfileTask object of the given name, or create if it doesn't exist

--- a/src/c_api/c_api_profile.cc
+++ b/src/c_api/c_api_profile.cc
@@ -61,7 +61,7 @@ class ProfilingThreadData {
   /*!
    * \brief Constructor, nothrow
    */
-  inline ProfilingThreadData() noexcept {}
+  inline ProfilingThreadData() noexcept = default;
 
   /*!
    * \brief Retreive ProfileTask object of the given name, or create if it doesn't exist

--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -68,8 +68,8 @@ class NaiveEngine final : public Engine {
     objpool_var_ref_ = common::ObjectPool<NaiveVar>::_GetSharedRef();
   }
   // virtual destructor
-  ~NaiveEngine() override {
 #if MXNET_USE_CUDA
+  ~NaiveEngine() override {
     LOG(INFO) << "Engine shutdown";
     for (size_t i = 0; i < streams_.size(); ++i) {
       if (streams_[i] != nullptr) {
@@ -84,8 +84,10 @@ class NaiveEngine final : public Engine {
         aux_streams_[i] = nullptr;
       }
     }
-#endif
   }
+#else
+  ~NaiveEngine() override = default;
+#endif
 
   void Stop() override {
   }

--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -22,6 +22,7 @@
  * \file naive_engine.cc
  * \brief Implementation of NaiveEngine
  */
+#include <memory>
 #include <vector>
 #include <atomic>
 #include <thread>
@@ -67,7 +68,7 @@ class NaiveEngine final : public Engine {
     objpool_var_ref_ = common::ObjectPool<NaiveVar>::_GetSharedRef();
   }
   // virtual destructor
-  virtual ~NaiveEngine() {
+  ~NaiveEngine() override {
 #if MXNET_USE_CUDA
     LOG(INFO) << "Engine shutdown";
     for (size_t i = 0; i < streams_.size(); ++i) {
@@ -125,10 +126,10 @@ class NaiveEngine final : public Engine {
         if (opr->profiling) {
           std::unique_ptr<profiler::ProfileOperator::Attributes> attrs;
           if (profiler->AggregateEnabled()) {
-            attrs.reset(new profiler::ProfileOperator::Attributes());
+            attrs = std::make_unique<profiler::ProfileOperator::Attributes>();
           }
-          opr->opr_profile.reset(new profiler::ProfileOperator(opr->opr_name.c_str(),
-                                                               attrs.release()));
+          opr->opr_profile = std::make_unique<profiler::ProfileOperator>(opr->opr_name.c_str(),
+                                                               attrs.release());
           opr->opr_profile->startForDevice(exec_ctx.dev_type, exec_ctx.dev_id);
         }
         opr->fn(ctx, on_complete);
@@ -175,9 +176,9 @@ class NaiveEngine final : public Engine {
       opr->profiling = profiling;
       std::unique_ptr<profiler::ProfileOperator::Attributes> attrs;
       if (profiler->AggregateEnabled()) {
-        attrs.reset(new profiler::ProfileOperator::Attributes());
+        attrs = std::make_unique<profiler::ProfileOperator::Attributes>();
       }
-      opr->opr_profile.reset(new profiler::ProfileOperator(opr->opr_name.c_str(), attrs.release()));
+      opr->opr_profile = std::make_unique<profiler::ProfileOperator>(opr->opr_name.c_str(), attrs.release());
       opr->opr_profile->startForDevice(exec_ctx.dev_type, exec_ctx.dev_id);
     }
     if (exec_ctx.dev_mask() == gpu::kDevMask) {

--- a/src/engine/naive_engine.cc
+++ b/src/engine/naive_engine.cc
@@ -178,7 +178,8 @@ class NaiveEngine final : public Engine {
       if (profiler->AggregateEnabled()) {
         attrs = std::make_unique<profiler::ProfileOperator::Attributes>();
       }
-      opr->opr_profile = std::make_unique<profiler::ProfileOperator>(opr->opr_name.c_str(), attrs.release());
+      opr->opr_profile = std::make_unique<profiler::ProfileOperator>(opr->opr_name.c_str(),
+                                                                     attrs.release());
       opr->opr_profile->startForDevice(exec_ctx.dev_type, exec_ctx.dev_id);
     }
     if (exec_ctx.dev_mask() == gpu::kDevMask) {

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -28,6 +28,8 @@
 #include <dmlc/parameter.h>
 #include <dmlc/concurrency.h>
 #include <dmlc/thread_group.h>
+
+#include <memory>
 #include "../initialize.h"
 #include "./threaded_engine.h"
 #include "./thread_pool.h"
@@ -55,7 +57,7 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
   ThreadedEnginePerDevice() noexcept(false) {
     this->Start();
   }
-  ~ThreadedEnginePerDevice() noexcept(false) {
+  ~ThreadedEnginePerDevice() noexcept(false) override {
     this->StopNoWait();
   }
 
@@ -82,12 +84,12 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
     gpu_copy_nthreads_ = dmlc::GetEnv("MXNET_GPU_COPY_NTHREADS", 2);
     // create CPU task
     int cpu_priority_nthreads = dmlc::GetEnv("MXNET_CPU_PRIORITY_NTHREADS", 4);
-    cpu_priority_worker_.reset(new ThreadWorkerBlock<kPriorityQueue>());
-    cpu_priority_worker_->pool.reset(new ThreadPool(
+    cpu_priority_worker_ = std::make_unique<ThreadWorkerBlock<kPriorityQueue>>();
+    cpu_priority_worker_->pool = std::make_unique<ThreadPool>(
         cpu_priority_nthreads,
         [this](std::shared_ptr<dmlc::ManualEvent> ready_event) {
           this->CPUWorker(Context(), cpu_priority_worker_.get(), ready_event);
-        }, true));
+        }, true);
     // GPU tasks will be created lazily
   }
 
@@ -113,10 +115,10 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
           auto ptr =
           cpu_normal_workers_.Get(dev_id, [this, ctx, nthread]() {
               auto blk = new ThreadWorkerBlock<kWorkerQueue>();
-              blk->pool.reset(new ThreadPool(nthread,
+              blk->pool = std::make_unique<ThreadPool>(nthread,
                   [this, ctx, blk](std::shared_ptr<dmlc::ManualEvent> ready_event) {
                     this->CPUWorker(ctx, blk, ready_event);
-                  }, true));
+                  }, true);
             return blk;
           });
           if (ptr) {
@@ -139,12 +141,12 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
             // Signify to kernel that GPU is being used, so reserve cores as necessary
             OpenMP::Get()->set_reserve_cores(GetReserveCoreCount(true));
             auto blk = new ThreadWorkerBlock<kCopyQueue>();
-              blk->pool.reset(new ThreadPool(
+              blk->pool = std::make_unique<ThreadPool>(
                 nthread,
                 [this, ctx, is_copy, blk]
                   (std::shared_ptr<dmlc::ManualEvent> ready_event) {
                     this->GPUWorker(ctx, is_copy, blk, ready_event);
-                  }, true));
+                  }, true);
               return blk;
             });
           if (ptr) {
@@ -162,12 +164,12 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
               // Signify to kernel that GPU is being used, so reserve cores as necessary
               OpenMP::Get()->set_reserve_cores(GetReserveCoreCount(true));
                 auto blk = new ThreadWorkerBlock<kPriorityQueue>();
-                blk->pool.reset(new ThreadPool(
+                blk->pool = std::make_unique<ThreadPool>(
                   nthread,
                   [this, ctx, is_copy, blk]
                     (std::shared_ptr<dmlc::ManualEvent> ready_event) {
                       this->GPUWorker(ctx, is_copy, blk, ready_event);
-                    }, true));
+                    }, true);
                 return blk;
             });
             if (ptr) {
@@ -179,12 +181,12 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
               // Signify to kernel that GPU is being used, so reserve cores as necessary
               OpenMP::Get()->set_reserve_cores(GetReserveCoreCount(true));
                 auto blk = new ThreadWorkerBlock<kWorkerQueue>();
-                blk->pool.reset(new ThreadPool(
+                blk->pool = std::make_unique<ThreadPool>(
                   nthread,
                   [this, ctx, is_copy, blk]
                     (std::shared_ptr<dmlc::ManualEvent> ready_event) {
                       this->GPUWorker(ctx, is_copy, blk, ready_event);
-                    }, true));
+                    }, true);
                 return blk;
             });
             if (ptr) {
@@ -211,7 +213,7 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
     // constructor
     ThreadWorkerBlock() = default;
     // destructor
-    ~ThreadWorkerBlock() noexcept(false) {}
+    ~ThreadWorkerBlock() noexcept(false) = default;
   };
 
   /*! \brief whether this is a worker thread. */

--- a/src/engine/threaded_engine_perdevice.cc
+++ b/src/engine/threaded_engine_perdevice.cc
@@ -213,7 +213,7 @@ class ThreadedEnginePerDevice : public ThreadedEngine {
     // constructor
     ThreadWorkerBlock() = default;
     // destructor
-    ~ThreadWorkerBlock() noexcept(false) = default;
+    ~ThreadWorkerBlock() = default;
   };
 
   /*! \brief whether this is a worker thread. */

--- a/src/engine/threaded_engine_pooled.cc
+++ b/src/engine/threaded_engine_pooled.cc
@@ -27,6 +27,7 @@
 #include <dmlc/logging.h>
 #include <dmlc/concurrency.h>
 #include <cassert>
+#include <memory>
 #include <utility>
 #include "./threaded_engine.h"
 #include "./thread_pool.h"
@@ -50,7 +51,7 @@ class ThreadedEnginePooled : public ThreadedEngine {
     this->Start();
   }
 
-  ~ThreadedEnginePooled() noexcept(false) {
+  ~ThreadedEnginePooled() noexcept(false) override {
     StopNoWait();
   }
 
@@ -71,17 +72,17 @@ class ThreadedEnginePooled : public ThreadedEngine {
   }
 
   void Start() override {
-    streams_.reset(new StreamManager<kMaxNumGpus, kNumStreamsPerGpu>());
+    streams_ = std::make_unique<StreamManager<kMaxNumGpus, kNumStreamsPerGpu>>();
     task_queue_.reset(new dmlc::ConcurrentBlockingQueue<OprBlock*>());
     io_task_queue_.reset(new dmlc::ConcurrentBlockingQueue<OprBlock*>());
-    thread_pool_.reset(new ThreadPool(kNumWorkingThreads,
+    thread_pool_ = std::make_unique<ThreadPool>(kNumWorkingThreads,
                                       [this](std::shared_ptr<dmlc::ManualEvent> ready_event) {
                                         ThreadWorker(task_queue_, ready_event); },
-                                      true));
-    io_thread_pool_.reset(new ThreadPool(1,
+                                      true);
+    io_thread_pool_ = std::make_unique<ThreadPool>(1,
                                          [this](std::shared_ptr<dmlc::ManualEvent> ready_event) {
                                            ThreadWorker(io_task_queue_, ready_event); },
-                                         true));
+                                         true);
   }
 
  protected:

--- a/src/imperative/attach_op_execs_pass.cc
+++ b/src/imperative/attach_op_execs_pass.cc
@@ -188,7 +188,8 @@ class StatefulComputeExExecutor : public OpExecutor {
                                      OpStatePtr  state,
                                      FStatefulComputeEx  fcompute,
                                      ExecType exec_type)
-      : attrs_(std::move(attrs)), state_(std::move(state)), fcompute_(std::move(fcompute)), exec_type_(exec_type) {}
+      : attrs_(std::move(attrs)), state_(std::move(state)), fcompute_(std::move(fcompute)),
+        exec_type_(exec_type) {}
 
  private:
   NodeAttrs attrs_;

--- a/src/imperative/attach_op_execs_pass.cc
+++ b/src/imperative/attach_op_execs_pass.cc
@@ -27,6 +27,8 @@
 #include <mxnet/op_attr_types.h>
 #include <mxnet/graph_attr_types.h>
 #include <nnvm/graph_attr_types.h>
+
+#include <utility>
 #include "../common/utils.h"
 #include "../common/exec_utils.h"
 #include "./exec_pass.h"
@@ -45,8 +47,8 @@ namespace exec {
 // FComputeExecutor and FStatefulComputeExecutor inherit from this class
 class StorageFallbackOpExecutor : public OpExecutor {
  public:
-  explicit StorageFallbackOpExecutor(const std::vector<uint32_t> &mutate_idx)
-      : mutate_idx_(mutate_idx) {}
+  explicit StorageFallbackOpExecutor(std::vector<uint32_t> mutate_idx)
+      : mutate_idx_(std::move(mutate_idx)) {}
 
   void Setup() override {
     init_ = false;
@@ -136,12 +138,12 @@ class StatefulComputeExecutor : public StorageFallbackOpExecutor {
     return state_;
   }
 
-  explicit StatefulComputeExecutor(const OpStatePtr& state,
-                                   const FStatefulCompute& fcompute,
+  explicit StatefulComputeExecutor(OpStatePtr  state,
+                                   FStatefulCompute  fcompute,
                                    ExecType exec_type,
                                    const std::vector<uint32_t> &mutate_idx)
       : StorageFallbackOpExecutor(mutate_idx),
-        state_(state), fcompute_(fcompute), exec_type_(exec_type) {}
+        state_(std::move(state)), fcompute_(std::move(fcompute)), exec_type_(exec_type) {}
 
  private:
   OpStatePtr state_;
@@ -182,11 +184,11 @@ class StatefulComputeExExecutor : public OpExecutor {
     return state_;
   }
 
-  explicit StatefulComputeExExecutor(const NodeAttrs& attrs,
-                                     const OpStatePtr& state,
-                                     const FStatefulComputeEx& fcompute,
+  explicit StatefulComputeExExecutor(NodeAttrs  attrs,
+                                     OpStatePtr  state,
+                                     FStatefulComputeEx  fcompute,
                                      ExecType exec_type)
-      : attrs_(attrs), state_(state), fcompute_(fcompute), exec_type_(exec_type) {}
+      : attrs_(std::move(attrs)), state_(std::move(state)), fcompute_(std::move(fcompute)), exec_type_(exec_type) {}
 
  private:
   NodeAttrs attrs_;
@@ -214,10 +216,10 @@ class FComputeExecutor : public StorageFallbackOpExecutor {
     return exec_type_;
   }
 
-  explicit FComputeExecutor(const NodeAttrs& attrs, FCompute fcompute,
+  explicit FComputeExecutor(NodeAttrs  attrs, FCompute fcompute,
                             ExecType exec_type, const std::vector<uint32_t> &mutate_idx)
       : StorageFallbackOpExecutor(mutate_idx),
-        attrs_(attrs), fcompute_(fcompute), exec_type_(exec_type) {
+        attrs_(std::move(attrs)), fcompute_(std::move(fcompute)), exec_type_(exec_type) {
   }
 
  private:
@@ -250,9 +252,9 @@ class FComputeExExecutor : public OpExecutor {
     return exec_type_;
   }
 
-  explicit FComputeExExecutor(const NodeAttrs& attrs, FComputeEx fcompute,
+  explicit FComputeExExecutor(NodeAttrs  attrs, FComputeEx fcompute,
                               ExecType exec_type)
-      : attrs_(attrs), fcompute_(fcompute), exec_type_(exec_type) {
+      : attrs_(std::move(attrs)), fcompute_(std::move(fcompute)), exec_type_(exec_type) {
   }
 
  private:

--- a/src/imperative/cached_op.cc
+++ b/src/imperative/cached_op.cc
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include <memory>
 #include <unordered_set>
 #include <iostream>
 #include "./imperative_utils.h"
@@ -87,8 +88,7 @@ CachedOp::CachedOp(
   SetRefCounts(&fwd_graph_, full_graph_);
 }
 
-CachedOp::~CachedOp() {
-}
+CachedOp::~CachedOp() = default;
 
 std::vector<nnvm::NodeEntry> CachedOp::Gradient(
     const nnvm::ObjectPtr& node,
@@ -1286,7 +1286,7 @@ void CachedOpParamParser(nnvm::NodeAttrs* attrs) {
     std::vector<std::pair<std::string, std::string> > flags;
     for (const auto& attr : attrs->dict)
       flags.emplace_back(attr.first, attr.second);
-    attrs->parsed = CachedOpPtr(new CachedOp(sym, flags));
+    attrs->parsed = std::make_shared<CachedOp>(sym, flags);
   }
 }
 

--- a/src/imperative/cached_op_threadsafe.cc
+++ b/src/imperative/cached_op_threadsafe.cc
@@ -250,7 +250,7 @@ void CachedOpThreadSafeParamParser(nnvm::NodeAttrs* attrs) {
     throw dmlc::ParamError(os.str());
   }
 }
-CachedOpThreadSafe::~CachedOpThreadSafe() {}
+CachedOpThreadSafe::~CachedOpThreadSafe() = default;
 
 NNVM_REGISTER_OP(_CachedOpThreadSafe)
 .set_num_inputs([](const NodeAttrs& attrs) {

--- a/src/imperative/eliminate_common_expr_pass.cc
+++ b/src/imperative/eliminate_common_expr_pass.cc
@@ -184,10 +184,10 @@ void EliminateCommonNodes(Graph* g,
   // insert Copy nodes as appropriate
   const Op* copy_op = Op::Get("_copy");
   nnvm::NodeEntryMap<size_t> unique_outputs;
-  for (size_t i = 0; i < g->outputs.size(); ++i) {
-    auto kv = unique_outputs.find(g->outputs[i]);
+  for (auto & output : g->outputs) {
+    auto kv = unique_outputs.find(output);
     if (kv == unique_outputs.end()) {
-      unique_outputs.emplace(g->outputs[i], 0);
+      unique_outputs.emplace(output, 0);
     } else {
       ObjectPtr copy_node = Node::Create();
       std::ostringstream os;
@@ -196,7 +196,7 @@ void EliminateCommonNodes(Graph* g,
       copy_node->attrs.op = copy_op;
       copy_node->attrs.name = os.str();
       copy_node->inputs.emplace_back(kv->first);
-      g->outputs[i] = nnvm::NodeEntry{copy_node, 0, 0};
+      output = nnvm::NodeEntry{copy_node, 0, 0};
     }
   }
 }

--- a/src/imperative/imperative.cc
+++ b/src/imperative/imperative.cc
@@ -119,11 +119,11 @@ OpStatePtr Imperative::Invoke(
   SetWriteInplaceReq(inputs, outputs, &req);
   OpStatePtr ret = InvokeOp(ctx, attrs, inputs, outputs, req, dispatch_mode);
   // the followinng loop is used for finding out the correct shape when some shapes are dynamic
-  for (size_t i = 0; i < outputs.size(); i++) {
-    if (!shape_is_known(outputs[i]->shape())) {
+  for (auto output : outputs) {
+    if (!shape_is_known(output->shape())) {
       // the WaitToRead overhead here does not seem to be avoidable
-      outputs[i]->WaitToRead();
-      outputs[i]->SetShapeFromChunk();
+      output->WaitToRead();
+      output->SetShapeFromChunk();
     }
   }
   return ret;

--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -23,7 +23,7 @@
  * \brief initialize mxnet library
  */
 #include "initialize.h"
-#include <signal.h>
+#include <csignal>
 #include <dmlc/logging.h>
 #include <mxnet/engine.h>
 #include "./engine/openmp.h"

--- a/src/initialize.cc
+++ b/src/initialize.cc
@@ -23,7 +23,6 @@
  * \brief initialize mxnet library
  */
 #include "initialize.h"
-#include <csignal>
 #include <dmlc/logging.h>
 #include <mxnet/engine.h>
 #include "./engine/openmp.h"
@@ -33,7 +32,6 @@
 #endif  // MXNET_USE_OPENCV
 #include "common/utils.h"
 #include "engine/openmp.h"
-
 
 #if defined(_WIN32) || defined(_WIN64) || defined(__WINDOWS__)
 #include <windows.h>
@@ -56,6 +54,9 @@ void win_err(char **err) {
 #else
 #include <dlfcn.h>
 #endif
+
+#include <csignal>
+
 
 namespace mxnet {
 

--- a/src/io/batchify.cc
+++ b/src/io/batchify.cc
@@ -73,8 +73,8 @@ class GroupBatchify : public BatchifyFunction {
     }
   }
 
-  virtual bool Batchify(const std::vector<std::vector<NDArray> >& inputs,
-                        std::vector<NDArray>* outputs) {
+  bool Batchify(const std::vector<std::vector<NDArray> >& inputs,
+                        std::vector<NDArray>* outputs) override {
     auto bs = inputs.size();
     CHECK_GT(bs, 0) << "BatchifyFunction should handle at lease 1 sample";
     auto out_size = inputs[0].size();
@@ -84,8 +84,8 @@ class GroupBatchify : public BatchifyFunction {
     for (size_t i = 0; i < out_size; ++i) {
       std::vector<std::vector<NDArray> > inp;
       inp.reserve(inputs.size());
-      for (size_t j = 0; j < inputs.size(); ++j) {
-          std::vector<NDArray> curr({inputs[j][i]});
+      for (const auto & input : inputs) {
+          std::vector<NDArray> curr({input[i]});
           inp.emplace_back(curr);
       }
       std::vector<NDArray> tmp;
@@ -128,8 +128,8 @@ class StackBatchify : public BatchifyFunction {
     param_.InitAllowUnknown(kwargs);
   }
 
-  virtual bool Batchify(const std::vector<std::vector<NDArray> >& inputs,
-                        std::vector<NDArray>* outputs) {
+  bool Batchify(const std::vector<std::vector<NDArray> >& inputs,
+                        std::vector<NDArray>* outputs) override {
     auto out_size = SanityCheck(inputs);
     auto bs = inputs.size();
     outputs->resize(out_size);
@@ -235,8 +235,8 @@ class PadBatchify : public BatchifyFunction {
     param_.InitAllowUnknown(kwargs);
   }
 
-  virtual bool Batchify(const std::vector<std::vector<NDArray> >& inputs,
-                        std::vector<NDArray>* outputs) {
+  bool Batchify(const std::vector<std::vector<NDArray> >& inputs,
+                        std::vector<NDArray>* outputs) override {
     auto bs = inputs.size();
     CHECK_GT(bs, 0) << "BatchifyFunction should handle at lease 1 sample";
     auto out_size = inputs[0].size();

--- a/src/io/dataloader.cc
+++ b/src/io/dataloader.cc
@@ -63,13 +63,11 @@ DMLC_REGISTER_PARAMETER(ThreadedDataLoaderParam);
 template<typename DType = real_t>
 class ThreadedDataLoader : public IIterator<TBlobBatch> {
  public:
-  ThreadedDataLoader() {
-  }
+  ThreadedDataLoader() = default;
   // destructor
-  virtual ~ThreadedDataLoader(void) {
-  }
+  ~ThreadedDataLoader() override = default;
   // constructor
-  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
     param_.InitAllowUnknown(kwargs);
     int maxthread, threadget;
     #pragma omp parallel
@@ -90,15 +88,15 @@ class ThreadedDataLoader : public IIterator<TBlobBatch> {
     this->BeforeFirst();
   }
   // before first
-  void BeforeFirst(void) {
+  void BeforeFirst() override {
     sampler_->BeforeFirst();
   }
 
-  int64_t GetLenHint(void) const {
+  int64_t GetLenHint() const override {
     return sampler_->GetLenHint();
   }
 
-  bool Next(void) {
+  bool Next() override {
     bool has_next = sampler_->Next();
     if (!has_next) return false;
     auto samples = sampler_->Value();
@@ -152,7 +150,7 @@ class ThreadedDataLoader : public IIterator<TBlobBatch> {
     return true;
   }
 
-  const TBlobBatch &Value(void) const {
+  const TBlobBatch &Value() const override {
     return out_;
   }
 

--- a/src/io/dataset.cc
+++ b/src/io/dataset.cc
@@ -29,6 +29,7 @@
 #include <mxnet/ndarray.h>
 #include <mxnet/tensor_blob.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <algorithm>
@@ -75,11 +76,11 @@ class RecordFileDataset final : public Dataset {
     delete idx_stream;
   }
 
-  uint64_t GetLen() const {
+  uint64_t GetLen() const override {
     return idx_.size();
   }
 
-  bool GetItem(uint64_t idx, std::vector<NDArray>* ret) {
+  bool GetItem(uint64_t idx, std::vector<NDArray>* ret) override {
     ret->resize(1);
     auto& out = (*ret)[0];
     static thread_local std::unique_ptr<dmlc::Stream> stream;
@@ -193,11 +194,11 @@ class ImageRecordFileDataset : public Dataset {
     base_ = std::make_shared<RecordFileDataset>(kwargs);
   }
 
-  uint64_t GetLen() const {
+  uint64_t GetLen() const override {
     return base_->GetLen();
   }
 
-  bool GetItem(uint64_t idx, std::vector<NDArray>* ret) {
+  bool GetItem(uint64_t idx, std::vector<NDArray>* ret) override {
     CHECK_LT(idx, GetLen());
     std::vector<NDArray> raw;
     if (!base_->GetItem(idx, &raw)) return false;
@@ -292,11 +293,11 @@ class ImageSequenceDataset final : public Dataset {
     img_list_ = dmlc::Split(param_.img_list, param_.path_sep);
   }
 
-  uint64_t GetLen() const {
+  uint64_t GetLen() const override {
     return img_list_.size();
   }
 
-  bool GetItem(uint64_t idx, std::vector<NDArray>* ret) {
+  bool GetItem(uint64_t idx, std::vector<NDArray>* ret) override {
 #if MXNET_USE_OPENCV
     CHECK_LT(idx, img_list_.size())
       << "GetItem index: " << idx << " out of bound: " << img_list_.size();
@@ -355,11 +356,11 @@ class NDArrayDataset final : public Dataset {
     size_ = data_.shape().begin()[0];
   }
 
-  uint64_t GetLen() const {
+  uint64_t GetLen() const override {
     return size_;
   }
 
-  bool GetItem(uint64_t idx, std::vector<NDArray>* rets) {
+  bool GetItem(uint64_t idx, std::vector<NDArray>* rets) override {
     CHECK_LT(idx, size_)
       << "GetItem index: " << idx << " out of bound: " << size_;
     rets->resize(1);
@@ -430,11 +431,11 @@ class GroupDataset final : public Dataset {
     }
   }
 
-  uint64_t GetLen() const {
+  uint64_t GetLen() const override {
     return size_;
   }
 
-  bool GetItem(uint64_t idx, std::vector<NDArray>* ret) {
+  bool GetItem(uint64_t idx, std::vector<NDArray>* ret) override {
     CHECK_LT(idx, size_)
       << "GetItem index: " << idx << " out of bound: " << size_;
     ret->clear();
@@ -485,11 +486,11 @@ class IndexedDataset final : public Dataset {
     base_data_ = *static_cast<std::shared_ptr<Dataset>*>(reinterpret_cast<void*>(param_.base));
   }
 
-  uint64_t GetLen() const {
+  uint64_t GetLen() const override {
     return param_.indices.ndim();
   }
 
-  bool GetItem(uint64_t idx, std::vector<NDArray>* ret) {
+  bool GetItem(uint64_t idx, std::vector<NDArray>* ret) override {
     CHECK_GT(param_.indices.ndim(), idx) << "IndexError: " << idx
       << " from total: " << param_.indices.ndim();
     auto new_idx = param_.indices[idx];
@@ -545,15 +546,15 @@ class LazyTransformDataset final : public Dataset {
     this->pass_through_indices_ = other.pass_through_indices_;
     this->use_input_indices_ = other.use_input_indices_;
     this->num_outputs_ = other.num_outputs_;
-    this->cached_op_ = NaiveCachedOpPtr(new NaiveCachedOp(
-      other.cached_op_->sym_, other.cached_op_->flags_));
+    this->cached_op_ = std::make_shared<NaiveCachedOp>(
+      other.cached_op_->sym_, other.cached_op_->flags_);
     this->base_data_ = other.base_data_;
   }
 
   explicit LazyTransformDataset(const std::vector<std::pair<std::string, std::string> >& kwargs) {
     param_.InitAllowUnknown(kwargs);
     auto op = *static_cast<CachedOpPtr*>(reinterpret_cast<void*>(param_.cached_op));
-    cached_op_ = NaiveCachedOpPtr(new NaiveCachedOp(op->sym_, op->flags_));
+    cached_op_ = std::make_shared<NaiveCachedOp>(op->sym_, op->flags_);
     base_data_ = *static_cast<std::shared_ptr<Dataset>*>(reinterpret_cast<void*>(param_.dataset));
 
     // use first item to calculate size info
@@ -596,14 +597,13 @@ class LazyTransformDataset final : public Dataset {
     num_outputs_ = inputs.size() + cached_op_->num_outputs() - cached_op_->num_inputs();
   }
 
-  virtual ~LazyTransformDataset(void) {
-  }
+  ~LazyTransformDataset() override = default;
 
-  uint64_t GetLen() const {
+  uint64_t GetLen() const override {
     return base_data_->GetLen();
   }
 
-  bool GetItem(uint64_t idx, std::vector<NDArray>* outputs) {
+  bool GetItem(uint64_t idx, std::vector<NDArray>* outputs) override {
     std::vector<NDArray> inputs;
     if (!base_data_->GetItem(idx, &inputs)) return false;
     outputs->reserve(num_outputs_);
@@ -616,8 +616,8 @@ class LazyTransformDataset final : public Dataset {
     std::vector<NDArray*> ndinputs;
     std::vector<NDArray*> ndoutputs;
     ndinputs.reserve(inputs.size());
-    for (size_t i = 0; i < use_input_indices_.size(); ++i) {
-      ndinputs.emplace_back(&(inputs[use_input_indices_[i]]));
+    for (int use_input_indice : use_input_indices_) {
+      ndinputs.emplace_back(&(inputs[use_input_indice]));
     }
     ndoutputs.reserve(cached_op_->num_outputs());
     CHECK_LE(cached_op_->num_outputs(), outputs->size());
@@ -625,8 +625,8 @@ class LazyTransformDataset final : public Dataset {
       ndoutputs.emplace_back(&(outputs->at(i)));
     }
 
-    for (size_t i = 0; i < inputs.size(); ++i) {
-      inputs[i].WaitToRead();
+    for (auto & input : inputs) {
+      input.WaitToRead();
     }
     CHECK(inputs.size() > 0) << "dataset getitem requires at least one input";
     Context default_ctx = inputs[0].ctx();

--- a/src/io/image_aug_default.cc
+++ b/src/io/image_aug_default.cc
@@ -205,7 +205,7 @@ std::vector<dmlc::ParamFieldInfo> ListDefaultAugParams() {
 class DefaultImageAugmenter : public ImageAugmenter {
  public:
   // contructor
-  DefaultImageAugmenter() {}
+  DefaultImageAugmenter() = default;
   void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
     std::vector<std::pair<std::string, std::string> > kwargs_left;
     kwargs_left = param_.InitAllowUnknown(kwargs);

--- a/src/io/image_det_aug_default.cc
+++ b/src/io/image_det_aug_default.cc
@@ -404,7 +404,7 @@ class ImageDetLabel {
 class DefaultImageDetAugmenter : public ImageAugmenter {
  public:
   // contructor
-  DefaultImageDetAugmenter() {}
+  DefaultImageDetAugmenter() = default;
 
   void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
     std::vector<std::pair<std::string, std::string> > kwargs_left;

--- a/src/io/iter_csv.cc
+++ b/src/io/iter_csv.cc
@@ -62,16 +62,16 @@ class CSVIterBase: public IIterator<DataInst> {
   CSVIterBase() {
     out_.data.resize(2);
   }
-  virtual ~CSVIterBase() {}
+  ~CSVIterBase() override = default;
 
   // initialize iterator loads data in
-  virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) = 0;
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override = 0;
   /*! \brief reset the iterator */
-  virtual void BeforeFirst(void) = 0;
+  void BeforeFirst() override = 0;
   /*! \brief move to next item */
-  virtual bool Next(void) = 0;
+  bool Next() override = 0;
   /*! \brief get current data */
-  virtual const DataInst &Value(void) const {
+  const DataInst &Value() const override {
     return out_;
   }
 
@@ -93,9 +93,9 @@ class CSVIterBase: public IIterator<DataInst> {
 template <typename DType>
 class CSVIterTyped: public CSVIterBase {
  public:
-  virtual ~CSVIterTyped() {}
+  ~CSVIterTyped() override = default;
   // intialize iterator loads data in
-  virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
     param_.InitAllowUnknown(kwargs);
     data_parser_.reset(dmlc::Parser<uint32_t, DType>::Create(param_.data_csv.c_str(), 0, 1, "csv"));
     if (param_.label_csv != "NULL") {
@@ -108,7 +108,7 @@ class CSVIterTyped: public CSVIterBase {
     }
   }
 
-  virtual void BeforeFirst() {
+  void BeforeFirst() override {
     data_parser_->BeforeFirst();
     if (label_parser_.get() != nullptr) {
       label_parser_->BeforeFirst();
@@ -119,7 +119,7 @@ class CSVIterTyped: public CSVIterBase {
     end_ = false;
   }
 
-  virtual bool Next() {
+  bool Next() override {
     if (end_) return false;
     while (data_ptr_ >= data_size_) {
       if (!data_parser_->Next()) {
@@ -163,11 +163,11 @@ class CSVIterTyped: public CSVIterBase {
 
 class CSVIter: public IIterator<DataInst> {
  public:
-  CSVIter() {}
-  virtual ~CSVIter() {}
+  CSVIter() = default;
+  ~CSVIter() override = default;
 
   // intialize iterator loads data in
-  virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
     param_.InitAllowUnknown(kwargs);
     bool dtype_has_value = false;
     int target_dtype = -1;
@@ -195,15 +195,15 @@ class CSVIter: public IIterator<DataInst> {
     iterator_->Init(kwargs);
   }
 
-  virtual void BeforeFirst() {
+  void BeforeFirst() override {
     iterator_->BeforeFirst();
   }
 
-  virtual bool Next() {
+  bool Next() override {
     return iterator_->Next();
   }
 
-  virtual const DataInst &Value(void) const {
+  const DataInst &Value() const override {
     return iterator_->Value();
   }
 

--- a/src/io/iter_image_det_recordio.cc
+++ b/src/io/iter_image_det_recordio.cc
@@ -32,6 +32,7 @@
 #include <dmlc/parameter.h>
 #include <dmlc/recordio.h>
 #include <dmlc/threadediter.h>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 #include <cstdlib>
@@ -213,7 +214,7 @@ class ImageDetRecordIOParser {
   inline void Init(const std::vector<std::pair<std::string, std::string> >& kwargs);
 
   // set record to the head
-  inline void BeforeFirst(void) {
+  inline void BeforeFirst() {
     return source_->BeforeFirst();
   }
   // parse next set of records, return an array of
@@ -273,8 +274,8 @@ inline void ImageDetRecordIOParser<DType>::Init(
     prnds_.emplace_back(new common::RANDOM_ENGINE((i + 1) * kRandMagic));
   }
   if (param_.path_imglist.length() != 0) {
-    label_map_.reset(new ImageDetLabelMap(param_.path_imglist.c_str(),
-      param_.label_width, !param_.verbose));
+    label_map_ = std::make_unique<ImageDetLabelMap>(param_.path_imglist.c_str(),
+      param_.label_width, !param_.verbose);
   }
   CHECK(param_.path_imgrec.length() != 0)
       << "ImageDetRecordIOIterator: must specify image_rec";
@@ -510,12 +511,12 @@ class ImageDetRecordIter : public IIterator<DataInst> {
  public:
   ImageDetRecordIter() : data_(nullptr) { }
   // destructor
-  virtual ~ImageDetRecordIter(void) {
+  ~ImageDetRecordIter() override {
     iter_.Destroy();
     delete data_;
   }
   // constructor
-  virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
     param_.InitAllowUnknown(kwargs);
     // use the kwarg to init parser
     parser_.Init(kwargs);
@@ -533,13 +534,13 @@ class ImageDetRecordIter : public IIterator<DataInst> {
     rnd_.seed(kRandMagic + param_.seed);
   }
   // before first
-  virtual void BeforeFirst(void) {
+  void BeforeFirst() override {
     iter_.BeforeFirst();
     inst_order_.clear();
     inst_ptr_ = 0;
   }
 
-  virtual bool Next(void) {
+  bool Next() override {
     while (true) {
       if (inst_ptr_ < inst_order_.size()) {
         std::pair<unsigned, unsigned> p = inst_order_[inst_ptr_];
@@ -553,7 +554,7 @@ class ImageDetRecordIter : public IIterator<DataInst> {
         for (unsigned i = 0; i < data_->size(); ++i) {
           const InstVector<DType>& tmp = (*data_)[i];
           for (unsigned j = 0; j < tmp.Size(); ++j) {
-            inst_order_.push_back(std::make_pair(i, j));
+            inst_order_.emplace_back(i, j);
           }
         }
         // shuffle instance order if needed
@@ -566,7 +567,7 @@ class ImageDetRecordIter : public IIterator<DataInst> {
     return false;
   }
 
-  virtual const DataInst &Value(void) const {
+  const DataInst &Value() const override {
     return out_;
   }
 

--- a/src/io/iter_libsvm.cc
+++ b/src/io/iter_libsvm.cc
@@ -66,11 +66,11 @@ struct LibSVMIterParam : public dmlc::Parameter<LibSVMIterParam> {
 
 class LibSVMIter: public SparseIIterator<DataInst> {
  public:
-  LibSVMIter() {}
-  virtual ~LibSVMIter() {}
+  LibSVMIter() = default;
+  ~LibSVMIter() override = default;
 
   // intialize iterator loads data in
-  virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
     param_.InitAllowUnknown(kwargs);
     CHECK_EQ(param_.data_shape.ndim(), 1) << "dimension of data_shape is expected to be 1";
     CHECK_GT(param_.num_parts, 0) << "number of parts should be positive";
@@ -97,7 +97,7 @@ class LibSVMIter: public SparseIIterator<DataInst> {
     }
   }
 
-  virtual void BeforeFirst() {
+  void BeforeFirst() override {
     data_parser_->BeforeFirst();
     if (label_parser_.get() != nullptr) {
       label_parser_->BeforeFirst();
@@ -108,7 +108,7 @@ class LibSVMIter: public SparseIIterator<DataInst> {
     end_ = false;
   }
 
-  virtual bool Next() {
+  bool Next() override {
     if (end_) return false;
     while (data_ptr_ >= data_size_) {
       if (!data_parser_->Next()) {
@@ -144,16 +144,16 @@ class LibSVMIter: public SparseIIterator<DataInst> {
     return true;
   }
 
-  virtual const DataInst &Value(void) const {
+  const DataInst &Value() const override {
     return out_;
   }
 
-  virtual const NDArrayStorageType GetStorageType(bool is_data) const {
+  const NDArrayStorageType GetStorageType(bool is_data) const override {
     if (is_data) return kCSRStorage;
     return param_.label_shape.Size() > 1 ? kCSRStorage : kDefaultStorage;
   }
 
-  virtual const mxnet::TShape GetShape(bool is_data) const {
+  const mxnet::TShape GetShape(bool is_data) const override {
     if (is_data) return param_.data_shape;
     return param_.label_shape;
   }

--- a/src/io/iter_mnist.cc
+++ b/src/io/iter_mnist.cc
@@ -79,15 +79,15 @@ struct MNISTParam : public dmlc::Parameter<MNISTParam> {
 
 class MNISTIter: public IIterator<TBlobBatch> {
  public:
-  MNISTIter(void) : loc_(0), inst_offset_(0) {
+  MNISTIter()  {
     img_.dptr_ = nullptr;
     out_.data.resize(2);
   }
-  virtual ~MNISTIter(void) {
+  ~MNISTIter() override {
     delete []img_.dptr_;
   }
   // intialize iterator loads data in
-  virtual void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) {
+  void Init(const std::vector<std::pair<std::string, std::string> >& kwargs) override {
     std::map<std::string, std::string> kmap(kwargs.begin(), kwargs.end());
     param_.InitAllowUnknown(kmap);
     this->LoadImage();
@@ -115,10 +115,10 @@ class MNISTIter: public IIterator<TBlobBatch> {
       }
     }
   }
-  virtual void BeforeFirst(void) {
+  void BeforeFirst() override {
     this->loc_ = 0;
   }
-  virtual bool Next(void) {
+  bool Next() override {
     if (loc_ + param_.batch_size <= img_.size(0)) {
       batch_data_.dptr_ = img_[loc_].dptr_;
       batch_label_.dptr_ = &labels_[loc_];
@@ -135,7 +135,7 @@ class MNISTIter: public IIterator<TBlobBatch> {
       return false;
     }
   }
-  virtual const TBlobBatch &Value(void) const {
+  const TBlobBatch &Value() const override {
     return out_;
   }
 
@@ -151,7 +151,7 @@ class MNISTIter: public IIterator<TBlobBatch> {
         static_cast<double>(count) / param_.num_parts * (param_.part_index+1));
   }
 
-  inline void LoadImage(void) {
+  inline void LoadImage() {
     dmlc::SeekStream* stdimg
         = dmlc::SeekStream::CreateForRead(param_.image.c_str());
     ReadInt(stdimg);
@@ -184,7 +184,7 @@ class MNISTIter: public IIterator<TBlobBatch> {
     img_ *= 1.0f / 256.0f;
     delete stdimg;
   }
-  inline void LoadLabel(void) {
+  inline void LoadLabel() {
     dmlc::SeekStream* stdlabel
         = dmlc::SeekStream::CreateForRead(param_.label.c_str());
     ReadInt(stdlabel);
@@ -206,7 +206,7 @@ class MNISTIter: public IIterator<TBlobBatch> {
     }
     delete stdlabel;
   }
-  inline void Shuffle(void) {
+  inline void Shuffle() {
     std::shuffle(inst_.begin(), inst_.end(), common::RANDOM_ENGINE(kRandMagic + param_.seed));
     std::vector<float> tmplabel(labels_.size());
     mshadow::TensorContainer<cpu, 3> tmpimg(img_.shape_);
@@ -238,7 +238,7 @@ class MNISTIter: public IIterator<TBlobBatch> {
   /*! \brief output */
   TBlobBatch out_;
   /*! \brief current location */
-  index_t loc_;
+  index_t loc_{0};
   /*! \brief image content */
   mshadow::Tensor<cpu, 3> img_;
   /*! \brief label content */
@@ -248,7 +248,7 @@ class MNISTIter: public IIterator<TBlobBatch> {
   /*! \brief batch label tensor  */
   mshadow::Tensor<cpu, 2> batch_label_;
   /*! \brief instance index offset */
-  unsigned inst_offset_;
+  unsigned inst_offset_{0};
   /*! \brief instance index */
   std::vector<unsigned> inst_;
   // magic number to setup randomness

--- a/src/kvstore/kvstore.cc
+++ b/src/kvstore/kvstore.cc
@@ -23,7 +23,6 @@
  * \brief implement kv_store
  */
 #include <mxnet/kvstore.h>
-#include <cstdlib>
 #include <dmlc/logging.h>
 #include "./kvstore_local.h"
 
@@ -35,6 +34,8 @@ std::atomic<int> mxnet::kvstore::KVStoreDist::customer_id_{0};
 #if MXNET_USE_NCCL
 #include "./kvstore_nccl.h"
 #endif  // MXNET_USE_NCCL
+
+#include <cstdlib>
 
 namespace mxnet {
 

--- a/src/kvstore/kvstore.cc
+++ b/src/kvstore/kvstore.cc
@@ -23,7 +23,7 @@
  * \brief implement kv_store
  */
 #include <mxnet/kvstore.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <dmlc/logging.h>
 #include "./kvstore_local.h"
 

--- a/src/nnvm/gradient.cc
+++ b/src/nnvm/gradient.cc
@@ -168,8 +168,8 @@ Graph Gradient(Graph src) {
   // information is needed in later stages to determine whether putting a node
   // on the mirror path can be beneficial or not.
   using mxnet::ShapeVector;
-  ShapeVector in_arg_shapes = std::move(src.GetAttr<ShapeVector>("in_arg_shapes"));
-  DTypeVector in_arg_dtypes = std::move(src.GetAttr<DTypeVector>("in_arg_dtypes"));
+  ShapeVector in_arg_shapes = src.GetAttr<ShapeVector>("in_arg_shapes");
+  DTypeVector in_arg_dtypes = src.GetAttr<DTypeVector>("in_arg_dtypes");
   src = mxnet::exec::InferShape(std::move(src), std::move(in_arg_shapes), "__shape__");
   src = mxnet::exec::InferType(std::move(src), std::move(in_arg_dtypes), "__dtype__");
   CHECK(src.GetAttr<size_t>("shape_num_unknown_nodes") == 0U);
@@ -583,8 +583,7 @@ Graph BuildGradientGraph(
     // gather all the output gradient entries and apply the aggregation function
     out_agg_grads.clear();
     auto& out_grad_vec = output_grads.at(src_fwd_node.get());
-    for (uint32_t i = 0; i < out_grad_vec.size(); ++i) {
-      GradEntry& e = out_grad_vec[i];
+    for (auto & e : out_grad_vec) {
       e.sum = agg_fun(std::move(e.grads));
       out_agg_grads.push_back(e.sum);
     }
@@ -698,7 +697,7 @@ Graph BuildGradientGraph(
 
 // register pass
 NNVM_REGISTER_PASS(MXGradient)
-.describe("Return a gradient graph of src.attrs[\"ys\"] wrt src.attrs[\"xs\"]")
+.describe(R"(Return a gradient graph of src.attrs["ys"] wrt src.attrs["xs"])")
 .set_body(Gradient)
 .set_change_graph(true)
 .depend_graph_attr("grad_ys")

--- a/src/nnvm/graph_editor.cc
+++ b/src/nnvm/graph_editor.cc
@@ -27,6 +27,8 @@
 #include <nnvm/graph.h>
 #include <nnvm/node.h>
 
+#include <utility>
+
 namespace nnvm {
 ObjectPtr CreateVariableNode(const std::string& name);
 }
@@ -67,7 +69,7 @@ bool CutGraphInputs(const std::vector<nnvm::NodeEntry *> &input_entries,
                     bool skip_var, std::vector<nnvm::NodeEntry> *orig_entries) {
   struct pred_entry {
     nnvm::NodeEntry e;
-    explicit pred_entry(const nnvm::NodeEntry &_e): e(_e) {}
+    explicit pred_entry(nnvm::NodeEntry _e): e(std::move(_e)) {}
     bool operator()(const nnvm::NodeEntry e1) {
       return e.node == e1.node && e.index == e1.index;
     }

--- a/src/nnvm/low_precision_pass.cc
+++ b/src/nnvm/low_precision_pass.cc
@@ -134,11 +134,10 @@ static bool CheckConditionalFP32(
       auto it_params = it->second;
       // For each param name, iterate through param values to check
       // if the provided param name is equal to any of the values
-      for (auto it_param = it_params.begin(); it_param != it_params.end();
-           it_param++) {
-        auto param_key = node->attrs.dict.find(it_param->first);
+      for (auto & it_param : it_params) {
+        auto param_key = node->attrs.dict.find(it_param.first);
         if (param_key != node->attrs.dict.end()) {
-          auto it_param_vals = it_param->second;
+          auto it_param_vals = it_param.second;
           if (std::find(it_param_vals.begin(), it_param_vals.end(),
                         param_key->second) != it_param_vals.end()) {
             return true;
@@ -282,13 +281,13 @@ Graph ReducePrecision(Graph &&src) {
           << "can't handle the widest_dtype_ops with mutable inputs.";
       int out_dtype = target_dtype;
       bool have_unknown_dtype = false;
-      for (size_t i = 0; i < node->inputs.size(); ++i) {
+      for (auto & input : node->inputs) {
         // Try to infer output dtype based on input dtype
-        if (!mirror_target_dtype_map.count(node->inputs[i])
-            && !mirror_fp32_map.count(node->inputs[i])) {
+        if (!mirror_target_dtype_map.count(input)
+            && !mirror_fp32_map.count(input)) {
           have_unknown_dtype = true;
           break;
-        } else if (mirror_fp32_map.count(node->inputs[i])) {
+        } else if (mirror_fp32_map.count(input)) {
           out_dtype = mshadow::kFloat32;
         }
       }

--- a/src/nnvm/tvm_bridge.cc
+++ b/src/nnvm/tvm_bridge.cc
@@ -40,6 +40,7 @@
 #include <mxnet/engine.h>
 
 #include <memory>
+#include <utility>
 
 namespace mxnet {
 
@@ -55,7 +56,7 @@ class TVMFunctor {
  public:
   // constructor
   explicit TVMFunctor(PackedFunc func, PackedFunc fset_stream)
-      : func_(func), fset_stream_(fset_stream) {}
+      : func_(std::move(func)), fset_stream_(std::move(fset_stream)) {}
 
   void Init(const TVMArgs& args,
             const std::vector<int>& const_loc,

--- a/src/operator/contrib/boolean_mask.cc
+++ b/src/operator/contrib/boolean_mask.cc
@@ -68,8 +68,8 @@ bool BooleanMaskBackStorageType(const nnvm::NodeAttrs& attrs,
   for (int &attr : *out_attrs) {
     attr = kDefaultStorage;
   }
-  for (size_t i = 0; i < out_attrs->size(); i++)
-    out_attrs->at(i) = kDefaultStorage;
+  for (int & out_attr : *out_attrs)
+    out_attr = kDefaultStorage;
   *dispatch_mode = DispatchMode::kFComputeEx;
   return true;
 }

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -418,7 +418,7 @@ static void RandomSample(size_t set_size,
     sampled_idxs.insert(distribution(generator));
   }
   out->clear();
-  for (unsigned long sampled_idx : sampled_idxs) {
+  for (size_t sampled_idx : sampled_idxs) {
     out->push_back(sampled_idx);
   }
 }
@@ -621,15 +621,15 @@ static void SampleSubgraph(const NDArray &csr,
     // First we push the size of neighbor vector
     neighbor_list.push_back(tmp_sampled_edge_list.size());
     // Then push the vertices
-    for (long & i : tmp_sampled_src_list) {
+    for (dgl_id_t & i : tmp_sampled_src_list) {
       neighbor_list.push_back(i);
     }
     // Finally we push the edge list
-    for (long & i : tmp_sampled_edge_list) {
+    for (dgl_id_t & i : tmp_sampled_edge_list) {
       neighbor_list.push_back(i);
     }
     num_edges += tmp_sampled_src_list.size();
-    for (long & i : tmp_sampled_src_list) {
+    for (dgl_id_t & i : tmp_sampled_src_list) {
       // If we have sampled the max number of vertices, we have to stop.
       if (sub_ver_mp.size() >= max_num_vertices)
         break;

--- a/src/operator/contrib/dgl_graph.cc
+++ b/src/operator/contrib/dgl_graph.cc
@@ -26,6 +26,7 @@
 #include <dmlc/optional.h>
 #include <algorithm>
 #include <random>
+#include <utility>
 
 #include "../elemwise_op_common.h"
 #include "../../imperative/imperative_utils.h"
@@ -63,7 +64,7 @@ class ArrayHeap {
       }
     }
   }
-  ~ArrayHeap() {}
+  ~ArrayHeap() = default;
 
   /*
    * Remove term from index (this costs O(log m) steps)
@@ -417,8 +418,8 @@ static void RandomSample(size_t set_size,
     sampled_idxs.insert(distribution(generator));
   }
   out->clear();
-  for (auto it = sampled_idxs.begin(); it != sampled_idxs.end(); it++) {
-    out->push_back(*it);
+  for (unsigned long sampled_idx : sampled_idxs) {
+    out->push_back(sampled_idx);
   }
 }
 
@@ -528,9 +529,9 @@ static void GetNonUniformSample(const float* probability,
 struct neigh_list {
   std::vector<dgl_id_t> neighs;
   std::vector<dgl_id_t> edges;
-  neigh_list(const std::vector<dgl_id_t> &_neighs,
-             const std::vector<dgl_id_t> &_edges)
-    : neighs(_neighs), edges(_edges) {}
+  neigh_list(std::vector<dgl_id_t> _neighs,
+             std::vector<dgl_id_t> _edges)
+    : neighs(std::move(_neighs)), edges(std::move(_edges)) {}
 };
 
 /*
@@ -620,25 +621,25 @@ static void SampleSubgraph(const NDArray &csr,
     // First we push the size of neighbor vector
     neighbor_list.push_back(tmp_sampled_edge_list.size());
     // Then push the vertices
-    for (size_t i = 0; i < tmp_sampled_src_list.size(); ++i) {
-      neighbor_list.push_back(tmp_sampled_src_list[i]);
+    for (long & i : tmp_sampled_src_list) {
+      neighbor_list.push_back(i);
     }
     // Finally we push the edge list
-    for (size_t i = 0; i < tmp_sampled_edge_list.size(); ++i) {
-      neighbor_list.push_back(tmp_sampled_edge_list[i]);
+    for (long & i : tmp_sampled_edge_list) {
+      neighbor_list.push_back(i);
     }
     num_edges += tmp_sampled_src_list.size();
-    for (size_t i = 0; i < tmp_sampled_src_list.size(); ++i) {
+    for (long & i : tmp_sampled_src_list) {
       // If we have sampled the max number of vertices, we have to stop.
       if (sub_ver_mp.size() >= max_num_vertices)
         break;
       // We need to add the neighbor in the hashtable here. This ensures that
       // the vertex in the queue is unique. If we see a vertex before, we don't
       // need to add it to the queue again.
-      auto ret = sub_ver_mp.insert(tmp_sampled_src_list[i]);
+      auto ret = sub_ver_mp.insert(i);
       // If the sampled neighbor is inserted to the map successfully.
       if (ret.second)
-        sub_vers.emplace_back(tmp_sampled_src_list[i], cur_node_level + 1);
+        sub_vers.emplace_back(i, cur_node_level + 1);
     }
   }
   // Let's check if there is a vertex that we haven't sampled its neighbors.
@@ -960,8 +961,8 @@ static bool DGLSubgraphStorageType(const nnvm::NodeAttrs& attrs,
 
   bool success = true;
   *dispatch_mode = DispatchMode::kFComputeEx;
-  for (size_t i = 0; i < out_attrs->size(); i++) {
-    if (!type_assign(&(*out_attrs)[i], mxnet::kCSRStorage))
+  for (int & out_attr : *out_attrs) {
+    if (!type_assign(&out_attr, mxnet::kCSRStorage))
     success = false;
   }
   return success;
@@ -999,8 +1000,8 @@ static bool DGLSubgraphType(const nnvm::NodeAttrs& attrs,
   for (size_t i = 0; i < num_g; i++) {
     CHECK_EQ(in_attrs->at(i + 1), mshadow::kInt64);
   }
-  for (size_t i = 0; i < out_attrs->size(); i++) {
-    out_attrs->at(i) = in_attrs->at(0);
+  for (int & out_attr : *out_attrs) {
+    out_attr = in_attrs->at(0);
   }
   return true;
 }
@@ -1016,7 +1017,7 @@ class Bitmap {
  public:
   Bitmap(const dgl_id_t *vid_data, int64_t len): map(size) {
     for (int64_t i = 0; i < len; ++i) {
-      map[hash(vid_data[i])] = 1;
+      map[hash(vid_data[i])] = true;
     }
   }
 
@@ -1531,8 +1532,8 @@ static bool SubgraphCompactStorageType(const nnvm::NodeAttrs& attrs,
 
   bool success = true;
   *dispatch_mode = DispatchMode::kFComputeEx;
-  for (size_t i = 0; i < out_attrs->size(); i++) {
-    if (!type_assign(&(*out_attrs)[i], mxnet::kCSRStorage))
+  for (int & out_attr : *out_attrs) {
+    if (!type_assign(&out_attr, mxnet::kCSRStorage))
       success = false;
   }
   return success;
@@ -1570,11 +1571,11 @@ static bool SubgraphCompactShape(const nnvm::NodeAttrs& attrs,
 static bool SubgraphCompactType(const nnvm::NodeAttrs& attrs,
                                 std::vector<int> *in_attrs,
                                 std::vector<int> *out_attrs) {
-  for (size_t i = 0; i < in_attrs->size(); i++) {
-    CHECK_EQ(in_attrs->at(i), mshadow::kInt64);
+  for (int & in_attr : *in_attrs) {
+    CHECK_EQ(in_attr, mshadow::kInt64);
   }
-  for (size_t i = 0; i < out_attrs->size(); i++) {
-    out_attrs->at(i) = mshadow::kInt64;
+  for (int & out_attr : *out_attrs) {
+    out_attr = mshadow::kInt64;
   }
   return true;
 }

--- a/src/operator/contrib/multi_proposal.cc
+++ b/src/operator/contrib/multi_proposal.cc
@@ -289,11 +289,11 @@ class MultiProposalOp : public Operator{
     this->param_ = param;
   }
 
-  virtual void Forward(const OpContext &ctx,
+  void Forward(const OpContext &ctx,
                        const std::vector<TBlob> &in_data,
                        const std::vector<OpReqType> &req,
                        const std::vector<TBlob> &out_data,
-                       const std::vector<TBlob> &aux_states) {
+                       const std::vector<TBlob> &aux_states) override {
     using namespace mshadow;
     using namespace mshadow::expr;
     CHECK_EQ(in_data.size(), 3);
@@ -458,13 +458,13 @@ class MultiProposalOp : public Operator{
     }
   }
 
-  virtual void Backward(const OpContext &ctx,
+  void Backward(const OpContext &ctx,
                         const std::vector<TBlob> &out_grad,
                         const std::vector<TBlob> &in_data,
                         const std::vector<TBlob> &out_data,
                         const std::vector<OpReqType> &req,
                         const std::vector<TBlob> &in_grad,
-                        const std::vector<TBlob> &aux_states) {
+                        const std::vector<TBlob> &aux_states) override {
     using namespace mshadow;
     using namespace mshadow::expr;
     CHECK_EQ(in_grad.size(), 3);

--- a/src/operator/contrib/proposal.cc
+++ b/src/operator/contrib/proposal.cc
@@ -278,11 +278,11 @@ class ProposalOp : public Operator{
     this->param_ = param;
   }
 
-  virtual void Forward(const OpContext &ctx,
+  void Forward(const OpContext &ctx,
                        const std::vector<TBlob> &in_data,
                        const std::vector<OpReqType> &req,
                        const std::vector<TBlob> &out_data,
-                       const std::vector<TBlob> &aux_states) {
+                       const std::vector<TBlob> &aux_states) override {
     using namespace mshadow;
     using namespace mshadow::expr;
     CHECK_EQ(in_data.size(), 3);
@@ -420,13 +420,13 @@ class ProposalOp : public Operator{
     }
   }
 
-  virtual void Backward(const OpContext &ctx,
+  void Backward(const OpContext &ctx,
                         const std::vector<TBlob> &out_grad,
                         const std::vector<TBlob> &in_data,
                         const std::vector<TBlob> &out_data,
                         const std::vector<OpReqType> &req,
                         const std::vector<TBlob> &in_grad,
-                        const std::vector<TBlob> &aux_states) {
+                        const std::vector<TBlob> &aux_states) override {
     using namespace mshadow;
     using namespace mshadow::expr;
     CHECK_EQ(in_grad.size(), 3);

--- a/src/operator/contrib/rroi_align.cc
+++ b/src/operator/contrib/rroi_align.cc
@@ -27,7 +27,7 @@
  */
 #include "./rroi_align-inl.h"
 #include <mshadow/tensor.h>
-#include "math.h"
+#include <cmath>
 
 using std::max;
 using std::min;

--- a/src/operator/control_flow.cc
+++ b/src/operator/control_flow.cc
@@ -24,6 +24,8 @@
 #include <mxnet/operator_util.h>
 #include <dmlc/logging.h>
 #include <dmlc/optional.h>
+
+#include <utility>
 #include "./operator_common.h"
 #include "./elemwise_op_common.h"
 #include "../imperative/imperative_utils.h"
@@ -648,9 +650,9 @@ static void WhileLoopComputeExCPU(const OpStatePtr& state_ptr,
     const_cast<NDArray &>(outputs[i]).SetShapeFromChunk();
   }
   if (state.n_iterations == 0) {
-    for (size_t i = 0; i < outputs.size(); ++i) {
-      if (!shape_is_known(outputs[i].shape())) {
-        const_cast<NDArray &>(outputs[i]).ReshapeAndAlloc({1});
+    for (const auto & output : outputs) {
+      if (!shape_is_known(output.shape())) {
+        const_cast<NDArray &>(output).ReshapeAndAlloc({1});
       }
     }
   }
@@ -865,11 +867,11 @@ class CondState {
   LoopState else_branch;
   int branch_selection;  // 1 if then branch; 0 if else branch; -1 if undefined
 
-  CondState(const CondParam &params,
+  CondState(CondParam params,
             const nnvm::Symbol &cond,
             const nnvm::Symbol &then_sym,
             const nnvm::Symbol &else_sym):
-            params(params),
+            params(std::move(params)),
             cond_op(LoopState::MakeSharedOp(cond)),
             then_branch(then_sym),
             else_branch(else_sym),

--- a/src/operator/leaky_relu.cc
+++ b/src/operator/leaky_relu.cc
@@ -202,7 +202,7 @@ The following modified ReLU Activation functions are supported:
 .set_attr<nnvm::FSetInputVarAttrOnCompose>("FSetInputVarAttrOnCompose",
     [](const nnvm::NodeAttrs& attrs, nnvm::ObjectPtr var, const int index) {
       if (index == 1 && var->attrs.dict.find("__init__") == var->attrs.dict.end()) {
-        var->attrs.dict["__init__"] = "[\"Constant\", {\"value\": 0.25}]";
+        var->attrs.dict["__init__"] = R"(["Constant", {"value": 0.25}])";
       }
     });
 

--- a/src/operator/numpy/np_einsum_op.cc
+++ b/src/operator/numpy/np_einsum_op.cc
@@ -56,8 +56,8 @@
  */
 
 #include "./np_einsum_op-inl.h"
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 namespace mxnet {
 namespace op {

--- a/src/operator/numpy/np_indexing_op.cc
+++ b/src/operator/numpy/np_indexing_op.cc
@@ -161,8 +161,8 @@ bool AdvancedIndexingOpBackStorageType(const nnvm::NodeAttrs& attrs,
   for (int &attr : *out_attrs) {
     attr = kDefaultStorage;
   }
-  for (size_t i = 0; i < out_attrs->size(); i++)
-    out_attrs->at(i) = kDefaultStorage;
+  for (int & out_attr : *out_attrs)
+    out_attr = kDefaultStorage;
   *dispatch_mode = DispatchMode::kFComputeEx;
   return true;
 }

--- a/src/operator/numpy/np_polynomial_op.cc
+++ b/src/operator/numpy/np_polynomial_op.cc
@@ -22,7 +22,7 @@
  * \file np_polynomial_op.cc
 */
 
-#include <math.h>
+#include <cmath>
 #include "np_polynomial_op-inl.h"
 
 namespace mxnet {

--- a/src/operator/operator_tune.cc
+++ b/src/operator/operator_tune.cc
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-#include <float.h>
+#include <cfloat>
 #include <atomic>
 #include "./mxnet_op.h"
 #include "./mshadow_op.h"

--- a/src/operator/quantization/quantize_graph_pass.cc
+++ b/src/operator/quantization/quantize_graph_pass.cc
@@ -225,8 +225,8 @@ static void MarkQuantizedNodes(const Graph& src,
     while (!task_queue.empty()) {
       const auto& node = task_queue.front();
       task_queue.pop();
-      for (size_t i = 0; i < node->inputs.size(); ++i) {
-        const auto& input = node->inputs[i].node;
+      for (auto & i : node->inputs) {
+        const auto& input = i.node;
         auto it = support_quantize_nodes.find(input);
         if (it != support_quantize_nodes.end()) {
           it->second = it->second | kFromInput;
@@ -243,8 +243,7 @@ static void MarkQuantizedNodes(const Graph& src,
       const auto& node = task_queue.front();
       task_queue.pop();
       const auto& outputs = node_output_map[node];
-      for (size_t i = 0; i < outputs.size(); ++i) {
-        const auto& output = outputs[i];
+      for (const auto & output : outputs) {
         auto it = support_quantize_nodes.find(output);
         if (it != support_quantize_nodes.end()) {
           it->second = it->second | kFromOutput;

--- a/src/operator/quantization/quantized_elemwise_mul.cc
+++ b/src/operator/quantization/quantized_elemwise_mul.cc
@@ -186,7 +186,7 @@ void QuantizedElemwiseMulOpForward(const nnvm::NodeAttrs &attrs,
         out_data[i] = static_cast<out_type>(a * b * out_scale);
       }
     } else {
-      typedef int32_t out_type;
+      using out_type = int32_t;
       auto *out_data = outputs[quantized_elemwise_mul::kOut].dptr<out_type>();
 #if !defined(_MSC_VER)
 #pragma omp simd
@@ -198,7 +198,7 @@ void QuantizedElemwiseMulOpForward(const nnvm::NodeAttrs &attrs,
       }
     }
   } else {
-    typedef float_t out_type;
+    using out_type = float_t;
     auto *out_data = outputs[quantized_elemwise_mul::kOut].dptr<out_type>();
 #if !defined(_MSC_VER)
 #pragma omp simd

--- a/src/operator/quantization/quantized_fully_connected.cc
+++ b/src/operator/quantization/quantized_fully_connected.cc
@@ -154,7 +154,7 @@ struct QuantizedSumInitKernelWithBias {
                                   const float *max_out, const float *min_bias,
                                   const float *max_bias) {
     typedef int32_t T1;
-    typedef int8_t  T2;
+    using T2 = int8_t;
     using mshadow::red::limits::MinValue;
     using mshadow::red::limits::MaxValue;
     float float_for_one_out_quant  =

--- a/src/operator/subgraph/default_subgraph_property.cc
+++ b/src/operator/subgraph/default_subgraph_property.cc
@@ -17,6 +17,8 @@
  * under the License.
  */
 
+#include <memory>
+
 #include "./common.h"
 #include "./subgraph_property.h"
 #include "../../imperative/cached_op.h"
@@ -33,15 +35,15 @@ class ContainOpSelector: public SubgraphSelector {
   explicit ContainOpSelector(const std::unordered_set<std::string>& op_names)
     : op_names_(op_names) {}
 
-  virtual bool Select(const nnvm::Node &seed_node) {
+  bool Select(const nnvm::Node &seed_node) override {
     return !seed_node.is_variable() && op_names_.count(seed_node.op()->name);
   }
 
-  virtual bool SelectInput(const nnvm::Node &cur_node, const nnvm::Node &input_node) {
+  bool SelectInput(const nnvm::Node &cur_node, const nnvm::Node &input_node) override {
     return !input_node.is_variable() && op_names_.count(input_node.op()->name);
   }
 
-  virtual bool SelectOutput(const nnvm::Node &cur_node, const nnvm::Node &output_node) {
+  bool SelectOutput(const nnvm::Node &cur_node, const nnvm::Node &output_node) override {
     return !output_node.is_variable() && op_names_.count(output_node.op()->name);
   }
  private:
@@ -55,19 +57,19 @@ class ContainOpSelector: public SubgraphSelector {
 class DefaultSubgraphProperty: public SubgraphProperty {
  public:
   static SubgraphPropertyPtr Create() { return std::make_shared<DefaultSubgraphProperty>(); }
-  virtual nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol &sym,
-                                           const int subgraph_id = 0) const {
+  nnvm::ObjectPtr CreateSubgraphNode(const nnvm::Symbol &sym,
+                                           const int subgraph_id = 0) const override {
     nnvm::ObjectPtr n = nnvm::Node::Create();
     n->attrs.op = Op::Get("_CachedOp");
     n->attrs.name = "_CachedOp" + std::to_string(subgraph_id);
     n->attrs.subgraphs.push_back(std::make_shared<nnvm::Symbol>(sym));
 
     std::vector<std::pair<std::string, std::string> > flags{{"static_alloc", "true"}};
-    n->attrs.parsed = CachedOpPtr(new CachedOp(sym, flags));
+    n->attrs.parsed = std::make_shared<CachedOp>(sym, flags);
 
     return n;
   }
-  virtual SubgraphSelectorPtr CreateSubgraphSelector() const {
+  SubgraphSelectorPtr CreateSubgraphSelector() const override {
     return std::make_shared<ContainOpSelector>(
         this->GetAttr<std::unordered_set<std::string>>("op_names"));
   }

--- a/src/operator/subgraph/default_subgraph_property_v2.cc
+++ b/src/operator/subgraph/default_subgraph_property_v2.cc
@@ -18,6 +18,8 @@
  */
 
 
+#include <memory>
+
 #include "./common.h"
 #include "./subgraph_property.h"
 #include "../../imperative/cached_op.h"
@@ -68,7 +70,7 @@ class DefaultSubgraphProperty: public SubgraphProperty {
     n->attrs.subgraphs.push_back(std::make_shared<nnvm::Symbol>(sym));
 
     std::vector<std::pair<std::string, std::string> > flags{{"static_alloc", "true"}};
-    n->attrs.parsed = CachedOpPtr(new CachedOp(sym, flags));
+    n->attrs.parsed = std::make_shared<CachedOp>(sym, flags);
 
     return n;
   }

--- a/src/profiler/aggregate_stats.cc
+++ b/src/profiler/aggregate_stats.cc
@@ -235,8 +235,8 @@ void AggregateStats::DumpJson(std::ostream& os, int sort_by, int ascending) {
      << "    }" << std::endl
      << "," << std::endl
      << "    \"Unit\": {" << std::endl
-     << "        \"Time\": \"ms\"," << std::endl
-     << "        \"Memory\": \"kB\"" << std::endl
+     << R"(        "Time": "ms",)" << std::endl
+     << R"(        "Memory": "kB")" << std::endl
      << "    }" << std::endl
      << "}" << std::endl
      << std::flush;

--- a/src/profiler/profiler.cc
+++ b/src/profiler/profiler.cc
@@ -154,9 +154,9 @@ void Profiler::SetConfig(int mode,
  */
 void Profiler::EmitPid(std::ostream *os, const std::string& name, size_t pid) {
   (*os) << "        {\n"
-        << "            \"ph\": \"" << static_cast<char>(ProfileStat::kMetadata) <<  "\",\n"
+        << R"(            "ph": ")" << static_cast<char>(ProfileStat::kMetadata) <<  "\",\n"
         << "            \"args\": {\n"
-        << "                \"name\": \"" << name << "\"\n"
+        << R"(                "name": ")" << name << "\"\n"
         << "            },\n"
         << "            \"pid\": " << pid << ",\n"
         << "            \"name\": \"process_name\"\n"
@@ -246,7 +246,7 @@ void Profiler::DumpProfile(bool perform_cleanup) {
   if (last_pass) {
     file << "\n" << std::endl;
     file << "    ]," << std::endl;
-    file << "    \"displayTimeUnit\": \"ms\"" << std::endl;
+    file << R"(    "displayTimeUnit": "ms")" << std::endl;
     file << "}" << std::endl;
   }
   enable_output_ = continuous_dump_ && !last_pass;  // If we're appending, then continue.

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -92,8 +92,7 @@ struct SpaceAllocator {
 // Implements resource manager
 class ResourceManagerImpl : public ResourceManager {
  public:
-  ResourceManagerImpl() noexcept(false)
-       {
+  ResourceManagerImpl() noexcept(false) {
     cpu_temp_space_copy_ = dmlc::GetEnv("MXNET_CPU_TEMP_COPY", 4);
     gpu_temp_space_copy_ = dmlc::GetEnv("MXNET_GPU_TEMP_COPY", 1);
     cpu_native_rand_copy_ = dmlc::GetEnv("MXNET_CPU_PARALLEL_RAND_COPY", 1);

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -31,6 +31,7 @@
 #include <mxnet/resource.h>
 #include <limits>
 #include <atomic>
+#include <memory>
 #include "./common/lazy_alloc_array.h"
 #include "./common/utils.h"
 #include "./common/cuda_utils.h"
@@ -92,7 +93,7 @@ struct SpaceAllocator {
 class ResourceManagerImpl : public ResourceManager {
  public:
   ResourceManagerImpl() noexcept(false)
-      : global_seed_(0) {
+       {
     cpu_temp_space_copy_ = dmlc::GetEnv("MXNET_CPU_TEMP_COPY", 4);
     gpu_temp_space_copy_ = dmlc::GetEnv("MXNET_GPU_TEMP_COPY", 1);
     cpu_native_rand_copy_ = dmlc::GetEnv("MXNET_CPU_PARALLEL_RAND_COPY", 1);
@@ -102,14 +103,14 @@ class ResourceManagerImpl : public ResourceManager {
 #endif  // MXNET_USE_CUDNN == 1
     engine_ref_ = Engine::_GetSharedRef();
     storage_ref_ = Storage::_GetSharedRef();
-    cpu_rand_.reset(new ResourceRandom<cpu>(
-        Context::CPU(), global_seed_));
-    cpu_space_.reset(new ResourceTempSpace<ResourceRequest::kTempSpace>(
-        Context::CPU(), cpu_temp_space_copy_));
-    cpu_parallel_rand_.reset(new ResourceParallelRandom<cpu>(
-        Context::CPU(), cpu_native_rand_copy_, global_seed_));
+    cpu_rand_ = std::make_unique<ResourceRandom<cpu>>(
+        Context::CPU(), global_seed_);
+    cpu_space_ = std::make_unique<ResourceTempSpace<ResourceRequest::kTempSpace>>(
+        Context::CPU(), cpu_temp_space_copy_);
+    cpu_parallel_rand_ = std::make_unique<ResourceParallelRandom<cpu>>(
+        Context::CPU(), cpu_native_rand_copy_, global_seed_);
   }
-  ~ResourceManagerImpl() {
+  ~ResourceManagerImpl() override {
     // need explicit delete, before engine get killed
     cpu_rand_.reset(nullptr);
     cpu_space_.reset(nullptr);
@@ -390,7 +391,7 @@ class ResourceManagerImpl : public ResourceManager {
   /*! \brief Reference to the storage */
   std::shared_ptr<Storage> storage_ref_;
   /*! \brief internal seed to the random number generator */
-  uint32_t global_seed_;
+  uint32_t global_seed_{0};
   /*! \brief CPU random number resources */
   std::unique_ptr<ResourceRandom<cpu> > cpu_rand_;
   /*! \brief CPU temp space resources */

--- a/src/runtime/registry.cc
+++ b/src/runtime/registry.cc
@@ -44,7 +44,7 @@ struct Registry::Manager {
   std::mutex mutex;
 
   // vtable for extension type is not suported for now
-  Manager() {}
+  Manager() = default;
 
   static Manager* Global() {
     // We deliberately leak the Manager instance, to avoid leak sanitizers

--- a/src/storage/storage.cc
+++ b/src/storage/storage.cc
@@ -44,7 +44,7 @@ class StorageImpl : public Storage {
 
   void SharedIncrementRefCount(Handle handle) override;
   StorageImpl() = default;
-  virtual ~StorageImpl() = default;
+  ~StorageImpl() override = default;
 
  private:
   std::shared_ptr<StorageManager> storage_manager(const Context &ctx) {

--- a/tests/cpp/engine/thread_local_test.cc
+++ b/tests/cpp/engine/thread_local_test.cc
@@ -23,7 +23,6 @@
  * \brief Tests thread safety and lifetime of thread local store
 */
 #include <gtest/gtest.h>
-#include <ctime>
 #include <dmlc/logging.h>
 #include <dmlc/thread_group.h>
 #include <dmlc/omp.h>
@@ -31,6 +30,7 @@
 #include <mxnet/engine.h>
 #include <mxnet/ndarray.h>
 #include <dmlc/timer.h>
+#include <ctime>
 #include <cstdio>
 #include <thread>
 #include <chrono>

--- a/tests/cpp/engine/thread_local_test.cc
+++ b/tests/cpp/engine/thread_local_test.cc
@@ -23,7 +23,7 @@
  * \brief Tests thread safety and lifetime of thread local store
 */
 #include <gtest/gtest.h>
-#include <time.h>
+#include <ctime>
 #include <dmlc/logging.h>
 #include <dmlc/thread_group.h>
 #include <dmlc/omp.h>

--- a/tests/cpp/engine/threaded_engine_test.cc
+++ b/tests/cpp/engine/threaded_engine_test.cc
@@ -22,7 +22,6 @@
  * \file threaded_engine_test.cc
  * \brief threaded engine tests
 */
-#include <ctime>
 #include <dmlc/logging.h>
 #include <dmlc/thread_group.h>
 #include <dmlc/omp.h>
@@ -31,6 +30,7 @@
 #include <mxnet/engine.h>
 #include <mxnet/ndarray.h>
 #include <dmlc/timer.h>
+#include <ctime>
 #include <cstdio>
 #include <thread>
 #include <chrono>

--- a/tests/cpp/engine/threaded_engine_test.cc
+++ b/tests/cpp/engine/threaded_engine_test.cc
@@ -22,7 +22,7 @@
  * \file threaded_engine_test.cc
  * \brief threaded engine tests
 */
-#include <time.h>
+#include <ctime>
 #include <dmlc/logging.h>
 #include <dmlc/thread_group.h>
 #include <dmlc/omp.h>
@@ -107,7 +107,7 @@ double EvaluateWorkloads(const std::vector<Workload>& workloads,
 
   for (const auto& wl : workloads) {
     if (wl.reads.size() == 0) continue;
-    if (engine == NULL) {
+    if (engine == nullptr) {
       EvaluateWorkload(wl, data);
     } else {
       auto func = [wl, data](RunContext ctx, Engine::CallbackOnComplete cb) {
@@ -152,13 +152,13 @@ TEST(Engine, RandSumExpr) {
   std::vector<double> t(num_engine, 0.0);
   std::vector<mxnet::Engine*> engine(num_engine);
 
-  engine[0] = NULL;
+  engine[0] = nullptr;
   engine[1] = mxnet::engine::CreateNaiveEngine();
   engine[2] = mxnet::engine::CreateThreadedEnginePooled();
   engine[3] = mxnet::engine::CreateThreadedEnginePerDevice();
 
   for (int repeat = 0; repeat < num_repeat; ++repeat) {
-    srand(time(NULL) + repeat);
+    srand(time(nullptr) + repeat);
     int num_var = 100;
     GenerateWorkload(10000, num_var, 2, 20, 1, 10, &workloads);
     std::vector<std::vector<double>> data(num_engine);

--- a/tests/cpp/operator/batchnorm_test.cc
+++ b/tests/cpp/operator/batchnorm_test.cc
@@ -566,10 +566,9 @@ static const test::op::kwargs_t nfs_ugs_kwargs_nocudnn = {
 
 #if !DISABLE_VALIDATION
 static bool isUGS(const test::op::kwargs_t& kwargs) {
-  for (test::op::kwargs_t::const_iterator i = kwargs.begin(),
-         e = kwargs.end(); i != e; ++i) {
-    if (!i->first.compare("use_global_stats")) {
-      return i->second.compare("True") == 0;
+  for (const auto & kwarg : kwargs) {
+    if (!kwarg.first.compare("use_global_stats")) {
+      return kwarg.second.compare("True") == 0;
     }
   }
   return false;
@@ -725,8 +724,8 @@ static test::op::OpInfoPair<OperatorProp1, OperatorProp2, OperatorExecutor> test
 
   size_t thisCount = 0;
 
-  typedef typename OperatorExecutor::DataType DType;
-  typedef typename OperatorExecutor::AccRealType AccReal;
+  using DType = typename OperatorExecutor::DataType;
+  using AccReal = typename OperatorExecutor::AccRealType;
 
   do {
     const bool isLast = thisCount == cycleCount - 1;
@@ -1288,8 +1287,8 @@ static void testSaveAndLoad(const std::vector<size_t>& dims,
 TEST(BATCH_NORM, TestChannelAxisSaveAndLoad) {
   std::cout << std::endl << std::flush;
 
-  typedef float DType;
-  typedef float AccReal;
+  using DType = float;
+  using AccReal = float;
 
   const std::vector<std::vector<DType>> myData =
     { { 1.0f, 1.0f, 1.0f, 1.0f },
@@ -1346,8 +1345,8 @@ static void runChannelAxisTest(
   const size_t numberOfPasses = 5
 
 ) {
-  typedef float DType;
-  typedef float AccReal;
+  using DType = float;
+  using AccReal = float;
 
   size_t spatialSize = 1;
   for (size_t x = 1, n = shape.size(); x < n; ++x) {

--- a/tests/cpp/operator/batchnorm_test.cc
+++ b/tests/cpp/operator/batchnorm_test.cc
@@ -277,7 +277,7 @@ class BatchNormValidator : public test::op::Validator<DType, AccReal> {
   typedef test::op::Validator<DType, AccReal> Super;
 
   /*! \brief Only static functions in this class */
-  BatchNormValidator() = delete;
+  BatchNormValidator() = delete;  // NOLINT
 
   /*! \brief Check batch norm output - 1D */
   static void checkBatchNorm1D(const TBlob *blob) {

--- a/tests/cpp/operator/runner/core_op_runner_test.cc
+++ b/tests/cpp/operator/runner/core_op_runner_test.cc
@@ -148,7 +148,7 @@ TEST(CORE_OP_RUNNER, ExecuteBidirectionalRunnerSimpleUnary) {
 }
 
 TEST(CORE_OP_RUNNER, ExecuteBidirectionalRunner) {
-  typedef float DType;
+  using DType = float;
   mxnet::TShape shape({5, 5});
   for (const std::pair<std::string, std::string>& i : test_binary_operators) {
     const char *op_name = i.first.c_str();
@@ -163,7 +163,7 @@ TEST(CORE_OP_RUNNER, ExecuteBidirectionalRunner) {
  * \brief Test RunBidirectional dot product, which has different shaped inputs and outputs
  */
 TEST(CORE_OP_RUNNER, ExecuteBidirectionalRunnerDotProduct) {
-  typedef float DType;
+  using DType = float;
   const char *op_name = "dot";
   const char *backward_op_name = "_backward_dot";
   test::op::CoreOperatorRunner<DType> runner;
@@ -179,7 +179,7 @@ TEST(CORE_OP_RUNNER, ExecuteBidirectionalRunnerDotProduct) {
  * \brief Timing tests for CPU
  */
 TEST(CORE_OP_RUNNER, TimingCPUSimpleUnary) {
-  typedef float DType;
+  using DType = float;
 
   const char *op_name = "relu";
 
@@ -210,7 +210,7 @@ TEST(CORE_OP_RUNNER, TimingCPUSimpleUnary) {
 }
 
 TEST(CORE_OP_RUNNER, TimingCPUBinary) {
-  typedef float DType;
+  using DType = float;
 
   const char *op_name = "elemwise_add";
   const char *backward_op_name = "_backward_add";
@@ -246,7 +246,7 @@ TEST(CORE_OP_RUNNER, TimingCPUBinary) {
  * \brief Performance run dot product, which has different shaped inputs and outputs
  */
 TEST(CORE_OP_RUNNER, TimingCPUBinaryDotProduct) {
-  typedef float DType;
+  using DType = float;
 
   const char *op_name = "dot";
   const char *backward_op_name = "_backward_dot";

--- a/tests/cpp/storage/storage_test.cc
+++ b/tests/cpp/storage/storage_test.cc
@@ -21,7 +21,7 @@
  * \file storage_test.cc
  * \brief cpu/gpu storage tests
 */
-#include <stdlib.h>
+#include <cstdlib>
 #include <gtest/gtest.h>
 #include <dmlc/logging.h>
 #include <mxnet/storage.h>

--- a/tests/cpp/storage/storage_test.cc
+++ b/tests/cpp/storage/storage_test.cc
@@ -21,11 +21,11 @@
  * \file storage_test.cc
  * \brief cpu/gpu storage tests
 */
-#include <cstdlib>
 #include <gtest/gtest.h>
 #include <dmlc/logging.h>
 #include <mxnet/storage.h>
 #include <cstdio>
+#include <cstdlib>
 #include "test_util.h"
 
 TEST(Storage, Basic_CPU) {

--- a/tools/im2rec.cc
+++ b/tools/im2rec.cc
@@ -247,7 +247,7 @@ int main(int argc, char *argv[]) {
 
     if (unchanged != 1) {
       cv::Mat img = cv::imdecode(decode_buf, color_mode);
-      CHECK(img.data != NULL) << "OpenCV decode fail:" << path;
+      CHECK(img.data != nullptr) << "OpenCV decode fail:" << path;
       cv::Mat res = img;
       if (new_size > 0) {
         if (center_crop) {


### PR DESCRIPTION
## Description ##
Run clang-tidy via cmake only on the code managed by mxnet (and not 3rdparty dependencies), update to clang-tidy-10 and run clang-tidy-10 -fix to fix all the warnings that are enforced on CI.

Developers can run clang-tidy by specifying the `-DCMAKE_CXX_CLANG_TIDY="clang-tidy-10"` to cmake, or using the `python ci/build.py -R --platform ubuntu_cpu /work/runtime_functions.sh build_ubuntu_cpu_clang_tidy` script.

See https://github.com/apache/incubator-mxnet/issues/17968#issuecomment-613681904 for rationale