### PR TITLE
fix set default website version rewrite rule for cdn

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -26,6 +26,7 @@ RewriteOptions AllowNoSlash
 RewriteCond %{REQUEST_URI} !^/versions/
 RewriteCond %{HTTP_REFERER} !mxnet.apache.org
 RewriteCond %{HTTP_REFERER} !mxnet.incubator.apache.org
+RewriteCond %{HTTP_REFERER} !mxnet.cdn.apache.org
 RewriteRule ^(.*)$ /versions/1.6/$1 [r=307,L]
 
 # Redirect Chinese visitors to Chinese CDN, temporary solution for slow site speed in China


### PR DESCRIPTION
## Description ##
Current MXNet website has 3 domain names:
+ [mxnet.apache.org](https://mxnet.apache.org)
+ [mxnet.incubator.apache.org](https://mxnet.incubator.apache.org)
+ [mxnet.cdn.apache.org](https://mxnet.cdn.apache.org) (mainly used in China to avoid slow load speed)

To set website default version using rewrite rules, we check for `HTTP_REFERER` to see if the request is from one of the MXNet domains. But previously `mxnet.cdn.apache.org` was missed, which made master website unreachable from this domain. Added it in this PR.

### Changes ###
- [x] Fix rewrite rule for mxnet.cdn.apache.org 

