### PR TITLE
[FEATURE]Enable large tensor support for batch flatten

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -243,7 +243,7 @@ inline bool FlattenShape(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(out_attrs->size(), 1U);
   const mxnet::TShape &dshape = (*in_attrs)[0];
   if (!shape_is_known(dshape)) return false;
-  int target_dim = 1;
+  size_t target_dim = 1;
   for (int i = 1; i < dshape.ndim(); ++i) {
     target_dim *= dshape[i];
   }

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -651,7 +651,6 @@ def test_constraint_check():
 
 # broken
 @use_np
-@pytest.mark.skip(reason='Does not support large tensor; to be fixed')
 def test_batch_flatten():
     A = np.ones((2, 1, INT_OVERFLOW))
     A.attach_grad()


### PR DESCRIPTION
## Description ##
Enable large tensor support for batch_flatten

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

## Testing  ##
```
(pytest) ubuntu@ip-172-31-0-156 ~/workspace/incubator-mxnet (fix_batch_flatten) $ python -m pytest --verbose tests/nightly/test_np_large_array.py::test_batch_flatten
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.5, pytest-6.0.1, py-1.9.0, pluggy-0.13.1 -- /home/ubuntu/anaconda3/envs/pytest/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/workspace/incubator-mxnet, configfile: pytest.ini
collected 1 item

tests/nightly/test_np_large_array.py::test_batch_flatten PASSED                                                                                                                                             [100%]

================================================================================================ warnings summary =================================================================================================
/home/ubuntu/anaconda3/envs/pytest/lib/python3.8/site-packages/_pytest/config/__init__.py:1148
  /home/ubuntu/anaconda3/envs/pytest/lib/python3.8/site-packages/_pytest/config/__init__.py:1148: PytestConfigWarning: Unknown config ini key: env

    self._warn_or_fail_if_strict("Unknown config ini key: {}\n".format(key))

/home/ubuntu/anaconda3/envs/pytest/lib/python3.8/site-packages/_pytest/config/__init__.py:1148
  /home/ubuntu/anaconda3/envs/pytest/lib/python3.8/site-packages/_pytest/config/__init__.py:1148: PytestConfigWarning: Unknown config ini key: timeout

    self._warn_or_fail_if_strict("Unknown config ini key: {}\n".format(key))

tests/nightly/test_np_large_array.py:84
  /home/ubuntu/workspace/incubator-mxnet/tests/nightly/test_np_large_array.py:84: DeprecationWarning: invalid escape sequence \
    '''

tests/nightly/test_np_large_array.py:574
  /home/ubuntu/workspace/incubator-mxnet/tests/nightly/test_np_large_array.py:574: DeprecationWarning: invalid escape sequence \
    '''

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================================================================================= 1 passed, 4 warnings in 26.16s ==========================================================================================
```