### PR TITLE
Re-enable the linker version scripts for binary distribution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,7 +658,7 @@ if(UNIX)
     # set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
     # Symbols from statically linked libraries can be discarded via -Wl,--exclude-libs,ALL
     if(APPLE)
-      set_target_properties(mxnet PROPERTIES LINK_FLAGS "-Wl,-exported_symbols_list,${PROJECT_SOURCE_DIR}/make/config/libmxnet.sym")
+      set_target_properties(mxnet PROPERTIES LINK_FLAGS "-Wl,-exported_symbols_list,${PROJECT_SOURCE_DIR}/cmake/libmxnet.sym")
     else()
       set_target_properties(mxnet PROPERTIES LINK_FLAGS "-Wl,--version-script=${PROJECT_SOURCE_DIR}/cmake/libmxnet.ver")
     endif()
@@ -878,7 +878,7 @@ if(INSTALL_PYTHON_VERSIONS)
   endforeach()
 endif()
 
-if(CMAKE_BUILD_TYPE STREQUAL "Distribution")
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Distribution")
   # Staticbuild applies linker version script to hide private symbols, breaking unit tests
   add_subdirectory(tests)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,20 +312,6 @@ include_directories("3rdparty/tvm/include")
 include_directories("3rdparty/dmlc-core/include")
 include_directories("3rdparty/dlpack/include")
 
-# commented out until PR goes through
-#if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/dlpack)
-#  add_subdirectory(3rdparty/dlpack)
-#endif()
-
-# Prevent stripping out symbols (operator registrations, for example)
-if(NOT MSVC AND NOT APPLE)
-  set(BEGIN_WHOLE_ARCHIVE -Wl,--whole-archive)
-  set(END_WHOLE_ARCHIVE -Wl,--no-whole-archive)
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  # using regular Clang or AppleClang
-  set(BEGIN_WHOLE_ARCHIVE -Wl,-force_load)
-endif()
-
 if(UNIX)
   find_library(RTLIB rt)
   if(RTLIB)
@@ -665,6 +651,18 @@ if(UNIX)
     target_compile_options(mxnet PUBLIC "--coverage")
     target_link_libraries(mxnet PUBLIC gcov)
   endif()
+  if(CMAKE_BUILD_TYPE STREQUAL "Distribution")
+    # TODO For handling mxnet's symbols the following can be replace by
+    # annotating symbol visibility in source code, specifying
+    # set(CMAKE_CXX_VISIBILITY_PRESET hidden) and
+    # set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+    # Symbols from statically linked libraries can be discarded via -Wl,--exclude-libs,ALL
+    if(APPLE)
+      set_target_properties(mxnet PROPERTIES LINK_FLAGS "-Wl,-exported_symbols_list,${PROJECT_SOURCE_DIR}/make/config/libmxnet.sym")
+    else()
+      set_target_properties(mxnet PROPERTIES LINK_FLAGS "-Wl,--version-script=${PROJECT_SOURCE_DIR}/cmake/libmxnet.ver")
+    endif()
+  endif()
 elseif(MSVC)
   if(USE_CUDA)
     if(USE_SPLIT_ARCH_DLL)
@@ -834,8 +832,12 @@ endif()
 include(GNUInstallDirs)
 install(TARGETS mxnet
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          COMPONENT   MXNET_Runtime
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          COMPONENT            MXNET_Runtime
+          NAMELINK_COMPONENT   MXNET_Development
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          COMPONENT   MXNET_Development
 )
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/dlpack/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/dmlc-core/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
@@ -876,7 +878,10 @@ if(INSTALL_PYTHON_VERSIONS)
   endforeach()
 endif()
 
-add_subdirectory(tests)
+if(CMAKE_BUILD_TYPE STREQUAL "Distribution")
+  # Staticbuild applies linker version script to hide private symbols, breaking unit tests
+  add_subdirectory(tests)
+endif()
 
 # ---[ Linter target
 find_package(Python3)

--- a/cmake/libmxnet.sym
+++ b/cmake/libmxnet.sym
@@ -1,0 +1,15 @@
+MX*
+NN*
+_MX*
+_NN*
+mx*
+nn*
+_mx*
+_nn*
+Java_org_apache_mxnet*
+*NDArray*
+*Engine*Get*
+*Storage*Get*
+*on_enter_api*
+*on_exit_api*
+*MXAPISetLastError*

--- a/cmake/libmxnet.ver
+++ b/cmake/libmxnet.ver
@@ -1,0 +1,19 @@
+{
+    global:
+        NN*;
+        MX*;
+        _NN*;
+        _MX*;
+        nn*;
+        mx*;
+        _nn*;
+        _mx*;
+        Java_org_apache_mxnet*;
+        *NDArray*;
+        *Engine*Get*;
+        *Storage*Get*;
+        *on_enter_api*;
+        *on_exit_api*;
+        *MXAPISetLastError*;
+    local: *;
+};


### PR DESCRIPTION
## Description ##
Wasn't ported from Makefile binary distribution build yet, but required to avoid

"According to the ELF lookup rules all symbols in the dynamic symbol table can be
interposed (unless the visibility of the symbol is restricted). I.e.,definitions
from other objects can be used. This means that local references cannot be bound
at linktime. If it is known or intended that the local definition should always
be used the symbol in the reference must not be exported or the visibility
mustbe restricted" https://www.akkadia.org/drepper/dsohowto.pdf Section 2.2

Related https://github.com/apache/incubator-mxnet/issues/18855