### PR TITLE
[BUGFIX] autograd.grad

### DIFF
--- a/python/mxnet/autograd.py
+++ b/python/mxnet/autograd.py
@@ -316,7 +316,8 @@ def grad(heads, variables, head_grads=None, retain_graph=None, create_graph=Fals
     """
     head_handles, hgrad_handles = _parse_head(heads, head_grads)
 
-    if isinstance(variables, NDArray):
+    var_not_list = isinstance(variables, NDArray)
+    if var_not_list:
         variables = [variables]
     else:
         assert len(variables), "variables cannot be an empty list."
@@ -341,7 +342,7 @@ def grad(heads, variables, head_grads=None, retain_graph=None, create_graph=Fals
     ret = [_ndarray_cls(ctypes.cast(grad_vars[i], NDArrayHandle),
                         stype=grad_stypes[i])
            for i in range(len(var_handles))]
-    if isinstance(variables, NDArray):
+    if var_not_list:
         return ret[0]
     return ret
 


### PR DESCRIPTION
## Description ##
previous behavior: input variable output list
intended behavior: input variable output variable

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [-] All changes have test coverage
- [-] Code is well-documented

## Comments ##
- Potentially backward incompatible but people who use it should be able to notice the inconsistency and avoid this particular use case.
- Edge case: what if the input is neither a variable nor a list? Proper input validation should be done.