### PR TITLE
Add issue template for website and documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,16 @@
+---
+name: Documentation & Website
+about: Issues regarding documentation and website
+title: '[DOC/WEBSITE] '
+labels: Doc, Website, needs triage
+assignees: ''
+
+---
+
+## Current state
+Link: (Insert link to location where faulty documentation is located)
+
+(Describe what you are currently seeing in the faulty state or insert a screenshot)
+
+## Expected state
+(Describe what you'd rather expect)


### PR DESCRIPTION
Add issue template for documentation and website since we have an increasing number of issues which are not directly related with MXNet itself but rather our documentation or website.