### PR TITLE
[DOC] 4. set v1.7 website as default version

### DIFF
--- a/docs/static_site/src/.htaccess
+++ b/docs/static_site/src/.htaccess
@@ -22,12 +22,12 @@ RewriteOptions AllowNoSlash
 
 </IfModule>
 
-# Set default website version to old stable (v1.6)
+# Set default website version to old stable (v1.7)
 RewriteCond %{REQUEST_URI} !^/versions/
 RewriteCond %{HTTP_REFERER} !mxnet.apache.org
 RewriteCond %{HTTP_REFERER} !mxnet.incubator.apache.org
 RewriteCond %{HTTP_REFERER} !mxnet.cdn.apache.org
-RewriteRule ^(.*)$ /versions/1.6/$1 [r=307,L]
+RewriteRule ^(.*)$ /versions/1.7/$1 [r=307,L]
 
 # Redirect Chinese visitors to Chinese CDN, temporary solution for slow site speed in China
 RewriteCond %{ENV:GEOIP_COUNTRY_CODE} ^CN$


### PR DESCRIPTION
## Description ##
To launch v1.7 website:

1. Create v1.7 website artifact -DONE
2. Add entry to v1.7 on master website - DONE #19116 
3. Add entry to v1.7 on previous version website - DONE
4. Update redirect rule to set 1.7 as default website version - CURRENT

v1.7 website release complete!

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Set 1.7 as default website version

## Comments ##
- Preview: http://ec2-34-219-134-42.us-west-2.compute.amazonaws.com/

