### PR TITLE
[Numpy] Improve np.linalg.qr user documentation

### DIFF
--- a/python/mxnet/numpy/linalg.py
+++ b/python/mxnet/numpy/linalg.py
@@ -428,6 +428,11 @@ def qr(a, mode='reduced'):
     MXNetError
         If factoring fails.
 
+    Notes
+    -----
+    Currently, the gradient for the QR factorization is well-defined
+    only when the first K columns of the input matrix are linearly independent.
+
     Examples
     --------
     >>> from mxnet import np

--- a/src/operator/numpy/linalg/np_qr-inl.h
+++ b/src/operator/numpy/linalg/np_qr-inl.h
@@ -518,7 +518,8 @@ struct QrBackHelper_G2 {
   }
 };
 
-
+// QR backward methodology is explained in detail in
+// https://arxiv.org/abs/2009.10071
 struct qr_backward {
   template<typename xpu, typename DType>
   static void op(const Tensor<xpu, 3, DType>& dA,


### PR DESCRIPTION

Currently, there is no user documentation for the backward method in np.linalg.qr .

The user can backpropagate through the factorization and should know what assumptions are being made by the autodiff methodology (and reflected in our unit tests), as detailed in the reference document:

[QR and LQ Decomposition Matrix Backpropagation Algorithms for Square, Wide, and Deep Matrices and Their Software Implementation](https://arxiv.org/abs/2009.10071)
