### PR TITLE
Switch to GCC 8 for distribution build

### DIFF
--- a/cd/mxnet_lib/static/Jenkins_pipeline.groovy
+++ b/cd/mxnet_lib/static/Jenkins_pipeline.groovy
@@ -32,8 +32,8 @@ libmxnet = 'lib/libmxnet.so'
 licenses = 'licenses/*'
 
 // libmxnet dependencies
-mx_native_deps = 'lib/libgfortran.so.4, lib/libopenblas.so.0'
-mx_deps = 'lib/libgfortran.so.4, lib/libopenblas.so.0, include/mkldnn/dnnl_version.h, include/mkldnn/dnnl_config.h'
+mx_native_deps = 'lib/libgfortran.so.*, lib/libopenblas.so.0'
+mx_deps = 'lib/libgfortran.so.*, lib/libopenblas.so.0, include/mkldnn/dnnl_version.h, include/mkldnn/dnnl_config.h'
 
 // library type
 // either static or dynamic - depending on how it links to its dependencies

--- a/ci/docker/Dockerfile.build.centos7
+++ b/ci/docker/Dockerfile.build.centos7
@@ -53,6 +53,7 @@ RUN yum -y check-update || true && \
         protobuf-devel \
         # CentOS Software Collections https://www.softwarecollections.org
         devtoolset-7 \
+        devtoolset-8 \
         rh-python36 \
         rh-maven35 \
         # Libraries
@@ -69,8 +70,8 @@ RUN yum -y check-update || true && \
         libzstd-devel && \
     yum clean all
 
-# Make GCC7, Python 3.5 and Maven 3.3 Software Collections available by default
-# during build and runtime of this container
+# Make Python 3.6 and Maven 3.3 Software Collections available by default during
+# the following build steps in this Dockerfile
 SHELL [ "/usr/bin/scl", "enable", "devtoolset-7", "rh-python36", "rh-maven35" ]
 
 # Install minimum required cmake version

