### PR TITLE
set_lower_bound(1) so that stride is not zero

### DIFF
--- a/python/mxnet/test_utils.py
+++ b/python/mxnet/test_utils.py
@@ -1514,7 +1514,7 @@ def check_consistency(sym, ctx_list, scale=1.0, grad_req='write',
         Provided ideal result to be compared against
     equal_nan : bool, optional, defaults to False
         Should nans be treated as equal in the comparison
-    use_unifrom: bool
+    use_uniform: bool
         Optional, When flag set to true,
         random input data generated follows uniform distribution,
         not normal distribution

--- a/src/operator/correlation-inl.h
+++ b/src/operator/correlation-inl.h
@@ -54,9 +54,9 @@ struct CorrelationParam : public dmlc::Parameter<CorrelationParam> {
     .describe("kernel size for Correlation must be an odd number");
     DMLC_DECLARE_FIELD(max_displacement).set_default(1)
     .describe("Max displacement of Correlation ");
-    DMLC_DECLARE_FIELD(stride1).set_default(1)
+    DMLC_DECLARE_FIELD(stride1).set_default(1).set_lower_bound(1)
     .describe("stride1 quantize data1 globally");
-    DMLC_DECLARE_FIELD(stride2).set_default(1)
+    DMLC_DECLARE_FIELD(stride2).set_default(1).set_lower_bound(1)
     .describe("stride2 quantize data2 within the neighborhood centered around data1");
     DMLC_DECLARE_FIELD(pad_size).set_default(0)
     .describe("pad for Correlation");

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -3164,6 +3164,14 @@ def correlation_backward(out_grad,tmp1,tmp2,data1,data2,pad_size,kernel_size,str
 
 def unittest_correlation(data_shape,kernel_size,max_displacement,stride1,stride2,pad_size,is_multiply,dtype):
 
+    def check_lower_bound(stride1, stride2):
+        with pytest.raises(MXNetError):
+            stride1 < 1
+        with pytest.raises(MXNetError):
+            stride2 < 1
+
+    check_lower_bound(stride1, stride2)
+
     img1 = np.random.random(data_shape)
     img1 = img1.astype(dtype)
     img2 = np.random.random(data_shape)
@@ -3232,6 +3240,10 @@ def test_correlation():
         unittest_correlation((5,1,6,4), kernel_size = 3,max_displacement = 1,stride1 = 2,stride2 = 1,pad_size = 2,is_multiply = False, dtype = dtype)
         unittest_correlation((5,1,11,11), kernel_size = 5,max_displacement = 1,stride1 = 1,stride2 = 1,pad_size = 2,is_multiply = False, dtype = dtype)
 
+        unittest_correlation((1,3,10,10), kernel_size = 1,max_displacement = 4,stride1 = 0,stride2 = 1,pad_size = 4,is_multiply = False, dtype = dtype)
+        unittest_correlation((5,1,15,15), kernel_size = 1,max_displacement = 5,stride1 = 1,stride2 = 0,pad_size = 5,is_multiply = False, dtype = dtype)
+        unittest_correlation((5,1,15,15), kernel_size = 1,max_displacement = 5,stride1 = 1,stride2 = 0,pad_size = 5,is_multiply = True, dtype = dtype)
+        unittest_correlation((1,3,10,10), kernel_size = 1,max_displacement = 4,stride1 = 0,stride2 = 1,pad_size = 4,is_multiply = True, dtype = dtype)
 
 # Seed set because the test is not robust enough to operate on random data
 @with_seed(1234)

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -3164,14 +3164,6 @@ def correlation_backward(out_grad,tmp1,tmp2,data1,data2,pad_size,kernel_size,str
 
 def unittest_correlation(data_shape,kernel_size,max_displacement,stride1,stride2,pad_size,is_multiply,dtype):
 
-    def check_lower_bound(stride1, stride2):
-        with pytest.raises(MXNetError):
-            stride1 < 1
-        with pytest.raises(MXNetError):
-            stride2 < 1
-
-    check_lower_bound(stride1, stride2)
-
     img1 = np.random.random(data_shape)
     img1 = img1.astype(dtype)
     img2 = np.random.random(data_shape)
@@ -3239,11 +3231,15 @@ def test_correlation():
         unittest_correlation((5,1,4,4), kernel_size = 3,max_displacement = 1,stride1 = 2,stride2 = 1,pad_size = 2,is_multiply = False, dtype = dtype)
         unittest_correlation((5,1,6,4), kernel_size = 3,max_displacement = 1,stride1 = 2,stride2 = 1,pad_size = 2,is_multiply = False, dtype = dtype)
         unittest_correlation((5,1,11,11), kernel_size = 5,max_displacement = 1,stride1 = 1,stride2 = 1,pad_size = 2,is_multiply = False, dtype = dtype)
-
-        unittest_correlation((1,3,10,10), kernel_size = 1,max_displacement = 4,stride1 = 0,stride2 = 1,pad_size = 4,is_multiply = False, dtype = dtype)
-        unittest_correlation((5,1,15,15), kernel_size = 1,max_displacement = 5,stride1 = 1,stride2 = 0,pad_size = 5,is_multiply = False, dtype = dtype)
-        unittest_correlation((5,1,15,15), kernel_size = 1,max_displacement = 5,stride1 = 1,stride2 = 0,pad_size = 5,is_multiply = True, dtype = dtype)
-        unittest_correlation((1,3,10,10), kernel_size = 1,max_displacement = 4,stride1 = 0,stride2 = 1,pad_size = 4,is_multiply = True, dtype = dtype)
+        
+        with pytest.raises(MXNetError):
+            unittest_correlation((1,3,10,10), kernel_size = 1,max_displacement = 4,stride1 = 0,stride2 = 1,pad_size = 4,is_multiply = False, dtype = dtype)
+        with pytest.raises(MXNetError):
+            unittest_correlation((5,1,15,15), kernel_size = 1,max_displacement = 5,stride1 = 1,stride2 = 0,pad_size = 5,is_multiply = False, dtype = dtype)
+        with pytest.raises(MXNetError):
+            unittest_correlation((5,1,15,15), kernel_size = 1,max_displacement = 5,stride1 = 1,stride2 = 0,pad_size = 5,is_multiply = True, dtype = dtype)
+        with pytest.raises(MXNetError):
+            unittest_correlation((1,3,10,10), kernel_size = 1,max_displacement = 4,stride1 = 0,stride2 = 1,pad_size = 4,is_multiply = True, dtype = dtype)
 
 # Seed set because the test is not robust enough to operate on random data
 @with_seed(1234)


### PR DESCRIPTION
in issue: https://github.com/apache/incubator-mxnet/issues/18942, an error was occurring where strides became zero. to solve the issue, the lower bounds of stride1 and stride2 have been set to 1.

in issue: https://github.com/apache/incubator-mxnet/issues/18994, a typo was mentioned. that has also been cleared.

fix #18942 
fix #18994 

## Description ##
(Brief description on what this PR is about)
When the correlation function is called on two arrays when the stride is zero, it results in a floating point exception as a division by zero is carried out. Thus, the lower bounds of stride1 and stride2 have been set to 1.

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
