### PR TITLE
[BUGFIX]Fix cuDNN dropout reproducibility

### DIFF
--- a/include/mxnet/resource.h
+++ b/include/mxnet/resource.h
@@ -202,7 +202,7 @@ struct Resource {
   void get_cudnn_dropout_desc(
       cudnnDropoutDescriptor_t *dropout_desc,
       mshadow::Stream<gpu> *stream,
-      const float dropout, uint64_t seed,
+      const float dropout,
       const std::string &name = MXNET_RESOURCE_DEFAULT_NAME_FARG("cudnn_dropout_state")) const;
 #endif  // MXNET_USE_CUDNN == 1
 

--- a/include/mxnet/resource.h
+++ b/include/mxnet/resource.h
@@ -196,6 +196,7 @@ struct Resource {
    *
    * \param dropout_desc  reference to previously created cuDNN dropout descriptor.
    * \param stream  the stream of returning tensor.
+   * \param dropout the ratio of inputs to keep.
    * \param name    the name of the operator requesting the resource.
    * \return the mshadow tensor requested.
    */

--- a/src/operator/nn/dropout-inl.h
+++ b/src/operator/nn/dropout-inl.h
@@ -226,6 +226,7 @@ class DropoutOp {
       CUDNN_CALL(cudnnCreateTensorDescriptor(&y_desc_));
       CUDNN_CALL(cudnnCreateTensorDescriptor(&dx_desc_));
       CUDNN_CALL(cudnnCreateTensorDescriptor(&dy_desc_));
+      CUDNN_CALL(cudnnCreateDropoutDescriptor(&dropout_desc_));
     }
 #endif  // MXNET_USE_CUDNN_DROPOUT
   }
@@ -237,6 +238,7 @@ class DropoutOp {
       CUDNN_CALL(cudnnDestroyTensorDescriptor(y_desc_));
       CUDNN_CALL(cudnnDestroyTensorDescriptor(dx_desc_));
       CUDNN_CALL(cudnnDestroyTensorDescriptor(dy_desc_));
+      CUDNN_CALL(cudnnDestroyDropoutDescriptor(dropout_desc_));
     }
 #endif  // MXNET_USE_CUDNN_DROPOUT
   }
