### PR TITLE
Update cuda arch for cu110 dynamic build

### DIFF
--- a/ci/docker/runtime_functions.sh
+++ b/ci/docker/runtime_functions.sh
@@ -124,6 +124,13 @@ build_dynamic_libmxnet() {
             -DUSE_MKLDNN=OFF \
             -DUSE_CUDA=OFF \
             -G Ninja /work/mxnet
+    elif [[ ${mxnet_variant} = "cu110" ]]; then
+        cmake -DUSE_MKL_IF_AVAILABLE=OFF \
+            -DUSE_MKLDNN=ON \
+            -DUSE_DIST_KVSTORE=ON \
+            -DUSE_CUDA=ON \
+            -MXNET_CUDA_ARCH="5.0;6.0;7.0;8.0" \
+            -G Ninja /work/mxnet
     elif [[ ${mxnet_variant} =~ cu[0-9]+$ ]]; then
         cmake -DUSE_MKL_IF_AVAILABLE=OFF \
             -DUSE_MKLDNN=ON \


### PR DESCRIPTION
## Description ##
Currently the mxnet dynamic build pipeline uses `Auto` flag to specify cuda arch: https://github.com/apache/incubator-mxnet/blob/9f8af7bebd8b9354fb162b5ec07499b27ec1badf/CMakeLists.txt#L43
This includes cuda arch 3.0 into cu110 build and causes build error (cu110 does not support arch 3.0).
This PR aims to correct the cuda arch for cu110 dynamic build.
