### PR TITLE
[BUGFIX][BACKPORT]#19214 from v1.x to v1.8.x delete executor before reallocating it memory

### DIFF
--- a/src/executor/graph_executor.cc
+++ b/src/executor/graph_executor.cc
@@ -2006,6 +2006,7 @@ Executor *Executor::SimpleBind(nnvm::Symbol symbol,
                                    default_ctx, group2ctx, &tmp_in_arg_ctxes, &tmp_arg_grad_ctxes,
                                    &tmp_grad_req_types, &tmp_aux_state_ctxes, verbose);
       // Subgraph cannot be recreated from unoptimized symbol
+      delete exec;
       exec = new exec::GraphExecutor(symbol);
       exec->Init(symbol.Copy(), default_ctx, group2ctx, tmp_in_arg_ctxes, tmp_arg_grad_ctxes,
                  tmp_aux_state_ctxes, arg_shape_map, arg_dtype_map, arg_stype_map,
@@ -2077,6 +2078,7 @@ Executor *Executor::Bind(nnvm::Symbol symbol,
                                    &tmp_arg_grad_store, &tmp_grad_req_type, &tmp_aux_states,
                                    verbose);
       // Subgraph cannot be recreated from unoptimized symbol
+      delete exec;
       exec = new exec::GraphExecutor(symbol);
     }
   }


### PR DESCRIPTION
## Description ##
Fixes memory leak in executor
