### PR TITLE
[FEATURE] add .asf.yaml for enabling wiki

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,15 @@
+notifications:
+    commits:      commits@mxnet.apache.org
+    issues:       issues@mxnet.apache.org
+    pullrequests: commits@mxnet.apache.org
+
+github:
+  features:
+    wiki: true
+    issues: true
+    projects: true
+
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  true


### PR DESCRIPTION
## Description ##
add .asf.yaml for enabling wiki

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] add .asf.yaml for enabling wiki

## Comments ##
- Doc on this feature: https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
- Github wiki can be used as a place for building a dashboard for monitoring. It's not intended to replace cwiki which allows write access control