### PR TITLE
Opt in to newer GCC C++ ABI on Red Hat Developer Toolset

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -112,6 +112,8 @@ build_dynamic_libmxnet() {
 
     cd /work/build
     source /opt/rh/devtoolset-8/enable
+    # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
+    export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     if [[ ${mxnet_variant} = "cpu" ]]; then
         cmake -DUSE_MKL_IF_AVAILABLE=OFF \
             -DUSE_MKLDNN=ON \
@@ -257,6 +259,8 @@ build_centos7_cpu() {
     set -ex
     cd /work/build
     source /opt/rh/devtoolset-7/enable
+    # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
+    export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     cmake \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DENABLE_TESTCOVERAGE=ON \
@@ -272,6 +276,8 @@ build_centos7_mkldnn() {
     set -ex
     cd /work/build
     source /opt/rh/devtoolset-7/enable
+    # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
+    export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     cmake \
         -DUSE_MKL_IF_AVAILABLE=OFF \
         -DUSE_MKLDNN=ON \
@@ -284,6 +290,8 @@ build_centos7_gpu() {
     set -ex
     cd /work/build
     source /opt/rh/devtoolset-7/enable
+    # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
+    export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     cmake \
         -DCMAKE_BUILD_TYPE="RelWithDebInfo" \
         -DUSE_MKL_IF_AVAILABLE=OFF \
@@ -1231,6 +1239,8 @@ build_static_libmxnet() {
     pushd .
     source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
+    # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
+    export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     local mxnet_variant=${1:?"This function requires a python command as the first argument"}
     source tools/staticbuild/build.sh ${mxnet_variant}
     popd
@@ -1254,6 +1264,8 @@ cd_package_pypi() {
     pushd .
     source /opt/rh/devtoolset-7/enable
     source /opt/rh/rh-python36/enable
+    # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
+    export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     local mxnet_variant=${1:?"This function requires a python command as the first argument"}
     ./cd/python/pypi/pypi_package.sh ${mxnet_variant}
     popd
@@ -1296,6 +1308,8 @@ build_static_python_cpu() {
     export mxnet_variant=cpu
     source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
+    # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
+    export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     ./ci/publish/python/build.sh
     popd
 }
@@ -1306,6 +1320,8 @@ build_static_python_cu102() {
     export mxnet_variant=cu102
     source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
+    # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
+    export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     ./ci/publish/python/build.sh
     popd
 }

--- a/tools/staticbuild/build.sh
+++ b/tools/staticbuild/build.sh
@@ -50,8 +50,8 @@ export MAKE="make $ADD_MAKE_FLAG"
 
 export CC="gcc"
 export CXX="g++"
-export CFLAGS="-fPIC -mno-avx"
-export CXXFLAGS="-fPIC -mno-avx"
+export CFLAGS="${CFLAGS:+${CFLAGS}} -fPIC -mno-avx"
+export CXXFLAGS="${CXXFLAGS:+${CXXFLAGS}} -fPIC -mno-avx"
 export FC="gfortran"
 export PKG_CONFIG_PATH=$DEPS_PATH/lib/pkgconfig:$DEPS_PATH/lib64/pkgconfig:$DEPS_PATH/lib/x86_64-linux-gnu/pkgconfig:$PKG_CONFIG_PATH
 export CPATH=$DEPS_PATH/include:$CPATH


### PR DESCRIPTION
Target version 11, which first appeared in G++7 and which is supported by
default by any G++ version up until 10 (the most recent version at time of
writing) due to their respective default value of -fabi-compat-version=11.

By default, Red Hat Developer Toolset targets ABI version 2, which is unnecessarily old and causes issues
when trying to link the generated libmxnet.so with libraries that were compiled with newer versions of gcc (which no longer support the ABI version 2 by default).

Generate aliases for ABI version 7, which first appeared in G++ 4.8 and is the oldest
G++ version shipped by default on a non-EOL system (RHEL7 based systems such as
Amazon Linux 1).