### PR TITLE
[COMMUNITY] add Manu Seth as a new committer

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -116,6 +116,7 @@ healthy project. The community actively look for new committers from contributor
 * [Lai Wei](https://github.com/roywei)
 * [Lin Yuan](https://github.com/apeforest)
   - Lin supports MXNet distributed training using Horovod and is also a major contributor to higher order gradients.
+* [Manu Seth](https://github.com/mseth10/)
 * [Nicolas Modrzyk](https://github.com/hellonico)
 * [Patric Zhao](https://github.com/pengzhao-intel)
 * - Patric is a parallel computing expert and a major contributor to the MXNet MKL-DNN backend.
@@ -219,7 +220,6 @@ List of Contributors
 * [Xizhou Zhu](https://github.com/einsiedler0408/)
 * [Jean Kossaifi](https://github.com/JeanKossaifi/)
 * [Kenta Kubo](https://github.com/kkk669/)
-* [Manu Seth](https://github.com/mseth10/)
 * [Calum Leslie](https://github.com/calumleslie)
 * [Andre Tamm](https://github.com/andretamm)
 * [Julian Salazar](https://github.com/JulianSlzr)


### PR DESCRIPTION
## Description ##
Please join me in welcoming Manu Seth (@mseth10) as a new committer of Apache MXNet! Manu has been working on MXNet since 2018 and contributed ~40 patches to MXNet with increasing technical depth. He worked on improving tests and infrastructure, performance, and more recently on graph partitioning in CachedOp in the presence of dynamic shape operators, so that a neural network graph with dynamic shape operators can be just as performant as a static graph.

Congratulations to @mseth10!

PRs he authored: https://github.com/apache/incubator-mxnet/pulls?q=is%3Apr+author%3Amseth10+
Issues he participated in: https://github.com/apache/incubator-mxnet/issues?q=is%3Aissue+involves%3Amseth10
Code reviews: https://github.com/apache/incubator-mxnet/pulls?q=is%3Apr+reviewed-by%3Amseth10

### Changes ###
- [x] add Manu Seth as a new committer