### PR TITLE
[DOC] add v1.7 website entries to general version dropdown

### DIFF
--- a/docs/python_docs/themes/mx-theme/mxtheme/header_top.html
+++ b/docs/python_docs/themes/mx-theme/mxtheme/header_top.html
@@ -25,6 +25,7 @@
           </span>
           <div class="dropdown-content">
             <a class="dropdown-option-active" href="/">master</a><br>
+            <a class="dropdown-option" href="/versions/1.7/">1.7</a><br>
             <a class="dropdown-option" href="/versions/1.6/">1.6</a><br>
             <a class="dropdown-option" href="/versions/1.5.0/">1.5.0</a><br>
             <a class="dropdown-option" href="/versions/1.4.1/">1.4.1</a><br>

--- a/docs/static_site/src/_config.yml
+++ b/docs/static_site/src/_config.yml
@@ -39,6 +39,7 @@ github_username:  apache/incubator-mxnet
 youtube_username: apachemxnet
 versions: 
   - master
+  - 1.7
   - 1.6
   - 1.5.0
   - 1.4.1

--- a/docs/static_site/src/_config_beta.yml
+++ b/docs/static_site/src/_config_beta.yml
@@ -41,6 +41,7 @@ github_username:  apache/incubator-mxnet
 youtube_username: apachemxnet
 versions: 
   - master
+  - 1.7
   - 1.6
   - 1.5.0
   - 1.4.1

--- a/docs/static_site/src/_config_prod.yml
+++ b/docs/static_site/src/_config_prod.yml
@@ -41,6 +41,7 @@ youtube_username: apachemxnet
 google_analytics: UA-96378503-1
 versions: 
   - master
+  - 1.7
   - 1.6
   - 1.5.0
   - 1.4.1


### PR DESCRIPTION
## Description ##
To launch v1.7 website:
1. Create v1.7 website artifact -DONE
2. Add entry to v1.7 on master website - CURRENT 
3. Add entry to v1.7 on previous version website - PENDING
4. Update redirect rule to set 1.7 as default website version - PENDING


## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] add v1.7 link in general version dropdown on main site and Python site

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/
