### PR TITLE
[FEATURE] Enable large tensor support for insert

### DIFF
--- a/src/api/operator/numpy/np_delete_op.cc
+++ b/src/api/operator/numpy/np_delete_op.cc
@@ -45,9 +45,9 @@ MXNET_REGISTER_API("_npi.delete")
     if (args[1].type_code() == kDLInt ||
         args[1].type_code() == kDLFloat) {
       if (args[1].type_code() == kDLInt) {
-        param.int_ind = args[1].operator int();
+        param.int_ind = args[1].operator int64_t();
       } else if (args[1].type_code() == kDLFloat) {
-        param.int_ind = static_cast<int>(args[1].operator double());
+        param.int_ind = static_cast<int64_t>(args[1].operator double());
       }
       if (args[2].type_code() == kDLInt) {
         param.axis = args[2].operator int();
@@ -66,19 +66,19 @@ MXNET_REGISTER_API("_npi.delete")
   } else {
     num_inputs = 1;
     if (args[1].type_code() == kDLInt) {
-      param.start = args[1].operator int();
+      param.start = args[1].operator int64_t();
     } else if (args[1].type_code() == kDLFloat) {
-      param.start = static_cast<int>(args[1].operator double());
+      param.start = static_cast<int64_t>(args[1].operator double());
     }
     if (args[2].type_code() == kDLInt) {
-      param.stop = args[2].operator int();
+      param.stop = args[2].operator int64_t();
     } else if (args[2].type_code() == kDLFloat) {
-      param.stop = static_cast<int>(args[2].operator double());
+      param.stop = static_cast<int64_t>(args[2].operator double());
     }
     if (args[3].type_code() == kDLInt) {
-      param.step = args[3].operator int();
+      param.step = args[3].operator int64_t();
     } else if (args[3].type_code() == kDLFloat) {
-      param.step = static_cast<int>(args[3].operator double());
+      param.step = static_cast<int64_t>(args[3].operator double());
     }
     if (args[4].type_code() == kDLInt) {
       param.axis = args[4].operator int();

--- a/src/api/operator/numpy/np_insert_op.cc
+++ b/src/api/operator/numpy/np_insert_op.cc
@@ -51,7 +51,11 @@ MXNET_REGISTER_API("_npi.insert_scalar")
     param.val = dmlc::nullopt;
     num_inputs = 2;
   }
-  param.int_ind = args[2].operator int64_t();
+  if(features::is_enabled(features::INT64_TENSOR_SIZE)) {
+    param.int_ind = args[2].operator int64_t();
+  } else {
+    param.int_ind = args[2].operator int();
+  }
   if (args[3].type_code() == kNull) {
     param.axis = dmlc::nullopt;
   } else {

--- a/src/api/operator/numpy/np_insert_op.cc
+++ b/src/api/operator/numpy/np_insert_op.cc
@@ -51,7 +51,7 @@ MXNET_REGISTER_API("_npi.insert_scalar")
     param.val = dmlc::nullopt;
     num_inputs = 2;
   }
-  if(features::is_enabled(features::INT64_TENSOR_SIZE)) {
+  if (features::is_enabled(features::INT64_TENSOR_SIZE)) {
     param.int_ind = args[2].operator int64_t();
   } else {
     param.int_ind = args[2].operator int();

--- a/src/api/operator/numpy/np_insert_op.cc
+++ b/src/api/operator/numpy/np_insert_op.cc
@@ -51,7 +51,7 @@ MXNET_REGISTER_API("_npi.insert_scalar")
     param.val = dmlc::nullopt;
     num_inputs = 2;
   }
-  param.int_ind = args[2].operator int();
+  param.int_ind = args[2].operator int64_t();
   if (args[3].type_code() == kNull) {
     param.axis = dmlc::nullopt;
   } else {
@@ -89,17 +89,17 @@ MXNET_REGISTER_API("_npi.insert_slice")
   if (args[2].type_code() == kNull) {
     param.start = dmlc::nullopt;
   } else {
-    param.start = args[2].operator int();
+    param.start = args[2].operator int64_t();
   }
   if (args[3].type_code() == kNull) {
     param.stop = dmlc::nullopt;
   } else {
-    param.stop = args[3].operator int();
+    param.stop = args[3].operator int64_t();
   }
   if (args[4].type_code() == kNull) {
     param.step = dmlc::nullopt;
   } else {
-    param.step = args[4].operator int();
+    param.step = args[4].operator int64_t();
   }
   if (args[5].type_code() == kNull) {
     param.axis = dmlc::nullopt;

--- a/src/operator/numpy/np_delete_op-inl.h
+++ b/src/operator/numpy/np_delete_op-inl.h
@@ -48,23 +48,23 @@ namespace mxnet {
 namespace op {
 
 struct NumpyDeleteParam : public dmlc::Parameter<NumpyDeleteParam> {
-  dmlc::optional<int> start;
-  dmlc::optional<int> stop;
-  dmlc::optional<int> step;
-  dmlc::optional<int> int_ind;
+  dmlc::optional<index_t> start;
+  dmlc::optional<index_t> stop;
+  dmlc::optional<index_t> step;
+  dmlc::optional<index_t> int_ind;
   dmlc::optional<int> axis;
   DMLC_DECLARE_PARAMETER(NumpyDeleteParam) {
     DMLC_DECLARE_FIELD(start)
-    .set_default(dmlc::optional<int>())
+    .set_default(dmlc::optional<index_t>())
     .describe("If 'obj' is slice, 'start' is one of it's arguments.");
     DMLC_DECLARE_FIELD(stop)
-    .set_default(dmlc::optional<int>())
+    .set_default(dmlc::optional<index_t>())
     .describe("If 'obj' is slice, 'stop' is one of it's arguments.");
     DMLC_DECLARE_FIELD(step)
-    .set_default(dmlc::optional<int>())
+    .set_default(dmlc::optional<index_t>())
     .describe("If 'obj' is slice, 'step' is one of it's arguments.");
     DMLC_DECLARE_FIELD(int_ind)
-    .set_default(dmlc::optional<int>())
+    .set_default(dmlc::optional<index_t>())
     .describe("If 'obj' is int, 'int_ind' is the index before which"
               "'values' is inserted");
     DMLC_DECLARE_FIELD(axis)
@@ -111,9 +111,9 @@ struct IsDeleteCal {
    * \param indices the indices need to be deleted
    */
   template<typename IType>
-  MSHADOW_XINLINE static void Map(int i, int N, bool* is_delete, const IType* indices) {
+  MSHADOW_XINLINE static void Map(index_t i, int N, bool* is_delete, const IType* indices) {
     if ((indices[i] >= 0) && (indices[i] < N)) {
-      is_delete[static_cast<int>(indices[i])] = true;
+      is_delete[static_cast<index_t>(indices[i])] = true;
     }
   }
 };
@@ -125,7 +125,7 @@ struct OutPosCal {
    *          is_delete         F T T F F
    *          out_position      0 - - 1 2
    */
-  MSHADOW_XINLINE static void Map(int i, int64_t* out_pos, const bool* is_delete) {
+  MSHADOW_XINLINE static void Map(index_t i, int64_t* out_pos, const bool* is_delete) {
     if (!is_delete[i]) {
       int cnt = 0;
       for (int j = 0; j < i; ++j) {
@@ -151,7 +151,7 @@ struct DeleteKernel {
    * \param axis - delete sub-array along this axis
    */
   template<typename DType>
-  MSHADOW_XINLINE static void Map(int i, DType* out_data,
+  MSHADOW_XINLINE static void Map(index_t i, DType* out_data,
                                   const DType* in_arr,
                                   const bool* is_delete,
                                   const int64_t* out_pos,
@@ -178,11 +178,11 @@ struct DeleteKernel {
  * /return step - slice.indices(range).step
  * /return tot - total number of slice.indices(range)
  */
-inline void SliceIndices(const dmlc::optional<int>& pstart,
-                         const dmlc::optional<int>& pstop,
-                         const dmlc::optional<int>& pstep,
-                         const int range,
-                         int* start, int* stop, int* step,
+inline void SliceIndices(const dmlc::optional<index_t>& pstart,
+                         const dmlc::optional<index_t>& pstop,
+                         const dmlc::optional<index_t>& pstep,
+                         const index_t range,
+                         index_t* start, index_t* stop, index_t* step,
                          size_t* tot) {
   *step = pstep.has_value() ? pstep.value() : 1;
   CHECK_NE(*step, 0) << "'step' can not equal to 0.";
@@ -197,10 +197,10 @@ inline void SliceIndices(const dmlc::optional<int>& pstart,
   if (pstart.has_value()) {
     *start = pstart.value();
     *start += (*start < 0) ? range : 0;
-    *start = (*start < 0) ? ((*step < 0) ? -1 : 0) : *start;
-    *start = (*start >= range) ? ((*step < 0) ? range - 1 : range) : *start;
+    *start = (*start < 0) ? ((*step < 0) ? index_t{-1} : 0) : *start;
+    *start = (*start >= range) ? ((*step < 0) ? range - index_t{1} : range) : *start;
   } else {
-    *start = (*step > 0) ? 0 : range - 1;
+    *start = (*step > 0) ? 0 : range - index_t{1};
   }
   if (*step > 0 && *stop >= *start) {
     *tot = static_cast<size_t>((*stop - *start + *step - 1) / *step);
@@ -244,14 +244,14 @@ void NumpyDeleteCompute(const nnvm::NodeAttrs& attrs,
   }
 
   axis = CheckAxis(axis, ndim);
-  int N = (arr.shape())[axis];
+  index_t N = (arr.shape())[axis];
   mxnet::TShape outshape(arr.shape());
   // if obj is slice, they're obj's arguments
-  int start = 0, stop = 0, step = 0;
+  index_t start = 0, stop = 0, step = 0;
   // total number to be deleted
   size_t numtodel = 0;
   // if obj is scaler, index is it's value
-  int index = 0;
+  index_t index = 0;
 
   if (param.step.has_value()) {  // obj is slice
     SliceIndices(param.start, param.stop, param.step,
@@ -325,7 +325,7 @@ void NumpyDeleteCompute(const nnvm::NodeAttrs& attrs,
                                      reinterpret_cast<bool*>(is_delete_ptr) + arr.shape()[axis]);
     #endif
     numtodel = 0;
-    for (int i = 0; i < arr.shape()[axis]; ++i) {
+    for (index_t i = 0; i < arr.shape()[axis]; ++i) {
       if (vec_is_delete[i]) {
         numtodel++;
       }

--- a/src/operator/numpy/np_delete_op-inl.h
+++ b/src/operator/numpy/np_delete_op-inl.h
@@ -125,7 +125,7 @@ struct OutPosCal {
    *          is_delete         F T T F F
    *          out_position      0 - - 1 2
    */
-  MSHADOW_XINLINE static void Map(index_t i, index_t* out_pos, const bool* is_delete) {
+  MSHADOW_XINLINE static void Map(index_t i, int64_t* out_pos, const bool* is_delete) {
     if (!is_delete[i]) {
       int cnt = 0;
       for (int j = 0; j < i; ++j) {
@@ -154,7 +154,7 @@ struct DeleteKernel {
   MSHADOW_XINLINE static void Map(index_t i, DType* out_data,
                                   const DType* in_arr,
                                   const bool* is_delete,
-                                  const index_t* out_pos,
+                                  const int64_t* out_pos,
                                   const mshadow::Shape<ndim> arrshape,
                                   const mshadow::Shape<ndim> out_stride,
                                   const int axis) {
@@ -282,14 +282,14 @@ void NumpyDeleteCompute(const nnvm::NodeAttrs& attrs,
   char* is_delete_ptr = nullptr;
   MSHADOW_TYPE_SWITCH(((inputs.size() == 2U) ?  // obj is tensor
                       inputs[delete_::kObj].dtype() :
-                      mshadow::DataType<index_t>::kFlag), IType, {
-    size_t temp_mem_size = sizeof(index_t) * arr.shape()[axis] +
+                      mshadow::DataType<int64_t>::kFlag), IType, {
+    size_t temp_mem_size = sizeof(int64_t) * arr.shape()[axis] +
                            sizeof(IType) * numtodel +
                            sizeof(bool) * arr.shape()[axis];
     Tensor<xpu, 1, char> temp_mem =
       ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(temp_mem_size), s);
     out_pos_ptr = temp_mem.dptr_;
-    indices_ptr = out_pos_ptr + sizeof(index_t) * arr.shape()[axis];
+    indices_ptr = out_pos_ptr + sizeof(int64_t) * arr.shape()[axis];
     is_delete_ptr = indices_ptr + sizeof(IType) * numtodel;
     if (param.step.has_value()) {  // obj is slice, transfer slice to tensor
       Kernel<SliceToIndices, xpu>::Launch(
@@ -311,7 +311,7 @@ void NumpyDeleteCompute(const nnvm::NodeAttrs& attrs,
       reinterpret_cast<IType*>(indices_ptr));
     // calculate output data's original position in input arr
     Kernel<OutPosCal, xpu>::Launch(
-      s, arr.shape()[axis], reinterpret_cast<index_t*>(out_pos_ptr),
+      s, arr.shape()[axis], reinterpret_cast<int64_t*>(out_pos_ptr),
       reinterpret_cast<bool*>(is_delete_ptr));
   });
 
@@ -336,7 +336,7 @@ void NumpyDeleteCompute(const nnvm::NodeAttrs& attrs,
 
   MSHADOW_TYPE_SWITCH(((inputs.size() == 2U) ?  // obj is tensor
                       inputs[delete_::kObj].dtype() :
-                      mshadow::DataType<index_t>::kFlag), IType, {
+                      mshadow::DataType<int64_t>::kFlag), IType, {
     MXNET_NDIM_SWITCH(outshape.ndim(), ndim, {
       mshadow::Shape<ndim> out_strides = mxnet_op::calc_stride(outshape.get<ndim>());
       MSHADOW_TYPE_SWITCH(outputs[delete_::kOut].dtype(), DType, {
@@ -346,7 +346,7 @@ void NumpyDeleteCompute(const nnvm::NodeAttrs& attrs,
             outputs[delete_::kOut].data().dptr<DType>(),
             arr.data().dptr<DType>(),
             reinterpret_cast<bool*>(is_delete_ptr),
-            reinterpret_cast<index_t*>(out_pos_ptr),
+            reinterpret_cast<int64_t*>(out_pos_ptr),
             arr.shape().get<ndim>(),
             out_strides, axis);
         });

--- a/src/operator/numpy/np_insert_op-inl.h
+++ b/src/operator/numpy/np_insert_op-inl.h
@@ -156,7 +156,7 @@ struct InsertSingleIndexKernel {
                                   const VType* in_val, const DType* in_arr,
                                   const mshadow::Shape<ndim> outshape,
                                   const mshadow::Shape<ndim> valshape,
-                                  const int N, const index_t* in_obj, const int numnew,
+                                  const index_t N, const int64_t* in_obj, const size_t numnew,
                                   const mshadow::Shape<ndim> val_stride,
                                   const mshadow::Shape<ndim> old_val_stride,
                                   const mshadow::Shape<ndim> arr_stride,
@@ -263,8 +263,8 @@ struct InsertSeqIndicesKernel {
 };
 
 struct ObjToIndices {
-  MSHADOW_XINLINE static void Map(index_t i, index_t* indices,
-                                  int N, const index_t* obj) {
+  MSHADOW_XINLINE static void Map(index_t i, int64_t* indices,
+                                  int N, const int64_t* obj) {
     indices[i] = obj[i];
     if (indices[i] < 0) {
       indices[i] += static_cast<index_t>(N);
@@ -273,19 +273,19 @@ struct ObjToIndices {
 };
 
 struct IndicesModify {
-  MSHADOW_XINLINE static void Map(index_t i, index_t* indices, const index_t* order) {
+  MSHADOW_XINLINE static void Map(index_t i, int64_t* indices, const index_t* order) {
     indices[order[i]] += i;
   }
 };
 
 struct SetIsInsert {
-  MSHADOW_XINLINE static void Map(index_t i, index_t* indices, index_t* is_insert) {
+  MSHADOW_XINLINE static void Map(index_t i, int64_t* indices, index_t* is_insert) {
     is_insert[static_cast<index_t>(indices[i])] = 1;
   }
 };
 
 struct SetOriginValuesIdx {
-  MSHADOW_XINLINE static void Map(index_t i, const index_t* indices, index_t* origin_idx) {
+  MSHADOW_XINLINE static void Map(index_t i, const int64_t* indices, index_t* origin_idx) {
     origin_idx[static_cast<index_t>(indices[i])] = i;
   }
 };
@@ -350,7 +350,7 @@ void InsertSizeOneTensorImpl(mshadow::Stream<xpu> *s, const TBlob& output,
       Kernel<InsertSingleIndexKernel<ndim>, xpu>::Launch(
         s, len, output.dptr<DType>(),
         values.dptr<VType>(), arr.dptr<DType>(),
-        k_outshape, k_valshape, N, index.dptr<index_t>(), numnew,
+        k_outshape, k_valshape, N, index.dptr<int64_t>(), numnew,
         val_strides, old_val_strides, arr_strides, out_strides,
         axis, moveaxis, req);
     });

--- a/src/operator/numpy/np_insert_op-inl.h
+++ b/src/operator/numpy/np_insert_op-inl.h
@@ -40,26 +40,26 @@ namespace op {
 
 struct NumpyInsertParam : public dmlc::Parameter<NumpyInsertParam> {
   dmlc::optional<double> val;
-  dmlc::optional<int> start;
-  dmlc::optional<int> stop;
-  dmlc::optional<int> step;
-  dmlc::optional<int> int_ind;
+  dmlc::optional<index_t> start;
+  dmlc::optional<index_t> stop;
+  dmlc::optional<index_t> step;
+  dmlc::optional<index_t> int_ind;
   dmlc::optional<int> axis;
   DMLC_DECLARE_PARAMETER(NumpyInsertParam) {
     DMLC_DECLARE_FIELD(val)
     .set_default(dmlc::optional<double>())
     .describe("A scaler to be inserted into 'array'");
     DMLC_DECLARE_FIELD(start)
-    .set_default(dmlc::optional<int>())
+    .set_default(dmlc::optional<index_t>())
     .describe("If 'obj' is slice, 'start' is one of it's arguments.");
     DMLC_DECLARE_FIELD(stop)
-    .set_default(dmlc::optional<int>())
+    .set_default(dmlc::optional<index_t>())
     .describe("If 'obj' is slice, 'stop' is one of it's arguments.");
     DMLC_DECLARE_FIELD(step)
-    .set_default(dmlc::optional<int>())
+    .set_default(dmlc::optional<index_t>())
     .describe("If 'obj' is slice, 'step' is one of it's arguments.");
     DMLC_DECLARE_FIELD(int_ind)
-    .set_default(dmlc::optional<int>())
+    .set_default(dmlc::optional<index_t>())
     .describe("If 'obj' is int, 'int_ind' is the index before which"
               "'values' is inserted");
     DMLC_DECLARE_FIELD(axis)
@@ -103,22 +103,22 @@ struct NumpyInsertParam : public dmlc::Parameter<NumpyInsertParam> {
 template<int ndim>
 struct InsertSingleIndexKernel {
   template<typename DType, typename VType>
-  MSHADOW_XINLINE static void Map(int i, DType* out_data,
+  MSHADOW_XINLINE static void Map(index_t i, DType* out_data,
                                   const VType* in_val, const DType* in_arr,
                                   const mshadow::Shape<ndim> outshape,
                                   const mshadow::Shape<ndim> valshape,
-                                  const int index, const int numnew,
+                                  const index_t index, const size_t numnew,
                                   const mshadow::Shape<ndim> val_stride,
                                   const mshadow::Shape<ndim> old_val_stride,
                                   const mshadow::Shape<ndim> arr_stride,
                                   const mshadow::Shape<ndim> out_stride,
-                                  const int axis, bool moveaxis, const int req) {
+                                  const index_t axis, bool moveaxis, const int req) {
     // i is the global flattened index in the output
     // out_idx: i -> position in output's shape
     mshadow::Shape<ndim> out_idx = mxnet_op::unravel(i, outshape);
-    int64_t dest_idx;
+    index_t dest_idx;
     if (out_idx[axis] >= index && out_idx[axis] < index + numnew) {  // from 'value'
-      int idx_val = out_idx[axis] - index;
+      index_t idx_val = out_idx[axis] - index;
       // val_idx: i -> position in values's shape
       mshadow::Shape<ndim> val_idx(out_idx);
       val_idx[axis] = idx_val;
@@ -141,7 +141,7 @@ struct InsertSingleIndexKernel {
       }
       KERNEL_ASSIGN(out_data[i], req, static_cast<DType>(in_val[dest_idx]));
     } else {  // from 'arr'
-      int idx_arr = (out_idx[axis] < index) ?
+      index_t idx_arr = (out_idx[axis] < index) ?
                      out_idx[axis] : out_idx[axis] - numnew;
       // arr_idx: i -> position in arr's shape
       mshadow::Shape<ndim> arr_idx(out_idx);
@@ -152,7 +152,7 @@ struct InsertSingleIndexKernel {
   }
 
   template<typename DType, typename VType>
-  MSHADOW_XINLINE static void Map(int i, DType* out_data,
+  MSHADOW_XINLINE static void Map(index_t i, DType* out_data,
                                   const VType* in_val, const DType* in_arr,
                                   const mshadow::Shape<ndim> outshape,
                                   const mshadow::Shape<ndim> valshape,
@@ -221,23 +221,23 @@ struct InsertSingleIndexKernel {
 template<int ndim>
 struct InsertSeqIndicesKernel {
   template<typename DType, typename VType>
-  MSHADOW_XINLINE static void Map(int i, DType* out_data,
+  MSHADOW_XINLINE static void Map(index_t i, DType* out_data,
                                   const VType* in_val, const DType* in_arr,
                                   const mshadow::Shape<ndim> outshape,
                                   const mshadow::Shape<ndim> valshape,
-                                  const int* is_insert,
-                                  const int* origin_idx,
+                                  const index_t* is_insert,
+                                  const index_t* origin_idx,
                                   const mshadow::Shape<ndim> val_stride,
                                   const mshadow::Shape<ndim> arr_stride,
                                   const mshadow::Shape<ndim> out_stride,
-                                  const int axis, const int req) {
+                                  const index_t axis, const int req) {
     // i is the global flattened index in the output
     // out_idx: i -> position in output's shape
     mshadow::Shape<ndim> out_idx = mxnet_op::unravel(i, outshape);
-    int64_t dest_idx;
+    index_t dest_idx;
     if (is_insert[out_idx[axis]]) {
       // the data of output[i] is from 'values'
-      int idx_val = origin_idx[out_idx[axis]];
+      index_t idx_val = origin_idx[out_idx[axis]];
       // insert_idx: i -> position in insert's shape
       mshadow::Shape<ndim> insert_idx(out_idx);
       insert_idx[axis] = idx_val;
@@ -263,7 +263,7 @@ struct InsertSeqIndicesKernel {
 };
 
 struct ObjToIndices {
-  MSHADOW_XINLINE static void Map(int i, int64_t* indices,
+  MSHADOW_XINLINE static void Map(index_t i, index_t* indices,
                                   int N, const int64_t* obj) {
     indices[i] = obj[i];
     if (indices[i] < 0) {
@@ -273,29 +273,29 @@ struct ObjToIndices {
 };
 
 struct IndicesModify {
-  MSHADOW_XINLINE static void Map(int i, int64_t* indices, const int* order) {
+  MSHADOW_XINLINE static void Map(index_t i, index_t* indices, const index_t* order) {
     indices[order[i]] += i;
   }
 };
 
 struct SetIsInsert {
-  MSHADOW_XINLINE static void Map(int i, int64_t* indices, int* is_insert) {
-    is_insert[static_cast<int>(indices[i])] = 1;
+  MSHADOW_XINLINE static void Map(index_t i, index_t* indices, index_t* is_insert) {
+    is_insert[static_cast<index_t>(indices[i])] = 1;
   }
 };
 
 struct SetOriginValuesIdx {
-  MSHADOW_XINLINE static void Map(int i, const int64_t* indices, int* origin_idx) {
-    origin_idx[static_cast<int>(indices[i])] = i;
+  MSHADOW_XINLINE static void Map(index_t i, const index_t* indices, index_t* origin_idx) {
+    origin_idx[static_cast<index_t>(indices[i])] = i;
   }
 };
 
 struct SetOriginArrIdx {
-  MSHADOW_XINLINE static void Map(int i, const int* is_insert,
-                         int* origin_idx) {
+  MSHADOW_XINLINE static void Map(index_t i, const index_t* is_insert,
+                         index_t* origin_idx) {
     if (!is_insert[i]) {
-      int cnt = 0;
-      for (int j = 0; j < i; ++j) {
+      index_t cnt = 0;
+      for (index_t j = 0; j < i; ++j) {
         if (is_insert[j] == 0) {
           cnt++;
         }
@@ -315,7 +315,7 @@ void InsertScalerImpl(mshadow::Stream<xpu> *s, const TBlob& output,
                       const mshadow::Shape<ndim>& k_outshape,
                       const mshadow::Shape<ndim>& k_valshape,
                       const int dtype, const int vtype, const int req,
-                      const int axis, const int index, const int numnew,
+                      const int axis, const index_t index, const size_t numnew,
                       const size_t len, const bool moveaxis) {
   using namespace mshadow;
   using namespace mxnet_op;
@@ -341,8 +341,8 @@ void InsertSizeOneTensorImpl(mshadow::Stream<xpu> *s, const TBlob& output,
                              const mshadow::Shape<ndim>& k_outshape,
                              const mshadow::Shape<ndim>& k_valshape,
                              const int dtype, const int vtype, const int req,
-                             const int axis, const TBlob& index, const int numnew,
-                             const int N, const size_t len, const bool moveaxis) {
+                             const int axis, const TBlob& index, const size_t numnew,
+                             const index_t N, const size_t len, const bool moveaxis) {
   using namespace mshadow;
   using namespace mxnet_op;
   MSHADOW_TYPE_SWITCH(dtype, DType, {
@@ -365,7 +365,7 @@ void InsertSequenceImpl(mshadow::Stream<xpu> *s, const TBlob& output,
                         const mshadow::Shape<ndim>& out_strides,
                         const mshadow::Shape<ndim>& k_outshape,
                         const mshadow::Shape<ndim>& k_valshape,
-                        const int* is_insert, const int* origin_idx,
+                        const index_t* is_insert, const index_t* origin_idx,
                         const int dtype, const int vtype, const int req,
                         const int axis, const size_t len) {
   using namespace mshadow;

--- a/src/operator/numpy/np_insert_op-inl.h
+++ b/src/operator/numpy/np_insert_op-inl.h
@@ -156,7 +156,7 @@ struct InsertSingleIndexKernel {
                                   const VType* in_val, const DType* in_arr,
                                   const mshadow::Shape<ndim> outshape,
                                   const mshadow::Shape<ndim> valshape,
-                                  const int N, const int64_t* in_obj, const int numnew,
+                                  const int N, const index_t* in_obj, const int numnew,
                                   const mshadow::Shape<ndim> val_stride,
                                   const mshadow::Shape<ndim> old_val_stride,
                                   const mshadow::Shape<ndim> arr_stride,
@@ -165,10 +165,10 @@ struct InsertSingleIndexKernel {
     // i is the global flattened index in the output
     // out_idx: i -> position in output's shape
     mshadow::Shape<ndim> out_idx = mxnet_op::unravel(i, outshape);
-    int64_t dest_idx;
-    int64_t index = in_obj[0];
-    if (static_cast<int64_t>(index) < 0) {
-      index += static_cast<int64_t>(N);
+    index_t dest_idx;
+    index_t index = in_obj[0];
+    if (static_cast<index_t>(index) < 0) {
+      index += static_cast<index_t>(N);
     }
     if (out_idx[axis] >= index && out_idx[axis] < index + numnew) {  // from 'value'
       int idx_val = out_idx[axis] - index;
@@ -264,10 +264,10 @@ struct InsertSeqIndicesKernel {
 
 struct ObjToIndices {
   MSHADOW_XINLINE static void Map(index_t i, index_t* indices,
-                                  int N, const int64_t* obj) {
+                                  int N, const index_t* obj) {
     indices[i] = obj[i];
     if (indices[i] < 0) {
-      indices[i] += static_cast<int64_t>(N);
+      indices[i] += static_cast<index_t>(N);
     }
   }
 };
@@ -350,7 +350,7 @@ void InsertSizeOneTensorImpl(mshadow::Stream<xpu> *s, const TBlob& output,
       Kernel<InsertSingleIndexKernel<ndim>, xpu>::Launch(
         s, len, output.dptr<DType>(),
         values.dptr<VType>(), arr.dptr<DType>(),
-        k_outshape, k_valshape, N, index.dptr<int64_t>(), numnew,
+        k_outshape, k_valshape, N, index.dptr<index_t>(), numnew,
         val_strides, old_val_strides, arr_strides, out_strides,
         axis, moveaxis, req);
     });

--- a/src/operator/numpy/np_insert_op_scalar-inl.h
+++ b/src/operator/numpy/np_insert_op_scalar-inl.h
@@ -81,13 +81,13 @@ void NumpyInsertScalarCompute(const nnvm::NodeAttrs& attrs,
     axis += (axis < 0) ? arr.shape_.ndim() : 0;
   }
 
-  int N = arr.shape_[axis];
-  int numnew = 0;  // numnew = output.shape[axis] - arr.shape[axis]
-  int index = 0;  // save modified index, because index may be negative integer
+  index_t N = arr.shape_[axis];
+  size_t numnew = 0;  // numnew = output.shape[axis] - arr.shape[axis]
+  index_t index = 0;  // save modified index, because index may be negative integer
   mxnet::TShape val_newshape(arr.shape_.ndim(), -1);
   // modify values's ndim to arr's ndim, for broadcast easily later
   // e.g. value shape: (2,) arr shape: (3, 2) => value shape: (1, 2)
-  for (int i = values.shape_.ndim() - 1, j = arr.shape_.ndim() - 1;
+  for (index_t i = values.shape_.ndim() - 1, j = arr.shape_.ndim() - 1;
         i >= 0 || j >= 0;
         --i, --j) {
     if (i >= 0 && j >= 0) {

--- a/src/operator/numpy/np_insert_op_slice-inl.h
+++ b/src/operator/numpy/np_insert_op_slice-inl.h
@@ -154,24 +154,24 @@ void NumpyInsertSliceCompute(const nnvm::NodeAttrs& attrs,
       CHECK((values.shape_[i] == 1) || (values.shape_[i] == sz));
     }
     size_t temp_storage_bytes, temp_mem_size;
-    temp_storage_bytes = SortByKeyWorkspaceSize<int64_t, int, xpu>(indices_len, false, true);
-    temp_mem_size = indices_len * sizeof(int64_t) * 2 +
-                    indices_len * sizeof(int) +
-                    outshape[axis] * sizeof(int) * 2 +
+    temp_storage_bytes = SortByKeyWorkspaceSize<index_t, int, xpu>(indices_len, false, true);
+    temp_mem_size = indices_len * sizeof(index_t) * 2 +
+                    indices_len * sizeof(index_t) +
+                    outshape[axis] * sizeof(index_t) * 2 +
                     temp_storage_bytes;
     Tensor<xpu, 1, char> temp_mem =
       ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(temp_mem_size), s);
-    int64_t* indices_ptr = reinterpret_cast<int64_t*>(temp_mem.dptr_);
-    int64_t* sorted_indices_ptr = reinterpret_cast<int64_t*>(indices_ptr + indices_len);
+    index_t* indices_ptr = reinterpret_cast<index_t*>(temp_mem.dptr_);
+    index_t* sorted_indices_ptr = reinterpret_cast<index_t*>(indices_ptr + indices_len);
     index_t* order_ptr = reinterpret_cast<index_t*>(sorted_indices_ptr + indices_len);
     index_t* is_insert = reinterpret_cast<index_t*>(order_ptr + indices_len);
     index_t* origin_idx = reinterpret_cast<index_t*>(is_insert + outshape[axis]);
     Tensor<xpu, 1, char> temp_storage(reinterpret_cast<char*>(origin_idx + outshape[axis]),
                                       Shape1(temp_storage_bytes), s);
-    Tensor<xpu, 1, int64_t> indices(indices_ptr, Shape1(indices_len), s);
-    Tensor<xpu, 1, int64_t> sorted_indices(sorted_indices_ptr, Shape1(indices_len), s);
+    Tensor<xpu, 1, index_t> indices(indices_ptr, Shape1(indices_len), s);
+    Tensor<xpu, 1, index_t> sorted_indices(sorted_indices_ptr, Shape1(indices_len), s);
     Tensor<xpu, 1, index_t> order(order_ptr, Shape1(indices_len), s);
-    int num_bits = 8 * sizeof(int64_t);
+    int num_bits = 8 * sizeof(index_t);
     Kernel<SliceToIndices, xpu>::Launch(s, indices_len, indices_ptr, start, step);
     Kernel<range_fwd, xpu>::Launch(s, indices_len, index_t{1}, index_t{0}, index_t{1},
                                    kWriteTo, order_ptr);

--- a/src/operator/numpy/np_insert_op_slice-inl.h
+++ b/src/operator/numpy/np_insert_op_slice-inl.h
@@ -154,24 +154,24 @@ void NumpyInsertSliceCompute(const nnvm::NodeAttrs& attrs,
       CHECK((values.shape_[i] == 1) || (values.shape_[i] == sz));
     }
     size_t temp_storage_bytes, temp_mem_size;
-    temp_storage_bytes = SortByKeyWorkspaceSize<index_t, int, xpu>(indices_len, false, true);
-    temp_mem_size = indices_len * sizeof(index_t) * 2 +
+    temp_storage_bytes = SortByKeyWorkspaceSize<int64_t, int, xpu>(indices_len, false, true);
+    temp_mem_size = indices_len * sizeof(int64_t) * 2 +
                     indices_len * sizeof(index_t) +
                     outshape[axis] * sizeof(index_t) * 2 +
                     temp_storage_bytes;
     Tensor<xpu, 1, char> temp_mem =
       ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(temp_mem_size), s);
-    index_t* indices_ptr = reinterpret_cast<index_t*>(temp_mem.dptr_);
-    index_t* sorted_indices_ptr = reinterpret_cast<index_t*>(indices_ptr + indices_len);
+    int64_t* indices_ptr = reinterpret_cast<int64_t*>(temp_mem.dptr_);
+    int64_t* sorted_indices_ptr = reinterpret_cast<int64_t*>(indices_ptr + indices_len);
     index_t* order_ptr = reinterpret_cast<index_t*>(sorted_indices_ptr + indices_len);
     index_t* is_insert = reinterpret_cast<index_t*>(order_ptr + indices_len);
     index_t* origin_idx = reinterpret_cast<index_t*>(is_insert + outshape[axis]);
     Tensor<xpu, 1, char> temp_storage(reinterpret_cast<char*>(origin_idx + outshape[axis]),
                                       Shape1(temp_storage_bytes), s);
-    Tensor<xpu, 1, index_t> indices(indices_ptr, Shape1(indices_len), s);
-    Tensor<xpu, 1, index_t> sorted_indices(sorted_indices_ptr, Shape1(indices_len), s);
+    Tensor<xpu, 1, int64_t> indices(indices_ptr, Shape1(indices_len), s);
+    Tensor<xpu, 1, int64_t> sorted_indices(sorted_indices_ptr, Shape1(indices_len), s);
     Tensor<xpu, 1, index_t> order(order_ptr, Shape1(indices_len), s);
-    int num_bits = 8 * sizeof(index_t);
+    int num_bits = 8 * sizeof(int64_t);
     Kernel<SliceToIndices, xpu>::Launch(s, indices_len, indices_ptr, start, step);
     Kernel<range_fwd, xpu>::Launch(s, indices_len, index_t{1}, index_t{0}, index_t{1},
                                    kWriteTo, order_ptr);

--- a/src/operator/numpy/np_insert_op_slice-inl.h
+++ b/src/operator/numpy/np_insert_op_slice-inl.h
@@ -80,9 +80,9 @@ void NumpyInsertSliceCompute(const nnvm::NodeAttrs& attrs,
     axis += (axis < 0) ? arr.shape_.ndim() : 0;
   }
 
-  int N = arr.shape_[axis];
+  index_t N = arr.shape_[axis];
   size_t indices_len = 0;  // indices amount
-  int start = 0, stop = 0, step = 0;  // arguments from 'obj' when it's 'slice'
+  index_t start = 0, stop = 0, step = 0;  // arguments from 'obj' when it's 'slice'
 
   // get and check indices from slice or sequence of ints
   SliceIndices(param.start, param.stop, param.step,
@@ -117,7 +117,7 @@ void NumpyInsertSliceCompute(const nnvm::NodeAttrs& attrs,
       index += N;
     }
   } else {
-    numnew = static_cast<int>(indices_len);
+    numnew = static_cast<index_t>(indices_len);
   }
 
   const mxnet::TShape& outshape = outputs[out_pos].shape_;
@@ -147,7 +147,7 @@ void NumpyInsertSliceCompute(const nnvm::NodeAttrs& attrs,
   } else {
     // broadcast check
     for (int i = outshape.ndim() - 1; i >= 0; --i) {
-      int sz = outshape[i];
+      index_t sz = outshape[i];
       if (i == axis) {
         sz = numnew;
       }
@@ -163,17 +163,17 @@ void NumpyInsertSliceCompute(const nnvm::NodeAttrs& attrs,
       ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(temp_mem_size), s);
     int64_t* indices_ptr = reinterpret_cast<int64_t*>(temp_mem.dptr_);
     int64_t* sorted_indices_ptr = reinterpret_cast<int64_t*>(indices_ptr + indices_len);
-    int* order_ptr = reinterpret_cast<int*>(sorted_indices_ptr + indices_len);
-    int* is_insert = reinterpret_cast<int*>(order_ptr + indices_len);
-    int* origin_idx = reinterpret_cast<int*>(is_insert + outshape[axis]);
+    index_t* order_ptr = reinterpret_cast<index_t*>(sorted_indices_ptr + indices_len);
+    index_t* is_insert = reinterpret_cast<index_t*>(order_ptr + indices_len);
+    index_t* origin_idx = reinterpret_cast<index_t*>(is_insert + outshape[axis]);
     Tensor<xpu, 1, char> temp_storage(reinterpret_cast<char*>(origin_idx + outshape[axis]),
                                       Shape1(temp_storage_bytes), s);
     Tensor<xpu, 1, int64_t> indices(indices_ptr, Shape1(indices_len), s);
     Tensor<xpu, 1, int64_t> sorted_indices(sorted_indices_ptr, Shape1(indices_len), s);
-    Tensor<xpu, 1, int> order(order_ptr, Shape1(indices_len), s);
+    Tensor<xpu, 1, index_t> order(order_ptr, Shape1(indices_len), s);
     int num_bits = 8 * sizeof(int64_t);
     Kernel<SliceToIndices, xpu>::Launch(s, indices_len, indices_ptr, start, step);
-    Kernel<range_fwd, xpu>::Launch(s, indices_len, 1, 0, 1, kWriteTo, order_ptr);
+    Kernel<range_fwd, xpu>::Launch(s, indices_len, index_t{1}, index_t{0}, index_t{1}, kWriteTo, order_ptr);
     mxnet::op::SortByKey(indices, order, true, &temp_storage, 0, num_bits, &sorted_indices);
     Kernel<IndicesModify, xpu>::Launch(s, indices_len, indices_ptr, order_ptr);
 

--- a/src/operator/numpy/np_insert_op_slice-inl.h
+++ b/src/operator/numpy/np_insert_op_slice-inl.h
@@ -173,7 +173,8 @@ void NumpyInsertSliceCompute(const nnvm::NodeAttrs& attrs,
     Tensor<xpu, 1, index_t> order(order_ptr, Shape1(indices_len), s);
     int num_bits = 8 * sizeof(int64_t);
     Kernel<SliceToIndices, xpu>::Launch(s, indices_len, indices_ptr, start, step);
-    Kernel<range_fwd, xpu>::Launch(s, indices_len, index_t{1}, index_t{0}, index_t{1}, kWriteTo, order_ptr);
+    Kernel<range_fwd, xpu>::Launch(s, indices_len, index_t{1}, index_t{0}, index_t{1},
+                                   kWriteTo, order_ptr);
     mxnet::op::SortByKey(indices, order, true, &temp_storage, 0, num_bits, &sorted_indices);
     Kernel<IndicesModify, xpu>::Launch(s, indices_len, indices_ptr, order_ptr);
 

--- a/src/operator/numpy/np_insert_op_slice.cc
+++ b/src/operator/numpy/np_insert_op_slice.cc
@@ -74,10 +74,10 @@ bool NumpyInsertSliceShape(const nnvm::NodeAttrs& attrs,
     axis += (axis < 0) ? arrshape.ndim() : 0;
   }
 
-  int seq_cnt = -1;
-  int N = arrshape[axis];
-  int step = param.step.value();
-  int stop, start;
+  index_t seq_cnt = -1;
+  index_t N = arrshape[axis];
+  index_t step = param.step.value();
+  index_t stop, start;
   if (param.stop.has_value()) {
     stop = param.stop.value();
     stop += (stop < 0) ? N : 0;
@@ -103,7 +103,7 @@ bool NumpyInsertSliceShape(const nnvm::NodeAttrs& attrs,
 
   mxnet::TShape newshape(arrshape);
   mxnet::TShape val_newshape(arrshape.ndim(), -1);
-  int numnew = 0;  // amount of new column insert to 'arr' in 'axis'
+  size_t numnew = 0;  // amount of new column insert to 'arr' in 'axis'
   // modify values's ndim to arr's ndim, for broadcast easily later
   // e.g. value shape: (2,) arr shape: (3, 2) => value shape: (1, 2)
   for (int i = valshape.ndim() - 1, j = arrshape.ndim() - 1; i >= 0 || j >= 0; --i, --j) {

--- a/src/operator/numpy/np_insert_op_tensor-inl.h
+++ b/src/operator/numpy/np_insert_op_tensor-inl.h
@@ -182,8 +182,8 @@ void NumpyInsertTensorCompute(const nnvm::NodeAttrs& attrs,
       CHECK((values.shape_[i] == 1) || (values.shape_[i] == sz));
     }
     size_t temp_storage_bytes, temp_mem_size;
-    temp_storage_bytes = SortByKeyWorkspaceSize<index_t, index_t, xpu>(indices_len, false, true);
-    temp_mem_size = indices_len * sizeof(index_t) * 2 +
+    temp_storage_bytes = SortByKeyWorkspaceSize<int64_t, index_t, xpu>(indices_len, false, true);
+    temp_mem_size = indices_len * sizeof(int64_t) * 2 +
                     indices_len * sizeof(index_t) +
                     outshape[axis] * sizeof(index_t) * 2 +
                     temp_storage_bytes;

--- a/src/operator/numpy/np_insert_op_tensor-inl.h
+++ b/src/operator/numpy/np_insert_op_tensor-inl.h
@@ -90,15 +90,15 @@ void NumpyInsertTensorCompute(const nnvm::NodeAttrs& attrs,
     axis += (axis < 0) ? arr.shape_.ndim() : 0;
   }
 
-  int N = arr.shape_[axis];
+  size_t N = arr.shape_[axis];
   size_t indices_len = inputs[obj_pos].shape_.Size();  // indices amount
 
   // get and check indices from tensor
-  int numnew = 0;  // numnew = output.shape[axis] - arr.shape[axis]
+  size_t numnew = 0;  // numnew = output.shape[axis] - arr.shape[axis]
   mxnet::TShape val_newshape(arr.shape_.ndim(), -1);
   // modify values's ndim to arr's ndim, for broadcast easily later
   // e.g. value shape: (2,) arr shape: (3, 2) => value shape: (1, 2)
-  for (int i = values.shape_.ndim() - 1, j = arr.shape_.ndim() - 1;
+  for (index_t i = values.shape_.ndim() - 1, j = arr.shape_.ndim() - 1;
         i >= 0 || j >= 0;
         --i, --j) {
     if (i >= 0 && j >= 0) {
@@ -133,7 +133,7 @@ void NumpyInsertTensorCompute(const nnvm::NodeAttrs& attrs,
   } else if (indices_len == 1) {  // tensor with only one element
     numnew = values.shape_[axis];
   } else {
-    numnew = static_cast<int>(indices_len);
+    numnew = static_cast<index_t>(indices_len);
   }
 
   const mxnet::TShape& outshape = outputs[out_pos].shape_;
@@ -175,34 +175,34 @@ void NumpyInsertTensorCompute(const nnvm::NodeAttrs& attrs,
   } else {
     // broadcast check
     for (int i = outshape.ndim() - 1; i >= 0; --i) {
-      int sz = outshape[i];
+      size_t sz = outshape[i];
       if (i == axis) {
         sz = numnew;
       }
       CHECK((values.shape_[i] == 1) || (values.shape_[i] == sz));
     }
     size_t temp_storage_bytes, temp_mem_size;
-    temp_storage_bytes = SortByKeyWorkspaceSize<int64_t, int, xpu>(indices_len, false, true);
+    temp_storage_bytes = SortByKeyWorkspaceSize<int64_t, index_t, xpu>(indices_len, false, true);
     temp_mem_size = indices_len * sizeof(int64_t) * 2 +
-                    indices_len * sizeof(int) +
-                    outshape[axis] * sizeof(int) * 2 +
+                    indices_len * sizeof(index_t) +
+                    outshape[axis] * sizeof(index_t) * 2 +
                     temp_storage_bytes;
     Tensor<xpu, 1, char> temp_mem =
       ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(temp_mem_size), s);
     int64_t* indices_ptr = reinterpret_cast<int64_t*>(temp_mem.dptr_);
     int64_t* sorted_indices_ptr = reinterpret_cast<int64_t*>(indices_ptr + indices_len);
-    int* order_ptr = reinterpret_cast<int*>(sorted_indices_ptr + indices_len);
-    int* is_insert = reinterpret_cast<int*>(order_ptr + indices_len);
-    int* origin_idx = reinterpret_cast<int*>(is_insert + outshape[axis]);
+    index_t* order_ptr = reinterpret_cast<index_t*>(sorted_indices_ptr + indices_len);
+    index_t* is_insert = reinterpret_cast<index_t*>(order_ptr + indices_len);
+    index_t* origin_idx = reinterpret_cast<index_t*>(is_insert + outshape[axis]);
     Tensor<xpu, 1, char> temp_storage(reinterpret_cast<char*>(origin_idx + outshape[axis]),
                                       Shape1(temp_storage_bytes), s);
     Tensor<xpu, 1, int64_t> indices(indices_ptr, Shape1(indices_len), s);
     Tensor<xpu, 1, int64_t> sorted_indices(sorted_indices_ptr, Shape1(indices_len), s);
-    Tensor<xpu, 1, int> order(order_ptr, Shape1(indices_len), s);
+    Tensor<xpu, 1, index_t> order(order_ptr, Shape1(indices_len), s);
     int num_bits = 8 * sizeof(int64_t);
     Kernel<ObjToIndices, xpu>::Launch(s, indices_len, indices_ptr, N,
                                       inputs[obj_pos].dptr<int64_t>());
-    Kernel<range_fwd, xpu>::Launch(s, indices_len, 1, 0, 1, kWriteTo, order_ptr);
+    Kernel<range_fwd, xpu>::Launch(s, indices_len, index_t{1}, index_t{0}, index_t{1}, kWriteTo, order_ptr);
     mxnet::op::SortByKey(indices, order, true, &temp_storage, 0, num_bits, &sorted_indices);
     Kernel<IndicesModify, xpu>::Launch(s, indices_len, indices_ptr, order_ptr);
 

--- a/src/operator/numpy/np_insert_op_tensor-inl.h
+++ b/src/operator/numpy/np_insert_op_tensor-inl.h
@@ -182,26 +182,26 @@ void NumpyInsertTensorCompute(const nnvm::NodeAttrs& attrs,
       CHECK((values.shape_[i] == 1) || (values.shape_[i] == sz));
     }
     size_t temp_storage_bytes, temp_mem_size;
-    temp_storage_bytes = SortByKeyWorkspaceSize<int64_t, index_t, xpu>(indices_len, false, true);
-    temp_mem_size = indices_len * sizeof(int64_t) * 2 +
+    temp_storage_bytes = SortByKeyWorkspaceSize<index_t, index_t, xpu>(indices_len, false, true);
+    temp_mem_size = indices_len * sizeof(index_t) * 2 +
                     indices_len * sizeof(index_t) +
                     outshape[axis] * sizeof(index_t) * 2 +
                     temp_storage_bytes;
     Tensor<xpu, 1, char> temp_mem =
       ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(temp_mem_size), s);
-    int64_t* indices_ptr = reinterpret_cast<int64_t*>(temp_mem.dptr_);
-    int64_t* sorted_indices_ptr = reinterpret_cast<int64_t*>(indices_ptr + indices_len);
+    index_t* indices_ptr = reinterpret_cast<index_t*>(temp_mem.dptr_);
+    index_t* sorted_indices_ptr = reinterpret_cast<index_t*>(indices_ptr + indices_len);
     index_t* order_ptr = reinterpret_cast<index_t*>(sorted_indices_ptr + indices_len);
     index_t* is_insert = reinterpret_cast<index_t*>(order_ptr + indices_len);
     index_t* origin_idx = reinterpret_cast<index_t*>(is_insert + outshape[axis]);
     Tensor<xpu, 1, char> temp_storage(reinterpret_cast<char*>(origin_idx + outshape[axis]),
                                       Shape1(temp_storage_bytes), s);
-    Tensor<xpu, 1, int64_t> indices(indices_ptr, Shape1(indices_len), s);
-    Tensor<xpu, 1, int64_t> sorted_indices(sorted_indices_ptr, Shape1(indices_len), s);
+    Tensor<xpu, 1, index_t> indices(indices_ptr, Shape1(indices_len), s);
+    Tensor<xpu, 1, index_t> sorted_indices(sorted_indices_ptr, Shape1(indices_len), s);
     Tensor<xpu, 1, index_t> order(order_ptr, Shape1(indices_len), s);
-    int num_bits = 8 * sizeof(int64_t);
+    int num_bits = 8 * sizeof(index_t);
     Kernel<ObjToIndices, xpu>::Launch(s, indices_len, indices_ptr, N,
-                                      inputs[obj_pos].dptr<int64_t>());
+                                      inputs[obj_pos].dptr<index_t>());
     Kernel<range_fwd, xpu>::Launch(s, indices_len, index_t{1}, index_t{0}, index_t{1},
                                    kWriteTo, order_ptr);
     mxnet::op::SortByKey(indices, order, true, &temp_storage, 0, num_bits, &sorted_indices);

--- a/src/operator/numpy/np_insert_op_tensor-inl.h
+++ b/src/operator/numpy/np_insert_op_tensor-inl.h
@@ -202,7 +202,8 @@ void NumpyInsertTensorCompute(const nnvm::NodeAttrs& attrs,
     int num_bits = 8 * sizeof(int64_t);
     Kernel<ObjToIndices, xpu>::Launch(s, indices_len, indices_ptr, N,
                                       inputs[obj_pos].dptr<int64_t>());
-    Kernel<range_fwd, xpu>::Launch(s, indices_len, index_t{1}, index_t{0}, index_t{1}, kWriteTo, order_ptr);
+    Kernel<range_fwd, xpu>::Launch(s, indices_len, index_t{1}, index_t{0}, index_t{1},
+                                   kWriteTo, order_ptr);
     mxnet::op::SortByKey(indices, order, true, &temp_storage, 0, num_bits, &sorted_indices);
     Kernel<IndicesModify, xpu>::Launch(s, indices_len, indices_ptr, order_ptr);
 

--- a/src/operator/numpy/np_insert_op_tensor-inl.h
+++ b/src/operator/numpy/np_insert_op_tensor-inl.h
@@ -189,19 +189,19 @@ void NumpyInsertTensorCompute(const nnvm::NodeAttrs& attrs,
                     temp_storage_bytes;
     Tensor<xpu, 1, char> temp_mem =
       ctx.requested[0].get_space_typed<xpu, 1, char>(Shape1(temp_mem_size), s);
-    index_t* indices_ptr = reinterpret_cast<index_t*>(temp_mem.dptr_);
-    index_t* sorted_indices_ptr = reinterpret_cast<index_t*>(indices_ptr + indices_len);
+    int64_t* indices_ptr = reinterpret_cast<int64_t*>(temp_mem.dptr_);
+    int64_t* sorted_indices_ptr = reinterpret_cast<int64_t*>(indices_ptr + indices_len);
     index_t* order_ptr = reinterpret_cast<index_t*>(sorted_indices_ptr + indices_len);
     index_t* is_insert = reinterpret_cast<index_t*>(order_ptr + indices_len);
     index_t* origin_idx = reinterpret_cast<index_t*>(is_insert + outshape[axis]);
     Tensor<xpu, 1, char> temp_storage(reinterpret_cast<char*>(origin_idx + outshape[axis]),
                                       Shape1(temp_storage_bytes), s);
-    Tensor<xpu, 1, index_t> indices(indices_ptr, Shape1(indices_len), s);
-    Tensor<xpu, 1, index_t> sorted_indices(sorted_indices_ptr, Shape1(indices_len), s);
+    Tensor<xpu, 1, int64_t> indices(indices_ptr, Shape1(indices_len), s);
+    Tensor<xpu, 1, int64_t> sorted_indices(sorted_indices_ptr, Shape1(indices_len), s);
     Tensor<xpu, 1, index_t> order(order_ptr, Shape1(indices_len), s);
-    int num_bits = 8 * sizeof(index_t);
+    int num_bits = 8 * sizeof(int64_t);
     Kernel<ObjToIndices, xpu>::Launch(s, indices_len, indices_ptr, N,
-                                      inputs[obj_pos].dptr<index_t>());
+                                      inputs[obj_pos].dptr<int64_t>());
     Kernel<range_fwd, xpu>::Launch(s, indices_len, index_t{1}, index_t{0}, index_t{1},
                                    kWriteTo, order_ptr);
     mxnet::op::SortByKey(indices, order, true, &temp_storage, 0, num_bits, &sorted_indices);

--- a/src/operator/numpy/np_insert_op_tensor.cc
+++ b/src/operator/numpy/np_insert_op_tensor.cc
@@ -42,7 +42,7 @@ bool NumpyInsertTensorType(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(out_type->size(), 1U);
   int obj_pos = input_count;
   CHECK_NE((*in_type)[obj_pos], -1) << "Index type must be set for insert operator\n";
-  CHECK_EQ((*in_type)[obj_pos], mshadow::DataType<int64_t>::kFlag)
+  CHECK_EQ((*in_type)[obj_pos], mshadow::DataType<index_t>::kFlag)
     << "Index type only support int64.\n";
   TYPE_ASSIGN_CHECK(*out_type, 0, (*in_type)[0]);  // output type equals to input arr's
   TYPE_ASSIGN_CHECK(*in_type, 0, (*out_type)[0]);

--- a/src/operator/numpy/np_insert_op_tensor.cc
+++ b/src/operator/numpy/np_insert_op_tensor.cc
@@ -42,7 +42,7 @@ bool NumpyInsertTensorType(const nnvm::NodeAttrs& attrs,
   CHECK_EQ(out_type->size(), 1U);
   int obj_pos = input_count;
   CHECK_NE((*in_type)[obj_pos], -1) << "Index type must be set for insert operator\n";
-  CHECK_EQ((*in_type)[obj_pos], mshadow::DataType<index_t>::kFlag)
+  CHECK_EQ((*in_type)[obj_pos], mshadow::DataType<int64_t>::kFlag)
     << "Index type only support int64.\n";
   TYPE_ASSIGN_CHECK(*out_type, 0, (*in_type)[0]);  // output type equals to input arr's
   TYPE_ASSIGN_CHECK(*in_type, 0, (*out_type)[0]);

--- a/src/operator/numpy/np_insert_op_tensor.cc
+++ b/src/operator/numpy/np_insert_op_tensor.cc
@@ -81,6 +81,8 @@ bool NumpyInsertTensorShape(const nnvm::NodeAttrs& attrs,
         << "alueError: assignment to 0-d array.";
       out_shape->push_back(valshape);
     }
+    CHECK_LT((*out_shape)[0].Size(), (int64_t{1} << 31) - 1) <<
+        "Large Tensor Support is not support for [insert_tensor] variant of insert operator";
     return shape_is_known(out_shape[0]);
   } else {
     CHECK(axis >= -1 * arrshape.ndim() && axis < arrshape.ndim())
@@ -114,6 +116,8 @@ bool NumpyInsertTensorShape(const nnvm::NodeAttrs& attrs,
 
   newshape[axis] += numnew;
   out_shape->push_back(newshape);
+  CHECK_LT((*out_shape)[0].Size(), (int64_t{1} << 31) - 1) <<
+      "Large Tensor Support is not support for [insert_tensor] variant of insert operator";
   return shape_is_known(newshape);
 }
 

--- a/src/operator/numpy/np_insert_op_tensor.cc
+++ b/src/operator/numpy/np_insert_op_tensor.cc
@@ -88,11 +88,11 @@ bool NumpyInsertTensorShape(const nnvm::NodeAttrs& attrs,
     axis += (axis < 0) ? arrshape.ndim() : 0;
   }
 
-  int seq_cnt = objShape.Size();
+  size_t seq_cnt = objShape.Size();
 
   mxnet::TShape newshape(arrshape);
   mxnet::TShape val_newshape(arrshape.ndim(), -1);
-  int numnew = 0;  // amount of new column insert to 'arr' in 'axis'
+  index_t numnew = 0;  // amount of new column insert to 'arr' in 'axis'
   // modify values's ndim to arr's ndim, for broadcast easily later
   // e.g. value shape: (2,) arr shape: (3, 2) => value shape: (1, 2)
   for (int i = valshape.ndim() - 1, j = arrshape.ndim() - 1; i >= 0 || j >= 0; --i, --j) {

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -2035,7 +2035,6 @@ def test_vstack():
 
 
 @use_np
-<<<<<<< HEAD
 def test_ediff1d():
     inp = np.zeros((2, INT_OVERFLOW))
     inp[0, -1], inp[1, 0] = 1, 3

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -2304,4 +2304,5 @@ def test_insert():
     assert out2.shape == (INT_OVERFLOW * 2 + 2,)
     assert out[0, 1] == 1 and out[-1, 1] == 2
     assert out2[1] == 5 and out2[2] == 6
+    assertRaises(MXNetError, np.insert, arr=inp3, obj=np.array([2, 2], dtype=np.int64), values=np.array([5, 6]))
 

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -2035,6 +2035,7 @@ def test_vstack():
 
 
 @use_np
+<<<<<<< HEAD
 def test_ediff1d():
     inp = np.zeros((2, INT_OVERFLOW))
     inp[0, -1], inp[1, 0] = 1, 3
@@ -2289,3 +2290,18 @@ def test_fill_diagonal():
     data2 = np.zeros((INT_OVERFLOW, 2))
     np.fill_diagonal(data2, [1, 2], wrap=True)
     assert data2[0, 0] == 1 and data2[-1, -1] == 2
+
+
+@use_np
+def test_insert():
+    inp = np.zeros((INT_OVERFLOW, 2))
+    inp2 = np.ones((INT_OVERFLOW))
+    inp2[-1] = 2
+    inp3 = inp.flatten()
+    out = np.insert(inp, 1, inp2, axis=1)
+    out2 = np.insert(inp3, slice(1, 2), np.array([5, 6]))
+    assert out.shape == (INT_OVERFLOW, 3)
+    assert out2.shape == (INT_OVERFLOW * 2 + 2,)
+    assert out[0, 1] == 1 and out[-1, 1] == 2
+    assert out2[1] == 5 and out2[2] == 6
+


### PR DESCRIPTION
## Description ##
Enable LTS for numpy insert op for 2/3 insert kernels(`insert_scalar` and `insert_slice`). Performance of `insert_tensor` needs to be optimized first before enabling large tensor for it. Currently if the user attempts to use `insert_tensor` the program will give error message that large tensor is not supported for insert_tensor kernel.

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Testing ###
```
(pytest) ubuntu@ip-172-31-90-243 ~/workspace/incubator-mxnet (insert_lt) $ python -m pytest -s --exitfirst --verbose tests/nightly/test_np_large_array.py::test_insert
==================================================================================================================================== test session starts ====================================================================================================================================
platform linux -- Python 3.6.10, pytest-5.3.5, py-1.8.2, pluggy-0.13.1 -- /home/ubuntu/anaconda3/envs/pytest/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/workspace/incubator-mxnet, inifile: pytest.ini
plugins: timeout-1.4.2
timeout: 1200.0s
timeout method: signal
timeout func_only: False
collected 1 item

tests/nightly/test_np_large_array.py::test_insert Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=1610131494 to reproduce.
[20:31:33] ../src/storage/storage.cc:199: Using Pooled (Naive) StorageManager for CPU
PASSED

===================================================================================================================================== warnings summary ======================================================================================================================================
tests/nightly/test_np_large_array.py:92
  /home/ubuntu/workspace/incubator-mxnet/tests/nightly/test_np_large_array.py:92: DeprecationWarning: invalid escape sequence \
    '''

tests/nightly/test_np_large_array.py:1243
  /home/ubuntu/workspace/incubator-mxnet/tests/nightly/test_np_large_array.py:1243: DeprecationWarning: invalid escape sequence \
    '''

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================================================================================================= 1 passed, 2 warnings in 68.90s (0:01:08) ==========================================================================================================================
```
