### PR TITLE
More extensions fixes

### DIFF
--- a/include/mxnet/lib_api.h
+++ b/include/mxnet/lib_api.h
@@ -912,25 +912,25 @@ class Registry {
 
 /*! \brief declare a variable with custom name */
 #define MX_REGISTER_NAME_(Name) MXNet ## _CustomOp ## _
-#define MX_REGISTER_DEF_(Name) CustomOp MX_REGISTER_NAME_(Name)
+#define MX_REGISTER_DEF_(Name) mxnet::ext::CustomOp MX_REGISTER_NAME_(Name)
 
 #define MX_REGISTER_PROP_NAME_(Name) MXNet ## _CustomSubProp ## _
-#define MX_REGISTER_PROP_DEF_(Name) CustomPartitioner MX_REGISTER_PROP_NAME_(Name)
+#define MX_REGISTER_PROP_DEF_(Name) mxnet::ext::CustomPartitioner MX_REGISTER_PROP_NAME_(Name)
 
 #define MX_REGISTER_PASS_NAME_(Name) MXNet ## _CustomPass ## _
-#define MX_REGISTER_PASS_DEF_(Name) CustomPass MX_REGISTER_PASS_NAME_(Name)
+#define MX_REGISTER_PASS_DEF_(Name) mxnet::ext::CustomPass MX_REGISTER_PASS_NAME_(Name)
 
 /*! \brief assign a var to a value */
 #define REGISTER_OP(Name) MX_STR_CONCAT(MX_REGISTER_DEF_(Name), __COUNTER__) = \
-    Registry<CustomOp>::get()->add(MX_TOSTRING(Name))
+    mxnet::ext::Registry<mxnet::ext::CustomOp>::get()->add(MX_TOSTRING(Name))
 
 #define REGISTER_PARTITIONER(Name) \
   MX_STR_CONCAT(MX_REGISTER_PROP_DEF_(Name), __COUNTER__) = \
-    Registry<CustomPartitioner>::get()->add(MX_TOSTRING(Name))
+    mxnet::ext::Registry<mxnet::ext::CustomPartitioner>::get()->add(MX_TOSTRING(Name))
 
 #define REGISTER_PASS(Name) \
   MX_STR_CONCAT(MX_REGISTER_PASS_DEF_(Name), __COUNTER__) = \
-    Registry<CustomPass>::get()->add(MX_TOSTRING(Name))
+    mxnet::ext::Registry<mxnet::ext::CustomPass>::get()->add(MX_TOSTRING(Name))
 
 /* -------------- BELOW ARE CTYPE FUNCTIONS PROTOTYPES --------------- */
 

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -1072,7 +1072,7 @@ class HybridBlock(Block):
                                            'added to the parameter dicts.\n'
                                            'Please check the backend.')
 
-                    param = Parameter(name)
+                    param = Parameter(name, dtype=param_data.dtype)
                     param._var_name = name
                     serialization_name = name  # HybridBlock.export
                     param._load_init(param_data, args[0].context)

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -400,10 +400,13 @@ class Parameter(object):
         ctx = context.cpu()
         if self._stype == 'default':
             block = self.list_data()
-            if is_np_array():
-                data = sum([w.copyto(ctx) for w in block]) / len(block)
+            if len(block) > 1:
+                if is_np_array():                
+                    data = sum([w.copyto(ctx) for w in block]) / len(block)
+                else:
+                    data = ndarray.add_n(*(w.copyto(ctx) for w in block)) / len(block)
             else:
-                data = ndarray.add_n(*(w.copyto(ctx) for w in block)) / len(block)
+                data = self.data(ctx)
         else:
             # fetch all rows for 'row_sparse' param
             all_row_ids = ndarray.arange(0, self.shape[0], dtype='int64', ctx=ctx)

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -401,7 +401,7 @@ class Parameter(object):
         if self._stype == 'default':
             block = self.list_data()
             if len(block) > 1:
-                if is_np_array():                
+                if is_np_array():
                     data = sum([w.copyto(ctx) for w in block]) / len(block)
                 else:
                     data = ndarray.add_n(*(w.copyto(ctx) for w in block)) / len(block)

--- a/python/mxnet/gluon/parameter.py
+++ b/python/mxnet/gluon/parameter.py
@@ -406,7 +406,7 @@ class Parameter(object):
                 else:
                     data = ndarray.add_n(*(w.copyto(ctx) for w in block)) / len(block)
             else:
-                data = self.data(ctx)
+                data = self.data().copyto(ctx)
         else:
             # fetch all rows for 'row_sparse' param
             all_row_ids = ndarray.arange(0, self.shape[0], dtype='int64', ctx=ctx)

--- a/src/c_api/c_api.cc
+++ b/src/c_api/c_api.cc
@@ -1433,7 +1433,7 @@ void registerPasses(void *lib, int verbose, mxnet::ext::msgSize_t msgSize,
       // this temp workspace holds memory allocated by custom library via OpResource
       auto ndarray_alloc = [&](const mxnet::TShape &shape, Context ctx, int dtype,
                                std::string name, bool isArg) {
-        NDArray* arr = new NDArray(shape, ctx, dtype);
+        NDArray* arr = new NDArray(shape, ctx, false, dtype);
         if (isArg) {
           new_args.push_back(arr);
           new_arg_names.push_back(name);

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -101,6 +101,8 @@ shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet-build/3rdparty/mshadow/mshadow'
                 os.path.join(CURRENT_DIR, 'mxnet/include/mshadow'))
 shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet-build/3rdparty/tvm/nnvm/include/nnvm'),
                 os.path.join(CURRENT_DIR, 'mxnet/include/nnvm'))
+shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet/src/lib_api.cc'),
+                os.path.join(CURRENT_DIR, 'mxnet/src'))
 
 package_name = 'mxnet'
 

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -101,8 +101,10 @@ shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet-build/3rdparty/mshadow/mshadow'
                 os.path.join(CURRENT_DIR, 'mxnet/include/mshadow'))
 shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet-build/3rdparty/tvm/nnvm/include/nnvm'),
                 os.path.join(CURRENT_DIR, 'mxnet/include/nnvm'))
-shutil.copytree(os.path.join(CURRENT_DIR, 'mxnet/src/lib_api.cc'),
-                os.path.join(CURRENT_DIR, 'mxnet/src'))
+
+# copy cc file for mxnet extensions
+shutil.copy(os.path.join(CURRENT_DIR, 'mxnet-build/src/lib_api.cc'),
+            os.path.join(CURRENT_DIR, 'mxnet/src'))
 
 package_name = 'mxnet'
 


### PR DESCRIPTION
## Description ##
- Fixes for custom subgraph op shape/type/stype inference bugs from #18779
- Fixes for Gluon params from #19354
- Fixes for namespace in registration macros
- Addes `lib_api.cc` into pip wheel so users can easily build extensions with their pip installed MXNet (without downloading the files from GitHub). Addresses feedback from @ZiyueHuang in https://github.com/apache/incubator-mxnet/pull/19016#issuecomment-708984989

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
