### PR TITLE
Fix Nightly CD

### DIFF
--- a/ci/Jenkinsfile_utils.groovy
+++ b/ci/Jenkinsfile_utils.groovy
@@ -162,7 +162,7 @@ def collect_test_results_windows(original_file_name, new_file_name) {
 def docker_run(platform, function_name, use_nvidia = false, shared_mem = '500m', env_vars = [],
                build_args = "") {
   def command = "ci/build.py %ENV_VARS% %BUILD_ARGS% --docker-registry ${env.DOCKER_CACHE_REGISTRY} %USE_NVIDIA% --platform %PLATFORM% --docker-build-retries 3 --shm-size %SHARED_MEM% /work/runtime_functions.sh %FUNCTION_NAME%"
-  if (env_vars instanceof String) {
+  if (env_vars instanceof String || env_vars instanceof GString) {
     env_vars = [env_vars]
   }
   env_vars << "BRANCH=${env.BRANCH_NAME}"


### PR DESCRIPTION
This is a follow up of https://github.com/apache/incubator-mxnet/pull/19284

So after that PR CD was still having the same issue. I researched it a little more and realized templated strings are of class `GString` so we should check for that rather than `String`. But for the sake of robustness we can check for both

@szha 