### PR TITLE
[v1.x] TRT test update

### DIFF
--- a/tests/python/tensorrt/test_tensorrt.py
+++ b/tests/python/tensorrt/test_tensorrt.py
@@ -22,6 +22,7 @@ from mxnet.base import SymbolHandle, check_call, _LIB, mx_uint, c_str_array, c_s
 from mxnet.symbol import Symbol
 import numpy as np
 from mxnet.test_utils import assert_almost_equal
+from mxnet.numpy_extension import get_cuda_compute_capability
 from mxnet import gluon
 from mxnet.gluon import nn
 from mxnet import nd
@@ -135,17 +136,25 @@ def get_top1(logits):
 
 
 def test_tensorrt_symbol_int8():
+    ctx = mx.gpu(0)
+    cuda_arch = get_cuda_compute_capability(ctx)
+    cuda_arch_min = 70
+    if cuda_arch < cuda_arch_min:
+        print('Bypassing test_tensorrt_symbol_int8 on cuda arch {}, need arch >= {}).'.format(
+              cuda_arch, cuda_arch_min))
+        return
+
     # INT8 engine output are not lossless, so we don't expect numerical uniformity,
     # but we have to compare the TOP1 metric
 
     batch_shape=(1,3,224,224)
     sym, arg_params, aux_params = get_model(batch_shape=batch_shape)
     calibration_iters = 700
