### PR TITLE
Numpy fill_diagonal large tensor fix

### DIFF
--- a/src/operator/numpy/np_fill_diagonal_op-inl.h
+++ b/src/operator/numpy/np_fill_diagonal_op-inl.h
@@ -89,7 +89,7 @@ template<int req>
 struct FillDiagonalOpForwardImpl {
   template<typename DType>
   MSHADOW_XINLINE static void Map(index_t i, DType* out_data, const DType* in_data,
-                                  const double* val, int length, int step, int end){
+                                  const double* val, int length, index_t step, index_t end){
     using namespace mxnet_op;
     if (i < end) {
       if (i % step == 0) {

--- a/tests/nightly/test_np_large_array.py
+++ b/tests/nightly/test_np_large_array.py
@@ -2211,3 +2211,15 @@ def test_symmetric_padding():
     assert out[-1][-1] == INT_OVERFLOW - 1
     assert out.shape == (INT_OVERFLOW + 2, 4 + 2)
 
+
+@use_np
+def test_fill_diagonal():
+    # test 2d square matrix case
+    N = 2**16
+    data1 = np.zeros((N, N))
+    np.fill_diagonal(data1, [1, 2, 3, 4])
+    assert data1[0, 0] == 1 and data1[-1, -1] == 4
+    # test 2d long matrix case with wrap
+    data2 = np.zeros((INT_OVERFLOW, 2))
+    np.fill_diagonal(data2, [1, 2], wrap=True)
+    assert data2[0, 0] == 1 and data2[-1, -1] == 2


### PR DESCRIPTION
This pr enables large tensors on numpy fill_diagonal

local run:

```
ubuntu@ip-172-31-38-169:~/myspace$ pytest tests/nightly/test_np_large_array.py::test_fill_diagonal
=================================================== test session starts ===================================================
platform linux -- Python 3.7.7, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /home/ubuntu/myspace, inifile: pytest.ini
plugins: remotedata-0.3.2, openfiles-0.4.0, astropy-header-0.1.2, hypothesis-5.8.3, arraydiff-0.3, doctestplus-0.5.0
collected 1 item                                                                                                          

tests/nightly/test_np_large_array.py    .                                                                              [100%]

==================================================== warnings summary =====================================================
tests/nightly/test_np_large_array.py:91
  /home/ubuntu/myspace/tests/nightly/test_np_large_array.py:91: DeprecationWarning: invalid escape sequence \ 
    '''

tests/nightly/test_np_large_array.py:1322
  /home/ubuntu/myspace/tests/nightly/test_np_large_array.py:1322: DeprecationWarning: invalid escape sequence \ 
    '''

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================== 1 passed, 2 warnings in 186.14s (0:03:06) =================================

```