### PR TITLE
Fix possible IMA in amp_multicast fusion

### DIFF
--- a/src/common/cuda/rtc/forward_functions-inl.h
+++ b/src/common/cuda/rtc/forward_functions-inl.h
@@ -148,7 +148,7 @@ __device__ inline vector::VectorizedStorage<DType, nvec> load_slice(const DType 
   vector::VectorizedStorage<DType, nvec> ret;
   #pragma unroll
   for (int j = 0; j < nvec; j++) {
-      ret.scratch_.separate[j] = *(input + idx[j]);
+      ret.scratch_.separate[j] = idx[j] < shape.size ? *(input + idx[j]) : DType {};
   }
   return ret;
 }


### PR DESCRIPTION
## Description ##
The patch fixes possible CUDA Invalid Memory Access when fusing amp_multicast op with inputs of different sizes.

It has been observed on Yolo3 model from GluonCV.

## Checklist ##
### Essentials ###
- [X] Changes are complete (i.e. I finished coding on this PR)

@ptrendx 