### PR TITLE
Numpy Dot Large Tensor Fix

### DIFF
--- a/3rdparty/mshadow/mshadow/dot_engine-inl.h
+++ b/3rdparty/mshadow/mshadow/dot_engine-inl.h
@@ -299,17 +299,17 @@ struct BLASEngine<cpu, float> {
   }
   inline static void gemm(Stream<cpu> *stream,
                           bool transa, bool transb,
-                          int m, int n, int k, float alpha,
-                          const float *A, int lda, const float *B, int ldb,
-                          float beta, float *C, int ldc) {
+                          index_t m, index_t n, index_t k, float alpha,
+                          const float *A, index_t lda, const float *B, index_t ldb,
+                          float beta, float *C, index_t ldc) {
     cblas_sgemm(CblasColMajor, GetT(transa), GetT(transb),
                 m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
   }
   inline static void batched_gemm(Stream<cpu> *stream,
                                   bool transa, bool transb,
-                                  int m, int n, int k, float alpha,
-                                  const float *A, int lda, const float *B, int ldb,
-                                  float beta, float *C, int ldc, int batch_count,
+                                  index_t m, index_t n, index_t k, float alpha,
+                                  const float *A, index_t lda, const float *B, index_t ldb,
+                                  float beta, float *C, index_t ldc, index_t batch_count,
                                   float **workspace) {
 #if (MSHADOW_USE_MKL && INTEL_MKL_VERSION >= 20160000)
   // since same m/n/k is used for all single gemms, so we put all gemms into one group
@@ -408,17 +408,17 @@ struct BLASEngine<cpu, double> {
   }
   inline static void gemm(Stream<cpu> *stream,
                           bool transa, bool transb,
-                          int m, int n, int k, double alpha,
-                          const double *A, int lda, const double *B, int ldb,
-                          double beta, double *C, int ldc) {
+                          index_t m, index_t n, index_t k, double alpha,
+                          const double *A, index_t lda, const double *B, index_t ldb,
+                          double beta, double *C, index_t ldc) {
     cblas_dgemm(CblasColMajor, GetT(transa), GetT(transb),
                 m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
   }
   inline static void batched_gemm(Stream<cpu> *stream,
                                   bool transa, bool transb,
-                                  int m, int n, int k, double alpha,
-                                  const double *A, int lda, const double *B, int ldb,
-                                  double beta, double *C, int ldc, int batch_count,
+                                  index_t m, index_t n, index_t k, double alpha,
+                                  const double *A, index_t lda, const double *B, index_t ldb,
+                                  double beta, double *C, index_t ldc, index_t batch_count,
                                   double **workspace) {
 #if (MSHADOW_USE_MKL && INTEL_MKL_VERSION >= 20160000)
   // since same m/n/k is used for all single gemms, so we put all gemms into one group

--- a/src/operator/numpy/np_tensordot_op-inl.h
+++ b/src/operator/numpy/np_tensordot_op-inl.h
@@ -60,10 +60,10 @@ inline void ShiftAxes(Tuple<int>* axes_summed, const int ndim) {
 /**
  * Gets matrix dimensions of a and b after transpose and reshape.
  */
-inline void GetMatrixDimensions(int* ad1,
-                                int* ad2,
-                                int* bd1,
-                                int* bd2,
+inline void GetMatrixDimensions(index_t* ad1,
+                                index_t* ad2,
+                                index_t* bd1,
+                                index_t* bd2,
                                 const mxnet::Tuple<int>& a_axes_remained,
                                 const mxnet::Tuple<int>& a_axes_summed,
                                 const mxnet::Tuple<int>& b_axes_remained,
@@ -157,10 +157,10 @@ void MatrixDot(const OpContext& ctx,
                const TBlob& b,
                const TBlob& out,
                const OpReqType req,
-               const int ad1,
-               const int ad2,
-               const int bd1,
-               const int bd2,
+               const index_t ad1,
+               const index_t ad2,
+               const index_t bd1,
+               const index_t bd2,
                const bool aT = false,
                const bool bT = false) {
   using namespace mshadow;
@@ -266,7 +266,7 @@ void TensordotImpl(const Tuple<int>& a_axes_summed,
       GetReorderedAxes(a_axes_summed, &a_axes_remained, &a_axes, b_axes_summed, &b_axes_remained,
                        &b_axes, a_shape, b_shape);
 
-      int ad1 = 1, ad2 = 1, bd1 = 1, bd2 = 1;
+      index_t ad1 = 1, ad2 = 1, bd1 = 1, bd2 = 1;
       GetMatrixDimensions(&ad1, &ad2, &bd1, &bd2, a_axes_remained, a_axes_summed,
                           b_axes_remained, b_axes_summed, a_shape, b_shape);
 
@@ -435,7 +435,7 @@ void TensordotBackwardImpl(const Tuple<int>& a_axes_summed,
       GetReorderedAxes(a_axes_summed, &a_axes_remained, &a_axes, b_axes_summed, &b_axes_remained,
                       &b_axes, a_shape, b_shape);
 
-      int ad1 = 1, ad2 = 1, bd1 = 1, bd2 = 1;
+      index_t ad1 = 1, ad2 = 1, bd1 = 1, bd2 = 1;
       GetMatrixDimensions(&ad1, &ad2, &bd1, &bd2, a_axes_remained, a_axes_summed,
                           b_axes_remained, b_axes_summed, a_shape, b_shape);
 
@@ -653,7 +653,7 @@ void TensordotIntAxesImpl(const int axes,
       GetReorderedAxes(a_axes_summed, &a_axes_remained, &a_axes, b_axes_summed, &b_axes_remained,
                       &b_axes, a_shape, b_shape);
 
-      int ad1 = 1, ad2 = 1, bd1 = 1, bd2 = 1;
+      index_t ad1 = 1, ad2 = 1, bd1 = 1, bd2 = 1;
       GetMatrixDimensions(&ad1, &ad2, &bd1, &bd2, a_axes_remained, a_axes_summed,
                           b_axes_remained, b_axes_summed, a_shape, b_shape);
       MatrixDot<xpu>(ctx, a, b, out, req, ad1, ad2, bd1, bd2);
@@ -746,7 +746,7 @@ void TensordotIntAxesBackwardImpl(const int axes,
       GetReorderedAxes(a_axes_summed, &a_axes_remained, &a_axes, b_axes_summed, &b_axes_remained,
                       &b_axes, a_shape, b_shape);
 
-      int ad1 = 1, ad2 = 1, bd1 = 1, bd2 = 1;
+      index_t ad1 = 1, ad2 = 1, bd1 = 1, bd2 = 1;
       GetMatrixDimensions(&ad1, &ad2, &bd1, &bd2, a_axes_remained, a_axes_summed,
                           b_axes_remained, b_axes_summed, a_shape, b_shape);
 

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -36,6 +36,7 @@ MEDIUM_X = 10000
 LARGE_X = 100000000
 SMALL_X = 100
 SMALL_Y = 50
+INT_32_MAX = 2 ** 31 - 1
 
 
 @use_np
@@ -76,3 +77,11 @@ def test_softmax():
         true_output = np.full((SMALL_Y, LARGE_X), (1 / input_data.shape[axis]))
         output = npx.softmax(input_data, axis=axis)
         assert_almost_equal(output.asnumpy(), true_output, rtol=1e-5, atol=1e-5)
+
+@pytest.mark.skip(reason="CI hasn't switch to ILP64 OpenBLAS yet")
+@use_np
+def test_dot():
+    A = np.ones((1, INT_MAX + 1))
+    B = np.ones((INT_MAX + 1, 1))
+    C = np.dot(A, B)
+    assert_almost_equal(C.asnumpy(), [INT_MAX + 1], rtol=1e-5, atol=1e-5)

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -81,7 +81,7 @@ def test_softmax():
 @pytest.mark.skip(reason="CI hasn't switch to ILP64 OpenBLAS yet")
 @use_np
 def test_dot():
-    A = np.ones((1, INT_MAX + 1))
-    B = np.ones((INT_MAX + 1, 1))
+    A = np.ones((1, INT_32_MAX + 1))
+    B = np.ones((INT_32_MAX + 1, 1))
     C = np.dot(A, B)
-    assert_almost_equal(C.asnumpy(), [INT_MAX + 1], rtol=1e-5, atol=1e-5)
+    assert_almost_equal(C.asnumpy(), [INT_32_MAX + 1], rtol=1e-5, atol=1e-5)


### PR DESCRIPTION
This PR fixes numpy dot on large tensors. This fix also requires ILP 64 Blas which CI has not migrated to yet, so for now we are skipping the test. 

With this fix numpy dot will no longer error out on > 2**31 dimensions. However there seems to be a precision issue with ILP64 openblas: https://github.com/xianyi/OpenBLAS/issues/2779
So on my remote computer
```
A = np.ones((1, 2**31))
B = np.ones((2**31, 1))
C = np.dot(A, B)
```
Will give 1.93274e+09
```
A = np.ones((2**31, 1), dtype='float64')
B = np.ones((1, 2**31), dtype='float64')
```
Will give the arithmetically correct result 2.14748365e+09
Issue at https://github.com/apache/incubator-mxnet/issues/18926




Update: regardless of the precision issue mentioned above, this pr should be a general fix for numpy.dot and should be the same regardless of which blas we use