### PR TITLE
Update .htaccess

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -22,12 +22,12 @@ RewriteOptions AllowNoSlash
 
 </IfModule>
 
-# Set default website version to current stable (v1.7)
+# Set default website version to old stable (v1.6)
 RewriteCond %{REQUEST_URI} !^/versions/
 RewriteCond %{HTTP_REFERER} !mxnet.apache.org
 RewriteCond %{HTTP_REFERER} !mxnet.incubator.apache.org
 RewriteCond %{HTTP_REFERER} !mxnet.cdn.apache.org
-RewriteRule ^(.*)$ /versions/1.7/$1 [r=307,L]
+RewriteRule ^(.*)$ /versions/1.6/$1 [r=307,L]
 
 # Redirect Chinese visitors to Chinese CDN, temporary solution for slow site speed in China
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^CN$


### PR DESCRIPTION
mxnet.apache.org redirects to https://mxnet.apache.org/versions/1.7/404.html which "The page isn’t redirecting properly"