-    trt_sym = sym.optimize_for('TensorRT', args=arg_params, aux=aux_params, ctx=mx.gpu(0),
+    trt_sym = sym.optimize_for('TensorRT', args=arg_params, aux=aux_params, ctx=ctx,
                                precision='int8',
                                calibration_iters=calibration_iters)
     
-    executor = trt_sym.simple_bind(ctx=mx.gpu(), data=batch_shape,
+    executor = trt_sym.simple_bind(ctx=ctx, data=batch_shape,
                                grad_req='null', force_rebind=True)
     
     dali_val_iter = get_dali_iter()

--- a/tests/python/tensorrt/test_tensorrt.py
+++ b/tests/python/tensorrt/test_tensorrt.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import os
+import sys
 import ctypes
 import mxnet as mx
 from mxnet.base import SymbolHandle, check_call, _LIB, mx_uint, c_str_array, c_str, mx_real_t
@@ -27,6 +28,10 @@ from mxnet import gluon
 from mxnet.gluon import nn
 from mxnet import nd
 from mxnet.gluon.model_zoo import vision
+
+curr_path = os.path.dirname(os.path.abspath(os.path.expanduser(__file__)))
+sys.path.insert(0, os.path.join(curr_path, '../unittest'))
+from common import setup_module, with_seed, teardown
 
 ####################################
 ######### FP32/FP16 tests ##########
@@ -61,7 +66,7 @@ def get_baseline(input_data):
     return output
 
 
-def check_tensorrt_symbol(baseline, input_data, fp16_mode, tol):
+def check_tensorrt_symbol(baseline, input_data, fp16_mode, rtol=None, atol=None):
     sym, arg_params, aux_params = get_model(batch_shape=input_data.shape)
     trt_sym = sym.optimize_for('TensorRT', args=arg_params, aux=aux_params, ctx=mx.gpu(0),
                                precision='fp16' if fp16_mode else 'fp32')
@@ -70,17 +75,18 @@ def check_tensorrt_symbol(baseline, input_data, fp16_mode, tol):
                                    grad_req='null', force_rebind=True)
 
     output = executor.forward(is_train=False, data=input_data)
-    assert_almost_equal(output[0].asnumpy(), baseline[0].asnumpy(), atol=tol[0], rtol=tol[1])
+    assert_almost_equal(output[0], baseline[0], rtol=rtol, atol=atol)
 
+@with_seed()
 def test_tensorrt_symbol():
     batch_shape = (32, 3, 224, 224)
     input_data = mx.nd.random.uniform(shape=(batch_shape), ctx=mx.gpu(0))
     baseline = get_baseline(input_data)
     print("Testing resnet50 with TensorRT backend numerical accuracy...")
     print("FP32")
-    check_tensorrt_symbol(baseline, input_data, fp16_mode=False, tol=(1e-4, 1e-4))
+    check_tensorrt_symbol(baseline, input_data, fp16_mode=False)
     print("FP16")
-    check_tensorrt_symbol(baseline, input_data, fp16_mode=True, tol=(1e-1, 1e-2))
+    check_tensorrt_symbol(baseline, input_data, fp16_mode=True, rtol=1e-2, atol=1e-1)
 
 ##############################
 ######### INT8 tests ##########

--- a/tests/python/unittest/test_numpy_op.py
+++ b/tests/python/unittest/test_numpy_op.py
@@ -2528,6 +2528,27 @@ def test_np_mixed_precision_binary_funcs():
             def hybrid_forward(self, F, a, b, *args, **kwargs):
                 return getattr(F.np, self._func)(a, b)
 
+        if (func in ['multiply', 'mod', 'equal', 'not_equal', 'greater',
+                    'greater_equal', 'less', 'less_equal']) and \
+            (lshape == () or rshape == ()) :
+        # the behaviors of infer type in dealing with the input shape of '()' are different between np and onp
+        # for example,
+        # mx_test_x1 = np.random.uniform(-2, 2, (2,3)).astype(np.float32)
+        # mx_test_x2 = np.random.uniform(-2, 2, ()).astype(np.float16)
+        # np_out = _np.mod(mx_test_x1.asnumpy(), mx_test_x2.asnumpy()) # float16
+        # mx_out = np.mod(mx_test_x1, mx_test_x2) # float32
+
+        # logcial ops: when two numbers are only different in precision, NumPy also has a weird behavior
+        # for example,
+        # a = np.array([[1.441]], dtype = np.float16)
+        # b = np.array(1.4413278, dtype = np.float32)
+        # c = np.array([1.4413278], dtype = np.float32)
+        # np.greater(a,b), np.greater(a,c) # True True
+        # _np.greater(a.asnumpy(),b.asnumpy()), _np.greater(a.asnumpy(),c.asnumpy()) # False True
+
+        # thus, skip the tests
+            return
+
         np_func = getattr(_np, func)
         mx_func = TestMixedBinary(func)
         np_test_x1 = _np.random.uniform(low, high, lshape).astype(ltype)


### PR DESCRIPTION
## Description ##
This PR includes improvements discovered during the testing of the v1.8.x branch:

- For the test_tensorrt.py:test_tensorrt_symbol test, the explicitly set tolerances were removed for the 32-bit model test.  This allows the test to pass on A100 by allowing the framework to detect the A100 context and choose the relaxed tolerance appropriate for a TF32 calculation.
- For the test_tensorrt.py:test_tensorrt_symbol_int8 test, logic was inserted to avoid running the test on GPU architectures earlier than Volta (PASCAL, MAXWELL, etc.).  On PASCAL, where int8 is not supported, a message was printed, but then the test hung. 
 With this PR, the test is skipped.  In general, users should not attempt running TRT int8 on PASCAL GPUs or earlier.
- Finally, a CI failure was seen in test_operator_gpu.py:test_np_mixed_precision_binary_funcs for seed MXNET_TEST_SEED=590323404.  Additional repro'd failures all seemed to occur when the data shape was ().  This behavior was seen and fixed in master PR https://github.com/apache/incubator-mxnet/pull/18660.  This PR includes only the portion of that PR that skips the test when the data shape is ().  The full PR should still be backported by the author to 1.x if deemed useful.

@yzhliu @Kh4L @samskalicky 
## Checklist ##
### Essentials ###
- [X ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X ] Changes are complete (i.e. I finished coding on this PR)
- [X ] All changes have test coverage
- [X ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
