### PR TITLE
backport slice assign large tensor fix #19032

### DIFF
--- a/src/operator/tensor/matrix_op-inl.h
+++ b/src/operator/tensor/matrix_op-inl.h
@@ -1094,7 +1094,7 @@ inline bool SliceAssignOpShape(const nnvm::NodeAttrs& attrs,
     common::StaticArray<index_t, ndim> begin, end, step;
     GetIndexRange(dshape, param.begin, param.end, param.step, &begin, &end, &step);
     for (int i = 0; i < param.begin.ndim(); ++i) {
-      const int b = begin[i], e = end[i], s = step[i];
+      const index_t b = begin[i], e = end[i], s = step[i];
       SetSliceOpOutputDimSize(dshape, i, b, e, s, &vshape);
     }
   })
@@ -1137,7 +1137,7 @@ void SliceAssignOpForward(const nnvm::NodeAttrs& attrs,
     }
     MSHADOW_TYPE_SWITCH(out.type_flag_, DType, {
       MXNET_ASSIGN_REQ_SWITCH(req[0], Req, {
-        int num_threads = val.shape_.FlatTo2D()[0];
+        index_t num_threads = val.shape_.FlatTo2D()[0];
         if (std::is_same<xpu, gpu>::value) {
           num_threads *= val.shape_.get<ndim>()[ndim - 1];
         }
@@ -1241,7 +1241,7 @@ void SliceAssignScalarOpForward(const nnvm::NodeAttrs& attrs,
       return;  // slice_assign of zero-sized subspaced needs no operation.
     }
     for (index_t i = 0; i < param.begin.ndim(); ++i) {
-      const int b = begin[i], e = end[i], s = step[i];
+      const index_t b = begin[i], e = end[i], s = step[i];
       SetSliceOpOutputDimSize(data.shape_, i, b, e, s, &vshape);
     }
     MSHADOW_TYPE_SWITCH_WITH_BOOL(out.type_flag_, DType, {

--- a/tests/nightly/test_large_array.py
+++ b/tests/nightly/test_large_array.py
@@ -1791,6 +1791,17 @@ def test_sparse_dot():
     assert out.shape == (2, 2)
 
 
+def test_slice_assign():
+    # test _slice_assign
+    A = np.zeros((2**31, 2))
+    A[-1] = np.ones((1))
+    assert A[-1, 0] == 1 and A[-1, 1] == 1
+    # test _slice_assign_scalar
+    B = np.zeros((2**31, 2))
+    B[-1] = 2
+    assert B[-1, 0] == 2 and B[-1, 1] == 2
+
+
 if __name__ == '__main__':
     import nose
     nose.runmodule()


### PR DESCRIPTION
backports #19032

local run:
```
ubuntu@ip-172-31-38-169:~/myspace$ pytest tests/nightly/test_large_array.py::test_slice_assign
============================================= test session starts ==============================================
platform linux -- Python 3.7.7, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/ubuntu/myspace
plugins: remotedata-0.3.2, openfiles-0.4.0, astropy-header-0.1.2, hypothesis-5.8.3, arraydiff-0.3, doctestplus-0.5.0
collected 1 item                                                                                               

tests/nightly/test_large_array.py .                                                                      [100%]

=============================================== warnings summary ===============================================
/home/ubuntu/anaconda3/lib/python3.7/site-packages/nose/importer.py:12
  /home/ubuntu/anaconda3/lib/python3.7/site-packages/nose/importer.py:12: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    from imp import find_module, load_module, acquire_lock, release_lock

-- Docs: https://docs.pytest.org/en/latest/warnings.html
========================================= 1 passed, 1 warning in 2.21s ==================================
```