### PR TITLE
Fix default CPU allocator memory alignment

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -953,7 +953,7 @@ inline int GetDefaultDtype(int dtype) {
 inline bool AlignedMemAlloc(void** ptr, size_t size, size_t alignment) {
 #if _MSC_VER
   *ptr = _aligned_malloc(size, alignment);
-  if(*ptr == nullptr)
+  if (*ptr == nullptr)
     return false;
 #else
   int res = posix_memalign(ptr, alignment, size);

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -953,7 +953,7 @@ inline int GetDefaultDtype(int dtype) {
 inline bool AlignedMemAlloc(void** ptr, size_t size, size_t alignment) {
 #if _MSC_VER
   *ptr = _aligned_malloc(size, alignment);
-  if(ptr == nullptr)
+  if(*ptr == nullptr)
     return false;
 #else
   int res = posix_memalign(ptr, alignment, size);

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -950,6 +950,28 @@ inline int GetDefaultDtype(int dtype) {
          mshadow::kFloat32;
 }
 
+inline bool AlignedMemAlloc(void** ptr, size_t size, size_t alignment) {
+#if _MSC_VER
+  *ptr = _aligned_malloc(size, alignment);
+  if(ptr == nullptr)
+    return false;
+#else
+  int res = posix_memalign(ptr, alignment, size);
+  if (res != 0)
+    return false;
+#endif
+  return true;
+}
+
+inline void AlignedMemFree(void* ptr) {
+#if _MSC_VER
+  _aligned_free(ptr);
+#else
+  free(ptr);
+#endif
+}
+
+
 }  // namespace common
 }  // namespace mxnet
 #endif  // MXNET_COMMON_UTILS_H_

--- a/src/storage/cpu_device_storage.h
+++ b/src/storage/cpu_device_storage.h
@@ -60,21 +60,12 @@ class CPUDeviceStorage {
 };  // class CPUDeviceStorage
 
 inline void CPUDeviceStorage::Alloc(Storage::Handle* handle) {
-#if _MSC_VER
-  handle->dptr = _aligned_malloc(handle->size, alignment_);
-  if (handle->dptr == nullptr) LOG(FATAL) << "Failed to allocate CPU Memory";
-#else
-  int ret = posix_memalign(&handle->dptr, alignment_, handle->size);
-  if (ret != 0) LOG(FATAL) << "Failed to allocate CPU Memory";
-#endif
+  bool success = mxnet::common::AlignedMemAlloc(&(handle->dptr), handle->size, alignment_);
+  if (!success) LOG(FATAL) << "Failed to allocate CPU Memory";
 }
 
 inline void CPUDeviceStorage::Free(Storage::Handle handle) {
-#if _MSC_VER
-  _aligned_free(handle.dptr);
-#else
-  free(handle.dptr);
-#endif
+  mxnet::common::AlignedMemFree(handle.dptr);
 }
 
 }  // namespace storage

--- a/src/storage/storage_manager_helpers.h
+++ b/src/storage/storage_manager_helpers.h
@@ -42,6 +42,7 @@ typedef  mxnet::common::cuda::DeviceStore CudaDeviceStore;
 #endif  // _WIN32
 
 #include <tuple>
+#include "../common/utils.h"
 
 namespace mxnet {
 namespace storage {
@@ -110,10 +111,22 @@ class ContextHelperCPU : public ContextHelper {
   }
 
   int Malloc(void **ppNtr, size_t size) const override {
-    return (*ppNtr = std::malloc(size))? 0 : -1;
+    bool success = mxnet::common::AlignedMemAlloc(ppNtr, size, alignment_);
+    return success ? 0 : -1;
   }
 
-  void Free(void *dptr) const override                  { std::free(dptr); }
+  void Free(void *dptr) const override {
+    mxnet::common::AlignedMemFree(dptr);
+ }
+
+ private:
+#if MXNET_USE_MKLDNN == 1
+  // MKLDNN requires special alignment. 64 is used by the MKLDNN library in
+  // memory allocation.
+  static constexpr size_t alignment_ = kMKLDNNAlign;
+#else
+  static constexpr size_t alignment_ = 16;
+#endif
 };
 
 #if MXNET_USE_CUDA
@@ -155,7 +168,6 @@ class ContextHelperPinned : public ContextHelperGPU {
 #else
 typedef  ContextHelperCPU ContextHelperPinned;
 #endif
-
 }  // namespace storage
 }  // namespace mxnet
 

--- a/src/storage/storage_manager_helpers.h
+++ b/src/storage/storage_manager_helpers.h
@@ -117,7 +117,7 @@ class ContextHelperCPU : public ContextHelper {
 
   void Free(void *dptr) const override {
     mxnet::common::AlignedMemFree(dptr);
- }
+  }
 
  private:
 #if MXNET_USE_MKLDNN == 1

--- a/tests/cpp/storage/storage_test.cc
+++ b/tests/cpp/storage/storage_test.cc
@@ -47,6 +47,29 @@ TEST(Storage, Basic_CPU) {
   storage->Free(handle);
 }
 
+TEST(Storage, CPU_MemAlign) {
+  #if MXNET_USE_MKLDNN == 1
+  // MKLDNN requires special alignment. 64 is used by the MKLDNN library in
+  // memory allocation.
+    static constexpr size_t alignment_ = mxnet::kMKLDNNAlign;
+  #else
+    static constexpr size_t alignment_ = 16;
+  #endif
+
+  auto&& storage = mxnet::Storage::Get();
+  mxnet::Context context_cpu = mxnet::Context::CPU(0);
+
+  for(int i=0; i < 5; ++i) {
+    const size_t kSize = (std::rand() % 1024) + 1;
+    auto&& handle = storage->Alloc(kSize, context_cpu);
+    EXPECT_EQ(handle.ctx, context_cpu);
+    EXPECT_EQ(handle.size, kSize);
+    EXPECT_EQ(reinterpret_cast<intptr_t>(handle.dptr) % alignment_, 0);
+    storage->Free(handle);
+  }
+}
+
+
 #if MXNET_USE_CUDA
 TEST(Storage_GPU, Basic_GPU) {
   if (mxnet::test::unitTestsWithCuda) {

--- a/tests/cpp/storage/storage_test.cc
+++ b/tests/cpp/storage/storage_test.cc
@@ -59,7 +59,7 @@ TEST(Storage, CPU_MemAlign) {
   auto&& storage = mxnet::Storage::Get();
   mxnet::Context context_cpu = mxnet::Context::CPU(0);
 
-  for(int i=0; i < 5; ++i) {
+  for (int i = 0; i < 5; ++i) {
     const size_t kSize = (std::rand() % 1024) + 1;
     auto&& handle = storage->Alloc(kSize, context_cpu);
     EXPECT_EQ(handle.ctx, context_cpu);


### PR DESCRIPTION
## Description ##
This PR deals with issue https://github.com/apache/incubator-mxnet/issues/18854


Benchmark:
```
import mxnet as mx
import time

mx.random.seed(123)
tic = time.time()

for i in range(1000):
    rand_a = mx.nd.random.randint(1000, 10000).asscalar()
    rand_b = mx.nd.random.randint(1000, 10000).asscalar()
    shape = (rand_a, rand_b)
    a = mx.nd.random.uniform(shape=shape)
    b = mx.nd.softmax(a)
    a.wait_to_read()
    b.wait_to_read()

toc = time.time()
print(toc - tic)
```

Intel(R) Xeon(R) CPU E5-2697 v2 @ 2.70GHz  (without AVX512)
```
KMP_AFFINITY=granularity=fine,noduplicates,compact,1,0 OMP_NUM_THREADS=12 numactl --physcpubind=0-11 --membind=0 python3 bench.py  
```
| Aligned | Not Aligned |
| ------ | ------ |
| 232.6839632987976 | 225.73387098312378 |
| 231.99822640419006 | 225.51357173919678 | 

It's about 3% performance drop on this particular test case.

Intel(R) Xeon(R) Platinum 8260L CPU @ 2.40GHz
```
KMP_AFFINITY=granularity=fine,noduplicates,compact,1,0 OMP_NUM_THREADS=24 numactl --physcpubind=0-23 --membind=0 python3 bench.py
```

| Aligned | Not Aligned |
| ------ | ------ |
| 15.814676523208618 | 15.833234071731567 |
| 15.925291061401367 | 15.907763004302979 | 
| 15.941178321838379 | 15.9696786403656| 
| 16.01563811302185 | 16.00200080871582 | 

For better CPU with AVX512 there is no difference in this case

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
