### PR TITLE
[BUGFIX] Free up executor memory when reassigning new executor

### DIFF
--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -2006,6 +2006,7 @@ Executor *Executor::SimpleBind(nnvm::Symbol symbol,
                                    default_ctx, group2ctx, &tmp_in_arg_ctxes, &tmp_arg_grad_ctxes,
                                    &tmp_grad_req_types, &tmp_aux_state_ctxes, verbose);
       // Subgraph cannot be recreated from unoptimized symbol
+      delete exec;
       exec = new exec::GraphExecutor(symbol);
       exec->Init(symbol.Copy(), default_ctx, group2ctx, tmp_in_arg_ctxes, tmp_arg_grad_ctxes,
                  tmp_aux_state_ctxes, arg_shape_map, arg_dtype_map, arg_stype_map,
@@ -2077,6 +2078,7 @@ Executor *Executor::Bind(nnvm::Symbol symbol,
                                    &tmp_arg_grad_store, &tmp_grad_req_type, &tmp_aux_states,
                                    verbose);
       // Subgraph cannot be recreated from unoptimized symbol
+      delete exec;
       exec = new exec::GraphExecutor(symbol);
     }
   }


### PR DESCRIPTION
## Description ##
Fixes memory leak caused due to not freeing up of graph executor object.

## Checklist ##
### Essentials ###
- [X] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented
