### PR TITLE
[PIP] add build target in cmake for osx compat

### DIFF
--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -26,8 +26,13 @@ import shutil
 import platform
 
 if platform.system() == 'Linux':
-    sys.argv.append('--universal')
+    sys.argv.append('--python-tag')
+    sys.argv.append('py3')
     sys.argv.append('--plat-name=manylinux2014_x86_64')
+elif platform.system() == 'Darwin':
+    sys.argv.append('--python-tag')
+    sys.argv.append('py3')
+    sys.argv.append('--plat-name=macosx_10_13_x86_64')
 
 from setuptools import setup, find_packages
 from setuptools.dist import Distribution

--- a/tools/staticbuild/build_lib.sh
+++ b/tools/staticbuild/build_lib.sh
@@ -30,7 +30,11 @@ git submodule update --init --recursive || true
 
 # Build libmxnet.so
 rm -rf build; mkdir build; cd build
-cmake -GNinja -C $cmake_config -DCMAKE_PREFIX_PATH=${DEPS_PATH} -DCMAKE_FIND_ROOT_PATH=${DEPS_PATH} ..
+cmake -GNinja -C $cmake_config \
+      -DCMAKE_PREFIX_PATH=${DEPS_PATH} \
+      -DCMAKE_FIND_ROOT_PATH=${DEPS_PATH} \
+      -DCMAKE_OSX_DEPLOYMENT_TARGET=10.13 \
+      ..
 ninja
 cd -
 


### PR DESCRIPTION
## Description ##
add build target in cmake for osx compat with [`CMAKE_OSX_DEPLOYMENT_TARGET`](https://cmake.org/cmake/help/v3.13/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html#cmake-osx-deployment-target)

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] add build target in cmake for osx compat with [`CMAKE_OSX_DEPLOYMENT_TARGET`](https://cmake.org/cmake/help/v3.13/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html#cmake-osx-deployment-target) in tools/staticbuild/build_lib.sh