### PR TITLE
[v1.x]fix gelu to use erf based algorithm (#18827)

### DIFF
--- a/src/operator/nn/mkldnn/mkldnn_act.cc
+++ b/src/operator/nn/mkldnn/mkldnn_act.cc
@@ -100,7 +100,7 @@ mkldnn::algorithm GetMKLDNNActAlgo(const LeakyReLUParam& param) {
     case leakyrelu::kELU:
       return mkldnn::algorithm::eltwise_elu;
     case leakyrelu::kGELU:
-      return mkldnn::algorithm::eltwise_gelu;
+      return mkldnn::algorithm::eltwise_gelu_erf;
     default:
       LOG(FATAL) << "unknown activation type for LeakyReLU: " << param.act_type;
       return mkldnn::algorithm::eltwise_relu;


### PR DESCRIPTION
## Description ##
Backport #18827 to v1.x branch, which changed the gelu to use erf based algorithm for MLKDNN (oneDNN) backend.


@TaoLv @pengzhao-intel 
