### PR TITLE
[poc] Make OpenBLAS use the LAPACKE apis

### DIFF
--- a/src/operator/c_lapack_api.cc
+++ b/src/operator/c_lapack_api.cc
@@ -19,7 +19,7 @@
 
 #include "c_lapack_api.h"
 
-#if (MSHADOW_USE_MKL && MXNET_USE_LAPACK)
+#if (MSHADOW_USE_MKL || MXNET_USE_BLAS_OPEN) && MXNET_USE_LAPACK)
 #elif MXNET_USE_LAPACK
 #else
   // use pragma message instead of warning

--- a/src/operator/c_lapack_api.cc
+++ b/src/operator/c_lapack_api.cc
@@ -19,7 +19,7 @@
 
 #include "c_lapack_api.h"
 
-#if (MSHADOW_USE_MKL || MXNET_USE_BLAS_OPEN) && MXNET_USE_LAPACK)
+#if ((MSHADOW_USE_MKL || MXNET_USE_BLAS_OPEN) && MXNET_USE_LAPACK)
 #elif MXNET_USE_LAPACK
 #else
   // use pragma message instead of warning

--- a/src/operator/c_lapack_api.h
+++ b/src/operator/c_lapack_api.h
@@ -70,8 +70,8 @@
 
 using namespace mshadow;
 
-// Will cause clash with MKL fortran layer headers
-#if MSHADOW_USE_MKL == 0
+// Will cause clash with MKL/OpenBLAS fortran layer headers
+#if MSHADOW_USE_MKL == 0 && MXNET_USE_BLAS_OPEN == 0
 
 extern "C" {
 
@@ -243,11 +243,19 @@ inline void flip(int m, int n, DType *b, int ldb, DType *a, int lda) {
 }
 
 
-#if (MSHADOW_USE_MKL && MXNET_USE_LAPACK)
+#if ((MSHADOW_USE_MKL || MXNET_USE_BLAS_OPEN) && MXNET_USE_LAPACK)
 
-  // We interface with the C-interface of MKL
+  // We interface with the LAPACKE C-interface of MKL/OpenBLAS
   // as this is the preferred way.
-  #include <mkl_lapacke.h>
+  
+  #if MSHADOW_USE_MKL
+    #include <mkl_lapacke.h>
+  #elif
+    #if MXNET_USE_INT64_TENSOR_SIZE
+      #define lapack_int int64_t
+    #endif
+    #include <lapacke.h>
+  #endif
 
   #define MXNET_LAPACK_ROW_MAJOR LAPACK_ROW_MAJOR
   #define MXNET_LAPACK_COL_MAJOR LAPACK_COL_MAJOR

--- a/src/operator/c_lapack_api.h
+++ b/src/operator/c_lapack_api.h
@@ -247,7 +247,7 @@ inline void flip(int m, int n, DType *b, int ldb, DType *a, int lda) {
 
   // We interface with the LAPACKE C-interface of MKL/OpenBLAS
   // as this is the preferred way.
-  
+
   #if MSHADOW_USE_MKL
     #include <mkl_lapacke.h>
   #else
@@ -255,9 +255,9 @@ inline void flip(int m, int n, DType *b, int ldb, DType *a, int lda) {
     #define lapack_complex_float float _Complex
     #define lapack_complex_double double _Complex
     // uncomment this after ilp64 blas/lapack is supported
-    //#if MXNET_USE_INT64_TENSOR_SIZE
-    //  #define lapack_int int64_t
-    //#endif
+    // #if MXNET_USE_INT64_TENSOR_SIZE
+    //   #define lapack_int int64_t
+    // #endif
     #include <lapacke.h>
   #endif
 

--- a/src/operator/c_lapack_api.h
+++ b/src/operator/c_lapack_api.h
@@ -250,7 +250,7 @@ inline void flip(int m, int n, DType *b, int ldb, DType *a, int lda) {
   
   #if MSHADOW_USE_MKL
     #include <mkl_lapacke.h>
-  #elif
+  #else
     #if MXNET_USE_INT64_TENSOR_SIZE
       #define lapack_int int64_t
     #endif

--- a/src/operator/c_lapack_api.h
+++ b/src/operator/c_lapack_api.h
@@ -251,9 +251,13 @@ inline void flip(int m, int n, DType *b, int ldb, DType *a, int lda) {
   #if MSHADOW_USE_MKL
     #include <mkl_lapacke.h>
   #else
-    #if MXNET_USE_INT64_TENSOR_SIZE
-      #define lapack_int int64_t
-    #endif
+    // prevent multiple inclusion of complex.h in lapacke.h
+    #define lapack_complex_float float _Complex
+    #define lapack_complex_double double _Complex
+    // uncomment this after ilp64 blas/lapack is supported
+    //#if MXNET_USE_INT64_TENSOR_SIZE
+    //  #define lapack_int int64_t
+    //#endif
     #include <lapacke.h>
   #endif
 


### PR DESCRIPTION
In mxnet we wrap lapack functions in c_lapack_api.h so that we hide the differences in the underlying blas/lapack libraries such as mkl, openblas, atlas, and accelerate. 

For mkl we use/wrap the LAPACKE (https://www.netlib.org/lapack/lapacke.html) c interfaces which are the cleanest. For the rest of the libraries we wrap the old CLAPACK interfaces. 

While atlas and accelerate don't provide the LAPACKE interfaces, openblas does have it. This pr makes mxnet also use the LAPACKE apis when openblas is chosen. 

This change will make ilp64 blas/lapack support easier as now we have the same wrapping logic or both mkl and openblas. Support for ilp64 mkl https://github.com/apache/incubator-mxnet/pull/19067 will automatically mean support for ilp64 openblas. 