### PR TITLE
[BUGFIX] [1.x] Backport of "Avoid logging seed for skipped tests #19322"

### DIFF
--- a/tests/python/unittest/common.py
+++ b/tests/python/unittest/common.py
@@ -30,6 +30,7 @@ sys.path.insert(0, os.path.join(curr_path, '../../../python'))
 
 import models
 from contextlib import contextmanager
+from nose import SkipTest
 from nose.tools import make_decorator, assert_raises
 import tempfile
 
@@ -216,6 +217,9 @@ def with_seed(seed=None):
                 logger.log(log_level, pre_test_msg)
                 try:
                     orig_test(*args, **kwargs)
+                except SkipTest:
+                    # no need to log seed info for skipped nosetests
+                    raise
                 except:
                     # With exceptions, repeat test_msg at WARNING level to be sure it's seen.
                     if log_level < logging.WARNING:


### PR DESCRIPTION
## Description ##
This fixes issue https://github.com/apache/incubator-mxnet/issues/19255, where it was noted that when a unittest was skipped, the skip-exception caused the with_seed() decorator to log the seed. While the 1.x branch uses nosetests, not pytest, the same behavior is seen on 1.x.  With this PR the seed is no longer logged.

This PR doesn't have any testing added- I will inspect the CI log for skipped tests such as test_operator.py:test_activation to verify that the seed logging has been successfully eliminated.

@leezu @samskalicky 
## Checklist ##
### Essentials ###
- [X ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [X ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [X ] Code is well-documented
