### PR TITLE
Add size check for numpy ctc loss

### DIFF
--- a/src/operator/nn/ctc_loss-inl.h
+++ b/src/operator/nn/ctc_loss-inl.h
@@ -238,6 +238,8 @@ inline bool CTCLossOpShape(const nnvm::NodeAttrs &attrs,
     CHECK_GE(dshape[0], lshape[1]) << "The max number of labels cannot exceed "
                                       "the maximum sequence length of the "
                                       "data.";
+    CHECK_LT(dshape.Size(), INT32_MAX) << "CTC Loss does not support large"
+        << " tensors where total size >= 2^31.";
 
     mxnet::TShape oshape(1, -1);
     oshape[0] = dshape[1];  // batch size
@@ -348,7 +350,7 @@ void CTCLossOpForward(const nnvm::NodeAttrs& attrs,
                                batch_size, data.kDevCPU ? false : true, &size_bytes);
 
     // round-up so there are enough elems in memory
-    int num_tmp_elems = (size_bytes + sizeof(real_t) - 1) / sizeof(real_t);
+    size_t num_tmp_elems = (size_bytes + sizeof(real_t) - 1) / sizeof(real_t);
     Tensor<xpu, 1, real_t> workspace =
       ctx.requested[0].get_space_typed<xpu, 1, real_t>(Shape1(num_tmp_elems), s);
 

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -907,7 +907,7 @@ def test_rnn():
 @use_np
 def test_ctc_loss():
     def test_ctc_loss_size_check(A, label):
-        assertRaises(MXNetError, npx.ctc_loss, A, label)
+        assertRaises(ValueError, npx.ctc_loss, A, label)
     
     L_SEQ, L_ALP, L_LAB, BAT = 2**10, 2**20, 2**6, 2
     A = np.zeros((L_SEQ, BAT, L_ALP))

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -906,12 +906,15 @@ def test_rnn():
 
 @use_np
 def test_ctc_loss():
-    # test size check
+    def test_ctc_loss_size_check(A, label):
+        assertRaises(MXNetError, npx.ctc_loss, A, label)
+    
     L_SEQ, L_ALP, L_LAB, BAT = 2**10, 2**20, 2**6, 2
     A = np.zeros((L_SEQ, BAT, L_ALP))
     label = np.random.randint(0, L_ALP, (BAT, L_LAB))
-    assertRaises(MXNetError, npx.ctc_loss, A, label)
-    # now we shrink the size a little bit
+    # test for expected exception
+    test_ctc_loss_size_check(A, label)
+    # now we shrink the size a little bit and test for an allowed case
     L_ALP = 2**20 - 1
     A = np.zeros((L_SEQ, BAT, L_ALP))
     label = np.random.randint(0, L_ALP, (BAT, L_LAB))

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -905,17 +905,24 @@ def test_rnn():
     assert type(out[0]).__name__ == 'ndarray'
 
 @use_np
-@pytest.mark.skip(reason='backward errors out')
 def test_ctc_loss():
-    A = np.ones((2, INT_OVERFLOW, 4))
+    # test size check
+    L_SEQ, L_ALP, L_LAB, BAT = 2**10, 2**20, 2**6, 2
+    A = np.zeros((L_SEQ, BAT, L_ALP))
+    label = np.random.randint(0, L_ALP, (BAT, L_LAB))
+    assertRaises(MXNetError, npx.ctc_loss, A, label)
+    # now we shrink the size a little bit
+    L_ALP = 2**20 - 1
+    A = np.zeros((L_SEQ, BAT, L_ALP))
+    label = np.random.randint(0, L_ALP, (BAT, L_LAB))
     A.attach_grad()
     with mx.autograd.record():
-        B = npx.ctc_loss(A, np.ones((INT_OVERFLOW, 2)))
-    assert B.shape == (INT_OVERFLOW, )
-    assert type(B).__name__ == 'ndarray'
+        B = npx.ctc_loss(A, label)
+    assert B.shape == (BAT, )
+    assert type(B[0]).__name__ == 'ndarray'
     B.backward()
-    assert A.grad.shape == (2, INT_OVERFLOW, 4)
-    assert A.grad[0][0][0] == 0
+    assert A.grad.shape == (L_SEQ, BAT, L_ALP)
+    assert type(A[0]).__name__ == 'ndarray'
 
 @use_np
 def test_erf():


### PR DESCRIPTION
This pr adds large size check for the npx ctc loss operator.

Because of the way the current implementation is written, the operator only works when the total size of the input is < 2^31.  I.e. data is of shape (sequence_length, batch_size, alphabet_size), and the product of the tree dimension must < 2^31.

I closely examined the code and tried to only add the 2^31 upper bound to each of the 3 dimensions and change int->index_t wherever those dimensions are multiplied together, but this turned out to be unpractical since there are ~ 200 ints, ~10 different functions, and several control flow branches. With that effort one might as well refactor the whole thing to support int64 dimensions to begin with.

@szha what do you think? 

