### PR TITLE
Improve createOpState for custom ops

### DIFF
--- a/example/extensions/lib_custom_op/gemm_lib.cc
+++ b/example/extensions/lib_custom_op/gemm_lib.cc
@@ -204,6 +204,9 @@ class MyStatefulGemm : public CustomStatefulOp {
 };
 
 MXReturnValue createOpState(const std::unordered_map<std::string, std::string>& attrs,
+                            const MXContext& ctx,
+                            const std::vector<std::vector<unsigned int> >& in_shapes,
+                            const std::vector<int> in_types,
                             CustomStatefulOp** op_inst) {
   // testing passing of keyword arguments
   int count = attrs.count("test_kw") > 0 ? std::stoi(attrs.at("test_kw")) : 0;

--- a/example/extensions/lib_custom_op/relu_lib.cc
+++ b/example/extensions/lib_custom_op/relu_lib.cc
@@ -116,12 +116,18 @@ MXReturnValue MyStatefulReluGPU::Backward(std::vector<MXTensor>* inputs,
 
 
 MXReturnValue createOpStateCPU(const std::unordered_map<std::string, std::string>& attrs,
+                               const MXContext& ctx,
+                               const std::vector<std::vector<unsigned int> >& in_shapes,
+                               const std::vector<int> in_types,
                                CustomStatefulOp** op_inst) {
   *op_inst = new MyStatefulReluCPU(attrs);
   return MX_SUCCESS;
 }
 
 MXReturnValue createOpStateGPU(const std::unordered_map<std::string, std::string>& attrs,
+                               const MXContext& ctx,
+                               const std::vector<std::vector<unsigned int> >& in_shapes,
+                               const std::vector<int> in_types,
                                CustomStatefulOp** op_inst) {
   *op_inst = new MyStatefulReluGPU(attrs);
   return MX_SUCCESS;

--- a/example/extensions/lib_custom_op/transposecsr_lib.cc
+++ b/example/extensions/lib_custom_op/transposecsr_lib.cc
@@ -176,6 +176,9 @@ class MyStatefulTransposeCSR : public CustomStatefulOp {
 };
 
 MXReturnValue createOpState(const std::unordered_map<std::string, std::string>& attrs,
+                            const MXContext& ctx,
+                            const std::vector<std::vector<unsigned int> >& in_shapes,
+                            const std::vector<int> in_types,
                             CustomStatefulOp** op_inst) {
   // testing passing of keyword arguments
   int count = attrs.count("test_kw") > 0 ? std::stoi(attrs.at("test_kw")) : 0;

--- a/example/extensions/lib_custom_op/transposerowsp_lib.cc
+++ b/example/extensions/lib_custom_op/transposerowsp_lib.cc
@@ -178,6 +178,9 @@ class MyStatefulTransposeRowSP : public CustomStatefulOp {
 };
 
 MXReturnValue createOpState(const std::unordered_map<std::string, std::string>& attrs,
+                            const MXContext& ctx,
+                            const std::vector<std::vector<unsigned int> >& in_shapes,
+                            const std::vector<int> in_types,
                             CustomStatefulOp** op_inst) {
   // testing passing of keyword arguments
   int count = attrs.count("test_kw") > 0 ? std::stoi(attrs.at("test_kw")) : 0;

--- a/example/extensions/lib_subgraph/subgraph_lib.cc
+++ b/example/extensions/lib_subgraph/subgraph_lib.cc
@@ -156,6 +156,9 @@ class MyStatefulOp : public CustomStatefulOp {
 };
 
 MXReturnValue createOpState(const std::unordered_map<std::string, std::string>& attrs,
+                            const MXContext& ctx,
+                            const std::vector<std::vector<unsigned int> >& in_shapes,
+                            const std::vector<int> in_types,
                             CustomStatefulOp** op_inst) {
   std::string serialized_subgraph = "[empty]";
   // MXNet subgraph is stored as Symbol in operator node attrs subgraphs field

--- a/include/mxnet/lib_api.h
+++ b/include/mxnet/lib_api.h
@@ -732,6 +732,9 @@ typedef MXReturnValue (*mutateInputs_t)(const std::unordered_map<std::string,
                                         std::vector<int>* input_indices);
 typedef MXReturnValue (*createOpState_t)(const std::unordered_map<std::string,
                                          std::string>& attributes,
+                                         const MXContext& ctx,
+                                         const std::vector<std::vector<unsigned int> >& in_shapes,
+                                         const std::vector<int> in_types,
                                          CustomStatefulOp**);
 
 /*!
@@ -1000,8 +1003,9 @@ typedef int (*opCallMutateInputs_t)(mutateInputs_t mutate, const char* const* ke
 
 #define MXLIB_OPCALLCREATEOPSTATE_STR "_opCallCreateOpState"
 typedef int (*opCallCreateOpState_t)(createOpState_t create_op, const char* const* keys,
-                                     const char* const* vals, int num,
-                                     void** state_op);
+                                     const char* const* vals, int num, const char* dev_type,
+                                     int dev_id, unsigned int** inshapes, int* indims,
+                                     int num_in, const int* intypes, void** state_op);
 
 #define MXLIB_OPCALLFSTATEFULCOMP_STR "_opCallFStatefulCompute"
 typedef int (*opCallFStatefulComp_t)(int is_forward, void* state_op,
@@ -1190,9 +1194,10 @@ extern "C" {
 
   /*! \brief returns status of calling createStatefulOp function for operator from library */
   MX_INT_RET _opCallCreateOpState(mxnet::ext::createOpState_t create_op, const char* const* keys,
-                                  const char* const* vals, int num,
-                                  void** state_op);
-
+                                  const char* const* vals, int num, const char* dev_type,
+                                  int dev_id, unsigned int** inshapes, int* indims,
+                                  int num_in, const int* intypes, void** state_op);
+  
   /*! \brief returns status of calling Stateful Forward/Backward for operator from library */
   MX_INT_RET _opCallFStatefulCompute(int is_forward, void* state_op, const int64_t** inshapes,
                                      int* indims, void** indata, int* intypes, size_t* inIDs,

--- a/include/mxnet/lib_api.h
+++ b/include/mxnet/lib_api.h
@@ -1197,7 +1197,7 @@ extern "C" {
                                   const char* const* vals, int num, const char* dev_type,
                                   int dev_id, unsigned int** inshapes, int* indims,
                                   int num_in, const int* intypes, void** state_op);
-  
+
   /*! \brief returns status of calling Stateful Forward/Backward for operator from library */
   MX_INT_RET _opCallFStatefulCompute(int is_forward, void* state_op, const int64_t** inshapes,
                                      int* indims, void** indata, int* intypes, size_t* inIDs,

--- a/src/lib_api.cc
+++ b/src/lib_api.cc
@@ -1204,19 +1204,36 @@ MX_INT_RET _opCallMutateInputs(mxnet::ext::mutateInputs_t mutate, const char* co
 
 /*! \brief returns status of calling createStatefulOp function for operator from library */
 MX_INT_RET _opCallCreateOpState(mxnet::ext::createOpState_t create_op, const char* const* keys,
-                                const char* const* vals, int num,
-                                void** state_op) {
+                                     const char* const* vals, int num, const char* dev_type,
+                                     int dev_id, unsigned int** inshapes, int* indims,
+                                     int num_in, const int* intypes, void** state_op) {
   // create map of attributes from list
   std::unordered_map<std::string, std::string> attrs;
   for (int i = 0; i < num; i++) {
     attrs[std::string(keys[i])] = std::string(vals[i]);
   }
 
+  mxnet::ext::MXContext ctx(dev_type, dev_id);
+
+  // create a vector of shapes for inputs
+  std::vector<std::vector<unsigned int> > in_shapes(num_in);
+  for (int i = 0; i < num_in; i++) {
+    for (int j = 0; j < indims[i]; j++) {
+      in_shapes[i].push_back(inshapes[i][j]);
+    }
+  }
+
+  // create a vector of types for inputs
+  std::vector<int> in_types(num_in);
+  for (int i = 0; i < num_in; i++) {
+    in_types[i] = intypes[i];
+  }
+
   // void pointer to hold custom state op instance created in custom library
   // eventually state_op pointer is populated by instance from custom library
   mxnet::ext::CustomStatefulOp** op_ptr =
     reinterpret_cast<mxnet::ext::CustomStatefulOp**>(state_op);
-  return create_op(attrs, op_ptr);
+  return create_op(attrs, ctx, in_shapes, in_types, op_ptr);
 }
 
 /*! \brief returns status of calling Stateful Forward/Backward for operator from library */


### PR DESCRIPTION
## Description ##
Support passing all args from createOpState to custom ops: context, input shapes & types

- Also updates test_gemm.py and test_relu.py for custom ops on 2.0 now that Symbol.bind is deprecated

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
