### PR TITLE
CPU reduce kernel optimization

### DIFF
--- a/src/operator/tensor/broadcast_reduce-inl.h
+++ b/src/operator/tensor/broadcast_reduce-inl.h
@@ -268,7 +268,7 @@ MSHADOW_XINLINE void binary_broadcast_assign(const index_t idx, const bool addto
 }
 
 template<typename Reducer, int ndim, typename AType, typename DType, typename OType, typename OP,
-	 typename IndexOP = mxnet::op::mshadow_op::set_index_no_op<AType, index_t>>
+         typename IndexOP = mxnet::op::mshadow_op::set_index_no_op<AType, index_t>>
 MSHADOW_XINLINE AType seq_reduce_assign_block(size_t start, size_t len,
                                               size_t j,
                                               const DType* __restrict big,
@@ -308,10 +308,9 @@ MSHADOW_XINLINE void seq_reduce_assign(const index_t idx, const size_t M, const 
         IndexOP::Op(&temp, k);
       Reducer::Reduce(val, temp, residual);
     }
-  }
-  else {
+  } else {
     const int thread_count = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
-    AType vals[thread_count];
+    auto vals = std::make_unique<AType[]>(thread_count);
     #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
     for (int i = 0; i < thread_count; ++i) {
       vals[i] = seq_reduce_assign_block<Reducer, ndim, AType, DType, OType, OP, IndexOP>
@@ -362,7 +361,7 @@ void seq_reduce_compute(const size_t N, const size_t M, const bool addto,
                         const Shape<ndim> sshape, const Shape<ndim> rshape,
                         const Shape<ndim> rstride) {
   const int thread_count = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
-  #pragma omp parallel for num_threads(thread_count) if (N >= thread_count) 
+  #pragma omp parallel for num_threads(thread_count) if (N >= thread_count)
   for (index_t idx = 0; idx < static_cast<index_t>(N); ++idx) {
     seq_reduce_assign<Reducer, ndim, AType, DType, OType, OP, IndexOP>
         (idx, M, addto, big, small, bshape, sshape, rshape, rstride, N < thread_count);

--- a/src/operator/tensor/broadcast_reduce-inl.h
+++ b/src/operator/tensor/broadcast_reduce-inl.h
@@ -267,6 +267,26 @@ MSHADOW_XINLINE void binary_broadcast_assign(const index_t idx, const bool addto
   assign(&out[idx], addto, OP::Map(lhs[j], rhs[k]));
 }
 
+template<typename Reducer, int ndim, typename AType, typename DType, typename OType, typename OP,
+	 typename IndexOP = mxnet::op::mshadow_op::set_index_no_op<AType, index_t>>
+MSHADOW_XINLINE std::pair<AType, AType> seq_reduce_assign_block(size_t start, size_t len,
+                                              size_t j,
+                                              const DType* __restrict big,
+                                              const Shape<ndim>& rshape,
+                                              const Shape<ndim>& rstride) {
+  Shape<ndim> coord;
+  AType val, residual;
+  Reducer::SetInitValue(val, residual);
+  for (size_t k = start; k < start + len; ++k) {
+    coord = mxnet_op::unravel(k, rshape);
+    AType temp = OP::Map(big[j + mxnet_op::dot(coord, rstride)]);
+    if (IndexOP::do_op)
+      IndexOP::Op(&temp, k);
+    Reducer::Reduce(val, temp, residual);
+  }
+  return std::make_pair(val, residual);
+}
+
 template<typename Reducer, int ndim, typename AType, typename DType, typename OType,
          typename OP, typename IndexOP = mxnet::op::mshadow_op::set_index_no_op<AType, index_t>>
 MSHADOW_XINLINE void seq_reduce_assign(const index_t idx, const size_t M, const bool addto,
@@ -277,13 +297,29 @@ MSHADOW_XINLINE void seq_reduce_assign(const index_t idx, const size_t M, const 
   index_t j = mxnet_op::ravel(coord, bshape);
   AType val, residual;
   Reducer::SetInitValue(val, residual);
-  for (size_t k = 0; k < M; ++k) {
-    coord = mxnet_op::unravel(k, rshape);
-    AType temp = OP::Map(big[j + mxnet_op::dot(coord, rstride)]);
-    // argmin/max, set IndexedNum.idx
-    if (IndexOP::do_op)
-      IndexOP::Op(&temp, k);
-    Reducer::Reduce(val, temp, residual);
+  if (false) {
+    for (size_t k = 0; k < M; ++k) {
+      coord = mxnet_op::unravel(k, rshape);
+      AType temp = OP::Map(big[j + mxnet_op::dot(coord, rstride)]);
+      // argmin/max, set IndexedNum.idx
+      if (IndexOP::do_op)
+        IndexOP::Op(&temp, k);
+      Reducer::Reduce(val, temp, residual);
+    }
+  }
+  else {
+    int thread_count = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
+    std::pair<AType, AType> pairs[thread_count];
+    #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+    for (int i = 0; i < thread_count; ++i) {
+      pairs[i] = seq_reduce_assign_block<Reducer, ndim, AType, DType, OType, OP, IndexOP>
+          (i * (M / thread_count),
+          i < (thread_count - 1) ? (M / thread_count) : (M / thread_count) + M % thread_count,
+          j, big, rshape, rstride);
+    }
+    for (int i = 0; i < thread_count; ++i) {
+      Reducer::Merge(val, residual, pairs[i].first, pairs[i].second);
+    }
   }
   Reducer::Finalize(val, residual);
   assign(&small[idx], addto, OType(val));
@@ -323,7 +359,8 @@ void seq_reduce_compute(const size_t N, const size_t M, const bool addto,
                         const DType *big, OType *small, const Shape<ndim> bshape,
                         const Shape<ndim> sshape, const Shape<ndim> rshape,
                         const Shape<ndim> rstride) {
-  #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
+  std::cout << engine::OpenMP::Get()->GetRecommendedOMPThreadCount() << std::endl;
+  //#pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
   for (index_t idx = 0; idx < static_cast<index_t>(N); ++idx) {
     seq_reduce_assign<Reducer, ndim, AType, DType, OType, OP, IndexOP>(idx, M, addto, big, small,
         bshape, sshape, rshape, rstride);


### PR DESCRIPTION
This pr optimizes the cpu reduce kernel. This is used in many ops: `np.sum`, `np.mean`, `np.prod`, `np.argmin`, `np.argmax`, `np.var`, `np.std`, `np.constraint`, `np.norm`, `np.where`, `fully_connected`, etc.

Before
``` c++
template<typename Reducer, int ndim, typename AType, typename DType, typename OType, typename OP>
void seq_reduce_compute(const size_t N, const size_t M, const bool addto,
                        const DType *big, OType *small, const Shape<ndim> bshape,
                        const Shape<ndim> sshape, const Shape<ndim> rshape,
                        const Shape<ndim> rstride) {
  #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
  for (index_t idx = 0; idx < static_cast<index_t>(N); ++idx) {
    seq_reduce_assign<Reducer, ndim, AType, DType, OType, OP>(idx, M, addto, big, small,
        bshape, sshape, rshape, rstride);
  }
}

template<typename Reducer, int ndim, typename AType, typename DType, typename OType, typename OP>
void seq_reduce_compute(const size_t N, const size_t M, const bool addto,
                        const DType *big, OType *small, const Shape<ndim> bshape,
                        const Shape<ndim> sshape, const Shape<ndim> rshape,
                        const Shape<ndim> rstride) {
  #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
  for (index_t idx = 0; idx < static_cast<index_t>(N); ++idx) {
    seq_reduce_assign<Reducer, ndim, AType, DType, OType, OP>(idx, M, addto, big, small,
        bshape, sshape, rshape, rstride);
  }
}
```


Before this pr we use openmp to parallelize the rows along the axis to be reduced (`N`). However when `N` is smaller than the number of omp threads, such as when `axis=None` or the product of the other dimension is smaller than the number of threads, then parallelism is not used to the fullest. This pr optimizes such cases by parallelizing within the row (`M`). So now we have: 1.) N >= omp_thread_count, then parallelize `N` 2.) else parallelize `M`

Now
``` c++
template<typename Reducer, int ndim, typename AType, typename DType, typename OType, typename OP,
         typename IndexOP = mxnet::op::mshadow_op::set_index_no_op<AType, index_t>>
MSHADOW_XINLINE AType seq_reduce_assign_block(size_t start, size_t len,
                                              size_t j,
                                              const DType* __restrict big,
                                              const Shape<ndim>& rshape,
                                              const Shape<ndim>& rstride) {
  Shape<ndim> coord;
  AType val, residual;
  Reducer::SetInitValue(val, residual);
  for (size_t k = start; k < start + len; ++k) {
    coord = mxnet_op::unravel(k, rshape);
    AType temp = OP::Map(big[j + mxnet_op::dot(coord, rstride)]);
    if (IndexOP::do_op)
      IndexOP::Op(&temp, k);
    Reducer::Reduce(val, temp, residual);
  }
  Reducer::Finalize(val, residual);
  return val;
}

template<typename Reducer, int ndim, typename AType, typename DType, typename OType,
         typename OP, typename IndexOP = mxnet::op::mshadow_op::set_index_no_op<AType, index_t>>
MSHADOW_XINLINE void seq_reduce_assign(const index_t idx, const size_t M, const bool addto,
                                       const DType* __restrict big, OType *small,
                                       const Shape<ndim>& bshape, const Shape<ndim>& sshape,
                                       const Shape<ndim>& rshape, const Shape<ndim>& rstride,
                                       const bool use_omp = false) {
  Shape<ndim> coord = mxnet_op::unravel(idx, sshape);
  index_t j = mxnet_op::ravel(coord, bshape);
  AType val, residual;
  Reducer::SetInitValue(val, residual);
  if (!use_omp) {
    for (size_t k = 0; k < M; ++k) {
      coord = mxnet_op::unravel(k, rshape);
      AType temp = OP::Map(big[j + mxnet_op::dot(coord, rstride)]);
      // argmin/max, set IndexedNum.idx
      if (IndexOP::do_op)
        IndexOP::Op(&temp, k);
      Reducer::Reduce(val, temp, residual);
    }
  } else {
    const int thread_count = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
    auto vals = std::make_unique<AType[]>(thread_count);
    #pragma omp parallel for num_threads(engine::OpenMP::Get()->GetRecommendedOMPThreadCount())
    for (int i = 0; i < thread_count; ++i) {
      vals[i] = seq_reduce_assign_block<Reducer, ndim, AType, DType, OType, OP, IndexOP>
          (i * (M / thread_count),
          i < (thread_count - 1) ? (M / thread_count) : (M / thread_count) + M % thread_count,
          j, big, rshape, rstride);
    }
    for (int i = 0; i < thread_count; ++i) {
      Reducer::Reduce(val, vals[i], residual);
    }
  }
  Reducer::Finalize(val, residual);
  assign(&small[idx], addto, OType(val));
}

template<typename Reducer, int ndim, typename AType, typename DType, typename OType, typename OP,
         typename IndexOP = mxnet::op::mshadow_op::set_index_no_op<AType, index_t>>
void seq_reduce_compute(const size_t N, const size_t M, const bool addto,
                        const DType *big, OType *small, const Shape<ndim> bshape,
                        const Shape<ndim> sshape, const Shape<ndim> rshape,
                        const Shape<ndim> rstride) {
  const int thread_count = engine::OpenMP::Get()->GetRecommendedOMPThreadCount();
  #pragma omp parallel for num_threads(thread_count) if (N >= thread_count)
  for (index_t idx = 0; idx < static_cast<index_t>(N); ++idx) {
    seq_reduce_assign<Reducer, ndim, AType, DType, OType, OP, IndexOP>
        (idx, M, addto, big, small, bshape, sshape, rshape, rstride, N < thread_count);
  }
}
```

Performance improvement (np.sum, omp_thread_count=16):

> (8, 300000) float32 axis = 1
> before: 15.54 now: 8.02
> 
> (4, 300000) float32 axis = 1
> before: 15.51 now: 4.07
> 
> (300000, 4) float32 axis = 0
> before: 15.57 now: 4.10
> 
> (5000, 5000) float32 axis=None
> before: 1284 now: 81
> 
> (500, 50000) float32 axis=None
> before: 1284 now: 82
> 
> (2, 2**25) float32 axis=1
> before: 1719 now: 217
> 
> (2, 2**25) float32 axis=None
> before: 3433 now: 217

unit is ms
