### PR TITLE
Fix Nightly CD

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -162,6 +162,9 @@ def collect_test_results_windows(original_file_name, new_file_name) {
 def docker_run(platform, function_name, use_nvidia = false, shared_mem = '500m', env_vars = [],
                build_args = "") {
   def command = "ci/build.py %ENV_VARS% %BUILD_ARGS% --docker-registry ${env.DOCKER_CACHE_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --docker-build-retries 3 --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
+  if (env_vars instanceof String) {
+    env_vars = [env_vars]
+  }
   env_vars << "BRANCH=${env.BRANCH_NAME}"
   env_vars = env_vars.collect { "-e ${it}" }
   def env_vars_str = env_vars.join(' ')


### PR DESCRIPTION
There is a minor command generation bug with cd pipeline. link: https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job/detail/mxnet-cd-release-job/1800/pipeline

Thanks @mseth10 for pointing out the initial direction. Quoting his comments:
```
Looks like this commit caused the failure: https://github.com/apache/incubator-mxnet/commit/d81692933f507e7631cbbbb8be920f02eaeaa585

More specifically, changes to env_vars in docker_run function in file ci/Jenkinsfile_utils.groovy, which gets called for the CD pipeline here:
https://github.com/apache/incubator-mxnet/blob/7d3e027846b2767e330d488092e0c12b2d01b36d/cd/python/pypi/Jenkins_pipeline.groovy#L52

The CD pipeline:
https://jenkins.mxnet-ci.amazon-ml.com/blue/organizations/jenkins/restricted-mxnet-cd%2Fmxnet-cd-release-job/detail/mxnet-cd-release-job/1775/pipeline/331

- ran this command (faulty) after the commit got merged:
`ci/build.py -e R -e E -e L -e E -e A -e S -e E -e _ -e B -e U -e I -e L -e D -e = -e  -e t -e r -e u -e e -e  --docker-registry mxnetci --nvidiadocker --platform centos7_gpu_cu102 --docker-build-retries 3 --shm-size 500m /work/runtime_functions.sh cd_package_pypi cu102`

- ran this command (correct) before the commit got merged:
`ci/build.py -e RELEASE_BUILD=true --docker-registry mxnetci --nvidiadocker --platform centos7_gpu_cu102 --docker-build-retries 3 --shm-size 500m /work/runtime_functions.sh cd_package_pypi cu102`
```

So basically if we are not specifying `env_vars` then its default value is `[]`, no problem. But if we pass in String obj then `env_vars = env_vars.collect { "-e ${it}" }` will break the string into letters. So we need to add:
```
if (env_vars instanceof String) {
    env_vars = [env_vars]
}
```

@szha 