--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -111,7 +111,7 @@ build_dynamic_libmxnet() {
     gather_licenses
 
     cd /work/build
-    source /opt/rh/devtoolset-7/enable
+    source /opt/rh/devtoolset-8/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
     if [[ ${mxnet_variant} = "cpu" ]]; then
@@ -1278,7 +1278,7 @@ checkout() {
 build_static_libmxnet() {
     set -ex
     pushd .
-    source /opt/rh/devtoolset-7/enable
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
@@ -1303,7 +1303,7 @@ ci_package_pypi() {
 cd_package_pypi() {
     set -ex
     pushd .
-    source /opt/rh/devtoolset-7/enable
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
@@ -1347,7 +1347,7 @@ build_static_python_cpu() {
     set -ex
     pushd .
     export mxnet_variant=cpu
-    source /opt/rh/devtoolset-7/enable
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"
@@ -1355,11 +1355,11 @@ build_static_python_cpu() {
     popd
 }
 
-build_static_python_cu92() {
+build_static_python_cu102() {
     set -ex
     pushd .
-    export mxnet_variant=cu92
-    source /opt/rh/devtoolset-7/enable
+    export mxnet_variant=cu102
+    source /opt/rh/devtoolset-8/enable
     source /opt/rh/rh-python36/enable
     # Opt in to newer GCC C++ ABI. devtoolset defaults to ABI Version 2.
     export CXXFLAGS="-fabi-version=11 -fabi-compat-version=7"

--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -37,7 +37,8 @@ mx_tensorrt_lib = 'build/libmxnet.so, build/3rdparty/tvm/libtvm_runtime.so, buil
 mx_lib_cpp_examples = 'build/libmxnet.so, build/3rdparty/tvm/libtvm_runtime.so, build/libtvmop.so, build/tvmop.conf, build/3rdparty/openmp/runtime/src/libomp.so, build/libcustomop_lib.so, build/libcustomop_gpu_lib.so, build/libsubgraph_lib.so, python/mxnet/_cy3/*.so, python/mxnet/_ffi/_cy3/*.so'
 mx_lib_cpp_examples_no_tvm_op = 'build/libmxnet.so, build/libcustomop_lib.so, build/libcustomop_gpu_lib.so, build/libsubgraph_lib.so, build/3rdparty/openmp/runtime/src/libomp.so, python/mxnet/_cy3/*.so, python/mxnet/_ffi/_cy3/*.so'
 mx_lib_cpp_examples_cpu = 'build/libmxnet.so, build/3rdparty/tvm/libtvm_runtime.so, build/libtvmop.so, build/tvmop.conf, build/3rdparty/openmp/runtime/src/libomp.so'
-mx_cd_lib = 'lib/libmxnet.so, licenses/*, lib/libgfortran.so.4, lib/libopenblas.so.0, include/mkldnn/dnnl_version.h, include/mkldnn/dnnl_config.h'
+mx_cd_lib = 'lib/libmxnet.so, licenses/*, lib/libgfortran.so.*, lib/libopenblas.so.0, include/mkldnn/dnnl_version.h, include/mkldnn/dnnl_config.h'
+
 
 // Python unittest for CPU
 // Python 3
@@ -634,7 +635,7 @@ def compile_static_python_gpu() {
         ws('workspace/ut-publish-python-gpu') {
           timeout(time: max_time, unit: 'MINUTES') {
             utils.init_git()
-            utils.docker_run('centos7_gpu_cu92', 'build_static_python_cu92')
+            utils.docker_run('centos7_gpu_cu102', 'build_static_python_cu102')
           }
         }
     }

--- a/docs/static_site/src/pages/get_started/build_from_source.md
+++ b/docs/static_site/src/pages/get_started/build_from_source.md
@@ -74,13 +74,13 @@ sudo apt-get install -y build-essential git ninja-build ccache libopenblas-dev l
 sudo yum install epel-release centos-release-scl
 sudo yum install git make ninja-build automake autoconf libtool protobuf-compiler protobuf-devel \
     atlas-devel openblas-devel lapack-devel opencv-devel openssl-devel zeromq-devel python3 \ 
-    devtoolset-7
+    devtoolset-8
 source /opt/rh/devtoolset-7/enable
 ```
-Here `devtoolset-7` refers to the [Developer Toolset
-7](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-7/) created by
+Here `devtoolset-8` refers to the [Developer Toolset
+8](https://www.softwarecollections.org/en/scls/rhscl/devtoolset-8/) created by
 Red Hat for developers working on CentOS or Red Hat Enterprise Linux platform
-and providing the GNU Compiler Collection 7.
+and providing the GNU Compiler Collection 9.
 
 ### macOS
 ```bash

--- a/tests/cpp/operator/mkldnn_test.cc
+++ b/tests/cpp/operator/mkldnn_test.cc
@@ -100,7 +100,7 @@ static void VerifyDefMem(const mkldnn::memory &mem) {
 
 TEST(MKLDNN_UTIL_FUNC, MemFormat) {
   // Check whether the number of format is correct.
-  CHECK_EQ(mkldnn_format_tag_last, 205);
+  CHECK_EQ(mkldnn_format_tag_last, 219);
   CHECK_EQ(mkldnn_nchw, 5);
   CHECK_EQ(mkldnn_oihw, 5);
 }

--- a/tools/dependencies/protobuf.sh
+++ b/tools/dependencies/protobuf.sh
@@ -20,6 +20,11 @@
 # This script builds the static library of protobuf along with protoc, that can be used as dependency of mxnet.
 set -ex
 PROTOBUF_VERSION=3.5.1
+if [[ $PLATFORM == 'darwin' ]]; then
+    DY_EXT="dylib"
+else
+    DY_EXT="so"
+fi
 
 LIBPROTOBUF="$DEPS_PATH/lib/libprotobuf.$DY_EXT"
 LIBPROTOC="$DEPS_PATH/lib/libprotoc.$DY_EXT"

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -151,9 +151,12 @@ if platform.system() == 'Linux':
     if os.path.exists(os.path.join(libdir, 'libgfortran.so.3')):
         shutil.copy(os.path.join(libdir, 'libgfortran.so.3'), mxdir)
         package_data['mxnet'].append('mxnet/libgfortran.so.3')
-    else:
+    elif os.path.exists(os.path.join(libdir, 'libgfortran.so.4')):
         shutil.copy(os.path.join(libdir, 'libgfortran.so.4'), mxdir)
         package_data['mxnet'].append('mxnet/libgfortran.so.4')
+    elif os.path.exists(os.path.join(libdir, 'libgfortran.so.5')):
+        shutil.copy(os.path.join(libdir, 'libgfortran.so.5'), mxdir)
+        package_data['mxnet'].append('mxnet/libgfortran.so.5')
     if os.path.exists(os.path.join(libdir, 'libopenblas.so.0')):
         shutil.copy(os.path.join(libdir, 'libopenblas.so.0'), mxdir)
         package_data['mxnet'].append('mxnet/libopenblas.so.0')


### PR DESCRIPTION
## Description ##
Resubmit https://github.com/apache/incubator-mxnet/pull/19034 which was temporarily reverted due to oneDNN issues with GCC 8.

@TaoLV can your team help debug / fix the oneDNN issues?

When both gcc8 + oneDNN 1.6.3 is present, we get the following nan bugs:

```
[2020-09-17T17:48:04.979Z] ______________________ test_dc_hybridblock_deferred_init _______________________
[2020-09-17T17:48:04.979Z] [gw0] linux -- Python 3.6.9 /opt/rh/rh-python36/root/usr/bin/python3
[2020-09-17T17:48:04.979Z] 
[2020-09-17T17:48:04.979Z]     def test_dc_hybridblock_deferred_init():
[2020-09-17T17:48:04.979Z]         class MyBlock(mx.gluon.HybridBlock):
[2020-09-17T17:48:04.979Z]             def __init__(self):
[2020-09-17T17:48:04.979Z]                 super().__init__()
[2020-09-17T17:48:04.979Z]                 self.dense = mx.gluon.nn.Dense(units=10)
[2020-09-17T17:48:04.979Z]                 self.weight = mx.gluon.Parameter('weight', allow_deferred_init=True)
[2020-09-17T17:48:04.979Z]     
[2020-09-17T17:48:04.979Z]             def infer_shape(self, x):
[2020-09-17T17:48:04.979Z]                 self.weight.shape = (x.shape[1], )
[2020-09-17T17:48:04.979Z]     
[2020-09-17T17:48:04.979Z]             def forward(self, x):
[2020-09-17T17:48:04.979Z]                 return self.dense(x) + self.weight.data(x.context)
[2020-09-17T17:48:04.979Z]     
[2020-09-17T17:48:04.979Z]         net = MyBlock()
[2020-09-17T17:48:04.979Z]         net.initialize()
[2020-09-17T17:48:04.979Z] >       _assert_dc_gluon(_dc_gluon_simple_setup, net, numpy=False)
[2020-09-17T17:48:04.979Z] 
[2020-09-17T17:48:04.979Z] tests/python/unittest/test_deferred_compute.py:504: 
[2020-09-17T17:48:04.979Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[2020-09-17T17:48:04.979Z] tests/python/unittest/test_deferred_compute.py:421: in _assert_dc_gluon
[2020-09-17T17:48:04.979Z]     _all_same(ys_np, ys_hybrid_np)
[2020-09-17T17:48:04.979Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
[2020-09-17T17:48:04.979Z] 
[2020-09-17T17:48:04.979Z] arrays1 = [array([        nan,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z]         0.07460972, -0.08127148, -0.32424796,...33878, -0.10624887,
[2020-09-17T17:48:04.979Z]         0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z]       dtype=float32), ...]
[2020-09-17T17:48:04.979Z] arrays2 = [array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z]         0.07460972, -0.08127148, -0.32424796,...33878, -0.10624887,
[2020-09-17T17:48:04.979Z]         0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z]       dtype=float32), ...]
[2020-09-17T17:48:04.979Z] message = ''
[2020-09-17T17:48:04.979Z] 
[2020-09-17T17:48:04.979Z]     def _all_same(arrays1, arrays2, message=''):
[2020-09-17T17:48:04.979Z]         same = all(np.array_equal(a1, a2) for a1, a2 in zip(arrays1, arrays2))
[2020-09-17T17:48:04.979Z]         if not same:
[2020-09-17T17:48:04.979Z] >           raise AssertionError('Arrays not equal ({}):\n{}\n\n{}'.format(message, arrays1, arrays2))
[2020-09-17T17:48:04.979Z] E           AssertionError: Arrays not equal ():
[2020-09-17T17:48:04.979Z] E           [array([        nan,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([        nan,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([        nan,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32)]
[2020-09-17T17:48:04.979Z] E           
[2020-09-17T17:48:04.979Z] E           [array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32), array([ 0.01286458,  0.2107217 , -0.06851891,  0.16233878, -0.10624887,
[2020-09-17T17:48:04.979Z] E                   0.07460972, -0.08127148, -0.32424796, -0.0124862 , -0.1862593 ],
[2020-09-17T17:48:04.979Z] E                 dtype=float32)]
```

Reverting either to gcc7 (which was done) or reverting the oneDNN update (https://github.com/apache/incubator-mxnet/pull/19180) fixes the issue.