### PR TITLE
[NumPy] add tests for sklearn interoperability

### DIFF
--- a/ci/docker/Dockerfile.test.arm
+++ b/ci/docker/Dockerfile.test.arm
@@ -40,6 +40,7 @@ RUN pip3 install --no-cache-dir --upgrade pip && \
     pytest-cov==2.8.1 \
     pytest-xdist==1.31.0 \
     pytest-timeout==1.3.4 \
+    scikit-learn==0.23.1 \
     mock==2.0.0
 
 ARG USER_ID=0

--- a/ci/docker/install/requirements
+++ b/ci/docker/install/requirements
@@ -45,6 +45,7 @@ flaky==3.6.1
 setuptools
 wheel
 mock==2.0.0
+scikit-learn<=0.24
 
 # TVM dependencies
 decorator==4.4.0

--- a/docker/install/python.sh
+++ b/docker/install/python.sh
@@ -24,4 +24,4 @@ apt-get update && apt-get install -y python3-dev
 # the version of the pip shipped with ubuntu may be too lower, install a recent version here
 cd /tmp && wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
 
-pip3 install pylint numpy requests Pillow pytest==5.3.2 pytest-env==0.6.2 pytest-cov==2.8.1 pytest-xdist==1.31.0
+pip3 install pylint numpy requests Pillow pytest==5.3.2 pytest-env==0.6.2 pytest-cov==2.8.1 pytest-xdist==1.31.0 scikit-learn<=0.24

--- a/python/mxnet/ndarray/ndarray.py
+++ b/python/mxnet/ndarray/ndarray.py
@@ -533,6 +533,8 @@ fixed-size items.
         array([[ 6.,  5.,  5.],
                [ 6.,  0.,  4.]], dtype=float32)
         """
+        if not self.writable:
+            raise ValueError('NDArray is not writable.')
         if self.ndim == 0:
             if not isinstance(key, (tuple, py_slice)):
                 raise IndexError('scalar tensor can only accept `()` and `:` as index')
@@ -4990,9 +4992,15 @@ from_numpy_doc = """Returns an MXNet's NDArray backed by numpy's ndarray.
     ----------
     ndarray: NDArray
         input data
-    zero_copy: bool
-        Whether we use DLPack's zero-copy conversion to convert to MXNet's NDArray.
-        This is only available for c-contiguous arrays, i.e. array.flags[C_CONTIGUOUS] == True.
+    zero_copy: bool, default True
+        Whether we use DLPack's zero-copy conversion to convert to MXNet's
+        NDArray.
+        This is only available for c-arrays, i.e. array.flags['CARRAY'] == True.
+    writable: bool, default False
+        In the case of zero-copy, whether the created MXNet's NDArray is writeable.
+        If True, the output MXNet's NDArray is writable while the input array is not.
+        If False, the output MXNet's NDArray is not writable while the input array remains
+        writeable.
 
     Returns
     -------

--- a/python/mxnet/ndarray/numpy/_op.py
+++ b/python/mxnet/ndarray/numpy/_op.py
@@ -8051,6 +8051,8 @@ def shares_memory(a, b, max_work=None):
     - Does not support `max_work`, it is a dummy argument
     - Actually it is same as `may_share_memory` in MXNet np
     """
+    if a.ctx != b.ctx and not ('cpu' in a.ctx.device_type and 'cpu' in b.ctx.device_type):
+        return False
     return _api_internal.share_memory(a, b).item()
 
 
@@ -8092,6 +8094,8 @@ def may_share_memory(a, b, max_work=None):
     - Does not support `max_work`, it is a dummy argument
     - Actually it is same as `shares_memory` in MXNet np
     """
+    if a.ctx != b.ctx and not ('cpu' in a.ctx.device_type and 'cpu' in b.ctx.device_type):
+        return False
     return _api_internal.share_memory(a, b).item()
 
 

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -841,6 +841,8 @@ class ndarray(NDArray):
         For imformation related to boolean indexing, please refer to
         https://docs.scipy.org/doc/numpy-1.17.0/reference/arrays.indexing.html.
         """
+        if not self.writable:
+            raise ValueError('NDArray is not writable.')
         if isinstance(value, NDArray) and not isinstance(value, ndarray):
             raise TypeError('Cannot assign mx.nd.NDArray to mxnet.numpy.ndarray')
         if isinstance(key, bool): # otherwise will be treated as 0 and 1

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -1478,6 +1478,35 @@ class ndarray(NDArray):
         else:
             raise TypeError('copyto does not support type ' + str(type(other)))
 
+    def __array__(self, dtype=None):
+        """Returns a ``numpy.ndarray`` object with value copied from this array.
+
+        Examples
+        --------
+        >>> x = mx.np.ones((2,3))
+        >>> y = x.asnumpy()
+        >>> type(y)
+        <type 'numpy.ndarray'>
+        >>> y
+        array([[ 1.,  1.,  1.],
+               [ 1.,  1.,  1.]], dtype=float32)
+        >>> z = mx.np.ones((2,3), dtype='int32')
+        >>> z.asnumpy()
+        array([[1, 1, 1],
+               [1, 1, 1]], dtype=int32)
+        >>> z[0][0]
+        >>> z[0][0].asnumpy()
+        """
+        if dtype is None:
+            dtype = self.dtype
+        data = _np.empty(self.shape, dtype=dtype)
+        if data.size > 0:
+            check_call(_LIB.MXNDArraySyncCopyToCPU(
+                self.handle,
+                data.ctypes.data_as(ctypes.c_void_p),
+                ctypes.c_size_t(data.size)))
+        return data
+
     def asscalar(self):
         raise AttributeError('mxnet.numpy.ndarray object has no attribute asscalar')
 

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -186,7 +186,7 @@ def _as_mx_np_array(object, ctx=None, zero_copy=False, writable=False):
         return object
     elif isinstance(object, _np.ndarray):
         from_numpy = ndarray_from_numpy(ndarray, array)
-        return from_numpy(object, zero_copy and object.flags['C_CONTIGUOUS'])
+        return from_numpy(object, zero_copy and object.flags['CARRAY'])
     elif isinstance(object, (integer_types, numeric_types)):
         return object
     elif isinstance(object, (_np.bool_, _np.bool)):
@@ -253,6 +253,7 @@ def wrap_mxnp_np_ufunc(func):
     Function
         A function wrapped with type casted.
     """
+
     @functools.wraps(func)
     def _wrap_mxnp_np_ufunc(x1, x2):
         if isinstance(x2, _np.ndarray):
@@ -1499,12 +1500,14 @@ class ndarray(NDArray):
         """
         if dtype is None:
             dtype = self.dtype
-        data = _np.empty(self.shape, dtype=dtype)
+        data = _np.empty(self.shape, dtype=self.dtype)
         if data.size > 0:
             check_call(_LIB.MXNDArraySyncCopyToCPU(
                 self.handle,
                 data.ctypes.data_as(ctypes.c_void_p),
                 ctypes.c_size_t(data.size)))
+        if dtype != self.dtype:
+            data = data.astype(dtype)
         return data
 
     def asscalar(self):

--- a/python/mxnet/numpy_extension/utils.py
+++ b/python/mxnet/numpy_extension/utils.py
@@ -172,10 +172,15 @@ from_numpy_doc = """Returns an MXNet's np.ndarray backed by numpy's ndarray.
     ----------
     ndarray: np.ndarray
         input data
-    zero_copy: bool
+    zero_copy: bool, default True
         Whether we use DLPack's zero-copy conversion to convert to MXNet's
         np.ndarray.
-        This is only available for c-contiguous arrays, i.e. array.flags[C_CONTIGUOUS] == True.
+        This is only available for c-arrays, i.e. array.flags['CARRAY'] == True.
+    writable: bool, default False
+        In the case of zero-copy, whether the created MXNet's np.ndarray is writeable.
+        If True, the output MXNet's np.ndarray is writable while the input array is not.
+        If False, the output MXNet's np.ndarray is not writable while the input array remains
+        writeable.
 
     Returns
     -------

--- a/python/mxnet/runtime.py
+++ b/python/mxnet/runtime.py
@@ -66,6 +66,9 @@ class Feature(ctypes.Structure):
         """True if MXNet was compiled with the given compile-time feature."""
         return self._enabled
 
+    def __bool__(self):
+        return self.enabled
+
     def __repr__(self):
         if self.enabled:
             return "✔ {}".format(self.name)

--- a/python/mxnet/util.py
+++ b/python/mxnet/util.py
@@ -681,17 +681,17 @@ def numpy_fallback(func):
         else:
             return object, None
 
-    from .ndarray import from_numpy
+    from .npx import from_numpy
     from .numpy import array
     from .context import current_context
     def _as_mx_np_array(object, ctx=current_context()):
         import numpy as _np
         if isinstance(object, _np.ndarray):
             try:
-                ret = from_numpy(object).as_np_ndarray()
+                ret = from_numpy(object)
             except ValueError:
                 ret = array(object, dtype=object.dtype, ctx=ctx)
-            return (ret if ('cpu' in str(ctx)) else ret.as_in_ctx(ctx))
+            return ret if 'cpu' in ctx.device_type else ret.as_in_ctx(ctx)
         elif isinstance(object, (list, tuple)):
             tmp = [_as_mx_np_array(arr, ctx) for arr in object]
             return object.__class__(tmp)

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -39,6 +39,9 @@ from test_operator import *
 from test_numpy_ndarray import *
 from test_numpy_op import *
 from test_numpy_interoperability import *
+from test_numpy_sklearn_discriminant_analysis import *
+from test_numpy_sklearn_forest import *
+from test_numpy_sklearn_pca import *
 from test_gluon_probability_v1 import *
 from test_gluon_probability_v2 import *
 from test_optimizer import *

--- a/tests/python/unittest/test_image.py
+++ b/tests/python/unittest/test_image.py
@@ -109,6 +109,8 @@ def _test_imageiter_last_batch(imageiter_list, assert_data_shape):
         pass
 
 
+@pytest.mark.skipif(not mx.runtime.Features()['OPENCV'].enabled,
+                    reason="Skip tests that require opencv as it's not enabled in mxnet.")
 class TestImage(unittest.TestCase):
     IMAGES_URL = "https://repo.mxnet.io/gluon/dataset/test/test_images-9cebe48a.tar.gz"
 

--- a/tests/python/unittest/test_numpy_contrib_gluon_data_vision.py
+++ b/tests/python/unittest/test_numpy_contrib_gluon_data_vision.py
@@ -23,6 +23,7 @@ from common import assertRaises, with_seed, setup_module, teardown_module
 import shutil
 import tempfile
 import unittest
+import pytest
 
 def _get_data(url, dirname):
     import os, tarfile
@@ -50,6 +51,8 @@ def _generate_objects():
     return [2, 5] + label
 
 
+@pytest.mark.skipif(not mx.runtime.Features()['OPENCV'].enabled,
+                    reason="Skip tests that require opencv as it's not enabled in mxnet.")
 class TestImage(unittest.TestCase):
     IMAGES_URL = "https://repo.mxnet.io/gluon/dataset/test/test_images-9cebe48a.tar.gz"
 

