### PR TITLE
Switch to GCC 9 for static build

### DIFF
--- a/cd/mxnet_lib/static/Jenkins_pipeline.groovy
+++ b/cd/mxnet_lib/static/Jenkins_pipeline.groovy
@@ -32,8 +32,8 @@ libmxnet = 'lib/libmxnet.so'
 licenses = 'licenses/*'
 
 // libmxnet dependencies
-mx_native_deps = 'lib/libgfortran.so.4, lib/libquadmath.so.0, lib/libopenblas.so.0'
-mx_deps = 'lib/libgfortran.so.4, lib/libquadmath.so.0, lib/libopenblas.so.0, include/mkldnn/dnnl_version.h, include/mkldnn/dnnl_config.h'
+mx_native_deps = 'lib/libgfortran.so.*, lib/libquadmath.so.0, lib/libopenblas.so.0'
+mx_deps = 'lib/libgfortran.so.*, lib/libquadmath.so.0, lib/libopenblas.so.0, include/mkldnn/dnnl_version.h, include/mkldnn/dnnl_config.h'
 
 // library type
 // either static or dynamic - depending on how it links to its dependencies

--- a/ci/docker/Dockerfile.build.centos7
+++ b/ci/docker/Dockerfile.build.centos7
@@ -53,7 +53,7 @@ RUN yum -y check-update || true && \
         protobuf-devel \
         # CentOS Software Collections https://www.softwarecollections.org
         devtoolset-7 \
-        devtoolset-9 \
+        devtoolset-8 \
         rh-python36 \
         rh-maven35 \
         # Libraries

--- a/ci/docker/Dockerfile.build.centos7
+++ b/ci/docker/Dockerfile.build.centos7
@@ -53,6 +53,7 @@ RUN yum -y check-update || true && \
         protobuf-devel \
         # CentOS Software Collections https://www.softwarecollections.org
         devtoolset-7 \
+        devtoolset-9 \
         rh-python36 \
         rh-maven35 \
         # Libraries
@@ -69,8 +70,8 @@ RUN yum -y check-update || true && \
         libzstd-devel && \
     yum clean all
 
