### PR TITLE
[v1.8.x] Backport "Explore behavior of flakey R test UNET from test_img_seg.R" #19186

### DIFF
--- a/R-package/tests/testthat/test_img_seg.R
+++ b/R-package/tests/testthat/test_img_seg.R
@@ -154,12 +154,11 @@ test_that("UNET", {
   train.y.array <- train.y
   dim(train.y.array) <- c(IMG_SIZE, IMG_SIZE, 1, 30)
   
-  devices <- mx.ctx.default()
   mx.set.seed(0)
   
   net <- get_unet()
   
   model <- mx.model.FeedForward.create(net, X = train.array, y = train.y.array, 
-    ctx = devices, num.round = 2, initializer = mx.init.normal(sqrt(2/576)), 
+    ctx = mx.ctx.default(), num.round = 2, initializer = mx.init.normal(sqrt(2/576)),
     learning.rate = 0.05, momentum = 0.99, array.batch.size = 2)
 })


### PR DESCRIPTION
## Description ##
This is a backport of PR https://github.com/apache/incubator-mxnet/pull/19186 from v1.x to v1.8.x.  With this PR's non-functional change to the UNET test of test_img_seg.R, the frequent but non-deterministic failure has not reoccurred.  This suggests a race condition of some sort, but this has not been root-caused.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X] Changes are complete (i.e. I finished coding on this PR)
- [X] All changes have test coverage
- [X] Code is well-documented

@samskalicky 