### PR TITLE
[v1.x] backport remove upper bound (#18857)

### DIFF
--- a/src/operator/contrib/bilinear_resize-inl.h
+++ b/src/operator/contrib/bilinear_resize-inl.h
@@ -61,10 +61,10 @@ struct BilinearSampleParam : public dmlc::Parameter<BilinearSampleParam> {
   int mode;
   bool align_corners;
   DMLC_DECLARE_PARAMETER(BilinearSampleParam) {
-    DMLC_DECLARE_FIELD(height).set_default(1).set_range(1, 10000)
+    DMLC_DECLARE_FIELD(height).set_default(1).set_lower_bound(1)
     .describe("output height (required, but ignored if scale_height is defined or mode is not "
               "\"size\")");
-    DMLC_DECLARE_FIELD(width).set_default(1).set_range(1, 10000)
+    DMLC_DECLARE_FIELD(width).set_default(1).set_lower_bound(1)
     .describe("output width (required, but ignored if scale_width is defined or mode is not "
               "\"size\")");
     DMLC_DECLARE_FIELD(scale_height).set_default(dmlc::optional<float>())

--- a/src/operator/contrib/deformable_convolution-inl.h
+++ b/src/operator/contrib/deformable_convolution-inl.h
@@ -75,13 +75,13 @@ struct DeformableConvolutionParam : public dmlc::Parameter<DeformableConvolution
       .describe("Convolution dilate: (h, w) or (d, h, w). Defaults to 1 for each dimension.");
     DMLC_DECLARE_FIELD(pad).set_default(mxnet::TShape(0, -1))
       .describe("Zero pad for convolution: (h, w) or (d, h, w). Defaults to no padding.");
-    DMLC_DECLARE_FIELD(num_filter).set_range(1, 100000)
+    DMLC_DECLARE_FIELD(num_filter).set_lower_bound(1)
       .describe("Convolution filter(channel) number");
     DMLC_DECLARE_FIELD(num_group).set_default(1)
       .describe("Number of group partitions.");
     DMLC_DECLARE_FIELD(num_deformable_group).set_default(1)
       .describe("Number of deformable group partitions.");
-    DMLC_DECLARE_FIELD(workspace).set_default(1024).set_range(0, 8192)
+    DMLC_DECLARE_FIELD(workspace).set_default(1024).set_lower_bound(0)
       .describe("Maximum temperal workspace allowed for convolution (MB).");
     DMLC_DECLARE_FIELD(no_bias).set_default(false)
       .describe("Whether to disable bias parameter.");

--- a/src/operator/contrib/modulated_deformable_convolution-inl.h
+++ b/src/operator/contrib/modulated_deformable_convolution-inl.h
@@ -77,13 +77,13 @@ struct ModulatedDeformableConvolutionParam
       .describe("Convolution dilate: (h, w) or (d, h, w). Defaults to 1 for each dimension.");
     DMLC_DECLARE_FIELD(pad).set_default(mxnet::TShape(0, -1))
       .describe("Zero pad for convolution: (h, w) or (d, h, w). Defaults to no padding.");
-    DMLC_DECLARE_FIELD(num_filter).set_range(1, 100000)
+    DMLC_DECLARE_FIELD(num_filter).set_lower_bound(1)
       .describe("Convolution filter(channel) number");
     DMLC_DECLARE_FIELD(num_group).set_default(1)
       .describe("Number of group partitions.");
     DMLC_DECLARE_FIELD(num_deformable_group).set_default(1)
       .describe("Number of deformable group partitions.");
-    DMLC_DECLARE_FIELD(workspace).set_default(1024).set_range(0, 8192)
+    DMLC_DECLARE_FIELD(workspace).set_default(1024).set_lower_bound(0)
       .describe("Maximum temperal workspace allowed for convolution (MB).");
     DMLC_DECLARE_FIELD(no_bias).set_default(false)
       .describe("Whether to disable bias parameter.");

--- a/src/operator/convolution_v1-inl.h
+++ b/src/operator/convolution_v1-inl.h
@@ -70,12 +70,12 @@ struct ConvolutionV1Param : public dmlc::Parameter<ConvolutionV1Param> {
     .describe("convolution dilate: (h, w) or (d, h, w)");
     DMLC_DECLARE_FIELD(pad).set_default(mxnet::TShape(0, 0))
     .describe("pad for convolution: (h, w) or (d, h, w)");
-    DMLC_DECLARE_FIELD(num_filter).set_range(1, 100000)
+    DMLC_DECLARE_FIELD(num_filter).set_lower_bound(1)
     .describe("convolution filter(channel) number");
     DMLC_DECLARE_FIELD(num_group).set_default(1)
     .describe("Number of group partitions. Equivalent to slicing input into num_group\n    "
               "partitions, apply convolution on each, then concatenate the results");
-    DMLC_DECLARE_FIELD(workspace).set_default(1024).set_range(0, 8192)
+    DMLC_DECLARE_FIELD(workspace).set_default(1024).set_lower_bound(0)
     .describe("Maximum temporary workspace allowed for convolution (MB)."
               "This parameter determines the effective batch size of the convolution "
               "kernel, which may be smaller than the given batch size. "

--- a/src/operator/nn/convolution-inl.h
+++ b/src/operator/nn/convolution-inl.h
@@ -75,11 +75,11 @@ struct ConvolutionParam : public dmlc::Parameter<ConvolutionParam> {
     .describe("Convolution dilate: (w,), (h, w) or (d, h, w). Defaults to 1 for each dimension.");
     DMLC_DECLARE_FIELD(pad).set_default(mxnet::TShape(0, 0))
     .describe("Zero pad for convolution: (w,), (h, w) or (d, h, w). Defaults to no padding.");
-    DMLC_DECLARE_FIELD(num_filter).set_range(1, 100000)
+    DMLC_DECLARE_FIELD(num_filter).set_lower_bound(1)
     .describe("Convolution filter(channel) number");
     DMLC_DECLARE_FIELD(num_group).set_default(1)
     .describe("Number of group partitions.");
-    DMLC_DECLARE_FIELD(workspace).set_default(1024).set_range(0, 8192)
+    DMLC_DECLARE_FIELD(workspace).set_default(1024).set_lower_bound(0)
     .describe("Maximum temporary workspace allowed (MB) in convolution."
               "This parameter has two usages. When CUDNN is not used, it determines the "
               "effective batch size of the convolution kernel. When CUDNN is used, it controls "

--- a/src/operator/nn/deconvolution-inl.h
+++ b/src/operator/nn/deconvolution-inl.h
@@ -85,11 +85,11 @@ struct DeconvolutionParam : public dmlc::Parameter<DeconvolutionParam> {
                   "`adj` will be ignored and computed accordingly.");
     DMLC_DECLARE_FIELD(target_shape).set_default(mxnet::TShape(0, 0))
         .describe("Shape of the output tensor: (w,), (h, w) or (d, h, w).");
-    DMLC_DECLARE_FIELD(num_filter).set_range(1, 100000)
+    DMLC_DECLARE_FIELD(num_filter).set_lower_bound(1)
         .describe("Number of output filters.");
     DMLC_DECLARE_FIELD(num_group).set_default(1)
         .describe("Number of groups partition.");
-    DMLC_DECLARE_FIELD(workspace).set_default(512).set_range(0, 8192)
+    DMLC_DECLARE_FIELD(workspace).set_default(512).set_lower_bound(0)
         .describe("Maximum temporary workspace allowed (MB) in deconvolution."
                   "This parameter has two usages. When CUDNN is not used, it determines the "
                   "effective batch size of the deconvolution kernel. When CUDNN is used, "

--- a/src/operator/nn/upsampling-inl.h
+++ b/src/operator/nn/upsampling-inl.h
@@ -56,7 +56,7 @@ struct UpSamplingParam : public dmlc::Parameter<UpSamplingParam> {
   uint64_t workspace;
   DMLC_DECLARE_PARAMETER(UpSamplingParam) {
     DMLC_DECLARE_FIELD(scale)
-    .set_range(1, 1000)
+    .set_lower_bound(1)
     .describe("Up sampling scale");
     DMLC_DECLARE_FIELD(num_filter)
     .describe("Input filter. Only used by bilinear sample_type."
@@ -79,7 +79,7 @@ struct UpSamplingParam : public dmlc::Parameter<UpSamplingParam> {
     "upsampling, this can be 1-N; the size of output will be"
     "(scale*h_0,scale*w_0) and all other inputs will be upsampled to the"
     "same size. For bilinear upsampling this must be 2; 1 input and 1 weight.");
-    DMLC_DECLARE_FIELD(workspace).set_default(512).set_range(0, 8192)
+    DMLC_DECLARE_FIELD(workspace).set_default(512).set_lower_bound(0)
     .describe("Tmp workspace for deconvolution (MB)");
   }
 };  // struct UpSamplingParam


### PR DESCRIPTION
## Description ##
Backport #18857 

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
