### PR TITLE
Support for fp16 in SpM x DnsM on GPU

### DIFF
--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -24,6 +24,8 @@ import mxnet as mx
 import numpy as np
 import pytest
 import itertools
+import scipy.sparse as sps
+import mxnet.ndarray.sparse as mxsps
 from mxnet.test_utils import check_consistency, set_default_context, assert_almost_equal, assert_allclose
 from mxnet.test_utils import check_symbolic_forward, check_symbolic_backward, discard_stderr
 from mxnet.test_utils import default_context, rand_shape_2d, rand_ndarray, same, environment
@@ -2308,3 +2310,12 @@ def test_arange_like_dtype():
         for v in out:
             assert v.dtype == t
 
+
+def test_fp16_spmm():
+    inp = mxsps.csr_matrix(sps.coo_matrix(([2.0], ([150], [100000]))).tocsr())
+    inp = inp.astype('float16', copy=False)
+    weight = mx.nd.random.randn(100001, 151)
+    weight = weight.astype('float16', copy=False)
+    out = mxsps.dot(inp, weight)
+    out_np = mx.nd.dot(inp, weight)
+    assert_almost_equal(out.asnumpy(), out_np, rtol=1e-3, atol=1e-5)


### PR DESCRIPTION
## Description ##
enables fp16 DType suport in following case

```
dot(csr, dense1) = dense2 and dot(csr.T, dense1) = dense2
```
Will add test case shortly

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Testing ###

```
pytest) ubuntu@ip-172-31-90-243 ~/workspace/incubator-mxnet (spgemm_fp16) $ python -m pytest -s --exitfirst --verbose tests/python/gpu/test_operator_gpu.py::test_fp16_spmm
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.10, pytest-5.3.5, py-1.8.2, pluggy-0.13.1 -- /home/ubuntu/anaconda3/envs/pytest/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/workspace/incubator-mxnet, inifile: pytest.ini
collected 1 item

tests/python/gpu/test_operator_gpu.py::test_fp16_spmm [09:52:41] ../src/base.cc:84: Upgrade advisory: this mxnet has been built against cuDNN lib version 7501, which is older than the oldest version tested by CI (7600).  Set MXNET_CUDNN_LIB_CHECKING=0 to quiet this warning.
[09:52:43] ../src/storage/storage.cc:198: Using Pooled (Naive) StorageManager for GPU
PASSED
```