### PR TITLE
[BUGFIX] Fix intgemm flaky test in #19197 for master

### DIFF
--- a/tests/python/unittest/test_contrib_intgemm.py
+++ b/tests/python/unittest/test_contrib_intgemm.py
@@ -51,7 +51,8 @@ def test_contrib_intgemm_prepare_data(shape, max_quant):
     scaled = m * 127.0 / max_quant
     # Rounding 0.5 can go up or down.  Move values away from 0.5.
     too_close = mx.nd.abs(mx.nd.round(scaled) - scaled) > 0.45
-    m += max_quant / 127.0 * 0.05 * too_close
+    # Add 0.2 in scaled space so (0.45, 0.55) maps to (0.65, 0.75) which will round consistently.
+    m += max_quant / 127.0 * 0.2 * too_close
 
     # Reference: scale and round
     ref = mx.nd.round(m * 127.0 / max_quant)


### PR DESCRIPTION
## Description ##
This is a twin of #19201 to fix #19197.  I made a flaky test, sorry.  

It's testing a quantizer that entails rounding but rounding 0.5 is ambiguous.  So I intended to ban 0.5 by adding a small value.  The code checks the interval (0.45, 0.55) and adds 0.05 to anything there.  But that just shifts it to (0.5, 0.6) when I meant to go further from 0.5.  Now it shifts to (0.65, 0.75) so 0.5 won't appear.  

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
Fix flaky test `test_contrib_intgemm_prepare_data`

## Comments ##
Another approach would be to allow some tolerance for quantized values around 0.5.  