### PR TITLE
[submodule] Upgrade oneDNN to v1.6.4

### DIFF
--- a/tests/cpp/operator/mkldnn_test.cc
+++ b/tests/cpp/operator/mkldnn_test.cc
@@ -100,7 +100,7 @@ static void VerifyDefMem(const mkldnn::memory &mem) {
 
 TEST(MKLDNN_UTIL_FUNC, MemFormat) {
   // Check whether the number of format is correct.
-  CHECK_EQ(mkldnn_format_tag_last, 205);
+  CHECK_EQ(mkldnn_format_tag_last, 219);
   CHECK_EQ(mkldnn_nchw, 5);
   CHECK_EQ(mkldnn_oihw, 5);
 }


### PR DESCRIPTION
This change will upgrade oneDNN to v1.6.4 which includes fix for compiling problems with gcc8.