--- a/tests/python/unittest/test_numpy_gluon_data_vision.py
+++ b/tests/python/unittest/test_numpy_gluon_data_vision.py
@@ -32,6 +32,7 @@ import random
 from mxnet.base import MXNetError
 from mxnet.gluon.data.vision import transforms
 from mxnet import image
+import pytest
 
 @with_seed()
 @use_np
@@ -100,6 +101,8 @@ def test_normalize():
 
 @with_seed()
 @use_np
+@pytest.mark.skipif(not mx.runtime.Features()['OPENCV'].enabled,
+                    reason="Skip tests that require opencv as it's not enabled in mxnet.")
 def test_resize():
     def _test_resize_with_diff_type(dtype):
         # test normal case
@@ -138,6 +141,8 @@ def test_resize():
 
 @with_seed()
 @use_np
+@pytest.mark.skipif(not mx.runtime.Features()['OPENCV'].enabled,
+                    reason="Skip tests that require opencv as it's not enabled in mxnet.")
 def test_crop_resize():
     def _test_crop_resize_with_diff_type(dtype):
         # test normal case
@@ -219,6 +224,8 @@ def test_flip_top_bottom():
 
 @with_seed()
 @use_np
+@pytest.mark.skipif(not mx.runtime.Features()['OPENCV'].enabled,
+                    reason="Skip tests that require opencv as it's not enabled in mxnet.")
 def test_transformer():
     from mxnet.gluon.data.vision import transforms
 
@@ -243,6 +250,8 @@ def test_transformer():
 
 @with_seed()
 @use_np
+@pytest.mark.skipif(not mx.runtime.Features()['OPENCV'].enabled,
+                    reason="Skip tests that require opencv as it's not enabled in mxnet.")
 def test_random_crop():
     x = mx.np.ones((245, 480, 3), dtype='uint8')
     y = mx.npx.image.random_crop(x, width=100, height=100)
@@ -250,6 +259,8 @@ def test_random_crop():
 
 @with_seed()
 @use_np
+@pytest.mark.skipif(not mx.runtime.Features()['OPENCV'].enabled,
+                    reason="Skip tests that require opencv as it's not enabled in mxnet.")
 def test_random_resize_crop():
     x = mx.np.ones((245, 480, 3), dtype='uint8')
     y = mx.npx.image.random_resized_crop(x, width=100, height=100)
@@ -257,6 +268,8 @@ def test_random_resize_crop():
 
 @with_seed()
 @use_np
+@pytest.mark.skipif(not mx.runtime.Features()['OPENCV'].enabled,
+                    reason="Skip tests that require opencv as it's not enabled in mxnet.")
 def test_hybrid_transformer():
     from mxnet.gluon.data.vision import transforms
 
@@ -337,6 +350,8 @@ def test_random_rotation():
 
 @with_seed()
 @use_np
+@pytest.mark.skipif(not mx.runtime.Features()['OPENCV'].enabled,
+                    reason="Skip tests that require opencv as it's not enabled in mxnet.")
 def test_random_transforms():
     from mxnet.gluon.data.vision import transforms
 

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -1368,6 +1368,8 @@ def _add_workload_fabs():
 
 def _add_workload_add(array_pool):
     OpArgMngr.add_workload('add', array_pool['4x1'], array_pool['1x2'])
+    OpArgMngr.add_workload('add', array_pool['4x1'].asnumpy(), array_pool['1x2'])
+    OpArgMngr.add_workload('add', array_pool['4x1'], array_pool['1x2'].asnumpy())
     OpArgMngr.add_workload('add', array_pool['4x1'], 2)
     OpArgMngr.add_workload('add', 2, array_pool['4x1'])
     OpArgMngr.add_workload('add', array_pool['4x1'], array_pool['1x1x0'])
@@ -1375,6 +1377,8 @@ def _add_workload_add(array_pool):
 
 def _add_workload_arctan2():
     OpArgMngr.add_workload('arctan2', np.array([1, -1, 1]), np.array([1, 1, -1]))
+    OpArgMngr.add_workload('arctan2', np.array([1, -1, 1]).asnumpy(), np.array([1, 1, -1]))
+    OpArgMngr.add_workload('arctan2', np.array([1, -1, 1]), np.array([1, 1, -1]).asnumpy())
     OpArgMngr.add_workload('arctan2', np.array([np.PZERO, np.NZERO]), np.array([np.NZERO, np.NZERO]))
     OpArgMngr.add_workload('arctan2', np.array([np.PZERO, np.NZERO]), np.array([np.PZERO, np.PZERO]))
     OpArgMngr.add_workload('arctan2', np.array([np.PZERO, np.NZERO]), np.array([-1, -1]))
@@ -1389,6 +1393,8 @@ def _add_workload_arctan2():
 
 def _add_workload_copysign():
     OpArgMngr.add_workload('copysign', np.array([1, 0, 0]), np.array([-1, -1, 1]))
+    OpArgMngr.add_workload('copysign', np.array([1, 0, 0]).asnumpy(), np.array([-1, -1, 1]))
+    OpArgMngr.add_workload('copysign', np.array([1, 0, 0]), np.array([-1, -1, 1]).asnumpy())
     OpArgMngr.add_workload('copysign', np.array([-2, 5, 1, 4, 3], dtype=np.float16), np.array([0, 1, 2, 4, 2], dtype=np.float16))
 
 
@@ -1400,6 +1406,8 @@ def _add_workload_degrees():
 def _add_workload_true_divide():
     for dt in [np.float32, np.float64, np.float16]:
         OpArgMngr.add_workload('true_divide', np.array([10, 10, -10, -10], dt), np.array([20, -20, 20, -20], dt))
+        OpArgMngr.add_workload('true_divide', np.array([10, 10, -10, -10], dt).asnumpy(), np.array([20, -20, 20, -20], dt))
+        OpArgMngr.add_workload('true_divide', np.array([10, 10, -10, -10], dt), np.array([20, -20, 20, -20], dt).asnumpy())
 
 
 def _add_workload_inner():

--- a/tests/python/unittest/test_numpy_ndarray.py
+++ b/tests/python/unittest/test_numpy_ndarray.py
@@ -1428,3 +1428,16 @@ def test_mixed_array_types_share_memory():
     mx_pinned_array = mx_array.as_in_ctx(mx.cpu_pinned(0))
     assert not _np.may_share_memory(np_array, mx_pinned_array)
     assert not _np.shares_memory(np_array, mx_pinned_array)
+
+@use_np
+@pytest.mark.parametrize('np_array', [
+    # ordinary numpy array
+    _np.array([[1, 2], [3, 4], [5, 6]], dtype="float32"),
+    # 0-dim
+    _np.array((1, )).reshape(()),
+    # 0-size
+    _np.array(()).reshape((1, 0, 2)),
+])
+def test_numpy_array(np_array):
+    mx_array = mx.npx.from_numpy(np_array)
+    mx.test_utils.assert_almost_equal(np_array, _np.array(mx_array))

