### PR TITLE
[CI] remove unnecessary usage of pretrained models, and prefer smaller size in tests

### DIFF
--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -192,11 +192,11 @@ def test_parameter_str():
 
     net = Net()
     lines = str(net.collect_params()).splitlines()
-    
+
     assert 'dense0.weight' in lines[0]
     assert '(10, 5)' in lines[0]
     assert 'float32' in lines[0]
-    
+
 
 @with_seed()
 def test_collect_parameters():
@@ -312,7 +312,7 @@ def test_symbol_block(tmpdir):
     net_fp32.cast('float64')
     net_fp32.hybridize()
     data = mx.nd.zeros((1,3,224,224), dtype='float64', ctx=ctx)
-    net_fp32.forward(data)
+    net_fp32(data)
     sym_file, params_file = net_fp32.export(tmpfile, 0)
 
     # 2.a Load the saved model and verify if all the params are loaded correctly.
@@ -1119,23 +1119,26 @@ def test_embedding():
     check_embedding_large_input(False)
 
 @with_seed()
-def test_export():
+def test_export(tmpdir):
+    tmpfile = os.path.join(str(tmpdir), 'gluon')
     ctx = mx.context.current_context()
     model = gluon.model_zoo.vision.resnet18_v1(
-        ctx=ctx, pretrained=True)
+        ctx=ctx, pretrained=False)
+    model.initialize()
     model.hybridize()
     data = mx.nd.random.normal(shape=(1, 3, 32, 32))
     out = model(data)
 
-    symbol_filename, params_filename = model.export('gluon')
-    assert symbol_filename == 'gluon-symbol.json'
-    assert params_filename == 'gluon-0000.params'
+    symbol_filename, params_filename = model.export(tmpfile)
+    assert symbol_filename == tmpfile+'-symbol.json'
+    assert params_filename == tmpfile+'-0000.params'
 
 @with_seed()
 def test_import():
     ctx = mx.context.current_context()
     net1 = gluon.model_zoo.vision.resnet18_v1(
-        ctx=ctx, pretrained=True)
+        ctx=ctx, pretrained=False)
+    net1.initialize()
     net1.hybridize()
     data = mx.nd.random.normal(shape=(1, 3, 32, 32))
     out1 = net1(data)
@@ -1440,7 +1443,9 @@ def test_req():
 
 @with_seed()
 def test_save_load(tmpdir):
-    net = mx.gluon.model_zoo.vision.get_resnet(1, 18, pretrained=True, root=str(tmpdir))
+    net = mx.gluon.model_zoo.vision.get_resnet(1, 18, pretrained=False, root=str(tmpdir))
+    net.initialize()
+    net(mx.nd.ones((1,3,224,224)))
     net.save_parameters(os.path.join(str(tmpdir), 'test_save_load.params'))
 
     net = mx.gluon.model_zoo.vision.get_resnet(1, 18)
@@ -1598,17 +1603,19 @@ def test_zero_grad():
                     _test_grad_reset(ctx, dtype=type, sparse=sparse, embeddingType=embType)
 
 
-def check_hybrid_static_memory(**kwargs):
+@with_seed()
+@pytest.mark.parametrize('static_alloc', [False, True])
+@pytest.mark.parametrize('static_shape', [False, True])
+def test_hybrid_static_memory(static_alloc, static_shape):
+    if static_shape and not static_alloc:
+        pytest.skip()
     x = mx.nd.random.uniform(shape=(2, 3, 32, 32))
     x.attach_grad()
 
-    net1 = gluon.model_zoo.vision.get_resnet(
-        1, 18, pretrained=True, ctx=mx.context.current_context())
-    net2 = gluon.model_zoo.vision.get_resnet(
-        1, 18, pretrained=True, ctx=mx.context.current_context())
-    net2.hybridize(**kwargs)
-    net1(x)
-    net2(x)
+    net = gluon.model_zoo.vision.get_resnet(
+        1, 18, pretrained=False, ctx=mx.context.current_context())
+    net.initialize()
+    net(x)
 
     def test(net, x):
         with mx.autograd.record():
@@ -1619,23 +1626,25 @@ def check_hybrid_static_memory(**kwargs):
 
         return y, grads
 
-    y1, grads1 = test(net1, x)
-    y2, grads2 = test(net2, x)
+    y1, grads1 = test(net, x)
+    net.hybridize(static_alloc=static_alloc, static_shape=static_shape)
+    y2, grads2 = test(net, x)
 
     assert_almost_equal(y1.asnumpy(), y2.asnumpy(), rtol=1e-3, atol=1e-5)
     for key in grads1:
         assert_almost_equal(grads1[key].asnumpy(), grads2[key].asnumpy(), rtol=1e-3, atol=1e-4)
 
