### PR TITLE
Fix a bug in TensorRT partitioning

### DIFF
--- a/src/operator/subgraph/tensorrt/tensorrt-inl.h
+++ b/src/operator/subgraph/tensorrt/tensorrt-inl.h
@@ -302,7 +302,7 @@ class TensorrtProperty : public SubgraphProperty {
     TRTParam param;
     std::ostringstream params_oss;
     for (auto &param_name : new_sym.ListInputNames(nnvm::Symbol::kAll)) {
-      NDArray *cache;
+      NDArray *cache = nullptr;
       auto it_args = in_args_dict.find(param_name);
       if (it_args != in_args_dict.end()) {
         cache = it_args->second;


### PR DESCRIPTION
## Description ##
In TensorRT's partitioning backend `CreateSubgraphNode`, a pointer to the parameter was not properly init to `nullptr` and was causing the partitioning to fail. 

## Fix ##

Init the `cache` pointer to `nullptr`.