### PR TITLE
backport fixes in master branch

### DIFF
--- a/python/mxnet/gluon/loss.py
+++ b/python/mxnet/gluon/loss.py
@@ -476,7 +476,7 @@ class KLDivLoss(Loss):
             pred = F.log_softmax(pred, self._axis)
         loss = label * (F.log(label + 1e-12) - pred)
         loss = _apply_weighting(F, loss, self._weight, sample_weight)
-        return F.mean(loss, axis=self._batch_axis, exclude=True)
+        return F.sum(loss, axis=self._batch_axis, exclude=True)
 
 
 class CTCLoss(Loss):
@@ -1010,8 +1010,7 @@ class SDMLLoss(Loss):
         confident output distributions." arXiv preprint arXiv:1701.06548 (2017).
         """
 
-        # TODO: replace with mx.nd.eye(batch_size) with mxnet 1.2
-        gold = F.one_hot(F.arange(batch_size), batch_size)
+        gold = F.eye(batch_size)
         labels = gold * (1 - self.smoothing_parameter) + (1 - gold) * self.smoothing_parameter / (batch_size - 1)
         return labels
 
@@ -1038,8 +1037,9 @@ class SDMLLoss(Loss):
         labels = self._compute_labels(F, batch_size)
         distances = self._compute_distances(x1, x2)
         log_probabilities = F.log_softmax(-distances, axis=1)
-        # multiply for the number of labels to obtain the correct loss (gluon kl_loss averages instead of sum)
-        return self.kl_loss(log_probabilities, labels.as_in_context(distances.context)) * batch_size
+        # PR#18423:multiply for the number of labels should multiply x1.shape[1] rather than x1.shape[0])
+        # After PR#18423, it is no need to multiply it anymore.
+        return self.kl_loss(log_probabilities, labels.as_in_context(distances.context))
 
 
     def hybrid_forward(self, F, x1, x2):


### PR DESCRIPTION
## Description ##
In the current version of KLDivLoss, the return value is not the same value calculated by SoftmaxCrossEntropyLoss, which is not documented. It may due to the incorrect settings which using mean rather than sum dealing with the return value.
I provide a fix of this setting, which will keep the return value of `KLDivLoss` and `SoftmaxCrossEntropyLoss` almost the same when `from_logits=False` and `sparse_label=False` are set to these functions seperately.
Now, the behave of KLDivLoss is exactly the same to what the document say.

to reproduce the misbehave in the current master branch:
```
import mxnet as mx
a=mx.nd.array([[-1,1],[1,-1]])
b=mx.nd.array([1,0]).one_hot(2)
TrueLoss=mx.gluon.loss.SoftmaxCrossEntropyLoss(sparse_label=False)
FalseLoss=mx.gluon.loss.KLDivLoss(from_logits=False)
c=TrueLoss(a,b)
d=FalseLoss(a,b)*a.shape[-1]
assert((c-d).abs().sum()==0 and a.shape[-1]==2)
```
## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [x] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at https://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [x] Now, the behave of KLDivLoss is exactly the same to what the document say.

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
