### PR TITLE
Fix HybridBlock.forward and autograd use of reshape with 0-shapes

### DIFF
--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -300,10 +300,15 @@ NDArray NDArray::ReshapeWithRecord(const mxnet::TShape &shape) {
   }
 
   nnvm::NodeAttrs attrs;
-  attrs.op = nnvm::Op::Get("Reshape");;
   std::ostringstream os;
   os << shape;
-  attrs.dict.insert({"shape", os.str()});
+  if (!Imperative::Get()->is_np_shape()) {
+      attrs.op = nnvm::Op::Get("Reshape");;
+      attrs.dict.insert({"shape", os.str()});
+  } else {
+      attrs.op = nnvm::Op::Get("_np_reshape");;
+      attrs.dict.insert({"newshape", os.str()});
+  }
   attrs.op->attr_parser(&attrs);
   std::vector<NDArray*> inputs(1, this), outputs(1, &ret);
 

--- a/tests/python/unittest/test_deferred_compute.py
+++ b/tests/python/unittest/test_deferred_compute.py
@@ -575,3 +575,18 @@ def test_indexing_shape_change():
     net.hybridize()
     net(mx.np.random.uniform(size=(8, 16)))
     net(mx.np.random.uniform(size=(8, 8)))
+
+
+def test_indexing_empty_shape():
+    @mx.util.use_np
+    class TestModel(mx.gluon.HybridBlock):
+        def forward(self, x):
+            return x[0]
+
+    net = TestModel()
+    net.hybridize()
+    try:
+        mx.npx.set_np()
+        net(mx.np.zeros((2, 2, 4, 0, 128)))
+    finally:
+        mx.npx.reset_np()


### PR DESCRIPTION
## Description ##
Record np_reshape instead of Reshape in np mode.

Fixes https://github.com/apache/incubator-mxnet/issues/19286

This bug is related to legacy (non-numpy) reshape operator. Reshape with `0` implies "copy this dimension from input".

We can see that all shapes are correct prior to infer_shape pass:

```
frame #6: 0x00007fff3bd1cb8b libmxnet.so`mxnet::imperative::SetShapeType(ctx=0x00007fffffff8f18, attrs=0x00007fffffff97a8, inputs=size=1, outputs=size=1, dispatch_mode=0x00007fffffff8f24) at imperative_utils.h:208:26
   205        common::ConvertToNumpyShape(&in_shapes);
   206        common::ConvertToNumpyShape(&out_shapes);
   207      }
-> 208      const bool success = infershape[attrs.op](attrs, &in_shapes, &out_shapes);
   209      if (!success) {
   210        std::stringstream os;
   211        os << "Operator " << attrs.op->name << " inferring shapes failed.\n";
(lldb) parray 5 in_shapes[0].data_heap_
(long *) $15 = 0x0000555555f45700 {
  (long) [0] = 1
  (long) [1] = 2
  (long) [2] = 4
  (long) [3] = 0
  (long) [4] = 128
}
(lldb) p out_shapes                                                                                                                                                                    (mxnet::ShapeVector) $16 = size=1 {
  [0] = {
    mxnet::Tuple<long> = {
      ndim_ = 4
      num_heap_allocated_ = 0
      data_stack_ = ([0] = 2, [1] = 4, [2] = 0, [3] = 128)
      data_heap_ = 0x0000000000000000
    }
  }
}
```

But after infer_shape, `0` is replaced by `4`.

```
frame #1: 0x00007fff4968c1be libmxnet.so`mxnet::op::ReshapeShape(attrs=0x00007fffffff97a8, in_attrs=0x00005555569cbb68, out_attrs=0x00005555569cbb80) at matrix_op-inl.h:235:3
   232      << "Target: " << oshape
   233      << "\nSource: " << dshape;
   234  #endif
-> 235    SHAPE_ASSIGN_CHECK(*out_attrs, 0, oshape);
   236    return ReverseReshapeInferShape(&(*in_attrs)[0], (*out_attrs)[0]);
   237  }
   238
(lldb) p oshape
(mxnet::TShape) $17 = {
  mxnet::Tuple<long> = {
    ndim_ = 4
    num_heap_allocated_ = 0
    data_stack_ = ([0] = 2, [1] = 4, [2] = 4, [3] = 128)
    data_heap_ = 0x0000000000000000
  }
}
```

https://github.com/apache/incubator-mxnet/blob/f732530c8e1f8dcc11134e935430e3793ddbf4c8/src/operator/tensor/matrix_op-inl.h#L194-L237

The root cause is that `MXNDArrayAt`, `MXNDArrayReshape` and `MXNDArraySlice` do not sufficiently distinguish between the numpy and non-numpy mode and always record legacy operators.

We need to update the recording step to record numpy / legacy operator based on if numpy / legacy mode is enabled:

 https://github.com/apache/incubator-mxnet/blob/72eff9b66ecc683c3e7f9ad2c0ba69efa8dd423b/src/ndarray/ndarray.cc#L302-L308 
