### PR TITLE
[FEATURE] Enable large tensor support for interp

### DIFF
--- a/src/operator/numpy/np_interp_op-inl.h
+++ b/src/operator/numpy/np_interp_op-inl.h
@@ -78,12 +78,12 @@ struct NumpyInterpParam : public dmlc::Parameter<NumpyInterpParam> {
 };
 
 struct interp {
-  MSHADOW_XINLINE static void Map(int i,
+  MSHADOW_XINLINE static void Map(index_t i,
                                   double* out,
                                   const double* x,
                                   const double* xp,
                                   const double* fp,
-                                  const int dsize,
+                                  const size_t dsize,
                                   const double left,
                                   const double right,
                                   const bool has_left,
@@ -99,11 +99,11 @@ struct interp {
     } else if (x_value < xp_low) {
       out[i] = lval;
     } else {
-      int imin = 0;
-      int imax = dsize;
-      int imid;
+      index_t imin = 0;
+      index_t imax = static_cast<index_t>(dsize);
+      index_t imid;
       while (imin < imax) {
-        imid = static_cast<int>((imax + imin) / 2);
+        imid = static_cast<index_t>((imax + imin) / 2);
         if (x_value >= xp[imid]) {
           imin = imid + 1;
         } else {
@@ -111,7 +111,7 @@ struct interp {
         }
       }  // biserction search
 
-      int j = imin;
+      index_t j = imin;
       if (j == dsize) {
         out[i] = fp[dsize-1];
       } else if (x_value == xp[j-1]) {
@@ -130,20 +130,20 @@ struct interp {
 };
 
 struct interp_period {
-  MSHADOW_XINLINE static void Map(int i,
+  MSHADOW_XINLINE static void Map(index_t i,
                                   double* out,
                                   const double* x,
                                   const double* xp,
                                   const double* fp,
                                   const index_t* idx,
-                                  const int dsize,
+                                  const size_t dsize,
                                   const double period) {
     double x_value = x[i];
-    int imin = 0;
-    int imax = dsize;
-    int imid;
+    index_t imin = 0;
+    index_t imax = static_cast<index_t>(dsize);
+    index_t imid;
     while (imin < imax) {
-      imid = static_cast<int>((imax + imin) / 2);
+      imid = static_cast<index_t>((imax + imin) / 2);
       if (x_value >= xp[idx[imid]]) {
         imin = imid + 1;
       } else {
@@ -151,7 +151,7 @@ struct interp_period {
       }
     }  // biserction search
 
-    int j = imin;
+    index_t j = imin;
     double xp_below, xp_above;
     double fp1, fp2;
     if (j == 0) {

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -2133,3 +2133,20 @@ def test_nan_to_num():
     assert inp.grad.shape == inp.shape
     assert inp.grad[0, -1] == 0 and inp.grad[1, -1] == 0
     assert inp.grad[0, 0] == 1 and inp.grad[2, -1] == 0
+
+
+@use_np
+def test_interp():
+    xp = np.array([1, 2, 3])
+    fp = np.array([3, 2, 1])
+    inp = np.ones((2, INT_OVERFLOW))
+    inp[-1, -1] = 2.5
+    inp.attach_grad()
+    with mx.autograd.record():
+        B = np.interp(inp, xp, fp)
+        B.backward()
+    assert B.shape == inp.shape
+    assert B[-1, -1] == 1.5
+    assert inp.grad.shape == inp.shape
+    assert inp.grad[-1, -1] == 0
+


### PR DESCRIPTION
## Description ##
Enables LTS for interp (forward and backward passes)

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Testing ###
```
(pytest) ubuntu@ip-172-31-90-243 ~/workspace/incubator-mxnet (interp_lt) $ python -m pytest -s --exitfirst --verbose tests/nightly/test_np_large_array.py::test_interp
==================================================================================================================================== test session starts ====================================================================================================================================
platform linux -- Python 3.6.10, pytest-5.3.5, py-1.8.2, pluggy-0.13.1 -- /home/ubuntu/anaconda3/envs/pytest/bin/python
cachedir: .pytest_cache
rootdir: /home/ubuntu/workspace/incubator-mxnet, inifile: pytest.ini
plugins: timeout-1.4.2
timeout: 1200.0s
timeout method: signal
timeout func_only: False
collected 1 item

tests/nightly/test_np_large_array.py::test_interp Setting module np/mx/python random seeds, use MXNET_MODULE_SEED=815080247 to reproduce.
[20:23:36] ../src/storage/storage.cc:199: Using Pooled (Naive) StorageManager for CPU
[20:23:37] ../src/base.cc:84: Upgrade advisory: this mxnet has been built against cuDNN lib version 7501, which is older than the oldest version tested by CI (7600).  Set MXNET_CUDNN_LIB_CHECKING=0 to quiet this warning.
PASSED

=============================================================================================================================== 1 passed in 243.68s (0:04:03) ===============================================================================================================================
```
