### PR TITLE
Make C Runtime API a C API again

### DIFF
--- a/include/mxnet/c_api_error.h
+++ b/include/mxnet/c_api_error.h
@@ -21,6 +21,10 @@
  *  Copyright (c) 2018 by Contributors
  * \file c_api_error.h
  * \brief Error handling for C API.
+
+ *  WARNING: THIS IS NOT A C API. THE FILE IS TEMPORARILY KEPT UNDER THE NAME
+ *  C_API_ERROR.H FOR BACKWARDS COMPATIBILITY REASONS. DO NOT RELY ON THIS FILE
+ *  WHEN WRITING NEW CODE.
  */
 #include <string>
 

--- a/include/mxnet/c_api_error.h
+++ b/include/mxnet/c_api_error.h
@@ -22,9 +22,52 @@
  * \file c_api_error.h
  * \brief Error handling for C API.
  */
-#include <mxnet/runtime/c_runtime_api.h>
+#include <string>
 
 #ifndef MXNET_C_API_ERROR_H_
 #define MXNET_C_API_ERROR_H_
 
+/*!
+ * \brief Macros to guard beginning and end section of all functions
+ * every function starts with API_BEGIN()
+ * and finishes with API_END() or API_END_HANDLE_ERROR()
+ * The finally clause contains procedure to cleanup states when an error happens.
+ */
+#define MX_API_BEGIN()                                                         \
+  try {                                                                        \
+    on_enter_api(__FUNCTION__);
+#define MX_API_END()                                                           \
+  }                                                                            \
+  catch (const std::exception &_except_) {                                     \
+    on_exit_api();                                                             \
+    return MXAPIHandleException(_except_);                                     \
+  }                                                                            \
+  on_exit_api();                                                               \
+  return 0; // NOLINT(*)
+#define MX_API_END_HANDLE_ERROR(Finalize)                                      \
+  }                                                                            \
+  catch (const std::exception &_except_) {                                     \
+    Finalize;                                                                  \
+    on_exit_api();                                                             \
+    return MXAPIHandleException(_except_);                                     \
+  }                                                                            \
+  on_exit_api();                                                               \
+  return 0; // NOLINT(*)
+
+/*!
+ * \brief Set the last error message needed by C API
+ * \param msg The error message to set.
+ */
+void MXAPISetLastError(const char* msg);
+/*!
+ * \brief handle exception throwed out
+ * \param e the exception
+ * \return the return value of API after exception is handled
+ */
+int MXAPIHandleException(const std::exception &e);
+
+namespace mxnet {
+extern void on_enter_api(const char *function);
+extern void on_exit_api();
+}
 #endif  // MXNET_C_API_ERROR_H_

--- a/include/mxnet/runtime/c_runtime_api.h
+++ b/include/mxnet/runtime/c_runtime_api.h
@@ -26,7 +26,6 @@
 #define MXNET_RUNTIME_C_RUNTIME_API_H_
 
 #include <dlpack/dlpack.h>
-#include <string>
 
 #ifdef __cplusplus
 extern "C" {
@@ -178,50 +177,4 @@ MXNET_DLL int MXNetObjectTypeKey2Index(const char* type_key, unsigned* out_tinde
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-
-
-/*!
- * \brief Macros to guard beginning and end section of all functions
- * every function starts with API_BEGIN()
- * and finishes with API_END() or API_END_HANDLE_ERROR()
- * The finally clause contains procedure to cleanup states when an error happens.
- */
-#define MX_API_BEGIN()                                                         \
-  try {                                                                        \
-    on_enter_api(__FUNCTION__);
-#define MX_API_END()                                                           \
-  }                                                                            \
-  catch (const std::exception &_except_) {                                     \
-    on_exit_api();                                                             \
-    return MXAPIHandleException(_except_);                                     \
-  }                                                                            \
-  on_exit_api();                                                               \
-  return 0; // NOLINT(*)
-#define MX_API_END_HANDLE_ERROR(Finalize)                                      \
-  }                                                                            \
-  catch (const std::exception &_except_) {                                     \
-    Finalize;                                                                  \
-    on_exit_api();                                                             \
-    return MXAPIHandleException(_except_);                                     \
-  }                                                                            \
-  on_exit_api();                                                               \
-  return 0; // NOLINT(*)
-
-/*!
- * \brief Set the last error message needed by C API
- * \param msg The error message to set.
- */
-void MXAPISetLastError(const char* msg);
-/*!
- * \brief handle exception throwed out
- * \param e the exception
- * \return the return value of API after exception is handled
- */
-int MXAPIHandleException(const std::exception &e);
-
-namespace mxnet {
-extern void on_enter_api(const char *function);
-extern void on_exit_api();
-}
-
 #endif  // MXNET_RUNTIME_C_RUNTIME_API_H_

--- a/src/c_api/c_api_common.h
+++ b/src/c_api/c_api_common.h
@@ -29,7 +29,7 @@
 #include <dmlc/logging.h>
 #include <dmlc/thread_local.h>
 #include <mxnet/c_api.h>
-#include <mxnet/runtime/c_runtime_api.h>
+#include <mxnet/c_api_error.h>
 #include <mxnet/base.h>
 #include <mxnet/op_attr_types.h>
 #include <nnvm/graph.h>


### PR DESCRIPTION
## Description ##
https://github.com/apache/incubator-mxnet/commit/bbc39fa6ef5a21cf6016b52f1efffc7aa5bdd1c0 move C++ code into the C Runtime API Header. Revert this part of bbc39fa6ef5a21cf6016b52f1efffc7aa5bdd1c0.

See https://github.com/apache/incubator-mxnet/issues/19084 for the fundamental issue.