### PR TITLE
[1.x] Enable CUDA Graphs for TRT 

### DIFF
--- a/src/operator/subgraph/tensorrt/tensorrt.cc
+++ b/src/operator/subgraph/tensorrt/tensorrt.cc
@@ -370,6 +370,11 @@ NNVM_REGISTER_OP(_TensorRT)
     .set_attr<nnvm::FListInputNames>("FListInputNames", TRTListInputNames)
     .set_attr<nnvm::FListOutputNames>("FListOutputNames", DefaultSubgraphOpListOutputs)
     .set_attr<FCreateOpState>("FCreateOpState", TRTCreateState)
+    .set_attr<FIsCUDAGraphsCompatible>("FIsCUDAGraphsCompatible",
+        [](const NodeAttrs& attrs, const bool) {
+          const TRTParam& param = nnvm::get<TRTParam>(attrs.parsed);
+          return !param.int8_mode;
+        })
     .set_attr<FInferStorageType>("FInferStorageType", TRTInferStorageType);
 
 MXNET_REGISTER_SUBGRAPH_BACKEND(TensorRT);


### PR DESCRIPTION
## Description ##
This PR enables CUDA Graphs for TRT FP32 and FP16.
CUDA Graph for INT8 requires more complex work and will be added in a future PR.
