### PR TITLE
[1.x] Backport Enable Numpy support for Gluon Block optimize_for to v1.x

### DIFF
--- a/ci/docker/install/centos7_python.sh
+++ b/ci/docker/install/centos7_python.sh
@@ -30,4 +30,4 @@ yum -y install python36u
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 python3.6 get-pip.py
 # Restrict numpy version to < 1.19.0 due to https://github.com/apache/incubator-mxnet/issues/18600
-pip3 install nose pylint 'numpy>1.16.0,<1.19.0' nose-timer requests h5py scipy==1.2.3
+pip3 install nose pylint 'numpy>1.16.0,<1.19.0' nose-timer requests h5py==2.8.0rc1 scipy==1.2.3

--- a/python/mxnet/gluon/block.py
+++ b/python/mxnet/gluon/block.py
@@ -966,6 +966,10 @@ class HybridBlock(Block):
             # Partition the graph.
             out = out.optimize_for(self._backend, arg_dict, aux_dict, ctx, **self._backend_opts)
 
+            # convert to numpy symbol if needed
+            if _mx_npx.is_np_array():
+                out = out.as_np_ndarray()
+
             #update cached graph with partitioned graph
             self._cached_graph = data, out
 


### PR DESCRIPTION
## Description ##
Backport #19455 and aligned h5py in other 2 places to match #19476

## Checklist ##
### Essentials ###
- [ ] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
