### PR TITLE
Fix CentOS CI builds: Only create symlink when target doesn't exist.

### DIFF
--- a/ci/docker/Dockerfile.build.centos7
+++ b/ci/docker/Dockerfile.build.centos7
@@ -67,9 +67,10 @@ RUN yum -y check-update || true && \
         gperf \
         libb2-devel \
         libzstd-devel && \
-    yum clean all && \
-    # Centos 7 only provides ninja-build
-    ln -s /usr/bin/ninja-build /usr/bin/ninja
+    yum clean all
+
+# Centos 7 only provides ninja-build
+RUN if [ ! -e /usr/bin/ninja ]; then ln -s /usr/bin/ninja-build /usr/bin/ninja; fi
 
 # Make GCC7, Python 3.5 and Maven 3.3 Software Collections available by default
 # during build and runtime of this container


### PR DESCRIPTION
The command for creating a symlink from /usr/bin/ninja-build to /usr/bin/ninja is failing, because it already exists. It looks like CentOS may have changed their packages to create this file/symlink. This PR only attempts to create it if it doesn't already exists.