### PR TITLE
Fix LeakyRelu behaviour on empty input (#18934)

### DIFF
--- a/src/operator/leaky_relu-inl.h
+++ b/src/operator/leaky_relu-inl.h
@@ -353,6 +353,7 @@ void LeakyReLUCompute(const nnvm::NodeAttrs& attrs,
                       const OpContext& ctx, const std::vector<TBlob>& inputs,
                       const std::vector<OpReqType>& req,
                       const std::vector<TBlob>& outputs) {
+  if (inputs[0].Size() == 0U) return;
   const LeakyReLUParam &param = nnvm::get<LeakyReLUParam>(attrs.parsed);
   const std::vector<TBlob> no_use_but_adapt_origin_api;
   size_t expected = param.act_type == leakyrelu::kPReLU ? 2 : 1;
@@ -370,6 +371,7 @@ void LeakyReLUGradCompute(const nnvm::NodeAttrs& attrs,
                           const std::vector<TBlob>& inputs,
                           const std::vector<OpReqType>& req,
                           const std::vector<TBlob>& outputs) {
+  if (inputs[0].Size() == 0U) return;
   const LeakyReLUParam& param = nnvm::get<LeakyReLUParam>(attrs.parsed);
   const std::vector<TBlob> no_use_but_adapt_origin_api;
   // inputs: out_grad, input_data, input_gamma, output, output_mask

--- a/src/operator/leaky_relu.cc
+++ b/src/operator/leaky_relu.cc
@@ -90,6 +90,7 @@ static void LeakyReLUComputeExCPU(const nnvm::NodeAttrs& attrs,
                                   const std::vector<NDArray>& inputs,
                                   const std::vector<OpReqType>& req,
                                   const std::vector<NDArray>& outputs) {
+  if (inputs[0].shape().Size() == 0U) return;
   const LeakyReLUParam& param = nnvm::get<LeakyReLUParam>(attrs.parsed);
   size_t expected = param.act_type == leakyrelu::kPReLU ? 2 : 1;
   CHECK_EQ(inputs.size(), expected);
@@ -107,6 +108,7 @@ void LeakyReLUGradComputeExCPU(const nnvm::NodeAttrs& attrs,
                                const std::vector<NDArray>& inputs,
                                const std::vector<OpReqType>& req,
                                const std::vector<NDArray>& outputs) {
+  if (inputs[0].shape().Size() == 0U) return;
   const LeakyReLUParam& param = nnvm::get<LeakyReLUParam>(attrs.parsed);
   if (SupportMKLDNNLeakyRelu(param, inputs[0])) {
     std::vector<NDArray> in_data{inputs[0], inputs[1]};

--- a/src/operator/nn/mkldnn/mkldnn_act-inl.h
+++ b/src/operator/nn/mkldnn/mkldnn_act-inl.h
@@ -74,13 +74,6 @@ MKLDNNActForward &GetActForward(const MKLDNNActParam& param,
                                 const OpContext &ctx, const NDArray &in_data,
                                 const mkldnn::memory &in_mem);
 
-void MKLDNNActivationForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                             const NDArray &in_data, const OpReqType &req,
-                             const NDArray &out_data);
-void MKLDNNLeakyReluForward(const nnvm::NodeAttrs& attrs, const OpContext &ctx,
-                            const NDArray &in_data, const OpReqType &req,
-                            const NDArray &out_data);
-
 mkldnn::eltwise_backward::primitive_desc GetActBwdDescImpl(
     const MKLDNNActParam &param, const mkldnn::memory &input_mem,
     const mkldnn::memory &diff_dst_memory);

--- a/src/operator/quantization/mkldnn/mkldnn_quantized_act.cc
+++ b/src/operator/quantization/mkldnn/mkldnn_quantized_act.cc
@@ -24,7 +24,7 @@
 */
 #if MXNET_USE_MKLDNN == 1
 
-#include "../../nn/mkldnn/mkldnn_act-inl.h"
+#include "../../nn/mkldnn/mkldnn_ops-inl.h"
 #include "../quantization_utils.h"
 
 namespace mxnet {

--- a/tests/python/unittest/test_smoke.py
+++ b/tests/python/unittest/test_smoke.py
@@ -56,3 +56,14 @@ def test_18933_channel_0():
     with autograd.record():
         a = npx.instance_norm(arr, gamma, beta)
     a.backward()
+
+@use_np
+@with_environment('MXNET_ENGINE_TYPE', 'NaiveEngine')
+def test_18934_empty_leaky_relu():
+    arr = np.random.rand(0,2)
+    arr_grad = np.empty_like(arr)
+
+    autograd.mark_variables([arr], [arr_grad])
+    with autograd.record():
+        res = npx.leaky_relu(arr)
+    res.backward()


### PR DESCRIPTION
## Description ##

fix #18934

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change


## Comments ##

In numpy mode everything works fine.
NDArray mode throws:

```
  File "leaky.py", line 5, in <module>
    b = mx.ndarray.LeakyReLU(input)
  File "<string>", line 72, in LeakyReLU
  File "/home/wihajster/Desktop/incubator-mxnet/python/mxnet/_ctypes/ndarray.py", line 82, in _imperative_invoke
    check_call(_LIB.MXImperativeInvokeEx(
  File "/home/wihajster/Desktop/incubator-mxnet/python/mxnet/base.py", line 246, in check_call
    raise get_last_ffi_error()
mxnet.base.MXNetError: Traceback (most recent call last):
  File "../src/imperative/imperative.cc", line 678
MXNetError: Check failed: shape_is_known(arr.shape()):
```

I think this is correct behavior, as legacy mode doesn’t let empty arrays.
