### PR TITLE
[v1.x] fixing breaking change introduced in #17123 when batch_axis=0

### DIFF
--- a/python/mxnet/gluon/utils.py
+++ b/python/mxnet/gluon/utils.py
@@ -77,10 +77,15 @@ def split_data(data, num_slice, batch_axis=0, even_split=True):
         slices = _mx_np.split(data, indices_or_sections=list(div_points[1: -1]), axis=batch_axis)
     else:
         slices = []
-        for i in range(num_slice):
-            st = div_points[i]
-            end = div_points[i + 1]
-            slices.append(ndarray.slice_axis(data, axis=batch_axis, begin=st, end=end))
+        if batch_axis != 0:
+            for i in range(num_slice):
+                st = div_points[i]
+                end = div_points[i + 1]
+                slices.append(ndarray.slice_axis(data, axis=batch_axis, begin=st, end=end))
+        else:
+            # Fixes issue: https://github.com/apache/incubator-mxnet/issues/19268
+            slices = [data[div_points[i]:div_points[i + 1]] if i < num_slice - 1 else data[div_points[i]:size]
+                      for i in range(num_slice)]
     return slices
 
 

--- a/tests/python/unittest/test_gluon.py
+++ b/tests/python/unittest/test_gluon.py
@@ -29,6 +29,8 @@ from mxnet.test_utils import use_np
 import mxnet.numpy as _mx_np
 from common import (setup_module, with_seed, assertRaises, teardown,
                     assert_raises_cudnn_not_satisfied, environment)
+import mxnet.ndarray.sparse as mxsps
+import scipy.sparse as sps
 import numpy as np
 from numpy.testing import assert_array_equal
 from nose.tools import raises, assert_raises
@@ -3228,6 +3230,15 @@ def test_reqs_switching_training_inference():
     grad2 = x.grad.asnumpy()
 
     mx.test_utils.assert_almost_equal(grad1, grad2)
+
+
+def test_split_and_load():
+    ctx_list = (mx.cpu(0), mx.cpu(0))
+    csr_arr = mxsps.csr_matrix(sps.coo_matrix(([2.0], ([99], [999]))).tocsr(), ctx=mx.cpu(0))
+    arr_list = gluon.utils.split_and_load(csr_arr, ctx_list)
+    assert hasattr(arr_list[0], 'indices')
+    assert isinstance(arr_list[0], mxsps.CSRNDArray)
+
 
 if __name__ == '__main__':
     import nose


### PR DESCRIPTION
## Description ##
earlier `split_and_save` on batch_axis=0 would take in CSRNDArray and return CSRNDArray but now its not doing the same and returns NDArray. This causes change in external API behaviour. More details in #19268. Change was introduced in #17123 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

## Behaviour After Fix ##
```
import scipy.sparse as sps
import mxnet.ndarray.sparse as mxsps
import mxnet as mx
x = mxsps.csr_matrix(sps.coo_matrix(([2.0], ([99], [999]))).tocsr(), ctx=mx.gpu(0))
y = mx.gluon.utils.split_and_load(x, (mx.gpu(0), mx.gpu(0)))
print(x)
print(y)
```
output:
```
[20:54:45] ../src/base.cc:84: Upgrade advisory: this mxnet has been built against cuDNN lib version 7501, which is older than the oldest version tested by CI (7600).  Set MXNET_CUDNN_LIB_CHECKING=0 to quiet this warning.

<CSRNDArray 100x1000 @gpu(0)>
[
<CSRNDArray 50x1000 @gpu(0)>,
<CSRNDArray 50x1000 @gpu(0)>]
```