### PR TITLE
[FEATURE] Enable large tensor support for array_split

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -2958,8 +2958,8 @@ inline bool SplitOpShapeImpl(const nnvm::NodeAttrs& attrs,
   squeezed_dshape = mxnet::TShape(&squeezed_dshape[0], &squeezed_dshape[squeezed_dshape.ndim()-1]);
   // Assign shape to every output
   for (int i = 0; i < num_outputs; ++i) {
-    int start = indices[i];
-    int end = (i < num_outputs - 1) ? indices[i + 1] : ishape[real_axis];
+    index_t start = indices[i];
+    index_t end = (i < num_outputs - 1) ? indices[i + 1] : ishape[real_axis];
     if (ishape[real_axis] == 0U) {
       end = start;
     } else {

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -1874,3 +1874,15 @@ def test_cross():
     assert inp.grad[0, 0] == 1 and inp.grad[0, 1] == -1 and inp.grad[0, 2] == 0
     assert inp.grad[-1, 0] == 5 and inp.grad[-1, 1] == -4 and inp.grad[-1, 2] == -1
 
+
+@use_np
+def test_array_split():
+    inp = np.ones((INT_OVERFLOW, 2))
+    inp[0][0] = 0
+    inp[-1][-1] = 2
+    out = np.array_split(inp, 2)
+    assert out[0].shape ==(HALF_INT_OVERFLOW, 2)
+    assert out[1].shape ==(HALF_INT_OVERFLOW, 2)
+    assert out[0][0][0] == 0
+    assert out[1][-1][-1] == 2
+


### PR DESCRIPTION
## Description ##
LTS for numpy operator `array_split`

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Testing ###
```
(pytest) ubuntu@ip-172-31-90-243 ~/workspace/incubator-mxnet (array_split_lt) $ python -m pytest -s --exitfirst --verbose tests/nightly/test_np_large_array.py::test_array_split
==================================================================================================================================== test session starts ====================================================================================================================================
platform linux -- Python 3.6.10, pytest-5.3.5, py-1.8.2, pluggy-0.13.1 -- /home/ubuntu/anaconda3/envs/pytest/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/workspace/incubator-mxnet, inifile: pytest.ini
plugins: timeout-1.4.2
timeout: 1200.0s
timeout method: signal
timeout func_only: False
collected 1 item

tests/nightly/test_np_large_array.py::test_array_split [22:37:13] ../src/storage/storage.cc:199: Using Pooled (Naive) StorageManager for CPU
PASSED

===================================================================================================================================== warnings summary ======================================================================================================================================
tests/nightly/test_np_large_array.py:92
  /home/ubuntu/workspace/incubator-mxnet/tests/nightly/test_np_large_array.py:92: DeprecationWarning: invalid escape sequence \
    '''

tests/nightly/test_np_large_array.py:721
  /home/ubuntu/workspace/incubator-mxnet/tests/nightly/test_np_large_array.py:721: DeprecationWarning: invalid escape sequence \
    '''

-- Docs: https://docs.pytest.org/en/latest/warnings.html
=============================================================================================================================== 1 passed, 2 warnings in 7.92s ===============================================================================================================================
```