--- a/tests/python/unittest/test_numpy_sklearn_discriminant_analysis.py
+++ b/tests/python/unittest/test_numpy_sklearn_discriminant_analysis.py
@@ -1,0 +1,503 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: skip-file
+
+import mxnet as mx
+from mxnet import np
+import numpy as _np
+
+import pytest
+
+from scipy import linalg
+
+from sklearn.utils import check_random_state
+from numpy.testing import assert_array_equal, assert_no_warnings
+from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_allclose
+from numpy.testing import assert_raises
+from numpy.testing import assert_warns
+
+from sklearn.datasets import make_blobs
+from sklearn.discriminant_analysis import LinearDiscriminantAnalysis
+from sklearn.discriminant_analysis import QuadraticDiscriminantAnalysis
+from sklearn.discriminant_analysis import _cov
+
+from mxnet.test_utils import same, assert_almost_equal, rand_shape_nd, rand_ndarray, use_np
+
+mx.npx.set_np()
+
+# Data is just 6 separable points in the plane
+X = np.array([[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]], dtype='f')
+y = np.array([1, 1, 1, 2, 2, 2])
+y3 = np.array([1, 1, 2, 2, 3, 3])
+
+# Degenerate data with only one feature (still should be separable)
+X1 = np.array([[-2, ], [-1, ], [-1, ], [1, ], [1, ], [2, ]], dtype='f')
+
+# Data is just 9 separable points in the plane
+X6 = np.array([[0, 0], [-2, -2], [-2, -1], [-1, -1], [-1, -2],
+               [1, 3], [1, 2], [2, 1], [2, 2]])
+y6 = np.array([1, 1, 1, 1, 1, 2, 2, 2, 2])
+y7 = np.array([1, 2, 3, 2, 3, 1, 2, 3, 1])
+
+# Degenerate data with 1 feature (still should be separable)
+X7 = np.array([[-3, ], [-2, ], [-1, ], [-1, ], [0, ], [1, ], [1, ],
+               [2, ], [3, ]])
+
+# Data that has zero variance in one dimension and needs regularization
+X2 = np.array([[-3, 0], [-2, 0], [-1, 0], [-1, 0], [0, 0], [1, 0], [1, 0],
+               [2, 0], [3, 0]])
+
+# One element class
+y4 = np.array([1, 1, 1, 1, 1, 1, 1, 1, 2])
+
+# Data with less samples in a class than n_features
+X5 = mx.npx.from_numpy(_np.c_[_np.arange(8), _np.zeros((8, 3))])
+y5 = np.array([0, 0, 0, 0, 0, 1, 1, 1])
+
+solver_shrinkage = [('svd', None), ('lsqr', None), ('eigen', None),
+                    ('lsqr', 'auto'), ('lsqr', 0), ('lsqr', 0.43),
+                    ('eigen', 'auto'), ('eigen', 0), ('eigen', 0.43)]
+
+mx.npx.reset_np()
+
+@use_np
+def test_lda_predict():
+    # Test LDA classification.
+    # This checks that LDA implements fit and predict and returns correct
+    # values for simple toy data.
+    for test_case in solver_shrinkage:
+        solver, shrinkage = test_case
+        clf = LinearDiscriminantAnalysis(solver=solver, shrinkage=shrinkage)
+        y_pred = clf.fit(X, y).predict(X)
+        assert_array_equal(y_pred, y, 'solver %s' % solver)
+
+        # Assert that it works with 1D data
+        y_pred1 = clf.fit(X1, y).predict(X1)
+        assert_array_equal(y_pred1, y, 'solver %s' % solver)
+
+        # Test probability estimates
+        y_proba_pred1 = clf.predict_proba(X1)
+        assert_array_equal((y_proba_pred1[:, 1] > 0.5) + 1, y,
+                           'solver %s' % solver)
+        y_log_proba_pred1 = clf.predict_log_proba(X1)
+        assert_allclose(_np.exp(y_log_proba_pred1), y_proba_pred1,
+                        rtol=1e-6, atol=1e-6, err_msg='solver %s' % solver)
+
+        # Primarily test for commit 2f34950 -- "reuse" of priors
+        y_pred3 = clf.fit(X, y3).predict(X)
+        # LDA shouldn't be able to separate those
+        assert np.any(y_pred3 != y3), 'solver %s' % solver
+
+    # Test invalid shrinkages
+    clf = LinearDiscriminantAnalysis(solver="lsqr", shrinkage=-0.2231)
+    assert_raises(ValueError, clf.fit, X, y)
+    clf = LinearDiscriminantAnalysis(solver="eigen", shrinkage="dummy")
+    assert_raises(ValueError, clf.fit, X, y)
+    clf = LinearDiscriminantAnalysis(solver="svd", shrinkage="auto")
+    assert_raises(NotImplementedError, clf.fit, X, y)
+    # Test unknown solver
+    clf = LinearDiscriminantAnalysis(solver="dummy")
+    assert_raises(ValueError, clf.fit, X, y)
+
+
+@use_np
+@mx.use_np_default_dtype
+@pytest.mark.parametrize("n_classes", [2, 3])
+@pytest.mark.parametrize("solver", ["svd", "lsqr", "eigen"])
+def test_lda_predict_proba(solver, n_classes):
+    def generate_dataset(n_samples, centers, covariances, random_state=None):
+        """Generate a multivariate normal data given some centers and
+        covariances"""
+        rng = check_random_state(random_state)
+        X = _np.vstack([rng.multivariate_normal(mean, cov,
+                                                size=n_samples // len(centers))
+                       for mean, cov in zip(centers, covariances)])
+        y = _np.hstack([[clazz] * (n_samples // len(centers))
+                        for clazz in range(len(centers))])
+        return np.array(X), np.array(y)
+
+    blob_centers = np.array([[0, 0], [-10, 40], [-30, 30]])[:n_classes]
+    blob_stds = np.array([[[10, 10], [10, 100]]] * len(blob_centers))
+    X, y = generate_dataset(
+        n_samples=90000, centers=blob_centers, covariances=blob_stds,
+        random_state=42
+    )
+    lda = LinearDiscriminantAnalysis(solver=solver, store_covariance=True,
+                                     shrinkage=None).fit(X, y)
+    # check that the empirical means and covariances are close enough to the
+    # one used to generate the data
+    assert_allclose(lda.means_, blob_centers, atol=1e-1)
+    assert_allclose(lda.covariance_, blob_stds[0], atol=1)
+
+    # implement the method to compute the probability given in The Elements
+    # of Statistical Learning (cf. p.127, Sect. 4.4.5 "Logistic Regression
+    # or LDA?")
+    precision = linalg.inv(blob_stds[0])
+    alpha_k = []
+    alpha_k_0 = []
+    for clazz in range(len(blob_centers) - 1):
+        alpha_k.append(
+            _np.dot(precision,
+                    (blob_centers[clazz] - blob_centers[-1])[:, np.newaxis]))
+        alpha_k_0.append(
+            _np.dot(- 0.5 * (blob_centers[clazz] +
+                             blob_centers[-1])[np.newaxis, :], alpha_k[-1]))
+
+    sample = np.array([[-22, 22]])
+
+    def discriminant_func(sample, coef, intercept, clazz):
+        return np.exp(intercept[clazz] + np.dot(sample, coef[clazz]))
+
+    prob = np.array([float(
+        discriminant_func(sample, alpha_k, alpha_k_0, clazz) /
+        (1 + sum([discriminant_func(sample, alpha_k, alpha_k_0, clazz)
+                  for clazz in range(n_classes - 1)]))) for clazz in range(
+                      n_classes - 1)])
+
+    prob_ref = 1 - np.sum(prob)
+
+    # check the consistency of the computed probability
+    # all probabilities should sum to one
+    prob_ref_2 = float(
+        1 / (1 + sum([discriminant_func(sample, alpha_k, alpha_k_0, clazz)
+                      for clazz in range(n_classes - 1)]))
+    )
+
+    assert prob_ref.asnumpy() == pytest.approx(prob_ref_2)
+    # check that the probability of LDA are close to the theoretical
+    # probabilties
+    assert_allclose(lda.predict_proba(sample),
+                    np.hstack([prob, prob_ref])[np.newaxis],
+                    atol=1e-2)
+
+
+@use_np
+def test_lda_priors():
+    # Test that priors passed as a list are correctly handled (run to see if
+    # failure)
+    clf = LinearDiscriminantAnalysis(priors=[0.5, 0.5])
+    clf.fit(X, y)
+
+    # Test that priors always sum to 1
+    priors = np.array([0.5, 0.6])
+    prior_norm = np.array([0.45, 0.55])
+    clf = LinearDiscriminantAnalysis(priors=priors)
+    assert_warns(UserWarning, clf.fit, X, y)
+    assert_array_almost_equal(clf.priors_, prior_norm, 2)
+
+
+@use_np
+def test_lda_coefs():
+    # Test if the coefficients of the solvers are approximately the same.
+    n_features = 2
+    n_classes = 2
+    n_samples = 1000
+    X, y = make_blobs(n_samples=n_samples, n_features=n_features,
+                      centers=n_classes, random_state=11)
+
+    clf_lda_svd = LinearDiscriminantAnalysis(solver="svd")
+    clf_lda_lsqr = LinearDiscriminantAnalysis(solver="lsqr")
+    clf_lda_eigen = LinearDiscriminantAnalysis(solver="eigen")
+
+    clf_lda_svd.fit(X, y)
+    clf_lda_lsqr.fit(X, y)
+    clf_lda_eigen.fit(X, y)
+
+    assert_array_almost_equal(clf_lda_svd.coef_, clf_lda_lsqr.coef_, 1)
+    assert_array_almost_equal(clf_lda_svd.coef_, clf_lda_eigen.coef_, 1)
+    assert_array_almost_equal(clf_lda_eigen.coef_, clf_lda_lsqr.coef_, 1)
+
+
+@use_np
+def test_lda_transform():
+    # Test LDA transform.
+    clf = LinearDiscriminantAnalysis(solver="svd", n_components=1)
+    X_transformed = clf.fit(X, y).transform(X)
+    assert X_transformed.shape[1] == 1
+    clf = LinearDiscriminantAnalysis(solver="eigen", n_components=1)
+    X_transformed = clf.fit(X, y).transform(X)
+    assert X_transformed.shape[1] == 1
+
+
+@use_np
+def test_lda_explained_variance_ratio():
+    # Test if the sum of the normalized eigen vectors values equals 1,
+    # Also tests whether the explained_variance_ratio_ formed by the
+    # eigen solver is the same as the explained_variance_ratio_ formed
+    # by the svd solver
+
+    state = _np.random.RandomState(0)
+    X = state.normal(loc=0, scale=100, size=(40, 20))
+    y = state.randint(0, 3, size=(40,))
+
+    clf_lda_eigen = LinearDiscriminantAnalysis(solver="eigen")
+    clf_lda_eigen.fit(X, y)
+    assert_almost_equal(clf_lda_eigen.explained_variance_ratio_.sum(), 1.0, 3)
+    assert clf_lda_eigen.explained_variance_ratio_.shape == (2,), (
+        "Unexpected length for explained_variance_ratio_")
+
+    clf_lda_svd = LinearDiscriminantAnalysis(solver="svd")
+    clf_lda_svd.fit(X, y)
+    assert_almost_equal(clf_lda_svd.explained_variance_ratio_.sum(), 1.0, 3)
+    assert clf_lda_svd.explained_variance_ratio_.shape == (2,), (
+        "Unexpected length for explained_variance_ratio_")
+
+    assert_array_almost_equal(clf_lda_svd.explained_variance_ratio_,
+                              clf_lda_eigen.explained_variance_ratio_)
+
+
+@use_np
+def test_lda_orthogonality():
+    # arrange four classes with their means in a kite-shaped pattern
+    # the longer distance should be transformed to the first component, and
+    # the shorter distance to the second component.
+    means = np.array([[0, 0, -1], [0, 2, 0], [0, -2, 0], [0, 0, 5]])
+
+    # We construct perfectly symmetric distributions, so the LDA can estimate
+    # precise means.
+    scatter = np.array([[0.1, 0, 0], [-0.1, 0, 0], [0, 0.1, 0], [0, -0.1, 0],
+                        [0, 0, 0.1], [0, 0, -0.1]])
+
+    X = (means[:, np.newaxis, :] + scatter[np.newaxis, :, :]).reshape((-1, 3))
+    y = np.repeat(np.arange(means.shape[0]), scatter.shape[0])
+
+    # Fit LDA and transform the means
+    clf = LinearDiscriminantAnalysis(solver="svd").fit(X, y)
+    means_transformed = clf.transform(means)
+
+    d1 = means_transformed[3] - means_transformed[0]
+    d2 = means_transformed[2] - means_transformed[1]
+    d1 /= _np.sqrt(_np.sum(d1 ** 2))
+    d2 /= _np.sqrt(_np.sum(d2 ** 2))
+
+    # the transformed within-class covariance should be the identity matrix
+    assert_almost_equal(np.cov(clf.transform(scatter).T), np.eye(2), atol=1e-4, rtol=1e-4)
+
+    # the means of classes 0 and 3 should lie on the first component
+    assert_almost_equal(_np.abs(_np.dot(d1[:2], [1, 0])), 1.0)
+
+    # the means of classes 1 and 2 should lie on the second component
+    assert_almost_equal(_np.abs(_np.dot(d2[:2], [0, 1])), 1.0)
+
+
+@use_np
+def test_lda_scaling():
+    # Test if classification works correctly with differently scaled features.
+    n = 100
+    rng = _np.random.RandomState(1234)
+    # use uniform distribution of features to make sure there is absolutely no
+    # overlap between classes.
+    x1 = rng.uniform(-1, 1, (n, 3)) + [-10, 0, 0]
+    x2 = rng.uniform(-1, 1, (n, 3)) + [10, 0, 0]
+    x = _np.vstack((x1, x2)) * [1, 100, 10000]
+    y = [-1] * n + [1] * n
+
+    for solver in ('svd', 'lsqr', 'eigen'):
+        clf = LinearDiscriminantAnalysis(solver=solver)
+        # should be able to separate the data perfectly
+        assert clf.fit(x, y).score(x, y) == 1.0, (
+            'using covariance: %s' % solver)
+
+
+@use_np
+def test_lda_store_covariance():
+    # Test for solver 'lsqr' and 'eigen'
+    # 'store_covariance' has no effect on 'lsqr' and 'eigen' solvers
+    for solver in ('lsqr', 'eigen'):
+        clf = LinearDiscriminantAnalysis(solver=solver).fit(X6, y6)
+        assert hasattr(clf, 'covariance_')
+
+        # Test the actual attribute:
+        clf = LinearDiscriminantAnalysis(solver=solver,
+                                         store_covariance=True).fit(X6, y6)
+        assert hasattr(clf, 'covariance_')
+
+        assert_array_almost_equal(
+            clf.covariance_,
+            np.array([[0.422222, 0.088889], [0.088889, 0.533333]])
+        )
+
+    # Test for SVD solver, the default is to not set the covariances_ attribute
+    clf = LinearDiscriminantAnalysis(solver='svd').fit(X6, y6)
+    assert not hasattr(clf, 'covariance_')
+
+    # Test the actual attribute:
+    clf = LinearDiscriminantAnalysis(solver=solver,
+                                     store_covariance=True).fit(X6, y6)
+    assert hasattr(clf, 'covariance_')
+
+    assert_array_almost_equal(
+        clf.covariance_,
+        np.array([[0.422222, 0.088889], [0.088889, 0.533333]])
+    )
+
+
+@use_np
+@pytest.mark.parametrize('n_features', [3, 5])
+@pytest.mark.parametrize('n_classes', [5, 3])
+def test_lda_dimension_warning(n_classes, n_features):
+    rng = check_random_state(0)
+    n_samples = 10
+    X = rng.randn(n_samples, n_features)
+    # we create n_classes labels by repeating and truncating a
+    # range(n_classes) until n_samples
+    y = _np.tile(range(n_classes), n_samples // n_classes + 1)[:n_samples]
+    max_components = min(n_features, n_classes - 1)
+
+    for n_components in [max_components - 1, None, max_components]:
+        # if n_components <= min(n_classes - 1, n_features), no warning
+        lda = LinearDiscriminantAnalysis(n_components=n_components)
+        assert_no_warnings(lda.fit, X, y)
+
+    for n_components in [max_components + 1,
+                         max(n_features, n_classes - 1) + 1]:
+        # if n_components > min(n_classes - 1, n_features), raise error.
+        # We test one unit higher than max_components, and then something
+        # larger than both n_features and n_classes - 1 to ensure the test
+        # works for any value of n_component
+        lda = LinearDiscriminantAnalysis(n_components=n_components)
+        msg = "n_components cannot be larger than "
+        with pytest.raises(ValueError, match=msg):
+            lda.fit(X, y)
+
+
+@use_np
+def test_lda_numeric_consistency_float32_float64():
+    for (solver, shrinkage) in solver_shrinkage:
+        clf_32 = LinearDiscriminantAnalysis(solver=solver, shrinkage=shrinkage)
+        clf_32.fit(X.astype(np.float32), y.astype(np.float32))
+        clf_64 = LinearDiscriminantAnalysis(solver=solver, shrinkage=shrinkage)
+        clf_64.fit(X.astype(np.float64), y.astype(np.float64))
+
+        # Check value consistency between types
+        rtol = 1e-6
+        assert_allclose(clf_32.coef_, clf_64.coef_, rtol=rtol)
+
+
+@use_np
+def test_qda():
+    # QDA classification.
+    # This checks that QDA implements fit and predict and returns
+    # correct values for a simple toy dataset.
+    clf = QuadraticDiscriminantAnalysis()
+    y_pred = clf.fit(X6, y6).predict(X6)
+    assert_array_equal(y_pred, y6)
+
+    # Assure that it works with 1D data
+    y_pred1 = clf.fit(X7, y6).predict(X7)
+    assert_array_equal(y_pred1, y6)
+
+    # Test probas estimates
+    y_proba_pred1 = clf.predict_proba(X7)
+    assert_array_equal((y_proba_pred1[:, 1] > 0.5) + 1, y6)
+    y_log_proba_pred1 = clf.predict_log_proba(X7)
+    assert_array_almost_equal(_np.exp(y_log_proba_pred1), y_proba_pred1, 8)
+
+    y_pred3 = clf.fit(X6, y7).predict(X6)
+    # QDA shouldn't be able to separate those
+    assert np.any(y_pred3 != y7)
+
+    # Classes should have at least 2 elements
+    assert_raises(ValueError, clf.fit, X6, y4)
+
+
+@use_np
+def test_qda_priors():
+    clf = QuadraticDiscriminantAnalysis()
+    y_pred = clf.fit(X6, y6).predict(X6)
+    n_pos = _np.sum(y_pred == 2)
+
+    neg = 1e-10
+    clf = QuadraticDiscriminantAnalysis(priors=np.array([neg, 1 - neg]))
+    y_pred = clf.fit(X6, y6).predict(X6)
+    n_pos2 = _np.sum(y_pred == 2)
+
+    assert n_pos2 > n_pos
+
+
+@use_np
+def test_qda_store_covariance():
+    # The default is to not set the covariances_ attribute
+    clf = QuadraticDiscriminantAnalysis().fit(X6, y6)
+    assert not hasattr(clf, 'covariance_')
+
+    # Test the actual attribute:
+    clf = QuadraticDiscriminantAnalysis(store_covariance=True).fit(X6, y6)
+    assert hasattr(clf, 'covariance_')
+
+    assert_array_almost_equal(
+        clf.covariance_[0],
+        np.array([[0.7, 0.45], [0.45, 0.7]])
+    )
+
+    assert_array_almost_equal(
+        clf.covariance_[1],
+        np.array([[0.33333333, -0.33333333], [-0.33333333, 0.66666667]])
+    )
+
+
+@use_np
+def test_qda_regularization():
+    # the default is reg_param=0. and will cause issues
+    # when there is a constant variable
+    clf = QuadraticDiscriminantAnalysis()
+    y_pred = clf.fit(X2, y6).predict(X2)
+    assert np.any(y_pred != y6)
+
+    # adding a little regularization fixes the problem
+    clf = QuadraticDiscriminantAnalysis(reg_param=0.01)
+    clf.fit(X2, y6)
+    y_pred = clf.predict(X2)
+    assert_array_equal(y_pred, y6)
+
+    # Case n_samples_in_a_class < n_features
+    clf = QuadraticDiscriminantAnalysis(reg_param=0.1)
+    clf.fit(X5, y5)
+    y_pred5 = clf.predict(X5)
+    assert_array_equal(y_pred5, y5)
+
+
+@use_np
+def test_covariance():
+    x, y = make_blobs(n_samples=100, n_features=5,
+                      centers=1, random_state=42)
+
+    # make features correlated
+    x = _np.dot(x, np.arange(x.shape[1] ** 2, dtype='float64').reshape(x.shape[1], x.shape[1]))
+
+    c_e = _cov(x, 'empirical')
+    assert_almost_equal(c_e, c_e.T)
+
+    c_s = _cov(x, 'auto')
+    assert_almost_equal(c_s, c_s.T)
+
+
+@use_np
+@pytest.mark.parametrize("solver", ['svd, lsqr', 'eigen'])
+def test_raises_value_error_on_same_number_of_classes_and_samples(solver):
+    """
+    Tests that if the number of samples equals the number
+    of classes, a ValueError is raised.
+    """
+    X = np.array([[0.5, 0.6], [0.6, 0.5]])
+    y = np.array([1, 2])
+    clf = LinearDiscriminantAnalysis(solver=solver)
+    with pytest.raises(ValueError, match="The number of samples must be more"):
+        clf.fit(X, y)
+

--- a/tests/python/unittest/test_numpy_sklearn_forest.py
+++ b/tests/python/unittest/test_numpy_sklearn_forest.py
@@ -1,0 +1,1050 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: skip-file
+
+import mxnet as mx
+from mxnet import np
+import numpy as _np
+
+import pytest
+import pickle
+import math
+from collections import defaultdict
+import itertools
+from itertools import combinations
+from itertools import product
+from typing import Dict, Any
+
+from scipy.special import comb
+
+from sklearn.utils._testing import assert_array_almost_equal
+from sklearn.utils._testing import assert_array_equal
+from sklearn.utils._testing import assert_raises
+from sklearn.utils._testing import assert_warns
+from sklearn.utils._testing import assert_warns_message
+from sklearn.utils._testing import ignore_warnings
+from sklearn.utils._testing import skip_if_no_parallel
+
+from sklearn.exceptions import NotFittedError
+
+from sklearn import datasets
+from sklearn.decomposition import TruncatedSVD
+from sklearn.ensemble import ExtraTreesClassifier
+from sklearn.ensemble import ExtraTreesRegressor
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.ensemble import RandomTreesEmbedding
+from sklearn.model_selection import GridSearchCV
+from sklearn.svm import LinearSVC
+from sklearn.utils.validation import check_random_state
+
+from mxnet.test_utils import same, assert_almost_equal, rand_shape_nd, use_np
+
+
+# toy sample
+X = np.array([[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1]])
+y = np.array([-1, -1, -1, 1, 1, 1])
+T = np.array([[-1, -1], [2, 2], [3, 2]])
+true_result = np.array([-1, 1, 1])
+
+# Larger classification sample used for testing feature importances
+X_large, y_large = datasets.make_classification(
+    n_samples=500, n_features=10, n_informative=3, n_redundant=0,
+    n_repeated=0, shuffle=False, random_state=0)
+
+# also load the iris dataset
+# and randomly permute it
+iris = datasets.load_iris()
+rng = check_random_state(0)
+perm = rng.permutation(iris.target.size)
+iris.data = np.array(iris.data[perm])
+iris.target = np.array(iris.target[perm])
+
+# Make regression dataset
+X_reg, y_reg = datasets.make_regression(n_samples=500, n_features=10,
+                                        random_state=1)
+X_reg, y_reg = np.array(X_reg), np.array(y_reg)
+
+# also make a hastie_10_2 dataset
+hastie_X, hastie_y = datasets.make_hastie_10_2(n_samples=20, random_state=1)
+hastie_X = np.array(hastie_X).astype(np.float32)
+hastie_y = np.array(hastie_y)
+
+FOREST_CLASSIFIERS = {
+    "ExtraTreesClassifier": ExtraTreesClassifier,
+    "RandomForestClassifier": RandomForestClassifier,
+}
+
+FOREST_REGRESSORS = {
+    "ExtraTreesRegressor": ExtraTreesRegressor,
+    "RandomForestRegressor": RandomForestRegressor,
+}
+
+FOREST_TRANSFORMERS = {
+    "RandomTreesEmbedding": RandomTreesEmbedding,
+}
+
+FOREST_ESTIMATORS: Dict[str, Any] = dict()
+FOREST_ESTIMATORS.update(FOREST_CLASSIFIERS)
+FOREST_ESTIMATORS.update(FOREST_REGRESSORS)
+FOREST_ESTIMATORS.update(FOREST_TRANSFORMERS)
+
+FOREST_CLASSIFIERS_REGRESSORS: Dict[str, Any] = FOREST_CLASSIFIERS.copy()
+FOREST_CLASSIFIERS_REGRESSORS.update(FOREST_REGRESSORS)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+def test_classification_toy(name):
+    """Check classification on a toy dataset."""
+    ForestClassifier = FOREST_CLASSIFIERS[name]
+
+    clf = ForestClassifier(n_estimators=10, random_state=1)
+    clf.fit(X, y)
+    assert_array_equal(clf.predict(T), true_result)
+    assert 10 == len(clf)
+
+    clf = ForestClassifier(n_estimators=10, max_features=1, random_state=1)
+    clf.fit(X, y)
+    assert_array_equal(clf.predict(T), true_result)
+    assert 10 == len(clf)
+
+    # also test apply
+    leaf_indices = clf.apply(X)
+    assert leaf_indices.shape == (len(X), clf.n_estimators)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+@pytest.mark.parametrize('criterion', ("gini", "entropy"))
+def test_iris_criterion(name, criterion):
+    # Check consistency on dataset iris.
+    ForestClassifier = FOREST_CLASSIFIERS[name]
+
+    clf = ForestClassifier(n_estimators=10, criterion=criterion,
+                           random_state=1)
+    clf.fit(iris.data, iris.target)
+    score = clf.score(iris.data, iris.target)
+    assert score > 0.9, ("Failed with criterion %s and score = %f"
+                         % (criterion, score))
+
+    clf = ForestClassifier(n_estimators=10, criterion=criterion,
+                           max_features=2, random_state=1)
+    clf.fit(iris.data, iris.target)
+    score = clf.score(iris.data, iris.target)
+    assert score > 0.5, ("Failed with criterion %s and score = %f"
+                         % (criterion, score))
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_REGRESSORS)
+@pytest.mark.parametrize('criterion', ("mse", "mae", "friedman_mse"))
+def test_regression_criterion(name, criterion):
+    # Check consistency on regression dataset.
+    ForestRegressor = FOREST_REGRESSORS[name]
+
+    reg = ForestRegressor(n_estimators=5, criterion=criterion,
+                          random_state=1)
+    reg.fit(X_reg, y_reg)
+    score = reg.score(X_reg, y_reg)
+    assert score > 0.93, ("Failed with max_features=None, criterion %s "
+                          "and score = %f" % (criterion, score))
+
+    reg = ForestRegressor(n_estimators=5, criterion=criterion,
+                          max_features=6, random_state=1)
+    reg.fit(X_reg, y_reg)
+    score = reg.score(X_reg, y_reg)
+    assert score > 0.92, ("Failed with max_features=6, criterion %s "
+                          "and score = %f" % (criterion, score))
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_REGRESSORS)
+def check_regressor_attributes(name):
+    # Regression models should not have a classes_ attribute.
+    r = FOREST_REGRESSORS[name](random_state=0)
+    assert not hasattr(r, "classes_")
+    assert not hasattr(r, "n_classes_")
+
+    r.fit([[1, 2, 3], [4, 5, 6]], [1, 2])
+    assert not hasattr(r, "classes_")
+    assert not hasattr(r, "n_classes_")
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+def test_probability(name):
+    # Predict probabilities.
+    ForestClassifier = FOREST_CLASSIFIERS[name]
+    with _np.errstate(divide="ignore"):
+        clf = ForestClassifier(n_estimators=10, random_state=1, max_features=1,
+                               max_depth=1)
+        clf.fit(iris.data, iris.target)
+        assert_array_almost_equal(_np.sum(clf.predict_proba(iris.data), axis=1),
+                                  np.ones(iris.data.shape[0]))
+        assert_array_almost_equal(clf.predict_proba(iris.data),
+                                  _np.exp(clf.predict_log_proba(iris.data)))
+
+
+@use_np
+@pytest.mark.parametrize('dtype', (np.float64, np.float32))
+@pytest.mark.parametrize(
+        'name, criterion',
+        itertools.chain(product(FOREST_CLASSIFIERS,
+                                ["gini", "entropy"]),
+                        product(FOREST_REGRESSORS,
+                                ["mse", "friedman_mse", "mae"])))
+def test_importances(name, criterion, dtype):
+    tolerance = 0.01
+    if name in FOREST_REGRESSORS and criterion == "mae":
+        tolerance = 0.05
+    # cast as dype
+    X = X_large.astype(dtype, copy=False)
+    y = y_large.astype(dtype, copy=False)
+
+    ForestEstimator = FOREST_ESTIMATORS[name]
+
+    est = ForestEstimator(n_estimators=10, criterion=criterion,
+                          random_state=0)
+    est.fit(X, y)
+    importances = est.feature_importances_
+
+    # The forest estimator can detect that only the first 3 features of the
+    # dataset are informative:
+    n_important = _np.sum(importances > 0.1)
+    assert importances.shape[0] == 10
+    assert n_important == 3
+    assert _np.all(importances[:3] > 0.1)
+
+    # Check with parallel
+    importances = est.feature_importances_
+    est.set_params(n_jobs=2)
+    importances_parallel = est.feature_importances_
+    assert_array_almost_equal(importances, importances_parallel)
+
+    # Check with sample weights
+    sample_weight = check_random_state(0).randint(1, 10, len(X))
+    est = ForestEstimator(n_estimators=10, random_state=0, criterion=criterion)
+    est.fit(X, y, sample_weight=sample_weight)
+    importances = est.feature_importances_
+    assert _np.all(importances >= 0.0)
+
+    for scale in [0.5, 100]:
+        est = ForestEstimator(n_estimators=10, random_state=0,
+                              criterion=criterion)
+        est.fit(X, y, sample_weight=scale * sample_weight)
+        importances_bis = est.feature_importances_
+        assert _np.abs(importances - importances_bis).mean() < tolerance
+
+
+def check_oob_score(name, X, y, n_estimators=20):
+    # Check that oob prediction is a good estimation of the generalization
+    # error.
+
+    # Proper behavior
+    est = FOREST_ESTIMATORS[name](oob_score=True, random_state=0,
+                                  n_estimators=n_estimators, bootstrap=True)
+    n_samples = X.shape[0]
+    est.fit(X[:n_samples // 2, :], y[:n_samples // 2])
+    test_score = est.score(X[n_samples // 2:, :], y[n_samples // 2:])
+    oob_score = est.oob_score_
+
+    assert abs(test_score - oob_score) < 0.1 and oob_score > 0.7
+
+    # Check warning if not enough estimators
+    with _np.errstate(divide="ignore", invalid="ignore"):
+        est = FOREST_ESTIMATORS[name](oob_score=True, random_state=0,
+                                      n_estimators=1, bootstrap=True)
+        assert_warns(UserWarning, est.fit, X, y)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+def test_oob_score_classifiers(name):
+    check_oob_score(name, iris.data, iris.target)
+
+    # non-contiguous targets in classification
+    check_oob_score(name, iris.data, iris.target * 2 + 1)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_REGRESSORS)
+def test_oob_score_regressors(name):
+    check_oob_score(name, X_reg, y_reg, 50)
+
+
+def check_oob_score_raise_error(name):
+    ForestEstimator = FOREST_ESTIMATORS[name]
+
+    if name in FOREST_TRANSFORMERS:
+        for oob_score in [True, False]:
+            assert_raises(TypeError, ForestEstimator, oob_score=oob_score)
+
+        assert_raises(NotImplementedError, ForestEstimator()._set_oob_score,
+                      X, y)
+
+    else:
+        # Unfitted /  no bootstrap / no oob_score
+        for oob_score, bootstrap in [(True, False), (False, True),
+                                     (False, False)]:
+            est = ForestEstimator(oob_score=oob_score, bootstrap=bootstrap,
+                                  random_state=0)
+            assert not hasattr(est, "oob_score_")
+
+        # No bootstrap
+        assert_raises(ValueError, ForestEstimator(oob_score=True,
+                                                  bootstrap=False).fit, X, y)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_ESTIMATORS)
+def test_oob_score_raise_error(name):
+    check_oob_score_raise_error(name)
+
+
+def check_gridsearch(name):
+    forest = FOREST_CLASSIFIERS[name]()
+    clf = GridSearchCV(forest, {'n_estimators': (1, 2), 'max_depth': (1, 2)})
+    clf.fit(iris.data, iris.target)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+def test_gridsearch(name):
+    # Check that base trees can be grid-searched.
+    check_gridsearch(name)
+
+
+def check_parallel(name, X, y):
+    """Check parallel computations in classification"""
+    ForestEstimator = FOREST_ESTIMATORS[name]
+    forest = ForestEstimator(n_estimators=10, n_jobs=3, random_state=0)
+
+    forest.fit(X, y)
+    assert len(forest) == 10
+
+    forest.set_params(n_jobs=1)
+    y1 = forest.predict(X)
+    forest.set_params(n_jobs=2)
+    y2 = forest.predict(X)
+    assert_array_almost_equal(y1, y2, 3)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS_REGRESSORS)
+def test_parallel(name):
+    if name in FOREST_CLASSIFIERS:
+        X = iris.data
+        y = iris.target
+    elif name in FOREST_REGRESSORS:
+        X = X_reg
+        y = y_reg
+
+    check_parallel(name, X, y)
+
+
+def check_pickle(name, X, y):
+    # Check pickability.
+
+    ForestEstimator = FOREST_ESTIMATORS[name]
+    obj = ForestEstimator(random_state=0)
+    obj.fit(X, y)
+    score = obj.score(X, y)
+    pickle_object = pickle.dumps(obj)
+
+    obj2 = pickle.loads(pickle_object)
+    assert type(obj2) == obj.__class__
+    score2 = obj2.score(X, y)
+    assert score == score2
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS_REGRESSORS)
+def test_pickle(name):
+    if name in FOREST_CLASSIFIERS:
+        X = iris.data
+        y = iris.target
+    elif name in FOREST_REGRESSORS:
+        X = X_reg
+        y = y_reg
+
+    check_pickle(name, X[::2], y[::2])
+
+
+def check_multioutput(name):
+    # Check estimators on multi-output problems.
+
+    X_train = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [-2, 1],
+               [-1, 1], [-1, 2], [2, -1], [1, -1], [1, -2]]
+    y_train = [[-1, 0], [-1, 0], [-1, 0], [1, 1], [1, 1], [1, 1], [-1, 2],
+               [-1, 2], [-1, 2], [1, 3], [1, 3], [1, 3]]
+    X_test = [[-1, -1], [1, 1], [-1, 1], [1, -1]]
+    y_test = [[-1, 0], [1, 1], [-1, 2], [1, 3]]
+
+    est = FOREST_ESTIMATORS[name](random_state=0, bootstrap=False)
+    y_pred = est.fit(X_train, y_train).predict(X_test)
+    assert_array_almost_equal(y_pred, y_test)
+
+    if name in FOREST_CLASSIFIERS:
+        with _np.errstate(divide="ignore"):
+            proba = est.predict_proba(X_test)
+            assert len(proba) == 2
+            assert proba[0].shape == (4, 2)
+            assert proba[1].shape == (4, 4)
+
+            log_proba = est.predict_log_proba(X_test)
+            assert len(log_proba) == 2
+            assert log_proba[0].shape == (4, 2)
+            assert log_proba[1].shape == (4, 4)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS_REGRESSORS)
+def test_multioutput(name):
+    check_multioutput(name)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+def test_multioutput_string(name):
+    # Check estimators on multi-output problems with string outputs.
+
+    X_train = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [-2, 1],
+               [-1, 1], [-1, 2], [2, -1], [1, -1], [1, -2]]
+    y_train = [["red", "blue"], ["red", "blue"], ["red", "blue"],
+               ["green", "green"], ["green", "green"], ["green", "green"],
+               ["red", "purple"], ["red", "purple"], ["red", "purple"],
+               ["green", "yellow"], ["green", "yellow"], ["green", "yellow"]]
+    X_test = [[-1, -1], [1, 1], [-1, 1], [1, -1]]
+    y_test = [["red", "blue"], ["green", "green"],
+              ["red", "purple"], ["green", "yellow"]]
+
+    est = FOREST_ESTIMATORS[name](random_state=0, bootstrap=False)
+    y_pred = est.fit(X_train, y_train).predict(X_test)
+    assert_array_equal(y_pred, y_test)
+
+    with _np.errstate(divide="ignore"):
+        proba = est.predict_proba(X_test)
+        assert len(proba) == 2
+        assert proba[0].shape == (4, 2)
+        assert proba[1].shape == (4, 4)
+
+        log_proba = est.predict_log_proba(X_test)
+        assert len(log_proba) == 2
+        assert log_proba[0].shape == (4, 2)
+        assert log_proba[1].shape == (4, 4)
+
+
+def check_classes_shape(name):
+    # Test that n_classes_ and classes_ have proper shape.
+    ForestClassifier = FOREST_CLASSIFIERS[name]
+
+    # Classification, single output
+    clf = ForestClassifier(random_state=0).fit(X, y)
+
+    assert clf.n_classes_ == 2
+    assert_array_equal(clf.classes_, [-1, 1])
+
+    # Classification, multi-output
+    print(type(y), type(np.array(y) * 2))
+    _y = _np.vstack((y, np.array(y) * 2)).T
+    clf = ForestClassifier(random_state=0).fit(X, _y)
+
+    assert_array_equal(clf.n_classes_, [2, 2])
+    assert_array_equal(clf.classes_, [[-1, 1], [-2, 2]])
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+def test_classes_shape(name):
+    check_classes_shape(name)
+
+
+@use_np
+def test_random_trees_dense_type():
+    # Test that the `sparse_output` parameter of RandomTreesEmbedding
+    # works by returning a dense array.
+
+    # Create the RTE with sparse=False
+    hasher = RandomTreesEmbedding(n_estimators=10, sparse_output=False)
+    X, y = datasets.make_circles(factor=0.5)
+    X, y = np.array(X), np.array(y)
+    X_transformed = hasher.fit_transform(X)
+
+    # Assert that type is ndarray, not scipy.sparse.csr.csr_matrix
+    assert type(X_transformed) == _np.ndarray
+
+
+@use_np
+def test_random_trees_dense_equal():
+    # Test that the `sparse_output` parameter of RandomTreesEmbedding
+    # works by returning the same array for both argument values.
+
+    # Create the RTEs
+    hasher_dense = RandomTreesEmbedding(n_estimators=10, sparse_output=False,
+                                        random_state=0)
+    hasher_sparse = RandomTreesEmbedding(n_estimators=10, sparse_output=True,
+                                         random_state=0)
+    X, y = datasets.make_circles(factor=0.5)
+    X, y = np.array(X), np.array(y)
+    X_transformed_dense = hasher_dense.fit_transform(X)
+    X_transformed_sparse = hasher_sparse.fit_transform(X)
+
+    # Assert that dense and sparse hashers have same array.
+    assert_array_equal(X_transformed_sparse.toarray(), X_transformed_dense)
+
+
+@use_np
+def test_random_hasher():
+    # test random forest hashing on circles dataset
+    # make sure that it is linearly separable.
+    # even after projected to two SVD dimensions
+    # Note: Not all random_states produce perfect results.
+    hasher = RandomTreesEmbedding(n_estimators=30, random_state=1)
+    X, y = datasets.make_circles(factor=0.5)
+    X, y = np.array(X), np.array(y)
+    X_transformed = hasher.fit_transform(X)
+
+    # test fit and transform:
+    hasher = RandomTreesEmbedding(n_estimators=30, random_state=1)
+    assert_array_equal(hasher.fit(X).transform(X).toarray(),
+                       X_transformed.toarray())
+
+    # one leaf active per data point per forest
+    assert X_transformed.shape[0] == X.shape[0]
+    assert_array_equal(X_transformed.sum(axis=1), hasher.n_estimators)
+    svd = TruncatedSVD(n_components=2)
+    X_reduced = svd.fit_transform(X_transformed)
+    linear_clf = LinearSVC()
+    linear_clf.fit(X_reduced, y)
+    assert linear_clf.score(X_reduced, y) == 1.
+
+
+@use_np
+def test_parallel_train():
+    rng = check_random_state(12321)
+    n_samples, n_features = 80, 30
+    X_train = rng.randn(n_samples, n_features)
+    y_train = rng.randint(0, 2, n_samples)
+
+    clfs = [
+        RandomForestClassifier(n_estimators=20, n_jobs=n_jobs,
+                               random_state=12345).fit(X_train, y_train)
+        for n_jobs in [1, 2, 3, 8, 16, 32]
+    ]
+
+    X_test = rng.randn(n_samples, n_features)
+    probas = [clf.predict_proba(X_test) for clf in clfs]
+    for proba1, proba2 in zip(probas, probas[1:]):
+        assert_array_almost_equal(proba1, proba2)
+
+
+@use_np
+def test_distribution():
+    rng = check_random_state(12321)
+
+    # Single variable with 4 values
+    X = rng.randint(0, 4, size=(1000, 1))
+    y = rng.rand(1000)
+    n_trees = 500
+
+    reg = ExtraTreesRegressor(n_estimators=n_trees, random_state=42).fit(X, y)
+
+    uniques = defaultdict(int)
+    for tree in reg.estimators_:
+        tree = "".join(("%d,%d/" % (f, int(t)) if f >= 0 else "-")
+                       for f, t in zip(tree.tree_.feature,
+                                       tree.tree_.threshold))
+
+        uniques[tree] += 1
+
+    uniques = sorted([(1. * count / n_trees, tree)
+                      for tree, count in uniques.items()])
+
+    # On a single variable problem where X_0 has 4 equiprobable values, there
+    # are 5 ways to build a random tree. The more compact (0,1/0,0/--0,2/--) of
+    # them has probability 1/3 while the 4 others have probability 1/6.
+
+    assert len(uniques) == 5
+    assert 0.20 > uniques[0][0]  # Rough approximation of 1/6.
+    assert 0.20 > uniques[1][0]
+    assert 0.20 > uniques[2][0]
+    assert 0.20 > uniques[3][0]
+    assert uniques[4][0] > 0.3
+    assert uniques[4][1] == "0,1/0,0/--0,2/--"
+
+    # Two variables, one with 2 values, one with 3 values
+    X = np.empty((1000, 2))
+    X[:, 0] = np.random.randint(0, 2, 1000)
+    X[:, 1] = np.random.randint(0, 3, 1000)
+    y = rng.rand(1000)
+
+    reg = ExtraTreesRegressor(max_features=1, random_state=1).fit(X, y)
+
+    uniques = defaultdict(int)
+    for tree in reg.estimators_:
+        tree = "".join(("%d,%d/" % (f, int(t)) if f >= 0 else "-")
+                       for f, t in zip(tree.tree_.feature,
+                                       tree.tree_.threshold))
+
+        uniques[tree] += 1
+
+    uniques = [(count, tree) for tree, count in uniques.items()]
+    assert len(uniques) == 8
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_ESTIMATORS)
+def test_max_leaf_nodes_max_depth(name):
+    X, y = hastie_X, hastie_y
+
+    # Test precedence of max_leaf_nodes over max_depth.
+    ForestEstimator = FOREST_ESTIMATORS[name]
+    est = ForestEstimator(max_depth=1, max_leaf_nodes=4,
+                          n_estimators=1, random_state=0).fit(X, y)
+    assert est.estimators_[0].get_depth() == 1
+
+    est = ForestEstimator(max_depth=1, n_estimators=1,
+                          random_state=0).fit(X, y)
+    assert est.estimators_[0].get_depth() == 1
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_ESTIMATORS)
+def test_min_samples_split(name):
+    X, y = hastie_X, hastie_y
+    ForestEstimator = FOREST_ESTIMATORS[name]
+
+    # test boundary value
+    assert_raises(ValueError,
+                  ForestEstimator(min_samples_split=-1).fit, X, y)
+    assert_raises(ValueError,
+                  ForestEstimator(min_samples_split=0).fit, X, y)
+    assert_raises(ValueError,
+                  ForestEstimator(min_samples_split=1.1).fit, X, y)
+
+    est = ForestEstimator(min_samples_split=10, n_estimators=1, random_state=0)
+    est.fit(X, y)
+    node_idx = est.estimators_[0].tree_.children_left != -1
+    node_samples = est.estimators_[0].tree_.n_node_samples[node_idx]
+
+    assert _np.min(node_samples) > len(X) * 0.5 - 1, (
+        "Failed with {0}".format(name))
+
+    est = ForestEstimator(min_samples_split=0.5, n_estimators=1,
+                          random_state=0)
+    est.fit(X, y)
+    node_idx = est.estimators_[0].tree_.children_left != -1
+    node_samples = est.estimators_[0].tree_.n_node_samples[node_idx]
+
+    assert _np.min(node_samples) > len(X) * 0.5 - 1, (
+        "Failed with {0}".format(name))
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS_REGRESSORS)
+@pytest.mark.parametrize('dtype', (np.float64, np.float32))
+def test_memory_layout(name, dtype):
+    # Check that it works no matter the memory layout
+
+    est = FOREST_ESTIMATORS[name](random_state=0, bootstrap=False)
+
+    # Nothing
+    X = np.array(_np.asarray(iris.data, dtype=dtype))
+    y = np.array(iris.target)
+    assert_array_almost_equal(est.fit(X, y).predict(X), y)
+
+    # C-order
+    X = np.array(_np.asarray(iris.data, order="C", dtype=dtype))
+    y = iris.target
+    assert_array_almost_equal(est.fit(X, y).predict(X), y)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_ESTIMATORS)
+def test_1d_input(name):
+    X = iris.data[:, 0]
+    X_2d = iris.data[:, 0].reshape((-1, 1))
+    y = iris.target
+
+    with ignore_warnings():
+        ForestEstimator = FOREST_ESTIMATORS[name]
+        assert_raises(ValueError, ForestEstimator(n_estimators=1,
+                                                  random_state=0).fit, X, y)
+
+        est = ForestEstimator(random_state=0)
+        est.fit(X_2d, y)
+
+        if name in FOREST_CLASSIFIERS or name in FOREST_REGRESSORS:
+            assert_raises(ValueError, est.predict, X)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+def check_class_weights(name):
+    # Check class_weights resemble sample_weights behavior.
+    ForestClassifier = FOREST_CLASSIFIERS[name]
+
+    # Iris is balanced, so no effect expected for using 'balanced' weights
+    clf1 = ForestClassifier(random_state=0)
+    clf1.fit(iris.data, iris.target)
+    clf2 = ForestClassifier(class_weight='balanced', random_state=0)
+    clf2.fit(iris.data, iris.target)
+    assert_almost_equal(clf1.feature_importances_, clf2.feature_importances_)
+
+    # Make a multi-output problem with three copies of Iris
+    iris_multi = _np.vstack((iris.target, iris.target, iris.target)).T
+    # Create user-defined weights that should balance over the outputs
+    clf3 = ForestClassifier(class_weight=[{0: 2., 1: 2., 2: 1.},
+                                          {0: 2., 1: 1., 2: 2.},
+                                          {0: 1., 1: 2., 2: 2.}],
+                            random_state=0)
+    clf3.fit(iris.data, iris_multi)
+    assert_almost_equal(clf2.feature_importances_, clf3.feature_importances_)
+    # Check against multi-output "balanced" which should also have no effect
+    clf4 = ForestClassifier(class_weight='balanced', random_state=0)
+    clf4.fit(iris.data, iris_multi)
+    assert_almost_equal(clf3.feature_importances_, clf4.feature_importances_)
+
+    # Inflate importance of class 1, check against user-defined weights
+    sample_weight = np.ones(iris.target.shape)
+    sample_weight[iris.target == 1] *= 100
+    class_weight = {0: 1., 1: 100., 2: 1.}
+    clf1 = ForestClassifier(random_state=0)
+    clf1.fit(iris.data, iris.target, sample_weight)
+    clf2 = ForestClassifier(class_weight=class_weight, random_state=0)
+    clf2.fit(iris.data, iris.target)
+    assert_almost_equal(clf1.feature_importances_, clf2.feature_importances_)
+
+    # Check that sample_weight and class_weight are multiplicative
+    clf1 = ForestClassifier(random_state=0)
+    clf1.fit(iris.data, iris.target, sample_weight ** 2)
+    clf2 = ForestClassifier(class_weight=class_weight, random_state=0)
+    clf2.fit(iris.data, iris.target, sample_weight)
+    assert_almost_equal(clf1.feature_importances_, clf2.feature_importances_)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+def test_class_weight_balanced_and_bootstrap_multi_output(name):
+    # Test class_weight works for multi-output"""
+    ForestClassifier = FOREST_CLASSIFIERS[name]
+    _y = _np.vstack((y, np.array(y) * 2)).T
+    clf = ForestClassifier(class_weight='balanced', random_state=0)
+    clf.fit(X, _y)
+    clf = ForestClassifier(class_weight=[{-1: 0.5, 1: 1.}, {-2: 1., 2: 1.}],
+                           random_state=0)
+    clf.fit(X, _y)
+    # smoke test for balanced subsample
+    clf = ForestClassifier(class_weight='balanced_subsample', random_state=0)
+    clf.fit(X, _y)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS)
+def test_class_weight_errors(name):
+    # Test if class_weight raises errors and warnings when expected.
+    ForestClassifier = FOREST_CLASSIFIERS[name]
+    _y = _np.vstack((y, np.array(y) * 2)).T
+
+    # Invalid preset string
+    clf = ForestClassifier(class_weight='the larch', random_state=0)
+    assert_raises(ValueError, clf.fit, X, y)
+    assert_raises(ValueError, clf.fit, X, _y)
+
+    # Warning warm_start with preset
+    clf = ForestClassifier(class_weight='balanced', warm_start=True,
+                           random_state=0)
+    assert_warns(UserWarning, clf.fit, X, y)
+    assert_warns(UserWarning, clf.fit, X, _y)
+
+    # Not a list or preset for multi-output
+    clf = ForestClassifier(class_weight=1, random_state=0)
+    assert_raises(ValueError, clf.fit, X, _y)
+
+    # Incorrect length list for multi-output
+    clf = ForestClassifier(class_weight=[{-1: 0.5, 1: 1.}], random_state=0)
+    assert_raises(ValueError, clf.fit, X, _y)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_ESTIMATORS)
+def test_warm_start(name, random_state=42):
+    # Test if fitting incrementally with warm start gives a forest of the
+    # right size and the same results as a normal fit.
+    X, y = hastie_X, hastie_y
+    ForestEstimator = FOREST_ESTIMATORS[name]
+    est_ws = None
+    for n_estimators in [5, 10]:
+        if est_ws is None:
+            est_ws = ForestEstimator(n_estimators=n_estimators,
+                                     random_state=random_state,
+                                     warm_start=True)
+        else:
+            est_ws.set_params(n_estimators=n_estimators)
+        est_ws.fit(X, y)
+        assert len(est_ws) == n_estimators
+
+    est_no_ws = ForestEstimator(n_estimators=10, random_state=random_state,
+                                warm_start=False)
+    est_no_ws.fit(X, y)
+
+    assert (set([tree.random_state for tree in est_ws]) ==
+            set([tree.random_state for tree in est_no_ws]))
+
+    assert_array_equal(est_ws.apply(X), est_no_ws.apply(X),
+                       err_msg="Failed with {0}".format(name))
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_ESTIMATORS)
+def test_warm_start_clear(name):
+    # Test if fit clears state and grows a new forest when warm_start==False.
+    X, y = hastie_X, hastie_y
+    ForestEstimator = FOREST_ESTIMATORS[name]
+    est = ForestEstimator(n_estimators=5, max_depth=1, warm_start=False,
+                          random_state=1)
+    est.fit(X, y)
+
+    est_2 = ForestEstimator(n_estimators=5, max_depth=1, warm_start=True,
+                            random_state=2)
+    est_2.fit(X, y)  # inits state
+    est_2.set_params(warm_start=False, random_state=1)
+    est_2.fit(X, y)  # clears old state and equals est
+
+    assert_array_almost_equal(est_2.apply(X), est.apply(X))
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_ESTIMATORS)
+def test_warm_start_smaller_n_estimators(name):
+    # Test if warm start second fit with smaller n_estimators raises error.
+    X, y = hastie_X, hastie_y
+    ForestEstimator = FOREST_ESTIMATORS[name]
+    est = ForestEstimator(n_estimators=5, max_depth=1, warm_start=True)
+    est.fit(X, y)
+    est.set_params(n_estimators=4)
+    assert_raises(ValueError, est.fit, X, y)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_ESTIMATORS)
+def test_warm_start_equal_n_estimators(name):
+    # Test if warm start with equal n_estimators does nothing and returns the
+    # same forest and raises a warning.
+    X, y = hastie_X, hastie_y
+    ForestEstimator = FOREST_ESTIMATORS[name]
+    est = ForestEstimator(n_estimators=5, max_depth=3, warm_start=True,
+                          random_state=1)
+    est.fit(X, y)
+
+    est_2 = ForestEstimator(n_estimators=5, max_depth=3, warm_start=True,
+                            random_state=1)
+    est_2.fit(X, y)
+    # Now est_2 equals est.
+
+    est_2.set_params(random_state=2)
+    assert_warns(UserWarning, est_2.fit, X, y)
+    # If we had fit the trees again we would have got a different forest as we
+    # changed the random state.
+    assert_array_equal(est.apply(X), est_2.apply(X))
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS_REGRESSORS)
+def test_warm_start_oob(name):
+    # Test that the warm start computes oob score when asked.
+    X, y = hastie_X, hastie_y
+    ForestEstimator = FOREST_ESTIMATORS[name]
+    # Use 15 estimators to avoid 'some inputs do not have OOB scores' warning.
+    est = ForestEstimator(n_estimators=15, max_depth=3, warm_start=False,
+                          random_state=1, bootstrap=True, oob_score=True)
+    est.fit(X, y)
+
+    est_2 = ForestEstimator(n_estimators=5, max_depth=3, warm_start=False,
+                            random_state=1, bootstrap=True, oob_score=False)
+    est_2.fit(X, y)
+
+    est_2.set_params(warm_start=True, oob_score=True, n_estimators=15)
+    est_2.fit(X, y)
+
+    assert hasattr(est_2, 'oob_score_')
+    assert est.oob_score_ == est_2.oob_score_
+
+    # Test that oob_score is computed even if we don't need to train
+    # additional trees.
+    est_3 = ForestEstimator(n_estimators=15, max_depth=3, warm_start=True,
+                            random_state=1, bootstrap=True, oob_score=False)
+    est_3.fit(X, y)
+    assert not hasattr(est_3, 'oob_score_')
+
+    est_3.set_params(oob_score=True)
+    ignore_warnings(est_3.fit)(X, y)
+
+    assert est.oob_score_ == est_3.oob_score_
+
+
+@use_np
+def test_dtype_convert(n_classes=15):
+    classifier = RandomForestClassifier(random_state=0, bootstrap=False)
+
+    X = np.eye(n_classes)
+    y = [ch for ch in 'ABCDEFGHIJKLMNOPQRSTU'[:n_classes]]
+
+    result = classifier.fit(X, y).predict(X)
+    assert_array_equal(classifier.classes_, y)
+    assert_array_equal(result, y)
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS_REGRESSORS)
+def test_decision_path(name):
+    X, y = hastie_X, hastie_y
+    n_samples = X.shape[0]
+    ForestEstimator = FOREST_ESTIMATORS[name]
+    est = ForestEstimator(n_estimators=5, max_depth=1, warm_start=False,
+                          random_state=1)
+    est.fit(X, y)
+    indicator, n_nodes_ptr = est.decision_path(X)
+
+    assert indicator.shape[1] == n_nodes_ptr[-1]
+    assert indicator.shape[0] == n_samples
+    assert_array_equal(_np.diff(n_nodes_ptr),
+                       [e.tree_.node_count for e in est.estimators_])
+
+    # Assert that leaves index are correct
+    leaves = est.apply(X)
+    for est_id in range(leaves.shape[1]):
+        leave_indicator = [indicator[i, n_nodes_ptr[est_id] + j]
+                           for i, j in enumerate(leaves[:, est_id])]
+        assert_array_almost_equal(leave_indicator, np.ones(shape=n_samples))
+
+
+@use_np
+def test_min_impurity_split():
+    # Test if min_impurity_split of base estimators is set
+    # Regression test for #8006
+    X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)
+    X, y = np.array(X), np.array(y)
+    all_estimators = [RandomForestClassifier, RandomForestRegressor,
+                      ExtraTreesClassifier, ExtraTreesRegressor]
+
+    for Estimator in all_estimators:
+        est = Estimator(min_impurity_split=0.1)
+        est = assert_warns_message(FutureWarning,
+                                   "min_impurity_decrease",
+                                   est.fit, X, y)
+        for tree in est.estimators_:
+            assert tree.min_impurity_split == 0.1
+
+
+@use_np
+def test_min_impurity_decrease():
+    X, y = datasets.make_hastie_10_2(n_samples=100, random_state=1)
+    X, y = np.array(X), np.array(y)
+    all_estimators = [RandomForestClassifier, RandomForestRegressor,
+                      ExtraTreesClassifier, ExtraTreesRegressor]
+
+    for Estimator in all_estimators:
+        est = Estimator(min_impurity_decrease=0.1)
+        est.fit(X, y)
+        for tree in est.estimators_:
+            # Simply check if the parameter is passed on correctly. Tree tests
+            # will suffice for the actual working of this param
+            assert tree.min_impurity_decrease == 0.1
+
+
+@use_np
+def test_forest_feature_importances_sum():
+    X, y = datasets.make_classification(n_samples=15, n_informative=3, random_state=1,
+                                        n_classes=3)
+    X, y = np.array(X), np.array(y)
+    clf = RandomForestClassifier(min_samples_leaf=5, random_state=42,
+                                 n_estimators=200).fit(X, y)
+    assert math.isclose(1, clf.feature_importances_.sum(), abs_tol=1e-7)
+
+
+@use_np
+def test_forest_degenerate_feature_importances():
+    # build a forest of single node trees. See #13636
+    X = np.zeros((10, 10))
+    y = np.ones((10,))
+    gbr = RandomForestRegressor(n_estimators=10).fit(X, y)
+    assert_array_equal(gbr.feature_importances_,
+                       np.zeros(10, dtype=np.float64))
+
+
+@use_np
+@pytest.mark.parametrize('name', FOREST_CLASSIFIERS_REGRESSORS)
+@pytest.mark.parametrize(
+    'max_samples, exc_type, exc_msg',
+    [(int(1e9), ValueError,
+      "`max_samples` must be in range 1 to 6 but got value 1000000000"),
+     (1.0, ValueError,
+      r"`max_samples` must be in range \(0, 1\) but got value 1.0"),
+     (2.0, ValueError,
+      r"`max_samples` must be in range \(0, 1\) but got value 2.0"),
+     (0.0, ValueError,
+      r"`max_samples` must be in range \(0, 1\) but got value 0.0"),
+     (np.nan, ValueError,
+      r"`max_samples` must be in range \(0, 1\) but got value nan"),
+     (np.inf, ValueError,
+      r"`max_samples` must be in range \(0, 1\) but got value inf"),
+     ('str max_samples?!', TypeError,
+      r"`max_samples` should be int or float, but got "
+      r"type '\<class 'str'\>'"),
+])
+def test_max_samples_exceptions(name, max_samples, exc_type, exc_msg):
+    # Check invalid `max_samples` values
+    est = FOREST_CLASSIFIERS_REGRESSORS[name](max_samples=max_samples)
+    with pytest.raises(exc_type, match=exc_msg):
+        est.fit(X, y)
+
+
+@use_np
+@pytest.mark.parametrize(
+    'ForestClass', [RandomForestClassifier, RandomForestRegressor]
+)
+def test_little_tree_with_small_max_samples(ForestClass):
+    rng = _np.random.RandomState(1)
+
+    X = rng.randn(10000, 2)
+    y = rng.randn(10000) > 0
+
+    # First fit with no restriction on max samples
+    est1 = ForestClass(
+        n_estimators=1,
+        random_state=rng,
+        max_samples=None,
+    )
+
+    # Second fit with max samples restricted to just 2
+    est2 = ForestClass(
+        n_estimators=1,
+        random_state=rng,
+        max_samples=2,
+    )
+
+    est1.fit(X, y)
+    est2.fit(X, y)
+
+    tree1 = est1.estimators_[0].tree_
+    tree2 = est2.estimators_[0].tree_
+
+    msg = "Tree without `max_samples` restriction should have more nodes"
+    assert tree1.node_count > tree2.node_count, msg

