### PR TITLE
Fix AtWithRecord

### DIFF
--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -402,7 +402,8 @@ NDArray NDArray::AtWithRecord(index_t idx) {
         attrs.op = nnvm::Op::Get("Reshape");;
         attrs.dict.insert({"shape", os.str()});
     } else {
-        os << mxnet::TShape({-3, -4});  // See NumpyXReshapeInferShape for definition of magic numbers
+        // See NumpyXReshapeInferShape for definition of magic numbers
+        os << mxnet::TShape({-3, -4});
         attrs.op = nnvm::Op::Get("_npx_reshape");;
         attrs.dict.insert({"newshape", os.str()});
     }

--- a/src/ndarray/ndarray.cc
+++ b/src/ndarray/ndarray.cc
@@ -389,11 +389,37 @@ NDArray NDArray::At(index_t idx) const {
 NDArray NDArray::AtWithRecord(index_t idx) {
   CHECK(storage_type() == kDefaultStorage)
       << "Storage type " << storage_type() << " doesn't support At()";
-  NDArray ret = this->SliceWithRecord(idx, idx+1);
+  NDArray sliced = this->SliceWithRecord(idx, idx+1);
   if (shape_.ndim() > 1 || Imperative::Get()->is_np_shape()) {
-    return ret.ReshapeWithRecord(mxnet::TShape(shape_.data()+1, shape_.data()+shape_.ndim()));
+    // Imperative reshape with concrete shape
+    NDArray reshaped = sliced.Reshape(mxnet::TShape(shape_.data()+1, shape_.data()+shape_.ndim()));
+
+    // Record reshape with magic numbers
+    nnvm::NodeAttrs attrs;
+    std::ostringstream os;
+    if (!Imperative::Get()->is_np_shape()) {
+        os << mxnet::TShape({-3, -2});  // See ndarray.py reshape for definition of magic numbers
+        attrs.op = nnvm::Op::Get("Reshape");;
+        attrs.dict.insert({"shape", os.str()});
+    } else {
+        os << mxnet::TShape({-3, -4});  // See NumpyXReshapeInferShape for definition of magic numbers
+        attrs.op = nnvm::Op::Get("_npx_reshape");;
+        attrs.dict.insert({"newshape", os.str()});
+    }
+    attrs.op->attr_parser(&attrs);
+    std::vector<NDArray*> inputs(1, &sliced), outputs(1, &reshaped);
+
+    bool is_recording = Imperative::Get()->is_recording();
+    bool is_deferred_compute = Imperative::Get()->is_deferred_compute();
+    if (is_recording) {
+        Imperative::Get()->RecordOp(std::move(attrs), inputs, outputs);
+    } else if (is_deferred_compute) {
+        Imperative::Get()->RecordDeferredCompute(std::move(attrs), inputs, outputs);
+    }
+
+    return reshaped;
   } else {
-    return ret;
+    return sliced;
   }
 }
 

--- a/tests/python/unittest/test_deferred_compute.py
+++ b/tests/python/unittest/test_deferred_compute.py
@@ -588,5 +588,6 @@ def test_indexing_empty_shape():
     try:
         mx.npx.set_np()
         net(mx.np.zeros((2, 2, 4, 0, 128)))
+        net(mx.np.zeros((2, 2, 4, 2, 128)))  # test indexing after input shape change
     finally:
         mx.npx.reset_np()


### PR DESCRIPTION
Prior implementation recorded reshape with concrete shapes used during the particular invocation of At.
New implementation uses records reshape with magic numbers to match symbolic interface.

## Example of failure without this patch
```
=================================== FAILURES ===================================
______________________ test_gpt2_incremental_states[ctx0] ______________________

ctx = cpu(0)

    def test_gpt2_incremental_states(ctx):
        with ctx:
            batch_size = 4
            sequence_length = 5
            inputs = mx.np.random.randint(0, 1000, (batch_size, sequence_length), ctx=ctx)
    
            cfg = GPT2Model.get_cfg()
            gpt2_model = GPT2Model.from_cfg(cfg)
            gpt2_model.initialize(ctx=ctx)
            gpt2_model.hybridize()
    
            one_time_hiddens, one_time_states = gpt2_model(
                inputs,
                gpt2_model.init_states(batch_size, ctx)
            )
    
            states = gpt2_model.init_states(batch_size, ctx)
            hiddens_l = []
            for i in range(sequence_length):
>               hiddens, states = gpt2_model(
                    inputs[:, i:i+1],
                    states
                )

tests/test_models_gpt2.py:96: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.8.5/x64/lib/python3.8/site-packages/mxnet/util.py:298: in _with_np_shape
    return func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.8.5/x64/lib/python3.8/site-packages/mxnet/util.py:482: in _with_np_array
    return func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.8.5/x64/lib/python3.8/site-packages/mxnet/gluon/block.py:1429: in __call__
    return self._call_cached_op(x, *args)
/opt/hostedtoolcache/Python/3.8.5/x64/lib/python3.8/site-packages/mxnet/util.py:298: in _with_np_shape
    return func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.8.5/x64/lib/python3.8/site-packages/mxnet/util.py:482: in _with_np_array
    return func(*args, **kwargs)
/opt/hostedtoolcache/Python/3.8.5/x64/lib/python3.8/site-packages/mxnet/gluon/block.py:1131: in _call_cached_op
    out = self._cached_op(*cargs)
/opt/hostedtoolcache/Python/3.8.5/x64/lib/python3.8/site-packages/mxnet/_ctypes/ndarray.py:171: in __call__
    check_call(_LIB.MXInvokeCachedOp(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

ret = -1

    def check_call(ret):
        """Check the return value of C API call.
    
        This function will raise an exception when an error occurs.
        Wrap every API call with this function.
    
        Parameters
        ----------
        ret : int
            return value from API calls.
        """
        if ret != 0:
>           raise get_last_ffi_error()
E           mxnet.base.MXNetError: MXNetError: Error in operator node_16288: [02:57:54] ../src/operator/numpy/np_matrix_op.cc:149: Check failed: src.Size() == dst->Size() (6144 vs. 0) : Cannot reshape array of size 6144 into shape [2,4,0,768]
```


## Details on failure
Json export of the recorded graph contains the following segment. We can see the shape of the first forward pass was hardcoded by the `AtWithRecord` implementation.

```
    {
      "op": "slice",
      "name": "node_10",
      "attrs": {
        "begin": "0",
        "end": "1"
      },
      "inputs": [[5, 0, 0]]
    },
    {
      "op": "_np_reshape",
      "name": "node_11",
      "attrs": {"newshape": "[2,4,0,768]"},
      "inputs": [[14, 0, 0]]
}
```