### PR TITLE
Limit the number of ElementWiseSum kernels compiled by RTC

### DIFF
--- a/src/operator/tensor/elemwise_sum.cu
+++ b/src/operator/tensor/elemwise_sum.cu
@@ -128,10 +128,12 @@ void VectorizedElementwiseSum(const nnvm::NodeAttrs &attrs,
         params.inputs[j] = inputs[i + j].dptr_;
       }
       params.outputs[0] = outputs[0].dptr_;
+      const std::vector<TBlob> new_inputs(inputs.begin() + i,
+                                          inputs.begin() + i + params.num_inputs);
       VectorizedKernelRTCLauncher(code, "elementwise_sum_kernel",
                                   elementwise_sum_kernel, nvec,
                                   size, 1, s, params,
-                                  inputs, outputs,
+                                  new_inputs, outputs,
                                   ctx.run_ctx.get_ctx().dev_id);
     } else {
       /* During subsequent launches we need to
@@ -144,7 +146,8 @@ void VectorizedElementwiseSum(const nnvm::NodeAttrs &attrs,
         params.inputs[j] = inputs[i + j].dptr_;
       }
       params.outputs[0] = outputs[0].dptr_;
-      const std::vector<TBlob> new_inputs(inputs.begin() + i, inputs.end());
+      const std::vector<TBlob> new_inputs(inputs.begin() + i,
+                                          inputs.begin() + i + params.num_inputs);
       VectorizedKernelRTCLauncher(code, "elementwise_sum_kernel",
                                   elementwise_sum_kernel, nvec,
                                   size, 1, s, params,

--- a/src/operator/tensor/elemwise_sum.cu
+++ b/src/operator/tensor/elemwise_sum.cu
@@ -118,42 +118,22 @@ void VectorizedElementwiseSum(const nnvm::NodeAttrs &attrs,
                      : 1;
   const index_t size = inputs[0].Size();
   for (size_t i = 0; i < inputs.size(); i += num_inputs_per_kernel) {
-    if (i == 0) {
-      const std::string code = std::string("const OpReqType req = ") +
-                               util::to_string(req[0]) +
-                               ";\n";
-      elementwise_sum_params params{};
-      params.num_inputs = std::min(num_inputs_per_kernel, inputs.size() - i);
-      for (int j = 0; j < params.num_inputs; ++j) {
-        params.inputs[j] = inputs[i + j].dptr_;
-      }
-      params.outputs[0] = outputs[0].dptr_;
-      const std::vector<TBlob> new_inputs(inputs.begin() + i,
-                                          inputs.begin() + i + params.num_inputs);
-      VectorizedKernelRTCLauncher(code, "elementwise_sum_kernel",
-                                  elementwise_sum_kernel, nvec,
-                                  size, 1, s, params,
-                                  new_inputs, outputs,
-                                  ctx.run_ctx.get_ctx().dev_id);
-    } else {
-      /* During subsequent launches we need to
-         accumulate into the previous outputs
-      */
-      const std::string code = "const OpReqType req = OpReqType::kAddTo;\n";
-      elementwise_sum_params params{};
-      params.num_inputs = std::min(num_inputs_per_kernel, inputs.size() - i);
-      for (int j = 0; j < params.num_inputs; ++j) {
-        params.inputs[j] = inputs[i + j].dptr_;
-      }
-      params.outputs[0] = outputs[0].dptr_;
-      const std::vector<TBlob> new_inputs(inputs.begin() + i,
-                                          inputs.begin() + i + params.num_inputs);
-      VectorizedKernelRTCLauncher(code, "elementwise_sum_kernel",
-                                  elementwise_sum_kernel, nvec,
-                                  size, 1, s, params,
-                                  new_inputs, outputs,
-                                  ctx.run_ctx.get_ctx().dev_id);
+    const std::string code = std::string("const OpReqType req = ") +
+                             util::to_string(i == 0 ? req[0] : kAddTo) +
+                             ";\n";
+    elementwise_sum_params params{};
+    params.num_inputs = std::min(num_inputs_per_kernel, inputs.size() - i);
+    for (int j = 0; j < params.num_inputs; ++j) {
+      params.inputs[j] = inputs[i + j].dptr_;
     }
+    params.outputs[0] = outputs[0].dptr_;
+    const std::vector<TBlob> new_inputs(inputs.begin() + i,
+                                        inputs.begin() + i + params.num_inputs);
+    VectorizedKernelRTCLauncher(code, "elementwise_sum_kernel",
+                                elementwise_sum_kernel, nvec,
+                                size, 1, s, params,
+                                new_inputs, outputs,
+                                ctx.run_ctx.get_ctx().dev_id);
   }
 }
 


### PR DESCRIPTION
## Description ##
This PR limits the number of kernels compiled by RTC for ElementWiseSum - not limiting the inputs to the launcher was resulting in code like this:
```
using InputType0 = float32;
...
using InputType10 = float32;
```
which, even though the types beyond 4 were not used, was treated by a kernel cache as a new kernel, increasing the time needed to start the computation (as more kernels needed to be compiled).