### PR TITLE
[Bug Fix] Fix image.flip_xx_xx operator where center element not being copied

### DIFF
--- a/src/operator/image/image_random-inl.h
+++ b/src/operator/image/image_random-inl.h
@@ -552,7 +552,9 @@ void FlipImpl(const mxnet::TShape &shape, DType *src, DType *dst) {
   for (int i = axis+1; i < shape.ndim(); ++i) tail *= shape[i];
 
   for (int i = 0; i < head; ++i) {
-    for (int j = 0; j < (mid >> 1); ++j) {
+    // if inplace flip, skip the mid point in axis, otherwise copy is required
+    int mid2 = (src == dst) ? mid >> 1 : (mid + 1) >> 1;
+    for (int j = 0; j < mid2; ++j) {
       int idx1 = (i*mid + j) * tail;
       int idx2 = idx1 + (mid-(j << 1)-1) * tail;
       for (int k = 0; k < tail; ++k, ++idx1, ++idx2) {

--- a/tests/python/unittest/test_gluon_data_vision.py
+++ b/tests/python/unittest/test_gluon_data_vision.py
@@ -194,18 +194,20 @@ def test_crop_resize():
 
 @with_seed()
 def test_flip_left_right():
-    data_in = np.random.uniform(0, 255, (300, 300, 3)).astype(dtype=np.uint8)
-    flip_in = data_in[:, ::-1, :]
-    data_trans = nd.image.flip_left_right(nd.array(data_in, dtype='uint8'))
-    assert_almost_equal(flip_in, data_trans.asnumpy())
+    for width in range(3, 301, 7):
+        data_in = np.random.uniform(0, 255, (300, width, 3)).astype(dtype=np.uint8)
+        flip_in = data_in[:, ::-1, :]
+        data_trans = nd.image.flip_left_right(nd.array(data_in, dtype='uint8'))
+        assert_almost_equal(flip_in, data_trans.asnumpy())
 
 
 @with_seed()
 def test_flip_top_bottom():
-    data_in = np.random.uniform(0, 255, (300, 300, 3)).astype(dtype=np.uint8)
-    flip_in = data_in[::-1, :, :]
-    data_trans = nd.image.flip_top_bottom(nd.array(data_in, dtype='uint8'))
-    assert_almost_equal(flip_in, data_trans.asnumpy())
+    for height in range(3, 301, 7):
+        data_in = np.random.uniform(0, 255, (height, 300, 3)).astype(dtype=np.uint8)
+        flip_in = data_in[::-1, :, :]
+        data_trans = nd.image.flip_top_bottom(nd.array(data_in, dtype='uint8'))
+        assert_almost_equal(flip_in, data_trans.asnumpy())
 
 
 @with_seed()
@@ -445,4 +447,3 @@ def test_bbox_crop():
     im_out, im_bbox = transform(img, bbox)
     assert im_out.shape == (3, 3, 3)
     assert im_bbox[0][2] == 3
-


### PR DESCRIPTION
## Description ##
Fix https://github.com/apache/incubator-mxnet/issues/18911 , in particular, when the flip axis element # is odd and the operator is not performing inplace flipping, the center element is not being copied.


## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
