### PR TITLE
[v1.x] Fix CD builds - error in docker command.

### DIFF
--- a/cd/python/docker/python_images.sh
+++ b/cd/python/docker/python_images.sh
@@ -45,7 +45,7 @@ fi
 
 build() {
     # NOTE: Ensure the correct context root is passed in when building - Dockerfile expects ./wheel_build
-    docker build -t "${image_name}" --build-arg --build-arg BASE_IMAGE="${base_image}" --build-arg MXNET_COMMIT_ID=${GIT_COMMIT} -f ${resources_path}/Dockerfile ./wheel_build
+    docker build -t "${image_name}" --build-arg BASE_IMAGE="${base_image}" --build-arg MXNET_COMMIT_ID=${GIT_COMMIT} -f ${resources_path}/Dockerfile ./wheel_build
 }
 
 test() {


### PR DESCRIPTION
## Description ##
Remove extra --build-arg causing docker command to fail.

Errors with:

15:53:16 docker build -t mxnet/python:nightly_cpu_py3 --build-arg --build-arg BASE_IMAGE=ubuntu:16.04 --build-arg MXNET_COMMIT_ID=xxx -f cd/python/docker/Dockerfile ./wheel_build
15:53:16  "docker build" requires exactly 1 argument.
15:53:16  See 'docker build --help'.

This may not of been an issue, but we recently updated docker versions and this command is failiing.

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