-@with_seed()
-def test_hybrid_static_memory():
-    check_hybrid_static_memory()
-    check_hybrid_static_memory(static_alloc=True)
-    check_hybrid_static_memory(static_alloc=True, static_shape=True)
 
-def check_hybrid_static_memory_switching(**kwargs):
+@with_seed()
+@pytest.mark.parametrize('static_alloc', [False, True])
+@pytest.mark.parametrize('static_shape', [False, True])
+def test_hybrid_static_memory_switching(static_alloc, static_shape):
+    if static_shape and not static_alloc:
+        pytest.skip()
     net = gluon.model_zoo.vision.get_resnet(
-        1, 18, pretrained=True, ctx=mx.context.current_context())
-    net.hybridize(**kwargs)
+        1, 18, pretrained=False, ctx=mx.context.current_context())
+    net.initialize()
+    net.hybridize(static_alloc=static_alloc, static_shape=static_shape)
 
     x = mx.nd.random.uniform(shape=(4, 3, 32, 32))
     net(x)
@@ -1648,12 +1657,6 @@ def check_hybrid_static_memory_switching(**kwargs):
         y = net(x)
         y.backward()
     mx.nd.waitall()
-
-@with_seed()
-def test_hybrid_static_memory_switching():
-    check_hybrid_static_memory_switching()
-    check_hybrid_static_memory_switching(static_alloc=True)
-    check_hybrid_static_memory_switching(static_alloc=True, static_shape=True)
 
 @with_seed()
 def test_hook():
@@ -1734,7 +1737,7 @@ def test_op_hook_output_names():
     model.add(mx.gluon.nn.AvgPool1D())
     model.initialize()
     model.hybridize()
-    check_name(model, ['hybridsequential_avgpool1d0_fwd_data', 'hybridsequential_avgpool1d0_fwd_output'], 
+    check_name(model, ['hybridsequential_avgpool1d0_fwd_data', 'hybridsequential_avgpool1d0_fwd_output'],
                expected_opr_names=["Pooling"], monitor_all=True)
 
     # stack two layers and test
@@ -1850,7 +1853,8 @@ def test_sparse_hybrid_block():
 
 def test_hybrid_static_memory_recording():
     net = gluon.model_zoo.vision.get_resnet(
-        1, 18, pretrained=True, ctx=mx.context.current_context())
+        1, 18, pretrained=False, ctx=mx.context.current_context())
+    net.initialize()
     net.hybridize(static_alloc=True)
 
     x = mx.nd.random.uniform(shape=(1, 3, 32, 32))

--- a/tests/python/unittest/test_gluon_estimator.py
+++ b/tests/python/unittest/test_gluon_estimator.py
@@ -144,7 +144,9 @@ def test_initializer():
                         context=ctx)
         assert 'Network already fully initialized' in str(w[-1].message)
     # net partially initialized, fine tuning use case
-    net = gluon.model_zoo.vision.resnet18_v1(pretrained=True, ctx=ctx)
+    net = gluon.model_zoo.vision.resnet18_v1(pretrained=False, ctx=ctx)
+    net.features.initialize(ctx=ctx)
+    net.features(mx.nd.zeros((1, 3, 224, 224)))
     net.output = gluon.nn.Dense(10) #last layer not initialized
     est = Estimator(net, loss=loss, train_metrics=acc, context=ctx)
     dataset =  gluon.data.ArrayDataset(mx.nd.zeros((10, 3, 224, 224)), mx.nd.zeros((10, 10)))

--- a/tests/python/unittest/test_gluon_model_zoo.py
+++ b/tests/python/unittest/test_gluon_model_zoo.py
@@ -41,7 +41,7 @@ def eprint(*args, **kwargs):
     'mobilenetv2_1.0', 'mobilenetv2_0.75', 'mobilenetv2_0.5', 'mobilenetv2_0.25'
 ])
 def test_models(model_name):
-    pretrained_to_test = set(['vgg19_bn'])
+    pretrained_to_test = set(['mobilenetv2_0.25'])
 
     test_pretrain = model_name in pretrained_to_test
     model = get_model(model_name, pretrained=test_pretrain, root='model/')


### PR DESCRIPTION
## Description ##
remove unnecessary usage of pretrained models, and prefer smaller size in tests

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] remove unnecessary usage of pretrained models, and prefer smaller size in tests

## Comments ##
- #18843 prevents the tests that use export from being switched.
- this attempts at addressing timeout in test_gluon_model_zoo
- the built-in gluon model zoo will be deprecated. later on, the models will be moved to test_utils.py only for testing purpose.