--- a/tests/python/unittest/test_numpy_sklearn_pca.py
+++ b/tests/python/unittest/test_numpy_sklearn_pca.py
@@ -1,0 +1,219 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# pylint: skip-file
+
+from mxnet import np
+from mxnet.test_utils import same, assert_almost_equal, rand_shape_nd, use_np
+import numpy as _np
+import scipy as sp
+
+import pytest
+
+from sklearn.utils._testing import assert_allclose
+
+from sklearn import datasets
+from sklearn.decomposition import PCA
+from sklearn.datasets import load_iris
+from sklearn.decomposition._pca import _assess_dimension
+from sklearn.decomposition._pca import _infer_dimension
+
+iris = datasets.load_iris()
+PCA_SOLVERS = ['full', 'arpack', 'randomized', 'auto']
+
+
+@use_np
+@pytest.mark.parametrize('svd_solver', PCA_SOLVERS)
+@pytest.mark.parametrize('n_components', range(1, iris.data.shape[1]))
+def test_pca(svd_solver, n_components):
+    X = np.array(iris.data)
+    pca = PCA(n_components=n_components, svd_solver=svd_solver)
+
+    # check the shape of fit.transform
+    X_r = pca.fit(X).transform(X)
+    print(type(X_r))
+    assert X_r.shape[1] == n_components
+
+    # check the equivalence of fit.transform and fit_transform
+    X_r2 = pca.fit_transform(X)
+    assert_allclose(X_r, X_r2, atol=1e-5, rtol=1e-5)
+    X_r = pca.transform(X)
+    assert_allclose(X_r, X_r2, atol=1e-5, rtol=1e-5)
+
+    # Test get_covariance and get_precision
+    cov = np.array(pca.get_covariance())
+    precision = np.array(pca.get_precision())
+    assert_allclose(np.dot(cov, precision), np.eye(X.shape[1]), rtol=1e-4, atol=1e-4)
+
+
+@use_np
+def test_no_empty_slice_warning():
+    # test if we avoid numpy warnings for computing over empty arrays
+    n_components = 10
+    n_features = n_components + 2  # anything > n_comps triggered it in 0.16
+    X = np.random.uniform(-1, 1, size=(n_components, n_features))
+    pca = PCA(n_components=n_components)
+    with pytest.warns(None) as record:
+        pca.fit(X)
+    assert not record.list
+
+
+@pytest.mark.parametrize('copy', [True, False])
+@pytest.mark.parametrize('solver', PCA_SOLVERS)
+@use_np
+def test_whitening(solver, copy):
+    # Check that PCA output has unit-variance
+    n_samples = 100
+    n_features = 80
+    n_components = 30
+    rank = 50
+
+    # some low rank data with correlated features
+    X = np.dot(np.random.randn(n_samples, rank),
+               np.dot(np.diag(np.linspace(10.0, 1.0, rank)),
+                      np.random.randn(rank, n_features)))
+    # the component-wise variance of the first 50 features is 3 times the
+    # mean component-wise variance of the remaining 30 features
+    X[:, :50] *= 3
+
+    assert X.shape == (n_samples, n_features)
+
+    # the component-wise variance is thus highly varying:
+    assert X.std(axis=0).std() > 35
+
+    # whiten the data while projecting to the lower dim subspace
+    X_ = X.copy()  # make sure we keep an original across iterations.
+    pca = PCA(n_components=n_components, whiten=True, copy=copy,
+              svd_solver=solver, random_state=0, iterated_power=7)
+    # test fit_transform
+    X_whitened = pca.fit_transform(X_.copy())
+    assert X_whitened.shape == (n_samples, n_components)
+    X_whitened2 = pca.transform(X_)
+    assert_allclose(X_whitened, X_whitened2, rtol=1e-3, atol=1e-3)
+
+    assert_allclose(X_whitened.std(ddof=1, axis=0), np.ones(n_components), atol=1e-5, rtol=1e-5)
+    assert_allclose(
+        X_whitened.mean(axis=0), np.zeros(n_components), atol=1e-5, rtol=1e-5
+    )
+
+    X_ = X.copy()
+    pca = PCA(n_components=n_components, whiten=False, copy=copy,
+              svd_solver=solver).fit(X_)
+    X_unwhitened = pca.transform(X_)
+    assert X_unwhitened.shape == (n_samples, n_components)
+
+
+@pytest.mark.parametrize('svd_solver', ['arpack', 'randomized'])
+@use_np
+def test_pca_explained_variance_equivalence_solver(svd_solver):
+    n_samples, n_features = 100, 80
+    X = np.random.randn(n_samples, n_features)
+
+    pca_full = PCA(n_components=2, svd_solver='full')
+    pca_other = PCA(n_components=2, svd_solver=svd_solver, random_state=0)
+
+    pca_full.fit(X)
+    pca_other.fit(X)
+
+    assert_allclose(
+        pca_full.explained_variance_,
+        pca_other.explained_variance_,
+        rtol=5e-2
+    )
+    assert_allclose(
+        pca_full.explained_variance_ratio_,
+        pca_other.explained_variance_ratio_,
+        rtol=5e-2
+    )
+
+
+@pytest.mark.parametrize("svd_solver", ['arpack', 'randomized'])
+@use_np
+def test_pca_singular_values_consistency(svd_solver):
+    n_samples, n_features = 100, 80
+    X = np.random.randn(n_samples, n_features)
+
+    pca_full = PCA(n_components=2, svd_solver='full')
+    pca_other = PCA(n_components=2, svd_solver=svd_solver)
+
+    pca_full.fit(X)
+    pca_other.fit(X)
+
+    assert_allclose(
+        pca_full.singular_values_, pca_other.singular_values_, rtol=5e-3
+    )
+
+
+@pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
+@use_np
+def test_pca_singular_values(svd_solver):
+    n_samples, n_features = 100, 80
+    X = np.random.randn(n_samples, n_features)
+
+    pca = PCA(n_components=2, svd_solver=svd_solver)
+    X_trans = np.array(pca.fit_transform(X))
+
+    # compare to the Frobenius norm
+    assert_allclose(
+        np.sum(np.array(pca.singular_values_ ** 2)), np.linalg.norm(X_trans, "fro") ** 2,
+        atol=1e-5, rtol=1e-5
+    )
+    # Compare to the 2-norms of the score vectors
+    assert_allclose(
+        pca.singular_values_, np.sqrt(np.sum(X_trans ** 2, axis=0)),
+        atol=1e-5, rtol=1e-5
+    )
+
+    # set the singular values and see what er get back
+    n_samples, n_features = 100, 110
+    X = np.random.randn(n_samples, n_features)
+
+    pca = PCA(n_components=3, svd_solver=svd_solver)
+    X_trans = np.array(pca.fit_transform(X))
+    X_trans /= np.sqrt(np.sum(X_trans ** 2, axis=0))
+    X_trans[:, 0] *= 3.142
+    X_trans[:, 1] *= 2.718
+    X_hat = np.dot(X_trans, np.array(pca.components_))
+    pca.fit(X_hat)
+    assert_allclose(pca.singular_values_, [3.142, 2.718, 1.0], atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
+@use_np
+def test_pca_check_projection(svd_solver):
+    # Test that the projection of data is correct
+    n, p = 100, 3
+    X = np.random.randn(n, p) * .1
+    X[:10] += np.array([3, 4, 5])
+    Xt = 0.1 * np.random.randn(1, p) + np.array([3, 4, 5])
+
+    Yt = PCA(n_components=2, svd_solver=svd_solver).fit(X).transform(Xt)
+    Yt /= np.sqrt((Yt ** 2).sum())
+
+    assert_allclose(np.abs(Yt[0][0]), 1., rtol=5e-3)
+
+
+@pytest.mark.parametrize("svd_solver", PCA_SOLVERS)
+@use_np
+def test_pca_check_projection_list(svd_solver):
+    # Test that the projection of data is correct
+    X = [[1.0, 0.0], [0.0, 1.0]]
+    pca = PCA(n_components=1, svd_solver=svd_solver, random_state=0)
+    X_trans = pca.fit_transform(X)
+    assert X_trans.shape, (2, 1)
+    assert_allclose(X_trans.mean(), 0.00, atol=1e-12)
+    assert_allclose(X_trans.std(), 0.71, rtol=5e-3)


### PR DESCRIPTION
## Description ##
add tests for sklearn interoperability

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] add tests for sklearn interoperability, for discriminant analysis
- [x] add implict numpy array creation
- [x] testing: skip cv tests when opencv is off
- [x] fix ufunc mixed type
- [x] add writable option to from_numpy
