### PR TITLE
Python level HybridBlock export API

### DIFF
--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -21,7 +21,6 @@
 __all__ = ['Block', 'HybridBlock', 'SymbolBlock']
 
 import copy
-import ctypes
 import inspect
 import warnings
 import weakref
@@ -1368,6 +1367,7 @@ class HybridBlock(Block):
 
         if remove_amp_cast:
             handle = SymbolHandle()
+            import ctypes
             check_call(_LIB.MXSymbolRemoveAmpCast(sym.handle, ctypes.byref(handle)))
             sym = type(sym)(handle)
         return sym, arg_dict

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -1532,8 +1532,10 @@ def test_symbol_block_save_load(tmpdir):
             backbone.initialize()
             backbone.hybridize()
             backbone(mx.nd.random.normal(shape=(1, 3, 32, 32)))
-            sym_file, params_file = backbone.export(tmpfile)
-            self.backbone = gluon.SymbolBlock.imports(sym_file, 'data', params_file)
+            sym, params = backbone.export(None)
+            data = mx.sym.var('data')
+            self.backbone = gluon.SymbolBlock(sym, data)
+            self.backbone.load_dict(params)
             self.body = nn.Conv2D(3, 1)
 
         def hybrid_forward(self, F, x):


### PR DESCRIPTION
## Description ##
Allow `HybridBlock.export` without writing to a file, but obtain symbol and param objects instead.
This is useful for users of `HybridBlock.forward` that would like to obtain a legacy Symbol object without accessing `HybridBlock._cached_op` internal data structure.