### PR TITLE
[EXAMPLE] Fix MNIST classification example

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -284,6 +284,7 @@ List of Contributors
 * [Connor Goggins](https://github.com/connorgoggins)
 * [Wei Chu](https://github.com/waytrue17)
 * [Joe Evans](https://github.com/josephevans)
+* [Nikolay Ulmasov](https://github.com/r3stl355)
 
 Label Bot
 ---------

--- a/example/gluon/mnist/README.md
+++ b/example/gluon/mnist/README.md
@@ -21,10 +21,9 @@ This script shows a simple example how to do image classification with Gluon.
 The model is trained on MNIST digits image dataset and the goal is to classify the digits ```0-9```.  The model has the following layout:
 ```
 net = nn.Sequential()
-with net.name_scope():
-    net.add(nn.Dense(128, activation='relu'))
-    net.add(nn.Dense(64, activation='relu'))
-    net.add(nn.Dense(10))
+net.add(nn.Dense(128, activation='relu'))
+net.add(nn.Dense(64, activation='relu'))
+net.add(nn.Dense(10))
 ```
 
 The script provides the following commandline arguments: 

--- a/example/gluon/mnist/mnist.py
+++ b/example/gluon/mnist/mnist.py
@@ -48,10 +48,9 @@ opt = parser.parse_args()
 # define network
 
 net = nn.Sequential()
-with net.name_scope():
-    net.add(nn.Dense(128, activation='relu'))
-    net.add(nn.Dense(64, activation='relu'))
-    net.add(nn.Dense(10))
+net.add(nn.Dense(128, activation='relu'))
+net.add(nn.Dense(64, activation='relu'))
+net.add(nn.Dense(10))
 
 # data
 


### PR DESCRIPTION
## Description ##
An attempt to run `example/gluon/mnist/mnist.py` throwing error `AttributeError: 'Sequential' object has no attribute 'name_scope'`. Removing `with net.name_scope():` fixed the problem. Script now runs and completes the training.

## Checklist ##
### Essentials ###
- [X ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X ] Changes are complete (i.e. I finished coding on this PR)
- [- ] All changes have test coverage - there are no tests but example script runs after this fix
- [X ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
