### PR TITLE
Remove duplicate setup and teardown functions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,14 @@ import random
 import pytest
 
 
+def pytest_configure(config):
+    # Load the user's locale settings to verify that MXNet works correctly when the C locale is set
+    # to anything other than the default value. Please see #16134 for an example of a bug caused by
+    # incorrect handling of C locales.
+    import locale
+    locale.setlocale(locale.LC_ALL, "")
+
+
 def pytest_sessionfinish(session, exitstatus):
     if exitstatus == 5:  # Don't fail if no tests were run
         session.exitstatus = 0
@@ -139,12 +147,6 @@ def module_scope_seed(request):
         # Use print() as module level fixture logging.warning messages never
         # shown to users. https://github.com/pytest-dev/pytest/issues/7819
         print('*** test-level seed set: all "@with_seed()" tests run deterministically ***')
-
-    # Load the user's locale settings to verify that MXNet works correctly when the C locale is set
-    # to anything other than the default value. Please see #16134 for an example of a bug caused by
-    # incorrect handling of C locales.
-    import locale
-    locale.setlocale(locale.LC_ALL, "")
 
     yield  # run all tests in the module
 

--- a/conftest.py
+++ b/conftest.py
@@ -24,7 +24,6 @@ instantiated before lower-scoped fixtures (such as ``function``).
 """
 
 import logging
-import gc
 import os
 import random
 
@@ -36,9 +35,38 @@ def pytest_sessionfinish(session, exitstatus):
         session.exitstatus = 0
 
 
-# * Random seed setup
-def pytest_configure():
-    """Pytest configuration hook to help reproduce test segfaults
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Make test outcome available to fixture.
+
+    https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
+    """
+    # execute all other hooks to obtain the report object
+    outcome = yield
+    rep = outcome.get_result()
+
+    # set a report attribute for each phase of a call, which can
+    # be "setup", "call", "teardown"
+    setattr(item, "rep_" + rep.when, rep)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def module_scope_waitall(request):
+    """A module scope fixture to issue waitall() operations between test modules."""
+    yield
+
+    try:
+        import mxnet as mx
+        mx.npx.waitall()
+    except:
+        # Use print() as module level fixture logging.warning messages never
+        # shown to users. https://github.com/pytest-dev/pytest/issues/7819
+        print('Unable to import numpy/mxnet. Skip mx.npx.waitall().')
+
+
+@pytest.fixture(scope='module', autouse=True)
+def module_scope_seed(request):
+    """Module scope fixture to help reproduce test segfaults
 
     Sets and outputs rng seeds.
 
@@ -83,17 +111,17 @@ def pytest_configure():
     4. When finished debugging the segfault, remember to unset any exported MXNET_ seed
        variables in the environment to return to non-deterministic testing (a good thing).
     """
-
     module_seed_str = os.getenv('MXNET_MODULE_SEED')
     if module_seed_str is None:
         seed = random.randint(0, 2**31-1)
     else:
         seed = int(module_seed_str)
-        logging.warning('*** module-level seed is set: '
-                        'all tests running deterministically ***')
-    logging.info('Setting module np/mx/python random seeds, '
-                 'use MXNET_MODULE_SEED={} to reproduce.'.format(seed))
-
+        # Use print() as module level fixture logging.warning messages never
+        # shown to users. https://github.com/pytest-dev/pytest/issues/7819
+        print('*** module-level seed is set: all tests running deterministically ***')
+    print('Setting module np/mx/python random seeds, '
+                    'use MXNET_MODULE_SEED={} to reproduce.'.format(seed))
+    old_state = random.getstate()
     random.seed(seed)
     try:
         import numpy as np
@@ -101,13 +129,16 @@ def pytest_configure():
         np.random.seed(seed)
         mx.random.seed(seed)
     except:
-        logging.warning('Unable to import numpy/mxnet. Skipping conftest.')
+        # Use print() as module level fixture logging.warning messages never
+        # shown to users. https://github.com/pytest-dev/pytest/issues/7819
+        print('Unable to import numpy/mxnet. Skip setting module-level seed.')
 
     # The MXNET_TEST_SEED environment variable will override MXNET_MODULE_SEED for tests with
     #  the 'with_seed()' decoration.  Inform the user of this once here at the module level.
     if os.getenv('MXNET_TEST_SEED') is not None:
-        logging.warning('*** test-level seed set: all "@with_seed()" '
-                        'tests run deterministically ***')
+        # Use print() as module level fixture logging.warning messages never
+        # shown to users. https://github.com/pytest-dev/pytest/issues/7819
+        print('*** test-level seed set: all "@with_seed()" tests run deterministically ***')
 
     # Load the user's locale settings to verify that MXNet works correctly when the C locale is set
     # to anything other than the default value. Please see #16134 for an example of a bug caused by
@@ -115,19 +146,9 @@ def pytest_configure():
     import locale
     locale.setlocale(locale.LC_ALL, "")
 
-@pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    """Make test outcome available to fixture.
+    yield  # run all tests in the module
 
