### PR TITLE
Update libcudnn version.

### DIFF
--- a/tools/setup_gpu_build_tools.sh
+++ b/tools/setup_gpu_build_tools.sh
@@ -36,7 +36,7 @@ if [[ $VARIANT == cu110* ]]; then
     CUDA_SOLVER_VERSION='10.6.0.245-1'
     CUDA_NVTX_VERSION='11.0.167-1'
     LIBCUDA_VERSION='450.51.06-0ubuntu1'
-    LIBCUDNN_VERSION='8.0.3.33-1+cuda11.0'
+    LIBCUDNN_VERSION='8.0.4.30-1+cuda11.0'
     LIBNCCL_VERSION='2.7.8-1+cuda11.0'
 elif [[ $VARIANT == cu102* ]]; then
     CUDA_VERSION='10.2.89-1'


### PR DESCRIPTION
## Description ##
The test_deconvolution unit test was failing on A100. Based on conversation with @DickJC123, updating to cudNN v8.0.4.30 fixes this as we did in #19272 for v1.x

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
