### PR TITLE
Fix numpy ndarray `__getitem__` for HybridBlock.forward usecase

### DIFF
--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -763,8 +763,11 @@ class ndarray(NDArray):
                 arr.ndim > 0) for arr in key):
             # Equivalent case in numpy/_symbol.py
             return _npi.advanced_indexing_multiple(self, _npi.stack(*key))
-        elif isinstance(key, tuple):
+        elif isinstance(key, tuple) and dc.is_deferred_compute():
             # Equivalent to isinstance(key, tuple) case in numpy/_symbol.py
+            # Only enabled in deferred compute mode, as this codepath prevents
+            # memory sharing which may be desired in non-deferred compute
+            # imperative mode.
             begin = []
             end = []
             step = []

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -115,7 +115,7 @@ class _Symbol(Symbol):
                     raise ValueError("slice step cannot be zero")
             elif isinstance(key, Symbol):
                 return _npi.advanced_indexing(self, key)
-            elif isinstance(key, tuple) and all(isinstance(key, Symbol) for arr in key):
+            elif isinstance(key, tuple) and all(isinstance(k, Symbol) for k in key):
                 key = _npi.stack(*[i for i in key])
                 sliced = _npi.advanced_indexing_multiple(self, key)
                 return sliced

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -115,6 +115,8 @@ class _Symbol(Symbol):
                     raise ValueError("slice step cannot be zero")
             elif isinstance(key, Symbol):
                 return _npi.advanced_indexing(self, key)
+            elif isinstance(key, tuple) and len(key) == 0:
+                return self
             elif isinstance(key, tuple) and all(isinstance(k, Symbol) for k in key):
                 key = _npi.stack(*[i for i in key])
                 sliced = _npi.advanced_indexing_multiple(self, key)
@@ -124,8 +126,7 @@ class _Symbol(Symbol):
                 end = []
                 step = []
                 new_shape = ()
-                if len(key) == 0:
-                    return self
+                assert len(key)  # len(key) == 0 handled above
                 for index in key:
                     if isinstance(index, py_slice):
                         if index.step is not None and index.step == 0:

--- a/python/mxnet/symbol/numpy/_symbol.py
+++ b/python/mxnet/symbol/numpy/_symbol.py
@@ -99,7 +99,7 @@ class _Symbol(Symbol):
                 raise TypeError('indices of symbol group must be integers or slices, not {}'
                                 .format(type(key)))
         else:
-            all = __builtins__['all']  # `def all` below shadows the all builtin
+            all = __builtins__['all']  # pylint: disable=redefined-outer-name
             if isinstance(key, integer_types):
                 if key == -1:
                     sliced = _npi.slice(self, [key], [None])

--- a/tests/python/unittest/test_deferred_compute.py
+++ b/tests/python/unittest/test_deferred_compute.py
@@ -561,3 +561,17 @@ def test_dc_hybridblock_symbolblock_error():
     net.hybridize()
     with pytest.raises(RuntimeError):
         out_hybrid = net(data)  # Raises RuntimeError
+
+
+def test_indexing_shape_change():
+    class ConcatBlock(mx.gluon.nn.HybridBlock):
+        def forward(self, inputs):
+            return mx.np.concatenate([
+                inputs,
+                mx.np.pad(inputs[:,1:], ((0,0), (0,1))),
+            ])
+
+    net = ConcatBlock()
+    net.hybridize()
+    net(mx.np.random.uniform(size=(8, 16)))
+    net(mx.np.random.uniform(size=(8, 8)))


### PR DESCRIPTION
## Description ##
Improve numpy ndarray `__getitem__` to ensure that cases which are supported both in imperative and symbolic mode take the same code-paths (modulo writable views https://github.com/apache/incubator-mxnet/issues/19170)

This fixes an issue where the imperative implementation of some indexing operations would record a fixed shape in the graph and thus break some models in the `HybridBlock.forward` model.