### PR TITLE
[BUGFIX] Fix for MKL symbol name clashing issue (#18855)

### DIFF
--- a/cmake/Modules/FindMKL.cmake
+++ b/cmake/Modules/FindMKL.cmake
@@ -148,7 +148,7 @@ set(INTEL_ROOT "/opt/intel" CACHE PATH "Folder contains intel libs")
   endif()
 
   if(MKL_USE_STATIC_LIBS AND UNIX)
-    set(MKL_LIBRARIES -Wl,--start-group "${MKL_LIBRARIES}" -Wl,--end-group)
+    set(MKL_LIBRARIES -Wl,--exclude-libs,ALL -Wl,--start-group "${MKL_LIBRARIES}" -Wl,--end-group)
   endif()
 
 


### PR DESCRIPTION
## Description ##
This change enables symbol exclusion of statically
linked MKL libraries to avoid the name clashing issue #18855.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] Code is well-documented
