### PR TITLE
Fix legacy codepath detection feature for decorated HybridBlocks

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -21,6 +21,7 @@
 __all__ = ['Block', 'HybridBlock', 'SymbolBlock']
 
 import copy
+import inspect
 import warnings
 import weakref
 from collections import OrderedDict, defaultdict
@@ -984,7 +985,7 @@ class HybridBlock(Block):
 
     def _get_graph(self, *args):
         if not self._cached_graph:
-            if self.hybrid_forward.__func__ is not HybridBlock.hybrid_forward:  # Gluon 1
+            if inspect.unwrap(self.hybrid_forward.__func__) is not HybridBlock.hybrid_forward:
                 return self._get_graph_v1(*args)
             else:  # Gluon 2 based on deferred compute mode
                 return self._get_graph_v2(*args)
@@ -1277,7 +1278,7 @@ class HybridBlock(Block):
 
     def infer_shape(self, *args):
         """Infers shape of Parameters from inputs."""
-        if self.hybrid_forward.__func__ is not HybridBlock.hybrid_forward:
+        if inspect.unwrap(self.hybrid_forward.__func__) is not HybridBlock.hybrid_forward:
             # Gluon 1 based on F:  hybrid_forward is defined by user
             self._infer_attrs('infer_shape', 'shape', *args)
         else:
@@ -1388,7 +1389,7 @@ class HybridBlock(Block):
             cld()._monitor_all = monitor_all
 
     def __call__(self, x, *args):
-        if self.hybrid_forward.__func__ is not HybridBlock.hybrid_forward:
+        if inspect.unwrap(self.hybrid_forward.__func__) is not HybridBlock.hybrid_forward:
             # Gluon 1 based on F:  hybrid_forward is defined by user
             return super().__call__(x, *args)
         else:  # Gluon 2 based on deferred compute mode

--- a/tests/python/unittest/test_deferred_compute.py
+++ b/tests/python/unittest/test_deferred_compute.py
@@ -307,8 +307,7 @@ def test_dc_dynamic_shape():
     def f(a, *, nd):
         return [mx.nd.np.flatnonzero(a)]
 
-    # Skip GraphExecutor test due to https://github.com/apache/incubator-mxnet/issues/17810
-    for mode in ('imperative', 'imperativewithnondccompute'):
+    for mode in ('imperative', 'imperativewithnondccompute', 'symbolic', 'all'):
         _assert_dc(_dc_simple_setup, f, mode=mode, numpy=True)
 
 
@@ -339,10 +338,6 @@ def test_dc_tuple_indexing():
 
 
 def test_dc_simple_boolean_indexing():
-    if mx.test_utils.default_context() == mx.gpu(0) and mx.runtime.Features().is_enabled("TVM_OP"):
-        # Skip due to https://github.com/apache/incubator-mxnet/issues/17886
-        return
-
     def setup(*, nd):
         assert nd is mx.np
         x = mx.np.array([[0, 1], [1, 1], [2, 2]])
@@ -351,10 +346,6 @@ def test_dc_simple_boolean_indexing():
     def f(a, idx, *, nd):
         assert nd is mx.np
         return [a[idx].reshape((2, 2))]
-
-    # Skip GraphExecutor test due to https://github.com/apache/incubator-mxnet/issues/17810
-    for mode in ('imperative', 'imperativewithnondccompute'):
-        _assert_dc(setup, f, mode=mode)
 
 
 def test_dc_list_indexing_error():
@@ -518,10 +509,6 @@ def test_dc_hybridblock_deferred_init():
 
 
 def test_dc_hybridblock_dynamic_shape():
-    if mx.test_utils.default_context() == mx.gpu(0) and mx.runtime.Features().is_enabled("TVM_OP"):
-        # Skip due to https://github.com/apache/incubator-mxnet/issues/17886
-        return
-
     class MyBlock(mx.gluon.HybridBlock):
         def __init__(self):
             super().__init__()


### PR DESCRIPTION
`if self.hybrid_forward.__func__ is not HybridBlock.hybrid_forward` check for detecting legacy Blocks yields false positives on Gluon 2 Blocks if they are wrapped with a class decorator. This leads to hybridization to silently fail on Gluon 2 Blocks that make use of class decorator such as `@use_np`.

Fix by using `inspect.unwrap`.