@@ -253,7 +255,7 @@ class DropoutOp {
       Stream<xpu> *s = ctx.get_stream<xpu>();
 
       // set dropout state.
-      ctx.requested[0].get_cudnn_dropout_desc(&dropout_desc_, s, 1.0f - this->pkeep_, seed_);
+      ctx.requested[0].get_cudnn_dropout_desc(&dropout_desc_, s, 1.0f - this->pkeep_);
 
       // describe input/output tensor
       int dim[4], stride[4];
@@ -490,7 +492,6 @@ class DropoutOp {
   Context ctx_;
   cudnnDataType_t dtype_;
   cudnnDropoutDescriptor_t dropout_desc_;
-  uint64_t seed_ = 17 + rand() % 4096;  // NOLINT(runtime/threadsafe_fn)
   size_t dropout_reserve_byte_;
   cudnnTensorDescriptor_t x_desc_, y_desc_, dx_desc_, dy_desc_;
 #endif  // MXNET_USE_CUDNN_DROPOUT

--- a/src/operator/rnn-inl.h
+++ b/src/operator/rnn-inl.h
@@ -498,6 +498,7 @@ class RNNOp {
       CUDNN_CALL(cudnnCreateFilterDescriptor(&dw_desc_));
 
       CUDNN_CALL(cudnnCreateRNNDescriptor(&rnn_desc_));
+      CUDNN_CALL(cudnnCreateDropoutDescriptor(&dropout_desc_));
 
 #if MXNET_USE_CUDNN_GE_7200
       CUDNN_CALL(cudnnCreateRNNDataDescriptor(&x_data_desc_));
@@ -540,6 +541,7 @@ class RNNOp {
     CUDNN_CALL(cudnnDestroyFilterDescriptor(w_desc_));
     CUDNN_CALL(cudnnDestroyFilterDescriptor(dw_desc_));
     CUDNN_CALL(cudnnDestroyRNNDescriptor(rnn_desc_));
+    CUDNN_CALL(cudnnDestroyDropoutDescriptor(dropout_desc_));
     if (dgrad_sync_event_created_)
       CUDA_CALL(cudaEventDestroy(dgrad_sync_event_));
 
@@ -1344,7 +1346,7 @@ class RNNOp {
 
       // Create Dropout descriptors
       ctx.requested[rnn_enum::kCuDNNDropoutDescSpace].get_cudnn_dropout_desc
-         (&dropout_desc_, s, param_.p, seed_);
+         (&dropout_desc_, s, param_.p);
 
       // RNN descriptors
       // adopt pseudo-fp16 for all architectures
@@ -1494,7 +1496,6 @@ class RNNOp {
   cudnnRNNInputMode_t input_mode_;
   cudnnDropoutDescriptor_t dropout_desc_;
   Storage::Handle reserve_space_;
-  uint64_t seed_ = 17 + rand() % 4096;  // NOLINT(runtime/threadsafe_fn)
   size_t workspace_byte_, reserve_space_byte_;
   int workspace_size_;
   std::vector<cudnnTensorDescriptor_t> x_desc_vec_, y_desc_vec_, dx_desc_vec_, dy_desc_vec_;

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -346,6 +346,8 @@ class ResourceManagerImpl : public ResourceManager {
                                              state_space->handle.size,
                                              current_seed));
         CUDNN_CALL(cudnnDestroyDropoutDescriptor(temp_descriptor));
+        cudaStream_t cuda_stream = mshadow::Stream<gpu>::GetStream(stream);
+        cudaStreamSynchronize(cuda_stream);
         on_complete();
       }, p->ctx, {}, {r->var}, FnProperty::kNormal, 0,
       "CUDNNDropoutDescriptorSeed");

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -161,8 +161,8 @@ class ResourceManagerImpl : public ResourceManager {
 #if MXNET_USE_CUDNN == 1
         case ResourceRequest::kCuDNNDropoutDesc: {
           return gpu_cudnn_dropout_state_.Get(ctx.dev_id, [ctx, this]() {
-            return new ResourceTempSpace<ResourceRequest::kCuDNNDropoutDesc>(
-                ctx, gpu_cudnn_dropout_state_copy_);
+            return new ResourceCUDNNDropout(
+                ctx, gpu_cudnn_dropout_state_copy_, global_seed_);
           })->GetNext();
         }
 #endif  // MXNET_USE_CUDNN == 1
@@ -187,7 +187,13 @@ class ResourceManagerImpl : public ResourceManager {
     gpu_parallel_rand_.ForEach([seed](size_t i, ResourceParallelRandom<gpu> *p) {
       p->SeedWithDeviceID(seed);
     });
-#endif
+#if MXNET_USE_CUDNN == 1
+    gpu_cudnn_dropout_state_.ForEach([seed](size_t i,
+                                            ResourceCUDNNDropout *p) {
+        ResourceManagerImpl::SeedCUDNNDropout(p, seed);
+    });
+#endif  // MXNET_USE_CUDNN
+#endif  // MXNET_USE_CUDA
   }
 
   void SeedRandom(Context ctx, uint32_t seed) override {
@@ -201,8 +207,15 @@ class ResourceManagerImpl : public ResourceManager {
       gpu_parallel_rand_.Get(ctx.dev_id, [ctx, seed, this]() {
         return new ResourceParallelRandom<gpu>(ctx, gpu_native_rand_copy_, seed);
       })->Seed(seed);
+#if MXNET_USE_CUDNN == 1
+      auto dropout_state = gpu_cudnn_dropout_state_.Get(ctx.dev_id, [ctx, seed, this]() {
+        return new ResourceCUDNNDropout(ctx, gpu_cudnn_dropout_state_copy_, seed);
+        });
+      ResourceManagerImpl::SeedCUDNNDropout(dropout_state.get(), seed);
+#endif  // MXNET_USE_CUDNN
     }
-#endif
+
+#endif  // MXNET_USE_CUDA
   }
 
  private:
@@ -275,7 +288,7 @@ class ResourceManagerImpl : public ResourceManager {
         CHECK_EQ(space[i].handle.size, 0U);
       }
     }
-    ~ResourceTempSpace() {
+    virtual ~ResourceTempSpace() {
       for (size_t i = 0; i < space.size(); ++i) {
         SpaceAllocator r = space[i];
         Engine::Get()->DeleteVariable(
@@ -297,6 +310,51 @@ class ResourceManagerImpl : public ResourceManager {
       return resource[ptr % space.size()];
     }
   };
+
+#if MXNET_USE_CUDNN == 1
+  struct ResourceCUDNNDropout : public ResourceTempSpace<ResourceRequest::kCuDNNDropoutDesc> {
+    explicit ResourceCUDNNDropout(Context ctx, size_t ncopy, uint32_t global_seed) :
+      ResourceTempSpace<ResourceRequest::kCuDNNDropoutDesc>(ctx, ncopy) {
+        ResourceManagerImpl::SeedCUDNNDropout(this, global_seed);
+    }
+  };
+
+  static void SeedCUDNNDropout(ResourceCUDNNDropout *p, uint32_t seed) {
+    for (size_t i = 0; i < p->space.size(); ++i) {
+      uint32_t current_seed = p->ctx.dev_id + i * kMaxNumGPUs + seed * kRandMagic;
+      Resource* r = &(p->resource[i]);
+      Engine::Get()->PushAsync(
+      [r, current_seed](RunContext rctx, Engine::CallbackOnComplete on_complete) {
+        auto state_space = static_cast<resource::SpaceAllocator*>(r->ptr_);
+        mshadow::Stream<gpu>* stream = rctx.get_stream<gpu>();
+        CHECK_EQ(state_space->ctx.dev_id, stream->dev_id)
+          << "The device id of cudnn dropout state space doesn't match that from stream.";
+        if (!state_space->handle.size) {
+          // not allocated yet
+          size_t dropout_state_size;
+          CUDNN_CALL(cudnnDropoutGetStatesSize(stream->dnn_handle_, &dropout_state_size));
+          // reserve GPU space
+          Storage::Get()->DirectFree(
+            Storage::Get()->Alloc(dropout_state_size, state_space->ctx));
+          state_space->GetSpace(dropout_state_size);
+        }
+        cudnnDropoutDescriptor_t temp_descriptor;
+        CUDNN_CALL(cudnnCreateDropoutDescriptor(&temp_descriptor));
+        CUDNN_CALL(cudnnSetDropoutDescriptor(temp_descriptor, stream->dnn_handle_,
+                                             0.5,
+                                             state_space->handle.dptr,
+                                             state_space->handle.size,
+                                             current_seed));
+        CUDNN_CALL(cudnnDestroyDropoutDescriptor(temp_descriptor));
+        on_complete();
+      }, p->ctx, {}, {r->var}, FnProperty::kNormal, 0,
+      "CUDNNDropoutDescriptorSeed");
+    }
+
+    p->curr_ptr.store(0);
+  }
+
+#endif  // MXNET_USE_CUDNN
 
   // the parallel random sampler resources
   // it use device API for GPU
@@ -408,7 +466,7 @@ class ResourceManagerImpl : public ResourceManager {
   /*! \brief number of copies in GPU cudnn dropout descriptor resources */
   int gpu_cudnn_dropout_state_copy_;
   /*! \brief GPU parallel (on device) random number resources */
-  common::LazyAllocArray<ResourceTempSpace<ResourceRequest::kCuDNNDropoutDesc>>
+  common::LazyAllocArray<ResourceCUDNNDropout>
     gpu_cudnn_dropout_state_;
 #endif  // MXNET_USE_CUDNN == 1
 #endif
@@ -428,37 +486,28 @@ void* Resource::get_host_space_internal(size_t size) const {
 void Resource::get_cudnn_dropout_desc(
     cudnnDropoutDescriptor_t *dropout_desc,
     mshadow::Stream<gpu> *stream,
-    const float dropout, uint64_t seed,
+    const float dropout,
     const std::string &name) const {
 
   CHECK_EQ(req.type, ResourceRequest::kCuDNNDropoutDesc);
   auto state_space = static_cast<resource::SpaceAllocator*>(ptr_);
   CHECK_EQ(state_space->ctx.dev_id, stream->dev_id)
-    << "The device id of cuDNN dropout state space doesn't match that from stream.";
-  CUDNN_CALL(cudnnCreateDropoutDescriptor(dropout_desc));
+    << "The device id of cudnn dropout state space doesn't match that from stream.";
   if (dropout <= 0) {
     CUDNN_CALL(cudnnSetDropoutDescriptor(*dropout_desc, stream->dnn_handle_,
                                          dropout,
                                          nullptr,
                                          0, seed));
-  } else if (!state_space->handle.size) {
-    // not initialized yet.
-    size_t dropout_state_size;
-    CUDNN_CALL(cudnnDropoutGetStatesSize(stream->dnn_handle_, &dropout_state_size));
-    // reserve GPU space
-    Storage::Get()->DirectFree(Storage::Get()->Alloc(dropout_state_size, state_space->ctx));
-    CUDNN_CALL(cudnnSetDropoutDescriptor(*dropout_desc, stream->dnn_handle_,
-                                         dropout,
-                                         state_space->GetSpace(dropout_state_size, name),
-                                         dropout_state_size, seed));
   } else {
+    CHECK(state_space->handle.size > 0)
+      << "CUDNN dropout descriptor was not initialized yet!";
     // cudnnRestoreDropoutDescriptor() introduced with cuDNN v7
     STATIC_ASSERT_CUDNN_VERSION_GE(7000);
     CUDNN_CALL(cudnnRestoreDropoutDescriptor(*dropout_desc, stream->dnn_handle_,
                                              dropout,
                                              state_space->handle.dptr,
                                              state_space->handle.size,
-                                             seed));
+                                             0));
   }
 }
 #endif  // MXNET_USE_CUDNN == 1

--- a/src/resource.cc
+++ b/src/resource.cc
@@ -190,7 +190,7 @@ class ResourceManagerImpl : public ResourceManager {
 #if MXNET_USE_CUDNN == 1
     gpu_cudnn_dropout_state_.ForEach([seed](size_t i,
                                             ResourceCUDNNDropout *p) {
-        ResourceManagerImpl::SeedCUDNNDropout(p, seed);
+        ResourceManagerImpl::SeedCUDNNDropout(p, seed, "cudnn_dropout_state");
     });
 #endif  // MXNET_USE_CUDNN
 #endif  // MXNET_USE_CUDA
@@ -211,7 +211,7 @@ class ResourceManagerImpl : public ResourceManager {
       auto dropout_state = gpu_cudnn_dropout_state_.Get(ctx.dev_id, [ctx, seed, this]() {
         return new ResourceCUDNNDropout(ctx, gpu_cudnn_dropout_state_copy_, seed);
         });
-      ResourceManagerImpl::SeedCUDNNDropout(dropout_state.get(), seed);
+      ResourceManagerImpl::SeedCUDNNDropout(dropout_state.get(), seed, "cudnn_dropout_state");
 #endif  // MXNET_USE_CUDNN
     }
 
@@ -315,11 +315,11 @@ class ResourceManagerImpl : public ResourceManager {
   struct ResourceCUDNNDropout : public ResourceTempSpace<ResourceRequest::kCuDNNDropoutDesc> {
     explicit ResourceCUDNNDropout(Context ctx, size_t ncopy, uint32_t global_seed) :
       ResourceTempSpace<ResourceRequest::kCuDNNDropoutDesc>(ctx, ncopy) {
-        ResourceManagerImpl::SeedCUDNNDropout(this, global_seed);
+        ResourceManagerImpl::SeedCUDNNDropout(this, global_seed, "cudnn_dropout_state");
     }
   };
 
-  static void SeedCUDNNDropout(ResourceCUDNNDropout *p, uint32_t seed) {
+  static void SeedCUDNNDropout(ResourceCUDNNDropout *p, uint32_t seed, const std::string &name) {
     for (size_t i = 0; i < p->space.size(); ++i) {
       uint32_t current_seed = p->ctx.dev_id + i * kMaxNumGPUs + seed * kRandMagic;
       Resource* r = &(p->resource[i]);
@@ -336,7 +336,7 @@ class ResourceManagerImpl : public ResourceManager {
           // reserve GPU space
           Storage::Get()->DirectFree(
             Storage::Get()->Alloc(dropout_state_size, state_space->ctx));
-          state_space->GetSpace(dropout_state_size);
+          state_space->GetSpace(dropout_state_size, name);
         }
         cudnnDropoutDescriptor_t temp_descriptor;
         CUDNN_CALL(cudnnCreateDropoutDescriptor(&temp_descriptor));
@@ -497,7 +497,7 @@ void Resource::get_cudnn_dropout_desc(
     CUDNN_CALL(cudnnSetDropoutDescriptor(*dropout_desc, stream->dnn_handle_,
                                          dropout,
                                          nullptr,
-                                         0, seed));
+                                         0, 0));
   } else {
     CHECK(state_space->handle.size > 0)
       << "CUDNN dropout descriptor was not initialized yet!";

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -648,7 +648,6 @@ def test_gemms_true_fp16():
                         atol=atol, rtol=rtol)
 
 @with_seed()
-@assert_raises_cudnn_not_satisfied(min_version='7.0.0')
 def test_cudnn_dropout_reproducibility():
     d = nn.Dropout(0.5)
     d.initialize()

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -648,6 +648,7 @@ def test_gemms_true_fp16():
                         atol=atol, rtol=rtol)
 
 @with_seed()
+@assert_raises_cudnn_not_satisfied(min_version='7.0.0')
 def test_cudnn_dropout_reproducibility():
     d = nn.Dropout(0.5)
     d.initialize()


### PR DESCRIPTION
## Description ##
Fixes #15662

This PR seeds the dropout states inside the `ResourceManager` when `mx.random.seed` method is called and makes Dropout and RNN ops reuse those states in their dropout descriptors.

@szha @eric-haibin-lin @DickJC123 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented