### PR TITLE
Numpy Random Ops Fix & Testcases

### DIFF
--- a/src/operator/numpy/random/dist_common.h
+++ b/src/operator/numpy/random/dist_common.h
@@ -59,9 +59,9 @@ inline int FillShape(const mxnet::TShape &lshape, const mxnet::TShape &rshape,
   int j = 0;
   dim_t lprod = 1, rprod = 1, oprod = 1;
   for (int i = 0; i < oshape.ndim(); ++i) {
-    index_t l = 1;
-    index_t r = 1;
-    index_t o = oshape[i];
+    dim_t l = 1;
+    dim_t r = 1;
+    dim_t o = oshape[i];
     if (i >= bl) l = lshape[i - bl];
     if (i >= br) r = rshape[i - br];
     if ((lprod != rprod || lprod != oprod || l != r || l != o) &&

--- a/src/operator/numpy/random/dist_common.h
+++ b/src/operator/numpy/random/dist_common.h
@@ -59,9 +59,9 @@ inline int FillShape(const mxnet::TShape &lshape, const mxnet::TShape &rshape,
   int j = 0;
   dim_t lprod = 1, rprod = 1, oprod = 1;
   for (int i = 0; i < oshape.ndim(); ++i) {
-    int l = 1;
-    int r = 1;
-    int o = oshape[i];
+    index_t l = 1;
+    index_t r = 1;
+    index_t o = oshape[i];
     if (i >= bl) l = lshape[i - bl];
     if (i >= br) r = rshape[i - br];
     if ((lprod != rprod || lprod != oprod || l != r || l != o) &&

--- a/src/operator/numpy/random/dist_common.h
+++ b/src/operator/numpy/random/dist_common.h
@@ -56,7 +56,8 @@ inline int FillShape(const mxnet::TShape &lshape, const mxnet::TShape &rshape,
   *new_oshape = mxnet::TShape(odim, 1);
   int bl = oshape.ndim() - lshape.ndim();
   int br = oshape.ndim() - rshape.ndim();
-  int j = 0, lprod = 1, rprod = 1, oprod = 1;
+  int j = 0;
+  dim_t lprod = 1, rprod = 1, oprod = 1;
   for (int i = 0; i < oshape.ndim(); ++i) {
     int l = 1;
     int r = 1;
@@ -99,7 +100,7 @@ inline void CheckBroadcastable(const mxnet::TShape &from,
   const int bl = to.ndim() - from.ndim();
   const int br = 0;
   for (int i = 0; i < to.ndim(); ++i) {
-    int l = 1, r = 1;
+    dim_t l = 1, r = 1;
     if (i >= bl) l = from[i - bl];
     if (i >= br) r = to[i - br];
     if (!mxnet::dim_size_is_known(l) || !mxnet::dim_size_is_known(r)) continue;
@@ -121,7 +122,7 @@ inline void InferBroadcastShape(const mxnet::TShape &lhs,
   const int bl = out.ndim() - lhs.ndim();
   const int br = out.ndim() - rhs.ndim();
   for (int i = 0; i < out.ndim(); ++i) {
-    int l = 1, r = 1;
+    dim_t l = 1, r = 1;
     if (i >= bl) l = lhs[i - bl];
     if (i >= br) r = rhs[i - br];
     if (!mxnet::dim_size_is_known(l) || !mxnet::dim_size_is_known(r)) continue;
@@ -154,7 +155,7 @@ inline bool TwoparamsDistOpShape(const nnvm::NodeAttrs &attrs,
   std::vector<dim_t> oshape_vec;
   if (param.size.has_value()) {
     // Size declared.
-    const decltype(param.size.value()) &size = param.size.value();
+    const auto &size = param.size.value();
     index_t head = size[0];
     if (head == -2) {
       concat_mode = true;

--- a/src/operator/numpy/random/np_bernoulli_op.h
+++ b/src/operator/numpy/random/np_bernoulli_op.h
@@ -46,12 +46,12 @@ struct NumpyBernoulliParam : public dmlc::Parameter<NumpyBernoulliParam> {
   std::string ctx;
   int dtype;
   bool is_logit;
-  dmlc::optional<mxnet::Tuple<int>> size;
+  dmlc::optional<mxnet::Tuple<index_t>> size;
   DMLC_DECLARE_PARAMETER(NumpyBernoulliParam) {
     DMLC_DECLARE_FIELD(prob);
     DMLC_DECLARE_FIELD(logit);
     DMLC_DECLARE_FIELD(size)
-        .set_default(dmlc::optional<mxnet::Tuple<int>>())
+        .set_default(dmlc::optional<mxnet::Tuple<index_t>>())
         .describe(
             "Output shape. If the given shape is, "
             "e.g., (m, n, k), then m * n * k samples are drawn. "

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -547,13 +547,17 @@ def test_random_weibull():
 def test_random_shuffle():
     A = np.ones((INT_OVERFLOW, 2))
     np.random.shuffle(A)
-    assert A.shape == (INT_OVERFLOW, 2)
     assert type(A[0]).__name__ == 'ndarray'
 
 @use_np
 def test_random_lognormal():
     A = np.random.lognormal(mean=0, sigma=1.0, size=(2**31))
     assert type(A[0]).__name__ == 'ndarray'
+
+@use_np
+def test_random_randint():
+    A = np.random.randint(low=0, high=5, size=(2, 2**31))
+    assert A[0][0] < 5 and A[0][0] >= 0
 
 '''
                                      _               _

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -832,15 +832,6 @@ def test_smooth_l1():
     assert A.grad[0] == 0
 
 @use_np
-@pytest.mark.skip(reason='np.random broken on large tensor; npx.random \
-    to be re-examined after np.random is fixed')
-def test_random():
-    prob = np.random.uniform(size=(INT_OVERFLOW, 2))
-    A = npx.random.bernoulli(prob=prob, size=(INT_OVERFLOW, 2))
-    assert A.shape == (INT_OVERFLOW, 2)
-    assert int((A == 0).sum() + (A == 1).sum()) == A.size
-
-@use_np
 def test_gamma():
     A = np.ones((2, INT_OVERFLOW))
     A[0][0] = 5

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -543,6 +543,18 @@ def test_random_weibull():
     A = np.random.weibull(a=1.0, size=(INT_OVERFLOW))
     assert type(A[0]).__name__ == 'ndarray'
 
+@use_np
+def test_random_shuffle():
+    A = np.ones((INT_OVERFLOW, 2))
+    np.random.shuffle(A)
+    assert A.shape == (INT_OVERFLOW, 2)
+    assert type(A[0]).__name__ == 'ndarray'
+
+@use_np
+def test_random_lognormal():
+    A = np.random.lognormal(mean=0, sigma=1.0, size=(2**31))
+    assert type(A[0]).__name__ == 'ndarray'
+
 '''
                                      _               _
   _ _ _  _ _ __  _ __ _  _   _____ _| |_ ___ _ _  __(_)___ _ _
@@ -1037,3 +1049,11 @@ def test_save_load():
     assert B[0].shape == (2, INT_OVERFLOW)
     assert B[0][0][100] == 100
 
+@use_np
+def test_random_bernoulli():
+    prob = np.zeros((INT_OVERFLOW))
+    prob[0] = 1
+    A = npx.random.bernoulli(prob=prob, size=(INT_OVERFLOW))
+    assert A.shape == (INT_OVERFLOW, )
+    assert A[0] == 1
+    assert A[1] == 0


### PR DESCRIPTION
This PR fixes npx.random.bernoulli against large tensor. Testcases for npx.random.bernoulli, np.random.lognormal, np.random.randint, and np.random.shuffle are also added.

Now all np.random and np.random ops should be fixed.

Notice that large tensors tests are not added for the following ops:
op (reason)
np.random.rand  (special case of np.rand.uniform)
np.random.multivariate-normal (falls back on python custom op which is going to be deprecated)
np.random.randn (special case of np.rand.normal)
np.random.f np.random.beta np.random.chisquare (internally calls np.random.gamma which is covered)
npx.random.normal_n (internally calls np.random.normal)
npx.random.uniform_n (internally calls np.random.uniform_n)


Tests added all passed locally. Sample result:
```
pytest tests/nightly/test_np_large_array.py::test_random_randint
/home/ubuntu/anaconda3/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
  return f(*args, **kwds)
/home/ubuntu/anaconda3/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
  return f(*args, **kwds)
/home/ubuntu/anaconda3/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
  return f(*args, **kwds)
==================================== test session starts =====================================
platform linux -- Python 3.7.7, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/ubuntu/incubator-mxnet, inifile: pytest.ini
plugins: remotedata-0.3.2, openfiles-0.4.0, astropy-header-0.1.2, hypothesis-5.8.3, arraydiff-0.3, doctestplus-0.5.0
collected 1 item                                                                             

tests/nightly/test_np_large_array.py    .                                                 [100%]

====================================== warnings summary ======================================
tests/nightly/test_np_large_array.py:88
  /home/ubuntu/incubator-mxnet/tests/nightly/test_np_large_array.py:88: DeprecationWarning: invalid escape sequence \ 
    '''

tests/nightly/test_np_large_array.py:568
  /home/ubuntu/incubator-mxnet/tests/nightly/test_np_large_array.py:568: DeprecationWarning: invalid escape sequence \ 
    '''

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================== 1 passed, 2 warnings in 26.14s ===============================
```
previous work:https://github.com/apache/incubator-mxnet/commit/46c0fb3483dab4634bed72ac9da4408980c18219