### PR TITLE
Fix numpy equal broadcast 

### DIFF
--- a/src/api/operator/ufunc_helper.cc
+++ b/src/api/operator/ufunc_helper.cc
@@ -52,7 +52,7 @@ void UFuncHelper(NDArray* lhs, NDArray* rhs, NDArray* out,
   }
 }
 
-void UFuncHelper(NDArray* lhs, int rhs, NDArray* out,
+void UFuncHelper(NDArray* lhs, index_t rhs, NDArray* out,
                  runtime::MXNetRetValue* ret, const nnvm::Op* op) {
   using namespace runtime;
   nnvm::NodeAttrs attrs;
@@ -96,7 +96,7 @@ void UFuncHelper(NDArray* lhs, double rhs, NDArray* out,
   }
 }
 
-void UFuncHelper(int lhs, NDArray* rhs, NDArray* out,
+void UFuncHelper(index_t lhs, NDArray* rhs, NDArray* out,
                  runtime::MXNetRetValue* ret, const nnvm::Op* op) {
   using namespace runtime;
   nnvm::NodeAttrs attrs;
@@ -151,12 +151,12 @@ void UFuncHelper(runtime::MXNetArgs args,
     if (args[1].type_code() == kNDArrayHandle) {
       UFuncHelper(args[0].operator NDArray*(), args[1].operator NDArray*(), out, ret, fn_array);
     } else if (args[1].type_code() == kDLInt) {
-      UFuncHelper(args[0].operator NDArray*(), args[1].operator int(), out, ret, lfn_scalar);
+      UFuncHelper(args[0].operator NDArray*(), args[1].operator index_t(), out, ret, lfn_scalar);
     } else {
       UFuncHelper(args[0].operator NDArray*(), args[1].operator double(), out, ret, lfn_scalar);
     }
   } else if (args[0].type_code() == kDLInt) {
-    UFuncHelper(args[0].operator int(), args[1].operator NDArray*(), out, ret,
+    UFuncHelper(args[0].operator index_t(), args[1].operator NDArray*(), out, ret,
                 rfn_scalar ? rfn_scalar : lfn_scalar);
   } else {
     UFuncHelper(args[0].operator double(), args[1].operator NDArray*(), out, ret,

--- a/src/api/operator/ufunc_helper.cc
+++ b/src/api/operator/ufunc_helper.cc
@@ -52,7 +52,7 @@ void UFuncHelper(NDArray* lhs, NDArray* rhs, NDArray* out,
   }
 }
 
-void UFuncHelper(NDArray* lhs, index_t rhs, NDArray* out,
+void UFuncHelper(NDArray* lhs, int64_t rhs, NDArray* out,
                  runtime::MXNetRetValue* ret, const nnvm::Op* op) {
   using namespace runtime;
   nnvm::NodeAttrs attrs;
@@ -96,7 +96,7 @@ void UFuncHelper(NDArray* lhs, double rhs, NDArray* out,
   }
 }
 
-void UFuncHelper(index_t lhs, NDArray* rhs, NDArray* out,
+void UFuncHelper(int64_t lhs, NDArray* rhs, NDArray* out,
                  runtime::MXNetRetValue* ret, const nnvm::Op* op) {
   using namespace runtime;
   nnvm::NodeAttrs attrs;
@@ -151,12 +151,12 @@ void UFuncHelper(runtime::MXNetArgs args,
     if (args[1].type_code() == kNDArrayHandle) {
       UFuncHelper(args[0].operator NDArray*(), args[1].operator NDArray*(), out, ret, fn_array);
     } else if (args[1].type_code() == kDLInt) {
-      UFuncHelper(args[0].operator NDArray*(), args[1].operator index_t(), out, ret, lfn_scalar);
+      UFuncHelper(args[0].operator NDArray*(), args[1].operator int64_t(), out, ret, lfn_scalar);
     } else {
       UFuncHelper(args[0].operator NDArray*(), args[1].operator double(), out, ret, lfn_scalar);
     }
   } else if (args[0].type_code() == kDLInt) {
-    UFuncHelper(args[0].operator index_t(), args[1].operator NDArray*(), out, ret,
+    UFuncHelper(args[0].operator int64_t(), args[1].operator NDArray*(), out, ret,
                 rfn_scalar ? rfn_scalar : lfn_scalar);
   } else {
     UFuncHelper(args[0].operator double(), args[1].operator NDArray*(), out, ret,

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -744,7 +744,6 @@ def test_sigmoid():
                 rtol=1e-3, atol=1e-5)
 
 @use_np
-#@pytest.mark.skip(reason='Does not support large tensor; to be fixed')
 def test_shape_array():
     A = np.zeros((INT_OVERFLOW, 2))
     A.attach_grad()

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -744,7 +744,7 @@ def test_sigmoid():
                 rtol=1e-3, atol=1e-5)
 
 @use_np
-@pytest.mark.skip(reason='Does not support large tensor; to be fixed')
+#@pytest.mark.skip(reason='Does not support large tensor; to be fixed')
 def test_shape_array():
     A = np.zeros((INT_OVERFLOW, 2))
     A.attach_grad()


### PR DESCRIPTION
fixes https://github.com/apache/incubator-mxnet/issues/19006

Now this can run
``` python
import mxnet
from mxnet import np, npx
INT_OVERFLOW = 2**31
A = np.array([INT_OVERFLOW], dtype='int64')
# now they all work
assert A == INT_OVERFLOW
assert INT_OVERFLOW == A
assert A < (INT_OVERFLOW+1)
assert (INT_OVERFLOW+1) > A
assert A != (INT_OVERFLOW+1)
assert (INT_OVERFLOW+1) != A

```

I also unskipped a test which will pass now given this fix.

local run:

```
ubuntu@ip-172-31-38-169:~/incubator-mxnet$ pytest tests/nightly/test_np_large_array.py::test_shape_array
/home/ubuntu/anaconda3/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
  return f(*args, **kwds)
/home/ubuntu/anaconda3/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
  return f(*args, **kwds)
/home/ubuntu/anaconda3/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: numpy.ufunc size changed, may indicate binary incompatibility. Expected 192 from C header, got 216 from PyObject
  return f(*args, **kwds)
==================================== test session starts =====================================
platform linux -- Python 3.7.7, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/ubuntu/incubator-mxnet, inifile: pytest.ini
plugins: remotedata-0.3.2, openfiles-0.4.0, astropy-header-0.1.2, hypothesis-5.8.3, arraydiff-0.3, doctestplus-0.5.0
collected 1 item                                                                             

tests/nightly/test_np_large_array.py .                                                 [100%]

===================================== 1 passed in 3.64s ======================================
```