### PR TITLE
Fix default context handling in Gluon 2

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1411,7 +1411,8 @@ class HybridBlock(Block):
                 # HybridBlock is a child block of a HybridBlock that has been hybridized.
                 return super().__call__(x, *args)
 
-            return self._call_cached_op(x, *args)
+            with x.ctx:
+                return self._call_cached_op(x, *args)
 
     def forward(self, x, *args):
         """Defines the forward computation. Arguments can be either


### PR DESCRIPTION
Ensure that parameters are retrieved from the correct context when calling the CachedOp, by setting the default context.
Prior tests did not catch this issue, as MXNet GPU testing strategy is implemented by changing the default context to gpu context globally:

https://github.com/apache/incubator-mxnet/blob/6b01dc24ad89894b1d42021072c3f181b570fbb1/tests/python/gpu/test_deferred_compute_gpu.py#L21-L28