-# Make GCC7, Python 3.5 and Maven 3.3 Software Collections available by default
-# during build and runtime of this container
+# Make Python 3.6 and Maven 3.3 Software Collections available by default during
+# the following build steps in this Dockerfile
 SHELL [ "/usr/bin/scl", "enable", "devtoolset-7", "rh-python36", "rh-maven35" ]
 
 # Install minimum required cmake version

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -111,7 +111,7 @@ build_dynamic_libmxnet() {
     gather_licenses
 
     cd /work/build
-    source /opt/rh/devtoolset-7/enable
+    source /opt/rh/devtoolset-9/enable
     if [[ ${mxnet_variant} = "cpu" ]]; then
         cmake -DUSE_MKL_IF_AVAILABLE=OFF \
             -DUSE_MKLDNN=ON \
@@ -1229,7 +1229,7 @@ checkout() {
 build_static_libmxnet() {
     set -ex
     pushd .
-    source /opt/rh/devtoolset-7/enable
+    source /opt/rh/devtoolset-9/enable
     source /opt/rh/rh-python36/enable
     local mxnet_variant=${1:?"This function requires a python command as the first argument"}
     source tools/staticbuild/build.sh ${mxnet_variant}
@@ -1294,7 +1294,7 @@ build_static_python_cpu() {
     set -ex
     pushd .
     export mxnet_variant=cpu
-    source /opt/rh/devtoolset-7/enable
+    source /opt/rh/devtoolset-9/enable
     source /opt/rh/rh-python36/enable
     ./ci/publish/python/build.sh
     popd
@@ -1304,7 +1304,7 @@ build_static_python_cu92() {
     set -ex
     pushd .
     export mxnet_variant=cu92
-    source /opt/rh/devtoolset-7/enable
+    source /opt/rh/devtoolset-9/enable
     source /opt/rh/rh-python36/enable
     ./ci/publish/python/build.sh
     popd

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -1300,10 +1300,10 @@ build_static_python_cpu() {
     popd
 }
 
-build_static_python_cu92() {
+build_static_python_cu102() {
     set -ex
     pushd .
-    export mxnet_variant=cu92
+    export mxnet_variant=cu102
     source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     ./ci/publish/python/build.sh

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -111,7 +111,7 @@ build_dynamic_libmxnet() {
     gather_licenses
 
     cd /work/build
-    source /opt/rh/devtoolset-9/enable
+    source /opt/rh/devtoolset-8/enable
     if [[ ${mxnet_variant} = "cpu" ]]; then
         cmake -DUSE_MKL_IF_AVAILABLE=OFF \
             -DUSE_MKLDNN=ON \
@@ -1229,7 +1229,7 @@ checkout() {
 build_static_libmxnet() {
     set -ex
     pushd .
-    source /opt/rh/devtoolset-9/enable
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     local mxnet_variant=${1:?"This function requires a python command as the first argument"}
     source tools/staticbuild/build.sh ${mxnet_variant}
@@ -1294,7 +1294,7 @@ build_static_python_cpu() {
     set -ex
     pushd .
     export mxnet_variant=cpu
-    source /opt/rh/devtoolset-9/enable
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     ./ci/publish/python/build.sh
     popd
@@ -1304,7 +1304,7 @@ build_static_python_cu92() {
     set -ex
     pushd .
     export mxnet_variant=cu92
-    source /opt/rh/devtoolset-9/enable
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     ./ci/publish/python/build.sh
     popd

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -37,7 +37,7 @@ mx_tensorrt_lib = 'build/libmxnet.so, build/3rdparty/tvm/libtvm_runtime.so, buil
 mx_lib_cpp_examples = 'build/libmxnet.so, build/3rdparty/tvm/libtvm_runtime.so, build/libtvmop.so, build/tvmop.conf, build/3rdparty/openmp/runtime/src/libomp.so, build/libcustomop_lib.so, build/libcustomop_gpu_lib.so, build/libsubgraph_lib.so, python/mxnet/_cy3/*.so, python/mxnet/_ffi/_cy3/*.so'
 mx_lib_cpp_examples_no_tvm_op = 'build/libmxnet.so, build/libcustomop_lib.so, build/libcustomop_gpu_lib.so, build/libsubgraph_lib.so, build/3rdparty/openmp/runtime/src/libomp.so, python/mxnet/_cy3/*.so, python/mxnet/_ffi/_cy3/*.so'
 mx_lib_cpp_examples_cpu = 'build/libmxnet.so, build/3rdparty/tvm/libtvm_runtime.so, build/libtvmop.so, build/tvmop.conf, build/3rdparty/openmp/runtime/src/libomp.so'
-mx_cd_lib = 'lib/libmxnet.so, licenses/*, lib/libgfortran.so.4, lib/libquadmath.so.0, lib/libopenblas.so.0, include/mkldnn/dnnl_version.h, include/mkldnn/dnnl_config.h'
+mx_cd_lib = 'lib/libmxnet.so, licenses/*, lib/libgfortran.so.*, lib/libquadmath.so.0, lib/libopenblas.so.0, include/mkldnn/dnnl_version.h, include/mkldnn/dnnl_config.h'
 
 // Python unittest for CPU
 // Python 3

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -634,7 +634,7 @@ def compile_static_python_gpu() {
         ws('workspace/ut-publish-python-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
-            utils.docker_run('centos7_gpu_cu92', 'build_static_python_cu92')
+            utils.docker_run('centos7_gpu_cu102', 'build_static_python_cu102')
           }
         }
     }

--- a/docs/static_site/src/pages/get_started/build_from_source.md
+++ b/docs/static_site/src/pages/get_started/build_from_source.md
@@ -74,13 +74,13 @@ sudo apt-get install -y build-essential git ninja-build ccache libopenblas-dev l
 sudo yum install epel-release centos-release-scl
 sudo yum install git make ninja-build automake autoconf libtool protobuf-compiler protobuf-devel \
     atlas-devel openblas-devel lapack-devel opencv-devel openssl-devel zeromq-devel python3 \ 
-    devtoolset-7
+    devtoolset-9
 source /opt/rh/devtoolset-7/enable
 ```
-Here `devtoolset-7` refers to the [Developer Toolset
-7](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/) created by
+Here `devtoolset-9` refers to the [Developer Toolset
+9](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-9/) created by
 Red Hat for developers working on CentOS or Red Hat Enterprise Linux platform
-and providing the GNU Compiler Collection 7.
+and providing the GNU Compiler Collection 9.
 
 ### macOS
 ```bash

--- a/docs/static_site/src/pages/get_started/build_from_source.md
+++ b/docs/static_site/src/pages/get_started/build_from_source.md
@@ -74,11 +74,11 @@ sudo apt-get install -y build-essential git ninja-build ccache libopenblas-dev l
 sudo yum install epel-release centos-release-scl
 sudo yum install git make ninja-build automake autoconf libtool protobuf-compiler protobuf-devel \
     atlas-devel openblas-devel lapack-devel opencv-devel openssl-devel zeromq-devel python3 \ 
-    devtoolset-9
+    devtoolset-8
 source /opt/rh/devtoolset-7/enable
 ```
-Here `devtoolset-9` refers to the [Developer Toolset
-9](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-9/) created by
+Here `devtoolset-8` refers to the [Developer Toolset
+8](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-8/) created by
 Red Hat for developers working on CentOS or Red Hat Enterprise Linux platform
 and providing the GNU Compiler Collection 9.
 

--- a/tools/dependencies/protobuf.sh
+++ b/tools/dependencies/protobuf.sh
@@ -20,6 +20,11 @@
 # This script builds the static library of protobuf along with protoc, that can be used as dependency of mxnet.
 set -ex
 PROTOBUF_VERSION=3.5.1
+if [[ $PLATFORM == 'darwin' ]]; then
+    DY_EXT="dylib"
+else
+    DY_EXT="so"
+fi
 
 LIBPROTOBUF="$DEPS_PATH/lib/libprotobuf.$DY_EXT"
 LIBPROTOC="$DEPS_PATH/lib/libprotoc.$DY_EXT"

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -155,7 +155,7 @@ if platform.system() == 'Linux':
     elif os.path.exists(os.path.join(libdir, 'libgfortran.so.4')):
         shutil.copy(os.path.join(libdir, 'libgfortran.so.4'), mxdir)
         package_data['mxnet'].append('mxnet/libgfortran.so.4')
-    else:
+    elif os.path.exists(os.path.join(libdir, 'libgfortran.so.5')):
         shutil.copy(os.path.join(libdir, 'libgfortran.so.5'), mxdir)
         package_data['mxnet'].append('mxnet/libgfortran.so.5')
     if os.path.exists(os.path.join(libdir, 'libopenblas.so.0')):

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -157,9 +157,12 @@ if platform.system() == 'Linux':
     if os.path.exists(os.path.join(libdir, 'libgfortran.so.3')):
         shutil.copy(os.path.join(libdir, 'libgfortran.so.3'), mxdir)
         package_data['mxnet'].append('mxnet/libgfortran.so.3')
-    else:
+    elif os.path.exists(os.path.join(libdir, 'libgfortran.so.4')):
         shutil.copy(os.path.join(libdir, 'libgfortran.so.4'), mxdir)
         package_data['mxnet'].append('mxnet/libgfortran.so.4')
+    else:
+        shutil.copy(os.path.join(libdir, 'libgfortran.so.5'), mxdir)
+        package_data['mxnet'].append('mxnet/libgfortran.so.5')
     shutil.copy(os.path.join(libdir, 'libquadmath.so.0'), mxdir)
     package_data['mxnet'].append('mxnet/libquadmath.so.0')
     if os.path.exists(os.path.join(libdir, 'libopenblas.so.0')):


### PR DESCRIPTION
## Description ##
Use GCC 9 for building libmxnet.so in the static build Dockerfiles / on CD:

> Of 51 benchmarks ran across these three tested GCC compiler releases, GCC 9.0.0 was the fastest in 23 of the cases while 19 times saw GCC 8.2 the fastest and then nine times saw the two-year-old GCC 7.4.0 winning. Those wishing to dig through all of these compiler benchmark numbers can find them on OpenBenchmarking.org.

https://www.phoronix.com/scan.php?page=article&item=gcc9-eoy-2018

Also fix file exists check in tools/dependencies/protobuf.sh 

The build continues to run on CentOS7 and meet the [manylinux2014 requirements](https://www.python.org/dev/peps/pep-0599/).