### PR TITLE
[FEATURE] Enable large tensor support for numpy cross

### DIFF
--- a/src/operator/numpy/np_cross-inl.h
+++ b/src/operator/numpy/np_cross-inl.h
@@ -90,8 +90,8 @@ struct NumpyCrossParam : public dmlc::Parameter<NumpyCrossParam> {
 
 struct CrossInAssign {
   template<typename DType>
-  MSHADOW_XINLINE static void Map(int i, const DType *in_ptr, DType *out_ptr,
-                                  const int stride, const int index, const int msize) {
+  MSHADOW_XINLINE static void Map(index_t i, const DType *in_ptr, DType *out_ptr,
+                                  const index_t stride, const index_t index, const size_t msize) {
     if (index < stride && i * stride + index < msize) {
       out_ptr[i] = in_ptr[i * stride + index];
     }
@@ -101,9 +101,9 @@ struct CrossInAssign {
 template<int req>
 struct CrossOutAssign {
   template<typename DType>
-  MSHADOW_XINLINE static void Map(int i, const DType *in_ptr, DType *out_ptr,
-                                  const int positive, const int stride,
-                                  const int index, const int msize) {
+  MSHADOW_XINLINE static void Map(index_t i, const DType *in_ptr, DType *out_ptr,
+                                  const int positive, const index_t stride,
+                                  const index_t index, const size_t msize) {
     if (index < stride && i * stride + index < msize) {
       KERNEL_ASSIGN(out_ptr[i * stride + index], req, positive == 1 ? in_ptr[i] : -in_ptr[i]);
     }
@@ -113,7 +113,7 @@ struct CrossOutAssign {
 template<int req>
 struct ResAssign {
   template<typename DType>
-  MSHADOW_XINLINE static void Map(int i, const DType *in_data, DType *out_data) {
+  MSHADOW_XINLINE static void Map(index_t i, const DType *in_data, DType *out_data) {
     KERNEL_ASSIGN(out_data[i], req, in_data[i]);
   }
 };
@@ -153,7 +153,7 @@ inline mxnet::TShape GetMoveaxisShape(const Tuple<int>& moveaxis_index,
   const int ndim = org_shape.ndim();
   if (ndim == 0) { return mxnet::TShape(0, 0); }
   CHECK_EQ(moveaxis_index.ndim(), org_shape.ndim()) << "moveaxis index dismatch original shape.";
-  std::vector<int> moveaxis_shape_vec(ndim, -1);
+  std::vector<size_t> moveaxis_shape_vec(ndim, -1);
   for (int i = 0; i < ndim; ++i) {
     moveaxis_shape_vec[i] = org_shape[moveaxis_index[i]];
   }

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -1839,3 +1839,22 @@ def test_round():
     output = np.round(input)
     assert output.shape == (INT_OVERFLOW, 2)
     assert output[-1][0] == 2
+
+
+@use_np
+def test_cross():
+    inp = np.ones((INT_OVERFLOW, 3))
+    inp2 = np.ones((INT_OVERFLOW, 2))
+    inp[-1] = np.array([1, 2, 3])
+    inp2[-1] = np.array([4, 5])
+    inp.attach_grad()
+    with mx.autograd.record():
+        out = np.cross(inp, inp2)
+        out.backward()
+    assert out.shape == (INT_OVERFLOW, 3)
+    assert out[0, 0] == -1 and out[0, 1] == 1 and out[0, 2] == 0
+    assert out[-1, 0] == -15 and out[-1, 1] == 12 and out[-1, 2] == -3
+    assert inp.grad.shape == inp.shape
+    assert inp.grad[0, 0] == 1 and inp.grad[0, 1] == -1 and inp.grad[0, 2] == 0
+    assert inp.grad[-1, 0] == 5 and inp.grad[-1, 1] == -4 and inp.grad[-1, 2] == -1
+


### PR DESCRIPTION
## Description ##
LTS for numpy cross operator (both backward and forward)

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Testing ###
```
(pytest) ubuntu@ip-172-31-90-243 ~/workspace/incubator-mxnet (cross_lt) $ python -m pytest -s --exitfirst --verbose tests/nightly/test_np_large_array.py::test_cross
==================================================================================================================================== test session starts ====================================================================================================================================
platform linux -- Python 3.6.10, pytest-5.3.5, py-1.8.2, pluggy-0.13.1 -- /home/ubuntu/anaconda3/envs/pytest/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/workspace/incubator-mxnet, inifile: pytest.ini
plugins: timeout-1.4.2
timeout: 1200.0s
timeout method: signal
timeout func_only: False
collected 1 item

tests/nightly/test_np_large_array.py::test_cross [21:43:36] ../src/storage/storage.cc:199: Using Pooled (Naive) StorageManager for CPU
[21:43:40] ../src/base.cc:84: Upgrade advisory: this mxnet has been built against cuDNN lib version 7501, which is older than the oldest version tested by CI (7600).  Set MXNET_CUDNN_LIB_CHECKING=0 to quiet this warning.
PASSED

===================================================================================================================================== warnings summary ======================================================================================================================================
tests/nightly/test_np_large_array.py:92
  /home/ubuntu/workspace/incubator-mxnet/tests/nightly/test_np_large_array.py:92: DeprecationWarning: invalid escape sequence \
    '''

tests/nightly/test_np_large_array.py:721
  /home/ubuntu/workspace/incubator-mxnet/tests/nightly/test_np_large_array.py:721: DeprecationWarning: invalid escape sequence \
    '''

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================================================= 1 passed, 2 warnings in 70.96s (0:01:10) ==========================================================================================================================
```