### PR TITLE
[BUGFIX] Fix ConvTranspose __repr__ (#19338)

### DIFF
--- a/python/mxnet/gluon/nn/conv_layers.py
+++ b/python/mxnet/gluon/nn/conv_layers.py
@@ -170,8 +170,12 @@ class _Conv(HybridBlock):
             s += ', {}'.format(self.act)
         s += ')'
         shape = self.weight.shape
+        if 'Transpose' in self.__class__.__name__:
+            mapping = '{1} -> {0}'
+        else:
+            mapping = '{0} -> {1}'
         return s.format(name=self.__class__.__name__,
-                        mapping='{0} -> {1}'.format(shape[1] if shape[1] else None, shape[0]),
+                        mapping=mapping.format(shape[1] if shape[1] else None, shape[0]),
                         **self._kwargs)
 
 


### PR DESCRIPTION
Fix the direction of in_channels -> out_channels in the repr function for ConvTranspose classes.

Co-authored-by: g4b1nagy <gabrian.nagy@gmail.com>

fixes #19338 
