### PR TITLE
[Numpy] Update fallback.py

### DIFF
--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -20,6 +20,7 @@
 
 import sys
 import numpy as onp
+from functools import wraps
 
 fallbacks = [
     '__version__',
@@ -116,10 +117,11 @@ fallback_mod = sys.modules[__name__]
 
 def get_func(obj, doc):
     """Get new numpy function with object and doc"""
-    def fn(*args, **kwargs):
+    @wraps(obj)
+    def wrapper(*args, **kwargs):
         return obj(*args, **kwargs)
-    fn.__doc__ = doc
-    return fn
+    wrapper.__doc__ = doc
+    return wrapper
 
 for obj_name in fallbacks:
     onp_obj = getattr(onp, obj_name)

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -114,11 +114,16 @@ fallbacks = [
 
 fallback_mod = sys.modules[__name__]
 
+def get_func(obj, doc):
+    """Get new numpy function with object and doc"""
+    def fn(*args, **kwargs):
+        return obj(*args, **kwargs)
+    fn.__doc__ = doc
+    return fn
+
 for obj_name in fallbacks:
     onp_obj = getattr(onp, obj_name)
     if callable(onp_obj):
-        def fn(*args, **kwargs):
-            return onp_obj(*args, **kwargs)
         new_fn_doc = onp_obj.__doc__
         if obj_name in {'divmod', 'float_power', 'frexp', 'heaviside', 'modf', 'signbit', 'spacing'}:
             # remove reference of kwargs doc and the reference to ufuncs
@@ -128,8 +133,7 @@ for obj_name in fallbacks:
             # remove unused reference
             new_fn_doc = new_fn_doc.replace(
                 '.. [1] Wikipedia page: https://en.wikipedia.org/wiki/Trapezoidal_rule', '')
-        fn.__doc__ = new_fn_doc
-        setattr(fallback_mod, obj_name, fn)
+        setattr(fallback_mod, obj_name, get_func(onp_obj, new_fn_doc))
     else:
         setattr(fallback_mod, obj_name, onp_obj)
 

--- a/python/mxnet/numpy/fallback.py
+++ b/python/mxnet/numpy/fallback.py
@@ -19,8 +19,8 @@
 """Operators that fallback to official NumPy implementation."""
 
 import sys
-import numpy as onp
 from functools import wraps
+import numpy as onp
 
 fallbacks = [
     '__version__',

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -11382,7 +11382,12 @@ def atleast_1d(*arys):
     >>> np.atleast_1d(np.array(1), np.array([3, 4]))
     [array([1.]), array([3., 4.])]
     """
-    return _mx_nd_np.atleast_1d(*arys)
+    res = []
+    for ary in arys:
+        ary, _ = _as_onp_array(ary)
+        ary = _np.asanyarray(ary)
+        res.append(_as_mx_np_array(ary))
+    return _mx_nd_np.atleast_1d(*res)
 
 
 @set_module('mxnet.numpy')
@@ -11414,7 +11419,12 @@ def atleast_2d(*arys):
     >>> np.atleast_2d(np.array(1), np.array([1, 2]), np.array([[1, 2]]))
     [array([[1.]]), array([[1., 2.]]), array([[1., 2.]])]
     """
-    return _mx_nd_np.atleast_2d(*arys)
+    res = []
+    for ary in arys:
+        ary, _ = _as_onp_array(ary)
+        ary = _np.asanyarray(ary)
+        res.append(_as_mx_np_array(ary))
+    return _mx_nd_np.atleast_2d(*res)
 
 
 @set_module('mxnet.numpy')
@@ -11457,7 +11467,12 @@ def atleast_3d(*arys):
       [2.]]] (1, 2, 1)
     [[[1. 2.]]] (1, 1, 2)
     """
-    return _mx_nd_np.atleast_3d(*arys)
+    res = []
+    for ary in arys:
+        ary, _ = _as_onp_array(ary)
+        ary = _np.asanyarray(ary)
+        res.append(_as_mx_np_array(ary))
+    return _mx_nd_np.atleast_3d(*res)
 
 
 @set_module('mxnet.numpy')

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -11384,10 +11384,7 @@ def atleast_1d(*arys):
     """
     res = []
     for ary in arys:
-        if isinstance(ary, (tuple, list)):
-            ary = stack(ary)
-        elif isinstance(ary, numeric_types):
-            ary = array(ary)
+        ary = array(ary)
         res.append(ary)
     return _mx_nd_np.atleast_1d(*res)
 
@@ -11423,10 +11420,7 @@ def atleast_2d(*arys):
     """
     res = []
     for ary in arys:
-        if isinstance(ary, (tuple, list)):
-            ary = stack(ary)
-        elif isinstance(ary, numeric_types):
-            ary = array(ary)
+        ary = array(ary)
         res.append(ary)
     return _mx_nd_np.atleast_2d(*res)
 
@@ -11473,10 +11467,7 @@ def atleast_3d(*arys):
     """
     res = []
     for ary in arys:
-        if isinstance(ary, (tuple, list)):
-            ary = stack(ary)
-        elif isinstance(ary, numeric_types):
-            ary = array(ary)
+        ary = array(ary)
         res.append(ary)
     return _mx_nd_np.atleast_3d(*res)
 

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -11384,7 +11384,8 @@ def atleast_1d(*arys):
     """
     res = []
     for ary in arys:
-        ary = array(ary)
+        if not isinstance(ary, NDArray):
+            ary = array(ary)
         res.append(ary)
     return _mx_nd_np.atleast_1d(*res)
 
@@ -11420,7 +11421,8 @@ def atleast_2d(*arys):
     """
     res = []
     for ary in arys:
-        ary = array(ary)
+        if not isinstance(ary, NDArray):
+            ary = array(ary)
         res.append(ary)
     return _mx_nd_np.atleast_2d(*res)
 
@@ -11467,7 +11469,8 @@ def atleast_3d(*arys):
     """
     res = []
     for ary in arys:
-        ary = array(ary)
+        if not isinstance(ary, NDArray):
+            ary = array(ary)
         res.append(ary)
     return _mx_nd_np.atleast_3d(*res)
 

--- a/python/mxnet/numpy/multiarray.py
+++ b/python/mxnet/numpy/multiarray.py
@@ -11384,9 +11384,11 @@ def atleast_1d(*arys):
     """
     res = []
     for ary in arys:
-        ary, _ = _as_onp_array(ary)
-        ary = _np.asanyarray(ary)
-        res.append(_as_mx_np_array(ary))
+        if isinstance(ary, (tuple, list)):
+            ary = stack(ary)
+        elif isinstance(ary, numeric_types):
+            ary = array(ary)
+        res.append(ary)
     return _mx_nd_np.atleast_1d(*res)
 
 
@@ -11421,9 +11423,11 @@ def atleast_2d(*arys):
     """
     res = []
     for ary in arys:
-        ary, _ = _as_onp_array(ary)
-        ary = _np.asanyarray(ary)
-        res.append(_as_mx_np_array(ary))
+        if isinstance(ary, (tuple, list)):
+            ary = stack(ary)
+        elif isinstance(ary, numeric_types):
+            ary = array(ary)
+        res.append(ary)
     return _mx_nd_np.atleast_2d(*res)
 
 
@@ -11469,9 +11473,11 @@ def atleast_3d(*arys):
     """
     res = []
     for ary in arys:
-        ary, _ = _as_onp_array(ary)
-        ary = _np.asanyarray(ary)
-        res.append(_as_mx_np_array(ary))
+        if isinstance(ary, (tuple, list)):
+            ary = stack(ary)
+        elif isinstance(ary, numeric_types):
+            ary = array(ary)
+        res.append(ary)
     return _mx_nd_np.atleast_3d(*res)
 
 

--- a/tests/python/unittest/test_numpy_interoperability.py
+++ b/tests/python/unittest/test_numpy_interoperability.py
@@ -3255,13 +3255,15 @@ def _check_interoperability_helper(op_name, rel_tol, abs_tol, *args, **kwargs):
     strs = op_name.split('.')
     if len(strs) == 1:
         onp_op = getattr(_np, op_name)
+        mxnp_op = getattr(np, op_name)
     elif len(strs) == 2:
         onp_op = getattr(getattr(_np, strs[0]), strs[1])
+        mxnp_op = getattr(getattr(np, strs[0]), strs[1])
     else:
         assert False
     if not is_op_runnable():
         return
-    out = onp_op(*args, **kwargs)
+    out = mxnp_op(*args, **kwargs)
     expected_out = _get_numpy_op_output(onp_op, *args, **kwargs)
     if isinstance(out, (tuple, list)):
         assert type(out) == type(expected_out)


### PR DESCRIPTION
## Description ##
Workaround for #19454  to make mxnet numpy operators fall back to the correct official numpy function. 

## Checklist ##
### Essentials ###
- [x] PR's title starts with a category (e.g. [BUGFIX], [MODEL], [TUTORIAL], [FEATURE], [DOC], etc)
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [x] Code is well-documented

### Changes ###
- [x] Add `get_func` to get official numpy function 

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
