### PR TITLE
Call the function `Stop` when custom op released

### DIFF
--- a/src/operator/custom/custom-inl.h
+++ b/src/operator/custom/custom-inl.h
@@ -204,6 +204,9 @@ class CustomOperator {
   CustomOperator() {
     this->Start();
   }
+  ~CustomOperator() {
+    this->Stop();
+  }
   void ThreadTarget() {
     std::unique_lock<std::mutex> lock(mutex_);
     while (!q_.empty() || !destructing_) {


### PR DESCRIPTION
## Description ##
Hi there,
As title, it may fix #18789

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