-    https://docs.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
-    """
-    # execute all other hooks to obtain the report object
-    outcome = yield
-    rep = outcome.get_result()
-
-    # set a report attribute for each phase of a call, which can
-    # be "setup", "call", "teardown"
-    setattr(item, "rep_" + rep.when, rep)
+    random.setstate(old_state)
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -171,20 +192,17 @@ def function_scope_seed(request):
         seed = int(env_seed_str)
     else:
         seed = random.randint(0, 2**31-1)
-
+    old_state = random.getstate()
     random.seed(seed)
     try:
         import numpy as np
         import mxnet as mx
-        post_test_state = np.random.get_state()
         np.random.seed(seed)
         mx.random.seed(seed)
     except:
-        logging.warning('Unable to import numpy/mxnet. Skipping seeding for numpy/mxnet.')
-        np = None
+        logging.warning('Unable to import numpy/mxnet. Skip setting function-level seed.')
 
-    seed_message = ('np/mx/python random seeds are set to '
-                    '{}, use MXNET_TEST_SEED={} to reproduce.')
+    seed_message = 'np/mx/python random seeds are set to {}, use MXNET_TEST_SEED={} to reproduce.'
     seed_message = seed_message.format(seed, seed)
 
     # Always log seed on DEBUG log level. This makes sure we can find out the
@@ -193,12 +211,6 @@ def function_scope_seed(request):
     logging.debug(seed_message)
 
     yield  # run the test
-
-    try:
-        import mxnet as mx
-        mx.nd.waitall()
-    except:
-        logging.warning('Unable to import mxnet. Skipping for mxnet engine.')
 
     if request.node.rep_setup.failed:
         logging.info("Setting up a test failed: {}", request.node.nodeid)
@@ -209,24 +221,4 @@ def function_scope_seed(request):
         # On failure also log seed on INFO log level
         logging.info(seed_message)
 
-    if np:
-        np.random.set_state(post_test_state)
-
-
-# * Shared test fixtures
-@pytest.fixture(params=[True, False])
-def hybridize(request):
-    return request.param
-
-@pytest.fixture(autouse=True)
-def doctest(doctest_namespace):
-    try:
-        import numpy as np
-        import mxnet as mx
-        doctest_namespace['np'] = np
-        doctest_namespace['mx'] = mx
-        doctest_namespace['gluon'] = mx.gluon
-    except:
-        logging.warning('Unable to import numpy/mxnet. Skipping conftest.')
-    import doctest
-    doctest.ELLIPSIS_MARKER = '-etc-'
+    random.setstate(old_state)

--- a/tests/python/gpu/test_contrib_amp.py
+++ b/tests/python/gpu/test_contrib_amp.py
@@ -32,7 +32,7 @@ from mxnet.contrib.amp import amp
 from mxnet.operator import get_all_registered_operators_grouped
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../unittest'))
-from common import with_seed, teardown_module, assert_raises_cudnn_not_satisfied
+from common import with_seed, assert_raises_cudnn_not_satisfied
 sys.path.insert(0, os.path.join(curr_path, '../train'))
 set_default_context(mx.gpu(0))
 

--- a/tests/python/gpu/test_fusion.py
+++ b/tests/python/gpu/test_fusion.py
@@ -26,7 +26,7 @@ from mxnet.test_utils import *
 
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../unittest'))
-from common import setup_module, teardown_module, with_seed
+from common import with_seed
 
 def check_fused_symbol(sym, **kwargs):
     inputs = sym.list_inputs()

--- a/tests/python/gpu/test_gluon_gpu.py
+++ b/tests/python/gpu/test_gluon_gpu.py
@@ -30,7 +30,7 @@ import pytest
 
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../unittest'))
-from common import setup_module, with_seed, teardown_module, assert_raises_cudnn_not_satisfied, run_in_spawned_process
+from common import with_seed, assert_raises_cudnn_not_satisfied, run_in_spawned_process
 from test_gluon import *
 from test_loss import *
 from test_numpy_loss import *

--- a/tests/python/gpu/test_gluon_model_zoo_gpu.py
+++ b/tests/python/gpu/test_gluon_model_zoo_gpu.py
@@ -28,7 +28,7 @@ import unittest
 import pytest
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../unittest'))
-from common import setup_module, with_seed, teardown_module
+from common import with_seed
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)

--- a/tests/python/gpu/test_gluon_transforms.py
+++ b/tests/python/gpu/test_gluon_transforms.py
@@ -27,7 +27,7 @@ from mxnet.test_utils import assert_almost_equal, set_default_context
 from mxnet.test_utils import almost_equal, same
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../unittest'))
-from common import assertRaises, setup_module, with_seed, teardown_module
+from common import assertRaises, with_seed
 from test_gluon_data_vision import test_to_tensor, test_normalize, test_crop_resize
 
 set_default_context(mx.gpu(0))

--- a/tests/python/gpu/test_kvstore_gpu.py
+++ b/tests/python/gpu/test_kvstore_gpu.py
@@ -24,7 +24,7 @@ import pytest
 from mxnet.test_utils import assert_almost_equal, default_context, environment
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../unittest'))
-from common import setup_module, with_seed, teardown_module
+from common import with_seed
 
 shape = (4, 4)
 keys = [5, 7, 11]

--- a/tests/python/gpu/test_operator_gpu.py
+++ b/tests/python/gpu/test_operator_gpu.py
@@ -34,7 +34,7 @@ from mxnet import autograd
 
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../unittest'))
-from common import setup_module, with_seed, teardown_module, assert_raises_cudnn_not_satisfied, assert_raises_cuda_not_satisfied
+from common import with_seed, assert_raises_cudnn_not_satisfied, assert_raises_cuda_not_satisfied
 from common import run_in_spawned_process
 from test_operator import check_sequence_reverse, allclose_function
 from test_operator import *

--- a/tests/python/gpu/test_tvm_op_gpu.py
+++ b/tests/python/gpu/test_tvm_op_gpu.py
@@ -21,7 +21,6 @@ import os
 import sys
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '../unittest'))
-from common import setup_module, teardown_module
 from test_tvm_op import *
 
 set_default_context(mx.gpu(0))

--- a/tests/python/unittest/onnx/mxnet_export_test.py
+++ b/tests/python/unittest/onnx/mxnet_export_test.py
@@ -23,7 +23,7 @@ import logging
 import tempfile
 curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
 sys.path.insert(0, os.path.join(curr_path, '..'))
-from common import setup_module, teardown_module, with_seed
+from common import with_seed
 from mxnet import nd, sym
 from mxnet.test_utils import set_default_context
 from mxnet.gluon import nn

--- a/tests/python/unittest/test_autograd.py
+++ b/tests/python/unittest/test_autograd.py
@@ -21,7 +21,7 @@ from mxnet.ndarray import zeros_like
 from mxnet.autograd import *
 from mxnet.test_utils import *
 
-from common import setup_module, with_seed, teardown_module, xfail_when_nonstandard_decimal_separator
+from common import with_seed, xfail_when_nonstandard_decimal_separator
 from mxnet.test_utils import environment
 
 import pytest

--- a/tests/python/unittest/test_base.py
+++ b/tests/python/unittest/test_base.py
@@ -20,7 +20,7 @@ from numpy.testing import assert_equal
 from mxnet.base import data_dir
 from mxnet.test_utils import environment
 from mxnet.util import getenv
-from common import setup_module, teardown_module, with_environment
+from common import with_environment
 import os
 import logging
 import os.path as op

--- a/tests/python/unittest/test_contrib_gluon_data_vision.py
+++ b/tests/python/unittest/test_contrib_gluon_data_vision.py
@@ -19,7 +19,7 @@ import mxnet as mx
 import numpy as np
 import scipy.ndimage
 from mxnet.test_utils import *
-from common import assertRaises, with_seed, setup_module, teardown_module
+from common import assertRaises, with_seed
 import shutil
 import tempfile
 import unittest

--- a/tests/python/unittest/test_exc_handling.py
+++ b/tests/python/unittest/test_exc_handling.py
@@ -19,7 +19,7 @@ import os
 import mxnet as mx
 import numpy as np
 from mxnet import gluon
-from common import setup_module, with_seed, teardown_module
+from common import with_seed
 from mxnet.gluon import nn
 from mxnet.base import MXNetError
 from mxnet.test_utils import assert_exception, default_context, set_default_context, use_np

--- a/tests/python/unittest/test_executor.py
+++ b/tests/python/unittest/test_executor.py
@@ -17,7 +17,7 @@
 
 import numpy as np
 import mxnet as mx
-from common import setup_module, with_seed, teardown_module
+from common import with_seed
 from mxnet.test_utils import assert_almost_equal, environment
 
 

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -27,7 +27,7 @@ from mxnet.util import is_np_array
 from mxnet.ndarray.ndarray import _STORAGE_TYPE_STR_TO_ID
 from mxnet.test_utils import use_np
 import mxnet.numpy as _mx_np
-from common import (setup_module, with_seed, assertRaises, teardown_module,
+from common import (with_seed, assertRaises,
                     assert_raises_cudnn_not_satisfied, xfail_when_nonstandard_decimal_separator, environment)
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/tests/python/unittest/test_gluon_data.py
+++ b/tests/python/unittest/test_gluon_data.py
@@ -24,7 +24,7 @@ import numpy as np
 import random
 from mxnet import gluon
 import platform
-from common import setup_module, with_seed, teardown_module
+from common import with_seed
 from mxnet.gluon.data import DataLoader
 import mxnet.ndarray as nd
 from mxnet import context

--- a/tests/python/unittest/test_gluon_data_vision.py
+++ b/tests/python/unittest/test_gluon_data_vision.py
@@ -25,7 +25,7 @@ from mxnet.base import MXNetError
 from mxnet.gluon.data.vision import transforms
 from mxnet import image
 from mxnet.test_utils import *
-from common import assertRaises, setup_module, with_seed, teardown_module, \
+from common import assertRaises, with_seed, \
     xfail_when_nonstandard_decimal_separator
 
 import numpy as np

--- a/tests/python/unittest/test_gluon_model_zoo.py
+++ b/tests/python/unittest/test_gluon_model_zoo.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 import mxnet as mx
 from mxnet.gluon.model_zoo.vision import get_model
 import sys
-from common import setup_module, with_seed, teardown_module
+from common import with_seed
 import multiprocessing
 import pytest
 

--- a/tests/python/unittest/test_gluon_trainer.py
+++ b/tests/python/unittest/test_gluon_trainer.py
@@ -22,7 +22,7 @@ import numpy as np
 from mxnet import gluon
 from mxnet.gluon import nn
 from mxnet.test_utils import assert_almost_equal
-from common import setup_module, with_seed, assertRaises, xfail_when_nonstandard_decimal_separator
+from common import with_seed, assertRaises, xfail_when_nonstandard_decimal_separator
 from copy import deepcopy
 import pytest
 

--- a/tests/python/unittest/test_kvstore.py
+++ b/tests/python/unittest/test_kvstore.py
@@ -20,7 +20,7 @@ import mxnet as mx
 import numpy as np
 import unittest
 from mxnet.test_utils import rand_ndarray, assert_almost_equal
-from common import setup_module, with_seed, assertRaises, teardown_module
+from common import with_seed, assertRaises
 from mxnet.base import py_str, MXNetError
 import pytest
 

--- a/tests/python/unittest/test_kvstore_custom.py
+++ b/tests/python/unittest/test_kvstore_custom.py
@@ -20,7 +20,7 @@ import mxnet as mx
 import numpy as np
 import unittest
 from mxnet.test_utils import rand_ndarray, assert_almost_equal
-from common import setup_module, with_seed, assertRaises, teardown_module
+from common import with_seed, assertRaises
 from mxnet.base import py_str, MXNetError
 
 shape = (4, 4)

--- a/tests/python/unittest/test_loss.py
+++ b/tests/python/unittest/test_loss.py
@@ -19,7 +19,7 @@ import mxnet as mx
 import numpy as np
 from mxnet import gluon, autograd
 from mxnet.test_utils import assert_almost_equal, default_context
-from common import setup_module, with_seed, teardown_module, xfail_when_nonstandard_decimal_separator
+from common import with_seed, xfail_when_nonstandard_decimal_separator
 import unittest
 
 

--- a/tests/python/unittest/test_memory_opt.py
+++ b/tests/python/unittest/test_memory_opt.py
@@ -19,7 +19,7 @@
 import mxnet as mx
 import os
 import sys
-from common import setup_module, teardown_module, with_environment
+from common import with_environment
 from mxnet.test_utils import environment
 
 num_hidden = 4096

--- a/tests/python/unittest/test_ndarray.py
+++ b/tests/python/unittest/test_ndarray.py
@@ -24,7 +24,7 @@ import pickle as pkl
 import random
 import functools
 import pytest
-from common import with_seed, assertRaises, TemporaryDirectory, setup_module, teardown_module
+from common import with_seed, assertRaises, TemporaryDirectory
 from mxnet.test_utils import almost_equal
 from mxnet.test_utils import assert_almost_equal, assert_exception
 from mxnet.test_utils import default_context

--- a/tests/python/unittest/test_numpy_contrib_gluon_data_vision.py
+++ b/tests/python/unittest/test_numpy_contrib_gluon_data_vision.py
@@ -19,7 +19,7 @@ import mxnet as mx
 import numpy as np
 import scipy.ndimage
 from mxnet.test_utils import *
-from common import assertRaises, with_seed, setup_module, teardown_module
+from common import assertRaises, with_seed
 import shutil
 import tempfile
 import unittest

--- a/tests/python/unittest/test_numpy_gluon_data_vision.py
+++ b/tests/python/unittest/test_numpy_gluon_data_vision.py
@@ -26,8 +26,7 @@ import numpy as _np
 import mxnet as mx
 from mxnet import gluon, autograd, np, npx
 from mxnet.test_utils import use_np, assert_almost_equal, check_gluon_hybridize_consistency, same, check_symbolic_backward
-from common import assertRaises, setup_module, with_seed, teardown_module, \
-    xfail_when_nonstandard_decimal_separator
+from common import assertRaises, with_seed, xfail_when_nonstandard_decimal_separator
 import random
 from mxnet.base import MXNetError
 from mxnet.gluon.data.vision import transforms

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -29,7 +29,7 @@ from mxnet import np
 from mxnet.test_utils import assert_almost_equal
 from mxnet.test_utils import use_np
 from mxnet.test_utils import is_op_runnable
-from common import assertRaises, with_seed, random_seed, setup_module, teardown_module
+from common import assertRaises, with_seed, random_seed
 from mxnet.numpy_dispatch_protocol import with_array_function_protocol, with_array_ufunc_protocol
 from mxnet.numpy_dispatch_protocol import _NUMPY_ARRAY_FUNCTION_LIST, _NUMPY_ARRAY_UFUNC_LIST
 

--- a/tests/python/unittest/test_numpy_loss.py
+++ b/tests/python/unittest/test_numpy_loss.py
@@ -19,7 +19,7 @@ import mxnet as mx
 import numpy as np
 from mxnet import gluon, autograd
 from mxnet.test_utils import assert_almost_equal, default_context, use_np
-from common import setup_module, with_seed, teardown_module, xfail_when_nonstandard_decimal_separator
+from common import with_seed, xfail_when_nonstandard_decimal_separator
 import pytest
 
 

--- a/tests/python/unittest/test_operator.py
+++ b/tests/python/unittest/test_operator.py
@@ -29,7 +29,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 from mxnet.test_utils import *
 from mxnet.operator import *
 from mxnet.base import py_str, MXNetError, _as_list
-from common import setup_module, with_seed, teardown_module, assert_raises_cudnn_not_satisfied, assert_raises_cuda_not_satisfied, assertRaises
+from common import with_seed, assert_raises_cudnn_not_satisfied, assert_raises_cuda_not_satisfied, assertRaises
 from common import xfail_when_nonstandard_decimal_separator, with_environment
 import pytest
 import os

--- a/tests/python/unittest/test_optimizer.py
+++ b/tests/python/unittest/test_optimizer.py
@@ -25,8 +25,7 @@ import unittest
 import pytest
 import math
 from mxnet.test_utils import *
-from common import setup_module, with_seed, teardown_module, retry, \
-    xfail_when_nonstandard_decimal_separator
+from common import with_seed, retry, xfail_when_nonstandard_decimal_separator
 
 @with_seed()
 def test_learning_rate():

--- a/tests/python/unittest/test_random.py
+++ b/tests/python/unittest/test_random.py
@@ -22,7 +22,7 @@ import mxnet as mx
 from mxnet.test_utils import verify_generator, gen_buckets_probs_with_ppf, assert_almost_equal
 import numpy as np
 import random as rnd
-from common import setup_module, with_seed, retry, random_seed, teardown_module
+from common import with_seed, retry, random_seed
 import scipy.stats as ss
 import unittest
 import pytest

--- a/tests/python/unittest/test_recordio.py
+++ b/tests/python/unittest/test_recordio.py
@@ -21,7 +21,7 @@ import mxnet as mx
 import numpy as np
 import random
 import string
-from common import setup_module, with_seed, teardown_module
+from common import with_seed
 
 @with_seed()
 def test_recordio(tmpdir):

--- a/tests/python/unittest/test_smoke.py
+++ b/tests/python/unittest/test_smoke.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from mxnet import np, npx, use_np, autograd, initializer, gluon
-from common import setup_module, teardown_module, with_environment
+from common import with_environment
 import pytest
 
 @use_np

--- a/tests/python/unittest/test_sparse_ndarray.py
+++ b/tests/python/unittest/test_sparse_ndarray.py
@@ -20,7 +20,7 @@ import pickle as pkl
 from mxnet.ndarray import NDArray
 import mxnet as mx
 from mxnet.test_utils import *
-from common import setup_module, with_seed, random_seed, teardown_module
+from common import with_seed, random_seed
 from mxnet.base import mx_real_t
 from numpy.testing import assert_allclose
 import numpy.random as rnd

--- a/tests/python/unittest/test_sparse_operator.py
+++ b/tests/python/unittest/test_sparse_operator.py
@@ -18,7 +18,7 @@
 from mxnet.test_utils import *
 from mxnet.base import MXNetError
 import pytest
-from common import setup_module, with_seed, teardown_module, assertRaises
+from common import with_seed, assertRaises
 import random
 import warnings
 

--- a/tests/python/unittest/test_subgraph.py
+++ b/tests/python/unittest/test_subgraph.py
@@ -22,7 +22,7 @@ import mxnet as mx
 import copy
 from mxnet.test_utils import *
 import pytest
-from common import setup_module, with_seed, teardown_module
+from common import with_seed
 from mxnet.gluon.model_zoo.vision import get_model
 
 def make_subgraph(subg, *args):


### PR DESCRIPTION
faccd91071cc34ed0b3a192d3c7932441fe7e35e introduced a automatic pytest hooks for handling MXNET_MODULE_SEED adapted from https://github.com/dmlc/gluon-nlp/blob/917855b/conftest.py but didn't yet remove the existing seed handling via explicit setup and teardown functions.

This commit removes the explicit setup and teardown functions in favor of the
automatic pytest version, and thereby also ensures that the seed handling code
is not executed twice. As a side benefit, seed handling now works correctly even
if contributors forget to add the magic setup_module and teardown_module
imports in new test files.

If pytest is run with --capture=no (or -s shorthand), output of the module level
fixtures is shown to the user.